### PR TITLE
feat(jupyterlite): report JupyterLite generation as its own build phase

### DIFF
--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -663,12 +663,20 @@ async def process_course_with_backend(
 ):
     """Process course and optionally watch for changes."""
     from clm.core.utils.execution_utils import (
+        JUPYTERLITE_STAGE,
         NUM_EXECUTION_STAGES,
         execution_stages,
         get_stage_name,
     )
 
     only_sections_mode = config.resolved_section_selection is not None
+
+    # JupyterLite runs as its own phase after the per-file stages so the
+    # progress bar doesn't overrun the HTML stage total. It is skipped in
+    # `--only-sections` mode and when no target opts in.
+    jupyterlite_job_count = 0 if only_sections_mode else course.count_jupyterlite_operations()
+    has_jupyterlite_phase = jupyterlite_job_count > 0
+    total_stages = NUM_EXECUTION_STAGES + (1 if has_jupyterlite_phase else 0)
 
     async def _run_stages() -> None:
         _report_duplicate_file_warnings(course, build_reporter)
@@ -697,6 +705,11 @@ async def process_course_with_backend(
             # dir-groups run a full build.
             if not only_sections_mode:
                 await course.process_dir_group(backend)
+                if has_jupyterlite_phase:
+                    build_reporter.start_stage(
+                        get_stage_name(JUPYTERLITE_STAGE),
+                        jupyterlite_job_count,
+                    )
                 await course.process_jupyterlite_for_targets(backend)
 
         finally:
@@ -731,7 +744,7 @@ async def process_course_with_backend(
         build_reporter.start_build(
             course_name=course.name.en,
             total_files=total_files,
-            total_stages=NUM_EXECUTION_STAGES,
+            total_stages=total_stages,
             output_dirs=output_dir_names,
         )
 
@@ -758,7 +771,7 @@ async def process_course_with_backend(
             build_reporter.start_build(
                 course_name=course.name.en,
                 total_files=total_files,
-                total_stages=NUM_EXECUTION_STAGES,
+                total_stages=total_stages,
                 output_dirs=output_dir_names,
             )
 

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -389,6 +389,27 @@ class Course(NotebookMixin):
 
         return total_count
 
+    def count_jupyterlite_operations(self) -> int:
+        """Count JupyterLite site-build jobs that will be submitted.
+
+        Matches the iteration in :meth:`process_jupyterlite_for_targets`:
+        one job per ``(target, language)`` pair on targets that both
+        include the ``jupyterlite`` format and resolve to a non-``None``
+        :py:meth:`OutputTarget.effective_jupyterlite_config`.
+
+        Returns:
+            Number of ``BuildJupyterLiteSiteOperation`` jobs that will be
+            submitted for this course, or ``0`` if no target opts in.
+        """
+        count = 0
+        for target in self.output_targets:
+            if not target.includes_format("jupyterlite"):
+                continue
+            if target.effective_jupyterlite_config() is None:
+                continue
+            count += len(target.languages)
+        return count
+
     async def process_jupyterlite_for_targets(self, backend: Backend):
         """Submit JupyterLite site-build jobs for any opted-in target.
 

--- a/src/clm/core/utils/execution_utils.py
+++ b/src/clm/core/utils/execution_utils.py
@@ -26,12 +26,19 @@ HTML_COMPLETED_STAGE = 4
 LAST_EXECUTION_STAGE = 4
 NUM_EXECUTION_STAGES = LAST_EXECUTION_STAGE - FIRST_EXECUTION_STAGE + 1
 
+# Post-processing phases that do not iterate per-file and therefore are
+# not part of ``execution_stages()``. They are still surfaced to the
+# build reporter as distinct phases so that progress reporting shows a
+# fresh progress bar (instead of overrunning the last file stage).
+JUPYTERLITE_STAGE = LAST_EXECUTION_STAGE + 1
+
 # Human-readable names for each execution stage
 STAGE_NAMES: dict[int, str] = {
     FIRST_EXECUTION_STAGE: "Processing",
     COPY_GENERATED_IMAGES_STAGE: "Images",
     HTML_SPEAKER_STAGE: "HTML Speaker",
     HTML_COMPLETED_STAGE: "HTML Completed",
+    JUPYTERLITE_STAGE: "JupyterLite",
 }
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

- JupyterLite site generation now appears as its own phase in the CLI build reporter (e.g. `Stage 5/5: JupyterLite`) instead of running silently after stage 4.
- Previously the HTML Completed progress bar appeared stuck at 44/44 and then counted past the total (45/44, 46/44…) while JupyterLite ran — because job-completion callbacks kept attributing to the last started stage.
- Adds `JUPYTERLITE_STAGE` + stage name, a `Course.count_jupyterlite_operations()` helper that mirrors the submission loop in `process_jupyterlite_for_targets`, and a `build_reporter.start_stage("JupyterLite", n)` call right before JupyterLite generation. `total_stages` passed to `start_build` is now dynamic (only includes the JupyterLite phase when at least one target opts in, and never in `--only-sections` mode).

## Test plan

- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy` on modified files
- [x] `uv run pytest tests/cli/test_build_output.py tests/workers/jupyterlite/ tests/core/operations/ tests/core/test_output_target.py tests/core/test_output_target_spec.py tests/core/course_spec_test.py`
- [x] Pre-commit hook (fast pytest suite) passes on commit
- [ ] Manually verify on a course with a `jupyterlite` target that the CLI now shows a fresh `Stage N/N: JupyterLite` bar with correct totals after HTML Completed finishes
- [ ] Verify `--only-sections` builds still show 4 stages total

🤖 Generated with [Claude Code](https://claude.com/claude-code)