### PR TITLE
feat(voiceover): multi-file input, merge mode, Langfuse tracing, training data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ clm-faststream-backend-old/
 
 # Diagnostic output from the voiceover test tool
 tools/diagnostic_output/
+
+# CLM local data (voiceover trace logs, etc.)
+.clm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - New routes: `POST /set-lang`, `POST /lectures/refresh`.
   - JSON status API includes both `armed_deck` (new) and `armed_topic`
     (deprecated alias) for transition.
+- **`clm voiceover sync` now accepts multiple video files** (breaking CLI
+  change): argument order flipped from `sync VIDEO SLIDES` to
+  `sync SLIDES VIDEO...`. Multiple video parts are processed independently
+  (transcription + transition detection per part) and merged into a single
+  logical timeline using running offsets — no on-disk concatenation. Each
+  `TranscriptSegment` and `TransitionEvent` carries a `source_part_index`
+  for downstream consumers. Single-video invocations work as before (just
+  swap the argument order).
 
 ### Fixed
 - **`parse_dir_groups` now respects `<section enabled="false">`**: previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `TranscriptSegment` and `TransitionEvent` carries a `source_part_index`
   for downstream consumers. Single-video invocations work as before (just
   swap the argument order).
+- **`clm voiceover sync` now merges into existing voiceover cells by
+  default** instead of overwriting them. The merge uses a single-pass LLM
+  call (Claude Sonnet 4.6 via OpenRouter by default) that preserves baseline
+  content, integrates substantive transcript additions, and filters recording
+  noise (greetings, self-corrections, code-typing dictation, operator
+  asides). Use `--overwrite` to restore the old destructive behavior.
+  - Factual contradictions in the transcript may rewrite baseline bullets;
+    every rewrite is tracked in a structured `rewrites` field.
+  - `--dry-run` now emits a colored unified diff with rewrite annotations.
+  - `--mode verbatim` without `--overwrite` is now an error (verbatim has
+    no noise filter, so merging raw transcript would be unsafe).
+  - Every merge run writes a JSONL trace log to
+    `.clm/voiceover-traces/` for future training data extraction.
+  - LLM calls are batched across slides (20k char budget per batch) with
+    automatic per-slide fallback on JSON parse failure.
 
 ### Fixed
 - **`parse_dir_groups` now respects `<section enabled="false">`**: previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Langfuse tracing for all LLM calls**: when `LANGFUSE_HOST` (or
+  `LANGFUSE_BASE_URL`), `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` are
+  set, `_build_client` returns a Langfuse-observed `openai.AsyncOpenAI` that
+  traces all LLM calls automatically. Benefits `clm voiceover sync` (merge),
+  `clm polish`, and `clm summarize`. Env vars absent = no change. Langfuse
+  unreachable = warning, pipeline continues. `langfuse>=3.0.0` added to the
+  `[voiceover]` extra. Each voiceover merge invocation groups traces into a
+  Langfuse session with per-batch trace IDs, tags, and metadata; the
+  `langfuse_trace_id` is also written to the local JSONL trace log for
+  correlation.
+
 ### Changed
 - **Recordings dashboard: slide-deck-based lecture selection**: The
   `/lectures` page now lists individual slide decks (notebook files)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Training data extraction**: new `clm voiceover extract-training-data`
+  command reads JSONL trace logs produced by `clm voiceover sync` and
+  correlates each entry with the current slide file state to produce training
+  triples (`input.baseline`, `input.transcript`, `llm_output`, `human_final`,
+  `delta_vs_llm`). Entries where the human final matches the LLM output are
+  emitted with an empty delta as positive training examples. Entries with
+  unreachable `git_head` commits are skipped with a warning. Supports
+  `--base-dir`, `--tag`, `--no-check-git`, and `--output` options.
 - **Langfuse tracing for all LLM calls**: when `LANGFUSE_HOST` (or
   `LANGFUSE_BASE_URL`), `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` are
   set, `_build_client` returns a Langfuse-observed `openai.AsyncOpenAI` that

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ clm --help
 - **Recording Management**: Manage video recording workflows with pluggable backends — local ONNX pipeline, iZotope RX 11 external tool, or Auphonic cloud processing — plus assembly, job tracking, and per-course status (`clm recordings`)
 - **MCP Server**: Model Context Protocol server for AI-assisted slide authoring (`clm mcp`) with 12 tools for course navigation, validation, normalization, and bilingual editing
 - **Slide Authoring Tools**: Topic resolution (`clm resolve-topic`), fuzzy search (`clm search-slides`), spec/slide validation (`clm validate-spec`, `clm validate-slides`), normalization (`clm normalize-slides`), bilingual language view (`clm language-view`), sync suggestions (`clm suggest-sync`), voiceover extraction (`clm extract-voiceover`), and structured JSON outlines (`clm outline --format json`)
-- **Voiceover Sync**: Synchronize video recordings with slides to auto-generate speaker notes (`clm voiceover sync`)
+- **Voiceover Sync**: Synchronize video recordings with slides to auto-generate speaker notes (`clm voiceover sync`), with multi-file input for part-based recordings and intelligent merge mode that preserves existing content while integrating transcript additions and filtering recording noise
 - **LLM Polish**: Clean up speaker notes with LLM-powered text polishing (`clm polish`)
 - **Git Integration**: Manage output repos with `clm git init/sync/status`, including `--amend` and `--force-with-lease` for iterative workflows
 - **Flexible Remote URLs**: Configurable git remote URL templates for SSH, custom hosts, etc.

--- a/docs/claude/voiceover-sync-improvements-handover-archive.md
+++ b/docs/claude/voiceover-sync-improvements-handover-archive.md
@@ -1,3 +1,18 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-04-12 -->
+
+# Handover Archive: Voiceover Sync Improvements
+
+> **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete.
+> **There is no active handover document.** It must **not** be used
+> with `/resume-feature`, `/implement-next-phase`, or similar commands
+> that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
+
 # Voiceover Sync Improvements — Handover
 
 **Status**: All four phases complete.

--- a/docs/claude/voiceover-sync-improvements-handover.md
+++ b/docs/claude/voiceover-sync-improvements-handover.md
@@ -1,6 +1,6 @@
 # Voiceover Sync Improvements — Handover
 
-**Status**: Phase 2 complete. Phase 3 (Langfuse tracing) is next.
+**Status**: Phase 3 complete. Phase 4 (training data extraction) is next.
 **Branch**: `worktree-purring-strolling-crab` (worktree off `master`).
 **Source of truth (design)**: [`docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md`](../proposals/VOICEOVER_SYNC_IMPROVEMENTS.md)
 **Related prior work**: [`docs/claude/voiceover-design.md`](voiceover-design.md), [`docs/claude/voiceover-sync-windows-crash.md`](voiceover-sync-windows-crash.md)
@@ -262,7 +262,7 @@ rewrites. Local trace log is written on every run.
 
 ---
 
-### Phase 3 — Langfuse tracing [TODO]
+### Phase 3 — Langfuse tracing [DONE]
 
 **Goal**: LLM calls are traced to Langfuse when
 `LANGFUSE_HOST`/`LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` are all set.
@@ -324,8 +324,8 @@ training triples.
 
 ## 4. Current Status
 
-**Phase 2 is complete.** Merge mode implemented and tested.
-Phase 3 (Langfuse tracing) is next.
+**Phase 3 is complete.** Langfuse tracing implemented and tested.
+Phase 4 (training data extraction) is next.
 
 **Completed**:
 
@@ -375,6 +375,28 @@ Phase 3 (Langfuse tracing) is next.
     write, required fields, git HEAD, Langfuse ID), `test_merge_cli.py`
     (5 tests — verbatim+merge error, --overwrite flag, help text).
   - All 187 voiceover tests pass; 3045 total tests pass.
+- **Phase 3 implemented (2026-04-12)**:
+  - `_build_client` in `src/clm/infrastructure/llm/client.py` now returns
+    a Langfuse-wrapped `AsyncOpenAI` when `LANGFUSE_HOST` (or
+    `LANGFUSE_BASE_URL`), `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY`
+    are all set and the `langfuse` package is installed. Falls back to
+    plain `openai.AsyncOpenAI` otherwise.
+  - New `_langfuse_configured()` checks env vars (empty strings treated
+    as absent). New `flush_langfuse()` flushes pending traces (best-effort,
+    never raises).
+  - `langfuse>=3.0.0` added to `[voiceover]` extra in `pyproject.toml`.
+  - `polish_and_merge()` and `merge_batch()` in `src/clm/voiceover/merge.py`
+    accept `langfuse_context: dict | None` forwarded to `create()` calls.
+  - CLI `_merge_notes()` builds per-batch Langfuse context with
+    `session_id`, `trace_id`, `tags`, `metadata`, and `user_id` (git
+    user.name). Passes `langfuse_trace_id` to trace log. Flushes Langfuse
+    at end.
+  - The wrapping benefits all LLM-using modules (`summarize_notebook`,
+    `polish_text`, merge) — not just voiceover.
+  - 22 new tests in `test_langfuse.py`: env-var gating (9), client
+    wrapping/fallback (5), flush behavior (3), merge context forwarding
+    (4), trace log ID (2).
+  - All 209 voiceover tests pass; 3067 total tests pass.
 
 **In progress**: none.
 
@@ -393,41 +415,50 @@ Phase 3 (Langfuse tracing) is next.
   merge needs.
 - **Default model** (Phase 2): `anthropic/claude-sonnet-4-6` via
   OpenRouter per user preference.
+- **LANGFUSE_HOST vs LANGFUSE_BASE_URL** (Phase 3): accept both.
+  `LANGFUSE_HOST` is the name in the proposal; `LANGFUSE_BASE_URL` is the
+  newer Langfuse SDK convention. Either works.
+- **Langfuse SDK integration pattern** (Phase 3): used
+  `from langfuse.openai import AsyncOpenAI` (drop-in replacement). SDK v3
+  accepts per-call metadata via `metadata={"langfuse_session_id": ...,
+  "langfuse_tags": [...]}` kwargs on `create()`. These are stripped before
+  reaching the OpenAI API.
 
 **Open questions**: none.
 
-**Tests**: 187 voiceover tests pass. Fast suite runs via pre-commit.
+**Tests**: 209 voiceover tests pass. Fast suite runs via pre-commit.
 Use `pytest -m "not docker"` for the pre-release full run.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 3 — Langfuse tracing.** In order:
+**Start Phase 4 — Training data extraction.** In order:
 
-1. **Read `src/clm/infrastructure/llm/client.py`.** The `_build_client`
-   factory is the single hook point. When Langfuse env vars are set,
-   wrap the returned `openai.AsyncOpenAI` with the Langfuse observer.
+1. **Read `src/clm/voiceover/trace_log.py`** to understand the JSONL
+   schema written by Phase 2/3.
 
-2. **Add `langfuse` to `[voiceover]` extra** in `pyproject.toml`.
+2. **Implement `src/clm/voiceover/training_export.py`** — trace log
+   reader that parses each JSONL entry, correlates it against the
+   current slide file state to produce training triples:
+   `{input.baseline, input.transcript, llm_output, human_final,
+   delta_vs_llm}`.
 
-3. **Implement env-var gated wrapping.** When `LANGFUSE_HOST`,
-   `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` are all set,
-   `_build_client` returns a Langfuse-wrapped client. Otherwise plain.
+3. **Add `clm voiceover extract-training-data` subcommand** in
+   `src/clm/cli/commands/voiceover.py`. Takes a trace log path,
+   emits training JSONL.
 
-4. **Thread session/metadata into merge calls.** `session_id`,
-   metadata, and tags in `src/clm/voiceover/merge.py`.
-
-5. **Record Langfuse trace ID in trace log.** The `langfuse_trace_id`
-   field in `trace_log.py` is already plumbed; wire it up.
-
-6. **Write tests.** Env-var gating, failure isolation (unreachable
-   Langfuse → warning + continue), plain client when vars absent.
+4. **Write tests.** Round-trip: synthetic trace log + synthetic slide
+   state → expected training triples. Handle unreachable `git_head`
+   gracefully (skip with warning).
 
 **Gotchas**:
 
-- Langfuse must never break the pipeline. Unreachable → warning.
-- The wrapping benefits all LLM-using modules, not just voiceover.
+- Entries whose `git_head` commit is unreachable must be skipped with
+  a warning, not crash the extraction.
+- `human_final == llm_output` is a valid positive training example
+  (no hand edits) — emit with empty `delta_vs_llm`.
+- Low priority until a corpus has accumulated from real sync runs.
 
 ---
 
@@ -471,12 +502,17 @@ Use `pytest -m "not docker"` for the pre-release full run.
 | `tests/voiceover/test_trace_log.py` | 13 tests: create, write, required fields, git HEAD, Langfuse ID |
 | `tests/voiceover/test_merge_cli.py` | 5 tests: verbatim+merge error, --overwrite flag, help text |
 
+### Files created in Phase 3
+
+| File | Purpose |
+|---|---|
+| `tests/voiceover/test_langfuse.py` | 22 tests: env-var gating, client wrapping/fallback, flush behavior, merge context forwarding, trace log ID |
+
 ### New files planned (future phases)
 
 | File | Purpose | Phase |
 |---|---|---|
 | `src/clm/voiceover/training_export.py` | Trace-log reader + slide-state correlator for training triples | 4 |
-| `tests/voiceover/test_langfuse_*.py` | Langfuse fallback tests | 3 |
 
 ### How the components connect
 

--- a/docs/claude/voiceover-sync-improvements-handover.md
+++ b/docs/claude/voiceover-sync-improvements-handover.md
@@ -1,6 +1,6 @@
 # Voiceover Sync Improvements — Handover
 
-**Status**: Phase 1 complete. Phase 2 (merge mode) is next.
+**Status**: Phase 2 complete. Phase 3 (Langfuse tracing) is next.
 **Branch**: `worktree-purring-strolling-crab` (worktree off `master`).
 **Source of truth (design)**: [`docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md`](../proposals/VOICEOVER_SYNC_IMPROVEMENTS.md)
 **Related prior work**: [`docs/claude/voiceover-design.md`](voiceover-design.md), [`docs/claude/voiceover-sync-windows-crash.md`](voiceover-sync-windows-crash.md)
@@ -208,7 +208,7 @@ processes them segment-wise into a single logical timeline.
 
 ---
 
-### Phase 2 — Merge mode (core) [TODO]
+### Phase 2 — Merge mode (core) [DONE]
 
 **Goal**: `sync` merges into existing voiceover cells by default;
 `--overwrite` restores old behavior. Single-pass `polish_and_merge`
@@ -324,8 +324,8 @@ training triples.
 
 ## 4. Current Status
 
-**Phase 1 is complete.** Multi-file input implemented and tested.
-Phase 2 (merge mode) is next.
+**Phase 2 is complete.** Merge mode implemented and tested.
+Phase 3 (Langfuse tracing) is next.
 
 **Completed**:
 
@@ -347,87 +347,87 @@ Phase 2 (merge mode) is next.
   - `src/clm/cli/info_topics/commands.md` updated.
   - 40 new tests (21 in `test_timeline.py`, 19 in `test_multi_part.py`).
   - All 132 voiceover tests pass; 2960 total tests pass.
+- **Phase 2 implemented (2026-04-12)**:
+  - Default `sync` behavior changed to merge; `--overwrite` restores old
+    behavior.
+  - `--mode verbatim` without `--overwrite` errors with a clear message.
+  - New `src/clm/voiceover/merge.py` with `polish_and_merge` (single-pass
+    LLM call returning structured JSON), `MergeResult` / `SlideInput`
+    dataclasses, batching logic (`build_batches`, `merge_batch`) with
+    20k char budget and per-slide fallback on parse failure.
+  - Language-specific merge prompts in `src/clm/voiceover/prompts/`
+    (`merge_de.md`, `merge_en.md`) with invariants, filter rules, and
+    structured JSON response schema.
+  - New `src/clm/voiceover/trace_log.py` — JSONL writer for
+    `.clm/voiceover-traces/<stem>-<timestamp>.jsonl`. Logs every merge
+    call with baseline, transcript, LLM output, rewrites, dropped phrases,
+    git HEAD, and optional Langfuse trace ID.
+  - `.clm/` added to `.gitignore`.
+  - Baseline read from `SlideGroup.notes_text` via `slide_parser`
+    (decided against the MCP `extract_voiceover` path — simpler).
+  - Default merge model: `anthropic/claude-sonnet-4-6` (via OpenRouter).
+  - `--dry-run` emits colored unified diff with rewrite annotations.
+  - Boundary hint set conservatively in multi-part mode (always True).
+  - `src/clm/cli/info_topics/commands.md` updated with merge docs.
+  - 55 new tests: `test_merge.py` (37 tests — prompt building, JSON
+    parsing, batching, mocked LLM, noise fixtures DE/EN, rewrite
+    detection, prompt loading), `test_trace_log.py` (13 tests — create,
+    write, required fields, git HEAD, Langfuse ID), `test_merge_cli.py`
+    (5 tests — verbatim+merge error, --overwrite flag, help text).
+  - All 187 voiceover tests pass; 3045 total tests pass.
 
 **In progress**: none.
 
 **Blockers**: none.
 
-**Resolved open questions from Phase 1**:
+**Resolved open questions**:
 
-- **`--keep-audio` vs `--keep-temp`**: kept `--keep-audio` (existing flag).
-  In multi-part mode it preserves all per-part audio extractions.
-- **Matcher per-part strategy**: added `video_paths: list[Path] | None`
-  and `total_duration: float | None` parameters to
-  `match_events_to_slides`. A new `_extract_event_frame` helper uses
-  `event.local_timestamp` + `event.source_part_index` to seek the
-  correct video part. Sequential alignment runs across all events
-  (all parts) in one pass.
+- **`--keep-audio` vs `--keep-temp`** (Phase 1): kept `--keep-audio`
+  (existing flag). In multi-part mode it preserves all per-part audio
+  extractions.
+- **Matcher per-part strategy** (Phase 1): added `video_paths` and
+  `total_duration` parameters to `match_events_to_slides`.
+- **Baseline reading** (Phase 2): using `SlideGroup.notes_text` from
+  `slide_parser.py`, not the MCP `extract_voiceover` path. The parser
+  already groups notes cells per slide group, which is exactly what the
+  merge needs.
+- **Default model** (Phase 2): `anthropic/claude-sonnet-4-6` via
+  OpenRouter per user preference.
 
-**Open questions** (for Phase 2):
+**Open questions**: none.
 
-- `slide_parser` / `slide_writer` expose voiceover cell reading via the
-  MCP `extract_voiceover` path (see `src/clm/slides/voiceover_tools.py`).
-  Evaluate whether to reuse this function directly or add a lower-level
-  helper. Decide during Phase 2.
-
-**Tests**: 132 voiceover tests pass. Fast suite runs via pre-commit.
+**Tests**: 187 voiceover tests pass. Fast suite runs via pre-commit.
 Use `pytest -m "not docker"` for the pre-release full run.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 2 — Merge mode.** In order:
+**Start Phase 3 — Langfuse tracing.** In order:
 
