### PR TITLE
Calculate file indices up-front to avoid globally shared processing state…

### DIFF
--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -25,7 +25,6 @@ class Course:
     template_dir: Path = None
     prog_lang: str = "python"
     documents: list[Document] = field(default_factory=list)
-    notebook_indices: dict[str, int] = field(default_factory=dict)
 
     # noinspection PyTypeChecker
     def __post_init__(self):
@@ -35,33 +34,6 @@ class Course:
             raise ValueError(
                 "Target directory for a course must be absolute."
             )  # TODO: should we force other paths to be absolute as well?
-
-    def get_index(self, nb_path: PathOrStr):
-        """Return an index that increases per directory.
-
-        >>> cs = Course(Path("/tmp").absolute(), Path("/tmp").absolute())
-        >>> cs.get_index("/foo/bar.py")
-        1
-        >>> cs.get_index("/foo/baz.py")
-        2
-        >>> cs.get_index("/quux/foobar.py")
-        1
-        >>> cs.get_index("/foo/bar.py")
-        1
-        >>> cs.get_index("/foo/xxx.py")
-        3
-        """
-        nb_path = Path(nb_path)
-
-        nb_key = nb_path.as_posix()
-        current_index = self.notebook_indices.get(nb_key, None)
-        if current_index is None:
-            parent_key = nb_path.parent.as_posix()
-            current_index = self.notebook_indices.get(parent_key, 0) + 1
-            self.notebook_indices[parent_key] = current_index
-            self.notebook_indices[nb_key] = current_index
-        self.notebook_indices[nb_key] = current_index
-        return current_index
 
     @staticmethod
     def from_spec(course_spec: CourseSpec):

--- a/src/clm/core/course_specs.py
+++ b/src/clm/core/course_specs.py
@@ -309,6 +309,7 @@ class CourseSpec:
         return sorted(
             (
                 DocumentSpec.from_source_file(base_dir, file, file_num)
+                # FIXME: use separate counters by file kind, not only by directory.
                 for file_num, file in enumerate(find_potential_course_files(base_dir), 1)
             ),
             key=attrgetter("source_file"),
@@ -433,8 +434,9 @@ class CourseSpec:
             if data:
                 if len(data) == 3:
                     source_file, target_dir_fragment, kind = data
-                    file_num = file_counters[target_dir_fragment] + 1
-                    file_counters[target_dir_fragment] = file_num
+                    counter_key = (target_dir_fragment, kind)
+                    file_num = file_counters[counter_key] + 1
+                    file_counters[counter_key] = file_num
                     document_specs.append(DocumentSpec(*data, file_num))
                 else:
                     logging.error(f"Skipping bad entry in CSV file: {data}.")

--- a/src/clm/core/course_specs.py
+++ b/src/clm/core/course_specs.py
@@ -309,7 +309,7 @@ class CourseSpec:
         return sorted(
             (
                 DocumentSpec.from_source_file(base_dir, file, file_num)
-                for file_num, file in enumerate(find_potential_course_files(base_dir))
+                for file_num, file in enumerate(find_potential_course_files(base_dir), 1)
             ),
             key=attrgetter("source_file"),
         )

--- a/src/clm/core/course_specs.py
+++ b/src/clm/core/course_specs.py
@@ -434,6 +434,8 @@ class CourseSpec:
             if data:
                 if len(data) == 3:
                     source_file, target_dir_fragment, kind = data
+                    if source_file.startswith('#'):
+                        continue  # line is temporarily commented out
                     counter_key = (target_dir_fragment, kind)
                     file_num = file_counters[counter_key] + 1
                     file_counters[counter_key] = file_num

--- a/src/clm/core/course_specs.py
+++ b/src/clm/core/course_specs.py
@@ -433,8 +433,8 @@ class CourseSpec:
             if data:
                 if len(data) == 3:
                     source_file, target_dir_fragment, kind = data
-                    file_num = file_counters[target_dir_fragment]
-                    file_counters[target_dir_fragment] = file_num + 1
+                    file_num = file_counters[target_dir_fragment] + 1
+                    file_counters[target_dir_fragment] = file_num
                     document_specs.append(DocumentSpec(*data, file_num))
                 else:
                     logging.error(f"Skipping bad entry in CSV file: {data}.")

--- a/src/clm/core/document.py
+++ b/src/clm/core/document.py
@@ -58,6 +58,7 @@ class Document(ABC):
     source_file: Path
     target_dir_fragment: str
     prog_lang: str
+    file_num: int
 
     def __post_init__(self):
         super().__init__()
@@ -104,6 +105,7 @@ class Document(ABC):
             source_file=source_file,
             target_dir_fragment=document_spec.target_dir_fragment,
             prog_lang=prog_lang,
+            file_num=document_spec.file_num,
         )
 
     @abstractmethod
@@ -212,7 +214,6 @@ class Notebook(Document):
     expanded_notebook: str = field(default="", repr=False)
     unprocessed_notebook: NotebookNode | None = field(default=None, repr=False)
     processed_notebook: NotebookNode | None = field(default=None, repr=False)
-    serial_number: ClassVar[int] = 0
 
     def __post_init__(self):
         try:
@@ -378,7 +379,6 @@ class Notebook(Document):
 
     def process(self, course: "Course", output_spec: OutputSpec):
         logging.info(f"Processing notebook {self.source_file}.")
-        Notebook.serial_number += 1
         expanded_nb = self.load_and_expand_jinja_template(course, output_spec)
         self.expanded_notebook = expanded_nb
         try:
@@ -398,7 +398,7 @@ class Notebook(Document):
         target_file_fragment = Path(self.target_dir_fragment) / out_name
 
         path = self.source_file.with_name(
-            f"{course.get_index(target_file_fragment) :0>2} {out_name}"
+            f"{self.file_num :0>2} {out_name}"
         )
         return path.with_suffix(f".{output_spec.file_suffix}").name
 


### PR DESCRIPTION
… and thus a dependency on the processing thread.

Also remove "Notebook.serial_number", which was apparently unused.

See https://github.com/hoelzl/clm/pull/1#issuecomment-1517509660