### PR TITLE
feat(recordings): superseded folder, OBS controls, watcher scan, dynamic parts, deck status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- **Recordings dashboard: slide-deck-based lecture selection**: The
+  `/lectures` page now lists individual slide decks (notebook files)
+  instead of topics. This matches how recordings are actually made — one
+  video per slide deck, not one per topic (a topic can contain multiple
+  slide files).
+  - The page builds a full `Course` object from the spec file at startup,
+    reusing `Course.from_spec()` to resolve topics, find slide files,
+    extract bilingual titles, and assign section numbers.
+  - **Language toggle** (DE/EN): a cookie-based selector on the lectures
+    page switches between German and English section names, slide deck
+    titles, and course slugs. Default: German.
+  - **Refresh button**: rebuilds the `Course` from disk without restarting
+    the server, picking up title changes and new slides.
+  - **Multi-part recording support**: the arm form now accepts a
+    `part_number` field. When `part > 0`, filenames include a
+    `(part N)` suffix (e.g. `03 Streaming (part 2)--RAW.mp4`).
+  - `ArmedTopic` renamed to `ArmedDeck` with a `deck_name` field
+    (replacing `topic_name`) and a `part_number` field.  Backward-compat
+    aliases (`ArmedTopic`, `SessionSnapshot.armed_topic`,
+    `RecordingSession.armed_topic`) are preserved.
+  - Naming helpers (`raw_filename`, `final_filename`) accept `deck_name`
+    (was `topic_name`) and a keyword-only `part` parameter.  New
+    `parse_part()` function extracts the optional `(part N)` suffix from
+    a base name.
+  - New routes: `POST /set-lang`, `POST /lectures/refresh`.
+  - JSON status API includes both `armed_deck` (new) and `armed_topic`
+    (deprecated alias) for transition.
+
 ### Fixed
 - **`parse_dir_groups` now respects `<section enabled="false">`**: previously
   `CourseSpec.parse_dir_groups` used `root.iter("dir-group")` and walked the

--- a/docs/claude/recordings-deck-selection-handover.md
+++ b/docs/claude/recordings-deck-selection-handover.md
@@ -1,0 +1,200 @@
+# Handover: Slide-Deck-Based Lecture Selection & Dashboard Improvements
+
+## 1. Feature Overview
+
+Converted the recordings dashboard Lectures page from topic-based listing to
+slide-deck-based listing, then added a suite of usability improvements
+identified during smoke testing: a superseded-recordings folder, OBS
+connect/disconnect controls, watcher scan-on-start, dynamic multi-part naming,
+and per-deck recording status with manual processing.
+
+**Branch**: `worktree-magical-chasing-cookie`
+**Plan**: `~/.claude/plans/inherited-coalescing-mitten.md`
+**Status**: All phases complete, ready to merge.
+
+## 2. Design Decisions
+
+### Deck-based listing (original commit)
+Replaced topic-based listing with individual slide-deck (notebook file) rows.
+Course object is built once at startup via `Course.from_spec()` and cached in
+`app.state.course`. Language toggle uses a `clm_lang` cookie.
+
+### Superseded folder (Phase 1a)
+When re-recording over an existing file, the old recording moves to
+`superseded/` rather than being overwritten or causing an error. Preserves
+directory structure mirroring `to-process/`. Incrementing `(2)`, `(3)` suffixes
+prevent collisions in superseded. Also moves companion `.wav` files.
+
+**Why not just overwrite?** User wants the ability to recover old takes.
+**Why not `trash/` or `deleted/`?** The term "superseded" is more precise —
+these files were replaced by a newer recording, not explicitly deleted.
+
+### OBS connect/disconnect (Phase 1b)
+Added because OBS may not be running at server startup. The `ObsClient` already
+supports disconnect+reconnect since callbacks are stored in
+`_record_callbacks` and re-registered on each `connect()` call. Simple
+POST endpoints + buttons in the status partial.
+
+### Watcher scan-existing (Phase 2)
+Added a `_submitted` set alongside `_processing` in `WatcherState` to prevent
+double-dispatch across stop/start cycles. `_scan_existing()` walks
+`to-process/` after the observer starts, using the same `_on_file_event` path
+as live events.
+
+**Why not check job manager for existing jobs?** Couples watcher to job manager
+internals. The `_submitted` set is simpler and sufficient for a single server
+lifetime.
+
+### Dynamic part naming (Phase 3)
+**Rule**: single recording = no `(part N)` suffix; multiple parts = all get
+suffixes including part 1. When recording part N>0 and an unsuffixed file
+exists, it's renamed to `(part 1)` — cascade includes companion `.wav` and
+matching files in `final/`. Supersede logic handles re-recording an existing
+part.
+
+**Why not always use part suffixes?** User preference: single recordings should
+have clean names matching the slide deck exactly.
+
+### Deck recording status (Phase 4)
+New `deck_status.py` module scans `to-process/` and `final/` per-section.
+Priority: completed > ready > recorded > failed > no_recording. Status badges,
+visible part-number input, and a "Process" button for manual job submission
+added to the lectures template.
+
+## 3. Phase Breakdown
+
+### Phase 0: Slide-deck-based lecture selection [DONE]
+- Commit `3d71b1e`: `ArmedTopic` → `ArmedDeck`, Course object caching,
+  `/lectures` with deck rows, language toggle, `/lectures/refresh`
+
+### Phase 1a: Superseded folder [DONE]
+- Added `superseded/` as fourth subdirectory
+- `_supersede_file()` helper in `session.py`
+- Integrated into `_rename_recording()` — if target exists, supersede first
+
+### Phase 1b: OBS connect/disconnect buttons [DONE]
+- `POST /obs/connect` and `POST /obs/disconnect` endpoints
+- Connect/Disconnect buttons in status partial next to OBS badge
+
+### Phase 2: Watcher scans existing files on start [DONE]
+- `WatcherState._submitted` set prevents double-dispatch
+- `_scan_existing()` walks `to-process/` after observer starts
+- `mark_submitted()` called after successful `job_manager.submit()`
+
+### Phase 3: Dynamic part naming [DONE]
+- `find_existing_recordings()` in `naming.py` scans directory for matching files
+- `_prepare_target_slot()` in `session.py` handles cascade rename and supersede
+- `_rename_final_to_part1()` handles the `final/` directory cascade
+
+### Phase 4: Deck recording status + manual processing [DONE]
+- New `deck_status.py` module with `DeckRecordingState` enum and `DeckStatus`
+- `scan_section_deck_statuses()` for batch scanning
+- Status badges, part-number input, Process button in `lectures.html`
+- `POST /process` endpoint for manual job submission
+- `_get_failed_jobs_map()` helper in routes
+
+## 4. Current Status
+
+**All phases complete.** 444 recordings tests pass. Ruff clean.
+
+### Bug fix applied during smoke test
+`_build_course()` in `app.py` was using `spec_file.parent` as course root.
+Fixed to use `resolve_course_paths(spec_file)` which correctly goes up 2 levels
+for spec files in `course-specs/` subdirectories.
+
+### Not yet done
+- [ ] Commit the changes (14 modified files, 2 new files)
+- [ ] Merge to master
+- [ ] Manual smoke test of the full feature set with live course spec
+
+## 5. Next Steps
+
+1. **Commit** all changes as a single commit (or split by phase if preferred)
+2. **Smoke test** with the ML-AZAV course spec:
+   - Start server: `clm recordings serve C:\Users\tc\Tmp\AuphonicTest --spec-file ...machine-learning-azav.xml`
+   - Verify lectures page shows status badges
+   - Arm a deck, record, check supersede on re-record
+   - Test OBS connect/disconnect
+   - Test watcher picking up pre-existing files
+   - Test manual Process button
+3. **Merge** to master
+
+## 6. Key Files & Architecture
+
+### Source files modified
+
+| File | Change |
+|---|---|
+| `src/clm/recordings/web/app.py` | Fixed `_build_course()` to use `resolve_course_paths()` |
+| `src/clm/recordings/web/routes.py` | Added `/obs/connect`, `/obs/disconnect`, `/process` endpoints; deck status integration in `/lectures`; `_get_failed_jobs_map()` helper |
+| `src/clm/recordings/web/templates/base.html` | CSS for new deck status badges |
+| `src/clm/recordings/web/templates/lectures.html` | Status column, part-number input, Process button |
+| `src/clm/recordings/web/templates/partials/status.html` | OBS Connect/Disconnect buttons |
+| `src/clm/recordings/workflow/directories.py` | `superseded/` in `SUBDIRS`; `superseded_dir()` helper |
+| `src/clm/recordings/workflow/naming.py` | `find_existing_recordings()` — scans dir for matching raw files |
+| `src/clm/recordings/workflow/session.py` | `_supersede_file()`, `_prepare_target_slot()`, `_rename_final_to_part1()`; updated `_rename_recording()` to use them |
+| `src/clm/recordings/workflow/watcher.py` | `WatcherState._submitted` set; `mark_submitted()`; `_scan_existing()` called from `start()` |
+
+### New source files
+
+| File | Purpose |
+|---|---|
+| `src/clm/recordings/workflow/deck_status.py` | `DeckRecordingState` enum, `DeckStatus` dataclass, `scan_deck_status()`, `scan_section_deck_statuses()` |
+
+### Test files modified/created
+
+| File | Change |
+|---|---|
+| `tests/recordings/test_directories.py` | `superseded_dir()` test; updated assertion counts |
+| `tests/recordings/test_naming.py` | `TestFindExistingRecordings` class (7 tests) |
+| `tests/recordings/test_session.py` | `TestSupersede` (5 tests), `TestDynamicPartNaming` (7 tests) |
+| `tests/recordings/test_watcher.py` | Submitted-set tests (3), `TestScanExisting` (3 tests) |
+| `tests/recordings/test_web.py` | `TestObsControls` (5 tests) |
+| `tests/recordings/test_deck_status.py` | New: `TestScanDeckStatus` (8 tests), `TestScanSectionDeckStatuses` (1 test) |
+
+### Architecture
+
+```
+lectures page request
+  └─► routes.lectures()
+        ├─► Course.sections → deck list
+        ├─► scan_section_deck_statuses() → status per deck
+        └─► render lectures.html (badges, part input, process btn)
+
+recording flow
+  └─► session.arm(course, section, deck, part)
+        └─► OBS record → _rename_recording()
+              └─► _prepare_target_slot()
+                    ├─► find_existing_recordings() — survey what exists
+                    ├─► rename unsuffixed → (part 1) if adding parts
+                    └─► _supersede_file() if target exists
+
+watcher.start()
+  ├─► Observer (watchdog) for new files
+  └─► _scan_existing() for pre-existing files
+        └─► _on_file_event() → _dispatch() → job_manager.submit()
+```
+
+## 7. Testing Approach
+
+- **Unit tests**: All logic tested via pytest with `tmp_path` fixtures
+- **Session tests**: Mock OBS client, `_fire_event()` helper simulates OBS events, `_wait_for_state()` polls for async completion
+- **Web tests**: FastAPI `TestClient` with mocked OBS; mock Course objects injected via `app.state.course`
+- **Watcher tests**: `_FakeBackend` + `_InMemoryJobStore` test doubles; both unit dispatch tests and live watchdog observer tests
+- **Run**: `uv run pytest tests/recordings/ -x` (444 tests, ~8s)
+
+## 8. Session Notes
+
+### Deferred work (from original feature)
+- **(c) Discard & re-record**: UI button to move bad takes to `discarded/`.
+  Currently manual file operations. (Partially addressed by the superseded
+  folder — re-recording now auto-supersedes.)
+- **(d) Retrospective split**: UI button to rename recording to part 1 and
+  re-arm as part 2. Currently manual.
+
+### Sanitization note
+`recording_relative_dir()` sanitizes both course slug and section name for
+filesystem safety. `find_existing_recordings()` and `scan_deck_status()`
+must match against the sanitized form. The `scan_deck_status` function uses
+the directory names directly (already sanitized) but matches deck names via
+`sanitize_file_name()`.

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -145,6 +145,42 @@ This generates a self-contained HTML page with:
 
 Open `comparison.html` in a browser to listen and compare.
 
