### PR TITLE
fix(recordings): Auphonic model validation + resilient async poller + job management CLI

### DIFF
--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -764,6 +764,11 @@ def list_jobs(cli_root: Path | None, show_all: bool, limit: int):
             console.print("[yellow]No jobs found.[/yellow] Use 'clm recordings submit' to add one.")
             return
 
+        # Only show the "Last poll error" column if at least one job
+        # actually has one — otherwise it's dead space for the common
+        # healthy-state listing.
+        show_poll_error_column = any(j.last_poll_error for j in jobs)
+
         table = Table(title=f"Jobs under {root}")
         table.add_column("ID", style="dim")
         table.add_column("Backend", style="cyan")
@@ -771,6 +776,8 @@ def list_jobs(cli_root: Path | None, show_all: bool, limit: int):
         table.add_column("Progress")
         table.add_column("Input")
         table.add_column("Message")
+        if show_poll_error_column:
+            table.add_column("Last poll error", style="yellow")
 
         for job in jobs:
             state_style = {
@@ -778,14 +785,17 @@ def list_jobs(cli_root: Path | None, show_all: bool, limit: int):
                 "failed": "red",
                 "cancelled": "yellow",
             }.get(job.state.value, "blue")
-            table.add_row(
+            row = [
                 job.id[:8],
                 job.backend_name,
                 f"[{state_style}]{job.state.value}[/{state_style}]",
                 f"{int(job.progress * 100)}%",
                 job.raw_path.name,
                 (job.error or job.message or "")[:60],
-            )
+            ]
+            if show_poll_error_column:
+                row.append((job.last_poll_error or "")[:60])
+            table.add_row(*row)
 
         console.print(table)
     finally:
@@ -835,6 +845,88 @@ def cancel_job(job_id: str, cli_root: Path | None):
         manager.shutdown()
 
 
+def _render_poll_result_table(polled, *, title: str) -> Table:
+    """Build a Rich Table summarizing the result of a poll tick."""
+    table = Table(title=title)
+    table.add_column("ID", style="dim")
+    table.add_column("State")
+    table.add_column("Progress")
+    table.add_column("Message")
+    table.add_column("Last poll error", style="yellow")
+    for job in polled:
+        state_style = {
+            "completed": "green",
+            "failed": "red",
+            "cancelled": "yellow",
+        }.get(job.state.value, "blue")
+        table.add_row(
+            job.id[:8],
+            f"[{state_style}]{job.state.value}[/{state_style}]",
+            f"{int(job.progress * 100)}%",
+            (job.error or job.message or "")[:60],
+            (job.last_poll_error or "")[:60],
+        )
+    return table
+
+
+@jobs_group.command("fail")
+@click.argument("job_id")
+@click.option(
+    "--root",
+    "cli_root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Recordings root (defaults to recordings.root_dir from config).",
+)
+@click.option(
+    "--reason",
+    default="Manually marked failed by user",
+    show_default=True,
+    help="Error text stored on the job (shown by 'jobs list').",
+)
+def fail_job(job_id: str, cli_root: Path | None, reason: str):
+    """Manually mark JOB_ID as FAILED without touching the backend.
+
+    Unlike ``jobs cancel`` — which deletes the remote production so
+    no credits are burned — ``fail`` only changes the local job
+    state. Use this for rescuing stuck jobs where the remote work is
+    actually fine (so you still want to download/inspect it) but the
+    local poll loop is wedged with repeated transient errors.
+
+    Refuses already-terminal jobs (completed/failed/cancelled) so you
+    can't accidentally overwrite a real completion.
+    """
+    root = _resolve_recordings_root(cli_root)
+    manager = _make_job_manager_for_root(root)
+
+    try:
+        target = _resolve_job_by_prefix(manager, job_id)
+        if target.is_terminal:
+            console.print(
+                f"[yellow]Job {target.id[:8]} is already {target.state.value}; "
+                "refusing to overwrite.[/yellow]"
+            )
+            raise SystemExit(1)
+
+        updated = manager.mark_failed(target.id, reason=reason)
+        if updated is None:
+            # Race: something else changed the job between the prefix
+            # resolve and the mark_failed call. Rare, but surface it.
+            console.print(
+                f"[red]Could not mark job {target.id[:8]} as failed "
+                "(state changed concurrently?).[/red]"
+            )
+            raise SystemExit(1)
+        console.print(
+            f"[red]Marked failed[/red] job {updated.id[:8]} "
+            f"(reason: {updated.error}). The backend production was "
+            "[bold]not[/bold] cancelled — use 'jobs cancel' if you "
+            "also want to delete it upstream."
+        )
+    finally:
+        manager.shutdown()
+
+
 @jobs_group.command("poll")
 @click.argument("job_id", required=False)
 @click.option(
@@ -844,14 +936,37 @@ def cancel_job(job_id: str, cli_root: Path | None):
     default=None,
     help="Recordings root (defaults to recordings.root_dir from config).",
 )
-def poll_jobs(job_id: str | None, cli_root: Path | None):
-    """Run one poll cycle against in-flight jobs and print their state.
+@click.option(
+    "-w",
+    "--watch",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Run this many poll cycles back-to-back, sleeping --interval "
+    "seconds between ticks. Stops early when no jobs remain in-flight.",
+)
+@click.option(
+    "-i",
+    "--interval",
+    type=float,
+    default=30.0,
+    show_default=True,
+    help="Seconds to sleep between ticks when --watch > 1.",
+)
+def poll_jobs(
+    job_id: str | None,
+    cli_root: Path | None,
+    watch: int,
+    interval: float,
+):
+    """Run one or more poll cycles and print job state after each tick.
 
     Without an argument, polls every in-flight job. With JOB_ID (prefix
     match accepted), polls only that job. Useful for asynchronous
     backends like Auphonic when you don't want to run the full
-    dashboard just to check on progress — it runs exactly one poll
-    tick, prints the result, and exits.
+    dashboard just to check on progress — with ``--watch 1`` (the
+    default) it runs a single tick and exits, with higher values it
+    loops for a bounded amount of time.
 
     Transient errors (network blips, HTTP 5xx, schema drift) are
     recorded on the job's ``last_poll_error`` but do NOT mark the job