-1. **Read existing voiceover cell extraction code.** Check
-   `src/clm/slides/voiceover_tools.py` (MCP's `extract_voiceover`)
-   and `src/clm/notebooks/slide_parser.py` to understand how existing
-   voiceover cell content is read per slide group. Decide whether to
-   reuse the MCP helper or add a lower-level function.
+1. **Read `src/clm/infrastructure/llm/client.py`.** The `_build_client`
+   factory is the single hook point. When Langfuse env vars are set,
+   wrap the returned `openai.AsyncOpenAI` with the Langfuse observer.
 
-2. **Read `src/clm/notebooks/polish.py`.** This is the hook point —
-   `polish_and_merge` generalizes `polish_text`. When `baseline == ""`
-   it degrades to the current polish behavior.
+2. **Add `langfuse` to `[voiceover]` extra** in `pyproject.toml`.
 
-3. **Design the merge prompt.** Build the structured system prompt with
-   invariants (preserve baseline, filter noise, relaxed rewrite rule)
-   per the proposal doc §"Prompt structure". Create language-specific
-   variants in `src/clm/voiceover/prompts/`.
+3. **Implement env-var gated wrapping.** When `LANGFUSE_HOST`,
+   `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` are all set,
+   `_build_client` returns a Langfuse-wrapped client. Otherwise plain.
 
-4. **Implement `polish_and_merge` in `src/clm/notebooks/polish.py`.**
-   Takes `(baseline_bullets, transcript_text, slide_content, language,
-   boundary_hint)` and returns a `MergeResult` with `merged_bullets`,
-   `rewrites`, `dropped_from_transcript`. Expects JSON from the LLM.
+4. **Thread session/metadata into merge calls.** `session_id`,
+   metadata, and tags in `src/clm/voiceover/merge.py`.
 
-5. **Implement batching in `src/clm/voiceover/merge.py`.** Pack slides
-   up to 20k char budget per LLM call; parse JSON response keyed by
-   `slide_id`; fall back to per-slide calls on parse failure.
+5. **Record Langfuse trace ID in trace log.** The `langfuse_trace_id`
+   field in `trace_log.py` is already plumbed; wire it up.
 
-6. **Wire into `sync` orchestration.** Add `--overwrite` flag (default:
-   merge). Error on `--mode verbatim` without `--overwrite`. Read
-   baseline from existing voiceover cells. `--dry-run` emits unified
-   diff. Update `commands.md`.
-
-7. **Implement local trace log** in `src/clm/voiceover/trace_log.py`.
-   Write one JSONL line per LLM call to
-   `.clm/voiceover-traces/<topic>-<timestamp>.jsonl`. Add `.clm/` to
-   `.gitignore`.
-
-8. **Write tests.** Noise-filter fixtures (see §8 Session Notes for
-   seed data), snapshot tests with mocked LLM, rewrite detection,
-   `--overwrite` parity, trace log assertions.
+6. **Write tests.** Env-var gating, failure isolation (unreachable
+   Langfuse → warning + continue), plain client when vars absent.
 
 **Gotchas**:
 
-- **Single-pass LLM only.** Do not build a multi-pass
-  additions/anchor pipeline. See Design Decisions §2.2.
-- **Relaxed baseline rule is auditable.** Every rewrite must appear
-  in the structured `rewrites` field. See Design Decisions §2.3.
-- **`--mode verbatim` + merge = error.** Verbatim has no noise
-  filter; merging raw transcript is unsafe.
-- **Boundary hint from Phase 1.** The `source_part_index` on
-  segments tells the merge prompt which slides span a part boundary,
-  so it can be extra suspicious of greeting/sign-off noise there.
+- Langfuse must never break the pipeline. Unreachable → warning.
+- The wrapping benefits all LLM-using modules, not just voiceover.
 
 ---
 
@@ -458,16 +458,24 @@ Use `pytest -m "not docker"` for the pre-release full run.
 | `tests/voiceover/test_timeline.py` | 21 unit/integration tests for timeline module |
 | `tests/voiceover/test_multi_part.py` | 19 tests for cross-module multi-part support (data classes, matcher routing, CLI signature, serialization) |
 
+### Files created in Phase 2
+
+| File | Purpose |
+|---|---|
+| `src/clm/voiceover/merge.py` | `polish_and_merge`, `MergeResult`, `SlideInput`, `build_batches`, `merge_batch`, JSON parsing, prompt loading |
+| `src/clm/voiceover/trace_log.py` | `TraceLog` class — JSONL writer for `.clm/voiceover-traces/` |
+| `src/clm/voiceover/prompts/__init__.py` | Package marker |
+| `src/clm/voiceover/prompts/merge_de.md` | German merge prompt (invariants + filter rules + structured JSON schema) |
+| `src/clm/voiceover/prompts/merge_en.md` | English merge prompt |
+| `tests/voiceover/test_merge.py` | 37 tests: prompt building, JSON parsing, batching, mocked LLM, noise fixtures (DE/EN), rewrite detection, prompt loading |
+| `tests/voiceover/test_trace_log.py` | 13 tests: create, write, required fields, git HEAD, Langfuse ID |
+| `tests/voiceover/test_merge_cli.py` | 5 tests: verbatim+merge error, --overwrite flag, help text |
+
 ### New files planned (future phases)
 
 | File | Purpose | Phase |
 |---|---|---|
-| `src/clm/voiceover/merge.py` | Batching, prompt packing, JSON response parsing, per-slide fallback | 2 |
-| `src/clm/voiceover/trace_log.py` | JSONL writer for `.clm/voiceover-traces/` | 2 |
-| `src/clm/voiceover/prompts/merge_de.md` | German merge prompt (invariants + filter rules + style) | 2 |
-| `src/clm/voiceover/prompts/merge_en.md` | English merge prompt | 2 |
 | `src/clm/voiceover/training_export.py` | Trace-log reader + slide-state correlator for training triples | 4 |
-| `tests/voiceover/test_merge_*.py` | Merge-mode tests including noise fixtures | 2 |
 | `tests/voiceover/test_langfuse_*.py` | Langfuse fallback tests | 3 |
 
 ### How the components connect

--- a/docs/claude/voiceover-sync-improvements-handover.md
+++ b/docs/claude/voiceover-sync-improvements-handover.md
@@ -1,6 +1,6 @@
 # Voiceover Sync Improvements — Handover
 
-**Status**: Phase 3 complete. Phase 4 (training data extraction) is next.
+**Status**: All four phases complete.
 **Branch**: `worktree-purring-strolling-crab` (worktree off `master`).
 **Source of truth (design)**: [`docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md`](../proposals/VOICEOVER_SYNC_IMPROVEMENTS.md)
 **Related prior work**: [`docs/claude/voiceover-design.md`](voiceover-design.md), [`docs/claude/voiceover-sync-windows-crash.md`](voiceover-sync-windows-crash.md)
@@ -294,7 +294,7 @@ rewrites. Local trace log is written on every run.
 
 ---
 
-### Phase 4 — Training data extraction [TODO]
+### Phase 4 — Training data extraction [DONE]
 
 **Goal**: `clm voiceover extract-training-data` reads local JSONL trace
 logs and correlates them with the current slide state to produce
@@ -324,8 +324,7 @@ training triples.
 
 ## 4. Current Status
 
-**Phase 3 is complete.** Langfuse tracing implemented and tested.
-Phase 4 (training data extraction) is next.
+**All four phases are complete.**
 
 **Completed**:
 
@@ -397,6 +396,22 @@ Phase 4 (training data extraction) is next.
     wrapping/fallback (5), flush behavior (3), merge context forwarding
     (4), trace log ID (2).
   - All 209 voiceover tests pass; 3067 total tests pass.
+- **Phase 4 implemented (2026-04-12)**:
+  - New `src/clm/voiceover/training_export.py` with `TraceEntry`,
+    `TrainingTriple` dataclasses, `read_trace_log`, `extract_training_data`,
+    `_read_voiceover_for_slide`, `_compute_delta`, `_git_commit_exists`.
+  - New `clm voiceover extract-training-data` subcommand with `--base-dir`,
+    `--tag`, `--no-check-git`, and `--output` options.
+  - Reads JSONL trace logs, correlates with current slide file state via
+    `parse_slides`, computes unified diff between LLM output and
+    human-edited final.
+  - Entries with unreachable `git_head` skipped with warning.
+  - Entries where `human_final == llm_output` emitted with empty
+    `delta_vs_llm` (positive training examples).
+  - 36 new tests in `test_training_export.py`: trace log reading (7),
+    compute delta (5), read voiceover for slide (6), training triple
+    serialization (3), extract integration (11), CLI subcommand (4).
+  - All 245 voiceover tests pass; 3103 total tests pass.
 
 **In progress**: none.
 
@@ -426,39 +441,23 @@ Phase 4 (training data extraction) is next.
 
 **Open questions**: none.
 
-**Tests**: 209 voiceover tests pass. Fast suite runs via pre-commit.
+**Tests**: 245 voiceover tests pass. Fast suite runs via pre-commit.
 Use `pytest -m "not docker"` for the pre-release full run.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 4 — Training data extraction.** In order:
+**All four phases are complete.** The feature is ready for use. Future
+work might include:
 
-1. **Read `src/clm/voiceover/trace_log.py`** to understand the JSONL
-   schema written by Phase 2/3.
-
-2. **Implement `src/clm/voiceover/training_export.py`** — trace log
-   reader that parses each JSONL entry, correlates it against the
-   current slide file state to produce training triples:
-   `{input.baseline, input.transcript, llm_output, human_final,
-   delta_vs_llm}`.
-
-3. **Add `clm voiceover extract-training-data` subcommand** in
-   `src/clm/cli/commands/voiceover.py`. Takes a trace log path,
-   emits training JSONL.
-
-4. **Write tests.** Round-trip: synthetic trace log + synthetic slide
-   state → expected training triples. Handle unreachable `git_head`
-   gracefully (skip with warning).
-
-**Gotchas**:
-
-- Entries whose `git_head` commit is unreachable must be skipped with
-  a warning, not crash the extraction.
-- `human_final == llm_output` is a valid positive training example
-  (no hand edits) — emit with empty `delta_vs_llm`.
-- Low priority until a corpus has accumulated from real sync runs.
+- Accumulate a trace corpus from real `sync` runs against course
+  recordings.
+- Use `clm voiceover extract-training-data` to produce training JSONL
+  once enough hand-edited examples exist.
+- Fine-tune or LoRA-train a merge model on the extracted triples.
+- Consider promoting the `[voiceover]` Langfuse dependency to a
+  top-level `[tracing]` extra if other modules adopt it.
 
 ---
 
@@ -508,11 +507,12 @@ Use `pytest -m "not docker"` for the pre-release full run.
 |---|---|
 | `tests/voiceover/test_langfuse.py` | 22 tests: env-var gating, client wrapping/fallback, flush behavior, merge context forwarding, trace log ID |
 
-### New files planned (future phases)
+### Files created in Phase 4
 
-| File | Purpose | Phase |
-|---|---|---|
-| `src/clm/voiceover/training_export.py` | Trace-log reader + slide-state correlator for training triples | 4 |
+| File | Purpose |
+|---|---|
+| `src/clm/voiceover/training_export.py` | `TraceEntry`, `TrainingTriple`, `read_trace_log`, `extract_training_data`, slide-state correlator |
+| `tests/voiceover/test_training_export.py` | 36 tests: trace log reading, delta computation, slide reading, integration, CLI |
 
 ### How the components connect
 

--- a/docs/claude/voiceover-sync-improvements-handover.md
+++ b/docs/claude/voiceover-sync-improvements-handover.md
@@ -1,0 +1,657 @@
+# Voiceover Sync Improvements — Handover
+
+**Status**: Phase 1 complete. Phase 2 (merge mode) is next.
+**Branch**: `worktree-purring-strolling-crab` (worktree off `master`).
+**Source of truth (design)**: [`docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md`](../proposals/VOICEOVER_SYNC_IMPROVEMENTS.md)
+**Related prior work**: [`docs/claude/voiceover-design.md`](voiceover-design.md), [`docs/claude/voiceover-sync-windows-crash.md`](voiceover-sync-windows-crash.md)
+
+This handover tracks implementation state across four phases. The proposal
+doc is the design source of truth — do not duplicate design content here.
+If you need to know *what* to build or *why* a design choice was made, read
+the proposal. This file tells you *where we are* and *what to do next*.
+
+---
+
+## 1. Feature Overview
+
+**Name**: `clm voiceover sync` — multi-file input and merge mode.
+
+**One-paragraph description**: Two improvements to `clm voiceover sync` that
+together make the command usable on real OBS recordings. (1) Accept
+multiple video parts on a single invocation and process them per-part with
+running offsets, so the aligner sees one logical timeline without the
+pipeline ever concatenating files on disk. (2) Change the default behavior
+from "overwrite voiceover cells" to "merge into existing voiceover cells"
+via a single-pass LLM call that preserves baseline content, integrates
+substantive additions from the transcript, filters noise (greetings,
+recording self-corrections, code-typing narration), and reports any
+baseline rewrites as structured metadata. Observability via Langfuse and
+a local trace log that accumulates training data are layered on top.
+
+**Problem it solves**:
+
+- OBS recordings are routinely split into multiple parts for pedagogical
+  and robustness reasons. The current CLI accepts exactly one video, so
+  users either concat manually (throwaway files), run sync per part
+  (wrong — aligner needs one timeline), or skip sync entirely. The last
+  workaround is what actually happened for `topic_045_streaming_generators`
+  during AZAV ML W04 Phase 4.
+- Re-recording a video today either loses hand-edits (if you run sync
+  over them) or loses improvisations (if you don't run sync). Neither is
+  acceptable for a course that gets revised.
+- The existing polish LLM step has no way to reject code-typing dictation
+  or part-boundary greetings, so these end up in the voiceover.
+
+**Why this matters**: The AZAV ML course restructure is the immediate
+consumer. Without these improvements, every topic that was recorded as
+multiple parts either skips sync or loses content on every revision pass.
+
+---
+
+## 2. Design Decisions
+
+Only the decisions that drove the architecture are captured here. Full
+rationale lives in the proposal doc — this section is for a fresh session
+that needs to understand the *shape* of the implementation in one minute.
+
+### Segment-wise per-part processing (not concatenation)
+
+**Decision**: Each video part is transcribed and keyframe-detected
+independently; the results are merged into a single logical timeline using
+running offsets (`Σ duration(part_0..i-1)`). No ffmpeg concat demuxer, no
+fused temp file.
+
+**Why**:
+
+1. The merge prompt (Phase 2) needs boundary metadata to recognize
+   greeting/sign-off noise at part boundaries. Concatenation erases this.
+2. A fused file creates a visual discontinuity at each concat point that
+   the slide-transition detector will almost certainly flag as a fake
+   slide change. Per-part avoids the class of bug entirely.
+3. Encoding mismatch across parts becomes a non-issue because each part
+   is decoded by its own ASR call.
+
+**Rejected alternative**: ffmpeg concat demuxer to temp file, then run
+the existing single-video pipeline. Rejected for the three reasons above.
+The proposal originally framed this as "simpler but worse"; on
+reflection, segment-wise is *also* simpler because it eliminates the
+fake-transition post-processing.
+
+### Single-pass `polish_and_merge` LLM call
+
+**Decision**: Merge is one LLM call per slide (or per batch of slides) —
+not a multi-pass "compute additions → anchor → insert" pipeline. The LLM
+receives `(baseline, transcript, slide_content, language, boundary_hint)`
+and returns the merged bullet list plus structured rewrites.
+
+**Why**: Multi-pass workflows are slower, more expensive, and more
+failure-prone in production. A single LLM call with a disciplined prompt
+handles noise filtering, content preservation, addition integration, and
+bullet ordering holistically. Git diff is the review layer for placement
+and wording — we don't need the pipeline to second-guess the LLM's
+decisions.
+
+**Rejected alternative**: A two-pass approach where the LLM first returns
+an "additions list" with anchor indices, and a second pass inserts them.
+Rejected in discussion: more brittle, slower, and the anchor metadata
+adds complexity for no real benefit when git diff does the job.
+
+### Relaxed "baseline is sacred" rule (structured rewrite log)
+
+**Decision**: The LLM MAY rewrite a baseline bullet if the transcript
+*directly contradicts or corrects* that bullet. Style tweaks and
+paraphrases are forbidden — only factual contradictions. Every rewrite is
+reported in a structured `rewrites` field so reviewers can spot them
+without hunting through diffs.
+
+**Why**: Trainers often correct baseline errors live during recording
+("actually, `extend` mutates in place, not returns a new list"). A strict
+preserve-baseline rule would lose these corrections. The structured
+rewrite log plus dry-run annotation keeps the relaxation auditable.
+
+**Rejected alternative**: Strict preservation. Rejected because the user
+explicitly prefers to capture live corrections over safe append-only
+merging.
+
+### Merge as the new default; `--overwrite` for old behavior
+
+**Decision**: `sync` merges into existing voiceover cells by default.
+`--overwrite` restores the old destructive behavior.
+
+**Why**: Merge is less destructive. Running sync twice by accident should
+not lose content. The only current user (the proposal author) has
+confirmed the breaking-change cost is acceptable.
+
+**Rejected alternative**: `--update` flag to opt in to merge. Rejected:
+merge is the safer default and the flag inversion follows.
+
+### Local JSON trace log + optional Langfuse
+
+**Decision**: Phase 2 always writes a local JSONL trace log to
+`.clm/voiceover-traces/<topic>-<timestamp>.jsonl`. Langfuse integration
+in Phase 3 is additive, env-var gated, and wraps
+`clm.infrastructure.llm.client._build_client` at a single point so all
+LLM-using modules benefit.
+
+**Why**: Langfuse is optional per-deployment (the user has a local
+Docker, but not everyone will). A local file-based log is durable,
+independent of Langfuse availability, and is the substrate the Phase 4
+training-data extraction tool reads. Trace collection starts from day
+one of Phase 2 so a corpus accumulates before anyone wants to train.
+
+### No MCP tool for video transcription
+
+**Decision**: The MCP server (`src/clm/mcp/tools.py`) will not get a tool
+that runs `clm voiceover sync` or any other video-transcription operation.
+
+**Why**: Transcription is minutes long with multi-MB inputs and
+multi-KB outputs — a batch CLI job, not an MCP round trip. Confirmed
+during design discussion: the MCP server currently exposes only
+slide-file manipulation (`extract_voiceover`, `inline_voiceover`,
+`suggest_sync`) and will stay that way.
+
+### Breaking CLI change: `sync SLIDES VIDEO...`
+
+**Decision**: Positional argument order flips from current
+`sync VIDEO SLIDES` to `sync SLIDES VIDEO...` (slides first, videos
+variadic via click's `nargs=-1`).
+
+**Why**: Click's `nargs=-1` consumes positional arguments greedily, so
+the variadic argument must come last. Slides-first reads naturally
+("sync these slides against these recordings").
+
+**Migration**: Acceptable because the only current user is the proposal
+author. No deprecation shim needed.
+
+---
+
+## 3. Phase Breakdown
+
+### Phase 1 — Multi-file input [DONE]
+
+**Goal**: `clm voiceover sync` accepts one or more video parts and
+processes them segment-wise into a single logical timeline.
+
+**Files touched**:
+
+- `src/clm/cli/commands/voiceover.py` — rewrite the `sync` command
+  signature and orchestration loop.
+- `src/clm/voiceover/transcribe.py` — either add a multi-part entry point
+  or call the existing `transcribe_video` per part and merge results.
+- `src/clm/voiceover/keyframes.py` — same pattern for `detect_transitions`.
+- `src/clm/voiceover/matcher.py` — `match_events_to_slides` currently
+  takes a single `video` arg for OCR; must become part-aware.
+- `src/clm/voiceover/aligner.py` — no change expected; it already
+  operates on `Transcript` + `list[TimelineEntry]`.
+- New: `src/clm/voiceover/timeline.py` (or similar) to hold the
+  per-part duration probe, offset arithmetic, and merge helpers.
+- Tests: `tests/voiceover/test_multi_part_*.py`.
+
+**Acceptance criteria**:
+
+1. `clm voiceover sync slides.py part1.mp4 part2.mp4 part3.mp4 --lang de`
+   runs end-to-end on a real three-part recording and produces a sensible
+   notes_map.
+2. Running with one part produces the same result as the current
+   single-file behavior (regression check).
+3. Each `TranscriptSegment` carries a `source_part_index` (or equivalent)
+   that downstream consumers can read.
+4. Each slide-transition event carries the same index.
+5. The aligner produces a single `AlignmentResult` spanning all parts;
+   timestamps are offset correctly.
+6. Part ordering is preserved as passed on the CLI (no mtime/name sort).
+7. Failure on a single unreadable part reports the part index clearly.
+8. `--slides-range` filters against the merged timeline.
+9. Existing single-video tests still pass (argument-order flip aside).
+
+**Out of Phase 1**: no LLM changes, no merge behavior, no trace log.
+
+---
+
+### Phase 2 — Merge mode (core) [TODO]
+
+**Goal**: `sync` merges into existing voiceover cells by default;
+`--overwrite` restores old behavior. Single-pass `polish_and_merge`
+handles noise filtering, content preservation, additions, and baseline
+rewrites. Local trace log is written on every run.
+
+**Files touched**:
+
+- `src/clm/notebooks/polish.py` — add `polish_and_merge` function
+  (generalization of `polish_text`). Build structured system prompt with
+  invariants, filter rules, and style guidance. Expect JSON-formatted
+  LLM output.
+- `src/clm/notebooks/slide_parser.py` — need a way to read existing
+  voiceover cell content per slide group (inspect whether this already
+  exists; the MCP `extract_voiceover` tool does something similar).
+- `src/clm/notebooks/slide_writer.py` — `write_narrative` may need a
+  merge-aware variant that replaces in place rather than appending.
+- `src/clm/cli/commands/voiceover.py` — `--overwrite` flag, default
+  behavior change, merge orchestration, dry-run diff output, conflict
+  error when `--mode verbatim` meets merge.
+- New: `src/clm/voiceover/merge.py` — batching logic (pack slides up to
+  char budget, parse JSON response, per-slide fallback on parse failure).
+- New: `src/clm/voiceover/trace_log.py` — JSONL writer for
+  `.clm/voiceover-traces/<topic>-<timestamp>.jsonl`.
+- New: `src/clm/voiceover/prompts/` — language-specific prompt variants
+  (`merge_de.md`, `merge_en.md`, or equivalent).
+- Tests: fixtures for noise-filter keep/drop cases (see
+  §7 Testing Approach), snapshot tests for `polish_and_merge` with a
+  mocked LLM, end-to-end test against a small real recording.
+
+**Acceptance criteria**:
+
+1. Running `sync` on a slide file with existing voiceover cells produces
+   a merged result that preserves baseline content and integrates
+   substantive transcript additions.
+2. Running `sync --overwrite` on the same file produces the old
+   destructive behavior byte-for-byte.
+3. Noise fixtures (greetings, self-corrections, code-typing dictation)
+   are dropped from the merged output.
+4. A factual contradiction in the transcript produces a structured
+   rewrite entry and the rewritten bullet is marked in the dry-run diff.
+5. `--dry-run` emits a unified diff to stdout; no file is touched.
+6. `--mode verbatim` combined with merge (default) errors out with a
+   clear message; `--mode verbatim --overwrite` works as before.
+7. A slide with only the *other* tag (e.g. `notes` when `--tag voiceover`)
+   sees an empty baseline and gets a fresh voiceover cell inserted.
+8. Each run writes a JSONL trace log under
+   `.clm/voiceover-traces/`; `.clm/` is added to `.gitignore` by default.
+9. Batched LLM calls respect the 20k char budget; JSON parse failure
+   falls back to per-slide calls for that batch only.
+
+---
+
+### Phase 3 — Langfuse tracing [TODO]
+
+**Goal**: LLM calls are traced to Langfuse when
+`LANGFUSE_HOST`/`LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` are all set.
+
+**Files touched**:
+
+- `src/clm/infrastructure/llm/client.py` — `_build_client` returns a
+  Langfuse-wrapped `openai.AsyncOpenAI` when env vars are present.
+- `pyproject.toml` — add `langfuse` to the `[voiceover]` extra.
+- `src/clm/voiceover/merge.py` — thread `session_id`, metadata, and
+  tags into LLM calls so Langfuse groups them meaningfully.
+- `src/clm/voiceover/trace_log.py` — record the Langfuse trace ID in the
+  local JSONL log for later correlation.
+- Tests: smoke test that Langfuse-wrapped client falls back gracefully
+  when Langfuse is unreachable; unit test that env var absence → plain
+  client.
+
+**Acceptance criteria**:
+
+1. With all three Langfuse env vars set and a reachable host, a `sync`
+   invocation populates a Langfuse session containing one trace per LLM
+   batch, with input/output captured automatically.
+2. With env vars unset, the pipeline runs identically to Phase 2 (no
+   Langfuse calls, no warnings).
+3. With env vars set but host unreachable, the pipeline logs a warning
+   and continues to completion.
+4. The local JSONL trace log contains `langfuse_trace_id` when tracing
+   was active.
+
+---
+
+### Phase 4 — Training data extraction [TODO]
+
+**Goal**: `clm voiceover extract-training-data` reads local JSONL trace
+logs and correlates them with the current slide state to produce
+training triples.
+
+**Files touched**:
+
+- New: `src/clm/cli/commands/voiceover.py` — add subcommand.
+- New: `src/clm/voiceover/training_export.py` — trace log reader,
+  per-entry correlation (re-parse slide file at `git_head` and at HEAD,
+  diff the voiceover cell for the relevant `slide_id`).
+- Tests: round-trip fixtures for the reader and the correlator.
+
+**Acceptance criteria**:
+
+1. Given a trace log from a Phase 2 run plus a committed hand-edited
+   slide file, the command emits one JSONL line per slide with fields
+   `input.baseline`, `input.transcript`, `llm_output`, `human_final`,
+   `delta_vs_llm`.
+2. Slides where `human_final == llm_output` (no hand edits) are emitted
+   with an empty `delta_vs_llm` — these are useful as positive training
+   examples too.
+3. Trace entries whose `git_head` is unreachable (detached commit, etc.)
+   are skipped with a warning.
+
+---
+
+## 4. Current Status
+
+**Phase 1 is complete.** Multi-file input implemented and tested.
+Phase 2 (merge mode) is next.
+
+**Completed**:
+
+- [`docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md`](../proposals/VOICEOVER_SYNC_IMPROVEMENTS.md)
+  rewritten as the source of truth (2026-04-12).
+- This handover doc created (2026-04-12).
+- **Phase 1 implemented (2026-04-12)**:
+  - CLI argument order flipped to `sync SLIDES VIDEO...` with variadic
+    videos via `nargs=-1`.
+  - `TranscriptSegment` and `TransitionEvent` carry `source_part_index`.
+  - `TransitionEvent` also carries `local_timestamp` for per-part frame
+    extraction in the matcher.
+  - New `src/clm/voiceover/timeline.py` with `VideoPart`, `probe_duration`
+    (ffprobe), `build_parts`, `offset_transcript`, `offset_events`,
+    `merge_transcripts`.
+  - Matcher accepts optional `video_paths` and `total_duration` params;
+    new `_extract_event_frame` routes to correct video part.
+  - `sync` orchestration rewritten with per-part loop.
+  - `src/clm/cli/info_topics/commands.md` updated.
+  - 40 new tests (21 in `test_timeline.py`, 19 in `test_multi_part.py`).
+  - All 132 voiceover tests pass; 2960 total tests pass.
+
+**In progress**: none.
+
+**Blockers**: none.
+
+**Resolved open questions from Phase 1**:
+
+- **`--keep-audio` vs `--keep-temp`**: kept `--keep-audio` (existing flag).
+  In multi-part mode it preserves all per-part audio extractions.
+- **Matcher per-part strategy**: added `video_paths: list[Path] | None`
+  and `total_duration: float | None` parameters to
+  `match_events_to_slides`. A new `_extract_event_frame` helper uses
+  `event.local_timestamp` + `event.source_part_index` to seek the
+  correct video part. Sequential alignment runs across all events
+  (all parts) in one pass.
+
+**Open questions** (for Phase 2):
+
+- `slide_parser` / `slide_writer` expose voiceover cell reading via the
+  MCP `extract_voiceover` path (see `src/clm/slides/voiceover_tools.py`).
+  Evaluate whether to reuse this function directly or add a lower-level
+  helper. Decide during Phase 2.
+
+**Tests**: 132 voiceover tests pass. Fast suite runs via pre-commit.
+Use `pytest -m "not docker"` for the pre-release full run.
+
+---
+
+## 5. Next Steps
+
+**Start Phase 2 — Merge mode.** In order:
+
+1. **Read existing voiceover cell extraction code.** Check
+   `src/clm/slides/voiceover_tools.py` (MCP's `extract_voiceover`)
+   and `src/clm/notebooks/slide_parser.py` to understand how existing
+   voiceover cell content is read per slide group. Decide whether to
+   reuse the MCP helper or add a lower-level function.
+
+2. **Read `src/clm/notebooks/polish.py`.** This is the hook point —
+   `polish_and_merge` generalizes `polish_text`. When `baseline == ""`
+   it degrades to the current polish behavior.
+
+3. **Design the merge prompt.** Build the structured system prompt with
+   invariants (preserve baseline, filter noise, relaxed rewrite rule)
+   per the proposal doc §"Prompt structure". Create language-specific
+   variants in `src/clm/voiceover/prompts/`.
+
+4. **Implement `polish_and_merge` in `src/clm/notebooks/polish.py`.**
+   Takes `(baseline_bullets, transcript_text, slide_content, language,
+   boundary_hint)` and returns a `MergeResult` with `merged_bullets`,
+   `rewrites`, `dropped_from_transcript`. Expects JSON from the LLM.
+
+5. **Implement batching in `src/clm/voiceover/merge.py`.** Pack slides
+   up to 20k char budget per LLM call; parse JSON response keyed by
+   `slide_id`; fall back to per-slide calls on parse failure.
+
+6. **Wire into `sync` orchestration.** Add `--overwrite` flag (default:
+   merge). Error on `--mode verbatim` without `--overwrite`. Read
+   baseline from existing voiceover cells. `--dry-run` emits unified
+   diff. Update `commands.md`.
+
+7. **Implement local trace log** in `src/clm/voiceover/trace_log.py`.
+   Write one JSONL line per LLM call to
+   `.clm/voiceover-traces/<topic>-<timestamp>.jsonl`. Add `.clm/` to
+   `.gitignore`.
+
+8. **Write tests.** Noise-filter fixtures (see §8 Session Notes for
+   seed data), snapshot tests with mocked LLM, rewrite detection,
+   `--overwrite` parity, trace log assertions.
+
+**Gotchas**:
+
+- **Single-pass LLM only.** Do not build a multi-pass
+  additions/anchor pipeline. See Design Decisions §2.2.
+- **Relaxed baseline rule is auditable.** Every rewrite must appear
+  in the structured `rewrites` field. See Design Decisions §2.3.
+- **`--mode verbatim` + merge = error.** Verbatim has no noise
+  filter; merging raw transcript is unsafe.
+- **Boundary hint from Phase 1.** The `source_part_index` on
+  segments tells the merge prompt which slides span a part boundary,
+  so it can be extra suspicious of greeting/sign-off noise there.
+
+---
+
+## 6. Key Files & Architecture
+
+### Files that exist today and will be touched
+
+| File | Role | Phase |
+|---|---|---|
+| `src/clm/cli/commands/voiceover.py` | `sync` command definition and orchestration | 1, 2, 4 |
+| `src/clm/voiceover/transcribe.py` | ASR wrapper (`transcribe_video`) | 1 |
+| `src/clm/voiceover/keyframes.py` | Slide-transition detection (`detect_transitions`) | 1 |
+| `src/clm/voiceover/matcher.py` | Events → slide-timeline mapping (`match_events_to_slides`) | 1 |
+| `src/clm/voiceover/aligner.py` | Transcript → per-slide notes (`align_transcript`) | 1 (likely unchanged) |
+| `src/clm/notebooks/polish.py` | `polish_text` → generalized into `polish_and_merge` | 2 |
+| `src/clm/notebooks/slide_parser.py` | Percent-format slide parser | 2 (baseline read) |
+| `src/clm/notebooks/slide_writer.py` | `write_narrative` | 2 (merge-aware variant) |
+| `src/clm/slides/voiceover_tools.py` | Existing voiceover cell utilities (MCP-exposed) | 2 (reuse candidates) |
+| `src/clm/infrastructure/llm/client.py` | `_build_client` factory | 3 |
+| `src/clm/cli/info_topics/commands.md` | Version-accurate CLI docs (downstream contract) | 1, 2 |
+| `pyproject.toml` | `[voiceover]` extras (add `langfuse`) | 3 |
+
+### Files created in Phase 1
+
+| File | Purpose |
+|---|---|
+| `src/clm/voiceover/timeline.py` | `VideoPart` dataclass, `probe_duration` (ffprobe), `build_parts`, `offset_transcript`, `offset_events`, `merge_transcripts` |
+| `tests/voiceover/test_timeline.py` | 21 unit/integration tests for timeline module |
+| `tests/voiceover/test_multi_part.py` | 19 tests for cross-module multi-part support (data classes, matcher routing, CLI signature, serialization) |
+
+### New files planned (future phases)
+
+| File | Purpose | Phase |
+|---|---|---|
+| `src/clm/voiceover/merge.py` | Batching, prompt packing, JSON response parsing, per-slide fallback | 2 |
+| `src/clm/voiceover/trace_log.py` | JSONL writer for `.clm/voiceover-traces/` | 2 |
+| `src/clm/voiceover/prompts/merge_de.md` | German merge prompt (invariants + filter rules + style) | 2 |
+| `src/clm/voiceover/prompts/merge_en.md` | English merge prompt | 2 |
+| `src/clm/voiceover/training_export.py` | Trace-log reader + slide-state correlator for training triples | 4 |
+| `tests/voiceover/test_merge_*.py` | Merge-mode tests including noise fixtures | 2 |
+| `tests/voiceover/test_langfuse_*.py` | Langfuse fallback tests | 3 |
+
+### How the components connect
+
+Phase 1 data flow (single sync invocation with N parts):
+
+```
+CLI parses SLIDES + [VIDEO0, VIDEO1, ...]
+  │
+  ▼
+probe_durations([VIDEO0, VIDEO1, ...])  →  [VideoPart(0, ..., offset=0),
+                                             VideoPart(1, ..., offset=d0),
+                                             VideoPart(2, ..., offset=d0+d1)]
+  │
+  ▼
+for part in parts:
+    transcribe_video(part.path) → segments with offset applied, tagged
+    detect_transitions(part.path) → events with offset applied, tagged
+  │
+  ▼
+merged Transcript + merged events
+  │
+  ▼
+match_events_to_slides(events, slides, parts, lang) → timeline
+  │
+  ▼
+align_transcript(merged_transcript, timeline) → AlignmentResult  [unchanged]
+  │
+  ▼
+polish (Phase 1) / polish_and_merge (Phase 2)
+  │
+  ▼
+write_narrative (Phase 1 fresh) / merge-aware variant (Phase 2)
+```
+
+Phase 2 additions layer cleanly on top: the merge call replaces the
+polish call, baseline is read from the slide file before the pipeline
+runs, and every merge call writes to the trace log as a side effect.
+
+---
+
+## 7. Testing Approach
+
+### Phase 1
+
+- **Unit**: duration probe, offset arithmetic, per-part tagging.
+- **Integration**: synthetic three-part fixture (e.g. one real short
+  video split into three pieces) run through the full `sync` pipeline;
+  assert timeline is monotonic and aligner output matches a
+  single-file baseline for the reassembled duration.
+- **Regression**: existing single-video sync tests run with the
+  positional-argument flip. Any test that previously passed
+  `sync VIDEO SLIDES` now passes `sync SLIDES VIDEO`.
+- **Real-data smoke**: run against `topic_045_streaming_generators`
+  three-part recording at
+  `D:\OBS\Recordings\AZAV ML\05 RAG mit LangChain (Part 1)\`. This is
+  the real case that motivated the feature; if it doesn't produce
+  sensible output, Phase 1 is not done.
+
+### Phase 2
+
+- **Noise fixtures (most important)**: hand-authored `(transcript_text,
+  expected_drop_or_keep)` pairs covering every category in the prompt's
+  filter list — greetings, part transitions, self-corrections,
+  environment remarks, operator asides, code-typing dictation, off-topic
+  tangents. These become the test corpus for prompt tuning. Each
+  category needs ≥3 examples in each language (DE, EN).
+- **Snapshot tests** for `polish_and_merge` with a mocked LLM client.
+  The mock returns canned structured JSON; the test asserts that the
+  writer produces the expected cells.
+- **Rewrite detection**: fixture where baseline says X, transcript
+  contradicts with Y → assert the LLM output contains a non-empty
+  `rewrites` field and the dry-run diff marks it.
+- **Overwrite flag parity**: `sync --overwrite` on a fresh file must
+  produce byte-for-byte the same output as Phase 1 `sync` on the same
+  file.
+- **Trace log**: assert one line per LLM call, all required fields
+  present, `git_head` matches current HEAD.
+
+### Phase 3
+
+- **Env-var gating**: Langfuse client not constructed when env vars
+  absent (mock `os.environ`, check branch).
+- **Failure isolation**: Langfuse server unreachable → warning logged,
+  pipeline completes. Mock the Langfuse client to raise.
+
+### Phase 4
+
+- **Round-trip**: write a synthetic trace log, write a synthetic "final"
+  slide state, assert the extraction produces the expected training
+  triples including `delta_vs_llm` diffs.
+
+### Running tests
+
+```bash
+pytest                                     # fast suite (~30s)
+pytest -m "not docker"                     # pre-release full run
+pytest tests/voiceover/ -v                 # voiceover-only
+```
+
+---
+
+## 8. Session Notes
+
+### User preferences captured during design
+
+- **Multi-pass LLM workflows are bad.** The user explicitly rejected a
+  two-pass additions-list + anchor-insert design in favor of a
+  single-pass merge call. Rationale: slower, more expensive,
+  unpredictable production failures. Apply this instinct to future
+  design decisions — prefer one well-prompted LLM call over chained
+  calls unless there is a concrete, demonstrated reason otherwise.
+
+- **Git diff is the review layer.** The user will review merges via
+  `git diff` after the fact rather than through an in-CLI interactive
+  flow. Do not invest in prompt_toolkit / curses / `git add -p`-style
+  review UX. `--dry-run` outputs a unified diff; anything else is out
+  of scope.
+
+- **Observability matters from day one.** Local JSONL trace log is
+  part of Phase 2, not a later add-on. The user wants to accumulate a
+  training corpus as soon as the merge feature is used, not after.
+
+- **MCP is for slide-file manipulation, not batch jobs.** The user
+  confirmed during design that a video-transcription MCP tool would be
+  wrong-shape. If you find yourself wanting to add one, reread
+  Design Decisions §2.6 first.
+
+- **CLM is Windows-first.** Prefer Python scripts over bash.
+
+- **Auto-memory is in use.** A number of cross-cutting preferences
+  (worker test polling, Python 3.14 blocker, mypy cross-platform
+  ignores) live in the user's memory system under
+  `C:\Users\tc\.claude\projects\C--Users-tc-Programming-Python-Projects-clm\memory\`
+  and load into every conversation. Honor them without waiting for a
+  reminder.
+
+### Noise filter fixture seed (German)
+
+Concrete examples the user provided during design that should seed the
+Phase 2 fixture set:
+
+**Greetings / sign-offs / part transitions (drop)**:
+
+- "Hallo, willkommen zurück zu Teil 2, ich hatte die Aufnahme kurz
+  unterbrochen."
+- "So, das war's für heute, bis zum nächsten Mal!"
+- "Jetzt in Teil 2 angelangt."
+
+**Self-corrections (drop)**:
+
+- "Moment, ich hab da was übersehen, lass mich kurz zurückscrollen."
+- "Oh sorry, das war der falsche Slide, ich muss da nochmal hin."
+- "Uh, entschuldigung, das Mikrofon hat gerade kurz ausgesetzt."
+
+**Environment remarks (drop)**:
+
+- "Mein Docker-Container ist rot, weil ich das falsche Environment habe."
+- "Mein Editor zeigt da rot, das ist aber egal."
+
+**Operator asides (drop)**:
+
+- "Kannst du das nachher rausschneiden."
+- "Das kommt in den Schnitt."
+
+**Code-typing dictation (drop — NEW category from user)**:
+
+- "And then we define the function — def — fact — open paren — n —
+  colon…"
+- "For m comma n in range…"
+- "Close paren, colon, return."
+
+**Substantive additions (keep)**:
+
+- "Oh, and by the way — `extend` mutates the list in place, it doesn't
+  return a new one."
+- "The free OpenRouter tier has a rate limit of ~20 requests per minute,
+  so don't spam it when testing."
+- "One thing I forgot to put on the slide: you can also pass
+  `system_prompt` as a regular string instead of a `SystemMessage` in
+  newer LangChain versions."
+
+**Factual contradictions (keep AND mark as rewrite)**:
+
+- Baseline: "`extend` returns a new list."
+  Transcript: "actually, `extend` mutates in place and returns None."
+  → rewrite baseline bullet, record evidence.

--- a/docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md
+++ b/docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md
@@ -10,9 +10,9 @@ actually produced and how the current `sync` command consumes them.
 
 This document is the source of truth for implementation. Design decisions
 discussed and agreed upon with the user (April 2026) are captured in full
-below. A companion handover document at
-`docs/claude/voiceover-sync-improvements-handover.md` tracks phase-level
-implementation state.
+below. Implementation is complete (all four phases). The archived
+handover document is at
+`docs/claude/voiceover-sync-improvements-handover-archive.md`.
 
 ---
 

--- a/docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md
+++ b/docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md
@@ -1,14 +1,18 @@
-# Proposal: `clm voiceover sync` — Multi-File and Update Mode
+# Proposal: `clm voiceover sync` — Multi-File Input and Merge Mode
 
-**Status:** Draft
-**Scope:** `clm voiceover sync` (and the MCP equivalent)
+**Status:** Accepted — ready for implementation
+**Scope:** `clm voiceover sync` (CLI only; no MCP tool for video transcription)
 
-Two concrete improvements are wanted on `clm voiceover sync`, driven by real
-authoring experience during the AZAV ML course restructure (W04 streaming
-generators topic, April 2026).
+Two concrete improvements to `clm voiceover sync`, driven by real authoring
+experience during the AZAV ML course restructure (W04 streaming generators
+topic, April 2026). Both address a mismatch between how OBS recordings are
+actually produced and how the current `sync` command consumes them.
 
-Both improvements address a mismatch between how OBS recordings are actually
-produced and how the current `sync` command consumes them.
+This document is the source of truth for implementation. Design decisions
+discussed and agreed upon with the user (April 2026) are captured in full
+below. A companion handover document at
+`docs/claude/voiceover-sync-improvements-handover.md` tracks phase-level
+implementation state.
 
 ---
 
@@ -16,17 +20,20 @@ produced and how the current `sync` command consumes them.
 
 ### Problem
 
-OBS recordings are frequently split into multiple parts (`Teil 1.mp4`, `Teil
-2.mp4`, `Teil 3.mp4`, …). The reason is mainly that students dislike very long
-videos, so we split recordings into ~20-30 min chunks at natural breakpoints
-(e.g. slide transitions). But the recording process itself is also more robust
-when split into parts — if something goes wrong during recording, you only lose
-a small part instead of the whole thing. This also means that multi-file videos
-contain voiceover content that is only present because of the split, e.g.
-greetings at the start of each part ("Hallo, willkommen zurück zu Teil 2…") and
-sign-offs at the end ("So, das war's für heute, bis zum nächsten Mal!"). These
-are noise for the voiceover and should be filtered out, but they exist in the
-recording.
+OBS recordings are split into multiple parts (`Teil 1.mp4`, `Teil 2.mp4`, …)
+as a matter of course. Two reasons:
+
+- **Pedagogical:** students dislike very long videos, so we split recordings
+  into ~20-30 min chunks at natural breakpoints (slide transitions).
+- **Robustness:** if something goes wrong during recording, only a small
+  part is lost instead of the whole session.
+
+A consequence: multi-file recordings contain voiceover content that is only
+present because of the split — greetings at the start of each part ("Hallo,
+willkommen zurück zu Teil 2…") and sign-offs at the end ("So, das war's für
+heute, bis zum nächsten Mal!"). These are noise for the voiceover and must
+be filtered out (handled in Improvement 2), but they exist in every
+recording and the pipeline must know where they live.
 
 The current `clm voiceover sync` command takes exactly one `VIDEO`
 positional argument:
@@ -35,256 +42,479 @@ positional argument:
 @click.argument("video", type=click.Path(exists=True, path_type=Path))
 ```
 
-Callers are forced to either:
+Callers are forced into unacceptable workarounds: manual ffmpeg
+concatenation, running sync once per part (wrong — the aligner wants a
+single timeline), or skipping sync entirely (what we did for
+`topic_045_streaming_generators` during W04 Phase 4, losing any
+improvisations from the recording).
 
-1. **Concatenate the parts manually** with `ffmpeg -f concat`, producing a new
-   file that lives alongside the originals and has to be cleaned up later.
-2. **Run sync once per part**, which is the wrong shape — the slide-transition
-   detector and aligner want to see the whole timeline in order to
-   (a) assign transcript text to the right slide, and (b) produce a single
-   coherent notes_map.
-3. **Skip sync entirely**, which is what happened for `topic_045_streaming_generators`
-   during the W04 Phase 4 pass. The existing notes cells were already good
-   voiceover content, so we retagged manually and moved on — but we lost the
-   opportunity to pick up any improvisations or corrections from the recording.
+### Proposal: `sync SLIDES VIDEO...`
 
-None of these is acceptable as a default workflow.
-
-### Proposal
-
-Let `sync` accept one or more videos:
+The CLI signature becomes:
 
 ```bash
 clm voiceover sync --lang de \
-  --part "Teil 1.mp4" \
-  --part "Teil 2.mp4" \
-  --part "Teil 3.mp4" \
-  slides_010v_streaming_generators.py
+  slides_010v_streaming_generators.py \
+  "Teil 1.mp4" "Teil 2.mp4" "Teil 3.mp4"
 ```
 
-or, preferred, via a variadic positional (if click/typer makes that ergonomic
-alongside the slides argument):
+Slides first, videos variadic via click's `nargs=-1`. This is a breaking
+change to the positional argument order; acceptable because the only
+current user is the proposal author and the migration is trivial.
 
-```bash
-clm voiceover sync --lang de \
-  "Teil 1.mp4" "Teil 2.mp4" "Teil 3.mp4" \
-  -- slides_010v_streaming_generators.py
-```
+### Behavior: segment-wise per-part processing
 
-(or swap the order so slides comes first and videos are variadic — whichever
-reads better.)
+CLM does **not** concatenate the video files. Each part is transcribed and
+keyframe-detected independently, and results are merged into a single
+logical timeline using running offsets. Rationale:
 
-### Behavior
+1. **Boundary metadata is preserved.** The filter in Improvement 2 needs to
+   know exactly where part boundaries fall so it can be extra suspicious of
+   greeting/sign-off noise at those points. Concatenation erases this
+   metadata.
+2. **No spurious transitions.** If we concat into a fused file, the concat
+   point creates a visual discontinuity that the slide-transition detector
+   will almost certainly flag as a fake slide change. Per-part processing
+   avoids this class of bug entirely.
+3. **No encoding compatibility problem.** Each part is decoded by its own
+   ASR / keyframe call. Different codecs across parts are a non-issue.
 
-- CLM concatenates the parts **internally** for transcription / keyframe
-  detection purposes, without touching the source files.
-  - Either via the `ffmpeg concat` demuxer into a temp file,
-  - or by driving the transcription backend segment-by-segment and merging
-    the resulting transcripts + keyframe timestamps with a running offset.
-  - The second approach avoids re-encoding and is friendlier to very long
-    total runtimes, but is more work to implement.
-- The ordering of parts is authoritative: CLM must not re-sort by mtime or
-  filename.
-- The existing `detect_transitions`, `match_events_to_slides`, and
-  `align_transcript` pipeline then sees a single logical timeline spanning
-  all parts.
-- Slide-range filtering (`--slides-range`) still applies to the merged
-  timeline, not per-part.
+Per-part processing:
 
-### Edge cases to handle
+- `transcribe(part_i) → segments_i`, merge with offset
+  `Σ duration(part_0..i-1)`
+- `detect_transitions(part_i) → events_i`, merge with the same offset
+- Each segment and event is tagged with `source_part_index` for downstream
+  use (the merge prompt gets a `boundary_hint` when a slide spans a part
+  boundary)
+- `align_transcript` sees the single logical timeline it already expects
 
-- A greeting or sign-off at the boundary of each part ("Hallo, willkommen zurück
-  zu Teil 2, ich hatte die Aufnahme kurz unterbrochen…") — this is noise that
-  should NOT end up in the voiceover. See Improvement 2 for the general noise
-  filter.
-- Part files with different encoding parameters. Internal concatenation has to
-  handle this (either transcode to a common format or fall back to segment-wise
-  transcription).
-- Timestamps in the aligner must stay consistent across parts: if
-  `Teil 1.mp4` is 12:34 long, all events in `Teil 2.mp4` should be offset by
-  754 s before being handed to the matcher.
+`--slides-range` filtering applies to the merged timeline, as before.
+
+Part ordering is authoritative: CLM must **not** re-sort by mtime or
+filename. The caller passes parts in the order they should be stitched.
+
+### Edge cases
+
+- **Encoding mismatch between parts:** no special handling needed (each
+  part is processed independently). If a specific part is unreadable by
+  ffmpeg, fail loudly with the part index in the error message.
+- **Part boundary alignment:** when a transcript segment straddles a part
+  boundary, it is assigned to whichever side of the boundary holds the
+  majority of its duration (existing aligner behavior, unchanged).
+
+### Debug support
+
+`--keep-temp` preserves the per-part audio extractions next to the source
+videos for debugging.
 
 ### Out of scope
 
-- Automatic detection of "these files are parts of one recording". The caller
-  specifies the parts explicitly and in order.
-- Glob expansion (`Teil *.mp4`). If we get to it, it's a nice-to-have that sits
-  on top of the explicit-parts interface.
+- Automatic detection of "these files are parts of one recording." Caller
+  specifies parts explicitly.
+- Glob expansion (`Teil *.mp4`). Nice-to-have on top of the explicit
+  interface.
+- **MCP tool for video transcription.** A transcription job is a
+  multi-minute process with large inputs and outputs — that is a batch CLI
+  job, not an MCP round trip. The existing MCP server
+  (`src/clm/mcp/tools.py`) exposes only slide-file manipulation
+  (`extract_voiceover`, `inline_voiceover`, `suggest_sync`); no video-level
+  tool exists and none will be added.
 
 ---
 
-## Improvement 2 — Update / merge mode
+## Improvement 2 — Merge mode (new default)
 
 ### Problem
 
-Once a slide file already has voiceover cells (either hand-written or produced
-by an earlier `sync` run), running `sync` again today **overwrites** them.
-`write_narrative` doesn't currently have a concept of "merge this into whatever
-is already there."
+Once a slide file has voiceover cells — whether hand-written or from an
+earlier `sync` run — running `sync` again today **overwrites** them. That
+is unsafe for two reasons:
 
-That's a problem in two directions:
+**Direction A — trainer improvises during recording.** While recording,
+the trainer often notices something missing on a slide and explains it
+live. Examples:
 
-**Direction A — the trainer improvises during recording.**
-While recording a video, the trainer often notices something missing on a
-slide and explains it live. Examples from real recordings:
+- "Oh, and by the way — `extend` mutates the list in place, it doesn't
+  return a new one."
+- "The free OpenRouter tier has a rate limit of ~20 requests per minute,
+  so don't spam it when testing."
+- "One thing I forgot to put on the slide: you can also pass
+  `system_prompt` as a regular string instead of a `SystemMessage` in
+  newer LangChain versions."
 
-- "Oh, and by the way — `extend` mutates the list in place, it doesn't return
-  a new one. That's a common mistake."
-- "I should mention: the free OpenRouter tier has a rate limit of ~20 requests
-  per minute, so if you're testing, don't spam it."
-- "One thing I forgot to put on the slide: you can also pass `system_prompt`
-  as a regular string instead of a `SystemMessage` in newer LangChain
-  versions."
+These are valuable additions. When the video is re-recorded later, we want
+the additions to end up in the voiceover without re-watching the old
+recording from memory.
 
-These are valuable additions. When we re-record the video later (for a course
-revision), we want to **make sure these additions end up on the slides or in
-the voiceover**, so we don't have to remember them from memory or re-watch the
-old recording. Today there's no good place to park them — editing them into
-the voiceover manually is fine but tedious, and running `sync` against the
-new recording would wipe the hand-edits.
-
-**Direction B — the transcript also contains stuff that must NOT land in
+**Direction B — transcript also contains stuff that must NOT land in
 voiceover.** Examples:
 
-- Greetings and sign-offs at the boundary of multi-part recordings ("Hallo,
-  willkommen zurück, wir sind jetzt in Teil 2 angelangt…").
-- Recording mistakes:
-  - "Moment, ich hab da was übersehen, lass mich kurz zurückscrollen…"
-  - "Oh sorry, das war der falsche Slide, ich muss da nochmal hin."
-  - "Uh, entschuldigung, das Mikrofon hat gerade kurz ausgesetzt."
-- Environment noise ("mein Docker-Container ist rot, weil ich das falsche
-  Environment habe" — useful for the trainer but not for the student).
-- Off-topic tangents that were cut in post-production but are still in the
-  audio.
+- Greetings and sign-offs at part boundaries ("Hallo, willkommen zurück,
+  wir sind jetzt in Teil 2 angelangt…").
+- Recording self-corrections ("Moment, lass mich kurz zurückscrollen…",
+  "Oh sorry, das war der falsche Slide…").
+- Trainer-environment remarks ("mein Docker-Container ist rot, weil ich
+  das falsche Environment habe").
+- **Code-typing narration:** the trainer reading out syntax tokens while
+  live-coding ("And then we define the function — def — fact — open
+  paren — n — colon…"). Explanations of code stay; dictation of code
+  drops.
+- Off-topic tangents.
 
-Today these all end up in the polished notes map because the LLM polish step
-doesn't have a strong enough signal that they should be dropped.
+### Proposal: merge by default, `--overwrite` for old behavior
 
-### Proposal: a new `--update` mode (alias: `--merge`)
+`sync` is changed so that its default behavior is to merge into existing
+voiceover cells. The old destructive behavior is available via
+`--overwrite`. Rationale: merge is less destructive, and a user who runs
+`sync` twice against the same file by accident should not lose content.
 
 ```bash
-clm voiceover sync --lang de \
-  --update \
-  Teil*.mp4 \
-  slides_010v_streaming_generators.py
+# Default: merge into existing voiceover cells
+clm voiceover sync --lang de slides_010v.py "Teil 1.mp4" "Teil 2.mp4"
+
+# Old behavior: overwrite everything the sync produces
+clm voiceover sync --lang de --overwrite slides_010v.py "Teil 1.mp4" "Teil 2.mp4"
 ```
 
-Semantics:
+`--dry-run` produces output (see "Dry-run output" below) without touching
+disk.
 
-1. **Read the existing voiceover cells** from the slide file before doing
-   anything. For each slide group, capture the current voiceover text (per
-   language) as the **baseline**.
-2. **Run the normal pipeline** (transcribe, detect transitions, match, align)
-   to produce a fresh `notes_map` from the recording. Call this the
+### Semantics
+
+1. **Read the existing voiceover cells** from the slide file for the
+   current `--tag` (default: `voiceover`). Per slide group, capture the
+   current text as the **baseline**.
+2. **Run the normal pipeline** (transcribe, detect transitions, match,
+   align) to produce raw aligned transcript text per slide. Call this the
    **candidate**.
-3. **Diff** the candidate against the baseline, per slide. For each slide:
-   - Compute what's in the candidate that is NOT in the baseline — call these
-     **additions**.
-   - Pass additions through an LLM **noise-filter** prompt that rejects
-     content matching noise patterns (see list below).
-   - Present surviving additions to the user as **proposed merge hunks**:
-     "Slide 7: the recording adds this sentence about `extend` mutability —
-     append it?" (Interactive, or batch-approved via `--accept-all-additions`
-     / `--dry-run` as today.)
-   - Never delete or modify existing baseline content. Only append.
+3. **For each slide**, call
+   `polish_and_merge(baseline, candidate, slide_content, language,
+   boundary_hint)` — a single LLM call (batched, see below) that produces
+   the merged voiceover bullet list.
 4. **Write** the merged voiceover back into the file.
 
-### Noise filter
+Slides with no baseline in the current tag get the current polish behavior
+(insert fresh cell). The merge path degrades cleanly to the fresh-insert
+path when baseline is empty. There is no separate "new slide" code path.
 
-The noise filter is a prompt (for the polish LLM) that takes a candidate
-addition and decides whether to keep or drop it. Examples of drop patterns:
+### The `polish_and_merge` function
 
-- Mid-recording greetings / part transitions (`"willkommen zurück"`,
-  `"jetzt in Teil 2"`, `"so, weiter geht's"`).
-- Recording self-corrections (`"moment"`, `"lass mich kurz"`, `"falscher
-  slide"`, `"ich muss da nochmal"`, `"entschuldigung"` at sentence start).
-- Trainer-environment remarks about their own setup (`"mein Docker-Container"`,
-  `"mein Environment"`, `"das Mikrofon"`, `"mein Editor zeigt rot"`).
-- Content that was clearly said to the recording operator, not the student
-  ("kannst du das nachher rausschneiden", "das kommt in den Schnitt").
+This is a natural generalization of the existing `polish_text` in
+`src/clm/notebooks/polish.py`. It takes:
 
-The filter should be **conservative** — the default is "keep", and it only
-drops on high-confidence pattern matches. When in doubt, it keeps the
-addition and lets the trainer decide in the interactive review.
+```python
+async def polish_and_merge(
+    baseline_bullets: str,        # existing voiceover cell ("" if none)
+    transcript_text: str,         # raw aligned transcript for this slide
+    slide_content: str,           # slide code/markdown for context
+    language: str,                # de / en
+    boundary_hint: bool = False,  # transcript spans a part boundary
+    *,
+    model: str = "gpt-4o-mini",
+    ...
+) -> MergeResult
+```
 
-### Why not diff on words?
+When `baseline_bullets == ""`, it is the current polish behavior (clean
+transcript → bullets). When non-empty, it merges. One function, two
+behaviors.
 
-A naive word-level diff won't work because the trainer paraphrases between
-takes and between what's on the slide. The merge needs to operate at the
-**semantic** level: "does this candidate sentence express an idea that is
-already covered by any sentence in the baseline?" That's an LLM call, not a
-diff.
+### Prompt structure
 
-Rough shape of the per-slide merge prompt:
+The LLM handles noise filtering, content preservation, addition
+integration, and position-in-list **all in one call**. No multi-pass
+diff/anchor/insert scheme. Ordering of bullets in the output is the LLM's
+decision; git diff is the review layer (see "Dry-run output" below).
 
-> You are reviewing an improvement to existing voiceover text.
->
-> BASELINE (existing voiceover, known good):
-> {baseline}
->
-> CANDIDATE (new voiceover from a re-recording):
-> {candidate}
->
-> Return:
-> 1. A list of sentences from CANDIDATE that add *new, substantive*
->    information not already present (even in different wording) in BASELINE.
-> 2. For each such sentence, drop it if it is greeting/sign-off noise, a
->    recording self-correction, or trainer-environment commentary.
-> 3. Rewrite the surviving sentences into the same voice and style as
->    BASELINE (bullet list, direct student address, consistent tense).
->
-> If nothing substantive is added, return an empty list.
+System prompt shape (language-specific versions swapped based on `--lang`):
 
-Output is the set of **bullets to append** to the baseline for that slide.
+```
+You are an expert editor for educational course voiceover cells. You
+receive an existing voiceover (baseline bullets) and a raw transcript of
+what the trainer said while this slide was visible. Produce an updated
+voiceover as a bulleted list.
 
-### Interactive review
+Invariants:
+1. Default: PRESERVE every substantive point in the baseline. Integrate
+   new substantive content from the transcript in the narrative position
+   that matches how the trainer explained it.
+2. EXCEPTION: If the transcript directly contradicts or corrects a
+   specific baseline bullet, you MAY rewrite that bullet to incorporate
+   the correction. This is only permitted when the transcript makes a
+   clear factual contradiction (e.g., baseline says "extend returns a new
+   list", transcript says "extend mutates in place and doesn't return a
+   new list"). Style improvements, paraphrases, or clarifications are NOT
+   corrections — leave those alone.
+3. Never silently drop a baseline bullet. If you rewrite one, the
+   rewritten version replaces it; nothing disappears.
+4. Do not hallucinate. Every bullet must come from the baseline or the
+   transcript.
 
-Default `--update` behavior is interactive: for each slide with proposed
-additions, show baseline + addition + accept/skip/edit prompt, like
-`git add -p`. Non-interactive flags:
+Filter (drop from transcript, never from baseline):
+- Greetings, sign-offs, part-boundary transitions ("willkommen zurück",
+  "so, weiter geht's", "das war's für heute").
+- Recording self-corrections ("moment", "falscher Slide", "lass mich
+  kurz", "entschuldigung" at sentence start).
+- Trainer environment remarks ("mein Docker-Container", "das Mikrofon",
+  "mein Editor zeigt rot").
+- Content said to the recording operator ("kannst du das rausschneiden",
+  "das kommt in den Schnitt").
+- Code-typing narration: trainer reading out syntax tokens while
+  live-coding ("def fact open paren n colon", "and then a for loop, for
+  m comma n"). Keep explanations of the code; drop dictation of it.
+- Off-topic tangents.
 
-- `--dry-run` — already exists; show what *would* be appended and exit.
-- `--accept-all-additions` — merge without prompting (use with care).
-- `--reject-all-additions` — equivalent to running sync without `--update`
-  against an already-written file, i.e. a no-op. Mainly useful for testing
-  the noise filter without committing.
+Style:
+- Bulleted markdown ("- " prefix), one thought per bullet.
+- Direct student address, consistent tense (match baseline).
+- Same language as input (do not translate).
+
+Return STRUCTURED JSON per slide (see response schema).
+```
+
+User prompt per slide:
+
+```
+SLIDE CONTEXT (do not include in output):
+{slide_content}
+
+BASELINE VOICEOVER (preserve; may rewrite only on factual contradiction):
+{baseline_bullets}
+
+TRANSCRIPT (candidate additions, filter aggressively):
+{transcript_text}
+
+{boundary_hint_line if boundary_hint}
+```
+
+### Structured response schema
+
+Per slide, the LLM returns:
+
+```json
+{
+  "slide_id": "slides_010v/7",
+  "merged_bullets": "- ...\n- ...",
+  "rewrites": [
+    {
+      "original": "- extend returns a new list",
+      "revised": "- extend mutates the list in place and returns None",
+      "transcript_evidence": "actually, extend mutates in place, it doesn't return anything"
+    }
+  ],
+  "dropped_from_transcript": [
+    "willkommen zurück zu Teil 2",
+    "moment, falscher slide"
+  ]
+}
+```
+
+Fields:
+
+- `merged_bullets` is what gets written to the slide file.
+- `rewrites` lists every baseline bullet that was modified under invariant
+  2. Empty list = no rewrites happened. `--dry-run` surfaces these
+  prominently (e.g., `⚠ slide 7: 1 baseline rewrite`) so reviewers don't
+  have to hunt through diffs.
+- `dropped_from_transcript` is a best-effort record of noise the filter
+  rejected. Useful for tuning the filter and as a fixture source for
+  testing.
+
+### Batching
+
+LLM calls are batched across slides to reduce overhead and improve style
+consistency:
+
+- Input: list of `{slide_id, baseline, candidate, slide_content,
+  boundary_hint}` items packed into one user message up to a character
+  budget.
+- Default budget: 20,000 characters (configurable via
+  `--batch-char-limit`).
+- Response: JSON list of per-slide results keyed by `slide_id` — so
+  batch-internal ordering drift cannot corrupt the mapping.
+- On JSON parse failure for a whole batch: fall back to per-slide calls
+  for that batch.
+- Slides where both `baseline` and `transcript` are trivially empty are
+  early-returned without an LLM call.
+
+### Dry-run output
+
+`--dry-run` emits a **unified diff** of baseline → merged to stdout,
+scoped to the voiceover cells that changed. One diff per slide file,
+standard `diff -u` headers. Easy to scan, pipeable to `less`, matches the
+git-review mental model.
+
+Rewrites (under invariant 2) are annotated in the dry-run output with a
+warning marker so they do not get lost among append-only changes.
 
 ### Interaction with existing flags
 
-- `--tag voiceover` / `--tag notes` — baseline is read from the same tag the
-  command would write. Updating voiceover does not touch notes and vice
-  versa.
-- `--slides-range` — only slides in the range are candidates for merging.
+- `--tag voiceover` / `--tag notes`: baseline is read from and written to
+  the same tag. Merging voiceover does not touch notes and vice versa.
+  The default tag is `voiceover`.
+- **Baseline tag fallback: none.** If a slide has content only in the
+  *other* tag (e.g., `--tag voiceover` set but the slide only has a
+  `notes` cell), the merge sees an empty baseline and inserts a fresh
+  voiceover cell alongside the existing notes cell. Users who want to use
+  existing notes as baseline must retag manually first. This keeps the
+  rule simple: one run, one tag.
+- `--slides-range`: only slides in the range are candidates for merging.
   Out-of-range slides retain their baseline unchanged.
-- `--mode polished` / `--mode verbatim` — verbatim mode probably shouldn't
-  offer `--update`, since without the polish LLM there's no noise filter.
-  Either make `--update` imply `polished` or error out when combined with
-  `verbatim`.
+- `--mode polished` / `--mode verbatim`: **error** when `--mode verbatim`
+  is combined with merge (the new default). Verbatim mode has no polish
+  LLM and therefore no noise filter; merging raw transcript text into
+  existing voiceover would be unsafe. Users who want verbatim behavior
+  must also pass `--overwrite`.
 
 ### Out of scope (for this first pass)
 
-- Multi-language merge coordination (DE/EN). Treat each language
+- Multi-language merge coordination (DE/EN). Each language is merged
   independently. If the trainer recorded only in DE, the EN voiceover is
   untouched.
 - Merging into companion voiceover files (`extract-voiceover` output).
   Start with inline voiceover cells; extend later if needed.
-- Preserving ordering of additions relative to the slide's bullet structure
-  (just append to the end of the existing VO cell for now).
 
 ---
 
-## Priority and sequencing
+## Observability: Langfuse tracing
 
-**Improvement 1** (multi-file input) is the prerequisite that unblocks
-real-world use of sync for the AZAV ML course restructure. It's relatively
-mechanical.
+Langfuse integration is added to
+`clm.infrastructure.llm.client._build_client`. The change is minimal: when
+Langfuse environment variables are set, `_build_client` returns a
+Langfuse-wrapped `openai.AsyncOpenAI` instance; otherwise it returns the
+plain client. Every existing LLM call benefits automatically, not just
+voiceover.
 
-**Improvement 2** (update mode) is the bigger lift but is what makes
-re-recording a video cheap. Without it, every revision pass either loses
-hand-edits or loses new improvisations — both unacceptable.
+### Configuration
 
-Suggested order: ship (1) first, use it for a few topics to validate the
-pipeline, then add (2).
+Three standard environment variables:
+
+- `LANGFUSE_HOST` (e.g. `http://localhost:3000` for a local Docker
+  instance)
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+
+Absence of any of these disables tracing silently. Failure to reach
+Langfuse at runtime logs a warning and continues; tracing must never break
+the pipeline.
+
+The `langfuse` package is added to the `[voiceover]` extra. If Langfuse
+spreads to other modules, it can be promoted to a top-level `[tracing]`
+extra later.
+
+### Trace shape
+
+- `session_id = f"voiceover-sync-{topic}-{timestamp}"` — groups everything
+  from one `sync` invocation into a Langfuse dashboard view.
+- One trace per LLM call (each merge batch, each polish call).
+- `trace.name = "voiceover_merge_batch"` or `"polish_text"`.
+- `trace.metadata = {slide_ids, language, mode, topic, batch_char_count}`.
+- `trace.tags = ["voiceover-sync", language, mode]`.
+- `trace.user_id = <git user.name>`.
+- Input and output are captured automatically via the Langfuse openai
+  wrapper.
+
+---
+
+## Training data collection
+
+### Local trace log (always on)
+
+For every `sync` invocation, CLM writes a JSONL trace log to
+`.clm/voiceover-traces/<topic>-<YYYYMMDD-HHMMSS>.jsonl` inside the course
+repo. One line per LLM call, containing:
+
+```json
+{
+  "timestamp": "2026-04-12T01:20:20Z",
+  "slide_file": "slides_010v_streaming_generators.py",
+  "slide_id": "slides_010v/7",
+  "language": "de",
+  "baseline": "- ...",
+  "transcript": "...",
+  "llm_merged": "- ...",
+  "rewrites": [...],
+  "dropped_from_transcript": [...],
+  "langfuse_trace_id": "...",
+  "git_head": "<commit hash at sync time>"
+}
+```
+
+`.clm/voiceover-traces/` is added to the project's `.gitignore` by
+default. Users who want to version the logs can un-ignore them explicitly.
+
+The trace log is independent of Langfuse. It is the durable, local-first
+substrate for training data extraction. Langfuse, if configured, receives
+the same data via its own channels.
+
+### Training data extraction (later phase)
+
+A new command `clm voiceover extract-training-data <trace-log>` reads the
+trace log and correlates each entry against the current slide file to
+produce training triples:
+
+```json
+{
+  "input": {"baseline": "...", "transcript": "..."},
+  "llm_output": "...",
+  "human_final": "...",
+  "delta_vs_llm": "<diff>"
+}
+```
+
+Two kinds of training signal fall out:
+
+1. `(baseline + transcript) → human_final`: end-to-end supervised training
+   for a merge model.
+2. `(baseline + transcript + llm_output) → human_final`: correction
+   training for a critic/editor model.
+
+Both are suitable for LoRA / fine-tuning.
+
+The trace log itself ships as part of Phase 2 (so data accumulation starts
+immediately). The extraction command is deferred to Phase 4, since a
+corpus must accumulate before training is meaningful.
+
+---
+
+## Phase plan
+
+1. **Phase 1 — Multi-file input (Improvement 1).**
+   - `SLIDES VIDEO...` CLI signature (breaking change).
+   - Segment-wise transcription and keyframe detection per part.
+   - Running-offset merge into single logical timeline.
+   - `source_part_index` tagging on transcript segments and slide events.
+   - Boundary metadata plumbed through to downstream consumers.
+   - `--keep-temp` for debugging.
+   - No LLM changes.
+
+2. **Phase 2 — Merge mode (Improvement 2 core).**
+   - Default behavior changed to merge; `--overwrite` flag restores old
+     behavior.
+   - `polish_and_merge` in `src/clm/notebooks/polish.py` with
+     relaxed-baseline prompt returning structured rewrites.
+   - Batched LLM calls with 20k char budget and JSON-keyed response.
+   - Unified-diff `--dry-run` output, with rewrite annotations.
+   - Same-tag-only baseline policy.
+   - `--mode verbatim` + merge errors out.
+   - Language-specific prompt variants.
+   - Boundary hint forwarded from Phase 1.
+   - Local trace log (`.clm/voiceover-traces/`) wired in from day one.
+
+3. **Phase 3 — Langfuse integration.**
+   - Wrap `_build_client` to return Langfuse-enabled client when env vars
+     are set.
+   - Session / trace / span structure as specified above.
+   - `langfuse` added to `[voiceover]` extra.
+   - Benefits all LLM-using modules, not just voiceover.
+
+4. **Phase 4 — Training data extraction command.**
+   - `clm voiceover extract-training-data` reads trace logs, correlates
+     with current slide state, emits training jsonl.
+   - Low priority until a corpus has accumulated.
+
+---
 
 ## Reference — real case that prompted this proposal
 
@@ -296,13 +526,14 @@ pipeline, then add (2).
   `… (Teil 2).mp4`,
   `… (Teil 3).mp4`.
 - The handover doc for the restructure prescribed running
-  `clm voiceover sync` against a file named `(Teil 1+2+3).mp4`, which does
-  not exist and has never existed — the name was aspirational.
+  `clm voiceover sync` against a file named `(Teil 1+2+3).mp4`, which
+  does not exist and has never existed — the name was aspirational.
 - The pragmatic workaround was to skip sync entirely and retag the
-  hand-authored `notes` cells (which were already voiceover-style and well
-  paired in DE/EN) to `voiceover`. This worked for the first pass but means
-  we can't easily ingest any improvisations from a future re-recording.
+  hand-authored `notes` cells (which were already voiceover-style and
+  well paired in DE/EN) to `voiceover`. This worked for the first pass
+  but means we cannot easily ingest improvisations from a future
+  re-recording.
 - Both improvements above would have let us ingest the existing recording
-  cleanly: Improvement 1 handles the three-part input, Improvement 2 makes
-  the merge safe against both the retagged hand-authored baseline and the
+  cleanly: Phase 1 handles the three-part input, Phase 2 makes the merge
+  safe against both the retagged hand-authored baseline and the
   inevitable boundary-greetings between Teil 1/2/3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ voiceover = [
     "python-dateutil>=2.8.0", # Required by pandas (pytesseract dependency)
     "rapidfuzz>=3.0.0",       # Fuzzy text matching
     "Pillow>=10.0.0",         # Image handling
+    "langfuse>=3.0.0",        # LLM observability (optional, env-var gated)
 ]
 # Alternative voiceover backends (heavier deps, require torch)
 voiceover-cohere = [

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -8,6 +8,7 @@ Requires the ``[voiceover]`` extra.
 
 from __future__ import annotations
 
+import difflib
 import json
 import logging
 from pathlib import Path
@@ -41,6 +42,12 @@ def voiceover_group():
     type=click.Choice(["verbatim", "polished"]),
     help="Polished (default) runs LLM cleanup; verbatim keeps transcript as-is.",
 )
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing voiceover cells instead of merging (old behavior).",
+)
 @click.option("--whisper-model", default="large-v3", help="Whisper model size.")
 @click.option(
     "--backend",
@@ -64,12 +71,13 @@ def voiceover_group():
 @click.option("--dry-run", is_flag=True, help="Show mapping without writing changes.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None, help="Output file.")
 @click.option("--keep-audio", is_flag=True, help="Keep extracted audio files.")
-@click.option("--model", default=None, help="LLM model for polished mode.")
+@click.option("--model", default=None, help="LLM model for polished/merge mode.")
 def sync(
     slides,
     videos,
     lang,
     mode,
+    overwrite,
     whisper_model,
     backend_name,
     device,
@@ -83,7 +91,8 @@ def sync(
     """Synchronize speaker notes from one or more video recordings.
 
     Transcribes each VIDEO part, detects slide transitions, matches them
-    to SLIDES, and inserts/updates voiceover cells in the .py file.
+    to SLIDES, and merges voiceover cells in the .py file (preserving
+    existing content). Use --overwrite to replace instead of merge.
 
     Multiple video parts are processed independently and merged into a
     single timeline using running offsets. Part ordering is authoritative
@@ -93,7 +102,18 @@ def sync(
     Examples:
         clm voiceover sync slides.py video.mp4 --lang de
         clm voiceover sync slides.py "Teil 1.mp4" "Teil 2.mp4" --lang de
+        clm voiceover sync slides.py video.mp4 --lang de --overwrite
     """
+    # Validate: --mode verbatim without --overwrite is an error
+    if mode == "verbatim" and not overwrite:
+        raise click.UsageError(
+            "Cannot use --mode verbatim with merge (the default). "
+            "Verbatim mode has no noise filter, so merging raw transcript "
+            "into existing voiceover would be unsafe. "
+            "Use --overwrite to replace existing voiceover cells, or "
+            "use --mode polished (the default) for merge."
+        )
+
     from clm.notebooks.slide_parser import parse_slides
     from clm.notebooks.slide_writer import write_narrative
     from clm.voiceover.aligner import align_transcript
@@ -189,30 +209,299 @@ def sync(
         start, end = _parse_range(slides_range)
         slide_indices = {i for i in slide_indices if start <= i <= end}
 
-    # Build notes map
+    # Build notes map (raw transcript text per slide)
     notes_map: dict[int, str] = {}
     for idx in sorted(slide_indices):
         text = alignment.get_notes_text(idx)
         if text:
             notes_map[idx] = text
 
-    # Polish if requested
-    if mode == "polished" and notes_map:
+    if overwrite:
+        # Old behavior: polish or verbatim, then overwrite
+        if mode == "polished" and notes_map:
+            import asyncio
+
+            console.print("[bold]Polishing notes with LLM...[/bold]")
+            notes_map = asyncio.run(_polish_notes(notes_map, slide_groups, model=model, lang=lang))
+
+        _display_notes_summary(notes_map, slide_groups)
+
+        if dry_run:
+            console.print("\n[yellow]Dry run — no changes written.[/yellow]")
+            return
+
+        dest = write_narrative(slides, notes_map, lang, tag=tag, output_path=output)
+        console.print(f"\n[green]{tag.capitalize()} cells written to {dest}[/green]")
+    else:
+        # Merge mode (default): merge transcript into existing voiceover
         import asyncio
 
-        console.print("[bold]Polishing notes with LLM...[/bold]")
-        notes_map = asyncio.run(_polish_notes(notes_map, slide_groups, model=model, lang=lang))
+        asyncio.run(
+            _merge_notes(
+                slides=slides,
+                notes_map=notes_map,
+                slide_groups=slide_groups,
+                lang=lang,
+                tag=tag,
+                model=model,
+                dry_run=dry_run,
+                output=output,
+                multi_part=multi_part,
+                alignment=alignment,
+            )
+        )
 
-    # Display results
-    _display_notes_summary(notes_map, slide_groups)
 
-    if dry_run:
-        console.print("\n[yellow]Dry run — no changes written.[/yellow]")
+async def _merge_notes(
+    *,
+    slides: Path,
+    notes_map: dict[int, str],
+    slide_groups: list,
+    lang: str,
+    tag: str,
+    model: str | None,
+    dry_run: bool,
+    output: Path | None,
+    multi_part: bool,
+    alignment,
+) -> None:
+    """Merge transcript into existing voiceover cells."""
+    from clm.notebooks.slide_writer import write_narrative
+    from clm.voiceover.merge import (
+        DEFAULT_MERGE_MODEL,
+        MergeResult,
+        SlideInput,
+        build_batches,
+        merge_batch,
+    )
+    from clm.voiceover.trace_log import TraceLog
+
+    merge_model = model or DEFAULT_MERGE_MODEL
+
+    # Read existing voiceover baseline per slide from the parsed slide groups
+    slide_inputs: list[SlideInput] = []
+    for idx in sorted(notes_map.keys()):
+        transcript_text = notes_map[idx]
+
+        # Find the slide group and read its existing notes
+        baseline = ""
+        slide_content = ""
+        for sg in slide_groups:
+            if sg.index == idx:
+                slide_content = sg.text_content
+                # Read existing notes matching the target tag
+                baseline = _extract_baseline(sg, tag)
+                break
+
+        # Detect boundary hint: slide has segments from multiple parts
+        boundary_hint = False
+        if multi_part and idx in alignment.slide_notes:
+            boundary_hint = _has_boundary(alignment, idx)
+
+        slide_id = f"{slides.stem}/{idx}"
+
+        # Skip slides where both baseline and transcript are empty
+        if not baseline.strip() and not transcript_text.strip():
+            continue
+
+        slide_inputs.append(
+            SlideInput(
+                slide_id=slide_id,
+                baseline=baseline,
+                transcript=transcript_text,
+                slide_content=slide_content,
+                boundary_hint=boundary_hint,
+            )
+        )
+
+    if not slide_inputs:
+        console.print("[yellow]No slides to merge.[/yellow]")
         return
 
-    # Write cells
-    dest = write_narrative(slides, notes_map, lang, tag=tag, output_path=output)
-    console.print(f"\n[green]{tag.capitalize()} cells written to {dest}[/green]")
+    # Create trace log
+    trace = TraceLog.create(slides.name, base_dir=slides.parent)
+
+    # Build batches and run merge
+    batches = build_batches(slide_inputs)
+    console.print(
+        f"[bold]Merging {len(slide_inputs)} slides "
+        f"({len(batches)} batch{'es' if len(batches) != 1 else ''}) "
+        f"with {merge_model}...[/bold]"
+    )
+
+    all_results: list[MergeResult] = []
+    for batch_idx, batch in enumerate(batches):
+        if len(batches) > 1:
+            console.print(
+                f"  Batch {batch_idx + 1}/{len(batches)} "
+                f"({len(batch)} slide{'s' if len(batch) != 1 else ''})..."
+            )
+        results = await merge_batch(
+            batch,
+            language=lang,
+            model=merge_model,
+        )
+        all_results.extend(results)
+
+        # Log each result to the trace log
+        for slide_input, result in zip(batch, results, strict=True):
+            trace.log_merge_call(
+                slide_id=result.slide_id,
+                language=lang,
+                baseline=slide_input.baseline,
+                transcript=slide_input.transcript,
+                llm_merged=result.merged_bullets,
+                rewrites=result.rewrites,
+                dropped_from_transcript=result.dropped_from_transcript,
+            )
+
+    # Build merged notes_map from results
+    merged_map: dict[int, str] = {}
+    rewrite_count = 0
+    for result in all_results:
+        # Extract slide index from slide_id (format: "stem/idx")
+        try:
+            idx = int(result.slide_id.rsplit("/", 1)[-1])
+        except (ValueError, IndexError):
+            logger.warning("Cannot parse slide index from %s", result.slide_id)
+            continue
+        if result.merged_bullets.strip():
+            merged_map[idx] = result.merged_bullets
+        if result.rewrites:
+            rewrite_count += len(result.rewrites)
+
+    # Display results
+    _display_merge_summary(all_results, slide_groups)
+
+    if rewrite_count:
+        console.print(
+            f"\n[yellow]Warning: {rewrite_count} baseline rewrite(s) detected. "
+            f"Review the diff carefully.[/yellow]"
+        )
+
+    if dry_run:
+        # Emit unified diff
+        _emit_dry_run_diff(slides, merged_map, lang, tag, all_results)
+        console.print(f"\n[dim]Trace log: {trace.path}[/dim]")
+        console.print("[yellow]Dry run — no changes written.[/yellow]")
+        return
+
+    # Write merged cells
+    dest = write_narrative(slides, merged_map, lang, tag=tag, output_path=output)
+    console.print(f"\n[dim]Trace log: {trace.path}[/dim]")
+    console.print(f"[green]{tag.capitalize()} cells written to {dest}[/green]")
+
+
+def _extract_baseline(slide_group, tag: str) -> str:
+    """Extract existing voiceover/notes text for the given tag from a slide group."""
+    parts = []
+    for cell in slide_group.notes_cells:
+        # Only include cells matching the target tag
+        if tag in cell.metadata.tags:
+            text = cell.text_content()
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _has_boundary(alignment, slide_idx: int) -> bool:
+    """Check if a slide has transcript segments from multiple video parts.
+
+    Conservative heuristic: in multi-part mode, always returns True.
+    This means the merge prompt is extra suspicious of greeting/sign-off
+    noise near all slides, which is the safe default.
+    """
+    if slide_idx not in alignment.slide_notes:
+        return False
+    return True
+
+
+def _display_merge_summary(results: list, slide_groups: list):
+    """Display a summary table of merge results."""
+    table = Table(title="Merge Results")
+    table.add_column("Slide", style="cyan")
+    table.add_column("Title")
+    table.add_column("Length", style="green")
+    table.add_column("Rewrites", style="yellow")
+    table.add_column("Preview")
+
+    for result in results:
+        try:
+            idx = int(result.slide_id.rsplit("/", 1)[-1])
+        except (ValueError, IndexError):
+            idx = -1
+
+        title = ""
+        for sg in slide_groups:
+            if sg.index == idx:
+                title = sg.title[:30]
+                break
+
+        text = result.merged_bullets
+        preview = text[:50].replace("\n", " ") + ("..." if len(text) > 50 else "")
+        rewrites_str = str(len(result.rewrites)) if result.rewrites else ""
+
+        table.add_row(
+            str(idx),
+            title,
+            f"{len(text)} chars",
+            rewrites_str,
+            preview,
+        )
+
+    console.print(table)
+
+
+def _emit_dry_run_diff(
+    slides: Path,
+    merged_map: dict[int, str],
+    lang: str,
+    tag: str,
+    results: list,
+):
+    """Emit a unified diff of baseline -> merged for dry-run mode."""
+    from clm.notebooks.slide_writer import update_narrative
+
+    original_text = slides.read_text(encoding="utf-8")
+    updated_text = update_narrative(original_text, merged_map, lang, tag=tag)
+
+    if original_text == updated_text:
+        console.print("\n[dim]No changes — merged output matches baseline.[/dim]")
+        return
+
+    diff = difflib.unified_diff(
+        original_text.splitlines(keepends=True),
+        updated_text.splitlines(keepends=True),
+        fromfile=f"a/{slides.name}",
+        tofile=f"b/{slides.name}",
+    )
+
+    console.print()
+    for line in diff:
+        line = line.rstrip("\n")
+        if line.startswith("+++") or line.startswith("---"):
+            console.print(f"[bold]{line}[/bold]")
+        elif line.startswith("+"):
+            console.print(f"[green]{line}[/green]")
+        elif line.startswith("-"):
+            console.print(f"[red]{line}[/red]")
+        elif line.startswith("@@"):
+            console.print(f"[cyan]{line}[/cyan]")
+        else:
+            console.print(line)
+
+    # Annotate rewrites
+    for result in results:
+        if result.rewrites:
+            try:
+                idx = int(result.slide_id.rsplit("/", 1)[-1])
+            except (ValueError, IndexError):
+                idx = -1
+            for rw in result.rewrites:
+                console.print(
+                    f"[yellow]  Warning: slide {idx}: baseline rewrite: "
+                    f"{rw.get('original', '?')} -> {rw.get('revised', '?')}[/yellow]"
+                )
 
 
 @voiceover_group.command()

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -266,6 +266,13 @@ async def _merge_notes(
     alignment,
 ) -> None:
     """Merge transcript into existing voiceover cells."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    from clm.infrastructure.llm.client import (
+        _langfuse_configured,
+        flush_langfuse,
+    )
     from clm.notebooks.slide_writer import write_narrative
     from clm.voiceover.merge import (
         DEFAULT_MERGE_MODEL,
@@ -329,6 +336,13 @@ async def _merge_notes(
         f"with {merge_model}...[/bold]"
     )
 
+    # Langfuse session context (shared across all batches in this invocation)
+    use_langfuse = _langfuse_configured()
+    session_id = (
+        f"voiceover-sync-{slides.stem}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    )
+    git_user = _get_git_user_name() if use_langfuse else None
+
     all_results: list[MergeResult] = []
     for batch_idx, batch in enumerate(batches):
         if len(batches) > 1:
@@ -336,10 +350,36 @@ async def _merge_notes(
                 f"  Batch {batch_idx + 1}/{len(batches)} "
                 f"({len(batch)} slide{'s' if len(batch) != 1 else ''})..."
             )
+
+        # Build per-batch Langfuse context
+        langfuse_ctx = None
+        trace_id = None
+        if use_langfuse:
+            trace_id = str(uuid4())
+            langfuse_ctx = {
+                "name": "voiceover_merge_batch",
+                "trace_id": trace_id,
+                "metadata": {
+                    "langfuse_session_id": session_id,
+                    "langfuse_tags": ["voiceover-sync", lang, "merge"],
+                    "langfuse_user_id": git_user,
+                    "langfuse_metadata": {
+                        "slide_ids": [s.slide_id for s in batch],
+                        "language": lang,
+                        "topic": slides.stem,
+                        "batch_char_count": sum(
+                            len(s.baseline) + len(s.transcript) + len(s.slide_content)
+                            for s in batch
+                        ),
+                    },
+                },
+            }
+
         results = await merge_batch(
             batch,
             language=lang,
             model=merge_model,
+            langfuse_context=langfuse_ctx,
         )
         all_results.extend(results)
 
@@ -353,7 +393,12 @@ async def _merge_notes(
                 llm_merged=result.merged_bullets,
                 rewrites=result.rewrites,
                 dropped_from_transcript=result.dropped_from_transcript,
+                langfuse_trace_id=trace_id,
             )
+
+    # Flush Langfuse traces before exiting (best-effort)
+    if use_langfuse:
+        flush_langfuse()
 
     # Build merged notes_map from results
     merged_map: dict[int, str] = {}
@@ -680,6 +725,24 @@ async def _polish_notes(
         polished[idx] = await polish_text(text, slide_content, **kwargs)
 
     return polished
+
+
+def _get_git_user_name() -> str | None:
+    """Return the git user.name, or None if unavailable."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.name"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
 
 
 def _display_notes_summary(notes_map: dict[int, str], slide_groups: list):

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -32,8 +32,8 @@ def voiceover_group():
 
 
 @voiceover_group.command()
-@click.argument("video", type=click.Path(exists=True, path_type=Path))
 @click.argument("slides", type=click.Path(exists=True, path_type=Path))
+@click.argument("videos", nargs=-1, required=True, type=click.Path(exists=True, path_type=Path))
 @click.option("--lang", required=True, type=click.Choice(["de", "en"]), help="Video language.")
 @click.option(
     "--mode",
@@ -63,11 +63,11 @@ def voiceover_group():
 @click.option("--slides-range", default=None, help="Slide range to update (e.g. '5-20').")
 @click.option("--dry-run", is_flag=True, help="Show mapping without writing changes.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None, help="Output file.")
-@click.option("--keep-audio", is_flag=True, help="Keep extracted audio file.")
+@click.option("--keep-audio", is_flag=True, help="Keep extracted audio files.")
 @click.option("--model", default=None, help="LLM model for polished mode.")
 def sync(
-    video,
     slides,
+    videos,
     lang,
     mode,
     whisper_model,
@@ -80,51 +80,108 @@ def sync(
     keep_audio,
     model,
 ):
-    """Synchronize speaker notes from a video recording.
+    """Synchronize speaker notes from one or more video recordings.
 
-    Transcribes VIDEO, detects slide transitions, matches them to SLIDES,
-    and inserts/updates voiceover cells in the .py file.
+    Transcribes each VIDEO part, detects slide transitions, matches them
+    to SLIDES, and inserts/updates voiceover cells in the .py file.
+
+    Multiple video parts are processed independently and merged into a
+    single timeline using running offsets. Part ordering is authoritative
+    -- pass parts in the order they should be stitched.
+
+    \b
+    Examples:
+        clm voiceover sync slides.py video.mp4 --lang de
+        clm voiceover sync slides.py "Teil 1.mp4" "Teil 2.mp4" --lang de
     """
     from clm.notebooks.slide_parser import parse_slides
     from clm.notebooks.slide_writer import write_narrative
     from clm.voiceover.aligner import align_transcript
-    from clm.voiceover.keyframes import detect_transitions
+    from clm.voiceover.keyframes import TransitionEvent, detect_transitions
     from clm.voiceover.matcher import match_events_to_slides
+    from clm.voiceover.timeline import (
+        build_parts,
+        merge_transcripts,
+        offset_events,
+        offset_transcript,
+    )
     from clm.voiceover.transcribe import transcribe_video
+
+    video_paths = [Path(v) for v in videos]
+    multi_part = len(video_paths) > 1
 
     # Parse slides
     console.print(f"[bold]Parsing slides:[/bold] {slides}")
     slide_groups = parse_slides(slides, lang)
     console.print(f"  Found {len(slide_groups)} slide groups")
 
-    # Transcribe
-    console.print(f"[bold]Transcribing:[/bold] {video} (backend={backend_name}, device={device})")
-    transcript = transcribe_video(
-        video,
-        language=lang,
-        backend_name=backend_name,
-        model_size=whisper_model,
-        device=device,
-        keep_audio=keep_audio,
-    )
-    console.print(
-        f"  {len(transcript.segments)} segments, "
-        f"{transcript.duration:.0f}s, language={transcript.language}"
-    )
+    # Probe durations and build parts
+    if multi_part:
+        console.print(f"[bold]Probing {len(video_paths)} video parts...[/bold]")
+    parts = build_parts(video_paths)
+    total_duration = sum(p.duration for p in parts)
+    if multi_part:
+        for part in parts:
+            console.print(
+                f"  Part {part.index}: {part.path.name} "
+                f"({part.duration:.0f}s, offset={part.offset:.0f}s)"
+            )
+        console.print(f"  Total duration: {total_duration:.0f}s")
 
-    # Detect transitions
-    console.print("[bold]Detecting slide transitions...[/bold]")
-    events, _diffs = detect_transitions(video)
-    console.print(f"  {len(events)} transitions detected")
+    # Per-part transcription and transition detection
+    all_transcripts = []
+    all_events: list[TransitionEvent] = []
+
+    for part in parts:
+        part_label = f" (part {part.index})" if multi_part else ""
+        console.print(
+            f"[bold]Transcribing{part_label}:[/bold] {part.path.name} "
+            f"(backend={backend_name}, device={device})"
+        )
+        transcript = transcribe_video(
+            part.path,
+            language=lang,
+            backend_name=backend_name,
+            model_size=whisper_model,
+            device=device,
+            keep_audio=keep_audio,
+        )
+        console.print(
+            f"  {len(transcript.segments)} segments, "
+            f"{transcript.duration:.0f}s, language={transcript.language}"
+        )
+
+        console.print(f"[bold]Detecting slide transitions{part_label}...[/bold]")
+        events, _diffs = detect_transitions(part.path)
+        console.print(f"  {len(events)} transitions detected")
+
+        # Apply offsets and tag with part index
+        all_transcripts.append(offset_transcript(transcript, part))
+        all_events.extend(offset_events(events, part))
+
+    # Merge transcripts
+    merged_transcript = merge_transcripts(all_transcripts)
+    if multi_part:
+        console.print(
+            f"[bold]Merged:[/bold] {len(merged_transcript.segments)} segments, "
+            f"{merged_transcript.duration:.0f}s total"
+        )
 
     # Match to slides
     console.print("[bold]Matching transitions to slides...[/bold]")
-    match_result = match_events_to_slides(events, slide_groups, video, lang=lang)
+    match_result = match_events_to_slides(
+        all_events,
+        slide_groups,
+        video_paths[0],
+        video_paths=video_paths if multi_part else None,
+        total_duration=total_duration,
+        lang=lang,
+    )
     console.print(f"  {len(match_result.timeline)} timeline entries")
 
     # Align transcript to slides
     console.print("[bold]Aligning transcript to slides...[/bold]")
-    alignment = align_transcript(transcript, match_result.timeline)
+    alignment = align_transcript(merged_transcript, match_result.timeline)
 
     # Apply slide range filter
     slide_indices = set(alignment.slide_notes.keys())

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -689,6 +689,83 @@ def identify(video, slides, lang, output):
         console.print(table)
 
 
+@voiceover_group.command("extract-training-data")
+@click.argument("trace_log", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--base-dir",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Project root for resolving slide file paths. Defaults to trace log's project root.",
+)
+@click.option(
+    "--tag",
+    default="voiceover",
+    help="Cell tag to read from slide files: 'voiceover' (default) or 'notes'.",
+)
+@click.option(
+    "--no-check-git",
+    is_flag=True,
+    default=False,
+    help="Skip git_head reachability check (useful for detached repos).",
+)
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None, help="Output file.")
+def extract_training_data(trace_log, base_dir, tag, no_check_git, output):
+    """Extract training data from a voiceover merge trace log.
+
+    Reads a JSONL trace log produced by `clm voiceover sync` and
+    correlates each entry with the current slide file state to produce
+    training triples. Each output line contains the LLM merge input,
+    output, and the human-edited final version.
+
+    \b
+    Output fields per line:
+        input.baseline    — existing voiceover before merge
+        input.transcript  — raw transcript fed to the LLM
+        llm_output        — what the LLM produced
+        human_final       — current slide file state (after hand edits)
+        delta_vs_llm      — unified diff (empty = no hand edits)
+
+    \b
+    Examples:
+        clm voiceover extract-training-data .clm/voiceover-traces/slides_intro-20260412-012020.jsonl
+        clm voiceover extract-training-data trace.jsonl -o training.jsonl
+        clm voiceover extract-training-data trace.jsonl --no-check-git
+    """
+    from clm.voiceover.training_export import extract_training_data as do_extract
+
+    console.print(f"[bold]Reading trace log:[/bold] {trace_log}")
+
+    triples = do_extract(
+        trace_log,
+        base_dir=base_dir,
+        tag=tag,
+        check_git_head=not no_check_git,
+    )
+
+    if not triples:
+        console.print("[yellow]No training triples extracted.[/yellow]")
+        return
+
+    # Count positive examples (no hand edits)
+    positive = sum(1 for t in triples if not t.delta_vs_llm)
+    edited = len(triples) - positive
+
+    console.print(
+        f"  Extracted {len(triples)} training triple(s): "
+        f"{positive} positive (no edits), {edited} with hand edits"
+    )
+
+    # Serialize
+    lines = [json.dumps(t.to_dict(), ensure_ascii=False) for t in triples]
+    output_text = "\n".join(lines) + "\n"
+
+    if output:
+        output.write_text(output_text, encoding="utf-8")
+        console.print(f"[green]Training data written to {output}[/green]")
+    else:
+        click.echo(output_text, nl=False)
+
+
 def _parse_range(range_str: str) -> tuple[int, int]:
     """Parse a slide range string like '5-20' into (start, end)."""
     if "-" in range_str:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -603,8 +603,14 @@ Requires `clm[voiceover]` extra.
 #### `clm voiceover sync`
 
 Full pipeline: transcribe one or more video parts, detect transitions, match
-slides, insert notes. Multiple video parts are processed independently and
-merged into a single timeline using running offsets — no on-disk concatenation.
+slides, and merge voiceover cells in the .py file. By default, existing
+voiceover content is preserved and transcript additions are merged in using
+a single-pass LLM call that also filters recording noise (greetings,
+self-corrections, code-typing dictation). Use `--overwrite` to replace
+existing voiceover cells instead of merging.
+
+Multiple video parts are processed independently and merged into a single
+timeline using running offsets — no on-disk concatenation.
 
 ```
 clm voiceover sync SLIDES VIDEO... --lang {de|en} [OPTIONS]
@@ -617,15 +623,32 @@ Part ordering is authoritative — pass parts in the order they should be stitch
 |--------|-------------|
 | `--lang TEXT` | Video language (`de` or `en`) (required) |
 | `--mode [verbatim\|polished]` | `verbatim` = raw transcript; `polished` = LLM cleanup (default: `polished`) |
+| `--overwrite` | Overwrite existing voiceover cells instead of merging (old behavior) |
 | `--whisper-model TEXT` | Whisper model size (default: `large-v3`) |
 | `--backend [faster-whisper\|cohere\|granite]` | Transcription backend (default: `faster-whisper`) |
 | `--device [auto\|cpu\|cuda]` | Device for transcription (default: `auto`) |
 | `--tag TEXT` | Cell tag for inserted cells: `voiceover` (default) or `notes` |
 | `--slides-range TEXT` | Slide range to update (e.g. `5-20`) |
-| `--dry-run` | Show mapping without writing |
+| `--dry-run` | Show unified diff without writing changes |
 | `-o, --output PATH` | Output file |
 | `--keep-audio` | Keep extracted audio files |
-| `--model TEXT` | LLM model for polished mode |
+| `--model TEXT` | LLM model for merge/polished mode (default: `anthropic/claude-sonnet-4-6` via OpenRouter) |
+
+**Merge behavior (default):**
+- Existing voiceover cells are read as baseline; transcript additions are
+  integrated while preserving all baseline content.
+- Recording noise (greetings, self-corrections, code-typing dictation,
+  operator asides) is filtered from the transcript.
+- If the transcript contradicts a baseline bullet, the bullet is rewritten
+  and logged in a structured rewrite report.
+- `--dry-run` emits a unified diff showing exactly what would change.
+- A JSONL trace log is written to `.clm/voiceover-traces/` on every run.
+- `--mode verbatim` without `--overwrite` is an error (verbatim has no
+  noise filter, so merging raw transcript would be unsafe).
+
+**Overwrite behavior (`--overwrite`):**
+- Old behavior: voiceover cells are replaced entirely with transcript content.
+- `--mode verbatim --overwrite` writes raw transcript without LLM cleanup.
 
 #### `clm voiceover transcribe`
 
@@ -672,8 +695,10 @@ Examples:
 
 ```bash
 clm voiceover sync slides.py video.mp4 --lang de
-clm voiceover sync slides.py video.mp4 --lang en --mode polished
+clm voiceover sync slides.py video.mp4 --lang de --dry-run
 clm voiceover sync slides.py "Teil 1.mp4" "Teil 2.mp4" "Teil 3.mp4" --lang de
+clm voiceover sync slides.py video.mp4 --lang de --overwrite
+clm voiceover sync slides.py video.mp4 --lang de --overwrite --mode verbatim
 clm voiceover sync slides.py video.mp4 --lang de --slides-range 5-20 --dry-run
 clm voiceover transcribe video.mp4 --lang de -o transcript.txt
 clm voiceover detect video.mp4 -o transitions.txt

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -602,11 +602,16 @@ Requires `clm[voiceover]` extra.
 
 #### `clm voiceover sync`
 
-Full pipeline: transcribe video, detect transitions, match slides, insert notes.
+Full pipeline: transcribe one or more video parts, detect transitions, match
+slides, insert notes. Multiple video parts are processed independently and
+merged into a single timeline using running offsets — no on-disk concatenation.
 
 ```
-clm voiceover sync VIDEO SLIDES --lang {de|en} [OPTIONS]
+clm voiceover sync SLIDES VIDEO... --lang {de|en} [OPTIONS]
 ```
+
+**Note:** The argument order is `SLIDES` first, then one or more `VIDEO` files.
+Part ordering is authoritative — pass parts in the order they should be stitched.
 
 | Option | Description |
 |--------|-------------|
@@ -619,7 +624,7 @@ clm voiceover sync VIDEO SLIDES --lang {de|en} [OPTIONS]
 | `--slides-range TEXT` | Slide range to update (e.g. `5-20`) |
 | `--dry-run` | Show mapping without writing |
 | `-o, --output PATH` | Output file |
-| `--keep-audio` | Keep extracted audio file |
+| `--keep-audio` | Keep extracted audio files |
 | `--model TEXT` | LLM model for polished mode |
 
 #### `clm voiceover transcribe`
@@ -666,9 +671,10 @@ clm voiceover identify VIDEO SLIDES --lang {de|en} [OPTIONS]
 Examples:
 
 ```bash
-clm voiceover sync video.mp4 slides.py --lang de
-clm voiceover sync video.mp4 slides.py --lang en --mode polished
-clm voiceover sync video.mp4 slides.py --lang de --slides-range 5-20 --dry-run
+clm voiceover sync slides.py video.mp4 --lang de
+clm voiceover sync slides.py video.mp4 --lang en --mode polished
+clm voiceover sync slides.py "Teil 1.mp4" "Teil 2.mp4" "Teil 3.mp4" --lang de
+clm voiceover sync slides.py video.mp4 --lang de --slides-range 5-20 --dry-run
 clm voiceover transcribe video.mp4 --lang de -o transcript.txt
 clm voiceover detect video.mp4 -o transitions.txt
 clm voiceover identify video.mp4 slides.py --lang de

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -691,6 +691,27 @@ clm voiceover identify VIDEO SLIDES --lang {de|en} [OPTIONS]
 | `--lang TEXT` | Video language (`de` or `en`) (required) |
 | `-o, --output PATH` | Output file |
 
+#### `clm voiceover extract-training-data`
+
+Extract training data from a voiceover merge trace log. Reads a JSONL trace
+log produced by `clm voiceover sync` and correlates each entry with the
+current slide file state to produce training triples suitable for fine-tuning.
+
+```
+clm voiceover extract-training-data TRACE_LOG [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--base-dir PATH` | Project root for resolving slide file paths (default: inferred from trace log location) |
+| `--tag TEXT` | Cell tag to read from slide files: `voiceover` (default) or `notes` |
+| `--no-check-git` | Skip `git_head` reachability check |
+| `-o, --output PATH` | Output file (default: stdout) |
+
+Output fields per JSONL line: `input.baseline`, `input.transcript`,
+`llm_output`, `human_final`, `delta_vs_llm` (empty = no hand edits, valid
+positive training example).
+
 Examples:
 
 ```bash
@@ -700,6 +721,8 @@ clm voiceover sync slides.py "Teil 1.mp4" "Teil 2.mp4" "Teil 3.mp4" --lang de
 clm voiceover sync slides.py video.mp4 --lang de --overwrite
 clm voiceover sync slides.py video.mp4 --lang de --overwrite --mode verbatim
 clm voiceover sync slides.py video.mp4 --lang de --slides-range 5-20 --dry-run
+clm voiceover extract-training-data .clm/voiceover-traces/slides_intro-20260412-012020.jsonl
+clm voiceover extract-training-data trace.jsonl -o training.jsonl --no-check-git
 clm voiceover transcribe video.mp4 --lang de -o transcript.txt
 clm voiceover detect video.mp4 -o transitions.txt
 clm voiceover identify video.mp4 slides.py --lang de

--- a/src/clm/infrastructure/llm/client.py
+++ b/src/clm/infrastructure/llm/client.py
@@ -1,7 +1,14 @@
-"""Thin async wrapper around the OpenAI SDK for LLM summarization calls."""
+"""Thin async wrapper around the OpenAI SDK for LLM summarization calls.
+
+When Langfuse environment variables are set and the ``langfuse`` package is
+installed, :func:`_build_client` returns a Langfuse-observed
+``openai.AsyncOpenAI`` that automatically traces all LLM calls.  Otherwise
+it returns a plain ``openai.AsyncOpenAI``.  See :func:`_langfuse_configured`.
+"""
 
 import asyncio
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -16,19 +23,70 @@ def _get_semaphore(max_concurrent: int) -> asyncio.Semaphore:
     return _semaphore
 
 
+def _langfuse_configured() -> bool:
+    """Return True when all required Langfuse env vars are set.
+
+    Checks ``LANGFUSE_HOST`` (or ``LANGFUSE_BASE_URL``),
+    ``LANGFUSE_PUBLIC_KEY``, and ``LANGFUSE_SECRET_KEY``.  Empty strings
+    are treated as absent.
+    """
+    host = os.environ.get("LANGFUSE_HOST") or os.environ.get("LANGFUSE_BASE_URL")
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY")
+    return bool(host and public_key and secret_key)
+
+
 def _build_client(
     api_base: str | None = None,
     api_key: str | None = None,
 ):
-    """Build an AsyncOpenAI client with the given configuration."""
-    import openai
+    """Build an AsyncOpenAI client with the given configuration.
 
+    When :func:`_langfuse_configured` is True and the ``langfuse`` package
+    is importable, returns a Langfuse-wrapped client whose LLM calls are
+    traced automatically.  Callers can pass extra Langfuse kwargs (``name``,
+    ``trace_id``, ``metadata`` with ``langfuse_*`` keys) to
+    ``client.chat.completions.create()`` — they are stripped before reaching
+    the OpenAI API.
+
+    Falls back to a plain ``openai.AsyncOpenAI`` when Langfuse is not
+    configured, not installed, or fails to initialise.
+    """
     kwargs: dict = {}
     if api_base:
         kwargs["base_url"] = api_base
     if api_key:
         kwargs["api_key"] = api_key
+
+    if _langfuse_configured():
+        try:
+            from langfuse.openai import AsyncOpenAI
+
+            logger.debug("Using Langfuse-wrapped OpenAI client")
+            return AsyncOpenAI(**kwargs)
+        except ImportError:
+            logger.debug("langfuse package not installed, using plain OpenAI client")
+        except Exception as exc:
+            logger.warning(
+                "Failed to create Langfuse-wrapped client, falling back to plain: %s",
+                exc,
+            )
+
+    import openai
+
     return openai.AsyncOpenAI(**kwargs)
+
+
+def flush_langfuse() -> None:
+    """Flush pending Langfuse traces.  No-op when Langfuse is not active."""
+    if not _langfuse_configured():
+        return
+    try:
+        from langfuse import get_client
+
+        get_client().flush()
+    except Exception as exc:
+        logger.debug("Langfuse flush failed (best-effort): %s", exc)
 
 
 def _format_llm_error(exc: Exception, notebook_title: str) -> str:

--- a/src/clm/infrastructure/llm/client.py
+++ b/src/clm/infrastructure/llm/client.py
@@ -60,7 +60,7 @@ def _build_client(
 
     if _langfuse_configured():
         try:
-            from langfuse.openai import AsyncOpenAI
+            from langfuse.openai import AsyncOpenAI  # type: ignore[import-not-found, unused-ignore]
 
             logger.debug("Using Langfuse-wrapped OpenAI client")
             return AsyncOpenAI(**kwargs)
@@ -82,7 +82,7 @@ def flush_langfuse() -> None:
     if not _langfuse_configured():
         return
     try:
-        from langfuse import get_client
+        from langfuse import get_client  # type: ignore[import-not-found, unused-ignore]
 
         get_client().flush()
     except Exception as exc:

--- a/src/clm/voiceover/keyframes.py
+++ b/src/clm/voiceover/keyframes.py
@@ -56,6 +56,8 @@ class TransitionEvent:
     peak_diff: float  # highest diff score in the cluster
     confidence: float  # confidence of the peak candidate
     num_frames: int  # number of raw candidates in the cluster
+    source_part_index: int = 0  # which video part this event came from
+    local_timestamp: float | None = None  # pre-offset timestamp for frame extraction
 
 
 def get_video_info(video_path: str | Path) -> VideoInfo:

--- a/src/clm/voiceover/matcher.py
+++ b/src/clm/voiceover/matcher.py
@@ -119,6 +119,8 @@ def match_events_to_slides(
     slides: list[SlideGroup],
     video_path: str | Path,
     *,
+    video_paths: list[Path] | None = None,
+    total_duration: float | None = None,
     lang: str = "de",
     frame_offset: float = 1.0,
 ) -> MatchResult:
@@ -139,6 +141,12 @@ def match_events_to_slides(
             chronologically.
         slides: Parsed slide groups from slide_parser.
         video_path: Path to the video file (for frame extraction).
+            Ignored when ``video_paths`` is provided.
+        video_paths: Per-part video paths for multi-part recordings.
+            When provided, each event's ``source_part_index`` and
+            ``local_timestamp`` are used to extract the correct frame.
+        total_duration: Total duration for timeline end. If None,
+            approximated from the last event timestamp.
         lang: Video language ("de" or "en"). Affects OCR language setting.
         frame_offset: Seconds after transition peak to capture frame
             (default: 1.0, for stabilization after animation).
@@ -156,7 +164,7 @@ def match_events_to_slides(
 
     for event in events:
         try:
-            frame = get_frame_at(video_path, event.timestamp, offset=frame_offset)
+            frame = _extract_event_frame(event, video_path, video_paths, frame_offset)
         except (ValueError, FileNotFoundError) as e:
             logger.warning("Could not get frame at %.1fs: %s", event.timestamp, e)
             continue
@@ -178,10 +186,23 @@ def match_events_to_slides(
 
     # Phase 3: Build timeline
     header_indices = {s.index for s in slides if s.slide_type == "header"}
-    video_duration = events[-1].timestamp + 30.0  # approximate end
+    video_duration = total_duration if total_duration is not None else events[-1].timestamp + 30.0
     timeline = _build_timeline(aligned, video_duration, header_indices=header_indices)
 
     return MatchResult(timeline=timeline, slides=slides)
+
+
+def _extract_event_frame(
+    event: TransitionEvent,
+    video_path: str | Path,
+    video_paths: list[Path] | None,
+    frame_offset: float,
+) -> np.ndarray:
+    """Extract the frame for an event, using per-part paths when available."""
+    if video_paths is not None and event.local_timestamp is not None:
+        part_path = video_paths[event.source_part_index]
+        return get_frame_at(part_path, event.local_timestamp, offset=frame_offset)
+    return get_frame_at(video_path, event.timestamp, offset=frame_offset)
 
 
 def _sequential_align(

--- a/src/clm/voiceover/merge.py
+++ b/src/clm/voiceover/merge.py
@@ -225,6 +225,7 @@ async def polish_and_merge(
     api_base: str | None = None,
     api_key: str | None = None,
     slide_id: str = "",
+    langfuse_context: dict | None = None,
 ) -> MergeResult:
     """Merge baseline voiceover with transcript using a single LLM call.
 
@@ -244,6 +245,10 @@ async def polish_and_merge(
         api_base: API base URL (e.g. OpenRouter).
         api_key: API key override.
         slide_id: Identifier for the slide (used in results).
+        langfuse_context: Optional dict of Langfuse-specific kwargs
+            (``name``, ``trace_id``, ``metadata``) forwarded to the
+            ``create()`` call.  Ignored when the client is not
+            Langfuse-wrapped.
 
     Returns:
         MergeResult with merged bullets and structured metadata.
@@ -273,15 +278,19 @@ async def polish_and_merge(
         len(transcript_text),
     )
 
+    create_kwargs: dict = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+        "temperature": temperature,
+    }
+    if langfuse_context:
+        create_kwargs.update(langfuse_context)
+
     try:
-        response = await client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_message},
-            ],
-            temperature=temperature,
-        )
+        response = await client.chat.completions.create(**create_kwargs)
     except Exception as exc:
         raise LLMError(f"Merge LLM call failed for slide {slide_id}: {exc}") from exc
 
@@ -309,6 +318,7 @@ async def merge_batch(
     temperature: float = 0.3,
     api_base: str | None = None,
     api_key: str | None = None,
+    langfuse_context: dict | None = None,
 ) -> list[MergeResult]:
     """Merge a batch of slides in a single LLM call.
 
@@ -321,6 +331,7 @@ async def merge_batch(
         temperature: Sampling temperature.
         api_base: API base URL.
         api_key: API key override.
+        langfuse_context: Optional Langfuse kwargs forwarded to ``create()``.
 
     Returns:
         List of MergeResult, one per input slide, in order.
@@ -339,6 +350,7 @@ async def merge_batch(
             api_base=api_base,
             api_key=api_key,
             slide_id=slides[0].slide_id,
+            langfuse_context=langfuse_context,
         )
         return [result]
 
@@ -350,15 +362,19 @@ async def merge_batch(
 
     logger.debug("Batch merge: %d slides", len(slides))
 
+    create_kwargs: dict = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+        "temperature": temperature,
+    }
+    if langfuse_context:
+        create_kwargs.update(langfuse_context)
+
     try:
-        response = await client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_message},
-            ],
-            temperature=temperature,
-        )
+        response = await client.chat.completions.create(**create_kwargs)
     except Exception as exc:
         raise LLMError(f"Batch merge LLM call failed: {exc}") from exc
 
@@ -384,6 +400,7 @@ async def merge_batch(
                 api_base=api_base,
                 api_key=api_key,
                 slide_id=slide.slide_id,
+                langfuse_context=langfuse_context,
             )
             results.append(result)
         return results
@@ -409,6 +426,7 @@ async def merge_batch(
                 api_base=api_base,
                 api_key=api_key,
                 slide_id=slide.slide_id,
+                langfuse_context=langfuse_context,
             )
             results.append(result)
 

--- a/src/clm/voiceover/merge.py
+++ b/src/clm/voiceover/merge.py
@@ -1,0 +1,415 @@
+"""Merge voiceover content using a single-pass LLM call.
+
+This module implements the ``polish_and_merge`` function and the batching
+logic that packs multiple slides into a single LLM call for efficiency.
+When the baseline is empty, it degrades to the current polish behavior
+(insert fresh voiceover from transcript only).
+
+The merge prompt is a single LLM call per slide (or batch of slides) that
+handles noise filtering, content preservation, addition integration, and
+baseline rewrites holistically. No multi-pass pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default character budget for batching multiple slides into one LLM call.
+DEFAULT_BATCH_CHAR_LIMIT = 20_000
+
+# Default model for merge operations (Claude Sonnet 4.6 via OpenRouter).
+DEFAULT_MERGE_MODEL = "anthropic/claude-sonnet-4-6"
+
+
+@dataclass
+class MergeResult:
+    """Result of merging baseline + transcript for one slide."""
+
+    slide_id: str
+    merged_bullets: str
+    rewrites: list[dict] = field(default_factory=list)
+    dropped_from_transcript: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SlideInput:
+    """Input data for one slide's merge operation."""
+
+    slide_id: str
+    baseline: str
+    transcript: str
+    slide_content: str
+    boundary_hint: bool = False
+
+
+def _load_system_prompt(language: str) -> str:
+    """Load the language-specific merge system prompt."""
+    filename = f"merge_{language}.md"
+    prompt_dir = Path(__file__).parent / "prompts"
+    prompt_path = prompt_dir / filename
+    if prompt_path.exists():
+        return prompt_path.read_text(encoding="utf-8")
+    # Fallback to English
+    fallback = prompt_dir / "merge_en.md"
+    if fallback.exists():
+        return fallback.read_text(encoding="utf-8")
+    raise FileNotFoundError(f"No merge prompt found for language '{language}'")
+
+
+def _build_user_prompt(slide: SlideInput) -> str:
+    """Build the user prompt for a single slide."""
+    parts = []
+
+    if slide.slide_content.strip():
+        parts.append(f"SLIDE CONTEXT (do not include in output):\n{slide.slide_content.strip()}")
+
+    baseline_label = "BASELINE VOICEOVER (preserve; may rewrite only on factual contradiction):"
+    if slide.baseline.strip():
+        parts.append(f"{baseline_label}\n{slide.baseline.strip()}")
+    else:
+        parts.append(f"{baseline_label}\n(empty -- no existing voiceover)")
+
+    parts.append(
+        f"TRANSCRIPT (candidate additions, filter aggressively):\n{slide.transcript.strip()}"
+    )
+
+    if slide.boundary_hint:
+        parts.append(
+            "NOTE: This slide spans a recording part boundary. "
+            "Be extra suspicious of greeting/sign-off noise near the "
+            "start or end of the transcript."
+        )
+
+    return "\n\n".join(parts)
+
+
+def _build_batch_user_prompt(slides: list[SlideInput]) -> str:
+    """Build a user prompt containing multiple slides for batch processing."""
+    parts = []
+    parts.append(
+        f"Process the following {len(slides)} slides. "
+        "Return a JSON array with one result object per slide, "
+        "keyed by slide_id. Each object follows the same schema as "
+        "a single-slide response."
+    )
+
+    for slide in slides:
+        parts.append(f"--- SLIDE: {slide.slide_id} ---")
+        parts.append(_build_user_prompt(slide))
+
+    return "\n\n".join(parts)
+
+
+def _parse_single_result(raw: str, slide_id: str) -> MergeResult:
+    """Parse a single-slide JSON response from the LLM."""
+    # Strip markdown code fences if present
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1]).strip()
+
+    data = json.loads(text)
+
+    return MergeResult(
+        slide_id=slide_id,
+        merged_bullets=data.get("merged_bullets", ""),
+        rewrites=data.get("rewrites", []),
+        dropped_from_transcript=data.get("dropped_from_transcript", []),
+    )
+
+
+def _parse_batch_result(raw: str, slide_ids: list[str]) -> dict[str, MergeResult]:
+    """Parse a batch JSON response from the LLM.
+
+    Returns a dict of slide_id -> MergeResult.
+
+    Raises:
+        json.JSONDecodeError: If the response is not valid JSON.
+        ValueError: If the response structure is unexpected.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1]).strip()
+
+    data = json.loads(text)
+
+    # Accept both a JSON array and a JSON object keyed by slide_id
+    results: dict[str, MergeResult] = {}
+
+    if isinstance(data, list):
+        for item in data:
+            sid = item.get("slide_id", "")
+            results[sid] = MergeResult(
+                slide_id=sid,
+                merged_bullets=item.get("merged_bullets", ""),
+                rewrites=item.get("rewrites", []),
+                dropped_from_transcript=item.get("dropped_from_transcript", []),
+            )
+    elif isinstance(data, dict):
+        # Could be a single result or keyed by slide_id
+        if "merged_bullets" in data:
+            # Single result in a dict
+            sid = data.get("slide_id", slide_ids[0] if slide_ids else "")
+            results[sid] = MergeResult(
+                slide_id=sid,
+                merged_bullets=data.get("merged_bullets", ""),
+                rewrites=data.get("rewrites", []),
+                dropped_from_transcript=data.get("dropped_from_transcript", []),
+            )
+        else:
+            # Keyed by slide_id
+            for sid, item in data.items():
+                if isinstance(item, dict):
+                    results[sid] = MergeResult(
+                        slide_id=sid,
+                        merged_bullets=item.get("merged_bullets", ""),
+                        rewrites=item.get("rewrites", []),
+                        dropped_from_transcript=item.get("dropped_from_transcript", []),
+                    )
+    else:
+        raise ValueError(f"Unexpected JSON structure: {type(data)}")
+
+    return results
+
+
+def _estimate_chars(slide: SlideInput) -> int:
+    """Estimate character count for a slide input."""
+    return len(slide.baseline) + len(slide.transcript) + len(slide.slide_content)
+
+
+def build_batches(
+    slides: list[SlideInput],
+    char_limit: int = DEFAULT_BATCH_CHAR_LIMIT,
+) -> list[list[SlideInput]]:
+    """Pack slides into batches respecting the character budget.
+
+    Each batch stays under ``char_limit`` total input characters.
+    A single slide that exceeds the limit gets its own batch.
+    """
+    batches: list[list[SlideInput]] = []
+    current_batch: list[SlideInput] = []
+    current_chars = 0
+
+    for slide in slides:
+        slide_chars = _estimate_chars(slide)
+
+        if current_batch and current_chars + slide_chars > char_limit:
+            batches.append(current_batch)
+            current_batch = []
+            current_chars = 0
+
+        current_batch.append(slide)
+        current_chars += slide_chars
+
+    if current_batch:
+        batches.append(current_batch)
+
+    return batches
+
+
+async def polish_and_merge(
+    baseline_bullets: str,
+    transcript_text: str,
+    slide_content: str = "",
+    language: str = "de",
+    boundary_hint: bool = False,
+    *,
+    model: str = DEFAULT_MERGE_MODEL,
+    temperature: float = 0.3,
+    api_base: str | None = None,
+    api_key: str | None = None,
+    slide_id: str = "",
+) -> MergeResult:
+    """Merge baseline voiceover with transcript using a single LLM call.
+
+    When ``baseline_bullets`` is empty, this degrades to the current
+    polish behavior (clean transcript into bullets). When non-empty, it
+    merges the transcript additions into the baseline while preserving
+    existing content and filtering noise.
+
+    Args:
+        baseline_bullets: Existing voiceover cell content ("" if none).
+        transcript_text: Raw aligned transcript for this slide.
+        slide_content: Slide code/markdown for context.
+        language: Language code ("de" or "en").
+        boundary_hint: Whether this slide spans a recording part boundary.
+        model: LLM model identifier.
+        temperature: Sampling temperature.
+        api_base: API base URL (e.g. OpenRouter).
+        api_key: API key override.
+        slide_id: Identifier for the slide (used in results).
+
+    Returns:
+        MergeResult with merged bullets and structured metadata.
+
+    Raises:
+        LLMError: On LLM call failure.
+    """
+    from clm.infrastructure.llm.client import LLMError, _build_client
+
+    slide_input = SlideInput(
+        slide_id=slide_id,
+        baseline=baseline_bullets,
+        transcript=transcript_text,
+        slide_content=slide_content,
+        boundary_hint=boundary_hint,
+    )
+
+    system_prompt = _load_system_prompt(language)
+    user_message = _build_user_prompt(slide_input)
+
+    client = _build_client(api_base=api_base, api_key=api_key)
+
+    logger.debug(
+        "polish_and_merge slide=%s baseline=%d chars, transcript=%d chars",
+        slide_id,
+        len(baseline_bullets),
+        len(transcript_text),
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=temperature,
+        )
+    except Exception as exc:
+        raise LLMError(f"Merge LLM call failed for slide {slide_id}: {exc}") from exc
+
+    raw = str(response.choices[0].message.content).strip()
+
+    try:
+        return _parse_single_result(raw, slide_id)
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        logger.warning(
+            "Failed to parse JSON from LLM for slide %s, using raw text as merged_bullets: %s",
+            slide_id,
+            exc,
+        )
+        return MergeResult(
+            slide_id=slide_id,
+            merged_bullets=raw,
+        )
+
+
+async def merge_batch(
+    slides: list[SlideInput],
+    *,
+    language: str = "de",
+    model: str = DEFAULT_MERGE_MODEL,
+    temperature: float = 0.3,
+    api_base: str | None = None,
+    api_key: str | None = None,
+) -> list[MergeResult]:
+    """Merge a batch of slides in a single LLM call.
+
+    On JSON parse failure, falls back to per-slide calls for the batch.
+
+    Args:
+        slides: List of slide inputs to merge.
+        language: Language code ("de" or "en").
+        model: LLM model identifier.
+        temperature: Sampling temperature.
+        api_base: API base URL.
+        api_key: API key override.
+
+    Returns:
+        List of MergeResult, one per input slide, in order.
+    """
+    from clm.infrastructure.llm.client import LLMError, _build_client
+
+    if len(slides) == 1:
+        result = await polish_and_merge(
+            slides[0].baseline,
+            slides[0].transcript,
+            slides[0].slide_content,
+            language,
+            slides[0].boundary_hint,
+            model=model,
+            temperature=temperature,
+            api_base=api_base,
+            api_key=api_key,
+            slide_id=slides[0].slide_id,
+        )
+        return [result]
+
+    system_prompt = _load_system_prompt(language)
+    user_message = _build_batch_user_prompt(slides)
+    slide_ids = [s.slide_id for s in slides]
+
+    client = _build_client(api_base=api_base, api_key=api_key)
+
+    logger.debug("Batch merge: %d slides", len(slides))
+
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=temperature,
+        )
+    except Exception as exc:
+        raise LLMError(f"Batch merge LLM call failed: {exc}") from exc
+
+    raw = str(response.choices[0].message.content).strip()
+
+    try:
+        parsed = _parse_batch_result(raw, slide_ids)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning(
+            "Batch JSON parse failed (%s), falling back to per-slide calls",
+            exc,
+        )
+        results = []
+        for slide in slides:
+            result = await polish_and_merge(
+                slide.baseline,
+                slide.transcript,
+                slide.slide_content,
+                language,
+                slide.boundary_hint,
+                model=model,
+                temperature=temperature,
+                api_base=api_base,
+                api_key=api_key,
+                slide_id=slide.slide_id,
+            )
+            results.append(result)
+        return results
+
+    # Return results in input order
+    results = []
+    for slide in slides:
+        if slide.slide_id in parsed:
+            results.append(parsed[slide.slide_id])
+        else:
+            logger.warning(
+                "Slide %s missing from batch response, falling back to per-slide call",
+                slide.slide_id,
+            )
+            result = await polish_and_merge(
+                slide.baseline,
+                slide.transcript,
+                slide.slide_content,
+                language,
+                slide.boundary_hint,
+                model=model,
+                temperature=temperature,
+                api_base=api_base,
+                api_key=api_key,
+                slide_id=slide.slide_id,
+            )
+            results.append(result)
+
+    return results

--- a/src/clm/voiceover/prompts/__init__.py
+++ b/src/clm/voiceover/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Language-specific merge prompts for voiceover sync."""

--- a/src/clm/voiceover/prompts/merge_de.md
+++ b/src/clm/voiceover/prompts/merge_de.md
@@ -1,0 +1,61 @@
+Du bist ein Experte fuer die Bearbeitung von Voiceover-Zellen in
+Schulungskursen. Du erhaeltst ein bestehendes Voiceover (Baseline-Bullets)
+und ein Rohtranskript dessen, was der Trainer gesagt hat, waehrend diese
+Folie sichtbar war. Erstelle ein aktualisiertes Voiceover als Aufzaehlung.
+
+Invarianten:
+1. Standard: BEWAHRE jeden inhaltlichen Punkt der Baseline. Integriere
+   neuen inhaltlichen Content aus dem Transkript an der narrativen
+   Position, die dem Erklaerungsfluss des Trainers entspricht.
+2. AUSNAHME: Wenn das Transkript einem bestimmten Baseline-Bullet direkt
+   widerspricht oder ihn korrigiert, DARFST du diesen Bullet umschreiben,
+   um die Korrektur einzuarbeiten. Dies ist nur erlaubt bei klarem
+   sachlichen Widerspruch (z.B. Baseline sagt "extend gibt eine neue Liste
+   zurueck", Transkript sagt "extend aendert die Liste in-place und gibt
+   nichts zurueck"). Stilverbesserungen, Umformulierungen oder
+   Praezisierungen sind KEINE Korrekturen -- lass sie unveraendert.
+3. Loesche niemals stillschweigend einen Baseline-Bullet. Wenn du einen
+   umschreibst, ersetzt die neue Version den alten; nichts verschwindet.
+4. Halluziniere nicht. Jeder Bullet muss aus der Baseline oder dem
+   Transkript stammen.
+
+Filter (aus dem Transkript entfernen, niemals aus der Baseline):
+- Begruessung, Verabschiedung, Teil-Uebergaenge ("willkommen zurueck",
+  "so, weiter geht's", "das war's fuer heute").
+- Aufnahme-Selbstkorrekturen ("Moment", "falscher Slide", "lass mich
+  kurz", "Entschuldigung" am Satzanfang).
+- Trainer-Umgebungsbemerkungen ("mein Docker-Container", "das Mikrofon",
+  "mein Editor zeigt rot").
+- Inhalte an den Aufnahme-Operator ("kannst du das rausschneiden",
+  "das kommt in den Schnitt").
+- Code-Tipp-Diktat: Trainer liest Syntax-Tokens vor beim Live-Coding
+  ("def fact Klammer auf n Doppelpunkt", "und dann eine for-Schleife, for
+  m Komma n"). Behalte Erklaerungen des Codes; entferne das Diktieren.
+- Themenfremde Abschweifungen ohne Bezug zum Folieninhalt.
+
+Stil:
+- Markdown-Aufzaehlung ("- " Praefix), ein Gedanke pro Bullet.
+- Direkte Studentenansprache, konsistente Zeitform (an Baseline orientieren).
+- Gleiche Sprache wie die Eingabe (nicht uebersetzen).
+
+Wenn die Baseline leer ist, erstelle eine saubere Bullet-Liste nur aus
+dem Transkript (gleiche Filter- und Stilregeln gelten).
+
+Gib deine Antwort als JSON-Objekt mit folgendem Schema zurueck:
+{
+  "merged_bullets": "- Bullet 1\n- Bullet 2\n...",
+  "rewrites": [
+    {
+      "original": "- der originale Baseline-Bullet",
+      "revised": "- der korrigierte Bullet",
+      "transcript_evidence": "was der Trainer gesagt hat, das dem Original widerspricht"
+    }
+  ],
+  "dropped_from_transcript": ["gefilterte Phrase 1", "gefilterte Phrase 2"]
+}
+
+Regeln fuer die JSON-Antwort:
+- "merged_bullets" ist der finale Voiceover-Text, ein Bullet pro Zeile mit "- " Praefix.
+- "rewrites" listet jeden Baseline-Bullet auf, den du geaendert hast (leeres Array falls keine).
+- "dropped_from_transcript" listet Transkript-Phrasen auf, die du gefiltert hast (Best-Effort).
+- Gib NUR das JSON-Objekt zurueck, keine Markdown-Fences, kein Kommentar.

--- a/src/clm/voiceover/prompts/merge_en.md
+++ b/src/clm/voiceover/prompts/merge_en.md
@@ -1,0 +1,61 @@
+You are an expert editor for educational course voiceover cells. You
+receive an existing voiceover (baseline bullets) and a raw transcript of
+what the trainer said while this slide was visible. Produce an updated
+voiceover as a bulleted list.
+
+Invariants:
+1. Default: PRESERVE every substantive point in the baseline. Integrate
+   new substantive content from the transcript in the narrative position
+   that matches how the trainer explained it.
+2. EXCEPTION: If the transcript directly contradicts or corrects a
+   specific baseline bullet, you MAY rewrite that bullet to incorporate
+   the correction. This is only permitted when the transcript makes a
+   clear factual contradiction (e.g., baseline says "extend returns a new
+   list", transcript says "extend mutates in place and doesn't return a
+   new list"). Style improvements, paraphrases, or clarifications are NOT
+   corrections -- leave those alone.
+3. Never silently drop a baseline bullet. If you rewrite one, the
+   rewritten version replaces it; nothing disappears.
+4. Do not hallucinate. Every bullet must come from the baseline or the
+   transcript.
+
+Filter (drop from transcript, never from baseline):
+- Greetings, sign-offs, part-boundary transitions ("welcome back",
+  "let's continue", "that's it for today").
+- Recording self-corrections ("wait", "wrong slide", "let me go back",
+  "sorry" at sentence start).
+- Trainer environment remarks ("my Docker container", "the microphone",
+  "my editor shows red").
+- Content said to the recording operator ("you can cut that out",
+  "that goes in the edit").
+- Code-typing narration: trainer reading out syntax tokens while
+  live-coding ("def fact open paren n colon", "and then a for loop, for
+  m comma n"). Keep explanations of the code; drop dictation of it.
+- Off-topic tangents unrelated to the slide content.
+
+Style:
+- Bulleted markdown ("- " prefix), one thought per bullet.
+- Direct student address, consistent tense (match baseline).
+- Same language as input (do not translate).
+
+When baseline is empty, produce a clean bullet list from the transcript
+only (same filter and style rules apply).
+
+Return your response as a JSON object with the following schema:
+{
+  "merged_bullets": "- bullet 1\n- bullet 2\n...",
+  "rewrites": [
+    {
+      "original": "- the original baseline bullet",
+      "revised": "- the corrected bullet",
+      "transcript_evidence": "what the trainer said that contradicts the original"
+    }
+  ],
+  "dropped_from_transcript": ["phrase 1 that was filtered out", "phrase 2"]
+}
+
+Rules for the JSON response:
+- "merged_bullets" is the final voiceover text, one bullet per line with "- " prefix.
+- "rewrites" lists every baseline bullet you modified (empty array if none).
+- "dropped_from_transcript" lists transcript phrases you filtered out (best-effort).
+- Return ONLY the JSON object, no markdown fences, no commentary.

--- a/src/clm/voiceover/timeline.py
+++ b/src/clm/voiceover/timeline.py
@@ -1,0 +1,202 @@
+"""Multi-part video timeline construction.
+
+This module provides helpers for processing multiple video parts into a
+single logical timeline. Each part is transcribed and keyframe-detected
+independently; results are merged using running offsets so the aligner
+sees one continuous timeline without any on-disk concatenation.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from clm.voiceover.keyframes import TransitionEvent
+from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VideoPart:
+    """A single video part in a multi-part recording."""
+
+    index: int  # 0, 1, 2, ...
+    path: Path
+    duration: float  # seconds, from ffprobe
+    offset: float  # cumulative start time (Sigma duration of parts 0..i-1)
+
+
+def probe_duration(video_path: Path) -> float:
+    """Probe the duration of a video file using ffprobe.
+
+    Args:
+        video_path: Path to the video file.
+
+    Returns:
+        Duration in seconds.
+
+    Raises:
+        FileNotFoundError: If the video file does not exist.
+        RuntimeError: If ffprobe fails or returns no duration.
+    """
+    if not video_path.exists():
+        raise FileNotFoundError(f"Video not found: {video_path}")
+
+    cmd = [
+        "ffprobe",
+        "-v",
+        "quiet",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(video_path),
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffprobe failed for {video_path.name} "
+            f"(exit {result.returncode}): {result.stderr[:500]}"
+        )
+
+    try:
+        return float(result.stdout.strip())
+    except ValueError:
+        raise RuntimeError(
+            f"ffprobe returned non-numeric duration for {video_path.name}: "
+            f"{result.stdout.strip()!r}"
+        ) from None
+
+
+def build_parts(video_paths: list[Path]) -> list[VideoPart]:
+    """Probe durations and build VideoPart list with running offsets.
+
+    Args:
+        video_paths: Ordered list of video file paths. Order is
+            authoritative -- parts are NOT sorted by name or mtime.
+
+    Returns:
+        List of VideoPart with computed offsets.
+
+    Raises:
+        FileNotFoundError: If any video file does not exist (includes
+            the part index in the error message).
+        RuntimeError: If ffprobe fails on any part.
+    """
+    parts: list[VideoPart] = []
+    cumulative_offset = 0.0
+
+    for i, path in enumerate(video_paths):
+        try:
+            duration = probe_duration(path)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Video part {i} not found: {path}") from None
+        except RuntimeError as exc:
+            raise RuntimeError(f"Failed to probe video part {i} ({path.name}): {exc}") from exc
+
+        parts.append(
+            VideoPart(
+                index=i,
+                path=path,
+                duration=duration,
+                offset=cumulative_offset,
+            )
+        )
+        cumulative_offset += duration
+
+    logger.info(
+        "Built %d video parts, total duration %.1fs",
+        len(parts),
+        cumulative_offset,
+    )
+    return parts
+
+
+def offset_transcript(transcript: Transcript, part: VideoPart) -> Transcript:
+    """Apply time offset to a transcript's segments and tag with part index.
+
+    Creates a new Transcript with all segment timestamps shifted by the
+    part's offset and ``source_part_index`` set.
+
+    Args:
+        transcript: Per-part transcript with local timestamps.
+        part: The video part this transcript belongs to.
+
+    Returns:
+        New Transcript with offset timestamps.
+    """
+    offset_segments = [
+        TranscriptSegment(
+            start=seg.start + part.offset,
+            end=seg.end + part.offset,
+            text=seg.text,
+            source_part_index=part.index,
+        )
+        for seg in transcript.segments
+    ]
+    return Transcript(
+        segments=offset_segments,
+        language=transcript.language,
+        duration=transcript.duration,
+    )
+
+
+def offset_events(
+    events: list[TransitionEvent],
+    part: VideoPart,
+) -> list[TransitionEvent]:
+    """Apply time offset to transition events and tag with part index.
+
+    Each event's ``timestamp`` is shifted by the part's offset.
+    The original timestamp is preserved in ``local_timestamp`` for
+    per-part frame extraction by the matcher.
+
+    Args:
+        events: Per-part transition events with local timestamps.
+        part: The video part these events belong to.
+
+    Returns:
+        New list of TransitionEvent with offset timestamps.
+    """
+    return [
+        TransitionEvent(
+            timestamp=event.timestamp + part.offset,
+            peak_diff=event.peak_diff,
+            confidence=event.confidence,
+            num_frames=event.num_frames,
+            source_part_index=part.index,
+            local_timestamp=event.timestamp,
+        )
+        for event in events
+    ]
+
+
+def merge_transcripts(
+    transcripts: list[Transcript],
+) -> Transcript:
+    """Merge multiple (already-offset) transcripts into one.
+
+    Args:
+        transcripts: Offset transcripts, one per part, in order.
+
+    Returns:
+        Single merged Transcript spanning all parts.
+    """
+    all_segments: list[TranscriptSegment] = []
+    total_duration = 0.0
+    language = transcripts[0].language if transcripts else "unknown"
+
+    for transcript in transcripts:
+        all_segments.extend(transcript.segments)
+        total_duration += transcript.duration
+
+    return Transcript(
+        segments=all_segments,
+        language=language,
+        duration=total_duration,
+    )

--- a/src/clm/voiceover/trace_log.py
+++ b/src/clm/voiceover/trace_log.py
@@ -1,0 +1,115 @@
+"""JSONL trace log for voiceover merge operations.
+
+Writes one line per LLM call to
+``.clm/voiceover-traces/<topic>-<timestamp>.jsonl`` inside the working
+directory. The log is independent of Langfuse and provides a durable,
+local-first substrate for training data extraction (Phase 4).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _get_git_head() -> str | None:
+    """Return the current HEAD commit hash, or None if not in a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+class TraceLog:
+    """Append-only JSONL trace log for voiceover merge operations.
+
+    Usage::
+
+        trace = TraceLog.create("slides_intro.py")
+        trace.log_merge_call(
+            slide_id="slides_intro/3",
+            language="de",
+            baseline="- existing bullet",
+            transcript="the trainer said...",
+            llm_merged="- merged bullet",
+            rewrites=[],
+            dropped_from_transcript=["willkommen zurück"],
+        )
+    """
+
+    def __init__(self, path: Path, slide_file: str, git_head: str | None):
+        self._path = path
+        self._slide_file = slide_file
+        self._git_head = git_head
+
+    @classmethod
+    def create(cls, slide_file: str, base_dir: Path | None = None) -> TraceLog:
+        """Create a new trace log for a sync invocation.
+
+        Args:
+            slide_file: Name of the slide file being synced.
+            base_dir: Base directory for ``.clm/``. Defaults to cwd.
+
+        Returns:
+            A new TraceLog instance.
+        """
+        base = base_dir or Path.cwd()
+        traces_dir = base / ".clm" / "voiceover-traces"
+        traces_dir.mkdir(parents=True, exist_ok=True)
+
+        stem = Path(slide_file).stem
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        log_path = traces_dir / f"{stem}-{timestamp}.jsonl"
+
+        git_head = _get_git_head()
+
+        logger.info("Trace log: %s", log_path)
+        return cls(path=log_path, slide_file=slide_file, git_head=git_head)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def log_merge_call(
+        self,
+        *,
+        slide_id: str,
+        language: str,
+        baseline: str,
+        transcript: str,
+        llm_merged: str,
+        rewrites: list[dict],
+        dropped_from_transcript: list[str],
+        langfuse_trace_id: str | None = None,
+    ) -> None:
+        """Append one merge-call entry to the trace log."""
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "slide_file": self._slide_file,
+            "slide_id": slide_id,
+            "language": language,
+            "baseline": baseline,
+            "transcript": transcript,
+            "llm_merged": llm_merged,
+            "rewrites": rewrites,
+            "dropped_from_transcript": dropped_from_transcript,
+            "git_head": self._git_head,
+        }
+        if langfuse_trace_id:
+            entry["langfuse_trace_id"] = langfuse_trace_id
+
+        with self._path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/src/clm/voiceover/training_export.py
+++ b/src/clm/voiceover/training_export.py
@@ -1,0 +1,302 @@
+"""Extract training data from voiceover merge trace logs.
+
+Reads JSONL trace logs written by :mod:`clm.voiceover.trace_log` and
+correlates each entry with the current slide file state to produce
+training triples suitable for fine-tuning or LoRA training.
+
+Two kinds of training signal fall out:
+
+1. ``(baseline + transcript) → human_final``: end-to-end supervised
+   training for a merge model.
+2. ``(baseline + transcript + llm_output) → human_final``: correction
+   training for a critic/editor model.
+
+Entries where ``human_final == llm_output`` (no hand edits after the
+LLM merge) are emitted with an empty ``delta_vs_llm`` — these are
+valid positive training examples.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TraceEntry:
+    """A single parsed entry from a JSONL trace log."""
+
+    slide_file: str
+    slide_id: str
+    language: str
+    baseline: str
+    transcript: str
+    llm_merged: str
+    rewrites: list[dict] = field(default_factory=list)
+    dropped_from_transcript: list[str] = field(default_factory=list)
+    git_head: str | None = None
+    langfuse_trace_id: str | None = None
+    timestamp: str = ""
+
+
+@dataclass
+class TrainingTriple:
+    """One training example extracted from a trace entry."""
+
+    slide_file: str
+    slide_id: str
+    language: str
+    input_baseline: str
+    input_transcript: str
+    llm_output: str
+    human_final: str
+    delta_vs_llm: str
+    rewrites: list[dict] = field(default_factory=list)
+    dropped_from_transcript: list[str] = field(default_factory=list)
+    git_head: str | None = None
+    timestamp: str = ""
+
+    def to_dict(self) -> dict:
+        """Serialize to a dict suitable for JSONL output."""
+        return {
+            "slide_file": self.slide_file,
+            "slide_id": self.slide_id,
+            "language": self.language,
+            "input": {
+                "baseline": self.input_baseline,
+                "transcript": self.input_transcript,
+            },
+            "llm_output": self.llm_output,
+            "human_final": self.human_final,
+            "delta_vs_llm": self.delta_vs_llm,
+            "rewrites": self.rewrites,
+            "dropped_from_transcript": self.dropped_from_transcript,
+            "git_head": self.git_head,
+            "timestamp": self.timestamp,
+        }
+
+
+def read_trace_log(path: Path) -> list[TraceEntry]:
+    """Read and parse a JSONL trace log file.
+
+    Args:
+        path: Path to the ``.jsonl`` trace log.
+
+    Returns:
+        List of parsed trace entries.
+
+    Raises:
+        FileNotFoundError: If the trace log does not exist.
+    """
+    entries: list[TraceEntry] = []
+    with path.open(encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping malformed JSON at %s:%d: %s", path, line_num, exc)
+                continue
+
+            entries.append(
+                TraceEntry(
+                    slide_file=data.get("slide_file", ""),
+                    slide_id=data.get("slide_id", ""),
+                    language=data.get("language", ""),
+                    baseline=data.get("baseline", ""),
+                    transcript=data.get("transcript", ""),
+                    llm_merged=data.get("llm_merged", ""),
+                    rewrites=data.get("rewrites", []),
+                    dropped_from_transcript=data.get("dropped_from_transcript", []),
+                    git_head=data.get("git_head"),
+                    langfuse_trace_id=data.get("langfuse_trace_id"),
+                    timestamp=data.get("timestamp", ""),
+                )
+            )
+    return entries
+
+
+def _git_commit_exists(commit: str) -> bool:
+    """Check whether a git commit is reachable in the current repo."""
+    try:
+        result = subprocess.run(
+            ["git", "cat-file", "-t", commit],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0 and "commit" in result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _read_voiceover_for_slide(
+    slide_file: Path,
+    slide_id: str,
+    language: str,
+    tag: str = "voiceover",
+) -> str | None:
+    """Read the current voiceover text for a specific slide.
+
+    Parses the slide file at its current state on disk and extracts
+    the voiceover/notes text for the slide matching ``slide_id``.
+
+    Args:
+        slide_file: Path to the ``.py`` slide file.
+        slide_id: Slide identifier in ``"stem/index"`` format.
+        language: Language code (``"de"`` or ``"en"``).
+        tag: Cell tag to read (``"voiceover"`` or ``"notes"``).
+
+    Returns:
+        The voiceover text for the slide, or ``None`` if the slide
+        file does not exist or the slide is not found.
+    """
+    if not slide_file.exists():
+        return None
+
+    from clm.notebooks.slide_parser import parse_slides
+
+    try:
+        slide_groups = parse_slides(slide_file, language)
+    except Exception as exc:
+        logger.warning("Failed to parse %s: %s", slide_file, exc)
+        return None
+
+    # Extract slide index from slide_id ("stem/index" format)
+    try:
+        target_idx = int(slide_id.rsplit("/", 1)[-1])
+    except (ValueError, IndexError):
+        logger.warning("Cannot parse slide index from slide_id=%s", slide_id)
+        return None
+
+    for sg in slide_groups:
+        if sg.index == target_idx:
+            # Extract text from cells matching the target tag
+            parts = []
+            for cell in sg.notes_cells:
+                if tag in cell.metadata.tags:
+                    text = cell.text_content()
+                    if text:
+                        parts.append(text)
+            return "\n".join(parts) if parts else ""
+
+    return None
+
+
+def _compute_delta(llm_output: str, human_final: str) -> str:
+    """Compute a unified diff between LLM output and the human-edited final.
+
+    Returns an empty string when they are identical (positive training
+    example — no hand edits needed).
+    """
+    if llm_output.strip() == human_final.strip():
+        return ""
+
+    diff_lines = difflib.unified_diff(
+        llm_output.splitlines(keepends=True),
+        human_final.splitlines(keepends=True),
+        fromfile="llm_output",
+        tofile="human_final",
+    )
+    return "".join(diff_lines)
+
+
+def extract_training_data(
+    trace_log_path: Path,
+    *,
+    base_dir: Path | None = None,
+    tag: str = "voiceover",
+    check_git_head: bool = True,
+) -> list[TrainingTriple]:
+    """Extract training triples from a trace log.
+
+    For each entry in the trace log, reads the current slide file state
+    to determine the ``human_final`` text, then computes the delta
+    between the LLM output and the human edit.
+
+    Args:
+        trace_log_path: Path to the ``.jsonl`` trace log file.
+        base_dir: Base directory for resolving slide file paths.
+            Defaults to the trace log's grandparent directory
+            (i.e. the project root, assuming the trace log is at
+            ``.clm/voiceover-traces/...``).
+        tag: Cell tag to read from slide files.
+        check_git_head: Whether to verify that the ``git_head``
+            commit is reachable. If True, entries with unreachable
+            commits are skipped with a warning.
+
+    Returns:
+        List of training triples, one per trace entry that could
+        be successfully correlated.
+    """
+    entries = read_trace_log(trace_log_path)
+
+    if base_dir is None:
+        # Trace logs are at .clm/voiceover-traces/<file>.jsonl
+        # so grandparent is the project root
+        base_dir = trace_log_path.parent.parent.parent
+
+    triples: list[TrainingTriple] = []
+    skipped_git = 0
+    skipped_missing = 0
+
+    for entry in entries:
+        # Check git_head reachability
+        if check_git_head and entry.git_head:
+            if not _git_commit_exists(entry.git_head):
+                logger.warning(
+                    "Skipping %s: git_head %s is unreachable",
+                    entry.slide_id,
+                    entry.git_head,
+                )
+                skipped_git += 1
+                continue
+
+        # Resolve slide file path
+        slide_file = base_dir / entry.slide_file
+
+        # Read current voiceover state for this slide
+        human_final = _read_voiceover_for_slide(slide_file, entry.slide_id, entry.language, tag=tag)
+
+        if human_final is None:
+            logger.warning(
+                "Skipping %s: slide file %s not found or slide not present",
+                entry.slide_id,
+                slide_file,
+            )
+            skipped_missing += 1
+            continue
+
+        delta = _compute_delta(entry.llm_merged, human_final)
+
+        triples.append(
+            TrainingTriple(
+                slide_file=entry.slide_file,
+                slide_id=entry.slide_id,
+                language=entry.language,
+                input_baseline=entry.baseline,
+                input_transcript=entry.transcript,
+                llm_output=entry.llm_merged,
+                human_final=human_final,
+                delta_vs_llm=delta,
+                rewrites=entry.rewrites,
+                dropped_from_transcript=entry.dropped_from_transcript,
+                git_head=entry.git_head,
+                timestamp=entry.timestamp,
+            )
+        )
+
+    if skipped_git:
+        logger.info("Skipped %d entries with unreachable git_head commits", skipped_git)
+    if skipped_missing:
+        logger.info("Skipped %d entries with missing slide files/slides", skipped_missing)
+
+    return triples

--- a/src/clm/voiceover/transcribe.py
+++ b/src/clm/voiceover/transcribe.py
@@ -30,6 +30,7 @@ class TranscriptSegment:
     start: float  # seconds
     end: float  # seconds
     text: str
+    source_part_index: int = 0  # which video part this segment came from
 
     @property
     def duration(self) -> float:
@@ -40,11 +41,19 @@ class TranscriptSegment:
         return (self.start + self.end) / 2.0
 
     def to_dict(self) -> dict:
-        return {"start": self.start, "end": self.end, "text": self.text}
+        d: dict = {"start": self.start, "end": self.end, "text": self.text}
+        if self.source_part_index != 0:
+            d["source_part_index"] = self.source_part_index
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> TranscriptSegment:
-        return cls(start=data["start"], end=data["end"], text=data["text"])
+        return cls(
+            start=data["start"],
+            end=data["end"],
+            text=data["text"],
+            source_part_index=data.get("source_part_index", 0),
+        )
 
 
 @dataclass

--- a/tests/voiceover/test_langfuse.py
+++ b/tests/voiceover/test_langfuse.py
@@ -1,0 +1,445 @@
+"""Tests for Langfuse tracing integration (Phase 3).
+
+Tests env-var gating, client wrapping/fallback, flush behavior,
+and merge-context forwarding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _langfuse_configured
+# ---------------------------------------------------------------------------
+class TestLangfuseConfigured:
+    """Env-var gating for Langfuse integration."""
+
+    def _configured(self) -> bool:
+        from clm.infrastructure.llm.client import _langfuse_configured
+
+        return _langfuse_configured()
+
+    def test_all_vars_set(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        assert self._configured() is True
+
+    def test_missing_host(self, monkeypatch):
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        assert self._configured() is False
+
+    def test_missing_public_key(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        assert self._configured() is False
+
+    def test_missing_secret_key(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+        assert self._configured() is False
+
+    def test_empty_host_treated_as_missing(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_HOST", "")
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        assert self._configured() is False
+
+    def test_empty_public_key_treated_as_missing(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        assert self._configured() is False
+
+    def test_base_url_accepted_instead_of_host(self, monkeypatch):
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.setenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        assert self._configured() is True
+
+    def test_no_vars_at_all(self, monkeypatch):
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+        assert self._configured() is False
+
+
+# ---------------------------------------------------------------------------
+# _build_client — Langfuse wrapping
+# ---------------------------------------------------------------------------
+class TestBuildClientLangfuse:
+    """_build_client returns Langfuse-wrapped client when configured."""
+
+    def _no_langfuse_env(self, monkeypatch):
+        """Clear all Langfuse env vars."""
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+    def _set_langfuse_env(self, monkeypatch):
+        """Set all required Langfuse env vars."""
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+
+    def test_plain_client_when_no_env_vars(self, monkeypatch):
+        import openai
+
+        from clm.infrastructure.llm.client import _build_client
+
+        self._no_langfuse_env(monkeypatch)
+        client = _build_client()
+        assert type(client) is openai.AsyncOpenAI
+
+    def test_langfuse_client_when_configured(self, monkeypatch):
+        from clm.infrastructure.llm.client import _build_client
+
+        self._set_langfuse_env(monkeypatch)
+
+        # Create a fake langfuse.openai module with a mock AsyncOpenAI
+        mock_async_openai_cls = MagicMock(name="LangfuseAsyncOpenAI")
+        mock_instance = MagicMock(name="langfuse_client_instance")
+        mock_async_openai_cls.return_value = mock_instance
+
+        fake_module = ModuleType("langfuse.openai")
+        fake_module.AsyncOpenAI = mock_async_openai_cls  # type: ignore[attr-defined]
+
+        with patch.dict(sys.modules, {"langfuse.openai": fake_module}):
+            client = _build_client(api_base="http://api.example.com", api_key="test-key")
+
+        assert client is mock_instance
+        mock_async_openai_cls.assert_called_once_with(
+            base_url="http://api.example.com", api_key="test-key"
+        )
+
+    def test_falls_back_when_langfuse_not_installed(self, monkeypatch):
+        import openai
+
+        from clm.infrastructure.llm.client import _build_client
+
+        self._set_langfuse_env(monkeypatch)
+
+        # Make langfuse.openai import raise ImportError
+        with patch.dict(sys.modules, {"langfuse.openai": None}):
+            # None in sys.modules causes ImportError on import
+            client = _build_client()
+
+        assert type(client) is openai.AsyncOpenAI
+
+    def test_falls_back_on_langfuse_init_error(self, monkeypatch):
+        import openai
+
+        from clm.infrastructure.llm.client import _build_client
+
+        self._set_langfuse_env(monkeypatch)
+
+        # langfuse.openai.AsyncOpenAI() raises during construction
+        fake_module = ModuleType("langfuse.openai")
+        fake_module.AsyncOpenAI = MagicMock(  # type: ignore[attr-defined]
+            side_effect=RuntimeError("Langfuse init failed")
+        )
+
+        with patch.dict(sys.modules, {"langfuse.openai": fake_module}):
+            client = _build_client()
+
+        assert type(client) is openai.AsyncOpenAI
+
+    def test_api_base_forwarded_to_langfuse_client(self, monkeypatch):
+        from clm.infrastructure.llm.client import _build_client
+
+        self._set_langfuse_env(monkeypatch)
+
+        mock_cls = MagicMock()
+        fake_module = ModuleType("langfuse.openai")
+        fake_module.AsyncOpenAI = mock_cls  # type: ignore[attr-defined]
+
+        with patch.dict(sys.modules, {"langfuse.openai": fake_module}):
+            _build_client(api_base="https://openrouter.ai/api/v1")
+
+        mock_cls.assert_called_once_with(base_url="https://openrouter.ai/api/v1")
+
+
+# ---------------------------------------------------------------------------
+# flush_langfuse
+# ---------------------------------------------------------------------------
+class TestFlushLangfuse:
+    """flush_langfuse is best-effort and never raises."""
+
+    def test_noop_when_not_configured(self, monkeypatch):
+        from clm.infrastructure.llm.client import flush_langfuse
+
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+        # Should not raise
+        flush_langfuse()
+
+    def test_calls_flush_when_configured(self, monkeypatch):
+        from clm.infrastructure.llm.client import flush_langfuse
+
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+
+        mock_client = MagicMock()
+        mock_get_client = MagicMock(return_value=mock_client)
+
+        fake_langfuse = ModuleType("langfuse")
+        fake_langfuse.get_client = mock_get_client  # type: ignore[attr-defined]
+
+        with patch.dict(sys.modules, {"langfuse": fake_langfuse}):
+            flush_langfuse()
+
+        mock_get_client.assert_called_once()
+        mock_client.flush.assert_called_once()
+
+    def test_swallows_exception(self, monkeypatch):
+        from clm.infrastructure.llm.client import flush_langfuse
+
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+
+        fake_langfuse = ModuleType("langfuse")
+        fake_langfuse.get_client = MagicMock(  # type: ignore[attr-defined]
+            side_effect=RuntimeError("connection refused")
+        )
+
+        with patch.dict(sys.modules, {"langfuse": fake_langfuse}):
+            # Must not raise
+            flush_langfuse()
+
+
+# ---------------------------------------------------------------------------
+# Merge context forwarding
+# ---------------------------------------------------------------------------
+class TestMergeContextForwarding:
+    """Langfuse context is forwarded to create() calls."""
+
+    def _make_mock_client(self, response_json: str) -> MagicMock:
+        """Build a mock OpenAI client that returns canned JSON."""
+        mock_message = MagicMock()
+        mock_message.content = response_json
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        return mock_client
+
+    def test_polish_and_merge_forwards_langfuse_context(self):
+        import json
+
+        from clm.voiceover.merge import polish_and_merge
+
+        response = json.dumps(
+            {
+                "slide_id": "test/0",
+                "merged_bullets": "- bullet",
+                "rewrites": [],
+                "dropped_from_transcript": [],
+            }
+        )
+        mock_client = self._make_mock_client(response)
+        langfuse_ctx = {
+            "name": "test_generation",
+            "trace_id": "trace-abc-123",
+            "metadata": {
+                "langfuse_session_id": "session-xyz",
+                "langfuse_tags": ["test"],
+            },
+        }
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = asyncio.run(
+                polish_and_merge(
+                    "- existing",
+                    "transcript text",
+                    slide_id="test/0",
+                    langfuse_context=langfuse_ctx,
+                )
+            )
+
+        # Verify create() was called with langfuse kwargs
+        call_kwargs = mock_client.chat.completions.create.call_args
+        assert call_kwargs.kwargs.get("name") == "test_generation"
+        assert call_kwargs.kwargs.get("trace_id") == "trace-abc-123"
+        assert call_kwargs.kwargs.get("metadata") == langfuse_ctx["metadata"]
+        assert result.merged_bullets == "- bullet"
+
+    def test_polish_and_merge_no_context_when_none(self):
+        import json
+
+        from clm.voiceover.merge import polish_and_merge
+
+        response = json.dumps(
+            {
+                "slide_id": "test/0",
+                "merged_bullets": "- bullet",
+                "rewrites": [],
+                "dropped_from_transcript": [],
+            }
+        )
+        mock_client = self._make_mock_client(response)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            asyncio.run(
+                polish_and_merge(
+                    "- existing",
+                    "transcript text",
+                    slide_id="test/0",
+                    langfuse_context=None,
+                )
+            )
+
+        # Verify create() was NOT called with langfuse kwargs
+        call_kwargs = mock_client.chat.completions.create.call_args
+        assert "name" not in call_kwargs.kwargs
+        assert "trace_id" not in call_kwargs.kwargs
+        assert "metadata" not in call_kwargs.kwargs
+
+    def test_merge_batch_forwards_langfuse_context(self):
+        import json
+
+        from clm.voiceover.merge import SlideInput, merge_batch
+
+        response = json.dumps(
+            [
+                {
+                    "slide_id": "test/0",
+                    "merged_bullets": "- a",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+                {
+                    "slide_id": "test/1",
+                    "merged_bullets": "- b",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+            ]
+        )
+        mock_client = self._make_mock_client(response)
+        langfuse_ctx = {
+            "name": "voiceover_merge_batch",
+            "trace_id": "trace-batch-001",
+            "metadata": {"langfuse_session_id": "sess-001"},
+        }
+
+        slides = [
+            SlideInput(slide_id="test/0", baseline="- old", transcript="new", slide_content=""),
+            SlideInput(slide_id="test/1", baseline="- old2", transcript="new2", slide_content=""),
+        ]
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            results = asyncio.run(merge_batch(slides, language="en", langfuse_context=langfuse_ctx))
+
+        call_kwargs = mock_client.chat.completions.create.call_args
+        assert call_kwargs.kwargs.get("name") == "voiceover_merge_batch"
+        assert call_kwargs.kwargs.get("trace_id") == "trace-batch-001"
+        assert len(results) == 2
+
+    def test_merge_batch_single_slide_forwards_context(self):
+        """Single-slide batch delegates to polish_and_merge with context."""
+        import json
+
+        from clm.voiceover.merge import SlideInput, merge_batch
+
+        response = json.dumps(
+            {
+                "slide_id": "test/0",
+                "merged_bullets": "- result",
+                "rewrites": [],
+                "dropped_from_transcript": [],
+            }
+        )
+        mock_client = self._make_mock_client(response)
+        langfuse_ctx = {"name": "test", "trace_id": "t-single"}
+
+        slides = [
+            SlideInput(slide_id="test/0", baseline="- old", transcript="new", slide_content=""),
+        ]
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            results = asyncio.run(merge_batch(slides, language="en", langfuse_context=langfuse_ctx))
+
+        call_kwargs = mock_client.chat.completions.create.call_args
+        assert call_kwargs.kwargs.get("trace_id") == "t-single"
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Trace log records langfuse_trace_id
+# ---------------------------------------------------------------------------
+class TestTraceLogLangfuseId:
+    """Verify trace log records langfuse_trace_id when provided."""
+
+    def test_trace_id_written_to_jsonl(self, tmp_path):
+        import json
+
+        from clm.voiceover.trace_log import TraceLog
+
+        trace = TraceLog(
+            path=tmp_path / "test.jsonl",
+            slide_file="slides.py",
+            git_head="abc123",
+        )
+        trace.log_merge_call(
+            slide_id="test/0",
+            language="de",
+            baseline="- old",
+            transcript="new text",
+            llm_merged="- merged",
+            rewrites=[],
+            dropped_from_transcript=[],
+            langfuse_trace_id="langfuse-trace-xyz-789",
+        )
+
+        lines = trace.path.read_text(encoding="utf-8").strip().split("\n")
+        entry = json.loads(lines[0])
+        assert entry["langfuse_trace_id"] == "langfuse-trace-xyz-789"
+
+    def test_trace_id_omitted_when_none(self, tmp_path):
+        import json
+
+        from clm.voiceover.trace_log import TraceLog
+
+        trace = TraceLog(
+            path=tmp_path / "test.jsonl",
+            slide_file="slides.py",
+            git_head="abc123",
+        )
+        trace.log_merge_call(
+            slide_id="test/0",
+            language="de",
+            baseline="- old",
+            transcript="new text",
+            llm_merged="- merged",
+            rewrites=[],
+            dropped_from_transcript=[],
+            langfuse_trace_id=None,
+        )
+
+        lines = trace.path.read_text(encoding="utf-8").strip().split("\n")
+        entry = json.loads(lines[0])
+        assert "langfuse_trace_id" not in entry

--- a/tests/voiceover/test_langfuse.py
+++ b/tests/voiceover/test_langfuse.py
@@ -104,7 +104,7 @@ class TestBuildClientLangfuse:
         from clm.infrastructure.llm.client import _build_client
 
         self._no_langfuse_env(monkeypatch)
-        client = _build_client()
+        client = _build_client(api_key="test-key")
         assert type(client) is openai.AsyncOpenAI
 
     def test_langfuse_client_when_configured(self, monkeypatch):
@@ -138,7 +138,7 @@ class TestBuildClientLangfuse:
         # Make langfuse.openai import raise ImportError
         with patch.dict(sys.modules, {"langfuse.openai": None}):
             # None in sys.modules causes ImportError on import
-            client = _build_client()
+            client = _build_client(api_key="test-key")
 
         assert type(client) is openai.AsyncOpenAI
 
@@ -156,7 +156,7 @@ class TestBuildClientLangfuse:
         )
 
         with patch.dict(sys.modules, {"langfuse.openai": fake_module}):
-            client = _build_client()
+            client = _build_client(api_key="test-key")
 
         assert type(client) is openai.AsyncOpenAI
 

--- a/tests/voiceover/test_merge.py
+++ b/tests/voiceover/test_merge.py
@@ -1,0 +1,679 @@
+"""Tests for voiceover merge module.
+
+Tests the core merge logic: prompt building, JSON parsing, batching,
+polish_and_merge with mocked LLM, and noise filter fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clm.voiceover.merge import (
+    DEFAULT_BATCH_CHAR_LIMIT,
+    MergeResult,
+    SlideInput,
+    _build_batch_user_prompt,
+    _build_user_prompt,
+    _parse_batch_result,
+    _parse_single_result,
+    build_batches,
+    merge_batch,
+    polish_and_merge,
+)
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUserPrompt:
+    def test_basic_prompt_with_all_fields(self):
+        slide = SlideInput(
+            slide_id="test/1",
+            baseline="- existing point",
+            transcript="the trainer said something new",
+            slide_content="# My Slide Title",
+        )
+        prompt = _build_user_prompt(slide)
+        assert "SLIDE CONTEXT" in prompt
+        assert "My Slide Title" in prompt
+        assert "BASELINE VOICEOVER" in prompt
+        assert "existing point" in prompt
+        assert "TRANSCRIPT" in prompt
+        assert "trainer said something new" in prompt
+
+    def test_empty_baseline_says_empty(self):
+        slide = SlideInput(
+            slide_id="test/1",
+            baseline="",
+            transcript="some transcript",
+            slide_content="# Title",
+        )
+        prompt = _build_user_prompt(slide)
+        assert "(empty -- no existing voiceover)" in prompt
+
+    def test_boundary_hint_included(self):
+        slide = SlideInput(
+            slide_id="test/1",
+            baseline="- bullet",
+            transcript="transcript",
+            slide_content="",
+            boundary_hint=True,
+        )
+        prompt = _build_user_prompt(slide)
+        assert "recording part boundary" in prompt
+        assert "greeting/sign-off noise" in prompt
+
+    def test_no_boundary_hint_by_default(self):
+        slide = SlideInput(
+            slide_id="test/1",
+            baseline="- bullet",
+            transcript="transcript",
+            slide_content="",
+        )
+        prompt = _build_user_prompt(slide)
+        assert "recording part boundary" not in prompt
+
+    def test_empty_slide_content_omitted(self):
+        slide = SlideInput(
+            slide_id="test/1",
+            baseline="- bullet",
+            transcript="transcript",
+            slide_content="   ",
+        )
+        prompt = _build_user_prompt(slide)
+        assert "SLIDE CONTEXT" not in prompt
+
+
+class TestBuildBatchUserPrompt:
+    def test_batch_prompt_contains_all_slides(self):
+        slides = [
+            SlideInput("s/1", "- a", "transcript a", "slide a"),
+            SlideInput("s/2", "- b", "transcript b", "slide b"),
+        ]
+        prompt = _build_batch_user_prompt(slides)
+        assert "2 slides" in prompt
+        assert "--- SLIDE: s/1 ---" in prompt
+        assert "--- SLIDE: s/2 ---" in prompt
+        assert "transcript a" in prompt
+        assert "transcript b" in prompt
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseSingleResult:
+    def test_valid_json(self):
+        raw = json.dumps(
+            {
+                "merged_bullets": "- bullet one\n- bullet two",
+                "rewrites": [],
+                "dropped_from_transcript": ["hello there"],
+            }
+        )
+        result = _parse_single_result(raw, "test/1")
+        assert result.slide_id == "test/1"
+        assert result.merged_bullets == "- bullet one\n- bullet two"
+        assert result.rewrites == []
+        assert result.dropped_from_transcript == ["hello there"]
+
+    def test_strips_code_fences(self):
+        raw = (
+            '```json\n{"merged_bullets": "- x", "rewrites": [], "dropped_from_transcript": []}\n```'
+        )
+        result = _parse_single_result(raw, "test/1")
+        assert result.merged_bullets == "- x"
+
+    def test_with_rewrites(self):
+        raw = json.dumps(
+            {
+                "merged_bullets": "- corrected bullet",
+                "rewrites": [
+                    {
+                        "original": "- wrong fact",
+                        "revised": "- corrected bullet",
+                        "transcript_evidence": "the trainer said otherwise",
+                    }
+                ],
+                "dropped_from_transcript": [],
+            }
+        )
+        result = _parse_single_result(raw, "test/2")
+        assert len(result.rewrites) == 1
+        assert result.rewrites[0]["original"] == "- wrong fact"
+
+
+class TestParseBatchResult:
+    def test_array_format(self):
+        raw = json.dumps(
+            [
+                {
+                    "slide_id": "s/1",
+                    "merged_bullets": "- a",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+                {
+                    "slide_id": "s/2",
+                    "merged_bullets": "- b",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+            ]
+        )
+        results = _parse_batch_result(raw, ["s/1", "s/2"])
+        assert "s/1" in results
+        assert "s/2" in results
+        assert results["s/1"].merged_bullets == "- a"
+        assert results["s/2"].merged_bullets == "- b"
+
+    def test_dict_keyed_format(self):
+        raw = json.dumps(
+            {
+                "s/1": {
+                    "merged_bullets": "- a",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+                "s/2": {
+                    "merged_bullets": "- b",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+            }
+        )
+        results = _parse_batch_result(raw, ["s/1", "s/2"])
+        assert "s/1" in results
+        assert results["s/1"].merged_bullets == "- a"
+
+    def test_single_dict_format(self):
+        raw = json.dumps(
+            {
+                "slide_id": "s/1",
+                "merged_bullets": "- a",
+                "rewrites": [],
+                "dropped_from_transcript": [],
+            }
+        )
+        results = _parse_batch_result(raw, ["s/1"])
+        assert "s/1" in results
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            _parse_batch_result("not json at all", ["s/1"])
+
+
+# ---------------------------------------------------------------------------
+# Batching
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBatches:
+    def test_single_slide_single_batch(self):
+        slides = [SlideInput("s/1", "a" * 100, "b" * 100, "c" * 100)]
+        batches = build_batches(slides, char_limit=1000)
+        assert len(batches) == 1
+        assert len(batches[0]) == 1
+
+    def test_splits_when_over_budget(self):
+        slides = [
+            SlideInput("s/1", "a" * 5000, "b" * 5000, "c" * 5000),
+            SlideInput("s/2", "d" * 5000, "e" * 5000, "f" * 5000),
+        ]
+        batches = build_batches(slides, char_limit=16000)
+        assert len(batches) == 2
+
+    def test_packs_small_slides_together(self):
+        slides = [SlideInput(f"s/{i}", "a" * 10, "b" * 10, "c" * 10) for i in range(10)]
+        batches = build_batches(slides, char_limit=1000)
+        # 30 chars per slide, 10 slides = 300 chars total, fits in one batch
+        assert len(batches) == 1
+
+    def test_oversized_slide_gets_own_batch(self):
+        slides = [
+            SlideInput("s/1", "a" * 10, "b" * 10, "c" * 10),
+            SlideInput("s/2", "x" * 30000, "y" * 30000, "z" * 30000),
+            SlideInput("s/3", "a" * 10, "b" * 10, "c" * 10),
+        ]
+        batches = build_batches(slides, char_limit=20000)
+        # s/1 alone, s/2 alone (oversized), s/3 alone
+        assert len(batches) == 3
+
+    def test_empty_input(self):
+        batches = build_batches([], char_limit=1000)
+        assert batches == []
+
+
+# ---------------------------------------------------------------------------
+# polish_and_merge with mocked LLM
+# ---------------------------------------------------------------------------
+
+
+def _mock_llm_response(content: str):
+    """Create a mock OpenAI response."""
+    choice = MagicMock()
+    choice.message.content = content
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+class TestPolishAndMerge:
+    @pytest.mark.asyncio
+    async def test_merge_with_baseline(self):
+        mock_response = _mock_llm_response(
+            json.dumps(
+                {
+                    "merged_bullets": "- existing point\n- new addition from transcript",
+                    "rewrites": [],
+                    "dropped_from_transcript": ["willkommen zurück"],
+                }
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_merge(
+                baseline_bullets="- existing point",
+                transcript_text="new addition from transcript. willkommen zurück",
+                slide_content="# Test Slide",
+                language="de",
+                slide_id="test/1",
+            )
+
+        assert result.slide_id == "test/1"
+        assert "existing point" in result.merged_bullets
+        assert "new addition" in result.merged_bullets
+        assert result.rewrites == []
+        assert "willkommen zurück" in result.dropped_from_transcript
+
+    @pytest.mark.asyncio
+    async def test_empty_baseline_degrades_to_polish(self):
+        """When baseline is empty, should produce fresh bullets."""
+        mock_response = _mock_llm_response(
+            json.dumps(
+                {
+                    "merged_bullets": "- point from transcript",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                }
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_merge(
+                baseline_bullets="",
+                transcript_text="point from transcript",
+                slide_content="# Test",
+                language="en",
+                slide_id="test/2",
+            )
+
+        assert result.merged_bullets == "- point from transcript"
+
+    @pytest.mark.asyncio
+    async def test_rewrite_detection(self):
+        """Baseline rewrite should be captured in rewrites field."""
+        mock_response = _mock_llm_response(
+            json.dumps(
+                {
+                    "merged_bullets": "- extend mutates the list in place and returns None",
+                    "rewrites": [
+                        {
+                            "original": "- extend returns a new list",
+                            "revised": "- extend mutates the list in place and returns None",
+                            "transcript_evidence": "actually, extend mutates in place",
+                        }
+                    ],
+                    "dropped_from_transcript": [],
+                }
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_merge(
+                baseline_bullets="- extend returns a new list",
+                transcript_text="actually, extend mutates in place, it doesn't return anything",
+                slide_content="",
+                language="en",
+                slide_id="test/3",
+            )
+
+        assert len(result.rewrites) == 1
+        assert result.rewrites[0]["original"] == "- extend returns a new list"
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure_uses_raw_text(self):
+        """When LLM returns non-JSON, fall back to raw text."""
+        mock_response = _mock_llm_response("- just plain bullets\n- no json here")
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_merge(
+                baseline_bullets="- old",
+                transcript_text="something",
+                language="en",
+                slide_id="test/4",
+            )
+
+        assert "just plain bullets" in result.merged_bullets
+        assert result.rewrites == []
+
+    @pytest.mark.asyncio
+    async def test_llm_error_raises(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API down"))
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            with pytest.raises(Exception, match="Merge LLM call failed"):
+                await polish_and_merge(
+                    baseline_bullets="- x",
+                    transcript_text="y",
+                    language="en",
+                    slide_id="test/5",
+                )
+
+
+class TestMergeBatch:
+    @pytest.mark.asyncio
+    async def test_single_slide_batch_delegates_to_polish_and_merge(self):
+        mock_response = _mock_llm_response(
+            json.dumps(
+                {
+                    "merged_bullets": "- result",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                }
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        slides = [SlideInput("s/1", "- baseline", "transcript", "content")]
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            results = await merge_batch(slides, language="en")
+
+        assert len(results) == 1
+        assert results[0].merged_bullets == "- result"
+
+    @pytest.mark.asyncio
+    async def test_multi_slide_batch_parses_array(self):
+        batch_response = json.dumps(
+            [
+                {
+                    "slide_id": "s/1",
+                    "merged_bullets": "- merged a",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+                {
+                    "slide_id": "s/2",
+                    "merged_bullets": "- merged b",
+                    "rewrites": [],
+                    "dropped_from_transcript": [],
+                },
+            ]
+        )
+
+        mock_response = _mock_llm_response(batch_response)
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        slides = [
+            SlideInput("s/1", "- a", "transcript a", "content a"),
+            SlideInput("s/2", "- b", "transcript b", "content b"),
+        ]
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            results = await merge_batch(slides, language="en")
+
+        assert len(results) == 2
+        assert results[0].merged_bullets == "- merged a"
+        assert results[1].merged_bullets == "- merged b"
+
+    @pytest.mark.asyncio
+    async def test_batch_json_failure_falls_back_to_per_slide(self):
+        """When batch JSON parse fails, fall back to per-slide calls."""
+        # First call (batch) returns garbage
+        # Subsequent calls (per-slide) return valid JSON
+        call_count = 0
+
+        async def fake_create(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Batch call returns non-JSON
+                return _mock_llm_response("this is not json")
+            # Per-slide fallback calls
+            slide_id = f"s/{call_count - 1}"
+            return _mock_llm_response(
+                json.dumps(
+                    {
+                        "merged_bullets": f"- fallback {call_count - 1}",
+                        "rewrites": [],
+                        "dropped_from_transcript": [],
+                    }
+                )
+            )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=fake_create)
+
+        slides = [
+            SlideInput("s/1", "- a", "tx a", "c a"),
+            SlideInput("s/2", "- b", "tx b", "c b"),
+        ]
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            results = await merge_batch(slides, language="en")
+
+        assert len(results) == 2
+        # Fallback produced results (call_count was incremented)
+        assert call_count == 3  # 1 batch + 2 per-slide
+
+
+# ---------------------------------------------------------------------------
+# Noise filter fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseFixturesGerman:
+    """Fixture data for noise categories that should be filtered.
+
+    These are the concrete examples from the proposal. The actual filtering
+    is done by the LLM — these tests verify that the prompt builder includes
+    the right context and that the fixture data is well-structured for
+    future prompt tuning.
+    """
+
+    GREETINGS_DROP = [
+        "Hallo, willkommen zurück zu Teil 2, ich hatte die Aufnahme kurz unterbrochen.",
+        "So, das war's für heute, bis zum nächsten Mal!",
+        "Jetzt in Teil 2 angelangt.",
+    ]
+
+    SELF_CORRECTIONS_DROP = [
+        "Moment, ich hab da was übersehen, lass mich kurz zurückscrollen.",
+        "Oh sorry, das war der falsche Slide, ich muss da nochmal hin.",
+        "Uh, entschuldigung, das Mikrofon hat gerade kurz ausgesetzt.",
+    ]
+
+    ENVIRONMENT_REMARKS_DROP = [
+        "Mein Docker-Container ist rot, weil ich das falsche Environment habe.",
+        "Mein Editor zeigt da rot, das ist aber egal.",
+    ]
+
+    OPERATOR_ASIDES_DROP = [
+        "Kannst du das nachher rausschneiden.",
+        "Das kommt in den Schnitt.",
+    ]
+
+    CODE_TYPING_DICTATION_DROP = [
+        "And then we define the function — def — fact — open paren — n — colon…",
+        "For m comma n in range…",
+        "Close paren, colon, return.",
+    ]
+
+    SUBSTANTIVE_KEEP = [
+        "Oh, and by the way — extend mutates the list in place, it doesn't return a new one.",
+        "The free OpenRouter tier has a rate limit of ~20 requests per minute, so don't spam it when testing.",
+        "One thing I forgot to put on the slide: you can also pass system_prompt as a regular string instead of a SystemMessage in newer LangChain versions.",
+    ]
+
+    def test_drop_categories_are_non_empty(self):
+        """Ensure each noise category has enough examples for testing."""
+        assert len(self.GREETINGS_DROP) >= 3
+        assert len(self.SELF_CORRECTIONS_DROP) >= 3
+        assert len(self.ENVIRONMENT_REMARKS_DROP) >= 2
+        assert len(self.OPERATOR_ASIDES_DROP) >= 2
+        assert len(self.CODE_TYPING_DICTATION_DROP) >= 3
+
+    def test_keep_examples_are_substantive(self):
+        """Substantive additions should be non-trivial sentences."""
+        for text in self.SUBSTANTIVE_KEEP:
+            assert len(text) > 30
+
+    def test_prompt_contains_filter_categories(self):
+        """Verify the merge prompt mentions all filter categories."""
+        from clm.voiceover.merge import _load_system_prompt
+
+        prompt = _load_system_prompt("de")
+        # Check that key filter categories are mentioned
+        assert "Begruessung" in prompt or "Verabschiedung" in prompt
+        assert "Selbstkorrektur" in prompt or "Aufnahme-Selbstkorrektur" in prompt
+        assert "Umgebungsbemerkung" in prompt or "Docker" in prompt
+        assert "Operator" in prompt or "rausschneiden" in prompt
+        assert "Code-Tipp" in prompt or "Live-Coding" in prompt
+
+    def test_en_prompt_contains_filter_categories(self):
+        """Verify the English merge prompt mentions all filter categories."""
+        from clm.voiceover.merge import _load_system_prompt
+
+        prompt = _load_system_prompt("en")
+        assert "Greetings" in prompt or "sign-off" in prompt
+        assert "self-correction" in prompt or "wrong slide" in prompt
+        assert "environment" in prompt or "Docker" in prompt
+        assert "operator" in prompt or "cut that out" in prompt
+        assert "Code-typing" in prompt or "live-coding" in prompt
+
+
+class TestNoiseFixturesEnglish:
+    """English noise fixture seed data."""
+
+    GREETINGS_DROP = [
+        "Welcome back to part 2, I had to pause the recording briefly.",
+        "Alright, that's it for today, see you next time!",
+        "Now arriving in part 3.",
+    ]
+
+    SELF_CORRECTIONS_DROP = [
+        "Wait, I overlooked something, let me scroll back.",
+        "Oh sorry, that was the wrong slide, I need to go back.",
+        "Uh, excuse me, the microphone just cut out briefly.",
+    ]
+
+    ENVIRONMENT_REMARKS_DROP = [
+        "My Docker container is red because I have the wrong environment.",
+        "My editor shows red there, but that's fine.",
+    ]
+
+    SUBSTANTIVE_KEEP = [
+        "Oh, and by the way -- extend mutates the list in place, it doesn't return a new one.",
+        "The free OpenRouter tier has a rate limit of about 20 requests per minute.",
+        "One thing I forgot: you can also pass system_prompt as a regular string.",
+    ]
+
+    def test_drop_categories_are_non_empty(self):
+        assert len(self.GREETINGS_DROP) >= 3
+        assert len(self.SELF_CORRECTIONS_DROP) >= 3
+        assert len(self.ENVIRONMENT_REMARKS_DROP) >= 2
+
+    def test_keep_examples_are_substantive(self):
+        for text in self.SUBSTANTIVE_KEEP:
+            assert len(text) > 30
+
+
+# ---------------------------------------------------------------------------
+# Rewrite detection
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteDetection:
+    """Tests that rewrite metadata flows through correctly."""
+
+    @pytest.mark.asyncio
+    async def test_rewrite_preserved_in_result(self):
+        rewrite = {
+            "original": "- extend returns a new list",
+            "revised": "- extend mutates the list in place and returns None",
+            "transcript_evidence": "actually, extend mutates in place",
+        }
+        mock_response = _mock_llm_response(
+            json.dumps(
+                {
+                    "merged_bullets": "- extend mutates the list in place and returns None",
+                    "rewrites": [rewrite],
+                    "dropped_from_transcript": [],
+                }
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_merge(
+                baseline_bullets="- extend returns a new list",
+                transcript_text="actually, extend mutates in place and returns None",
+                language="en",
+                slide_id="test/rewrite",
+            )
+
+        assert len(result.rewrites) == 1
+        assert result.rewrites[0]["original"] == "- extend returns a new list"
+        assert "mutates" in result.rewrites[0]["revised"]
+        assert "transcript_evidence" in result.rewrites[0]
+
+
+# ---------------------------------------------------------------------------
+# System prompt loading
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptLoading:
+    def test_load_de_prompt(self):
+        from clm.voiceover.merge import _load_system_prompt
+
+        prompt = _load_system_prompt("de")
+        assert "Voiceover" in prompt
+        assert "JSON" in prompt
+
+    def test_load_en_prompt(self):
+        from clm.voiceover.merge import _load_system_prompt
+
+        prompt = _load_system_prompt("en")
+        assert "voiceover" in prompt
+        assert "JSON" in prompt
+
+    def test_unknown_language_falls_back_to_en(self):
+        from clm.voiceover.merge import _load_system_prompt
+
+        prompt = _load_system_prompt("fr")
+        assert "voiceover" in prompt  # English fallback

--- a/tests/voiceover/test_merge_cli.py
+++ b/tests/voiceover/test_merge_cli.py
@@ -1,0 +1,134 @@
+"""Tests for CLI sync command merge mode changes.
+
+Tests --overwrite flag, --mode verbatim + merge error, and
+the new default merge behavior at the CLI level.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.voiceover import sync, voiceover_group
+
+
+class TestVerbatimMergeError:
+    """--mode verbatim without --overwrite should error."""
+
+    def test_verbatim_without_overwrite_errors(self, tmp_path):
+        # Create a dummy slide file
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text('# %% [markdown] lang="de" tags=["slide"]\n# Title\n')
+
+        # Create a dummy video file
+        video_file = tmp_path / "video.mp4"
+        video_file.write_text("fake video")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync",
+                str(slide_file),
+                str(video_file),
+                "--lang",
+                "de",
+                "--mode",
+                "verbatim",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Cannot use --mode verbatim with merge" in result.output
+
+    def test_verbatim_with_overwrite_does_not_error(self, tmp_path):
+        """--mode verbatim --overwrite should NOT produce the usage error.
+
+        We can't run the full pipeline (no real video), but we verify
+        the usage-error check passes by checking we get a different error.
+        """
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text('# %% [markdown] lang="de" tags=["slide"]\n# Title\n')
+
+        video_file = tmp_path / "video.mp4"
+        video_file.write_text("fake video")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync",
+                str(slide_file),
+                str(video_file),
+                "--lang",
+                "de",
+                "--mode",
+                "verbatim",
+                "--overwrite",
+            ],
+        )
+        # Should NOT contain the verbatim+merge error
+        assert "Cannot use --mode verbatim with merge" not in result.output
+
+
+class TestSyncOverwriteFlag:
+    """Verify --overwrite flag is accepted by the CLI."""
+
+    def test_overwrite_flag_is_recognized(self, tmp_path):
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text('# %% [markdown] lang="de" tags=["slide"]\n# Title\n')
+
+        video_file = tmp_path / "video.mp4"
+        video_file.write_text("fake video")
+
+        runner = CliRunner()
+        # Just check that the flag is accepted (pipeline will fail on video)
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync",
+                str(slide_file),
+                str(video_file),
+                "--lang",
+                "de",
+                "--overwrite",
+            ],
+        )
+        assert "no such option: --overwrite" not in result.output
+
+    def test_polished_mode_without_overwrite_is_merge(self, tmp_path):
+        """Default behavior (no --overwrite) should attempt merge mode."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text('# %% [markdown] lang="de" tags=["slide"]\n# Title\n')
+
+        video_file = tmp_path / "video.mp4"
+        video_file.write_text("fake video")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync",
+                str(slide_file),
+                str(video_file),
+                "--lang",
+                "de",
+            ],
+        )
+        # Should NOT contain the verbatim error (polished + merge is fine)
+        assert "Cannot use --mode verbatim" not in result.output
+
+
+class TestSyncHelpText:
+    """Verify updated help text."""
+
+    def test_help_mentions_merge(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["sync", "--help"])
+        assert "--overwrite" in result.output
+
+    def test_help_mentions_overwrite(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["sync", "--help"])
+        assert "Overwrite" in result.output or "overwrite" in result.output

--- a/tests/voiceover/test_multi_part.py
+++ b/tests/voiceover/test_multi_part.py
@@ -1,0 +1,212 @@
+"""Tests for multi-part support across voiceover modules.
+
+Covers: source_part_index on data classes, matcher frame extraction
+routing, CLI argument order, and serialization round-trips.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clm.voiceover.keyframes import TransitionEvent
+from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+# ---------------------------------------------------------------------------
+# TranscriptSegment.source_part_index
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptSegmentPartIndex:
+    def test_default_is_zero(self):
+        seg = TranscriptSegment(start=0.0, end=1.0, text="hello")
+        assert seg.source_part_index == 0
+
+    def test_explicit_part_index(self):
+        seg = TranscriptSegment(start=0.0, end=1.0, text="hello", source_part_index=3)
+        assert seg.source_part_index == 3
+
+    def test_frozen(self):
+        seg = TranscriptSegment(start=0.0, end=1.0, text="hello", source_part_index=1)
+        with pytest.raises(AttributeError):
+            seg.source_part_index = 2  # type: ignore[misc]
+
+    def test_to_dict_omits_zero(self):
+        seg = TranscriptSegment(start=0.0, end=1.0, text="hi")
+        d = seg.to_dict()
+        assert "source_part_index" not in d
+
+    def test_to_dict_includes_nonzero(self):
+        seg = TranscriptSegment(start=0.0, end=1.0, text="hi", source_part_index=2)
+        d = seg.to_dict()
+        assert d["source_part_index"] == 2
+
+    def test_from_dict_without_part_index(self):
+        seg = TranscriptSegment.from_dict({"start": 0.0, "end": 1.0, "text": "hi"})
+        assert seg.source_part_index == 0
+
+    def test_from_dict_with_part_index(self):
+        seg = TranscriptSegment.from_dict(
+            {"start": 0.0, "end": 1.0, "text": "hi", "source_part_index": 5}
+        )
+        assert seg.source_part_index == 5
+
+    def test_roundtrip_with_part_index(self):
+        original = TranscriptSegment(start=1.5, end=3.0, text="test", source_part_index=2)
+        restored = TranscriptSegment.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_roundtrip_without_part_index(self):
+        original = TranscriptSegment(start=1.5, end=3.0, text="test")
+        restored = TranscriptSegment.from_dict(original.to_dict())
+        assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# TransitionEvent.source_part_index and .local_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionEventPartFields:
+    def test_defaults(self):
+        event = TransitionEvent(timestamp=5.0, peak_diff=0.5, confidence=3.0, num_frames=2)
+        assert event.source_part_index == 0
+        assert event.local_timestamp is None
+
+    def test_explicit_values(self):
+        event = TransitionEvent(
+            timestamp=105.0,
+            peak_diff=0.5,
+            confidence=3.0,
+            num_frames=2,
+            source_part_index=1,
+            local_timestamp=5.0,
+        )
+        assert event.source_part_index == 1
+        assert event.local_timestamp == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Matcher: _extract_event_frame routing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEventFrame:
+    def test_single_video_uses_event_timestamp(self):
+        from clm.voiceover.matcher import _extract_event_frame
+
+        event = TransitionEvent(timestamp=10.0, peak_diff=0.5, confidence=3.0, num_frames=1)
+        mock_frame = MagicMock()
+
+        with patch("clm.voiceover.matcher.get_frame_at", return_value=mock_frame) as mock_get:
+            result = _extract_event_frame(event, Path("video.mp4"), None, 1.0)
+            mock_get.assert_called_once_with(Path("video.mp4"), 10.0, offset=1.0)
+            assert result is mock_frame
+
+    def test_multi_part_uses_local_timestamp(self):
+        from clm.voiceover.matcher import _extract_event_frame
+
+        event = TransitionEvent(
+            timestamp=110.0,
+            peak_diff=0.5,
+            confidence=3.0,
+            num_frames=1,
+            source_part_index=1,
+            local_timestamp=10.0,
+        )
+        video_paths = [Path("p0.mp4"), Path("p1.mp4"), Path("p2.mp4")]
+        mock_frame = MagicMock()
+
+        with patch("clm.voiceover.matcher.get_frame_at", return_value=mock_frame) as mock_get:
+            result = _extract_event_frame(event, Path("ignored.mp4"), video_paths, 1.0)
+            mock_get.assert_called_once_with(Path("p1.mp4"), 10.0, offset=1.0)
+            assert result is mock_frame
+
+    def test_multi_part_without_local_timestamp_falls_back(self):
+        """If local_timestamp is None, fall back to single-video behavior."""
+        from clm.voiceover.matcher import _extract_event_frame
+
+        event = TransitionEvent(timestamp=10.0, peak_diff=0.5, confidence=3.0, num_frames=1)
+        mock_frame = MagicMock()
+
+        with patch("clm.voiceover.matcher.get_frame_at", return_value=mock_frame) as mock_get:
+            result = _extract_event_frame(event, Path("fallback.mp4"), [Path("p0.mp4")], 1.0)
+            mock_get.assert_called_once_with(Path("fallback.mp4"), 10.0, offset=1.0)
+            assert result is mock_frame
+
+
+# ---------------------------------------------------------------------------
+# Matcher: total_duration parameter
+# ---------------------------------------------------------------------------
+
+
+class TestMatcherTotalDuration:
+    def test_total_duration_used_in_timeline(self):
+        """When total_duration is provided, it sets the last entry's end_time."""
+        from clm.voiceover.matcher import _build_timeline
+
+        aligned = [
+            (
+                TransitionEvent(timestamp=5.0, peak_diff=0.5, confidence=3.0, num_frames=1),
+                1,
+                90.0,
+            ),
+        ]
+        timeline = _build_timeline(aligned, video_duration=300.0)
+        assert timeline[-1].end_time == pytest.approx(300.0)
+
+
+# ---------------------------------------------------------------------------
+# CLI argument order
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCliSignature:
+    def test_help_shows_slides_first(self):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["sync", "--help"])
+        assert result.exit_code == 0
+        # SLIDES should appear before VIDEOS in the usage line
+        usage_line = result.output.split("\n")[0]
+        slides_pos = usage_line.find("SLIDES")
+        videos_pos = usage_line.find("VIDEOS")
+        assert slides_pos < videos_pos, (
+            f"SLIDES should appear before VIDEOS in usage. Got: {usage_line}"
+        )
+
+    def test_sync_requires_at_least_one_video(self):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        runner = CliRunner()
+        # Only slides, no videos — should fail
+        result = runner.invoke(voiceover_group, ["sync", "slides.py", "--lang", "de"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Transcript serialization with source_part_index
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptSerializationWithParts:
+    def test_roundtrip_preserves_part_indices(self):
+        transcript = Transcript(
+            segments=[
+                TranscriptSegment(start=0.0, end=5.0, text="a", source_part_index=0),
+                TranscriptSegment(start=60.0, end=65.0, text="b", source_part_index=1),
+            ],
+            language="de",
+            duration=120.0,
+        )
+        data = transcript.to_dict()
+        restored = Transcript.from_dict(data)
+        assert restored.segments[0].source_part_index == 0
+        assert restored.segments[1].source_part_index == 1

--- a/tests/voiceover/test_timeline.py
+++ b/tests/voiceover/test_timeline.py
@@ -1,0 +1,335 @@
+"""Tests for multi-part video timeline construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clm.voiceover.keyframes import TransitionEvent
+from clm.voiceover.timeline import (
+    VideoPart,
+    build_parts,
+    merge_transcripts,
+    offset_events,
+    offset_transcript,
+    probe_duration,
+)
+from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+# ---------------------------------------------------------------------------
+# probe_duration
+# ---------------------------------------------------------------------------
+
+
+class TestProbeDuration:
+    def test_nonexistent_file_raises(self):
+        with pytest.raises(FileNotFoundError, match="Video not found"):
+            probe_duration(Path("/nonexistent/video.mp4"))
+
+    @patch("clm.voiceover.timeline.subprocess.run")
+    def test_ffprobe_failure_raises(self, mock_run, tmp_path):
+        video = tmp_path / "test.mp4"
+        video.write_text("fake")
+        mock_run.return_value = type("R", (), {"returncode": 1, "stderr": "error", "stdout": ""})()
+        with pytest.raises(RuntimeError, match="ffprobe failed"):
+            probe_duration(video)
+
+    @patch("clm.voiceover.timeline.subprocess.run")
+    def test_non_numeric_output_raises(self, mock_run, tmp_path):
+        video = tmp_path / "test.mp4"
+        video.write_text("fake")
+        mock_run.return_value = type("R", (), {"returncode": 0, "stderr": "", "stdout": "N/A"})()
+        with pytest.raises(RuntimeError, match="non-numeric duration"):
+            probe_duration(video)
+
+    @patch("clm.voiceover.timeline.subprocess.run")
+    def test_returns_duration(self, mock_run, tmp_path):
+        video = tmp_path / "test.mp4"
+        video.write_text("fake")
+        mock_run.return_value = type(
+            "R", (), {"returncode": 0, "stderr": "", "stdout": "123.45\n"}
+        )()
+        assert probe_duration(video) == pytest.approx(123.45)
+
+
+# ---------------------------------------------------------------------------
+# build_parts
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParts:
+    @patch("clm.voiceover.timeline.probe_duration")
+    def test_single_part(self, mock_probe):
+        mock_probe.return_value = 60.0
+        parts = build_parts([Path("video.mp4")])
+        assert len(parts) == 1
+        assert parts[0].index == 0
+        assert parts[0].offset == pytest.approx(0.0)
+        assert parts[0].duration == pytest.approx(60.0)
+
+    @patch("clm.voiceover.timeline.probe_duration")
+    def test_three_parts_offsets(self, mock_probe):
+        mock_probe.side_effect = [100.0, 200.0, 150.0]
+        paths = [Path("p1.mp4"), Path("p2.mp4"), Path("p3.mp4")]
+        parts = build_parts(paths)
+
+        assert len(parts) == 3
+        assert parts[0].offset == pytest.approx(0.0)
+        assert parts[1].offset == pytest.approx(100.0)
+        assert parts[2].offset == pytest.approx(300.0)
+
+    @patch("clm.voiceover.timeline.probe_duration")
+    def test_preserves_path_order(self, mock_probe):
+        mock_probe.return_value = 10.0
+        paths = [Path("z.mp4"), Path("a.mp4"), Path("m.mp4")]
+        parts = build_parts(paths)
+        assert [p.path for p in parts] == paths
+
+    @patch("clm.voiceover.timeline.probe_duration")
+    def test_part_index_in_error(self, mock_probe):
+        mock_probe.side_effect = [10.0, FileNotFoundError("gone")]
+        paths = [Path("ok.mp4"), Path("missing.mp4")]
+        with pytest.raises(FileNotFoundError, match="part 1"):
+            build_parts(paths)
+
+
+# ---------------------------------------------------------------------------
+# offset_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestOffsetTranscript:
+    def test_offsets_applied(self):
+        transcript = Transcript(
+            segments=[
+                TranscriptSegment(start=0.0, end=5.0, text="hello"),
+                TranscriptSegment(start=5.0, end=10.0, text="world"),
+            ],
+            language="de",
+            duration=10.0,
+        )
+        part = VideoPart(index=2, path=Path("p2.mp4"), duration=10.0, offset=100.0)
+        result = offset_transcript(transcript, part)
+
+        assert result.segments[0].start == pytest.approx(100.0)
+        assert result.segments[0].end == pytest.approx(105.0)
+        assert result.segments[1].start == pytest.approx(105.0)
+        assert result.segments[1].end == pytest.approx(110.0)
+
+    def test_source_part_index_tagged(self):
+        transcript = Transcript(
+            segments=[TranscriptSegment(start=0.0, end=5.0, text="hi")],
+            language="en",
+            duration=5.0,
+        )
+        part = VideoPart(index=3, path=Path("p3.mp4"), duration=5.0, offset=50.0)
+        result = offset_transcript(transcript, part)
+        assert result.segments[0].source_part_index == 3
+
+    def test_text_preserved(self):
+        transcript = Transcript(
+            segments=[TranscriptSegment(start=0.0, end=5.0, text="preserve me")],
+            language="de",
+            duration=5.0,
+        )
+        part = VideoPart(index=0, path=Path("p0.mp4"), duration=5.0, offset=0.0)
+        result = offset_transcript(transcript, part)
+        assert result.segments[0].text == "preserve me"
+
+    def test_zero_offset_first_part(self):
+        transcript = Transcript(
+            segments=[TranscriptSegment(start=1.0, end=2.0, text="a")],
+            language="de",
+            duration=2.0,
+        )
+        part = VideoPart(index=0, path=Path("p0.mp4"), duration=2.0, offset=0.0)
+        result = offset_transcript(transcript, part)
+        assert result.segments[0].start == pytest.approx(1.0)
+        assert result.segments[0].source_part_index == 0
+
+
+# ---------------------------------------------------------------------------
+# offset_events
+# ---------------------------------------------------------------------------
+
+
+class TestOffsetEvents:
+    def test_timestamps_offset(self):
+        events = [
+            TransitionEvent(timestamp=5.0, peak_diff=0.5, confidence=3.0, num_frames=2),
+            TransitionEvent(timestamp=15.0, peak_diff=0.7, confidence=4.0, num_frames=3),
+        ]
+        part = VideoPart(index=1, path=Path("p1.mp4"), duration=20.0, offset=100.0)
+        result = offset_events(events, part)
+
+        assert result[0].timestamp == pytest.approx(105.0)
+        assert result[1].timestamp == pytest.approx(115.0)
+
+    def test_local_timestamp_preserved(self):
+        events = [
+            TransitionEvent(timestamp=5.0, peak_diff=0.5, confidence=3.0, num_frames=2),
+        ]
+        part = VideoPart(index=1, path=Path("p1.mp4"), duration=20.0, offset=100.0)
+        result = offset_events(events, part)
+        assert result[0].local_timestamp == pytest.approx(5.0)
+
+    def test_source_part_index_set(self):
+        events = [
+            TransitionEvent(timestamp=5.0, peak_diff=0.5, confidence=3.0, num_frames=2),
+        ]
+        part = VideoPart(index=2, path=Path("p2.mp4"), duration=20.0, offset=200.0)
+        result = offset_events(events, part)
+        assert result[0].source_part_index == 2
+
+    def test_peak_diff_and_confidence_preserved(self):
+        events = [
+            TransitionEvent(timestamp=5.0, peak_diff=0.42, confidence=3.7, num_frames=5),
+        ]
+        part = VideoPart(index=0, path=Path("p0.mp4"), duration=20.0, offset=0.0)
+        result = offset_events(events, part)
+        assert result[0].peak_diff == pytest.approx(0.42)
+        assert result[0].confidence == pytest.approx(3.7)
+        assert result[0].num_frames == 5
+
+
+# ---------------------------------------------------------------------------
+# merge_transcripts
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTranscripts:
+    def test_merge_two(self):
+        t1 = Transcript(
+            segments=[TranscriptSegment(start=0.0, end=5.0, text="a", source_part_index=0)],
+            language="de",
+            duration=10.0,
+        )
+        t2 = Transcript(
+            segments=[TranscriptSegment(start=10.0, end=15.0, text="b", source_part_index=1)],
+            language="de",
+            duration=10.0,
+        )
+        merged = merge_transcripts([t1, t2])
+        assert len(merged.segments) == 2
+        assert merged.duration == pytest.approx(20.0)
+        assert merged.language == "de"
+
+    def test_segments_in_order(self):
+        t1 = Transcript(
+            segments=[
+                TranscriptSegment(start=0.0, end=3.0, text="first"),
+                TranscriptSegment(start=3.0, end=6.0, text="second"),
+            ],
+            language="en",
+            duration=10.0,
+        )
+        t2 = Transcript(
+            segments=[
+                TranscriptSegment(start=10.0, end=13.0, text="third"),
+            ],
+            language="en",
+            duration=10.0,
+        )
+        merged = merge_transcripts([t1, t2])
+        texts = [s.text for s in merged.segments]
+        assert texts == ["first", "second", "third"]
+
+    def test_timestamps_monotonic_across_parts(self):
+        """Merged timestamps should be monotonically increasing."""
+        t1 = Transcript(
+            segments=[
+                TranscriptSegment(start=0.0, end=5.0, text="a", source_part_index=0),
+                TranscriptSegment(start=5.0, end=10.0, text="b", source_part_index=0),
+            ],
+            language="de",
+            duration=10.0,
+        )
+        t2 = Transcript(
+            segments=[
+                TranscriptSegment(start=10.0, end=15.0, text="c", source_part_index=1),
+                TranscriptSegment(start=15.0, end=20.0, text="d", source_part_index=1),
+            ],
+            language="de",
+            duration=10.0,
+        )
+        merged = merge_transcripts([t1, t2])
+        starts = [s.start for s in merged.segments]
+        assert starts == sorted(starts)
+
+    def test_total_duration_is_sum(self):
+        parts = [
+            Transcript(segments=[], language="de", duration=100.0),
+            Transcript(segments=[], language="de", duration=200.0),
+            Transcript(segments=[], language="de", duration=150.0),
+        ]
+        merged = merge_transcripts(parts)
+        assert merged.duration == pytest.approx(450.0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: full per-part pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestMultiPartPipeline:
+    """Integration test using the timeline module end-to-end."""
+
+    @patch("clm.voiceover.timeline.probe_duration")
+    def test_three_part_offset_chain(self, mock_probe):
+        """Three parts produce correctly offset segments and events."""
+        mock_probe.side_effect = [60.0, 120.0, 90.0]
+        paths = [Path("p0.mp4"), Path("p1.mp4"), Path("p2.mp4")]
+        parts = build_parts(paths)
+
+        # Simulate per-part transcripts and events
+        transcripts = []
+        all_events = []
+
+        for part in parts:
+            seg = TranscriptSegment(start=1.0, end=2.0, text=f"part{part.index}")
+            t = Transcript(segments=[seg], language="de", duration=part.duration)
+            transcripts.append(offset_transcript(t, part))
+
+            ev = TransitionEvent(timestamp=0.5, peak_diff=0.5, confidence=3.0, num_frames=1)
+            all_events.extend(offset_events([ev], part))
+
+        merged = merge_transcripts(transcripts)
+
+        # Check segment offsets
+        assert merged.segments[0].start == pytest.approx(1.0)  # part 0: offset=0
+        assert merged.segments[1].start == pytest.approx(61.0)  # part 1: offset=60
+        assert merged.segments[2].start == pytest.approx(181.0)  # part 2: offset=180
+
+        # Check event offsets
+        assert all_events[0].timestamp == pytest.approx(0.5)  # part 0
+        assert all_events[1].timestamp == pytest.approx(60.5)  # part 1
+        assert all_events[2].timestamp == pytest.approx(180.5)  # part 2
+
+        # Check local timestamps
+        assert all_events[0].local_timestamp == pytest.approx(0.5)
+        assert all_events[1].local_timestamp == pytest.approx(0.5)
+        assert all_events[2].local_timestamp == pytest.approx(0.5)
+
+        # Check source_part_index
+        assert [s.source_part_index for s in merged.segments] == [0, 1, 2]
+        assert [e.source_part_index for e in all_events] == [0, 1, 2]
+
+        # Check total duration
+        assert merged.duration == pytest.approx(270.0)
+
+    @patch("clm.voiceover.timeline.probe_duration")
+    def test_single_part_matches_direct_behavior(self, mock_probe):
+        """Single-part should produce same timestamps as direct (no offset)."""
+        mock_probe.return_value = 300.0
+        parts = build_parts([Path("single.mp4")])
+
+        seg = TranscriptSegment(start=10.0, end=20.0, text="content")
+        transcript = Transcript(segments=[seg], language="en", duration=300.0)
+        result = offset_transcript(transcript, parts[0])
+
+        # With offset=0, timestamps are unchanged
+        assert result.segments[0].start == pytest.approx(10.0)
+        assert result.segments[0].end == pytest.approx(20.0)
+        assert result.segments[0].source_part_index == 0

--- a/tests/voiceover/test_trace_log.py
+++ b/tests/voiceover/test_trace_log.py
@@ -1,0 +1,228 @@
+"""Tests for voiceover trace log module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clm.voiceover.trace_log import TraceLog
+
+
+class TestTraceLogCreate:
+    def test_creates_trace_dir(self, tmp_path):
+        trace = TraceLog.create("slides_intro.py", base_dir=tmp_path)
+        traces_dir = tmp_path / ".clm" / "voiceover-traces"
+        assert traces_dir.exists()
+
+    def test_log_path_contains_stem_and_timestamp(self, tmp_path):
+        trace = TraceLog.create("slides_intro.py", base_dir=tmp_path)
+        assert "slides_intro" in trace.path.name
+        assert trace.path.suffix == ".jsonl"
+
+    def test_log_path_in_correct_directory(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        assert trace.path.parent == tmp_path / ".clm" / "voiceover-traces"
+
+
+class TestTraceLogWrite:
+    def test_writes_jsonl_line(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="slides_test/1",
+            language="de",
+            baseline="- existing",
+            transcript="new content",
+            llm_merged="- existing\n- new content",
+            rewrites=[],
+            dropped_from_transcript=["willkommen zurück"],
+        )
+
+        lines = trace.path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 1
+
+        entry = json.loads(lines[0])
+        assert entry["slide_id"] == "slides_test/1"
+        assert entry["language"] == "de"
+        assert entry["baseline"] == "- existing"
+        assert entry["transcript"] == "new content"
+        assert entry["llm_merged"] == "- existing\n- new content"
+        assert entry["rewrites"] == []
+        assert entry["dropped_from_transcript"] == ["willkommen zurück"]
+
+    def test_multiple_writes_append(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+
+        for i in range(3):
+            trace.log_merge_call(
+                slide_id=f"slides_test/{i}",
+                language="en",
+                baseline=f"- baseline {i}",
+                transcript=f"transcript {i}",
+                llm_merged=f"- merged {i}",
+                rewrites=[],
+                dropped_from_transcript=[],
+            )
+
+        lines = trace.path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 3
+
+        for i, line in enumerate(lines):
+            entry = json.loads(line)
+            assert entry["slide_id"] == f"slides_test/{i}"
+
+    def test_includes_timestamp(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert "timestamp" in entry
+        assert "T" in entry["timestamp"]  # ISO format
+
+    def test_includes_slide_file(self, tmp_path):
+        trace = TraceLog.create("slides_intro.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["slide_file"] == "slides_intro.py"
+
+    def test_includes_git_head(self, tmp_path):
+        with patch("clm.voiceover.trace_log._get_git_head", return_value="abc123"):
+            trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["git_head"] == "abc123"
+
+    def test_git_head_none_when_not_in_repo(self, tmp_path):
+        with patch("clm.voiceover.trace_log._get_git_head", return_value=None):
+            trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["git_head"] is None
+
+    def test_langfuse_trace_id_included_when_set(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+            langfuse_trace_id="lf-abc123",
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["langfuse_trace_id"] == "lf-abc123"
+
+    def test_langfuse_trace_id_omitted_when_none(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert "langfuse_trace_id" not in entry
+
+    def test_rewrites_structure(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="- wrong fact",
+            transcript="corrected",
+            llm_merged="- corrected fact",
+            rewrites=[
+                {
+                    "original": "- wrong fact",
+                    "revised": "- corrected fact",
+                    "transcript_evidence": "the trainer corrected this",
+                }
+            ],
+            dropped_from_transcript=["hello", "goodbye"],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert len(entry["rewrites"]) == 1
+        assert entry["rewrites"][0]["original"] == "- wrong fact"
+        assert len(entry["dropped_from_transcript"]) == 2
+
+
+class TestTraceLogRequiredFields:
+    """Verify all required fields are present in every log entry."""
+
+    REQUIRED_FIELDS = {
+        "timestamp",
+        "slide_file",
+        "slide_id",
+        "language",
+        "baseline",
+        "transcript",
+        "llm_merged",
+        "rewrites",
+        "dropped_from_transcript",
+        "git_head",
+    }
+
+    def test_all_required_fields_present(self, tmp_path):
+        with patch("clm.voiceover.trace_log._get_git_head", return_value="deadbeef"):
+            trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="de",
+            baseline="- test",
+            transcript="test transcript",
+            llm_merged="- merged test",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        missing = self.REQUIRED_FIELDS - set(entry.keys())
+        assert not missing, f"Missing required fields: {missing}"

--- a/tests/voiceover/test_training_export.py
+++ b/tests/voiceover/test_training_export.py
@@ -1,0 +1,657 @@
+"""Tests for voiceover training data extraction module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clm.voiceover.training_export import (
+    TraceEntry,
+    TrainingTriple,
+    _compute_delta,
+    _read_voiceover_for_slide,
+    extract_training_data,
+    read_trace_log,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SLIDE_FILE_CONTENT = """\
+# j2 from 'macros.j2' import header
+# {{ header("Test", "Test") }}
+
+# %% [markdown] lang="de" tags=["slide"]
+# ## Slide 1 Title
+
+# %% [markdown] lang="de" tags=["voiceover"]
+# - Existing bullet from hand edit
+# - Another edited bullet
+
+# %% [markdown] lang="de" tags=["slide"]
+# ## Slide 2 Title
+
+# %% [markdown] lang="de" tags=["voiceover"]
+# - Slide 2 voiceover after editing
+
+# %% [markdown] lang="de" tags=["slide"]
+# ## Slide 3 No Voiceover
+"""
+
+
+def _make_trace_entry(
+    slide_id: str = "slides_test/1",
+    baseline: str = "- original baseline",
+    transcript: str = "the trainer said something new",
+    llm_merged: str = "- original baseline\n- something new",
+    git_head: str | None = "abc123",
+    **kwargs,
+) -> dict:
+    """Build a trace log entry dict."""
+    entry = {
+        "timestamp": "2026-04-12T01:20:20Z",
+        "slide_file": "slides_test.py",
+        "slide_id": slide_id,
+        "language": "de",
+        "baseline": baseline,
+        "transcript": transcript,
+        "llm_merged": llm_merged,
+        "rewrites": [],
+        "dropped_from_transcript": [],
+        "git_head": git_head,
+    }
+    entry.update(kwargs)
+    return entry
+
+
+def _write_trace_log(tmp_path: Path, entries: list[dict]) -> Path:
+    """Write a JSONL trace log and return its path."""
+    # Simulate the .clm/voiceover-traces/ directory structure
+    traces_dir = tmp_path / ".clm" / "voiceover-traces"
+    traces_dir.mkdir(parents=True, exist_ok=True)
+    log_path = traces_dir / "slides_test-20260412-012020.jsonl"
+    lines = [json.dumps(e, ensure_ascii=False) for e in entries]
+    log_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return log_path
+
+
+# ---------------------------------------------------------------------------
+# read_trace_log
+# ---------------------------------------------------------------------------
+
+
+class TestReadTraceLog:
+    def test_reads_single_entry(self, tmp_path):
+        entry = _make_trace_entry()
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        entries = read_trace_log(log_path)
+        assert len(entries) == 1
+        assert entries[0].slide_id == "slides_test/1"
+        assert entries[0].language == "de"
+        assert entries[0].baseline == "- original baseline"
+
+    def test_reads_multiple_entries(self, tmp_path):
+        entries_data = [
+            _make_trace_entry(slide_id="slides_test/1"),
+            _make_trace_entry(slide_id="slides_test/2"),
+            _make_trace_entry(slide_id="slides_test/3"),
+        ]
+        log_path = _write_trace_log(tmp_path, entries_data)
+
+        entries = read_trace_log(log_path)
+        assert len(entries) == 3
+        assert [e.slide_id for e in entries] == [
+            "slides_test/1",
+            "slides_test/2",
+            "slides_test/3",
+        ]
+
+    def test_skips_malformed_lines(self, tmp_path):
+        traces_dir = tmp_path / ".clm" / "voiceover-traces"
+        traces_dir.mkdir(parents=True, exist_ok=True)
+        log_path = traces_dir / "bad.jsonl"
+        log_path.write_text(
+            json.dumps(_make_trace_entry()) + "\n"
+            "not valid json\n" + json.dumps(_make_trace_entry(slide_id="slides_test/2")) + "\n",
+            encoding="utf-8",
+        )
+
+        entries = read_trace_log(log_path)
+        assert len(entries) == 2
+
+    def test_skips_empty_lines(self, tmp_path):
+        traces_dir = tmp_path / ".clm" / "voiceover-traces"
+        traces_dir.mkdir(parents=True, exist_ok=True)
+        log_path = traces_dir / "empty.jsonl"
+        log_path.write_text(
+            json.dumps(_make_trace_entry())
+            + "\n\n\n"
+            + json.dumps(_make_trace_entry(slide_id="slides_test/2"))
+            + "\n",
+            encoding="utf-8",
+        )
+
+        entries = read_trace_log(log_path)
+        assert len(entries) == 2
+
+    def test_preserves_langfuse_trace_id(self, tmp_path):
+        entry = _make_trace_entry(langfuse_trace_id="lf-xyz")
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        entries = read_trace_log(log_path)
+        assert entries[0].langfuse_trace_id == "lf-xyz"
+
+    def test_handles_missing_optional_fields(self, tmp_path):
+        # Minimal entry with only required fields
+        minimal = {
+            "slide_file": "slides.py",
+            "slide_id": "slides/1",
+            "language": "en",
+            "baseline": "",
+            "transcript": "text",
+            "llm_merged": "- text",
+        }
+        log_path = _write_trace_log(tmp_path, [minimal])
+
+        entries = read_trace_log(log_path)
+        assert len(entries) == 1
+        assert entries[0].git_head is None
+        assert entries[0].rewrites == []
+        assert entries[0].dropped_from_transcript == []
+        assert entries[0].langfuse_trace_id is None
+
+    def test_preserves_rewrites_structure(self, tmp_path):
+        entry = _make_trace_entry(
+            rewrites=[
+                {
+                    "original": "- wrong",
+                    "revised": "- correct",
+                    "transcript_evidence": "actually...",
+                }
+            ],
+            dropped_from_transcript=["willkommen zurück"],
+        )
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        entries = read_trace_log(log_path)
+        assert len(entries[0].rewrites) == 1
+        assert entries[0].rewrites[0]["original"] == "- wrong"
+        assert entries[0].dropped_from_transcript == ["willkommen zurück"]
+
+
+# ---------------------------------------------------------------------------
+# _compute_delta
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDelta:
+    def test_identical_returns_empty(self):
+        assert _compute_delta("- bullet one\n- bullet two", "- bullet one\n- bullet two") == ""
+
+    def test_identical_ignoring_trailing_whitespace(self):
+        assert _compute_delta("- bullet one\n- bullet two  ", "- bullet one\n- bullet two") == ""
+
+    def test_different_returns_unified_diff(self):
+        delta = _compute_delta("- old bullet", "- new bullet")
+        assert delta != ""
+        assert "--- llm_output" in delta
+        assert "+++ human_final" in delta
+        assert "- old bullet" in delta or "-- old bullet" in delta
+        assert "+ new bullet" in delta or "+- new bullet" in delta
+
+    def test_addition_in_diff(self):
+        delta = _compute_delta("- bullet one", "- bullet one\n- added bullet")
+        assert delta != ""
+        assert "added bullet" in delta
+
+    def test_empty_strings_identical(self):
+        assert _compute_delta("", "") == ""
+
+
+# ---------------------------------------------------------------------------
+# _read_voiceover_for_slide
+# ---------------------------------------------------------------------------
+
+
+class TestReadVoiceoverForSlide:
+    def test_reads_existing_voiceover(self, tmp_path):
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        text = _read_voiceover_for_slide(slide_file, "slides_test/1", "de")
+        assert text is not None
+        assert "Existing bullet from hand edit" in text
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        slide_file = tmp_path / "nonexistent.py"
+        result = _read_voiceover_for_slide(slide_file, "s/1", "de")
+        assert result is None
+
+    def test_returns_none_for_missing_slide(self, tmp_path):
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        # Slide index 99 doesn't exist
+        result = _read_voiceover_for_slide(slide_file, "slides_test/99", "de")
+        assert result is None
+
+    def test_returns_empty_for_slide_without_voiceover(self, tmp_path):
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        # Slide 3 has no voiceover cell
+        result = _read_voiceover_for_slide(slide_file, "slides_test/3", "de")
+        assert result is not None
+        assert result == ""
+
+    def test_reads_correct_slide_by_index(self, tmp_path):
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        text = _read_voiceover_for_slide(slide_file, "slides_test/2", "de")
+        assert text is not None
+        assert "Slide 2 voiceover" in text
+
+    def test_invalid_slide_id_format(self, tmp_path):
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        result = _read_voiceover_for_slide(slide_file, "invalid", "de")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TrainingTriple.to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingTripleToDict:
+    def test_serializes_all_fields(self):
+        triple = TrainingTriple(
+            slide_file="slides.py",
+            slide_id="slides/1",
+            language="de",
+            input_baseline="- baseline",
+            input_transcript="transcript text",
+            llm_output="- merged",
+            human_final="- hand edited",
+            delta_vs_llm="--- a\n+++ b\n",
+            rewrites=[{"original": "x", "revised": "y"}],
+            dropped_from_transcript=["hello"],
+            git_head="abc123",
+            timestamp="2026-04-12T01:20:20Z",
+        )
+        d = triple.to_dict()
+        assert d["slide_file"] == "slides.py"
+        assert d["input"]["baseline"] == "- baseline"
+        assert d["input"]["transcript"] == "transcript text"
+        assert d["llm_output"] == "- merged"
+        assert d["human_final"] == "- hand edited"
+        assert d["delta_vs_llm"] == "--- a\n+++ b\n"
+        assert len(d["rewrites"]) == 1
+        assert d["git_head"] == "abc123"
+
+    def test_json_serializable(self):
+        triple = TrainingTriple(
+            slide_file="s.py",
+            slide_id="s/1",
+            language="en",
+            input_baseline="",
+            input_transcript="t",
+            llm_output="- t",
+            human_final="- t",
+            delta_vs_llm="",
+        )
+        # Should not raise
+        json.dumps(triple.to_dict(), ensure_ascii=False)
+
+    def test_positive_example_has_empty_delta(self):
+        triple = TrainingTriple(
+            slide_file="s.py",
+            slide_id="s/1",
+            language="en",
+            input_baseline="",
+            input_transcript="t",
+            llm_output="- t",
+            human_final="- t",
+            delta_vs_llm="",
+        )
+        d = triple.to_dict()
+        assert d["delta_vs_llm"] == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_training_data (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTrainingData:
+    def test_basic_extraction(self, tmp_path):
+        """Normal case: trace entry matches slide file, human edited."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(
+            slide_id="slides_test/1",
+            llm_merged="- LLM produced this",
+        )
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 1
+        assert triples[0].slide_id == "slides_test/1"
+        assert triples[0].llm_output == "- LLM produced this"
+        assert "Existing bullet from hand edit" in triples[0].human_final
+        # LLM output != human final, so delta should be non-empty
+        assert triples[0].delta_vs_llm != ""
+
+    def test_positive_example_no_edits(self, tmp_path):
+        """human_final == llm_output → empty delta_vs_llm."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        # Read what the parser will return for slide 2
+        from clm.notebooks.slide_parser import parse_slides
+
+        groups = parse_slides(slide_file, "de")
+        slide2_text = ""
+        for sg in groups:
+            if sg.index == 2:
+                for cell in sg.notes_cells:
+                    if "voiceover" in cell.metadata.tags:
+                        slide2_text = cell.text_content()
+                break
+
+        entry = _make_trace_entry(
+            slide_id="slides_test/2",
+            llm_merged=slide2_text,
+        )
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 1
+        assert triples[0].delta_vs_llm == ""
+
+    def test_skips_unreachable_git_head(self, tmp_path):
+        """Entries with unreachable git_head are skipped with warning."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(git_head="deadbeef123")
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=False,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 0
+
+    def test_no_check_git_skips_validation(self, tmp_path):
+        """check_git_head=False bypasses the reachability check."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(git_head="deadbeef123")
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        # Don't mock _git_commit_exists — it should not be called
+        triples = extract_training_data(log_path, base_dir=tmp_path, check_git_head=False)
+
+        assert len(triples) == 1
+
+    def test_skips_missing_slide_file(self, tmp_path):
+        """Entries whose slide file doesn't exist are skipped."""
+        entry = _make_trace_entry(slide_id="slides_test/1")
+        log_path = _write_trace_log(tmp_path, [entry])
+        # No slide file written to tmp_path
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 0
+
+    def test_skips_missing_slide_in_file(self, tmp_path):
+        """Entries for a slide index not present in the file are skipped."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(slide_id="slides_test/99")
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 0
+
+    def test_multiple_entries(self, tmp_path):
+        """Multiple trace entries produce multiple triples."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entries = [
+            _make_trace_entry(slide_id="slides_test/1", llm_merged="- llm slide 1"),
+            _make_trace_entry(slide_id="slides_test/2", llm_merged="- llm slide 2"),
+        ]
+        log_path = _write_trace_log(tmp_path, entries)
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 2
+        assert triples[0].slide_id == "slides_test/1"
+        assert triples[1].slide_id == "slides_test/2"
+
+    def test_null_git_head_not_checked(self, tmp_path):
+        """Entries with git_head=None are not checked for reachability."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(git_head=None)
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        # check_git_head=True but git_head is None → should not call _git_commit_exists
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+        ) as mock_check:
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        mock_check.assert_not_called()
+        assert len(triples) == 1
+
+    def test_default_base_dir_from_trace_path(self, tmp_path):
+        """base_dir defaults to trace log's grandparent (project root)."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry()
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            # Don't pass base_dir — should infer from trace log path
+            triples = extract_training_data(log_path)
+
+        assert len(triples) == 1
+
+    def test_preserves_metadata_in_triples(self, tmp_path):
+        """Rewrites, dropped phrases, and timestamps are preserved."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(
+            rewrites=[{"original": "- x", "revised": "- y"}],
+            dropped_from_transcript=["willkommen"],
+            timestamp="2026-04-12T01:20:20Z",
+        )
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 1
+        assert triples[0].rewrites == [{"original": "- x", "revised": "- y"}]
+        assert triples[0].dropped_from_transcript == ["willkommen"]
+        assert triples[0].timestamp == "2026-04-12T01:20:20Z"
+
+    def test_slide_without_voiceover_gives_empty_human_final(self, tmp_path):
+        """A slide with no voiceover cell produces empty human_final."""
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(
+            slide_id="slides_test/3",
+            llm_merged="- something the LLM wrote",
+        )
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            triples = extract_training_data(log_path, base_dir=tmp_path)
+
+        assert len(triples) == 1
+        assert triples[0].human_final == ""
+        # LLM wrote something but human removed it → non-empty delta
+        assert triples[0].delta_vs_llm != ""
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTrainingDataCLI:
+    def test_help_text(self):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["extract-training-data", "--help"])
+        assert result.exit_code == 0
+        assert "training" in result.output.lower()
+        assert "--no-check-git" in result.output
+        assert "--tag" in result.output
+
+    def test_basic_invocation(self, tmp_path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(llm_merged="- from LLM")
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        runner = CliRunner()
+        with patch(
+            "clm.voiceover.training_export._git_commit_exists",
+            return_value=True,
+        ):
+            result = runner.invoke(
+                voiceover_group,
+                [
+                    "extract-training-data",
+                    str(log_path),
+                    "--base-dir",
+                    str(tmp_path),
+                    "--no-check-git",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Output should contain JSON
+        output_lines = [line for line in result.output.strip().split("\n") if line.startswith("{")]
+        assert len(output_lines) == 1
+        data = json.loads(output_lines[0])
+        assert data["slide_id"] == "slides_test/1"
+        assert "input" in data
+        assert "llm_output" in data
+
+    def test_output_to_file(self, tmp_path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        slide_file = tmp_path / "slides_test.py"
+        slide_file.write_text(SLIDE_FILE_CONTENT, encoding="utf-8")
+
+        entry = _make_trace_entry(llm_merged="- from LLM")
+        log_path = _write_trace_log(tmp_path, [entry])
+        output_file = tmp_path / "output.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "extract-training-data",
+                str(log_path),
+                "--base-dir",
+                str(tmp_path),
+                "--no-check-git",
+                "-o",
+                str(output_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        data = json.loads(output_file.read_text(encoding="utf-8").strip())
+        assert data["slide_id"] == "slides_test/1"
+
+    def test_no_results_message(self, tmp_path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        # Trace log referencing a slide file that doesn't exist
+        entry = _make_trace_entry()
+        log_path = _write_trace_log(tmp_path, [entry])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "extract-training-data",
+                str(log_path),
+                "--base-dir",
+                str(tmp_path),
+                "--no-check-git",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "No training triples" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1074,6 +1074,7 @@ tui = [
 ]
 voiceover = [
     { name = "faster-whisper" },
+    { name = "langfuse" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pytesseract" },
@@ -1157,6 +1158,7 @@ requires-dist = [
     { name = "langchain-qdrant", marker = "extra == 'ml'" },
     { name = "langchain-text-splitters", marker = "extra == 'ml'" },
     { name = "langfuse", marker = "extra == 'ml'" },
+    { name = "langfuse", marker = "extra == 'voiceover'", specifier = ">=3.0.0" },
     { name = "langgraph", marker = "extra == 'ml'", specifier = ">=1.1.2" },
     { name = "langsmith", marker = "extra == 'ml'" },
     { name = "loguru", specifier = ">=0.7.0" },


### PR DESCRIPTION
## Summary

- **Phase 1**: `clm voiceover sync` now accepts multiple video files (`sync SLIDES VIDEO...`), processing each part independently with running offsets into a single logical timeline. Breaking CLI change: argument order flipped from `sync VIDEO SLIDES` to `sync SLIDES VIDEO...`.
- **Phase 2**: Default behavior changed from overwrite to merge. Single-pass LLM call preserves baseline voiceover content, integrates transcript additions, and filters recording noise (greetings, self-corrections, code-typing dictation). `--overwrite` restores old behavior. JSONL trace log written on every run.
- **Phase 3**: Langfuse tracing for all LLM calls when env vars are set. Benefits all LLM-using modules, not just voiceover. Falls back gracefully when Langfuse is unavailable.
- **Phase 4**: `clm voiceover extract-training-data` reads trace logs and correlates with current slide state to produce training triples for fine-tuning.

245 voiceover tests, 3103 total tests pass. Design doc: `docs/proposals/VOICEOVER_SYNC_IMPROVEMENTS.md`.

## Test plan

- [ ] `uv run pytest` (fast suite, 3103 tests)
- [ ] `uv run pytest -m "not docker"` (pre-release full run)
- [ ] Verify `clm voiceover sync --help` shows new options
- [ ] Verify `clm voiceover extract-training-data --help` works
- [ ] Smoke test multi-file sync against real OBS recordings

🤖 Generated with [Claude Code](https://claude.com/claude-code)