### PR TITLE
fix(ci)+test: fix mypy on Linux and eliminate worker-lifecycle flakes

### DIFF
--- a/src/clm/voiceover/transcribe.py
+++ b/src/clm/voiceover/transcribe.py
@@ -255,7 +255,7 @@ class CohereTranscribeBackend:
             # torch stubs mis-type .to() with a PreTrainedModel parameter;
             # passing a device string works correctly at runtime.
             self._model = CohereAsrForConditionalGeneration.from_pretrained(self.MODEL_ID).to(
-                self._resolved_device  # type: ignore[arg-type]
+                self._resolved_device  # type: ignore[arg-type, unused-ignore]
             )
             logger.info("Model loaded on %s.", self._resolved_device)
         return self._model, self._processor

--- a/tests/e2e/test_e2e_course_conversion.py
+++ b/tests/e2e/test_e2e_course_conversion.py
@@ -34,6 +34,7 @@ Test fixtures:
 import json
 import logging
 import tempfile
+import time
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -46,6 +47,38 @@ from clm.infrastructure.workers.pool_manager import WorkerPoolManager
 from clm.infrastructure.workers.worker_executor import WorkerConfig
 
 logger = logging.getLogger(__name__)
+
+
+async def _wait_for_workers_active(
+    manager: WorkerPoolManager,
+    expected_count: int,
+    *,
+    timeout: float = 30.0,
+    interval: float = 0.1,
+) -> int:
+    """Poll until *expected_count* workers have transitioned to ``idle``/``busy``.
+
+    Replaces ``await asyncio.sleep(2)`` "give workers time to register" in the
+    e2e fixtures. Workers are pre-registered as ``created`` and activate
+    asynchronously — under xdist -n auto, a fixed 2s wait is not always
+    enough, causing intermittent ERRORs like those observed in
+    ``test_e2e_managed_workers_auto_lifecycle``. Polling is both faster when
+    it succeeds and deterministic when it fails.
+    """
+    import asyncio
+
+    deadline = time.monotonic() + timeout
+    while True:
+        conn = manager.job_queue._get_conn()
+        cursor = conn.execute("SELECT COUNT(*) FROM workers WHERE status IN ('idle', 'busy')")
+        count = cursor.fetchone()[0]
+        if count >= expected_count:
+            return count
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Expected {expected_count} active workers within {timeout}s; got {count}"
+            )
+        await asyncio.sleep(interval)
 
 
 # Check if worker modules are available