@@ -859,6 +974,11 @@ def poll_jobs(job_id: str | None, cli_root: Path | None):
     401/403/404/410, explicit Auphonic ERROR status) mark the job
     failed immediately.
     """
+    import time as _time
+
+    if watch < 1:
+        raise click.BadParameter("--watch must be >= 1")
+
     root = _resolve_recordings_root(cli_root)
     manager = _make_job_manager_for_root(root)
 
@@ -874,37 +994,32 @@ def poll_jobs(job_id: str | None, cli_root: Path | None):
                 return
             target_id = target.id
 
-        polled = manager.poll_once(job_id=target_id)
-        if not polled:
-            if target_id is not None:
-                console.print(
-                    "[yellow]Job is not in a pollable state "
-                    "(must be processing/uploading/downloading).[/yellow]"
-                )
-            else:
-                console.print("[dim]No in-flight jobs to poll.[/dim]")
-            return
+        for tick in range(1, watch + 1):
+            polled = manager.poll_once(job_id=target_id)
+            if not polled:
+                if target_id is not None:
+                    console.print(
+                        "[yellow]Job is not in a pollable state "
+                        "(must be processing/uploading/downloading).[/yellow]"
+                    )
+                else:
+                    console.print("[dim]No in-flight jobs to poll.[/dim]")
+                return
 
-        table = Table(title="Poll result")
-        table.add_column("ID", style="dim")
-        table.add_column("State")
-        table.add_column("Progress")
-        table.add_column("Message")
-        table.add_column("Last poll error", style="yellow")
-        for job in polled:
-            state_style = {
-                "completed": "green",
-                "failed": "red",
-                "cancelled": "yellow",
-            }.get(job.state.value, "blue")
-            table.add_row(
-                job.id[:8],
-                f"[{state_style}]{job.state.value}[/{state_style}]",
-                f"{int(job.progress * 100)}%",
-                (job.error or job.message or "")[:60],
-                (job.last_poll_error or "")[:60],
-            )
-        console.print(table)
+            title = "Poll result" if watch == 1 else f"Poll tick {tick}/{watch}"
+            console.print(_render_poll_result_table(polled, title=title))
+
+            # If every polled job reached terminal state, stop early —
+            # nothing more to do. This matters most when watching a
+            # single JOB_ID that has just completed.
+            if all(job.is_terminal for job in polled):
+                if watch > 1:
+                    console.print("[dim]All polled jobs are terminal; stopping.[/dim]")
+                return
+
+            # Sleep between ticks, but not after the last one.
+            if tick < watch:
+                _time.sleep(interval)
     finally:
         manager.shutdown()
 

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -792,6 +792,24 @@ def list_jobs(cli_root: Path | None, show_all: bool, limit: int):
         manager.shutdown()
 
 
+def _resolve_job_by_prefix(manager, job_id: str):
+    """Resolve *job_id* against the manager's jobs, allowing a prefix.
+
+    Exits with a helpful message on no-match or ambiguous-match so
+    every CLI subcommand that takes a job id behaves identically.
+    """
+    candidates = [j for j in manager.list_jobs() if j.id.startswith(job_id)]
+    if not candidates:
+        console.print(f"[red]No job matching id prefix {job_id!r}.[/red]")
+        raise SystemExit(1)
+    if len(candidates) > 1:
+        console.print(f"[red]Ambiguous prefix {job_id!r} matches {len(candidates)} jobs:[/red]")
+        for job in candidates:
+            console.print(f"  {job.id}  {job.state.value}  {job.raw_path.name}")
+        raise SystemExit(1)
+    return candidates[0]
+
+
 @jobs_group.command("cancel")
 @click.argument("job_id")
 @click.option(
@@ -807,22 +825,311 @@ def cancel_job(job_id: str, cli_root: Path | None):
     manager = _make_job_manager_for_root(root)
 
     try:
-        # Allow prefix match for convenience.
-        candidates = [j for j in manager.list_jobs() if j.id.startswith(job_id)]
-        if not candidates:
-            console.print(f"[red]No job matching id prefix {job_id!r}.[/red]")
-            raise SystemExit(1)
-        if len(candidates) > 1:
-            console.print(f"[red]Ambiguous prefix {job_id!r} matches {len(candidates)} jobs:[/red]")
-            for job in candidates:
-                console.print(f"  {job.id}  {job.state.value}  {job.raw_path.name}")
-            raise SystemExit(1)
-
-        job = manager.cancel(candidates[0].id)
+        target = _resolve_job_by_prefix(manager, job_id)
+        job = manager.cancel(target.id)
         if job is None:
             console.print(f"[red]Unknown job id {job_id!r}.[/red]")
             raise SystemExit(1)
         console.print(f"[green]Cancelled[/green] job {job.id} (state={job.state.value})")
+    finally:
+        manager.shutdown()
+
+
+@jobs_group.command("poll")
+@click.argument("job_id", required=False)
+@click.option(
+    "--root",
+    "cli_root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Recordings root (defaults to recordings.root_dir from config).",
+)
+def poll_jobs(job_id: str | None, cli_root: Path | None):
+    """Run one poll cycle against in-flight jobs and print their state.
+
+    Without an argument, polls every in-flight job. With JOB_ID (prefix
+    match accepted), polls only that job. Useful for asynchronous
+    backends like Auphonic when you don't want to run the full
+    dashboard just to check on progress — it runs exactly one poll
+    tick, prints the result, and exits.
+
+    Transient errors (network blips, HTTP 5xx, schema drift) are
+    recorded on the job's ``last_poll_error`` but do NOT mark the job
+    failed; the next poll tick will retry. Permanent errors (HTTP
+    401/403/404/410, explicit Auphonic ERROR status) mark the job
+    failed immediately.
+    """
+    root = _resolve_recordings_root(cli_root)
+    manager = _make_job_manager_for_root(root)
+
+    try:
+        target_id: str | None = None
+        if job_id is not None:
+            target = _resolve_job_by_prefix(manager, job_id)
+            if target.is_terminal:
+                console.print(
+                    f"[yellow]Job {target.id[:8]} is already {target.state.value}; "
+                    "nothing to poll.[/yellow]"
+                )
+                return
+            target_id = target.id
+
+        polled = manager.poll_once(job_id=target_id)
+        if not polled:
+            if target_id is not None:
+                console.print(
+                    "[yellow]Job is not in a pollable state "
+                    "(must be processing/uploading/downloading).[/yellow]"
+                )
+            else:
+                console.print("[dim]No in-flight jobs to poll.[/dim]")
+            return
+
+        table = Table(title="Poll result")
+        table.add_column("ID", style="dim")
+        table.add_column("State")
+        table.add_column("Progress")
+        table.add_column("Message")
+        table.add_column("Last poll error", style="yellow")
+        for job in polled:
+            state_style = {
+                "completed": "green",
+                "failed": "red",
+                "cancelled": "yellow",
+            }.get(job.state.value, "blue")
+            table.add_row(
+                job.id[:8],
+                f"[{state_style}]{job.state.value}[/{state_style}]",
+                f"{int(job.progress * 100)}%",
+                (job.error or job.message or "")[:60],
+                (job.last_poll_error or "")[:60],
+            )
+        console.print(table)
+    finally:
+        manager.shutdown()
+
+
+@jobs_group.command("wait")
+@click.argument("job_id")
+@click.option(
+    "--root",
+    "cli_root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Recordings root (defaults to recordings.root_dir from config).",
+)
+@click.option(
+    "--interval",
+    type=float,
+    default=30.0,
+    show_default=True,
+    help="Seconds between poll ticks.",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Give up after this many seconds (default: wait forever).",
+)
+def wait_job(
+    job_id: str,
+    cli_root: Path | None,
+    interval: float,
+    timeout: float | None,
+):
+    """Block until JOB_ID reaches a terminal state.
+
+    Runs poll cycles at ``--interval`` (default 30s) and prints each
+    state transition, exiting when the job is completed, failed, or
+    cancelled. Use ``--timeout`` to give up after N seconds. A simple
+    alternative to ``clm recordings serve`` when you only care about
+    one specific job.
+
+    Transient poll errors are surfaced but do NOT end the wait — the
+    next tick retries. Use Ctrl+C to abort.
+    """
+    import time
+
+    from clm.recordings.workflow.jobs import JobState
+
+    root = _resolve_recordings_root(cli_root)
+    manager = _make_job_manager_for_root(root)
+
+    try:
+        target = _resolve_job_by_prefix(manager, job_id)
+        if target.is_terminal:
+            console.print(f"[yellow]Job {target.id[:8]} is already {target.state.value}.[/yellow]")
+            return
+
+        started_at = time.monotonic()
+        last_state: JobState | None = None
+        last_message: str | None = None
+        last_poll_error: str | None = None
+
+        while True:
+            polled = manager.poll_once(job_id=target.id)
+            current = manager.get(target.id)
+            if current is None:
+                console.print(f"[red]Job {target.id[:8]} disappeared from store.[/red]")
+                raise SystemExit(1)
+
+            # Print on any state/message/error transition.
+            if (
+                current.state != last_state
+                or current.message != last_message
+                or current.last_poll_error != last_poll_error
+            ):
+                state_style = {
+                    "completed": "green",
+                    "failed": "red",
+                    "cancelled": "yellow",
+                }.get(current.state.value, "blue")
+                line = (
+                    f"[{state_style}]{current.state.value}[/{state_style}]"
+                    f"  {int(current.progress * 100):3d}%  {current.message or ''}"
+                )
+                if current.last_poll_error:
+                    line += f"  [yellow](transient: {current.last_poll_error[:60]})[/yellow]"
+                console.print(line)
+                last_state = current.state
+                last_message = current.message
+                last_poll_error = current.last_poll_error
+
+            if current.is_terminal:
+                if current.state == JobState.COMPLETED:
+                    console.print(f"\n[green]Done.[/green] Output: {current.final_path}")
+                elif current.state == JobState.FAILED:
+                    console.print(f"\n[red]Failed: {current.error}[/red]")
+                    raise SystemExit(1)
+                else:
+                    console.print(f"\n[yellow]Terminated: {current.state.value}[/yellow]")
+                return
+
+            if polled == []:
+                # Nothing happened — job state didn't allow a poll. That
+                # means someone else (dashboard) moved it out of an
+                # in-flight state between our get() and our poll. Bail.
+                console.print(
+                    f"[yellow]Job {target.id[:8]} is no longer in a pollable state.[/yellow]"
+                )
+                return
+
+            if timeout is not None and (time.monotonic() - started_at) >= timeout:
+                console.print(
+                    f"[yellow]Timed out after {timeout}s; job is still {current.state.value}.[/yellow]"
+                )
+                raise SystemExit(2)
+
+            time.sleep(interval)
+    finally:
+        manager.shutdown()
+
+
+@jobs_group.command("prune")
+@click.option(
+    "--root",
+    "cli_root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Recordings root (defaults to recordings.root_dir from config).",
+)
+@click.option(
+    "--state",
+    "states",
+    type=click.Choice(["completed", "failed", "cancelled", "terminal"]),
+    multiple=True,
+    default=("failed", "cancelled"),
+    help=(
+        "Job state(s) to prune. May be given multiple times. "
+        "'terminal' expands to completed+failed+cancelled. "
+        "Default: failed+cancelled."
+    ),
+)
+@click.option(
+    "--id",
+    "job_id",
+    default=None,
+    help="Prune only the job with this id (prefix match). "
+    "Overrides --state; refuses to prune in-flight jobs.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt.",
+)
+def prune_jobs(
+    cli_root: Path | None,
+    states: tuple[str, ...],
+    job_id: str | None,
+    assume_yes: bool,
+):
+    """Delete terminal jobs from the on-disk store.
+
+    In-flight jobs (queued/uploading/processing/downloading) are
+    never pruned — cancel them first with ``jobs cancel`` if you
+    want them gone.
+    """
+    from clm.recordings.workflow.jobs import JobState
+
+    root = _resolve_recordings_root(cli_root)
+    manager = _make_job_manager_for_root(root)
+
+    try:
+        if job_id is not None:
+            target = _resolve_job_by_prefix(manager, job_id)
+            if not target.is_terminal:
+                console.print(
+                    f"[red]Refusing to prune in-flight job {target.id[:8]} "
+                    f"(state={target.state.value}). Cancel it first with "
+                    f"'clm recordings jobs cancel {target.id[:8]}'.[/red]"
+                )
+                raise SystemExit(1)
+            victims = [target]
+        else:
+            # Expand 'terminal' shorthand.
+            wanted_states: set[JobState] = set()
+            for s in states:
+                if s == "terminal":
+                    wanted_states.update({JobState.COMPLETED, JobState.FAILED, JobState.CANCELLED})
+                else:
+                    wanted_states.add(JobState(s))
+            victims = [j for j in manager.list_jobs() if j.state in wanted_states]
+
+        if not victims:
+            console.print("[dim]No matching jobs to prune.[/dim]")
+            return
+
+        table = Table(title=f"About to prune {len(victims)} job(s)")
+        table.add_column("ID", style="dim")
+        table.add_column("State")
+        table.add_column("Input")
+        table.add_column("Message")
+        for job in victims:
+            state_style = {
+                "completed": "green",
+                "failed": "red",
+                "cancelled": "yellow",
+            }.get(job.state.value, "blue")
+            table.add_row(
+                job.id[:8],
+                f"[{state_style}]{job.state.value}[/{state_style}]",
+                job.raw_path.name,
+                (job.error or job.message or "")[:60],
+            )
+        console.print(table)
+
+        if not assume_yes:
+            if not click.confirm(f"Delete these {len(victims)} job(s) from the store?"):
+                console.print("[yellow]Aborted.[/yellow]")
+                return
+
+        deleted = 0
+        for job in victims:
+            if manager.delete_job(job.id):
+                deleted += 1
+        console.print(f"[green]Pruned[/green] {deleted} job(s).")
     finally:
         manager.shutdown()
 

--- a/src/clm/recordings/workflow/backends/auphonic_client.py
+++ b/src/clm/recordings/workflow/backends/auphonic_client.py
@@ -34,7 +34,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 if TYPE_CHECKING:  # pragma: no cover — only for type checking
     import httpx
@@ -101,6 +101,12 @@ class AuphonicOutputFile(BaseModel):
     only the ones the backend uses (download URL + format + optional
     ending). Unknown fields are ignored via ``extra="ignore"`` so the
     client is robust to Auphonic adding fields in the future.
+
+    Note on null handling: Auphonic frequently returns ``null`` for
+    string fields that are "not applicable yet" — e.g. ``download_url``
+    is ``null`` until a production has finished rendering its outputs.
+    The ``_none_to_empty`` validator coerces those to empty strings so
+    downstream truthy checks (``if not out.download_url``) keep working.
     """
 
     model_config = {"extra": "ignore"}
