### PR TITLE
Add recordings module: audio pipeline, OBS integration, web dashboard, file watcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         # Install all dependencies except ML (PyTorch, FastAI, etc.) which aren't needed for tests
-        uv pip install --system -e ".[all-workers,summarize,dev,tui,web]"
+        uv pip install --system -e ".[all-workers,summarize,recordings,dev,tui,web]"
 
     - name: Start Xvfb
       run: |
@@ -133,7 +133,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv pip install --system -e ".[dev,tui,web,notebook,summarize]"
+        uv pip install --system -e ".[dev,tui,web,notebook,summarize,recordings]"
 
     - name: Run ruff check
       run: |
@@ -212,7 +212,7 @@ jobs:
     - name: Install dependencies
       run: |
         # Install all dependencies except ML (PyTorch, FastAI, etc.) which aren't needed for tests
-        uv pip install --system -e ".[all-workers,dev,tui,web]"
+        uv pip install --system -e ".[all-workers,recordings,dev,tui,web]"
 
     - name: Run Docker integration tests
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Recordings web dashboard** (`recordings/web/`): HTMX-based web UI for the recording
   workflow, launched via `clm recordings serve`. Features: lecture selection with arm/disarm
   buttons, real-time status dashboard with SSE updates, pending pairs view, OBS connection
-  indicator. Uses Pico CSS (CDN) and HTMX with Jinja2 templates — no JavaScript framework.
+  indicator, file watcher controls. Uses Pico CSS (CDN) and HTMX with Jinja2 templates —
+  no JavaScript framework.
 - **`clm recordings serve`** CLI command: Starts the recordings dashboard on localhost,
   connects to OBS WebSocket, loads course structure from a spec file.
+- **File watcher** (`recordings/workflow/watcher.py`): Watchdog-based filesystem watcher
+  that monitors `to-process/` for new files and triggers assembly automatically. Features
+  stability detection (file-size polling), thread-safe file claim tracking, and
+  backend-aware behaviour (watches for `.wav` in external mode, raw video in ONNX mode).
+  Start/stop controllable from the web dashboard.
+- **Processing backends** (`recordings/workflow/backends.py`): Pluggable processing backend
+  protocol with two implementations:
+  - `ExternalBackend` — waits for an external tool (e.g. iZotope RX 11) to produce
+    processed `.wav` audio alongside the raw video
+  - `OnnxBackend` — processes locally: extracts audio, runs DeepFilterNet3 ONNX noise
+    reduction, applies FFmpeg audio filters, writes processed `.wav`
+- **Watcher config fields**: Added `processing_backend` (`"external"` or `"onnx"`),
+  `stability_check_interval` (seconds between file-size polls), and
+  `stability_check_count` (consecutive identical readings = stable) to `RecordingsConfig`.
 
 ### Changed
 - **Replaced DeepFilterNet CLI with ONNX inference**: The audio processing pipeline now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Recording management module** (`clm recordings`): New optional module for managing
   the video recording workflow for educational courses. Integrates the standalone
   recording processing pipeline into CLM as an optional `[recordings]` extra.
-  - `clm recordings check` — verify recording dependencies (ffmpeg, deepfilter)
+  - `clm recordings check` — verify recording dependencies (ffmpeg, onnxruntime)
   - `clm recordings process` — process a single recording through the 5-step audio
-    pipeline (extract → DeepFilterNet noise reduction → FFmpeg filters → AAC → mux)
+    pipeline (extract → DeepFilterNet3 ONNX noise reduction → FFmpeg filters → AAC → mux)
   - `clm recordings batch` — batch-process all recordings in a directory
   - `clm recordings status` — show per-lecture recording status for a course
   - `clm recordings compare` — generate A/B audio comparison HTML with blind test mode
@@ -24,6 +24,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **RecordingsConfig**: New `[recordings]` section in CLM's TOML configuration system
   with settings for OBS output directory, course list, active course, auto-processing,
   and audio processing pipeline parameters.
+
+### Changed
+- **Replaced DeepFilterNet CLI with ONNX inference**: The audio processing pipeline now
+  uses the DeepFilterNet3 streaming ONNX model via `onnxruntime` instead of the
+  `deepfilternet` CLI subprocess. This removes the dependency on the unmaintained
+  `deepfilternet` package (which pins `numpy<2.0` and lacks Python 3.12+ wheels).
+  Dependencies: `onnxruntime`, `soundfile`, `numpy`. The ONNX model is auto-downloaded
+  and cached on first use.
+- **Renamed config field**: `deepfilter_atten_lim` → `denoise_atten_lim` in both
+  `PipelineConfig` and `RecordingsProcessingConfig`.
 
 ## [1.1.9] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Recording management module** (`clm recordings`): New optional module for managing
+  the video recording workflow for educational courses. Integrates the standalone
+  recording processing pipeline into CLM as an optional `[recordings]` extra.
+  - `clm recordings check` — verify recording dependencies (ffmpeg, deepfilter)
+  - `clm recordings process` — process a single recording through the 5-step audio
+    pipeline (extract → DeepFilterNet noise reduction → FFmpeg filters → AAC → mux)
+  - `clm recordings batch` — batch-process all recordings in a directory
+  - `clm recordings status` — show per-lecture recording status for a course
+  - `clm recordings compare` — generate A/B audio comparison HTML with blind test mode
+- **Recording state manager** (`recordings/state.py`): Pydantic models for per-course
+  recording state stored as JSON files. Supports auto-assignment of recordings to lectures,
+  reassignment, and status tracking.
+- **Git commit capture** (`recordings/git_info.py`): Captures HEAD commit hash and dirty
+  state of the course repository at recording assignment time.
+- **RecordingsConfig**: New `[recordings]` section in CLM's TOML configuration system
+  with settings for OBS output directory, course list, active course, auto-processing,
+  and audio processing pipeline parameters.
+
 ## [1.1.9] - 2026-03-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   with settings for OBS output directory, course list, active course, auto-processing,
   and audio processing pipeline parameters. Includes `root_dir` (recordings root) and
   `raw_suffix` (default `--RAW`) for the workflow automation.
+- **OBS integration** (`recordings/workflow/obs.py`): OBS WebSocket client wrapper using
+  `obsws-python`. Manages request and event clients, provides `RecordStateChanged` event
+  callbacks, and queries recording status and output directory.
+- **Recording session manager** (`recordings/workflow/session.py`): Thread-safe state
+  machine coordinating the recording workflow. Tracks armed topics, responds to OBS
+  start/stop events, and auto-renames output files into the structured `to-process/`
+  directory tree. States: `idle → armed → recording → renaming → idle`.
+- **OBS config fields**: Added `obs_host`, `obs_port`, `obs_password` to `RecordingsConfig`
+  for OBS WebSocket connection settings.
+- **obsws-python dependency**: Added `obsws-python>=1.7.0` to the `[recordings]` optional
+  dependency group.
 
 ### Changed
 - **Replaced DeepFilterNet CLI with ONNX inference**: The audio processing pipeline now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - `clm recordings batch` — batch-process all recordings in a directory
   - `clm recordings status` — show per-lecture recording status for a course
   - `clm recordings compare` — generate A/B audio comparison HTML with blind test mode
+  - `clm recordings assemble` — scan for paired raw video + processed audio, mux final
+    output via FFmpeg, and archive originals
+- **Recording workflow automation** (`recordings/workflow/`): Foundation for automating
+  the recording → processing → assembly pipeline.
+  - `naming.py` — filename convention helpers (raw/final filenames, `--RAW` suffix parsing),
+    delegates sanitization to existing `sanitize_file_name` from core utils
+  - `directories.py` — three-tier directory structure (`to-process/`, `final/`, `archive/`)
+    management and pending pair scanning
+  - `assembler.py` — mux video + processed audio via FFmpeg and archive originals
 - **Recording state manager** (`recordings/state.py`): Pydantic models for per-course
   recording state stored as JSON files. Supports auto-assignment of recordings to lectures,
   reassignment, and status tracking.
@@ -23,7 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   state of the course repository at recording assignment time.
 - **RecordingsConfig**: New `[recordings]` section in CLM's TOML configuration system
   with settings for OBS output directory, course list, active course, auto-processing,
-  and audio processing pipeline parameters.
+  and audio processing pipeline parameters. Includes `root_dir` (recordings root) and
+  `raw_suffix` (default `--RAW`) for the workflow automation.
 
 ### Changed
 - **Replaced DeepFilterNet CLI with ONNX inference**: The audio processing pipeline now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   for OBS WebSocket connection settings.
 - **obsws-python dependency**: Added `obsws-python>=1.7.0` to the `[recordings]` optional
   dependency group.
+- **Recordings web dashboard** (`recordings/web/`): HTMX-based web UI for the recording
+  workflow, launched via `clm recordings serve`. Features: lecture selection with arm/disarm
+  buttons, real-time status dashboard with SSE updates, pending pairs view, OBS connection
+  indicator. Uses Pico CSS (CDN) and HTMX with Jinja2 templates — no JavaScript framework.
+- **`clm recordings serve`** CLI command: Starts the recordings dashboard on localhost,
+  connects to OBS WebSocket, loads course structure from a spec file.
 
 ### Changed
 - **Replaced DeepFilterNet CLI with ONNX inference**: The audio processing pipeline now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ clm recordings batch DIR        # Batch-process recordings in a directory
 clm recordings status COURSE    # Show recording status for a course
 clm recordings compare A B      # A/B audio comparison HTML page
 clm recordings assemble DIR     # Mux paired video+audio, archive originals
+clm recordings serve DIR        # Web dashboard for recording workflow
 clm monitor                     # TUI monitoring (requires [tui])
 clm serve                       # Web dashboard (requires [web])
 ```
@@ -112,6 +113,7 @@ clm/
 │   ├── recordings/             # Video recording management and audio processing
 │   │   ├── processing/         # Audio pipeline (DeepFilterNet3 ONNX + FFmpeg)
 │   │   ├── workflow/           # Recording workflow automation (naming, dirs, assembly, OBS)
+│   │   ├── web/               # HTMX web dashboard (FastAPI + Jinja2 + SSE)
 │   │   ├── state.py            # Per-course recording state (JSON CRUD)
 │   │   └── git_info.py         # Git commit capture at recording time
 │   └── cli/                    # Click-based CLI
@@ -122,7 +124,7 @@ clm/
 │   ├── cli/                    # CLI tests
 │   ├── notebooks/              # Slide parser/writer/polish tests
 │   ├── voiceover/              # Voiceover pipeline tests
-│   ├── recordings/             # Recording module tests (145 tests)
+│   ├── recordings/             # Recording module tests (162 tests)
 │   └── e2e/                    # End-to-end tests
 ├── docs/                       # Documentation
 │   ├── user-guide/             # User documentation
@@ -191,6 +193,7 @@ clm/
 - `assemble_one`, `assemble_all`, `mux_video_audio` - Assembly: mux video + audio, archive originals (`recordings/workflow/assembler.py`)
 - `ObsClient`, `RecordingEvent` - OBS WebSocket client wrapper with event callbacks (`recordings/workflow/obs.py`)
 - `RecordingSession`, `SessionState`, `ArmedTopic`, `SessionSnapshot` - Recording session state machine: arm/disarm topics, auto-rename on OBS stop (`recordings/workflow/session.py`)
+- `create_app` - Recordings web dashboard FastAPI app factory (`recordings/web/app.py`)
 
 ## Import Examples
 
@@ -262,6 +265,9 @@ clm recordings status python-basics                     # Show lecture recording
 clm recordings compare a.mp4 b.mp4 --label-a "iZotope" --label-b "DeepFilterNet"
 clm recordings assemble ~/Recordings                    # Mux paired video+audio, archive
 clm recordings assemble ~/Recordings --dry-run          # Preview pending pairs
+clm recordings serve ~/Recordings                       # Start web dashboard
+clm recordings serve ~/Recordings --spec-file course.xml # With lecture listing
+clm recordings serve ~/Recordings --obs-host 192.168.1.5 # Custom OBS host
 ```
 
 - Audio processing pipeline: extract audio → DeepFilterNet3 ONNX noise reduction → FFmpeg filters (highpass, compressor, two-pass EBU R128 loudness normalization) → AAC encode → mux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ pip install -e ".[all]"
 - `[plantuml]`: PlantUML conversion worker
 - `[drawio]`: Draw.io conversion worker
 - `[all-workers]`: All worker dependencies
+- `[recordings]`: Video recording management and audio processing (jinja2, python-multipart)
 - `[summarize]`: LLM-powered course summaries and polish (openai)
 - `[voiceover]`: Video-to-speaker-notes pipeline (faster-whisper, opencv-python, pytesseract, rapidfuzz)
 - `[ml]`: ML/LLM packages (PyTorch, FastAI, LangChain, OpenAI, etc.)
@@ -59,6 +60,11 @@ clm docker list                 # List available Docker images
 clm docker pull                 # Pull Docker images from Hub
 clm voiceover sync V S --lang de # Video → speaker notes (requires [voiceover])
 clm polish slides.py --lang de  # LLM-polish speaker notes (requires [summarize])
+clm recordings check            # Check recording deps (ffmpeg, deepfilter)
+clm recordings process F.mkv    # Process single recording through audio pipeline
+clm recordings batch DIR        # Batch-process recordings in a directory
+clm recordings status COURSE    # Show recording status for a course
+clm recordings compare A B      # A/B audio comparison HTML page
 clm monitor                     # TUI monitoring (requires [tui])
 clm serve                       # Web dashboard (requires [web])
 ```
@@ -102,6 +108,10 @@ clm/
 │   │   └── drawio/             # Draw.io conversion
 │   ├── notebooks/              # Slide file utilities (parser, writer, polish)
 │   ├── voiceover/              # Video-to-speaker-notes pipeline
+│   ├── recordings/             # Video recording management and audio processing
+│   │   ├── processing/         # Audio pipeline (DeepFilterNet + FFmpeg)
+│   │   ├── state.py            # Per-course recording state (JSON CRUD)
+│   │   └── git_info.py         # Git commit capture at recording time
 │   └── cli/                    # Click-based CLI
 │       └── info_topics/        # Markdown docs for `clm info` command
 ├── tests/                      # All tests
@@ -110,6 +120,7 @@ clm/
 │   ├── cli/                    # CLI tests
 │   ├── notebooks/              # Slide parser/writer/polish tests
 │   ├── voiceover/              # Voiceover pipeline tests
+│   ├── recordings/             # Recording module tests (52 tests)
 │   └── e2e/                    # End-to-end tests
 ├── docs/                       # Documentation
 │   ├── user-guide/             # User documentation
@@ -162,6 +173,16 @@ clm/
 - `matcher` - OCR + fuzzy matching for slide identification (`voiceover/matcher.py`)
 - `aligner` - Transcript-to-slide assignment with backtracking (`voiceover/aligner.py`)
 
+### Recordings (Recording Management)
+
+- `ProcessingPipeline` - 5-step audio pipeline: extract → DeepFilterNet → FFmpeg filters → AAC → mux (`recordings/processing/pipeline.py`)
+- `PipelineConfig`, `AudioFilterConfig` - Pydantic config for the processing pipeline (`recordings/processing/config.py`)
+- `CourseRecordingState` - Per-course recording state with assign/reassign/update CRUD (`recordings/state.py`)
+- `LectureState`, `RecordingPart` - Pydantic models for lecture/recording tracking (`recordings/state.py`)
+- `find_video_files`, `process_batch`, `BatchResult` - Batch processing utilities (`recordings/processing/batch.py`)
+- `get_git_info` - Capture git commit at recording time (`recordings/git_info.py`)
+- `RecordingsConfig` - Recording settings in CLM's config system (`infrastructure/config.py`)
+
 ## Import Examples
 
 ```python
@@ -188,6 +209,9 @@ from clm.infrastructure.database import JobQueue
 | `CLM_LLM__MODEL` | Default LLM model for summarize (default: `anthropic/claude-sonnet-4-6`) |
 | `CLM_LLM__API_KEY` | API key for LLM provider |
 | `CLM_LLM__API_BASE` | Custom API base URL for LLM |
+| `CLM_RECORDINGS__OBS_OUTPUT_DIR` | Directory where OBS saves recordings |
+| `CLM_RECORDINGS__ACTIVE_COURSE` | Currently active course ID for recording assignment |
+| `CLM_RECORDINGS__AUTO_PROCESS` | Auto-process recordings when detected (default: false) |
 
 ## Recent Features
 
@@ -209,6 +233,28 @@ clm voiceover identify video.mp4 slides.py --lang de           # Slide matching 
 - External tools: ffmpeg (audio extraction), Tesseract OCR
 - Supports `--mode verbatim|polished`, `--slides-range`, `--dry-run`
 - `--mode polished` also requires `[summarize]` extra (openai)
+
+### Recording Management (v1.2.0+)
+
+The `clm recordings` commands manage video recording workflows for educational courses:
+
+```bash
+clm recordings check                                    # Check ffmpeg/deepfilter
+clm recordings process raw.mkv                          # Process single recording
+clm recordings process raw.mkv -o final.mp4             # Custom output path
+clm recordings batch ~/Recordings -o ~/Processed        # Batch process directory
+clm recordings batch ~/Recordings -r                    # Recursive search
+clm recordings status python-basics                     # Show lecture recording status
+clm recordings compare a.mp4 b.mp4 --label-a "iZotope" --label-b "DeepFilterNet"
+```
+
+- Audio processing pipeline: extract audio → DeepFilterNet noise reduction → FFmpeg filters (highpass, compressor, two-pass EBU R128 loudness normalization) → AAC encode → mux
+- Per-course recording state stored as JSON under `~/.config/clm/recordings/`
+- Auto-assignment of recordings to lectures with `continue_current_lecture` mode
+- Git commit capture at recording assignment time
+- Configuration integrates into CLM's TOML config under `[recordings]`
+- External tools required: `ffmpeg`, `deepFilter` (from `deepfilternet` pip package)
+- Cross-platform: Windows and Linux
 
 ### LLM Polish (v1.1.9+)
 
@@ -510,4 +556,4 @@ See `docs/claude/TODO.md` for current bugs and planned improvements.
 
 **Repository**: https://github.com/hoelzl/clm/ | **Issues**: https://github.com/hoelzl/clm/issues
 
-**Last Updated**: 2026-03-05
+**Last Updated**: 2026-03-31

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ pip install -e ".[all]"
 - `[plantuml]`: PlantUML conversion worker
 - `[drawio]`: Draw.io conversion worker
 - `[all-workers]`: All worker dependencies
-- `[recordings]`: Video recording management and audio processing (jinja2, python-multipart)
+- `[recordings]`: Video recording management and audio processing (jinja2, python-multipart, obsws-python)
 - `[summarize]`: LLM-powered course summaries and polish (openai)
 - `[voiceover]`: Video-to-speaker-notes pipeline (faster-whisper, opencv-python, pytesseract, rapidfuzz)
 - `[ml]`: ML/LLM packages (PyTorch, FastAI, LangChain, OpenAI, etc.)
@@ -111,7 +111,7 @@ clm/
 │   ├── voiceover/              # Video-to-speaker-notes pipeline
 │   ├── recordings/             # Video recording management and audio processing
 │   │   ├── processing/         # Audio pipeline (DeepFilterNet3 ONNX + FFmpeg)
-│   │   ├── workflow/           # Recording workflow automation (naming, dirs, assembly)
+│   │   ├── workflow/           # Recording workflow automation (naming, dirs, assembly, OBS)
 │   │   ├── state.py            # Per-course recording state (JSON CRUD)
 │   │   └── git_info.py         # Git commit capture at recording time
 │   └── cli/                    # Click-based CLI
@@ -122,7 +122,7 @@ clm/
 │   ├── cli/                    # CLI tests
 │   ├── notebooks/              # Slide parser/writer/polish tests
 │   ├── voiceover/              # Voiceover pipeline tests
-│   ├── recordings/             # Recording module tests (101 tests)
+│   ├── recordings/             # Recording module tests (145 tests)
 │   └── e2e/                    # End-to-end tests
 ├── docs/                       # Documentation
 │   ├── user-guide/             # User documentation
@@ -189,6 +189,8 @@ clm/
 - `recording_relative_dir`, `raw_filename`, `final_filename`, `parse_raw_stem` - Naming convention helpers (`recordings/workflow/naming.py`)
 - `ensure_root`, `validate_root`, `find_pending_pairs`, `PendingPair` - Directory structure management (`recordings/workflow/directories.py`)
 - `assemble_one`, `assemble_all`, `mux_video_audio` - Assembly: mux video + audio, archive originals (`recordings/workflow/assembler.py`)
+- `ObsClient`, `RecordingEvent` - OBS WebSocket client wrapper with event callbacks (`recordings/workflow/obs.py`)
+- `RecordingSession`, `SessionState`, `ArmedTopic`, `SessionSnapshot` - Recording session state machine: arm/disarm topics, auto-rename on OBS stop (`recordings/workflow/session.py`)
 
 ## Import Examples
 
@@ -221,6 +223,9 @@ from clm.infrastructure.database import JobQueue
 | `CLM_RECORDINGS__AUTO_PROCESS` | Auto-process recordings when detected (default: false) |
 | `CLM_RECORDINGS__ROOT_DIR` | Root directory for recording workflow (to-process/, final/, archive/) |
 | `CLM_RECORDINGS__RAW_SUFFIX` | Suffix for raw recording filenames (default: `--RAW`) |
+| `CLM_RECORDINGS__OBS_HOST` | OBS WebSocket host (default: `localhost`) |
+| `CLM_RECORDINGS__OBS_PORT` | OBS WebSocket port (default: `4455`) |
+| `CLM_RECORDINGS__OBS_PASSWORD` | OBS WebSocket password (default: empty) |
 
 ## Recent Features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ clm recordings process F.mkv    # Process single recording through audio pipelin
 clm recordings batch DIR        # Batch-process recordings in a directory
 clm recordings status COURSE    # Show recording status for a course
 clm recordings compare A B      # A/B audio comparison HTML page
+clm recordings assemble DIR     # Mux paired video+audio, archive originals
 clm monitor                     # TUI monitoring (requires [tui])
 clm serve                       # Web dashboard (requires [web])
 ```
@@ -110,6 +111,7 @@ clm/
 │   ├── voiceover/              # Video-to-speaker-notes pipeline
 │   ├── recordings/             # Video recording management and audio processing
 │   │   ├── processing/         # Audio pipeline (DeepFilterNet3 ONNX + FFmpeg)
+│   │   ├── workflow/           # Recording workflow automation (naming, dirs, assembly)
 │   │   ├── state.py            # Per-course recording state (JSON CRUD)
 │   │   └── git_info.py         # Git commit capture at recording time
 │   └── cli/                    # Click-based CLI
@@ -120,7 +122,7 @@ clm/
 │   ├── cli/                    # CLI tests
 │   ├── notebooks/              # Slide parser/writer/polish tests
 │   ├── voiceover/              # Voiceover pipeline tests
-│   ├── recordings/             # Recording module tests (52 tests)
+│   ├── recordings/             # Recording module tests (101 tests)
 │   └── e2e/                    # End-to-end tests
 ├── docs/                       # Documentation
 │   ├── user-guide/             # User documentation
@@ -184,6 +186,9 @@ clm/
 - `find_video_files`, `process_batch`, `BatchResult` - Batch processing utilities (`recordings/processing/batch.py`)
 - `get_git_info` - Capture git commit at recording time (`recordings/git_info.py`)
 - `RecordingsConfig` - Recording settings in CLM's config system (`infrastructure/config.py`)
+- `recording_relative_dir`, `raw_filename`, `final_filename`, `parse_raw_stem` - Naming convention helpers (`recordings/workflow/naming.py`)
+- `ensure_root`, `validate_root`, `find_pending_pairs`, `PendingPair` - Directory structure management (`recordings/workflow/directories.py`)
+- `assemble_one`, `assemble_all`, `mux_video_audio` - Assembly: mux video + audio, archive originals (`recordings/workflow/assembler.py`)
 
 ## Import Examples
 
@@ -214,6 +219,8 @@ from clm.infrastructure.database import JobQueue
 | `CLM_RECORDINGS__OBS_OUTPUT_DIR` | Directory where OBS saves recordings |
 | `CLM_RECORDINGS__ACTIVE_COURSE` | Currently active course ID for recording assignment |
 | `CLM_RECORDINGS__AUTO_PROCESS` | Auto-process recordings when detected (default: false) |
+| `CLM_RECORDINGS__ROOT_DIR` | Root directory for recording workflow (to-process/, final/, archive/) |
+| `CLM_RECORDINGS__RAW_SUFFIX` | Suffix for raw recording filenames (default: `--RAW`) |
 
 ## Recent Features
 
@@ -248,9 +255,12 @@ clm recordings batch ~/Recordings -o ~/Processed        # Batch process director
 clm recordings batch ~/Recordings -r                    # Recursive search
 clm recordings status python-basics                     # Show lecture recording status
 clm recordings compare a.mp4 b.mp4 --label-a "iZotope" --label-b "DeepFilterNet"
+clm recordings assemble ~/Recordings                    # Mux paired video+audio, archive
+clm recordings assemble ~/Recordings --dry-run          # Preview pending pairs
 ```
 
 - Audio processing pipeline: extract audio → DeepFilterNet3 ONNX noise reduction → FFmpeg filters (highpass, compressor, two-pass EBU R128 loudness normalization) → AAC encode → mux
+- Assembly workflow: three-tier directory structure (`to-process/`, `final/`, `archive/`), auto-detect paired `--RAW.mp4` + `--RAW.wav` files, mux via FFmpeg, archive originals
 - Per-course recording state stored as JSON under `~/.config/clm/recordings/`
 - Auto-assignment of recordings to lectures with `continue_current_lecture` mode
 - Git commit capture at recording assignment time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ clm docker list                 # List available Docker images
 clm docker pull                 # Pull Docker images from Hub
 clm voiceover sync V S --lang de # Video → speaker notes (requires [voiceover])
 clm polish slides.py --lang de  # LLM-polish speaker notes (requires [summarize])
-clm recordings check            # Check recording deps (ffmpeg, deepfilter)
+clm recordings check            # Check recording deps (ffmpeg, onnxruntime)
 clm recordings process F.mkv    # Process single recording through audio pipeline
 clm recordings batch DIR        # Batch-process recordings in a directory
 clm recordings status COURSE    # Show recording status for a course
@@ -109,7 +109,7 @@ clm/
 │   ├── notebooks/              # Slide file utilities (parser, writer, polish)
 │   ├── voiceover/              # Video-to-speaker-notes pipeline
 │   ├── recordings/             # Video recording management and audio processing
-│   │   ├── processing/         # Audio pipeline (DeepFilterNet + FFmpeg)
+│   │   ├── processing/         # Audio pipeline (DeepFilterNet3 ONNX + FFmpeg)
 │   │   ├── state.py            # Per-course recording state (JSON CRUD)
 │   │   └── git_info.py         # Git commit capture at recording time
 │   └── cli/                    # Click-based CLI
@@ -175,7 +175,9 @@ clm/
 
 ### Recordings (Recording Management)
 
-- `ProcessingPipeline` - 5-step audio pipeline: extract → DeepFilterNet → FFmpeg filters → AAC → mux (`recordings/processing/pipeline.py`)
+- `ProcessingPipeline` - 5-step audio pipeline: extract → DeepFilterNet3 ONNX → FFmpeg filters → AAC → mux (`recordings/processing/pipeline.py`)
+- `run_onnx_denoise` - DeepFilterNet3 frame-by-frame ONNX inference (`recordings/processing/utils.py`)
+- `download_onnx_model` - Auto-download and cache the ONNX model (`recordings/processing/utils.py`)
 - `PipelineConfig`, `AudioFilterConfig` - Pydantic config for the processing pipeline (`recordings/processing/config.py`)
 - `CourseRecordingState` - Per-course recording state with assign/reassign/update CRUD (`recordings/state.py`)
 - `LectureState`, `RecordingPart` - Pydantic models for lecture/recording tracking (`recordings/state.py`)
@@ -239,7 +241,7 @@ clm voiceover identify video.mp4 slides.py --lang de           # Slide matching 
 The `clm recordings` commands manage video recording workflows for educational courses:
 
 ```bash
-clm recordings check                                    # Check ffmpeg/deepfilter
+clm recordings check                                    # Check ffmpeg/onnxruntime
 clm recordings process raw.mkv                          # Process single recording
 clm recordings process raw.mkv -o final.mp4             # Custom output path
 clm recordings batch ~/Recordings -o ~/Processed        # Batch process directory
@@ -248,12 +250,12 @@ clm recordings status python-basics                     # Show lecture recording
 clm recordings compare a.mp4 b.mp4 --label-a "iZotope" --label-b "DeepFilterNet"
 ```
 
-- Audio processing pipeline: extract audio → DeepFilterNet noise reduction → FFmpeg filters (highpass, compressor, two-pass EBU R128 loudness normalization) → AAC encode → mux
+- Audio processing pipeline: extract audio → DeepFilterNet3 ONNX noise reduction → FFmpeg filters (highpass, compressor, two-pass EBU R128 loudness normalization) → AAC encode → mux
 - Per-course recording state stored as JSON under `~/.config/clm/recordings/`
 - Auto-assignment of recordings to lectures with `continue_current_lecture` mode
 - Git commit capture at recording assignment time
 - Configuration integrates into CLM's TOML config under `[recordings]`
-- External tools required: `ffmpeg`, `deepFilter` (from `deepfilternet` pip package)
+- External tools required: `ffmpeg`; ONNX model auto-downloaded on first use
 - Cross-platform: Windows and Linux
 
 ### LLM Polish (v1.1.9+)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,8 @@ clm/
 - `assemble_one`, `assemble_all`, `mux_video_audio` - Assembly: mux video + audio, archive originals (`recordings/workflow/assembler.py`)
 - `ObsClient`, `RecordingEvent` - OBS WebSocket client wrapper with event callbacks (`recordings/workflow/obs.py`)
 - `RecordingSession`, `SessionState`, `ArmedTopic`, `SessionSnapshot` - Recording session state machine: arm/disarm topics, auto-rename on OBS stop (`recordings/workflow/session.py`)
+- `ProcessingBackend`, `ExternalBackend`, `OnnxBackend` - Pluggable processing backends: protocol + external (wait for RX 11) + local ONNX pipeline (`recordings/workflow/backends.py`)
+- `RecordingsWatcher`, `WatcherState` - Watchdog-based file watcher with stability detection, backend-aware event handling (`recordings/workflow/watcher.py`)
 - `create_app` - Recordings web dashboard FastAPI app factory (`recordings/web/app.py`)
 
 ## Import Examples
@@ -229,6 +231,9 @@ from clm.infrastructure.database import JobQueue
 | `CLM_RECORDINGS__OBS_HOST` | OBS WebSocket host (default: `localhost`) |
 | `CLM_RECORDINGS__OBS_PORT` | OBS WebSocket port (default: `4455`) |
 | `CLM_RECORDINGS__OBS_PASSWORD` | OBS WebSocket password (default: empty) |
+| `CLM_RECORDINGS__PROCESSING_BACKEND` | Processing backend: `external` (default) or `onnx` |
+| `CLM_RECORDINGS__STABILITY_CHECK_INTERVAL` | Seconds between file-size polls (default: `2.0`) |
+| `CLM_RECORDINGS__STABILITY_CHECK_COUNT` | Consecutive identical polls = stable (default: `3`) |
 
 ## Recent Features
 
@@ -275,6 +280,8 @@ clm recordings serve ~/Recordings --obs-host 192.168.1.5 # Custom OBS host
 - Per-course recording state stored as JSON under `~/.config/clm/recordings/`
 - Auto-assignment of recordings to lectures with `continue_current_lecture` mode
 - Git commit capture at recording assignment time
+- File watcher: monitors `to-process/` for new files, triggers assembly automatically, stability detection via file-size polling
+- Pluggable processing backends: `external` (wait for iZotope RX 11 or similar) or `onnx` (local DeepFilterNet3 pipeline)
 - Configuration integrates into CLM's TOML config under `[recordings]`
 - External tools required: `ffmpeg`; ONNX model auto-downloaded on first use
 - Cross-platform: Windows and Linux

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ clm --help
 - **Watch Mode**: Auto-rebuild on file changes
 - **Incremental Builds**: Content-based caching
 - **LLM Summaries**: Generate course summaries with `clm summarize` using any OpenAI-compatible LLM API
+- **Recording Management**: Manage video recording workflows — audio processing pipeline, assembly, and per-course tracking (`clm recordings`)
 - **Voiceover Sync**: Synchronize video recordings with slides to auto-generate speaker notes (`clm voiceover sync`)
 - **LLM Polish**: Clean up speaker notes with LLM-powered text polishing (`clm polish`)
 - **Git Integration**: Manage output repos with `clm git init/sync/status`, including `--amend` and `--force-with-lease` for iterative workflows

--- a/docs/claude/recordings-pipeline-handover.md
+++ b/docs/claude/recordings-pipeline-handover.md
@@ -209,7 +209,7 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 
 ---
 
-### Sub-Phase 3B-4: File Watcher and Pluggable Processing Backend [TODO]
+### Sub-Phase 3B-4: File Watcher and Pluggable Processing Backend [DONE]
 
 **Scope**: Add a filesystem watcher that monitors `to-process/` for new files and triggers assembly automatically. Add a pluggable processing backend so users can choose between "wait for external tool" (RX 11) and "process locally" (ONNX pipeline).
 
@@ -267,15 +267,17 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 | `src/clm/recordings/processing/utils.py` | `find_ffmpeg`, `find_ffprobe`, `run_subprocess`, `download_onnx_model`, `run_onnx_denoise`, `check_dependencies` |
 | `src/clm/recordings/processing/batch.py` | `find_video_files`, `process_batch`, `BatchResult` |
 | `src/clm/recordings/processing/compare.py` | A/B audio comparison HTML generator |
-| `src/clm/cli/commands/recordings.py` | CLI: `check`, `process`, `batch`, `status`, `compare`, `assemble` |
-| `src/clm/infrastructure/config.py` | `RecordingsConfig` (incl. `root_dir`, `raw_suffix`), `RecordingsCourseConfig`, `RecordingsProcessingConfig` |
+| `src/clm/cli/commands/recordings.py` | CLI: `check`, `process`, `batch`, `status`, `compare`, `assemble`, `serve` |
+| `src/clm/infrastructure/config.py` | `RecordingsConfig` (incl. `root_dir`, `raw_suffix`, `processing_backend`, `stability_check_interval`, `stability_check_count`), `RecordingsCourseConfig`, `RecordingsProcessingConfig` |
 | `src/clm/recordings/workflow/naming.py` | Filename convention: `raw_filename`, `final_filename`, `parse_raw_stem`, `recording_relative_dir` — delegates to `sanitize_file_name` |
 | `src/clm/recordings/workflow/directories.py` | `ensure_root`, `validate_root`, `find_pending_pairs`, `PendingPair` — three-tier dir management |
 | `src/clm/recordings/workflow/assembler.py` | `mux_video_audio`, `assemble_one`, `assemble_all`, `AssemblyResult`, `AssemblyBatchResult` |
 | `src/clm/recordings/workflow/obs.py` | OBS WebSocket client: `ObsClient`, `RecordingEvent` — connect/disconnect, event callbacks, recording status queries |
 | `src/clm/recordings/workflow/session.py` | Recording session state machine: `RecordingSession`, `SessionState`, `ArmedTopic`, `SessionSnapshot` — arm/disarm, OBS event handling, auto-rename |
-| `src/clm/recordings/web/app.py` | Recordings FastAPI app factory: OBS lifecycle, SSE queue, Jinja2 templates |
-| `src/clm/recordings/web/routes.py` | Dashboard, lectures, arm/disarm, status JSON/partial, SSE stream, pending pairs |
+| `src/clm/recordings/workflow/backends.py` | `ProcessingBackend` protocol, `ExternalBackend` (no-op), `OnnxBackend` (extract + denoise + filter) |
+| `src/clm/recordings/workflow/watcher.py` | `RecordingsWatcher`: watchdog-based file watcher with stability detection, backend-aware event handling, `WatcherState` for thread-safe claims |
+| `src/clm/recordings/web/app.py` | Recordings FastAPI app factory: OBS lifecycle, watcher lifecycle, SSE queue, Jinja2 templates |
+| `src/clm/recordings/web/routes.py` | Dashboard, lectures, arm/disarm, watcher start/stop, status JSON/partial, SSE stream, pending pairs |
 | `src/clm/recordings/web/templates/` | Jinja2 templates: `base.html` (Pico CSS + HTMX), `dashboard.html`, `lectures.html`, `partials/status.html`, `partials/pairs.html` |
 
 ### Existing web infrastructure (extend for recordings UI)
@@ -304,7 +306,9 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 | `tests/recordings/test_assembler.py` | Assembly mux + archive (11 unit + 1 integration) |
 | `tests/recordings/test_obs.py` | OBS client connection, queries, event dispatching (16 tests) |
 | `tests/recordings/test_session.py` | Session state machine: arm/disarm, OBS events, rename, callbacks (28 tests) |
-| `tests/recordings/test_web.py` | Web dashboard routes: dashboard, lectures, arm/disarm, status, SSE, pairs (17 tests) |
+| `tests/recordings/test_backends.py` | Processing backend protocol, ExternalBackend, OnnxBackend pipeline steps/config/errors (9 tests) |
+| `tests/recordings/test_watcher.py` | WatcherState, init/start/stop, stability, external/onnx mode, video matching, live events (35 tests) |
+| `tests/recordings/test_web.py` | Web dashboard routes: dashboard, lectures, arm/disarm, status, SSE, pairs, watcher controls (22 tests) |
 
 ---
 

--- a/docs/claude/recordings-pipeline-handover.md
+++ b/docs/claude/recordings-pipeline-handover.md
@@ -126,7 +126,7 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 
 ---
 
-### Sub-Phase 3B-2: OBS Integration [TODO]
+### Sub-Phase 3B-2: OBS Integration [DONE]
 
 **Scope**: Connect to OBS Studio via WebSocket v5, detect recording start/stop events, and auto-rename the OBS timestamp-named file to the structured name based on the currently "armed" topic.
 
@@ -272,6 +272,8 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 | `src/clm/recordings/workflow/naming.py` | Filename convention: `raw_filename`, `final_filename`, `parse_raw_stem`, `recording_relative_dir` — delegates to `sanitize_file_name` |
 | `src/clm/recordings/workflow/directories.py` | `ensure_root`, `validate_root`, `find_pending_pairs`, `PendingPair` — three-tier dir management |
 | `src/clm/recordings/workflow/assembler.py` | `mux_video_audio`, `assemble_one`, `assemble_all`, `AssemblyResult`, `AssemblyBatchResult` |
+| `src/clm/recordings/workflow/obs.py` | OBS WebSocket client: `ObsClient`, `RecordingEvent` — connect/disconnect, event callbacks, recording status queries |
+| `src/clm/recordings/workflow/session.py` | Recording session state machine: `RecordingSession`, `SessionState`, `ArmedTopic`, `SessionSnapshot` — arm/disarm, OBS event handling, auto-rename |
 
 ### Existing web infrastructure (extend for recordings UI)
 
@@ -297,6 +299,8 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 | `tests/recordings/test_naming.py` | Naming convention helpers (17 tests) |
 | `tests/recordings/test_directories.py` | Directory management and pair scanning (21 tests) |
 | `tests/recordings/test_assembler.py` | Assembly mux + archive (11 unit + 1 integration) |
+| `tests/recordings/test_obs.py` | OBS client connection, queries, event dispatching (16 tests) |
+| `tests/recordings/test_session.py` | Session state machine: arm/disarm, OBS events, rename, callbacks (28 tests) |
 
 ---
 
@@ -320,7 +324,7 @@ stability_check_count = 3                 # Consecutive identical polls = stable
 
 | Package | Sub-Phase | Purpose |
 |---------|-----------|---------|
-| `obsws-python>=1.7.0` | 3B-2 | OBS WebSocket v5 client |
+| `obsws-python>=1.7.0` | 3B-2 | OBS WebSocket v5 client (added) |
 
 All other dependencies (`fastapi`, `uvicorn`, `jinja2`, `watchdog`, `onnxruntime`, `soundfile`, `numpy`) are already present.
 

--- a/docs/claude/recordings-pipeline-handover.md
+++ b/docs/claude/recordings-pipeline-handover.md
@@ -72,33 +72,18 @@ A standalone comparison tool that tests multiple noise reduction approaches usin
 
 ## Part 3: Planned Changes (For Next Session)
 
-### 3A. Replace deepfilternet with ONNX in the processing pipeline
+### 3A. Replace deepfilternet with ONNX in the processing pipeline [DONE]
 
-**Goal**: Replace the `deepFilter` CLI subprocess call in `ProcessingPipeline._run_deepfilter()` with direct ONNX inference via `onnxruntime`.
+**Completed 2026-04-01.** Replaced the `deepFilter` CLI subprocess with direct ONNX inference via `onnxruntime`.
 
-**Files to modify**:
-
-- `src/clm/recordings/processing/pipeline.py` — Replace `_run_deepfilter()` with ONNX inference logic. The ONNX approach is ~30 lines:
-  ```python
-  import onnxruntime as ort
-  # Load model, process frame-by-frame (480 samples per frame at 48kHz)
-  # State vector: 45304 float32 values passed between frames
-  # Trim algorithmic delay: output[480 : orig_len + 480]
-  ```
-
-- `src/clm/recordings/processing/utils.py` — Remove `find_deepfilter()`, add `download_onnx_model()` that downloads from GitHub and caches locally. Keep `find_ffmpeg()`, `find_ffprobe()`.
-
-- `src/clm/recordings/processing/config.py` — Remove or repurpose `deepfilter_atten_lim` (the ONNX model accepts `atten_lim_db` as input, default 0.0).
-
-- `src/clm/cli/commands/recordings.py` — Update `check` command: check for onnxruntime instead of deepFilter binary.
-
-- `pyproject.toml` — Add `onnxruntime` to `[recordings]` dependencies (replaces `deepfilternet`). `onnxruntime` has no numpy upper bound and supports Python 3.11–3.14.
-
-- `tests/recordings/` — Update tests that mock `find_deepfilter` to instead mock the ONNX session.
-
-**Reference implementation**: `C:\Users\tc\Programming\Python\Tests\AudioDenoise\approaches\deepfilter_onnx.py`
-
-**Important**: The FFmpeg post-processing steps (highpass, compressor, two-pass EBU R128 loudness normalization, AAC encoding, muxing) must be preserved — they are responsible for the loudness and consistency that makes the reference audio sound better.
+**Changes made**:
+- `utils.py`: Removed `find_deepfilter()`. Added `download_onnx_model()` (caches to platformdirs user cache), `run_onnx_denoise()` (frame-by-frame streaming inference), `check_onnxruntime()`. Updated `check_dependencies()`.
+- `pipeline.py`: Replaced `_run_deepfilter()` with `_run_denoise()` (calls `run_onnx_denoise`). Removed deepfilter binary lookup from `__init__`.
+- `config.py`: Renamed `deepfilter_atten_lim` → `denoise_atten_lim` (default 35.0 preserved).
+- `infrastructure/config.py`: Same field rename in `RecordingsProcessingConfig`.
+- `recordings.py` CLI: Updated `check` command for onnxruntime, updated config mapping.
+- `pyproject.toml`: Added `onnxruntime>=1.17.0`, `soundfile>=0.12.0`, `numpy>=1.24.0` to `[recordings]`. Replaced `deepfilternet` with `onnxruntime`/`soundfile` in mypy overrides.
+- Tests: Updated all `deepfilter_atten_lim` references. All 52 tests pass.
 
 ### 3B. Recording Workflow Automation (Web App)
 
@@ -237,7 +222,7 @@ processing_backend = "external"           # "external" (RX 11) or "onnx" (local)
 
 ## Current State of Recordings Module
 
-### What exists (committed on `feature/recordings-integration`)
+### What exists (on `feature/recordings-integration`)
 
 ```
 src/clm/recordings/
@@ -248,9 +233,9 @@ src/clm/recordings/
     ├── __init__.py
     ├── batch.py             # Batch processing utilities
     ├── compare.py           # A/B audio comparison HTML page
-    ├── config.py            # PipelineConfig, AudioFilterConfig
-    ├── pipeline.py          # 5-step pipeline (extract → deepfilter → filters → AAC → mux)
-    └── utils.py             # Binary finding, subprocess execution
+    ├── config.py            # PipelineConfig (denoise_atten_lim), AudioFilterConfig
+    ├── pipeline.py          # 5-step pipeline (extract → ONNX denoise → filters → AAC → mux)
+    └── utils.py             # Binary finding, ONNX model download/inference, subprocess execution
 
 src/clm/cli/commands/recordings.py  # CLI: check, process, batch, status, compare
 src/clm/infrastructure/config.py    # RecordingsConfig, RecordingsProcessingConfig
@@ -259,9 +244,9 @@ tests/recordings/                   # 52 tests
 
 ### What needs to change
 
-1. **Pipeline step 2** (`_run_deepfilter`): Replace deepFilter subprocess with ONNX inference
-2. **`utils.py`**: Remove `find_deepfilter()`, add `download_onnx_model()` + ONNX inference function
-3. **`config.py`**: Adapt `deepfilter_atten_lim` for ONNX model's `atten_lim_db` input
-4. **CLI `check` command**: Check for `onnxruntime` import instead of `deepFilter` binary
-5. **Dependencies**: Replace `deepfilternet` with `onnxruntime` in `[recordings]` extra
-6. **New modules**: OBS integration, assembly watcher, web UI (Phase 3B)
+1. ~~**Pipeline step 2**: Replace deepFilter subprocess with ONNX inference~~ **[DONE]**
+2. ~~**`utils.py`**: Remove `find_deepfilter()`, add `download_onnx_model()` + ONNX inference~~ **[DONE]**
+3. ~~**`config.py`**: Rename `deepfilter_atten_lim` → `denoise_atten_lim`~~ **[DONE]**
+4. ~~**CLI `check` command**: Check for `onnxruntime` instead of `deepFilter` binary~~ **[DONE]**
+5. ~~**Dependencies**: Replace `deepfilternet` with `onnxruntime` in `[recordings]` extra~~ **[DONE]**
+6. **New modules**: OBS integration, assembly watcher, web UI (Phase 3B) — **next**

--- a/docs/claude/recordings-pipeline-handover.md
+++ b/docs/claude/recordings-pipeline-handover.md
@@ -1,0 +1,267 @@
+# Recordings Pipeline — Handover Document
+
+## Session Summary (2026-03-31)
+
+This session accomplished two things and planned a third:
+
+1. **Fixed `uv lock --upgrade` with `UV_EXCLUDE_NEWER`** — committed and pushed
+2. **Evaluated audio denoising alternatives** — test app built, approaches compared
+3. **Planned next steps** — replace deepfilternet with ONNX, build recording workflow automation
+
+---
+
+## Part 1: Dependency Fixes (Completed)
+
+**Branch**: `feature/recordings-integration`
+
+### Changes committed and pushed
+
+**Commit `6a634fe`** — Supply-chain safety:
+- `pyproject.toml`: Added `[tool.uv]` `exclude-newer = "14 days"` for supply-chain protection
+- `[tool.uv.exclude-newer-package]`: Set `torch = false`, `torchvision = false`, `torchaudio = false` (PyTorch's cu130 index has no upload dates, incompatible with exclude-newer)
+- Lowered `langgraph>=1.1.3` → `>=1.1.2` (1.1.3 not yet within cutoff)
+- Refreshed `uv.lock`
+
+**Commit `a5a0f4a`** — Recordings module:
+- Full recordings module with CLI, processing pipeline, tests (52 tests)
+
+### `deepfilternet` NOT added to pip dependencies
+The `deepfilternet` package (v0.5.6) pins `numpy<2.0` and `packaging<24.0`, conflicting with the `[ml]` extra's `numpy>=2.0.1`. The package is also unmaintained (last update Oct 2024, no Python 3.12+ wheels for the Rust core library `deepfilterlib`). This was the motivation for the research below.
+
+---
+
+## Part 2: Audio Denoising Research (Completed)
+
+### Test App
+
+Location: `C:\Users\tc\Programming\Python\Tests\AudioDenoise\`
+
+A standalone comparison tool that tests multiple noise reduction approaches using `uv` inline script metadata for dependency isolation. Each approach is a self-contained script.
+
+#### Approaches tested
+
+| Key | Approach | 48kHz | Quality | Speed (vs real-time) | Status |
+|-----|----------|-------|---------|---------------------|--------|
+| `onnx` | DeepFilterNet3 ONNX (onnxruntime) | Native | **Best** — on par with CLI | 0.24x (CPU) | **Working** |
+| `clearvoice` | ClearVoice MossFormer2_SE_48K | Native | Good but slightly below ONNX | 0.19x (CPU) | Working (needed float32→PCM16 workaround) |
+| `noisereduce` | Spectral gating (DSP) | Any | Noticeably worse, too aggressive | 0.02x | Working |
+| `dfcli` | DeepFilterNet CLI subprocess | Native | Reference quality | N/A | Broken (no Python 3.12+ wheels) |
+| `rnnoise` | Pedalboard + RNNoise VST3 | 48kHz only | Not tested | N/A | Needs VST3 download |
+| `nsnet2` | Microsoft NSNet2 | 16kHz only | Not tested | N/A | Broken (scipy compat) |
+
+#### Key findings
+
+1. **DeepFilterNet3 ONNX is the clear winner** — uses a streaming single-file model from `yuyun2000/SpeechDenoiser` that bakes all preprocessing (STFT, ERB bands, normalization) into the model. Inference is ~30 lines of Python. Dependencies: just `onnxruntime` + `numpy` + `soundfile`. No numpy upper bound, works on Python 3.11–3.14.
+
+2. **ClearVoice MossFormer2_SE_48K** has a bug in its audio reader (pydub misinterprets float32 WAV files). Workaround: convert to PCM_16 before passing. Quality is good but slightly below ONNX.
+
+3. **Neither ONNX nor ClearVoice includes the FFmpeg post-processing** (highpass, compressor, EBU R128 loudness normalization) that the current pipeline applies after denoising. This is why the reference audio sounds significantly better — it's louder and more consistent due to compression + normalization. The denoising quality itself is comparable.
+
+4. **No other 48kHz ONNX speech enhancement models exist** — DeepFilterNet3 is unique in this space.
+
+5. **For Windows/production recordings, iZotope RX 11 remains far superior** to all automated approaches. The user will continue using RX 11 for final recordings.
+
+#### ONNX model details
+
+- **Source**: `https://github.com/yuyun2000/SpeechDenoiser/raw/refs/heads/main/48k/denoiser_model.onnx`
+- **Size**: 15.4 MB, cached at `~/.cache/audio-denoise/models/deepfilter3_streaming.onnx`
+- **Interface**: Streaming frame-by-frame: `input_frame[480]` + `states[45304]` + `atten_lim_db[1]` → `enhanced_frame[480]` + `new_states[45304]` + `lsnr[1]`
+- **Originally exported by**: `grazder/DeepFilterNet` (torchDF-changes branch)
+
+---
+
+## Part 3: Planned Changes (For Next Session)
+
+### 3A. Replace deepfilternet with ONNX in the processing pipeline
+
+**Goal**: Replace the `deepFilter` CLI subprocess call in `ProcessingPipeline._run_deepfilter()` with direct ONNX inference via `onnxruntime`.
+
+**Files to modify**:
+
+- `src/clm/recordings/processing/pipeline.py` — Replace `_run_deepfilter()` with ONNX inference logic. The ONNX approach is ~30 lines:
+  ```python
+  import onnxruntime as ort
+  # Load model, process frame-by-frame (480 samples per frame at 48kHz)
+  # State vector: 45304 float32 values passed between frames
+  # Trim algorithmic delay: output[480 : orig_len + 480]
+  ```
+
+- `src/clm/recordings/processing/utils.py` — Remove `find_deepfilter()`, add `download_onnx_model()` that downloads from GitHub and caches locally. Keep `find_ffmpeg()`, `find_ffprobe()`.
+
+- `src/clm/recordings/processing/config.py` — Remove or repurpose `deepfilter_atten_lim` (the ONNX model accepts `atten_lim_db` as input, default 0.0).
+
+- `src/clm/cli/commands/recordings.py` — Update `check` command: check for onnxruntime instead of deepFilter binary.
+
+- `pyproject.toml` — Add `onnxruntime` to `[recordings]` dependencies (replaces `deepfilternet`). `onnxruntime` has no numpy upper bound and supports Python 3.11–3.14.
+
+- `tests/recordings/` — Update tests that mock `find_deepfilter` to instead mock the ONNX session.
+
+**Reference implementation**: `C:\Users\tc\Programming\Python\Tests\AudioDenoise\approaches\deepfilter_onnx.py`
+
+**Important**: The FFmpeg post-processing steps (highpass, compressor, two-pass EBU R128 loudness normalization, AAC encoding, muxing) must be preserved — they are responsible for the loudness and consistency that makes the reference audio sound better.
+
+### 3B. Recording Workflow Automation (Web App)
+
+**Goal**: Automate the recording → processing → assembly workflow, integrating with OBS Studio and optionally iZotope RX 11 on Windows.
+
+#### Workflow Overview
+
+Three phases:
+
+```
+Phase 1: RECORDING (automated naming)
+  User selects lecture in CLM web UI → OBS records → file auto-renamed to structured name
+
+Phase 2: AUDIO PROCESSING (manual or automated)
+  Option A (Windows/quality): Drag files into RX 11 Batch Processor → wait → .wav output
+  Option B (cross-platform): ONNX pipeline processes automatically
+
+Phase 3: ASSEMBLY (fully automated)
+  File watcher detects processed .wav → FFmpeg muxes video + processed audio → final output
+```
+
+#### Filename Convention
+
+```
+<course-slug>/<section-name>/<topic-name>--RAW.mp4
+```
+
+Where `section-name` and `topic-name` are sanitized names from the CLM course spec file (matching the folder structure used for course notebooks). The `--RAW` suffix signals an unprocessed recording. Final output drops the suffix:
+
+```
+<course-slug>/<section-name>/<topic-name>.mp4
+```
+
+#### Directory Structure
+
+Three separate hierarchies under the recordings root, each mirroring the course folder structure:
+
+```
+<recordings-root>/                  # Configurable, often on a different drive (videos are large)
+├── to-process/                     # Raw recordings land here; RX 11 also writes .wav here
+│   ├── <course-slug>/
+│   │   ├── <section-name>/
+│   │   │   ├── <topic-name>--RAW.mp4   # Raw OBS recording
+│   │   │   ├── <topic-name>--RAW.wav   # RX 11 processed audio (appears alongside .mp4)
+│   │   │   └── ...
+│   │   └── ...
+│   └── ...
+├── final/                          # Muxed output (watcher writes here)
+│   ├── <course-slug>/
+│   │   ├── <section-name>/
+│   │   │   ├── <topic-name>.mp4        # Final video with processed audio
+│   │   │   └── ...
+│   │   └── ...
+│   └── ...
+└── archive/                        # RAW files moved here after successful assembly
+    ├── <course-slug>/
+    │   ├── <section-name>/
+    │   │   ├── <topic-name>--RAW.mp4
+    │   │   ├── <topic-name>--RAW.wav
+    │   │   └── ...
+    │   └── ...
+    └── ...
+```
+
+**Workflow**: OBS writes to `to-process/`. RX 11 outputs `.wav` alongside the `.mp4` in the same `to-process/` subdirectory. When the watcher detects both `--RAW.mp4` and `--RAW.wav` present, it muxes the final video into `final/` and moves both RAW files to `archive/`. This avoids the watcher needing to check whether output already exists — the presence of files in `to-process/` always means work to do.
+
+The root directory is configured independently of the notebook output directory (`CLM_RECORDINGS__OUTPUT_DIR` or similar).
+
+#### FFmpeg Mux Command
+
+The exact command for combining video + processed audio (from the user's existing `replace-audio` PowerShell function):
+
+```bash
+ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 <output_video>
+```
+
+#### Components to Build
+
+**1. CLM Lecture Selection UI** (FastAPI + HTMX)
+- Display course structure from CLM spec file (courses → sections → topics)
+- Click a topic to "arm" it for recording
+- Show currently armed topic with derived filename
+- Un-arm button
+
+**2. OBS Integration Module**
+- Connect to OBS WebSocket v5 (built into OBS 28+, default `ws://localhost:4455`)
+- Detect recording start/stop events
+- After recording stops, rename the OBS timestamp-named file to the structured name
+- Configurable: host, port, password
+- Handle edge cases: OBS not running, multiple files, cancelled recordings
+
+**3. Assembly Watcher**
+- Monitor directories for new `--RAW.wav` files (using `watchdog`)
+- Stability detection: wait for file size to stop changing
+- Match `.wav` to corresponding `--RAW.mp4`
+- Run FFmpeg mux command
+- Archive RAW files after successful assembly
+- Report progress via SSE
+
+**4. Web Dashboard** (HTMX + SSE)
+- Recording status: armed topic, OBS connection, recording in progress
+- Processing queue: `--RAW.mp4` files awaiting audio processing
+- Assembly queue: `--RAW.wav` files detected, assembly status
+- Finished recordings list
+- Quick actions: open folders in file manager
+
+**5. Processing Backend** (pluggable)
+- Protocol/base class: `process(input_wav: Path) -> Path`
+- Implementation A: "Wait for external tool" (RX 11 mode — watcher detects `.wav` appearance)
+- Implementation B: "Process locally" (ONNX pipeline mode — automatic)
+- Selectable per-course or via UI toggle
+
+#### Dependencies to Add
+
+- `obsws-python` — OBS WebSocket v5 client
+- `watchdog` — filesystem event monitoring
+- `onnxruntime` — for ONNX-based processing (already needed for 3A)
+- FastAPI, Jinja2, uvicorn — already in CLM's dependencies
+
+#### Configuration
+
+```toml
+[recordings]
+root_dir = "D:/Recordings"                # Root dir (to-process/, final/, archive/ created under this)
+obs_host = "localhost"
+obs_port = 4455
+obs_password = ""
+filename_separator = "--"
+raw_suffix = "--RAW"
+stability_check_interval = 2              # seconds between file size polls
+stability_check_count = 3                 # consecutive identical polls = stable
+processing_backend = "external"           # "external" (RX 11) or "onnx" (local)
+```
+
+---
+
+## Current State of Recordings Module
+
+### What exists (committed on `feature/recordings-integration`)
+
+```
+src/clm/recordings/
+├── __init__.py
+├── git_info.py              # Git commit capture at recording time
+├── state.py                 # Per-course recording state (JSON CRUD)
+└── processing/
+    ├── __init__.py
+    ├── batch.py             # Batch processing utilities
+    ├── compare.py           # A/B audio comparison HTML page
+    ├── config.py            # PipelineConfig, AudioFilterConfig
+    ├── pipeline.py          # 5-step pipeline (extract → deepfilter → filters → AAC → mux)
+    └── utils.py             # Binary finding, subprocess execution
+
+src/clm/cli/commands/recordings.py  # CLI: check, process, batch, status, compare
+src/clm/infrastructure/config.py    # RecordingsConfig, RecordingsProcessingConfig
+tests/recordings/                   # 52 tests
+```
+
+### What needs to change
+
+1. **Pipeline step 2** (`_run_deepfilter`): Replace deepFilter subprocess with ONNX inference
+2. **`utils.py`**: Remove `find_deepfilter()`, add `download_onnx_model()` + ONNX inference function
+3. **`config.py`**: Adapt `deepfilter_atten_lim` for ONNX model's `atten_lim_db` input
+4. **CLI `check` command**: Check for `onnxruntime` import instead of `deepFilter` binary
+5. **Dependencies**: Replace `deepfilternet` with `onnxruntime` in `[recordings]` extra
+6. **New modules**: OBS integration, assembly watcher, web UI (Phase 3B)

--- a/docs/claude/recordings-pipeline-handover.md
+++ b/docs/claude/recordings-pipeline-handover.md
@@ -1,252 +1,336 @@
 # Recordings Pipeline — Handover Document
 
-## Session Summary (2026-03-31)
-
-This session accomplished two things and planned a third:
-
-1. **Fixed `uv lock --upgrade` with `UV_EXCLUDE_NEWER`** — committed and pushed
-2. **Evaluated audio denoising alternatives** — test app built, approaches compared
-3. **Planned next steps** — replace deepfilternet with ONNX, build recording workflow automation
+## Branch: `feature/recordings-integration`
 
 ---
 
-## Part 1: Dependency Fixes (Completed)
+## Completed Work
 
-**Branch**: `feature/recordings-integration`
+### Part 1: Dependency Fixes [DONE]
 
-### Changes committed and pushed
+**Commit `6a634fe`** — Supply-chain safety: `UV_EXCLUDE_NEWER` in pyproject.toml, PyTorch cu130 exemption, refreshed lock file.
 
-**Commit `6a634fe`** — Supply-chain safety:
-- `pyproject.toml`: Added `[tool.uv]` `exclude-newer = "14 days"` for supply-chain protection
-- `[tool.uv.exclude-newer-package]`: Set `torch = false`, `torchvision = false`, `torchaudio = false` (PyTorch's cu130 index has no upload dates, incompatible with exclude-newer)
-- Lowered `langgraph>=1.1.3` → `>=1.1.2` (1.1.3 not yet within cutoff)
-- Refreshed `uv.lock`
+### Part 2: Audio Denoising Research [DONE]
 
-**Commit `a5a0f4a`** — Recordings module:
-- Full recordings module with CLI, processing pipeline, tests (52 tests)
+Test app at `C:\Users\tc\Programming\Python\Tests\AudioDenoise\`. Compared 6 approaches; DeepFilterNet3 ONNX won (best quality, pure-Python dependencies, works on 3.11-3.14).
 
-### `deepfilternet` NOT added to pip dependencies
-The `deepfilternet` package (v0.5.6) pins `numpy<2.0` and `packaging<24.0`, conflicting with the `[ml]` extra's `numpy>=2.0.1`. The package is also unmaintained (last update Oct 2024, no Python 3.12+ wheels for the Rust core library `deepfilterlib`). This was the motivation for the research below.
+**Key findings**:
+- ONNX model: `yuyun2000/SpeechDenoiser` — 15.4 MB streaming model, cached at `~/.cache/clm/models/deepfilter3_streaming.onnx`
+- Interface: frame-by-frame `input_frame[480]` + `states[45304]` + `atten_lim_db[1]`
+- For production recordings, iZotope RX 11 on Windows remains far superior to all automated approaches
 
----
+### Part 3A: Replace deepfilternet with ONNX [DONE]
 
-## Part 2: Audio Denoising Research (Completed)
-
-### Test App
-
-Location: `C:\Users\tc\Programming\Python\Tests\AudioDenoise\`
-
-A standalone comparison tool that tests multiple noise reduction approaches using `uv` inline script metadata for dependency isolation. Each approach is a self-contained script.
-
-#### Approaches tested
-
-| Key | Approach | 48kHz | Quality | Speed (vs real-time) | Status |
-|-----|----------|-------|---------|---------------------|--------|
-| `onnx` | DeepFilterNet3 ONNX (onnxruntime) | Native | **Best** — on par with CLI | 0.24x (CPU) | **Working** |
-| `clearvoice` | ClearVoice MossFormer2_SE_48K | Native | Good but slightly below ONNX | 0.19x (CPU) | Working (needed float32→PCM16 workaround) |
-| `noisereduce` | Spectral gating (DSP) | Any | Noticeably worse, too aggressive | 0.02x | Working |
-| `dfcli` | DeepFilterNet CLI subprocess | Native | Reference quality | N/A | Broken (no Python 3.12+ wheels) |
-| `rnnoise` | Pedalboard + RNNoise VST3 | 48kHz only | Not tested | N/A | Needs VST3 download |
-| `nsnet2` | Microsoft NSNet2 | 16kHz only | Not tested | N/A | Broken (scipy compat) |
-
-#### Key findings
-
-1. **DeepFilterNet3 ONNX is the clear winner** — uses a streaming single-file model from `yuyun2000/SpeechDenoiser` that bakes all preprocessing (STFT, ERB bands, normalization) into the model. Inference is ~30 lines of Python. Dependencies: just `onnxruntime` + `numpy` + `soundfile`. No numpy upper bound, works on Python 3.11–3.14.
-
-2. **ClearVoice MossFormer2_SE_48K** has a bug in its audio reader (pydub misinterprets float32 WAV files). Workaround: convert to PCM_16 before passing. Quality is good but slightly below ONNX.
-
-3. **Neither ONNX nor ClearVoice includes the FFmpeg post-processing** (highpass, compressor, EBU R128 loudness normalization) that the current pipeline applies after denoising. This is why the reference audio sounds significantly better — it's louder and more consistent due to compression + normalization. The denoising quality itself is comparable.
-
-4. **No other 48kHz ONNX speech enhancement models exist** — DeepFilterNet3 is unique in this space.
-
-5. **For Windows/production recordings, iZotope RX 11 remains far superior** to all automated approaches. The user will continue using RX 11 for final recordings.
-
-#### ONNX model details
-
-- **Source**: `https://github.com/yuyun2000/SpeechDenoiser/raw/refs/heads/main/48k/denoiser_model.onnx`
-- **Size**: 15.4 MB, cached at `~/.cache/audio-denoise/models/deepfilter3_streaming.onnx`
-- **Interface**: Streaming frame-by-frame: `input_frame[480]` + `states[45304]` + `atten_lim_db[1]` → `enhanced_frame[480]` + `new_states[45304]` + `lsnr[1]`
-- **Originally exported by**: `grazder/DeepFilterNet` (torchDF-changes branch)
+**Commit `a4e4d65`** — Replaced deepFilter CLI subprocess with ONNX Runtime inference. All 52 tests pass. Changes: `utils.py` (ONNX download + inference), `pipeline.py` (ONNX step), `config.py` + `infrastructure/config.py` (renamed `deepfilter_atten_lim` to `denoise_atten_lim`), `pyproject.toml` (onnxruntime/soundfile/numpy deps).
 
 ---
 
-## Part 3: Planned Changes (For Next Session)
+## Part 3B: Recording Workflow Automation [TODO]
 
-### 3A. Replace deepfilternet with ONNX in the processing pipeline [DONE]
+**Goal**: Automate the recording -> processing -> assembly workflow, integrating with OBS Studio and optionally iZotope RX 11 on Windows.
 
-**Completed 2026-04-01.** Replaced the `deepFilter` CLI subprocess with direct ONNX inference via `onnxruntime`.
-
-**Changes made**:
-- `utils.py`: Removed `find_deepfilter()`. Added `download_onnx_model()` (caches to platformdirs user cache), `run_onnx_denoise()` (frame-by-frame streaming inference), `check_onnxruntime()`. Updated `check_dependencies()`.
-- `pipeline.py`: Replaced `_run_deepfilter()` with `_run_denoise()` (calls `run_onnx_denoise`). Removed deepfilter binary lookup from `__init__`.
-- `config.py`: Renamed `deepfilter_atten_lim` → `denoise_atten_lim` (default 35.0 preserved).
-- `infrastructure/config.py`: Same field rename in `RecordingsProcessingConfig`.
-- `recordings.py` CLI: Updated `check` command for onnxruntime, updated config mapping.
-- `pyproject.toml`: Added `onnxruntime>=1.17.0`, `soundfile>=0.12.0`, `numpy>=1.24.0` to `[recordings]`. Replaced `deepfilternet` with `onnxruntime`/`soundfile` in mypy overrides.
-- Tests: Updated all `deepfilter_atten_lim` references. All 52 tests pass.
-
-### 3B. Recording Workflow Automation (Web App)
-
-**Goal**: Automate the recording → processing → assembly workflow, integrating with OBS Studio and optionally iZotope RX 11 on Windows.
-
-#### Workflow Overview
-
-Three phases:
+### Workflow Overview
 
 ```
 Phase 1: RECORDING (automated naming)
-  User selects lecture in CLM web UI → OBS records → file auto-renamed to structured name
+  User selects lecture in CLM web UI -> OBS records -> file auto-renamed to structured name
 
 Phase 2: AUDIO PROCESSING (manual or automated)
-  Option A (Windows/quality): Drag files into RX 11 Batch Processor → wait → .wav output
+  Option A (Windows/quality): Drag files into RX 11 Batch Processor -> wait -> .wav output
   Option B (cross-platform): ONNX pipeline processes automatically
 
 Phase 3: ASSEMBLY (fully automated)
-  File watcher detects processed .wav → FFmpeg muxes video + processed audio → final output
+  File watcher detects processed .wav -> FFmpeg muxes video + processed audio -> final output
 ```
 
-#### Filename Convention
+### Directory Layout
 
-```
-<course-slug>/<section-name>/<topic-name>--RAW.mp4
-```
-
-Where `section-name` and `topic-name` are sanitized names from the CLM course spec file (matching the folder structure used for course notebooks). The `--RAW` suffix signals an unprocessed recording. Final output drops the suffix:
-
-```
-<course-slug>/<section-name>/<topic-name>.mp4
-```
-
-#### Directory Structure
-
-Three separate hierarchies under the recordings root, each mirroring the course folder structure:
+Three hierarchies under a configurable recordings root:
 
 ```
 <recordings-root>/                  # Configurable, often on a different drive (videos are large)
-├── to-process/                     # Raw recordings land here; RX 11 also writes .wav here
-│   ├── <course-slug>/
-│   │   ├── <section-name>/
-│   │   │   ├── <topic-name>--RAW.mp4   # Raw OBS recording
-│   │   │   ├── <topic-name>--RAW.wav   # RX 11 processed audio (appears alongside .mp4)
-│   │   │   └── ...
-│   │   └── ...
-│   └── ...
-├── final/                          # Muxed output (watcher writes here)
-│   ├── <course-slug>/
-│   │   ├── <section-name>/
-│   │   │   ├── <topic-name>.mp4        # Final video with processed audio
-│   │   │   └── ...
-│   │   └── ...
-│   └── ...
-└── archive/                        # RAW files moved here after successful assembly
-    ├── <course-slug>/
-    │   ├── <section-name>/
-    │   │   ├── <topic-name>--RAW.mp4
-    │   │   ├── <topic-name>--RAW.wav
-    │   │   └── ...
-    │   └── ...
-    └── ...
++-- to-process/                     # Raw recordings land here; RX 11 also writes .wav here
+|   +-- <course-slug>/
+|       +-- <section-name>/
+|           +-- <topic-name>--RAW.mp4   # Raw OBS recording
+|           +-- <topic-name>--RAW.wav   # RX 11 processed audio (appears alongside .mp4)
++-- final/                          # Muxed output (watcher writes here)
+|   +-- <course-slug>/
+|       +-- <section-name>/
+|           +-- <topic-name>.mp4        # Final video with processed audio
++-- archive/                        # RAW files moved here after successful assembly
+    +-- <course-slug>/
+        +-- <section-name>/
+            +-- <topic-name>--RAW.mp4
+            +-- <topic-name>--RAW.wav
 ```
 
-**Workflow**: OBS writes to `to-process/`. RX 11 outputs `.wav` alongside the `.mp4` in the same `to-process/` subdirectory. When the watcher detects both `--RAW.mp4` and `--RAW.wav` present, it muxes the final video into `final/` and moves both RAW files to `archive/`. This avoids the watcher needing to check whether output already exists — the presence of files in `to-process/` always means work to do.
+### Filename Convention
 
-The root directory is configured independently of the notebook output directory (`CLM_RECORDINGS__OUTPUT_DIR` or similar).
+```
+<course-slug>/<section-name>/<topic-name>--RAW.mp4     # Raw recording
+<course-slug>/<section-name>/<topic-name>--RAW.wav     # Processed audio (from RX 11 or ONNX)
+<course-slug>/<section-name>/<topic-name>.mp4           # Final muxed output
+```
 
-#### FFmpeg Mux Command
+Section and topic names are sanitized from the CLM course spec file. The `--RAW` suffix signals unprocessed; final output drops it.
 
-The exact command for combining video + processed audio (from the user's existing `replace-audio` PowerShell function):
+### FFmpeg Mux Command
 
 ```bash
 ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 <output_video>
 ```
 
-#### Components to Build
+(From the user's existing `replace-audio` PowerShell function.)
 
-**1. CLM Lecture Selection UI** (FastAPI + HTMX)
-- Display course structure from CLM spec file (courses → sections → topics)
-- Click a topic to "arm" it for recording
-- Show currently armed topic with derived filename
-- Un-arm button
+---
 
-**2. OBS Integration Module**
-- Connect to OBS WebSocket v5 (built into OBS 28+, default `ws://localhost:4455`)
-- Detect recording start/stop events
-- After recording stops, rename the OBS timestamp-named file to the structured name
-- Configurable: host, port, password
-- Handle edge cases: OBS not running, multiple files, cancelled recordings
+## Sub-Phase Breakdown
 
-**3. Assembly Watcher**
-- Monitor directories for new `--RAW.wav` files (using `watchdog`)
-- Stability detection: wait for file size to stop changing
-- Match `.wav` to corresponding `--RAW.mp4`
-- Run FFmpeg mux command
-- Archive RAW files after successful assembly
-- Report progress via SSE
+### Sub-Phase 3B-1: Foundation — Directory Management and Assembly [DONE]
 
-**4. Web Dashboard** (HTMX + SSE)
-- Recording status: armed topic, OBS connection, recording in progress
-- Processing queue: `--RAW.mp4` files awaiting audio processing
-- Assembly queue: `--RAW.wav` files detected, assembly status
-- Finished recordings list
-- Quick actions: open folders in file manager
+**Scope**: Build the directory structure manager, filename convention helpers, and the core assembly logic (detect paired .mp4/.wav, mux, archive). No web UI or OBS integration yet — everything is testable via unit tests and a CLI command.
 
-**5. Processing Backend** (pluggable)
-- Protocol/base class: `process(input_wav: Path) -> Path`
-- Implementation A: "Wait for external tool" (RX 11 mode — watcher detects `.wav` appearance)
-- Implementation B: "Process locally" (ONNX pipeline mode — automatic)
-- Selectable per-course or via UI toggle
+**Files to create**:
+- `src/clm/recordings/workflow/__init__.py` — Subpackage for workflow automation
+- `src/clm/recordings/workflow/naming.py` — Filename convention: sanitize topic/section names, build structured paths, parse `--RAW` suffix, derive final output path
+- `src/clm/recordings/workflow/directories.py` — Directory manager: initialize `to-process/`, `final/`, `archive/` under root; validate structure; list pending pairs
+- `src/clm/recordings/workflow/assembler.py` — Assembly logic: find paired `--RAW.mp4` + `--RAW.wav`; mux via FFmpeg (reuse `run_subprocess` from `processing/utils.py`); move originals to `archive/`; report results
+- `tests/recordings/test_naming.py` — Unit tests for naming helpers
+- `tests/recordings/test_directories.py` — Unit tests for directory manager
+- `tests/recordings/test_assembler.py` — Unit tests for assembly logic (with mocked FFmpeg)
 
-#### Dependencies to Add
+**Files to modify**:
+- `src/clm/infrastructure/config.py` — Extend `RecordingsConfig` with new fields: `root_dir` (recordings root), `raw_suffix` (default `"--RAW"`), `filename_separator` (default `"--"`)
+- `src/clm/cli/commands/recordings.py` — Add `clm recordings assemble <root-dir>` command: scan for ready pairs, mux, archive
+- `pyproject.toml` — No new dependencies expected (uses existing FFmpeg + pathlib)
 
-- `obsws-python` — OBS WebSocket v5 client
-- `watchdog` — filesystem event monitoring
-- `onnxruntime` — for ONNX-based processing (already needed for 3A)
-- FastAPI, Jinja2, uvicorn — already in CLM's dependencies
+**Key design decisions**:
+- Reuse `run_subprocess` and `find_ffmpeg` from `recordings/processing/utils.py` — do NOT duplicate
+- Assembly mux command is simpler than the full processing pipeline (just video copy + audio encode, no denoise/filters)
+- The assembler should be usable both as a one-shot CLI command and as a callable function (for the watcher in 3B-3)
+- Naming helpers must handle Windows path limitations (no `:`, `?`, etc.) and keep names filesystem-safe
 
-#### Configuration
+**Acceptance criteria**:
+1. `recordings/workflow/naming.py` can sanitize arbitrary topic/section names and produce valid paths
+2. `recordings/workflow/directories.py` can create the three-tier directory structure under any root
+3. `recordings/workflow/assembler.py` can: (a) find paired .mp4/.wav files, (b) mux them via FFmpeg, (c) move originals to archive
+4. `clm recordings assemble <root>` works end-to-end from the CLI
+5. All new code has tests; existing 52 tests still pass
+6. `ruff check` and `mypy` pass
+
+**Testing approach**:
+- Unit tests with `tmp_path` fixtures for directory and naming logic
+- Assembly tests mock `run_subprocess` to avoid requiring real FFmpeg
+- One integration test (marked `@pytest.mark.integration`) that runs real FFmpeg if available
+
+---
+
+### Sub-Phase 3B-2: OBS Integration [TODO]
+
+**Scope**: Connect to OBS Studio via WebSocket v5, detect recording start/stop events, and auto-rename the OBS timestamp-named file to the structured name based on the currently "armed" topic.
+
+**Depends on**: Sub-Phase 3B-1 (naming helpers)
+
+**Files to create**:
+- `src/clm/recordings/workflow/obs.py` — OBS WebSocket client: connect/disconnect, event subscriptions (RecordStateChanged), get current recording status, rename output file after recording stops
+- `src/clm/recordings/workflow/session.py` — Recording session manager: arm/disarm a topic for recording, track current recording state (idle/recording/post-processing), derive the target filename from armed topic using naming helpers
+- `tests/recordings/test_obs.py` — Unit tests with mocked WebSocket
+- `tests/recordings/test_session.py` — Unit tests for session state machine
+
+**Files to modify**:
+- `src/clm/infrastructure/config.py` — Add OBS fields to `RecordingsConfig`: `obs_host` (default `"localhost"`), `obs_port` (default `4455`), `obs_password` (default `""`)
+- `pyproject.toml` — Add `obsws-python>=1.7.0` to `[recordings]` extra
+
+**Key design decisions**:
+- Use `obsws-python` library (official OBS WebSocket v5 Python client)
+- Session manager is a state machine: `idle -> armed -> recording -> renaming -> idle`
+- OBS client should handle: OBS not running, connection drops, reconnection
+- File rename happens after OBS writes the file (poll for file existence + stability before rename)
+- The session manager should be UI-agnostic — usable from both CLI and web UI
+
+**Acceptance criteria**:
+1. OBS client can connect, subscribe to events, and detect recording start/stop
+2. Session manager tracks armed topic and transitions through states correctly
+3. After recording stops, the OBS output file is renamed to the structured name in `to-process/`
+4. Handles edge cases: OBS not running, connection lost mid-recording, no topic armed
+5. All new tests pass; existing tests unaffected
+
+**Testing approach**:
+- Mock `obsws-python` for unit tests (no real OBS needed)
+- State machine tests cover all transitions and edge cases
+- Integration tests (marked) require a running OBS instance — optional
+
+---
+
+### Sub-Phase 3B-3: Web UI — Lecture Selection and Dashboard [TODO]
+
+**Scope**: Build an HTMX-based web UI for the recording workflow. Two views: (1) lecture selection to arm topics for recording, (2) dashboard showing recording/processing/assembly status with real-time updates via SSE.
+
+**Depends on**: Sub-Phase 3B-1 (directories, naming), Sub-Phase 3B-2 (OBS session)
+
+**Existing infrastructure to build on**:
+- `src/clm/web/app.py` — FastAPI app factory with CORS, WebSocket, static file serving
+- `src/clm/web/api/routes.py` — REST API router at `/api/`
+- `src/clm/cli/commands/monitoring.py` — `clm serve` command (launches uvicorn)
+- Jinja2 already in `[recordings]` dependencies
+
+**Files to create**:
+- `src/clm/recordings/web/__init__.py` — Recordings web subpackage
+- `src/clm/recordings/web/app.py` — Recordings FastAPI app (separate from the main CLM dashboard): HTMX routes, SSE endpoint, Jinja2 template rendering
+- `src/clm/recordings/web/routes.py` — Routes: GET `/` (dashboard), GET `/lectures` (lecture list from spec), POST `/arm/{topic_id}` (arm topic), POST `/disarm` (disarm), GET `/status` (JSON status), GET `/events` (SSE stream)
+- `src/clm/recordings/web/templates/` — Jinja2 HTML templates: `base.html` (layout + HTMX script), `dashboard.html` (recording status, processing queue, assembly queue, finished list), `lectures.html` (course structure tree with arm buttons)
+- `src/clm/recordings/web/static/` — Minimal CSS (can use a classless CSS framework like Pico CSS)
+- `src/clm/cli/commands/recordings.py` — Add `clm recordings serve` subcommand
+- `tests/recordings/test_web.py` — Test routes with FastAPI TestClient
+
+**Files to modify**:
+- `pyproject.toml` — Ensure `uvicorn` is in `[recordings]` extra (or rely on it being a core dep already)
+
+**Key design decisions**:
+- This is a **separate** FastAPI app from the main `clm serve` dashboard — recordings have different lifecycle and dependencies
+- Use HTMX for dynamic updates (no JavaScript framework needed): `hx-get`, `hx-post`, `hx-trigger="sse:status"` for real-time
+- SSE (Server-Sent Events) for push updates instead of WebSocket — simpler for one-way server->client updates
+- Course structure loaded from CLM spec file (`CourseSpec.from_spec_file()`) at startup
+- The web UI calls the session manager (3B-2) and directory manager (3B-1) — it is a thin presentation layer
+
+**Acceptance criteria**:
+1. `clm recordings serve` starts a web server on localhost
+2. Dashboard shows: armed topic, OBS connection status, pending/processing/finished recordings
+3. Clicking a topic arms it for recording; disarm button works
+4. SSE endpoint pushes status updates when state changes
+5. UI works in a modern browser without JavaScript frameworks (HTMX only)
+6. All routes tested with FastAPI TestClient
+
+**Testing approach**:
+- FastAPI TestClient for route testing (no browser needed)
+- Mock session manager and directory manager
+- Manual browser testing for HTMX interactions (not automated)
+
+---
+
+### Sub-Phase 3B-4: File Watcher and Pluggable Processing Backend [TODO]
+
+**Scope**: Add a filesystem watcher that monitors `to-process/` for new files and triggers assembly automatically. Add a pluggable processing backend so users can choose between "wait for external tool" (RX 11) and "process locally" (ONNX pipeline).
+
+**Depends on**: Sub-Phase 3B-1 (assembler), Sub-Phase 3B-3 (SSE for progress reporting)
+
+**Files to create**:
+- `src/clm/recordings/workflow/watcher.py` — Filesystem watcher using `watchdog`: monitor `to-process/` for new `.wav` files; stability detection (wait for file size to stop changing); trigger assembly when `.mp4` + `.wav` pair is complete; report progress via callback
+- `src/clm/recordings/workflow/backends.py` — Processing backend protocol + implementations:
+  - `ProcessingBackend` protocol: `process(input_video: Path) -> Path` (returns path to processed audio)
+  - `ExternalBackend` — "Wait for external tool" mode: the watcher simply waits for the `.wav` to appear (RX 11 writes it)
+  - `OnnxBackend` — "Process locally" mode: extract audio, run ONNX denoise + FFmpeg filters, write `.wav` (reuse `ProcessingPipeline` from `recordings/processing/pipeline.py`)
+- `tests/recordings/test_watcher.py` — Unit tests for watcher with mocked filesystem events
+- `tests/recordings/test_backends.py` — Unit tests for both backends
+
+**Files to modify**:
+- `src/clm/infrastructure/config.py` — Add `processing_backend` field to `RecordingsConfig`: `"external"` (default, RX 11) or `"onnx"` (local)
+- `src/clm/infrastructure/config.py` — Add stability check config: `stability_check_interval` (default 2 sec), `stability_check_count` (default 3)
+- `src/clm/recordings/web/routes.py` — Add SSE events for watcher progress; add UI toggle for processing backend
+- `src/clm/recordings/web/templates/dashboard.html` — Show watcher status, processing queue, backend selector
+
+**Key design decisions**:
+- `watchdog` is already a core dependency (used for `clm build --watch`)
+- Watcher runs in a background thread, communicates via callbacks
+- Stability detection: poll file size every N seconds, require M consecutive identical polls before considering the file stable
+- ExternalBackend is just "do nothing and wait" — the watcher detects the `.wav` appearing. OnnxBackend actively processes.
+- The watcher should be startable/stoppable from the web UI and work headlessly from CLI
+
+**Acceptance criteria**:
+1. Watcher detects new `.wav` files in `to-process/` and triggers assembly
+2. Stability detection prevents acting on partially-written files
+3. ExternalBackend mode: watcher waits for `.wav` to appear alongside `.mp4`, then assembles
+4. OnnxBackend mode: watcher detects new `.mp4`, runs ONNX pipeline to produce `.wav`, then assembles
+5. Processing backend is selectable via config and via web UI toggle
+6. Progress reported via SSE to the dashboard
+7. All new tests pass; full suite green
+
+**Testing approach**:
+- Watcher tests use `tmp_path` + direct `watchdog` event simulation (no real filesystem polling in unit tests)
+- Backend tests mock the processing pipeline
+- Integration test (marked) runs the watcher against a real temp directory with a small test file
+
+---
+
+## Key Files Reference
+
+### Existing recordings module (do not rewrite, build on these)
+
+| File | Purpose |
+|------|---------|
+| `src/clm/recordings/__init__.py` | Package init |
+| `src/clm/recordings/state.py` | Per-course recording state: `CourseRecordingState`, `LectureState`, `RecordingPart` — JSON CRUD, assign/reassign/update, progress tracking |
+| `src/clm/recordings/git_info.py` | Git commit capture at recording time |
+| `src/clm/recordings/processing/pipeline.py` | 5-step audio pipeline: extract -> ONNX denoise -> FFmpeg filters -> AAC -> mux |
+| `src/clm/recordings/processing/config.py` | `PipelineConfig`, `AudioFilterConfig` |
+| `src/clm/recordings/processing/utils.py` | `find_ffmpeg`, `find_ffprobe`, `run_subprocess`, `download_onnx_model`, `run_onnx_denoise`, `check_dependencies` |
+| `src/clm/recordings/processing/batch.py` | `find_video_files`, `process_batch`, `BatchResult` |
+| `src/clm/recordings/processing/compare.py` | A/B audio comparison HTML generator |
+| `src/clm/cli/commands/recordings.py` | CLI: `check`, `process`, `batch`, `status`, `compare`, `assemble` |
+| `src/clm/infrastructure/config.py` | `RecordingsConfig` (incl. `root_dir`, `raw_suffix`), `RecordingsCourseConfig`, `RecordingsProcessingConfig` |
+| `src/clm/recordings/workflow/naming.py` | Filename convention: `raw_filename`, `final_filename`, `parse_raw_stem`, `recording_relative_dir` — delegates to `sanitize_file_name` |
+| `src/clm/recordings/workflow/directories.py` | `ensure_root`, `validate_root`, `find_pending_pairs`, `PendingPair` — three-tier dir management |
+| `src/clm/recordings/workflow/assembler.py` | `mux_video_audio`, `assemble_one`, `assemble_all`, `AssemblyResult`, `AssemblyBatchResult` |
+
+### Existing web infrastructure (extend for recordings UI)
+
+| File | Purpose |
+|------|---------|
+| `src/clm/web/app.py` | FastAPI app factory with CORS, WebSocket, static files |
+| `src/clm/web/api/routes.py` | REST API: `/api/health`, `/api/status`, `/api/workers`, `/api/jobs` |
+| `src/clm/web/api/websocket.py` | WebSocket endpoint with subscription management |
+| `src/clm/web/models.py` | Pydantic response models |
+| `src/clm/web/services/monitor_service.py` | Service layer for build monitoring |
+| `src/clm/cli/commands/monitoring.py` | `clm serve` command |
+
+### Test files
+
+| File | Tests |
+|------|-------|
+| `tests/recordings/test_state.py` | Recording state CRUD, assign/reassign/update |
+| `tests/recordings/test_processing_pipeline.py` | Pipeline steps with mocked FFmpeg/ONNX |
+| `tests/recordings/test_processing_config.py` | Config defaults and overrides |
+| `tests/recordings/test_batch.py` | Batch processing |
+| `tests/recordings/test_cli_recordings.py` | CLI command invocations |
+| `tests/recordings/test_git_info.py` | Git info capture |
+| `tests/recordings/test_naming.py` | Naming convention helpers (17 tests) |
+| `tests/recordings/test_directories.py` | Directory management and pair scanning (21 tests) |
+| `tests/recordings/test_assembler.py` | Assembly mux + archive (11 unit + 1 integration) |
+
+---
+
+## Configuration (target state after all sub-phases)
 
 ```toml
 [recordings]
-root_dir = "D:/Recordings"                # Root dir (to-process/, final/, archive/ created under this)
+root_dir = "D:/Recordings"                # Root dir (to-process/, final/, archive/ under this)
+raw_suffix = "--RAW"                      # Suffix for unprocessed files
+processing_backend = "external"           # "external" (RX 11) or "onnx" (local)
 obs_host = "localhost"
 obs_port = 4455
 obs_password = ""
-filename_separator = "--"
-raw_suffix = "--RAW"
-stability_check_interval = 2              # seconds between file size polls
-stability_check_count = 3                 # consecutive identical polls = stable
-processing_backend = "external"           # "external" (RX 11) or "onnx" (local)
+stability_check_interval = 2              # Seconds between file size polls
+stability_check_count = 3                 # Consecutive identical polls = stable
 ```
 
 ---
 
-## Current State of Recordings Module
+## Dependencies to Add (across all sub-phases)
 
-### What exists (on `feature/recordings-integration`)
+| Package | Sub-Phase | Purpose |
+|---------|-----------|---------|
+| `obsws-python>=1.7.0` | 3B-2 | OBS WebSocket v5 client |
 
-```
-src/clm/recordings/
-├── __init__.py
-├── git_info.py              # Git commit capture at recording time
-├── state.py                 # Per-course recording state (JSON CRUD)
-└── processing/
-    ├── __init__.py
-    ├── batch.py             # Batch processing utilities
-    ├── compare.py           # A/B audio comparison HTML page
-    ├── config.py            # PipelineConfig (denoise_atten_lim), AudioFilterConfig
-    ├── pipeline.py          # 5-step pipeline (extract → ONNX denoise → filters → AAC → mux)
-    └── utils.py             # Binary finding, ONNX model download/inference, subprocess execution
+All other dependencies (`fastapi`, `uvicorn`, `jinja2`, `watchdog`, `onnxruntime`, `soundfile`, `numpy`) are already present.
 
-src/clm/cli/commands/recordings.py  # CLI: check, process, batch, status, compare
-src/clm/infrastructure/config.py    # RecordingsConfig, RecordingsProcessingConfig
-tests/recordings/                   # 52 tests
-```
+---
 
-### What needs to change
+## Notes for Future Sessions
 
-1. ~~**Pipeline step 2**: Replace deepFilter subprocess with ONNX inference~~ **[DONE]**
-2. ~~**`utils.py`**: Remove `find_deepfilter()`, add `download_onnx_model()` + ONNX inference~~ **[DONE]**
-3. ~~**`config.py`**: Rename `deepfilter_atten_lim` → `denoise_atten_lim`~~ **[DONE]**
-4. ~~**CLI `check` command**: Check for `onnxruntime` instead of `deepFilter` binary~~ **[DONE]**
-5. ~~**Dependencies**: Replace `deepfilternet` with `onnxruntime` in `[recordings]` extra~~ **[DONE]**
-6. **New modules**: OBS integration, assembly watcher, web UI (Phase 3B) — **next**
+- The `[recordings]` extra already includes `jinja2` and `python-multipart` — no need to re-add for the web UI
+- `watchdog` is a core dependency (not under `[recordings]`) — used by `clm build --watch`
+- The existing `clm serve` dashboard is for build monitoring, completely separate from the recordings workflow
+- The recordings web app should be a separate FastAPI app with its own `clm recordings serve` command
+- `run_subprocess` in `recordings/processing/utils.py` handles Windows `CREATE_NO_WINDOW` — always reuse it for FFmpeg calls
+- Course structure can be loaded from spec files via `clm.core.course_spec.CourseSpec`

--- a/docs/claude/recordings-pipeline-handover.md
+++ b/docs/claude/recordings-pipeline-handover.md
@@ -163,7 +163,7 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 
 ---
 
-### Sub-Phase 3B-3: Web UI — Lecture Selection and Dashboard [TODO]
+### Sub-Phase 3B-3: Web UI — Lecture Selection and Dashboard [DONE]
 
 **Scope**: Build an HTMX-based web UI for the recording workflow. Two views: (1) lecture selection to arm topics for recording, (2) dashboard showing recording/processing/assembly status with real-time updates via SSE.
 
@@ -274,6 +274,9 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 | `src/clm/recordings/workflow/assembler.py` | `mux_video_audio`, `assemble_one`, `assemble_all`, `AssemblyResult`, `AssemblyBatchResult` |
 | `src/clm/recordings/workflow/obs.py` | OBS WebSocket client: `ObsClient`, `RecordingEvent` — connect/disconnect, event callbacks, recording status queries |
 | `src/clm/recordings/workflow/session.py` | Recording session state machine: `RecordingSession`, `SessionState`, `ArmedTopic`, `SessionSnapshot` — arm/disarm, OBS event handling, auto-rename |
+| `src/clm/recordings/web/app.py` | Recordings FastAPI app factory: OBS lifecycle, SSE queue, Jinja2 templates |
+| `src/clm/recordings/web/routes.py` | Dashboard, lectures, arm/disarm, status JSON/partial, SSE stream, pending pairs |
+| `src/clm/recordings/web/templates/` | Jinja2 templates: `base.html` (Pico CSS + HTMX), `dashboard.html`, `lectures.html`, `partials/status.html`, `partials/pairs.html` |
 
 ### Existing web infrastructure (extend for recordings UI)
 
@@ -301,6 +304,7 @@ ffmpeg -i <input_video> -i <input_audio> -c:v copy -c:a aac -map 0:v:0 -map 1:a:
 | `tests/recordings/test_assembler.py` | Assembly mux + archive (11 unit + 1 integration) |
 | `tests/recordings/test_obs.py` | OBS client connection, queries, event dispatching (16 tests) |
 | `tests/recordings/test_session.py` | Session state machine: arm/disarm, OBS events, rename, callbacks (28 tests) |
+| `tests/recordings/test_web.py` | Web dashboard routes: dashboard, lectures, arm/disarm, status, SSE, pairs (17 tests) |
 
 ---
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -16,6 +16,8 @@ CLM (Coding-Academy Lecture Manager) is a course content processing system that 
 - ✅ Watch for file changes and auto-rebuild
 - ✅ Synchronize video recordings with slides to generate speaker notes
 - ✅ Polish speaker notes with LLM-powered text cleanup
+- ✅ Process video recordings with AI noise reduction and loudness normalization
+- ✅ Track recordings per lecture with assignment and reassignment
 
 ## Quick Links
 
@@ -23,6 +25,7 @@ CLM (Coding-Academy Lecture Manager) is a course content processing system that 
 - **[Quick Start](quick-start.md)** - Get started in 5 minutes
 - **[Spec File Reference](spec-file-reference.md)** - Course specification XML format
 - **[Configuration](configuration.md)** - Configure courses and options
+- **[Recording Management](recordings.md)** - Process and track video recordings
 - **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
 
 ## Typical Workflow

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -1,0 +1,262 @@
+# Recording Management
+
+CLM includes a recording management module for handling the video recording
+workflow of educational courses. It automates audio processing, tracks which
+recordings belong to which lectures, and provides tools for comparing
+processing pipelines.
+
+## Overview
+
+The recording workflow is:
+
+1. **Record** a lecture with OBS (produces `.mkv` or `.mp4` files)
+2. **Process** the recording through the audio pipeline (noise reduction, loudness normalization)
+3. **Track** which recordings belong to which lectures in your course
+
+The audio processing pipeline replaces manual tools like iZotope RX with
+an automated, cross-platform solution using DeepFilterNet and FFmpeg.
+
+## Installation
+
+```bash
+# Install CLM with recording support
+pip install -e ".[recordings]"
+```
+
+### External Dependencies
+
+The recording module requires two external tools:
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| **ffmpeg** | Audio extraction, filtering, encoding, muxing | `winget install FFmpeg` (Windows) or `pacman -S ffmpeg` (Arch) |
+| **deepFilter** | AI-based noise reduction | `pip install deepfilternet` |
+
+Verify installation:
+
+```bash
+clm recordings check
+```
+
+This shows the status and path of each required tool.
+
+## Processing Recordings
+
+### Single File
+
+```bash
+# Process with auto-naming (creates raw_recording_final.mp4)
+clm recordings process raw_recording.mkv
+
+# Specify output path
+clm recordings process raw_recording.mkv -o final_lecture.mp4
+
+# Keep intermediate files for debugging
+clm recordings process raw_recording.mkv --keep-temp
+```
+
+The processing pipeline performs five steps:
+
+1. **Extract audio** from video as mono 16-bit WAV
+2. **DeepFilterNet** AI noise reduction
+3. **FFmpeg filters**: highpass (remove rumble), compressor (even out volume), two-pass EBU R128 loudness normalization
+4. **AAC encode** the processed audio
+5. **Mux** processed audio back into the original video (video stream is copied, not re-encoded)
+
+### Batch Processing
+
+```bash
+# Process all videos in a directory
+clm recordings batch ~/Recordings -o ~/Processed
+
+# Search subdirectories
+clm recordings batch ~/Recordings -r
+
+# Use custom config
+clm recordings batch ~/Recordings -c my_config.json
+```
+
+Supported video formats: `.mkv`, `.mp4`, `.avi`, `.mov`, `.webm`, `.ts`.
+
+Batch processing automatically skips files that already have output, so you
+can safely re-run it after adding new recordings.
+
+### Custom Configuration
+
+Processing settings can be configured via:
+
+1. **CLM's TOML config file** (`~/.config/clm/config.toml`):
+
+   ```toml
+   [recordings.processing]
+   deepfilter_atten_lim = 35.0   # DeepFilterNet strength (30-50)
+   sample_rate = 48000           # Audio sample rate
+   audio_bitrate = "192k"        # AAC bitrate
+   video_codec = "copy"          # "copy" = no re-encoding
+   highpass_freq = 80            # Remove rumble below this Hz
+   loudnorm_target = -16.0       # Target loudness in LUFS
+   ```
+
+2. **A standalone JSON config file** (passed via `-c`):
+
+   ```json
+   {
+     "deepfilter_atten_lim": 35.0,
+     "sample_rate": 48000,
+     "audio_bitrate": "192k",
+     "video_codec": "copy",
+     "output_extension": "mp4",
+     "audio_filters": {
+       "highpass_freq": 80,
+       "loudnorm_target": -16.0
+     }
+   }
+   ```
+
+3. **Environment variables**:
+
+   ```bash
+   export CLM_RECORDINGS__PROCESSING__DEEPFILTER_ATTEN_LIM=40.0
+   export CLM_RECORDINGS__PROCESSING__LOUDNORM_TARGET=-18.0
+   ```
+
+## A/B Comparison
+
+When migrating between audio processing tools (e.g., iZotope RX to
+DeepFilterNet), use the comparison tool to evaluate quality:
+
+```bash
+# Compare two processed versions
+clm recordings compare izotope.mp4 deepfilter.mp4 \
+    --label-a "iZotope RX 11" \
+    --label-b "DeepFilterNet"
+
+# Include original for reference, compare first 30 seconds
+clm recordings compare izotope.mp4 deepfilter.mp4 \
+    --original raw.mkv \
+    --start 10 --duration 30 \
+    -o comparison.html
+```
+
+This generates a self-contained HTML page with:
+- Side-by-side audio players for each version
+- A blind test mode where versions are randomly assigned to X and Y
+
+Open `comparison.html` in a browser to listen and compare.
+
+## Recording State
+
+Each course can track which recordings belong to which lectures. State is
+stored as JSON files under `~/.config/clm/recordings/`.
+
+### Viewing Status
+
+```bash
+clm recordings status python-basics
+```
+
+This shows a table of all lectures with their recording status, part counts,
+and which lecture is next to record.
+
+### State File Format
+
+Each course has a JSON state file (`~/.config/clm/recordings/<course-id>.json`):
+
+```json
+{
+  "course_id": "python-basics",
+  "lectures": [
+    {
+      "lecture_id": "010-intro",
+      "display_name": "Introduction to Python",
+      "parts": [
+        {
+          "part": 1,
+          "raw_file": "/obs/2025-03-01_10-15-22.mkv",
+          "processed_file": "/output/010-intro_part1.mp4",
+          "git_commit": "a1b2c3def456",
+          "git_dirty": false,
+          "recorded_at": "2025-03-01T10:15:22",
+          "status": "processed"
+        }
+      ]
+    }
+  ],
+  "next_lecture_index": 1,
+  "continue_current_lecture": false
+}
+```
+
+Recording status values: `pending`, `processing`, `processed`, `failed`.
+
+### Assignment Modes
+
+- **Sequential mode** (default): Each new recording is assigned to the next
+  unrecorded lecture, advancing `next_lecture_index`.
+- **Continue mode** (`continue_current_lecture: true`): New recordings are
+  assigned as additional parts of the current lecture (for multi-part lectures).
+- **Manual assignment**: Recordings can be assigned to any specific lecture
+  or reassigned after the fact.
+
+### Git Integration
+
+When a recording is assigned to a lecture, the tool captures the current
+git commit hash and dirty status of the course repository. This lets you
+correlate recordings with the exact version of the slides that were presented.
+
+## Course Configuration
+
+Courses are configured in CLM's TOML config:
+
+```toml
+[recordings]
+obs_output_dir = "/path/to/obs/recordings"
+active_course = "python-basics"
+auto_process = false
+
+[[recordings.courses]]
+id = "python-basics"
+name = "Python for Beginners"
+spec_file = "/path/to/python-basics/course.xml"
+course_repo = "/path/to/python-basics"
+input_dir = "/path/to/obs/recordings"
+output_dir = "/path/to/processed/python-basics"
+```
+
+## Troubleshooting
+
+### "deepFilter: NOT FOUND"
+
+Install DeepFilterNet:
+
+```bash
+pip install deepfilternet
+```
+
+On some systems the binary is named `deep-filter` or `deepfilter` rather
+than `deepFilter`. The tool checks all three names automatically.
+
+### "ffmpeg: NOT FOUND"
+
+Install FFmpeg for your platform:
+- **Windows**: `winget install FFmpeg` or download from https://ffmpeg.org/download.html
+- **Arch Linux**: `pacman -S ffmpeg`
+- **Ubuntu/Debian**: `apt install ffmpeg`
+
+### Processing is slow
+
+- The video codec defaults to `copy` (no re-encoding), which is fast. If
+  you changed `video_codec`, set it back to `copy`.
+- DeepFilterNet is the slowest step. It runs on CPU by default.
+- Loudness normalization uses two-pass for accuracy, which doubles the
+  FFmpeg filter step.
+
+### Output audio sounds wrong
+
+Check your filter settings:
+- `highpass_freq`: 80 Hz is safe for voice. Raise to 100-120 if you have
+  persistent low-frequency hum.
+- `loudnorm_target`: -16 LUFS is standard for YouTube/online video. Use
+  -14 for louder output or -18 for more dynamic range.
+- `deepfilter_atten_lim`: 35 dB is moderate. Lower values (25-30) are
+  gentler; higher values (40-50) are more aggressive.

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -14,7 +14,7 @@ The recording workflow is:
 3. **Track** which recordings belong to which lectures in your course
 
 The audio processing pipeline replaces manual tools like iZotope RX with
-an automated, cross-platform solution using DeepFilterNet and FFmpeg.
+an automated, cross-platform solution using DeepFilterNet3 (via ONNX Runtime) and FFmpeg.
 
 ## Installation
 
@@ -25,12 +25,13 @@ pip install -e ".[recordings]"
 
 ### External Dependencies
 
-The recording module requires two external tools:
+The recording module requires FFmpeg as an external tool. The DeepFilterNet3
+ONNX model is downloaded automatically on first use and cached locally.
 
 | Tool | Purpose | Install |
 |------|---------|---------|
 | **ffmpeg** | Audio extraction, filtering, encoding, muxing | `winget install FFmpeg` (Windows) or `pacman -S ffmpeg` (Arch) |
-| **deepFilter** | AI-based noise reduction | `pip install deepfilternet` |
+| **onnxruntime** | AI-based noise reduction (DeepFilterNet3) | Included in `[recordings]` extra |
 
 Verify installation:
 
@@ -38,7 +39,7 @@ Verify installation:
 clm recordings check
 ```
 
-This shows the status and path of each required tool.
+This shows the status of each required dependency (ffmpeg path, onnxruntime version).
 
 ## Processing Recordings
 
@@ -58,7 +59,7 @@ clm recordings process raw_recording.mkv --keep-temp
 The processing pipeline performs five steps:
 
 1. **Extract audio** from video as mono 16-bit WAV
-2. **DeepFilterNet** AI noise reduction
+2. **DeepFilterNet3 ONNX** AI noise reduction (streaming frame-by-frame inference)
 3. **FFmpeg filters**: highpass (remove rumble), compressor (even out volume), two-pass EBU R128 loudness normalization
 4. **AAC encode** the processed audio
 5. **Mux** processed audio back into the original video (video stream is copied, not re-encoded)
@@ -89,7 +90,7 @@ Processing settings can be configured via:
 
    ```toml
    [recordings.processing]
-   deepfilter_atten_lim = 35.0   # DeepFilterNet strength (30-50)
+   denoise_atten_lim = 35.0      # Noise reduction strength (0=unlimited, 30-50)
    sample_rate = 48000           # Audio sample rate
    audio_bitrate = "192k"        # AAC bitrate
    video_codec = "copy"          # "copy" = no re-encoding
@@ -101,7 +102,7 @@ Processing settings can be configured via:
 
    ```json
    {
-     "deepfilter_atten_lim": 35.0,
+     "denoise_atten_lim": 35.0,
      "sample_rate": 48000,
      "audio_bitrate": "192k",
      "video_codec": "copy",
@@ -116,23 +117,23 @@ Processing settings can be configured via:
 3. **Environment variables**:
 
    ```bash
-   export CLM_RECORDINGS__PROCESSING__DEEPFILTER_ATTEN_LIM=40.0
+   export CLM_RECORDINGS__PROCESSING__DENOISE_ATTEN_LIM=40.0
    export CLM_RECORDINGS__PROCESSING__LOUDNORM_TARGET=-18.0
    ```
 
 ## A/B Comparison
 
-When migrating between audio processing tools (e.g., iZotope RX to
-DeepFilterNet), use the comparison tool to evaluate quality:
+When migrating between audio processing tools (e.g., iZotope RX to the
+ONNX pipeline), use the comparison tool to evaluate quality:
 
 ```bash
 # Compare two processed versions
-clm recordings compare izotope.mp4 deepfilter.mp4 \
+clm recordings compare izotope.mp4 onnx.mp4 \
     --label-a "iZotope RX 11" \
-    --label-b "DeepFilterNet"
+    --label-b "DeepFilterNet3 ONNX"
 
 # Include original for reference, compare first 30 seconds
-clm recordings compare izotope.mp4 deepfilter.mp4 \
+clm recordings compare izotope.mp4 onnx.mp4 \
     --original raw.mkv \
     --start 10 --duration 30 \
     -o comparison.html
@@ -225,16 +226,16 @@ output_dir = "/path/to/processed/python-basics"
 
 ## Troubleshooting
 
-### "deepFilter: NOT FOUND"
+### "onnxruntime: NOT FOUND"
 
-Install DeepFilterNet:
+Install the `[recordings]` extra which includes onnxruntime:
 
 ```bash
-pip install deepfilternet
+pip install -e ".[recordings]"
 ```
 
-On some systems the binary is named `deep-filter` or `deepfilter` rather
-than `deepFilter`. The tool checks all three names automatically.
+The DeepFilterNet3 ONNX model (~15 MB) is downloaded automatically on first
+use and cached locally.
 
 ### "ffmpeg: NOT FOUND"
 
@@ -247,7 +248,7 @@ Install FFmpeg for your platform:
 
 - The video codec defaults to `copy` (no re-encoding), which is fast. If
   you changed `video_codec`, set it back to `copy`.
-- DeepFilterNet is the slowest step. It runs on CPU by default.
+- ONNX noise reduction is the slowest step. It runs on CPU by default.
 - Loudness normalization uses two-pass for accuracy, which doubles the
   FFmpeg filter step.
 
@@ -258,5 +259,5 @@ Check your filter settings:
   persistent low-frequency hum.
 - `loudnorm_target`: -16 LUFS is standard for YouTube/online video. Use
   -14 for louder output or -18 for more dynamic range.
-- `deepfilter_atten_lim`: 35 dB is moderate. Lower values (25-30) are
-  gentler; higher values (40-50) are more aggressive.
+- `denoise_atten_lim`: 35 dB is moderate. Lower values (25-30) are
+  gentler; higher values (40-50) are more aggressive. 0 = unlimited.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,9 @@ summarize = [
 recordings = [
     "jinja2>=3.1",
     "python-multipart>=0.0.6",
+    "onnxruntime>=1.17.0",
+    "soundfile>=0.12.0",
+    "numpy>=1.24.0",
 ]
 # Voiceover: video-to-speaker-notes synchronization
 voiceover = [
@@ -270,8 +273,10 @@ module = [
     "pytesseract",
     "rapidfuzz",
     "rapidfuzz.*",
-    "deepfilternet",
-    "deepfilternet.*",
+    "onnxruntime",
+    "onnxruntime.*",
+    "soundfile",
+    "soundfile.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ ml = [
     "langchain-core",
     "langchain-openai",
     "langchain-text-splitters",
-    "langgraph>=1.1.3",
+    "langgraph>=1.1.2",
     "qdrant-client>=1.13.0",
     "langchain-qdrant",
     "fastembed>=0.6.0",
@@ -138,6 +138,11 @@ ml = [
 # LLM summarization (lighter than [ml])
 summarize = [
     "openai>=1.0.0",
+]
+# Recordings: video recording management and audio processing
+recordings = [
+    "jinja2>=3.1",
+    "python-multipart>=0.0.6",
 ]
 # Voiceover: video-to-speaker-notes synchronization
 voiceover = [
@@ -170,7 +175,7 @@ web = [
 ]
 # Everything
 all = [
-    "coding-academy-lecture-manager[all-workers,ml,summarize,voiceover,dev,tui,web]",
+    "coding-academy-lecture-manager[all-workers,ml,summarize,voiceover,recordings,dev,tui,web]",
 ]
 
 [project.urls]
@@ -209,6 +214,7 @@ markers = [
     "integration: mark tests as integration tests requiring full worker setup",
     "e2e: mark tests as end-to-end tests that test full course conversion",
     "docker: mark tests that require Docker daemon (excluded by default)",
+    "recordings: mark tests for the recordings module",
 ]
 # Run fast unit tests by default, skip db_only, integration, slow, e2e, and docker tests
 addopts = "-v -m 'not slow and not db_only and not integration and not e2e and not docker'"
@@ -264,6 +270,8 @@ module = [
     "pytesseract",
     "rapidfuzz",
     "rapidfuzz.*",
+    "deepfilternet",
+    "deepfilternet.*",
 ]
 ignore_missing_imports = true
 
@@ -330,6 +338,17 @@ filename = "tests/workers/notebook/test_notebook_error_context.py"
 dev = [
     "pre-commit>=4.5.0",
 ]
+
+[tool.uv]
+# Only allow packages published at least 14 days ago (supply-chain safety).
+exclude-newer = "14 days"
+
+# Exempt PyTorch packages from exclude-newer: the cu130 index doesn't
+# provide upload dates on its wheels, so they must opt out entirely.
+[tool.uv.exclude-newer-package]
+torch = false
+torchvision = false
+torchaudio = false
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ recordings = [
     "onnxruntime>=1.17.0",
     "soundfile>=0.12.0",
     "numpy>=1.24.0",
+    "obsws-python>=1.7.0",
 ]
 # Voiceover: video-to-speaker-notes synchronization
 voiceover = [

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -378,6 +378,98 @@ def assemble(root_dir: Path, raw_suffix: str | None, dry_run: bool):
         raise SystemExit(1)
 
 
+@recordings_group.command("serve")
+@click.argument(
+    "root_dir",
+    type=click.Path(path_type=Path),
+)
+@click.option("--host", default="127.0.0.1", help="Host to bind to (default: 127.0.0.1).")
+@click.option("--port", type=int, default=8008, help="Port to bind to (default: 8008).")
+@click.option(
+    "--spec-file",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="CLM course spec XML file for lecture listing.",
+)
+@click.option("--obs-host", default=None, help="OBS WebSocket host (default: from config).")
+@click.option(
+    "--obs-port", type=int, default=None, help="OBS WebSocket port (default: from config)."
+)
+@click.option("--obs-password", default=None, help="OBS WebSocket password.")
+@click.option("--no-browser", is_flag=True, help="Do not auto-open browser.")
+def serve_recordings(
+    root_dir: Path,
+    host: str,
+    port: int,
+    spec_file: Path | None,
+    obs_host: str | None,
+    obs_port: int | None,
+    obs_password: str | None,
+    no_browser: bool,
+):
+    """Start the recordings dashboard web UI.
+
+    Launches an HTMX-based web dashboard for the recording workflow.
+    Connects to OBS Studio via WebSocket, lets you arm topics for
+    recording, and shows pending pairs and assembly status.
+
+    ROOT_DIR is the recordings root containing to-process/, final/,
+    and archive/ subdirectories (created automatically if missing).
+    """
+    try:
+        import uvicorn
+    except ImportError as exc:
+        console.print("[red]uvicorn is required. It should be a core CLM dependency.[/red]")
+        raise SystemExit(1) from exc
+
+    from clm.recordings.web.app import create_app
+
+    # Resolve OBS settings from CLI args or CLM config
+    cfg_obs_host, cfg_obs_port, cfg_obs_password = _get_obs_config()
+    obs_host = obs_host or cfg_obs_host
+    obs_port = obs_port or cfg_obs_port
+    obs_password = obs_password if obs_password is not None else cfg_obs_password
+    raw_suffix = _get_raw_suffix()
+
+    app = create_app(
+        recordings_root=root_dir,
+        obs_host=obs_host,
+        obs_port=obs_port,
+        obs_password=obs_password,
+        spec_file=spec_file,
+        raw_suffix=raw_suffix,
+    )
+
+    url = f"http://{host if host != '0.0.0.0' else 'localhost'}:{port}"
+
+    if not no_browser:
+        import webbrowser
+
+        console.print(f"Opening browser to {url}...")
+        webbrowser.open(url)
+
+    console.print(f"[bold]Recordings dashboard:[/bold] {url}")
+    console.print(f"[bold]Recordings root:[/bold]     {root_dir}")
+    console.print("Press CTRL+C to stop")
+
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="info")
+    except Exception as exc:
+        console.print(f"[red]Server error: {exc}[/red]")
+        raise SystemExit(1) from exc
+
+
+def _get_obs_config() -> tuple[str, int, str]:
+    """Get OBS connection settings from CLM config, falling back to defaults."""
+    try:
+        from clm.infrastructure.config import get_config
+
+        cfg = get_config().recordings
+        return cfg.obs_host, cfg.obs_port, cfg.obs_password
+    except Exception:
+        return "localhost", 4455, ""
+
+
 def _get_raw_suffix() -> str:
     """Get the raw suffix from CLM config, falling back to the default."""
     try:

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -1,0 +1,346 @@
+"""Recording management commands for CLM courses.
+
+This module provides the ``clm recordings`` command group with subcommands
+for checking dependencies, processing recordings, viewing status, and
+starting the recording manager web UI.
+
+Requires the ``[recordings]`` extra (for the web UI server).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+@click.group("recordings")
+def recordings_group():
+    """Manage video recordings for courses.
+
+    Record, process, and track educational video recordings
+    tied to CLM course lecture structures.
+    """
+
+
+@recordings_group.command()
+def check():
+    """Check that recording dependencies (ffmpeg, deepfilter) are installed."""
+    from clm.recordings.processing.utils import check_dependencies
+
+    deps = check_dependencies()
+    all_ok = True
+
+    table = Table(title="Recording Dependencies")
+    table.add_column("Tool", style="cyan")
+    table.add_column("Status")
+    table.add_column("Path")
+
+    for name, path in deps.items():
+        if path:
+            table.add_row(name, "[green]found[/green]", str(path))
+        else:
+            table.add_row(name, "[red]NOT FOUND[/red]", "")
+            all_ok = False
+
+    console.print(table)
+
+    if all_ok:
+        console.print("\n[green]All dependencies found.[/green]")
+    else:
+        console.print("\n[red]Some dependencies are missing. See above for details.[/red]")
+        raise SystemExit(1)
+
+
+@recordings_group.command()
+@click.argument("input_file", type=click.Path(exists=True, path_type=Path))
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None, help="Output file.")
+@click.option(
+    "-c",
+    "--config",
+    "config_file",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Config JSON file.",
+)
+@click.option("--keep-temp", is_flag=True, help="Keep intermediate files for debugging.")
+def process(input_file: Path, output: Path | None, config_file: Path | None, keep_temp: bool):
+    """Process a single recording through the audio pipeline.
+
+    Extracts audio, applies DeepFilterNet noise reduction, FFmpeg filters
+    (highpass, compressor, loudness normalization), and muxes back.
+    """
+    from clm.recordings.processing.pipeline import ProcessingPipeline
+
+    config = _load_pipeline_config(config_file)
+    if keep_temp:
+        config.keep_temp = True
+
+    if output is None:
+        output = input_file.parent / f"{input_file.stem}_final.{config.output_extension}"
+
+    console.print(f"[bold]Input:[/bold]  {input_file}")
+    console.print(f"[bold]Output:[/bold] {output}")
+    console.print()
+
+    pipeline = ProcessingPipeline(config)
+    start = time.monotonic()
+
+    def on_step(step: int, name: str, total: int) -> None:
+        console.print(f"  [{step}/{total}] {name}...")
+
+    result = pipeline.process(input_file, output, on_step=on_step)
+    elapsed = time.monotonic() - start
+
+    console.print()
+    if result.success:
+        in_size = input_file.stat().st_size / (1024 * 1024)
+        out_size = output.stat().st_size / (1024 * 1024)
+        console.print(f"[green]Done in {elapsed:.1f}s[/green]")
+        console.print(f"  Output:   {result.output_file}")
+        console.print(f"  Duration: {result.duration_seconds:.0f}s")
+        console.print(f"  Size:     {in_size:.1f} MB -> {out_size:.1f} MB")
+    else:
+        console.print(f"[red]Failed: {result.error}[/red]")
+        raise SystemExit(1)
+
+
+@recordings_group.command()
+@click.argument("input_dir", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "-o", "--output-dir", type=click.Path(path_type=Path), default=None, help="Output directory."
+)
+@click.option(
+    "-c",
+    "--config",
+    "config_file",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Config JSON file.",
+)
+@click.option("-r", "--recursive", is_flag=True, help="Search subdirectories.")
+def batch(input_dir: Path, output_dir: Path | None, config_file: Path | None, recursive: bool):
+    """Batch-process all recordings in a directory.
+
+    Finds video files (.mkv, .mp4, .avi, .mov, .webm, .ts) and processes
+    each through the audio pipeline. Skips files that already have output.
+    """
+    from clm.recordings.processing.batch import process_batch
+
+    config = _load_pipeline_config(config_file)
+    if output_dir is None:
+        output_dir = input_dir / "processed"
+
+    console.print(f"[bold]Input:[/bold]  {input_dir}")
+    console.print(f"[bold]Output:[/bold] {output_dir}")
+    console.print()
+
+    def on_file(i: int, f: Path, total: int) -> None:
+        console.print(f"\n[bold][{i + 1}/{total}] {f.name}[/bold]")
+
+    def on_step(step: int, name: str, total: int) -> None:
+        console.print(f"  [{step}/{total}] {name}...")
+
+    start = time.monotonic()
+    result = process_batch(
+        input_dir,
+        output_dir,
+        config=config,
+        recursive=recursive,
+        on_file=on_file,
+        on_step=on_step,
+    )
+    elapsed = time.monotonic() - start
+
+    console.print(f"\n{result.summary()}")
+    console.print(f"Total time: {elapsed:.1f}s")
+
+    if result.failed:
+        raise SystemExit(1)
+
+
+@recordings_group.command()
+@click.argument("course_id")
+def status(course_id: str):
+    """Show recording status for a course.
+
+    Displays a table of lectures with their recording status,
+    including file paths and part counts.
+    """
+    from clm.recordings.state import load_state
+
+    state = load_state(course_id)
+    if state is None:
+        console.print(f"[yellow]No recording state found for course '{course_id}'.[/yellow]")
+        console.print(
+            "Initialize recording state first via the web UI or by importing a spec file."
+        )
+        raise SystemExit(1)
+
+    recorded, total = state.progress
+    console.print(f"[bold]Course:[/bold] {course_id}")
+    console.print(f"[bold]Progress:[/bold] {recorded}/{total} lectures recorded")
+    console.print(
+        f"[bold]Continue mode:[/bold] {'on' if state.continue_current_lecture else 'off'}"
+    )
+    console.print()
+
+    table = Table(title=f"Lectures — {course_id}")
+    table.add_column("#", style="dim")
+    table.add_column("Lecture ID", style="cyan")
+    table.add_column("Name")
+    table.add_column("Parts", style="green")
+    table.add_column("Status")
+
+    for i, lecture in enumerate(state.lectures):
+        status_str = ""
+        if lecture.parts:
+            statuses = [p.status for p in lecture.parts]
+            if all(s == "processed" for s in statuses):
+                status_str = "[green]processed[/green]"
+            elif any(s == "failed" for s in statuses):
+                status_str = "[red]failed[/red]"
+            elif any(s == "processing" for s in statuses):
+                status_str = "[yellow]processing[/yellow]"
+            else:
+                status_str = "[blue]pending[/blue]"
+        else:
+            status_str = "[dim]unrecorded[/dim]"
+
+        marker = ""
+        if i == state.next_lecture_index:
+            marker = " [bold yellow]*[/bold yellow]"
+
+        table.add_row(
+            str(i + 1),
+            lecture.lecture_id + marker,
+            lecture.display_name,
+            str(len(lecture.parts)),
+            status_str,
+        )
+
+    console.print(table)
+    console.print("[dim]* = next lecture to record[/dim]")
+
+
+@recordings_group.command()
+@click.argument(
+    "version_a",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.argument(
+    "version_b",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option("--label-a", default="Version A", help="Label for version A.")
+@click.option("--label-b", default="Version B", help="Label for version B.")
+@click.option(
+    "--original",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Original unprocessed file.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=Path("comparison.html"),
+    help="Output HTML file.",
+)
+@click.option("--start", type=float, default=0, help="Start time in seconds.")
+@click.option("--duration", type=float, default=60, help="Duration in seconds (0=full).")
+def compare(
+    version_a: Path,
+    version_b: Path,
+    label_a: str,
+    label_b: str,
+    original: Path | None,
+    output: Path,
+    start: float,
+    duration: float,
+):
+    """Generate an A/B audio comparison HTML page.
+
+    Creates a self-contained HTML file with embedded audio players
+    and a blind test mode for comparing two audio processing pipelines.
+    """
+    import tempfile
+
+    from clm.recordings.processing.compare import (
+        audio_to_base64,
+        extract_audio_segment,
+        generate_comparison_html,
+    )
+    from clm.recordings.processing.utils import find_ffmpeg
+
+    ffmpeg = find_ffmpeg()
+
+    with tempfile.TemporaryDirectory(prefix="clm_compare_") as tmp:
+        tmp_dir = Path(tmp)
+
+        # Extract segments
+        console.print("[bold]Extracting audio segments...[/bold]")
+
+        a_wav = tmp_dir / "a.wav"
+        b_wav = tmp_dir / "b.wav"
+        extract_audio_segment(
+            ffmpeg, version_a, a_wav, start_seconds=start, duration_seconds=duration
+        )
+        extract_audio_segment(
+            ffmpeg, version_b, b_wav, start_seconds=start, duration_seconds=duration
+        )
+
+        original_b64 = None
+        if original:
+            orig_wav = tmp_dir / "orig.wav"
+            extract_audio_segment(
+                ffmpeg, original, orig_wav, start_seconds=start, duration_seconds=duration
+            )
+            original_b64 = audio_to_base64(orig_wav)
+
+        # Generate HTML
+        html = generate_comparison_html(
+            original_b64=original_b64,
+            version_a_b64=audio_to_base64(a_wav),
+            version_b_b64=audio_to_base64(b_wav),
+            label_a=label_a,
+            label_b=label_b,
+        )
+
+        output.write_text(html, encoding="utf-8")
+        console.print(f"[green]Comparison page written to {output}[/green]")
+
+
+def _load_pipeline_config(config_file: Path | None):
+    """Load pipeline config from a JSON file or CLM config, falling back to defaults."""
+    from clm.recordings.processing.config import AudioFilterConfig, PipelineConfig
+
+    if config_file:
+        return PipelineConfig.model_validate_json(config_file.read_text())
+
+    # Try to load from CLM's global config
+    try:
+        from clm.infrastructure.config import get_config
+
+        clm_config = get_config()
+        rec = clm_config.recordings.processing
+        return PipelineConfig(
+            deepfilter_atten_lim=rec.deepfilter_atten_lim,
+            sample_rate=rec.sample_rate,
+            audio_bitrate=rec.audio_bitrate,
+            video_codec=rec.video_codec,
+            output_extension=rec.output_extension,
+            audio_filters=AudioFilterConfig(
+                highpass_freq=rec.highpass_freq,
+                loudnorm_target=rec.loudnorm_target,
+            ),
+        )
+    except Exception:
+        return PipelineConfig()

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -319,6 +319,80 @@ def compare(
         console.print(f"[green]Comparison page written to {output}[/green]")
 
 
+@recordings_group.command()
+@click.argument("root_dir", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--raw-suffix", default=None, help="Override raw file suffix (default: from config or --RAW)."
+)
+@click.option("--dry-run", is_flag=True, help="Show pending pairs without assembling.")
+def assemble(root_dir: Path, raw_suffix: str | None, dry_run: bool):
+    """Assemble processed recordings (mux video + audio, archive originals).
+
+    Scans ROOT_DIR/to-process/ for matched video + audio pairs
+    (e.g. topic--RAW.mp4 + topic--RAW.wav), muxes them into
+    ROOT_DIR/final/, and archives the originals to ROOT_DIR/archive/.
+    """
+    from clm.recordings.workflow.directories import (
+        find_pending_pairs,
+        to_process_dir,
+        validate_root,
+    )
+
+    if raw_suffix is None:
+        raw_suffix = _get_raw_suffix()
+
+    errors = validate_root(root_dir)
+    if errors:
+        for err in errors:
+            console.print(f"[red]{err}[/red]")
+        console.print(
+            "\n[yellow]Run with a valid recordings root, or create the structure first.[/yellow]"
+        )
+        raise SystemExit(1)
+
+    pairs = find_pending_pairs(to_process_dir(root_dir), raw_suffix=raw_suffix)
+
+    if not pairs:
+        console.print("[yellow]No pending video + audio pairs found.[/yellow]")
+        return
+
+    console.print(f"[bold]Found {len(pairs)} pair(s) ready for assembly:[/bold]")
+    for pair in pairs:
+        console.print(f"  {pair.relative_dir / pair.video.name}")
+
+    if dry_run:
+        console.print("\n[dim]Dry run — no files changed.[/dim]")
+        return
+
+    from clm.recordings.workflow.assembler import assemble_all
+
+    console.print()
+
+    def on_pair(i: int, pair, total: int) -> None:
+        console.print(f"[{i + 1}/{total}] Assembling {pair.video.name}...")
+
+    result = assemble_all(root_dir, raw_suffix=raw_suffix, on_pair=on_pair)
+
+    console.print(f"\n{result.summary()}")
+    if result.failed:
+        raise SystemExit(1)
+
+
+def _get_raw_suffix() -> str:
+    """Get the raw suffix from CLM config, falling back to the default."""
+    try:
+        from clm.infrastructure.config import get_config
+
+        suffix = get_config().recordings.raw_suffix
+        if suffix:
+            return suffix
+    except Exception:
+        pass
+    from clm.recordings.workflow.naming import DEFAULT_RAW_SUFFIX
+
+    return DEFAULT_RAW_SUFFIX
+
+
 def _load_pipeline_config(config_file: Path | None):
     """Load pipeline config from a JSON file or CLM config, falling back to defaults."""
     from clm.recordings.processing.config import AudioFilterConfig, PipelineConfig

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -32,7 +32,7 @@ def recordings_group():
 
 @recordings_group.command()
 def check():
-    """Check that recording dependencies (ffmpeg, deepfilter) are installed."""
+    """Check that recording dependencies (ffmpeg, onnxruntime) are installed."""
     from clm.recordings.processing.utils import check_dependencies
 
     deps = check_dependencies()
@@ -41,11 +41,11 @@ def check():
     table = Table(title="Recording Dependencies")
     table.add_column("Tool", style="cyan")
     table.add_column("Status")
-    table.add_column("Path")
+    table.add_column("Info")
 
-    for name, path in deps.items():
-        if path:
-            table.add_row(name, "[green]found[/green]", str(path))
+    for name, value in deps.items():
+        if value:
+            table.add_row(name, "[green]found[/green]", str(value))
         else:
             table.add_row(name, "[red]NOT FOUND[/red]", "")
             all_ok = False
@@ -74,8 +74,9 @@ def check():
 def process(input_file: Path, output: Path | None, config_file: Path | None, keep_temp: bool):
     """Process a single recording through the audio pipeline.
 
-    Extracts audio, applies DeepFilterNet noise reduction, FFmpeg filters
-    (highpass, compressor, loudness normalization), and muxes back.
+    Extracts audio, applies DeepFilterNet3 noise reduction (ONNX),
+    FFmpeg filters (highpass, compressor, loudness normalization),
+    and muxes back.
     """
     from clm.recordings.processing.pipeline import ProcessingPipeline
 
@@ -332,7 +333,7 @@ def _load_pipeline_config(config_file: Path | None):
         clm_config = get_config()
         rec = clm_config.recordings.processing
         return PipelineConfig(
-            deepfilter_atten_lim=rec.deepfilter_atten_lim,
+            denoise_atten_lim=rec.denoise_atten_lim,
             sample_rate=rec.sample_rate,
             audio_bitrate=rec.audio_bitrate,
             video_codec=rec.video_codec,

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -431,6 +431,9 @@ def serve_recordings(
     obs_password = obs_password if obs_password is not None else cfg_obs_password
     raw_suffix = _get_raw_suffix()
 
+    # Resolve watcher settings from CLM config
+    cfg_backend, cfg_stab_interval, cfg_stab_count = _get_watcher_config()
+
     app = create_app(
         recordings_root=root_dir,
         obs_host=obs_host,
@@ -438,6 +441,9 @@ def serve_recordings(
         obs_password=obs_password,
         spec_file=spec_file,
         raw_suffix=raw_suffix,
+        processing_backend=cfg_backend,
+        stability_check_interval=cfg_stab_interval,
+        stability_check_count=cfg_stab_count,
     )
 
     url = f"http://{host if host != '0.0.0.0' else 'localhost'}:{port}"
@@ -483,6 +489,17 @@ def _get_raw_suffix() -> str:
     from clm.recordings.workflow.naming import DEFAULT_RAW_SUFFIX
 
     return DEFAULT_RAW_SUFFIX
+
+
+def _get_watcher_config() -> tuple[str, float, int]:
+    """Get watcher settings from CLM config, falling back to defaults."""
+    try:
+        from clm.infrastructure.config import get_config
+
+        cfg = get_config().recordings
+        return cfg.processing_backend, cfg.stability_check_interval, cfg.stability_check_count
+    except Exception:
+        return "external", 2.0, 3
 
 
 def _load_pipeline_config(config_file: Path | None):

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -328,6 +328,84 @@ clm polish slides.py --lang en --slides-range 5-10 --dry-run
 clm polish slides.py --lang de --model openai/gpt-4o -o polished.py
 ```
 
+### `clm recordings`
+
+Manage video recordings for educational courses. Provides audio processing,
+recording-to-lecture assignment, and status tracking.
+
+#### `clm recordings check`
+
+Check that recording dependencies (ffmpeg, deepfilter) are installed.
+
+```
+clm recordings check
+```
+
+#### `clm recordings process`
+
+Process a single recording through the audio pipeline (DeepFilterNet + FFmpeg filters).
+
+```
+clm recordings process INPUT_FILE [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output PATH` | Output file (default: auto-named `*_final.mp4`) |
+| `-c, --config PATH` | Config JSON file |
+| `--keep-temp` | Keep intermediate files for debugging |
+
+#### `clm recordings batch`
+
+Batch-process all recordings in a directory. Skips files that already have output.
+
+```
+clm recordings batch INPUT_DIR [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output-dir DIR` | Output directory (default: `INPUT_DIR/processed`) |
+| `-c, --config PATH` | Config JSON file |
+| `-r, --recursive` | Search subdirectories |
+
+#### `clm recordings status`
+
+Show recording status for a course, including per-lecture recording state.
+
+```
+clm recordings status COURSE_ID
+```
+
+#### `clm recordings compare`
+
+Generate an A/B audio comparison HTML page with embedded audio players
+and blind test mode.
+
+```
+clm recordings compare VERSION_A VERSION_B [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--label-a TEXT` | Label for version A (default: "Version A") |
+| `--label-b TEXT` | Label for version B (default: "Version B") |
+| `--original PATH` | Original unprocessed file (optional) |
+| `-o, --output PATH` | Output HTML file (default: `comparison.html`) |
+| `--start FLOAT` | Start time in seconds |
+| `--duration FLOAT` | Duration in seconds (default: 60) |
+
+Examples:
+
+```bash
+clm recordings check
+clm recordings process raw.mkv
+clm recordings process raw.mkv -o final.mp4 --keep-temp
+clm recordings batch ~/Recordings -o ~/Processed -r
+clm recordings status python-basics
+clm recordings compare izotope.mp4 deepfilter.mp4 --label-a "iZotope RX" --label-b "DeepFilterNet"
+```
+
 ### `clm monitor`
 
 Launch real-time TUI monitoring dashboard. Requires `clm[tui]` extra.
@@ -359,3 +437,9 @@ Create and manage ZIP archives of course output.
 | `CLM_LLM__API_BASE` | API base URL (e.g. `https://openrouter.ai/api/v1`) |
 | `CLM_LLM__MAX_CONCURRENT` | Max parallel LLM calls (default: 3) |
 | `CLM_LLM__TEMPERATURE` | LLM sampling temperature (default: 0.3) |
+| `CLM_RECORDINGS__OBS_OUTPUT_DIR` | Directory where OBS saves recordings |
+| `CLM_RECORDINGS__ACTIVE_COURSE` | Currently active course ID |
+| `CLM_RECORDINGS__AUTO_PROCESS` | Auto-process recordings when detected (default: false) |
+| `CLM_RECORDINGS__PROCESSING__DEEPFILTER_ATTEN_LIM` | DeepFilterNet attenuation limit (default: 35.0) |
+| `CLM_RECORDINGS__PROCESSING__SAMPLE_RATE` | Audio sample rate (default: 48000) |
+| `CLM_RECORDINGS__PROCESSING__LOUDNORM_TARGET` | Loudness target in LUFS (default: -16.0) |

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -335,7 +335,7 @@ recording-to-lecture assignment, and status tracking.
 
 #### `clm recordings check`
 
-Check that recording dependencies (ffmpeg, deepfilter) are installed.
+Check that recording dependencies (ffmpeg, onnxruntime) are installed.
 
 ```
 clm recordings check
@@ -343,7 +343,7 @@ clm recordings check
 
 #### `clm recordings process`
 
-Process a single recording through the audio pipeline (DeepFilterNet + FFmpeg filters).
+Process a single recording through the audio pipeline (DeepFilterNet3 ONNX + FFmpeg filters).
 
 ```
 clm recordings process INPUT_FILE [OPTIONS]
@@ -403,7 +403,7 @@ clm recordings process raw.mkv
 clm recordings process raw.mkv -o final.mp4 --keep-temp
 clm recordings batch ~/Recordings -o ~/Processed -r
 clm recordings status python-basics
-clm recordings compare izotope.mp4 deepfilter.mp4 --label-a "iZotope RX" --label-b "DeepFilterNet"
+clm recordings compare izotope.mp4 onnx.mp4 --label-a "iZotope RX" --label-b "DeepFilterNet3 ONNX"
 ```
 
 ### `clm monitor`

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -93,6 +93,11 @@ try:
 except ImportError:
     polish_cmd = None  # type: ignore[assignment]
 
+try:
+    from clm.cli.commands.recordings import recordings_group  # noqa: E402
+except ImportError:
+    recordings_group = None  # type: ignore[assignment]
+
 # Register individual commands
 cli.add_command(build)
 cli.add_command(list_targets, name="targets")
@@ -118,6 +123,8 @@ if voiceover_group is not None:
     cli.add_command(voiceover_group)
 if polish_cmd is not None:
     cli.add_command(polish_cmd)
+if recordings_group is not None:
+    cli.add_command(recordings_group)
 
 
 # Re-export commonly used functions for backwards compatibility with tests

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -500,9 +500,9 @@ class RecordingsCourseConfig(BaseModel):
 class RecordingsProcessingConfig(BaseModel):
     """Audio processing pipeline configuration for recordings."""
 
-    deepfilter_atten_lim: float = Field(
+    denoise_atten_lim: float = Field(
         default=35.0,
-        description="DeepFilterNet attenuation limit in dB (30-40 moderate, 50+ aggressive)",
+        description="Noise reduction attenuation limit in dB (0=unlimited, 30-40 moderate, 50+ aggressive)",
     )
     sample_rate: int = Field(
         default=48000,

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -573,6 +573,22 @@ class RecordingsConfig(BaseModel):
         default="",
         description="OBS WebSocket password (empty = no authentication)",
     )
+    processing_backend: str = Field(
+        default="external",
+        description="Processing backend: 'external' (wait for RX 11 / other tool) or 'onnx' (local ONNX pipeline)",
+    )
+    stability_check_interval: float = Field(
+        default=2.0,
+        ge=0.1,
+        le=30.0,
+        description="Seconds between file-size polls for stability detection",
+    )
+    stability_check_count: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description="Consecutive identical size readings required before considering a file stable",
+    )
     processing: RecordingsProcessingConfig = Field(
         default_factory=RecordingsProcessingConfig,
         description="Audio processing pipeline settings",

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -486,6 +486,79 @@ class GitConfig(BaseModel):
     )
 
 
+class RecordingsCourseConfig(BaseModel):
+    """Configuration for a single course's recording setup."""
+
+    id: str = Field(description="Unique course identifier (e.g., 'python-basics')")
+    name: str = Field(default="", description="Human-readable course name")
+    spec_file: str = Field(default="", description="Path to CLM course.xml spec file")
+    course_repo: str = Field(default="", description="Path to the course git repository")
+    input_dir: str = Field(default="", description="Directory for raw recordings")
+    output_dir: str = Field(default="", description="Directory for processed output")
+
+
+class RecordingsProcessingConfig(BaseModel):
+    """Audio processing pipeline configuration for recordings."""
+
+    deepfilter_atten_lim: float = Field(
+        default=35.0,
+        description="DeepFilterNet attenuation limit in dB (30-40 moderate, 50+ aggressive)",
+    )
+    sample_rate: int = Field(
+        default=48000,
+        description="Audio sample rate (48000 is standard for video)",
+    )
+    audio_bitrate: str = Field(
+        default="192k",
+        description="Output audio bitrate for AAC encoding",
+    )
+    video_codec: str = Field(
+        default="copy",
+        description="Output video codec ('copy' keeps original, fast and lossless)",
+    )
+    output_extension: str = Field(
+        default="mp4",
+        description="Output container format",
+    )
+    highpass_freq: int = Field(
+        default=80,
+        description="Highpass filter frequency in Hz (removes rumble below this)",
+    )
+    loudnorm_target: float = Field(
+        default=-16.0,
+        description="Loudness normalization target in LUFS (-16 is standard for online video)",
+    )
+
+
+class RecordingsConfig(BaseModel):
+    """Configuration for the recording management system.
+
+    Controls OBS output watching, course recording assignment, and
+    audio processing pipeline settings.
+    """
+
+    obs_output_dir: str = Field(
+        default="",
+        description="Directory where OBS saves recordings",
+    )
+    courses: list[RecordingsCourseConfig] = Field(
+        default_factory=list,
+        description="List of course configurations",
+    )
+    active_course: str = Field(
+        default="",
+        description="ID of the currently active course",
+    )
+    auto_process: bool = Field(
+        default=False,
+        description="Automatically process recordings when detected",
+    )
+    processing: RecordingsProcessingConfig = Field(
+        default_factory=RecordingsProcessingConfig,
+        description="Audio processing pipeline settings",
+    )
+
+
 class ClmConfig(BaseSettings):
     """Main CLM configuration.
 
@@ -551,6 +624,11 @@ class ClmConfig(BaseSettings):
     llm: LLMConfig = Field(
         default_factory=LLMConfig,
         description="LLM configuration for summarization",
+    )
+
+    recordings: RecordingsConfig = Field(
+        default_factory=RecordingsConfig,
+        description="Recording management configuration",
     )
 
     @classmethod

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -537,6 +537,14 @@ class RecordingsConfig(BaseModel):
     audio processing pipeline settings.
     """
 
+    root_dir: str = Field(
+        default="",
+        description="Root directory for recording workflow (to-process/, final/, archive/ under this)",
+    )
+    raw_suffix: str = Field(
+        default="--RAW",
+        description="Suffix appended to raw recording filenames (e.g. topic--RAW.mp4)",
+    )
     obs_output_dir: str = Field(
         default="",
         description="Directory where OBS saves recordings",

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -561,6 +561,18 @@ class RecordingsConfig(BaseModel):
         default=False,
         description="Automatically process recordings when detected",
     )
+    obs_host: str = Field(
+        default="localhost",
+        description="OBS WebSocket host",
+    )
+    obs_port: int = Field(
+        default=4455,
+        description="OBS WebSocket port",
+    )
+    obs_password: str = Field(
+        default="",
+        description="OBS WebSocket password (empty = no authentication)",
+    )
     processing: RecordingsProcessingConfig = Field(
         default_factory=RecordingsProcessingConfig,
         description="Audio processing pipeline settings",

--- a/src/clm/recordings/__init__.py
+++ b/src/clm/recordings/__init__.py
@@ -1,0 +1,8 @@
+"""Recording management for CLM courses.
+
+This module provides tools for managing the recording workflow for
+educational video courses: file watching, audio processing, and
+recording-to-lecture assignment tracking.
+
+Requires the ``[recordings]`` extra.
+"""

--- a/src/clm/recordings/git_info.py
+++ b/src/clm/recordings/git_info.py
@@ -1,0 +1,61 @@
+"""Git commit capture for recording assignment.
+
+Captures the current HEAD commit and dirty state of a course repository
+at the time a recording is assigned, so recordings can be correlated
+with the exact version of the course materials.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+def get_git_info(repo_path: Path) -> dict[str, Any]:
+    """Get current git commit hash and dirty status for a repository.
+
+    Args:
+        repo_path: Path to the git repository.
+
+    Returns:
+        Dict with 'commit' (str or None) and 'dirty' (bool or None).
+        Values are None if git operations fail (e.g., not a git repo).
+    """
+    commit = _git_rev_parse(repo_path)
+    dirty = _git_is_dirty(repo_path) if commit else None
+    return {"commit": commit, "dirty": dirty}
+
+
+def _git_rev_parse(repo_path: Path) -> str | None:
+    """Get the HEAD commit hash, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        logger.debug("git rev-parse failed in {}: {}", repo_path, e)
+        return None
+
+
+def _git_is_dirty(repo_path: Path) -> bool | None:
+    """Check if the working tree has uncommitted changes."""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip() != ""
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        logger.debug("git status failed in {}: {}", repo_path, e)
+        return None

--- a/src/clm/recordings/processing/__init__.py
+++ b/src/clm/recordings/processing/__init__.py
@@ -4,7 +4,7 @@ Replaces bash scripts with a Python implementation that works on
 both Windows and Linux. The processing steps are:
 
 1. Extract audio from the recording (FFmpeg)
-2. Run DeepFilterNet noise reduction
+2. Run DeepFilterNet3 noise reduction (ONNX Runtime)
 3. Apply FFmpeg audio filters (highpass, compressor, loudness normalization)
 4. Encode cleaned audio to AAC
 5. Mux processed audio back into the original video

--- a/src/clm/recordings/processing/__init__.py
+++ b/src/clm/recordings/processing/__init__.py
@@ -1,0 +1,11 @@
+"""Cross-platform video post-processing pipeline.
+
+Replaces bash scripts with a Python implementation that works on
+both Windows and Linux. The processing steps are:
+
+1. Extract audio from the recording (FFmpeg)
+2. Run DeepFilterNet noise reduction
+3. Apply FFmpeg audio filters (highpass, compressor, loudness normalization)
+4. Encode cleaned audio to AAC
+5. Mux processed audio back into the original video
+"""

--- a/src/clm/recordings/processing/batch.py
+++ b/src/clm/recordings/processing/batch.py
@@ -1,0 +1,125 @@
+"""Batch processing for multiple recordings."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from .config import PipelineConfig
+from .pipeline import ProcessingPipeline, ProcessingResult
+
+# Common video file extensions to look for.
+VIDEO_EXTENSIONS = {".mkv", ".mp4", ".avi", ".mov", ".webm", ".ts"}
+
+
+class BatchResult(BaseModel):
+    """Summary of a batch processing run."""
+
+    succeeded: list[ProcessingResult] = Field(default_factory=list)
+    failed: list[ProcessingResult] = Field(default_factory=list)
+    skipped: list[Path] = Field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.succeeded) + len(self.failed) + len(self.skipped)
+
+    def summary(self) -> str:
+        lines = [
+            f"Batch complete: {self.total} files",
+            f"  Succeeded: {len(self.succeeded)}",
+            f"  Skipped:   {len(self.skipped)}",
+            f"  Failed:    {len(self.failed)}",
+        ]
+        if self.failed:
+            lines.append("  Failed files:")
+            for r in self.failed:
+                lines.append(f"    - {r.input_file.name}: {r.error}")
+        return "\n".join(lines)
+
+
+def find_video_files(
+    directory: Path,
+    *,
+    recursive: bool = False,
+    extensions: set[str] | None = None,
+) -> list[Path]:
+    """Find video files in a directory.
+
+    Args:
+        directory: Directory to search.
+        recursive: Whether to search subdirectories.
+        extensions: Set of extensions to match (default: common video formats).
+
+    Returns:
+        Sorted list of video file paths.
+    """
+    exts = extensions or VIDEO_EXTENSIONS
+    if recursive:
+        files = [f for f in directory.rglob("*") if f.suffix.lower() in exts]
+    else:
+        files = [f for f in directory.iterdir() if f.is_file() and f.suffix.lower() in exts]
+    return sorted(files)
+
+
+def process_batch(
+    input_dir: Path,
+    output_dir: Path,
+    *,
+    config: PipelineConfig | None = None,
+    recursive: bool = False,
+    suffix: str = "_final",
+    on_file: Callable[[int, Path, int], None] | None = None,
+    on_step: Callable[[int, str, int], None] | None = None,
+) -> BatchResult:
+    """Process all video files in a directory.
+
+    Args:
+        input_dir: Directory containing raw recordings.
+        output_dir: Directory for processed output.
+        config: Pipeline configuration (uses defaults if None).
+        recursive: Search subdirectories.
+        suffix: Suffix to add to output filenames before extension.
+        on_file: Callback(file_index, file_path, total_files) for progress.
+        on_step: Passed through to pipeline.process() for per-step progress.
+
+    Returns:
+        BatchResult with details of all processed files.
+    """
+    config = config or PipelineConfig()
+    pipeline = ProcessingPipeline(config)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = find_video_files(input_dir, recursive=recursive)
+    result = BatchResult()
+    notify_file = on_file or (lambda i, f, t: None)
+
+    if not files:
+        logger.warning("No video files found in {}", input_dir)
+        return result
+
+    logger.info("Found {} video(s) in {}", len(files), input_dir)
+
+    for i, input_file in enumerate(files):
+        notify_file(i, input_file, len(files))
+        stem = input_file.stem
+        output_file = output_dir / f"{stem}{suffix}.{config.output_extension}"
+
+        # Skip if output already exists.
+        if output_file.is_file():
+            logger.info("Skipping {} (output exists)", input_file.name)
+            result.skipped.append(input_file)
+            continue
+
+        logger.info("[{}/{}] Processing {}", i + 1, len(files), input_file.name)
+
+        proc_result = pipeline.process(input_file, output_file, on_step=on_step)
+
+        if proc_result.success:
+            result.succeeded.append(proc_result)
+        else:
+            result.failed.append(proc_result)
+
+    return result

--- a/src/clm/recordings/processing/compare.py
+++ b/src/clm/recordings/processing/compare.py
@@ -1,0 +1,181 @@
+"""A/B comparison utility for comparing audio processing pipelines.
+
+Extracts audio from two versions of a recording (e.g., one processed with
+iZotope RX, one with DeepFilterNet) and produces a side-by-side comparison
+HTML page with audio players for quick quality evaluation.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from .utils import run_subprocess
+
+
+def extract_audio_segment(
+    ffmpeg: Path,
+    input_file: Path,
+    output_file: Path,
+    *,
+    start_seconds: float = 0,
+    duration_seconds: float = 60,
+) -> None:
+    """Extract a segment of audio as WAV for comparison."""
+    args: list[str | Path] = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        "-y",
+        "-i",
+        input_file,
+    ]
+    if start_seconds > 0:
+        args.extend(["-ss", str(start_seconds)])
+    if duration_seconds > 0:
+        args.extend(["-t", str(duration_seconds)])
+    args.extend(["-vn", "-acodec", "pcm_s16le", output_file])
+    run_subprocess(args)
+
+
+def audio_to_base64(audio_file: Path) -> str:
+    """Read an audio file and return its base64-encoded content."""
+    data = audio_file.read_bytes()
+    return base64.b64encode(data).decode("ascii")
+
+
+def generate_comparison_html(
+    *,
+    original_b64: str | None,
+    version_a_b64: str,
+    version_b_b64: str,
+    label_a: str,
+    label_b: str,
+) -> str:
+    """Generate an HTML page with embedded audio players for A/B comparison."""
+    original_section = ""
+    if original_b64:
+        original_section = f"""
+        <div class="player-card">
+            <h2>Original (unprocessed)</h2>
+            <audio controls preload="metadata">
+                <source src="data:audio/wav;base64,{original_b64}" type="audio/wav">
+            </audio>
+        </div>
+        """
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Audio A/B Comparison</title>
+    <style>
+        * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #1a1a2e; color: #e0e0e0;
+            padding: 2rem; max-width: 900px; margin: 0 auto;
+        }}
+        h1 {{ text-align: center; margin-bottom: 2rem; color: #e0e0e0; }}
+        .player-card {{
+            background: #16213e; border-radius: 12px; padding: 1.5rem;
+            margin-bottom: 1.5rem; border: 1px solid #0f3460;
+        }}
+        .player-card h2 {{
+            margin-bottom: 1rem; font-size: 1.1rem; color: #a0c4ff;
+        }}
+        audio {{ width: 100%; }}
+        .controls {{
+            display: flex; gap: 1rem; justify-content: center;
+            margin: 2rem 0; flex-wrap: wrap;
+        }}
+        button {{
+            padding: 0.75rem 1.5rem; border: none; border-radius: 8px;
+            cursor: pointer; font-size: 1rem; font-weight: 600;
+            transition: transform 0.1s;
+        }}
+        button:active {{ transform: scale(0.97); }}
+        .btn-a {{ background: #e94560; color: white; }}
+        .btn-b {{ background: #533483; color: white; }}
+        .btn-stop {{ background: #0f3460; color: white; }}
+        .instructions {{
+            text-align: center; color: #888; margin-bottom: 2rem;
+            font-size: 0.95rem; line-height: 1.6;
+        }}
+        .blind-mode {{
+            background: #0f3460; border-radius: 12px; padding: 1.5rem;
+            margin-top: 2rem; text-align: center;
+        }}
+        .blind-mode h2 {{ color: #a0c4ff; margin-bottom: 1rem; }}
+        .reveal {{ display: none; margin-top: 1rem; font-size: 1.1rem; }}
+        .reveal.show {{ display: block; }}
+    </style>
+</head>
+<body>
+    <h1>Audio A/B Comparison</h1>
+    <p class="instructions">
+        Listen to each version and compare quality.<br>
+        Use the blind test below for an unbiased comparison.
+    </p>
+
+    {original_section}
+
+    <div class="player-card">
+        <h2>Version A: {label_a}</h2>
+        <audio id="audioA" controls preload="metadata">
+            <source src="data:audio/wav;base64,{version_a_b64}" type="audio/wav">
+        </audio>
+    </div>
+
+    <div class="player-card">
+        <h2>Version B: {label_b}</h2>
+        <audio id="audioB" controls preload="metadata">
+            <source src="data:audio/wav;base64,{version_b_b64}" type="audio/wav">
+        </audio>
+    </div>
+
+    <div class="blind-mode">
+        <h2>Blind Test</h2>
+        <p style="color: #888; margin-bottom: 1rem;">
+            Versions are randomly assigned to X and Y. Listen, pick your
+            favourite, then reveal.
+        </p>
+        <div class="controls">
+            <button class="btn-a" onclick="playBlind('X')">Play X</button>
+            <button class="btn-b" onclick="playBlind('Y')">Play Y</button>
+            <button class="btn-stop" onclick="stopAll()">Stop</button>
+        </div>
+        <div class="controls">
+            <button class="btn-a" onclick="reveal()">Reveal</button>
+        </div>
+        <div id="reveal" class="reveal"></div>
+    </div>
+
+    <script>
+        const audioA = document.getElementById('audioA');
+        const audioB = document.getElementById('audioB');
+        const swap = Math.random() < 0.5;
+        const blindX = swap ? audioB : audioA;
+        const blindY = swap ? audioA : audioB;
+
+        function stopAll() {{
+            audioA.pause(); audioA.currentTime = 0;
+            audioB.pause(); audioB.currentTime = 0;
+        }}
+
+        function playBlind(label) {{
+            stopAll();
+            (label === 'X' ? blindX : blindY).play();
+        }}
+
+        function reveal() {{
+            const el = document.getElementById('reveal');
+            el.innerHTML = swap
+                ? 'X = {label_b}, Y = {label_a}'
+                : 'X = {label_a}, Y = {label_b}';
+            el.classList.add('show');
+        }}
+    </script>
+</body>
+</html>"""

--- a/src/clm/recordings/processing/config.py
+++ b/src/clm/recordings/processing/config.py
@@ -46,9 +46,9 @@ class AudioFilterConfig(BaseModel):
 class PipelineConfig(BaseModel):
     """Full pipeline configuration."""
 
-    # DeepFilterNet attenuation limit in dB.
-    # 30-40 is moderate; 50+ is aggressive. Start with 35.
-    deepfilter_atten_lim: float = 35.0
+    # Noise reduction attenuation limit in dB.
+    # 0 = unlimited, 30-40 = moderate, 50+ = aggressive.
+    denoise_atten_lim: float = 35.0
 
     # Audio sample rate. 48000 is standard for video.
     sample_rate: int = 48000

--- a/src/clm/recordings/processing/config.py
+++ b/src/clm/recordings/processing/config.py
@@ -1,0 +1,69 @@
+"""Pipeline configuration with sensible defaults for educational video processing."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class AudioFilterConfig(BaseModel):
+    """FFmpeg audio filter settings."""
+
+    # Highpass filter frequency in Hz. Removes low-end rumble below this.
+    # 80 is safe for voice; raise to 100-120 for persistent hum.
+    highpass_freq: int = 80
+
+    # Compressor settings — evens out volume differences.
+    # These defaults are gentle and suitable for spoken word.
+    compressor_attacks: float = 0.05
+    compressor_decays: float = 0.3
+    compressor_points: str = "-80/-80|-45/-30|-27/-20|0/-10"
+    compressor_gain: float = 5.0
+
+    # Loudness normalization (EBU R128).
+    # -16 LUFS is standard for online video (YouTube, etc.)
+    loudnorm_target: float = -16.0
+    loudnorm_true_peak: float = -1.5
+    loudnorm_lra: float = 11.0
+
+    @property
+    def compressor_filter(self) -> str:
+        return (
+            f"compand=attacks={self.compressor_attacks}"
+            f":decays={self.compressor_decays}"
+            f":points={self.compressor_points}"
+            f":gain={self.compressor_gain}"
+        )
+
+    @property
+    def loudnorm_filter(self) -> str:
+        return (
+            f"loudnorm=I={self.loudnorm_target}"
+            f":TP={self.loudnorm_true_peak}"
+            f":LRA={self.loudnorm_lra}"
+        )
+
+
+class PipelineConfig(BaseModel):
+    """Full pipeline configuration."""
+
+    # DeepFilterNet attenuation limit in dB.
+    # 30-40 is moderate; 50+ is aggressive. Start with 35.
+    deepfilter_atten_lim: float = 35.0
+
+    # Audio sample rate. 48000 is standard for video.
+    sample_rate: int = 48000
+
+    # Output video codec: "copy" keeps original (fast, no quality loss).
+    video_codec: str = "copy"
+
+    # Output audio bitrate for AAC encoding.
+    audio_bitrate: str = "192k"
+
+    # Output container format.
+    output_extension: str = "mp4"
+
+    # Keep intermediate files for debugging.
+    keep_temp: bool = False
+
+    # Audio filter settings.
+    audio_filters: AudioFilterConfig = Field(default_factory=AudioFilterConfig)

--- a/src/clm/recordings/processing/pipeline.py
+++ b/src/clm/recordings/processing/pipeline.py
@@ -2,7 +2,7 @@
 
 The processing steps are:
 1. Extract audio from the recording (FFmpeg)
-2. Run DeepFilterNet noise reduction
+2. Run DeepFilterNet3 noise reduction (ONNX Runtime)
 3. Apply FFmpeg audio filters (highpass, compressor, loudness normalization)
 4. Encode cleaned audio to AAC
 5. Mux processed audio back into the original video
@@ -25,10 +25,10 @@ from pydantic import BaseModel
 
 from .config import PipelineConfig
 from .utils import (
-    find_deepfilter,
     find_ffmpeg,
     find_ffprobe,
     get_audio_duration,
+    run_onnx_denoise,
     run_subprocess,
 )
 
@@ -60,11 +60,9 @@ class ProcessingPipeline:
         # Locate binaries once at init. Raises BinaryNotFoundError if missing.
         self.ffmpeg = find_ffmpeg()
         self.ffprobe = find_ffprobe()
-        self.deepfilter = find_deepfilter()
 
-        logger.info("FFmpeg:      {}", self.ffmpeg)
-        logger.info("FFprobe:     {}", self.ffprobe)
-        logger.info("DeepFilter:  {}", self.deepfilter)
+        logger.info("FFmpeg:  {}", self.ffmpeg)
+        logger.info("FFprobe: {}", self.ffprobe)
 
     def process(
         self,
@@ -114,9 +112,9 @@ class ProcessingPipeline:
             duration = get_audio_duration(self.ffprobe, audio_raw)
             logger.info("Audio extracted ({:.0f}s)", duration)
 
-            # Step 2: DeepFilterNet noise reduction
-            notify(2, "Noise reduction (DeepFilterNet)", total_steps)
-            self._run_deepfilter(audio_raw, audio_cleaned, temp_dir)
+            # Step 2: DeepFilterNet3 noise reduction (ONNX)
+            notify(2, "Noise reduction (DeepFilterNet3 ONNX)", total_steps)
+            self._run_denoise(audio_raw, audio_cleaned)
             logger.info("Noise reduction complete")
 
             # Step 3: FFmpeg audio filters
@@ -179,47 +177,13 @@ class ProcessingPipeline:
             ]
         )
 
-    def _run_deepfilter(self, input_file: Path, output_file: Path, temp_dir: Path) -> None:
-        """Run DeepFilterNet noise reduction.
-
-        DeepFilterNet writes output files to --output-dir with a suffix
-        or the same name. We handle the various naming conventions across
-        versions.
-        """
-        df_output_dir = temp_dir / "df_output"
-        df_output_dir.mkdir(exist_ok=True)
-
-        run_subprocess(
-            [
-                self.deepfilter,
-                input_file,
-                "--output-dir",
-                df_output_dir,
-                "--atten-lim",
-                str(self.config.deepfilter_atten_lim),
-            ]
+    def _run_denoise(self, input_file: Path, output_file: Path) -> None:
+        """Run DeepFilterNet3 noise reduction via ONNX Runtime."""
+        run_onnx_denoise(
+            input_file,
+            output_file,
+            atten_lim_db=self.config.denoise_atten_lim,
         )
-
-        # Find the output file. DeepFilterNet uses various naming schemes
-        # depending on version:
-        #   - <name>_DeepFilterNet3.wav
-        #   - <name>_DeepFilterNet2.wav
-        #   - <name>.wav (same name)
-        stem = input_file.stem
-        candidates = sorted(df_output_dir.glob(f"{stem}*.wav"))
-
-        if not candidates:
-            # Fallback: just grab any wav in the output dir.
-            candidates = sorted(df_output_dir.glob("*.wav"))
-
-        if not candidates:
-            raise FileNotFoundError(
-                f"DeepFilterNet produced no output in {df_output_dir}. "
-                f"Contents: {list(df_output_dir.iterdir())}"
-            )
-
-        # Use the first match (there should be exactly one).
-        shutil.move(str(candidates[0]), str(output_file))
 
     def _apply_audio_filters(self, input_file: Path, output_file: Path) -> None:
         """Apply highpass, compression, and two-pass loudness normalization."""

--- a/src/clm/recordings/processing/pipeline.py
+++ b/src/clm/recordings/processing/pipeline.py
@@ -1,0 +1,390 @@
+"""Cross-platform video post-processing pipeline.
+
+The processing steps are:
+1. Extract audio from the recording (FFmpeg)
+2. Run DeepFilterNet noise reduction
+3. Apply FFmpeg audio filters (highpass, compressor, loudness normalization)
+4. Encode cleaned audio to AAC
+5. Mux processed audio back into the original video
+
+All intermediate files are written to a temp directory and cleaned up
+on completion (unless keep_temp is set).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from loguru import logger
+from pydantic import BaseModel
+
+from .config import PipelineConfig
+from .utils import (
+    find_deepfilter,
+    find_ffmpeg,
+    find_ffprobe,
+    get_audio_duration,
+    run_subprocess,
+)
+
+
+class ProcessingResult(BaseModel):
+    """Result of processing a single recording."""
+
+    input_file: Path
+    output_file: Path
+    success: bool
+    duration_seconds: float = 0.0
+    error: str | None = None
+
+
+class ProcessingPipeline:
+    """Video post-processing pipeline.
+
+    Usage:
+        pipeline = ProcessingPipeline()
+        result = pipeline.process(
+            input_file=Path("raw_recording.mkv"),
+            output_file=Path("final_lecture.mp4"),
+        )
+    """
+
+    def __init__(self, config: PipelineConfig | None = None) -> None:
+        self.config = config or PipelineConfig()
+
+        # Locate binaries once at init. Raises BinaryNotFoundError if missing.
+        self.ffmpeg = find_ffmpeg()
+        self.ffprobe = find_ffprobe()
+        self.deepfilter = find_deepfilter()
+
+        logger.info("FFmpeg:      {}", self.ffmpeg)
+        logger.info("FFprobe:     {}", self.ffprobe)
+        logger.info("DeepFilter:  {}", self.deepfilter)
+
+    def process(
+        self,
+        input_file: Path,
+        output_file: Path,
+        *,
+        on_step: Callable[[int, str, int], None] | None = None,
+    ) -> ProcessingResult:
+        """Process a single recording through the full pipeline.
+
+        Args:
+            input_file: Path to the raw recording.
+            output_file: Path for the final output.
+            on_step: Optional callback called with (step_number, step_name, total_steps)
+                     for progress reporting.
+
+        Returns:
+            ProcessingResult with success status and details.
+        """
+        input_file = Path(input_file).resolve()
+        output_file = Path(output_file).resolve()
+
+        if not input_file.is_file():
+            return ProcessingResult(
+                input_file=input_file,
+                output_file=output_file,
+                success=False,
+                error=f"Input file not found: {input_file}",
+            )
+
+        # Ensure output directory exists.
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        total_steps = 5
+        notify = on_step or (lambda step, name, total: None)
+
+        temp_dir = Path(tempfile.mkdtemp(prefix="clm_recording_"))
+        try:
+            audio_raw = temp_dir / "audio_raw.wav"
+            audio_cleaned = temp_dir / "audio_cleaned.wav"
+            audio_processed = temp_dir / "audio_processed.wav"
+            audio_final = temp_dir / "audio_final.aac"
+
+            # Step 1: Extract audio
+            notify(1, "Extracting audio", total_steps)
+            self._extract_audio(input_file, audio_raw)
+            duration = get_audio_duration(self.ffprobe, audio_raw)
+            logger.info("Audio extracted ({:.0f}s)", duration)
+
+            # Step 2: DeepFilterNet noise reduction
+            notify(2, "Noise reduction (DeepFilterNet)", total_steps)
+            self._run_deepfilter(audio_raw, audio_cleaned, temp_dir)
+            logger.info("Noise reduction complete")
+
+            # Step 3: FFmpeg audio filters
+            notify(3, "Audio filters (highpass, compressor, loudnorm)", total_steps)
+            self._apply_audio_filters(audio_cleaned, audio_processed)
+            logger.info("Audio filters applied")
+
+            # Step 4: Encode to AAC
+            notify(4, "Encoding audio", total_steps)
+            self._encode_audio(audio_processed, audio_final)
+            logger.info("Audio encoded")
+
+            # Step 5: Mux video + cleaned audio
+            notify(5, "Muxing final video", total_steps)
+            self._mux_video(input_file, audio_final, output_file)
+            logger.info("Muxing complete: {}", output_file)
+
+            return ProcessingResult(
+                input_file=input_file,
+                output_file=output_file,
+                success=True,
+                duration_seconds=duration,
+            )
+
+        except Exception as e:
+            logger.error("Processing failed: {}", e)
+            return ProcessingResult(
+                input_file=input_file,
+                output_file=output_file,
+                success=False,
+                error=str(e),
+            )
+
+        finally:
+            if not self.config.keep_temp:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+                logger.debug("Cleaned up temp dir: {}", temp_dir)
+            else:
+                logger.info("Temp files kept at: {}", temp_dir)
+
+    def _extract_audio(self, input_file: Path, output: Path) -> None:
+        """Extract audio as mono 16-bit WAV."""
+        run_subprocess(
+            [
+                self.ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-y",
+                "-i",
+                input_file,
+                "-vn",
+                "-acodec",
+                "pcm_s16le",
+                "-ar",
+                str(self.config.sample_rate),
+                "-ac",
+                "1",
+                output,
+            ]
+        )
+
+    def _run_deepfilter(self, input_file: Path, output_file: Path, temp_dir: Path) -> None:
+        """Run DeepFilterNet noise reduction.
+
+        DeepFilterNet writes output files to --output-dir with a suffix
+        or the same name. We handle the various naming conventions across
+        versions.
+        """
+        df_output_dir = temp_dir / "df_output"
+        df_output_dir.mkdir(exist_ok=True)
+
+        run_subprocess(
+            [
+                self.deepfilter,
+                input_file,
+                "--output-dir",
+                df_output_dir,
+                "--atten-lim",
+                str(self.config.deepfilter_atten_lim),
+            ]
+        )
+
+        # Find the output file. DeepFilterNet uses various naming schemes
+        # depending on version:
+        #   - <name>_DeepFilterNet3.wav
+        #   - <name>_DeepFilterNet2.wav
+        #   - <name>.wav (same name)
+        stem = input_file.stem
+        candidates = sorted(df_output_dir.glob(f"{stem}*.wav"))
+
+        if not candidates:
+            # Fallback: just grab any wav in the output dir.
+            candidates = sorted(df_output_dir.glob("*.wav"))
+
+        if not candidates:
+            raise FileNotFoundError(
+                f"DeepFilterNet produced no output in {df_output_dir}. "
+                f"Contents: {list(df_output_dir.iterdir())}"
+            )
+
+        # Use the first match (there should be exactly one).
+        shutil.move(str(candidates[0]), str(output_file))
+
+    def _apply_audio_filters(self, input_file: Path, output_file: Path) -> None:
+        """Apply highpass, compression, and two-pass loudness normalization."""
+        cfg = self.config.audio_filters
+
+        base_filters = f"highpass=f={cfg.highpass_freq},{cfg.compressor_filter}"
+
+        # Pass 1: Measure loudness.
+        measured = self._measure_loudness(input_file, base_filters)
+
+        # Pass 2: Apply filters with measured values (or single-pass fallback).
+        if measured:
+            loudnorm = (
+                f"loudnorm=I={cfg.loudnorm_target}"
+                f":TP={cfg.loudnorm_true_peak}"
+                f":LRA={cfg.loudnorm_lra}"
+                f":measured_I={measured['input_i']}"
+                f":measured_TP={measured['input_tp']}"
+                f":measured_LRA={measured['input_lra']}"
+                f":measured_thresh={measured['input_thresh']}"
+                f":linear=true"
+            )
+            logger.info(
+                "Measured loudness: I={} LUFS, TP={} dBTP, LRA={}",
+                measured["input_i"],
+                measured["input_tp"],
+                measured["input_lra"],
+            )
+        else:
+            logger.warning("Could not parse loudnorm measurements; using single-pass.")
+            loudnorm = cfg.loudnorm_filter
+
+        full_filter = f"{base_filters},{loudnorm}"
+
+        run_subprocess(
+            [
+                self.ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-y",
+                "-i",
+                input_file,
+                "-af",
+                full_filter,
+                "-ar",
+                str(self.config.sample_rate),
+                output_file,
+            ]
+        )
+
+    def _measure_loudness(self, input_file: Path, base_filters: str) -> dict[str, str] | None:
+        """Run FFmpeg loudnorm first pass to measure loudness values.
+
+        Returns a dict with measured values, or None if parsing fails.
+        """
+        cfg = self.config.audio_filters
+        measure_filter = (
+            f"{base_filters},"
+            f"loudnorm=I={cfg.loudnorm_target}"
+            f":TP={cfg.loudnorm_true_peak}"
+            f":LRA={cfg.loudnorm_lra}"
+            f":print_format=json"
+        )
+
+        # loudnorm prints its JSON to stderr.
+        import sys
+
+        result = run_subprocess(
+            [
+                self.ffmpeg,
+                "-hide_banner",
+                "-y",
+                "-i",
+                input_file,
+                "-af",
+                measure_filter,
+                "-f",
+                "null",
+                # Cross-platform null device
+                "NUL" if sys.platform == "win32" else "/dev/null",
+            ],
+            check=False,
+        )
+
+        # Parse the JSON block from stderr. FFmpeg outputs it at the end
+        # of the loudnorm filter output.
+        stderr = result.stdout + "\n" + result.stderr
+        return self._parse_loudnorm_json(stderr)
+
+    @staticmethod
+    def _parse_loudnorm_json(output: str) -> dict[str, str] | None:
+        """Extract loudnorm measurement values from FFmpeg output.
+
+        FFmpeg prints a JSON block like:
+        {
+            "input_i" : "-24.50",
+            "input_tp" : "-3.20",
+            "input_lra" : "8.10",
+            "input_thresh" : "-35.00",
+            ...
+        }
+        """
+        json_match = re.search(
+            r'\{[^{}]*"input_i"\s*:\s*"[^"]*"[^{}]*\}',
+            output,
+            re.DOTALL,
+        )
+        if not json_match:
+            return None
+
+        try:
+            data = json.loads(json_match.group())
+        except json.JSONDecodeError:
+            return None
+
+        required = ["input_i", "input_tp", "input_lra", "input_thresh"]
+        if all(k in data for k in required):
+            return {k: data[k] for k in required}
+        return None
+
+    def _encode_audio(self, input_file: Path, output_file: Path) -> None:
+        """Encode processed audio to AAC."""
+        run_subprocess(
+            [
+                self.ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-y",
+                "-i",
+                input_file,
+                "-c:a",
+                "aac",
+                "-b:a",
+                self.config.audio_bitrate,
+                "-ar",
+                str(self.config.sample_rate),
+                output_file,
+            ]
+        )
+
+    def _mux_video(self, video_source: Path, audio_source: Path, output: Path) -> None:
+        """Mux original video with processed audio."""
+        run_subprocess(
+            [
+                self.ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-y",
+                "-i",
+                video_source,
+                "-i",
+                audio_source,
+                "-c:v",
+                self.config.video_codec,
+                "-c:a",
+                "copy",
+                "-map",
+                "0:v:0",
+                "-map",
+                "1:a:0",
+                "-movflags",
+                "+faststart",
+                output,
+            ]
+        )

--- a/src/clm/recordings/processing/utils.py
+++ b/src/clm/recordings/processing/utils.py
@@ -5,10 +5,24 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import urllib.request
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
+
+# DeepFilterNet3 streaming ONNX model from yuyun2000/SpeechDenoiser.
+# Originally exported via grazder/DeepFilterNet (torchDF-changes branch).
+ONNX_MODEL_URL = (
+    "https://github.com/yuyun2000/SpeechDenoiser/raw/refs/heads/main/48k/denoiser_model.onnx"
+)
+ONNX_MODEL_FILENAME = "deepfilter3_streaming.onnx"
+ONNX_MODEL_CACHE_DIR = "clm"
+
+# ONNX model constants
+ONNX_HOP_SIZE = 480  # samples per frame at 48 kHz (10 ms)
+ONNX_FFT_SIZE = 960
+ONNX_STATE_SIZE = 45304
 
 
 class BinaryNotFoundError(Exception):
@@ -74,43 +88,119 @@ def find_ffprobe() -> Path:
         raise BinaryNotFoundError("ffprobe", "Installed alongside ffmpeg") from None
 
 
-def find_deepfilter() -> Path:
-    """Find the DeepFilterNet CLI binary.
+def download_onnx_model(cache_dir: Path | None = None) -> Path:
+    """Download the DeepFilterNet3 ONNX model if not already cached.
 
-    The binary name varies by platform and installation method:
-    - pip install: 'deepFilter' (case-sensitive on Linux)
-    - Some versions: 'deep-filter' or 'deepfilter'
+    Returns the path to the cached model file.
     """
-    names_to_try = ["deepFilter", "deep-filter", "deepfilter"]
-    for name in names_to_try:
-        try:
-            return find_binary(name)
-        except BinaryNotFoundError:
-            continue
+    if cache_dir is None:
+        import platformdirs
 
-    raise BinaryNotFoundError(
-        "deepFilter",
-        "pip install deepfilternet",
-    )
+        cache_dir = Path(platformdirs.user_cache_dir(ONNX_MODEL_CACHE_DIR)) / "models"
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    model_path = cache_dir / ONNX_MODEL_FILENAME
+
+    if model_path.exists():
+        logger.debug("ONNX model cached at {}", model_path)
+        return model_path
+
+    logger.info("Downloading DeepFilterNet3 ONNX model...")
+    urllib.request.urlretrieve(ONNX_MODEL_URL, model_path)
+    logger.info("Model saved to {}", model_path)
+    return model_path
 
 
-def check_dependencies() -> dict[str, Path | None]:
-    """Check all required dependencies and return their paths.
+def check_onnxruntime() -> str | None:
+    """Check that onnxruntime is importable. Returns version or None."""
+    try:
+        import onnxruntime as ort
 
-    Returns a dict mapping tool name to path (or None if not found).
+        return str(ort.__version__)
+    except ImportError:
+        return None
+
+
+def run_onnx_denoise(input_file: Path, output_file: Path, *, atten_lim_db: float = 35.0) -> None:
+    """Run DeepFilterNet3 noise reduction via ONNX Runtime.
+
+    Processes the input WAV file frame-by-frame through the streaming ONNX
+    model and writes the enhanced audio to output_file.
+
+    Args:
+        input_file: Path to input WAV (mono, 48 kHz expected).
+        output_file: Path for the denoised output WAV.
+        atten_lim_db: Attenuation limit in dB (0 = unlimited, 35 = moderate).
     """
-    deps: dict[str, Path | None] = {}
+    import numpy as np
+    import onnxruntime as ort
+    import soundfile as sf
+
+    model_path = download_onnx_model()
+    session = ort.InferenceSession(str(model_path))
+
+    audio, sr = sf.read(str(input_file), dtype="float32")
+    if sr != 48000:
+        raise ValueError(f"Expected 48 kHz audio, got {sr} Hz")
+
+    # Handle stereo by taking first channel
+    if audio.ndim > 1:
+        audio = audio[:, 0]
+
+    orig_len = len(audio)
+
+    # Pad to hop_size boundary
+    pad_len = (ONNX_HOP_SIZE - (orig_len % ONNX_HOP_SIZE)) % ONNX_HOP_SIZE
+    if pad_len > 0:
+        audio = np.concatenate([audio, np.zeros(pad_len, dtype=np.float32)])
+
+    # Initialize state
+    state = np.zeros(ONNX_STATE_SIZE, dtype=np.float32)
+    atten = np.array([atten_lim_db], dtype=np.float32)
+
+    # Process frame by frame
+    num_frames = len(audio) // ONNX_HOP_SIZE
+    output_frames = []
+
+    for i in range(num_frames):
+        frame = audio[i * ONNX_HOP_SIZE : (i + 1) * ONNX_HOP_SIZE]
+        enhanced_frame, state, _lsnr = session.run(
+            None,
+            {
+                "input_frame": frame,
+                "states": state,
+                "atten_lim_db": atten,
+            },
+        )
+        output_frames.append(enhanced_frame)
+
+    output = np.concatenate(output_frames)
+
+    # Trim algorithmic delay and restore original length
+    delay = ONNX_FFT_SIZE - ONNX_HOP_SIZE
+    output = output[delay : orig_len + delay]
+
+    sf.write(str(output_file), output, sr, subtype="FLOAT")
+
+
+def check_dependencies() -> dict[str, str | Path | None]:
+    """Check all required dependencies and return their status.
+
+    Returns a dict mapping tool name to path/version (or None if not found).
+    """
+    deps: dict[str, str | Path | None] = {}
 
     for name, finder in [
         ("ffmpeg", find_ffmpeg),
         ("ffprobe", find_ffprobe),
-        ("deepFilter", find_deepfilter),
     ]:
         try:
             deps[name] = finder()
         except BinaryNotFoundError as e:
             logger.warning(str(e))
             deps[name] = None
+
+    deps["onnxruntime"] = check_onnxruntime()
 
     return deps
 

--- a/src/clm/recordings/processing/utils.py
+++ b/src/clm/recordings/processing/utils.py
@@ -1,0 +1,182 @@
+"""Cross-platform utility functions for finding binaries and running subprocesses."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+class BinaryNotFoundError(Exception):
+    """Raised when a required external binary is not found."""
+
+    def __init__(self, name: str, install_hint: str = "") -> None:
+        msg = f"Required binary not found: {name}"
+        if install_hint:
+            msg += f"\n  Install: {install_hint}"
+        super().__init__(msg)
+        self.name = name
+
+
+def find_binary(name: str) -> Path:
+    """Find a binary on PATH, returning its full path.
+
+    On Windows, also checks for common pip script locations if the binary
+    isn't on PATH directly.
+    """
+    found = shutil.which(name)
+    if found:
+        return Path(found)
+
+    # On Windows, pip-installed scripts may be in the user scripts dir
+    # and not on PATH.
+    if sys.platform == "win32":
+        candidates = [
+            Path(sys.prefix) / "Scripts" / f"{name}.exe",
+            Path(sys.prefix) / "Scripts" / name,
+            Path.home()
+            / "AppData"
+            / "Local"
+            / "Programs"
+            / "Python"
+            / f"Python{sys.version_info.major}{sys.version_info.minor}"
+            / "Scripts"
+            / f"{name}.exe",
+        ]
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate
+
+    raise BinaryNotFoundError(name)
+
+
+def find_ffmpeg() -> Path:
+    """Find ffmpeg binary."""
+    try:
+        return find_binary("ffmpeg")
+    except BinaryNotFoundError:
+        if sys.platform == "win32":
+            hint = "Download from https://ffmpeg.org/download.html or: winget install FFmpeg"
+        else:
+            hint = "pacman -S ffmpeg (Arch) or apt install ffmpeg (Debian/Ubuntu)"
+        raise BinaryNotFoundError("ffmpeg", hint) from None
+
+
+def find_ffprobe() -> Path:
+    """Find ffprobe binary."""
+    try:
+        return find_binary("ffprobe")
+    except BinaryNotFoundError:
+        raise BinaryNotFoundError("ffprobe", "Installed alongside ffmpeg") from None
+
+
+def find_deepfilter() -> Path:
+    """Find the DeepFilterNet CLI binary.
+
+    The binary name varies by platform and installation method:
+    - pip install: 'deepFilter' (case-sensitive on Linux)
+    - Some versions: 'deep-filter' or 'deepfilter'
+    """
+    names_to_try = ["deepFilter", "deep-filter", "deepfilter"]
+    for name in names_to_try:
+        try:
+            return find_binary(name)
+        except BinaryNotFoundError:
+            continue
+
+    raise BinaryNotFoundError(
+        "deepFilter",
+        "pip install deepfilternet",
+    )
+
+
+def check_dependencies() -> dict[str, Path | None]:
+    """Check all required dependencies and return their paths.
+
+    Returns a dict mapping tool name to path (or None if not found).
+    """
+    deps: dict[str, Path | None] = {}
+
+    for name, finder in [
+        ("ffmpeg", find_ffmpeg),
+        ("ffprobe", find_ffprobe),
+        ("deepFilter", find_deepfilter),
+    ]:
+        try:
+            deps[name] = finder()
+        except BinaryNotFoundError as e:
+            logger.warning(str(e))
+            deps[name] = None
+
+    return deps
+
+
+def run_subprocess(
+    args: list[str | Path],
+    *,
+    check: bool = True,
+    capture_output: bool = True,
+    cwd: Path | None = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess with consistent settings across platforms.
+
+    On Windows, suppresses console window popups via CREATE_NO_WINDOW.
+
+    Args:
+        args: Command and arguments.
+        check: Raise CalledProcessError on non-zero exit.
+        capture_output: Capture stdout and stderr.
+        cwd: Working directory.
+
+    Returns:
+        CompletedProcess with text output.
+    """
+    str_args = [str(a) for a in args]
+    logger.debug("Running: {}", " ".join(str_args))
+
+    extra_kwargs: dict[str, Any] = {}
+    if sys.platform == "win32":
+        CREATE_NO_WINDOW = 0x08000000
+        extra_kwargs["creationflags"] = CREATE_NO_WINDOW
+
+    result = subprocess.run(
+        str_args,
+        check=check,
+        capture_output=capture_output,
+        text=True,
+        cwd=cwd,
+        **extra_kwargs,
+        **kwargs,
+    )
+
+    if result.returncode != 0 and not check:
+        logger.warning(
+            "Command exited with {}: {}\nstderr: {}",
+            result.returncode,
+            " ".join(str_args),
+            result.stderr,
+        )
+
+    return result
+
+
+def get_audio_duration(ffprobe: Path, audio_file: Path) -> float:
+    """Get audio duration in seconds using ffprobe."""
+    result = run_subprocess(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(audio_file),
+        ]
+    )
+    return float(result.stdout.strip())

--- a/src/clm/recordings/state.py
+++ b/src/clm/recordings/state.py
@@ -1,0 +1,255 @@
+"""Per-course recording state manager.
+
+Manages JSON state files that track which recordings belong to which
+lectures in a course. Each course has its own state file stored under
+the CLM config directory.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+import platformdirs
+from loguru import logger
+from pydantic import BaseModel, Field
+
+RecordingStatus = Literal["pending", "processing", "processed", "failed"]
+
+
+class RecordingPart(BaseModel):
+    """A single recording part for a lecture."""
+
+    part: int
+    raw_file: str
+    processed_file: str | None = None
+    git_commit: str | None = None
+    git_dirty: bool = False
+    recorded_at: str = ""
+    status: RecordingStatus = "pending"
+
+
+class LectureState(BaseModel):
+    """Recording state for a single lecture."""
+
+    lecture_id: str
+    display_name: str
+    parts: list[RecordingPart] = Field(default_factory=list)
+
+    @property
+    def is_recorded(self) -> bool:
+        return len(self.parts) > 0
+
+    @property
+    def latest_status(self) -> RecordingStatus | None:
+        if not self.parts:
+            return None
+        return self.parts[-1].status
+
+
+class CourseRecordingState(BaseModel):
+    """Complete recording state for a course."""
+
+    course_id: str
+    lectures: list[LectureState] = Field(default_factory=list)
+    next_lecture_index: int = 0
+    continue_current_lecture: bool = False
+
+    def save(self, path: Path) -> None:
+        """Save state to a JSON file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        logger.debug("Saved recording state to {}", path)
+
+    @classmethod
+    def load(cls, path: Path) -> CourseRecordingState:
+        """Load state from a JSON file."""
+        return cls.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def get_lecture(self, lecture_id: str) -> LectureState | None:
+        """Find a lecture by ID."""
+        for lecture in self.lectures:
+            if lecture.lecture_id == lecture_id:
+                return lecture
+        return None
+
+    def get_next_lecture(self) -> LectureState | None:
+        """Get the next lecture to record based on next_lecture_index."""
+        if self.next_lecture_index < len(self.lectures):
+            return self.lectures[self.next_lecture_index]
+        return None
+
+    def get_current_lecture(self) -> LectureState | None:
+        """Get the current lecture (the one being recorded, i.e. index - 1)."""
+        idx = self.next_lecture_index - 1
+        if 0 <= idx < len(self.lectures):
+            return self.lectures[idx]
+        return None
+
+    def assign_recording(
+        self,
+        raw_file: str,
+        *,
+        lecture_id: str | None = None,
+        git_commit: str | None = None,
+        git_dirty: bool = False,
+    ) -> tuple[str, int]:
+        """Assign a raw recording file to a lecture.
+
+        If lecture_id is given, assigns to that specific lecture.
+        Otherwise, uses continue_current_lecture and next_lecture_index
+        to determine assignment automatically.
+
+        Returns:
+            Tuple of (lecture_id, part_number) for the assignment.
+
+        Raises:
+            ValueError: If no lecture is available for assignment.
+        """
+        if lecture_id:
+            lecture = self.get_lecture(lecture_id)
+            if not lecture:
+                raise ValueError(f"Lecture not found: {lecture_id}")
+        elif self.continue_current_lecture:
+            lecture = self.get_current_lecture()
+            if not lecture:
+                raise ValueError("No current lecture to continue")
+        else:
+            lecture = self.get_next_lecture()
+            if not lecture:
+                raise ValueError("No more lectures to record")
+            # Advance to next lecture for the next recording.
+            self.next_lecture_index += 1
+
+        part_number = len(lecture.parts) + 1
+        part = RecordingPart(
+            part=part_number,
+            raw_file=raw_file,
+            git_commit=git_commit,
+            git_dirty=git_dirty,
+            recorded_at=datetime.now().isoformat(timespec="seconds"),
+        )
+        lecture.parts.append(part)
+
+        logger.info(
+            "Assigned {} to {} part {}",
+            Path(raw_file).name,
+            lecture.lecture_id,
+            part_number,
+        )
+        return lecture.lecture_id, part_number
+
+    def reassign_recording(
+        self,
+        raw_file: str,
+        target_lecture_id: str,
+    ) -> tuple[str, int]:
+        """Move a recording from its current lecture to a different one.
+
+        Args:
+            raw_file: The raw file path to find and move.
+            target_lecture_id: The lecture to move the recording to.
+
+        Returns:
+            Tuple of (new_lecture_id, new_part_number).
+
+        Raises:
+            ValueError: If the recording or target lecture is not found.
+        """
+        # Find and remove from current lecture.
+        source_part: RecordingPart | None = None
+        for lecture in self.lectures:
+            for part in lecture.parts:
+                if part.raw_file == raw_file:
+                    source_part = part
+                    lecture.parts.remove(part)
+                    logger.debug(
+                        "Removed {} from {}",
+                        Path(raw_file).name,
+                        lecture.lecture_id,
+                    )
+                    break
+            if source_part:
+                break
+
+        if not source_part:
+            raise ValueError(f"Recording not found: {raw_file}")
+
+        # Add to target lecture.
+        target = self.get_lecture(target_lecture_id)
+        if not target:
+            raise ValueError(f"Target lecture not found: {target_lecture_id}")
+
+        new_part_number = len(target.parts) + 1
+        source_part.part = new_part_number
+        target.parts.append(source_part)
+
+        logger.info(
+            "Reassigned {} to {} part {}",
+            Path(raw_file).name,
+            target_lecture_id,
+            new_part_number,
+        )
+        return target_lecture_id, new_part_number
+
+    def update_recording_status(
+        self,
+        raw_file: str,
+        status: RecordingStatus,
+        *,
+        processed_file: str | None = None,
+    ) -> None:
+        """Update the status of a recording part.
+
+        Args:
+            raw_file: The raw file path to identify the recording.
+            status: New status value.
+            processed_file: Path to processed output (set when status='processed').
+
+        Raises:
+            ValueError: If the recording is not found.
+        """
+        for lecture in self.lectures:
+            for part in lecture.parts:
+                if part.raw_file == raw_file:
+                    part.status = status
+                    if processed_file is not None:
+                        part.processed_file = processed_file
+                    logger.debug("Updated {} status to {}", Path(raw_file).name, status)
+                    return
+
+        raise ValueError(f"Recording not found: {raw_file}")
+
+    @property
+    def progress(self) -> tuple[int, int]:
+        """Return (recorded_count, total_count) for progress tracking."""
+        total = len(self.lectures)
+        recorded = sum(1 for lec in self.lectures if lec.is_recorded)
+        return recorded, total
+
+
+def get_recordings_dir() -> Path:
+    """Get the recordings state directory under CLM's config dir."""
+    config_dir = Path(platformdirs.user_config_dir("clm", appauthor=False))
+    return config_dir / "recordings"
+
+
+def get_state_path(course_id: str) -> Path:
+    """Get the path to a course's recording state file."""
+    return get_recordings_dir() / f"{course_id}.json"
+
+
+def load_state(course_id: str) -> CourseRecordingState | None:
+    """Load a course's recording state, or None if it doesn't exist."""
+    path = get_state_path(course_id)
+    if not path.is_file():
+        return None
+    return CourseRecordingState.load(path)
+
+
+def save_state(state: CourseRecordingState) -> Path:
+    """Save a course's recording state and return the file path."""
+    path = get_state_path(state.course_id)
+    state.save(path)
+    return path

--- a/src/clm/recordings/web/__init__.py
+++ b/src/clm/recordings/web/__init__.py
@@ -1,0 +1,1 @@
+"""Recordings web UI: HTMX-based dashboard for the recording workflow."""

--- a/src/clm/recordings/web/app.py
+++ b/src/clm/recordings/web/app.py
@@ -1,0 +1,117 @@
+"""FastAPI application for the recordings workflow dashboard.
+
+This is a **separate** app from the main ``clm serve`` dashboard.
+It provides an HTMX-based UI for arming topics, monitoring OBS recording
+state, and viewing pending/finished recordings.
+
+Launch with ``clm recordings serve``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from loguru import logger
+
+from clm.__version__ import __version__
+
+from .routes import router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Application lifespan: connect to OBS on startup, disconnect on shutdown."""
+    obs = getattr(app.state, "obs", None)
+
+    if obs is not None:
+        try:
+            obs.connect()
+            logger.info("Connected to OBS on startup")
+        except Exception as exc:
+            logger.warning("Could not connect to OBS on startup: {}", exc)
+
+    yield
+
+    if obs is not None:
+        obs.disconnect()
+
+
+def create_app(
+    recordings_root: Path,
+    *,
+    obs_host: str = "localhost",
+    obs_port: int = 4455,
+    obs_password: str = "",
+    spec_file: Path | None = None,
+    raw_suffix: str = "--RAW",
+) -> FastAPI:
+    """Create the recordings dashboard FastAPI application.
+
+    Args:
+        recordings_root: Root directory (``to-process/``, ``final/``, ``archive/``).
+        obs_host: OBS WebSocket host.
+        obs_port: OBS WebSocket port.
+        obs_password: OBS WebSocket password.
+        spec_file: Optional CLM course spec XML file for lecture listing.
+        raw_suffix: Raw filename suffix (default ``--RAW``).
+    """
+    from clm.recordings.workflow.directories import ensure_root
+    from clm.recordings.workflow.obs import ObsClient
+    from clm.recordings.workflow.session import RecordingSession
+
+    app = FastAPI(
+        title="CLM Recordings Dashboard",
+        version=__version__,
+        lifespan=lifespan,
+    )
+
+    # Ensure directory structure
+    ensure_root(recordings_root)
+
+    # OBS client and session manager
+    obs = ObsClient(host=obs_host, port=obs_port, password=obs_password)
+
+    # SSE event queue — session state changes are pushed here
+    sse_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=256)
+
+    def on_state_change(snapshot: object) -> None:
+        """Push state change into the SSE queue (called from OBS thread)."""
+        try:
+            sse_queue.put_nowait("state_changed")
+        except asyncio.QueueFull:
+            pass  # Drop oldest-style: consumer will get the next one
+
+    session = RecordingSession(
+        obs,
+        recordings_root,
+        raw_suffix=raw_suffix,
+        on_state_change=on_state_change,
+    )
+
+    # Store in app state for route handlers
+    app.state.recordings_root = recordings_root
+    app.state.raw_suffix = raw_suffix
+    app.state.obs = obs
+    app.state.session = session
+    app.state.sse_queue = sse_queue
+    app.state.spec_file = spec_file
+
+    # Templates and static files
+    templates_dir = Path(__file__).parent / "templates"
+    static_dir = Path(__file__).parent / "static"
+
+    app.state.templates = Jinja2Templates(directory=str(templates_dir))
+
+    if static_dir.is_dir():
+        app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    # Include routes
+    app.include_router(router)
+
+    return app

--- a/src/clm/recordings/web/app.py
+++ b/src/clm/recordings/web/app.py
@@ -2,7 +2,7 @@
 
 This is a **separate** app from the main ``clm serve`` dashboard.
 It provides an HTMX-based UI for arming topics, monitoring OBS recording
-state, and viewing pending/finished recordings.
+state, viewing pending/finished recordings, and managing the file watcher.
 
 Launch with ``clm recordings serve``.
 """
@@ -28,6 +28,7 @@ from .routes import router
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Application lifespan: connect to OBS on startup, disconnect on shutdown."""
     obs = getattr(app.state, "obs", None)
+    watcher = getattr(app.state, "watcher", None)
 
     if obs is not None:
         try:
@@ -37,6 +38,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             logger.warning("Could not connect to OBS on startup: {}", exc)
 
     yield
+
+    if watcher is not None:
+        watcher.stop()
 
     if obs is not None:
         obs.disconnect()
@@ -50,6 +54,9 @@ def create_app(
     obs_password: str = "",
     spec_file: Path | None = None,
     raw_suffix: str = "--RAW",
+    processing_backend: str = "external",
+    stability_check_interval: float = 2.0,
+    stability_check_count: int = 3,
 ) -> FastAPI:
     """Create the recordings dashboard FastAPI application.
 
@@ -60,10 +67,14 @@ def create_app(
         obs_password: OBS WebSocket password.
         spec_file: Optional CLM course spec XML file for lecture listing.
         raw_suffix: Raw filename suffix (default ``--RAW``).
+        processing_backend: ``"external"`` or ``"onnx"``.
+        stability_check_interval: Seconds between file-size polls.
+        stability_check_count: Consecutive identical polls = stable.
     """
     from clm.recordings.workflow.directories import ensure_root
     from clm.recordings.workflow.obs import ObsClient
     from clm.recordings.workflow.session import RecordingSession
+    from clm.recordings.workflow.watcher import RecordingsWatcher
 
     app = FastAPI(
         title="CLM Recordings Dashboard",
@@ -77,15 +88,18 @@ def create_app(
     # OBS client and session manager
     obs = ObsClient(host=obs_host, port=obs_port, password=obs_password)
 
-    # SSE event queue — session state changes are pushed here
+    # SSE event queue — session and watcher events are pushed here
     sse_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=256)
+
+    def _push_sse(event: str) -> None:
+        try:
+            sse_queue.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
 
     def on_state_change(snapshot: object) -> None:
         """Push state change into the SSE queue (called from OBS thread)."""
-        try:
-            sse_queue.put_nowait("state_changed")
-        except asyncio.QueueFull:
-            pass  # Drop oldest-style: consumer will get the next one
+        _push_sse("state_changed")
 
     session = RecordingSession(
         obs,
@@ -94,11 +108,24 @@ def create_app(
         on_state_change=on_state_change,
     )
 
+    # File watcher
+    watcher = RecordingsWatcher(
+        recordings_root,
+        backend=processing_backend,
+        raw_suffix=raw_suffix,
+        stability_interval=stability_check_interval,
+        stability_checks=stability_check_count,
+        on_assembled=lambda result: _push_sse("assembled"),
+        on_processing=lambda path: _push_sse("processing"),
+        on_error=lambda path, err: _push_sse("watcher_error"),
+    )
+
     # Store in app state for route handlers
     app.state.recordings_root = recordings_root
     app.state.raw_suffix = raw_suffix
     app.state.obs = obs
     app.state.session = session
+    app.state.watcher = watcher
     app.state.sse_queue = sse_queue
     app.state.spec_file = spec_file
 

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -8,6 +8,8 @@ Provides:
 - ``GET /status`` — JSON session status snapshot
 - ``GET /events`` — SSE stream for real-time updates
 - ``GET /pairs`` — Pending pairs list (HTMX partial)
+- ``POST /watcher/start`` — Start the file watcher
+- ``POST /watcher/stop`` — Stop the file watcher
 """
 
 from __future__ import annotations
@@ -20,12 +22,17 @@ from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from loguru import logger
 
 from clm.recordings.workflow.session import RecordingSession, SessionSnapshot
+from clm.recordings.workflow.watcher import RecordingsWatcher
 
 router = APIRouter()
 
 
 def _get_session(request: Request) -> RecordingSession:
     return cast(RecordingSession, request.app.state.session)
+
+
+def _get_watcher(request: Request) -> RecordingsWatcher:
+    return cast(RecordingsWatcher, request.app.state.watcher)
 
 
 def _get_templates(request: Request):
@@ -42,6 +49,7 @@ async def dashboard(request: Request):
     """Render the main dashboard page."""
     templates = _get_templates(request)
     session = _get_session(request)
+    watcher = _get_watcher(request)
     snap = session.snapshot()
     pairs = _get_pending_pairs(request)
 
@@ -51,6 +59,8 @@ async def dashboard(request: Request):
         {
             "snapshot": snap,
             "pairs": pairs,
+            "watcher_running": watcher.running,
+            "watcher_mode": watcher.mode,
         },
     )
 
@@ -144,6 +154,27 @@ async def disarm(request: Request):
 
 
 # ------------------------------------------------------------------
+# Watcher
+# ------------------------------------------------------------------
+
+
+@router.post("/watcher/start", response_class=HTMLResponse)
+async def watcher_start(request: Request):
+    """Start the file watcher."""
+    watcher = _get_watcher(request)
+    watcher.start()
+    return await status_partial(request)
+
+
+@router.post("/watcher/stop", response_class=HTMLResponse)
+async def watcher_stop(request: Request):
+    """Stop the file watcher."""
+    watcher = _get_watcher(request)
+    watcher.stop()
+    return await status_partial(request)
+
+
+# ------------------------------------------------------------------
 # Status
 # ------------------------------------------------------------------
 
@@ -161,6 +192,7 @@ async def status_partial(request: Request):
     """Return the status panel as an HTMX partial."""
     templates = _get_templates(request)
     session = _get_session(request)
+    watcher = _get_watcher(request)
     snap = session.snapshot()
     pairs = _get_pending_pairs(request)
 
@@ -170,6 +202,8 @@ async def status_partial(request: Request):
         {
             "snapshot": snap,
             "pairs": pairs,
+            "watcher_running": watcher.running,
+            "watcher_mode": watcher.mode,
         },
     )
 

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -1,0 +1,260 @@
+"""Route handlers for the recordings dashboard.
+
+Provides:
+- ``GET /`` — Dashboard page (Jinja2 template)
+- ``GET /lectures`` — Lecture list from course spec (HTMX partial)
+- ``POST /arm`` — Arm a topic for recording
+- ``POST /disarm`` — Disarm the current topic
+- ``GET /status`` — JSON session status snapshot
+- ``GET /events`` — SSE stream for real-time updates
+- ``GET /pairs`` — Pending pairs list (HTMX partial)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from loguru import logger
+
+from clm.recordings.workflow.session import RecordingSession, SessionSnapshot
+
+router = APIRouter()
+
+
+def _get_session(request: Request) -> RecordingSession:
+    return cast(RecordingSession, request.app.state.session)
+
+
+def _get_templates(request: Request):
+    return request.app.state.templates
+
+
+# ------------------------------------------------------------------
+# Pages
+# ------------------------------------------------------------------
+
+
+@router.get("/", response_class=HTMLResponse)
+async def dashboard(request: Request):
+    """Render the main dashboard page."""
+    templates = _get_templates(request)
+    session = _get_session(request)
+    snap = session.snapshot()
+    pairs = _get_pending_pairs(request)
+
+    return templates.TemplateResponse(
+        request,
+        "dashboard.html",
+        {
+            "snapshot": snap,
+            "pairs": pairs,
+        },
+    )
+
+
+@router.get("/lectures", response_class=HTMLResponse)
+async def lectures(request: Request):
+    """Render the lecture list from the course spec file.
+
+    Returns an HTMX partial — a list of sections with arm buttons.
+    """
+    templates = _get_templates(request)
+    spec_file = request.app.state.spec_file
+    session = _get_session(request)
+    snap = session.snapshot()
+
+    sections: list[dict] = []
+    error: str | None = None
+
+    if spec_file is not None:
+        try:
+            from pathlib import Path
+
+            from clm.core.course_spec import CourseSpec
+
+            spec = CourseSpec.from_file(Path(spec_file))
+            for section in spec.sections:
+                topics = []
+                for topic in section.topics:
+                    topics.append(
+                        {
+                            "id": topic.id,
+                            "name": topic.id.split("/")[-1] if "/" in topic.id else topic.id,
+                        }
+                    )
+                sections.append(
+                    {
+                        "name": section.name.en or section.name.de,
+                        "topics": topics,
+                    }
+                )
+        except Exception as exc:
+            error = str(exc)
+            logger.warning("Could not load course spec: {}", exc)
+    else:
+        error = "No course spec file configured. Pass --spec-file to clm recordings serve."
+
+    return templates.TemplateResponse(
+        request,
+        "lectures.html",
+        {
+            "sections": sections,
+            "snapshot": snap,
+            "error": error,
+        },
+    )
+
+
+# ------------------------------------------------------------------
+# Actions
+# ------------------------------------------------------------------
+
+
+@router.post("/arm", response_class=HTMLResponse)
+async def arm_topic(
+    request: Request,
+    course_slug: str = Form(...),
+    section_name: str = Form(...),
+    topic_name: str = Form(...),
+):
+    """Arm a topic for the next recording."""
+    session = _get_session(request)
+    try:
+        session.arm(course_slug, section_name, topic_name)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    # Return updated status partial for HTMX swap
+    return await status_partial(request)
+
+
+@router.post("/disarm", response_class=HTMLResponse)
+async def disarm(request: Request):
+    """Disarm the currently armed topic."""
+    session = _get_session(request)
+    try:
+        session.disarm()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return await status_partial(request)
+
+
+# ------------------------------------------------------------------
+# Status
+# ------------------------------------------------------------------
+
+
+@router.get("/status", response_class=JSONResponse)
+async def status_json(request: Request):
+    """Return session status as JSON."""
+    session = _get_session(request)
+    snap = session.snapshot()
+    return _snapshot_to_dict(snap)
+
+
+@router.get("/status-partial", response_class=HTMLResponse)
+async def status_partial(request: Request):
+    """Return the status panel as an HTMX partial."""
+    templates = _get_templates(request)
+    session = _get_session(request)
+    snap = session.snapshot()
+    pairs = _get_pending_pairs(request)
+
+    return templates.TemplateResponse(
+        request,
+        "partials/status.html",
+        {
+            "snapshot": snap,
+            "pairs": pairs,
+        },
+    )
+
+
+@router.get("/pairs-partial", response_class=HTMLResponse)
+async def pairs_partial(request: Request):
+    """Return the pending pairs list as an HTMX partial."""
+    templates = _get_templates(request)
+    pairs = _get_pending_pairs(request)
+
+    return templates.TemplateResponse(
+        request,
+        "partials/pairs.html",
+        {
+            "pairs": pairs,
+        },
+    )
+
+
+# ------------------------------------------------------------------
+# SSE
+# ------------------------------------------------------------------
+
+
+@router.get("/events")
+async def events(request: Request):
+    """Server-Sent Events stream for real-time dashboard updates.
+
+    Pushes ``event: status`` whenever the session state changes, plus
+    a periodic heartbeat every 15 seconds to keep the connection alive.
+    """
+    sse_queue: asyncio.Queue[str] = request.app.state.sse_queue
+
+    async def event_generator():
+        while True:
+            try:
+                # Wait for an event or timeout for heartbeat
+                msg = await asyncio.wait_for(sse_queue.get(), timeout=15.0)
+                yield f"event: status\ndata: {msg}\n\n"
+            except asyncio.TimeoutError:
+                yield ": heartbeat\n\n"
+            except asyncio.CancelledError:
+                break
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _snapshot_to_dict(snap: SessionSnapshot) -> dict:
+    """Convert a SessionSnapshot to a JSON-serializable dict."""
+    armed = None
+    if snap.armed_topic:
+        armed = {
+            "course_slug": snap.armed_topic.course_slug,
+            "section_name": snap.armed_topic.section_name,
+            "topic_name": snap.armed_topic.topic_name,
+        }
+    return {
+        "state": snap.state.value,
+        "armed_topic": armed,
+        "obs_connected": snap.obs_connected,
+        "last_output": str(snap.last_output) if snap.last_output else None,
+        "error": snap.error,
+    }
+
+
+def _get_pending_pairs(request: Request) -> list:
+    """Get pending pairs from the recordings root."""
+    from clm.recordings.workflow.directories import find_pending_pairs, to_process_dir
+
+    root = request.app.state.recordings_root
+    raw_suffix = request.app.state.raw_suffix
+    try:
+        return find_pending_pairs(to_process_dir(root), raw_suffix=raw_suffix)
+    except Exception:
+        return []

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}CLM Recordings{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4"
+            integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
+            crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.4/dist/ext/sse.js"></script>
+    <style>
+        :root {
+            --pico-font-size: 16px;
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 0.2em 0.6em;
+            border-radius: 4px;
+            font-size: 0.85em;
+            font-weight: 600;
+        }
+        .badge-idle { background: #6b7280; color: white; }
+        .badge-armed { background: #2563eb; color: white; }
+        .badge-recording { background: #dc2626; color: white; }
+        .badge-renaming { background: #d97706; color: white; }
+        .badge-connected { background: #16a34a; color: white; }
+        .badge-disconnected { background: #9ca3af; color: white; }
+        .error-box {
+            background: #fef2f2;
+            border: 1px solid #fecaca;
+            color: #991b1b;
+            padding: 0.75em 1em;
+            border-radius: 6px;
+            margin-bottom: 1em;
+        }
+        .armed-info {
+            background: #eff6ff;
+            border: 1px solid #bfdbfe;
+            padding: 0.75em 1em;
+            border-radius: 6px;
+            margin-bottom: 1em;
+        }
+        .topic-btn {
+            font-size: 0.85em;
+            padding: 0.3em 0.8em;
+        }
+        nav ul li strong {
+            color: var(--pico-primary);
+        }
+    </style>
+</head>
+<body>
+    <nav class="container-fluid">
+        <ul>
+            <li><strong>CLM Recordings</strong></li>
+        </ul>
+        <ul>
+            <li><a href="/">Dashboard</a></li>
+            <li><a href="/lectures">Lectures</a></li>
+        </ul>
+    </nav>
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+    <footer class="container">
+        <small>CLM Recordings Dashboard</small>
+    </footer>
+</body>
+</html>

--- a/src/clm/recordings/web/templates/dashboard.html
+++ b/src/clm/recordings/web/templates/dashboard.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Dashboard — CLM Recordings{% endblock %}
+{% block content %}
+<h1>Recording Dashboard</h1>
+
+<div id="status-panel"
+     hx-ext="sse"
+     sse-connect="/events"
+     sse-swap="status"
+     hx-get="/status-partial"
+     hx-trigger="sse:status"
+     hx-swap="innerHTML">
+    {% include "partials/status.html" %}
+</div>
+{% endblock %}

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Lectures — CLM Recordings{% endblock %}
+{% block content %}
+<h1>Lectures</h1>
+
+{% if snapshot.armed_topic %}
+<div class="armed-info">
+    <strong>Armed:</strong>
+    {{ snapshot.armed_topic.course_slug }} /
+    {{ snapshot.armed_topic.section_name }} /
+    {{ snapshot.armed_topic.topic_name }}
+    <form hx-post="/disarm" hx-target=".armed-info" hx-swap="outerHTML"
+          style="display:inline; margin-left:1em;">
+        <button type="submit" class="outline secondary topic-btn">Disarm</button>
+    </form>
+</div>
+{% endif %}
+
+{% if error %}
+<div class="error-box">{{ error }}</div>
+{% endif %}
+
+{% for section in sections %}
+<article>
+    <header><h3>{{ section.name }}</h3></header>
+    <table>
+        <tbody>
+            {% for topic in section.topics %}
+            <tr>
+                <td>{{ topic.name }}</td>
+                <td style="text-align:right">
+                    <form hx-post="/arm" hx-target="body" style="display:inline">
+                        <input type="hidden" name="course_slug" value="course">
+                        <input type="hidden" name="section_name" value="{{ section.name }}">
+                        <input type="hidden" name="topic_name" value="{{ topic.name }}">
+                        <button type="submit" class="outline topic-btn">Arm</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</article>
+{% endfor %}
+
+{% if not sections and not error %}
+<p>No sections found in the course spec.</p>
+{% endif %}
+{% endblock %}

--- a/src/clm/recordings/web/templates/partials/pairs.html
+++ b/src/clm/recordings/web/templates/partials/pairs.html
@@ -1,0 +1,30 @@
+{% if pairs %}
+<article>
+    <header><h3>Pending Pairs ({{ pairs|length }})</h3></header>
+    <table>
+        <thead>
+            <tr>
+                <th>Directory</th>
+                <th>Topic</th>
+                <th>Video</th>
+                <th>Audio</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for pair in pairs %}
+            <tr>
+                <td>{{ pair.relative_dir }}</td>
+                <td>{{ pair.base_name }}</td>
+                <td>{{ pair.video.name }}</td>
+                <td>{{ pair.audio.name }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</article>
+{% else %}
+<article>
+    <header><h3>Pending Pairs</h3></header>
+    <p>No video + audio pairs ready for assembly.</p>
+</article>
+{% endif %}

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -40,4 +40,36 @@
     {% endif %}
 </article>
 
+<article>
+    <header>
+        <hgroup>
+            <h3>File Watcher</h3>
+            <p>
+                Status:
+                {% if watcher_running %}
+                <span class="status-badge badge-connected">running</span>
+                {% else %}
+                <span class="status-badge badge-idle">stopped</span>
+                {% endif %}
+                &nbsp;
+                Mode:
+                <span class="status-badge badge-armed">{{ watcher_mode }}</span>
+            </p>
+        </hgroup>
+    </header>
+    <div>
+        {% if watcher_running %}
+        <form hx-post="/watcher/stop" hx-target="#status-panel" hx-swap="innerHTML"
+              style="display:inline">
+            <button type="submit" class="outline secondary topic-btn">Stop Watcher</button>
+        </form>
+        {% else %}
+        <form hx-post="/watcher/start" hx-target="#status-panel" hx-swap="innerHTML"
+              style="display:inline">
+            <button type="submit" class="outline topic-btn">Start Watcher</button>
+        </form>
+        {% endif %}
+    </div>
+</article>
+
 {% include "partials/pairs.html" %}

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -1,0 +1,43 @@
+<article>
+    <header>
+        <hgroup>
+            <h3>Session Status</h3>
+            <p>
+                State:
+                <span class="status-badge badge-{{ snapshot.state.value }}">
+                    {{ snapshot.state.value }}
+                </span>
+                &nbsp;
+                OBS:
+                {% if snapshot.obs_connected %}
+                <span class="status-badge badge-connected">connected</span>
+                {% else %}
+                <span class="status-badge badge-disconnected">disconnected</span>
+                {% endif %}
+            </p>
+        </hgroup>
+    </header>
+
+    {% if snapshot.error %}
+    <div class="error-box">{{ snapshot.error }}</div>
+    {% endif %}
+
+    {% if snapshot.armed_topic %}
+    <div class="armed-info">
+        <strong>Armed:</strong>
+        {{ snapshot.armed_topic.course_slug }} /
+        {{ snapshot.armed_topic.section_name }} /
+        {{ snapshot.armed_topic.topic_name }}
+        <form hx-post="/disarm" hx-target="#status-panel" hx-swap="innerHTML"
+              style="display:inline; margin-left:1em;">
+            <button type="submit" class="outline secondary topic-btn">Disarm</button>
+        </form>
+    </div>
+    {% endif %}
+
+    {% if snapshot.last_output %}
+    <p><strong>Last output:</strong> <code>{{ snapshot.last_output }}</code></p>
+    {% endif %}
+</article>
+
+{% include "partials/pairs.html" %}

--- a/src/clm/recordings/workflow/__init__.py
+++ b/src/clm/recordings/workflow/__init__.py
@@ -1,1 +1,1 @@
-"""Recording workflow automation: naming, directory management, and assembly."""
+"""Recording workflow automation: naming, directory management, assembly, and OBS integration."""

--- a/src/clm/recordings/workflow/__init__.py
+++ b/src/clm/recordings/workflow/__init__.py
@@ -1,0 +1,1 @@
+"""Recording workflow automation: naming, directory management, and assembly."""

--- a/src/clm/recordings/workflow/assembler.py
+++ b/src/clm/recordings/workflow/assembler.py
@@ -1,0 +1,189 @@
+"""Assembly logic: mux raw video with processed audio and archive originals.
+
+Reuses ``find_ffmpeg`` and ``run_subprocess`` from the recording processing
+module to avoid duplicating binary lookup and Windows subprocess handling.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from clm.recordings.processing.utils import find_ffmpeg, run_subprocess
+
+from .directories import (
+    PendingPair,
+    archive_dir,
+    final_dir,
+    find_pending_pairs,
+    to_process_dir,
+)
+from .naming import DEFAULT_RAW_SUFFIX
+
+
+class AssemblyResult(BaseModel):
+    """Result of assembling a single video + audio pair."""
+
+    video: Path
+    output_file: Path
+    success: bool
+    error: str | None = None
+
+
+class AssemblyBatchResult(BaseModel):
+    """Summary of assembling all pending pairs under a root directory."""
+
+    results: list[AssemblyResult] = Field(default_factory=list)
+
+    @property
+    def succeeded(self) -> list[AssemblyResult]:
+        return [r for r in self.results if r.success]
+
+    @property
+    def failed(self) -> list[AssemblyResult]:
+        return [r for r in self.results if not r.success]
+
+    def summary(self) -> str:
+        lines = [
+            f"Assembly complete: {len(self.results)} pair(s)",
+            f"  Succeeded: {len(self.succeeded)}",
+            f"  Failed:    {len(self.failed)}",
+        ]
+        for r in self.failed:
+            lines.append(f"    - {r.video.name}: {r.error}")
+        return "\n".join(lines)
+
+
+def mux_video_audio(
+    ffmpeg: Path,
+    video: Path,
+    audio: Path,
+    output: Path,
+) -> None:
+    """Mux video stream from *video* with audio from *audio* into *output*.
+
+    Uses ``-c:v copy`` (no re-encode) and ``-c:a aac`` for the audio.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    run_subprocess(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "warning",
+            "-y",
+            "-i",
+            video,
+            "-i",
+            audio,
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0",
+            "-movflags",
+            "+faststart",
+            output,
+        ]
+    )
+
+
+def archive_pair(pair: PendingPair, archive: Path) -> None:
+    """Move the raw video and audio files to the archive directory."""
+    dest_dir = archive / pair.relative_dir
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(pair.video), str(dest_dir / pair.video.name))
+    shutil.move(str(pair.audio), str(dest_dir / pair.audio.name))
+    logger.debug("Archived {} and {} to {}", pair.video.name, pair.audio.name, dest_dir)
+
+
+def assemble_one(
+    pair: PendingPair,
+    final: Path,
+    archive: Path,
+    *,
+    ffmpeg: Path | None = None,
+    output_ext: str = ".mp4",
+) -> AssemblyResult:
+    """Mux a single video + audio pair, then archive the originals.
+
+    Args:
+        pair: The matched raw video + processed audio.
+        final: Root of the ``final/`` directory tree.
+        archive: Root of the ``archive/`` directory tree.
+        ffmpeg: Path to ffmpeg binary (auto-detected if None).
+        output_ext: Extension for the output file.
+
+    Returns:
+        AssemblyResult indicating success or failure.
+    """
+    if ffmpeg is None:
+        ffmpeg = find_ffmpeg()
+
+    output_file = final / pair.relative_dir / f"{pair.base_name}{output_ext}"
+
+    try:
+        mux_video_audio(ffmpeg, pair.video, pair.audio, output_file)
+    except Exception as e:
+        logger.error("Assembly failed for {}: {}", pair.video.name, e)
+        return AssemblyResult(
+            video=pair.video,
+            output_file=output_file,
+            success=False,
+            error=str(e),
+        )
+
+    try:
+        archive_pair(pair, archive)
+    except Exception as e:
+        logger.warning("Mux succeeded but archiving failed for {}: {}", pair.video.name, e)
+
+    logger.info("Assembled {} -> {}", pair.video.name, output_file)
+    return AssemblyResult(video=pair.video, output_file=output_file, success=True)
+
+
+def assemble_all(
+    root_dir: Path,
+    *,
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+    output_ext: str = ".mp4",
+    on_pair: Callable[[int, PendingPair, int], None] | None = None,
+) -> AssemblyBatchResult:
+    """Find and assemble all pending pairs under *root_dir*.
+
+    Args:
+        root_dir: Recordings root containing ``to-process/``, ``final/``, ``archive/``.
+        raw_suffix: Suffix identifying raw files (default ``--RAW``).
+        output_ext: Extension for output files.
+        on_pair: Optional progress callback ``(index, pair, total)``.
+
+    Returns:
+        AssemblyBatchResult with per-pair results.
+    """
+    tp = to_process_dir(root_dir)
+    fl = final_dir(root_dir)
+    ar = archive_dir(root_dir)
+
+    pairs = find_pending_pairs(tp, raw_suffix=raw_suffix)
+    batch = AssemblyBatchResult()
+
+    if not pairs:
+        logger.info("No pending pairs found in {}", tp)
+        return batch
+
+    ffmpeg = find_ffmpeg()
+
+    for i, pair in enumerate(pairs):
+        if on_pair:
+            on_pair(i, pair, len(pairs))
+        result = assemble_one(pair, fl, ar, ffmpeg=ffmpeg, output_ext=output_ext)
+        batch.results.append(result)
+
+    return batch

--- a/src/clm/recordings/workflow/backends.py
+++ b/src/clm/recordings/workflow/backends.py
@@ -1,0 +1,154 @@
+"""Pluggable processing backends for the recording workflow.
+
+Two backends are provided:
+
+- :class:`ExternalBackend` — "wait for external tool" mode.  The user
+  processes audio externally (e.g. iZotope RX 11) and the file watcher
+  simply waits for the ``.wav`` to appear alongside the raw video.
+
+- :class:`OnnxBackend` — "process locally" mode.  Extracts audio from
+  the raw video, runs the ONNX DeepFilterNet3 denoising pipeline, applies
+  FFmpeg audio filters, and writes the processed ``.wav``.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from loguru import logger
+
+
+@runtime_checkable
+class ProcessingBackend(Protocol):
+    """Protocol for audio processing backends."""
+
+    def process(self, video: Path, output_wav: Path) -> None:
+        """Extract and process audio from a video file.
+
+        Args:
+            video: Input raw video file.
+            output_wav: Destination path for the processed WAV audio.
+
+        Raises:
+            Exception: On processing failure.
+        """
+        ...
+
+
+class ExternalBackend:
+    """Backend that relies on an external tool for audio processing.
+
+    This backend does **not** process files itself.  In external mode the
+    file watcher monitors ``to-process/`` for ``.wav`` files that appear
+    from an external tool (e.g. iZotope RX 11 Batch Processor) and
+    triggers assembly when the matching video is found.
+    """
+
+    def process(self, video: Path, output_wav: Path) -> None:  # pragma: no cover
+        raise NotImplementedError(
+            "ExternalBackend does not process files. "
+            "Audio is processed by an external tool (e.g. iZotope RX 11)."
+        )
+
+
+class OnnxBackend:
+    """Process audio locally using the ONNX DeepFilterNet3 pipeline.
+
+    Reuses the existing :class:`~clm.recordings.processing.pipeline.ProcessingPipeline`
+    to: extract audio → ONNX denoise → FFmpeg filters → write WAV.
+
+    Unlike the full pipeline (which muxes back into video), this backend
+    stops after producing the processed ``.wav`` so that the assembler
+    can pair it with the original video.
+    """
+
+    def __init__(self, config: object | None = None) -> None:
+        # Lazy import to avoid hard dependency on onnxruntime at import time
+        self._config = config
+
+    def process(self, video: Path, output_wav: Path) -> None:
+        """Extract audio, denoise via ONNX, apply filters, write WAV.
+
+        Args:
+            video: Input raw video file (must contain an audio stream).
+            output_wav: Output path for the processed WAV audio.
+        """
+        from clm.recordings.processing.config import PipelineConfig
+        from clm.recordings.processing.utils import (
+            find_ffmpeg,
+            find_ffprobe,
+            get_audio_duration,
+            run_onnx_denoise,
+            run_subprocess,
+        )
+
+        config = self._config if isinstance(self._config, PipelineConfig) else PipelineConfig()
+        ffmpeg = find_ffmpeg()
+        ffprobe = find_ffprobe()
+
+        output_wav.parent.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.TemporaryDirectory(prefix="clm_onnx_") as tmp:
+            tmp_dir = Path(tmp)
+            audio_raw = tmp_dir / "audio_raw.wav"
+            audio_cleaned = tmp_dir / "audio_cleaned.wav"
+
+            # Step 1: Extract audio as mono 16-bit WAV
+            logger.info("Extracting audio from {}", video.name)
+            run_subprocess(
+                [
+                    ffmpeg,
+                    "-hide_banner",
+                    "-loglevel",
+                    "warning",
+                    "-y",
+                    "-i",
+                    video,
+                    "-vn",
+                    "-acodec",
+                    "pcm_s16le",
+                    "-ar",
+                    str(config.sample_rate),
+                    "-ac",
+                    "1",
+                    audio_raw,
+                ]
+            )
+            duration = get_audio_duration(ffprobe, audio_raw)
+            logger.info("Audio extracted ({:.0f}s)", duration)
+
+            # Step 2: ONNX denoise
+            logger.info("Running ONNX noise reduction")
+            run_onnx_denoise(
+                audio_raw,
+                audio_cleaned,
+                atten_lim_db=config.denoise_atten_lim,
+            )
+            logger.info("Noise reduction complete")
+
+            # Step 3: Apply FFmpeg audio filters and write final WAV
+            logger.info("Applying audio filters")
+            cfg = config.audio_filters
+            base_filters = f"highpass=f={cfg.highpass_freq},{cfg.compressor_filter}"
+            loudnorm = cfg.loudnorm_filter
+            full_filter = f"{base_filters},{loudnorm}"
+
+            run_subprocess(
+                [
+                    ffmpeg,
+                    "-hide_banner",
+                    "-loglevel",
+                    "warning",
+                    "-y",
+                    "-i",
+                    audio_cleaned,
+                    "-af",
+                    full_filter,
+                    "-ar",
+                    str(config.sample_rate),
+                    output_wav,
+                ]
+            )
+            logger.info("Processed audio written to {}", output_wav)

--- a/src/clm/recordings/workflow/directories.py
+++ b/src/clm/recordings/workflow/directories.py
@@ -1,0 +1,109 @@
+"""Directory structure management for the recording workflow.
+
+Manages the three-tier directory layout under the recordings root::
+
+    <root>/
+    +-- to-process/   # Raw recordings and externally processed audio
+    +-- final/        # Muxed output (video + processed audio)
+    +-- archive/      # Originals moved here after successful assembly
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+from pydantic import BaseModel
+
+from clm.recordings.processing.batch import VIDEO_EXTENSIONS
+
+from .naming import DEFAULT_RAW_SUFFIX, parse_raw_stem
+
+SUBDIRS = ("to-process", "final", "archive")
+
+
+class PendingPair(BaseModel):
+    """A matched raw video + processed audio pair ready for assembly."""
+
+    video: Path
+    audio: Path
+    relative_dir: Path
+    raw_suffix: str = DEFAULT_RAW_SUFFIX
+
+    @property
+    def base_name(self) -> str:
+        """Topic name without the raw suffix."""
+        name, _ = parse_raw_stem(self.video.stem, self.raw_suffix)
+        return name
+
+
+def ensure_root(root_dir: Path) -> None:
+    """Create the ``to-process/``, ``final/``, and ``archive/`` subdirectories."""
+    for name in SUBDIRS:
+        (root_dir / name).mkdir(parents=True, exist_ok=True)
+    logger.debug("Ensured recording directories under {}", root_dir)
+
+
+def validate_root(root_dir: Path) -> list[str]:
+    """Check that the recording directory structure exists.
+
+    Returns a list of error messages (empty if valid).
+    """
+    errors: list[str] = []
+    if not root_dir.is_dir():
+        errors.append(f"Root directory does not exist: {root_dir}")
+        return errors
+    for name in SUBDIRS:
+        if not (root_dir / name).is_dir():
+            errors.append(f"Missing subdirectory: {root_dir / name}")
+    return errors
+
+
+def to_process_dir(root_dir: Path) -> Path:
+    return root_dir / "to-process"
+
+
+def final_dir(root_dir: Path) -> Path:
+    return root_dir / "final"
+
+
+def archive_dir(root_dir: Path) -> Path:
+    return root_dir / "archive"
+
+
+def find_pending_pairs(
+    to_process: Path,
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+) -> list[PendingPair]:
+    """Scan ``to-process/`` for raw video + audio pairs ready for assembly.
+
+    A pair is "pending" when both ``<topic>--RAW.<video-ext>`` and
+    ``<topic>--RAW.wav`` exist in the same directory.
+    """
+    pairs: list[PendingPair] = []
+
+    for video_file in sorted(to_process.rglob("*")):
+        if not video_file.is_file():
+            continue
+        if video_file.suffix.lower() not in VIDEO_EXTENSIONS:
+            continue
+
+        stem = video_file.stem
+        _, is_raw = parse_raw_stem(stem, raw_suffix)
+        if not is_raw:
+            continue
+
+        audio_file = video_file.with_name(f"{stem}.wav")
+        if audio_file.is_file():
+            relative_dir = video_file.parent.relative_to(to_process)
+            pairs.append(
+                PendingPair(
+                    video=video_file,
+                    audio=audio_file,
+                    relative_dir=relative_dir,
+                    raw_suffix=raw_suffix,
+                )
+            )
+
+    logger.debug("Found {} pending pair(s) in {}", len(pairs), to_process)
+    return pairs

--- a/src/clm/recordings/workflow/naming.py
+++ b/src/clm/recordings/workflow/naming.py
@@ -1,0 +1,51 @@
+"""Filename convention helpers for the recording workflow.
+
+Naming scheme:
+    <course-slug>/<section-name>/<topic-name>--RAW.mp4   (raw recording)
+    <course-slug>/<section-name>/<topic-name>--RAW.wav   (processed audio)
+    <course-slug>/<section-name>/<topic-name>.mp4         (final output)
+
+All name components are sanitized via ``sanitize_file_name`` from
+``clm.core.utils.text_utils`` to ensure filesystem-safe paths.
+
+This module is pure functions with no I/O.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from clm.core.utils.text_utils import sanitize_file_name
+
+DEFAULT_RAW_SUFFIX = "--RAW"
+
+
+def recording_relative_dir(course_slug: str, section_name: str) -> PurePosixPath:
+    """Build the relative directory for a recording: ``<course>/<section>/``.
+
+    Both components are sanitized for filesystem safety.
+    """
+    return PurePosixPath(sanitize_file_name(course_slug)) / sanitize_file_name(section_name)
+
+
+def raw_filename(topic_name: str, ext: str = ".mp4", raw_suffix: str = DEFAULT_RAW_SUFFIX) -> str:
+    """Build a raw recording filename: ``<topic>--RAW.mp4``."""
+    return f"{sanitize_file_name(topic_name)}{raw_suffix}{ext}"
+
+
+def final_filename(topic_name: str, ext: str = ".mp4") -> str:
+    """Build the final output filename: ``<topic>.mp4``."""
+    return f"{sanitize_file_name(topic_name)}{ext}"
+
+
+def parse_raw_stem(stem: str, raw_suffix: str = DEFAULT_RAW_SUFFIX) -> tuple[str, bool]:
+    """Parse a file stem into ``(base_name, is_raw)``.
+
+    >>> parse_raw_stem("my_topic--RAW")
+    ('my_topic', True)
+    >>> parse_raw_stem("my_topic")
+    ('my_topic', False)
+    """
+    if stem.endswith(raw_suffix):
+        return stem[: -len(raw_suffix)], True
+    return stem, False

--- a/src/clm/recordings/workflow/obs.py
+++ b/src/clm/recordings/workflow/obs.py
@@ -1,0 +1,199 @@
+"""OBS WebSocket client wrapper for recording workflow integration.
+
+Wraps ``obsws-python`` to provide a focused interface for recording-related
+operations: connection lifecycle, recording status queries, and event
+subscriptions for ``RecordStateChanged``.
+
+The ``obsws-python`` package uses lazy imports so that the rest of the
+recordings module can be used without OBS installed.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+@dataclass
+class RecordingEvent:
+    """Data from an OBS ``RecordStateChanged`` event."""
+
+    output_active: bool
+    output_state: str
+    output_path: str | None = None
+
+
+class ObsClient:
+    """Thin wrapper around obsws-python for recording operations.
+
+    Manages both a *request* client (for queries like ``get_record_status``)
+    and an *event* client (for ``RecordStateChanged`` callbacks).
+
+    Usage::
+
+        client = ObsClient(host="localhost", port=4455)
+        client.on_record_state_changed(my_callback)
+        client.connect()
+        ...
+        client.disconnect()
+
+    Or as a context manager::
+
+        with ObsClient() as client:
+            ...
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 4455,
+        password: str = "",
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._password = password
+        self._req: Any | None = None  # obsws_python.ReqClient
+        self._evt: Any | None = None  # obsws_python.EventClient
+        self._record_callbacks: list[Callable[[RecordingEvent], None]] = []
+        self._lock = threading.Lock()
+
+    @property
+    def connected(self) -> bool:
+        """Whether the client is currently connected to OBS."""
+        return self._req is not None
+
+    def connect(self) -> None:
+        """Connect to OBS WebSocket (both request and event clients).
+
+        Raises:
+            ImportError: If ``obsws-python`` is not installed.
+            ConnectionError: If OBS is not reachable.
+        """
+        import obsws_python  # type: ignore[import-untyped]
+
+        try:
+            req = obsws_python.ReqClient(
+                host=self._host,
+                port=self._port,
+                password=self._password,
+            )
+        except Exception as exc:
+            raise ConnectionError(
+                f"Cannot connect to OBS at {self._host}:{self._port}: {exc}"
+            ) from exc
+
+        try:
+            evt = obsws_python.EventClient(
+                host=self._host,
+                port=self._port,
+                password=self._password,
+            )
+            evt.callback.register(self._make_record_handler())
+        except Exception as exc:
+            req.disconnect()
+            raise ConnectionError(
+                f"Cannot connect OBS event client at {self._host}:{self._port}: {exc}"
+            ) from exc
+
+        with self._lock:
+            self._req = req
+            self._evt = evt
+
+        logger.info("Connected to OBS at {}:{}", self._host, self._port)
+
+    def disconnect(self) -> None:
+        """Disconnect from OBS, cleaning up both clients."""
+        with self._lock:
+            evt, self._evt = self._evt, None
+            req, self._req = self._req, None
+
+        if evt is not None:
+            try:
+                evt.disconnect()
+            except Exception:
+                pass
+        if req is not None:
+            try:
+                req.disconnect()
+            except Exception:
+                pass
+
+        logger.info("Disconnected from OBS")
+
+    def on_record_state_changed(self, callback: Callable[[RecordingEvent], None]) -> None:
+        """Register a callback for OBS ``RecordStateChanged`` events.
+
+        Callbacks are invoked on the obsws-python daemon thread.
+        Register callbacks *before* calling :meth:`connect` to avoid
+        missing early events.
+        """
+        self._record_callbacks.append(callback)
+
+    def get_record_status(self) -> RecordingEvent:
+        """Query the current recording status from OBS.
+
+        Returns a :class:`RecordingEvent` with ``output_active`` and
+        ``output_state`` populated.  ``output_path`` may be ``None``
+        depending on OBS version.
+        """
+        req = self._require_connected()
+        resp = req.get_record_status()
+        return RecordingEvent(
+            output_active=resp.output_active,
+            output_state=getattr(resp, "output_state", "unknown"),
+            output_path=getattr(resp, "output_path", None),
+        )
+
+    def get_record_directory(self) -> Path:
+        """Get the directory where OBS saves recordings."""
+        req = self._require_connected()
+        resp = req.get_record_directory()
+        return Path(resp.record_directory)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_connected(self) -> Any:
+        """Return the request client or raise if not connected."""
+        req = self._req
+        if req is None:
+            raise ConnectionError("Not connected to OBS. Call connect() first.")
+        return req
+
+    def _make_record_handler(self) -> Callable:
+        """Create a handler whose name matches the obsws-python convention.
+
+        ``obsws-python`` dispatches events by matching the callback function
+        name to ``on_<event_name_snake_case>``.
+        """
+
+        def on_record_state_changed(data: Any) -> None:
+            event = RecordingEvent(
+                output_active=data.output_active,
+                output_state=getattr(data, "output_state", "unknown"),
+                output_path=getattr(data, "output_path", None),
+            )
+            for cb in self._record_callbacks:
+                try:
+                    cb(event)
+                except Exception:
+                    logger.exception("Error in record state callback")
+
+        return on_record_state_changed
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> ObsClient:
+        self.connect()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.disconnect()

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -1,0 +1,281 @@
+"""Recording session state machine.
+
+Coordinates the recording workflow by tracking which topic is "armed"
+for recording and responding to OBS events to rename the output file
+into the structured directory layout.
+
+State transitions::
+
+    idle ──arm()──► armed ──OBS starts──► recording ──OBS stops──► renaming ──done──► idle
+      ▲               │                                                                │
+      └──disarm()─────┘                                                                │
+      └────────────────────────────────────────────────────────────────────────────────┘
+
+The session manager is **thread-safe**.  OBS events arrive on a background
+thread (from ``obsws-python``), while :meth:`arm` / :meth:`disarm` are
+called from the main thread or a web request handler.
+"""
+
+from __future__ import annotations
+
+import enum
+import shutil
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+from .directories import to_process_dir
+from .naming import DEFAULT_RAW_SUFFIX, raw_filename, recording_relative_dir
+from .obs import ObsClient, RecordingEvent
+
+
+class SessionState(enum.Enum):
+    """Recording session states."""
+
+    IDLE = "idle"
+    ARMED = "armed"
+    RECORDING = "recording"
+    RENAMING = "renaming"
+
+
+@dataclass(frozen=True)
+class ArmedTopic:
+    """Identifies the topic armed for the next recording."""
+
+    course_slug: str
+    section_name: str
+    topic_name: str
+
+
+@dataclass
+class SessionSnapshot:
+    """Immutable snapshot of session state for UI consumption."""
+
+    state: SessionState
+    armed_topic: ArmedTopic | None = None
+    obs_connected: bool = False
+    last_output: Path | None = None
+    error: str | None = None
+
+
+class RecordingSession:
+    """State machine managing the recording → rename workflow.
+
+    Args:
+        obs: Connected (or soon-to-be-connected) OBS client.
+        recordings_root: Root directory containing ``to-process/``,
+            ``final/``, ``archive/`` subdirectories.
+        raw_suffix: Suffix for raw recording filenames (default ``--RAW``).
+        stability_interval: Seconds between file-size polls when waiting
+            for the recording file to stabilise after OBS stops.
+        stability_checks: Number of consecutive identical size readings
+            required before considering the file stable.
+        on_state_change: Optional callback invoked (outside the lock)
+            after every state transition.  Receives a :class:`SessionSnapshot`.
+    """
+
+    def __init__(
+        self,
+        obs: ObsClient,
+        recordings_root: Path,
+        *,
+        raw_suffix: str = DEFAULT_RAW_SUFFIX,
+        stability_interval: float = 1.0,
+        stability_checks: int = 3,
+        on_state_change: Callable[[SessionSnapshot], None] | None = None,
+    ) -> None:
+        self._obs = obs
+        self._root = recordings_root
+        self._raw_suffix = raw_suffix
+        self._stability_interval = stability_interval
+        self._stability_checks = stability_checks
+        self._on_state_change = on_state_change
+
+        self._state = SessionState.IDLE
+        self._armed: ArmedTopic | None = None
+        self._last_output: Path | None = None
+        self._error: str | None = None
+        self._lock = threading.Lock()
+
+        # Wire up OBS events
+        self._obs.on_record_state_changed(self._handle_record_event)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> SessionState:
+        return self._state
+
+    @property
+    def armed_topic(self) -> ArmedTopic | None:
+        return self._armed
+
+    def snapshot(self) -> SessionSnapshot:
+        """Thread-safe snapshot of the current session state."""
+        with self._lock:
+            return SessionSnapshot(
+                state=self._state,
+                armed_topic=self._armed,
+                obs_connected=self._obs.connected,
+                last_output=self._last_output,
+                error=self._error,
+            )
+
+    def arm(self, course_slug: str, section_name: str, topic_name: str) -> None:
+        """Arm a topic for the next recording.
+
+        Can be called from ``IDLE`` or ``ARMED`` (to switch topics).
+
+        Raises:
+            RuntimeError: If a recording or rename is in progress.
+        """
+        with self._lock:
+            if self._state not in (SessionState.IDLE, SessionState.ARMED):
+                raise RuntimeError(
+                    f"Cannot arm while in state '{self._state.value}'. "
+                    "Wait for the current recording to finish."
+                )
+            self._armed = ArmedTopic(course_slug, section_name, topic_name)
+            self._error = None
+            self._state = SessionState.ARMED
+
+        self._notify()
+
+    def disarm(self) -> None:
+        """Disarm the currently armed topic, returning to ``IDLE``.
+
+        Raises:
+            RuntimeError: If a recording is in progress.
+        """
+        with self._lock:
+            if self._state == SessionState.RECORDING:
+                raise RuntimeError("Cannot disarm while recording is in progress.")
+            if self._state == SessionState.RENAMING:
+                raise RuntimeError("Cannot disarm while rename is in progress.")
+            self._armed = None
+            self._state = SessionState.IDLE
+
+        self._notify()
+
+    # ------------------------------------------------------------------
+    # OBS event handling
+    # ------------------------------------------------------------------
+
+    def _handle_record_event(self, event: RecordingEvent) -> None:
+        """Respond to an OBS ``RecordStateChanged`` event.
+
+        Called on the obsws-python daemon thread.
+        """
+        rename_args: tuple[Path, ArmedTopic] | None = None
+
+        with self._lock:
+            if event.output_active:
+                # Recording started
+                if self._state == SessionState.ARMED:
+                    self._state = SessionState.RECORDING
+                    logger.info("Recording started for {}", self._armed)
+                else:
+                    logger.info("Recording started (state={}, no auto-rename)", self._state.value)
+            else:
+                # Recording stopped
+                if self._state == SessionState.RECORDING and self._armed is not None:
+                    if event.output_path:
+                        self._state = SessionState.RENAMING
+                        rename_args = (Path(event.output_path), self._armed)
+                    else:
+                        logger.warning("Recording stopped but no output path reported")
+                        self._error = "OBS did not report the output file path"
+                        self._armed = None
+                        self._state = SessionState.IDLE
+                elif self._state == SessionState.RECORDING:
+                    # Was recording but nothing armed — just go back to idle
+                    self._state = SessionState.IDLE
+                else:
+                    logger.debug("Recording stopped event ignored (state={})", self._state.value)
+
+        self._notify()
+
+        if rename_args:
+            threading.Thread(
+                target=self._rename_recording,
+                args=rename_args,
+                daemon=True,
+                name="recording-rename",
+            ).start()
+
+    # ------------------------------------------------------------------
+    # File rename (runs on a background thread)
+    # ------------------------------------------------------------------
+
+    def _rename_recording(self, obs_output: Path, topic: ArmedTopic) -> None:
+        """Move the OBS output file into the structured ``to-process/`` tree."""
+        try:
+            self._wait_for_stable(obs_output)
+
+            rel_dir = recording_relative_dir(topic.course_slug, topic.section_name)
+            target_name = raw_filename(
+                topic.topic_name,
+                ext=obs_output.suffix,
+                raw_suffix=self._raw_suffix,
+            )
+            target_dir = to_process_dir(self._root) / str(rel_dir)
+            target_dir.mkdir(parents=True, exist_ok=True)
+            target = target_dir / target_name
+
+            shutil.move(str(obs_output), str(target))
+            logger.info("Renamed {} → {}", obs_output.name, target)
+
+            with self._lock:
+                self._last_output = target
+                self._armed = None
+                self._state = SessionState.IDLE
+
+        except Exception as exc:
+            logger.error("Failed to rename recording: {}", exc)
+            with self._lock:
+                self._error = str(exc)
+                self._armed = None
+                self._state = SessionState.IDLE
+
+        self._notify()
+
+    def _wait_for_stable(self, path: Path) -> None:
+        """Poll file size until it stops changing.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        prev_size = -1
+        stable_count = 0
+
+        while stable_count < self._stability_checks:
+            if not path.exists():
+                raise FileNotFoundError(f"Recording file not found: {path}")
+
+            size = path.stat().st_size
+            if size == prev_size and size > 0:
+                stable_count += 1
+            else:
+                stable_count = 0
+            prev_size = size
+
+            if stable_count < self._stability_checks:
+                time.sleep(self._stability_interval)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _notify(self) -> None:
+        """Emit state-change callback outside the lock."""
+        if self._on_state_change:
+            try:
+                self._on_state_change(self.snapshot())
+            except Exception:
+                logger.exception("Error in state change callback")

--- a/src/clm/recordings/workflow/watcher.py
+++ b/src/clm/recordings/workflow/watcher.py
@@ -1,0 +1,323 @@
+"""Filesystem watcher for the recording workflow.
+
+Monitors ``to-process/`` for new files and triggers assembly
+automatically.  Behaviour depends on the active processing backend:
+
+- **external** — watches for ``.wav`` files (produced by an external
+  tool such as iZotope RX 11).  When a ``.wav`` is stable and a
+  matching raw video exists, assembly is triggered.
+
+- **onnx** — watches for raw video files (``--RAW.{ext}``).  When a
+  video is stable, the ONNX backend processes it to produce a ``.wav``,
+  then assembly is triggered.
+
+The watcher runs on a background thread via ``watchdog``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from loguru import logger
+from watchdog.events import FileCreatedEvent, FileMovedEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from clm.recordings.processing.batch import VIDEO_EXTENSIONS
+from clm.recordings.workflow.assembler import AssemblyResult, assemble_one
+from clm.recordings.workflow.directories import (
+    PendingPair,
+    archive_dir,
+    final_dir,
+    to_process_dir,
+)
+from clm.recordings.workflow.naming import DEFAULT_RAW_SUFFIX, parse_raw_stem
+
+from .backends import OnnxBackend, ProcessingBackend
+
+
+class WatcherState:
+    """Thread-safe container for watcher runtime state."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._processing: set[Path] = set()
+
+    def try_claim(self, path: Path) -> bool:
+        """Claim a file for processing.  Returns False if already claimed."""
+        with self._lock:
+            if path in self._processing:
+                return False
+            self._processing.add(path)
+            return True
+
+    def release(self, path: Path) -> None:
+        with self._lock:
+            self._processing.discard(path)
+
+
+class RecordingsWatcher:
+    """Filesystem watcher that monitors ``to-process/`` and triggers assembly.
+
+    Args:
+        root_dir: Recordings root (``to-process/``, ``final/``, ``archive/``).
+        backend: ``"external"`` or ``"onnx"`` (or a :class:`ProcessingBackend`
+            instance for the onnx path).
+        raw_suffix: Suffix identifying raw files (default ``--RAW``).
+        stability_interval: Seconds between file-size polls.
+        stability_checks: Consecutive identical readings = stable.
+        on_assembled: Callback after a successful assembly.
+        on_processing: Callback when processing starts for a file.
+        on_error: Callback on processing/assembly error.
+    """
+
+    def __init__(
+        self,
+        root_dir: Path,
+        *,
+        backend: str | ProcessingBackend = "external",
+        raw_suffix: str = DEFAULT_RAW_SUFFIX,
+        stability_interval: float = 2.0,
+        stability_checks: int = 3,
+        on_assembled: Callable[[AssemblyResult], None] | None = None,
+        on_processing: Callable[[Path], None] | None = None,
+        on_error: Callable[[Path, str], None] | None = None,
+    ) -> None:
+        self._root = root_dir
+        self._raw_suffix = raw_suffix
+        self._stability_interval = stability_interval
+        self._stability_checks = stability_checks
+        self._on_assembled = on_assembled
+        self._on_processing = on_processing
+        self._on_error = on_error
+
+        # Resolve backend
+        if isinstance(backend, str):
+            if backend == "onnx":
+                self._backend: ProcessingBackend | None = OnnxBackend()
+                self._mode = "onnx"
+            else:
+                self._backend = None
+                self._mode = "external"
+        else:
+            self._backend = backend
+            self._mode = "onnx"
+
+        self._observer: Observer | None = None  # type: ignore[valid-type]
+        self._state = WatcherState()
+
+    @property
+    def running(self) -> bool:
+        return self._observer is not None and self._observer.is_alive()
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def start(self) -> None:
+        """Start watching ``to-process/`` for new files."""
+        if self.running:
+            return
+
+        watch_dir = to_process_dir(self._root)
+        watch_dir.mkdir(parents=True, exist_ok=True)
+
+        handler = _WatchHandler(self)
+        self._observer = Observer()
+        self._observer.schedule(handler, str(watch_dir), recursive=True)
+        self._observer.daemon = True
+        self._observer.start()
+        logger.info(
+            "Watcher started (mode={}, dir={})",
+            self._mode,
+            watch_dir,
+        )
+
+    def stop(self) -> None:
+        """Stop the watcher."""
+        if self._observer is not None:
+            self._observer.stop()
+            self._observer.join(timeout=5.0)
+            self._observer = None
+            logger.info("Watcher stopped")
+
+    # ------------------------------------------------------------------
+    # Called by the event handler (on background threads)
+    # ------------------------------------------------------------------
+
+    def _on_file_event(self, path: Path) -> None:
+        """Respond to a new or moved file in ``to-process/``."""
+        if self._mode == "external":
+            self._handle_external(path)
+        else:
+            self._handle_onnx(path)
+
+    def _handle_external(self, path: Path) -> None:
+        """External mode: react to new ``.wav`` files."""
+        if path.suffix.lower() != ".wav":
+            return
+
+        # Must be a raw-suffixed wav
+        _, is_raw = parse_raw_stem(path.stem, self._raw_suffix)
+        if not is_raw:
+            return
+
+        if not self._state.try_claim(path):
+            return
+
+        threading.Thread(
+            target=self._process_external_wav,
+            args=(path,),
+            daemon=True,
+            name=f"watcher-ext-{path.stem}",
+        ).start()
+
+    def _handle_onnx(self, path: Path) -> None:
+        """ONNX mode: react to new raw video files."""
+        if path.suffix.lower() not in VIDEO_EXTENSIONS:
+            return
+
+        _, is_raw = parse_raw_stem(path.stem, self._raw_suffix)
+        if not is_raw:
+            return
+
+        if not self._state.try_claim(path):
+            return
+
+        threading.Thread(
+            target=self._process_onnx_video,
+            args=(path,),
+            daemon=True,
+            name=f"watcher-onnx-{path.stem}",
+        ).start()
+
+    # ------------------------------------------------------------------
+    # Background processing threads
+    # ------------------------------------------------------------------
+
+    def _process_external_wav(self, wav_path: Path) -> None:
+        """Wait for the .wav to stabilise, find matching video, assemble."""
+        try:
+            self._wait_for_stable(wav_path)
+
+            # Find matching raw video
+            video = self._find_matching_video(wav_path)
+            if video is None:
+                logger.debug("No matching video for {}, skipping", wav_path.name)
+                return
+
+            self._assemble_pair(video, wav_path)
+
+        except Exception as exc:
+            logger.error("Watcher error (external) for {}: {}", wav_path.name, exc)
+            if self._on_error:
+                self._on_error(wav_path, str(exc))
+        finally:
+            self._state.release(wav_path)
+
+    def _process_onnx_video(self, video_path: Path) -> None:
+        """Wait for video to stabilise, run ONNX, assemble."""
+        try:
+            self._wait_for_stable(video_path)
+
+            if self._on_processing:
+                self._on_processing(video_path)
+
+            # Produce the .wav alongside the video
+            wav_path = video_path.with_name(f"{video_path.stem}.wav")
+
+            assert self._backend is not None
+            self._backend.process(video_path, wav_path)
+            logger.info("ONNX processing complete: {}", wav_path.name)
+
+            self._assemble_pair(video_path, wav_path)
+
+        except Exception as exc:
+            logger.error("Watcher error (onnx) for {}: {}", video_path.name, exc)
+            if self._on_error:
+                self._on_error(video_path, str(exc))
+        finally:
+            self._state.release(video_path)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _find_matching_video(self, wav_path: Path) -> Path | None:
+        """Find a raw video file matching the given .wav file."""
+        stem = wav_path.stem  # e.g. "topic--RAW"
+        for ext in VIDEO_EXTENSIONS:
+            candidate = wav_path.with_name(f"{stem}{ext}")
+            if candidate.is_file():
+                return candidate
+        return None
+
+    def _assemble_pair(self, video: Path, audio: Path) -> None:
+        """Build a PendingPair and run assembly."""
+        tp = to_process_dir(self._root)
+        fl = final_dir(self._root)
+        ar = archive_dir(self._root)
+
+        relative_dir = video.parent.relative_to(tp)
+        pair = PendingPair(
+            video=video,
+            audio=audio,
+            relative_dir=relative_dir,
+            raw_suffix=self._raw_suffix,
+        )
+
+        result = assemble_one(pair, fl, ar)
+
+        if self._on_assembled:
+            self._on_assembled(result)
+
+        if result.success:
+            logger.info("Watcher assembled: {}", result.output_file)
+        else:
+            logger.error("Watcher assembly failed for {}: {}", video.name, result.error)
+            if self._on_error:
+                self._on_error(video, result.error or "Assembly failed")
+
+    def _wait_for_stable(self, path: Path) -> None:
+        """Poll file size until it stops changing.
+
+        Raises:
+            FileNotFoundError: If the file disappears during polling.
+        """
+        prev_size = -1
+        stable_count = 0
+
+        while stable_count < self._stability_checks:
+            if not path.exists():
+                raise FileNotFoundError(f"File disappeared during stability check: {path}")
+
+            size = path.stat().st_size
+            if size == prev_size and size > 0:
+                stable_count += 1
+            else:
+                stable_count = 0
+            prev_size = size
+
+            if stable_count < self._stability_checks:
+                time.sleep(self._stability_interval)
+
+
+class _WatchHandler(FileSystemEventHandler):
+    """Watchdog event handler that delegates to :class:`RecordingsWatcher`."""
+
+    def __init__(self, watcher: RecordingsWatcher) -> None:
+        super().__init__()
+        self._watcher = watcher
+
+    def on_created(self, event: FileCreatedEvent) -> None:  # type: ignore[override]
+        if event.is_directory:
+            return
+        self._watcher._on_file_event(Path(str(event.src_path)))
+
+    def on_moved(self, event: FileMovedEvent) -> None:  # type: ignore[override]
+        if event.is_directory:
+            return
+        # Treat the destination as a new file
+        self._watcher._on_file_event(Path(str(event.dest_path)))

--- a/tests/e2e/test_e2e_course_conversion.py
+++ b/tests/e2e/test_e2e_course_conversion.py
@@ -768,7 +768,8 @@ async def test_course_1_notebooks_native_workers(e2e_course_1, sqlite_backend_wi
     logger.info(f"Found {en_notebook_count} English notebooks and {en_html_count} HTML files")
 
     # Validate at least one notebook has correct Jupyter structure and content
-    de_notebooks = list(de_dir.rglob("*.ipynb"))
+    # Sort to get deterministic ordering across filesystems (NTFS vs ext4)
+    de_notebooks = sorted(de_dir.rglob("*.ipynb"))
     if de_notebooks:
         first_notebook = de_notebooks[0]
         notebook_data = validate_notebook_file_content(
@@ -778,7 +779,7 @@ async def test_course_1_notebooks_native_workers(e2e_course_1, sqlite_backend_wi
         assert len(notebook_data["cells"]) > 0, "Notebook should have cells"
 
     # Validate at least one HTML file exists and has content
-    de_html_files = list(de_dir.rglob("*.html"))
+    de_html_files = sorted(de_dir.rglob("*.html"))
     if de_html_files:
         first_html = de_html_files[0]
         validate_html_file_content(
@@ -1044,14 +1045,15 @@ async def test_course_3_single_notebook_e2e(e2e_course_3, sqlite_backend_with_no
     logger.info(f"Found {en_notebook_count} English notebooks and {en_html_count} HTML files")
 
     # Validate notebook has correct Jupyter structure
-    de_notebooks = list(de_dir.rglob("*.ipynb"))
+    # Sort to get deterministic ordering across filesystems (NTFS vs ext4)
+    de_notebooks = sorted(de_dir.rglob("*.ipynb"))
     assert len(de_notebooks) >= 2, f"Expected at least 2 German notebooks, got {len(de_notebooks)}"
     first_notebook = de_notebooks[0]
     notebook_data = validate_notebook_structure(first_notebook)
     assert len(notebook_data["cells"]) > 0, "Notebook should have cells"
 
     # Validate HTML files exist and have content
-    de_html_files = list(de_dir.rglob("*.html"))
+    de_html_files = sorted(de_dir.rglob("*.html"))
     assert len(de_html_files) >= 2, (
         f"Expected at least 2 German HTML files, got {len(de_html_files)}"
     )

--- a/tests/recordings/test_assembler.py
+++ b/tests/recordings/test_assembler.py
@@ -1,0 +1,297 @@
+"""Tests for recordings workflow assembler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clm.recordings.workflow.assembler import (
+    AssemblyBatchResult,
+    AssemblyResult,
+    assemble_all,
+    assemble_one,
+    mux_video_audio,
+)
+from clm.recordings.workflow.directories import PendingPair, ensure_root
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def recording_root(tmp_path: Path) -> Path:
+    """A tmp recordings root with the three-tier structure."""
+    root = tmp_path / "recordings"
+    ensure_root(root)
+    return root
+
+
+def _make_pair(root: Path, rel_dir: str, stem: str) -> PendingPair:
+    """Create a fake raw video + audio pair in to-process/."""
+    tp = root / "to-process" / rel_dir
+    tp.mkdir(parents=True, exist_ok=True)
+    video = tp / f"{stem}--RAW.mp4"
+    audio = tp / f"{stem}--RAW.wav"
+    video.write_bytes(b"fake video content")
+    audio.write_bytes(b"fake audio content")
+    return PendingPair(
+        video=video,
+        audio=audio,
+        relative_dir=Path(rel_dir),
+    )
+
+
+# ---------------------------------------------------------------------------
+# mux_video_audio
+# ---------------------------------------------------------------------------
+
+
+class TestMuxVideoAudio:
+    @patch("clm.recordings.workflow.assembler.run_subprocess")
+    def test_calls_ffmpeg_with_correct_args(self, mock_run, tmp_path: Path):
+        ffmpeg = Path("/usr/bin/ffmpeg")
+        video = tmp_path / "in.mp4"
+        audio = tmp_path / "in.wav"
+        output = tmp_path / "out" / "final.mp4"
+
+        mux_video_audio(ffmpeg, video, audio, output)
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == ffmpeg
+        assert str(video) in [str(a) for a in args]
+        assert str(audio) in [str(a) for a in args]
+        assert str(output) in [str(a) for a in args]
+        assert "-c:v" in [str(a) for a in args]
+        assert "copy" in [str(a) for a in args]
+
+    @patch("clm.recordings.workflow.assembler.run_subprocess")
+    def test_creates_output_directory(self, mock_run, tmp_path: Path):
+        ffmpeg = Path("/usr/bin/ffmpeg")
+        output = tmp_path / "deep" / "nested" / "out.mp4"
+
+        mux_video_audio(ffmpeg, tmp_path / "v.mp4", tmp_path / "a.wav", output)
+
+        assert output.parent.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# assemble_one
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleOne:
+    @patch("clm.recordings.workflow.assembler.run_subprocess")
+    def test_success(self, mock_run, recording_root: Path):
+        pair = _make_pair(recording_root, "course/section", "topic")
+        final = recording_root / "final"
+        archive = recording_root / "archive"
+
+        result = assemble_one(pair, final, archive, ffmpeg=Path("ffmpeg"))
+
+        assert result.success is True
+        assert result.output_file == final / "course" / "section" / "topic.mp4"
+        # Originals should be archived
+        assert not pair.video.exists()
+        assert not pair.audio.exists()
+        assert (archive / "course" / "section" / "topic--RAW.mp4").exists()
+        assert (archive / "course" / "section" / "topic--RAW.wav").exists()
+
+    @patch(
+        "clm.recordings.workflow.assembler.run_subprocess", side_effect=RuntimeError("ffmpeg died")
+    )
+    def test_failure(self, mock_run, recording_root: Path):
+        pair = _make_pair(recording_root, "course/section", "topic")
+
+        result = assemble_one(
+            pair,
+            recording_root / "final",
+            recording_root / "archive",
+            ffmpeg=Path("ffmpeg"),
+        )
+
+        assert result.success is False
+        assert "ffmpeg died" in result.error
+        # Originals should NOT be archived on failure
+        assert pair.video.exists()
+        assert pair.audio.exists()
+
+    @patch("clm.recordings.workflow.assembler.run_subprocess")
+    def test_custom_output_ext(self, mock_run, recording_root: Path):
+        pair = _make_pair(recording_root, "course/section", "topic")
+
+        result = assemble_one(
+            pair,
+            recording_root / "final",
+            recording_root / "archive",
+            ffmpeg=Path("ffmpeg"),
+            output_ext=".mkv",
+        )
+
+        assert result.output_file.suffix == ".mkv"
+
+
+# ---------------------------------------------------------------------------
+# assemble_all
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleAll:
+    @patch("clm.recordings.workflow.assembler.find_ffmpeg", return_value=Path("ffmpeg"))
+    @patch("clm.recordings.workflow.assembler.run_subprocess")
+    def test_assembles_all_pairs(self, mock_run, mock_ffmpeg, recording_root: Path):
+        _make_pair(recording_root, "course/s1", "alpha")
+        _make_pair(recording_root, "course/s2", "beta")
+
+        result = assemble_all(recording_root)
+
+        assert len(result.succeeded) == 2
+        assert len(result.failed) == 0
+
+    @patch("clm.recordings.workflow.assembler.find_ffmpeg", return_value=Path("ffmpeg"))
+    @patch("clm.recordings.workflow.assembler.run_subprocess")
+    def test_calls_progress_callback(self, mock_run, mock_ffmpeg, recording_root: Path):
+        _make_pair(recording_root, "course/section", "topic")
+        callback = MagicMock()
+
+        assemble_all(recording_root, on_pair=callback)
+
+        callback.assert_called_once()
+        args = callback.call_args[0]
+        assert args[0] == 0  # index
+        assert args[2] == 1  # total
+
+    @patch("clm.recordings.workflow.assembler.find_ffmpeg", return_value=Path("ffmpeg"))
+    def test_no_pairs(self, mock_ffmpeg, recording_root: Path):
+        result = assemble_all(recording_root)
+        assert len(result.results) == 0
+
+    @patch("clm.recordings.workflow.assembler.find_ffmpeg", return_value=Path("ffmpeg"))
+    @patch("clm.recordings.workflow.assembler.run_subprocess", side_effect=RuntimeError("boom"))
+    def test_partial_failure(self, mock_run, mock_ffmpeg, recording_root: Path):
+        _make_pair(recording_root, "course/s1", "alpha")
+        _make_pair(recording_root, "course/s2", "beta")
+
+        result = assemble_all(recording_root)
+
+        assert len(result.failed) == 2
+        assert "boom" in result.summary()
+
+
+# ---------------------------------------------------------------------------
+# AssemblyBatchResult
+# ---------------------------------------------------------------------------
+
+
+class TestAssemblyBatchResult:
+    def test_summary_no_failures(self):
+        batch = AssemblyBatchResult(
+            results=[
+                AssemblyResult(video=Path("a.mp4"), output_file=Path("a_out.mp4"), success=True),
+                AssemblyResult(video=Path("b.mp4"), output_file=Path("b_out.mp4"), success=True),
+            ]
+        )
+        s = batch.summary()
+        assert "Succeeded: 2" in s
+        assert "Failed:    0" in s
+
+    def test_summary_with_failures(self):
+        batch = AssemblyBatchResult(
+            results=[
+                AssemblyResult(video=Path("a.mp4"), output_file=Path("a_out.mp4"), success=True),
+                AssemblyResult(
+                    video=Path("b.mp4"),
+                    output_file=Path("b_out.mp4"),
+                    success=False,
+                    error="oops",
+                ),
+            ]
+        )
+        s = batch.summary()
+        assert "Failed:    1" in s
+        assert "oops" in s
+
+
+# ---------------------------------------------------------------------------
+# Integration test (requires real ffmpeg)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestAssembleIntegration:
+    """End-to-end assembly with real FFmpeg.
+
+    Skipped unless ``pytest -m integration`` is used.
+    """
+
+    def test_assemble_real_files(self, recording_root: Path):
+        """Create a minimal valid video + audio, assemble them."""
+        import shutil
+        import subprocess
+
+        if shutil.which("ffmpeg") is None:
+            pytest.skip("ffmpeg not installed")
+
+        # Generate a 1-second silent video and audio via ffmpeg
+        tp = recording_root / "to-process" / "test-course" / "test-section"
+        tp.mkdir(parents=True)
+
+        video = tp / "intro--RAW.mp4"
+        audio = tp / "intro--RAW.wav"
+
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=black:s=320x240:d=1",
+                "-f",
+                "lavfi",
+                "-i",
+                "anullsrc=r=48000:cl=mono",
+                "-t",
+                "1",
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+                str(video),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "anullsrc=r=48000:cl=mono",
+                "-t",
+                "1",
+                str(audio),
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        result = assemble_all(recording_root)
+
+        assert len(result.succeeded) == 1
+        output = recording_root / "final" / "test-course" / "test-section" / "intro.mp4"
+        assert output.is_file()
+        assert output.stat().st_size > 0
+
+        # Originals archived
+        assert (
+            recording_root / "archive" / "test-course" / "test-section" / "intro--RAW.mp4"
+        ).is_file()
+        assert (
+            recording_root / "archive" / "test-course" / "test-section" / "intro--RAW.wav"
+        ).is_file()

--- a/tests/recordings/test_backends.py
+++ b/tests/recordings/test_backends.py
@@ -1,0 +1,175 @@
+"""Tests for recording workflow processing backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clm.recordings.workflow.backends import (
+    ExternalBackend,
+    OnnxBackend,
+    ProcessingBackend,
+)
+
+# ------------------------------------------------------------------
+# Protocol conformance
+# ------------------------------------------------------------------
+
+
+class TestProcessingBackendProtocol:
+    def test_onnx_backend_is_processing_backend(self):
+        assert isinstance(OnnxBackend(), ProcessingBackend)
+
+    def test_external_backend_is_processing_backend(self):
+        assert isinstance(ExternalBackend(), ProcessingBackend)
+
+
+# ------------------------------------------------------------------
+# ExternalBackend
+# ------------------------------------------------------------------
+
+
+class TestExternalBackend:
+    def test_process_raises_not_implemented(self, tmp_path: Path):
+        backend = ExternalBackend()
+        with pytest.raises(NotImplementedError, match="external tool"):
+            backend.process(tmp_path / "video.mp4", tmp_path / "audio.wav")
+
+
+# ------------------------------------------------------------------
+# OnnxBackend
+# ------------------------------------------------------------------
+
+
+class TestOnnxBackend:
+    def test_init_default_config(self):
+        backend = OnnxBackend()
+        assert backend._config is None
+
+    def test_init_with_config(self):
+        from clm.recordings.processing.config import PipelineConfig
+
+        config = PipelineConfig(sample_rate=44100)
+        backend = OnnxBackend(config=config)
+        assert backend._config is config
+
+    @patch("clm.recordings.processing.utils.run_subprocess")
+    @patch("clm.recordings.processing.utils.run_onnx_denoise")
+    @patch("clm.recordings.processing.utils.get_audio_duration", return_value=120.0)
+    @patch("clm.recordings.processing.utils.find_ffprobe", return_value=Path("/usr/bin/ffprobe"))
+    @patch("clm.recordings.processing.utils.find_ffmpeg", return_value=Path("/usr/bin/ffmpeg"))
+    def test_process_calls_pipeline_steps(
+        self,
+        mock_ffmpeg: MagicMock,
+        mock_ffprobe: MagicMock,
+        mock_duration: MagicMock,
+        mock_denoise: MagicMock,
+        mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ):
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"fake video")
+        output_wav = tmp_path / "output" / "audio.wav"
+
+        backend = OnnxBackend()
+        backend.process(video, output_wav)
+
+        # Should create output directory
+        assert output_wav.parent.is_dir()
+
+        # Step 1: Extract audio (first run_subprocess call)
+        assert mock_subprocess.call_count == 2  # extract + filters
+        extract_call = mock_subprocess.call_args_list[0]
+        extract_args = [str(a) for a in extract_call[0][0]]
+        assert str(Path("/usr/bin/ffmpeg")) in extract_args
+        assert str(video) in extract_args
+
+        # Step 2: ONNX denoise
+        mock_denoise.assert_called_once()
+        denoise_kwargs = mock_denoise.call_args
+        assert denoise_kwargs.kwargs["atten_lim_db"] == 35.0
+
+        # Step 3: Audio filters (second run_subprocess call)
+        filter_call = mock_subprocess.call_args_list[1]
+        filter_args = [str(a) for a in filter_call[0][0]]
+        assert "-af" in filter_args
+        assert str(output_wav) in filter_args
+
+    @patch("clm.recordings.processing.utils.run_subprocess")
+    @patch("clm.recordings.processing.utils.run_onnx_denoise")
+    @patch("clm.recordings.processing.utils.get_audio_duration", return_value=60.0)
+    @patch("clm.recordings.processing.utils.find_ffprobe", return_value=Path("/usr/bin/ffprobe"))
+    @patch("clm.recordings.processing.utils.find_ffmpeg", return_value=Path("/usr/bin/ffmpeg"))
+    def test_process_uses_custom_config(
+        self,
+        mock_ffmpeg: MagicMock,
+        mock_ffprobe: MagicMock,
+        mock_duration: MagicMock,
+        mock_denoise: MagicMock,
+        mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ):
+        from clm.recordings.processing.config import PipelineConfig
+
+        config = PipelineConfig(denoise_atten_lim=50.0, sample_rate=44100)
+        backend = OnnxBackend(config=config)
+
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"fake video")
+        output_wav = tmp_path / "audio.wav"
+
+        backend.process(video, output_wav)
+
+        # Should use custom attenuation limit
+        mock_denoise.assert_called_once()
+        assert mock_denoise.call_args.kwargs["atten_lim_db"] == 50.0
+
+        # Should use custom sample rate
+        extract_args = [str(a) for a in mock_subprocess.call_args_list[0][0][0]]
+        assert "44100" in extract_args
+
+    @patch(
+        "clm.recordings.processing.utils.run_subprocess", side_effect=RuntimeError("ffmpeg fail")
+    )
+    @patch("clm.recordings.processing.utils.find_ffprobe", return_value=Path("/usr/bin/ffprobe"))
+    @patch("clm.recordings.processing.utils.find_ffmpeg", return_value=Path("/usr/bin/ffmpeg"))
+    def test_process_propagates_errors(
+        self,
+        mock_ffmpeg: MagicMock,
+        mock_ffprobe: MagicMock,
+        mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ):
+        backend = OnnxBackend()
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"fake video")
+
+        with pytest.raises(RuntimeError, match="ffmpeg fail"):
+            backend.process(video, tmp_path / "audio.wav")
+
+    @patch("clm.recordings.processing.utils.run_subprocess")
+    @patch("clm.recordings.processing.utils.run_onnx_denoise")
+    @patch("clm.recordings.processing.utils.get_audio_duration", return_value=60.0)
+    @patch("clm.recordings.processing.utils.find_ffprobe", return_value=Path("/usr/bin/ffprobe"))
+    @patch("clm.recordings.processing.utils.find_ffmpeg", return_value=Path("/usr/bin/ffmpeg"))
+    def test_process_falls_back_to_default_config_for_non_pipeline_config(
+        self,
+        mock_ffmpeg: MagicMock,
+        mock_ffprobe: MagicMock,
+        mock_duration: MagicMock,
+        mock_denoise: MagicMock,
+        mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ):
+        """When config is not a PipelineConfig instance, use defaults."""
+        backend = OnnxBackend(config="not-a-config")
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"fake video")
+
+        backend.process(video, tmp_path / "audio.wav")
+
+        # Should use default attenuation limit (35.0)
+        mock_denoise.assert_called_once()
+        assert mock_denoise.call_args.kwargs["atten_lim_db"] == 35.0

--- a/tests/recordings/test_batch.py
+++ b/tests/recordings/test_batch.py
@@ -1,0 +1,85 @@
+"""Tests for batch processing utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.recordings.processing.batch import BatchResult, find_video_files
+
+
+class TestFindVideoFiles:
+    def test_finds_common_formats(self, tmp_path: Path):
+        (tmp_path / "video.mkv").touch()
+        (tmp_path / "video.mp4").touch()
+        (tmp_path / "video.avi").touch()
+        (tmp_path / "readme.txt").touch()
+        (tmp_path / "image.png").touch()
+
+        files = find_video_files(tmp_path)
+        names = {f.name for f in files}
+        assert names == {"video.mkv", "video.mp4", "video.avi"}
+
+    def test_case_insensitive(self, tmp_path: Path):
+        (tmp_path / "video.MKV").touch()
+        (tmp_path / "video.Mp4").touch()
+
+        files = find_video_files(tmp_path)
+        assert len(files) == 2
+
+    def test_non_recursive_by_default(self, tmp_path: Path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "top.mkv").touch()
+        (sub / "nested.mkv").touch()
+
+        files = find_video_files(tmp_path, recursive=False)
+        assert len(files) == 1
+        assert files[0].name == "top.mkv"
+
+    def test_recursive(self, tmp_path: Path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "top.mkv").touch()
+        (sub / "nested.mkv").touch()
+
+        files = find_video_files(tmp_path, recursive=True)
+        assert len(files) == 2
+
+    def test_sorted_output(self, tmp_path: Path):
+        (tmp_path / "c.mkv").touch()
+        (tmp_path / "a.mkv").touch()
+        (tmp_path / "b.mkv").touch()
+
+        files = find_video_files(tmp_path)
+        names = [f.name for f in files]
+        assert names == ["a.mkv", "b.mkv", "c.mkv"]
+
+    def test_empty_directory(self, tmp_path: Path):
+        files = find_video_files(tmp_path)
+        assert files == []
+
+
+class TestBatchResult:
+    def test_total(self):
+        from clm.recordings.processing.pipeline import ProcessingResult
+
+        result = BatchResult(
+            succeeded=[
+                ProcessingResult(input_file=Path("a.mkv"), output_file=Path("a.mp4"), success=True)
+            ],
+            failed=[
+                ProcessingResult(
+                    input_file=Path("b.mkv"),
+                    output_file=Path("b.mp4"),
+                    success=False,
+                    error="failed",
+                )
+            ],
+            skipped=[Path("c.mkv")],
+        )
+        assert result.total == 3
+
+    def test_summary(self):
+        result = BatchResult()
+        summary = result.summary()
+        assert "0 files" in summary

--- a/tests/recordings/test_cli_recordings.py
+++ b/tests/recordings/test_cli_recordings.py
@@ -40,5 +40,5 @@ class TestRecordingsConfig:
         assert isinstance(config.recordings, RecordingsConfig)
         assert config.recordings.auto_process is False
         assert config.recordings.active_course == ""
-        assert config.recordings.processing.deepfilter_atten_lim == 35.0
+        assert config.recordings.processing.denoise_atten_lim == 35.0
         assert config.recordings.processing.sample_rate == 48000

--- a/tests/recordings/test_cli_recordings.py
+++ b/tests/recordings/test_cli_recordings.py
@@ -1,0 +1,44 @@
+"""Tests for the recordings CLI command registration and basic help."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from clm.cli.commands.recordings import recordings_group
+
+
+class TestRecordingsGroup:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["--help"])
+        assert result.exit_code == 0
+        assert "recordings" in result.output.lower() or "Manage video" in result.output
+
+    def test_subcommands_listed(self):
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["--help"])
+        assert result.exit_code == 0
+        assert "check" in result.output
+        assert "process" in result.output
+        assert "batch" in result.output
+        assert "status" in result.output
+        assert "compare" in result.output
+
+    def test_recordings_registered_in_cli(self):
+        from clm.cli.main import cli
+
+        command_names = list(cli.commands)
+        assert "recordings" in command_names
+
+
+class TestRecordingsConfig:
+    def test_recordings_config_in_clm_config(self):
+        """RecordingsConfig should be accessible via CLM's config system."""
+        from clm.infrastructure.config import ClmConfig, RecordingsConfig
+
+        config = ClmConfig()
+        assert isinstance(config.recordings, RecordingsConfig)
+        assert config.recordings.auto_process is False
+        assert config.recordings.active_course == ""
+        assert config.recordings.processing.deepfilter_atten_lim == 35.0
+        assert config.recordings.processing.sample_rate == 48000

--- a/tests/recordings/test_directories.py
+++ b/tests/recordings/test_directories.py
@@ -1,0 +1,183 @@
+"""Tests for recordings workflow directory management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.recordings.workflow.directories import (
+    SUBDIRS,
+    PendingPair,
+    archive_dir,
+    ensure_root,
+    final_dir,
+    find_pending_pairs,
+    to_process_dir,
+    validate_root,
+)
+
+
+class TestEnsureRoot:
+    def test_creates_all_subdirs(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        for name in SUBDIRS:
+            assert (root / name).is_dir()
+
+    def test_idempotent(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        ensure_root(root)  # second call should not fail
+        for name in SUBDIRS:
+            assert (root / name).is_dir()
+
+    def test_preserves_existing_content(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        marker = root / "to-process" / "marker.txt"
+        marker.write_text("keep me")
+        ensure_root(root)
+        assert marker.read_text() == "keep me"
+
+
+class TestValidateRoot:
+    def test_valid_root(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        assert validate_root(root) == []
+
+    def test_missing_root(self, tmp_path: Path):
+        root = tmp_path / "nonexistent"
+        errors = validate_root(root)
+        assert len(errors) == 1
+        assert "does not exist" in errors[0]
+
+    def test_missing_subdir(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        root.mkdir()
+        (root / "to-process").mkdir()
+        (root / "final").mkdir()
+        # archive/ intentionally missing
+        errors = validate_root(root)
+        assert len(errors) == 1
+        assert "archive" in errors[0]
+
+    def test_all_subdirs_missing(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        root.mkdir()
+        errors = validate_root(root)
+        assert len(errors) == 3
+
+
+class TestDirHelpers:
+    def test_to_process_dir(self, tmp_path: Path):
+        assert to_process_dir(tmp_path) == tmp_path / "to-process"
+
+    def test_final_dir(self, tmp_path: Path):
+        assert final_dir(tmp_path) == tmp_path / "final"
+
+    def test_archive_dir(self, tmp_path: Path):
+        assert archive_dir(tmp_path) == tmp_path / "archive"
+
+
+class TestPendingPair:
+    def test_base_name(self, tmp_path: Path):
+        pair = PendingPair(
+            video=tmp_path / "topic--RAW.mp4",
+            audio=tmp_path / "topic--RAW.wav",
+            relative_dir=Path("course/section"),
+        )
+        assert pair.base_name == "topic"
+
+    def test_base_name_no_suffix(self, tmp_path: Path):
+        pair = PendingPair(
+            video=tmp_path / "topic.mp4",
+            audio=tmp_path / "topic.wav",
+            relative_dir=Path("course/section"),
+        )
+        assert pair.base_name == "topic"
+
+
+class TestFindPendingPairs:
+    def _make_pair(self, tp: Path, rel_dir: str, stem: str) -> None:
+        """Create a raw video + audio pair in the to-process tree."""
+        d = tp / rel_dir
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{stem}--RAW.mp4").write_bytes(b"video")
+        (d / f"{stem}--RAW.wav").write_bytes(b"audio")
+
+    def test_finds_pair(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        self._make_pair(tp, "course/section", "topic")
+        pairs = find_pending_pairs(tp)
+        assert len(pairs) == 1
+        assert pairs[0].base_name == "topic"
+        assert pairs[0].relative_dir == Path("course/section")
+
+    def test_ignores_video_without_audio(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        d = tp / "course" / "section"
+        d.mkdir(parents=True)
+        (d / "topic--RAW.mp4").write_bytes(b"video")
+        # No .wav file
+        assert find_pending_pairs(tp) == []
+
+    def test_ignores_audio_without_video(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        d = tp / "course" / "section"
+        d.mkdir(parents=True)
+        (d / "topic--RAW.wav").write_bytes(b"audio")
+        # No video file
+        assert find_pending_pairs(tp) == []
+
+    def test_ignores_non_raw_files(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        d = tp / "course" / "section"
+        d.mkdir(parents=True)
+        (d / "topic.mp4").write_bytes(b"video")
+        (d / "topic.wav").write_bytes(b"audio")
+        assert find_pending_pairs(tp) == []
+
+    def test_multiple_pairs_sorted(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        self._make_pair(tp, "course/s2", "beta")
+        self._make_pair(tp, "course/s1", "alpha")
+        pairs = find_pending_pairs(tp)
+        assert len(pairs) == 2
+        assert pairs[0].base_name == "alpha"
+        assert pairs[1].base_name == "beta"
+
+    def test_mkv_extension(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        d = tp / "course" / "section"
+        d.mkdir(parents=True)
+        (d / "topic--RAW.mkv").write_bytes(b"video")
+        (d / "topic--RAW.wav").write_bytes(b"audio")
+        pairs = find_pending_pairs(tp)
+        assert len(pairs) == 1
+
+    def test_custom_suffix(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        d = tp / "course" / "section"
+        d.mkdir(parents=True)
+        (d / "topic__ORIG.mp4").write_bytes(b"video")
+        (d / "topic__ORIG.wav").write_bytes(b"audio")
+        pairs = find_pending_pairs(tp, raw_suffix="__ORIG")
+        assert len(pairs) == 1
+        assert pairs[0].base_name == "topic"
+
+    def test_empty_directory(self, tmp_path: Path):
+        tp = tmp_path / "to-process"
+        tp.mkdir()
+        assert find_pending_pairs(tp) == []
+
+    def test_flat_structure(self, tmp_path: Path):
+        """Pairs directly in to-process/ (no subdirectories)."""
+        tp = tmp_path / "to-process"
+        tp.mkdir()
+        (tp / "lecture--RAW.mp4").write_bytes(b"video")
+        (tp / "lecture--RAW.wav").write_bytes(b"audio")
+        pairs = find_pending_pairs(tp)
+        assert len(pairs) == 1
+        assert pairs[0].relative_dir == Path(".")

--- a/tests/recordings/test_git_info.py
+++ b/tests/recordings/test_git_info.py
@@ -1,0 +1,28 @@
+"""Tests for git info capture."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.recordings.git_info import get_git_info
+
+
+class TestGetGitInfo:
+    def test_returns_commit_for_git_repo(self, tmp_path: Path):
+        """Test against a real git repo (this project itself)."""
+        # Use the CLM project directory as a known git repo
+        clm_root = Path(__file__).resolve().parents[2]
+        if not (clm_root / ".git").exists():
+            import pytest
+
+            pytest.skip("Not running inside a git repo")
+
+        info = get_git_info(clm_root)
+        assert info["commit"] is not None
+        assert len(info["commit"]) == 40  # full SHA
+        assert isinstance(info["dirty"], bool)
+
+    def test_returns_none_for_non_git_dir(self, tmp_path: Path):
+        info = get_git_info(tmp_path)
+        assert info["commit"] is None
+        assert info["dirty"] is None

--- a/tests/recordings/test_naming.py
+++ b/tests/recordings/test_naming.py
@@ -1,0 +1,93 @@
+"""Tests for recordings workflow naming helpers."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+import pytest
+
+from clm.recordings.workflow.naming import (
+    DEFAULT_RAW_SUFFIX,
+    final_filename,
+    parse_raw_stem,
+    raw_filename,
+    recording_relative_dir,
+)
+
+
+class TestRecordingRelativeDir:
+    def test_basic(self):
+        result = recording_relative_dir("python-basics", "Week 1")
+        assert result == PurePosixPath("python-basics/Week 1")
+
+    def test_sanitizes_special_chars(self):
+        result = recording_relative_dir("my/course", "section<1>")
+        assert "/" not in result.parts[0]
+        assert "<" not in str(result.parts[1])
+
+    def test_preserves_underscores_and_hyphens(self):
+        result = recording_relative_dir("ml-course_v2", "week_01")
+        assert result == PurePosixPath("ml-course_v2/week_01")
+
+    def test_sanitizes_csharp(self):
+        result = recording_relative_dir("C# Basics", "Intro")
+        assert "CSharp" in str(result.parts[0])
+
+
+class TestRawFilename:
+    def test_default(self):
+        assert raw_filename("my_topic") == "my_topic--RAW.mp4"
+
+    def test_custom_ext(self):
+        assert raw_filename("my_topic", ext=".mkv") == "my_topic--RAW.mkv"
+
+    def test_custom_suffix(self):
+        assert raw_filename("my_topic", raw_suffix="__RAW") == "my_topic__RAW.mp4"
+
+    def test_sanitizes_name(self):
+        result = raw_filename("topic with $pecial chars!")
+        assert "$" not in result
+        assert "!" not in result
+        assert result.endswith("--RAW.mp4")
+
+
+class TestFinalFilename:
+    def test_default(self):
+        assert final_filename("my_topic") == "my_topic.mp4"
+
+    def test_custom_ext(self):
+        assert final_filename("my_topic", ext=".mkv") == "my_topic.mkv"
+
+    def test_sanitizes_name(self):
+        result = final_filename("topic<1>")
+        assert "<" not in result
+        assert result.endswith(".mp4")
+
+
+class TestParseRawStem:
+    def test_raw_stem(self):
+        base, is_raw = parse_raw_stem("my_topic--RAW")
+        assert base == "my_topic"
+        assert is_raw is True
+
+    def test_non_raw_stem(self):
+        base, is_raw = parse_raw_stem("my_topic")
+        assert base == "my_topic"
+        assert is_raw is False
+
+    def test_custom_suffix(self):
+        base, is_raw = parse_raw_stem("topic__UNPROCESSED", raw_suffix="__UNPROCESSED")
+        assert base == "topic"
+        assert is_raw is True
+
+    def test_partial_match_not_raw(self):
+        base, is_raw = parse_raw_stem("topic--RA")
+        assert base == "topic--RA"
+        assert is_raw is False
+
+    def test_suffix_in_middle_not_matched(self):
+        base, is_raw = parse_raw_stem("--RAW_topic")
+        assert is_raw is False
+
+    def test_default_suffix_constant(self):
+        assert DEFAULT_RAW_SUFFIX == "--RAW"

--- a/tests/recordings/test_obs.py
+++ b/tests/recordings/test_obs.py
@@ -1,0 +1,218 @@
+"""Tests for the OBS WebSocket client wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clm.recordings.workflow.obs import ObsClient, RecordingEvent
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_obsws():
+    """Patch obsws_python with mock ReqClient and EventClient."""
+    with (
+        patch("obsws_python.ReqClient") as MockReq,
+        patch("obsws_python.EventClient") as MockEvt,
+    ):
+        req_instance = MagicMock()
+        evt_instance = MagicMock()
+        MockReq.return_value = req_instance
+        MockEvt.return_value = evt_instance
+        yield {
+            "ReqClient": MockReq,
+            "EventClient": MockEvt,
+            "req": req_instance,
+            "evt": evt_instance,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestObsClientConnection:
+    def test_connect_creates_both_clients(self, mock_obsws):
+        client = ObsClient(host="myhost", port=9999, password="secret")
+        client.connect()
+
+        mock_obsws["ReqClient"].assert_called_once_with(host="myhost", port=9999, password="secret")
+        mock_obsws["EventClient"].assert_called_once_with(
+            host="myhost", port=9999, password="secret"
+        )
+        assert client.connected is True
+
+    def test_connect_registers_event_handler(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+
+        mock_obsws["evt"].callback.register.assert_called_once()
+        handler = mock_obsws["evt"].callback.register.call_args[0][0]
+        assert handler.__name__ == "on_record_state_changed"
+
+    def test_connected_false_before_connect(self):
+        client = ObsClient()
+        assert client.connected is False
+
+    def test_disconnect_cleans_up(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        client.disconnect()
+
+        mock_obsws["req"].disconnect.assert_called_once()
+        mock_obsws["evt"].disconnect.assert_called_once()
+        assert client.connected is False
+
+    def test_disconnect_when_not_connected(self):
+        client = ObsClient()
+        client.disconnect()  # Should not raise
+
+    def test_connect_req_failure_raises(self):
+        with patch("obsws_python.ReqClient", side_effect=Exception("refused")):
+            client = ObsClient()
+            with pytest.raises(ConnectionError, match="Cannot connect to OBS"):
+                client.connect()
+
+    def test_connect_evt_failure_disconnects_req(self):
+        req_mock = MagicMock()
+        with (
+            patch("obsws_python.ReqClient", return_value=req_mock),
+            patch("obsws_python.EventClient", side_effect=Exception("evt fail")),
+        ):
+            client = ObsClient()
+            with pytest.raises(ConnectionError, match="event client"):
+                client.connect()
+            req_mock.disconnect.assert_called_once()
+            assert client.connected is False
+
+    def test_context_manager(self, mock_obsws):
+        with ObsClient() as client:
+            assert client.connected is True
+        assert client.connected is False
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+
+class TestObsClientQueries:
+    def test_get_record_status(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+
+        mock_obsws["req"].get_record_status.return_value = MagicMock(
+            output_active=True,
+            output_state="OBS_WEBSOCKET_OUTPUT_STARTED",
+            output_path=None,
+        )
+
+        status = client.get_record_status()
+        assert status.output_active is True
+        assert status.output_state == "OBS_WEBSOCKET_OUTPUT_STARTED"
+
+    def test_get_record_status_not_connected(self):
+        client = ObsClient()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.get_record_status()
+
+    def test_get_record_directory(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+
+        mock_obsws["req"].get_record_directory.return_value = MagicMock(
+            record_directory="C:/Videos"
+        )
+
+        result = client.get_record_directory()
+        assert result == Path("C:/Videos")
+
+    def test_get_record_directory_not_connected(self):
+        client = ObsClient()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.get_record_directory()
+
+
+# ---------------------------------------------------------------------------
+# Event dispatching
+# ---------------------------------------------------------------------------
+
+
+class TestObsClientEvents:
+    def test_callback_receives_recording_event(self, mock_obsws):
+        client = ObsClient()
+        callback = MagicMock()
+        client.on_record_state_changed(callback)
+        client.connect()
+
+        # Get the handler that was registered with obsws-python
+        handler = mock_obsws["evt"].callback.register.call_args[0][0]
+
+        # Simulate an OBS event
+        fake_data = MagicMock(
+            output_active=False,
+            output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+            output_path="/tmp/recording.mkv",
+        )
+        handler(fake_data)
+
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert isinstance(event, RecordingEvent)
+        assert event.output_active is False
+        assert event.output_state == "OBS_WEBSOCKET_OUTPUT_STOPPED"
+        assert event.output_path == "/tmp/recording.mkv"
+
+    def test_callback_handles_missing_output_path(self, mock_obsws):
+        client = ObsClient()
+        callback = MagicMock()
+        client.on_record_state_changed(callback)
+        client.connect()
+
+        handler = mock_obsws["evt"].callback.register.call_args[0][0]
+
+        # Event data without output_path attribute
+        fake_data = MagicMock(spec=["output_active"])
+        fake_data.output_active = True
+        handler(fake_data)
+
+        event = callback.call_args[0][0]
+        assert event.output_path is None
+        assert event.output_state == "unknown"
+
+    def test_multiple_callbacks(self, mock_obsws):
+        client = ObsClient()
+        cb1 = MagicMock()
+        cb2 = MagicMock()
+        client.on_record_state_changed(cb1)
+        client.on_record_state_changed(cb2)
+        client.connect()
+
+        handler = mock_obsws["evt"].callback.register.call_args[0][0]
+        fake_data = MagicMock(output_active=True, output_state="started")
+        handler(fake_data)
+
+        cb1.assert_called_once()
+        cb2.assert_called_once()
+
+    def test_callback_exception_does_not_stop_others(self, mock_obsws):
+        client = ObsClient()
+        cb1 = MagicMock(side_effect=ValueError("boom"))
+        cb2 = MagicMock()
+        client.on_record_state_changed(cb1)
+        client.on_record_state_changed(cb2)
+        client.connect()
+
+        handler = mock_obsws["evt"].callback.register.call_args[0][0]
+        fake_data = MagicMock(output_active=True, output_state="started")
+        handler(fake_data)
+
+        # cb2 should still be called despite cb1 raising
+        cb2.assert_called_once()

--- a/tests/recordings/test_obs.py
+++ b/tests/recordings/test_obs.py
@@ -9,6 +9,11 @@ import pytest
 
 from clm.recordings.workflow.obs import ObsClient, RecordingEvent
 
+# obsws_python is an optional dependency ([recordings] extra).
+# Skip the entire module if it is not installed so that CI environments
+# without the extra don't fail on patch targets.
+pytest.importorskip("obsws_python", reason="obsws-python not installed")
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/recordings/test_processing_config.py
+++ b/tests/recordings/test_processing_config.py
@@ -40,7 +40,7 @@ class TestAudioFilterConfig:
 class TestPipelineConfig:
     def test_defaults(self):
         cfg = PipelineConfig()
-        assert cfg.deepfilter_atten_lim == 35.0
+        assert cfg.denoise_atten_lim == 35.0
         assert cfg.sample_rate == 48000
         assert cfg.video_codec == "copy"
         assert cfg.output_extension == "mp4"
@@ -49,7 +49,7 @@ class TestPipelineConfig:
 
     def test_json_roundtrip(self, tmp_path: Path):
         cfg = PipelineConfig(
-            deepfilter_atten_lim=50.0,
+            denoise_atten_lim=50.0,
             sample_rate=44100,
             audio_filters=AudioFilterConfig(highpass_freq=120),
         )
@@ -57,22 +57,22 @@ class TestPipelineConfig:
         path.write_text(cfg.model_dump_json(indent=2))
 
         loaded = PipelineConfig.model_validate_json(path.read_text())
-        assert loaded.deepfilter_atten_lim == 50.0
+        assert loaded.denoise_atten_lim == 50.0
         assert loaded.sample_rate == 44100
         assert loaded.audio_filters.highpass_freq == 120
 
     def test_dump_produces_valid_json(self):
         cfg = PipelineConfig()
         data = json.loads(cfg.model_dump_json())
-        assert "deepfilter_atten_lim" in data
+        assert "denoise_atten_lim" in data
         assert "audio_filters" in data
         assert "highpass_freq" in data["audio_filters"]
 
     def test_partial_config_uses_defaults(self):
         """Partial JSON should fill in defaults for missing keys."""
-        partial = '{"deepfilter_atten_lim": 42.0, "audio_filters": {"highpass_freq": 100}}'
+        partial = '{"denoise_atten_lim": 42.0, "audio_filters": {"highpass_freq": 100}}'
         loaded = PipelineConfig.model_validate_json(partial)
-        assert loaded.deepfilter_atten_lim == 42.0
+        assert loaded.denoise_atten_lim == 42.0
         assert loaded.sample_rate == 48000  # default
         assert loaded.audio_filters.highpass_freq == 100
         assert loaded.audio_filters.loudnorm_target == -16.0  # default

--- a/tests/recordings/test_processing_config.py
+++ b/tests/recordings/test_processing_config.py
@@ -1,0 +1,78 @@
+"""Tests for the recording processing pipeline configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clm.recordings.processing.config import AudioFilterConfig, PipelineConfig
+
+
+class TestAudioFilterConfig:
+    def test_defaults(self):
+        cfg = AudioFilterConfig()
+        assert cfg.highpass_freq == 80
+        assert cfg.loudnorm_target == -16.0
+
+    def test_compressor_filter_string(self):
+        cfg = AudioFilterConfig()
+        f = cfg.compressor_filter
+        assert "compand=" in f
+        assert "attacks=0.05" in f
+        assert "gain=5.0" in f
+
+    def test_loudnorm_filter_string(self):
+        cfg = AudioFilterConfig()
+        f = cfg.loudnorm_filter
+        assert "loudnorm=" in f
+        assert "I=-16.0" in f
+        assert "TP=-1.5" in f
+        assert "LRA=11.0" in f
+
+    def test_custom_values(self):
+        cfg = AudioFilterConfig(highpass_freq=120, loudnorm_target=-20.0)
+        assert cfg.highpass_freq == 120
+        assert cfg.loudnorm_target == -20.0
+
+
+class TestPipelineConfig:
+    def test_defaults(self):
+        cfg = PipelineConfig()
+        assert cfg.deepfilter_atten_lim == 35.0
+        assert cfg.sample_rate == 48000
+        assert cfg.video_codec == "copy"
+        assert cfg.output_extension == "mp4"
+        assert cfg.keep_temp is False
+        assert isinstance(cfg.audio_filters, AudioFilterConfig)
+
+    def test_json_roundtrip(self, tmp_path: Path):
+        cfg = PipelineConfig(
+            deepfilter_atten_lim=50.0,
+            sample_rate=44100,
+            audio_filters=AudioFilterConfig(highpass_freq=120),
+        )
+        path = tmp_path / "config.json"
+        path.write_text(cfg.model_dump_json(indent=2))
+
+        loaded = PipelineConfig.model_validate_json(path.read_text())
+        assert loaded.deepfilter_atten_lim == 50.0
+        assert loaded.sample_rate == 44100
+        assert loaded.audio_filters.highpass_freq == 120
+
+    def test_dump_produces_valid_json(self):
+        cfg = PipelineConfig()
+        data = json.loads(cfg.model_dump_json())
+        assert "deepfilter_atten_lim" in data
+        assert "audio_filters" in data
+        assert "highpass_freq" in data["audio_filters"]
+
+    def test_partial_config_uses_defaults(self):
+        """Partial JSON should fill in defaults for missing keys."""
+        partial = '{"deepfilter_atten_lim": 42.0, "audio_filters": {"highpass_freq": 100}}'
+        loaded = PipelineConfig.model_validate_json(partial)
+        assert loaded.deepfilter_atten_lim == 42.0
+        assert loaded.sample_rate == 48000  # default
+        assert loaded.audio_filters.highpass_freq == 100
+        assert loaded.audio_filters.loudnorm_target == -16.0  # default

--- a/tests/recordings/test_processing_pipeline.py
+++ b/tests/recordings/test_processing_pipeline.py
@@ -1,0 +1,102 @@
+"""Tests for the recording processing pipeline.
+
+These tests cover logic that doesn't require external binaries
+(ffmpeg, deepFilter). Integration tests with real binaries are
+marked with @pytest.mark.recordings.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from clm.recordings.processing.pipeline import ProcessingPipeline, ProcessingResult
+
+
+class TestLoudnormParsing:
+    """Test parsing of FFmpeg loudnorm measurement output."""
+
+    def test_parses_typical_output(self):
+        output = textwrap.dedent("""\
+            [Parsed_loudnorm_2 @ 0x55f4c8]
+            {
+                "input_i" : "-24.50",
+                "input_tp" : "-3.20",
+                "input_lra" : "8.10",
+                "input_thresh" : "-35.00",
+                "output_i" : "-16.00",
+                "output_tp" : "-1.50",
+                "output_lra" : "7.80",
+                "output_thresh" : "-26.50",
+                "normalization_type" : "dynamic",
+                "target_offset" : "0.00"
+            }
+        """)
+        result = ProcessingPipeline._parse_loudnorm_json(output)
+        assert result is not None
+        assert result["input_i"] == "-24.50"
+        assert result["input_tp"] == "-3.20"
+        assert result["input_lra"] == "8.10"
+        assert result["input_thresh"] == "-35.00"
+        # Should not include output values.
+        assert "output_i" not in result
+
+    def test_parses_with_surrounding_noise(self):
+        output = (
+            "frame= 0 fps=0.0 q=0.0 size= 0kB time=00:00:00.00\n"
+            "lots of other ffmpeg output here\n"
+            "{\n"
+            '    "input_i" : "-20.00",\n'
+            '    "input_tp" : "-1.00",\n'
+            '    "input_lra" : "5.00",\n'
+            '    "input_thresh" : "-30.00",\n'
+            '    "output_i" : "-16.00",\n'
+            '    "output_tp" : "-1.50",\n'
+            '    "output_lra" : "4.50",\n'
+            '    "output_thresh" : "-26.50",\n'
+            '    "normalization_type" : "dynamic",\n'
+            '    "target_offset" : "0.00"\n'
+            "}\n"
+            "more output after\n"
+        )
+        result = ProcessingPipeline._parse_loudnorm_json(output)
+        assert result is not None
+        assert result["input_i"] == "-20.00"
+
+    def test_returns_none_for_empty_output(self):
+        assert ProcessingPipeline._parse_loudnorm_json("") is None
+
+    def test_returns_none_for_no_json(self):
+        output = "frame= 100 fps=50.0 q=0.0 size= 1234kB\n"
+        assert ProcessingPipeline._parse_loudnorm_json(output) is None
+
+    def test_returns_none_for_incomplete_json(self):
+        output = '{"input_i": "-24.50", "input_tp": "-3.20"}'
+        assert ProcessingPipeline._parse_loudnorm_json(output) is None
+
+
+class TestProcessingResult:
+    def test_model_dump(self):
+        r = ProcessingResult(
+            input_file=Path("/in/test.mkv"),
+            output_file=Path("/out/test.mp4"),
+            success=True,
+            duration_seconds=120.5,
+        )
+        d = r.model_dump()
+        assert d["success"] is True
+        assert d["duration_seconds"] == 120.5
+        assert d["error"] is None
+
+    def test_failed_result(self):
+        r = ProcessingResult(
+            input_file=Path("/in/test.mkv"),
+            output_file=Path("/out/test.mp4"),
+            success=False,
+            error="Something went wrong",
+        )
+        assert not r.success
+        assert r.error == "Something went wrong"
+        assert r.duration_seconds == 0.0

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -1,0 +1,408 @@
+"""Tests for the recording session state machine."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clm.recordings.workflow.directories import ensure_root
+from clm.recordings.workflow.obs import ObsClient, RecordingEvent
+from clm.recordings.workflow.session import (
+    ArmedTopic,
+    RecordingSession,
+    SessionSnapshot,
+    SessionState,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_obs() -> MagicMock:
+    """A mock ObsClient that tracks registered callbacks."""
+    obs = MagicMock(spec=ObsClient)
+    obs.connected = True
+    obs._record_callbacks: list = []
+
+    def register_cb(cb):
+        obs._record_callbacks.append(cb)
+
+    obs.on_record_state_changed.side_effect = register_cb
+    return obs
+
+
+@pytest.fixture()
+def recording_root(tmp_path: Path) -> Path:
+    """A tmp recordings root with the three-tier structure."""
+    root = tmp_path / "recordings"
+    ensure_root(root)
+    return root
+
+
+@pytest.fixture()
+def session(mock_obs: MagicMock, recording_root: Path) -> RecordingSession:
+    """A session with short stability checks for fast tests."""
+    return RecordingSession(
+        mock_obs,
+        recording_root,
+        stability_interval=0.01,
+        stability_checks=1,
+    )
+
+
+def _fire_event(mock_obs: MagicMock, event: RecordingEvent) -> None:
+    """Simulate an OBS event by calling registered callbacks."""
+    for cb in mock_obs._record_callbacks:
+        cb(event)
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+
+class TestInitialState:
+    def test_starts_idle(self, session: RecordingSession):
+        assert session.state is SessionState.IDLE
+
+    def test_no_armed_topic(self, session: RecordingSession):
+        assert session.armed_topic is None
+
+    def test_snapshot_initial(self, session: RecordingSession):
+        snap = session.snapshot()
+        assert snap.state is SessionState.IDLE
+        assert snap.armed_topic is None
+        assert snap.obs_connected is True
+        assert snap.last_output is None
+        assert snap.error is None
+
+    def test_registers_obs_callback(self, mock_obs: MagicMock):
+        RecordingSession(mock_obs, Path("/tmp/root"))
+        mock_obs.on_record_state_changed.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Arming / disarming
+# ---------------------------------------------------------------------------
+
+
+class TestArmDisarm:
+    def test_arm_from_idle(self, session: RecordingSession):
+        session.arm("python-basics", "Section 01", "intro")
+        assert session.state is SessionState.ARMED
+        assert session.armed_topic == ArmedTopic("python-basics", "Section 01", "intro")
+
+    def test_arm_from_armed_switches_topic(self, session: RecordingSession):
+        session.arm("course-a", "s1", "topic1")
+        session.arm("course-b", "s2", "topic2")
+        assert session.armed_topic == ArmedTopic("course-b", "s2", "topic2")
+        assert session.state is SessionState.ARMED
+
+    def test_arm_clears_previous_error(self, session: RecordingSession):
+        # Manually set an error
+        session._error = "old error"
+        session.arm("c", "s", "t")
+        assert session.snapshot().error is None
+
+    def test_arm_while_recording_raises(self, session: RecordingSession, mock_obs):
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert session.state is SessionState.RECORDING
+
+        with pytest.raises(RuntimeError, match="Cannot arm"):
+            session.arm("c", "s", "other")
+
+    def test_disarm_from_armed(self, session: RecordingSession):
+        session.arm("c", "s", "t")
+        session.disarm()
+        assert session.state is SessionState.IDLE
+        assert session.armed_topic is None
+
+    def test_disarm_from_idle(self, session: RecordingSession):
+        session.disarm()  # No-op, should not raise
+        assert session.state is SessionState.IDLE
+
+    def test_disarm_while_recording_raises(self, session: RecordingSession, mock_obs):
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+
+        with pytest.raises(RuntimeError, match="Cannot disarm"):
+            session.disarm()
+
+
+# ---------------------------------------------------------------------------
+# Recording start event
+# ---------------------------------------------------------------------------
+
+
+class TestRecordingStart:
+    def test_armed_transitions_to_recording(self, session: RecordingSession, mock_obs):
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert session.state is SessionState.RECORDING
+
+    def test_idle_stays_idle_on_start(self, session: RecordingSession, mock_obs):
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert session.state is SessionState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# Recording stop event — no rename
+# ---------------------------------------------------------------------------
+
+
+class TestRecordingStopNoRename:
+    def test_stop_without_armed_topic_goes_idle(self, session: RecordingSession, mock_obs):
+        # Force into RECORDING state without armed topic
+        session._state = SessionState.RECORDING
+        session._armed = None
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path="/tmp/out.mkv",
+            ),
+        )
+        assert session.state is SessionState.IDLE
+
+    def test_stop_while_idle_is_ignored(self, session: RecordingSession, mock_obs):
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="stopped"),
+        )
+        assert session.state is SessionState.IDLE
+
+    def test_stop_without_output_path_sets_error(self, session: RecordingSession, mock_obs):
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="stopped", output_path=None),
+        )
+        assert session.state is SessionState.IDLE
+        snap = session.snapshot()
+        assert snap.error is not None
+        assert "output file path" in snap.error
+
+
+# ---------------------------------------------------------------------------
+# Recording stop event — with rename
+# ---------------------------------------------------------------------------
+
+
+class TestRecordingStopWithRename:
+    @patch("clm.recordings.workflow.session.shutil.move")
+    def test_rename_moves_file(self, mock_move, session: RecordingSession, mock_obs, tmp_path):
+        # Create a fake OBS output file
+        obs_output = tmp_path / "2025-04-01_12-00-00.mkv"
+        obs_output.write_bytes(b"video data")
+
+        session.arm("python-basics", "Section 01", "intro")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+
+        assert session.state is SessionState.RECORDING
+
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+        # Wait for the rename thread to complete
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+
+        assert session.state is SessionState.IDLE
+        mock_move.assert_called_once()
+        src, dst = mock_move.call_args[0]
+        assert src == str(obs_output)
+        assert "python-basics" in dst
+        assert "Section 01" in dst
+        assert "intro--RAW.mkv" in dst
+
+    @patch("clm.recordings.workflow.session.shutil.move")
+    def test_rename_sets_last_output(self, mock_move, session, mock_obs, tmp_path):
+        obs_output = tmp_path / "rec.mp4"
+        obs_output.write_bytes(b"data")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+
+        snap = session.snapshot()
+        assert snap.last_output is not None
+        assert snap.last_output.name == "t--RAW.mp4"
+
+    @patch("clm.recordings.workflow.session.shutil.move")
+    def test_rename_clears_armed_topic(self, mock_move, session, mock_obs, tmp_path):
+        obs_output = tmp_path / "rec.mp4"
+        obs_output.write_bytes(b"data")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+        assert session.armed_topic is None
+
+    def test_rename_file_not_found_sets_error(self, session, mock_obs):
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path="/nonexistent/file.mkv",
+            ),
+        )
+
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+
+        snap = session.snapshot()
+        assert snap.error is not None
+        assert "not found" in snap.error.lower() or "nonexistent" in snap.error.lower()
+
+    @patch(
+        "clm.recordings.workflow.session.shutil.move",
+        side_effect=PermissionError("access denied"),
+    )
+    def test_rename_failure_sets_error(self, mock_move, session, mock_obs, tmp_path):
+        obs_output = tmp_path / "rec.mp4"
+        obs_output.write_bytes(b"data")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+
+        snap = session.snapshot()
+        assert snap.error is not None
+        assert "access denied" in snap.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# State change callbacks
+# ---------------------------------------------------------------------------
+
+
+class TestStateChangeCallback:
+    def test_arm_triggers_callback(self, mock_obs, recording_root):
+        callback = MagicMock()
+        session = RecordingSession(mock_obs, recording_root, on_state_change=callback)
+        session.arm("c", "s", "t")
+
+        callback.assert_called_once()
+        snap = callback.call_args[0][0]
+        assert isinstance(snap, SessionSnapshot)
+        assert snap.state is SessionState.ARMED
+
+    def test_disarm_triggers_callback(self, mock_obs, recording_root):
+        callback = MagicMock()
+        session = RecordingSession(mock_obs, recording_root, on_state_change=callback)
+        session.arm("c", "s", "t")
+        callback.reset_mock()
+        session.disarm()
+
+        callback.assert_called_once()
+        snap = callback.call_args[0][0]
+        assert snap.state is SessionState.IDLE
+
+    def test_recording_start_triggers_callback(self, mock_obs, recording_root):
+        callback = MagicMock()
+        session = RecordingSession(mock_obs, recording_root, on_state_change=callback)
+        session.arm("c", "s", "t")
+        callback.reset_mock()
+
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+
+        callback.assert_called_once()
+        snap = callback.call_args[0][0]
+        assert snap.state is SessionState.RECORDING
+
+    def test_callback_exception_does_not_break_session(self, mock_obs, recording_root):
+        callback = MagicMock(side_effect=RuntimeError("callback error"))
+        session = RecordingSession(mock_obs, recording_root, on_state_change=callback)
+
+        # Should not raise despite callback error
+        session.arm("c", "s", "t")
+        assert session.state is SessionState.ARMED
+
+
+# ---------------------------------------------------------------------------
+# ArmedTopic
+# ---------------------------------------------------------------------------
+
+
+class TestArmedTopic:
+    def test_frozen(self):
+        topic = ArmedTopic("c", "s", "t")
+        with pytest.raises(AttributeError):
+            topic.course_slug = "other"  # type: ignore[misc]
+
+    def test_equality(self):
+        a = ArmedTopic("c", "s", "t")
+        b = ArmedTopic("c", "s", "t")
+        assert a == b
+
+    def test_inequality(self):
+        a = ArmedTopic("c", "s", "t")
+        b = ArmedTopic("c", "s", "other")
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_state(
+    session: RecordingSession,
+    expected: SessionState,
+    timeout: float = 5.0,
+) -> None:
+    """Block until the session reaches the expected state or timeout."""
+    deadline = threading.Event()
+    deadline.wait(0)
+    import time
+
+    start = time.monotonic()
+    while session.state != expected:
+        if time.monotonic() - start > timeout:
+            raise TimeoutError(
+                f"Session did not reach {expected.value} within {timeout}s "
+                f"(stuck at {session.state.value})"
+            )
+        time.sleep(0.01)

--- a/tests/recordings/test_state.py
+++ b/tests/recordings/test_state.py
@@ -1,0 +1,198 @@
+"""Tests for the recording state manager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.recordings.state import (
+    CourseRecordingState,
+    LectureState,
+    RecordingPart,
+)
+
+
+@pytest.fixture
+def sample_state() -> CourseRecordingState:
+    """A sample course recording state with 3 lectures."""
+    return CourseRecordingState(
+        course_id="test-course",
+        lectures=[
+            LectureState(lecture_id="010-intro", display_name="Introduction"),
+            LectureState(lecture_id="020-variables", display_name="Variables"),
+            LectureState(lecture_id="030-functions", display_name="Functions"),
+        ],
+        next_lecture_index=0,
+    )
+
+
+class TestCourseRecordingState:
+    def test_get_lecture(self, sample_state: CourseRecordingState):
+        lecture = sample_state.get_lecture("020-variables")
+        assert lecture is not None
+        assert lecture.display_name == "Variables"
+
+    def test_get_lecture_not_found(self, sample_state: CourseRecordingState):
+        assert sample_state.get_lecture("999-missing") is None
+
+    def test_get_next_lecture(self, sample_state: CourseRecordingState):
+        lecture = sample_state.get_next_lecture()
+        assert lecture is not None
+        assert lecture.lecture_id == "010-intro"
+
+    def test_get_next_lecture_past_end(self, sample_state: CourseRecordingState):
+        sample_state.next_lecture_index = 3
+        assert sample_state.get_next_lecture() is None
+
+    def test_progress(self, sample_state: CourseRecordingState):
+        recorded, total = sample_state.progress
+        assert recorded == 0
+        assert total == 3
+
+
+class TestAssignRecording:
+    def test_assign_to_next_lecture(self, sample_state: CourseRecordingState):
+        lecture_id, part = sample_state.assign_recording("/obs/rec1.mkv")
+        assert lecture_id == "010-intro"
+        assert part == 1
+        assert sample_state.next_lecture_index == 1
+
+    def test_assign_advances_index(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv")
+        sample_state.assign_recording("/obs/rec2.mkv")
+
+        assert sample_state.next_lecture_index == 2
+        assert sample_state.lectures[0].parts[0].raw_file == "/obs/rec1.mkv"
+        assert sample_state.lectures[1].parts[0].raw_file == "/obs/rec2.mkv"
+
+    def test_assign_to_specific_lecture(self, sample_state: CourseRecordingState):
+        lecture_id, part = sample_state.assign_recording(
+            "/obs/rec1.mkv", lecture_id="030-functions"
+        )
+        assert lecture_id == "030-functions"
+        assert part == 1
+        # next_lecture_index should NOT advance when assigning to specific lecture
+        assert sample_state.next_lecture_index == 0
+
+    def test_assign_continue_current_lecture(self, sample_state: CourseRecordingState):
+        # First, assign one recording to advance past the first lecture
+        sample_state.assign_recording("/obs/rec1.mkv")
+        assert sample_state.next_lecture_index == 1
+
+        # Enable continue mode
+        sample_state.continue_current_lecture = True
+
+        # Next assignment should go to the current (first) lecture as part 2
+        lecture_id, part = sample_state.assign_recording("/obs/rec2.mkv")
+        assert lecture_id == "010-intro"
+        assert part == 2
+
+    def test_assign_captures_git_info(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording(
+            "/obs/rec1.mkv",
+            git_commit="abc123",
+            git_dirty=True,
+        )
+        recording = sample_state.lectures[0].parts[0]
+        assert recording.git_commit == "abc123"
+        assert recording.git_dirty is True
+
+    def test_assign_sets_recorded_at(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv")
+        recording = sample_state.lectures[0].parts[0]
+        assert recording.recorded_at != ""
+
+    def test_assign_no_more_lectures(self, sample_state: CourseRecordingState):
+        sample_state.next_lecture_index = 3
+        with pytest.raises(ValueError, match="No more lectures"):
+            sample_state.assign_recording("/obs/rec1.mkv")
+
+    def test_assign_to_unknown_lecture(self, sample_state: CourseRecordingState):
+        with pytest.raises(ValueError, match="Lecture not found"):
+            sample_state.assign_recording("/obs/rec1.mkv", lecture_id="999-missing")
+
+
+class TestReassignRecording:
+    def test_reassign(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv")
+        assert sample_state.lectures[0].is_recorded
+
+        lecture_id, part = sample_state.reassign_recording("/obs/rec1.mkv", "030-functions")
+        assert lecture_id == "030-functions"
+        assert part == 1
+        # Source lecture should now be empty
+        assert not sample_state.lectures[0].is_recorded
+        # Target lecture should have the recording
+        assert sample_state.lectures[2].is_recorded
+        assert sample_state.lectures[2].parts[0].raw_file == "/obs/rec1.mkv"
+
+    def test_reassign_not_found(self, sample_state: CourseRecordingState):
+        with pytest.raises(ValueError, match="Recording not found"):
+            sample_state.reassign_recording("/obs/nonexistent.mkv", "010-intro")
+
+    def test_reassign_target_not_found(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv")
+        with pytest.raises(ValueError, match="Target lecture not found"):
+            sample_state.reassign_recording("/obs/rec1.mkv", "999-missing")
+
+
+class TestUpdateRecordingStatus:
+    def test_update_status(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv")
+        sample_state.update_recording_status("/obs/rec1.mkv", "processing")
+        assert sample_state.lectures[0].parts[0].status == "processing"
+
+    def test_update_status_with_processed_file(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv")
+        sample_state.update_recording_status(
+            "/obs/rec1.mkv",
+            "processed",
+            processed_file="/out/010-intro_part1.mp4",
+        )
+        part = sample_state.lectures[0].parts[0]
+        assert part.status == "processed"
+        assert part.processed_file == "/out/010-intro_part1.mp4"
+
+    def test_update_status_not_found(self, sample_state: CourseRecordingState):
+        with pytest.raises(ValueError, match="Recording not found"):
+            sample_state.update_recording_status("/obs/nonexistent.mkv", "processed")
+
+
+class TestStatePersistence:
+    def test_save_and_load(self, tmp_path: Path, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv", git_commit="abc123")
+
+        path = tmp_path / "test-course.json"
+        sample_state.save(path)
+
+        loaded = CourseRecordingState.load(path)
+        assert loaded.course_id == "test-course"
+        assert len(loaded.lectures) == 3
+        assert loaded.lectures[0].parts[0].raw_file == "/obs/rec1.mkv"
+        assert loaded.lectures[0].parts[0].git_commit == "abc123"
+        assert loaded.next_lecture_index == 1
+
+    def test_save_creates_directories(self, tmp_path: Path, sample_state: CourseRecordingState):
+        path = tmp_path / "sub" / "dir" / "state.json"
+        sample_state.save(path)
+        assert path.is_file()
+
+
+class TestLectureState:
+    def test_is_recorded(self):
+        lecture = LectureState(lecture_id="010-intro", display_name="Intro")
+        assert not lecture.is_recorded
+
+        lecture.parts.append(RecordingPart(part=1, raw_file="/obs/rec1.mkv"))
+        assert lecture.is_recorded
+
+    def test_latest_status(self):
+        lecture = LectureState(lecture_id="010-intro", display_name="Intro")
+        assert lecture.latest_status is None
+
+        lecture.parts.append(RecordingPart(part=1, raw_file="/obs/rec1.mkv", status="pending"))
+        assert lecture.latest_status == "pending"
+
+        lecture.parts.append(RecordingPart(part=2, raw_file="/obs/rec2.mkv", status="processed"))
+        assert lecture.latest_status == "processed"

--- a/tests/recordings/test_watcher.py
+++ b/tests/recordings/test_watcher.py
@@ -1,0 +1,552 @@
+"""Tests for the recordings filesystem watcher."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from clm.recordings.workflow.directories import ensure_root
+from clm.recordings.workflow.watcher import RecordingsWatcher, WatcherState, _WatchHandler
+
+# ------------------------------------------------------------------
+# WatcherState
+# ------------------------------------------------------------------
+
+
+class TestWatcherState:
+    def test_try_claim_returns_true_first_time(self):
+        state = WatcherState()
+        assert state.try_claim(Path("/a.wav")) is True
+
+    def test_try_claim_returns_false_if_already_claimed(self):
+        state = WatcherState()
+        state.try_claim(Path("/a.wav"))
+        assert state.try_claim(Path("/a.wav")) is False
+
+    def test_release_allows_reclaim(self):
+        state = WatcherState()
+        p = Path("/a.wav")
+        state.try_claim(p)
+        state.release(p)
+        assert state.try_claim(p) is True
+
+    def test_release_unclaimed_path_is_safe(self):
+        state = WatcherState()
+        state.release(Path("/nonexistent"))  # should not raise
+
+    def test_concurrent_claims(self):
+        """Two threads racing to claim the same path — only one wins."""
+        state = WatcherState()
+        p = Path("/race.wav")
+        results: list[bool] = []
+        barrier = threading.Barrier(2)
+
+        def claim():
+            barrier.wait()
+            results.append(state.try_claim(p))
+
+        t1 = threading.Thread(target=claim)
+        t2 = threading.Thread(target=claim)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert sorted(results) == [False, True]
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — construction
+# ------------------------------------------------------------------
+
+
+class TestWatcherInit:
+    def test_default_mode_is_external(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        assert watcher.mode == "external"
+        assert watcher._backend is None
+
+    def test_onnx_mode_from_string(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path, backend="onnx")
+        assert watcher.mode == "onnx"
+        assert watcher._backend is not None
+
+    def test_onnx_mode_from_backend_instance(self, tmp_path: Path):
+        from clm.recordings.workflow.backends import OnnxBackend
+
+        backend = OnnxBackend()
+        watcher = RecordingsWatcher(tmp_path, backend=backend)
+        assert watcher.mode == "onnx"
+        assert watcher._backend is backend
+
+    def test_not_running_initially(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        assert watcher.running is False
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — start / stop
+# ------------------------------------------------------------------
+
+
+class TestWatcherStartStop:
+    def test_start_creates_to_process_dir(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher.start()
+        try:
+            assert (tmp_path / "to-process").is_dir()
+            assert watcher.running is True
+        finally:
+            watcher.stop()
+
+    def test_stop_marks_not_running(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher.start()
+        watcher.stop()
+        assert watcher.running is False
+
+    def test_start_is_idempotent(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher.start()
+        observer1 = watcher._observer
+        watcher.start()  # should not create a second observer
+        assert watcher._observer is observer1
+        watcher.stop()
+
+    def test_stop_when_not_started_is_safe(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher.stop()  # should not raise
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — stability detection
+# ------------------------------------------------------------------
+
+
+class TestStabilityDetection:
+    def test_stable_file_passes(self, tmp_path: Path):
+        f = tmp_path / "test.wav"
+        f.write_bytes(b"data")
+
+        watcher = RecordingsWatcher(tmp_path, stability_interval=0.01, stability_checks=2)
+        watcher._wait_for_stable(f)  # should not raise
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path, stability_interval=0.01, stability_checks=2)
+        with pytest.raises(FileNotFoundError, match="disappeared"):
+            watcher._wait_for_stable(tmp_path / "missing.wav")
+
+    def test_empty_file_waits(self, tmp_path: Path):
+        """Empty files (size 0) are never considered stable."""
+        f = tmp_path / "empty.wav"
+        f.write_bytes(b"")
+
+        watcher = RecordingsWatcher(tmp_path, stability_interval=0.01, stability_checks=2)
+
+        # Write data after a tiny delay to make the file non-empty
+        def grow():
+            time.sleep(0.05)
+            f.write_bytes(b"real data")
+
+        t = threading.Thread(target=grow, daemon=True)
+        t.start()
+        watcher._wait_for_stable(f)
+        t.join()
+        assert f.stat().st_size > 0
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — external mode event handling
+# ------------------------------------------------------------------
+
+
+class TestExternalModeEvents:
+    def _make_root(self, tmp_path: Path) -> Path:
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        return root
+
+    def test_ignores_non_wav_files(self, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        watcher = RecordingsWatcher(root, stability_interval=0.01, stability_checks=1)
+
+        # A .mp4 file should be ignored in external mode
+        mp4 = root / "to-process" / "topic--RAW.mp4"
+        mp4.write_bytes(b"video data")
+
+        watcher._on_file_event(mp4)
+        # No error, no processing — just ignored
+
+    def test_ignores_non_raw_wav(self, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        watcher = RecordingsWatcher(root, stability_interval=0.01, stability_checks=1)
+
+        # A wav without --RAW suffix should be ignored
+        wav = root / "to-process" / "topic.wav"
+        wav.write_bytes(b"audio data")
+
+        watcher._on_file_event(wav)
+
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_assembles_when_video_exists(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        tp = root / "to-process"
+
+        # Create matching pair
+        video = tp / "topic--RAW.mp4"
+        audio = tp / "topic--RAW.wav"
+        video.write_bytes(b"video")
+        audio.write_bytes(b"audio")
+
+        mock_assemble.return_value = MagicMock(success=True, output_file=Path("out.mp4"))
+        on_assembled = MagicMock()
+
+        watcher = RecordingsWatcher(
+            root,
+            stability_interval=0.01,
+            stability_checks=1,
+            on_assembled=on_assembled,
+        )
+        # Directly call the handler synchronously
+        watcher._process_external_wav(audio)
+
+        mock_assemble.assert_called_once()
+        on_assembled.assert_called_once()
+
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_skips_when_no_matching_video(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        tp = root / "to-process"
+
+        # Only audio, no video
+        audio = tp / "topic--RAW.wav"
+        audio.write_bytes(b"audio")
+
+        watcher = RecordingsWatcher(root, stability_interval=0.01, stability_checks=1)
+        watcher._process_external_wav(audio)
+
+        mock_assemble.assert_not_called()
+
+    def test_error_callback_on_failure(self, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        on_error = MagicMock()
+
+        watcher = RecordingsWatcher(
+            root,
+            stability_interval=0.01,
+            stability_checks=1,
+            on_error=on_error,
+        )
+        # Non-existent file → FileNotFoundError in stability check
+        watcher._process_external_wav(root / "to-process" / "missing--RAW.wav")
+
+        on_error.assert_called_once()
+        assert "disappeared" in on_error.call_args[0][1]
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — ONNX mode event handling
+# ------------------------------------------------------------------
+
+
+class TestOnnxModeEvents:
+    def _make_root(self, tmp_path: Path) -> Path:
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        return root
+
+    def test_ignores_non_video_files(self, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        mock_backend = MagicMock()
+        watcher = RecordingsWatcher(
+            root, backend=mock_backend, stability_interval=0.01, stability_checks=1
+        )
+
+        wav = root / "to-process" / "topic--RAW.wav"
+        wav.write_bytes(b"audio")
+
+        watcher._on_file_event(wav)
+        mock_backend.process.assert_not_called()
+
+    def test_ignores_non_raw_video(self, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        mock_backend = MagicMock()
+        watcher = RecordingsWatcher(
+            root, backend=mock_backend, stability_interval=0.01, stability_checks=1
+        )
+
+        video = root / "to-process" / "topic.mp4"
+        video.write_bytes(b"video")
+
+        watcher._on_file_event(video)
+        mock_backend.process.assert_not_called()
+
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_processes_and_assembles_raw_video(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        tp = root / "to-process"
+
+        video = tp / "topic--RAW.mp4"
+        video.write_bytes(b"video data")
+
+        mock_backend = MagicMock()
+
+        # The backend writes a .wav as a side effect
+        def fake_process(v, out):
+            out.write_bytes(b"processed audio")
+
+        mock_backend.process.side_effect = fake_process
+
+        mock_assemble.return_value = MagicMock(success=True, output_file=Path("out.mp4"))
+        on_processing = MagicMock()
+        on_assembled = MagicMock()
+
+        watcher = RecordingsWatcher(
+            root,
+            backend=mock_backend,
+            stability_interval=0.01,
+            stability_checks=1,
+            on_processing=on_processing,
+            on_assembled=on_assembled,
+        )
+        watcher._process_onnx_video(video)
+
+        mock_backend.process.assert_called_once()
+        on_processing.assert_called_once_with(video)
+        mock_assemble.assert_called_once()
+        on_assembled.assert_called_once()
+
+    def test_error_callback_on_backend_failure(self, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        tp = root / "to-process"
+
+        video = tp / "topic--RAW.mp4"
+        video.write_bytes(b"video data")
+
+        mock_backend = MagicMock()
+        mock_backend.process.side_effect = RuntimeError("ONNX crash")
+        on_error = MagicMock()
+
+        watcher = RecordingsWatcher(
+            root,
+            backend=mock_backend,
+            stability_interval=0.01,
+            stability_checks=1,
+            on_error=on_error,
+        )
+        watcher._process_onnx_video(video)
+
+        on_error.assert_called_once()
+        assert "ONNX crash" in on_error.call_args[0][1]
+
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_assembly_error_triggers_callback(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = self._make_root(tmp_path)
+        tp = root / "to-process"
+
+        video = tp / "topic--RAW.mp4"
+        video.write_bytes(b"video data")
+
+        mock_backend = MagicMock()
+        mock_backend.process.side_effect = lambda v, o: o.write_bytes(b"audio")
+
+        mock_assemble.return_value = MagicMock(
+            success=False, output_file=Path("out.mp4"), error="mux failed"
+        )
+        on_error = MagicMock()
+
+        watcher = RecordingsWatcher(
+            root,
+            backend=mock_backend,
+            stability_interval=0.01,
+            stability_checks=1,
+            on_error=on_error,
+        )
+        watcher._process_onnx_video(video)
+
+        on_error.assert_called_once()
+        assert "mux failed" in on_error.call_args[0][1]
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — matching video lookup
+# ------------------------------------------------------------------
+
+
+class TestFindMatchingVideo:
+    def test_finds_mp4(self, tmp_path: Path):
+        wav = tmp_path / "topic--RAW.wav"
+        mp4 = tmp_path / "topic--RAW.mp4"
+        wav.write_bytes(b"audio")
+        mp4.write_bytes(b"video")
+
+        watcher = RecordingsWatcher(tmp_path)
+        assert watcher._find_matching_video(wav) == mp4
+
+    def test_finds_mkv(self, tmp_path: Path):
+        wav = tmp_path / "topic--RAW.wav"
+        mkv = tmp_path / "topic--RAW.mkv"
+        wav.write_bytes(b"audio")
+        mkv.write_bytes(b"video")
+
+        watcher = RecordingsWatcher(tmp_path)
+        assert watcher._find_matching_video(wav) == mkv
+
+    def test_returns_none_when_no_video(self, tmp_path: Path):
+        wav = tmp_path / "topic--RAW.wav"
+        wav.write_bytes(b"audio")
+
+        watcher = RecordingsWatcher(tmp_path)
+        assert watcher._find_matching_video(wav) is None
+
+
+# ------------------------------------------------------------------
+# RecordingsWatcher — subdirectory support
+# ------------------------------------------------------------------
+
+
+class TestSubdirectorySupport:
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_external_assembles_in_subdirectory(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = root / "to-process"
+        sub = tp / "course" / "section"
+        sub.mkdir(parents=True)
+
+        video = sub / "topic--RAW.mp4"
+        audio = sub / "topic--RAW.wav"
+        video.write_bytes(b"video")
+        audio.write_bytes(b"audio")
+
+        mock_assemble.return_value = MagicMock(success=True, output_file=Path("out.mp4"))
+
+        watcher = RecordingsWatcher(root, stability_interval=0.01, stability_checks=1)
+        watcher._process_external_wav(audio)
+
+        mock_assemble.assert_called_once()
+        pair = mock_assemble.call_args[0][0]
+        assert pair.relative_dir == Path("course/section")
+
+
+# ------------------------------------------------------------------
+# _WatchHandler
+# ------------------------------------------------------------------
+
+
+class TestWatchHandler:
+    def test_on_created_delegates_to_watcher(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher._on_file_event = MagicMock()
+
+        handler = _WatchHandler(watcher)
+        event = MagicMock(is_directory=False, src_path=str(tmp_path / "test.wav"))
+        handler.on_created(event)
+
+        watcher._on_file_event.assert_called_once_with(tmp_path / "test.wav")
+
+    def test_on_created_ignores_directories(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher._on_file_event = MagicMock()
+
+        handler = _WatchHandler(watcher)
+        event = MagicMock(is_directory=True, src_path=str(tmp_path / "subdir"))
+        handler.on_created(event)
+
+        watcher._on_file_event.assert_not_called()
+
+    def test_on_moved_uses_dest_path(self, tmp_path: Path):
+        watcher = RecordingsWatcher(tmp_path)
+        watcher._on_file_event = MagicMock()
+
+        handler = _WatchHandler(watcher)
+        event = MagicMock(
+            is_directory=False,
+            src_path=str(tmp_path / "old.wav"),
+            dest_path=str(tmp_path / "new--RAW.wav"),
+        )
+        handler.on_moved(event)
+
+        watcher._on_file_event.assert_called_once_with(tmp_path / "new--RAW.wav")
+
+
+# ------------------------------------------------------------------
+# Integration: live watcher with real filesystem events
+# ------------------------------------------------------------------
+
+
+class TestWatcherLiveEvents:
+    """Tests that exercise the real watchdog Observer with short timeouts."""
+
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_external_detects_new_wav(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = root / "to-process"
+
+        # Pre-create the matching video
+        video = tp / "lecture--RAW.mp4"
+        video.write_bytes(b"video content")
+
+        mock_assemble.return_value = MagicMock(success=True, output_file=Path("out.mp4"))
+        assembled_event = threading.Event()
+
+        def on_assembled(result):
+            assembled_event.set()
+
+        watcher = RecordingsWatcher(
+            root,
+            stability_interval=0.05,
+            stability_checks=2,
+            on_assembled=on_assembled,
+        )
+        watcher.start()
+
+        try:
+            # Create the .wav — watcher should detect it
+            wav = tp / "lecture--RAW.wav"
+            wav.write_bytes(b"processed audio content")
+
+            # Wait for assembly (with timeout)
+            assert assembled_event.wait(timeout=5.0), "Watcher did not trigger assembly"
+            mock_assemble.assert_called_once()
+        finally:
+            watcher.stop()
+
+    @patch("clm.recordings.workflow.watcher.assemble_one")
+    def test_onnx_detects_new_video(self, mock_assemble: MagicMock, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = root / "to-process"
+
+        mock_backend = MagicMock()
+        mock_backend.process.side_effect = lambda v, o: o.write_bytes(b"processed")
+
+        mock_assemble.return_value = MagicMock(success=True, output_file=Path("out.mp4"))
+        assembled_event = threading.Event()
+
+        def on_assembled(result):
+            assembled_event.set()
+
+        watcher = RecordingsWatcher(
+            root,
+            backend=mock_backend,
+            stability_interval=0.05,
+            stability_checks=2,
+            on_assembled=on_assembled,
+        )
+        watcher.start()
+
+        try:
+            video = tp / "lecture--RAW.mp4"
+            video.write_bytes(b"raw video content")
+
+            assert assembled_event.wait(timeout=5.0), "Watcher did not trigger assembly"
+            mock_backend.process.assert_called_once()
+            mock_assemble.assert_called_once()
+        finally:
+            watcher.stop()

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -1,0 +1,266 @@
+"""Tests for the recordings web dashboard routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.recordings.workflow.directories import ensure_root
+from clm.recordings.workflow.session import SessionState
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def recording_root(tmp_path: Path) -> Path:
+    root = tmp_path / "recordings"
+    ensure_root(root)
+    return root
+
+
+@pytest.fixture()
+def app(recording_root: Path):
+    """Create a test app with mocked OBS (no real connection)."""
+    with patch("clm.recordings.workflow.obs.ObsClient") as MockObs:
+        mock_obs = MagicMock()
+        mock_obs.connected = False
+        # Register callbacks so the session manager wiring works
+        mock_obs._record_callbacks = []
+        mock_obs.on_record_state_changed.side_effect = lambda cb: mock_obs._record_callbacks.append(
+            cb
+        )
+        MockObs.return_value = mock_obs
+
+        from clm.recordings.web.app import create_app
+
+        application = create_app(
+            recordings_root=recording_root,
+            obs_host="localhost",
+            obs_port=4455,
+        )
+        # Prevent lifespan from trying to connect
+        mock_obs.connect.side_effect = ConnectionError("OBS not running")
+        yield application
+
+
+@pytest.fixture()
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestDashboard:
+    def test_get_dashboard(self, client: TestClient):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "CLM Recordings" in resp.text
+        assert "Session Status" in resp.text
+
+    def test_dashboard_shows_idle_state(self, client: TestClient):
+        resp = client.get("/")
+        assert "idle" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Lectures
+# ---------------------------------------------------------------------------
+
+
+class TestLectures:
+    def test_get_lectures_no_spec(self, client: TestClient):
+        resp = client.get("/lectures")
+        assert resp.status_code == 200
+        assert "No course spec file" in resp.text
+
+    def test_get_lectures_with_spec(self, app, recording_root: Path, tmp_path: Path):
+        spec_xml = tmp_path / "course.xml"
+        spec_xml.write_text(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <course>
+                <name>
+                    <de>Test Kurs</de>
+                    <en>Test Course</en>
+                </name>
+                <prog-lang>python</prog-lang>
+                <description>
+                    <de>Beschreibung</de>
+                    <en>Description</en>
+                </description>
+                <certificate>
+                    <de>Zertifikat</de>
+                    <en>Certificate</en>
+                </certificate>
+                <sections>
+                    <section>
+                        <name>
+                            <de>Einleitung</de>
+                            <en>Introduction</en>
+                        </name>
+                        <topics>
+                            <topic>intro/overview</topic>
+                            <topic>intro/setup</topic>
+                        </topics>
+                    </section>
+                </sections>
+            </course>
+            """,
+            encoding="utf-8",
+        )
+        app.state.spec_file = spec_xml
+
+        with TestClient(app) as c:
+            resp = c.get("/lectures")
+        assert resp.status_code == 200
+        assert "Introduction" in resp.text
+        assert "overview" in resp.text
+        assert "setup" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Arm / Disarm
+# ---------------------------------------------------------------------------
+
+
+class TestArmDisarm:
+    def test_arm_topic(self, client: TestClient):
+        resp = client.post(
+            "/arm",
+            data={
+                "course_slug": "python-basics",
+                "section_name": "intro",
+                "topic_name": "hello",
+            },
+        )
+        assert resp.status_code == 200
+        assert "python-basics" in resp.text
+        assert "hello" in resp.text
+
+    def test_arm_changes_state(self, app, client: TestClient):
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "topic_name": "t",
+            },
+        )
+        session = app.state.session
+        assert session.state is SessionState.ARMED
+        assert session.armed_topic is not None
+        assert session.armed_topic.topic_name == "t"
+
+    def test_disarm(self, client: TestClient):
+        # Arm first
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "topic_name": "t",
+            },
+        )
+        # Then disarm
+        resp = client.post("/disarm")
+        assert resp.status_code == 200
+        assert "idle" in resp.text
+
+    def test_disarm_from_idle(self, client: TestClient):
+        resp = client.post("/disarm")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    def test_status_json(self, client: TestClient):
+        resp = client.get("/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["state"] == "idle"
+        assert data["armed_topic"] is None
+        assert "obs_connected" in data
+
+    def test_status_json_after_arm(self, client: TestClient):
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "topic_name": "t",
+            },
+        )
+        resp = client.get("/status")
+        data = resp.json()
+        assert data["state"] == "armed"
+        assert data["armed_topic"]["topic_name"] == "t"
+
+    def test_status_partial(self, client: TestClient):
+        resp = client.get("/status-partial")
+        assert resp.status_code == 200
+        assert "Session Status" in resp.text
+
+    def test_pairs_partial(self, client: TestClient):
+        resp = client.get("/pairs-partial")
+        assert resp.status_code == 200
+        assert "Pending Pairs" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# SSE Events
+# ---------------------------------------------------------------------------
+
+
+class TestSSEEvents:
+    def test_events_route_is_registered(self, app):
+        """SSE endpoint should be registered in the app."""
+        routes = [r.path for r in app.routes if hasattr(r, "path")]
+        assert "/events" in routes
+
+    def test_sse_queue_is_configured(self, app):
+        """App should have an SSE queue in state."""
+        assert hasattr(app.state, "sse_queue")
+        assert app.state.sse_queue is not None
+
+    def test_arm_pushes_to_sse_queue(self, app, client: TestClient):
+        """Arming a topic should push a state_changed event to the SSE queue."""
+        client.post(
+            "/arm",
+            data={"course_slug": "c", "section_name": "s", "topic_name": "t"},
+        )
+        # The session's on_state_change callback pushes to the queue
+        queue = app.state.sse_queue
+        assert not queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# Pending pairs display
+# ---------------------------------------------------------------------------
+
+
+class TestPendingPairsDisplay:
+    def test_dashboard_shows_no_pairs(self, client: TestClient):
+        resp = client.get("/")
+        assert "No video + audio pairs" in resp.text
+
+    def test_dashboard_shows_pairs(self, app, recording_root: Path):
+        tp = recording_root / "to-process" / "course" / "section"
+        tp.mkdir(parents=True)
+        (tp / "topic--RAW.mp4").write_bytes(b"video")
+        (tp / "topic--RAW.wav").write_bytes(b"audio")
+
+        with TestClient(app) as c:
+            resp = c.get("/")
+        assert "topic" in resp.text
+        assert "1" in resp.text  # pair count

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -264,3 +264,38 @@ class TestPendingPairsDisplay:
             resp = c.get("/")
         assert "topic" in resp.text
         assert "1" in resp.text  # pair count
+
+
+# ---------------------------------------------------------------------------
+# Watcher controls
+# ---------------------------------------------------------------------------
+
+
+class TestWatcherControls:
+    def test_dashboard_shows_watcher_section(self, client: TestClient):
+        resp = client.get("/")
+        assert "File Watcher" in resp.text
+        assert "stopped" in resp.text
+
+    def test_dashboard_shows_watcher_mode(self, client: TestClient):
+        resp = client.get("/")
+        assert "external" in resp.text
+
+    def test_start_watcher(self, app, client: TestClient):
+        resp = client.post("/watcher/start")
+        assert resp.status_code == 200
+        assert app.state.watcher.running
+        assert "running" in resp.text
+        app.state.watcher.stop()
+
+    def test_stop_watcher(self, app, client: TestClient):
+        app.state.watcher.start()
+        resp = client.post("/watcher/stop")
+        assert resp.status_code == 200
+        assert not app.state.watcher.running
+        assert "stopped" in resp.text
+
+    def test_status_partial_includes_watcher(self, client: TestClient):
+        resp = client.get("/status-partial")
+        assert resp.status_code == 200
+        assert "File Watcher" in resp.text

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,7 @@ all = [
     { name = "newspaper4k" },
     { name = "numba" },
     { name = "numpy" },
+    { name = "onnxruntime" },
     { name = "openai" },
     { name = "opencv-python" },
     { name = "packaging" },
@@ -928,6 +929,7 @@ all = [
     { name = "seaborn" },
     { name = "sentencepiece" },
     { name = "skorch" },
+    { name = "soundfile" },
     { name = "sqlalchemy" },
     { name = "tenacity" },
     { name = "textual" },
@@ -1042,7 +1044,10 @@ plantuml = [
 ]
 recordings = [
     { name = "jinja2" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
     { name = "python-multipart" },
+    { name = "soundfile" },
 ]
 summarize = [
     { name = "openai" },
@@ -1121,6 +1126,8 @@ requires-dist = [
     { name = "newspaper4k", marker = "extra == 'ml'", specifier = ">=0.2.8" },
     { name = "numba", marker = "extra == 'ml'", specifier = ">=0.60.0" },
     { name = "numpy", marker = "extra == 'ml'", specifier = ">=2.0.1" },
+    { name = "numpy", marker = "extra == 'recordings'", specifier = ">=1.24.0" },
+    { name = "onnxruntime", marker = "extra == 'recordings'", specifier = ">=1.17.0" },
     { name = "openai", marker = "extra == 'ml'", specifier = ">=2.8.1" },
     { name = "openai", marker = "extra == 'summarize'", specifier = ">=1.0.0" },
     { name = "opencv-python", marker = "extra == 'voiceover'", specifier = ">=4.8.0" },
@@ -1154,6 +1161,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'ml'", specifier = ">=0.13.2" },
     { name = "sentencepiece", marker = "extra == 'ml'", specifier = ">=0.2.1" },
     { name = "skorch", marker = "extra == 'ml'", git = "https://github.com/skorch-dev/skorch.git" },
+    { name = "soundfile", marker = "extra == 'recordings'", specifier = ">=0.12.0" },
     { name = "sqlalchemy", marker = "extra == 'ml'", specifier = ">=2.0.32" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tenacity", marker = "extra == 'drawio'", specifier = "~=9.0.0" },
@@ -6612,6 +6620,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/28/e2a36573ccbcf3d57c00626a21fe51989380636e821b341d36ccca0c1c3a/soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445", size = 25751, upload-time = "2025-01-25T09:16:44.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/73e97a5b3cc46bba7ff8650a1504348fa1863a6f9d57d7001c6b67c5f20e/soundfile-0.13.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:82dc664d19831933fe59adad199bf3945ad06d84bc111a5b4c0d3089a5b9ec33", size = 1142250, upload-time = "2025-01-25T09:16:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/58fd1a8d7b26fc113af244f966ee3aecf03cb9293cb935daaddc1e455e18/soundfile-0.13.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:743f12c12c4054921e15736c6be09ac26b3b3d603aef6fd69f9dde68748f2593", size = 1101406, upload-time = "2025-01-25T09:16:49.662Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ae/c0e4a53d77cf6e9a04179535766b3321b0b9ced5f70522e4caf9329f0046/soundfile-0.13.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9c9e855f5a4d06ce4213f31918653ab7de0c5a8d8107cd2427e44b42df547deb", size = 1235729, upload-time = "2025-01-25T09:16:53.018Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646, upload-time = "2025-01-25T09:16:54.872Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881, upload-time = "2025-01-25T09:16:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162, upload-time = "2025-01-25T09:16:59.573Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,14 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-03-17T15:04:28Z"
+
+[options.exclude-newer-package]
+torchvision = false
+torchaudio = false
+torch = false
+
 [[package]]
 name = "accelerate"
 version = "1.13.0"
@@ -184,7 +192,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.86.0"
+version = "0.85.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -196,22 +204,22 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/08/c620a0eb8625539a8ea9f5a6e06f13d131be0bc8b5b714c235d4b25dd1b5/anthropic-0.85.0.tar.gz", hash = "sha256:d45b2f38a1efb1a5d15515a426b272179a0d18783efa2bb4c3925fa773eb50b9", size = 542034, upload-time = "2026-03-16T17:00:44.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5a/9d85b85686d5cdd79f5488c8667e668d7920d06a0a1a1beb454a5b77b2db/anthropic-0.85.0-py3-none-any.whl", hash = "sha256:b4f54d632877ed7b7b29c6d9ba7299d5e21c4c92ae8de38947e9d862bff74adf", size = 458237, upload-time = "2026-03-16T17:00:45.877Z" },
 ]
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
 ]
 
 [[package]]
@@ -342,11 +350,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "26.1.0"
+version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
@@ -909,6 +917,7 @@ all = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
+    { name = "python-multipart" },
     { name = "qdrant-client" },
     { name = "ragas" },
     { name = "rapidfuzz" },
@@ -1031,6 +1040,10 @@ plantuml = [
     { name = "aiofiles" },
     { name = "tenacity" },
 ]
+recordings = [
+    { name = "jinja2" },
+    { name = "python-multipart" },
+]
 summarize = [
     { name = "openai" },
 ]
@@ -1066,7 +1079,7 @@ requires-dist = [
     { name = "bm25s", extras = ["core"], marker = "extra == 'ml'", specifier = ">=0.3.2.post1" },
     { name = "clean-text", marker = "extra == 'ml'", specifier = ">=0.6.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "coding-academy-lecture-manager", extras = ["all-workers", "ml", "summarize", "voiceover", "dev", "tui", "web"], marker = "extra == 'all'" },
+    { name = "coding-academy-lecture-manager", extras = ["all-workers", "ml", "summarize", "voiceover", "recordings", "dev", "tui", "web"], marker = "extra == 'all'" },
     { name = "coding-academy-lecture-manager", extras = ["notebook", "plantuml", "drawio"], marker = "extra == 'all-workers'" },
     { name = "cookiecutter", marker = "extra == 'ml'" },
     { name = "diffusers", marker = "extra == 'ml'", specifier = ">=0.35.1" },
@@ -1088,6 +1101,7 @@ requires-dist = [
     { name = "ipython", marker = "extra == 'notebook'", specifier = "~=8.26.0" },
     { name = "ipywidgets", marker = "extra == 'notebook'", specifier = ">=8.1.0" },
     { name = "jinja2", marker = "extra == 'notebook'", specifier = "~=3.1.4" },
+    { name = "jinja2", marker = "extra == 'recordings'", specifier = ">=3.1" },
     { name = "jupytext", marker = "extra == 'notebook'", specifier = ">=1.16.4" },
     { name = "langchain", marker = "extra == 'ml'", specifier = ">=1.2.7" },
     { name = "langchain-anthropic", marker = "extra == 'ml'" },
@@ -1097,7 +1111,7 @@ requires-dist = [
     { name = "langchain-qdrant", marker = "extra == 'ml'" },
     { name = "langchain-text-splitters", marker = "extra == 'ml'" },
     { name = "langfuse", marker = "extra == 'ml'" },
-    { name = "langgraph", marker = "extra == 'ml'", specifier = ">=1.1.3" },
+    { name = "langgraph", marker = "extra == 'ml'", specifier = ">=1.1.2" },
     { name = "langsmith", marker = "extra == 'ml'" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "matplotlib", marker = "extra == 'ml'", specifier = ">=3.9.2" },
@@ -1128,6 +1142,7 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.2.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", marker = "extra == 'recordings'", specifier = ">=0.0.6" },
     { name = "qdrant-client", marker = "extra == 'ml'", specifier = ">=1.13.0" },
     { name = "ragas", marker = "extra == 'ml'" },
     { name = "rapidfuzz", marker = "extra == 'voiceover'", specifier = ">=3.0.0" },
@@ -1160,7 +1175,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'web'", specifier = ">=0.18.0" },
     { name = "wsproto", marker = "extra == 'web'", specifier = ">=1.2.0" },
 ]
-provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summarize", "voiceover", "dev", "tui", "web", "all"]
+provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summarize", "recordings", "voiceover", "dev", "tui", "web", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pre-commit", specifier = ">=4.5.0" }]
@@ -1185,11 +1200,15 @@ wheels = [
 
 [[package]]
 name = "confection"
-version = "1.3.3"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "srsly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/d3/57c6631159a1b48d273b40865c315cf51f89df7a9d1101094ef12e3a37c2/confection-0.1.5.tar.gz", hash = "sha256:8e72dd3ca6bd4f48913cd220f10b8275978e740411654b6e8ca6d7008c590f0e", size = 38924, upload-time = "2024-05-31T16:17:01.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/00/3106b1854b45bd0474ced037dfe6b73b90fe68a68968cef47c23de3d43d2/confection-0.1.5-py3-none-any.whl", hash = "sha256:e29d3c3f8eac06b3f77eb9dfb4bf2fc6bcc9622a98ca00a698e3d019c6430b14", size = 35451, upload-time = "2024-05-31T16:16:59.075Z" },
 ]
 
 [[package]]
@@ -1470,10 +1489,10 @@ wheels = [
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.5.0"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/66/0c02bd330e7d976f83fa68583d6198d76f23581bcbb5c0e98a6148f326e5/cuda_pathfinder-1.5.0-py3-none-any.whl", hash = "sha256:498f90a9e9de36044a7924742aecce11c50c49f735f1bc53e05aa46de9ea4110", size = 49739, upload-time = "2026-03-24T21:14:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/59/911a1a597264f1fb7ac176995a0f0b6062e37f8c1b6e0f23071a76838507/cuda_pathfinder-1.4.3-py3-none-any.whl", hash = "sha256:4345d8ead1f701c4fb8a99be6bc1843a7348b6ba0ef3b031f5a2d66fb128ae4c", size = 47951, upload-time = "2026-03-16T21:31:25.526Z" },
 ]
 
 [[package]]
@@ -1599,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "4.8.4"
+version = "4.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -1617,9 +1636,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/22/73e46ac7a8c25e7ef0b3bd6f10da3465021d90219a32eb0b4d2afea4c56e/datasets-4.8.4.tar.gz", hash = "sha256:a1429ed853275ce7943a01c6d2e25475b4501eb758934362106a280470df3a52", size = 604382, upload-time = "2026-03-23T14:21:17.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/02/741da3bed890bdf9720eb1b24780a58456bfdde49c4c78237953bb08abae/datasets-4.8.2.tar.gz", hash = "sha256:c6ad7e6c28c7436a9c6c23f817d1a450d395c771df881252dfe63697297cbcdf", size = 603879, upload-time = "2026-03-17T01:09:55.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl", hash = "sha256:cdc8bee4698e549d78bf1fed6aea2eebc760b22b084f07e6fc020c6577a6ce6d", size = 526991, upload-time = "2026-03-23T14:21:15.89Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7e/1649f47eb4f20ba2edb80e239a021e8ad9e199774d9925efc28179621066/datasets-4.8.2-py3-none-any.whl", hash = "sha256:433a07acb2e5c7e413e54a579cf2fb161397eecb36bc1a99439f0df103f15ae5", size = 526646, upload-time = "2026-03-17T01:09:53.858Z" },
 ]
 
 [[package]]
@@ -1809,7 +1828,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.135.2"
+version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1818,18 +1837,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833, upload-time = "2026-03-23T14:12:41.697Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407, upload-time = "2026-03-23T14:12:43.284Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
 name = "fastcore"
-version = "1.12.31"
+version = "1.12.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/72/acab01c6b68c7f94080f79049b3d67bbec3af98b65ef101775e08cd11f41/fastcore-1.12.31.tar.gz", hash = "sha256:684a7b05b9f49d94d9ebbf7e104bbe54fa001aa8c78fa681cc7aabbd12d1bbde", size = 94319, upload-time = "2026-03-22T02:21:21.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/28/95f6ba3d70351eef8856f0561b78275475ed20dd408489d677752a4f3596/fastcore-1.12.26.tar.gz", hash = "sha256:794501f75bca9d45b512319c5d79e82118ed94ddb1acc335ffff7eb438550bff", size = 93661, upload-time = "2026-03-17T00:27:45.624Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5c/9516828037b1680de14bae4d93b2868b26417059e1e5cb7d8ad7be649197/fastcore-1.12.31-py3-none-any.whl", hash = "sha256:2634f117fe3a2f6c250f8500f70211c96158399936e90fa6d1010d2d516bf03a", size = 98509, upload-time = "2026-03-22T02:21:19.274Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/04/254dbe1ecda21d35256fa40da2559b4ae1505d20809efb8b2d3942e3c9e0/fastcore-1.12.26-py3-none-any.whl", hash = "sha256:b97b8529de9ab575e31b5d69ad48d2a3c11b82002d4ce25f254f8d6b478a99cc", size = 97905, upload-time = "2026-03-17T00:27:44.181Z" },
 ]
 
 [[package]]
@@ -1847,7 +1866,7 @@ wheels = [
 
 [[package]]
 name = "fastembed"
-version = "0.8.0"
+version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1861,9 +1880,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/c2/9c708680de1b54480161e0505f9d6d3d8eb47a1dc1a1f7f3c5106ba355d2/fastembed-0.7.4.tar.gz", hash = "sha256:8b8a4ea860ca295002f4754e8f5820a636e1065a9444959e18d5988d7f27093b", size = 68807, upload-time = "2025-12-05T12:08:10.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/8da01492bc8b69184257d0c951bf0e77aec8ce110f06d8ce16c6ed9084f7/fastembed-0.7.4-py3-none-any.whl", hash = "sha256:79250a775f70bd6addb0e054204df042b5029ecae501e40e5bbd08e75844ad83", size = 108491, upload-time = "2025-12-05T12:08:09.059Z" },
 ]
 
 [[package]]
@@ -2162,7 +2181,7 @@ wheels = [
 
 [[package]]
 name = "gradio"
-version = "6.10.0"
+version = "6.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2173,7 +2192,6 @@ dependencies = [
     { name = "ffmpy" },
     { name = "gradio-client" },
     { name = "groovy" },
-    { name = "hf-gradio" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "jinja2" },
@@ -2196,14 +2214,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/74/740c507b076263f9064ca39c5c244d773c8d4063e1ce630b57d6197ac50f/gradio-6.10.0.tar.gz", hash = "sha256:f76797536f5b62bc1558f622017351133d0087ee5f51aab139af04e82ed3bf2a", size = 58021607, upload-time = "2026-03-24T21:20:13.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/83/29bdbf94b212512e3c775482d390f5b699a72d71a2c431dea367a6e45a37/gradio-6.9.0.tar.gz", hash = "sha256:593e60e33233f3586452ebfa9f741817c5ae849a98cc70945f3ccb8dc895eb22", size = 57904480, upload-time = "2026-03-06T17:44:26.025Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/ba/fc89989d0a62e4d38c82f54c44b1145e455466a688297cc69cdcbf321ea5/gradio-6.10.0-py3-none-any.whl", hash = "sha256:e20035ef046a30266c0b5ddbe05f2168193d06914dd89eebe2decde77ec510fe", size = 42962248, upload-time = "2026-03-24T21:20:09.938Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/dc357ab966544e4dc898a2fee326d755c5f54da82af71a1a802e3476e78e/gradio-6.9.0-py3-none-any.whl", hash = "sha256:c173dd330c9247002a42222c85d76c0ecee65437eff808084e360862e7bbd24f", size = 42940853, upload-time = "2026-03-06T17:44:22.009Z" },
 ]
 
 [[package]]
 name = "gradio-client"
-version = "2.4.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
@@ -2212,9 +2230,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/4a/ddfaa8b3fef0238768a42301a3361981af1afd90f92c27adfe6cd031eca7/gradio_client-2.4.0.tar.gz", hash = "sha256:781885374f86759b8db5195e13e716c301d14e48e0442aef63362f1eeea4cce2", size = 58203, upload-time = "2026-03-24T21:20:25.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d2/de2037f5eff13a5145cdf6982fd34c9735f0806e8a2ee5d4bfe9a7d25a54/gradio_client-2.3.0.tar.gz", hash = "sha256:1c700dc60e65bae4386ba7cf3732b9f9d5bcf5fb8eb451df3944fe092d7d9a29", size = 57552, upload-time = "2026-03-06T17:44:38.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/b3/10cb03cf684aab2bec97cb0b9bbba4f93e7a20c6e0f3b4100c235a55ad93/gradio_client-2.4.0-py3-none-any.whl", hash = "sha256:7c170807b924ed6056b2a1fa9d659d349dd20567c00ee0b4dc249dc1e2def620", size = 59156, upload-time = "2026-03-24T21:20:24.018Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6a/41752781399811afbf8ac858f63c20eff354ed35169daa39604aefced4e8/gradio_client-2.3.0-py3-none-any.whl", hash = "sha256:9ec51a927888fc188e123a0ac5ad341d9265b325539a399554d1fc2604942e74", size = 58531, upload-time = "2026-03-06T17:44:36.961Z" },
 ]
 
 [[package]]
@@ -2344,18 +2362,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
-name = "hf-gradio"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "gradio-client" },
-    { name = "typer" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/52/04816d2a15691a63cec3187e3e592c4493448eb4834492eadd532972b035/hf_gradio-0.3.0-py3-none-any.whl", hash = "sha256:159d33d1f0affae8164d29c0c51a63dfcc0bbc90803b07c6f139137206a796ae", size = 4154, upload-time = "2026-03-23T19:50:08.586Z" },
 ]
 
 [[package]]
@@ -2495,7 +2501,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.7.2"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2508,9 +2514,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/15/eafc1c57bf0f8afffb243dcd4c0cceb785e956acc17bba4d9bf2ae21fc9c/huggingface_hub-1.7.2.tar.gz", hash = "sha256:7f7e294e9bbb822e025bdb2ada025fa4344d978175a7f78e824d86e35f7ab43b", size = 724684, upload-time = "2026-03-20T10:36:08.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a8/94ccc0aec97b996a3a68f3e1fa06a4bd7185dd02bf22bfba794a0ade8440/huggingface_hub-1.7.1.tar.gz", hash = "sha256:be38fe66e9b03c027ad755cb9e4b87ff0303c98acf515b5d579690beb0bf3048", size = 722097, upload-time = "2026-03-13T09:36:07.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/de/3ad061a05f74728927ded48c90b73521b9a9328c85d841bdefb30e01fb85/huggingface_hub-1.7.2-py3-none-any.whl", hash = "sha256:288f33a0a17b2a73a1359e2a5fd28d1becb2c121748c6173ab8643fb342c850e", size = 618036, upload-time = "2026-03-20T10:36:06.824Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/ca21955d6117a394a482c7862ce96216239d0e3a53133ae8510727a8bcfa/huggingface_hub-1.7.1-py3-none-any.whl", hash = "sha256:38c6cce7419bbde8caac26a45ed22b0cea24152a8961565d70ec21f88752bfaa", size = 616308, upload-time = "2026-03-13T09:36:06.062Z" },
 ]
 
 [[package]]
@@ -2840,11 +2846,11 @@ wheels = [
 
 [[package]]
 name = "jsonpointer"
-version = "3.1.1"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
 ]
 
 [[package]]
@@ -3057,30 +3063,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.13"
+version = "1.2.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/e5/56fdeedaa0ef1be3c53721d382d9e21c63930179567361610ea6102c04ea/langchain-1.2.13.tar.gz", hash = "sha256:d566ef67c8287e7f2e2df3c99bf3953a6beefd2a75a97fe56ecce905e21f3ef4", size = 573819, upload-time = "2026-03-19T17:16:07.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/1d/1af2fc0ac084d4781778b7846b1aed62e05006bf2d73fdf84ac3a8f5225c/langchain-1.2.12.tar.gz", hash = "sha256:ed705b5b293799f7e3e394387f398a1b71707542758283206c8c21415759d991", size = 566444, upload-time = "2026-03-11T22:21:00.712Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/1d/a509af07535d8f4621d77f3ba5ec846ee6d52c59d2239e1385ec3b29bf92/langchain-1.2.13-py3-none-any.whl", hash = "sha256:37d4526ac4b0cdd3d7706a6366124c30dc0771bf5340865b37cdc99d5e5ad9b1", size = 112488, upload-time = "2026-03-19T17:16:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/51/09bb1cfb0b57ae9440ca56cc576e4dc792f83d030eef7637d2c516dcb0a0/langchain-1.2.12-py3-none-any.whl", hash = "sha256:60eff184b8f92c2610f5a4c9a97ad339a891adb01901e83e4df8e6c9c69cf852", size = 112373, upload-time = "2026-03-11T22:20:59.508Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.0"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/c7/259d4d805c6ac90c8695714fc15498a4557bb515eb24f692fd611966e383/langchain_anthropic-1.4.0.tar.gz", hash = "sha256:bbf64e99f9149a34ba67813e9582b2160a0968de9e9f54f7ba8d1658f253c2e5", size = 674360, upload-time = "2026-03-17T18:42:20.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ef/a096793dd880423254ddeaa92909342f9b04a11ef9000c0d121d45605800/langchain_anthropic-1.3.5.tar.gz", hash = "sha256:0745f181b8696b03f7b66a95ed97f43cc90b1b086850ebbf17804f605e640f6e", size = 674070, upload-time = "2026-03-14T03:12:33.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/c0/77f99373276d4f06c38a887ef6023f101cfc7ba3b2bf9af37064cdbadde5/langchain_anthropic-1.4.0-py3-none-any.whl", hash = "sha256:c84f55722336935f7574d5771598e674f3959fdca0b51de14c9788dbf52761be", size = 48463, upload-time = "2026-03-17T18:42:19.742Z" },
+    { url = "https://files.pythonhosted.org/packages/07/22/d967f55651f6a1d9157ecefd335f6c6232f4826b637a7e89c92495288524/langchain_anthropic-1.3.5-py3-none-any.whl", hash = "sha256:1666f83ddef74d9fa844ff3d1f9d23dd12004b0799d1ca1ff329cbaf3944d3c6", size = 48250, upload-time = "2026-03-14T03:12:32.165Z" },
 ]
 
 [[package]]
@@ -3126,7 +3132,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.22"
+version = "1.2.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -3138,23 +3144,23 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/a3/c4cd6827a1df46c821e7214b7f7b7a28b189e6c9b84ef15c6d629c5e3179/langchain_core-1.2.22.tar.gz", hash = "sha256:8d8f726d03d3652d403da915126626bb6250747e8ba406537d849e68b9f5d058", size = 842487, upload-time = "2026-03-24T18:48:44.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/da/075720d37ebc668f48743bd540b047b2b08b8ba22b46d8f61166c5ad1d1c/langchain_core-1.2.19.tar.gz", hash = "sha256:87fa82c3eb4cc3d7a65f574cb447b5df09ec2131c8c2a0a02d4737ad02685438", size = 836647, upload-time = "2026-03-13T13:44:54.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/a6/2ffacf0f1a3788f250e75d0b52a24896c413be11be3a6d42bcdf46fbea48/langchain_core-1.2.22-py3-none-any.whl", hash = "sha256:7e30d586b75918e828833b9ec1efc25465723566845dd652c277baf751e9c04b", size = 506829, upload-time = "2026-03-24T18:48:43.286Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/8704b2a22c0987627ed29464d23a45fb15e10a28fb482f4d84c3bddcbf27/langchain_core-1.2.19-py3-none-any.whl", hash = "sha256:6e74cb0fb443a8046ee298c05c99b67abe54cc57fcbc6d1cd3b0f2485ee47574", size = 503456, upload-time = "2026-03-13T13:44:53.241Z" },
 ]
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.12"
+version = "1.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/cd/439be2b8deb8bd0d4c470c7c7f66698a84d823e583c3d36a322483cb7cab/langchain_openai-1.1.11.tar.gz", hash = "sha256:44b003a2960d1f6699f23721196b3b97d0c420d2e04444950869213214b7a06a", size = 1088560, upload-time = "2026-03-09T23:02:36.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0f/e4cb42848c25f65969adfb500a06dea1a541831604250fd0d8aa6e54fef5/langchain_openai-1.1.11-py3-none-any.whl", hash = "sha256:a03596221405d38d6852fb865467cb0d9ff9e79f335905eb6a576e8c4874ac71", size = 87694, upload-time = "2026-03-09T23:02:35.651Z" },
 ]
 
 [[package]]
@@ -3185,7 +3191,7 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "4.0.1"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -3198,14 +3204,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/94/ab00e21fa5977d6b9c68fb3a95de2aa1a1e586964ff2af3e37405bf65d9f/langfuse-4.0.1.tar.gz", hash = "sha256:40a6daf3ab505945c314246d5b577d48fcfde0a47e8c05267ea6bd494ae9608e", size = 272749, upload-time = "2026-03-19T14:03:34.508Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/4b/8df7cd1684b46b6760d9c03893cbbc9ddbdd3f72eaf003b3859cec308587/langfuse-4.0.0.tar.gz", hash = "sha256:10df126c8d68e5746ff39a0a5100233f9f29446626c478e7770b1c775e4c4e17", size = 271030, upload-time = "2026-03-10T16:21:51.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8f/3145ef00940f9c29d7e0200fd040f35616eac21c6ab4610a1ba14f3a04c1/langfuse-4.0.1-py3-none-any.whl", hash = "sha256:e22f49ea31304f97fc31a97c014ba63baa8802d9568295d54f06b00b43c30524", size = 465049, upload-time = "2026-03-19T14:03:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/84/56/7f14cbe189e8a10c805609d52a4578b5f1bca3d4060b531baf920827d4f5/langfuse-4.0.0-py3-none-any.whl", hash = "sha256:4afe6a114937fa544e7f5f86c34533c711f0f12ebf77480239b626da28bbae68", size = 462159, upload-time = "2026-03-10T16:21:49.701Z" },
 ]
 
 [[package]]
 name = "langgraph"
-version = "1.1.3"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -3215,9 +3221,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/b2/e7db624e8b0ee063ecfbf7acc09467c0836a05914a78e819dfb3744a0fac/langgraph-1.1.3.tar.gz", hash = "sha256:ee496c297a9c93b38d8560be15cbb918110f49077d83abd14976cb13ac3b3370", size = 545120, upload-time = "2026-03-18T23:42:58.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a8/8494057db9149eb850258e5d4ae961a8dbda9a283e56e1b957393d9df0cd/langgraph-1.1.2.tar.gz", hash = "sha256:c4385ce349823a590891b3f6b1c46b54f51d0134164056866e95034985f047c9", size = 544288, upload-time = "2026-03-12T17:11:17.99Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/f7/221cc479e95e03e260496616e5ce6fb50c1ea01472e3a5bc481a9b8a2f83/langgraph-1.1.3-py3-none-any.whl", hash = "sha256:57cd6964ebab41cbd211f222293a2352404e55f8b2312cecde05e8753739b546", size = 168149, upload-time = "2026-03-18T23:42:56.967Z" },
+    { url = "https://files.pythonhosted.org/packages/52/38/3117cd90325635893a76132cdae74f5b1f53c93c33b3dc6124521cec9825/langgraph-1.1.2-py3-none-any.whl", hash = "sha256:5fd43c839ec2b5af564e9ae2d2d4f22ce0a006a0b58e800cc4e8de4dd9cbb643", size = 167543, upload-time = "2026-03-12T17:11:16.965Z" },
 ]
 
 [[package]]
@@ -3248,20 +3254,20 @@ wheels = [
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.12"
+version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/a1/012f0e0f5c9fd26f92bdc9d244756ad673c428230156ef668e6ec7c18cee/langgraph_sdk-0.3.12.tar.gz", hash = "sha256:c9c9ec22b3c0fcd352e2b8f32a815164f69446b8648ca22606329f4ff4c59a71", size = 194932, upload-time = "2026-03-18T22:15:54.592Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/cd/a019f1b1e97c519f2425593f9bccd3ac463a18fb5d2111cff59ce1ef62fe/langgraph_sdk-0.3.11.tar.gz", hash = "sha256:3640134835d89d2c7c8bb7de73bd10673d4b282db3ff0e2fdaf1cee9e50cb1eb", size = 190387, upload-time = "2026-03-11T00:46:45.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/4d/4f796e86b03878ab20d9b30aaed1ad459eda71a5c5b67f7cfe712f3548f2/langgraph_sdk-0.3.12-py3-none-any.whl", hash = "sha256:44323804965d6ec2a07127b3cf08a0428ea6deaeb172c2d478d5cd25540e3327", size = 95834, upload-time = "2026-03-18T22:15:53.545Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c8/b8d15d4b9a320a3f57a851030a371066b91dbd1420f097d3d0338da9adc9/langgraph_sdk-0.3.11-py3-none-any.whl", hash = "sha256:18905fd6248ade98b0995d859a98672d57c811fbfffc0d63d1c107a512351b26", size = 94887, upload-time = "2026-03-11T00:46:43.855Z" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.7.22"
+version = "0.7.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3274,9 +3280,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/2a/2d5e6c67396fd228670af278c4da7bd6db2b8d11deaf6f108490b6d3f561/langsmith-0.7.22.tar.gz", hash = "sha256:35bfe795d648b069958280760564632fd28ebc9921c04f3e209c0db6a6c7dc04", size = 1134923, upload-time = "2026-03-19T22:45:23.492Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/a8/31e9e7b42089cf194a0d873cbfc1ecec6d6dd0cc693808f1cb64494cbd0c/langsmith-0.7.18.tar.gz", hash = "sha256:d7e6e1f9c9300ee83b9f201c9254b4a32799218de102a5b1d2b217e00be2dfa2", size = 1134635, upload-time = "2026-03-16T18:54:19.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/94/1f5d72655ab6534129540843776c40eff757387b88e798d8b3bf7e313fd4/langsmith-0.7.22-py3-none-any.whl", hash = "sha256:6e9d5148314d74e86748cb9d3898632cad0320c9323d95f70f969e5bc078eee4", size = 359927, upload-time = "2026-03-19T22:45:21.603Z" },
+    { url = "https://files.pythonhosted.org/packages/29/58/244a14e29c7feccf06ed3929c9ab65a747a9ee94d5ac43d40862053b2f54/langsmith-0.7.18-py3-none-any.whl", hash = "sha256:3253c171fe2f6506056a42f9077983a34749b7a1629e41d8fb8e2005d8960886", size = 359268, upload-time = "2026-03-16T18:54:17.397Z" },
 ]
 
 [[package]]
@@ -4079,11 +4085,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "2.18.1"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/96/45218c2fdec4c9f22178f905086e85ef1a6d63862dcc3cd68eb60f1867f5/narwhals-2.18.1.tar.gz", hash = "sha256:652a1fcc9d432bbf114846688884c215f17eb118aa640b7419295d2f910d2a8b", size = 620578, upload-time = "2026-03-24T15:11:25.456Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/b4/02a8add181b8d2cd5da3b667cd102ae536e8c9572ab1a130816d70a89edb/narwhals-2.18.0.tar.gz", hash = "sha256:1de5cee338bc17c338c6278df2c38c0dd4290499fcf70d75e0a51d5f22a6e960", size = 620222, upload-time = "2026-03-10T15:51:27.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl", hash = "sha256:a0a8bb80205323851338888ba3a12b4f65d352362c8a94be591244faf36504ad", size = 444952, upload-time = "2026-03-24T15:11:23.801Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl", hash = "sha256:68378155ee706ac9c5b25868ef62ecddd62947b6df7801a0a156bc0a615d2d0d", size = 444865, upload-time = "2026-03-10T15:51:24.085Z" },
 ]
 
 [[package]]
@@ -4161,7 +4167,7 @@ wheels = [
 
 [[package]]
 name = "newspaper4k"
-version = "0.9.4.1"
+version = "0.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -4176,14 +4182,14 @@ dependencies = [
     { name = "tldextract" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/cc/cf743a3d06b10907cec76a675fe0857445907ded0e64ec4624483c1467ce/newspaper4k-0.9.4.1.tar.gz", hash = "sha256:5b1a92dfb04d6d379f9484fad4ad44741deb9ac3d55a6c178badf2a0d4bba903", size = 3971874, upload-time = "2025-11-18T06:08:56.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/7d/2f8c048a1a04023f156ddc77825900de9e9c98e05b80106484cfa84a40a4/newspaper4k-0.9.4.tar.gz", hash = "sha256:3299f654ee932272cb4fd28ab68733793df092473cefe407d4bcef86dc734858", size = 3970805, upload-time = "2025-11-15T21:53:29.933Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/e8/7e6c6a6e626fec2ec25f7b69fa0c446d1ca8a7fad121b61f2672e5779b76/newspaper4k-0.9.4.1-py3-none-any.whl", hash = "sha256:fab18fdb0637da0ea2452e18c5986c4af2263ba3016ff684f1c522f696bd39bd", size = 306153, upload-time = "2025-11-18T06:08:54.9Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/bd/8a71f1b8ec2b64c9c0c44808828c5f918cb110c06d19b42874fd2759d0b6/newspaper4k-0.9.4-py3-none-any.whl", hash = "sha256:10d1f98e9c00d35b32283cfab344790ea3b89d8a923865a19ad7dcf49b16096c", size = 305978, upload-time = "2025-11-15T21:53:28.314Z" },
 ]
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -4191,9 +4197,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/8f/915e1c12df07c70ed779d18ab83d065718a926e70d3ea33eb0cd66ffb7c0/nltk-3.9.3.tar.gz", hash = "sha256:cb5945d6424a98d694c2b9a0264519fab4363711065a46aa0ae7a2195b92e71f", size = 2923673, upload-time = "2026-02-24T12:05:53.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7e/9af5a710a1236e4772de8dfcc6af942a561327bb9f42b5b4a24d0cf100fd/nltk-3.9.3-py3-none-any.whl", hash = "sha256:60b3db6e9995b3dd976b1f0fa7dec22069b2677e759c28eb69b62ddd44870522", size = 1525385, upload-time = "2026-02-24T12:05:46.54Z" },
 ]
 
 [[package]]
@@ -4472,7 +4478,7 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.24.4"
+version = "1.24.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
@@ -4482,35 +4488,35 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2", size = 17332131, upload-time = "2026-03-17T22:05:49.005Z" },
-    { url = "https://files.pythonhosted.org/packages/38/e9/8c901c150ce0c368da38638f44152fb411059c0c7364b497c9e5c957321a/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046ff290045a387676941a02a8ae5c3ebec6b4f551ae228711968c4a69d8f6b7", size = 15152472, upload-time = "2026-03-17T22:03:26.176Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/b6/7a4df417cdd01e8f067a509e123ac8b31af450a719fa7ed81787dd6057ec/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e54ad52e61d2d4618dcff8fa1480ac66b24ee2eab73331322db1049f11ccf330", size = 17222993, upload-time = "2026-03-17T22:04:34.485Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/59/8febe015f391aa1757fa5ba82c759ea4b6c14ef970132efb5e316665ba61/onnxruntime-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b43b63eb24a2bc8fc77a09be67587a570967a412cccb837b6245ccb546691153", size = 12594863, upload-time = "2026-03-17T22:05:38.749Z" },
-    { url = "https://files.pythonhosted.org/packages/32/84/4155fcd362e8873eb6ce305acfeeadacd9e0e59415adac474bea3d9281bb/onnxruntime-1.24.4-cp311-cp311-win_arm64.whl", hash = "sha256:e26478356dba25631fb3f20112e345f8e8bf62c499bb497e8a559f7d69cf7e7b", size = 12259895, upload-time = "2026-03-17T22:05:28.812Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f0/8a21ec0a97e40abb7d8da1e8b20fb9e1af509cc6d191f6faa75f73622fb2/onnxruntime-1.24.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e99a48078baaefa2b50fe5836c319499f71f13f76ed32d0211f39109147a49e0", size = 17341922, upload-time = "2026-03-17T22:03:56.364Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/25/d7908de8e08cee9abfa15b8aa82349b79733ae5865162a3609c11598805d/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4aaed1e5e1aaacf2343c838a30a7c3ade78f13eeb16817411f929d04040a13", size = 15172290, upload-time = "2026-03-17T22:03:37.124Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/72/105ec27a78c5aa0154a7c0cd8c41c19a97799c3b12fc30392928997e3be3/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e30c972bc02e072911aabb6891453ec73795386c0af2b761b65444b8a4c4745f", size = 17244738, upload-time = "2026-03-17T22:04:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/05/fb/a592736d968c2f58e12de4d52088dda8e0e724b26ad5c0487263adb45875/onnxruntime-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:3b6ba8b0181a3aa88edab00eb01424ffc06f42e71095a91186c2249415fcff93", size = 12597435, upload-time = "2026-03-17T22:05:43.826Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/04/ae2479e9841b64bd2eb44f8a64756c62593f896514369a11243b1b86ca5c/onnxruntime-1.24.4-cp313-cp313-win_arm64.whl", hash = "sha256:71d6a5c1821d6e8586a024000ece458db8f2fc0ecd050435d45794827ce81e19", size = 12269852, upload-time = "2026-03-17T22:05:33.353Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/af/a479a536c4398ffaf49fbbe755f45d5b8726bdb4335ab31b537f3d7149b8/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1700f559c8086d06b2a4d5de51e62cb4ff5e2631822f71a36db8c72383db71ee", size = 15176861, upload-time = "2026-03-17T22:03:40.143Z" },
-    { url = "https://files.pythonhosted.org/packages/be/13/19f5da70c346a76037da2c2851ecbf1266e61d7f0dcdb887c667210d4608/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c74e268dc808e61e63784d43f9ddcdaf50a776c2819e8bd1d1b11ef64bf7e36", size = 17247454, upload-time = "2026-03-17T22:04:46.643Z" },
-    { url = "https://files.pythonhosted.org/packages/89/db/b30dbbd6037847b205ab75d962bc349bf1e46d02a65b30d7047a6893ffd6/onnxruntime-1.24.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:fbff2a248940e3398ae78374c5a839e49a2f39079b488bc64439fa0ec327a3e4", size = 17343300, upload-time = "2026-03-17T22:03:59.223Z" },
-    { url = "https://files.pythonhosted.org/packages/61/88/1746c0e7959961475b84c776d35601a21d445f463c93b1433a409ec3e188/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2b7969e72d8cb53ffc88ab6d49dd5e75c1c663bda7be7eb0ece192f127343d1", size = 15175936, upload-time = "2026-03-17T22:03:43.671Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/ba/4699cde04a52cece66cbebc85bd8335a0d3b9ad485abc9a2e15946a1349d/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14ed1f197fab812b695a5eaddb536c635e58a2fbbe50a517c78f082cc6ce9177", size = 17246432, upload-time = "2026-03-17T22:04:49.58Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/60/4590910841bb28bd3b4b388a9efbedf4e2d2cca99ddf0c863642b4e87814/onnxruntime-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:311e309f573bf3c12aa5723e23823077f83d5e412a18499d4485c7eb41040858", size = 12903276, upload-time = "2026-03-17T22:05:46.349Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
+    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
 ]
 
 [[package]]
 name = "openai"
-version = "2.29.0"
+version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4522,9 +4528,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/15/203d537e58986b5673e7f232453a2a2f110f22757b15921cbdeea392e520/openai-2.29.0.tar.gz", hash = "sha256:32d09eb2f661b38d3edd7d7e1a2943d1633f572596febe64c0cd370c86d52bec", size = 671128, upload-time = "2026-03-17T17:53:49.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/87/eb0abb4ef88ddb95b3c13149384c4c288f584f3be17d6a4f63f8c3e3c226/openai-2.28.0.tar.gz", hash = "sha256:bb7fdff384d2a787fa82e8822d1dd3c02e8cf901d60f1df523b7da03cbb6d48d", size = 670334, upload-time = "2026-03-13T19:56:27.306Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/b1/35b6f9c8cf9318e3dbb7146cc82dab4cf61182a8d5406fc9b50864362895/openai-2.29.0-py3-none-any.whl", hash = "sha256:b7c5de513c3286d17c5e29b92c4c98ceaf0d775244ac8159aeb1bddf840eb42a", size = 1141533, upload-time = "2026-03-17T17:53:47.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/5a/df122348638885526e53140e9c6b0d844af7312682b3bde9587eebc28b47/openai-2.28.0-py3-none-any.whl", hash = "sha256:79aa5c45dba7fef84085701c235cf13ba88485e1ef4f8dfcedc44fc2a698fc1d", size = 1141218, upload-time = "2026-03-13T19:56:25.46Z" },
 ]
 
 [[package]]
@@ -4853,89 +4859,86 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/46/5da1ec4a5171ee7bf1a0efa064aba70ba3d6e0788ce3f5acd1375d23c8c0/pillow-12.1.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e879bb6cd5c73848ef3b2b48b8af9ff08c5b71ecda8048b7dd22d8a33f60be32", size = 5304084, upload-time = "2026-02-11T04:20:27.501Z" },
-    { url = "https://files.pythonhosted.org/packages/78/93/a29e9bc02d1cf557a834da780ceccd54e02421627200696fcf805ebdc3fb/pillow-12.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:365b10bb9417dd4498c0e3b128018c4a624dc11c7b97d8cc54effe3b096f4c38", size = 4657866, upload-time = "2026-02-11T04:20:29.827Z" },
-    { url = "https://files.pythonhosted.org/packages/13/84/583a4558d492a179d31e4aae32eadce94b9acf49c0337c4ce0b70e0a01f2/pillow-12.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d4ce8e329c93845720cd2014659ca67eac35f6433fd3050393d85f3ecef0dad5", size = 6232148, upload-time = "2026-02-11T04:20:31.329Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e2/53c43334bbbb2d3b938978532fbda8e62bb6e0b23a26ce8592f36bcc4987/pillow-12.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc354a04072b765eccf2204f588a7a532c9511e8b9c7f900e1b64e3e33487090", size = 8038007, upload-time = "2026-02-11T04:20:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/3d0e79c8a9d58150dd98e199d7c1c56861027f3829a3a60b3c2784190180/pillow-12.1.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e7976bf1910a8116b523b9f9f58bf410f3e8aa330cd9a2bb2953f9266ab49af", size = 6345418, upload-time = "2026-02-11T04:20:35.858Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/c8/46dfeac5825e600579157eea177be43e2f7ff4a99da9d0d0a49533509ac5/pillow-12.1.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:597bd9c8419bc7c6af5604e55847789b69123bbe25d65cc6ad3012b4f3c98d8b", size = 7034590, upload-time = "2026-02-11T04:20:37.91Z" },
-    { url = "https://files.pythonhosted.org/packages/af/bf/e6f65d3db8a8bbfeaf9e13cc0417813f6319863a73de934f14b2229ada18/pillow-12.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2c1fc0f2ca5f96a3c8407e41cca26a16e46b21060fe6d5b099d2cb01412222f5", size = 6458655, upload-time = "2026-02-11T04:20:39.496Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c2/66091f3f34a25894ca129362e510b956ef26f8fb67a0e6417bc5744e56f1/pillow-12.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:578510d88c6229d735855e1f278aa305270438d36a05031dfaae5067cc8eb04d", size = 7159286, upload-time = "2026-02-11T04:20:41.139Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5a/24bc8eb526a22f957d0cec6243146744966d40857e3d8deb68f7902ca6c1/pillow-12.1.1-cp311-cp311-win32.whl", hash = "sha256:7311c0a0dcadb89b36b7025dfd8326ecfa36964e29913074d47382706e516a7c", size = 6328663, upload-time = "2026-02-11T04:20:43.184Z" },
-    { url = "https://files.pythonhosted.org/packages/31/03/bef822e4f2d8f9d7448c133d0a18185d3cce3e70472774fffefe8b0ed562/pillow-12.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:fbfa2a7c10cc2623f412753cddf391c7f971c52ca40a3f65dc5039b2939e8563", size = 7031448, upload-time = "2026-02-11T04:20:44.696Z" },
-    { url = "https://files.pythonhosted.org/packages/49/70/f76296f53610bd17b2e7d31728b8b7825e3ac3b5b3688b51f52eab7c0818/pillow-12.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:b81b5e3511211631b3f672a595e3221252c90af017e399056d0faabb9538aa80", size = 2453651, upload-time = "2026-02-11T04:20:46.243Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d3/8df65da0d4df36b094351dce696f2989bec731d4f10e743b1c5f4da4d3bf/pillow-12.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab323b787d6e18b3d91a72fc99b1a2c28651e4358749842b8f8dfacd28ef2052", size = 5262803, upload-time = "2026-02-11T04:20:47.653Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/71/5026395b290ff404b836e636f51d7297e6c83beceaa87c592718747e670f/pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:adebb5bee0f0af4909c30db0d890c773d1a92ffe83da908e2e9e720f8edf3984", size = 4657601, upload-time = "2026-02-11T04:20:49.328Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/2e/1001613d941c67442f745aff0f7cc66dd8df9a9c084eb497e6a543ee6f7e/pillow-12.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb66b7cc26f50977108790e2456b7921e773f23db5630261102233eb355a3b79", size = 6234995, upload-time = "2026-02-11T04:20:51.032Z" },
-    { url = "https://files.pythonhosted.org/packages/07/26/246ab11455b2549b9233dbd44d358d033a2f780fa9007b61a913c5b2d24e/pillow-12.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee2810642b2898bb187ced9b349e95d2a7272930796e022efaf12e99dccd293", size = 8045012, upload-time = "2026-02-11T04:20:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/8b/07587069c27be7535ac1fe33874e32de118fbd34e2a73b7f83436a88368c/pillow-12.1.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0b1cd6232e2b618adcc54d9882e4e662a089d5768cd188f7c245b4c8c44a397", size = 6349638, upload-time = "2026-02-11T04:20:54.444Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/79/6df7b2ee763d619cda2fb4fea498e5f79d984dae304d45a8999b80d6cf5c/pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7aac39bcf8d4770d089588a2e1dd111cbaa42df5a94be3114222057d68336bd0", size = 7041540, upload-time = "2026-02-11T04:20:55.97Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5e/2ba19e7e7236d7529f4d873bdaf317a318896bac289abebd4bb00ef247f0/pillow-12.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ab174cd7d29a62dd139c44bf74b698039328f45cb03b4596c43473a46656b2f3", size = 6462613, upload-time = "2026-02-11T04:20:57.542Z" },
-    { url = "https://files.pythonhosted.org/packages/03/03/31216ec124bb5c3dacd74ce8efff4cc7f52643653bad4825f8f08c697743/pillow-12.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:339ffdcb7cbeaa08221cd401d517d4b1fe7a9ed5d400e4a8039719238620ca35", size = 7166745, upload-time = "2026-02-11T04:20:59.196Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e7/7c4552d80052337eb28653b617eafdef39adfb137c49dd7e831b8dc13bc5/pillow-12.1.1-cp312-cp312-win32.whl", hash = "sha256:5d1f9575a12bed9e9eedd9a4972834b08c97a352bd17955ccdebfeca5913fa0a", size = 6328823, upload-time = "2026-02-11T04:21:01.385Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/17/688626d192d7261bbbf98846fc98995726bddc2c945344b65bec3a29d731/pillow-12.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:21329ec8c96c6e979cd0dfd29406c40c1d52521a90544463057d2aaa937d66a6", size = 7033367, upload-time = "2026-02-11T04:21:03.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/fe/a0ef1f73f939b0eca03ee2c108d0043a87468664770612602c63266a43c4/pillow-12.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:af9a332e572978f0218686636610555ae3defd1633597be015ed50289a03c523", size = 2453811, upload-time = "2026-02-11T04:21:05.116Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
-    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d0/bebb3ffbf31c5a8e97241476c4cf8b9828954693ce6744b4a2326af3e16b/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af", size = 4062652, upload-time = "2026-02-11T04:21:53.19Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c0/0e16fb0addda4851445c28f8350d8c512f09de27bbb0d6d0bbf8b6709605/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f", size = 4138823, upload-time = "2026-02-11T04:22:03.088Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fb/6170ec655d6f6bb6630a013dd7cf7bc218423d7b5fa9071bf63dc32175ae/pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642", size = 3601143, upload-time = "2026-02-11T04:22:04.909Z" },
-    { url = "https://files.pythonhosted.org/packages/59/04/dc5c3f297510ba9a6837cbb318b87dd2b8f73eb41a43cc63767f65cb599c/pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd", size = 5266254, upload-time = "2026-02-11T04:22:07.656Z" },
-    { url = "https://files.pythonhosted.org/packages/05/30/5db1236b0d6313f03ebf97f5e17cda9ca060f524b2fcc875149a8360b21c/pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202", size = 4657499, upload-time = "2026-02-11T04:22:09.613Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/008d2ca0eb612e81968e8be0bbae5051efba24d52debf930126d7eaacbba/pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f", size = 6232137, upload-time = "2026-02-11T04:22:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/70/f1/f14d5b8eeb4b2cd62b9f9f847eb6605f103df89ef619ac68f92f748614ea/pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f", size = 8042721, upload-time = "2026-02-11T04:22:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/d6/17824509146e4babbdabf04d8171491fa9d776f7061ff6e727522df9bd03/pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f", size = 6347798, upload-time = "2026-02-11T04:22:15.449Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ee/c85a38a9ab92037a75615aba572c85ea51e605265036e00c5b67dfafbfe2/pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e", size = 7039315, upload-time = "2026-02-11T04:22:17.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f3/bc8ccc6e08a148290d7523bde4d9a0d6c981db34631390dc6e6ec34cacf6/pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0", size = 6462360, upload-time = "2026-02-11T04:22:19.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ab/69a42656adb1d0665ab051eec58a41f169ad295cf81ad45406963105408f/pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb", size = 7165438, upload-time = "2026-02-11T04:22:21.041Z" },
-    { url = "https://files.pythonhosted.org/packages/02/46/81f7aa8941873f0f01d4b55cc543b0a3d03ec2ee30d617a0448bf6bd6dec/pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f", size = 6431503, upload-time = "2026-02-11T04:22:22.833Z" },
-    { url = "https://files.pythonhosted.org/packages/40/72/4c245f7d1044b67affc7f134a09ea619d4895333d35322b775b928180044/pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15", size = 7176748, upload-time = "2026-02-11T04:22:24.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ad/8a87bdbe038c5c698736e3348af5c2194ffb872ea52f11894c95f9305435/pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f", size = 2544314, upload-time = "2026-02-11T04:22:26.685Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9d/efd18493f9de13b87ede7c47e69184b9e859e4427225ea962e32e56a49bc/pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8", size = 5268612, upload-time = "2026-02-11T04:22:29.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f1/4f42eb2b388eb2ffc660dcb7f7b556c1015c53ebd5f7f754965ef997585b/pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9", size = 4660567, upload-time = "2026-02-11T04:22:31.799Z" },
-    { url = "https://files.pythonhosted.org/packages/01/54/df6ef130fa43e4b82e32624a7b821a2be1c5653a5fdad8469687a7db4e00/pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60", size = 6269951, upload-time = "2026-02-11T04:22:33.921Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/48/618752d06cc44bb4aae8ce0cd4e6426871929ed7b46215638088270d9b34/pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7", size = 8074769, upload-time = "2026-02-11T04:22:35.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/bd/f1d71eb39a72fa088d938655afba3e00b38018d052752f435838961127d8/pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f", size = 6381358, upload-time = "2026-02-11T04:22:37.698Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ef/c784e20b96674ed36a5af839305f55616f8b4f8aa8eeccf8531a6e312243/pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586", size = 7068558, upload-time = "2026-02-11T04:22:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cb/8059688b74422ae61278202c4e1ad992e8a2e7375227be0a21c6b87ca8d5/pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce", size = 6493028, upload-time = "2026-02-11T04:22:42.73Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/da/e3c008ed7d2dd1f905b15949325934510b9d1931e5df999bb15972756818/pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8", size = 7191940, upload-time = "2026-02-11T04:22:44.543Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
-    { url = "https://files.pythonhosted.org/packages/56/11/5d43209aa4cb58e0cc80127956ff1796a68b928e6324bbf06ef4db34367b/pillow-12.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:600fd103672b925fe62ed08e0d874ea34d692474df6f4bf7ebe148b30f89f39f", size = 5228606, upload-time = "2026-02-11T04:22:52.106Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/d5/3b005b4e4fda6698b371fa6c21b097d4707585d7db99e98d9b0b87ac612a/pillow-12.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:665e1b916b043cef294bc54d47bf02d87e13f769bc4bc5fa225a24b3a6c5aca9", size = 4622321, upload-time = "2026-02-11T04:22:53.827Z" },
-    { url = "https://files.pythonhosted.org/packages/df/36/ed3ea2d594356fd8037e5a01f6156c74bc8d92dbb0fa60746cc96cabb6e8/pillow-12.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:495c302af3aad1ca67420ddd5c7bd480c8867ad173528767d906428057a11f0e", size = 5247579, upload-time = "2026-02-11T04:22:56.094Z" },
-    { url = "https://files.pythonhosted.org/packages/54/9a/9cc3e029683cf6d20ae5085da0dafc63148e3252c2f13328e553aaa13cfb/pillow-12.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8fd420ef0c52c88b5a035a0886f367748c72147b2b8f384c9d12656678dfdfa9", size = 6989094, upload-time = "2026-02-11T04:22:58.288Z" },
-    { url = "https://files.pythonhosted.org/packages/00/98/fc53ab36da80b88df0967896b6c4b4cd948a0dc5aa40a754266aa3ae48b3/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3", size = 5313850, upload-time = "2026-02-11T04:23:00.554Z" },
-    { url = "https://files.pythonhosted.org/packages/30/02/00fa585abfd9fe9d73e5f6e554dc36cc2b842898cbfc46d70353dae227f8/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735", size = 5963343, upload-time = "2026-02-11T04:23:02.934Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/26/c56ce33ca856e358d27fda9676c055395abddb82c35ac0f593877ed4562e/pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e", size = 7029880, upload-time = "2026-02-11T04:23:04.783Z" },
+    { url = "https://files.pythonhosted.org/packages/db/26/77f8ed17ca4ffd60e1dcd220a6ec6d71210ba398cfa33a13a1cd614c5613/pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722", size = 5316531, upload-time = "2025-07-01T09:13:59.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/39/ee475903197ce709322a17a866892efb560f57900d9af2e55f86db51b0a5/pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288", size = 4686560, upload-time = "2025-07-01T09:14:01.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/442068a160fd179938ba55ec8c97050a612426fae5ec0a764e345839f76d/pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d", size = 5870978, upload-time = "2025-07-03T13:09:55.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/92/dcdd147ab02daf405387f0218dcf792dc6dd5b14d2573d40b4caeef01059/pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494", size = 7641168, upload-time = "2025-07-03T13:10:00.37Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/db/839d6ba7fd38b51af641aa904e2960e7a5644d60ec754c046b7d2aee00e5/pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58", size = 5973053, upload-time = "2025-07-01T09:14:04.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f", size = 6640273, upload-time = "2025-07-01T09:14:06.235Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ad/931694675ede172e15b2ff03c8144a0ddaea1d87adb72bb07655eaffb654/pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e", size = 6082043, upload-time = "2025-07-01T09:14:07.978Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/04/ba8f2b11fc80d2dd462d7abec16351b45ec99cbbaea4387648a44190351a/pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94", size = 6715516, upload-time = "2025-07-01T09:14:10.233Z" },
+    { url = "https://files.pythonhosted.org/packages/48/59/8cd06d7f3944cc7d892e8533c56b0acb68399f640786313275faec1e3b6f/pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0", size = 6274768, upload-time = "2025-07-01T09:14:11.921Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/cc/29c0f5d64ab8eae20f3232da8f8571660aa0ab4b8f1331da5c2f5f9a938e/pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac", size = 6986055, upload-time = "2025-07-01T09:14:13.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/df/90bd886fabd544c25addd63e5ca6932c86f2b701d5da6c7839387a076b4a/pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd", size = 2423079, upload-time = "2025-07-01T09:14:15.268Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328, upload-time = "2025-07-01T09:14:35.276Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652, upload-time = "2025-07-01T09:14:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443, upload-time = "2025-07-01T09:14:39.344Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474, upload-time = "2025-07-01T09:14:41.843Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038, upload-time = "2025-07-01T09:14:44.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407, upload-time = "2025-07-03T13:10:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094, upload-time = "2025-07-03T13:10:21.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503, upload-time = "2025-07-01T09:14:45.698Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574, upload-time = "2025-07-01T09:14:47.415Z" },
+    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060, upload-time = "2025-07-01T09:14:49.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407, upload-time = "2025-07-01T09:14:51.962Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841, upload-time = "2025-07-01T09:14:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450, upload-time = "2025-07-01T09:14:56.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055, upload-time = "2025-07-01T09:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110, upload-time = "2025-07-01T09:14:59.79Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547, upload-time = "2025-07-01T09:15:01.648Z" },
+    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554, upload-time = "2025-07-03T13:10:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132, upload-time = "2025-07-03T13:10:33.01Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001, upload-time = "2025-07-01T09:15:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814, upload-time = "2025-07-01T09:15:05.655Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124, upload-time = "2025-07-01T09:15:07.358Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186, upload-time = "2025-07-01T09:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546, upload-time = "2025-07-01T09:15:11.311Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102, upload-time = "2025-07-01T09:15:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803, upload-time = "2025-07-01T09:15:15.695Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520, upload-time = "2025-07-01T09:15:17.429Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116, upload-time = "2025-07-01T09:15:19.423Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597, upload-time = "2025-07-03T13:10:38.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246, upload-time = "2025-07-03T13:10:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336, upload-time = "2025-07-01T09:15:21.237Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699, upload-time = "2025-07-01T09:15:23.186Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789, upload-time = "2025-07-01T09:15:25.1Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386, upload-time = "2025-07-01T09:15:27.378Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911, upload-time = "2025-07-01T09:15:29.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383, upload-time = "2025-07-01T09:15:31.128Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385, upload-time = "2025-07-01T09:15:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129, upload-time = "2025-07-01T09:15:35.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580, upload-time = "2025-07-01T09:15:37.114Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860, upload-time = "2025-07-03T13:10:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694, upload-time = "2025-07-03T13:10:56.432Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888, upload-time = "2025-07-01T09:15:39.436Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330, upload-time = "2025-07-01T09:15:41.269Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089, upload-time = "2025-07-01T09:15:43.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206, upload-time = "2025-07-01T09:15:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370, upload-time = "2025-07-01T09:15:46.673Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500, upload-time = "2025-07-01T09:15:48.512Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835, upload-time = "2025-07-01T09:15:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e3/6fa84033758276fb31da12e5fb66ad747ae83b93c67af17f8c6ff4cc8f34/pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6", size = 5270566, upload-time = "2025-07-01T09:16:19.801Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ee/e8d2e1ab4892970b561e1ba96cbd59c0d28cf66737fc44abb2aec3795a4e/pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438", size = 4654618, upload-time = "2025-07-01T09:16:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6d/17f80f4e1f0761f02160fc433abd4109fa1548dcfdca46cfdadaf9efa565/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3", size = 4874248, upload-time = "2025-07-03T13:11:20.738Z" },
+    { url = "https://files.pythonhosted.org/packages/de/5f/c22340acd61cef960130585bbe2120e2fd8434c214802f07e8c03596b17e/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c", size = 6583963, upload-time = "2025-07-03T13:11:26.283Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
 ]
 
 [[package]]
@@ -4971,25 +4974,25 @@ wheels = [
 
 [[package]]
 name = "plum-dispatch"
-version = "2.8.0"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/2f2b0dd84edbb2951a845ba98d29f651bbbd467039c368fcfa22904905cd/plum_dispatch-2.8.0.tar.gz", hash = "sha256:453fc7bc67d2a39492c834b00c94d816871d148b5a0a5d3f49e2bbf2391e2619", size = 241272, upload-time = "2026-03-17T21:24:41.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/7a/5bbae2b6431df921757188f742be6e919393aa55787b582aecb281d1a4bf/plum_dispatch-2.7.1.tar.gz", hash = "sha256:38f04f42f2cc4f726083244e52ee04cfd155f53fad55423ec0fd1bfee3fc97a9", size = 242770, upload-time = "2026-02-21T09:27:49.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/ac/c502295727dd9c9bd2105c130ae4420762536faf411ed94b5b13c31b3e6b/plum_dispatch-2.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2b3aa8ff3f5a356e4a8f659bb35ce52c2dd9c67bfefb89fe35204bc9be3be77a", size = 162215, upload-time = "2026-03-17T21:24:26.81Z" },
-    { url = "https://files.pythonhosted.org/packages/65/51/ddb87d0f7190d176d2c22174b6ebc02c5d6d1d571dec2a5ab3f388e8a1c8/plum_dispatch-2.8.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:71a8619fe9017d9741ab96c73443b50afe1b7159202d94b332a64fa2ed760cdf", size = 192110, upload-time = "2026-03-17T21:24:28.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/41/0115bb8a2a6d06f9698fec20ede13350897271b46173b3d9e75f1711f73f/plum_dispatch-2.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c7d033348a6d60940476b5be9132dd1a87cb0d0ba335ad3bd4213137162bbf5", size = 146574, upload-time = "2026-03-17T21:24:29.805Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a3/cdb8130cc05a13c75237d2be4821f38c0b99d1a64980b6529d788a43a501/plum_dispatch-2.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fca6b6dbed8c686f6f827e9c95f60334ba70ee27cccef1f44a50d42a30221748", size = 165288, upload-time = "2026-03-17T21:24:31.203Z" },
-    { url = "https://files.pythonhosted.org/packages/25/fe/b1dbbdd1864d4ca825b3b5079fca852ea5e5a4f223aa866702f751b02dba/plum_dispatch-2.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:599025e7bd7e16f198e5ccaad0ca51036fcbeb43eb41525a5ef705b9a25bb192", size = 194360, upload-time = "2026-03-17T21:24:32.531Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/01/a8947d5c92824a6bc019696e5d9f150178736ecd8e6766db38b38e0f0fda/plum_dispatch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0e6146881b71eb6a6355d18476bed356071d1dff45a7cf4ae31f7f4bffb01b9", size = 146826, upload-time = "2026-03-17T21:24:34.076Z" },
-    { url = "https://files.pythonhosted.org/packages/68/25/380300b3468417999ca0db0522eeae1017798519fe28753e8ad110718174/plum_dispatch-2.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d60c0040207495afddab3f80c498a5e8f9dab29f8d143468c51d668fe70ed291", size = 165256, upload-time = "2026-03-17T21:24:35.341Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/94e4e62ad437996341d03471bd398f3f6bf4c5f3a1fa524ba53f02b6896d/plum_dispatch-2.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88aaf08a562e7a559851679a051b32306b67fd403ed6070915a966f048a83e9", size = 193632, upload-time = "2026-03-17T21:24:37.035Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d2/772d1e3071971a30e70b78df421f51788354337a7f94957d910ba3cd8a5a/plum_dispatch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:53bc084b335e5071b72353830a9f2cdacd58c9e959089be5778b6d638b5062f9", size = 146931, upload-time = "2026-03-17T21:24:38.8Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/7d/6d1a0a5851fb590564045471bdd6f405426ae4214cafe530ceba297e5c0d/plum_dispatch-2.8.0-py3-none-any.whl", hash = "sha256:f5dfffc46de1d8208ba281fdb0f41d6065c7341c1fde76fc83b4b78810c30c7e", size = 44547, upload-time = "2026-03-17T21:24:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bb/0186ce2350fb46d9adbb3247a81e6701f04c5dc15013e751746e0384a94f/plum_dispatch-2.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff9759c21e65f33f39bac9ca57bb049c624ce1b83e48545f62a0a461fc2d3281", size = 162197, upload-time = "2026-02-21T09:27:35.916Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e4/6019cdfd6ad699199ba5c5640dbce70f103e55dd3bef7eea275b2bc8f9b7/plum_dispatch-2.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f6f7ca4430bffc01833ecf1cd0eb342a84d777d1dd312a061e44bbd407c5867c", size = 191022, upload-time = "2026-02-21T09:27:37.513Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/c7b823c0b869d07f9cf687f8dfa4810e73ed76fe23423619d6a75d44eda3/plum_dispatch-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:9e5ecb41ba6fc554d55b93b4d906729c5d7fef972e9885e75cd2a24d0a15e138", size = 146569, upload-time = "2026-02-21T09:27:38.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/b6ac3e87fee0c22e973e7551257511271037457714d3d98a13c0a635f402/plum_dispatch-2.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9aae69d9239d9c8421d0874b2050f840e2dd0835ae56b521d0bc6cb8e0a2842d", size = 165265, upload-time = "2026-02-21T09:27:40.112Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/97/8fcd79b86d550350af486a09aafaf8405f84bc405aae17ce78358b02b386/plum_dispatch-2.7.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32680ac1990785065246bdc7f8b19a40fd5eb4114226b1dbc1bcbfc32580a3b1", size = 193280, upload-time = "2026-02-21T09:27:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c4/134e90aec2555198c2ed291bbf216066abe94e8239c0649ebfa5f1b3fbec/plum_dispatch-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d967d57077ae05a7f3c6bc3b72eaf6a83f0733f6f7cd417a2ba63f39490b446d", size = 146817, upload-time = "2026-02-21T09:27:42.939Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3b/0a31c5bf6500b1edd2a0dd1a562c58bf030d07f38644a78c84d3dae4e011/plum_dispatch-2.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f9b6c6d70b37525bae0f77e897c7fee49845b38429958ded50f5be7e3bebb535", size = 165237, upload-time = "2026-02-21T09:27:44.589Z" },
+    { url = "https://files.pythonhosted.org/packages/89/da/ac745bb38b466bdd2c374374391b6e1ab5e446c0a1e31424f9de841d6afc/plum_dispatch-2.7.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12653d78f1840e6411523fb42a72c46f4941a9b354cc6ecebdfaad471b11aa98", size = 192689, upload-time = "2026-02-21T09:27:46.03Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/6f3cef28ff828b9867d75d018dab100b1c969650bfdaf6b1a55f9b826ae0/plum_dispatch-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:fe2f149b9d1edc183a66c529259f1cfcc4bc6433574d7819dad2a6b280fe30bc", size = 146941, upload-time = "2026-02-21T09:27:47.57Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/61/52666dd036af3279351ba36a38dfcc0f1f6bc03975611ea5bcfa9cf8ba76/plum_dispatch-2.7.1-py3-none-any.whl", hash = "sha256:7f9fdf3f58fc8a738234f0b47569b079eac666e9ed6e095f1fcb7f158cbc3e1c", size = 44544, upload-time = "2026-02-21T09:27:48.708Z" },
 ]
 
 [[package]]
@@ -5022,54 +5025,54 @@ wheels = [
 
 [[package]]
 name = "preshed"
-version = "3.0.13"
+version = "3.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cymem" },
     { name = "murmurhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/34/eb4f5f0f678e152a96e826da867d2f41c4b18a2d589e40e1dd3347219e91/preshed-3.0.12.tar.gz", hash = "sha256:b73f9a8b54ee1d44529cc6018356896cff93d48f755f29c134734d9371c0d685", size = 15027, upload-time = "2025-11-17T13:00:33.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/d1/7bc39738388b38ff48cecbb326a9b2bb3f422bb32097be92e010f3162395/preshed-3.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5268c0e6fa96f50cdf87f516c2d4b32563c12706ee768e75c00e8d0098acd545", size = 136718, upload-time = "2026-03-23T08:56:23.889Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/65/de465b6801740140c2b5d2db6c312ca7937dcfd0442f1ae7d50dee529544/preshed-3.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:df642547a1a94079978a0ea8f4593ab4b8d3bd43f767bef0ef64d9a214f8c4c9", size = 137261, upload-time = "2026-03-23T08:56:25.303Z" },
-    { url = "https://files.pythonhosted.org/packages/89/83/478ee078746a4a413c841542caebd2ea74b659475b8bf5f2e3724b6fe655/preshed-3.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09397592d333a77f88454e72b7f1f941b2afaf040b392b9e74898dbc4648cdf5", size = 821010, upload-time = "2026-03-23T08:56:26.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/2e/1ac761e973966893cd3a0ad3256360365276e2d1e779e351448981a1156a/preshed-3.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8e6fe0620ed0f96a246d46447055c447e071cd8222731a045c235e8a758c918", size = 823096, upload-time = "2026-03-23T08:56:28.126Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/7824cfd85dd7fe547888de20228ebd87d9acd3708206d30b82211e382d23/preshed-3.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:502f93f49a22788203f02d3067d4ea077a0cca3864de6a792eae12e7ce589e14", size = 1812148, upload-time = "2026-03-23T08:56:29.755Z" },
-    { url = "https://files.pythonhosted.org/packages/34/48/32160a24705d56179de6af838c10a0c735c955dae5f9e4bb344750b79bc2/preshed-3.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:acd4d89abeca3678c5d8c89b3cd351314465bc67c7fa053d2644f8513e543386", size = 1881154, upload-time = "2026-03-23T08:56:31.49Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/22/0344b50f8b1ad9e3aac08099c47e1aba91c81602fd117d2673f6606ecae6/preshed-3.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:de87fbabb0f37c3c92d4dd9b94fc82ab73cdab4247cdfbd57ab3926caa983919", size = 122219, upload-time = "2026-03-23T08:56:32.74Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c4/812eeaa568510f396e27edab01100ca71418f032fd7098b107f12e572361/preshed-3.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:5e2753779832e411e93eb727f3d409c0a6b7408e5ce4dd868076d8ece48c7693", size = 109308, upload-time = "2026-03-23T08:56:33.839Z" },
-    { url = "https://files.pythonhosted.org/packages/39/fb/ccff23c44c04088c248539005fcda78b9014512a34d170c5360f02ad908b/preshed-3.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5d14eea14bd01291388928991d7df7d60b9fd19ae970e55006eb4d29b0c1e8eb", size = 138497, upload-time = "2026-03-23T08:56:35.321Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ce/cad5a8145881a771e6c0d002f2e585fc19b962f120860b54d32af5baa342/preshed-3.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f05b08ce92399c0655b5e0eb5a1cc1f9e295703ed3aabdfaf6538dfa8ae23d57", size = 138010, upload-time = "2026-03-23T08:56:36.399Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/a2/c5fed4fb3e946699259d11e4036a3cfdd8c89b3e542e3077d46781642425/preshed-3.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:62cf7f3113132891d6bba70ff547ad81c6fe50a31930bbbb8499f1d47cd122b7", size = 861498, upload-time = "2026-03-23T08:56:37.67Z" },
-    { url = "https://files.pythonhosted.org/packages/51/94/8c9bc48a6ea4903f53a1a0031ce8e35687526949f25821762ef21493c007/preshed-3.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b8de3f58043070a354477995acdd98626ce43e4193c708ebd0f694e467f5155", size = 868988, upload-time = "2026-03-23T08:56:39.324Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/df/ecd2f40055ff52527ca117ffbfafb888c1a3079b59fbabe03c5b8f9b7240/preshed-3.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:183b339956a9e1d7a4a00038a3b9587a734db9e8bd915939a49791bd1b372156", size = 1847382, upload-time = "2026-03-23T08:56:40.89Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/88/bdb244e40284ded3632a9f88c23bc80230bd7b2ae4a8b7f2cc91adead7a8/preshed-3.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2e77bed56aded7cbe5d28d6bd2178bc5b13eda0e0e464dab205fb578fa915000", size = 1919236, upload-time = "2026-03-23T08:56:42.616Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c9/c91ea56342e6c364fc69b444a1ac5432327857199c44032c9cc9dc4c3a23/preshed-3.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:04d8f13f2986e5d11af5ac51f55ce3106c70c41b483d20ea392e6180bdd0f870", size = 122938, upload-time = "2026-03-23T08:56:44.271Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/0b/6a99d99619fd83b14c696e2489caed7070647488d4d3ac0b723d35db2de0/preshed-3.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:19318dc1cd8cac6663c6c830bf7e0002d2de853769fb03e056774e97c21bedfd", size = 109194, upload-time = "2026-03-23T08:56:45.346Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/2a/401158195d6dc7f6aef0b354d74d0e95c9da124499448c2b3dbb95b71204/preshed-3.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0d0c14187dc0078d8a63bf190ec045a4d13e7748b6caeb557a7d575e411410b", size = 137289, upload-time = "2026-03-23T08:56:46.516Z" },
-    { url = "https://files.pythonhosted.org/packages/88/8f/e20e64573988528785447a6893b2e7ab287ecfd85b3888e978b28812fd20/preshed-3.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7770987c2e57497cd26124a9be5f652b5b3ccd0def89859ab0da8bca6144a3de", size = 136847, upload-time = "2026-03-23T08:56:47.572Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/72/18168f881359c4482d312f8dc196371bdd61c1583a52b34390da4c88bbea/preshed-3.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4a7bc48220de579be6bdb0a8715482cf36e2a625a6fd5ad26c9f43485a4a23b5", size = 831478, upload-time = "2026-03-23T08:56:48.769Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/3a/3543476091087102775568cea9885dde3453569e9aeee365809108de572f/preshed-3.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5c8462472f790c16708306aef3a102a762bd19dfe3d2f8ee08bd5e12f51b835", size = 839913, upload-time = "2026-03-23T08:56:49.937Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/65/b13f01329decc44ef53cfb6b4601ba85382dcb2a4ec78d9250f03a418066/preshed-3.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c046736239cc8d72670749b79b526e4111839a2fc461a58545d212797649129c", size = 1816452, upload-time = "2026-03-23T08:56:51.233Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c7/f1a996c6832234efd4d543041b582418d41ac480ee55c557ec9e65344637/preshed-3.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c333f18e9a81c8a6de0603fd8781e17115324b117c445ca91abdf7bfb1abe49", size = 1888978, upload-time = "2026-03-23T08:56:52.591Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/b9/96fb71499049885ce19545903fdd38877bbc2be0da47e37c04d01f3e9f66/preshed-3.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:461327f8dd36520dcf1fd55a671e0c3c2c97a2d95e22fc85faa31173f4785dda", size = 122134, upload-time = "2026-03-23T08:56:54.392Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/a7/32a4903019d936a2316fdd330bedddac287ac26326107d24fb76a1fbc60a/preshed-3.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:35d6c5acb3ee3b12b87a551913063f0cec784055c2af16e028c19fe875f079d0", size = 108497, upload-time = "2026-03-23T08:56:55.816Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/b5/993886c98f5caaa6f07a648cac97a7c62a3093091cad65e1e43a1bd41cc4/preshed-3.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2f1efae396cadab5f3890a2fd43d2ee65373ef9096ccbb805e51e8d8bcc563b", size = 137882, upload-time = "2026-03-23T08:56:56.878Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/86/b7fd137cbf140afd6c45e895946068a15f5b55642916de0075e6eb18581c/preshed-3.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8d6acc1f5031a535a55a6f7148e2f274554a8343a16309c700cebea0fe7aee8c", size = 138233, upload-time = "2026-03-23T08:56:58.318Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ca/21a7e79625614134273dfed32bca5bb4c2ec1313e33fbd12d41657536f1f/preshed-3.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7da9d931e7660dcdd757e5870269f0c159126d682ed73ed313971d199eb0f334", size = 834835, upload-time = "2026-03-23T08:56:59.48Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3a/2dbd299516461831ae90e0d5b0637137bf28520c4e6dd0b01d6f1886659a/preshed-3.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4ae5cfe075bb7a07982e382bca44f41ddf041f4d24cbd358e8cccfc049259b8", size = 834928, upload-time = "2026-03-23T08:57:01.075Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/d3/af654eba4f6587c4ee02c5043e62c194b0a1c4431ffef0c67b9518f6b61c/preshed-3.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7557963d0125a3a7bcdb2eb6948f3e45da31b5a7f066b55320de3dea22d7557f", size = 1820368, upload-time = "2026-03-23T08:57:02.351Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/9b/ebcb2b9e8cb881e40b55b0bf450f8a6b187e2ef3ae0c685cce81d2d85026/preshed-3.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c4bc60dc994864095d784b7e4d77dba3e64188d169ac88722b699d175561fddb", size = 1888251, upload-time = "2026-03-23T08:57:04.158Z" },
-    { url = "https://files.pythonhosted.org/packages/97/f7/c6c012779edcaa6e2cd092c554e98dc53e77f41205b07208655ba77e2327/preshed-3.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:208dcebbe294bf1881ce33fb015d56ab2a7587aece85a09147727174207892e4", size = 125211, upload-time = "2026-03-23T08:57:05.83Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/82/390ef87d732ef64e673ef6bf9e5d898453986e979efa50fb3a400e2c0766/preshed-3.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:cf8e1a7a1823b2a7765121446c630140ac6e8650c07a6efbf375e168d1fef4f7", size = 111942, upload-time = "2026-03-23T08:57:06.996Z" },
-    { url = "https://files.pythonhosted.org/packages/80/3a/a9dde3167bcecb27ae82ce4567b5ab1aa3989113ae6814c092ce223cc4ef/preshed-3.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9ca43ecbc3783eda4d6ab3416ae2ecd9ef23dca5f53995843f69f7457bcd0677", size = 144997, upload-time = "2026-03-23T08:57:08.064Z" },
-    { url = "https://files.pythonhosted.org/packages/74/d4/22d9355b50b6a13b407dcad0a81df83fb1d5602092d1f05834674dde8fda/preshed-3.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c8596e41a258ff213553a441e0bb3eb388fd8158e84a7bf3aae6d8ede2c166d3", size = 147294, upload-time = "2026-03-23T08:57:09.411Z" },
-    { url = "https://files.pythonhosted.org/packages/70/42/a225ee83fdb306d2a503f21a627953b820f4e079c90c8a84338957cb8ff5/preshed-3.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f8856ca3d88e9b250630d70abb4f260d8933151ddfb413024784b25b009868e", size = 952110, upload-time = "2026-03-23T08:57:10.592Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ba/09a9dfe3d22d7e745483fd5d7f2a82cd4d39c161f7d2daa0faa4bd6402be/preshed-3.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e5b2865aecbd2e1e10e5d19bb8bfad765863c1307c6c3e51f2a08bd64122409", size = 932217, upload-time = "2026-03-23T08:57:12.124Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/5c/e10e2e05133e7fcbd7c40536af1148c82dd24357b8f5726e2c7bc51cfd53/preshed-3.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:09f96b477c987755b3c945df214ea1c1c80bfb350e9f34e78da89585535b77e8", size = 1896542, upload-time = "2026-03-23T08:57:13.525Z" },
-    { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473, upload-time = "2026-03-23T08:57:15.706Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229, upload-time = "2026-03-23T08:57:17.457Z" },
-    { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339, upload-time = "2026-03-23T08:57:18.882Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/54/d1e02d0a0ea348fb6a769506166e366abfe87ee917c2f11f7139c7acbf10/preshed-3.0.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bc45fda3fd4ae1ae15c37f18f0777cf389ce9184ef8884b39b18894416fd1341", size = 128439, upload-time = "2025-11-17T12:59:21.317Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cb/685ca57ca6e438345b3f6c20226705a0e056a3de399a5bf8a9ee89b3dd2b/preshed-3.0.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75d6e628bc78c022dbb9267242715718f862c3105927732d166076ff009d65de", size = 124544, upload-time = "2025-11-17T12:59:22.944Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/07/018fcd3bf298304e1570065cf80601ac16acd29f799578fd47b715dd3ca2/preshed-3.0.12-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b901cff5c814facf7a864b0a4c14a16d45fa1379899a585b3fb48ee36a2dccdb", size = 824728, upload-time = "2025-11-17T12:59:24.614Z" },
+    { url = "https://files.pythonhosted.org/packages/79/dc/d888b328fcedae530df53396d9fc0006026aa8793fec54d7d34f57f31ff5/preshed-3.0.12-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d1099253bf73dd3c39313280bd5331841f769637b27ddb576ff362c4e7bad298", size = 825969, upload-time = "2025-11-17T12:59:26.493Z" },
+    { url = "https://files.pythonhosted.org/packages/21/51/f19933301f42ece1ffef1f7f4c370d09f0351c43c528e66fac24560e44d2/preshed-3.0.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1af4a049ffe9d0246e5dc10d6f54820ed064c40e5c3f7b6526127c664008297c", size = 842346, upload-time = "2025-11-17T12:59:28.092Z" },
+    { url = "https://files.pythonhosted.org/packages/51/46/025f60fd3d51bf60606a0f8f0cd39c40068b9b5e4d249bca1682e4ff09c3/preshed-3.0.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:57159bcedca0cb4c99390f8a6e730f8659fdb663a5a3efcd9c4531e0f54b150e", size = 865504, upload-time = "2025-11-17T12:59:29.648Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b5/2e6ee5ab19b03e7983fc5e1850c812fb71dc178dd140d6aca3b45306bdf7/preshed-3.0.12-cp311-cp311-win_amd64.whl", hash = "sha256:8fe9cf1745e203e5aa58b8700436f78da1dcf0f0e2efb0054b467effd9d7d19d", size = 117736, upload-time = "2025-11-17T12:59:30.974Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/17/8a0a8f4b01e71b5fb7c5cd4c9fec04d7b852d42f1f9e096b01e7d2b16b17/preshed-3.0.12-cp311-cp311-win_arm64.whl", hash = "sha256:12d880f8786cb6deac34e99b8b07146fb92d22fbca0023208e03325f5944606b", size = 105127, upload-time = "2025-11-17T12:59:32.171Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/ff3aca937eeaee19c52c45ddf92979546e52ed0686e58be4bc09c47e7d88/preshed-3.0.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2779861f5d69480493519ed123a622a13012d1182126779036b99d9d989bf7e9", size = 129958, upload-time = "2025-11-17T12:59:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/80/24/fd654a9c0f5f3ed1a9b1d8a392f063ae9ca29ad0b462f0732ae0147f7cee/preshed-3.0.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffe1fd7d92f51ed34383e20d8b734780c814ca869cfdb7e07f2d31651f90cdf4", size = 124550, upload-time = "2025-11-17T12:59:34.688Z" },
+    { url = "https://files.pythonhosted.org/packages/71/49/8271c7f680696f4b0880f44357d2a903d649cb9f6e60a1efc97a203104df/preshed-3.0.12-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:91893404858502cc4e856d338fef3d2a4a552135f79a1041c24eb919817c19db", size = 874987, upload-time = "2025-11-17T12:59:36.062Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a5/ca200187ca1632f1e2c458b72f1bd100fa8b55deecd5d72e1e4ebf09e98c/preshed-3.0.12-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9e06e8f2ba52f183eb9817a616cdebe84a211bb859a2ffbc23f3295d0b189638", size = 866499, upload-time = "2025-11-17T12:59:37.586Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a1/943b61f850c44899910c21996cb542d0ef5931744c6d492fdfdd8457e693/preshed-3.0.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bbe8b8a2d4f9af14e8a39ecca524b9de6defc91d8abcc95eb28f42da1c23272c", size = 878064, upload-time = "2025-11-17T12:59:39.651Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/75/d7fff7f1fa3763619aa85d6ba70493a5d9c6e6ea7958a6e8c9d3e6e88bbe/preshed-3.0.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5d0aaac9c5862f5471fddd0c931dc64d3af2efc5fe3eb48b50765adb571243b9", size = 900540, upload-time = "2025-11-17T12:59:41.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/12/a2285b78bd097a1e53fb90a1743bc8ce0d35e5b65b6853f3b3c47da398ca/preshed-3.0.12-cp312-cp312-win_amd64.whl", hash = "sha256:0eb8d411afcb1e3b12a0602fb6a0e33140342a732a795251a0ce452aba401dc0", size = 118298, upload-time = "2025-11-17T12:59:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/34/4e8443fe99206a2fcfc63659969a8f8c8ab184836533594a519f3899b1ad/preshed-3.0.12-cp312-cp312-win_arm64.whl", hash = "sha256:dcd3d12903c9f720a39a5c5f1339f7f46e3ab71279fb7a39776768fb840b6077", size = 104746, upload-time = "2025-11-17T12:59:43.934Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/36/1d3df6f9f37efc34be4ee3013b3bb698b06f1e372f80959851b54d8efdb2/preshed-3.0.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3deb3ab93d50c785eaa7694a8e169eb12d00263a99c91d56511fe943bcbacfb6", size = 128023, upload-time = "2025-11-17T12:59:45.157Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d4/3ca81f42978da1b81aa57b3e9b5193d8093e187787a3b2511d16b30b7c62/preshed-3.0.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604350001238dab63dc14774ee30c257b5d71c7be976dbecd1f1ed37529f60f", size = 122851, upload-time = "2025-11-17T12:59:46.439Z" },
+    { url = "https://files.pythonhosted.org/packages/17/73/f388398f8d789f69b510272d144a9186d658423f6d3ecc484c0fe392acec/preshed-3.0.12-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04fb860a8aab18d2201f06159337eda5568dc5eed218570d960fad79e783c7d0", size = 835926, upload-time = "2025-11-17T12:59:47.882Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c6/b7170933451cbc27eaefd57b36f61a5e7e7c8da50ae24f819172e0ca8a4d/preshed-3.0.12-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d0c8fcd44996031c46a0aa6773c7b7aa5ee58c3ee87bc05236dacd5599d35063", size = 827294, upload-time = "2025-11-17T12:59:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ec/6504730d811c0a375721db2107d31684ec17ee5b7bb3796ecfa41e704d41/preshed-3.0.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b07efc3abd3714ce01cf67db0a2dada6e829ab7def74039d446e49ddb32538c5", size = 838809, upload-time = "2025-11-17T12:59:51.234Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1a/09d13240c1fbadcc0603e2fe029623045a36c88b4b50b02e7fdc89e3b88e/preshed-3.0.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f184ef184b76e0e4707bce2395008779e4dfa638456b13b18469c2c1a42903a6", size = 861448, upload-time = "2025-11-17T12:59:52.702Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/35/9523160153037ee8337672249449be416ee92236f32602e7dd643767814f/preshed-3.0.12-cp313-cp313-win_amd64.whl", hash = "sha256:ebb3da2dc62ab09e5dc5a00ec38e7f5cdf8741c175714ab4a80773d8ee31b495", size = 117413, upload-time = "2025-11-17T12:59:54.4Z" },
+    { url = "https://files.pythonhosted.org/packages/79/eb/4263e6e896753b8e2ffa93035458165850a5ea81d27e8888afdbfd8fa9c4/preshed-3.0.12-cp313-cp313-win_arm64.whl", hash = "sha256:b36a2cf57a5ca6e78e69b569c92ef3bdbfb00e3a14859e201eec6ab3bdc27085", size = 104041, upload-time = "2025-11-17T12:59:55.596Z" },
+    { url = "https://files.pythonhosted.org/packages/77/39/7b33910b7ba3db9ce1515c39eb4657232913fb171fe701f792ef50726e60/preshed-3.0.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0d8b458dfbd6cc5007d045fa5638231328e3d6f214fd24ab999cc10f8b9097e5", size = 129211, upload-time = "2025-11-17T12:59:57.182Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/97dceebe0b2b4dd94333e4ec283d38614f92996de615859a952da082890d/preshed-3.0.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8e9196e2ea704243a69df203e0c9185eb7c5c58c3632ba1c1e2e2e0aa3aae3b4", size = 123311, upload-time = "2025-11-17T12:59:58.449Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6f/f3772f6eaad1eae787f82ffb65a81a4a1993277eacf5a78a29da34608323/preshed-3.0.12-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ffa644e1730012ed435fb9d0c3031ea19a06b11136eff5e9b96b2aa25ec7a5f5", size = 831683, upload-time = "2025-11-17T13:00:00.229Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/93/997d39ca61202486dd06c669b4707a5b8e5d0c2c922db9f7744fd6a12096/preshed-3.0.12-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:39e83a16ce53e4a3c41c091fe4fe1c3d28604e63928040da09ba0c5d5a7ca41e", size = 830035, upload-time = "2025-11-17T13:00:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f2/51bf44e3fdbef08d40a832181842cd9b21b11c3f930989f4ff17e9201e12/preshed-3.0.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2ec9bc0baee426303a644c7bf531333d4e7fd06fedf07f62ee09969c208d578d", size = 841728, upload-time = "2025-11-17T13:00:03.643Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b1/2d0e3d23d9f885f7647654d770227eb13e4d892deb9b0ed50b993d63fb18/preshed-3.0.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7db058f1b4a3d4d51c4c05b379c6cc9c36fcad00160923cb20ca1c7030581ea4", size = 858860, upload-time = "2025-11-17T13:00:05.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/57/7c28c7f6f9bfce02796b54f1f6acd2cebb3fa3f14a2dce6fb3c686e3c3a8/preshed-3.0.12-cp314-cp314-win_amd64.whl", hash = "sha256:c87a54a55a2ba98d0c3fd7886295f2825397aff5a7157dcfb89124f6aa2dca41", size = 120325, upload-time = "2025-11-17T13:00:06.428Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c3/df235ca679a08e09103983ec17c668f96abe897eadbe18d635972b43d8a9/preshed-3.0.12-cp314-cp314-win_arm64.whl", hash = "sha256:d9c5f10b4b971d71d163c2416b91b7136eae54ef3183b1742bb5993269af1b18", size = 107393, upload-time = "2025-11-17T13:00:07.718Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/f1/51a2a72381c8aa3aeb8305d88e720c745048527107e649c01b8d49d6b5bf/preshed-3.0.12-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2739a9c57efcfa16466fa6e0257d67f0075a9979dc729585fbadaed7383ab449", size = 137703, upload-time = "2025-11-17T13:00:09.001Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/f3c3d50647f3af6ce6441c596a4f6fb0216d549432ef51f61c0c1744c9b9/preshed-3.0.12-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:364249656bfbf98b4008fac707f35835580ec56207f7cbecdafef6ebb6a595a6", size = 134889, upload-time = "2025-11-17T13:00:10.29Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/012dbae28a0b88cd98eae99f87701ffbe3a7d2ea3de345cb8a6a6e1b16cd/preshed-3.0.12-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7f933d509ee762a90f62573aaf189eba94dfee478fca13ea2183b2f8a1bb8f7e", size = 911078, upload-time = "2025-11-17T13:00:11.911Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c1/0cd0f8cdb91f63c298320cf946c4b97adfb8e8d3a5d454267410c90fcfaa/preshed-3.0.12-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f73f4e29bf90e58034e6f5fa55e6029f3f2d7c042a7151ed487b49898b0ce887", size = 930506, upload-time = "2025-11-17T13:00:13.375Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1a/cab79b3181b2150eeeb0e2541c2bd4e0830e1e068b8836b24ea23610cec3/preshed-3.0.12-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a61ede0c3d18f1ae128113f785a396351a46f4634beccfdf617b0a86008b154d", size = 900009, upload-time = "2025-11-17T13:00:14.781Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9a/5ea9d6d95d5c07ba70166330a43bff7f0a074d0134eb7984eca6551e8c70/preshed-3.0.12-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eafc08a86f77be78e722d96aa8a3a0aef0e3c7ac2f2ada22186a138e63d4033c", size = 910826, upload-time = "2025-11-17T13:00:16.861Z" },
+    { url = "https://files.pythonhosted.org/packages/92/71/39024f9873ff317eac724b2759e94d013703800d970d51de77ccc6afff7e/preshed-3.0.12-cp314-cp314t-win_amd64.whl", hash = "sha256:fadaad54973b8697d5ef008735e150bd729a127b6497fd2cb068842074a6f3a7", size = 141358, upload-time = "2025-11-17T13:00:18.167Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0d/431bb85252119f5d2260417fa7d164619b31eed8f1725b364dc0ade43a8e/preshed-3.0.12-cp314-cp314t-win_arm64.whl", hash = "sha256:c0c0d3b66b4c1e40aa6042721492f7b07fc9679ab6c361bc121aa54a1c3ef63f", size = 114839, upload-time = "2025-11-17T13:00:19.513Z" },
 ]
 
 [[package]]
@@ -5185,17 +5188,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.6"
+version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
-    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
-    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
 ]
 
 [[package]]
@@ -5509,11 +5512,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.9.2"
+version = "6.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
 ]
 
 [[package]]
@@ -5592,16 +5595,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.1.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
@@ -5642,15 +5645,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.2.0"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/90/bcce6b46823c9bec1757c964dc37ed332579be512e17a30e9698095dcae4/python_discovery-1.2.0.tar.gz", hash = "sha256:7d33e350704818b09e3da2bd419d37e21e7c30db6e0977bb438916e06b41b5b1", size = 58055, upload-time = "2026-03-19T01:43:08.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/7e/9f3b0dd3a074a6c3e1e79f35e465b1f2ee4b262d619de00cfce523cc9b24/python_discovery-1.1.3.tar.gz", hash = "sha256:7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5", size = 56945, upload-time = "2026-03-10T15:08:15.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl", hash = "sha256:1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a", size = 31524, upload-time = "2026-03-19T01:43:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl", hash = "sha256:90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e", size = 31485, upload-time = "2026-03-10T15:08:13.06Z" },
 ]
 
 [[package]]
@@ -6252,27 +6255,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.7"
+version = "0.15.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
-    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
-    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
+    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
 ]
 
 [[package]]
@@ -6572,7 +6575,7 @@ wheels = [
 [[package]]
 name = "skorch"
 version = "1.3.2.dev0"
-source = { git = "https://github.com/skorch-dev/skorch.git#db11757090b066896efad5e7a8f7bc25d77b1d67" }
+source = { git = "https://github.com/skorch-dev/skorch.git#3bca8f2886d6b30e76d38e142bae07cb08da9089" }
 dependencies = [
     { name = "numpy" },
     { name = "scikit-learn" },
@@ -6622,11 +6625,10 @@ wheels = [
 
 [[package]]
 name = "spacy"
-version = "3.8.13"
+version = "3.8.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "catalogue" },
-    { name = "confection" },
     { name = "cymem" },
     { name = "jinja2" },
     { name = "murmurhash" },
@@ -6641,44 +6643,44 @@ dependencies = [
     { name = "srsly" },
     { name = "thinc" },
     { name = "tqdm" },
-    { name = "typer" },
+    { name = "typer-slim" },
     { name = "wasabi" },
     { name = "weasel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/d7/1924f32272f50d2f13275f16d6f869fcec47b2b676b64f91fa206bd30ef4/spacy-3.8.13.tar.gz", hash = "sha256:eb7c03c2bb16593c34d4c91974118f0931c6e6969dbfe895b1a026c6714176cf", size = 1328016, upload-time = "2026-03-23T17:44:32.042Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/9f/424244b0e2656afc9ff82fb7a96931a47397bfce5ba382213827b198312a/spacy-3.8.11.tar.gz", hash = "sha256:54e1e87b74a2f9ea807ffd606166bf29ac45e2bd81ff7f608eadc7b05787d90d", size = 1326804, upload-time = "2025-11-17T20:40:03.079Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/a8/21f5b9c3998c7a9cdd28715248e489ebd9300b1d349d5220166b951c3df4/spacy-3.8.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3fb3ec2a78a72bb87ca1cc22ad9fea2d37a3d88ec68ee6b4a02c967f35c8b0cb", size = 6617511, upload-time = "2026-03-23T17:42:17.689Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/24/0da6c637b3d25a37db605f836e53226cae65f035e865d2909ddf66b89185/spacy-3.8.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1c7d719ff171aad00a9aac31e7c7f6e1871be08b0be50c362885c632826d41ce", size = 6441498, upload-time = "2026-03-23T17:42:20.516Z" },
-    { url = "https://files.pythonhosted.org/packages/17/64/1eeb854dc194dde91582eedf523d38c8caa209fce45c79b175e3e7a00b9f/spacy-3.8.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:95c2bf7d0afbf699df89cca5431527dff4950a823fd093680618057aa2affff8", size = 32050555, upload-time = "2026-03-23T17:42:25.13Z" },
-    { url = "https://files.pythonhosted.org/packages/05/5b/7de5aae98f0a4547b9e44fd41e3f5820c199d67c78148782a08df83d19a8/spacy-3.8.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b118c9ca4250cba8a39c7fc73641820086d476dafb54b5d1f306a3f60098d3cd", size = 32296475, upload-time = "2026-03-23T17:42:30.151Z" },
-    { url = "https://files.pythonhosted.org/packages/96/33/624d0025097b6b26a2c6d1b3dd7e24dec5da495e8c2a0f379bcc3ec26d15/spacy-3.8.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:53a6ff574a4505339375e31ba3280ff7235e82e120377614210750fa66cb63df", size = 32288426, upload-time = "2026-03-23T17:42:35.418Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/be/93eec7f8266a6d96fb5229d4588d64bb6dfa037604b5121a703cad35debb/spacy-3.8.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cf07faad25a301efbd90da1343c1f62e35185d064c5e087bd0d11a5a6b3358fe", size = 33113494, upload-time = "2026-03-23T17:42:41.053Z" },
-    { url = "https://files.pythonhosted.org/packages/26/3d/0bd7d780642635e662b32fcd530ed5bed1844dbf977bc5eed43efefa034c/spacy-3.8.13-cp311-cp311-win_amd64.whl", hash = "sha256:740cafd3cb2331c48057f6689ed6be5652d35db92aa2980f32f3d78a9aba6300", size = 15359637, upload-time = "2026-03-23T17:42:45.168Z" },
-    { url = "https://files.pythonhosted.org/packages/be/78/11896d5b5987cd37ae498ef1ce795e0dd551f984fffa9cf6a7887655617e/spacy-3.8.13-cp311-cp311-win_arm64.whl", hash = "sha256:189bdd05cfd66fd3d1f79449d38ba4e2d0270743f762db1304617ccad9dd321c", size = 14717010, upload-time = "2026-03-23T17:42:48.915Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/e1/e8f6dc7fc00582b8dcbf40fac5bce6c0ff366cf6db212decdacfaf13e584/spacy-3.8.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dd8ab0deefe9d2c7dccce1be1e65660a32cfc3cc114d0aa222ff52ae11be58ba", size = 6218311, upload-time = "2026-03-23T17:42:51.938Z" },
-    { url = "https://files.pythonhosted.org/packages/31/fe/517de9e25a6ec469738c9e886c15cd96649b338c6ae475b9b3e4c4f5e03d/spacy-3.8.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eab059bc668336d0034f3f69aed6b661b626c174e97cc1b52296d0d923c24405", size = 6033843, upload-time = "2026-03-23T17:42:54.133Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a8/9a33c69f772f5c32a57c9ef7e692293b558e7bad202264d5586ab087fd29/spacy-3.8.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:96a8e141fd7ff749fa6693c9c72187f802d334bcadf48b6b9d6ca9bff315ca73", size = 32725183, upload-time = "2026-03-23T17:42:58.847Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/cf/dcc0ea61270cb23a46d3efc437fe760e7a9c3cabcfaa770591329d1430f2/spacy-3.8.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:32c16f5be8c8006197554da3647d83311fb89bb31bb417d38f0d1da585877b0d", size = 33205816, upload-time = "2026-03-23T17:43:03.717Z" },
-    { url = "https://files.pythonhosted.org/packages/90/6b/ce94ba2a166add3376aa2c976cb1a34d6387e9dc61103cfbe9192675d0b6/spacy-3.8.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7402154eae9d2c34d097f3f7f2bf3ed4ce6ef9d44e3035af15ccc7f357d122cb", size = 32090348, upload-time = "2026-03-23T17:43:08.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/20/df5076a162bda36b04cdfa9cd544ac2be4b47aed957b3922e4c8f75dc25a/spacy-3.8.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:879f467578569db73b5811aa0f0b9a3b3fb81a125c2f7a433dd5626bcaca53f6", size = 32991911, upload-time = "2026-03-23T17:43:14.543Z" },
-    { url = "https://files.pythonhosted.org/packages/41/17/316dfdf5f8d1dd33a205e4f5e7190b67db73802180f7d08c8b306eb44375/spacy-3.8.13-cp312-cp312-win_amd64.whl", hash = "sha256:a0c849b5c9cee5a930a5e8a63d0b07e095d4e3d371af6a70c496efa1d0851257", size = 14226861, upload-time = "2026-03-23T17:43:18.122Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a8/a794d5bbf7bc2df6770df2b14cd6811420d0e10fe81830920bf0e891c19a/spacy-3.8.13-cp312-cp312-win_arm64.whl", hash = "sha256:5d7f660f64c7d09778600b27b881a367075fe792cb5cc6932737aeda71a9aa09", size = 13628855, upload-time = "2026-03-23T17:43:22.162Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/2d/dc15440fa58c12bab25cbd368bbf3b754eb11d1d3cc37f3aee47caa63695/spacy-3.8.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6db8903cf3fd8b40db9dab669c1e823a8884100f223dc8ec63c3744ff505d5fd", size = 6202080, upload-time = "2026-03-23T17:43:25.044Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/27/6d723fa0c3c9872d7b8c3fb1c76edef65c1db2de441ee87d119128cb82f7/spacy-3.8.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c26258bfed2f3bf5563c5994ee752ea8662bbac70924d28fbea4d1c10df48fd0", size = 6015435, upload-time = "2026-03-23T17:43:28.281Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/36/d13f36204290e7753ce849106fb732a1a1ff6c1af0a200f2c2f493a56e60/spacy-3.8.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a5f02eab8e6e8e9e790b1e8da05b70b3b1d4b1fb10dc4f44203da96939fdb977", size = 32510675, upload-time = "2026-03-23T17:43:32.657Z" },
-    { url = "https://files.pythonhosted.org/packages/19/37/f2a0c986bc2d59b18547d5ffaabf57fd9d88e129ad7df5ebc9ccdc91e643/spacy-3.8.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17b14f28d83fe85390f420f89760ae36d515f3e0a236f8266c46335549806e3a", size = 32841103, upload-time = "2026-03-23T17:43:38.139Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/b4a86cc013e4ac3c3c290ecade748c4623709a78db8a368ee0e152931c0b/spacy-3.8.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:10fffb387e6afeba582e01efd9b5e0c5431ac323af134f4a71a749255182f4c8", size = 31763223, upload-time = "2026-03-23T17:43:42.823Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/fa/b3a406bdc2636aaa315b8539b88f262e78ca391afc4083e3e9806953b24a/spacy-3.8.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:500f6eb9e4711e75fc07d517962dbfb553ba144ccf1b1e8ffc71b014c9ad91b2", size = 32717863, upload-time = "2026-03-23T17:43:47.939Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/97/11ed2a980e7225b0a1a4041cb1cba44f40bd83682a08e450dd6171f054e4/spacy-3.8.13-cp313-cp313-win_amd64.whl", hash = "sha256:1e679a8c5dd86c564a1185d894b1b8e50b52fa81bee518120fc2f86349d1879c", size = 14220413, upload-time = "2026-03-23T17:43:51.922Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/e2/06633e779486f62b3ec7ddeeb4accc10fb9a356b59f5bed3771dfb89931b/spacy-3.8.13-cp313-cp313-win_arm64.whl", hash = "sha256:c086bff909d73be892b4eb6883070dd3e328592b8933f0059a6569c8c7904928", size = 13619060, upload-time = "2026-03-23T17:43:55.449Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/02/bf2943f61a8bd21cca90e4fe19c4da8752c386f02a76e326b33199e09953/spacy-3.8.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:edcdd4f99e2711fc90c6ba3e8e07f7dc9753d111377ba7b7b5eb0d7259b0d211", size = 6209920, upload-time = "2026-03-23T17:43:58.441Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/87/fa5e4eb2ccb660d5042eb9144134dc6238c132ec812131bb0aca296bcdd9/spacy-3.8.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b8fd0188f78e032ac58f70a00748d591e244f3d4718e0ead2d9418b4148c744d", size = 6040696, upload-time = "2026-03-23T17:44:00.704Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f3/9132878e0c18d627adffc1d23129a3706385d4f0fbe2ea5839523519452c/spacy-3.8.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0dc2d058cb919102bf0634b1b41aff64b867d9bab36bd35979ab658b5b2e4c27", size = 32431416, upload-time = "2026-03-23T17:44:05.435Z" },
-    { url = "https://files.pythonhosted.org/packages/80/73/396c5c3aaef5004d04abbda4ec736ce4d33944aff6722e974cebdd4023fd/spacy-3.8.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ef884df658d3b60d91cbc1e9b62a6d932589d2fa3f322c3f739b6ffdf3303e0c", size = 32483676, upload-time = "2026-03-23T17:44:10.913Z" },
-    { url = "https://files.pythonhosted.org/packages/71/01/15ceb2097a817c2912297eac29f801bd71d895e93d7557110937c88f7c77/spacy-3.8.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:86f58d686d1ba6f0dc818005ee6ad87ade8dde7224012f1870a0d31abccd349e", size = 31732468, upload-time = "2026-03-23T17:44:15.967Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c4/b4c39083df6209414faec7d7471994316dc6fca68c4d2f1f8f099f25c2e3/spacy-3.8.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbcb411b9749a1cd5e4325953212b3984d8c0f60b4976943e77fb0c7d5027383", size = 32473870, upload-time = "2026-03-23T17:44:21.36Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/5c/9b0fa420b01809c0170b3cf0bf509ec06b4da96214995360815615b8e8fa/spacy-3.8.13-cp314-cp314-win_amd64.whl", hash = "sha256:bf9b6879d70201acb73fc5f07d550ff488d3b5f15a959e9896717b2635c8e137", size = 14405303, upload-time = "2026-03-23T17:44:25.83Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/58/0001fd8124b62a2a9984278d793e3abfa1b70e969fc26a8668755178db84/spacy-3.8.13-cp314-cp314-win_arm64.whl", hash = "sha256:b2a402f229fcb5dba5454c346468757bd3a5215809e784b85d739ca84916f05b", size = 13834663, upload-time = "2026-03-23T17:44:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d3/0c795e6f31ee3535b6e70d08e89fc22247b95b61f94fc8334a01d39bf871/spacy-3.8.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a12d83e8bfba07563300ae5e0086548e41aa4bfe3734c97dda87e0eec813df0d", size = 6487958, upload-time = "2025-11-17T20:38:40.378Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2a/83ca9b4d0a2b31adcf0ced49fa667212d12958f75d4e238618a60eb50b10/spacy-3.8.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e07a50b69500ef376326545353a470f00d1ed7203c76341b97242af976e3681a", size = 6148078, upload-time = "2025-11-17T20:38:42.524Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f0/ff520df18a6152ba2dbf808c964014308e71a48feb4c7563f2a6cd6e668d/spacy-3.8.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:718b7bb5e83c76cb841ed6e407f7b40255d0b46af7101a426c20e04af3afd64e", size = 32056451, upload-time = "2025-11-17T20:38:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3a/6c44c0b9b6a70595888b8d021514ded065548a5b10718ac253bd39f9fd73/spacy-3.8.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f860f9d51c1aeb2d61852442b232576e4ca4d239cb3d1b40ac452118b8eb2c68", size = 32302908, upload-time = "2025-11-17T20:38:47.672Z" },
+    { url = "https://files.pythonhosted.org/packages/db/77/00e99e00efd4c2456772befc48400c2e19255140660d663e16b6924a0f2e/spacy-3.8.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ff8d928ce70d751b7bb27f60ee5e3a308216efd4ab4517291e6ff05d9b194840", size = 32280936, upload-time = "2025-11-17T20:38:50.893Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/da/692b51e9e5be2766d2d1fb9a7c8122cfd99c337570e621f09c40ce94ad17/spacy-3.8.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3f3cb91d7d42fafd92b8d5bf9f696571170d2f0747f85724a2c5b997753e33c9", size = 33117270, upload-time = "2025-11-17T20:38:53.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/13/a542ac9b61d071f3328fda1fd8087b523fb7a4f2c340010bc70b1f762485/spacy-3.8.11-cp311-cp311-win_amd64.whl", hash = "sha256:745c190923584935272188c604e0cc170f4179aace1025814a25d92ee90cf3de", size = 15348350, upload-time = "2025-11-17T20:38:56.833Z" },
+    { url = "https://files.pythonhosted.org/packages/23/53/975c16514322f6385d6caa5929771613d69f5458fb24f03e189ba533f279/spacy-3.8.11-cp311-cp311-win_arm64.whl", hash = "sha256:27535d81d9dee0483b66660cadd93d14c1668f55e4faf4386aca4a11a41a8b97", size = 14701913, upload-time = "2025-11-17T20:38:59.507Z" },
+    { url = "https://files.pythonhosted.org/packages/51/fb/01eadf4ba70606b3054702dc41fc2ccf7d70fb14514b3cd57f0ff78ebea8/spacy-3.8.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aa1ee8362074c30098feaaf2dd888c829a1a79c4311eec1b117a0a61f16fa6dd", size = 6073726, upload-time = "2025-11-17T20:39:01.679Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f8/07b03a2997fc2621aaeafae00af50f55522304a7da6926b07027bb6d0709/spacy-3.8.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:75a036d04c2cf11d6cb566c0a689860cc5a7a75b439e8fea1b3a6b673dabf25d", size = 5724702, upload-time = "2025-11-17T20:39:03.486Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0c/c4fa0f379dbe3258c305d2e2df3760604a9fcd71b34f8f65c23e43f4cf55/spacy-3.8.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cb599d2747d4a59a5f90e8a453c149b13db382a8297925cf126333141dbc4f7", size = 32727774, upload-time = "2025-11-17T20:39:05.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8e/6a4ba82bed480211ebdf5341b0f89e7271b454307525ac91b5e447825914/spacy-3.8.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:94632e302ad2fb79dc285bf1e9e4d4a178904d5c67049e0e02b7fb4a77af85c4", size = 33215053, upload-time = "2025-11-17T20:39:08.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/bc/44d863d248e9d7358c76a0aa8b3f196b8698df520650ed8de162e18fbffb/spacy-3.8.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aeca6cf34009d48cda9fb1bbfb532469e3d643817241a73e367b34ab99a5806f", size = 32074195, upload-time = "2025-11-17T20:39:11.601Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7d/0b115f3f16e1dd2d3f99b0f89497867fc11c41aed94f4b7a4367b4b54136/spacy-3.8.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:368a79b8df925b15d89dccb5e502039446fb2ce93cf3020e092d5b962c3349b9", size = 32996143, upload-time = "2025-11-17T20:39:14.705Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/48/7e9581b476df76aaf9ee182888d15322e77c38b0bbbd5e80160ba0bddd4c/spacy-3.8.11-cp312-cp312-win_amd64.whl", hash = "sha256:88d65941a87f58d75afca1785bd64d01183a92f7269dcbcf28bd9d6f6a77d1a7", size = 14217511, upload-time = "2025-11-17T20:39:17.316Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1f/307a16f32f90aa5ee7ad8d29ff8620a57132b80a4c8c536963d46d192e1a/spacy-3.8.11-cp312-cp312-win_arm64.whl", hash = "sha256:97b865d6d3658e2ab103a67d6c8a2d678e193e84a07f40d9938565b669ceee39", size = 13614446, upload-time = "2025-11-17T20:39:19.748Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5c/3f07cff8bc478fcf48a915ca9fe8637486a1ec676587ed3e6fd775423301/spacy-3.8.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ea4adeb399636059925be085c5bb852c1f3a2ebe1c2060332cbad6257d223bbc", size = 6051355, upload-time = "2025-11-17T20:39:22.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/44/4671e8098b62befec69c7848538a0824086559f74065284bbd57a5747781/spacy-3.8.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd785e6bd85a58fa037da0c18fcd7250e2daecdfc30464d3882912529d1ad588", size = 5700468, upload-time = "2025-11-17T20:39:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/98/5708bdfb39f94af0655568e14d953886117e18bd04c3aa3ab5ff1a60ea89/spacy-3.8.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:598c177054eb6196deed03cac6fb7a3229f4789719ad0c9f7483f9491e375749", size = 32521877, upload-time = "2025-11-17T20:39:26.291Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1f/731beb48f2c7415a71e2f655876fea8a0b3a6798be3d4d51b794f939623d/spacy-3.8.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a5a449ed3f2d03399481870b776f3ec61f2b831812d63dc1acedf6da70e5ab03", size = 32848355, upload-time = "2025-11-17T20:39:28.971Z" },
+    { url = "https://files.pythonhosted.org/packages/47/6b/f3d131d3f9bb1c7de4f355a12adcd0a5fa77f9f624711ddd0f19c517e88b/spacy-3.8.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a6c35c2cb93bade9b7360d1f9db608a066246a41301bb579309efb50764ba55b", size = 31764944, upload-time = "2025-11-17T20:39:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bf/37ea8134667a4f2787b5f0e0146f2e8df1fb36ab67d598ad06eb5ed2e7db/spacy-3.8.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0156ae575b20290021573faa1fed8a82b11314e9a1c28f034713359a5240a325", size = 32718517, upload-time = "2025-11-17T20:39:35.286Z" },
+    { url = "https://files.pythonhosted.org/packages/79/fe/436435dfa93cc355ed511f21cf3cda5302b7aa29716457317eb07f1cf2da/spacy-3.8.11-cp313-cp313-win_amd64.whl", hash = "sha256:6f39cf36f86bd6a8882076f86ca80f246c73aa41d7ebc8679fbbe41b6f8ec045", size = 14211913, upload-time = "2025-11-17T20:39:37.906Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/f89cfa51f54aa5e9c6c7a37f8bf4952d678f0902a5e1d81dfda33a94bfb2/spacy-3.8.11-cp313-cp313-win_arm64.whl", hash = "sha256:9a7151eee0814a5ced36642b42b1ecc8f98ac7225f3e378fb9f862ffbe84b8bf", size = 13605169, upload-time = "2025-11-17T20:39:40.455Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/78/ddeb09116b593f3cccc7eb489a713433076b11cf8cdfb98aec641b73a2c2/spacy-3.8.11-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:43c24d19a3f85bde0872935294a31fd9b3a6db3f92bb2b75074177cd3acec03f", size = 6067734, upload-time = "2025-11-17T20:39:42.629Z" },
+    { url = "https://files.pythonhosted.org/packages/65/bb/1bb630250dc70e00fa3821879c6e2cb65c19425aba38840d3484061285c1/spacy-3.8.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b6158c21da57b8373d2d1afb2b73977c4bc4235d2563e7788d44367fc384939a", size = 5732963, upload-time = "2025-11-17T20:39:44.872Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/56/c58071b3db23932ab2b934af3462a958e7edf472da9668e4869fe2a2199e/spacy-3.8.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1c0bd1bde1d91f1d7a44774ca4ca3fcf064946b72599a8eb34c25e014362ace1", size = 32447290, upload-time = "2025-11-17T20:39:47.392Z" },
+    { url = "https://files.pythonhosted.org/packages/34/eb/d3947efa2b46848372e89ced8371671d77219612a3eebef15db5690aa4d2/spacy-3.8.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:99b767c41a772e544cf2d48e0808764f42f17eb2fd6188db4a729922ff7f0c1e", size = 32488011, upload-time = "2025-11-17T20:39:50.408Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9e/8c6c01558b62388557247e553e48874f52637a5648b957ed01fbd628391d/spacy-3.8.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3c500f04c164e4366a1163a61bf39fd50f0c63abdb1fc17991281ec52a54ab4", size = 31731340, upload-time = "2025-11-17T20:39:53.221Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1f/21812ec34b187ef6ba223389760dfea09bbe27d2b84b553c5205576b4ac2/spacy-3.8.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a2bfe45c0c1530eaabc68f5434c52b1be8df10d5c195c54d4dc2e70cea97dc65", size = 32478557, upload-time = "2025-11-17T20:39:55.826Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/16/a0c9174a232dfe7b48281c05364957e2c6d0f80ef26b67ce8d28a49c2d91/spacy-3.8.11-cp314-cp314-win_amd64.whl", hash = "sha256:45d0bbc8442d18dcea9257be0d1ab26e884067e038b1fa133405bf2f20c74edf", size = 14396041, upload-time = "2025-11-17T20:39:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d0/a6aad5b73d523e4686474b0cfcf46f37f3d7a18765be5c1f56c1dcee4c18/spacy-3.8.11-cp314-cp314-win_arm64.whl", hash = "sha256:90a12961ecc44e0195fd42db9f0ce4aade17e6fe03f8ab98d4549911d9e6f992", size = 13823760, upload-time = "2025-11-17T20:40:00.831Z" },
 ]
 
 [[package]]
@@ -6754,53 +6756,48 @@ wheels = [
 
 [[package]]
 name = "srsly"
-version = "2.5.3"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "catalogue" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/77/5633c4ba65e3421b72b5b4bd93aa328360b351b3a1e5bf3c90eb224668e5/srsly-2.5.2.tar.gz", hash = "sha256:4092bc843c71b7595c6c90a0302a197858c5b9fe43067f62ae6a45bc3baa1c19", size = 492055, upload-time = "2025-11-17T14:11:02.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/36/5d7bb412d52e9cca787f9bfe838b596367189b254e50bf90f234a97184bf/srsly-2.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:785a09216ac31570fb301ddb9f61ee73d1f18f8b9561f712dce0b8ac8628bc88", size = 656760, upload-time = "2026-03-23T11:55:47.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/dc/124f008cd2be3e887e972cbdeb17c5aee0f42093eca02c7cfd63bb5daf19/srsly-2.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0017c7d2a0cd9a4f1bdc00d946b45edcf90bb0e271e8f084c1ce542bf6708c32", size = 657503, upload-time = "2026-03-23T11:55:48.681Z" },
-    { url = "https://files.pythonhosted.org/packages/35/8a/2c97244ebab125d55f1bfb7bb94e9572b3e819410dffd6a040eca1112350/srsly-2.5.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:66ebae2c70305987341519ec1a720072a3cb3e4b1d52ac0e9e841f4d02658d3d", size = 1139161, upload-time = "2026-03-23T11:55:50.179Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ea/ecd396188f7591d80b89665f7af9e3ae02e42683daef57033ad7993ad3f9/srsly-2.5.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca4a068f6e14d84113a02fcb875c6b50a6285a12938c0e7a157eb3a63c50a86", size = 1142438, upload-time = "2026-03-23T11:55:52.607Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/65/143e2e143c53d498ad0956f69d0e09189aa7a6e0ee6017758c285ba1ab2d/srsly-2.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e283fa2a8f7350fb9fb70ecdee28d59d39c92f4c7f1cc90a44d6b86db3b3a8b3", size = 1101783, upload-time = "2026-03-23T11:55:53.906Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/86/1392a5593de0cd3d08c2d6c071b877c84358a37f63172c4e9cb71706842d/srsly-2.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9ffc97e22730ea97b00f7c303ccc60b1305e786afadb2a4a46578dafa4d29da0", size = 1115876, upload-time = "2026-03-23T11:55:55.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/a5/6193aa4c08e488821538fcbce2282449e228fd2183ed67d118bb5ccd8b54/srsly-2.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:f09b551f6c3e334652831ac68c770ee4284741ce0a3895bf1ccf2a1178d66cdd", size = 651733, upload-time = "2026-03-23T11:55:56.964Z" },
-    { url = "https://files.pythonhosted.org/packages/66/a8/a73181743b6d237026615ca75c3fb3e4780736f1390550a7350d0c7f1149/srsly-2.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:21cf09e417d3e4f3fbf7dd337fd6d948c97abd01896b9b4cb80e81cd9778a73a", size = 639124, upload-time = "2026-03-23T11:55:58.532Z" },
-    { url = "https://files.pythonhosted.org/packages/02/cc/e9f7fcec4cc92ad8bad6316c4241638b8cf7380382d4489d94ec6c436452/srsly-2.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:71e51c046ccbeefb86524c6b1e17574f579c6ac4dc8ea4a09437d3e8f88342d3", size = 658379, upload-time = "2026-03-23T11:55:59.85Z" },
-    { url = "https://files.pythonhosted.org/packages/21/e4/fea4512e9785f58509b2cf67d993323848e583161b5fcfdc7dd9d7c1f3df/srsly-2.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f73c0db911552e94fe2016e1759d261d2f47926f68826664cada3723c87006a", size = 658513, upload-time = "2026-03-23T11:56:01.239Z" },
-    { url = "https://files.pythonhosted.org/packages/20/b1/53591681b6ff2699a4f97b2d5552ba196eaa6a979b0873605f4c04b5f7ee/srsly-2.5.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c1ac27ae5f4bb9163c7d2c45fc8ec173aac3d92e32086d9472b326c5c6e570e", size = 1172265, upload-time = "2026-03-23T11:56:02.589Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/c9/741e29f534919a944a16da4184924b1d3404c4bf60716ab2b91be771d1e3/srsly-2.5.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:99026bcd9cbd3211cc36517400b04ca0fc5d3e412b14daf84ee6e65f67d9a2d8", size = 1180873, upload-time = "2026-03-23T11:56:03.944Z" },
-    { url = "https://files.pythonhosted.org/packages/89/57/5554f786eccf78b2750d6ac63be126e1b67badec2cb409dd611cf6f8c52b/srsly-2.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:07d682679e639eb46ff7e6da4a92714f4d5ffe351d088ee66f221e9b1f8865bb", size = 1120437, upload-time = "2026-03-23T11:56:05.283Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/95/9b4f73b1be3692f86d72ccc131c8e50f26f824d5c8830a59390bcc5b60ef/srsly-2.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8e0542d85d6b55cf2934050d6ffcb1cd76c768dcf9572e7467002cf087bb366d", size = 1137376, upload-time = "2026-03-23T11:56:06.613Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/de/89ca640ca1953c4612279ce515d0af35658df3c06cdb324329bc91b4a7e1/srsly-2.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:598f1e494c18cacb978299d77125415a586417081959f8ec3f068b32d97f8933", size = 652459, upload-time = "2026-03-23T11:56:07.994Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/4f/7ab6d49e36d9cc72ee15746cabd116eb6f338be8a06c1882968ee9d6c7d7/srsly-2.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:4b1b721cd3ad1a9b2343519aadc786a4d09d5c0666962d49852eb12d6ec3fe26", size = 638411, upload-time = "2026-03-23T11:56:09.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/5c/12901e3794f4158abc6da750725aad6c2afddb1e4227b300fe7c71f66957/srsly-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e67b6bbacbfadea5e100266d2797f2d4cec9883ea4dc84a5537673850036a8d8", size = 656750, upload-time = "2026-03-23T11:56:10.708Z" },
-    { url = "https://files.pythonhosted.org/packages/04/61/181c26370995f96f56f1b64b801e3ca1e0d703fc36506ae28606d62369fb/srsly-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:348c231b4477d8fe86603131d0f166d2feac9c372704dfc4398be71cc5b6fb07", size = 656746, upload-time = "2026-03-23T11:56:12.28Z" },
-    { url = "https://files.pythonhosted.org/packages/77/c6/35876c78889f8ffe11ed3521644e666c3aef20ea31527b70f47456cf35c2/srsly-2.5.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b0938c2978c91ae1ef9c1f2ba35abb86330e198fb23469e356eba311e02233ee", size = 1155762, upload-time = "2026-03-23T11:56:14.075Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/da/40b71ca9906c8eb8f8feb6ac11d33dad458c85a56e1de764b96d402168a0/srsly-2.5.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f6a837954429ecbe6dcdd27390d2fb4c7d01a3f99c9ffcf9ce66b2a6dd1b738", size = 1161092, upload-time = "2026-03-23T11:56:15.778Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/14/c0dd30cc8b93ce8137ff4766f743c882440ce49195fffc5d50eaeef311a6/srsly-2.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3576c125c486ce2958c2047e8858fe3cfc9ea877adfa05203b0986f9badee355", size = 1109984, upload-time = "2026-03-23T11:56:17.056Z" },
-    { url = "https://files.pythonhosted.org/packages/08/f3/34354f183d8faafc631585571224b54d1b4b67e796972c36519c074ca355/srsly-2.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fb59c42922e095d1ea36085c55bc16e2adb06a7bfe57b24d381e0194ae699f2", size = 1128409, upload-time = "2026-03-23T11:56:18.761Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/d9/5531f8a19492060b4e76e4ab06aca6f096fb5128fe18cc813d1772daf653/srsly-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:111805927f05f5db440aeeacb85ce43da0b19ce7b2a09567a9ef8d30f3cc4d83", size = 650820, upload-time = "2026-03-23T11:56:20.096Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/8a/62fb7a971eca29e12f03fb9ddacb058548c14d33e5b5675ff0f85839cc7b/srsly-2.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:0f106b0a700ab56e4a7c431b0f1444009ab6cb332edc7bbf6811c2a43f4722cb", size = 637278, upload-time = "2026-03-23T11:56:21.439Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5b/e4ef43c2a381711230af98d4c94a5323df48d6a7899ee652e05bf889290e/srsly-2.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:39c13d552a9f9674a12cdcdc66b0c2f02f3430d0cd04c5f9cf598824c2bd3d65", size = 661294, upload-time = "2026-03-23T11:56:23.29Z" },
-    { url = "https://files.pythonhosted.org/packages/92/2d/ebce7f3717e52cd0a01f4ec570f388f3b7098526794fcf1ad734e0b8f852/srsly-2.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:14c930767cc169611a2dc14e23bc7638cfb616d6f79029700ade033607343540", size = 660952, upload-time = "2026-03-23T11:56:24.908Z" },
-    { url = "https://files.pythonhosted.org/packages/22/47/a8f3e9b214be2624c8e8a78d38ca7b1d4e26b92d57018412e4bfc4abe89a/srsly-2.5.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f2d464f0d0237e32fb53f0ec6f05418652c550e772b50e9918e83a1577cba4d", size = 1154554, upload-time = "2026-03-23T11:56:26.608Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/71/2a89dc3180a51e633a87a079ca064225f4aaf46c7b2a5fc720e28f261d98/srsly-2.5.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d18933248a5bb0ad56a1bae6003a9a7f37daac2ecb0c5bcbfaaf081b317e1c84", size = 1155746, upload-time = "2026-03-23T11:56:28.102Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/36/72e5ce3153927ca404b6f5bf5280e6ff3399c11557df472b153945468e0a/srsly-2.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7ea5412ea229e571ac9738cbe14f845cc06c8e4e956afb5f42061ccd087ef31f", size = 1112374, upload-time = "2026-03-23T11:56:29.591Z" },
-    { url = "https://files.pythonhosted.org/packages/04/b2/0895de109c28eca0d41a811ab7c076d4e4a505e8466f06bae22f5180a1dd/srsly-2.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8d3988970b4cf7d03bdd5b5169302ff84562dd2e1e0f84aeb34df3e5b5dc19bf", size = 1127732, upload-time = "2026-03-23T11:56:31.458Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/79/a37fa7759797fbdfe0a2e029ab13e78b1e81e191220d2bb8ff57d869aefb/srsly-2.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:6a02d7dcc16126c8fae1c1c09b2072798a1dc482ab5f9c52b12c7114dac47325", size = 656467, upload-time = "2026-03-23T11:56:33.14Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/25/0dae019b3b90ad9037f91de4c390555cdaac9460a93ad62b02b03babdff5/srsly-2.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:1c9129c4abe31903ff7996904a51afdd5428060de6c3d12af49a4da5e8df2821", size = 643040, upload-time = "2026-03-23T11:56:34.448Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/44/72dd5285b2e05435d98b0797f101d91d9b345d491ddc1fdb9bd09e27ccb8/srsly-2.5.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:29d5d01ba4c2e9c01f936e5e6d5babc4a47b38c9cbd6e1ec23f6d5a49df32605", size = 666200, upload-time = "2026-03-23T11:56:35.753Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ad/002c71b87fc3f648c9bf0ec47de0c3822bf2c95c8896a589dd03e7fd3977/srsly-2.5.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c8df4039426d99f0148b5743542842ab96b82daded0b342555e15a639927757", size = 667409, upload-time = "2026-03-23T11:56:37.172Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/2cea3d5e80aeecfc4ece9e7e1783e7792cc3bad7ab85ab585882e1db4e38/srsly-2.5.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06a43d63bde2e8cccadb953d7fff70b18196ca286b65dd2ad16006d65f3f8166", size = 1265941, upload-time = "2026-03-23T11:56:38.825Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/38/8a4d7e86dd0370a2e5af251b646000197bb5b7e0f9aa360c71bbfb253d0d/srsly-2.5.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:808cfafc047f0dec507a34c8fa8e4cda5722737fd33577df73452f52f7aca644", size = 1250693, upload-time = "2026-03-23T11:56:40.449Z" },
-    { url = "https://files.pythonhosted.org/packages/99/05/340129de5ea7b237271b12f8a6962cfa7eb0c5a3056794626d348c5ae7c7/srsly-2.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71d4cbe2b2a1335c76ed0acae2dc862163787d8b01a705e1949796907ed94ccd", size = 1242408, upload-time = "2026-03-23T11:56:41.8Z" },
-    { url = "https://files.pythonhosted.org/packages/01/cb/d7fee7ab27c6aa2e3f865fb7b50ba18c81a4c763bba12bdf53df246441bc/srsly-2.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f69083d33cb329cfc74317da937fb3270c0f40fabc1b4488702d8074b4a3e", size = 1242749, upload-time = "2026-03-23T11:56:43.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d1/9bad3a0f2fa7b72f4e0cf1d267b00513092d20ef538c47f72823ae4f7656/srsly-2.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:8ac016ffaeac35bc010992b71bf8afdd39d458f201c8138d84cf78778a936e6c", size = 673783, upload-time = "2026-03-23T11:56:44.875Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ae/57d1d7af907e20c077e113e0e4976f87b82c0a415403d99284a262229dd0/srsly-2.5.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d822083fe26ec6728bd8c273ac121fc4ab3864a0fdf0cf0ff3efb188fcd209ed", size = 650229, upload-time = "2026-03-23T11:56:46.148Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6e/2e3d07b38c1c2e98487f0af92f93b392c6741062d85c65cdc18c7b77448a/srsly-2.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e07babdcece2405b32c9eea25ef415749f214c889545e38965622bb66837ce", size = 655286, upload-time = "2025-11-17T14:09:52.468Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/587bcade6b72f919133e587edf60e06039d88049aef9015cd0bdea8df189/srsly-2.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1718fe40b73e5cc73b14625233f57e15fb23643d146f53193e8fe653a49e9a0f", size = 653094, upload-time = "2025-11-17T14:09:53.837Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/24/5c3aabe292cb4eb906c828f2866624e3a65603ef0a73e964e486ff146b84/srsly-2.5.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7b07e6103db7dd3199c0321935b0c8b9297fd6e018a66de97dc836068440111", size = 1141286, upload-time = "2025-11-17T14:09:55.535Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fe/2cbdcef2495e0c40dafb96da205d9ab3b9e59f64938277800bf65f923281/srsly-2.5.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2dedf03b2ae143dd70039f097d128fb901deba2482c3a749ac0a985ac735aad", size = 1144667, upload-time = "2025-11-17T14:09:57.24Z" },
+    { url = "https://files.pythonhosted.org/packages/91/7c/9a2c9d8141daf7b7a6f092c2be403421a0ab280e7c03cc62c223f37fdf47/srsly-2.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d5be1d8b79a4c4180073461425cb49c8924a184ab49d976c9c81a7bf87731d9", size = 1103935, upload-time = "2025-11-17T14:09:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ad/8ae727430368fedbb1a7fa41b62d7a86237558bc962c5c5a9aa8bfa82548/srsly-2.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c8e42d6bcddda2e6fc1a8438cc050c4a36d0e457a63bcc7117d23c5175dfedec", size = 1117985, upload-time = "2025-11-17T14:10:00.348Z" },
+    { url = "https://files.pythonhosted.org/packages/60/69/d6afaef1a8d5192fd802752115c7c3cc104493a7d604b406112b8bc2b610/srsly-2.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:e7362981e687eead00248525c3ef3b8ddd95904c93362c481988d91b26b6aeef", size = 654148, upload-time = "2025-11-17T14:10:01.772Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1c/21f658d98d602a559491b7886c7ca30245c2cd8987ff1b7709437c0f74b1/srsly-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6f92b4f883e6be4ca77f15980b45d394d310f24903e25e1b2c46df783c7edcce", size = 656161, upload-time = "2025-11-17T14:10:03.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a2/bc6fd484ed703857043ae9abd6c9aea9152f9480a6961186ee6c1e0c49e8/srsly-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ac4790a54b00203f1af5495b6b8ac214131139427f30fcf05cf971dde81930eb", size = 653237, upload-time = "2025-11-17T14:10:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ea/e3895da29a15c8d325e050ad68a0d1238eece1d2648305796adf98dcba66/srsly-2.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce5c6b016050857a7dd365c9dcdd00d96e7ac26317cfcb175db387e403de05bf", size = 1174418, upload-time = "2025-11-17T14:10:05.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a5/21996231f53ee97191d0746c3a672ba33a4d86a19ffad85a1c0096c91c5f/srsly-2.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:539c6d0016e91277b5e9be31ebed03f03c32580d49c960e4a92c9003baecf69e", size = 1183089, upload-time = "2025-11-17T14:10:07.335Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/df/eb17aa8e4a828e8df7aa7dc471295529d9126e6b710f1833ebe0d8568a8e/srsly-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f24b2c4f4c29da04083f09158543eb3f8893ba0ac39818693b3b259ee8044f0", size = 1122594, upload-time = "2025-11-17T14:10:08.899Z" },
+    { url = "https://files.pythonhosted.org/packages/80/74/1654a80e6c8ec3ee32370ea08a78d3651e0ba1c4d6e6be31c9efdb9a2d10/srsly-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d34675047460a3f6999e43478f40d9b43917ea1e93a75c41d05bf7648f3e872d", size = 1139594, upload-time = "2025-11-17T14:10:10.286Z" },
+    { url = "https://files.pythonhosted.org/packages/73/aa/8393344ca7f0e81965febba07afc5cad68335ed0426408d480b861ab915b/srsly-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:81fd133ba3c66c07f0e3a889d2b4c852984d71ea833a665238a9d47d8e051ba5", size = 654750, upload-time = "2025-11-17T14:10:11.637Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c5/dc29e65419692444253ea549106be156c5911041f16791f3b62fb90c14f2/srsly-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d976d6ae8e66006797b919e3d58533dce64cd48a5447a8ff7277f9b0505b0185", size = 654723, upload-time = "2025-11-17T14:10:13.305Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8c/8111e7e8c766b47b5a5f9864f27f532cf6bb92837a3e277eb297170bd6af/srsly-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:24f52ecd27409ea24ba116ee9f07a2bb1c4b9ba11284b32a0bf2ca364499d1c1", size = 651651, upload-time = "2025-11-17T14:10:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/45/de/3f99d4e44af427ee09004df6586d0746640536b382c948f456be027c599b/srsly-2.5.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b0667ce1effb32a57522db10705db7c78d144547fcacc8a06df62c4bb7f96e", size = 1158012, upload-time = "2025-11-17T14:10:16.176Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2f/66044ef5a10a487652913c1a7f32396cb0e9e32ecfc3fdc0a0bc0382e703/srsly-2.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:60782f6f79c340cdaf1ba7cbaa1d354a0f7c8f86b285f1e14e75edb51452895a", size = 1163258, upload-time = "2025-11-17T14:10:17.471Z" },
+    { url = "https://files.pythonhosted.org/packages/74/6b/698834048672b52937e8cf09b554adb81b106c0492f9bc62e41e3b46a69b/srsly-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eec51abb1b58e1e6c689714104aeeba6290c40c0bfad0243b9b594df89f05881", size = 1112214, upload-time = "2025-11-17T14:10:18.679Z" },
+    { url = "https://files.pythonhosted.org/packages/85/17/1efc70426be93d32a3c6c5c12d795eb266a9255d8b537fcb924a3de57fcb/srsly-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:76464e45f73afd20c2c34d2ef145bf788afc32e7d45f36f6393ed92a85189ed3", size = 1130687, upload-time = "2025-11-17T14:10:20.346Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/07f8c8a778bc0447ee15e37089b08af81b24fcc1d4a2c09eff4c3a79b241/srsly-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:009424a96d763951e4872b36ba38823f973bef094a1adbc11102e23e8d1ef429", size = 653128, upload-time = "2025-11-17T14:10:21.552Z" },
+    { url = "https://files.pythonhosted.org/packages/39/03/3d248f538abc141d9c7ed1aa10e61506c0f95515a61066ee90e888f0cd8f/srsly-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a0911dcf1026f982bd8c5f73e1c43f1bc868416408fcbc1f3d99eb59475420c5", size = 659866, upload-time = "2025-11-17T14:10:22.811Z" },
+    { url = "https://files.pythonhosted.org/packages/43/22/0fcff4c977ddfb32a6b10f33d904868b16ce655323756281f973c5a3449e/srsly-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f0ff3ac2942aee44235ca3c7712fcbd6e0d1a092e10ee16e07cef459ed6d7f65", size = 655868, upload-time = "2025-11-17T14:10:24.036Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c1/e158f26a5597ac31b0f306d2584411ec1f984058e8171d76c678bf439e96/srsly-2.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:78385fb75e1bf7b81ffde97555aee094d270a5e0ea66f8280f6e95f5bb508b3e", size = 1156753, upload-time = "2025-11-17T14:10:25.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/bc/2001cd27fd6ecdae79050cf6b655ca646dedc0b69a756e6a87993cc47314/srsly-2.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2e9943b70bd7655b9eefca77aab838c3b7acea00c9dd244fd218a43dc61c518b", size = 1157916, upload-time = "2025-11-17T14:10:26.705Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/dd/56f563c2d0cd76c8fd22fb9f1589f18af50b54d31dd3323ceb05fe7999b8/srsly-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7d235a2bb08f5240e47c6aba4d9688b228d830fbf4c858388d9c151a10039e6d", size = 1114582, upload-time = "2025-11-17T14:10:27.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e6/e155facc965a119e6f5d32b7e95082cadfb62cc5d97087d53db93f3a5a98/srsly-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ad94ee18b3042a6cdfdc022556e2ed9a7b52b876de86fe334c4d8ec58d59ecbc", size = 1129875, upload-time = "2025-11-17T14:10:29.295Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3a/c12a4d556349c9f491b0a9d27968483f22934d2a02dfb14fb1d3a7d9b837/srsly-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:6658467165d8fa4aec0f5f6e2da8fe977e087eaff13322b0ff20450f0d762cee", size = 658858, upload-time = "2025-11-17T14:10:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/70/db/52510cbf478ab3ae8cb6c95aff3a499f2ded69df6d84df8a293630e9f10a/srsly-2.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:517e907792acf574979752ce33e7b15985c95d4ed7d8e38ee47f36063dc985ac", size = 666843, upload-time = "2025-11-17T14:10:32.082Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/da/4257b1d4c3eb005ecd135414398c033c13c4d3dffb715f63c3acd63d8d1a/srsly-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5602797e6f87bf030b11ad356828142367c5c81e923303b5ff2a88dfb12d1e4", size = 663981, upload-time = "2025-11-17T14:10:33.542Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/f8/1ec5edd7299d8599def20fc3440372964f7c750022db8063e321747d1cf8/srsly-2.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3452306118f8604daaaac6d770ee8f910fca449e8f066dcc96a869b43ece5340", size = 1267808, upload-time = "2025-11-17T14:10:35.285Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/4ef9782c9a3f331ef80e1ea8fc6fab50fc3d32ae61a494625d2c5f30cc4c/srsly-2.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e2d59f1ce00d73397a7f5b9fc33e76d17816ce051abe4eb920cec879d2a9d4f4", size = 1252838, upload-time = "2025-11-17T14:10:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/39/da/d13cfc662d71eec3ccd4072433bf435bd2e11e1c5340150b4cc43fad46f4/srsly-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ebda3736651d33d92b17e26c525ba8d0b94d0ee379c9f92e8d937ba89dca8978", size = 1244558, upload-time = "2025-11-17T14:10:38.73Z" },
+    { url = "https://files.pythonhosted.org/packages/26/50/92bf62dfb19532b823ef52251bb7003149e1d4a89f50a63332c8ff5f894b/srsly-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:74a9338fcc044f4bdc7113b2d9db2db8e0a263c69f1cba965acf12c845d8b365", size = 1244935, upload-time = "2025-11-17T14:10:42.324Z" },
+    { url = "https://files.pythonhosted.org/packages/95/81/6ea10ef6228ce4438a240c803639f7ccf5eae3469fbc015f33bd84aa8df1/srsly-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:8e2b9058623c44b07441eb0d711dfdf6302f917f0634d0a294cae37578dcf899", size = 676105, upload-time = "2025-11-17T14:10:43.633Z" },
 ]
 
 [[package]]
@@ -6888,7 +6885,7 @@ wheels = [
 
 [[package]]
 name = "thinc"
-version = "8.3.13"
+version = "8.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blis" },
@@ -6904,40 +6901,40 @@ dependencies = [
     { name = "srsly" },
     { name = "wasabi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/3a/2d0f0be132b9faaa6d56f04565ae122684273e4bf4eab8dee5f48dc00f68/thinc-8.3.10.tar.gz", hash = "sha256:5a75109f4ee1c968fc055ce651a17cb44b23b000d9e95f04a4d047ab3cb3e34e", size = 194196, upload-time = "2025-11-17T17:21:46.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/72/ca06842a007e8c794e8c59462f242cdfd6167d7cc9d0155ad004b194b015/thinc-8.3.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4565102638038a01a2193c7f5d41ccbd6233fbdcb1f1b184322a06add4f51f18", size = 844359, upload-time = "2026-03-23T07:21:43.017Z" },
-    { url = "https://files.pythonhosted.org/packages/48/44/e6aef092f478d263f72eb3933b55a6f37ba97c6a0ea0a61d13fbf9bf0c19/thinc-8.3.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:859fbd9d9b16af5278da23589b4afbe2ab6b0dd615df4d3229b7c4e67cd3107e", size = 812089, upload-time = "2026-03-23T07:21:44.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8a/9ce0424d456cd3580cc3a855b23a7ff86b81d5299fceb496a2f56f06c1c0/thinc-8.3.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a518d5c761a0f2341e530e867de133dc3ed814558365b2a68ec53b89c482a43f", size = 4101388, upload-time = "2026-03-23T07:21:46.135Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/51/ec91c0434bd9a1096ab874bbd6dc110c5089d7fc513137e6af59bd051eec/thinc-8.3.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81337dfbee37f58f36c0c70f9a819dce1b32cdc13d959181e10de079621f6ac6", size = 4131972, upload-time = "2026-03-23T07:21:48.403Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/67/e30dea753c90cff5cb9e5feb34948fdb89a6774b84d849585b49e16a730e/thinc-8.3.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fbc0ee16edd260c6a4a9e365ff36d0a682c9e7ca6d7b985682659ef2e3e73826", size = 5101283, upload-time = "2026-03-23T07:21:49.991Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e9/b7544eddababa16e548b26a96fff29eeb307ce938df5fa4af9371fe8ed5d/thinc-8.3.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0355c37e40d1a9fc2a1b8e9c2e294d8586f6baa97bcac6b9002f2dddb4b82ae9", size = 5264488, upload-time = "2026-03-23T07:21:51.747Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a9/49391a40d703efc0f7a451310373261835f71fd3e6e2e8cfc08ee02f78ad/thinc-8.3.13-cp311-cp311-win_amd64.whl", hash = "sha256:0a0fa13dcfe4b319c3a396432c1dbff30d3de37dbbdee559e76600ee2b9486df", size = 1795058, upload-time = "2026-03-23T07:21:53.424Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/31/fd5348d44beda12a3ee415cbba9ed4fd0b17ce65db1d473c38a29a8d6153/thinc-8.3.13-cp311-cp311-win_arm64.whl", hash = "sha256:cd8a2b714c061969eee65802965167a6ada1fe708d82fe176d98dcb95ebe182a", size = 1721215, upload-time = "2026-03-23T07:21:55.027Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/af/f7c1ebfe92eb5d27d7f2f3da67a11e2eb57bc30ab1553279af6dc65b65a8/thinc-8.3.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:77a41f66285321d20aaedaea1e87d7cd48dca6d2427bed1867ec7cba7109fc8d", size = 821097, upload-time = "2026-03-23T07:21:56.698Z" },
-    { url = "https://files.pythonhosted.org/packages/45/8f/69d7338575d98df85d0b54c0f5fc277dba72587fe9ab846ecdd12a998bcb/thinc-8.3.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3710d318b4e5460cf366a6f7b5ddbefb5d39dbd4cfa408222750fdc6c27c4411", size = 791932, upload-time = "2026-03-23T07:21:58.38Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/a5/21d010c81e81e1589e5ccb4950e521804d13726e541e87f644c51815673b/thinc-8.3.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a08c87143a6d20177652dca1ec0dc815d88216d8fc62594a57e8bc45bf5ed49", size = 3854219, upload-time = "2026-03-23T07:21:59.819Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ff/6914bf370bd1d604d89e6dfb46b97d10cd9b00d42ff8c036283e92314a8c/thinc-8.3.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b5ec9ff313819e7d8667794a3559463fa89ff45aaa73e3fd8d6273b1e0d7a7f", size = 3903307, upload-time = "2026-03-23T07:22:01.652Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/3d/5572b47fa155fb3388c071515b74024fa17a6efd1df9406da378f0aa84ef/thinc-8.3.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5c9a48f2bc1e04f138240ed5f9b815a9141a5de26accd0f08fa0137fcefed258", size = 4836882, upload-time = "2026-03-23T07:22:03.565Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/f0/a8d77c7bac089697c6df302cc3c936a1ab36a4720deae889e6f1dbcbd0eb/thinc-8.3.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:79a29a44d76bd02f5ac0624268c6e42b3576ae472c791a8ae9c2d813ae789b59", size = 5033398, upload-time = "2026-03-23T07:22:05.045Z" },
-    { url = "https://files.pythonhosted.org/packages/21/82/5651bb1f904d04220fc7670035ada921bf0638e2cff6444d67c12887a968/thinc-8.3.13-cp312-cp312-win_amd64.whl", hash = "sha256:ed1dc709ac4f2f03b710457889e4e02f05de51bc8456980c241d0b28798bc7cb", size = 1721248, upload-time = "2026-03-23T07:22:06.749Z" },
-    { url = "https://files.pythonhosted.org/packages/94/8d/683703de021ffbe46833d722b70f49ffbbca8e5bd6876256977555d92d7d/thinc-8.3.13-cp312-cp312-win_arm64.whl", hash = "sha256:c6a049703a6011c8fe26ee41af7e70272145594140d82f79bb23de619c6a6525", size = 1645777, upload-time = "2026-03-23T07:22:08.104Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b9/7b46942176df459d1804a9e77b0976f7c56f3abf3ec7485d0e5f836a0382/thinc-8.3.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2811dfd8d46d8b5d3b39051b23e64006b2994a5143b1978b436938018792af8", size = 817337, upload-time = "2026-03-23T07:22:09.538Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/79/53085a72cd8f4fc4e6e313d05ea5aa98e870684f4a0fb318a9875fc0a964/thinc-8.3.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5593e6300cb1ebe0c0e546e9c9fb49e7c2627a0aa688795cd4f995a8b820d2ec", size = 788120, upload-time = "2026-03-23T07:22:11.215Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/3e/d61b462b16da95ac6885f95bb395e672040ee594833e571a6edcffd234f5/thinc-8.3.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f697174d3fb474966ce50b430bbafa101a6d2f7ffb559dac4b5c59389ef72d22", size = 3844666, upload-time = "2026-03-23T07:22:12.67Z" },
-    { url = "https://files.pythonhosted.org/packages/78/4c/898cc654bb123734c71ec5a425c02ca34439517d01ce1c95a6563295580e/thinc-8.3.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9c7c5c104737b414c8c4ec578e67d78b6c859afe25cbc0684402e721415bd7f", size = 3890658, upload-time = "2026-03-23T07:22:14.668Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/56/1abdbf0a4ad628e8a05d6516fe0745969649d805367a3dccad8ee872981b/thinc-8.3.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a99d0e242d1ccd23f9ae6bea7cd502f8626efa65c156b91d84581d0356696c3", size = 4819933, upload-time = "2026-03-23T07:22:16.85Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/22/b84dbdc6be5055bbdb2a7352e2c393f67e8593c137f1b83c82bf1e062b6e/thinc-8.3.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e676edd21a747afbe3e6b9f3fca8b962e36d146ded03b070cb0c28e2dfbe9499", size = 5018099, upload-time = "2026-03-23T07:22:18.356Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/a8/763cd7ba949334c9d2cddc92dadb68b344cb9546dc01b8d4a733dcaa16c1/thinc-8.3.13-cp313-cp313-win_amd64.whl", hash = "sha256:8ad40307f20e83f77af28ff5c6be0b86af7a8b251d1231c545508d2763157d8f", size = 1720309, upload-time = "2026-03-23T07:22:19.81Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/15/a11f7bb3cbc97dfecf32a90552f5a8f8a5c99316a99c6c17bdabf5baf256/thinc-8.3.13-cp313-cp313-win_arm64.whl", hash = "sha256:723949cab11d1925c15447928513a718276316cec6e0de28337cca0a62be0521", size = 1644606, upload-time = "2026-03-23T07:22:21.339Z" },
-    { url = "https://files.pythonhosted.org/packages/80/40/f4937d113912c6d669ffe982356ab29dcb6c7fe3be926a15981dbbb6a91c/thinc-8.3.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7badb0be4825535e6362c19e8a41872b65409e9da46d3453a391b843a0720865", size = 817024, upload-time = "2026-03-23T07:22:23.005Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/00/4d4ed1a11ba2920b85a03a0683b16d97dc5beb2e78078dbf0e13e43bcea7/thinc-8.3.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:565300b7e13de799e5abff00d445f537e9256cf7da4dcb0d0f005fc16748a29e", size = 792096, upload-time = "2026-03-23T07:22:24.349Z" },
-    { url = "https://files.pythonhosted.org/packages/44/5d/dc33d6932be8721af2ef76b4a3a6e8020648630eabae61fb916d2a861d1d/thinc-8.3.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c17cef1900a1aba7e1487493d16b8aa0a8633116f1b2a51c6649a4000697f17b", size = 3842215, upload-time = "2026-03-23T07:22:25.836Z" },
-    { url = "https://files.pythonhosted.org/packages/af/bc/a6d37d8dadc2c5b524f51192413481160c42c9dd6105e8d5551531623225/thinc-8.3.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f4f26d1eec9b2a6a8f2e0298a5515d13eb06d70730d0d9e1040bb329e12bf3fb", size = 3849253, upload-time = "2026-03-23T07:22:27.845Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/59/ce9c7067f1dfe5985875927de9cf7a79f9dae3e69487fd650dfba558029d/thinc-8.3.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a61a31fd0ce3c2771cf4901ba6df70e774ffe32febf1024c5b43d63575cd58fe", size = 4831163, upload-time = "2026-03-23T07:22:29.395Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a8/f57819347fc4d8bef2204d15fcbb9d7dff2d6cdd5f83d5ed91456ddacc55/thinc-8.3.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba8119daf84a12259ae4d251d36426417bafa0b34108890b4b7e2b50966bd990", size = 4986051, upload-time = "2026-03-23T07:22:30.933Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ef/a82214bb7c7c1e2d92b69e1a7654be90cfab180082c6108e45a98af2422c/thinc-8.3.13-cp314-cp314-win_amd64.whl", hash = "sha256:433e3826e018da489f1a8068e6de677f6eff3cc93991a599d90f12cd1bc26cdc", size = 1740382, upload-time = "2026-03-23T07:22:32.869Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/ef/1648fda54e9689058335ff54f650a7a314db2a42e21af1b83949b2dc748e/thinc-8.3.13-cp314-cp314-win_arm64.whl", hash = "sha256:11754fada9ad5ba2e02d5f3f234f940e24015b82333db58372f4a6aedad9b43f", size = 1667687, upload-time = "2026-03-23T07:22:34.967Z" },
+    { url = "https://files.pythonhosted.org/packages/38/43/01b662540888140b5e9f76c957c7118c203cb91f17867ce78fc4f2d3800f/thinc-8.3.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:72793e0bd3f0f391ca36ab0996b3c21db7045409bd3740840e7d6fcd9a044d81", size = 818632, upload-time = "2025-11-17T17:20:49.123Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ba/e0edcc84014bdde1bc9a082408279616a061566a82b5e3b90b9e64f33c1b/thinc-8.3.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4b13311acb061e04e3a0c4bd677b85ec2971e3a3674558252443b5446e378256", size = 770622, upload-time = "2025-11-17T17:20:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/0558f8cb69c13e1114428726a3fb36fe1adc5821a62ccd3fa7b7c1a5bd9a/thinc-8.3.10-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9ffddcf311fb7c998eb8988d22c618dc0f33b26303853c0445edb8a69819ac60", size = 4094652, upload-time = "2025-11-17T17:20:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/bb78601f74f9bcadb2d3d4d5b057c4dc3f2e52d9771bad3d93a4e38a9dc1/thinc-8.3.10-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b1e0511e8421f20abe4f22d8c8073a0d7ce4a31597cc7a404fdbad72bf38058", size = 4124379, upload-time = "2025-11-17T17:20:53.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3e/961e1b9794111c89f2ceadfef5692aba5097bec4aaaf89f1b8a04c5bc961/thinc-8.3.10-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e31e49441dfad8fd64b8ca5f5c9b8c33ee87a553bf79c830a15b4cd02efcc444", size = 5094221, upload-time = "2025-11-17T17:20:55.466Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/da163a1533faaef5b17dd11dfb9ffd9fd5627dbef56e1160da6edbe1b224/thinc-8.3.10-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9de5dd73ce7135dcf41d68625d35cd9f5cf8e5f55a3932001a188b45057c3379", size = 5262834, upload-time = "2025-11-17T17:20:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4e/449d29e33f7ddda6ba1b9e06de3ea5155c2dc33c21f438f8faafebde4e13/thinc-8.3.10-cp311-cp311-win_amd64.whl", hash = "sha256:b6d64e390a1996d489872b9d99a584142542aba59ebdc60f941f473732582f6f", size = 1791864, upload-time = "2025-11-17T17:20:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b3/68038d88d45d83a501c3f19bd654d275b7ac730c807f52bbb46f35f591bc/thinc-8.3.10-cp311-cp311-win_arm64.whl", hash = "sha256:3991b6ad72e611dfbfb58235de5b67bcc9f61426127cc023607f97e8c5f43e0e", size = 1717563, upload-time = "2025-11-17T17:21:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/34/ba3b386d92edf50784b60ee34318d47c7f49c198268746ef7851c5bbe8cf/thinc-8.3.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51bc6ef735bdbcab75ab2916731b8f61f94c66add6f9db213d900d3c6a244f95", size = 794509, upload-time = "2025-11-17T17:21:03.21Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f3/9f52d18115cd9d8d7b2590d226cb2752d2a5ffec61576b19462b48410184/thinc-8.3.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4f48b4d346915f98e9722c0c50ef911cc16c6790a2b7afebc6e1a2c96a6ce6c6", size = 741084, upload-time = "2025-11-17T17:21:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9c/129c2b740c4e3d3624b6fb3dec1577ef27cb804bc1647f9bc3e1801ea20c/thinc-8.3.10-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5003f4db2db22cc8d686db8db83509acc3c50f4c55ebdcb2bbfcc1095096f7d2", size = 3846337, upload-time = "2025-11-17T17:21:06.079Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/738cf188dea8240c2be081c83ea47270fea585eba446171757d2cdb9b675/thinc-8.3.10-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b12484c3ed0632331fada2c334680dd6bc35972d0717343432dfc701f04a9b4c", size = 3901216, upload-time = "2025-11-17T17:21:07.842Z" },
+    { url = "https://files.pythonhosted.org/packages/22/92/32f66eb9b1a29b797bf378a0874615d810d79eefca1d6c736c5ca3f8b918/thinc-8.3.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8677c446d3f9b97a465472c58683b785b25dfcf26c683e3f4e8f8c7c188e4362", size = 4827286, upload-time = "2025-11-17T17:21:09.62Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5f/7ceae1e1f2029efd67ed88e23cd6dc13a5ee647cdc2b35113101b2a62c10/thinc-8.3.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:759c385ac08dcf950238b60b96a28f9c04618861141766928dff4a51b1679b25", size = 5024421, upload-time = "2025-11-17T17:21:11.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/66/30f9d8d41049b78bc614213d492792fbcfeb1b28642adf661c42110a7ebd/thinc-8.3.10-cp312-cp312-win_amd64.whl", hash = "sha256:bf3f188c3fa1fdcefd547d1f90a1245c29025d6d0e3f71d7fdf21dad210b990c", size = 1718631, upload-time = "2025-11-17T17:21:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/44/32e2a5018a1165a304d25eb9b1c74e5310da19a533a35331e8d824dc6a88/thinc-8.3.10-cp312-cp312-win_arm64.whl", hash = "sha256:234b7e57a6ef4e0260d99f4e8fdc328ed12d0ba9bbd98fdaa567294a17700d1c", size = 1642224, upload-time = "2025-11-17T17:21:14.371Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fc/17a2818d1f460b8c4f33b8bd3f21b19d263a647bfd23b572768d175e6b64/thinc-8.3.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c7c3a50ddd423d1c49419899acef4ac80d800af3b423593acb9e40578384b543", size = 789771, upload-time = "2025-11-17T17:21:15.784Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/24/649f54774b1fbe791a1c2efd7d7f0a95cfd9244902553ca7dcf19daab1dd/thinc-8.3.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a1cb110398f51fc2b9a07a2a4daec6f91e166533a9c9f1c565225330f46569a", size = 737051, upload-time = "2025-11-17T17:21:17.933Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8c/5840c6c504c1fa9718e1c74d6e04d77a474f594888867dbba53f9317285f/thinc-8.3.10-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42318746a67403d04be57d862fe0c0015b58b6fb9bbbf7b6db01f3f103b73a99", size = 3839221, upload-time = "2025-11-17T17:21:20.003Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/e7fca88074cb0aa1c1a23195470b4549492c2797fe7dc9ff79a85500153a/thinc-8.3.10-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6b0e41e79973f8828adead770f885db8d0f199bfbaa9591d1d896c385842e993", size = 3885024, upload-time = "2025-11-17T17:21:21.735Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/eb/805e277aa019896009028d727460f071c6cf83843d70f6a69e58994d2203/thinc-8.3.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9ed982daa1eddbad813bfd079546483b849a68b98c01ad4a7e4efd125ddc5d7b", size = 4815939, upload-time = "2025-11-17T17:21:23.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f5/6425f12a60e3782091c9ec16394b9239f0c18c52c70218f3c8c047ff985c/thinc-8.3.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d22bd381410749dec5f629b3162b7d1f1e2d9b7364fd49a7ea555b61c93772b9", size = 5020260, upload-time = "2025-11-17T17:21:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a2/ae98feffe0b161400e87b7bfc8859e6fa1e6023fa7bcfa0a8cacd83b39a1/thinc-8.3.10-cp313-cp313-win_amd64.whl", hash = "sha256:9c32830446a57da13b6856cacb0225bc2f2104f279d9928d40500081c13aa9ec", size = 1717562, upload-time = "2025-11-17T17:21:27.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e0/faa1d04a6890ea33b9541727d2a3ca88bad794a89f73b9111af6f9aefe10/thinc-8.3.10-cp313-cp313-win_arm64.whl", hash = "sha256:aa43f9af76781d32f5f9fe29299204c8841d71e64cbb56e0e4f3d1e0387c2783", size = 1641536, upload-time = "2025-11-17T17:21:30.129Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/32/7a96e1f2cac159d778c6b0ab4ddd8a139bb57c602cef793b7606cd32428d/thinc-8.3.10-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:44d7038a5d28572105332b44ec9c4c3b6f7953b41d224588ad0473c9b79ccf9e", size = 793037, upload-time = "2025-11-17T17:21:32.538Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d8/81e8495e8ef412767c09d1f9d0d86dc60cd22e6ed75e61b49fbf1dcfcd65/thinc-8.3.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:639f20952af722cb0ab4c3d8a00e661686b60c04f82ef48d12064ceda3b8cd0c", size = 740768, upload-time = "2025-11-17T17:21:34.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/6d/716488a301d65c5463e92cb0eddae3672ca84f1d70937808cea9760f759c/thinc-8.3.10-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9306e62c7e7066c63b0c0ba1d164ae0c23bf38edf5a7df2e09cce69a2c290500", size = 3834983, upload-time = "2025-11-17T17:21:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a1/d28b21cab9b79e9c803671bebd14489e14c5226136fad6a1c44f96f8e4ef/thinc-8.3.10-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2982604c21096de1a87b04a781a645863eece71ec6ee9f139ac01b998fb5622d", size = 3845215, upload-time = "2025-11-17T17:21:38.362Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9d/ff64ead5f1c2298d9e6a9ccc1c676b2347ac06162ad3c5e5d895c32a719e/thinc-8.3.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6b82698e27846004d4eafc38317ace482eced888d4445f7fb9c548fd36777af", size = 4826596, upload-time = "2025-11-17T17:21:40.027Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/44/b80c863608d0fd31641a2d50658560c22d4841f1e445529201e22b3e1d0f/thinc-8.3.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2950acab8ae77427a86d11655ed0a161bc83a1edf9d31ba5c43deca6cd27ed4f", size = 4988146, upload-time = "2025-11-17T17:21:41.73Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6d/1bdd9344b2e7299faa55129dda624d50c334eed16a3761eb8b1dacd8bfcd/thinc-8.3.10-cp314-cp314-win_amd64.whl", hash = "sha256:c253139a5c873edf75a3b17ec9d8b6caebee072fdb489594bc64e35115df7625", size = 1738054, upload-time = "2025-11-17T17:21:43.328Z" },
+    { url = "https://files.pythonhosted.org/packages/45/c4/44e3163d48e398efb3748481656963ac6265c14288012871c921dc81d004/thinc-8.3.10-cp314-cp314-win_arm64.whl", hash = "sha256:ad6da67f534995d6ec257f16665377d7ad95bef5c1b1c89618fd4528657a6f24", size = 1665001, upload-time = "2025-11-17T17:21:45.019Z" },
 ]
 
 [[package]]
@@ -7005,7 +7002,7 @@ wheels = [
 
 [[package]]
 name = "timm"
-version = "1.0.26"
+version = "1.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -7016,9 +7013,9 @@ dependencies = [
     { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/1e/e924b3b2326a856aaf68586f9c52a5fc81ef45715eca408393b68c597e0e/timm-1.0.26.tar.gz", hash = "sha256:f66f082f2f381cf68431c22714c8b70f723837fa2a185b155961eab90f2d5b10", size = 2419859, upload-time = "2026-03-23T18:12:10.272Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/2c/593109822fe735e637382aca6640c1102c19797f7791f1fd1dab2d6c3cb1/timm-1.0.25.tar.gz", hash = "sha256:47f59fc2754725735cc81bb83bcbfce5bec4ebd5d4bb9e69da57daa92fcfa768", size = 2414743, upload-time = "2026-02-23T16:49:00.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/e9/bebf3d50e3fc847378988235f87c37ad3ac26d386041ab915d15e92025cd/timm-1.0.26-py3-none-any.whl", hash = "sha256:985c330de5ccc3a2aa0224eb7272e6a336084702390bb7e3801f3c91603d3683", size = 2568766, upload-time = "2026-03-23T18:12:08.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/50/de09f69a74278a16f08f1d562047a2d6713783765ee3c6971881a2b21a3f/timm-1.0.25-py3-none-any.whl", hash = "sha256:bef7f61dd717cb2dbbb7e326f143e13d660a47ecbd84116e6fe33732bed5c484", size = 2565837, upload-time = "2026-02-23T16:48:58.324Z" },
 ]
 
 [[package]]
@@ -7432,6 +7429,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typer-slim"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7747,22 +7756,22 @@ wheels = [
 
 [[package]]
 name = "weasel"
-version = "1.0.0"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpathlib" },
     { name = "confection" },
-    { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
+    { name = "requests" },
     { name = "smart-open" },
     { name = "srsly" },
-    { name = "typer" },
+    { name = "typer-slim" },
     { name = "wasabi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/d7/edd9c24e60cf8e5de130aa2e8af3b01521f4d0216c371d01212f580d0d8e/weasel-0.4.3.tar.gz", hash = "sha256:f293d6174398e8f478c78481e00c503ee4b82ea7a3e6d0d6a01e46a6b1396845", size = 38733, upload-time = "2025-11-13T23:52:28.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713, upload-time = "2026-03-20T08:10:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/74/a148b41572656904a39dfcfed3f84dd1066014eed94e209223ae8e9d088d/weasel-0.4.3-py3-none-any.whl", hash = "sha256:08f65b5d0dbded4879e08a64882de9b9514753d9eaa4c4e2a576e33666ac12cf", size = 50757, upload-time = "2025-11-13T23:52:26.982Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-17T15:04:28Z"
+exclude-newer = "2026-03-17T14:28:45Z"
 
 [options.exclude-newer-package]
 torchvision = false

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,7 @@ all = [
     { name = "newspaper4k" },
     { name = "numba" },
     { name = "numpy" },
+    { name = "obsws-python" },
     { name = "onnxruntime" },
     { name = "openai" },
     { name = "opencv-python" },
@@ -1045,6 +1046,7 @@ plantuml = [
 recordings = [
     { name = "jinja2" },
     { name = "numpy" },
+    { name = "obsws-python" },
     { name = "onnxruntime" },
     { name = "python-multipart" },
     { name = "soundfile" },
@@ -1127,6 +1129,7 @@ requires-dist = [
     { name = "numba", marker = "extra == 'ml'", specifier = ">=0.60.0" },
     { name = "numpy", marker = "extra == 'ml'", specifier = ">=2.0.1" },
     { name = "numpy", marker = "extra == 'recordings'", specifier = ">=1.24.0" },
+    { name = "obsws-python", marker = "extra == 'recordings'", specifier = ">=1.7.0" },
     { name = "onnxruntime", marker = "extra == 'recordings'", specifier = ">=1.17.0" },
     { name = "openai", marker = "extra == 'ml'", specifier = ">=2.8.1" },
     { name = "openai", marker = "extra == 'summarize'", specifier = ">=1.0.0" },
@@ -4485,6 +4488,18 @@ wheels = [
 ]
 
 [[package]]
+name = "obsws-python"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2f/624af34a5b0f09fbf858bf6743521a8626d712671ac49573e625ad1c97d3/obsws_python-1.8.0.tar.gz", hash = "sha256:e082894f80deb0836861fdc3c222e497308c8f66328da6075baba5b456a20971", size = 28727, upload-time = "2025-07-01T08:24:11.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/4b/537f3d372f065b2aeeac3812228066eb70f47436adf88aaacc94eb5fd4e1/obsws_python-1.8.0-py3-none-any.whl", hash = "sha256:537bde416e149b6f59e0b2f31761d4a40329feafec171bde6fc1346ab8516e28", size = 30819, upload-time = "2025-07-01T08:24:10.086Z" },
+]
+
+[[package]]
 name = "onnxruntime"
 version = "1.24.3"
 source = { registry = "https://pypi.org/simple" }
@@ -7808,6 +7823,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Recording management module** (`clm recordings`): Full video recording workflow for educational courses — audio processing pipeline (DeepFilterNet3 ONNX + FFmpeg), OBS Studio integration, HTMX web dashboard, and automated file watcher
- **8 commits** covering: supply-chain safety, ONNX migration, workflow foundation (naming/dirs/assembly), OBS WebSocket client + session state machine, web dashboard with SSE, and file watcher with pluggable processing backends
- **211 new tests** across 12 test files, all passing. Ruff + mypy clean.

### Key features
- `clm recordings process/batch` — 5-step audio pipeline (extract → ONNX denoise → FFmpeg filters → AAC → mux)
- `clm recordings assemble` — detect paired video+audio, mux via FFmpeg, archive originals
- `clm recordings serve` — HTMX web dashboard: arm topics for recording, OBS status, watcher controls, SSE real-time updates
- Pluggable processing backends: `external` (wait for iZotope RX 11) or `onnx` (local pipeline)
- File watcher with stability detection, automatic assembly on new files

## Test plan
- [x] 211 recordings tests pass (`uv run pytest tests/recordings/`)
- [x] ruff lint + format clean
- [x] mypy clean on all new files
- [ ] CI pipeline passes (full suite including Docker tests)
- [ ] Manual test: `clm recordings serve` with OBS connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)