@@ -461,10 +494,10 @@ async def sqlite_backend_with_notebook_workers(db_path_fixture, workspace_path_f
     # Start workers
     manager.start_pools()
 
-    # Give workers time to start up and register
-    import asyncio
-
-    await asyncio.sleep(2)
+    # Poll until workers are active rather than waiting a fixed 2s (which
+    # flakes under xdist -n auto when subprocess activation is slow).
+    expected = sum(c.count for c in manager.worker_configs)
+    await _wait_for_workers_active(manager, expected_count=expected)
     logger.info("Workers started and registered")
 
     async with backend:
@@ -569,10 +602,10 @@ async def sqlite_backend_with_plantuml_workers(db_path_fixture, workspace_path_f
     # Start workers
     manager.start_pools()
 
-    # Give workers time to start up and register
-    import asyncio
-
-    await asyncio.sleep(2)
+    # Poll until workers are active rather than waiting a fixed 2s (which
+    # flakes under xdist -n auto when subprocess activation is slow).
+    expected = sum(c.count for c in manager.worker_configs)
+    await _wait_for_workers_active(manager, expected_count=expected)
     logger.info("Workers started and registered")
 
     async with backend:
@@ -633,10 +666,10 @@ async def sqlite_backend_with_drawio_workers(db_path_fixture, workspace_path_fix
     # Start workers
     manager.start_pools()
 
-    # Give workers time to start up and register
-    import asyncio
-
-    await asyncio.sleep(2)
+    # Poll until workers are active rather than waiting a fixed 2s (which
+    # flakes under xdist -n auto when subprocess activation is slow).
+    expected = sum(c.count for c in manager.worker_configs)
+    await _wait_for_workers_active(manager, expected_count=expected)
     logger.info("Workers started and registered")
 
     async with backend:
@@ -701,11 +734,12 @@ async def sqlite_backend_with_all_workers(db_path_fixture, workspace_path_fixtur
     # Start workers
     manager.start_pools()
 
-    # Give workers time to start up and register
-    import asyncio
-
-    await asyncio.sleep(2)
-    logger.info("Workers started and registered (12 total)")
+    # Poll until all 12 workers are active rather than waiting a fixed 2s —
+    # under xdist load, starting 12 subprocesses reliably within 2s is not
+    # guaranteed, causing e2e test flakes.
+    expected = sum(c.count for c in manager.worker_configs)
+    await _wait_for_workers_active(manager, expected_count=expected)
+    logger.info(f"Workers started and registered ({expected} total)")
 
     async with backend:
         yield backend

--- a/tests/e2e/test_e2e_lifecycle.py
+++ b/tests/e2e/test_e2e_lifecycle.py
@@ -27,10 +27,50 @@ import pytest
 from clm.infrastructure.backends.sqlite_backend import SqliteBackend
 from clm.infrastructure.database.schema import init_database
 from clm.infrastructure.workers.config_loader import load_worker_config
-from clm.infrastructure.workers.discovery import WorkerDiscovery
+from clm.infrastructure.workers.discovery import DiscoveredWorker, WorkerDiscovery
 from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
 
 logger = logging.getLogger(__name__)
+
+
+async def _wait_for_healthy_workers_async(
+    db_path: Path,
+    expected_count: int,
+    *,
+    timeout: float = 30.0,
+    interval: float = 0.1,
+) -> list[DiscoveredWorker]:
+    """Poll ``WorkerDiscovery`` until at least *expected_count* workers are healthy.
+
+    Replaces the ``await asyncio.sleep(2)`` "give workers time to register"
+    idiom in e2e tests. Under xdist -n auto with 10+ workers spawning as
+    subprocesses, 2s is not always enough for every subprocess to flip from
+    ``created`` → ``idle``, causing intermittent failures in the parallel
+    non-docker gate. A polling wait is both faster when it succeeds and
+    deterministic when it fails (raises TimeoutError with a useful summary).
+    """
+    import asyncio
+
+    deadline = time.monotonic() + timeout
+    last: list[DiscoveredWorker] = []
+    while True:
+        discovery = WorkerDiscovery(db_path)
+        try:
+            discovered = discovery.discover_workers()
+        finally:
+            discovery.close()
+        healthy = [w for w in discovered if w.is_healthy]
+        last = discovered
+        if len(healthy) >= expected_count:
+            return discovered
+        if time.monotonic() > deadline:
+            statuses = [(w.worker_type, w.status, w.is_healthy) for w in last]
+            raise TimeoutError(
+                f"Expected {expected_count} healthy workers within {timeout}s; "
+                f"got {len(healthy)} healthy out of {len(last)} discovered: "
+                f"{statuses}"
+            )
+        await asyncio.sleep(interval)
 
 
 # Check if worker modules are available
@@ -133,15 +173,13 @@ async def test_e2e_managed_workers_auto_lifecycle(
     notebook_workers = [w for w in started_workers if w.worker_type == "notebook"]
     assert len(notebook_workers) == 8, "Should start 8 notebook workers"
 
-    # Wait for workers to register
-    import asyncio
-
-    await asyncio.sleep(2)
-
-    # Verify workers are healthy
-    discovery = WorkerDiscovery(db_path_fixture)
-    healthy_workers = discovery.discover_workers()
+    # Wait for all 10 workers to become healthy. Polling with a 30s ceiling
+    # avoids the flake seen under xdist -n auto, where a fixed asyncio.sleep(2)
+    # was not always enough for all subprocesses to activate.
+    healthy_workers = await _wait_for_healthy_workers_async(db_path_fixture, expected_count=10)
     assert len(healthy_workers) == 10, "All 10 workers should be healthy"
+
+    discovery = WorkerDiscovery(db_path_fixture)
 
     try:
         # Create backend
@@ -221,9 +259,10 @@ async def test_e2e_managed_workers_reuse_across_builds(
     started_workers1 = lifecycle_manager1.start_managed_workers()
     worker1_ids = [w.db_worker_id for w in started_workers1]
 
-    import asyncio
-
-    await asyncio.sleep(2)
+    # Wait for all 10 workers to become healthy before reuse-detection in
+    # the second build — count_healthy_workers() drives reuse, so checking
+    # before activation would bypass it.
+    await _wait_for_healthy_workers_async(db_path_fixture, expected_count=10)
 
     # Initialize variables for cleanup in finally block
     lifecycle_manager2 = None
@@ -308,19 +347,15 @@ async def test_e2e_worker_health_monitoring_during_build(
     # Start managed workers
     started_workers = lifecycle_manager.start_managed_workers()
 
-    import asyncio
-
-    await asyncio.sleep(2)
+    # Poll until all 10 workers are healthy rather than waiting a fixed 2s.
+    healthy_workers = await _wait_for_healthy_workers_async(db_path_fixture, expected_count=10)
+    assert len(healthy_workers) == 10, (
+        "All 10 workers should be healthy initially (8 notebook + 1 plantuml + 1 drawio)"
+    )
 
     discovery = WorkerDiscovery(db_path_fixture)
 
     try:
-        # Verify workers are healthy before processing
-        healthy_workers = discovery.discover_workers()
-        assert len(healthy_workers) == 10, (
-            "All 10 workers should be healthy initially (8 notebook + 1 plantuml + 1 drawio)"
-        )
-
         # Process course
         # Get timeout from environment variable (default: 120s for tests with workers, increased to 600s in CI)
         timeout = float(os.environ.get("CLM_E2E_TIMEOUT", "120"))

--- a/tests/infrastructure/workers/test_direct_integration.py
+++ b/tests/infrastructure/workers/test_direct_integration.py
@@ -19,6 +19,42 @@ from clm.infrastructure.workers.pool_manager import WorkerPoolManager
 from clm.infrastructure.workers.worker_executor import WorkerConfig
 
 
+def _wait_for_registered_workers(
+    manager: WorkerPoolManager,
+    expected_count: int,
+    *,
+    worker_type: str | None = None,
+    timeout: float = 15.0,
+    interval: float = 0.1,
+) -> int:
+    """Poll the ``workers`` table until ``expected_count`` rows with a valid
+    (non-``created``) status are present.
+
+    Replaces the ``time.sleep(2)`` "give workers time to register" idiom in
+    these integration tests. Under xdist -n auto, 2s is not always enough for
+    a subprocess to activate from ``created`` → ``idle``; polling is fast
+    when it succeeds and deterministic when it fails.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        conn = manager.job_queue._get_conn()
+        query = "SELECT COUNT(*) FROM workers WHERE status IN ('idle', 'busy')"
+        params: tuple = ()
+        if worker_type is not None:
+            query += " AND worker_type = ?"
+            params = (worker_type,)
+        cursor = conn.execute(query, params)
+        count = cursor.fetchone()[0]
+        if count >= expected_count:
+            return count
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Expected {expected_count} active workers within {timeout}s "
+                f"(worker_type={worker_type}); got {count}"
+            )
+        time.sleep(interval)
+
+
 # Check if worker modules are available
 def check_worker_module_available(module_name: str) -> bool:
     """Check if a worker module can be imported."""
@@ -93,12 +129,15 @@ class TestDirectWorkerIntegration:
         try:
             manager.start_pools()
 
-            # Give workers time to register
-            time.sleep(2)
+            # Poll until the worker activates from 'created' -> 'idle'.
+            _wait_for_registered_workers(manager, expected_count=1)
 
             # Check database for registered workers
             conn = manager.job_queue._get_conn()
-            cursor = conn.execute("SELECT id, worker_type, container_id, status FROM workers")
+            cursor = conn.execute(
+                "SELECT id, worker_type, container_id, status FROM workers "
+                "WHERE status IN ('idle', 'busy')"
+            )
             workers = cursor.fetchall()
 
             assert len(workers) == 1
@@ -126,12 +165,17 @@ class TestDirectWorkerIntegration:
         try:
             manager.start_pools()
 
-            # Give workers time to register
-            time.sleep(2)
+            # Wait for all 3 workers to activate (idle/busy), not just be pre-
+            # registered as 'created'. Fixed time.sleep(2) was a latent flake.
+            _wait_for_registered_workers(manager, expected_count=3)
 
             # Check database
             conn = manager.job_queue._get_conn()
-            cursor = conn.execute("SELECT worker_type, COUNT(*) FROM workers GROUP BY worker_type")
+            cursor = conn.execute(
+                "SELECT worker_type, COUNT(*) FROM workers "
+                "WHERE status IN ('idle', 'busy') "
+                "GROUP BY worker_type"
+            )
             results = {row[0]: row[1] for row in cursor.fetchall()}
 
             assert results.get("notebook", 0) == 2
@@ -226,8 +270,9 @@ class TestDirectWorkerIntegration:
         try:
             manager.start_pools()
 
-            # Give workers time to register
-            time.sleep(2)
+            # Wait until the worker has activated — a fixed time.sleep(2)
+            # can miss the activation under xdist load.
+            _wait_for_registered_workers(manager, expected_count=1)
 
             # Start monitoring
             manager.start_monitoring(check_interval=2)
@@ -258,11 +303,11 @@ class TestDirectWorkerIntegration:
 
         try:
             manager.start_pools()
-            time.sleep(2)
+            _wait_for_registered_workers(manager, expected_count=2)
 
             # Verify workers started
             conn = manager.job_queue._get_conn()
-            cursor = conn.execute("SELECT COUNT(*) FROM workers")
+            cursor = conn.execute("SELECT COUNT(*) FROM workers WHERE status IN ('idle', 'busy')")
             count = cursor.fetchone()[0]
             assert count == 2
 
@@ -341,8 +386,15 @@ class TestDirectWorkerIntegration:
         try:
             manager.start_pools()
 
-            # Give workers time to register
-            time.sleep(3)
+            # Wait for all workers to activate. Fixed time.sleep(3) was flaky
+            # at 32 workers on loaded CI — polling scales up with expected
+            # count and uses a 30s ceiling which is plenty for even 32 workers.
+            _wait_for_registered_workers(
+                manager,
+                expected_count=worker_count,
+                worker_type="notebook",
+                timeout=30.0,
+            )
 
             # Verify all workers registered
             conn = job_queue._get_conn()
@@ -448,11 +500,19 @@ class TestMixedModeIntegration:
 
         try:
             manager.start_pools()
-            time.sleep(3)
+            # Wait for at least the direct worker to activate; docker workers
+            # take longer and we tolerate either outcome below.
+            _wait_for_registered_workers(
+                manager,
+                expected_count=2 if has_docker else 1,
+                timeout=30.0,
+            )
 
             # Check database
             conn = manager.job_queue._get_conn()
-            cursor = conn.execute("SELECT worker_type, container_id FROM workers")
+            cursor = conn.execute(
+                "SELECT worker_type, container_id FROM workers WHERE status IN ('idle', 'busy')"
+            )
             workers = cursor.fetchall()
 
             # Should have at least the direct worker

--- a/tests/infrastructure/workers/test_lifecycle_integration.py
+++ b/tests/infrastructure/workers/test_lifecycle_integration.py
@@ -16,9 +16,50 @@ import pytest
 
 from clm.infrastructure.database.schema import init_database
 from clm.infrastructure.workers.config_loader import load_worker_config
-from clm.infrastructure.workers.discovery import WorkerDiscovery
+from clm.infrastructure.workers.discovery import DiscoveredWorker, WorkerDiscovery
 from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
 from clm.infrastructure.workers.worker_executor import WorkerConfig
+
+
+def _wait_for_healthy_workers(
+    db_path: Path,
+    expected_count: int,
+    *,
+    worker_type: str | None = None,
+    timeout: float = 15.0,
+    interval: float = 0.1,
+) -> list[DiscoveredWorker]:
+    """Poll ``WorkerDiscovery`` until at least *expected_count* workers are healthy.
+
+    Replaces the ``time.sleep(2)`` "give workers time to register" idiom,
+    which is a classic flake pattern under pytest-xdist. Workers are
+    pre-registered with status ``created`` and transition to ``idle``
+    asynchronously when their subprocess is ready — the duration of that
+    transition is non-deterministic under CPU contention.
+
+    A polling wait is both faster (returns as soon as workers are ready)
+    and more robust (tolerates slow scheduling).
+    """
+    deadline = time.monotonic() + timeout
+    last: list[DiscoveredWorker] = []
+    while True:
+        discovery = WorkerDiscovery(db_path)
+        try:
+            discovered = discovery.discover_workers(worker_type=worker_type)
+        finally:
+            discovery.close()
+        healthy = [w for w in discovered if w.is_healthy]
+        last = discovered
+        if len(healthy) >= expected_count:
+            return discovered
+        if time.monotonic() > deadline:
+            statuses = [(w.worker_type, w.status, w.is_healthy) for w in last]
+            raise TimeoutError(
+                f"Expected {expected_count} healthy workers within {timeout}s "
+                f"(worker_type={worker_type}); got {len(healthy)} healthy out of "
+                f"{len(last)} discovered: {statuses}"
+            )
+        time.sleep(interval)
 
 
 # Check if worker modules are available
@@ -122,15 +163,11 @@ class TestManagedWorkerLifecycle:
             assert workers[0].execution_mode == "direct"
             assert workers[0].db_worker_id > 0
 
-            # Give workers time to register
-            time.sleep(2)
-
-            # Verify workers in database
-            discovery = WorkerDiscovery(db_path)
-            discovered = discovery.discover_workers()
-            assert len(discovered) > 0
-            assert discovered[0].worker_type == "notebook"
-            assert discovered[0].is_healthy
+            # Wait for at least one worker to become healthy. A fixed
+            # time.sleep(2) is a classic flake under xdist load — workers
+            # may take longer than 2s to activate under CPU contention.
+            discovered = _wait_for_healthy_workers(db_path, expected_count=1)
+            assert any(w.worker_type == "notebook" and w.is_healthy for w in discovered)
 
         finally:
             # Stop workers
@@ -160,7 +197,10 @@ class TestManagedWorkerLifecycle:
         try:
             # Start managed workers first time
             workers1 = manager.start_managed_workers()
-            time.sleep(2)
+            # Must wait for the first worker to be healthy before the second
+            # call: reuse-detection is driven by count_healthy_workers(), and
+            # checking before the worker activates would bypass reuse.
+            _wait_for_healthy_workers(db_path, expected_count=1)
 
             worker1_id = workers1[0].db_worker_id
 
@@ -199,7 +239,7 @@ class TestManagedWorkerLifecycle:
         try:
             # Start managed workers first time
             workers1 = manager1.start_managed_workers()
-            time.sleep(2)
+            _wait_for_healthy_workers(db_path, expected_count=1)
 
             worker1_id = workers1[0].db_worker_id
 
@@ -215,7 +255,8 @@ class TestManagedWorkerLifecycle:
 
             # Start fresh workers
             workers2 = manager2.start_managed_workers()
-            time.sleep(2)
+            # Wait until both the old and new workers are healthy (count >= 2).
+            _wait_for_healthy_workers(db_path, expected_count=2)
 
             # Should be different worker
             assert len(workers2) == 1
@@ -278,17 +319,14 @@ class TestWorkerDiscovery:
         try:
             # Start workers
             workers = manager.start_managed_workers()
-            time.sleep(2)
 
-            # Discover workers
-            discovery = WorkerDiscovery(db_path)
-            discovered = discovery.discover_workers()
-
-            # Verify discovery
-            assert len(discovered) > 0
-            assert discovered[0].worker_type == "notebook"
-            assert discovered[0].is_healthy
-            assert discovered[0].status in ("idle", "busy")
+            # Poll until the worker has become healthy rather than waiting
+            # a fixed 2s (flake-prone under xdist load).
+            discovered = _wait_for_healthy_workers(db_path, expected_count=1)
+            assert any(
+                w.worker_type == "notebook" and w.is_healthy and w.status in ("idle", "busy")
+                for w in discovered
+            )
 
         finally:
             manager.stop_managed_workers(workers)
@@ -312,11 +350,19 @@ class TestWorkerDiscovery:
         try:
             # Start workers
             workers = manager.start_managed_workers()
-            time.sleep(2)
+
+            # Poll until the requested worker count is healthy before
+            # running the status-filtered query. Busy workers are fine too
+            # (the test just wants activation to have happened), so we
+            # wait via _wait_for_healthy_workers and then filter.
+            _wait_for_healthy_workers(db_path, expected_count=2, worker_type="notebook")
 
             # Discover idle workers
             discovery = WorkerDiscovery(db_path)
-            idle_workers = discovery.discover_workers(status_filter=["idle"])
+            try:
+                idle_workers = discovery.discover_workers(status_filter=["idle"])
+            finally:
+                discovery.close()
 
             # Should find idle workers
             assert len(idle_workers) > 0
@@ -396,24 +442,12 @@ class TestDockerWorkerLifecycle:
             assert workers[0].execution_mode == "docker"
             assert not workers[0].executor_id.startswith("direct-")
 
-            # Wait for Docker worker to become healthy (async startup)
-            # Docker containers need time to start and activate
-            discovery = WorkerDiscovery(db_path)
-            timeout = 30
-            start_time = time.time()
-            is_healthy = False
-
-            while (time.time() - start_time) < timeout:
-                discovered = discovery.discover_workers()
-                if discovered and discovered[0].is_healthy:
-                    is_healthy = True
-                    break
-                time.sleep(0.5)
-
-            # Verify workers in database
-            assert len(discovered) > 0
+            # Wait for Docker worker to become healthy (async startup).
+            # Docker containers need longer than direct workers to start and
+            # activate, so use a 30s timeout.
+            discovered = _wait_for_healthy_workers(db_path, expected_count=1, timeout=30.0)
             assert discovered[0].worker_type == "notebook"
-            assert is_healthy, f"Worker did not become healthy within {timeout}s"
+            assert discovered[0].is_healthy
 
         finally:
             # Stop workers

--- a/tests/infrastructure/workers/test_pool_manager.py
+++ b/tests/infrastructure/workers/test_pool_manager.py
@@ -13,6 +13,28 @@ from clm.infrastructure.database.schema import init_database
 from clm.infrastructure.workers.pool_manager import WorkerConfig, WorkerPoolManager
 
 
+@pytest.fixture(autouse=True)
+def mock_worker_api_server():
+    """Prevent tests from starting a real uvicorn server.
+
+    ``WorkerPoolManager.start_pools`` unconditionally starts
+    ``WorkerApiServer`` (binding uvicorn to 0.0.0.0:8765) whenever any of
+    its worker configs use the ``docker`` execution mode. Under pytest-xdist
+    -n auto this causes port collisions across worker processes
+    (``OSError: [WinError 10048]``) which surface as
+    ``PytestUnhandledThreadExceptionWarning: SystemExit: 1`` and, under
+    worse timing, can fail tests outright. These tests don't need a real
+    HTTP server — they just want ``start_pools`` to run — so stub it out.
+    """
+    with patch("clm.infrastructure.workers.pool_manager.start_worker_api_server") as mock_start:
+        mock_server = MagicMock()
+        mock_server.is_running = True
+        mock_server.docker_url = "http://host.docker.internal:8765"
+        mock_server.url = "http://0.0.0.0:8765"
+        mock_start.return_value = mock_server
+        yield mock_start
+
+
 @pytest.fixture
 def db_path():
     """Create a temporary database."""

--- a/tests/infrastructure/workers/test_worker_base.py
+++ b/tests/infrastructure/workers/test_worker_base.py
@@ -234,33 +234,38 @@ def test_worker_updates_heartbeat(worker_id, db_path):
     initial_heartbeat = cursor.fetchone()[0]
     queue.close()
 
-    # Sleep briefly to ensure time passes
-    time.sleep(0.1)
+    def _get_heartbeat() -> str | None:
+        queue = JobQueue(db_path)
+        try:
+            conn = queue._get_conn()
+            cursor = conn.execute("SELECT last_heartbeat FROM workers WHERE id = ?", (worker_id,))
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            queue.close()
 
     # Run worker briefly - but we need to check heartbeat BEFORE it stops
     # because workers now deregister (delete themselves) on graceful shutdown
     worker = MockWorker(worker_id, db_path)
     thread = threading.Thread(target=worker.run)
     thread.start()
+    try:
+        # Poll until the worker has pushed a fresh heartbeat. Using a
+        # predicate-based wait makes this deterministic under xdist load —
+        # a fixed 0.3s sleep can miss even one heartbeat poll (0.1s) when
+        # the worker thread is slow to start under CPU contention.
+        _wait_until(
+            lambda: (_get_heartbeat() or "") > (initial_heartbeat or ""),
+            timeout=5.0,
+        )
+        final_heartbeat = _get_heartbeat()
+    finally:
+        # Now stop the worker
+        worker.stop()
+        thread.join(timeout=5)
 
-    # Wait a bit for heartbeat to be updated during operation
-    time.sleep(0.3)
-
-    # Check heartbeat was updated while worker is still running
-    queue = JobQueue(db_path)
-    conn = queue._get_conn()
-    cursor = conn.execute("SELECT last_heartbeat FROM workers WHERE id = ?", (worker_id,))
-    row = cursor.fetchone()
-    queue.close()
-
-    # Worker should still exist at this point
-    assert row is not None, "Worker should still exist before stopping"
-    final_heartbeat = row[0]
+    assert final_heartbeat is not None
     assert final_heartbeat >= initial_heartbeat
-
-    # Now stop the worker
-    worker.stop()
-    thread.join(timeout=2)
 
 
 def test_worker_updates_status(worker_id, db_path):
@@ -276,53 +281,49 @@ def test_worker_updates_status(worker_id, db_path):
     )
     queue.close()
 
-    # Create worker with processing delay
+    # Create worker with processing delay long enough that we can observe the
+    # busy state from the test thread even under heavy xdist parallelism.
     worker = MockWorker(worker_id, db_path)
-    worker.process_delay = 0.3
+    worker.process_delay = 1.0
+
+    def _get_status() -> str | None:
+        queue = JobQueue(db_path)
+        try:
+            conn = queue._get_conn()
+            cursor = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,))
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            queue.close()
 
     thread = threading.Thread(target=worker.run)
     thread.start()
+    try:
+        # Wait (poll) until the worker transitions to 'busy'. Using a
+        # predicate-based wait instead of a fixed sleep is deterministic under
+        # parallel load — under xdist -n auto, a fixed 0.15s window can be
+        # missed entirely if the worker thread is slow to start.
+        _wait_until(lambda: _get_status() == "busy")
+        status_during = "busy"
 
-    # Check status changes to busy during processing
-    time.sleep(0.15)  # Give worker time to pick up job
-
-    queue = JobQueue(db_path)
-    conn = queue._get_conn()
-    cursor = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,))
-    row = cursor.fetchone()
-    queue.close()
-
-    assert row is not None, "Worker should exist during processing"
-    status_during = row[0]
-
-    # Wait for job completion, then check status before stopping
-    time.sleep(0.3)
-
-    queue = JobQueue(db_path)
-    conn = queue._get_conn()
-    cursor = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,))
-    row = cursor.fetchone()
-    queue.close()
-
-    # Worker should be idle after job completion but before shutdown
-    assert row is not None, "Worker should exist after job completion"
-    status_after_job = row[0]
-
-    # Now stop the worker
-    worker.stop()
-    thread.join(timeout=2)
+        # Wait (poll) until the job has been processed AND the worker has
+        # returned to idle. The processed_jobs list is appended to after
+        # process_job returns, but _update_status('idle') runs in the
+        # finally block immediately after, so we must wait for both.
+        _wait_until(lambda: job_id in worker.processed_jobs and _get_status() == "idle")
+        status_after_job = _get_status()
+    finally:
+        # Now stop the worker
+        worker.stop()
+        thread.join(timeout=5)
 
     # After graceful shutdown, worker deregisters (deletes itself from DB)
-    queue = JobQueue(db_path)
-    conn = queue._get_conn()
-    cursor = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,))
-    row_after_stop = cursor.fetchone()
-    queue.close()
+    row_after_stop_status = _get_status()
 
     assert status_during == "busy"
     assert status_after_job == "idle"
     # Worker should be deleted after graceful shutdown
-    assert row_after_stop is None, "Worker should be deregistered after graceful shutdown"
+    assert row_after_stop_status is None, "Worker should be deregistered after graceful shutdown"
 
 
 def test_worker_tracks_statistics(worker_id, db_path):
@@ -617,8 +618,12 @@ class TestParentProcessDeathDetection:
         thread = threading.Thread(target=worker.run)
         thread.start()
 
-        # Worker should stop quickly due to parent death detection
-        thread.join(timeout=2)
+        # Worker should stop due to parent death detection. Give it up to 10s:
+        # under xdist -n auto the worker thread can be slow to get scheduled,
+        # and the detection loop needs at least one full poll_interval plus
+        # parent_check_interval before the check fires. A tight 2s timeout is
+        # a latent flake (was observed flaking under CPU contention).
+        thread.join(timeout=10)
 
         assert not thread.is_alive()
         assert worker.running is False


### PR DESCRIPTION
## Summary

Two logically distinct fixes driven by the current master CI failure and a broader investigation into flaky tests uncovered along the way:

1. **`fix(ci)`**: Restore the `unused-ignore` companion on a cross-platform `# type: ignore` in `src/clm/voiceover/transcribe.py`. Master CI has been failing on `Run mypy` since `43890c3` reintroduced a plain `# type: ignore[arg-type]` without the companion code; this is the same gotcha `0e67503` already fixed for the `transformers` import, so the fix restores the existing convention in that file.

2. **`test`**: Replace fixed `time.sleep(2)` / `asyncio.sleep(2)` "give workers time to register" waits with polling helpers across 6 test files, and mock `start_worker_api_server` in `test_pool_manager` to stop it from racing to bind uvicorn port 8765 under xdist. Together these eliminate the recurring `PytestUnhandledThreadExceptionWarning: SystemExit(1)` warnings and several latent flakes in the `not docker` suite.

## Flakes caught and fixed

The `pytest -m "not docker"` gate reproduced failures before the fix:

- **`test_worker_updates_status`** (fast suite): `time.sleep(0.15)` / `time.sleep(0.3)` race around worker `idle → busy → idle` transitions. Replaced with `_wait_until()` predicates.
- **`test_worker_exits_when_parent_dies_during_run`** (fast suite): `thread.join(timeout=2)` too tight — bumped to 10s.
- **`test_e2e_managed_workers_auto_lifecycle`**, **`test_e2e_managed_workers_reuse_across_builds`** (non-docker): `asyncio.sleep(2)` waiting for 10 workers to activate; 14 errors in 1 of 2 runs. Fixed with a new `_wait_for_healthy_workers_async` helper.

Latent anti-pattern cleaned up preemptively (same root cause):

- `test_lifecycle_integration.py`: 6 × `time.sleep(2)` → `_wait_for_healthy_workers` helper, plus consolidation of the duplicated Docker polling loop.
- `test_direct_integration.py`: 5 × `time.sleep(2|3)` → new `_wait_for_registered_workers` helper (polls the `workers` table directly via the manager's `job_queue`).
- `test_e2e_course_conversion.py`: 4 × `asyncio.sleep(2)` in the fixture-level `sqlite_backend_with_*_workers` fixtures → new `_wait_for_workers_active` helper.

## Uvicorn port 8765 collision

Separately from the sleep anti-pattern, `WorkerPoolManager.start_pools` unconditionally calls `start_worker_api_server(self.db_path)` whenever any worker config is `docker`, and that function binds a real uvicorn server on the hardcoded port 8765. Under `-n auto` (32 xdist processes), every parallel process races to bind the same port and all but one get `OSError: [WinError 10048]` → `sys.exit(1)` in the uvicorn thread, which pytest then surfaces as `PytestUnhandledThreadExceptionWarning: SystemExit(1)`. These warnings were on every fast-suite run and could turn into failures under worse timing.

The fix is a new autouse fixture in `tests/infrastructure/workers/test_pool_manager.py` that patches `clm.infrastructure.workers.pool_manager.start_worker_api_server` to return a MagicMock with `is_running=True` and the expected URL attributes. Production code is unchanged.

## Verification

| Run | Result |
| --- | --- |
| Fast suite × 5 (after fix) | 2830 passed / run, **0 warnings** (was 4–7 SystemExit warnings per run) |
| Non-docker suite × 3 (after fix) | 2933 passed, 9 skipped / run |
| Non-docker suite × 2 (before fix) | 1 run clean, 1 run 1 failure + 14 errors |
| Integration + e2e × 2 (after fix) | 21 passed, 9 skipped / run |
| `ruff check src/ tests/` | clean |
| `ruff format --check src/ tests/` | clean |
| `mypy src/clm` | clean (216 files) |

## Test plan

- [x] Fast suite passes locally, repeated runs — **2830 × 5 runs clean**
- [x] Non-docker suite passes locally, repeated runs — **2933 × 3 runs clean**
- [x] E2E tests pass under xdist parallelism — **15/15**
- [x] Integration tests pass under xdist parallelism — **6/6 (9 docker skipped)**
- [x] ruff, mypy, pre-commit hooks pass
- [ ] CI passes on this PR (Lint and type check, Test on Python 3.11/3.12/3.13, Docker Integration Tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)