@@ -112,13 +118,20 @@ class AuphonicOutputFile(BaseModel):
     """File extension/type hint (e.g. ``"mp4"``, ``"DaVinciResolve.edl"``)."""
 
     download_url: str = ""
-    """Absolute URL for downloading this output; requires bearer auth."""
+    """Absolute URL for downloading this output; requires bearer auth.
+    Empty string until the production has finished rendering this output."""
 
     filename: str = ""
     """Filename Auphonic suggests for this output."""
 
     size: int | None = None
     """File size in bytes, if reported by the API."""
+
+    @field_validator("format", "ending", "download_url", "filename", mode="before")
+    @classmethod
+    def _none_to_empty(cls, value: Any) -> Any:
+        """Coerce ``None`` to ``""`` so unset Auphonic fields validate."""
+        return "" if value is None else value
 
 
 class AuphonicProduction(BaseModel):
@@ -127,6 +140,18 @@ class AuphonicProduction(BaseModel):
     We only parse what :class:`AuphonicBackend` cares about. Additional
     fields present in the API response (e.g. ``chapter_positions``) are
     ignored so backend code never has to track the full upstream schema.
+
+    Note on null handling: Auphonic returns ``null`` for several string
+    fields when they are "not applicable yet" — e.g. ``error_status`` is
+    ``null`` on a freshly created production that has never errored. The
+    ``_none_to_empty`` validator coerces those to empty strings so the
+    model validates successfully on every production lifecycle state.
+
+    Note on ``used_credits``: the current Auphonic API returns a nested
+    dict ``{"recurring": …, "onetime": …, "combined": …}`` (credit-source
+    breakdown). Older API versions returned a plain float. The field
+    accepts both shapes; use :attr:`used_credits_combined` for a single
+    number regardless of response version.
     """
 
     model_config = {"extra": "ignore"}
@@ -138,8 +163,36 @@ class AuphonicProduction(BaseModel):
     error_status: str = ""
     output_files: list[AuphonicOutputFile] = Field(default_factory=list)
     length: float | None = None
-    used_credits: float | None = None
+    used_credits: dict[str, Any] | float | None = None
     warning_message: str = ""
+
+    @field_validator(
+        "status_string",
+        "error_message",
+        "error_status",
+        "warning_message",
+        mode="before",
+    )
+    @classmethod
+    def _none_to_empty(cls, value: Any) -> Any:
+        """Coerce ``None`` to ``""`` so unset Auphonic fields validate."""
+        return "" if value is None else value
+
+    @property
+    def used_credits_combined(self) -> float | None:
+        """Return the total credits used for this production, if known.
+
+        Handles both response shapes: a plain float (older API) and a
+        ``{"recurring": …, "onetime": …, "combined": …}`` dict (current
+        API). Returns ``None`` when the field is absent.
+        """
+        credits = self.used_credits
+        if credits is None:
+            return None
+        if isinstance(credits, dict):
+            value = credits.get("combined")
+            return float(value) if value is not None else None
+        return float(credits)
 
 
 class AuphonicPreset(BaseModel):

--- a/src/clm/recordings/workflow/job_manager.py
+++ b/src/clm/recordings/workflow/job_manager.py
@@ -41,6 +41,44 @@ JOB_EVENT_TOPIC = "job"
 #: Individual backends may override via ``JobManager(poll_interval=…)``.
 DEFAULT_POLL_INTERVAL_SECONDS = 30.0
 
+#: HTTP status codes that make a poll error permanent (won't recover
+#: on retry). Everything else — including 5xx, 408, 429, network
+#: errors, and schema drift — is treated as transient so the next
+#: poll cycle can retry.
+#:
+#: * 401 Unauthorized — API key is wrong or revoked.
+#: * 403 Forbidden — account lacks permission for this action.
+#: * 404 Not Found — the backend production has been deleted.
+#: * 410 Gone — same as 404 but upstream is explicit about it.
+_PERMANENT_POLL_HTTP_STATUSES = frozenset({401, 403, 404, 410})
+
+
+def _is_permanent_poll_error(exc: BaseException) -> bool:
+    """Return ``True`` if *exc* will not be fixed by retrying the poll.
+
+    Used by :meth:`JobManager._poll_once` to decide whether a poll
+    exception should drive the job to :attr:`JobState.FAILED`
+    immediately or just be recorded on
+    :attr:`~clm.recordings.workflow.jobs.ProcessingJob.last_poll_error`
+    so the next tick can retry. The rationale for the specific
+    classification lives on :data:`_PERMANENT_POLL_HTTP_STATUSES`.
+
+    We deliberately treat **unknown exceptions** as transient: losing
+    a completed Auphonic production to an unhandled blip is worse
+    than leaving a stuck job in the list for a user to notice. The
+    ``last_poll_error`` field makes the stuck state visible.
+    """
+    # Lazy import to avoid a hard dependency on the auphonic backend
+    # from the manager module (other backends may not be installed).
+    try:
+        from clm.recordings.workflow.backends.auphonic_client import AuphonicHTTPError
+    except ImportError:  # pragma: no cover — defensive
+        return False
+
+    if isinstance(exc, AuphonicHTTPError):
+        return exc.status_code in _PERMANENT_POLL_HTTP_STATUSES
+    return False
+
 
 class _DefaultJobContext:
     """Default :class:`JobContext` implementation wired to a manager and bus."""
@@ -207,6 +245,32 @@ class JobManager:
         self._bus.publish(JOB_EVENT_TOPIC, job)
         return job
 
+    def delete_job(self, job_id: str) -> bool:
+        """Remove *job_id* from memory and the on-disk store.
+
+        Refuses to delete in-flight jobs (queued/uploading/processing/
+        downloading) — callers should cancel them first. Safe to call
+        for unknown ids; returns ``False`` in that case.
+
+        Returns:
+            ``True`` if a job was actually removed, ``False`` if the
+            id was unknown or the job was in-flight (not deleted).
+        """
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return False
+            if not job.is_terminal:
+                logger.warning(
+                    "Refusing to delete in-flight job {} (state={})",
+                    job.id,
+                    job.state.value,
+                )
+                return False
+            del self._jobs[job_id]
+        self._store.delete(job_id)
+        return True
+
     def shutdown(self, *, timeout: float | None = 5.0) -> None:
         """Stop the poller thread and wait for it to exit.
 