+## Web Dashboard
+
+The recordings dashboard is a browser-based UI for the recording workflow:
+
+```bash
+clm recordings serve <recordings-root> --spec-file course.xml
+```
+
+### Lecture Selection
+
+The **Lectures** page lists every slide deck in the course, grouped by
+section.  Each deck shows its numbered title (e.g. "03 Streaming mit
+Generatoren") and can be armed for the next recording with one click.
+
+- **Language toggle** (DE / EN) at the top of the page switches section
+  names, deck titles, and course slugs between German and English.  The
+  choice is stored in a cookie and persists across sessions.
+- **Refresh** rebuilds the course from disk without restarting the server,
+  picking up new slides or title changes.
+- **Multi-part recordings**: when a slide deck is too long for a single
+  video, arm it with an increasing part number.  Output filenames include
+  a `(part N)` suffix, e.g. `03 Streaming (part 2)--RAW.mp4`.
+
+### Dashboard Panels
+
+The main dashboard (`/`) shows:
+
+- **Session Status** — current state (idle / armed / recording / renaming),
+  OBS connection status, the armed slide deck (if any), and last output path.
+- **File Watcher** — start/stop controls and the active processing backend.
+- **Pending Pairs** — raw video + audio file pairs awaiting processing.
+- **Processing Jobs** — status of submitted processing jobs with progress
+  bars and cancel buttons.
+
+All panels update in real time via Server-Sent Events (SSE).
+
 ## Recording State
 
 Each course can track which recordings belong to which lectures. State is

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -166,7 +166,14 @@ Generatoren") and can be armed for the next recording with one click.
   picking up new slides or title changes.
 - **Multi-part recordings**: when a slide deck is too long for a single
   video, arm it with an increasing part number.  Output filenames include
-  a `(part N)` suffix, e.g. `03 Streaming (part 2)--RAW.mp4`.
+  a `(part N)` suffix (or `(Teil N)` for German), e.g.
+  `03 Streaming (part 2)--RAW.mp4`.
+
+  **Important:** always record part 0 (the initial, unsuffixed recording)
+  first.  When you then record part 2, the system automatically renames the
+  existing unsuffixed file to `(part 1)`.  Recording part 2 *before* part 0
+  does not trigger the rename cascade, so the part numbering will be
+  inconsistent.
 
 ### Dashboard Panels
 

--- a/src/clm/recordings/web/app.py
+++ b/src/clm/recordings/web/app.py
@@ -33,10 +33,11 @@ def _build_course(spec_file: Path) -> object | None:
     """
     try:
         from clm.core.course import Course
+        from clm.core.course_paths import resolve_course_paths
         from clm.core.course_spec import CourseSpec
 
         spec = CourseSpec.from_file(spec_file)
-        course_root = spec_file.parent
+        course_root, _ = resolve_course_paths(spec_file)
         return Course.from_spec(spec, course_root, output_root=course_root)
     except Exception as exc:
         logger.warning("Could not build Course from {}: {}", spec_file, exc)

--- a/src/clm/recordings/web/app.py
+++ b/src/clm/recordings/web/app.py
@@ -1,8 +1,9 @@
 """FastAPI application for the recordings workflow dashboard.
 
 This is a **separate** app from the main ``clm serve`` dashboard.
-It provides an HTMX-based UI for arming topics, monitoring OBS recording
-state, viewing pending/finished recordings, and managing the file watcher.
+It provides an HTMX-based UI for arming slide decks, monitoring OBS
+recording state, viewing pending/finished recordings, and managing the
+file watcher.
 
 Launch with ``clm recordings serve``.
 """
@@ -22,6 +23,24 @@ from loguru import logger
 from clm.__version__ import __version__
 
 from .routes import router
+
+
+def _build_course(spec_file: Path) -> object | None:
+    """Build a :class:`Course` from *spec_file*, or ``None`` on failure.
+
+    Returns the Course object (typed as ``object`` to avoid importing
+    heavy core modules at module level).
+    """
+    try:
+        from clm.core.course import Course
+        from clm.core.course_spec import CourseSpec
+
+        spec = CourseSpec.from_file(spec_file)
+        course_root = spec_file.parent
+        return Course.from_spec(spec, course_root, output_root=course_root)
+    except Exception as exc:
+        logger.warning("Could not build Course from {}: {}", spec_file, exc)
+        return None
 
 
 @asynccontextmanager
@@ -216,6 +235,9 @@ def create_app(
         on_error=lambda path, err: _push_sse("watcher_error"),
     )
 
+    # Build Course from spec file (if provided) for the lectures page
+    course = _build_course(spec_file) if spec_file is not None else None
+
     # Store in app state for route handlers
     app.state.recordings_root = recordings_root
     app.state.raw_suffix = raw_suffix
@@ -224,6 +246,7 @@ def create_app(
     app.state.watcher = watcher
     app.state.sse_queue = sse_queue
     app.state.spec_file = spec_file
+    app.state.course = course
     app.state.job_store = job_store
     app.state.event_bus = event_bus
     app.state.job_manager = job_manager

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -113,6 +113,7 @@ async def lectures(request: Request):
             root = request.app.state.recordings_root
             raw_suffix = request.app.state.raw_suffix
             failed_jobs = _get_failed_jobs_map(request)
+            active_jobs = _get_active_jobs_map(request)
 
             for section in course.sections:
                 decks = []
@@ -136,6 +137,7 @@ async def lectures(request: Request):
                     [d["deck_name"] for d in decks],
                     raw_suffix=raw_suffix,
                     failed_jobs=failed_jobs,
+                    active_jobs=active_jobs,
                 )
                 for deck in decks:
                     deck["status"] = statuses.get(deck["deck_name"])
@@ -184,8 +186,9 @@ async def arm_deck(
 ):
     """Arm a slide deck for the next recording."""
     session = _get_session(request)
+    lang = _get_lang(request)
     try:
-        session.arm(course_slug, section_name, deck_name, part_number=part_number)
+        session.arm(course_slug, section_name, deck_name, part_number=part_number, lang=lang)
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
@@ -209,20 +212,27 @@ async def disarm(request: Request):
 
 
 @router.post("/process", response_class=HTMLResponse)
-async def process_file(request: Request, raw_path: str = Form(...)):
-    """Manually submit a file for backend processing."""
+async def process_file(request: Request):
+    """Manually submit one or more files for backend processing."""
     from pathlib import Path as _Path
 
     from clm.recordings.workflow.jobs import ProcessingOptions
 
+    form = await request.form()
+    raw_paths = form.getlist("raw_path")
+    if not raw_paths:
+        raise HTTPException(status_code=400, detail="No raw_path provided")
+
     job_manager = _get_job_manager(request)
-    path = _Path(raw_path)
-    if not path.exists():
-        raise HTTPException(status_code=404, detail=f"File not found: {raw_path}")
-    try:
-        job_manager.submit(path, options=ProcessingOptions())
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    for raw_path in raw_paths:
+        path = _Path(str(raw_path))
+        if not path.exists():
+            logger.warning("Skipping missing file: {}", raw_path)
+            continue
+        try:
+            job_manager.submit(path, options=ProcessingOptions())
+        except Exception as exc:
+            logger.warning("Failed to submit {}: {}", raw_path, exc)
     return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
 
 
@@ -405,6 +415,30 @@ def _get_lang(request: Request) -> str:
     return request.cookies.get("clm_lang", "de")
 
 
+def _get_active_jobs_map(request: Request) -> dict[str, str]:
+    """Build a mapping of deck names to active (non-terminal) job IDs.
+
+    Scans recent jobs for those in queued/uploading/processing/downloading/
+    assembling states and maps the deck name to the job ID.
+    """
+    from clm.recordings.workflow.jobs import JobState
+    from clm.recordings.workflow.naming import parse_part, parse_raw_stem
+
+    manager = _get_job_manager(request)
+    raw_suffix = request.app.state.raw_suffix
+    terminal = {JobState.COMPLETED, JobState.FAILED, JobState.CANCELLED}
+    result: dict[str, str] = {}
+    try:
+        for job in manager.list_jobs():
+            if job.state not in terminal:
+                base_with_part, _ = parse_raw_stem(job.raw_path.stem, raw_suffix)
+                base, _ = parse_part(base_with_part)
+                result.setdefault(base, job.id)
+    except Exception:
+        pass
+    return result
+
+
 def _get_failed_jobs_map(request: Request) -> dict[str, str]:
     """Build a mapping of deck names to failed job IDs.
 
@@ -437,6 +471,7 @@ def _snapshot_to_dict(snap: SessionSnapshot) -> dict:
             "section_name": snap.armed_deck.section_name,
             "deck_name": snap.armed_deck.deck_name,
             "part_number": snap.armed_deck.part_number,
+            "lang": snap.armed_deck.lang,
         }
     return {
         "state": snap.state.value,

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -2,9 +2,9 @@
 
 Provides:
 - ``GET /`` — Dashboard page (Jinja2 template)
-- ``GET /lectures`` — Lecture list from course spec (HTMX partial)
-- ``POST /arm`` — Arm a topic for recording
-- ``POST /disarm`` — Disarm the current topic
+- ``GET /lectures`` — Lecture list from course (slide decks per section)
+- ``POST /arm`` — Arm a slide deck for recording
+- ``POST /disarm`` — Disarm the current deck
 - ``GET /status`` — JSON session status snapshot
 - ``GET /events`` — SSE stream for real-time updates
 - ``GET /pairs`` — Pending pairs list (HTMX partial)
@@ -13,6 +13,8 @@ Provides:
 - ``GET /jobs`` — Processing jobs list (HTMX partial)
 - ``POST /jobs/{id}/cancel`` — Cancel an in-flight job
 - ``GET /backends`` — Active backend + capabilities JSON
+- ``POST /set-lang`` — Set recording language cookie (de/en)
+- ``POST /lectures/refresh`` — Rebuild Course from disk
 """
 
 from __future__ import annotations
@@ -86,43 +88,50 @@ async def dashboard(request: Request):
 
 @router.get("/lectures", response_class=HTMLResponse)
 async def lectures(request: Request):
-    """Render the lecture list from the course spec file.
+    """Render the lecture list showing slide decks per section.
 
-    Returns an HTMX partial — a list of sections with arm buttons.
+    Uses the cached :class:`Course` object built at startup from the
+    spec file and the course directory on disk.
     """
     templates = _get_templates(request)
-    spec_file = request.app.state.spec_file
+    course = getattr(request.app.state, "course", None)
     session = _get_session(request)
     snap = session.snapshot()
+    lang = _get_lang(request)
 
     sections: list[dict] = []
+    course_slug: str = ""
     error: str | None = None
 
-    if spec_file is not None:
+    if course is not None:
         try:
-            from pathlib import Path
-
-            from clm.core.course_spec import CourseSpec
-
-            spec = CourseSpec.from_file(Path(spec_file))
-            for section in spec.sections:
-                topics = []
-                for topic in section.topics:
-                    topics.append(
+            for section in course.sections:
+                decks = []
+                for nb in section.notebooks:
+                    deck_name = nb.file_name(lang, "")
+                    decks.append(
                         {
-                            "id": topic.id,
-                            "name": topic.id.split("/")[-1] if "/" in topic.id else topic.id,
+                            "deck_name": deck_name,
+                            "display_name": deck_name,
+                            "title_de": nb.title.de,
+                            "title_en": nb.title.en,
                         }
                     )
                 sections.append(
                     {
-                        "name": section.name.en or section.name.de,
-                        "topics": topics,
+                        "name": section.name[lang],
+                        "decks": decks,
                     }
                 )
+            course_slug = course.output_dir_name[lang]
         except Exception as exc:
             error = str(exc)
-            logger.warning("Could not load course spec: {}", exc)
+            logger.warning("Could not build lecture list: {}", exc)
+    elif request.app.state.spec_file is not None:
+        error = (
+            "Course spec file was provided but the Course could not be built. "
+            "Check server logs for details."
+        )
     else:
         error = "No course spec file configured. Pass --spec-file to clm recordings serve."
 
@@ -131,6 +140,8 @@ async def lectures(request: Request):
         "lectures.html",
         {
             "sections": sections,
+            "course_slug": course_slug,
+            "lang": lang,
             "snapshot": snap,
             "error": error,
         },
@@ -143,16 +154,17 @@ async def lectures(request: Request):
 
 
 @router.post("/arm", response_class=HTMLResponse)
-async def arm_topic(
+async def arm_deck(
     request: Request,
     course_slug: str = Form(...),
     section_name: str = Form(...),
-    topic_name: str = Form(...),
+    deck_name: str = Form(...),
+    part_number: int = Form(0),
 ):
-    """Arm a topic for the next recording."""
+    """Arm a slide deck for the next recording."""
     session = _get_session(request)
     try:
-        session.arm(course_slug, section_name, topic_name)
+        session.arm(course_slug, section_name, deck_name, part_number=part_number)
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
@@ -194,6 +206,37 @@ async def watcher_stop(request: Request):
     watcher = _get_watcher(request)
     watcher.stop()
     return await status_partial(request)
+
+
+# ------------------------------------------------------------------
+# Language selection
+# ------------------------------------------------------------------
+
+
+@router.post("/set-lang", response_class=HTMLResponse)
+async def set_lang(request: Request, lang: str = Form(...)):
+    """Set the recording language cookie and redirect back to lectures."""
+    if lang not in ("de", "en"):
+        lang = "de"
+    response = HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+    response.set_cookie("clm_lang", lang, max_age=365 * 24 * 3600)
+    return response
+
+
+# ------------------------------------------------------------------
+# Lectures refresh
+# ------------------------------------------------------------------
+
+
+@router.post("/lectures/refresh", response_class=HTMLResponse)
+async def refresh_lectures(request: Request):
+    """Rebuild the Course object from disk (picks up title changes, new slides)."""
+    from .app import _build_course
+
+    spec_file = request.app.state.spec_file
+    if spec_file is not None:
+        request.app.state.course = _build_course(spec_file)
+    return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
 
 
 # ------------------------------------------------------------------
@@ -292,17 +335,25 @@ def _from_lectures(request: Request) -> bool:
     return "/lectures" in current_url
 
 
+def _get_lang(request: Request) -> str:
+    """Return the recording language from the ``clm_lang`` cookie (default ``"de"``)."""
+    return request.cookies.get("clm_lang", "de")
+
+
 def _snapshot_to_dict(snap: SessionSnapshot) -> dict:
     """Convert a SessionSnapshot to a JSON-serializable dict."""
     armed = None
-    if snap.armed_topic:
+    if snap.armed_deck:
         armed = {
-            "course_slug": snap.armed_topic.course_slug,
-            "section_name": snap.armed_topic.section_name,
-            "topic_name": snap.armed_topic.topic_name,
+            "course_slug": snap.armed_deck.course_slug,
+            "section_name": snap.armed_deck.section_name,
+            "deck_name": snap.armed_deck.deck_name,
+            "part_number": snap.armed_deck.part_number,
         }
     return {
         "state": snap.state.value,
+        "armed_deck": armed,
+        # Deprecated — kept for API consumers during transition
         "armed_topic": armed,
         "obs_connected": snap.obs_connected,
         "last_output": str(snap.last_output) if snap.last_output else None,

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -10,6 +10,8 @@ Provides:
 - ``GET /pairs`` — Pending pairs list (HTMX partial)
 - ``POST /watcher/start`` — Start the file watcher
 - ``POST /watcher/stop`` — Stop the file watcher
+- ``POST /obs/connect`` — Connect to OBS WebSocket
+- ``POST /obs/disconnect`` — Disconnect from OBS WebSocket
 - ``GET /jobs`` — Processing jobs list (HTMX partial)
 - ``POST /jobs/{id}/cancel`` — Cancel an in-flight job
 - ``GET /backends`` — Active backend + capabilities JSON
@@ -105,8 +107,16 @@ async def lectures(request: Request):
 
     if course is not None:
         try:
+            from clm.recordings.workflow.deck_status import scan_section_deck_statuses
+            from clm.recordings.workflow.naming import recording_relative_dir
+
+            root = request.app.state.recordings_root
+            raw_suffix = request.app.state.raw_suffix
+            failed_jobs = _get_failed_jobs_map(request)
+
             for section in course.sections:
                 decks = []
+                section_name = section.name[lang]
                 for nb in section.notebooks:
                     deck_name = nb.file_name(lang, "")
                     decks.append(
@@ -117,13 +127,24 @@ async def lectures(request: Request):
                             "title_en": nb.title.en,
                         }
                     )
+                course_slug = course.output_dir_name[lang]
+                rel_dir = recording_relative_dir(course_slug, section_name)
+                statuses = scan_section_deck_statuses(
+                    root,
+                    str(rel_dir.parts[0]) if rel_dir.parts else course_slug,
+                    str(rel_dir.parts[1]) if len(rel_dir.parts) > 1 else section_name,
+                    [d["deck_name"] for d in decks],
+                    raw_suffix=raw_suffix,
+                    failed_jobs=failed_jobs,
+                )
+                for deck in decks:
+                    deck["status"] = statuses.get(deck["deck_name"])
                 sections.append(
                     {
-                        "name": section.name[lang],
+                        "name": section_name,
                         "decks": decks,
                     }
                 )
-            course_slug = course.output_dir_name[lang]
         except Exception as exc:
             error = str(exc)
             logger.warning("Could not build lecture list: {}", exc)
@@ -187,6 +208,24 @@ async def disarm(request: Request):
     return await status_partial(request)
 
 
+@router.post("/process", response_class=HTMLResponse)
+async def process_file(request: Request, raw_path: str = Form(...)):
+    """Manually submit a file for backend processing."""
+    from pathlib import Path as _Path
+
+    from clm.recordings.workflow.jobs import ProcessingOptions
+
+    job_manager = _get_job_manager(request)
+    path = _Path(raw_path)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail=f"File not found: {raw_path}")
+    try:
+        job_manager.submit(path, options=ProcessingOptions())
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+
+
 # ------------------------------------------------------------------
 # Watcher
 # ------------------------------------------------------------------
@@ -205,6 +244,32 @@ async def watcher_stop(request: Request):
     """Stop the file watcher."""
     watcher = _get_watcher(request)
     watcher.stop()
+    return await status_partial(request)
+
+
+# ------------------------------------------------------------------
+# OBS connection
+# ------------------------------------------------------------------
+
+
+@router.post("/obs/connect", response_class=HTMLResponse)
+async def obs_connect(request: Request):
+    """Connect to OBS WebSocket."""
+    obs = request.app.state.obs
+    try:
+        obs.connect()
+        logger.info("Connected to OBS via dashboard button")
+    except Exception as exc:
+        logger.warning("Failed to connect to OBS: {}", exc)
+    return await status_partial(request)
+
+
+@router.post("/obs/disconnect", response_class=HTMLResponse)
+async def obs_disconnect(request: Request):
+    """Disconnect from OBS WebSocket."""
+    obs = request.app.state.obs
+    obs.disconnect()
+    logger.info("Disconnected from OBS via dashboard button")
     return await status_partial(request)
 
 
@@ -338,6 +403,29 @@ def _from_lectures(request: Request) -> bool:
 def _get_lang(request: Request) -> str:
     """Return the recording language from the ``clm_lang`` cookie (default ``"de"``)."""
     return request.cookies.get("clm_lang", "de")
+
+
+def _get_failed_jobs_map(request: Request) -> dict[str, str]:
+    """Build a mapping of deck names to failed job IDs.
+
+    Scans recent jobs for those in FAILED state and maps the raw path's
+    base name (deck name with part suffix stripped) to the job ID.
+    """
+    from clm.recordings.workflow.jobs import JobState
+    from clm.recordings.workflow.naming import parse_part, parse_raw_stem
+
+    manager = _get_job_manager(request)
+    raw_suffix = request.app.state.raw_suffix
+    result: dict[str, str] = {}
+    try:
+        for job in manager.list_jobs():
+            if job.state == JobState.FAILED:
+                base_with_part, _ = parse_raw_stem(job.raw_path.stem, raw_suffix)
+                base, _ = parse_part(base_with_part)
+                result.setdefault(base, job.id)
+    except Exception:
+        pass
+    return result
 
 
 def _snapshot_to_dict(snap: SessionSnapshot) -> dict:

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -26,6 +26,11 @@
         .badge-renaming { background: #d97706; color: white; }
         .badge-connected { background: #16a34a; color: white; }
         .badge-disconnected { background: #9ca3af; color: white; }
+        .badge-no_recording { background: #e5e7eb; color: #4b5563; }
+        .badge-recorded { background: #f59e0b; color: #78350f; }
+        .badge-ready { background: #34d399; color: #064e3b; }
+        .badge-completed { background: #16a34a; color: white; }
+        .badge-failed { background: #ef4444; color: white; }
         .error-box {
             background: #fef2f2;
             border: 1px solid #fecaca;

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -50,6 +50,40 @@
             font-size: 0.85em;
             padding: 0.3em 0.8em;
         }
+        /* Override PicoCSS defaults inside lecture table action cells */
+        .deck-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.4em;
+            justify-content: flex-end;
+            flex-wrap: nowrap;
+        }
+        .deck-actions form {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3em;
+            margin: 0;
+        }
+        .deck-actions label,
+        .deck-actions input,
+        .deck-actions button {
+            display: inline-block;
+            width: auto;
+            margin-bottom: 0;
+        }
+        .deck-actions input[type="number"] {
+            width: 3.5em;
+            padding: 0.2em 0.3em;
+            font-size: 0.85em;
+        }
+        .deck-actions label {
+            font-size: 0.8em;
+        }
+        /* Armed deck row highlight — override PicoCSS td backgrounds */
+        table tbody tr.row-armed td {
+            background-color: #dbeafe;
+        }
+        .badge-processing { background: #8b5cf6; color: white; }
         nav ul li strong {
             color: var(--pico-primary);
         }

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -3,12 +3,29 @@
 {% block content %}
 <h1>Lectures</h1>
 
-{% if snapshot.armed_topic %}
+<div style="display:flex; gap:1em; align-items:center; margin-bottom:1em;">
+    <form hx-post="/set-lang" style="display:inline">
+        <input type="hidden" name="lang" value="de">
+        <button type="submit" class="{% if lang == 'de' %}primary{% else %}outline{% endif %} topic-btn">DE</button>
+    </form>
+    <form hx-post="/set-lang" style="display:inline">
+        <input type="hidden" name="lang" value="en">
+        <button type="submit" class="{% if lang == 'en' %}primary{% else %}outline{% endif %} topic-btn">EN</button>
+    </form>
+    <form hx-post="/lectures/refresh" style="display:inline; margin-left:auto;">
+        <button type="submit" class="outline secondary topic-btn">Refresh</button>
+    </form>
+</div>
+
+{% if snapshot.armed_deck %}
 <div class="armed-info">
     <strong>Armed:</strong>
-    {{ snapshot.armed_topic.course_slug }} /
-    {{ snapshot.armed_topic.section_name }} /
-    {{ snapshot.armed_topic.topic_name }}
+    {{ snapshot.armed_deck.course_slug }} /
+    {{ snapshot.armed_deck.section_name }} /
+    {{ snapshot.armed_deck.deck_name }}
+    {% if snapshot.armed_deck.part_number > 0 %}
+    (part {{ snapshot.armed_deck.part_number }})
+    {% endif %}
     <form hx-post="/disarm" hx-target=".armed-info" hx-swap="outerHTML"
           style="display:inline; margin-left:1em;">
         <button type="submit" class="outline secondary topic-btn">Disarm</button>
@@ -25,14 +42,15 @@
     <header><h3>{{ section.name }}</h3></header>
     <table>
         <tbody>
-            {% for topic in section.topics %}
+            {% for deck in section.decks %}
             <tr>
-                <td>{{ topic.name }}</td>
+                <td>{{ deck.display_name }}</td>
                 <td style="text-align:right">
                     <form hx-post="/arm" hx-target="body" style="display:inline">
-                        <input type="hidden" name="course_slug" value="course">
+                        <input type="hidden" name="course_slug" value="{{ course_slug }}">
                         <input type="hidden" name="section_name" value="{{ section.name }}">
-                        <input type="hidden" name="topic_name" value="{{ topic.name }}">
+                        <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
+                        <input type="hidden" name="part_number" value="0">
                         <button type="submit" class="outline topic-btn">Arm</button>
                     </form>
                 </td>
@@ -44,6 +62,6 @@
 {% endfor %}
 
 {% if not sections and not error %}
-<p>No sections found in the course spec.</p>
+<p>No sections found in the course.</p>
 {% endif %}
 {% endblock %}

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -24,7 +24,7 @@
     {{ snapshot.armed_deck.section_name }} /
     {{ snapshot.armed_deck.deck_name }}
     {% if snapshot.armed_deck.part_number > 0 %}
-    (part {{ snapshot.armed_deck.part_number }})
+    ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
     {% endif %}
     <form hx-post="/disarm" hx-target=".armed-info" hx-swap="outerHTML"
           style="display:inline; margin-left:1em;">
@@ -50,33 +50,49 @@
         </thead>
         <tbody>
             {% for deck in section.decks %}
-            <tr>
+            {% set is_armed = snapshot.armed_deck and snapshot.armed_deck.deck_name == deck.deck_name and snapshot.armed_deck.section_name == section.name %}
+            <tr{% if is_armed %} class="row-armed"{% endif %}>
                 <td>{{ deck.display_name }}</td>
                 <td>
                     {% if deck.status %}
                     {% set st = deck.status.state.value %}
                     <span class="status-badge badge-{{ st }}">{{ st | replace("_", " ") }}</span>
-                    {% if deck.status.parts %}
-                    <small>({% if deck.status.parts | length == 1 %}1 part{% else %}{{ deck.status.parts | length }} parts{% endif %})</small>
+                    {% if deck.status.final_parts and deck.status.raw_parts %}
+                    <small>(done: {{ deck.status.final_parts | join(", ") }}; raw: {{ deck.status.raw_parts | join(", ") }})</small>
+                    {% elif deck.status.parts | length > 1 %}
+                    <small>(parts {{ deck.status.parts | join(", ") }})</small>
+                    {% elif deck.status.parts | length == 1 and deck.status.parts[0] != 0 %}
+                    <small>(part {{ deck.status.parts[0] }})</small>
                     {% endif %}
                     {% endif %}
                 </td>
-                <td style="text-align:right; white-space:nowrap;">
-                    <form hx-post="/arm" hx-target="body" style="display:inline">
-                        <input type="hidden" name="course_slug" value="{{ course_slug }}">
-                        <input type="hidden" name="section_name" value="{{ section.name }}">
-                        <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
-                        <label style="font-size:0.8em; margin-right:0.3em;">Part:</label>
-                        <input type="number" name="part_number" value="0" min="0" max="20"
-                               style="width:3.5em; display:inline; padding:0.2em 0.3em; font-size:0.85em; margin-right:0.3em;">
-                        <button type="submit" class="outline topic-btn">Arm</button>
-                    </form>
-                    {% if deck.status and deck.status.state.value in ('recorded', 'failed') and deck.status.raw_paths %}
-                    <form hx-post="/process" hx-target="body" style="display:inline; margin-left:0.5em;">
-                        <input type="hidden" name="raw_path" value="{{ deck.status.raw_paths[0] }}">
-                        <button type="submit" class="outline secondary topic-btn">Process</button>
-                    </form>
-                    {% endif %}
+                <td>
+                    <div class="deck-actions">
+                        {% if is_armed %}
+                        <form hx-post="/disarm" hx-target="body">
+                            <button type="submit" class="outline secondary topic-btn">Disarm</button>
+                        </form>
+                        {% else %}
+                        <form hx-post="/arm" hx-target="body">
+                            <input type="hidden" name="course_slug" value="{{ course_slug }}">
+                            <input type="hidden" name="section_name" value="{{ section.name }}">
+                            <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
+                            <label>Part:</label>
+                            <input type="number" name="part_number" value="0" min="0" max="20">
+                            <button type="submit" class="outline topic-btn">Arm</button>
+                        </form>
+                        {% endif %}
+                        {% if deck.status and deck.status.state.value in ('recorded', 'failed') and deck.status.raw_paths %}
+                        <form hx-post="/process" hx-target="body" hx-disabled-elt="find button">
+                            {% for rp in deck.status.raw_paths %}
+                            <input type="hidden" name="raw_path" value="{{ rp }}">
+                            {% endfor %}
+                            <button type="submit" class="outline secondary topic-btn">Process</button>
+                        </form>
+                        {% elif deck.status and deck.status.state.value == 'processing' %}
+                        <span class="status-badge badge-processing" style="font-size:0.8em;">processing&hellip;</span>
+                        {% endif %}
+                    </div>
                 </td>
             </tr>
             {% endfor %}

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -41,18 +41,42 @@
 <article>
     <header><h3>{{ section.name }}</h3></header>
     <table>
+        <thead>
+            <tr>
+                <th>Deck</th>
+                <th>Status</th>
+                <th style="text-align:right">Actions</th>
+            </tr>
+        </thead>
         <tbody>
             {% for deck in section.decks %}
             <tr>
                 <td>{{ deck.display_name }}</td>
-                <td style="text-align:right">
+                <td>
+                    {% if deck.status %}
+                    {% set st = deck.status.state.value %}
+                    <span class="status-badge badge-{{ st }}">{{ st | replace("_", " ") }}</span>
+                    {% if deck.status.parts %}
+                    <small>({% if deck.status.parts | length == 1 %}1 part{% else %}{{ deck.status.parts | length }} parts{% endif %})</small>
+                    {% endif %}
+                    {% endif %}
+                </td>
+                <td style="text-align:right; white-space:nowrap;">
                     <form hx-post="/arm" hx-target="body" style="display:inline">
                         <input type="hidden" name="course_slug" value="{{ course_slug }}">
                         <input type="hidden" name="section_name" value="{{ section.name }}">
                         <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
-                        <input type="hidden" name="part_number" value="0">
+                        <label style="font-size:0.8em; margin-right:0.3em;">Part:</label>
+                        <input type="number" name="part_number" value="0" min="0" max="20"
+                               style="width:3.5em; display:inline; padding:0.2em 0.3em; font-size:0.85em; margin-right:0.3em;">
                         <button type="submit" class="outline topic-btn">Arm</button>
                     </form>
+                    {% if deck.status and deck.status.state.value in ('recorded', 'failed') and deck.status.raw_paths %}
+                    <form hx-post="/process" hx-target="body" style="display:inline; margin-left:0.5em;">
+                        <input type="hidden" name="raw_path" value="{{ deck.status.raw_paths[0] }}">
+                        <button type="submit" class="outline secondary topic-btn">Process</button>
+                    </form>
+                    {% endif %}
                 </td>
             </tr>
             {% endfor %}

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -22,12 +22,15 @@
     <div class="error-box">{{ snapshot.error }}</div>
     {% endif %}
 
-    {% if snapshot.armed_topic %}
+    {% if snapshot.armed_deck %}
     <div class="armed-info">
         <strong>Armed:</strong>
-        {{ snapshot.armed_topic.course_slug }} /
-        {{ snapshot.armed_topic.section_name }} /
-        {{ snapshot.armed_topic.topic_name }}
+        {{ snapshot.armed_deck.course_slug }} /
+        {{ snapshot.armed_deck.section_name }} /
+        {{ snapshot.armed_deck.deck_name }}
+        {% if snapshot.armed_deck.part_number > 0 %}
+        (part {{ snapshot.armed_deck.part_number }})
+        {% endif %}
         <form hx-post="/disarm" hx-target="#status-panel" hx-swap="innerHTML"
               style="display:inline; margin-left:1em;">
             <button type="submit" class="outline secondary topic-btn">Disarm</button>

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -11,8 +11,16 @@
                 OBS:
                 {% if snapshot.obs_connected %}
                 <span class="status-badge badge-connected">connected</span>
+                <form hx-post="/obs/disconnect" hx-target="#status-panel" hx-swap="innerHTML"
+                      style="display:inline; margin-left:0.5em;">
+                    <button type="submit" class="outline secondary topic-btn">Disconnect</button>
+                </form>
                 {% else %}
                 <span class="status-badge badge-disconnected">disconnected</span>
+                <form hx-post="/obs/connect" hx-target="#status-panel" hx-swap="innerHTML"
+                      style="display:inline; margin-left:0.5em;">
+                    <button type="submit" class="outline topic-btn">Connect</button>
+                </form>
                 {% endif %}
             </p>
         </hgroup>

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -37,7 +37,7 @@
         {{ snapshot.armed_deck.section_name }} /
         {{ snapshot.armed_deck.deck_name }}
         {% if snapshot.armed_deck.part_number > 0 %}
-        (part {{ snapshot.armed_deck.part_number }})
+        ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
         {% endif %}
         <form hx-post="/disarm" hx-target="#status-panel" hx-swap="innerHTML"
               style="display:inline; margin-left:1em;">

--- a/src/clm/recordings/workflow/deck_status.py
+++ b/src/clm/recordings/workflow/deck_status.py
@@ -21,6 +21,7 @@ class DeckRecordingState(enum.Enum):
     NO_RECORDING = "no_recording"
     RECORDED = "recorded"  # Raw video exists, no processed audio
     READY = "ready"  # Video + audio pair exists (pending assembly)
+    PROCESSING = "processing"  # Job is queued or in progress
     COMPLETED = "completed"  # Final output exists
     FAILED = "failed"  # Job failed for this deck
 
@@ -31,7 +32,9 @@ class DeckStatus:
 
     state: DeckRecordingState
     parts: list[int] = field(default_factory=list)
+    raw_parts: list[int] = field(default_factory=list)
     raw_paths: list[Path] = field(default_factory=list)
+    final_parts: list[int] = field(default_factory=list)
     has_final: bool = False
     has_raw: bool = False
     has_pair: bool = False
@@ -45,6 +48,7 @@ def scan_deck_status(
     deck_name: str,
     raw_suffix: str = DEFAULT_RAW_SUFFIX,
     failed_jobs: dict[str, str] | None = None,
+    active_jobs: dict[str, str] | None = None,
 ) -> DeckStatus:
     """Check ``to-process/`` and ``final/`` for files matching a deck.
 
@@ -56,6 +60,8 @@ def scan_deck_status(
         raw_suffix: Raw filename suffix.
         failed_jobs: Optional dict mapping deck names to job IDs
             for failed jobs.
+        active_jobs: Optional dict mapping deck names to job IDs
+            for queued/in-progress jobs.
 
     Returns:
         :class:`DeckStatus` with the current state and part information.
@@ -81,30 +87,41 @@ def scan_deck_status(
             break
 
     # Scan final/ for completed outputs
-    has_final = False
+    final_parts: list[int] = []
     if f_dir.is_dir():
         for child in f_dir.iterdir():
             if not child.is_file():
                 continue
-            base, _ = parse_part(child.stem)
+            base, part_num = parse_part(child.stem)
             if base == sanitized:
-                has_final = True
-                break
+                final_parts.append(part_num)
+    final_parts.sort()
+    has_final = len(final_parts) > 0
+
+    # All known parts = union of raw and final
+    all_parts = sorted(set(parts) | set(final_parts))
 
     # Check for failed jobs
     failed_id = None
     if failed_jobs and deck_name in failed_jobs:
         failed_id = failed_jobs[deck_name]
 
-    # Determine state (priority: completed > ready > recorded > failed > none)
-    # Recorded takes precedence over failed because the raw file still
-    # exists and can be re-processed.
-    if has_final:
+    # Check for active (queued/in-progress) jobs
+    is_processing = bool(active_jobs and deck_name in active_jobs)
+
+    # Determine state:
+    # COMPLETED only when final output exists AND no unprocessed raw files remain
+    if has_final and not has_raw:
         state = DeckRecordingState.COMPLETED
+    elif is_processing:
+        state = DeckRecordingState.PROCESSING
     elif has_pair:
         state = DeckRecordingState.READY
     elif has_raw:
         state = DeckRecordingState.RECORDED
+    elif has_final:
+        # All parts processed (raw files cleaned up)
+        state = DeckRecordingState.COMPLETED
     elif failed_id:
         state = DeckRecordingState.FAILED
     else:
@@ -112,8 +129,10 @@ def scan_deck_status(
 
     return DeckStatus(
         state=state,
-        parts=parts,
+        parts=all_parts,
+        raw_parts=parts,
         raw_paths=raw_paths,
+        final_parts=final_parts,
         has_final=has_final,
         has_raw=has_raw,
         has_pair=has_pair,
@@ -128,12 +147,15 @@ def scan_section_deck_statuses(
     deck_names: list[str],
     raw_suffix: str = DEFAULT_RAW_SUFFIX,
     failed_jobs: dict[str, str] | None = None,
+    active_jobs: dict[str, str] | None = None,
 ) -> dict[str, DeckStatus]:
     """Scan status for all decks in a section.
 
     Returns a dict mapping deck names to their :class:`DeckStatus`.
     """
     return {
-        name: scan_deck_status(root, course_slug, section_name, name, raw_suffix, failed_jobs)
+        name: scan_deck_status(
+            root, course_slug, section_name, name, raw_suffix, failed_jobs, active_jobs
+        )
         for name in deck_names
     }

--- a/src/clm/recordings/workflow/deck_status.py
+++ b/src/clm/recordings/workflow/deck_status.py
@@ -1,0 +1,139 @@
+"""Deck recording status scanning for the lectures UI.
+
+Scans the recordings directory tree to determine the recording state
+of each slide deck: whether it has been recorded, processed, has
+pending pairs ready for assembly, or has failed jobs.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .directories import final_dir, to_process_dir
+from .naming import DEFAULT_RAW_SUFFIX, find_existing_recordings, parse_part
+
+
+class DeckRecordingState(enum.Enum):
+    """Recording status for a single slide deck."""
+
+    NO_RECORDING = "no_recording"
+    RECORDED = "recorded"  # Raw video exists, no processed audio
+    READY = "ready"  # Video + audio pair exists (pending assembly)
+    COMPLETED = "completed"  # Final output exists
+    FAILED = "failed"  # Job failed for this deck
+
+
+@dataclass
+class DeckStatus:
+    """Recording status for a deck, including part information."""
+
+    state: DeckRecordingState
+    parts: list[int] = field(default_factory=list)
+    raw_paths: list[Path] = field(default_factory=list)
+    has_final: bool = False
+    has_raw: bool = False
+    has_pair: bool = False
+    failed_job_id: str | None = None
+
+
+def scan_deck_status(
+    root: Path,
+    course_slug: str,
+    section_name: str,
+    deck_name: str,
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+    failed_jobs: dict[str, str] | None = None,
+) -> DeckStatus:
+    """Check ``to-process/`` and ``final/`` for files matching a deck.
+
+    Args:
+        root: Recordings root directory.
+        course_slug: Sanitized course slug (used as directory name).
+        section_name: Sanitized section name (used as directory name).
+        deck_name: The deck name (will be sanitized for matching).
+        raw_suffix: Raw filename suffix.
+        failed_jobs: Optional dict mapping deck names to job IDs
+            for failed jobs.
+
+    Returns:
+        :class:`DeckStatus` with the current state and part information.
+    """
+    from clm.core.utils.text_utils import sanitize_file_name
+
+    sanitized = sanitize_file_name(deck_name)
+
+    tp_dir = to_process_dir(root) / course_slug / section_name
+    f_dir = final_dir(root) / course_slug / section_name
+
+    # Scan to-process for raw recordings
+    existing = find_existing_recordings(tp_dir, deck_name, raw_suffix)
+    parts = sorted(existing.keys())
+    raw_paths = [existing[p] for p in parts]
+    has_raw = len(existing) > 0
+
+    # Check for companion audio (pair = ready for assembly)
+    has_pair = False
+    for path in existing.values():
+        if path.with_suffix(".wav").exists():
+            has_pair = True
+            break
+
+    # Scan final/ for completed outputs
+    has_final = False
+    if f_dir.is_dir():
+        for child in f_dir.iterdir():
+            if not child.is_file():
+                continue
+            base, _ = parse_part(child.stem)
+            if base == sanitized:
+                has_final = True
+                break
+
+    # Check for failed jobs
+    failed_id = None
+    if failed_jobs and deck_name in failed_jobs:
+        failed_id = failed_jobs[deck_name]
+
+    # Determine state (priority: completed > ready > recorded > failed > none)
+    # Recorded takes precedence over failed because the raw file still
+    # exists and can be re-processed.
+    if has_final:
+        state = DeckRecordingState.COMPLETED
+    elif has_pair:
+        state = DeckRecordingState.READY
+    elif has_raw:
+        state = DeckRecordingState.RECORDED
+    elif failed_id:
+        state = DeckRecordingState.FAILED
+    else:
+        state = DeckRecordingState.NO_RECORDING
+
+    return DeckStatus(
+        state=state,
+        parts=parts,
+        raw_paths=raw_paths,
+        has_final=has_final,
+        has_raw=has_raw,
+        has_pair=has_pair,
+        failed_job_id=failed_id,
+    )
+
+
+def scan_section_deck_statuses(
+    root: Path,
+    course_slug: str,
+    section_name: str,
+    deck_names: list[str],
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+    failed_jobs: dict[str, str] | None = None,
+) -> dict[str, DeckStatus]:
+    """Scan status for all decks in a section.
+
+    Returns a dict mapping deck names to their :class:`DeckStatus`.
+    """
+    return {
+        name: scan_deck_status(root, course_slug, section_name, name, raw_suffix, failed_jobs)
+        for name in deck_names
+    }

--- a/src/clm/recordings/workflow/directories.py
+++ b/src/clm/recordings/workflow/directories.py
@@ -1,11 +1,12 @@
 """Directory structure management for the recording workflow.
 
-Manages the three-tier directory layout under the recordings root::
+Manages the four-tier directory layout under the recordings root::
 
     <root>/
     +-- to-process/   # Raw recordings and externally processed audio
     +-- final/        # Muxed output (video + processed audio)
     +-- archive/      # Originals moved here after successful assembly
+    +-- superseded/   # Displaced recordings (re-recorded or overwritten)
 """
 
 from __future__ import annotations
@@ -19,7 +20,7 @@ from clm.recordings.processing.batch import VIDEO_EXTENSIONS
 
 from .naming import DEFAULT_RAW_SUFFIX, parse_raw_stem
 
-SUBDIRS = ("to-process", "final", "archive")
+SUBDIRS = ("to-process", "final", "archive", "superseded")
 
 
 class PendingPair(BaseModel):
@@ -38,7 +39,7 @@ class PendingPair(BaseModel):
 
 
 def ensure_root(root_dir: Path) -> None:
-    """Create the ``to-process/``, ``final/``, and ``archive/`` subdirectories."""
+    """Create the ``to-process/``, ``final/``, ``archive/``, and ``superseded/`` subdirectories."""
     for name in SUBDIRS:
         (root_dir / name).mkdir(parents=True, exist_ok=True)
     logger.debug("Ensured recording directories under {}", root_dir)
@@ -69,6 +70,10 @@ def final_dir(root_dir: Path) -> Path:
 
 def archive_dir(root_dir: Path) -> Path:
     return root_dir / "archive"
+
+
+def superseded_dir(root_dir: Path) -> Path:
+    return root_dir / "superseded"
 
 
 def find_pending_pairs(

--- a/src/clm/recordings/workflow/naming.py
+++ b/src/clm/recordings/workflow/naming.py
@@ -1,9 +1,11 @@
 """Filename convention helpers for the recording workflow.
 
-Naming scheme:
-    <course-slug>/<section-name>/<topic-name>--RAW.mp4   (raw recording)
-    <course-slug>/<section-name>/<topic-name>--RAW.wav   (processed audio)
-    <course-slug>/<section-name>/<topic-name>.mp4         (final output)
+Naming scheme::
+
+    <course-slug>/<section-name>/<deck-name>--RAW.mp4           (raw recording)
+    <course-slug>/<section-name>/<deck-name> (part N)--RAW.mp4  (multi-part raw)
+    <course-slug>/<section-name>/<deck-name>.mp4                (final output)
+    <course-slug>/<section-name>/<deck-name> (part N).mp4       (multi-part final)
 
 All name components are sanitized via ``sanitize_file_name`` from
 ``clm.core.utils.text_utils`` to ensure filesystem-safe paths.
@@ -13,11 +15,14 @@ This module is pure functions with no I/O.
 
 from __future__ import annotations
 
+import re
 from pathlib import PurePosixPath
 
 from clm.core.utils.text_utils import sanitize_file_name
 
 DEFAULT_RAW_SUFFIX = "--RAW"
+
+_PART_RE = re.compile(r"^(.*?) \(part (\d+)\)$")
 
 
 def recording_relative_dir(course_slug: str, section_name: str) -> PurePosixPath:
@@ -28,24 +33,66 @@ def recording_relative_dir(course_slug: str, section_name: str) -> PurePosixPath
     return PurePosixPath(sanitize_file_name(course_slug)) / sanitize_file_name(section_name)
 
 
-def raw_filename(topic_name: str, ext: str = ".mp4", raw_suffix: str = DEFAULT_RAW_SUFFIX) -> str:
-    """Build a raw recording filename: ``<topic>--RAW.mp4``."""
-    return f"{sanitize_file_name(topic_name)}{raw_suffix}{ext}"
+def _part_suffix(part: int) -> str:
+    """Return ``" (part N)"`` when *part* > 0, else ``""``."""
+    return f" (part {part})" if part > 0 else ""
 
 
-def final_filename(topic_name: str, ext: str = ".mp4") -> str:
-    """Build the final output filename: ``<topic>.mp4``."""
-    return f"{sanitize_file_name(topic_name)}{ext}"
+def raw_filename(
+    deck_name: str,
+    ext: str = ".mp4",
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+    *,
+    part: int = 0,
+) -> str:
+    """Build a raw recording filename.
+
+    >>> raw_filename("03 Intro")
+    '03 Intro--RAW.mp4'
+    >>> raw_filename("03 Intro", part=2)
+    '03 Intro (part 2)--RAW.mp4'
+    """
+    return f"{sanitize_file_name(deck_name)}{_part_suffix(part)}{raw_suffix}{ext}"
+
+
+def final_filename(deck_name: str, ext: str = ".mp4", *, part: int = 0) -> str:
+    """Build the final output filename.
+
+    >>> final_filename("03 Intro")
+    '03 Intro.mp4'
+    >>> final_filename("03 Intro", part=1)
+    '03 Intro (part 1).mp4'
+    """
+    return f"{sanitize_file_name(deck_name)}{_part_suffix(part)}{ext}"
 
 
 def parse_raw_stem(stem: str, raw_suffix: str = DEFAULT_RAW_SUFFIX) -> tuple[str, bool]:
     """Parse a file stem into ``(base_name, is_raw)``.
 
-    >>> parse_raw_stem("my_topic--RAW")
-    ('my_topic', True)
-    >>> parse_raw_stem("my_topic")
-    ('my_topic', False)
+    The base name includes the ``(part N)`` suffix when present so that
+    callers can use :func:`parse_part` to extract it separately.
+
+    >>> parse_raw_stem("my_deck--RAW")
+    ('my_deck', True)
+    >>> parse_raw_stem("my_deck (part 1)--RAW")
+    ('my_deck (part 1)', True)
+    >>> parse_raw_stem("my_deck")
+    ('my_deck', False)
     """
     if stem.endswith(raw_suffix):
         return stem[: -len(raw_suffix)], True
     return stem, False
+
+
+def parse_part(base_name: str) -> tuple[str, int]:
+    """Split an optional ``(part N)`` suffix from *base_name*.
+
+    >>> parse_part("03 Intro (part 2)")
+    ('03 Intro', 2)
+    >>> parse_part("03 Intro")
+    ('03 Intro', 0)
+    """
+    m = _PART_RE.match(base_name)
+    if m:
+        return m.group(1), int(m.group(2))
+    return base_name, 0

--- a/src/clm/recordings/workflow/naming.py
+++ b/src/clm/recordings/workflow/naming.py
@@ -23,7 +23,9 @@ from clm.core.utils.text_utils import sanitize_file_name
 
 DEFAULT_RAW_SUFFIX = "--RAW"
 
-_PART_RE = re.compile(r"^(.*?) \(part (\d+)\)$")
+_PART_RE = re.compile(r"^(.*?) \((?:part|Teil) (\d+)\)$")
+
+_PART_LABELS: dict[str, str] = {"de": "Teil", "en": "part"}
 
 
 def recording_relative_dir(course_slug: str, section_name: str) -> PurePosixPath:
@@ -34,9 +36,12 @@ def recording_relative_dir(course_slug: str, section_name: str) -> PurePosixPath
     return PurePosixPath(sanitize_file_name(course_slug)) / sanitize_file_name(section_name)
 
 
-def _part_suffix(part: int) -> str:
-    """Return ``" (part N)"`` when *part* > 0, else ``""``."""
-    return f" (part {part})" if part > 0 else ""
+def _part_suffix(part: int, lang: str = "en") -> str:
+    """Return ``" (part N)"`` or ``" (Teil N)"`` when *part* > 0, else ``""``."""
+    if part <= 0:
+        return ""
+    label = _PART_LABELS.get(lang, "part")
+    return f" ({label} {part})"
 
 
 def raw_filename(
@@ -45,6 +50,7 @@ def raw_filename(
     raw_suffix: str = DEFAULT_RAW_SUFFIX,
     *,
     part: int = 0,
+    lang: str = "en",
 ) -> str:
     """Build a raw recording filename.
 
@@ -52,19 +58,23 @@ def raw_filename(
     '03 Intro--RAW.mp4'
     >>> raw_filename("03 Intro", part=2)
     '03 Intro (part 2)--RAW.mp4'
+    >>> raw_filename("03 Intro", part=2, lang="de")
+    '03 Intro (Teil 2)--RAW.mp4'
     """
-    return f"{sanitize_file_name(deck_name)}{_part_suffix(part)}{raw_suffix}{ext}"
+    return f"{sanitize_file_name(deck_name)}{_part_suffix(part, lang)}{raw_suffix}{ext}"
 
 
-def final_filename(deck_name: str, ext: str = ".mp4", *, part: int = 0) -> str:
+def final_filename(deck_name: str, ext: str = ".mp4", *, part: int = 0, lang: str = "en") -> str:
     """Build the final output filename.
 
     >>> final_filename("03 Intro")
     '03 Intro.mp4'
     >>> final_filename("03 Intro", part=1)
     '03 Intro (part 1).mp4'
+    >>> final_filename("03 Intro", part=1, lang="de")
+    '03 Intro (Teil 1).mp4'
     """
-    return f"{sanitize_file_name(deck_name)}{_part_suffix(part)}{ext}"
+    return f"{sanitize_file_name(deck_name)}{_part_suffix(part, lang)}{ext}"
 
 
 def parse_raw_stem(stem: str, raw_suffix: str = DEFAULT_RAW_SUFFIX) -> tuple[str, bool]:

--- a/src/clm/recordings/workflow/naming.py
+++ b/src/clm/recordings/workflow/naming.py
@@ -10,13 +10,14 @@ Naming scheme::
 All name components are sanitized via ``sanitize_file_name`` from
 ``clm.core.utils.text_utils`` to ensure filesystem-safe paths.
 
-This module is pure functions with no I/O.
+Most functions are pure with no I/O; :func:`find_existing_recordings`
+is the exception — it scans a directory for matching files.
 """
 
 from __future__ import annotations
 
 import re
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 from clm.core.utils.text_utils import sanitize_file_name
 
@@ -96,3 +97,35 @@ def parse_part(base_name: str) -> tuple[str, int]:
     if m:
         return m.group(1), int(m.group(2))
     return base_name, 0
+
+
+def find_existing_recordings(
+    directory: Path,
+    deck_name: str,
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+) -> dict[int, Path]:
+    """Scan *directory* for raw recordings matching *deck_name*.
+
+    Returns a dict mapping part numbers to file paths.  Part 0 means
+    the unsuffixed file (``deck--RAW.ext``); part N>0 means a file
+    with ``(part N)`` in the name.
+
+    Only considers files whose stem ends with *raw_suffix*.
+    """
+    sanitized = sanitize_file_name(deck_name)
+    result: dict[int, Path] = {}
+
+    if not directory.is_dir():
+        return result
+
+    for child in directory.iterdir():
+        if not child.is_file():
+            continue
+        base_with_part, is_raw = parse_raw_stem(child.stem, raw_suffix)
+        if not is_raw:
+            continue
+        base, part = parse_part(base_with_part)
+        if base == sanitized:
+            result[part] = child
+
+    return result

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -55,6 +55,7 @@ class ArmedDeck:
     section_name: str
     deck_name: str
     part_number: int = 0
+    lang: str = "en"
 
 
 # Keep old name as alias for backward compatibility during transition
@@ -84,6 +85,7 @@ def _prepare_target_slot(
     part: int,
     raw_suffix: str,
     recordings_root: Path,
+    lang: str = "en",
 ) -> Path:
     """Ensure the target slot is clear and handle dynamic part renaming.
 
@@ -103,7 +105,9 @@ def _prepare_target_slot(
     # rename the unsuffixed file to (part 1)
     if part > 0 and 0 in existing:
         unsuffixed = existing[0]
-        part1_name = raw_filename(deck_name, ext=unsuffixed.suffix, raw_suffix=raw_suffix, part=1)
+        part1_name = raw_filename(
+            deck_name, ext=unsuffixed.suffix, raw_suffix=raw_suffix, part=1, lang=lang
+        )
         part1_target = target_dir / part1_name
         if not part1_target.exists():
             shutil.move(str(unsuffixed), str(part1_target))
@@ -113,15 +117,15 @@ def _prepare_target_slot(
             wav = unsuffixed.with_suffix(".wav")
             if wav.exists():
                 wav_target = target_dir / raw_filename(
-                    deck_name, ext=".wav", raw_suffix=raw_suffix, part=1
+                    deck_name, ext=".wav", raw_suffix=raw_suffix, part=1, lang=lang
                 )
                 shutil.move(str(wav), str(wav_target))
                 logger.info("Renamed {} → {} (companion)", wav.name, wav_target.name)
 
             # Also rename in final/
-            _rename_final_to_part1(deck_name, unsuffixed.suffix, recordings_root, target_dir)
+            _rename_final_to_part1(deck_name, unsuffixed.suffix, recordings_root, target_dir, lang)
 
-    target_name = raw_filename(deck_name, ext=ext, raw_suffix=raw_suffix, part=part)
+    target_name = raw_filename(deck_name, ext=ext, raw_suffix=raw_suffix, part=part, lang=lang)
     target = target_dir / target_name
 
     if target.exists():
@@ -131,7 +135,7 @@ def _prepare_target_slot(
 
 
 def _rename_final_to_part1(
-    deck_name: str, ext: str, recordings_root: Path, target_dir: Path
+    deck_name: str, ext: str, recordings_root: Path, target_dir: Path, lang: str = "en"
 ) -> None:
     """Rename unsuffixed final output to ``(part 1)`` when a multi-part cascade happens."""
     tp = to_process_dir(recordings_root)
@@ -154,7 +158,7 @@ def _rename_final_to_part1(
         from clm.core.utils.text_utils import sanitize_file_name
 
         if base == sanitize_file_name(deck_name) and part_num == 0:
-            new_name = final_filename(deck_name, ext=child.suffix, part=1)
+            new_name = final_filename(deck_name, ext=child.suffix, part=1, lang=lang)
             new_path = fd / new_name
             if not new_path.exists():
                 shutil.move(str(child), str(new_path))
@@ -275,6 +279,7 @@ class RecordingSession:
         deck_name: str,
         *,
         part_number: int = 0,
+        lang: str = "en",
     ) -> None:
         """Arm a slide deck for the next recording.
 
@@ -289,7 +294,7 @@ class RecordingSession:
                     f"Cannot arm while in state '{self._state.value}'. "
                     "Wait for the current recording to finish."
                 )
-            self._armed = ArmedDeck(course_slug, section_name, deck_name, part_number)
+            self._armed = ArmedDeck(course_slug, section_name, deck_name, part_number, lang)
             self._error = None
             self._state = SessionState.ARMED
 
@@ -395,6 +400,7 @@ class RecordingSession:
                 deck.part_number,
                 self._raw_suffix,
                 self._root,
+                lang=deck.lang,
             )
 
             shutil.move(str(obs_output), str(target))

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -1,6 +1,6 @@
 """Recording session state machine.
 
-Coordinates the recording workflow by tracking which topic is "armed"
+Coordinates the recording workflow by tracking which slide deck is "armed"
 for recording and responding to OBS events to rename the output file
 into the structured directory layout.
 
@@ -43,12 +43,17 @@ class SessionState(enum.Enum):
 
 
 @dataclass(frozen=True)
-class ArmedTopic:
-    """Identifies the topic armed for the next recording."""
+class ArmedDeck:
+    """Identifies the slide deck armed for the next recording."""
 
     course_slug: str
     section_name: str
-    topic_name: str
+    deck_name: str
+    part_number: int = 0
+
+
+# Keep old name as alias for backward compatibility during transition
+ArmedTopic = ArmedDeck
 
 
 @dataclass
@@ -56,10 +61,15 @@ class SessionSnapshot:
     """Immutable snapshot of session state for UI consumption."""
 
     state: SessionState
-    armed_topic: ArmedTopic | None = None
+    armed_deck: ArmedDeck | None = None
     obs_connected: bool = False
     last_output: Path | None = None
     error: str | None = None
+
+    @property
+    def armed_topic(self) -> ArmedDeck | None:
+        """Deprecated alias for :attr:`armed_deck`."""
+        return self.armed_deck
 
 
 class RecordingSession:
@@ -96,7 +106,7 @@ class RecordingSession:
         self._on_state_change = on_state_change
 
         self._state = SessionState.IDLE
-        self._armed: ArmedTopic | None = None
+        self._armed: ArmedDeck | None = None
         self._last_output: Path | None = None
         self._error: str | None = None
         self._lock = threading.Lock()
@@ -113,7 +123,12 @@ class RecordingSession:
         return self._state
 
     @property
-    def armed_topic(self) -> ArmedTopic | None:
+    def armed_topic(self) -> ArmedDeck | None:
+        """Deprecated alias for :attr:`armed_deck`."""
+        return self._armed
+
+    @property
+    def armed_deck(self) -> ArmedDeck | None:
         return self._armed
 
     def snapshot(self) -> SessionSnapshot:
@@ -121,16 +136,23 @@ class RecordingSession:
         with self._lock:
             return SessionSnapshot(
                 state=self._state,
-                armed_topic=self._armed,
+                armed_deck=self._armed,
                 obs_connected=self._obs.connected,
                 last_output=self._last_output,
                 error=self._error,
             )
 
-    def arm(self, course_slug: str, section_name: str, topic_name: str) -> None:
-        """Arm a topic for the next recording.
+    def arm(
+        self,
+        course_slug: str,
+        section_name: str,
+        deck_name: str,
+        *,
+        part_number: int = 0,
+    ) -> None:
+        """Arm a slide deck for the next recording.
 
-        Can be called from ``IDLE`` or ``ARMED`` (to switch topics).
+        Can be called from ``IDLE`` or ``ARMED`` (to switch decks).
 
         Raises:
             RuntimeError: If a recording or rename is in progress.
@@ -141,7 +163,7 @@ class RecordingSession:
                     f"Cannot arm while in state '{self._state.value}'. "
                     "Wait for the current recording to finish."
                 )
-            self._armed = ArmedTopic(course_slug, section_name, topic_name)
+            self._armed = ArmedDeck(course_slug, section_name, deck_name, part_number)
             self._error = None
             self._state = SessionState.ARMED
 
@@ -183,7 +205,7 @@ class RecordingSession:
         the definitive STOPPED event, otherwise the session transitions
         to ``IDLE`` before the output path is available.
         """
-        rename_args: tuple[Path, ArmedTopic] | None = None
+        rename_args: tuple[Path, ArmedDeck] | None = None
 
         with self._lock:
             if event.output_active:
@@ -231,16 +253,17 @@ class RecordingSession:
     # File rename (runs on a background thread)
     # ------------------------------------------------------------------
 
-    def _rename_recording(self, obs_output: Path, topic: ArmedTopic) -> None:
+    def _rename_recording(self, obs_output: Path, deck: ArmedDeck) -> None:
         """Move the OBS output file into the structured ``to-process/`` tree."""
         try:
             self._wait_for_stable(obs_output)
 
-            rel_dir = recording_relative_dir(topic.course_slug, topic.section_name)
+            rel_dir = recording_relative_dir(deck.course_slug, deck.section_name)
             target_name = raw_filename(
-                topic.topic_name,
+                deck.deck_name,
                 ext=obs_output.suffix,
                 raw_suffix=self._raw_suffix,
+                part=deck.part_number,
             )
             target_dir = to_process_dir(self._root) / str(rel_dir)
             target_dir.mkdir(parents=True, exist_ok=True)

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -28,8 +28,13 @@ from pathlib import Path
 
 from loguru import logger
 
-from .directories import to_process_dir
-from .naming import DEFAULT_RAW_SUFFIX, raw_filename, recording_relative_dir
+from .directories import final_dir, superseded_dir, to_process_dir
+from .naming import (
+    DEFAULT_RAW_SUFFIX,
+    find_existing_recordings,
+    raw_filename,
+    recording_relative_dir,
+)
 from .obs import ObsClient, RecordingEvent
 
 
@@ -70,6 +75,127 @@ class SessionSnapshot:
     def armed_topic(self) -> ArmedDeck | None:
         """Deprecated alias for :attr:`armed_deck`."""
         return self.armed_deck
+
+
+def _prepare_target_slot(
+    target_dir: Path,
+    deck_name: str,
+    ext: str,
+    part: int,
+    raw_suffix: str,
+    recordings_root: Path,
+) -> Path:
+    """Ensure the target slot is clear and handle dynamic part renaming.
+
+    Implements these rules:
+
+    - If the user records part N>0 and an unsuffixed (part 0) file exists,
+      rename the existing file to ``(part 1)`` (including companion ``.wav``
+      and any matching file in ``final/``).
+    - If the computed target already exists, supersede it.
+    - Single recording = no suffix; multiple parts = all get ``(part N)``.
+
+    Returns the final target :class:`Path` for the new recording.
+    """
+    existing = find_existing_recordings(target_dir, deck_name, raw_suffix)
+
+    # If user is adding a new part (part>0) and an unsuffixed file exists,
+    # rename the unsuffixed file to (part 1)
+    if part > 0 and 0 in existing:
+        unsuffixed = existing[0]
+        part1_name = raw_filename(deck_name, ext=unsuffixed.suffix, raw_suffix=raw_suffix, part=1)
+        part1_target = target_dir / part1_name
+        if not part1_target.exists():
+            shutil.move(str(unsuffixed), str(part1_target))
+            logger.info("Renamed {} → {} (multi-part cascade)", unsuffixed.name, part1_target.name)
+
+            # Also rename companion .wav
+            wav = unsuffixed.with_suffix(".wav")
+            if wav.exists():
+                wav_target = target_dir / raw_filename(
+                    deck_name, ext=".wav", raw_suffix=raw_suffix, part=1
+                )
+                shutil.move(str(wav), str(wav_target))
+                logger.info("Renamed {} → {} (companion)", wav.name, wav_target.name)
+
+            # Also rename in final/
+            _rename_final_to_part1(deck_name, unsuffixed.suffix, recordings_root, target_dir)
+
+    target_name = raw_filename(deck_name, ext=ext, raw_suffix=raw_suffix, part=part)
+    target = target_dir / target_name
+
+    if target.exists():
+        _supersede_file(target, recordings_root)
+
+    return target
+
+
+def _rename_final_to_part1(
+    deck_name: str, ext: str, recordings_root: Path, target_dir: Path
+) -> None:
+    """Rename unsuffixed final output to ``(part 1)`` when a multi-part cascade happens."""
+    tp = to_process_dir(recordings_root)
+    try:
+        rel = target_dir.relative_to(tp)
+    except ValueError:
+        return
+
+    fd = final_dir(recordings_root) / str(rel)
+    if not fd.is_dir():
+        return
+
+    from .naming import final_filename, parse_part
+
+    # Look for unsuffixed final file (any video extension)
+    for child in fd.iterdir():
+        if not child.is_file():
+            continue
+        base, part_num = parse_part(child.stem)
+        from clm.core.utils.text_utils import sanitize_file_name
+
+        if base == sanitize_file_name(deck_name) and part_num == 0:
+            new_name = final_filename(deck_name, ext=child.suffix, part=1)
+            new_path = fd / new_name
+            if not new_path.exists():
+                shutil.move(str(child), str(new_path))
+                logger.info("Renamed final {} → {}", child.name, new_path)
+            break
+
+
+def _supersede_file(existing: Path, recordings_root: Path) -> None:
+    """Move *existing* (and any companion ``.wav``) into ``superseded/``.
+
+    Preserves the directory structure relative to ``to-process/``.
+    If a file with the same name already exists in the superseded
+    directory, appends ``(2)``, ``(3)``, etc. before the extension.
+    """
+    tp = to_process_dir(recordings_root)
+    try:
+        rel = existing.parent.relative_to(tp)
+    except ValueError:
+        rel = Path(".")
+
+    dest_dir = superseded_dir(recordings_root) / str(rel)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    def _move_to_superseded(src: Path) -> None:
+        dest = dest_dir / src.name
+        if dest.exists():
+            stem = src.stem
+            ext = src.suffix
+            counter = 2
+            while dest.exists():
+                dest = dest_dir / f"{stem} ({counter}){ext}"
+                counter += 1
+        shutil.move(str(src), str(dest))
+        logger.info("Superseded {} → {}", src.name, dest)
+
+    _move_to_superseded(existing)
+
+    # Also move companion .wav if present
+    companion = existing.with_suffix(".wav")
+    if companion.exists():
+        _move_to_superseded(companion)
 
 
 class RecordingSession:
@@ -259,15 +385,17 @@ class RecordingSession:
             self._wait_for_stable(obs_output)
 
             rel_dir = recording_relative_dir(deck.course_slug, deck.section_name)
-            target_name = raw_filename(
-                deck.deck_name,
-                ext=obs_output.suffix,
-                raw_suffix=self._raw_suffix,
-                part=deck.part_number,
-            )
             target_dir = to_process_dir(self._root) / str(rel_dir)
             target_dir.mkdir(parents=True, exist_ok=True)
-            target = target_dir / target_name
+
+            target = _prepare_target_slot(
+                target_dir,
+                deck.deck_name,
+                obs_output.suffix,
+                deck.part_number,
+                self._raw_suffix,
+                self._root,
+            )
 
             shutil.move(str(obs_output), str(target))
             logger.info("Renamed {} → {}", obs_output.name, target)

--- a/src/clm/recordings/workflow/watcher.py
+++ b/src/clm/recordings/workflow/watcher.py
@@ -37,14 +37,20 @@ class WatcherState:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._processing: set[Path] = set()
+        self._submitted: set[Path] = set()
 
     def try_claim(self, path: Path) -> bool:
-        """Claim a file for processing.  Returns False if already claimed."""
+        """Claim a file for processing.  Returns False if already claimed or submitted."""
         with self._lock:
-            if path in self._processing:
+            if path in self._processing or path in self._submitted:
                 return False
             self._processing.add(path)
             return True
+
+    def mark_submitted(self, path: Path) -> None:
+        """Record that a file has been submitted to the job manager."""
+        with self._lock:
+            self._submitted.add(path)
 
     def release(self, path: Path) -> None:
         with self._lock:
@@ -120,6 +126,7 @@ class RecordingsWatcher:
             self.backend_name,
             watch_dir,
         )
+        self._scan_existing()
 
     def stop(self) -> None:
         """Stop the watcher."""
@@ -158,6 +165,7 @@ class RecordingsWatcher:
         try:
             self._wait_for_stable(path)
             job = self._job_manager.submit(path, options=ProcessingOptions())
+            self._state.mark_submitted(path)
             if self._on_submitted is not None:
                 self._on_submitted(job)
         except Exception as exc:
@@ -166,6 +174,18 @@ class RecordingsWatcher:
                 self._on_error(path, str(exc))
         finally:
             self._state.release(path)
+
+    def _scan_existing(self) -> None:
+        """Walk ``to-process/`` and dispatch any files the backend accepts.
+
+        Called once after the observer starts so that files created before
+        the watcher was running are picked up.  The ``_submitted`` set
+        prevents double-processing if the observer also sees the file.
+        """
+        watch_dir = to_process_dir(self._root)
+        for path in sorted(watch_dir.rglob("*")):
+            if path.is_file():
+                self._on_file_event(path)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tests/recordings/test_deck_status.py
+++ b/tests/recordings/test_deck_status.py
@@ -1,0 +1,131 @@
+"""Tests for deck recording status scanning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.recordings.workflow.deck_status import (
+    DeckRecordingState,
+    scan_deck_status,
+    scan_section_deck_statuses,
+)
+from clm.recordings.workflow.directories import ensure_root, final_dir, to_process_dir
+
+
+class TestScanDeckStatus:
+    def test_no_recording(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        status = scan_deck_status(root, "course", "section", "03 Intro")
+        assert status.state == DeckRecordingState.NO_RECORDING
+        assert status.parts == []
+        assert not status.has_raw
+        assert not status.has_final
+
+    def test_raw_video_only(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+
+        status = scan_deck_status(root, "course", "section", "03 Intro")
+        assert status.state == DeckRecordingState.RECORDED
+        assert status.parts == [0]
+        assert status.has_raw
+        assert len(status.raw_paths) == 1
+
+    def test_raw_pair_returns_ready(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+        (td / "03 Intro--RAW.wav").write_bytes(b"audio")
+
+        status = scan_deck_status(root, "course", "section", "03 Intro")
+        assert status.state == DeckRecordingState.READY
+        assert status.has_pair
+
+    def test_final_exists_returns_completed(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        fd = final_dir(root) / "course" / "section"
+        fd.mkdir(parents=True)
+        (fd / "03 Intro.mkv").write_bytes(b"final")
+
+        status = scan_deck_status(root, "course", "section", "03 Intro")
+        assert status.state == DeckRecordingState.COMPLETED
+        assert status.has_final
+
+    def test_failed_job_returns_failed(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+
+        status = scan_deck_status(
+            root,
+            "course",
+            "section",
+            "03 Intro",
+            failed_jobs={"03 Intro": "job-123"},
+        )
+        assert status.state == DeckRecordingState.FAILED
+        assert status.failed_job_id == "job-123"
+
+    def test_completed_takes_precedence_over_recorded(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+        fd = final_dir(root) / "course" / "section"
+        fd.mkdir(parents=True)
+        (fd / "03 Intro.mkv").write_bytes(b"final")
+
+        status = scan_deck_status(root, "course", "section", "03 Intro")
+        assert status.state == DeckRecordingState.COMPLETED
+
+    def test_multiple_parts_detected(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro (part 1)--RAW.mkv").write_bytes(b"p1")
+        (td / "03 Intro (part 2)--RAW.mkv").write_bytes(b"p2")
+
+        status = scan_deck_status(root, "course", "section", "03 Intro")
+        assert status.parts == [1, 2]
+        assert len(status.raw_paths) == 2
+
+    def test_failed_with_raw_prefers_recorded(self, tmp_path: Path):
+        """When raw exists and job failed, raw state (recorded) takes precedence."""
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+
+        status = scan_deck_status(
+            root,
+            "course",
+            "section",
+            "03 Intro",
+            failed_jobs={"03 Intro": "job-456"},
+        )
+        # Recorded takes priority since raw file exists
+        assert status.state == DeckRecordingState.RECORDED
+
+
+class TestScanSectionDeckStatuses:
+    def test_batch_scan(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "01 Intro--RAW.mkv").write_bytes(b"video")
+
+        result = scan_section_deck_statuses(root, "course", "section", ["01 Intro", "02 Loops"])
+        assert "01 Intro" in result
+        assert "02 Loops" in result
+        assert result["01 Intro"].state == DeckRecordingState.RECORDED
+        assert result["02 Loops"].state == DeckRecordingState.NO_RECORDING

--- a/tests/recordings/test_deck_status.py
+++ b/tests/recordings/test_deck_status.py
@@ -57,6 +57,8 @@ class TestScanDeckStatus:
         status = scan_deck_status(root, "course", "section", "03 Intro")
         assert status.state == DeckRecordingState.COMPLETED
         assert status.has_final
+        assert status.final_parts == [0]
+        assert status.parts == [0]
 
     def test_failed_job_returns_failed(self, tmp_path: Path):
         root = tmp_path / "rec"
@@ -72,18 +74,23 @@ class TestScanDeckStatus:
         assert status.state == DeckRecordingState.FAILED
         assert status.failed_job_id == "job-123"
 
-    def test_completed_takes_precedence_over_recorded(self, tmp_path: Path):
+    def test_partial_completion_shows_recorded(self, tmp_path: Path):
+        """When some parts are in final/ but raw files remain, state is RECORDED."""
         root = tmp_path / "rec"
         ensure_root(root)
         td = to_process_dir(root) / "course" / "section"
         td.mkdir(parents=True)
-        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+        (td / "03 Intro (part 2)--RAW.mkv").write_bytes(b"raw p2")
         fd = final_dir(root) / "course" / "section"
         fd.mkdir(parents=True)
-        (fd / "03 Intro.mkv").write_bytes(b"final")
+        (fd / "03 Intro (part 1).mkv").write_bytes(b"final p1")
 
         status = scan_deck_status(root, "course", "section", "03 Intro")
-        assert status.state == DeckRecordingState.COMPLETED
+        assert status.state == DeckRecordingState.RECORDED
+        assert status.final_parts == [1]
+        assert status.raw_parts == [2]
+        assert status.parts == [1, 2]
+        assert len(status.raw_paths) == 1
 
     def test_multiple_parts_detected(self, tmp_path: Path):
         root = tmp_path / "rec"
@@ -114,6 +121,39 @@ class TestScanDeckStatus:
         )
         # Recorded takes priority since raw file exists
         assert status.state == DeckRecordingState.RECORDED
+
+    def test_active_job_returns_processing(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+
+        status = scan_deck_status(
+            root,
+            "course",
+            "section",
+            "03 Intro",
+            active_jobs={"03 Intro": "job-789"},
+        )
+        assert status.state == DeckRecordingState.PROCESSING
+
+    def test_processing_takes_precedence_over_recorded(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "course" / "section"
+        td.mkdir(parents=True)
+        (td / "03 Intro--RAW.mkv").write_bytes(b"video")
+
+        status = scan_deck_status(
+            root,
+            "course",
+            "section",
+            "03 Intro",
+            failed_jobs={"03 Intro": "job-old"},
+            active_jobs={"03 Intro": "job-new"},
+        )
+        assert status.state == DeckRecordingState.PROCESSING
 
 
 class TestScanSectionDeckStatuses:

--- a/tests/recordings/test_directories.py
+++ b/tests/recordings/test_directories.py
@@ -13,6 +13,7 @@ from clm.recordings.workflow.directories import (
     ensure_root,
     final_dir,
     find_pending_pairs,
+    superseded_dir,
     to_process_dir,
     validate_root,
 )
@@ -58,6 +59,7 @@ class TestValidateRoot:
         root.mkdir()
         (root / "to-process").mkdir()
         (root / "final").mkdir()
+        (root / "superseded").mkdir()
         # archive/ intentionally missing
         errors = validate_root(root)
         assert len(errors) == 1
@@ -67,7 +69,7 @@ class TestValidateRoot:
         root = tmp_path / "recordings"
         root.mkdir()
         errors = validate_root(root)
-        assert len(errors) == 3
+        assert len(errors) == 4
 
 
 class TestDirHelpers:
@@ -79,6 +81,9 @@ class TestDirHelpers:
 
     def test_archive_dir(self, tmp_path: Path):
         assert archive_dir(tmp_path) == tmp_path / "archive"
+
+    def test_superseded_dir(self, tmp_path: Path):
+        assert superseded_dir(tmp_path) == tmp_path / "superseded"
 
 
 class TestPendingPair:

--- a/tests/recordings/test_naming.py
+++ b/tests/recordings/test_naming.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 import pytest
 
 from clm.recordings.workflow.naming import (
     DEFAULT_RAW_SUFFIX,
     final_filename,
+    find_existing_recordings,
     parse_part,
     parse_raw_stem,
     raw_filename,
@@ -149,3 +150,41 @@ class TestParsePart:
         base, part = parse_part(base_with_part)
         assert base == "03 Intro"
         assert part == 3
+
+
+class TestFindExistingRecordings:
+    def test_empty_directory(self, tmp_path: Path):
+        assert find_existing_recordings(tmp_path, "03 Intro") == {}
+
+    def test_nonexistent_directory(self, tmp_path: Path):
+        assert find_existing_recordings(tmp_path / "nope", "03 Intro") == {}
+
+    def test_finds_unsuffixed(self, tmp_path: Path):
+        (tmp_path / "03 Intro--RAW.mkv").write_bytes(b"v")
+        result = find_existing_recordings(tmp_path, "03 Intro")
+        assert 0 in result
+        assert result[0].name == "03 Intro--RAW.mkv"
+
+    def test_finds_part_2(self, tmp_path: Path):
+        (tmp_path / "03 Intro (part 2)--RAW.mkv").write_bytes(b"v")
+        result = find_existing_recordings(tmp_path, "03 Intro")
+        assert 2 in result
+        assert result[2].name == "03 Intro (part 2)--RAW.mkv"
+
+    def test_finds_multiple_parts(self, tmp_path: Path):
+        (tmp_path / "03 Intro--RAW.mkv").write_bytes(b"v0")
+        (tmp_path / "03 Intro (part 1)--RAW.mkv").write_bytes(b"v1")
+        (tmp_path / "03 Intro (part 3)--RAW.mkv").write_bytes(b"v3")
+        result = find_existing_recordings(tmp_path, "03 Intro")
+        assert sorted(result.keys()) == [0, 1, 3]
+
+    def test_ignores_non_matching_names(self, tmp_path: Path):
+        (tmp_path / "04 Other--RAW.mkv").write_bytes(b"v")
+        (tmp_path / "03 Intro.mkv").write_bytes(b"v")  # not raw
+        result = find_existing_recordings(tmp_path, "03 Intro")
+        assert result == {}
+
+    def test_ignores_non_raw_files(self, tmp_path: Path):
+        (tmp_path / "03 Intro.mkv").write_bytes(b"v")
+        result = find_existing_recordings(tmp_path, "03 Intro")
+        assert result == {}

--- a/tests/recordings/test_naming.py
+++ b/tests/recordings/test_naming.py
@@ -61,6 +61,14 @@ class TestRawFilename:
     def test_part_two_mkv(self):
         assert raw_filename("03 Intro", ext=".mkv", part=2) == "03 Intro (part 2)--RAW.mkv"
 
+    def test_part_one_german(self):
+        assert raw_filename("03 Intro", part=1, lang="de") == "03 Intro (Teil 1)--RAW.mp4"
+
+    def test_part_two_german(self):
+        assert (
+            raw_filename("03 Intro", ext=".mkv", part=2, lang="de") == "03 Intro (Teil 2)--RAW.mkv"
+        )
+
 
 class TestFinalFilename:
     def test_default(self):
@@ -79,6 +87,9 @@ class TestFinalFilename:
 
     def test_part_one(self):
         assert final_filename("03 Intro", part=1) == "03 Intro (part 1).mp4"
+
+    def test_part_one_german(self):
+        assert final_filename("03 Intro", part=1, lang="de") == "03 Intro (Teil 1).mp4"
 
 
 class TestParseRawStem:
@@ -119,6 +130,11 @@ class TestParseRawStem:
         assert base == "03 Intro (part 2)"
         assert is_raw is False
 
+    def test_raw_stem_with_teil(self):
+        base, is_raw = parse_raw_stem("03 Intro (Teil 1)--RAW")
+        assert base == "03 Intro (Teil 1)"
+        assert is_raw is True
+
 
 class TestParsePart:
     def test_no_part(self):
@@ -141,6 +157,16 @@ class TestParsePart:
         assert base == "Something (notes)"
         assert part == 0
 
+    def test_teil_one(self):
+        base, part = parse_part("03 Intro (Teil 1)")
+        assert base == "03 Intro"
+        assert part == 1
+
+    def test_teil_large_number(self):
+        base, part = parse_part("Deck Name (Teil 5)")
+        assert base == "Deck Name"
+        assert part == 5
+
     def test_round_trip_raw(self):
         """raw_filename → parse_raw_stem → parse_part recovers original values."""
         name = raw_filename("03 Intro", ext=".mp4", part=3)
@@ -150,6 +176,16 @@ class TestParsePart:
         base, part = parse_part(base_with_part)
         assert base == "03 Intro"
         assert part == 3
+
+    def test_round_trip_raw_german(self):
+        """German raw_filename → parse_raw_stem → parse_part recovers original values."""
+        name = raw_filename("03 Intro", ext=".mp4", part=2, lang="de")
+        stem = name.removesuffix(".mp4")
+        base_with_part, is_raw = parse_raw_stem(stem)
+        assert is_raw is True
+        base, part = parse_part(base_with_part)
+        assert base == "03 Intro"
+        assert part == 2
 
 
 class TestFindExistingRecordings:
@@ -188,3 +224,9 @@ class TestFindExistingRecordings:
         (tmp_path / "03 Intro.mkv").write_bytes(b"v")
         result = find_existing_recordings(tmp_path, "03 Intro")
         assert result == {}
+
+    def test_finds_german_teil_suffix(self, tmp_path: Path):
+        (tmp_path / "03 Intro (Teil 2)--RAW.mkv").write_bytes(b"v")
+        result = find_existing_recordings(tmp_path, "03 Intro")
+        assert 2 in result
+        assert result[2].name == "03 Intro (Teil 2)--RAW.mkv"

--- a/tests/recordings/test_naming.py
+++ b/tests/recordings/test_naming.py
@@ -9,6 +9,7 @@ import pytest
 from clm.recordings.workflow.naming import (
     DEFAULT_RAW_SUFFIX,
     final_filename,
+    parse_part,
     parse_raw_stem,
     raw_filename,
     recording_relative_dir,
@@ -36,58 +37,115 @@ class TestRecordingRelativeDir:
 
 class TestRawFilename:
     def test_default(self):
-        assert raw_filename("my_topic") == "my_topic--RAW.mp4"
+        assert raw_filename("my_deck") == "my_deck--RAW.mp4"
 
     def test_custom_ext(self):
-        assert raw_filename("my_topic", ext=".mkv") == "my_topic--RAW.mkv"
+        assert raw_filename("my_deck", ext=".mkv") == "my_deck--RAW.mkv"
 
     def test_custom_suffix(self):
-        assert raw_filename("my_topic", raw_suffix="__RAW") == "my_topic__RAW.mp4"
+        assert raw_filename("my_deck", raw_suffix="__RAW") == "my_deck__RAW.mp4"
 
     def test_sanitizes_name(self):
-        result = raw_filename("topic with $pecial chars!")
+        result = raw_filename("deck with $pecial chars!")
         assert "$" not in result
         assert "!" not in result
         assert result.endswith("--RAW.mp4")
 
+    def test_part_zero_no_suffix(self):
+        assert raw_filename("03 Intro", part=0) == "03 Intro--RAW.mp4"
+
+    def test_part_one(self):
+        assert raw_filename("03 Intro", part=1) == "03 Intro (part 1)--RAW.mp4"
+
+    def test_part_two_mkv(self):
+        assert raw_filename("03 Intro", ext=".mkv", part=2) == "03 Intro (part 2)--RAW.mkv"
+
 
 class TestFinalFilename:
     def test_default(self):
-        assert final_filename("my_topic") == "my_topic.mp4"
+        assert final_filename("my_deck") == "my_deck.mp4"
 
     def test_custom_ext(self):
-        assert final_filename("my_topic", ext=".mkv") == "my_topic.mkv"
+        assert final_filename("my_deck", ext=".mkv") == "my_deck.mkv"
 
     def test_sanitizes_name(self):
-        result = final_filename("topic<1>")
+        result = final_filename("deck<1>")
         assert "<" not in result
         assert result.endswith(".mp4")
+
+    def test_part_zero_no_suffix(self):
+        assert final_filename("03 Intro", part=0) == "03 Intro.mp4"
+
+    def test_part_one(self):
+        assert final_filename("03 Intro", part=1) == "03 Intro (part 1).mp4"
 
 
 class TestParseRawStem:
     def test_raw_stem(self):
-        base, is_raw = parse_raw_stem("my_topic--RAW")
-        assert base == "my_topic"
+        base, is_raw = parse_raw_stem("my_deck--RAW")
+        assert base == "my_deck"
         assert is_raw is True
 
     def test_non_raw_stem(self):
-        base, is_raw = parse_raw_stem("my_topic")
-        assert base == "my_topic"
+        base, is_raw = parse_raw_stem("my_deck")
+        assert base == "my_deck"
         assert is_raw is False
 
     def test_custom_suffix(self):
-        base, is_raw = parse_raw_stem("topic__UNPROCESSED", raw_suffix="__UNPROCESSED")
-        assert base == "topic"
+        base, is_raw = parse_raw_stem("deck__UNPROCESSED", raw_suffix="__UNPROCESSED")
+        assert base == "deck"
         assert is_raw is True
 
     def test_partial_match_not_raw(self):
-        base, is_raw = parse_raw_stem("topic--RA")
-        assert base == "topic--RA"
+        base, is_raw = parse_raw_stem("deck--RA")
+        assert base == "deck--RA"
         assert is_raw is False
 
     def test_suffix_in_middle_not_matched(self):
-        base, is_raw = parse_raw_stem("--RAW_topic")
+        base, is_raw = parse_raw_stem("--RAW_deck")
         assert is_raw is False
 
     def test_default_suffix_constant(self):
         assert DEFAULT_RAW_SUFFIX == "--RAW"
+
+    def test_raw_stem_with_part(self):
+        base, is_raw = parse_raw_stem("03 Intro (part 1)--RAW")
+        assert base == "03 Intro (part 1)"
+        assert is_raw is True
+
+    def test_non_raw_stem_with_part(self):
+        base, is_raw = parse_raw_stem("03 Intro (part 2)")
+        assert base == "03 Intro (part 2)"
+        assert is_raw is False
+
+
+class TestParsePart:
+    def test_no_part(self):
+        base, part = parse_part("03 Intro")
+        assert base == "03 Intro"
+        assert part == 0
+
+    def test_part_one(self):
+        base, part = parse_part("03 Intro (part 1)")
+        assert base == "03 Intro"
+        assert part == 1
+
+    def test_part_large_number(self):
+        base, part = parse_part("Deck Name (part 12)")
+        assert base == "Deck Name"
+        assert part == 12
+
+    def test_not_a_part_suffix(self):
+        base, part = parse_part("Something (notes)")
+        assert base == "Something (notes)"
+        assert part == 0
+
+    def test_round_trip_raw(self):
+        """raw_filename → parse_raw_stem → parse_part recovers original values."""
+        name = raw_filename("03 Intro", ext=".mp4", part=3)
+        stem = name.removesuffix(".mp4")
+        base_with_part, is_raw = parse_raw_stem(stem)
+        assert is_raw is True
+        base, part = parse_part(base_with_part)
+        assert base == "03 Intro"
+        assert part == 3

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -8,13 +8,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from clm.recordings.workflow.directories import ensure_root
+from clm.recordings.workflow.directories import (
+    ensure_root,
+    final_dir,
+    superseded_dir,
+    to_process_dir,
+)
 from clm.recordings.workflow.obs import ObsClient, RecordingEvent
 from clm.recordings.workflow.session import (
     ArmedDeck,
     RecordingSession,
     SessionSnapshot,
     SessionState,
+    _prepare_target_slot,
+    _supersede_file,
 )
 
 # ---------------------------------------------------------------------------
@@ -508,6 +515,207 @@ class TestArmedDeck:
         a = ArmedDeck("c", "s", "d", part_number=1)
         b = ArmedDeck("c", "s", "d", part_number=2)
         assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Supersede
+# ---------------------------------------------------------------------------
+
+
+class TestSupersede:
+    def test_supersede_moves_file(self, recording_root: Path):
+        tp = to_process_dir(recording_root) / "course" / "section"
+        tp.mkdir(parents=True)
+        f = tp / "deck--RAW.mkv"
+        f.write_bytes(b"video data")
+
+        _supersede_file(f, recording_root)
+
+        assert not f.exists()
+        dest = superseded_dir(recording_root) / "course" / "section" / "deck--RAW.mkv"
+        assert dest.exists()
+        assert dest.read_bytes() == b"video data"
+
+    def test_supersede_moves_companion_wav(self, recording_root: Path):
+        tp = to_process_dir(recording_root) / "course" / "section"
+        tp.mkdir(parents=True)
+        video = tp / "deck--RAW.mkv"
+        video.write_bytes(b"video")
+        audio = tp / "deck--RAW.wav"
+        audio.write_bytes(b"audio")
+
+        _supersede_file(video, recording_root)
+
+        assert not video.exists()
+        assert not audio.exists()
+        sup = superseded_dir(recording_root) / "course" / "section"
+        assert (sup / "deck--RAW.mkv").exists()
+        assert (sup / "deck--RAW.wav").exists()
+
+    def test_supersede_incrementing_suffix(self, recording_root: Path):
+        tp = to_process_dir(recording_root) / "course" / "section"
+        tp.mkdir(parents=True)
+        sup = superseded_dir(recording_root) / "course" / "section"
+        sup.mkdir(parents=True)
+
+        # Pre-populate superseded with two prior versions
+        (sup / "deck--RAW.mkv").write_bytes(b"v1")
+        (sup / "deck--RAW (2).mkv").write_bytes(b"v2")
+
+        f = tp / "deck--RAW.mkv"
+        f.write_bytes(b"v3")
+
+        _supersede_file(f, recording_root)
+
+        assert not f.exists()
+        assert (sup / "deck--RAW (3).mkv").exists()
+        assert (sup / "deck--RAW (3).mkv").read_bytes() == b"v3"
+
+    def test_supersede_no_companion(self, recording_root: Path):
+        """When no .wav companion exists, only the main file is moved."""
+        tp = to_process_dir(recording_root) / "course" / "section"
+        tp.mkdir(parents=True)
+        f = tp / "deck--RAW.mkv"
+        f.write_bytes(b"video")
+
+        _supersede_file(f, recording_root)
+
+        sup = superseded_dir(recording_root) / "course" / "section"
+        assert (sup / "deck--RAW.mkv").exists()
+        assert not (sup / "deck--RAW.wav").exists()
+
+    def test_rename_supersedes_existing_target(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path
+    ):
+        """When the target file already exists, it is moved to superseded/."""
+        tp = to_process_dir(recording_root) / "c" / "s"
+        tp.mkdir(parents=True)
+        existing = tp / "t--RAW.mkv"
+        existing.write_bytes(b"old recording")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new recording")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+
+        # New recording is at target
+        target = tp / "t--RAW.mkv"
+        assert target.exists()
+        assert target.read_bytes() == b"new recording"
+
+        # Old recording moved to superseded
+        sup = superseded_dir(recording_root) / "c" / "s" / "t--RAW.mkv"
+        assert sup.exists()
+        assert sup.read_bytes() == b"old recording"
+
+
+# ---------------------------------------------------------------------------
+# Dynamic part naming
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicPartNaming:
+    def test_part_0_no_existing(self, recording_root: Path):
+        """No files exist, part 0 → unsuffixed target."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        target = _prepare_target_slot(td, "deck", ".mkv", 0, "--RAW", recording_root)
+        assert target.name == "deck--RAW.mkv"
+
+    def test_part_2_renames_unsuffixed_to_part_1(self, recording_root: Path):
+        """Existing unsuffixed file renamed to (part 1) when part 2 is recorded."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "deck--RAW.mkv").write_bytes(b"old")
+
+        target = _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
+
+        assert target.name == "deck (part 2)--RAW.mkv"
+        assert not (td / "deck--RAW.mkv").exists()
+        assert (td / "deck (part 1)--RAW.mkv").exists()
+        assert (td / "deck (part 1)--RAW.mkv").read_bytes() == b"old"
+
+    def test_part_2_renames_companion_audio(self, recording_root: Path):
+        """Companion .wav is also renamed to (part 1)."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "deck--RAW.mkv").write_bytes(b"video")
+        (td / "deck--RAW.wav").write_bytes(b"audio")
+
+        _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
+
+        assert not (td / "deck--RAW.wav").exists()
+        assert (td / "deck (part 1)--RAW.wav").exists()
+
+    def test_part_2_renames_final_file(self, recording_root: Path):
+        """Unsuffixed file in final/ is also renamed to (part 1)."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "deck--RAW.mkv").write_bytes(b"raw")
+
+        fd = final_dir(recording_root) / "c" / "s"
+        fd.mkdir(parents=True)
+        (fd / "deck.mkv").write_bytes(b"final")
+
+        _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
+
+        assert not (fd / "deck.mkv").exists()
+        assert (fd / "deck (part 1).mkv").exists()
+
+    def test_supersede_only_recording(self, recording_root: Path):
+        """Re-recording the only file: old goes to superseded, target is unsuffixed."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "deck--RAW.mkv").write_bytes(b"old")
+
+        target = _prepare_target_slot(td, "deck", ".mkv", 0, "--RAW", recording_root)
+
+        assert target.name == "deck--RAW.mkv"
+        assert not (td / "deck--RAW.mkv").exists()  # superseded
+        sup = superseded_dir(recording_root) / "c" / "s" / "deck--RAW.mkv"
+        assert sup.exists()
+
+    def test_supersede_one_of_multiple_parts(self, recording_root: Path):
+        """Re-recording part 2 of a multi-part: old part 2 superseded."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "deck (part 1)--RAW.mkv").write_bytes(b"p1")
+        (td / "deck (part 2)--RAW.mkv").write_bytes(b"old p2")
+
+        target = _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
+
+        assert target.name == "deck (part 2)--RAW.mkv"
+        # Part 1 untouched
+        assert (td / "deck (part 1)--RAW.mkv").read_bytes() == b"p1"
+        # Old part 2 superseded
+        sup = superseded_dir(recording_root) / "c" / "s" / "deck (part 2)--RAW.mkv"
+        assert sup.exists()
+        assert sup.read_bytes() == b"old p2"
+
+    def test_part_3_with_existing_parts(self, recording_root: Path):
+        """Adding part 3 when parts 1 and 2 exist: no cascade needed."""
+        td = to_process_dir(recording_root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "deck (part 1)--RAW.mkv").write_bytes(b"p1")
+        (td / "deck (part 2)--RAW.mkv").write_bytes(b"p2")
+
+        target = _prepare_target_slot(td, "deck", ".mkv", 3, "--RAW", recording_root)
+
+        assert target.name == "deck (part 3)--RAW.mkv"
+        # Existing parts untouched
+        assert (td / "deck (part 1)--RAW.mkv").read_bytes() == b"p1"
+        assert (td / "deck (part 2)--RAW.mkv").read_bytes() == b"p2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -11,7 +11,7 @@ import pytest
 from clm.recordings.workflow.directories import ensure_root
 from clm.recordings.workflow.obs import ObsClient, RecordingEvent
 from clm.recordings.workflow.session import (
-    ArmedTopic,
+    ArmedDeck,
     RecordingSession,
     SessionSnapshot,
     SessionState,
@@ -70,13 +70,13 @@ class TestInitialState:
     def test_starts_idle(self, session: RecordingSession):
         assert session.state is SessionState.IDLE
 
-    def test_no_armed_topic(self, session: RecordingSession):
-        assert session.armed_topic is None
+    def test_no_armed_deck(self, session: RecordingSession):
+        assert session.armed_deck is None
 
     def test_snapshot_initial(self, session: RecordingSession):
         snap = session.snapshot()
         assert snap.state is SessionState.IDLE
-        assert snap.armed_topic is None
+        assert snap.armed_deck is None
         assert snap.obs_connected is True
         assert snap.last_output is None
         assert snap.error is None
@@ -93,18 +93,26 @@ class TestInitialState:
 
 class TestArmDisarm:
     def test_arm_from_idle(self, session: RecordingSession):
-        session.arm("python-basics", "Section 01", "intro")
+        session.arm("python-basics", "Section 01", "01 Intro")
         assert session.state is SessionState.ARMED
-        assert session.armed_topic == ArmedTopic("python-basics", "Section 01", "intro")
+        assert session.armed_deck == ArmedDeck("python-basics", "Section 01", "01 Intro")
 
-    def test_arm_from_armed_switches_topic(self, session: RecordingSession):
-        session.arm("course-a", "s1", "topic1")
-        session.arm("course-b", "s2", "topic2")
-        assert session.armed_topic == ArmedTopic("course-b", "s2", "topic2")
+    def test_arm_from_armed_switches_deck(self, session: RecordingSession):
+        session.arm("course-a", "s1", "01 Deck A")
+        session.arm("course-b", "s2", "02 Deck B")
+        assert session.armed_deck == ArmedDeck("course-b", "s2", "02 Deck B")
         assert session.state is SessionState.ARMED
+
+    def test_arm_with_part_number(self, session: RecordingSession):
+        session.arm("c", "s", "03 Intro", part_number=2)
+        assert session.armed_deck == ArmedDeck("c", "s", "03 Intro", 2)
+        assert session.armed_deck.part_number == 2
+
+    def test_arm_part_number_defaults_to_zero(self, session: RecordingSession):
+        session.arm("c", "s", "03 Intro")
+        assert session.armed_deck.part_number == 0
 
     def test_arm_clears_previous_error(self, session: RecordingSession):
-        # Manually set an error
         session._error = "old error"
         session.arm("c", "s", "t")
         assert session.snapshot().error is None
@@ -121,7 +129,7 @@ class TestArmDisarm:
         session.arm("c", "s", "t")
         session.disarm()
         assert session.state is SessionState.IDLE
-        assert session.armed_topic is None
+        assert session.armed_deck is None
 
     def test_disarm_from_idle(self, session: RecordingSession):
         session.disarm()  # No-op, should not raise
@@ -133,6 +141,17 @@ class TestArmDisarm:
 
         with pytest.raises(RuntimeError, match="Cannot disarm"):
             session.disarm()
+
+    def test_armed_topic_alias(self, session: RecordingSession):
+        """The deprecated armed_topic property returns the same as armed_deck."""
+        session.arm("c", "s", "t")
+        assert session.armed_topic is session.armed_deck
+
+    def test_snapshot_armed_topic_alias(self, session: RecordingSession):
+        """SessionSnapshot.armed_topic returns armed_deck for backward compat."""
+        session.arm("c", "s", "t")
+        snap = session.snapshot()
+        assert snap.armed_topic is snap.armed_deck
 
 
 # ---------------------------------------------------------------------------
@@ -157,8 +176,7 @@ class TestRecordingStart:
 
 
 class TestRecordingStopNoRename:
-    def test_stop_without_armed_topic_goes_idle(self, session: RecordingSession, mock_obs):
-        # Force into RECORDING state without armed topic
+    def test_stop_without_armed_deck_goes_idle(self, session: RecordingSession, mock_obs):
         session._state = SessionState.RECORDING
         session._armed = None
         _fire_event(
@@ -198,7 +216,6 @@ class TestRecordingStopNoRename:
         _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
         assert session.state is SessionState.RECORDING
 
-        # Intermediate STOPPING event — should NOT change state
         _fire_event(
             mock_obs,
             RecordingEvent(
@@ -207,12 +224,12 @@ class TestRecordingStopNoRename:
             ),
         )
         assert session.state is SessionState.RECORDING
-        assert session.armed_topic is not None
+        assert session.armed_deck is not None
 
     def test_stopping_then_stopped_completes_rename(
         self, session: RecordingSession, mock_obs, tmp_path
     ):
-        """Full STOPPING → STOPPED sequence: the rename only happens on
+        """Full STOPPING -> STOPPED sequence: the rename only happens on
         the STOPPED event that carries the output_path."""
         obs_output = tmp_path / "rec.mkv"
         obs_output.write_bytes(b"video data")
@@ -220,7 +237,6 @@ class TestRecordingStopNoRename:
         session.arm("c", "s", "t")
         _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
 
-        # Intermediate STOPPING — ignored
         _fire_event(
             mock_obs,
             RecordingEvent(
@@ -230,7 +246,6 @@ class TestRecordingStopNoRename:
         )
         assert session.state is SessionState.RECORDING
 
-        # Final STOPPED — triggers rename
         with patch("clm.recordings.workflow.session.shutil.move"):
             _fire_event(
                 mock_obs,
@@ -243,7 +258,7 @@ class TestRecordingStopNoRename:
             _wait_for_state(session, SessionState.IDLE, timeout=5.0)
 
         assert session.state is SessionState.IDLE
-        assert session.armed_topic is None
+        assert session.armed_deck is None
 
     def test_stopping_event_does_not_trigger_callback(
         self, mock_obs: MagicMock, recording_root: Path
@@ -279,11 +294,10 @@ class TestRecordingStopNoRename:
 class TestRecordingStopWithRename:
     @patch("clm.recordings.workflow.session.shutil.move")
     def test_rename_moves_file(self, mock_move, session: RecordingSession, mock_obs, tmp_path):
-        # Create a fake OBS output file
         obs_output = tmp_path / "2025-04-01_12-00-00.mkv"
         obs_output.write_bytes(b"video data")
 
-        session.arm("python-basics", "Section 01", "intro")
+        session.arm("python-basics", "Section 01", "01 Intro")
         _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
 
         assert session.state is SessionState.RECORDING
@@ -297,7 +311,6 @@ class TestRecordingStopWithRename:
             ),
         )
 
-        # Wait for the rename thread to complete
         _wait_for_state(session, SessionState.IDLE, timeout=5.0)
 
         assert session.state is SessionState.IDLE
@@ -306,7 +319,29 @@ class TestRecordingStopWithRename:
         assert src == str(obs_output)
         assert "python-basics" in dst
         assert "Section 01" in dst
-        assert "intro--RAW.mkv" in dst
+        assert "01 Intro--RAW.mkv" in dst
+
+    @patch("clm.recordings.workflow.session.shutil.move")
+    def test_rename_with_part_number(self, mock_move, session, mock_obs, tmp_path):
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"video data")
+
+        session.arm("c", "s", "03 Intro", part_number=2)
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+        _wait_for_state(session, SessionState.IDLE, timeout=5.0)
+
+        mock_move.assert_called_once()
+        _, dst = mock_move.call_args[0]
+        assert "03 Intro (part 2)--RAW.mkv" in dst
 
     @patch("clm.recordings.workflow.session.shutil.move")
     def test_rename_sets_last_output(self, mock_move, session, mock_obs, tmp_path):
@@ -331,7 +366,7 @@ class TestRecordingStopWithRename:
         assert snap.last_output.name == "t--RAW.mp4"
 
     @patch("clm.recordings.workflow.session.shutil.move")
-    def test_rename_clears_armed_topic(self, mock_move, session, mock_obs, tmp_path):
+    def test_rename_clears_armed_deck(self, mock_move, session, mock_obs, tmp_path):
         obs_output = tmp_path / "rec.mp4"
         obs_output.write_bytes(b"data")
 
@@ -347,7 +382,7 @@ class TestRecordingStopWithRename:
         )
 
         _wait_for_state(session, SessionState.IDLE, timeout=5.0)
-        assert session.armed_topic is None
+        assert session.armed_deck is None
 
     def test_rename_file_not_found_sets_error(self, session, mock_obs):
         session.arm("c", "s", "t")
@@ -436,30 +471,42 @@ class TestStateChangeCallback:
         callback = MagicMock(side_effect=RuntimeError("callback error"))
         session = RecordingSession(mock_obs, recording_root, on_state_change=callback)
 
-        # Should not raise despite callback error
         session.arm("c", "s", "t")
         assert session.state is SessionState.ARMED
 
 
 # ---------------------------------------------------------------------------
-# ArmedTopic
+# ArmedDeck
 # ---------------------------------------------------------------------------
 
 
-class TestArmedTopic:
+class TestArmedDeck:
     def test_frozen(self):
-        topic = ArmedTopic("c", "s", "t")
+        deck = ArmedDeck("c", "s", "d")
         with pytest.raises(AttributeError):
-            topic.course_slug = "other"  # type: ignore[misc]
+            deck.course_slug = "other"  # type: ignore[misc]
 
     def test_equality(self):
-        a = ArmedTopic("c", "s", "t")
-        b = ArmedTopic("c", "s", "t")
+        a = ArmedDeck("c", "s", "d")
+        b = ArmedDeck("c", "s", "d")
         assert a == b
 
     def test_inequality(self):
-        a = ArmedTopic("c", "s", "t")
-        b = ArmedTopic("c", "s", "other")
+        a = ArmedDeck("c", "s", "d")
+        b = ArmedDeck("c", "s", "other")
+        assert a != b
+
+    def test_default_part_number(self):
+        deck = ArmedDeck("c", "s", "d")
+        assert deck.part_number == 0
+
+    def test_custom_part_number(self):
+        deck = ArmedDeck("c", "s", "d", part_number=3)
+        assert deck.part_number == 3
+
+    def test_equality_includes_part(self):
+        a = ArmedDeck("c", "s", "d", part_number=1)
+        b = ArmedDeck("c", "s", "d", part_number=2)
         assert a != b
 
 

--- a/tests/recordings/test_watcher.py
+++ b/tests/recordings/test_watcher.py
@@ -130,6 +130,27 @@ class TestWatcherState:
         state.release(p)
         assert state.try_claim(p) is True
 
+    def test_try_claim_rejects_submitted(self):
+        state = WatcherState()
+        p = Path("/a.wav")
+        state.mark_submitted(p)
+        assert state.try_claim(p) is False
+
+    def test_mark_submitted_is_idempotent(self):
+        state = WatcherState()
+        p = Path("/a.wav")
+        state.mark_submitted(p)
+        state.mark_submitted(p)  # should not raise
+
+    def test_release_does_not_clear_submitted(self):
+        state = WatcherState()
+        p = Path("/a.wav")
+        state.try_claim(p)
+        state.mark_submitted(p)
+        state.release(p)
+        # Still rejected because it's in the submitted set
+        assert state.try_claim(p) is False
+
     def test_release_unclaimed_path_is_safe(self):
         state = WatcherState()
         state.release(Path("/nonexistent"))  # should not raise
@@ -488,5 +509,101 @@ class TestWatcherLiveEvents:
             # Give the watcher a moment to see the event and decide.
             time.sleep(0.5)
             assert backend.submit_calls == []
+        finally:
+            watcher.stop()
+
+
+# ------------------------------------------------------------------
+# Scan existing files on start
+# ------------------------------------------------------------------
+
+
+class TestScanExisting:
+    def test_scan_finds_pre_existing_files(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = root / "to-process"
+
+        # Create a file BEFORE starting the watcher
+        wav = tp / "lecture--RAW.wav"
+        wav.write_bytes(b"audio data")
+
+        backend = _FakeBackend(accepted_suffix=".wav")
+        manager = _make_manager(root, backend)
+        submitted_event = threading.Event()
+
+        watcher = RecordingsWatcher(
+            root,
+            manager,
+            backend,
+            stability_interval=0.05,
+            stability_checks=2,
+            on_submitted=lambda job: submitted_event.set(),
+        )
+        watcher.start()
+
+        try:
+            assert submitted_event.wait(timeout=5.0), "Pre-existing file not picked up"
+            assert len(backend.submit_calls) == 1
+            assert backend.submit_calls[0] == wav
+        finally:
+            watcher.stop()
+
+    def test_scan_ignores_rejected_files(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = root / "to-process"
+
+        # Only .wav accepted, but we put .mp4
+        (tp / "lecture--RAW.mp4").write_bytes(b"video data")
+
+        backend = _FakeBackend(accepted_suffix=".wav")
+        manager = _make_manager(root, backend)
+        watcher = RecordingsWatcher(
+            root, manager, backend, stability_interval=0.05, stability_checks=2
+        )
+        watcher.start()
+
+        try:
+            time.sleep(0.5)
+            assert backend.submit_calls == []
+        finally:
+            watcher.stop()
+
+    def test_submitted_file_not_resubmitted(self, tmp_path: Path):
+        """After dispatch completes, a stop+start cycle should not re-submit."""
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = root / "to-process"
+
+        wav = tp / "lecture--RAW.wav"
+        wav.write_bytes(b"audio data")
+
+        backend = _FakeBackend(accepted_suffix=".wav")
+        manager = _make_manager(root, backend)
+        submitted_event = threading.Event()
+
+        watcher = RecordingsWatcher(
+            root,
+            manager,
+            backend,
+            stability_interval=0.05,
+            stability_checks=2,
+            on_submitted=lambda job: submitted_event.set(),
+        )
+        watcher.start()
+
+        try:
+            assert submitted_event.wait(timeout=5.0)
+            assert len(backend.submit_calls) == 1
+        finally:
+            watcher.stop()
+
+        # Stop and restart — the file should NOT be re-submitted
+        submitted_event.clear()
+        watcher.start()
+        try:
+            time.sleep(0.5)
+            assert len(backend.submit_calls) == 1  # still just the one
         finally:
             watcher.stop()

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -99,48 +99,116 @@ class TestLectures:
         assert resp.status_code == 200
         assert "No course spec file" in resp.text
 
-    def test_get_lectures_with_spec(self, app, recording_root: Path, tmp_path: Path):
-        spec_xml = tmp_path / "course.xml"
-        spec_xml.write_text(
-            """<?xml version="1.0" encoding="UTF-8"?>
-            <course>
-                <name>
-                    <de>Test Kurs</de>
-                    <en>Test Course</en>
-                </name>
-                <prog-lang>python</prog-lang>
-                <description>
-                    <de>Beschreibung</de>
-                    <en>Description</en>
-                </description>
-                <certificate>
-                    <de>Zertifikat</de>
-                    <en>Certificate</en>
-                </certificate>
-                <sections>
-                    <section>
-                        <name>
-                            <de>Einleitung</de>
-                            <en>Introduction</en>
-                        </name>
-                        <topics>
-                            <topic>intro/overview</topic>
-                            <topic>intro/setup</topic>
-                        </topics>
-                    </section>
-                </sections>
-            </course>
-            """,
-            encoding="utf-8",
-        )
-        app.state.spec_file = spec_xml
+    def test_get_lectures_with_course(self, app, recording_root: Path):
+        """When a Course is cached, the lectures page shows section names
+        and slide deck display names."""
+        from clm.core.utils.text_utils import Text
+
+        mock_course = MagicMock()
+        mock_section = MagicMock()
+        mock_section.name = Text(de="Woche 1", en="Week 1")
+        mock_nb = MagicMock()
+        mock_nb.title = Text(de="Einführung", en="Introduction")
+        mock_nb.number_in_section = 1
+        mock_nb.file_name.return_value = "01 Einführung"
+        mock_section.notebooks = [mock_nb]
+        mock_course.sections = [mock_section]
+        mock_course.output_dir_name = Text(de="test-course-de", en="test-course-en")
+        app.state.course = mock_course
+
+        with TestClient(app) as c:
+            # Default lang is "de"
+            resp = c.get("/lectures")
+        assert resp.status_code == 200
+        assert "Woche 1" in resp.text
+        assert "01 Einführung" in resp.text
+
+    def test_get_lectures_english(self, app, recording_root: Path):
+        """When lang=en cookie is set, English names are shown."""
+        from clm.core.utils.text_utils import Text
+
+        mock_course = MagicMock()
+        mock_section = MagicMock()
+        mock_section.name = Text(de="Woche 1", en="Week 1")
+        mock_nb = MagicMock()
+        mock_nb.title = Text(de="Einführung", en="Introduction")
+        mock_nb.number_in_section = 1
+        mock_nb.file_name.return_value = "01 Introduction"
+        mock_section.notebooks = [mock_nb]
+        mock_course.sections = [mock_section]
+        mock_course.output_dir_name = Text(de="test-course-de", en="test-course-en")
+        app.state.course = mock_course
+
+        with TestClient(app, cookies={"clm_lang": "en"}) as c:
+            resp = c.get("/lectures")
+        assert resp.status_code == 200
+        assert "Week 1" in resp.text
+        assert "01 Introduction" in resp.text
+
+    def test_lectures_shows_course_slug(self, app, recording_root: Path):
+        """The arm form should include the correct course_slug."""
+        from clm.core.utils.text_utils import Text
+
+        mock_course = MagicMock()
+        mock_section = MagicMock()
+        mock_section.name = Text(de="Woche 1", en="Week 1")
+        mock_nb = MagicMock()
+        mock_nb.title = Text(de="Intro", en="Intro")
+        mock_nb.number_in_section = 1
+        mock_nb.file_name.return_value = "01 Intro"
+        mock_section.notebooks = [mock_nb]
+        mock_course.sections = [mock_section]
+        mock_course.output_dir_name = Text(de="kurs-de", en="course-en")
+        app.state.course = mock_course
 
         with TestClient(app) as c:
             resp = c.get("/lectures")
+        assert 'value="kurs-de"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Language selection
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageSelection:
+    def test_set_lang_de(self, client: TestClient):
+        resp = client.post("/set-lang", data={"lang": "de"}, follow_redirects=False)
         assert resp.status_code == 200
-        assert "Introduction" in resp.text
-        assert "overview" in resp.text
-        assert "setup" in resp.text
+        assert resp.headers.get("hx-redirect") == "/lectures"
+        assert "clm_lang" in resp.cookies
+        assert resp.cookies["clm_lang"] == "de"
+
+    def test_set_lang_en(self, client: TestClient):
+        resp = client.post("/set-lang", data={"lang": "en"}, follow_redirects=False)
+        assert resp.status_code == 200
+        assert resp.cookies["clm_lang"] == "en"
+
+    def test_set_lang_invalid_defaults_to_de(self, client: TestClient):
+        resp = client.post("/set-lang", data={"lang": "fr"}, follow_redirects=False)
+        assert resp.status_code == 200
+        assert resp.cookies["clm_lang"] == "de"
+
+
+# ---------------------------------------------------------------------------
+# Lectures refresh
+# ---------------------------------------------------------------------------
+
+
+class TestLecturesRefresh:
+    def test_refresh_rebuilds_course(self, app, client: TestClient, tmp_path: Path):
+        app.state.spec_file = tmp_path / "course.xml"
+        with patch("clm.recordings.web.app._build_course") as mock_build:
+            mock_build.return_value = MagicMock()
+            resp = client.post("/lectures/refresh", follow_redirects=False)
+        assert resp.status_code == 200
+        assert resp.headers.get("hx-redirect") == "/lectures"
+        mock_build.assert_called_once_with(app.state.spec_file)
+
+    def test_refresh_without_spec_file(self, app, client: TestClient):
+        app.state.spec_file = None
+        resp = client.post("/lectures/refresh", follow_redirects=False)
+        assert resp.status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -149,18 +217,19 @@ class TestLectures:
 
 
 class TestArmDisarm:
-    def test_arm_topic(self, client: TestClient):
+    def test_arm_deck(self, client: TestClient):
         resp = client.post(
             "/arm",
             data={
                 "course_slug": "python-basics",
                 "section_name": "intro",
-                "topic_name": "hello",
+                "deck_name": "01 Hello",
+                "part_number": "0",
             },
         )
         assert resp.status_code == 200
         assert "python-basics" in resp.text
-        assert "hello" in resp.text
+        assert "01 Hello" in resp.text
 
     def test_arm_changes_state(self, app, client: TestClient):
         client.post(
@@ -168,25 +237,38 @@ class TestArmDisarm:
             data={
                 "course_slug": "c",
                 "section_name": "s",
-                "topic_name": "t",
+                "deck_name": "01 Deck",
+                "part_number": "0",
             },
         )
         session = app.state.session
         assert session.state is SessionState.ARMED
-        assert session.armed_topic is not None
-        assert session.armed_topic.topic_name == "t"
+        assert session.armed_deck is not None
+        assert session.armed_deck.deck_name == "01 Deck"
 
-    def test_disarm(self, client: TestClient):
-        # Arm first
+    def test_arm_with_part_number(self, app, client: TestClient):
         client.post(
             "/arm",
             data={
                 "course_slug": "c",
                 "section_name": "s",
-                "topic_name": "t",
+                "deck_name": "03 Intro",
+                "part_number": "2",
             },
         )
-        # Then disarm
+        session = app.state.session
+        assert session.armed_deck.part_number == 2
+
+    def test_disarm(self, client: TestClient):
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
         resp = client.post("/disarm")
         assert resp.status_code == 200
         assert "idle" in resp.text
@@ -207,7 +289,7 @@ class TestStatus:
         assert resp.status_code == 200
         data = resp.json()
         assert data["state"] == "idle"
-        assert data["armed_topic"] is None
+        assert data["armed_deck"] is None
         assert "obs_connected" in data
 
     def test_status_json_after_arm(self, client: TestClient):
@@ -216,13 +298,30 @@ class TestStatus:
             data={
                 "course_slug": "c",
                 "section_name": "s",
-                "topic_name": "t",
+                "deck_name": "01 Deck",
+                "part_number": "0",
             },
         )
         resp = client.get("/status")
         data = resp.json()
         assert data["state"] == "armed"
-        assert data["armed_topic"]["topic_name"] == "t"
+        assert data["armed_deck"]["deck_name"] == "01 Deck"
+        assert data["armed_deck"]["part_number"] == 0
+
+    def test_status_json_backward_compat(self, client: TestClient):
+        """The JSON response still includes armed_topic for backward compat."""
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
+        data = client.get("/status").json()
+        assert data["armed_topic"] is not None
+        assert data["armed_topic"] == data["armed_deck"]
 
     def test_status_partial(self, client: TestClient):
         resp = client.get("/status-partial")
@@ -252,12 +351,16 @@ class TestSSEEvents:
         assert app.state.sse_queue is not None
 
     def test_arm_pushes_to_sse_queue(self, app, client: TestClient):
-        """Arming a topic should push a state_changed event to the SSE queue."""
+        """Arming a deck should push a state_changed event to the SSE queue."""
         client.post(
             "/arm",
-            data={"course_slug": "c", "section_name": "s", "topic_name": "t"},
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
         )
-        # The session's on_state_change callback pushes to the queue
         queue = app.state.sse_queue
         assert not queue.empty()
 
@@ -297,8 +400,6 @@ class TestWatcherControls:
 
     def test_dashboard_shows_watcher_mode(self, client: TestClient):
         resp = client.get("/")
-        # Default backend is now "onnx" (Phase C); the dashboard renders
-        # the backend's machine name in the watcher status panel.
         assert "onnx" in resp.text
 
     def test_start_watcher(self, app, client: TestClient):

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -420,3 +420,46 @@ class TestWatcherControls:
         resp = client.get("/status-partial")
         assert resp.status_code == 200
         assert "File Watcher" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# OBS controls
+# ---------------------------------------------------------------------------
+
+
+class TestObsControls:
+    def test_obs_connect_success(self, app, client: TestClient):
+        obs = app.state.obs
+        obs.connect.side_effect = None  # Clear the ConnectionError side_effect
+        obs.connected = True
+        resp = client.post("/obs/connect")
+        assert resp.status_code == 200
+        obs.connect.assert_called()
+        assert "connected" in resp.text
+
+    def test_obs_connect_failure(self, app, client: TestClient):
+        obs = app.state.obs
+        obs.connect.side_effect = ConnectionError("OBS not running")
+        obs.connected = False
+        resp = client.post("/obs/connect")
+        assert resp.status_code == 200
+        assert "disconnected" in resp.text
+
+    def test_obs_disconnect(self, app, client: TestClient):
+        obs = app.state.obs
+        obs.connected = False
+        resp = client.post("/obs/disconnect")
+        assert resp.status_code == 200
+        obs.disconnect.assert_called()
+
+    def test_status_shows_connect_button_when_disconnected(self, client: TestClient):
+        resp = client.get("/status-partial")
+        assert resp.status_code == 200
+        assert "disconnected" in resp.text
+        assert "/obs/connect" in resp.text
+
+    def test_status_shows_disconnect_button_when_connected(self, app, client: TestClient):
+        app.state.obs.connected = True
+        resp = client.get("/status-partial")
+        assert resp.status_code == 200
+        assert "/obs/disconnect" in resp.text


### PR DESCRIPTION
## Summary

- **Superseded folder**: re-recording moves old files to `superseded/` instead of overwriting, with incrementing suffixes for collision avoidance
- **OBS connect/disconnect**: dashboard buttons for manual OBS WebSocket connection management
- **Watcher scan-on-start**: walks `to-process/` after observer starts to pick up pre-existing files; `_submitted` set prevents double-dispatch
- **Dynamic part naming**: single recording = no suffix; adding parts triggers cascade rename (unsuffixed → part 1), including companion `.wav` and `final/` files. German recordings use "(Teil N)" suffix.
- **Deck recording status**: per-deck state badges (no_recording/recorded/ready/processing/completed/failed), visible part-number input, manual Process button (multi-part aware), armed-row highlight, partial-completion tracking
- **Bug fix**: `_build_course()` now uses `resolve_course_paths()` for correct course root resolution

454 recordings tests pass.

## Test plan

- [x] Verify lectures page shows deck status badges for each slide deck
- [x] Arm a deck and record — confirm file lands in `to-process/`
- [x] Re-record same deck — confirm old file moves to `superseded/`
- [x] Record part 2 — confirm unsuffixed file renames to (part 1) / (Teil 1)
- [x] Test OBS Connect/Disconnect buttons in status panel
- [x] Start server with pre-existing files in `to-process/` — confirm watcher picks them up
- [x] Test manual Process button on a recorded deck (single and multi-part)
- [x] Test language toggle (de/en) on lectures page
- [x] Verify armed deck row is highlighted and shows Disarm button
- [x] Verify partial completion shows done/raw breakdown and Process button for remaining parts

🤖 Generated with [Claude Code](https://claude.com/claude-code)