@@ -268,32 +332,94 @@ class JobManager:
 
     def _poller_loop(self) -> None:
         while not self._stop.is_set():
-            self._poll_once()
+            self.poll_once()
             self._stop.wait(self._poll_interval)
 
-    def _poll_once(self) -> None:
+    def poll_once(self, *, job_id: str | None = None) -> list[ProcessingJob]:
+        """Run a single poll cycle and return the jobs that were polled.
+
+        By default polls every in-flight job (``PROCESSING``,
+        ``UPLOADING``, ``DOWNLOADING``). Passing *job_id* narrows to a
+        single job — useful for the ``clm recordings jobs poll`` CLI
+        which lets the user drive one specific job without running the
+        dashboard. Unknown or terminal ids are silently skipped (no
+        error) so a prefix-match caller doesn't have to re-check.
+
+        On exception from the backend, the error is classified:
+
+        * Permanent errors (see :func:`_is_permanent_poll_error`) drive
+          the job to :attr:`JobState.FAILED` with ``error`` set.
+        * Transient errors (network blips, HTTP 5xx, schema drift,
+          unknown exceptions) are recorded on
+          :attr:`ProcessingJob.last_poll_error` but the job's
+          ``state`` is left unchanged — the next tick will retry.
+
+        Both permanent and transient error paths persist the job and
+        publish a ``job`` event so the UI stays in sync.
+
+        Returns:
+            The list of ``ProcessingJob`` instances that were polled,
+            in their post-tick state. Empty if there were no in-flight
+            jobs (or if *job_id* didn't match a pollable job).
+        """
         with self._lock:
-            in_flight = [
-                job
-                for job in self._jobs.values()
-                if job.state in (JobState.PROCESSING, JobState.UPLOADING, JobState.DOWNLOADING)
-            ]
+            if job_id is not None:
+                candidate = self._jobs.get(job_id)
+                in_flight = (
+                    [candidate]
+                    if candidate is not None
+                    and candidate.state
+                    in (JobState.PROCESSING, JobState.UPLOADING, JobState.DOWNLOADING)
+                    else []
+                )
+            else:
+                in_flight = [
+                    job
+                    for job in self._jobs.values()
+                    if job.state in (JobState.PROCESSING, JobState.UPLOADING, JobState.DOWNLOADING)
+                ]
 
         if not in_flight:
-            return
+            return []
 
+        polled: list[ProcessingJob] = []
         ctx = self._make_context()
         for job in in_flight:
             try:
                 updated = self._backend.poll(job, ctx=ctx)
             except Exception as exc:
-                logger.exception("Poll failed for {}: {}", job.id, exc)
-                job.state = JobState.FAILED
-                job.error = str(exc)
+                if _is_permanent_poll_error(exc):
+                    logger.error(
+                        "Permanent poll error for {}, marking FAILED: {}",
+                        job.id,
+                        exc,
+                    )
+                    job.state = JobState.FAILED
+                    job.error = str(exc)
+                    job.last_poll_error = None
+                else:
+                    logger.warning(
+                        "Transient poll error for {} (will retry next tick): {}",
+                        job.id,
+                        exc,
+                    )
+                    job.last_poll_error = str(exc)
                 job.touch()
                 self._store_job(job)
                 self._bus.publish(JOB_EVENT_TOPIC, job)
+                polled.append(job)
                 continue
 
+            # Successful poll: clear any lingering transient-error
+            # marker so the user sees a clean state next time they
+            # run `clm recordings jobs list`.
+            updated.last_poll_error = None
             self._store_job(updated)
             self._bus.publish(JOB_EVENT_TOPIC, updated)
+            polled.append(updated)
+        return polled
+
+    # Kept for backwards compatibility with any external caller that
+    # was reaching into the manager. New code should call ``poll_once``.
+    def _poll_once(self) -> None:
+        self.poll_once()

--- a/src/clm/recordings/workflow/job_manager.py
+++ b/src/clm/recordings/workflow/job_manager.py
@@ -245,6 +245,49 @@ class JobManager:
         self._bus.publish(JOB_EVENT_TOPIC, job)
         return job
 
+    def mark_failed(self, job_id: str, *, reason: str) -> ProcessingJob | None:
+        """Manually transition *job_id* to :attr:`JobState.FAILED`.
+
+        Unlike :meth:`cancel`, this does **not** call the backend's
+        ``cancel`` hook — the remote production (e.g. an Auphonic
+        production) is left untouched so the user can still download
+        it manually or inspect it upstream. Intended for rescuing
+        stuck jobs whose backend work is fine but whose local poll
+        loop is wedged (e.g. repeated transient errors that aren't
+        going to clear on their own).
+
+        Refuses already-terminal jobs so users can't accidentally
+        overwrite a genuine COMPLETED/CANCELLED state with a manual
+        FAILED.
+
+        Args:
+            job_id: The job to transition.
+            reason: Stored on ``job.error`` so it shows up in
+                ``jobs list``. Required — no silent defaults.
+
+        Returns:
+            The updated :class:`ProcessingJob`, or ``None`` if the id
+            is unknown or the job is already terminal.
+        """
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            if job.is_terminal:
+                logger.warning(
+                    "Refusing to mark already-terminal job {} as failed (current state={})",
+                    job.id,
+                    job.state.value,
+                )
+                return None
+            job.state = JobState.FAILED
+            job.error = reason
+            job.last_poll_error = None
+            job.touch()
+        self._store_job(job)
+        self._bus.publish(JOB_EVENT_TOPIC, job)
+        return job
+
     def delete_job(self, job_id: str) -> bool:
         """Remove *job_id* from memory and the on-disk store.
 

--- a/src/clm/recordings/workflow/jobs.py
+++ b/src/clm/recordings/workflow/jobs.py
@@ -154,6 +154,21 @@ class ProcessingJob(BaseModel):
     error: str | None = None
     """Populated when ``state`` is :attr:`JobState.FAILED`."""
 
+    last_poll_error: str | None = None
+    """Most recent transient poll error, if any.
+
+    Populated when the last poll cycle raised a transient exception
+    (network timeout, HTTP 5xx, rate limit, schema drift, …) and the
+    :class:`~clm.recordings.workflow.job_manager.JobManager` deliberately
+    left the job in its current state so the next tick can retry. Does
+    **not** imply ``state == FAILED`` — check :attr:`state` for that.
+    Cleared to ``None`` on the first successful poll.
+
+    Surfaced in ``clm recordings jobs list`` so the user can see why a
+    long-running job appears stuck even though it hasn't been marked
+    failed.
+    """
+
     artifacts: dict[str, Path] = Field(default_factory=dict)
     """Extra outputs keyed by kind (``"cut_list"``, ``"transcript"``, …)."""
 

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -269,6 +269,15 @@ class TestConfigHelpers:
     def test_find_config_files_empty(self, tmp_path, monkeypatch):
         """Test find_config_files when no config files exist."""
         monkeypatch.chdir(tmp_path)
+        # Isolate from any real user-config on the developer's machine
+        # (platformdirs would otherwise resolve to %LOCALAPPDATA%/clm on
+        # Windows or ~/.config/clm on Linux, and the test would fail if
+        # the developer happens to have a real clm config installed).
+        fake_user_config_dir = tmp_path / "user_config_home"
+        monkeypatch.setattr(
+            "clm.infrastructure.config.platformdirs.user_config_dir",
+            lambda *args, **kwargs: str(fake_user_config_dir),
+        )
 
         config_files = find_config_files()
         assert config_files["system"] is None

--- a/tests/recordings/test_auphonic_client.py
+++ b/tests/recordings/test_auphonic_client.py
@@ -99,6 +99,224 @@ class TestCreateProduction:
         assert info.value.status_code == 400
         assert "Bad metadata" in info.value.body
 
+    def test_null_string_fields_are_coerced_to_empty(self, client: AuphonicClient) -> None:
+        """Real Auphonic returns ``null`` for not-yet-applicable strings.
+
+        Regression test: ``error_status`` and every output's
+        ``download_url`` are ``null`` on a freshly created production
+        (no error yet, outputs not rendered yet). Pydantic rejected this
+        before we added the ``_none_to_empty`` validator, breaking the
+        happy path of ``clm recordings submit``.
+        """
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.post("/api/productions.json").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "status_code": 200,
+                        "error_code": None,
+                        "error_message": "",
+                        "form_errors": {},
+                        "data": {
+                            "uuid": "7Sg2vazmofYAmN2pHWah5S",
+                            "status": AuphonicStatus.INCOMPLETE_FORM,
+                            "status_string": "Incomplete Form",
+                            "error_status": None,
+                            "warning_message": None,
+                            "output_files": [
+                                {
+                                    "format": "video",
+                                    "ending": "mp4",
+                                    "download_url": None,
+                                    "filename": None,
+                                },
+                                {
+                                    "format": "cut-list",
+                                    "ending": "DaVinciResolve.edl",
+                                    "download_url": None,
+                                },
+                            ],
+                        },
+                    },
+                )
+            )
+            production = client.create_production(
+                metadata={"title": "Smoke Test"},
+                preset="CLM Lecture Recording",
+                output_files=[
+                    {"format": "video"},
+                    {"format": "cut-list"},
+                ],
+            )
+        assert production.uuid == "7Sg2vazmofYAmN2pHWah5S"
+        assert production.error_status == ""
+        assert production.warning_message == ""
+        assert len(production.output_files) == 2
+        assert production.output_files[0].download_url == ""
+        assert production.output_files[0].filename == ""
+        assert production.output_files[1].download_url == ""
+
+    def test_realistic_done_production_response(self, client: AuphonicClient) -> None:
+        """Validate against a full real-API DONE response.
+
+        Captured from a real production on 2026-04-12 during the
+        Auphonic smoke test. Exercises fields that the hand-crafted
+        happy-path fixtures missed: dict-shaped ``used_credits``, extra
+        ignored fields (``algorithms``, ``statistics``, ``chapters``,
+        ``speech_recognition``, ``metadata``, …), and output-file
+        metadata (``checksum``, ``size_string``, ``mono_mixdown``, …).
+
+        If Auphonic changes its response shape again, this test will
+        catch it without a round-trip through the real API.
+        """
+        realistic_payload = {
+            "status_code": 200,
+            "error_code": None,
+            "error_message": "",
+            "form_errors": {},
+            "data": {
+                "uuid": "ShfFXnXeAiHoB8U4uFJQS3",
+                "status": AuphonicStatus.DONE,
+                "status_string": "Done",
+                "error_message": "",
+                "error_status": None,
+                "warning_message": "",
+                "warning_status": None,
+                "length": 20.009319727891157,
+                "length_timestring": "00:00:20.009",
+                "used_credits": {
+                    "recurring": 0.0,
+                    "onetime": 0.05,
+                    "combined": 0.05,
+                },
+                "bitrate": 191.987,
+                "channels": 2,
+                "samplerate": 48000,
+                "format": "aac",
+                "has_video": True,
+                "input_file": "smoke--RAW.mp4",
+                "output_basename": "smoke--RAW",
+                "preset": "vS7YnceijKxUURDL6uZX3H",
+                "change_allowed": True,
+                "start_allowed": False,
+                "in_review": False,
+                "is_multitrack": False,
+                "review_before_publishing": False,
+                "cut_start": 0.0,
+                "cut_end": 0.0,
+                "creation_time": "2026-04-12T01:41:00.795Z",
+                "change_time": "2026-04-12T01:41:14.024Z",
+                "image": None,
+                "service": None,
+                "shownotes": None,
+                "thumbnail": None,
+                "webhook": None,
+                "chapters": [],
+                "cuts": [],
+                "multi_input_files": [],
+                "outgoing_services": [],
+                "edit_page": "https://auphonic.com/engine/upload/edit/ShfFXnXeAiHoB8U4uFJQS3",
+                "status_page": "https://auphonic.com/engine/status/ShfFXnXeAiHoB8U4uFJQS3",
+                "waveform_image": "https://auphonic.com/api/download/audio-result/ShfFXnXeAiHoB8U4uFJQS3/waveform.png",
+                "algorithms": {
+                    "filtering": True,
+                    "filtermethod": "autoeq",
+                    "leveler": True,
+                    "levelermode": "default",
+                    "compressor_speech": "auto",
+                },
+                "metadata": {
+                    "album": "",
+                    "subtitle": "",
+                    "license": "",
+                    "summary": "",
+                    "artist": "Matthias Hölzl",
+                    "track": "",
+                    "title": "smoke",
+                },
+                "speech_recognition": {
+                    "uuid": "atUCUJm5EYLRUUKSv8LMHm",
+                    "keywords": [""],
+                    "type": "whisper",
+                    "language": "auto",
+                    "shownotes": False,
+                },
+                "statistics": {
+                    "levels": {
+                        "input": {
+                            "signal_level": [-32.35, "dB"],
+                            "noise_level": [-73.14, "dB"],
+                            "snr": [40.79, "dB"],
+                        }
+                    }
+                },
+                "output_files": [
+                    {
+                        "format": "video",
+                        "ending": "mp4",
+                        "download_url": "https://auphonic.com/api/download/audio-result/ShfFXnXeAiHoB8U4uFJQS3/smoke--RAW.mp4",
+                        "filename": "smoke--RAW.mp4",
+                        "checksum": "96673128a7092c25039dc5bf5c63a312",
+                        "size": 1335528,
+                        "size_string": "1.3 MB",
+                        "bitrate": 191,
+                        "mono_mixdown": False,
+                        "split_on_chapters": False,
+                        "suffix": "",
+                        "outgoing_services": [],
+                    }
+                ],
+            },
+        }
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.get("/api/production/ShfFXnXeAiHoB8U4uFJQS3.json").mock(
+                return_value=httpx.Response(200, json=realistic_payload)
+            )
+            production = client.get_production("ShfFXnXeAiHoB8U4uFJQS3")
+
+        assert production.uuid == "ShfFXnXeAiHoB8U4uFJQS3"
+        assert production.status == AuphonicStatus.DONE
+        assert production.status_string == "Done"
+        assert production.error_status == ""  # coerced from None
+        assert production.warning_message == ""
+        assert production.length == pytest.approx(20.009319727891157)
+        # used_credits preserves the dict shape
+        assert isinstance(production.used_credits, dict)
+        assert production.used_credits["combined"] == 0.05
+        # …and the convenience accessor returns the combined total
+        assert production.used_credits_combined == pytest.approx(0.05)
+        # Output file parsing still works with extra fields present
+        assert len(production.output_files) == 1
+        output = production.output_files[0]
+        assert output.format == "video"
+        assert output.ending == "mp4"
+        assert output.download_url.endswith("/smoke--RAW.mp4")
+        assert output.filename == "smoke--RAW.mp4"
+        assert output.size == 1335528
+
+    def test_used_credits_combined_accepts_plain_float(self, client: AuphonicClient) -> None:
+        """Legacy API shape: ``used_credits`` as a plain float.
+
+        Keeps backward compatibility with older Auphonic responses
+        (and any staging deploys that still return the simpler shape).
+        """
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.get("/api/production/legacy.json").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "uuid": "legacy",
+                            "status": AuphonicStatus.DONE,
+                            "used_credits": 0.12,
+                        }
+                    },
+                )
+            )
+            production = client.get_production("legacy")
+        assert production.used_credits == 0.12
+        assert production.used_credits_combined == pytest.approx(0.12)
+
 
 # ---------------------------------------------------------------------
 # get_production / start_production / delete_production

--- a/tests/recordings/test_cli_recordings.py
+++ b/tests/recordings/test_cli_recordings.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 from click.testing import CliRunner
 
 from clm.cli.commands.recordings import recordings_group
@@ -29,6 +32,164 @@ class TestRecordingsGroup:
 
         command_names = list(cli.commands)
         assert "recordings" in command_names
+
+
+class TestJobsSubcommands:
+    """Smoke tests for the new jobs subcommands (poll/prune/wait).
+
+    These verify click-level registration and the main safety guards.
+    Deep logic lives on :class:`JobManager` and has its own unit tests;
+    here we just want to make sure the CLI wires up correctly and
+    refuses dangerous operations (prune of in-flight jobs).
+    """
+
+    def test_jobs_subcommands_registered(self):
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "--help"])
+        assert result.exit_code == 0
+        # The four jobs subcommands should all be listed.
+        assert "cancel" in result.output
+        assert "list" in result.output
+        assert "poll" in result.output
+        assert "prune" in result.output
+        assert "wait" in result.output
+
+    def _install_fake_manager(self, monkeypatch, tmp_path: Path):
+        """Return a pre-seeded JobManager and make the CLI use it.
+
+        Builds a real JobManager with a stub backend so we don't touch
+        the real user config, then monkeypatches the CLI's factory to
+        return that instance regardless of --root.
+        """
+        from clm.cli.commands import recordings as recordings_cli
+        from clm.recordings.workflow.backends.base import (
+            BackendCapabilities,
+            ProcessingBackend,
+        )
+        from clm.recordings.workflow.directories import ensure_root
+        from clm.recordings.workflow.event_bus import EventBus
+        from clm.recordings.workflow.job_manager import JobManager
+        from clm.recordings.workflow.job_store import JsonFileJobStore
+
+        class _StubBackend(ProcessingBackend):
+            capabilities = BackendCapabilities(
+                name="stub",
+                display_name="Stub",
+                is_synchronous=True,
+            )
+
+            def accepts_file(self, path: Path) -> bool:
+                return True
+
+            def submit(self, raw_path, final_path, *, options, ctx):
+                raise NotImplementedError
+
+            def poll(self, job, *, ctx):
+                return job
+
+            def cancel(self, job, *, ctx):
+                pass
+
+        ensure_root(tmp_path)
+        store = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        bus = EventBus()
+        manager = JobManager(
+            backend=_StubBackend(),
+            root_dir=tmp_path,
+            store=store,
+            bus=bus,
+        )
+        monkeypatch.setattr(
+            recordings_cli,
+            "_make_job_manager_for_root",
+            lambda root: manager,
+        )
+        monkeypatch.setattr(
+            recordings_cli,
+            "_resolve_recordings_root",
+            lambda cli_root: tmp_path,
+        )
+        return manager
+
+    def test_jobs_poll_with_no_jobs_reports_empty(self, tmp_path, monkeypatch):
+        self._install_fake_manager(monkeypatch, tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "poll"])
+        assert result.exit_code == 0, result.output
+        assert "No in-flight jobs" in result.output
+
+    def test_jobs_prune_deletes_failed_job(self, tmp_path, monkeypatch):
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        failed = ProcessingJob(
+            id="dead-dead-dead-dead",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "dead.mp4",
+            final_path=tmp_path / "final" / "dead.mp4",
+            relative_dir=Path(),
+            state=JobState.FAILED,
+            error="something broke",
+        )
+        manager._store_job(failed)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            ["jobs", "prune", "--yes", "--state", "failed"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Pruned 1 job" in result.output
+        assert manager.get(failed.id) is None
+
+    def test_jobs_prune_refuses_in_flight_job_by_id(self, tmp_path, monkeypatch):
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        in_flight = ProcessingJob(
+            id="live-live-live-live",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "live.mp4",
+            final_path=tmp_path / "final" / "live.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+        )
+        manager._store_job(in_flight)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            ["jobs", "prune", "--id", "live", "--yes"],
+        )
+        # Exits non-zero with a "cancel it first" warning.
+        assert result.exit_code == 1, result.output
+        assert "Refusing to prune in-flight job" in result.output
+        # Job is still in the store.
+        assert manager.get(in_flight.id) is not None
+
+    def test_jobs_poll_on_terminal_job_is_noop(self, tmp_path, monkeypatch):
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        done = ProcessingJob(
+            id="done-done-done-done",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "done.mp4",
+            final_path=tmp_path / "final" / "done.mp4",
+            relative_dir=Path(),
+            state=JobState.COMPLETED,
+            progress=1.0,
+            message="Done",
+        )
+        manager._store_job(done)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "poll", "done"])
+        assert result.exit_code == 0, result.output
+        assert "already completed" in result.output
 
 
 class TestRecordingsConfig:

--- a/tests/recordings/test_cli_recordings.py
+++ b/tests/recordings/test_cli_recordings.py
@@ -191,6 +191,211 @@ class TestJobsSubcommands:
         assert result.exit_code == 0, result.output
         assert "already completed" in result.output
 
+    def test_jobs_list_shows_last_poll_error_only_when_present(self, tmp_path, monkeypatch):
+        """The 'Last poll error' column should appear only if any job has one.
+
+        Keeps the healthy-state listing narrow. We assert on the
+        presence/absence of the error *content* rather than the header
+        string, because CliRunner captures Rich output at a narrow
+        terminal width that wraps column headers onto multiple lines.
+        """
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        # Short distinctive marker: the CliRunner captures Rich output
+        # at a narrow terminal width that truncates long cell values
+        # with an ellipsis, so we need something that fits in ~6 chars.
+        distinctive_error = "ZQZQ9"
+        healthy = ProcessingJob(
+            id="healthy-abcd-abcd-abcd",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "ok.mp4",
+            final_path=tmp_path / "final" / "ok.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.5,
+            message="Processing",
+        )
+        manager._store_job(healthy)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "list"])
+        assert result.exit_code == 0, result.output
+        # No transient error yet → the distinctive marker is absent.
+        assert distinctive_error not in result.output
+
+        # Now add a transient error and list again — the marker must
+        # appear somewhere in the output (i.e. the column is rendering).
+        healthy.last_poll_error = distinctive_error
+        manager._store_job(healthy)
+        result = runner.invoke(recordings_group, ["jobs", "list"])
+        assert result.exit_code == 0, result.output
+        assert distinctive_error in result.output
+
+    def test_jobs_fail_transitions_and_leaves_backend_alone(self, tmp_path, monkeypatch):
+        """jobs fail marks the job failed with the reason; backend untouched."""
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        stuck = ProcessingJob(
+            id="stuck-stuck-stuck-stuck",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "stuck.mp4",
+            final_path=tmp_path / "final" / "stuck.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            backend_ref="remote-xyz",
+        )
+        manager._store_job(stuck)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            ["jobs", "fail", "stuck", "--reason", "poll wedged"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Marked failed" in result.output
+        assert "poll wedged" in result.output
+        assert "not" in result.output  # "production was NOT cancelled"
+
+        after = manager.get(stuck.id)
+        assert after is not None
+        assert after.state == JobState.FAILED
+        assert after.error == "poll wedged"
+        # backend_ref preserved so the user can still manually retrieve.
+        assert after.backend_ref == "remote-xyz"
+
+    def test_jobs_fail_refuses_terminal_job(self, tmp_path, monkeypatch):
+        """You can't overwrite a COMPLETED job with a manual failure."""
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        done = ProcessingJob(
+            id="done-done-done-done",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "done.mp4",
+            final_path=tmp_path / "final" / "done.mp4",
+            relative_dir=Path(),
+            state=JobState.COMPLETED,
+            progress=1.0,
+            message="Done",
+        )
+        manager._store_job(done)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "fail", "done", "--reason", "nope"])
+        assert result.exit_code == 1, result.output
+        assert "already completed" in result.output
+
+        after = manager.get(done.id)
+        assert after is not None
+        assert after.state == JobState.COMPLETED
+        assert after.error is None
+
+    def test_jobs_poll_watch_rejects_zero(self, tmp_path, monkeypatch):
+        """--watch 0 is nonsense; click should reject it with BadParameter."""
+        self._install_fake_manager(monkeypatch, tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "poll", "--watch", "0"])
+        assert result.exit_code != 0, result.output
+
+    def test_jobs_poll_watch_stops_when_in_flight_clears(self, tmp_path, monkeypatch):
+        """--watch > 1 should break early when nothing is in-flight anymore.
+
+        With a stub backend whose poll() completes the job on the first
+        tick, watch=5 should finish after 1 tick, not sleep 4 times.
+        Verified indirectly via wall-clock time (no sleep called).
+        """
+        from clm.recordings.workflow.backends.base import (
+            BackendCapabilities,
+            ProcessingBackend,
+        )
+        from clm.recordings.workflow.directories import ensure_root
+        from clm.recordings.workflow.event_bus import EventBus
+        from clm.recordings.workflow.job_manager import JobManager
+        from clm.recordings.workflow.job_store import JsonFileJobStore
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        class _CompletesOnFirstPoll(ProcessingBackend):
+            capabilities = BackendCapabilities(
+                name="stub",
+                display_name="Stub",
+                is_synchronous=False,
+            )
+
+            def accepts_file(self, path):
+                return True
+
+            def submit(self, raw_path, final_path, *, options, ctx):
+                raise NotImplementedError
+
+            def poll(self, job, *, ctx):
+                job.state = JobState.COMPLETED
+                job.progress = 1.0
+                job.message = "Done"
+                return job
+
+            def cancel(self, job, *, ctx):
+                pass
+
+        ensure_root(tmp_path)
+        store = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        bus = EventBus()
+        manager = JobManager(
+            backend=_CompletesOnFirstPoll(),
+            root_dir=tmp_path,
+            store=store,
+            bus=bus,
+        )
+        job = ProcessingJob(
+            id="one-tick-one-tick",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "x.mp4",
+            final_path=tmp_path / "final" / "x.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+        )
+        manager._store_job(job)
+
+        from clm.cli.commands import recordings as recordings_cli
+
+        monkeypatch.setattr(
+            recordings_cli,
+            "_make_job_manager_for_root",
+            lambda root: manager,
+        )
+        monkeypatch.setattr(
+            recordings_cli,
+            "_resolve_recordings_root",
+            lambda cli_root: tmp_path,
+        )
+
+        # Fail the test loudly if the CLI actually sleeps: large watch
+        # + tiny timeout, and if we wait even a single second we know
+        # the early-stop path is broken.
+        import time
+
+        sleep_called = 0
+
+        def fake_sleep(seconds: float) -> None:
+            nonlocal sleep_called
+            sleep_called += 1
+
+        monkeypatch.setattr(time, "sleep", fake_sleep)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            ["jobs", "poll", "--watch", "5", "--interval", "0.01"],
+        )
+        assert result.exit_code == 0, result.output
+        # One tick ran, the job hit COMPLETED, loop broke — no sleeps.
+        assert sleep_called == 0
+        assert manager.get(job.id).state == JobState.COMPLETED
+
 
 class TestRecordingsConfig:
     def test_recordings_config_in_clm_config(self):

--- a/tests/recordings/test_job_manager.py
+++ b/tests/recordings/test_job_manager.py
@@ -327,6 +327,80 @@ class TestJobManagerSynchronousBackend:
         manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
         assert manager.delete_job("does-not-exist") is False
 
+    def test_mark_failed_transitions_in_flight_job(self, tmp_path: Path):
+        """mark_failed on an in-flight job sets state=FAILED with the reason."""
+        manager, _, _ = _make_manager(tmp_path, _AsyncFakeBackend())
+        raw = _make_raw_path(tmp_path)
+        job = ProcessingJob(
+            id="stuck-job",
+            backend_name="async-fake",
+            raw_path=raw,
+            final_path=tmp_path / "final" / "lecture.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.4,
+            message="Processing on Auphonic",
+            backend_ref="fake-ref",
+            last_poll_error="connection timed out",
+        )
+        manager._store_job(job)
+
+        updated = manager.mark_failed(job.id, reason="user gave up on retry")
+        assert updated is not None
+        assert updated.state == JobState.FAILED
+        assert updated.error == "user gave up on retry"
+        # Transient-error marker is cleared so the UI doesn't show both.
+        assert updated.last_poll_error is None
+        # Persisted through the store.
+        reopened = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        persisted = {j.id: j for j in reopened.load_all()}
+        assert persisted[job.id].state == JobState.FAILED
+        assert persisted[job.id].error == "user gave up on retry"
+
+    def test_mark_failed_does_not_call_backend_cancel(self, tmp_path: Path):
+        """mark_failed must NOT delete the remote production.
+
+        The whole point of `jobs fail` vs `jobs cancel` is that the
+        user wants to preserve the remote work — maybe to download
+        it manually later. If mark_failed called backend.cancel we'd
+        silently blow that away.
+        """
+        backend = _AsyncFakeBackend()
+        manager, _, _ = _make_manager(tmp_path, backend)
+        job = ProcessingJob(
+            id="preserve-remote",
+            backend_name="async-fake",
+            raw_path=_make_raw_path(tmp_path),
+            final_path=tmp_path / "final" / "lecture.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            backend_ref="remote-uuid",
+        )
+        manager._store_job(job)
+
+        manager.mark_failed(job.id, reason="poll wedged")
+        assert backend.cancels == [], (
+            f"mark_failed must not invoke backend.cancel — but got: {backend.cancels}"
+        )
+
+    def test_mark_failed_refuses_terminal_jobs(self, tmp_path: Path):
+        """mark_failed returns None for COMPLETED/FAILED/CANCELLED jobs."""
+        manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
+        completed = manager.submit(_make_raw_path(tmp_path))
+        assert completed.state == JobState.COMPLETED
+
+        result = manager.mark_failed(completed.id, reason="no")
+        assert result is None
+        # State is unchanged — the reason didn't overwrite it.
+        same = manager.get(completed.id)
+        assert same is not None
+        assert same.state == JobState.COMPLETED
+        assert same.error is None
+
+    def test_mark_failed_unknown_id_returns_none(self, tmp_path: Path):
+        manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
+        assert manager.mark_failed("does-not-exist", reason="n/a") is None
+
 
 class TestJobManagerAsynchronousBackend:
     def test_submit_leaves_job_in_processing(self, tmp_path: Path):

--- a/tests/recordings/test_job_manager.py
+++ b/tests/recordings/test_job_manager.py
@@ -118,10 +118,26 @@ class _AsyncFakeBackend:
 
 
 class _RaisingAsyncBackend(_AsyncFakeBackend):
-    """Async fake whose poll() raises so we can test error handling."""
+    """Async fake whose poll() raises so we can test error handling.
+
+    By default raises a generic ``RuntimeError`` (which the manager
+    classifies as *transient* — the job should stay in PROCESSING and
+    have ``last_poll_error`` populated). Tests that want to simulate
+    a permanent failure construct :class:`_RaisingAsyncBackend` with
+    a pre-built exception instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        poll_completes_after_calls: int = 3,
+        exc: BaseException | None = None,
+    ) -> None:
+        super().__init__(poll_completes_after_calls=poll_completes_after_calls)
+        self._exc = exc or RuntimeError("network unreachable")
 
     def poll(self, job, *, ctx):
-        raise RuntimeError("network unreachable")
+        raise self._exc
 
 
 # ----------------------------------------------------------------------
@@ -263,6 +279,54 @@ class TestJobManagerSynchronousBackend:
         # Path is <tmp>/final/py/week01/intro.mp4
         assert final.parts[-4:] == ("final", "py", "week01", "intro.mp4")
 
+    def test_delete_job_removes_terminal_job_from_store(self, tmp_path: Path):
+        """delete_job on a completed job wipes it from memory and disk."""
+        manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
+        job = manager.submit(_make_raw_path(tmp_path))
+        assert job.state == JobState.COMPLETED
+
+        assert manager.delete_job(job.id) is True
+        assert manager.get(job.id) is None
+
+        # A fresh store reading from disk should not see the job either.
+        reopened = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        assert reopened.load_all() == []
+
+    def test_delete_job_refuses_in_flight_jobs(self, tmp_path: Path):
+        """delete_job must NOT remove jobs that are still running.
+
+        The CLI guards against this too, but belt-and-suspenders at
+        the manager layer prevents a dashboard bug from losing work.
+
+        Pre-seeds the manager directly (rather than using submit)
+        so no background poller thread races the assertions.
+        """
+        manager, _, _ = _make_manager(tmp_path, _AsyncFakeBackend())
+        raw = _make_raw_path(tmp_path)
+        job = ProcessingJob(
+            id="in-flight-job",
+            backend_name="async-fake",
+            raw_path=raw,
+            final_path=tmp_path / "final" / "lecture.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.3,
+            message="pre-seeded",
+            backend_ref="fake-ref",
+        )
+        manager._store_job(job)
+
+        assert manager.delete_job(job.id) is False
+        # Job is still present in memory and the store.
+        assert manager.get(job.id) is not None
+        reopened = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        assert [j.id for j in reopened.load_all()] == [job.id]
+        assert manager._poller is None
+
+    def test_delete_job_unknown_id_returns_false(self, tmp_path: Path):
+        manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
+        assert manager.delete_job("does-not-exist") is False
+
 
 class TestJobManagerAsynchronousBackend:
     def test_submit_leaves_job_in_processing(self, tmp_path: Path):
@@ -292,19 +356,185 @@ class TestJobManagerAsynchronousBackend:
         finally:
             manager.shutdown(timeout=2.0)
 
-    def test_poller_failure_marks_job_failed(self, tmp_path: Path):
+    def test_transient_poll_error_is_recorded_but_job_stays_processing(self, tmp_path: Path):
+        """Generic exceptions are treated as transient.
+
+        A ``RuntimeError`` from the backend (simulating a network blip
+        or similar) must NOT drive the job to FAILED — losing a
+        completed remote production to a momentary glitch is worse
+        than leaving a stuck job visible. The error is recorded on
+        ``last_poll_error`` so the user can see what's going wrong.
+        """
         backend = _RaisingAsyncBackend()
+        manager, bus, _ = _make_manager(tmp_path, backend, poll_interval=0.02)
+        # Watch for poll events so we can assert the poll actually ran
+        # at least once without racing on time.sleep.
+        poll_event_seen = threading.Event()
+
+        def on_event(topic: str, payload: object) -> None:
+            if (
+                topic == JOB_EVENT_TOPIC
+                and isinstance(payload, ProcessingJob)
+                and payload.last_poll_error is not None
+            ):
+                poll_event_seen.set()
+
+        bus.subscribe(on_event)
+        try:
+            job = manager.submit(_make_raw_path(tmp_path))
+
+            assert poll_event_seen.wait(timeout=5.0), (
+                "poller did not record last_poll_error within timeout"
+            )
+
+            current = manager.get(job.id)
+            assert current is not None
+            # Job stays in-flight — transient errors never transition
+            # to FAILED automatically.
+            assert current.state == JobState.PROCESSING
+            assert current.error is None
+            assert current.last_poll_error is not None
+            assert "network unreachable" in current.last_poll_error
+        finally:
+            manager.shutdown(timeout=2.0)
+
+    def test_permanent_http_error_marks_job_failed(self, tmp_path: Path):
+        """HTTP 401/403/404/410 drive the job to FAILED immediately.
+
+        These statuses will not recover on retry (bad API key, deleted
+        production, …) so the poller must surface them as terminal
+        instead of leaving a zombie job that polls forever.
+        """
+        from clm.recordings.workflow.backends.auphonic_client import AuphonicHTTPError
+
+        exc = AuphonicHTTPError(
+            method="GET",
+            url="https://auphonic.test/api/production/deleted.json",
+            status_code=404,
+            body='{"error": "not found"}',
+        )
+        backend = _RaisingAsyncBackend(exc=exc)
         manager, bus, _ = _make_manager(tmp_path, backend, poll_interval=0.02)
         try:
             job = manager.submit(_make_raw_path(tmp_path))
 
             reached = _wait_for_state(manager, bus, job.id, JobState.FAILED)
-            assert reached.is_set(), "poller did not mark failing job as FAILED in time"
+            assert reached.is_set(), "permanent error did not mark job FAILED in time"
 
             final = manager.get(job.id)
             assert final is not None
             assert final.state == JobState.FAILED
-            assert "network unreachable" in (final.error or "")
+            assert final.error is not None
+            assert "404" in final.error
+            # last_poll_error is cleared on the terminal transition so
+            # the UI shows `error`, not both.
+            assert final.last_poll_error is None
+        finally:
+            manager.shutdown(timeout=2.0)
+
+    def test_poll_once_targets_a_specific_job(self, tmp_path: Path):
+        """poll_once(job_id=…) only ticks the named job.
+
+        The ``jobs poll <id>`` CLI relies on this — polling one job
+        manually must not accidentally advance every other in-flight
+        job in the store.
+
+        We pre-seed the manager with two PROCESSING jobs instead of
+        calling submit, which would start the background poller and
+        race the manual tick.
+        """
+        backend = _AsyncFakeBackend(poll_completes_after_calls=100)
+        manager, _, _ = _make_manager(tmp_path, backend)
+
+        raw_a = _make_raw_path(tmp_path, name="a--RAW.mp4")
+        raw_b = _make_raw_path(tmp_path, name="b--RAW.mp4")
+        a = ProcessingJob(
+            id="aaaa-job",
+            backend_name="async-fake",
+            raw_path=raw_a,
+            final_path=tmp_path / "final" / "a.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.1,
+            message="pre-seeded",
+            backend_ref="fake-ref-a",
+        )
+        b = ProcessingJob(
+            id="bbbb-job",
+            backend_name="async-fake",
+            raw_path=raw_b,
+            final_path=tmp_path / "final" / "b.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.1,
+            message="pre-seeded",
+            backend_ref="fake-ref-b",
+        )
+        manager._store_job(a)
+        manager._store_job(b)
+
+        polled = manager.poll_once(job_id=a.id)
+        assert len(polled) == 1
+        assert polled[0].id == a.id
+        # Only job a advanced; b is untouched.
+        a_after = manager.get(a.id)
+        b_after = manager.get(b.id)
+        assert a_after is not None and b_after is not None
+        assert a_after.progress > 0.1
+        assert b_after.progress == 0.1
+        # And poll was only called for a, not b.
+        assert backend._poll_calls.get(a.id, 0) == 1
+        assert backend._poll_calls.get(b.id, 0) == 0
+        # No poller thread was ever started, so no shutdown needed.
+        assert manager._poller is None
+
+    def test_poll_once_skips_terminal_or_unknown_jobs(self, tmp_path: Path):
+        """poll_once with a terminal or unknown id returns an empty list.
+
+        This is the shape the CLI relies on to print "nothing to poll"
+        without raising.
+        """
+        backend = _SyncFakeBackend()
+        manager, _, _ = _make_manager(tmp_path, backend)
+        # Sync backend drives the job to COMPLETED on submit.
+        job = manager.submit(_make_raw_path(tmp_path))
+        assert job.state == JobState.COMPLETED
+
+        # Terminal id → empty list, no exception.
+        assert manager.poll_once(job_id=job.id) == []
+        # Unknown id → empty list, no exception.
+        assert manager.poll_once(job_id="does-not-exist") == []
+
+    def test_successful_poll_clears_transient_error_marker(self, tmp_path: Path):
+        """A good poll after a bad one wipes last_poll_error."""
+
+        class _FlakyBackend(_AsyncFakeBackend):
+            """Raises once, then behaves normally."""
+
+            def __init__(self) -> None:
+                super().__init__(poll_completes_after_calls=2)
+                self._raised = False
+
+            def poll(self, job, *, ctx):
+                if not self._raised:
+                    self._raised = True
+                    raise RuntimeError("temporary blip")
+                return super().poll(job, ctx=ctx)
+
+        backend = _FlakyBackend()
+        manager, bus, _ = _make_manager(tmp_path, backend, poll_interval=0.02)
+        try:
+            job = manager.submit(_make_raw_path(tmp_path))
+
+            reached = _wait_for_state(manager, bus, job.id, JobState.COMPLETED)
+            assert reached.is_set(), "flaky backend did not eventually complete"
+
+            final = manager.get(job.id)
+            assert final is not None
+            assert final.state == JobState.COMPLETED
+            assert final.last_poll_error is None, (
+                "last_poll_error should be cleared after a successful poll"
+            )
         finally:
             manager.shutdown(timeout=2.0)
 


### PR DESCRIPTION
## Summary

- **Fix two pydantic validation bugs** that broke every first-time `clm recordings submit` against the real Auphonic API: null string fields (`error_status`, `download_url`, etc.) and dict-shaped `used_credits` were rejected by the Pydantic models, which only expected non-null strings and floats respectively. Both discovered end-to-end during a live smoke test.
- **Harden the async poller** so transient errors (network blips, HTTP 5xx, pydantic schema drift) no longer permanently mark jobs as FAILED — they're recorded on `last_poll_error` and retried on the next tick. Only permanent errors (HTTP 401/403/404/410) transition to FAILED.
- **Add six `jobs` subcommands** for managing async Auphonic jobs without running the full dashboard:
  - `jobs list` — now with a conditional "Last poll error" column when any job is stuck
  - `jobs poll` — one-shot or multi-tick (`--watch N`, `--interval`) poll with early exit
  - `jobs wait` — block until a specific job reaches terminal state
  - `jobs fail` — manually mark a stuck job as FAILED without deleting the remote production
  - `jobs prune` — delete terminal jobs from the store (`--state`, `--id`, `--yes`)
  - `jobs cancel` — refactored to share `_resolve_job_by_prefix` with the new commands
- **Drive-by fix** for a pre-existing test isolation bug in `test_find_config_files_empty` that failed on any dev machine with a real clm config installed.

## Test plan

- [ ] 370 recordings tests pass (up from 349 before this PR)
- [ ] Regression tests replay the exact real-API response shape captured from a live Auphonic production — both the freshly-created (null fields) and completed (dict `used_credits`) states
- [ ] Transient vs permanent error classification verified: generic `RuntimeError` stays PROCESSING; `AuphonicHTTPError(404)` transitions to FAILED; flaky backend recovers and clears `last_poll_error`
- [ ] `poll_once(job_id=...)` only ticks the targeted job; terminal/unknown IDs return empty lists
- [ ] `delete_job` / `mark_failed` refuse in-flight jobs with belt-and-suspenders guards
- [ ] CLI smoke tests cover `poll` (empty, terminal), `prune` (delete failed, refuse in-flight), `fail` (transition, refuse terminal), `list` (conditional column), `poll --watch` (early exit without sleeping)
- [ ] End-to-end dogfood: real Auphonic submit → upload → process → poll → download → archive all succeeded against a live smoke file
- [ ] Pre-commit hooks (ruff lint, ruff format, mypy, fast pytest) pass on all 4 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)