### PR TITLE
Recordings UX redesign: one-click record, takes model, live job progress, reconcile

### DIFF
--- a/docs/claude/design/recordings-job-progress-and-reconciliation.md
+++ b/docs/claude/design/recordings-job-progress-and-reconciliation.md
@@ -1,0 +1,305 @@
+# Recordings: Job Progress UX and Reconciliation
+
+**Status**: Draft for discussion
+**Author**: Claude (Opus 4.7) + TC
+**Date**: 2026-04-17
+**Scope**: `src/clm/recordings/workflow/job_manager.py`, `backends/auphonic.py`, `backends/auphonic_client.py`, `src/clm/recordings/web/`
+
+---
+
+## 1. Problems
+
+Two distinct pain points with the Processing Jobs pane, both observed on the Auphonic backend:
+
+### 1.1 UI appears frozen for minutes at a time
+
+During a long Auphonic job, the dashboard shows no change for several minutes even though work is happening. Three contributors, in rough order of impact:
+
+1. **Polling gaps.** `AUPHONIC_POLL_INITIAL_SECONDS = 30` (`auphonic.py:54`). Between the end of the upload phase and the first poll-based status update, 30 seconds pass with no new events. After 30 minutes the gap grows to 5 minutes (`AUPHONIC_POLL_LONG_SECONDS = 300`).
+2. **Upload progress is chunk-granular.** `DEFAULT_UPLOAD_CHUNK_SIZE = 8 MiB` (`auphonic_client.py:46`). On a slow uplink, each chunk is many seconds, and the progress bar only ticks when a chunk completes.
+3. **No elapsed-time heartbeat.** Between state transitions the job's `message` stays constant, so even when the poller runs it doesn't push a new SSE payload that looks different to the user.
+
+### 1.2 Jobs get stuck in a FAILED state even when Auphonic finished the work
+
+Concrete incident: user stopped the CLM server while an Auphonic job was processing. On restart the job showed up as FAILED, but Auphonic had actually completed the production on its end. Two code paths contribute:
+
+- `JobManager.__init__` (`job_manager.py:159`) transitions any `UPLOADING` job to FAILED with "Upload was interrupted by a process restart." If the upload actually *completed* before the crash, the production is fine upstream but we've already marked the job failed.
+- `_has_timed_out` (`auphonic.py:509`) fails any `PROCESSING` job whose `started_at + 120 min` is in the past. If the server was down for more than 120 minutes, every in-flight job fails on the first poll after restart — regardless of what Auphonic actually thinks.
+
+There is no reconciliation path today: the `AuphonicClient` has no `list_productions`, the backend has no `reconcile_job` method, and the UI has no "verify state" action.
+
+## 2. Goals
+
+1. Make the UI feel alive during Auphonic processing — every phase should have at least one visible tick per 5–10 seconds.
+2. Give the user a one-click way to reconcile any job's displayed state against reality (upstream API + local filesystem).
+3. Stop auto-failing jobs whose backend work is actually fine.
+4. Make the reconciliation protocol generic so audio-first backends (ONNX, External, RX 11) can use it too.
+
+## 3. Non-goals
+
+- Webhook-based Auphonic updates. Polling is fine; we just need it to be tighter and more generous about errors.
+- A full job-orchestration rewrite. This is an additive set of improvements to the existing `JobManager` / backend Protocol.
+- Retroactive fixing of jobs marked FAILED before this work lands. The reconcile action will naturally repair them on-demand.
+
+## 4. Live progress updates
+
+### 4.1 Time-based upload progress callback
+
+Change `AuphonicClient.upload_input` (`auphonic_client.py:382`) so `on_progress` fires on a time cadence *in addition to* on chunk boundaries. Implementation sketch:
+
+```python
+UPLOAD_PROGRESS_MIN_INTERVAL = 0.25  # seconds
+
+last_report = time.monotonic()
+for chunk in _read_chunks(path, self._chunk_size):
+    ... upload the chunk ...
+    sent += len(chunk)
+    now = time.monotonic()
+    if on_progress is not None and total_size > 0:
+        if (now - last_report) >= UPLOAD_PROGRESS_MIN_INTERVAL or sent == total_size:
+            on_progress(min(sent / total_size, 1.0))
+            last_report = now
+```
+
+No chunk-size change (8 MiB stays, throughput-friendly). The callback now fires at least 4× per second, which is what the UI needs.
+
+If we want sub-chunk progress (useful for slow uplinks where a single chunk takes 20+ seconds), we can switch the inner write to a streaming callback on `httpx` — but that's a second-order optimisation; the time-gate is the high-leverage change.
+
+### 4.2 "Poll soon" signal to kill the post-upload gap
+
+Today `JobManager._poller_loop` uses `self._stop.wait(self._poll_interval)`. The `Event` is only ever set on shutdown. Add a second trigger:
+
+```python
+self._wake = threading.Event()
+
+def _poller_loop(self) -> None:
+    while not self._stop.is_set():
+        self.poll_once()
+        # Wait for either the normal interval, an explicit wake, or shutdown.
+        self._wake.wait(self._poll_interval)
+        self._wake.clear()
+
+def request_poll_soon(self) -> None:
+    """Wake the poller to run again on the next scheduler tick."""
+    self._wake.set()
+```
+
+Expose `request_poll_soon` on `JobContext` so backends can call it. In `auphonic.py:submit`, call `ctx.request_poll_soon()` right after the transition to `PROCESSING` — the next poll happens immediately instead of waiting up to 30 seconds. The Auphonic API returns status in <1 second, so the first user-visible update arrives within ~1 second of upload-complete.
+
+### 4.3 Elapsed-time heartbeat in job messages
+
+In `AuphonicBackend._message_for` (`auphonic.py:524`), include time spent in the current phase:
+
+```python
+@staticmethod
+def _message_for(production: AuphonicProduction, job: ProcessingJob) -> str:
+    elapsed = ""
+    if job.started_at is not None:
+        delta = datetime.now(timezone.utc) - job.started_at
+        elapsed = f" — {_humanize_duration(delta)}"
+    status = production.status_string or f"status {production.status}"
+    return f"Auphonic: {status}{elapsed}"
+```
+
+Each poll publishes a new message even if Auphonic's status didn't change. The SSE queue gets an event, the dashboard row re-renders, and the user sees "Auphonic: Audio Processing — 3m 47s" ticking up. Trivial change, big perceptual effect.
+
+### 4.4 UI partial wiring
+
+Make sure `partials/jobs.html` renders the per-job progress bar *and* the current message, and that the SSE handler triggers a refresh on `event:job` (not just on generic `state_changed`). Audit during implementation.
+
+## 5. Manual reconciliation
+
+### 5.1 Generic backend method
+
+Extend the `ProcessingBackend` Protocol (`backends/base.py`) with an optional `reconcile`:
+
+```python
+def reconcile(self, job: ProcessingJob, *, ctx: JobContext) -> ProcessingJob:
+    """Verify a job's state against upstream reality and the filesystem.
+
+    Called by the JobManager when the user requests a status check on a job.
+    Must be safe to call on any state (including terminal states — a FAILED job
+    whose work actually completed upstream should be resurrected).
+    """
+```
+
+Default implementation (for backends that don't implement it): check the local filesystem for `final_path` existence and, if present, mark COMPLETED. This is already useful for audio-first backends that may have been interrupted mid-assembly.
+
+### 5.2 Auphonic implementation
+
+```python
+def reconcile(self, job: ProcessingJob, *, ctx: JobContext) -> ProcessingJob:
+    # 1. Check local filesystem first — cheapest win.
+    if job.final_path.exists() and job.final_path.stat().st_size > 0:
+        if job.raw_path.exists():
+            # Raw still sitting in to-process/ — finalize: archive raw, mark COMPLETED.
+            self._archive_raw(job)
+        job.state = JobState.COMPLETED
+        job.progress = 1.0
+        job.message = "Recovered: final already on disk"
+        job.completed_at = job.completed_at or datetime.now(timezone.utc)
+        ctx.report(job)
+        return job
+
+    # 2. If we have an upstream UUID, query Auphonic directly.
+    if job.backend_ref:
+        try:
+            production = self._client.get_production(job.backend_ref)
+        except AuphonicHTTPError as exc:
+            if exc.status_code in (404, 410):
+                self._fail(job, f"Auphonic production {job.backend_ref} no longer exists", ctx)
+                return job
+            raise  # transient — caller surfaces the error
+
+        if production.status == AuphonicStatus.DONE:
+            # Production is done — download and finalize.
+            return self._finalize(job, production, ctx)
+        if production.status == AuphonicStatus.ERROR:
+            self._fail(job, production.error_message or "Auphonic reported ERROR", ctx)
+            return job
+        # Still in-flight on their side. Resurrect from FAILED/UNKNOWN to PROCESSING.
+        job.state = JobState.PROCESSING
+        job.error = None
+        job.last_poll_error = None
+        job.message = self._message_for(production, job)
+        job.progress = self._progress_for(production.status, job.progress)
+        ctx.report(job)
+        return job
+
+    # 3. No UUID — try to find the production by title.
+    title = self._title_for(job.raw_path)
+    candidates = self._client.list_productions(title=title, since=job.created_at)
+    if len(candidates) == 1:
+        job.backend_ref = candidates[0].uuid
+        ctx.report(job)
+        # Recurse: branch 2 will pick it up next.
+        return self.reconcile(job, ctx=ctx)
+    if len(candidates) > 1:
+        job.message = f"Multiple Auphonic productions match '{title}' — resolve manually"
+        ctx.report(job)
+        return job
+    # No match — leave the job in its current state; nothing to recover.
+    return job
+```
+
+This handles the Auphonic-finished-while-server-was-down case, the user's motivating incident.
+
+### 5.3 `AuphonicClient.list_productions`
+
+Add a thin wrapper around `GET /api/productions.json` (an endpoint that already exists in the Auphonic API). Parameters: `title` for filtering (Auphonic supports title search), `since` to cap the result set. Return a list of `AuphonicProduction` objects (the existing model).
+
+### 5.4 `JobManager.reconcile`
+
+```python
+def reconcile(self, job_id: str) -> ProcessingJob | None:
+    """Run the backend's reconcile hook for *job_id*.
+
+    Works on any state (including terminal). Returns the updated job.
+    """
+    with self._lock:
+        job = self._jobs.get(job_id)
+    if job is None:
+        return None
+    ctx = self._make_context()
+    updated = self._backend.reconcile(job, ctx=ctx)
+    self._store_job(updated)
+    return updated
+```
+
+### 5.5 Web route and UI
+
+```
+POST /jobs/{id}/reconcile → calls JobManager.reconcile → returns updated jobs partial
+```
+
+UI: each row in the Processing Jobs table gains a "↻ Verify" button. Disabled briefly while a verify is in flight. Outcome is visible through the existing SSE job-event stream.
+
+## 6. Stop auto-failing healthy jobs
+
+### 6.1 Soften the hard timeout
+
+`AUPHONIC_POLL_TIMEOUT_MINUTES = 120` currently fails any job older than 2 hours. Change the semantics:
+
+- Keep the constant, but rename: `AUPHONIC_STALE_WARN_MINUTES`.
+- A job older than this is flagged as "stale" (new field `job.stale: bool`), *not* failed.
+- The UI renders stale jobs with a warning badge and a prominent Verify button.
+- Jobs are only marked FAILED on explicit upstream ERROR, upstream DELETED, or persistent permanent errors (401/403).
+
+If we want a hard cap as a safety net (e.g. 7 days), add `AUPHONIC_HARD_GIVEUP_DAYS = 7` with the current fail-the-job behavior.
+
+### 6.2 Soften UPLOADING → FAILED on restart
+
+Today `JobManager.__init__` (`job_manager.py:164`) unconditionally fails UPLOADING jobs. Replace with:
+
+```python
+if job.state == JobState.UPLOADING:
+    if job.backend_ref:
+        # Production exists upstream; try reconcile on first poll tick.
+        job.state = JobState.PROCESSING
+        job.message = "Resumed after restart — checking Auphonic"
+    else:
+        # No production created yet — upload never made it past step 1.
+        job.state = JobState.FAILED
+        job.error = "Upload was interrupted before the Auphonic production was created."
+```
+
+This handles the case where the crash happened mid-upload but after the production was created: reconcile will either find the upload complete (Auphonic kept it) or failed, and `poll` will surface the right state.
+
+## 7. Tests
+
+In `tests/recordings/test_job_manager.py`:
+
+- `test_request_poll_soon_wakes_the_loop`
+- `test_reconcile_routes_to_backend`
+- `test_reconcile_on_terminal_job_can_resurrect_from_failed`
+
+In `tests/recordings/test_auphonic.py` (new or extended):
+
+- `test_reconcile_with_local_final_marks_completed`
+- `test_reconcile_uses_backend_ref_when_present`
+- `test_reconcile_resurrects_failed_job_when_upstream_done`
+- `test_reconcile_finds_production_by_title_when_uuid_missing`
+- `test_reconcile_respects_http_404_as_deleted`
+- `test_message_for_includes_elapsed`
+
+In `tests/recordings/test_auphonic_client.py`:
+
+- `test_upload_input_reports_progress_on_time_interval`
+- `test_list_productions_filters_by_title`
+
+In `tests/recordings/web/test_routes.py`:
+
+- `test_reconcile_route_returns_updated_partial`
+- `test_reconcile_requires_known_job_id`
+
+## 8. Additional robustness hooks (smaller, adjacent issues)
+
+These came up during the analysis and are worth folding into this work because they share the same files.
+
+### 8.1 OBS reconnect loop
+
+`ObsClient.connect` currently exits after a single failure. Add an optional `auto_reconnect: bool = False` mode that runs a background watchdog: ping OBS every N seconds via `get_record_status`; on exception, mark the client disconnected and retry `connect` with exponential backoff. SSE events for `obs_connected` / `obs_disconnected` so the UI can show a warning when the EventClient silently dies (current symptom: arming and OBS events both appear to work but no events ever fire because the socket is dead).
+
+### 8.2 Rename-thread timeout
+
+`RecordingSession._wait_for_stable` (`session.py:423`) polls file size forever. If OBS is stuck with an open handle (rare but observed with hardware encoder stalls), the session wedges in `RENAMING`. Add a total timeout (default 10 minutes): on expiry, move the OBS output to `superseded/` with a clear reason, clear `_armed`, push an error event. User can then retake.
+
+### 8.3 `superseded/` retention
+
+Add `clm recordings prune-superseded --older-than=30d` CLI command. Not automatic — users who are still debugging a course may want the history for a while.
+
+## 9. Implementation order
+
+1. **Upload progress time-gate** (§4.1). Tiny change, immediate UX improvement. Ship.
+2. **"Poll soon" signal** (§4.2) + **elapsed-time message** (§4.3) + **UI partial audit** (§4.4). Ship.
+3. **Generic `reconcile` backend method** (§5.1) + **Auphonic implementation** (§5.2, §5.3) + **web route and UI** (§5.4, §5.5). Ship.
+4. **Soften hard timeout and UPLOADING-on-restart** (§6). Ship.
+5. **(Optional)** §8 additions as they're needed.
+
+Each step is independently testable and independently useful.
+
+## 10. Open questions
+
+- **Should `reconcile` be exposed on audio-first backends in this pass?** The generic default (check `final_path` existence) is enough for most recovery cases. ONNX-specific reconciliation (e.g. "was the denoise step partial?") can wait until someone actually needs it.
+- **Should we add a "reconcile all" button to the dashboard?** Tempting, but for a user with many jobs it's a lot of API calls. My lean: per-row only, with a CLI equivalent `clm recordings jobs reconcile --all` for bulk recovery.
+- **Do we want per-backend config for the poll cadence?** Today the Auphonic cadence is hardcoded. Making it configurable adds surface area; the "poll soon" signal covers the current motivating case without exposing a new knob. Keep it hardcoded.

--- a/docs/claude/design/recordings-parts-and-takes.md
+++ b/docs/claude/design/recordings-parts-and-takes.md
@@ -1,0 +1,258 @@
+# Recordings: Parts and Takes Model
+
+**Status**: Draft for discussion
+**Author**: Claude (Opus 4.7) + TC
+**Date**: 2026-04-17
+**Scope**: `src/clm/recordings/state.py`, `src/clm/recordings/workflow/session.py`, `directories.py`, `naming.py`
+
+---
+
+## 1. Problem
+
+The current code has a single concept called "part" that conflates two different user intents:
+
+- **Segment** — "this is part 2 of a 3-part lecture". Additive: parts 1, 2, 3 together make up the whole lecture.
+- **Take** — "I made a mistake in part 2; let me record it again". Supersedes: take 2 replaces take 1.
+
+Both intents end up routed through `ArmedDeck.part_number` and `RecordingPart.part`, which leads to several concrete bugs:
+
+- `session.arm(part_number=1)` after an existing part-0 recording triggers the cascade in `_prepare_target_slot` (`session.py:106`) so the existing unsuffixed file becomes `(part 1)`; the new recording *also* tries to land at `(part 1)`, and the `_supersede_file` call at `session.py:132` moves it into `superseded/`. Net result: both takes end up in wrong places.
+- `CourseRecordingState.assign_recording` (`state.py:125`) blindly uses `part = len(lecture.parts) + 1`, so state.json and the session's `part_number` can drift apart when the user types a number.
+- Retaking an already-processed part silently overwrites `final/.../deck.mp4` (via `_download_video`, `auphonic.py:383`) and either crashes (Windows `FileExistsError` in `_archive_raw`) or loses the old raw (Unix `shutil.move` overwrite). **Auphonic credits are burned and the previous good take is destroyed.**
+- When the filesystem cascade (`_prepare_target_slot`) renames a file on disk, state.json is not updated; its `raw_file` / `processed_file` paths become stale.
+
+## 2. Goals
+
+1. A single, unambiguous model with two distinct concepts: **part** (segment) and **take** (attempt).
+2. No data loss on retake: every previously-processed final is preserved somewhere retrievable.
+3. state.json and the filesystem stay consistent across every rename/supersede operation.
+4. The UI keeps the word "part" (matches the `(part N)` filename suffix users already see). "Take" is secondary, surfaced as a history indicator.
+5. Safe to implement incrementally — the schema change is additive.
+
+## 3. Model
+
+### 3.1 User-visible concepts
+
+| Concept | Meaning | Default when user omits |
+|---|---|---|
+| **Part** | A segment of a lecture. Parts 1..N together make up the whole lecture. | "Next available part for this lecture" = `max(existing_parts) + 1` |
+| **Take** | A recording attempt for a specific part. Later takes supersede earlier ones. | "Next available take for this part" = `max(existing_takes_for_part) + 1` |
+
+### 3.2 Filename convention
+
+The *active* take's filenames stay the way they are today — no take number in the name:
+
+- Active raw: `deck (part N)--RAW.mp4` (or unsuffixed if there's only ever one part)
+- Active final: `deck (part N).mp4`
+
+Superseded takes are moved to `takes/` with a take number in the filename:
+
+- Superseded raw: `takes/<rel>/deck (part N, take K)--RAW.mp4`
+- Superseded final: `takes/<rel>/deck (part N, take K).mp4`
+
+Rationale: the take concept is only visible when history exists, so putting it in the filename only for superseded files keeps the common case unchanged and makes the history self-describing.
+
+### 3.3 Directory layout
+
+```
+recordings/
+├── to-process/        live recordings waiting for processing
+├── final/             current take's processed output  (active)
+├── archive/           current take's raw               (active)
+├── takes/             superseded takes                  (history, new)
+│   └── <course>/<section>/
+│       ├── deck (part 2, take 1).mp4           ← old final
+│       └── deck (part 2, take 1)--RAW.mp4      ← old raw
+└── superseded/        unchanged (zero-length / abandoned before processing)
+```
+
+`takes/` is for **fully-processed takes that were replaced by a later take**. `superseded/` is for **pre-processing garbage** (zero-length OBS outputs, accidental re-recordings caught before processing finished). Keeping them separate means a user browsing `takes/` sees exactly what they spent Auphonic credits on.
+
+### 3.4 Single-part optimization
+
+When a lecture has only one part, its filenames are unsuffixed (`deck.mp4`, `deck--RAW.mp4`) — today's behavior is preserved by `_prepare_target_slot`'s cascade when the user records a second part. Adding takes doesn't change this: the takes/ shelf for a single-part lecture uses `deck (take 1).mp4` / `deck (take 2).mp4` without the `(part N)` prefix.
+
+## 4. Retake lifecycle
+
+User clicks **Retake** on part K of a lecture that has already been processed.
+
+1. **Session-level pre-move** (new logic, runs before the OBS output moves into `to-process/`):
+   - Compute `take = max(existing takes for part K) + 1`. If no history exists, `take = 2` (the current active take becomes take 1).
+   - If `final/<rel>/deck (part K).mp4` exists: move it to `takes/<rel>/deck (part K, take K-1).mp4`.
+   - If `archive/<rel>/deck (part K)--RAW.mp4` exists: move it to `takes/<rel>/deck (part K, take K-1)--RAW.mp4`.
+   - If `to-process/<rel>/deck (part K)--RAW.mp4` exists (incomplete previous take): same move.
+2. **Rename the new OBS output** into `to-process/<rel>/deck (part K)--RAW.mp4` (the normal slot).
+3. **Processing proceeds normally** — the backend sees a raw file in `to-process/` and produces a fresh final in the unadorned slot.
+
+This is idempotent: if the pre-move finds no existing files (because the user retook before the previous take finished processing), it simply does nothing for the missing pieces.
+
+## 5. state.json schema changes
+
+### 5.1 New `TakeRecord` dataclass
+
+```python
+class TakeRecord(BaseModel):
+    take: int                  # 1, 2, 3, ...
+    raw_file: str              # absolute or recordings-root-relative path
+    processed_file: str | None
+    git_commit: str | None = None
+    git_dirty: bool = False
+    recorded_at: str           # ISO 8601
+    status: RecordingStatus
+    superseded_at: str | None = None  # ISO 8601 of the moment this take was retired
+```
+
+### 5.2 `RecordingPart` additions
+
+```python
+class RecordingPart(BaseModel):
+    part: int
+    # Active take (current best):
+    raw_file: str
+    processed_file: str | None
+    git_commit: str | None
+    git_dirty: bool
+    recorded_at: str
+    status: RecordingStatus
+    # History:
+    takes: list[TakeRecord] = []    # NEW — superseded takes, oldest first
+    active_take: int = 1            # NEW — which take number the active fields refer to
+```
+
+All new fields have defaults, so existing state.json files load unchanged and are upgraded on the next save.
+
+### 5.3 Operations
+
+New methods on `CourseRecordingState`:
+
+```python
+def record_retake(
+    self,
+    lecture_id: str,
+    part: int,
+    new_raw_file: str,
+    *,
+    git_commit: str | None,
+    git_dirty: bool,
+) -> TakeRecord:
+    """Demote the part's active fields into `takes` and replace them with the new take.
+
+    Returns the TakeRecord that was just demoted (for the caller to move on disk).
+    Raises ValueError if the part does not exist.
+    """
+
+def restore_take(self, lecture_id: str, part: int, take: int) -> None:
+    """Swap take K with the current active take.
+
+    Used by the UI "restore this take" action. Moves the active fields into
+    `takes` and promotes the requested TakeRecord to active. The caller is
+    responsible for moving the corresponding files on disk (or this method
+    can accept a callback — see §7).
+    """
+
+def rename_recording_paths(
+    self,
+    old_raw: str,
+    new_raw: str,
+    *,
+    old_processed: str | None = None,
+    new_processed: str | None = None,
+) -> None:
+    """Update raw_file/processed_file references after a filesystem rename.
+
+    Scans all lectures, all parts, all takes. No-ops if the old paths aren't
+    found (cascade may have acted on files not yet tracked in state.json).
+    """
+```
+
+## 6. Session ↔ state.json reconciliation
+
+Today, the session (`RecordingSession`) and `CourseRecordingState` are decoupled: the session moves files, the state manager tracks files, and the watcher is the only glue (it calls `assign_recording` when a new raw lands in `to-process/`). This is why the cascade in `_prepare_target_slot` leaves state.json stale.
+
+**Proposal**: inject a `CourseRecordingState`-like handle into `RecordingSession` so every filesystem operation is paired with a state-mutation. Specifically:
+
+- When `_prepare_target_slot` renames a file on disk: call `state.rename_recording_paths(...)` in the same try-block.
+- When a retake pre-move fires: call `state.record_retake(...)` to update the in-memory model, then move the files.
+- On session shutdown / server stop: `state.save()` is already called after each mutation — no extra plumbing needed.
+
+The session should treat the state handle as optional (tests that don't care about state tracking can pass `None`), but the web app always wires it up.
+
+## 7. Answering the concrete question from the conversation
+
+> If we have already processed one or more parts of a recording and record either a new take for one of the existing parts or a new part, will "process" trigger the correct processing?
+
+### Case A — New part added after some parts were already processed
+
+**Correct today.** Traced through the code:
+
+- `RecordingsWatcher._on_file_event` (`watcher.py:143`) only sees events in `to-process/`. Previously processed parts have their raw in `archive/` (moved by `_archive_raw`, `auphonic.py:431`), not in `to-process/`, so the watcher never considers them again.
+- `_scan_existing` (`watcher.py:178`) on server restart only walks `to-process/`.
+- Every backend's `accepts_file` is filename-pattern only, but archived raws are outside `to-process/` so they never reach it.
+- Manual `/process` (`routes.py:214`) only lists files from `find_pending_pairs(to-process)` (`directories.py:79`), so archived raws aren't shown.
+
+The new part gets processed in isolation. ✅
+
+### Case B — New take for an already-processed part
+
+**Broken today.** This is the core motivation for the `takes/` directory and the session pre-move described in §4:
+
+1. `_prepare_target_slot` (`session.py:81`) only scans `to-process/`, so it doesn't see the previous take's raw in `archive/` or final in `final/`. No supersede happens.
+2. When the new take finishes processing, `_archive_raw` (`auphonic.py:431`) calls `shutil.move(raw, archive/.../deck (part K)--RAW.mp4)`. The destination already exists → on Windows this raises `FileExistsError`; on Unix it overwrites and the old raw is lost.
+3. `_download_video` (`auphonic.py:383`) writes unconditionally to `job.final_path` — the previous processed final is overwritten.
+4. state.json has no concept of takes; the part is double-booked.
+
+With the design in this document:
+
+1. Before the new OBS output lands in `to-process/`, the session's retake path moves the existing `final/` + `archive/` files into `takes/`.
+2. `_archive_raw` and `_download_video` now see clear destinations.
+3. state.json gets a new `TakeRecord` demoted into `takes[]` and fresh active fields for the new take.
+
+## 8. UI changes
+
+- Each lecture row shows its parts inline: `▶ 1 │ ▶ 2 │ ▶ 3` with a status dot per part.
+- Clicking a part opens a panel showing:
+  - Active take metadata (recorded_at, git commit, processed file path, play button).
+  - Takes history as a collapsed list. Expanding reveals each superseded take with restore/delete actions.
+- Next to the lecture title: a **+ Record next part** button (default action) and a separate **↻ Retake** dropdown with a row per existing part.
+
+The retake dropdown is what disambiguates "new part" from "new take of existing part" without a modal.
+
+## 9. Tests to add (`tests/recordings/`)
+
+In `test_session.py`:
+
+- `test_retake_moves_final_and_archive_to_takes` (happy path)
+- `test_retake_when_only_raw_exists` (processing failed before retake)
+- `test_retake_when_only_final_exists` (raw manually deleted)
+- `test_retake_when_nothing_exists_yet` (retake before first processing finished)
+- `test_new_part_after_processed_parts_preserves_existing` (regression guard for Case A)
+- `test_session_updates_state_json_after_cascade` (regression guard for the stale-paths bug)
+
+In `test_state.py`:
+
+- `test_record_retake_demotes_active_to_takes`
+- `test_record_retake_rejects_unknown_part`
+- `test_restore_take_swaps_active_and_history`
+- `test_rename_recording_paths_scans_all_takes`
+- `test_load_older_state_json_without_takes_field` (backcompat)
+
+In `test_directories.py`:
+
+- `test_takes_dir_helper_returns_correct_subtree`
+- `test_find_pending_pairs_ignores_takes_subtree`
+
+## 10. Implementation order
+
+1. **Schema-only change first**: add `takes: list[TakeRecord]` + `active_take` to `RecordingPart`, add `record_retake` / `restore_take` / `rename_recording_paths` methods. No UI, no filesystem changes. Ship — state.json upgrades transparently.
+2. **Directory helpers**: add `takes_dir(root)` to `directories.py`. Ship.
+3. **Session pre-move for retake**: update `_prepare_target_slot` (or a new `_prepare_retake_slot`) to move `archive/` + `final/` copies to `takes/` when a retake is detected, wire `state.record_retake` into the session, and fix the stale-paths bug via `rename_recording_paths`. Ship with full test coverage.
+4. **UI**: add the parts inline display and retake dropdown. Ship.
+5. **Restore**: add the restore-take UI + file-swap helper. Ship.
+
+Each step lands on master without breaking earlier releases.
+
+## 11. Open questions
+
+- **Should `takes/` be disk-pruneable?** Auphonic-processed videos are large; a course with many retakes accumulates gigabytes. Options: (a) keep everything forever (user prunes by hand), (b) prune takes older than N months, (c) make it a CLI command `clm recordings prune-takes --older-than=…`. My lean: ship (a) initially, add (c) when someone complains.
+- **When restoring a take, do we keep the current active as a new take, or discard it?** Proposal: always keep it. Restore is a swap, not an overwrite — matches the "never lose work" ethos.
+- **Should we also version the cut list artifact?** When Auphonic produces a cut list (`job.artifacts["cut_list"]`), today it's stored next to the final. Takes should preserve it too — use the same `(part N, take K)` suffix.

--- a/docs/claude/design/recordings-workflow-ux-redesign.md
+++ b/docs/claude/design/recordings-workflow-ux-redesign.md
@@ -1,0 +1,236 @@
+# Recordings Workflow UX Redesign (Record Button + Retake Handling)
+
+**Status**: Draft for discussion
+**Author**: Claude (Opus 4.7) + TC
+**Date**: 2026-04-17
+**Scope**: `src/clm/recordings/workflow/obs.py`, `session.py`, `src/clm/recordings/web/`
+
+---
+
+## 1. Problem
+
+The current workflow requires the user to:
+
+1. Connect to OBS (or ensure it is already running) before starting the CLM server.
+2. Arm the lecture in the CLM web UI.
+3. Switch to OBS and press Record.
+4. Switch back to OBS and press Stop when done.
+5. Switch back to the CLM web UI and Disarm.
+
+Two concrete pain points fall out of this:
+
+- **Alt-tabbing between CLM and OBS** on every take is slow and error-prone.
+- **If the user stops OBS, realizes they made a mistake, and hits Record again**, the second recording lands in OBS's default recording directory with no association to the armed deck. The existing state machine clears `_armed` the moment the STOPPED event fires (`session.py:411`), so the re-started recording takes the "Recording started (state=idle, no auto-rename)" branch at `session.py:347`. The user has to disarm, re-arm, and start over — but the first take is already sitting in OBS's default directory and needs manual cleanup.
+
+## 2. Goals
+
+1. Make "record this lecture" a single click in the CLM web UI.
+2. Make "I made a mistake, let me redo it" a single click (not a full disarm/re-arm cycle).
+3. Keep the low-level primitives (`arm`, `disarm`) available as escape hatches when OBS is unreachable or the user needs to recover by hand.
+4. Don't surprise the user by hijacking OBS recordings they didn't intend CLM to manage (e.g. a test recording after the lecture is already over).
+
+## 3. Non-goals
+
+- Replacing OBS as the recording tool. CLM remains a controller that drives OBS via WebSocket.
+- Multi-scene orchestration. OBS scenes, profiles, and scene collections remain user-managed.
+- Remote OBS control. The scope is the local OBS instance CLM is already configured for.
+
+## 4. Part / take semantics (prerequisite)
+
+See the sibling note `recordings-parts-and-takes.md` for the full model. Summary for this document:
+
+- **Part**: a segment of a lecture's content. Parts 1, 2, 3... add up to the whole lecture.
+- **Take**: a recording attempt at a given part. Take 2 of part 1 *supersedes* take 1 of part 1.
+- The UI keeps the term "part" (matches the `(part N)` filename suffix users see). "Take" is secondary, exposed as a small history indicator per part.
+
+## 5. Proposed workflow
+
+### 5.1 Default flow (one-click lecture recording)
+
+1. User opens the web dashboard. OBS is already running (or the dashboard shows a clear "Connect to OBS" action).
+2. User clicks **Record** on the current lecture row.
+   - CLM arms the deck as today.
+   - CLM calls `obs.start_record()` over WebSocket.
+   - Optionally (config flag, default off): CLM asks the OS to bring the OBS window to the foreground.
+3. Status panel shows "Recording part 1 (take 1) of &lt;lecture&gt;". The Record button is replaced by a **Stop** button.
+4. When the user is done, they press either:
+   - **Stop** in the OBS window (existing habit), or
+   - **Stop** in the CLM web UI (new, calls `obs.stop_record()`).
+5. CLM's existing STOPPED-event handling takes over: the file is renamed into `to-process/`, the job manager picks it up (see the job-reconciliation note for progress updates), and the lecture row updates to show "part 1 done".
+
+No alt-tabbing required for the common case.
+
+### 5.2 Retake after an obvious mistake
+
+Two overlapping features make this painless:
+
+**(a) Auto-supersede zero-length takes.**
+If OBS reports a recording stop within a threshold of the start (default: 5 s, configurable), treat the file as an accidental take: move it directly to `superseded/` without ever assigning it a part/take, and keep the deck armed. The user sees no state change on the dashboard — just a silent "that didn't count" note in the action log.
+
+This catches the most common mistake (start-then-immediately-stop to test audio levels, then start again for real).
+
+**(b) Stay armed across a deliberate stop/restart.**
+When a real take stops, the rename thread completes and the session transitions to a new `ARMED_AFTER_TAKE` state (instead of `IDLE`). In this state:
+
+- `_armed` is preserved.
+- A 60-second timer is started (configurable).
+- If OBS fires STARTED again within the timer: that recording gets associated with the same deck as the previous take, bumping the *take number* (not the part number), and the previous take moves to `takes/` as described in the parts-and-takes note.
+- If the timer expires without a new STARTED event: transition to `IDLE`, clear `_armed`, push a `state_changed` SSE event.
+- The user can click **Disarm** at any time to exit the window early.
+
+These two features together mean the user never has to manually re-arm to redo a take.
+
+### 5.3 Adding a new part to the same lecture
+
+- After a take completes (or after the `ARMED_AFTER_TAKE` timer expires), the user clicks **Record** again on the same lecture.
+- CLM arms the next *part* (part = highest existing part for this lecture + 1), take 1.
+- OBS starts recording. Flow continues as in 5.1.
+
+### 5.4 Retaking a specific (already-recorded) part
+
+- The lecture row shows each recorded part with a small "↻ Retake" action.
+- Clicking it arms that specific part with take = (highest existing take for this part) + 1.
+- The session's rename logic moves the previous active take's raw + final into `takes/` (see parts-and-takes note §4) *before* the new take's rename completes, so the slot is clear.
+
+### 5.5 Escape hatches
+
+- **`arm` / `disarm` primitives remain** and are wired to separate routes (`/arm`, `/disarm`). The UI shows these under an "Advanced" disclosure; they're useful when OBS is unreachable, when the user recorded outside CLM and wants to backfill the rename, or during debugging.
+- **Manual upload**: drag a file into `to-process/` still works; the file watcher picks it up as today.
+
+## 6. Design changes
+
+### 6.1 `ObsClient` additions (`src/clm/recordings/workflow/obs.py`)
+
+Add methods that the wrapper currently doesn't expose, using `obsws-python` primitives that already exist:
+
+```python
+def start_record(self) -> None:
+    """Tell OBS to begin recording. Raises if already recording or not connected."""
+
+def stop_record(self) -> None:
+    """Tell OBS to stop the current recording. No-op if not recording."""
+
+def raise_window(self) -> bool:
+    """Best-effort: bring the OBS window to the foreground.
+
+    Returns True if the platform-specific hook succeeded, False otherwise.
+    Never raises; a missing hook is logged at DEBUG and returned as False.
+    """
+```
+
+`raise_window` dispatches by `sys.platform`:
+
+| Platform | Implementation |
+|---|---|
+| `win32` | `ctypes.windll.user32.FindWindowW("Qt5QWindowIcon", None)` + `SetForegroundWindow` with `AllowSetForegroundWindow` pre-call. Multiple OBS window classes exist across OBS versions; probe several. |
+| `darwin` | `subprocess.run(["osascript", "-e", 'tell application "OBS" to activate'])`. |
+| `linux` | `subprocess.run(["wmctrl", "-a", "OBS"])` if `wmctrl` is on PATH; otherwise log-and-skip. |
+
+Default config: `focus_obs_on_record = False`. Opt-in only — stealing focus is polarizing.
+
+### 6.2 `RecordingSession` changes (`src/clm/recordings/workflow/session.py`)
+
+**New state** `ARMED_AFTER_TAKE` in the `SessionState` enum. Transition map:
+
+```
+IDLE ──arm()──► ARMED ──OBS STARTED──► RECORDING
+                                         │
+                                         ▼ OBS STOPPED
+                                       RENAMING
+                                         │ rename done
+                                         ▼
+                                 ARMED_AFTER_TAKE ──60s timer─► IDLE
+                                         │                        ▲
+                                         │ OBS STARTED            │
+                                         ▼                        │
+                                     RECORDING (same deck, take++)
+                                         │                        │
+                                         └────────────────────────┘ (on stop timer expires)
+```
+
+**Short-take detection**: when STOPPED fires, if `(stop_time - start_time) < short_take_threshold`, skip the rename entirely; move the OBS output directly to `superseded/` with a reason note, keep `_armed`, and stay in `ARMED`. Threshold defaults to 5 seconds, overridable via `RecordingsConfig.short_take_seconds`.
+
+**New high-level method** `record(course, section, deck, *, part_number=None, take_number=None, lang)`:
+
+```python
+def record(
+    self,
+    course_slug: str,
+    section_name: str,
+    deck_name: str,
+    *,
+    part_number: int | None = None,
+    take_number: int | None = None,
+    lang: str = "en",
+) -> None:
+    """Arm and start OBS in one step.
+
+    part_number=None → next available part for this deck.
+    take_number=None → next available take for (part_number).
+    """
+```
+
+This wraps `arm()` + `_obs.start_record()` under the session lock, so the UI gets a single atomic operation.
+
+**New method** `stop()` that calls `self._obs.stop_record()` — purely a convenience, lets the dashboard offer a Stop button.
+
+### 6.3 Web routes (`src/clm/recordings/web/routes.py`)
+
+| Route | Replaces | Behavior |
+|---|---|---|
+| `POST /record` | `POST /arm` as primary action | Calls `session.record(...)`. Returns status partial. On OBS failure, surface a clear error but do not roll back the arm — the user may still want to start OBS manually. |
+| `POST /stop` | — | Calls `session.stop()`. Returns status partial. |
+| `POST /arm` | kept as primitive | Same as today; surfaced under "Advanced". |
+| `POST /disarm` | kept | Same as today. Also valid during `ARMED_AFTER_TAKE` — lets the user exit the retake window immediately. |
+
+### 6.4 Short-take / `ARMED_AFTER_TAKE` configuration
+
+Add to `RecordingsConfig`:
+
+```python
+short_take_seconds: float = 5.0
+retake_window_seconds: float = 60.0
+focus_obs_on_record: bool = False
+```
+
+All with module-docstring comments explaining the UX intent.
+
+## 7. Edge cases and how they resolve
+
+| Scenario | Behavior |
+|---|---|
+| OBS not running when user clicks Record | Arm succeeds; `start_record` raises; UI shows "OBS is not running — start it and press Record again, or arm manually". Deck stays armed; existing OBS reconnect path applies. |
+| OBS crashes during a recording | EventClient dies; we don't detect it today (see the reconnect work in §8 of the reconciliation note). Out of scope here, tracked separately. |
+| User clicks Disarm during `ARMED_AFTER_TAKE` | Standard disarm path; cancel the timer; state → `IDLE`. |
+| Take ends within `short_take_seconds`, then user walks away | OBS file goes to `superseded/`, deck stays armed. If they don't come back, the dashboard shows "armed, waiting" until they disarm. No data is created silently. |
+| User clicks Record on a different lecture while `ARMED_AFTER_TAKE` is active | Cancel the timer; arm the new deck; start OBS. Normal arm semantics apply (the existing `arm()` allows re-arm from `ARMED`; we extend that to `ARMED_AFTER_TAKE`). |
+| `start_record` succeeds but no STARTED event arrives (network glitch) | The existing `get_record_status` query can be used as a fallback — 1 second after `start_record`, poll it; if `output_active` is true, synthesize a STARTED event to the session. |
+
+## 8. Tests to add
+
+In `tests/recordings/test_session.py`:
+
+- `test_record_arms_and_starts_obs`
+- `test_record_requires_obs_connected` (or returns a structured error)
+- `test_stop_calls_obs_stop_record`
+- `test_short_take_goes_to_superseded_and_keeps_armed`
+- `test_armed_after_take_rearms_on_subsequent_start`
+- `test_armed_after_take_times_out_to_idle`
+- `test_disarm_during_armed_after_take`
+
+In `tests/recordings/web/test_routes.py`:
+
+- `test_record_route_posts_arm_and_start`
+- `test_stop_route_calls_obs_stop`
+- `test_arm_route_still_works_as_primitive`
+
+Platform-specific `raise_window` behavior is best-effort and doesn't need unit tests; a smoke test on Windows (user-run, not CI) is sufficient.
+
+## 9. Implementation order
+
+1. Add `start_record` / `stop_record` to `ObsClient`. Wire `/record` and `/stop` routes. Keep the existing `arm`/`disarm` paths untouched. Ship.
+2. Add short-take detection. Ship.
+3. Add `ARMED_AFTER_TAKE` state + retake window. Ship.
+4. (Optional) Add `raise_window` behind the opt-in config flag.
+
+Each step is independently testable and independently shippable; no flag day.

--- a/docs/claude/recordings-ux-redesign-handover.md
+++ b/docs/claude/recordings-ux-redesign-handover.md
@@ -82,7 +82,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 
 ## 3. Phase Breakdown
 
-### Phase 1 — One-click record [TODO]
+### Phase 1 — One-click record [DONE]
 
 **Goal**: Single "Record" button in the dashboard that arms the deck and starts OBS in one step, plus a "Stop" button that tells OBS to stop.
 
@@ -106,7 +106,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 - Existing `/arm` + `/disarm` routes still work (regression).
 - If OBS is disconnected, `/record` surfaces a clear error and leaves the session in a recoverable state.
 
-### Phase 2 — Retake handling (short-take + ARMED_AFTER_TAKE) [TODO]
+### Phase 2 — Retake handling (short-take + ARMED_AFTER_TAKE) [DONE]
 
 **Goal**: Make stop-and-restart-during-a-take a no-click recovery flow.
 
@@ -126,7 +126,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 - Retake window expires → state → IDLE, `_armed` cleared, SSE event fires.
 - Rename thread stuck for > 10 min → force-exit, surface error, deck cleared.
 
-### Phase 3 — Part/take model + `takes/` directory [TODO]
+### Phase 3 — Part/take model + `takes/` directory [DONE]
 
 **Goal**: Formalize take numbering, stop destroying old processed finals, fix the state.json ↔ filesystem drift bug.
 
@@ -209,24 +209,37 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 
 ## 4. Current Status
 
-**Nothing implemented yet.** All five phases are TODO.
+**Phases 1–3 complete.** Phases 4–5 remain TODO.
 
 **Completed**:
-- Design docs authored 2026-04-17 (three files under `docs/claude/design/`). These capture goals, non-goals, file-level changes, test lists, and implementation order for each phase.
-- This handover document.
+- Design docs authored 2026-04-17 (three files under `docs/claude/design/`).
+- **Phase 1 (one-click record)**: `RecordingSession.record()` / `.stop()`, `ObsClient.start_record()` / `.stop_record()`, `POST /record` + `POST /stop` routes, UI primary-button swap.
+- **Phase 2 (retake handling)**: `SessionState.ARMED_AFTER_TAKE`, retake-window timer, short-take auto-supersede, rename-thread timeout.
+- **Phase 3 (part/take model)**:
+  - `TakeRecord` dataclass and `RecordingPart.takes` / `.active_take` fields on state.json (schema is backward-compatible — old files load with defaults).
+  - `CourseRecordingState.record_retake(...)`, `restore_take(...)`, `rename_recording_paths(...)`.
+  - `takes/` subdirectory (now part of `SUBDIRS`; `takes_dir(root)` helper in `directories.py`).
+  - Take-aware filename helpers: `take_filename`, `parse_part_take` in `naming.py`.
+  - Session-level **retake pre-move**: before a new OBS output lands, any active take files in `to-process/`, `archive/`, or `final/` for the same `(deck, part)` are demoted to `takes/` with a `(part N, take K)` suffix.
+  - Session constructor accepts optional `state: CourseRecordingState | None`; when provided, all disk renames performed by the session (retake pre-move + multi-part cascade) are mirrored via `state.rename_recording_paths(...)`.
 
-**In progress**: None.
+**In progress**: None — Phase 4 is the next slice.
+
+**Not yet done in Phase 3 (deferred to a follow-up)**:
+- Wiring `state.record_retake(...)` from the session (needs a lecture-id lookup strategy at the web-app level — currently the session knows the deck name but not the lecture_id). The rename_recording_paths hook already keeps paths in sync; record_retake would add proper take-history tracking inside state.json. Track-history on the filesystem already works without it.
+- Web-app side wiring (`app.py`): does not yet inject `CourseRecordingState` into `RecordingSession`. When that happens, `rename_recording_paths` will start firing for real state.json mutations (today it's exercised only by tests).
+- UI parts-inline display + retake dropdown + restore-take action (listed in the design doc §8 / step 4–5).
 
 **Open questions / decisions deferred**:
 - Should `takes/` be auto-pruneable? Current decision: ship without pruning, add `clm recordings prune-takes --older-than=…` CLI command later when it becomes a problem.
-- Cut-list artifact versioning on retake: when Auphonic produces an EDL, takes should preserve it too — use the same `(part N, take K)` suffix. Not yet specified in detail; resolve during Phase 3 implementation.
+- Cut-list artifact versioning on retake: when Auphonic produces an EDL, takes should preserve it too — use the same `(part N, take K)` suffix. Not yet implemented; no cut-list files are moved by the current pre-move scan (would need a dedicated sidecar scanner).
 - Should Phase 4 also add sub-chunk HTTP streaming progress? Not required for the motivating case; time-gating chunk callbacks is enough. Revisit if slow uplinks remain painful.
 
-**State of tests**: No new tests written. The existing 355 recordings tests still pass on master — new phases must not regress them.
+**State of tests**: 517 recordings tests pass (previously 355; + Phase 1/2/3 additions). Full fast suite: 3347 tests green.
 
 ## 5. Next Steps
 
-**Start with Phase 1 (One-click record)**. It's the smallest, highest-visibility win and has no dependencies on the other phases.
+**Start with Phase 4 (Job progress UX)**. Phases 1–3 are shipped. Phase 4 has no data-model dependencies on Phase 3; it touches the Auphonic backend and the jobs UI only.
 
 ### Prerequisites
 

--- a/docs/claude/recordings-ux-redesign-handover.md
+++ b/docs/claude/recordings-ux-redesign-handover.md
@@ -1,0 +1,383 @@
+# Handover: Recordings UX Redesign
+
+## 1. Feature Overview
+
+**Name**: Recordings UX Redesign (one-click record + takes model + live job progress + reconciliation)
+
+This feature overhauls the recording workflow in CLM's web dashboard and recording subsystem to address five concrete pain points the user hit after shipping the pluggable-backend / Auphonic work:
+
+1. **Alt-tabbing between CLM and OBS on every take** is tedious and slow.
+2. **Stopping and restarting OBS mid-take silently loses the deck association** — the second recording lands in OBS's default directory with no rename because the session clears `_armed` the moment STOPPED fires.
+3. **The web UI appears frozen for minutes** during Auphonic upload/processing because progress callbacks are chunk-granular (8 MiB) and polling has a 30-second gap between upload-complete and the first status query.
+4. **The "parts" concept conflates two user intents** ("add another segment" vs. "redo this segment") — asking for part=1 after recording part=0 will silently destroy the new take today, and retaking an already-processed part overwrites the old final (burning Auphonic credits and losing data).
+5. **Jobs get stuck in FAILED after server restart** even when the Auphonic production finished processing upstream — the 120-minute hard timeout and the UPLOADING→FAILED-on-restart rule both auto-fail healthy work with no recovery path.
+
+The redesign adds: a one-click Record button that drives OBS via WebSocket, a retake window that keeps the deck armed across stop/restart, a formal part/take model with a `takes/` directory that preserves superseded processed finals, time-gated progress updates, and a per-job "Verify" action that reconciles state against both the filesystem and the Auphonic API.
+
+**Branch**: TBD (start from `master`). No implementation commits exist yet.
+**Related prior work**: Pluggable-backend refactor merged 2026-04-06 (`docs/claude/design/recordings-backend-architecture.md`).
+**Design docs** (three, authored 2026-04-17):
+- `docs/claude/design/recordings-workflow-ux-redesign.md`
+- `docs/claude/design/recordings-parts-and-takes.md`
+- `docs/claude/design/recordings-job-progress-and-reconciliation.md`
+
+**Status**: No code changes. All work is TODO.
+
+## 2. Design Decisions
+
+### 2.1 Keep the term "part" in the UI; make "take" the secondary concept
+
+The filename convention users already see is `deck (part N)--RAW.mp4`. Renaming that to "segment" would be a churn-for-churn-sake rename. Instead, "part" keeps its meaning as **segment** (additive), and a new **take** concept (supersedes) rides alongside. The UI surfaces takes only when history exists — a small "N takes" indicator per part.
+
+**Alternative rejected**: renaming to "segment" + "take" across the UI and filenames. Too much user-facing churn.
+
+### 2.2 Active take uses unadorned filenames; only superseded takes carry `(take K)` in the name
+
+Active files stay at `final/.../deck (part N).mp4` and `archive/.../deck (part N)--RAW.mp4` (identical to today). Superseded takes move to `takes/.../deck (part N, take K).mp4`. This keeps the common case unchanged — anything already downloading the final doesn't need to learn about takes — and makes the history self-describing when you browse `takes/`.
+
+**Alternative rejected**: always include `(take 1)` in filenames. Breaks every existing tool and script that assumes the current naming.
+
+### 2.3 Separate `takes/` directory, not a subfolder of `superseded/`
+
+`takes/` holds **fully-processed takes replaced by a later take** (precious — cost Auphonic credits). `superseded/` holds **pre-processing garbage** (zero-length OBS outputs, accidental re-records caught before processing). Mixing them hides the expensive history behind the throwaway files.
+
+### 2.4 `ARMED_AFTER_TAKE` state + retake window, not unlimited-stay-armed
+
+When a take stops, we stay armed for a configurable window (default 60 s). A new OBS recording within the window is treated as a retake of the same deck; after the window expires, the deck disarms.
+
+**Alternative rejected**: never auto-disarm. Risk: if the user walks away after the last segment, the next unrelated OBS recording gets hijacked.
+
+**Alternative rejected**: require explicit retake click. Defeats the "I made a mistake, just start again" UX goal.
+
+### 2.5 Zero-length takes are auto-superseded without changing the armed state
+
+If OBS reports a stop within `short_take_seconds` (default 5 s) of start, the file goes straight to `superseded/` without being counted as a take. Matches the "start-and-immediately-stop to test audio levels, then start for real" habit.
+
+### 2.6 OBS window focus is opt-in (default off)
+
+Stealing focus is polarizing. `focus_obs_on_record = False` by default; Windows-first implementation via `ctypes` + `SetForegroundWindow`, best-effort AppleScript / `wmctrl` on other platforms.
+
+### 2.7 Progress UX uses three small, independent levers
+
+Rather than one big overhaul, three focused changes that each help:
+- **Time-gated upload callback** (every 250 ms, not just on 8 MiB boundaries) — kills upload-appears-stuck.
+- **`request_poll_soon()` signal** on `JobContext` — collapses the 30 s gap between upload-complete and first status poll.
+- **Elapsed-time in job message** (`"Auphonic: Audio Processing — 3m 47s"`) — gives the UI something to tick on every poll even when upstream status is unchanged.
+
+### 2.8 Reconciliation is a generic backend Protocol method, not Auphonic-only
+
+`ProcessingBackend.reconcile(job, ctx)` is optional. Auphonic implementation combines filesystem check + `get_production(uuid)` + fallback title-based `list_productions()`. Audio-first backends get a default implementation that checks `final_path` existence. Keeps the fix useful across the whole job subsystem.
+
+### 2.9 Soften timeouts rather than strengthen failure paths
+
+Current code fails jobs on the 120-minute wall-clock timeout and on server-restart-while-uploading. Both are wrong when Auphonic's own state is fine. Change semantics:
+- `AUPHONIC_POLL_TIMEOUT_MINUTES` → `AUPHONIC_STALE_WARN_MINUTES`: flag as stale, don't fail.
+- UPLOADING-on-restart: if `backend_ref` is set, transition to PROCESSING and let the next poll clarify; only fail if no production was ever created.
+
+**Alternative rejected**: leave fail-fast behavior and rely solely on reconcile to repair. Users shouldn't have to notice and fix every transient crash; the system should degrade gracefully.
+
+### 2.10 Five-phase rollout, each independently shippable
+
+No flag-day rewrite. Each phase adds behavior or wraps old behavior — never breaks the existing flow. Earlier phases are user-visible UX wins; later phases are data-integrity fixes that require more careful testing.
+
+## 3. Phase Breakdown
+
+### Phase 1 — One-click record [TODO]
+
+**Goal**: Single "Record" button in the dashboard that arms the deck and starts OBS in one step, plus a "Stop" button that tells OBS to stop.
+
+**What it accomplishes**:
+- New high-level session method `RecordingSession.record(course, section, deck, ...)` = `arm()` + `obs.start_record()`.
+- New `RecordingSession.stop()` = `obs.stop_record()`.
+- `ObsClient.start_record()` / `ObsClient.stop_record()` wrappers around `obsws-python` request methods.
+- New `POST /record` and `POST /stop` web routes; existing `/arm` and `/disarm` kept as primitives (moved under an "Advanced" disclosure in the UI).
+- Status partial renders a single primary button whose label and action switch between Record / Stop based on session state.
+
+**Files involved**:
+- `src/clm/recordings/workflow/obs.py` (add `start_record`, `stop_record`)
+- `src/clm/recordings/workflow/session.py` (add `record`, `stop`)
+- `src/clm/recordings/web/routes.py` (add `/record`, `/stop`)
+- `src/clm/recordings/web/templates/partials/status.html`
+- `src/clm/recordings/web/templates/lectures.html`
+
+**Acceptance criteria**:
+- Clicking "Record" on a lecture arms the deck and triggers OBS recording without the user leaving the web page.
+- Clicking "Stop" in the web UI or the OBS window both stop the recording cleanly and trigger the existing rename flow.
+- Existing `/arm` + `/disarm` routes still work (regression).
+- If OBS is disconnected, `/record` surfaces a clear error and leaves the session in a recoverable state.
+
+### Phase 2 — Retake handling (short-take + ARMED_AFTER_TAKE) [TODO]
+
+**Goal**: Make stop-and-restart-during-a-take a no-click recovery flow.
+
+**What it accomplishes**:
+- Short-take detection: OBS stops within `short_take_seconds` (default 5) → file to `superseded/`, keep `_armed`.
+- New `SessionState.ARMED_AFTER_TAKE`: after a real take completes, stay armed for `retake_window_seconds` (default 60). A second OBS start within the window = retake (take number bumps, part number unchanged). Window expiry → IDLE.
+- Rename-thread timeout (default 10 min) so a wedged `_wait_for_stable` can't freeze the session forever.
+
+**Files involved**:
+- `src/clm/recordings/workflow/session.py` (state enum, event handler, timers)
+- `tests/recordings/test_session.py` (new scenarios)
+- `src/clm/recordings/workflow/config.py` or equivalent (new config fields)
+
+**Acceptance criteria**:
+- Start recording → stop within 3 s → file appears in `superseded/`, dashboard unchanged, deck still armed.
+- Start → stop normally → dashboard shows "ready for retake (55s)" ticking down; start again → associated with same deck as a retake.
+- Retake window expires → state → IDLE, `_armed` cleared, SSE event fires.
+- Rename thread stuck for > 10 min → force-exit, surface error, deck cleared.
+
+### Phase 3 — Part/take model + `takes/` directory [TODO]
+
+**Goal**: Formalize take numbering, stop destroying old processed finals, fix the state.json ↔ filesystem drift bug.
+
+**What it accomplishes**:
+- New `TakeRecord` dataclass in `state.py`; `RecordingPart` gets `takes: list[TakeRecord]` + `active_take: int` (both defaulted — backcompat preserved for existing course state files).
+- New `CourseRecordingState.record_retake(...)`, `restore_take(...)`, `rename_recording_paths(...)` methods.
+- New `takes_dir(root)` helper in `directories.py`.
+- **Retake pre-move** in the session: before moving an OBS output into `to-process/`, scan `final/<rel>/deck (part K).mp4` and `archive/<rel>/deck (part K)--RAW.mp4`; if present, move to `takes/<rel>/deck (part K, take J).<ext>` (where J = max existing take for part K, or 1 if none).
+- Session constructor accepts an optional `state: CourseRecordingState | None`; when provided, filesystem renames are paired with `state.rename_recording_paths(...)` calls to kill the drift bug.
+
+**Files involved**:
+- `src/clm/recordings/state.py` (schema + methods)
+- `src/clm/recordings/workflow/directories.py` (`takes_dir`)
+- `src/clm/recordings/workflow/session.py` (retake pre-move, state wiring)
+- `src/clm/recordings/workflow/naming.py` (take-aware filename helpers)
+- `src/clm/recordings/web/app.py` (inject `CourseRecordingState` into session)
+- `tests/recordings/test_state.py`, `tests/recordings/test_session.py`, `tests/recordings/test_directories.py`
+
+**Acceptance criteria**:
+- Recording a retake of an already-processed part preserves the old final in `takes/` and the old raw in `takes/` (no data loss).
+- state.json `takes` list grows; `active_take` tracks the new take number; `raw_file` / `processed_file` point at the fresh active take.
+- Recording a new part after some parts are already processed continues to work (regression guard).
+- Loading a state.json written by the old schema succeeds (migration is implicit via Pydantic defaults).
+- All filesystem cascades update state.json in lockstep — no stale paths.
+
+### Phase 4 — Job progress UX [TODO]
+
+**Goal**: UI never appears frozen during Auphonic uploads or processing.
+
+**What it accomplishes**:
+- `AuphonicClient.upload_input`: time-gated `on_progress` (fires every 250 ms minimum, not just on chunk boundaries).
+- `JobManager` gains a `request_poll_soon()` wake-event; exposed on `JobContext`.
+- `AuphonicBackend.submit` calls `ctx.request_poll_soon()` after transitioning to PROCESSING.
+- `AuphonicBackend._message_for` includes elapsed time in the current phase.
+- UI audit: `partials/jobs.html` binds refresh to SSE `event:job` (not just `state_changed`), renders progress bar + message + elapsed.
+
+**Files involved**:
+- `src/clm/recordings/workflow/backends/auphonic_client.py`
+- `src/clm/recordings/workflow/backends/auphonic.py`
+- `src/clm/recordings/workflow/job_manager.py`
+- `src/clm/recordings/workflow/backends/base.py` (`JobContext.request_poll_soon` addition)
+- `src/clm/recordings/web/templates/partials/jobs.html`
+- `src/clm/recordings/web/static/*` (SSE handler binding)
+- `tests/recordings/test_auphonic_client.py`, `tests/recordings/test_job_manager.py`
+
+**Acceptance criteria**:
+- Upload to a 500 MB file on a simulated slow uplink ticks the progress bar at least 4× per second.
+- After upload completes, the first poll-driven message appears within 2 s (not 30 s).
+- During Auphonic processing, the job row updates at least once per poll even when the upstream status string is unchanged.
+
+### Phase 5 — Reconciliation [TODO]
+
+**Goal**: Per-job "Verify" action recovers jobs whose displayed state doesn't match reality. Soften timeouts that auto-fail healthy work.
+
+**What it accomplishes**:
+- `ProcessingBackend.reconcile(job, ctx)` Protocol addition with default implementation (check `final_path`).
+- `AuphonicBackend.reconcile` full implementation: local filesystem → `get_production(uuid)` → fallback to title-based `list_productions`.
+- New `AuphonicClient.list_productions(title=..., since=...)` wrapping `GET /api/productions.json`.
+- `JobManager.reconcile(job_id)` entry point.
+- New `POST /jobs/{id}/reconcile` web route.
+- UI: per-row "↻ Verify" button on the Processing Jobs table.
+- Soften hard timeout: `AUPHONIC_POLL_TIMEOUT_MINUTES` → `AUPHONIC_STALE_WARN_MINUTES`; add `job.stale: bool` field; optional `AUPHONIC_HARD_GIVEUP_DAYS = 7` safety net.
+- Soften UPLOADING-on-restart: if `backend_ref` is set, transition to PROCESSING; only fail if no production was ever created.
+
+**Files involved**:
+- `src/clm/recordings/workflow/backends/base.py`
+- `src/clm/recordings/workflow/backends/auphonic.py`
+- `src/clm/recordings/workflow/backends/auphonic_client.py`
+- `src/clm/recordings/workflow/job_manager.py`
+- `src/clm/recordings/workflow/jobs.py` (add `stale` field)
+- `src/clm/recordings/web/routes.py` (reconcile route)
+- `src/clm/recordings/web/templates/partials/jobs.html` (verify button, stale badge)
+- `tests/recordings/test_auphonic.py`, `test_auphonic_client.py`, `test_job_manager.py`, `web/test_routes.py`
+
+**Acceptance criteria**:
+- A FAILED job whose Auphonic production is actually DONE can be reconciled to COMPLETED from the UI (download + archive + state update).
+- A FAILED job whose raw is still in `to-process/` and whose `final_path` already exists can be reconciled (recover from mid-rename crash).
+- Server restart during UPLOADING with `backend_ref` set → job continues polling instead of failing.
+- Jobs older than `AUPHONIC_STALE_WARN_MINUTES` show a warning badge but are not auto-failed.
+
+## 4. Current Status
+
+**Nothing implemented yet.** All five phases are TODO.
+
+**Completed**:
+- Design docs authored 2026-04-17 (three files under `docs/claude/design/`). These capture goals, non-goals, file-level changes, test lists, and implementation order for each phase.
+- This handover document.
+
+**In progress**: None.
+
+**Open questions / decisions deferred**:
+- Should `takes/` be auto-pruneable? Current decision: ship without pruning, add `clm recordings prune-takes --older-than=…` CLI command later when it becomes a problem.
+- Cut-list artifact versioning on retake: when Auphonic produces an EDL, takes should preserve it too — use the same `(part N, take K)` suffix. Not yet specified in detail; resolve during Phase 3 implementation.
+- Should Phase 4 also add sub-chunk HTTP streaming progress? Not required for the motivating case; time-gating chunk callbacks is enough. Revisit if slow uplinks remain painful.
+
+**State of tests**: No new tests written. The existing 355 recordings tests still pass on master — new phases must not regress them.
+
+## 5. Next Steps
+
+**Start with Phase 1 (One-click record)**. It's the smallest, highest-visibility win and has no dependencies on the other phases.
+
+### Prerequisites
+
+1. Create a branch: `git checkout -b claude/recordings-ux-phase1-one-click-record` from `master`.
+2. Install deps if not already done: `pip install -e ".[all]"`.
+3. Verify the existing fast test suite passes: `pytest`.
+4. Read `docs/claude/design/recordings-workflow-ux-redesign.md` end-to-end before touching code. §5.1 (default flow) and §6 (design changes) are the load-bearing sections.
+
+### Implementation sketch
+
+1. **`src/clm/recordings/workflow/obs.py`**: add `start_record(self) -> None` and `stop_record(self) -> None`. Both call `self._require_connected()` and dispatch to `obsws-python`'s `ReqClient` methods (`req.start_record()` / `req.stop_record()`). Both log the action and re-raise on failure with a user-friendly message wrapping the underlying exception.
+
+2. **`src/clm/recordings/workflow/session.py`**: add `record(course_slug, section_name, deck_name, *, part_number=0, lang="en")` that takes the session lock, calls `self.arm(...)`, then calls `self._obs.start_record()`. On OBS failure, leave the deck armed (so the user can manually start OBS and retry). Add `stop()` that simply calls `self._obs.stop_record()`.
+
+3. **`src/clm/recordings/web/routes.py`**: add `@router.post("/record", response_class=HTMLResponse) async def record_deck(...)` mirroring the signature of the existing `arm_deck`. Add `@router.post("/stop")` that calls `session.stop()`. Return the status partial or an HX-Redirect as appropriate.
+
+4. **Templates**: in `partials/status.html`, change the primary action button to switch between "Record"/"Stop" based on `snapshot.state`. Move the old `arm`/`disarm` buttons under an `<details>` element labeled "Advanced".
+
+5. **Tests**:
+   - `tests/recordings/test_obs.py`: test `start_record`/`stop_record` delegate to the underlying client (mock `obsws-python`).
+   - `tests/recordings/test_session.py`: test `record()` arms + calls start_record; test `record()` leaves deck armed when OBS raises; test `stop()` calls stop_record.
+   - `tests/recordings/web/test_routes.py`: test `/record` hits session.record; test `/stop` hits session.stop; test `/arm` still works.
+
+### Gotchas to watch for
+
+- **OBS event dispatch uses daemon threads in `obsws-python`.** The existing `ObsClient` registers callbacks before `connect()`. Don't change that pattern — events registered after connect risk being missed during the initial state.
+- **The session lock protects the state machine but not OBS I/O.** `_obs.start_record()` is a blocking WebSocket call; don't hold the session lock across the call. The existing code style (update state under the lock, then call OBS / notify outside the lock) should be preserved.
+- **Windows path handling in tests**: the project is Windows-first; avoid hardcoded POSIX paths in new tests. Use `tmp_path` fixtures.
+- **HTMX partial refresh logic**: the existing `status_partial` returns the same template the full page uses for its status panel. If you split the Record/Stop button out into its own sub-partial, make sure both the full page and the HTMX swap paths include it.
+- **Don't tie Phase 1 to Phase 2 changes.** Phase 1 leaves `_armed` cleared on OBS STOPPED (current behavior). Retake-stay-armed is Phase 2. Users stop-and-restart recovery is still broken after Phase 1; that's fine — Phase 2 fixes it independently.
+- **Pre-commit hook runs ruff + mypy + fast tests.** Commits that fail the hook did *not* happen — fix the issue, re-stage, create a *new* commit. Don't `--amend` (CLAUDE.md rule).
+
+### After Phase 1 ships
+
+Read `docs/claude/design/recordings-parts-and-takes.md` §10 before starting Phase 2/3 — the ordering there suggests schema-only changes (state.json additions) in a separate commit before the session wiring, so existing state files upgrade safely.
+
+## 6. Key Files & Architecture
+
+### Existing files (to be modified across phases)
+
+| File | Role | Phases touching |
+|---|---|---|
+| `src/clm/recordings/workflow/obs.py` | Thin OBS WebSocket wrapper (ReqClient + EventClient) | 1 |
+| `src/clm/recordings/workflow/session.py` | Arm/disarm state machine, rename thread, cascade logic | 1, 2, 3 |
+| `src/clm/recordings/workflow/directories.py` | Directory-layout helpers (`to_process_dir`, `final_dir`, `archive_dir`, `superseded_dir`, `find_pending_pairs`) | 3 |
+| `src/clm/recordings/workflow/naming.py` | Filename parsing / building (`raw_filename`, `parse_part`, `find_existing_recordings`) | 3 |
+| `src/clm/recordings/state.py` | Per-course state JSON (`CourseRecordingState`, `LectureState`, `RecordingPart`) | 3 |
+| `src/clm/recordings/workflow/job_manager.py` | Job lifecycle; poller thread; UPLOADING-on-restart handling | 4, 5 |
+| `src/clm/recordings/workflow/backends/base.py` | `ProcessingBackend` Protocol; `JobContext` | 4, 5 |
+| `src/clm/recordings/workflow/backends/auphonic.py` | Auphonic backend (submit/poll/finalize/cancel) | 4, 5 |
+| `src/clm/recordings/workflow/backends/auphonic_client.py` | HTTP client wrapping Auphonic Complex JSON API | 4, 5 |
+| `src/clm/recordings/workflow/jobs.py` | `ProcessingJob` model, state enum, capabilities | 5 |
+| `src/clm/recordings/web/routes.py` | HTMX / SSE routes | 1, 5 |
+| `src/clm/recordings/web/app.py` | App factory, SSE queue wiring, session/job-manager construction | 1, 3, 4 |
+| `src/clm/recordings/web/templates/partials/status.html` | Arm/Record/Stop button and session-state display | 1, 2 |
+| `src/clm/recordings/web/templates/partials/jobs.html` | Processing Jobs list | 4, 5 |
+| `src/clm/recordings/web/templates/lectures.html` | Lectures table; per-part buttons | 1, 3 |
+
+### New files expected to be created
+
+| Path | Purpose | Phase |
+|---|---|---|
+| (none for Phase 1 — all additions happen in existing files) | | |
+| `src/clm/recordings/workflow/config.py` *(if not already present)* | Home for new config fields like `short_take_seconds`, `retake_window_seconds`, `focus_obs_on_record` | 2 |
+| Tests: `tests/recordings/test_session_retake.py` or extended `test_session.py` | Retake scenarios | 2 |
+| Tests: `tests/recordings/test_takes_model.py` or extended `test_state.py` | Take / state.json schema | 3 |
+| Tests: extended `test_auphonic_client.py`, `test_auphonic.py`, `test_job_manager.py` | Progress + reconciliation | 4, 5 |
+
+### Entry points and control flow
+
+1. **Web app startup** (`src/clm/recordings/web/app.py` `lifespan`) constructs: `ObsClient` → `RecordingSession` → `JobStore` → `JobManager` (with selected backend) → `RecordingsWatcher`. All are held on `app.state`.
+2. **Record flow (new, Phase 1)**: UI → `POST /record` → `RecordingSession.record(...)` → under lock: `self.arm(...)`; outside lock: `self._obs.start_record()`. OBS fires `RecordStateChanged` event → `_handle_record_event` on daemon thread → session transitions ARMED→RECORDING → SSE push.
+3. **Stop flow**: UI clicks Stop (or presses Stop in OBS) → OBS fires STOPPED → rename thread → `_prepare_target_slot` (Phase 3 extended with retake pre-move) → file moves to `to-process/` → watcher submits to JobManager → backend processes → `_archive_raw` moves raw to `archive/` → `final/` has processed output.
+4. **Retake flow (Phase 2)**: STOPPED → rename completes → `ARMED_AFTER_TAKE` state + timer. New STARTED within window → RECORDING with same deck + bumped take. Timer expires → IDLE.
+5. **Reconciliation flow (Phase 5)**: UI → `POST /jobs/{id}/reconcile` → `JobManager.reconcile(id)` → `backend.reconcile(job, ctx)` → (filesystem check → upstream query → title fallback) → `ctx.report(job)` → SSE.
+
+### Conventions to continue
+
+- **Thread safety**: session uses a `threading.Lock`. Mutate state under the lock; call OBS, emit SSE events, and fire callbacks outside the lock. See `RecordingSession._handle_record_event` for the canonical pattern.
+- **SSE pushing is thread-marshalled**: `_push_sse` in `app.py` uses `call_soon_threadsafe` for background-thread calls. New push sites must use this helper, not raw `asyncio.Queue.put_nowait`.
+- **Backend Protocol stays minimal**: don't add Auphonic-specific concepts to `ProcessingBackend`. Add optional methods with sensible defaults so audio-first backends keep working.
+- **Pydantic schema additions need defaults**: old state.json files must still load. Every new field on `RecordingPart` / `LectureState` / `CourseRecordingState` must have a default value.
+- **Filenames via `naming.py` helpers only**: don't construct `(part N)` / `(part N, take K)` strings inline. Add helpers to `naming.py` so the convention lives in one place.
+- **CLAUDE.md info-topics rule**: if any CLI command or spec-file behavior changes, update `src/clm/cli/info_topics/commands.md` or `spec-files.md` accordingly. Phase 1 adds no CLI changes, but Phase 5 (reconcile CLI command) will.
+
+## 7. Testing Approach
+
+### Strategy
+
+- **Unit tests per module**, heavy emphasis on the state machine and state.json transitions. The session and job manager are the integrity-critical surfaces; test exhaustively.
+- **Integration tests** at the web-route layer for the new `/record`, `/stop`, `/jobs/{id}/reconcile` routes — use FastAPI's `TestClient`.
+- **Mock OBS via a fake `ObsClient`** for session tests; do not require a running OBS during `pytest`. The existing `test_session.py` already has this pattern — extend it.
+- **Mock Auphonic HTTP** via `httpx.MockTransport` for `AuphonicClient` tests. The existing `test_auphonic_client.py` already establishes the pattern.
+- **No Docker-marker tests for this feature.** Everything should run in the fast or non-docker suite.
+
+### What's tested already (existing 355 recordings tests — regression guards)
+
+- Arm/disarm state transitions (`test_session.py`)
+- Multi-part cascade rename (`test_session.py::test_part_2_renames_*`)
+- Supersede logic (`test_session.py::test_supersede_*`)
+- Job submission, polling, permanent vs transient errors (`test_job_manager.py`)
+- UPLOADING-on-restart rehydration (`test_job_manager.py`)
+- State.json assign/reassign/status updates (`test_state.py`)
+- Watcher dispatch + scan-existing (`test_watcher.py`)
+- Auphonic client HTTP flows (`test_auphonic_client.py`)
+
+### What needs new tests (per phase)
+
+See §3 acceptance criteria and the "Tests to add" section of each design doc for the full list. Summary:
+
+- **Phase 1**: `record()` / `stop()` delegation; `/record` + `/stop` routes.
+- **Phase 2**: short-take auto-supersede; `ARMED_AFTER_TAKE` transitions; retake window timer; rename timeout.
+- **Phase 3**: `record_retake` demotes active → takes; `restore_take` swaps; `rename_recording_paths` scans all takes; retake pre-move preserves final + raw; old-schema state.json loads.
+- **Phase 4**: time-gated upload callback; `request_poll_soon` wakes poller; elapsed-time in message.
+- **Phase 5**: reconcile routes to backend; reconcile resurrects FAILED → COMPLETED when upstream done; reconcile uses local final when present; reconcile by title when UUID missing; UPLOADING-with-backend-ref transitions to PROCESSING on restart; stale flag doesn't fail.
+
+### How to run
+
+- Fast suite (runs as part of pre-commit): `pytest` — excludes `slow`, `integration`, `e2e`, `db_only`, `docker` markers. ~30 s.
+- Recordings-only: `pytest tests/recordings/` — useful while iterating.
+- Pre-release gate: `pytest -m "not docker"`. ~2 min.
+- Lint + format: `uv run ruff check src/ tests/` and `uv run ruff format src/ tests/`.
+- Type check: runs via the pre-commit hook; manual invocation is `uv run mypy src/`.
+
+## 8. Session Notes
+
+### User preferences expressed
+
+- Keep "part" as the UI term (matches filename convention the user sees). Don't rename to "segment".
+- Retakes must preserve previously-processed finals — Auphonic credits and time cost matter.
+- Windows-first. Every change needs to work on Windows (no POSIX-only path assumptions, no bash-only scripts; prefer Python for tooling).
+- Each phase should be shippable independently — don't batch everything into a big PR.
+- Auto mode is active for this work; the user expects continuous, autonomous progress on low-risk changes and explicit check-ins only for destructive or ambiguous choices.
+
+### Discoveries during analysis
+
+- The "stop-mistake, restart OBS" bug is caused by `_handle_record_event` clearing `_armed` on STOPPED (session.py:411). Phase 2's `ARMED_AFTER_TAKE` state is the clean fix.
+- The data-loss-on-retake bug has three contributing code paths: `_prepare_target_slot` only scans `to-process/` (not `archive/` / `final/`); `_archive_raw` uses `shutil.move` which raises `FileExistsError` on Windows or silently overwrites on Unix; `_download_video` writes to `final_path` unconditionally. Phase 3's retake pre-move clears all three.
+- `_prepare_target_slot` cascades filenames on disk but `state.json` is not updated, leaving stale `raw_file` / `processed_file` paths. Fixing this requires injecting `CourseRecordingState` into `RecordingSession` — currently the two are decoupled (state is only touched by the watcher on `assign_recording`).
+- Auphonic polling has a 30 s first-poll gap plus 5 min long-poll; combined with the chunk-granular upload progress, the perception of "UI frozen" is mostly about the lack of sub-10-second ticks. The three small fixes in Phase 4 are likely sufficient without deeper changes.
+- UPLOADING-on-restart failure is over-aggressive when `backend_ref` is set (production already exists upstream). This is the root cause of the user's real Auphonic incident.
+
+### Things explicitly *not* being done
+
+- No Auphonic webhook support (polling-only per the original backend design).
+- No automatic retention policy on `takes/` (user prunes by hand, or via a future CLI command).
+- No multi-OBS orchestration.
+- No rename of "part" → "segment" in UI or filenames.
+- No restore-take UI in Phase 3 initial scope — it's called out as a smaller follow-up (step 5 in the parts-and-takes doc) but can be deferred if time is short.
+
+---
+
+**Last updated**: 2026-04-17
+**Next action**: Start Phase 1 implementation on a fresh branch from `master`.

--- a/docs/claude/recordings-ux-redesign-handover.md
+++ b/docs/claude/recordings-ux-redesign-handover.md
@@ -177,7 +177,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 - After upload completes, the first poll-driven message appears within 2 s (not 30 s).
 - During Auphonic processing, the job row updates at least once per poll even when the upstream status string is unchanged.
 
-### Phase 5 — Reconciliation [TODO]
+### Phase 5 — Reconciliation [DONE]
 
 **Goal**: Per-job "Verify" action recovers jobs whose displayed state doesn't match reality. Soften timeouts that auto-fail healthy work.
 
@@ -209,7 +209,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 
 ## 4. Current Status
 
-**Phases 1–4 complete.** Phase 5 (reconciliation) remains TODO.
+**All five phases complete.** Feature is shippable.
 
 **Completed**:
 - Design docs authored 2026-04-17 (three files under `docs/claude/design/`).
@@ -228,6 +228,13 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
   - `AuphonicBackend.submit` nudges the poller after transitioning to PROCESSING; first in-processing update now arrives within ~1 s instead of up to 30 s.
   - `AuphonicBackend._message_for(production, job)` appends an elapsed-time heartbeat (`"Auphonic: Audio Processing — 3m 47s"`). Each poll publishes a visibly different message even when the upstream status string is unchanged.
   - SSE split: `/events` now emits `event: job` for job-lifecycle payloads (`"job"`, `"job:<id>"`, `"submitted:<id>"`) and `event: status` for everything else. Dashboard jobs-panel binds to both `sse:job` and `sse:status`; status-panel stays on `sse:status` only.
+- **Phase 5 (reconciliation + softened timeouts)**:
+  - `ProcessingBackend.reconcile(job, ctx)` Protocol method — safe on any job state, can resurrect from terminal FAILED when upstream work actually completed. Default implementation on `AudioFirstBackend` checks `final_path` existence.
+  - `AuphonicBackend.reconcile` full implementation: filesystem check → `get_production(uuid)` → title-based `list_productions` fallback. DONE productions are finalized, ERROR productions are failed, in-flight ones are resurrected to PROCESSING with all stale error markers cleared.
+  - `AuphonicClient.list_productions(title=…, limit=…)` wraps `GET /api/productions.json`, handles the wrapped/bare/single-dict response shapes the API returns across versions.
+  - `JobManager.reconcile(job_id)` entry point with permanent/transient error classification (same as `poll_once`), plus `POST /jobs/{id}/reconcile` web route and a per-row "Verify" button on the Processing Jobs panel.
+  - Softened hard timeout: `AUPHONIC_POLL_TIMEOUT_MINUTES` is now an alias for `AUPHONIC_STALE_WARN_MINUTES`. Jobs past this window are flagged `ProcessingJob.stale=True` (soft warning badge) instead of being failed. A new `AUPHONIC_HARD_GIVEUP_DAYS = 7` safety net only auto-fails jobs that are almost certainly garbage-collected upstream.
+  - Softened UPLOADING-on-restart: `JobManager.__init__` now resumes an UPLOADING job to PROCESSING when `backend_ref` is set (production exists upstream); only fails the job when no production was ever created.
 
 **In progress**: None — Phase 4 is the next slice.
 
@@ -241,11 +248,19 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 - Cut-list artifact versioning on retake: when Auphonic produces an EDL, takes should preserve it too — use the same `(part N, take K)` suffix. Not yet implemented; no cut-list files are moved by the current pre-move scan (would need a dedicated sidecar scanner).
 - Should Phase 4 also add sub-chunk HTTP streaming progress? Not required for the motivating case; time-gating chunk callbacks is enough. Revisit if slow uplinks remain painful.
 
-**State of tests**: 531 recordings tests pass (previously 355; + Phase 1/2/3/4 additions). Full fast suite: 3361 tests green.
+**State of tests**: 554 recordings tests pass (previously 355; + Phase 1/2/3/4/5 additions).
 
 ## 5. Next Steps
 
-**Start with Phase 5 (Reconciliation)**. Phases 1–4 are shipped. Phase 5 adds a per-job "Verify" action that reconciles the displayed state against upstream Auphonic + local filesystem, softens the hard poll timeout into a stale-warning flag, and fixes the UPLOADING→FAILED-on-restart bug when a production was already created upstream.
+**All five shippable phases complete.** Optional follow-ups from the design docs that were not folded into this scope:
+
+- **State record_retake wiring**: The session currently syncs state via `rename_recording_paths` but does not call `state.record_retake` (would need lecture-id resolution at the web-app layer). Tracking take-history inside `state.json` would be a clean next step.
+- **Web-app state injection**: `app.py` still does not inject `CourseRecordingState` into `RecordingSession`. Wiring it up activates the already-implemented rename propagation on real course state.
+- **UI parts-inline display**: The lectures page still shows one row per deck; the design calls for `▶ 1 │ ▶ 2 │ ▶ 3` with per-part status dots and a collapsible takes history.
+- **Restore-take UI**: `CourseRecordingState.restore_take` is implemented but not exposed in the UI yet.
+- **Cut-list artifact versioning on retake**: The retake pre-move moves video + wav files to `takes/`; cut-list sidecars are not yet handled.
+- **`clm recordings prune-takes --older-than=…` CLI**: For when accumulated `takes/` history starts eating disk.
+- **OBS reconnect loop** (design §8.1): Not implemented; the EventClient can silently die and the UI doesn't notice.
 
 ### Prerequisites
 

--- a/docs/claude/recordings-ux-redesign-handover.md
+++ b/docs/claude/recordings-ux-redesign-handover.md
@@ -152,7 +152,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 - Loading a state.json written by the old schema succeeds (migration is implicit via Pydantic defaults).
 - All filesystem cascades update state.json in lockstep — no stale paths.
 
-### Phase 4 — Job progress UX [TODO]
+### Phase 4 — Job progress UX [DONE]
 
 **Goal**: UI never appears frozen during Auphonic uploads or processing.
 
@@ -209,7 +209,7 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 
 ## 4. Current Status
 
-**Phases 1–3 complete.** Phases 4–5 remain TODO.
+**Phases 1–4 complete.** Phase 5 (reconciliation) remains TODO.
 
 **Completed**:
 - Design docs authored 2026-04-17 (three files under `docs/claude/design/`).
@@ -222,6 +222,12 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
   - Take-aware filename helpers: `take_filename`, `parse_part_take` in `naming.py`.
   - Session-level **retake pre-move**: before a new OBS output lands, any active take files in `to-process/`, `archive/`, or `final/` for the same `(deck, part)` are demoted to `takes/` with a `(part N, take K)` suffix.
   - Session constructor accepts optional `state: CourseRecordingState | None`; when provided, all disk renames performed by the session (retake pre-move + multi-part cascade) are mirrored via `state.rename_recording_paths(...)`.
+- **Phase 4 (live job progress)**:
+  - `AuphonicClient.upload_input` gates `on_progress` to fire at most every 250 ms (constant `UPLOAD_PROGRESS_MIN_INTERVAL`), preventing dashboard flooding on fast uplinks while preserving chunk-granular ticks on slow ones.
+  - `JobManager.request_poll_soon()` + `JobContext.request_poll_soon()` — backends can wake the poller on the next scheduler tick instead of waiting out the full `poll_interval`. `JobManager.shutdown()` uses the same wake event so the poller exits promptly.
+  - `AuphonicBackend.submit` nudges the poller after transitioning to PROCESSING; first in-processing update now arrives within ~1 s instead of up to 30 s.
+  - `AuphonicBackend._message_for(production, job)` appends an elapsed-time heartbeat (`"Auphonic: Audio Processing — 3m 47s"`). Each poll publishes a visibly different message even when the upstream status string is unchanged.
+  - SSE split: `/events` now emits `event: job` for job-lifecycle payloads (`"job"`, `"job:<id>"`, `"submitted:<id>"`) and `event: status` for everything else. Dashboard jobs-panel binds to both `sse:job` and `sse:status`; status-panel stays on `sse:status` only.
 
 **In progress**: None — Phase 4 is the next slice.
 
@@ -235,11 +241,11 @@ No flag-day rewrite. Each phase adds behavior or wraps old behavior — never br
 - Cut-list artifact versioning on retake: when Auphonic produces an EDL, takes should preserve it too — use the same `(part N, take K)` suffix. Not yet implemented; no cut-list files are moved by the current pre-move scan (would need a dedicated sidecar scanner).
 - Should Phase 4 also add sub-chunk HTTP streaming progress? Not required for the motivating case; time-gating chunk callbacks is enough. Revisit if slow uplinks remain painful.
 
-**State of tests**: 517 recordings tests pass (previously 355; + Phase 1/2/3 additions). Full fast suite: 3347 tests green.
+**State of tests**: 531 recordings tests pass (previously 355; + Phase 1/2/3/4 additions). Full fast suite: 3361 tests green.
 
 ## 5. Next Steps
 
-**Start with Phase 4 (Job progress UX)**. Phases 1–3 are shipped. Phase 4 has no data-model dependencies on Phase 3; it touches the Auphonic backend and the jobs UI only.
+**Start with Phase 5 (Reconciliation)**. Phases 1–4 are shipped. Phase 5 adds a per-job "Verify" action that reconciles the displayed state against upstream Auphonic + local filesystem, softens the hard poll timeout into a stale-warning flag, and fixes the UPLOADING→FAILED-on-restart bug when a production was already created upstream.
 
 ### Prerequisites
 

--- a/src/clm/recordings/state.py
+++ b/src/clm/recordings/state.py
@@ -18,8 +18,33 @@ from pydantic import BaseModel, Field
 RecordingStatus = Literal["pending", "processing", "processed", "failed"]
 
 
+class TakeRecord(BaseModel):
+    """A superseded take of a recording part.
+
+    Held on :class:`RecordingPart.takes` to preserve history when a
+    user retakes a part. The active fields on ``RecordingPart`` always
+    describe the current best take; older takes are demoted into this
+    list along with their filesystem paths (typically under ``takes/``).
+    """
+
+    take: int
+    raw_file: str
+    processed_file: str | None = None
+    git_commit: str | None = None
+    git_dirty: bool = False
+    recorded_at: str = ""
+    status: RecordingStatus = "pending"
+    superseded_at: str | None = None
+
+
 class RecordingPart(BaseModel):
-    """A single recording part for a lecture."""
+    """A single recording part for a lecture.
+
+    The unadorned fields (``raw_file``, ``processed_file``, …) describe
+    the *active* take. Superseded takes are kept on :attr:`takes`; the
+    active take's number is tracked by :attr:`active_take` so superseded
+    files can reason about their history without scanning disk.
+    """
 
     part: int
     raw_file: str
@@ -28,6 +53,8 @@ class RecordingPart(BaseModel):
     git_dirty: bool = False
     recorded_at: str = ""
     status: RecordingStatus = "pending"
+    takes: list[TakeRecord] = Field(default_factory=list)
+    active_take: int = 1
 
 
 class LectureState(BaseModel):
@@ -220,6 +247,150 @@ class CourseRecordingState(BaseModel):
                     return
 
         raise ValueError(f"Recording not found: {raw_file}")
+
+    def _find_part(self, lecture_id: str, part_number: int) -> RecordingPart:
+        """Return the ``RecordingPart`` for *lecture_id* / *part_number*.
+
+        Raises ``ValueError`` if either the lecture or the part is absent.
+        """
+        lecture = self.get_lecture(lecture_id)
+        if lecture is None:
+            raise ValueError(f"Lecture not found: {lecture_id}")
+        for part in lecture.parts:
+            if part.part == part_number:
+                return part
+        raise ValueError(f"Part {part_number} not found in lecture {lecture_id}")
+
+    def record_retake(
+        self,
+        lecture_id: str,
+        part_number: int,
+        new_raw_file: str,
+        *,
+        git_commit: str | None = None,
+        git_dirty: bool = False,
+        new_processed_file: str | None = None,
+    ) -> TakeRecord:
+        """Demote the part's current active take into ``takes`` and install a new one.
+
+        The caller is responsible for the corresponding filesystem moves
+        (typically into ``takes/``). The returned :class:`TakeRecord`
+        describes the take that was just demoted — useful for the caller
+        to know the old paths.
+
+        Raises:
+            ValueError: If the lecture or part does not exist.
+        """
+        part = self._find_part(lecture_id, part_number)
+
+        demoted = TakeRecord(
+            take=part.active_take,
+            raw_file=part.raw_file,
+            processed_file=part.processed_file,
+            git_commit=part.git_commit,
+            git_dirty=part.git_dirty,
+            recorded_at=part.recorded_at,
+            status=part.status,
+            superseded_at=datetime.now().isoformat(timespec="seconds"),
+        )
+        part.takes.append(demoted)
+
+        part.active_take = demoted.take + 1
+        part.raw_file = new_raw_file
+        part.processed_file = new_processed_file
+        part.git_commit = git_commit
+        part.git_dirty = git_dirty
+        part.recorded_at = datetime.now().isoformat(timespec="seconds")
+        part.status = "pending"
+
+        logger.info(
+            "Recorded retake {} for {} part {}",
+            part.active_take,
+            lecture_id,
+            part_number,
+        )
+        return demoted
+
+    def restore_take(self, lecture_id: str, part_number: int, take: int) -> None:
+        """Swap take *take* with the current active take.
+
+        The previous active take becomes a :class:`TakeRecord` entry,
+        and the requested historical take is promoted to active. Always
+        a swap — the caller never loses data. The caller is responsible
+        for moving the corresponding files on disk.
+
+        Raises:
+            ValueError: If the lecture, part, or take does not exist,
+                or if *take* is already the active one.
+        """
+        part = self._find_part(lecture_id, part_number)
+
+        if take == part.active_take:
+            raise ValueError(f"Take {take} is already active for part {part_number}")
+
+        target: TakeRecord | None = None
+        for existing in part.takes:
+            if existing.take == take:
+                target = existing
+                break
+        if target is None:
+            raise ValueError(f"Take {take} not found in part {part_number} of lecture {lecture_id}")
+
+        demoted = TakeRecord(
+            take=part.active_take,
+            raw_file=part.raw_file,
+            processed_file=part.processed_file,
+            git_commit=part.git_commit,
+            git_dirty=part.git_dirty,
+            recorded_at=part.recorded_at,
+            status=part.status,
+            superseded_at=datetime.now().isoformat(timespec="seconds"),
+        )
+
+        part.takes.remove(target)
+        part.takes.append(demoted)
+        part.takes.sort(key=lambda t: t.take)
+
+        part.active_take = target.take
+        part.raw_file = target.raw_file
+        part.processed_file = target.processed_file
+        part.git_commit = target.git_commit
+        part.git_dirty = target.git_dirty
+        part.recorded_at = target.recorded_at
+        part.status = target.status
+
+        logger.info(
+            "Restored take {} for {} part {}",
+            take,
+            lecture_id,
+            part_number,
+        )
+
+    def rename_recording_paths(
+        self,
+        old_raw: str,
+        new_raw: str,
+        *,
+        old_processed: str | None = None,
+        new_processed: str | None = None,
+    ) -> None:
+        """Update ``raw_file`` / ``processed_file`` references after a filesystem rename.
+
+        Scans every lecture, part, and take. No-op if neither ``old_raw``
+        nor ``old_processed`` matches any tracked path — a cascade may
+        have acted on files not yet assigned to the state.json model.
+        """
+        for lecture in self.lectures:
+            for part in lecture.parts:
+                if part.raw_file == old_raw:
+                    part.raw_file = new_raw
+                if old_processed is not None and part.processed_file == old_processed:
+                    part.processed_file = new_processed
+                for take in part.takes:
+                    if take.raw_file == old_raw:
+                        take.raw_file = new_raw
+                    if old_processed is not None and take.processed_file == old_processed:
+                        take.processed_file = new_processed
 
     @property
     def progress(self) -> tuple[int, int]:

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -3,8 +3,10 @@
 Provides:
 - ``GET /`` — Dashboard page (Jinja2 template)
 - ``GET /lectures`` — Lecture list from course (slide decks per section)
-- ``POST /arm`` — Arm a slide deck for recording
-- ``POST /disarm`` — Disarm the current deck
+- ``POST /arm`` — Arm a slide deck for recording (low-level primitive)
+- ``POST /disarm`` — Disarm the current deck (low-level primitive)
+- ``POST /record`` — Arm + start OBS recording in one step
+- ``POST /stop`` — Tell OBS to stop the current recording
 - ``GET /status`` — JSON session status snapshot
 - ``GET /events`` — SSE stream for real-time updates
 - ``GET /pairs`` — Pending pairs list (HTMX partial)
@@ -205,6 +207,55 @@ async def disarm(request: Request):
         session.disarm()
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    if _from_lectures(request):
+        return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+    return await status_partial(request)
+
+
+@router.post("/record", response_class=HTMLResponse)
+async def record_deck(
+    request: Request,
+    course_slug: str = Form(...),
+    section_name: str = Form(...),
+    deck_name: str = Form(...),
+    part_number: int = Form(0),
+):
+    """Arm a deck and start OBS recording in one step.
+
+    If OBS rejects the start request (e.g. not connected or already
+    recording), the deck is left armed and a 502 is returned with the
+    OBS error. The user can retry via the lower-level ``/arm`` route or
+    start OBS manually.
+    """
+    session = _get_session(request)
+    lang = _get_lang(request)
+    try:
+        session.record(course_slug, section_name, deck_name, part_number=part_number, lang=lang)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ConnectionError as exc:
+        logger.warning("OBS rejected start_record: {}", exc)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if _from_lectures(request):
+        return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+    return await status_partial(request)
+
+
+@router.post("/stop", response_class=HTMLResponse)
+async def stop_recording(request: Request):
+    """Tell OBS to stop the current recording.
+
+    The session's existing STOPPED-event handler takes care of the
+    rename. Returns the status partial so the dashboard updates.
+    """
+    session = _get_session(request)
+    try:
+        session.stop()
+    except ConnectionError as exc:
+        logger.warning("OBS rejected stop_record: {}", exc)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     if _from_lectures(request):
         return HTMLResponse("", headers={"HX-Redirect": "/lectures"})

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -634,6 +634,22 @@ async def cancel_job(request: Request, job_id: str):
     return await jobs_partial(request)
 
 
+@router.post("/jobs/{job_id}/reconcile", response_class=HTMLResponse)
+async def reconcile_job(request: Request, job_id: str):
+    """Verify a job's displayed state against upstream + filesystem.
+
+    Triggers the backend's ``reconcile`` hook. Useful when the user
+    sees a stuck ``FAILED`` job whose upstream work actually finished —
+    a common scenario after a server restart during an Auphonic
+    production. Returns the refreshed jobs panel so HTMX can swap it.
+    """
+    manager = _get_job_manager(request)
+    updated = manager.reconcile(job_id)
+    if updated is None:
+        raise HTTPException(status_code=404, detail=f"No job with id {job_id}")
+    return await jobs_partial(request)
+
+
 @router.get("/backends", response_class=JSONResponse)
 async def backends_info(request: Request):
     """Return the active backend and its capabilities as JSON.

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -419,12 +419,33 @@ async def pairs_partial(request: Request):
 # ------------------------------------------------------------------
 
 
+def _sse_event_name_for(payload: str) -> str:
+    """Classify an SSE queue *payload* into an ``event:`` name.
+
+    Job-lifecycle payloads (``"job"``, ``"job:<id>"``,
+    ``"submitted:<id>"``) are emitted as ``event: job`` so the
+    Processing Jobs panel can bind a refresh on them without
+    flooding the Status panel. Everything else (session transitions,
+    OBS connect/disconnect, watcher start/stop) stays on the
+    legacy ``event: status`` name.
+    """
+    return "job" if payload.startswith(("job", "submitted")) else "status"
+
+
 @router.get("/events")
 async def events(request: Request):
     """Server-Sent Events stream for real-time dashboard updates.
 
-    Pushes ``event: status`` whenever the session state changes, plus
-    a periodic heartbeat every 15 seconds to keep the connection alive.
+    Emits two event names so the dashboard can route updates without
+    cross-refreshing every panel on every tick:
+
+    * ``event: job`` — job-lifecycle messages (``"job"``, ``"job:<id>"``,
+      ``"submitted:<id>"``). Delivered to the Processing Jobs panel.
+    * ``event: status`` — everything else (session state changes, OBS
+      connect/disconnect, watcher start/stop). Delivered to the Status
+      panel.
+
+    A periodic heartbeat (``: heartbeat``) keeps idle connections alive.
     """
     sse_queue: asyncio.Queue[str] = request.app.state.sse_queue
 
@@ -433,7 +454,7 @@ async def events(request: Request):
             try:
                 # Wait for an event or timeout for heartbeat
                 msg = await asyncio.wait_for(sse_queue.get(), timeout=15.0)
-                yield f"event: status\ndata: {msg}\n\n"
+                yield f"event: {_sse_event_name_for(msg)}\ndata: {msg}\n\n"
             except asyncio.TimeoutError:
                 yield ": heartbeat\n\n"
             except asyncio.CancelledError:

--- a/src/clm/recordings/web/templates/dashboard.html
+++ b/src/clm/recordings/web/templates/dashboard.html
@@ -13,7 +13,7 @@
 
     <div id="jobs-panel"
          hx-get="/jobs"
-         hx-trigger="load, sse:status"
+         hx-trigger="load, sse:job, sse:status"
          hx-swap="innerHTML">
         {% include "partials/jobs.html" %}
     </div>

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -19,7 +19,9 @@
 
 {% if snapshot.armed_deck %}
 <div class="armed-info">
-    <strong>{% if snapshot.state.value == 'recording' %}Recording{% else %}Armed{% endif %}:</strong>
+    <strong>
+        {% if snapshot.state.value == 'recording' %}Recording{% elif snapshot.state.value == 'armed_after_take' %}Ready for retake{% else %}Armed{% endif %}:
+    </strong>
     {{ snapshot.armed_deck.course_slug }} /
     {{ snapshot.armed_deck.section_name }} /
     {{ snapshot.armed_deck.deck_name }}

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -19,17 +19,24 @@
 
 {% if snapshot.armed_deck %}
 <div class="armed-info">
-    <strong>Armed:</strong>
+    <strong>{% if snapshot.state.value == 'recording' %}Recording{% else %}Armed{% endif %}:</strong>
     {{ snapshot.armed_deck.course_slug }} /
     {{ snapshot.armed_deck.section_name }} /
     {{ snapshot.armed_deck.deck_name }}
     {% if snapshot.armed_deck.part_number > 0 %}
     ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
     {% endif %}
+    {% if snapshot.state.value == 'recording' %}
+    <form hx-post="/stop" hx-target="body"
+          style="display:inline; margin-left:1em;">
+        <button type="submit" class="primary topic-btn">Stop</button>
+    </form>
+    {% else %}
     <form hx-post="/disarm" hx-target=".armed-info" hx-swap="outerHTML"
           style="display:inline; margin-left:1em;">
         <button type="submit" class="outline secondary topic-btn">Disarm</button>
     </form>
+    {% endif %}
 </div>
 {% endif %}
 
@@ -69,18 +76,35 @@
                 <td>
                     <div class="deck-actions">
                         {% if is_armed %}
+                        {% if snapshot.state.value == 'recording' %}
+                        <form hx-post="/stop" hx-target="body">
+                            <button type="submit" class="primary topic-btn">Stop</button>
+                        </form>
+                        {% else %}
                         <form hx-post="/disarm" hx-target="body">
                             <button type="submit" class="outline secondary topic-btn">Disarm</button>
                         </form>
+                        {% endif %}
                         {% else %}
-                        <form hx-post="/arm" hx-target="body">
+                        <form hx-post="/record" hx-target="body">
                             <input type="hidden" name="course_slug" value="{{ course_slug }}">
                             <input type="hidden" name="section_name" value="{{ section.name }}">
                             <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
                             <label>Part:</label>
                             <input type="number" name="part_number" value="0" min="0" max="20">
-                            <button type="submit" class="outline topic-btn">Arm</button>
+                            <button type="submit" class="primary topic-btn">Record</button>
                         </form>
+                        <details class="advanced-actions">
+                            <summary>Advanced</summary>
+                            <form hx-post="/arm" hx-target="body">
+                                <input type="hidden" name="course_slug" value="{{ course_slug }}">
+                                <input type="hidden" name="section_name" value="{{ section.name }}">
+                                <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
+                                <label>Part:</label>
+                                <input type="number" name="part_number" value="0" min="0" max="20">
+                                <button type="submit" class="outline secondary topic-btn">Arm only</button>
+                            </form>
+                        </details>
                         {% endif %}
                         {% if deck.status and deck.status.state.value in ('recorded', 'failed') and deck.status.raw_paths %}
                         <form hx-post="/process" hx-target="body" hx-disabled-elt="find button">

--- a/src/clm/recordings/web/templates/partials/jobs.html
+++ b/src/clm/recordings/web/templates/partials/jobs.html
@@ -32,6 +32,11 @@
                     <span class="status-badge badge-{{ job.state.value }}">
                         {{ job.state.value }}
                     </span>
+                    {% if job.stale %}
+                    <span class="status-badge badge-failed" title="Older than the backend's stale-warning window — not failed, just long-running. Use Verify to double-check.">
+                        stale
+                    </span>
+                    {% endif %}
                 </td>
                 <td>
                     <progress value="{{ (job.progress * 100) | int }}" max="100">
@@ -41,11 +46,22 @@
                 <td>
                     {% if job.error %}
                     <span class="error-text">{{ job.error }}</span>
+                    {% elif job.last_poll_error %}
+                    <span class="error-text">{{ job.last_poll_error }}</span>
                     {% else %}
                     {{ job.message }}
                     {% endif %}
                 </td>
                 <td>
+                    <form hx-post="/jobs/{{ job.id }}/reconcile"
+                          hx-target="#jobs-panel"
+                          hx-swap="innerHTML"
+                          hx-disabled-elt="find button"
+                          style="display:inline">
+                        <button type="submit" class="outline topic-btn" title="Verify the job's state against upstream + disk; recovers from server-restart and upstream-completed-while-we-slept cases.">
+                            &#x21bb; Verify
+                        </button>
+                    </form>
                     {% if not job.is_terminal %}
                     <form hx-post="/jobs/{{ job.id }}/cancel"
                           hx-target="#jobs-panel"

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -32,17 +32,24 @@
 
     {% if snapshot.armed_deck %}
     <div class="armed-info">
-        <strong>Armed:</strong>
+        <strong>{% if snapshot.state.value == 'recording' %}Recording{% else %}Armed{% endif %}:</strong>
         {{ snapshot.armed_deck.course_slug }} /
         {{ snapshot.armed_deck.section_name }} /
         {{ snapshot.armed_deck.deck_name }}
         {% if snapshot.armed_deck.part_number > 0 %}
         ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
         {% endif %}
+        {% if snapshot.state.value == 'recording' %}
+        <form hx-post="/stop" hx-target="#status-panel" hx-swap="innerHTML"
+              style="display:inline; margin-left:1em;">
+            <button type="submit" class="primary topic-btn">Stop</button>
+        </form>
+        {% else %}
         <form hx-post="/disarm" hx-target="#status-panel" hx-swap="innerHTML"
               style="display:inline; margin-left:1em;">
             <button type="submit" class="outline secondary topic-btn">Disarm</button>
         </form>
+        {% endif %}
     </div>
     {% endif %}
 

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -32,7 +32,9 @@
 
     {% if snapshot.armed_deck %}
     <div class="armed-info">
-        <strong>{% if snapshot.state.value == 'recording' %}Recording{% else %}Armed{% endif %}:</strong>
+        <strong>
+            {% if snapshot.state.value == 'recording' %}Recording{% elif snapshot.state.value == 'armed_after_take' %}Ready for retake{% else %}Armed{% endif %}:
+        </strong>
         {{ snapshot.armed_deck.course_slug }} /
         {{ snapshot.armed_deck.section_name }} /
         {{ snapshot.armed_deck.deck_name }}

--- a/src/clm/recordings/workflow/backends/audio_first.py
+++ b/src/clm/recordings/workflow/backends/audio_first.py
@@ -138,6 +138,25 @@ class AudioFirstBackend(ABC):
         """Best-effort cancel; the in-flight subprocess call runs to completion."""
         return
 
+    def reconcile(self, job: ProcessingJob, *, ctx: JobContext) -> ProcessingJob:
+        """Filesystem-only reconcile for synchronous audio-first backends.
+
+        The audio pipeline runs entirely on the local machine, so the
+        only thing that can drift is the job record — if ``final_path``
+        exists and is non-empty, the work completed successfully even
+        if the job is currently stuck in ``FAILED`` or ``PROCESSING``
+        (e.g. a crash between finalize and state persistence).
+        """
+        if job.final_path.exists() and job.final_path.stat().st_size > 0:
+            if job.state != JobState.COMPLETED:
+                job.state = JobState.COMPLETED
+                job.progress = 1.0
+                job.message = "Recovered: final output already on disk"
+                job.error = None
+                job.last_poll_error = None
+                ctx.report(job)
+        return job
+
     # ------------------------------------------------------------------
     # Hooks for subclasses
     # ------------------------------------------------------------------

--- a/src/clm/recordings/workflow/backends/auphonic.py
+++ b/src/clm/recordings/workflow/backends/auphonic.py
@@ -101,6 +101,23 @@ DEFAULT_CUT_LIST_OUTPUT: dict[str, Any] = {
 }
 
 
+def _humanize_duration(delta: timedelta) -> str:
+    """Format *delta* as a compact human-readable duration.
+
+    ``0:00:45`` → ``"45s"``, ``0:03:47`` → ``"3m 47s"``, ``1:05:30`` →
+    ``"1h 5m"``. Seconds are dropped once the total exceeds an hour to
+    keep the string short in the jobs panel.
+    """
+    total_seconds = int(max(0.0, delta.total_seconds()))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
 class AuphonicBackend:
     """Asynchronous cloud backend that drives Auphonic productions.
 
@@ -237,6 +254,10 @@ class AuphonicBackend:
             if job.started_at is None:
                 job.started_at = datetime.now(timezone.utc)
             ctx.report(job)
+            # Auphonic returns status in <1s; nudge the poller so the
+            # dashboard sees the first in-processing update promptly
+            # rather than waiting out the full poll interval.
+            ctx.request_poll_soon()
         except Exception as exc:
             logger.exception("Auphonic submit failed for {}: {}", raw_path.name, exc)
             job.state = JobState.FAILED
@@ -315,7 +336,10 @@ class AuphonicBackend:
 
         # In-progress: surface Auphonic's own status_string plus a
         # heuristic progress value so the dashboard stays lively.
-        job.message = self._message_for(production)
+        # Passing *job* appends an elapsed-time heartbeat so every poll
+        # publishes a visibly different message even when Auphonic's
+        # own status hasn't changed.
+        job.message = self._message_for(production, job)
         job.progress = self._progress_for(production.status, job.progress)
         ctx.report(job)
         return job
@@ -521,11 +545,30 @@ class AuphonicBackend:
         return datetime.now(timezone.utc) > deadline
 
     @staticmethod
-    def _message_for(production: AuphonicProduction) -> str:
-        """Human-readable status message for an in-flight production."""
+    def _message_for(
+        production: AuphonicProduction,
+        job: ProcessingJob | None = None,
+    ) -> str:
+        """Human-readable status message for an in-flight production.
+
+        When *job* is supplied and its ``started_at`` is set, the elapsed
+        wall-clock time spent in the current phase is appended. This gives
+        the UI something to tick on every poll even when Auphonic's own
+        status string hasn't changed — the perceptual difference between
+        "frozen" and "working" is often just a heartbeat.
+        """
         if production.status_string:
-            return f"Auphonic: {production.status_string}"
-        return f"Auphonic status {production.status}"
+            base = f"Auphonic: {production.status_string}"
+        else:
+            base = f"Auphonic status {production.status}"
+
+        if job is None or job.started_at is None:
+            return base
+        anchor = job.started_at
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=timezone.utc)
+        delta = datetime.now(timezone.utc) - anchor
+        return f"{base} — {_humanize_duration(delta)}"
 
     @staticmethod
     def _progress_for(status: int, current: float) -> float:

--- a/src/clm/recordings/workflow/backends/auphonic.py
+++ b/src/clm/recordings/workflow/backends/auphonic.py
@@ -60,9 +60,25 @@ AUPHONIC_POLL_BACKOFF_AFTER_MINUTES = 30
 AUPHONIC_POLL_LONG_SECONDS = 300
 """Slow cadence: poll every 5 minutes once the job has been running long."""
 
-AUPHONIC_POLL_TIMEOUT_MINUTES = 120
-"""Default timeout: fail the job after this many total minutes.
-Overridable per-user via ``RecordingsConfig.auphonic.poll_timeout_minutes``.
+AUPHONIC_STALE_WARN_MINUTES = 120
+"""Soft warning window: jobs older than this are flagged ``stale``.
+
+A stale job is *not* failed automatically — the Auphonic production is
+probably still fine and the user may simply be watching a long-running
+transcript job. The dashboard surfaces a "stale" badge and prompts the
+user to click Verify. Overridable per-user via
+``RecordingsConfig.auphonic.poll_timeout_minutes`` (legacy name
+preserved for config compatibility).
+"""
+
+#: Backwards-compatible alias so existing imports keep working.
+AUPHONIC_POLL_TIMEOUT_MINUTES = AUPHONIC_STALE_WARN_MINUTES
+
+AUPHONIC_HARD_GIVEUP_DAYS = 7
+"""Hard upper bound. Jobs older than this are still auto-failed even if
+upstream hasn't reported an error — at this age the production has
+almost certainly been garbage-collected by Auphonic (the free and
+paid plans both prune old productions within weeks).
 """
 
 #: Preset name used by ``clm recordings auphonic preset sync``.
@@ -298,17 +314,19 @@ class AuphonicBackend:
             ctx.report(job)
             return job
 
-        # Enforce the local timeout regardless of Auphonic's state. The
-        # started_at anchor is set when the job enters PROCESSING.
-        if self._has_timed_out(job):
+        # Hard upper bound: past AUPHONIC_HARD_GIVEUP_DAYS the Auphonic
+        # production has almost certainly been garbage-collected, so keep
+        # the job alive is pointless. This is intentionally far longer
+        # than the stale-warn window below.
+        if self._has_hit_hard_giveup(job):
             logger.warning(
-                "Auphonic job {} timed out after {} minutes",
+                "Auphonic job {} exceeded hard giveup window ({} days); failing",
                 job.id,
-                self._poll_timeout_minutes,
+                AUPHONIC_HARD_GIVEUP_DAYS,
             )
             self._fail(
                 job,
-                f"Auphonic processing timed out after {self._poll_timeout_minutes} minutes",
+                f"Auphonic job still unfinished after {AUPHONIC_HARD_GIVEUP_DAYS} days",
                 ctx,
             )
             return job
@@ -341,6 +359,12 @@ class AuphonicBackend:
         # own status hasn't changed.
         job.message = self._message_for(production, job)
         job.progress = self._progress_for(production.status, job.progress)
+        # Soft stale-warning: flag long-running jobs so the UI can nudge
+        # the user to click Verify, but don't fail them — Auphonic is
+        # almost certainly still working and the cost of a false positive
+        # (lost credits, manual re-upload) is much higher than the cost
+        # of a slightly noisy dashboard.
+        job.stale = self._has_hit_stale_warn(job)
         ctx.report(job)
         return job
 
@@ -357,6 +381,106 @@ class AuphonicBackend:
                 job.backend_ref,
                 exc,
             )
+
+    def reconcile(self, job: ProcessingJob, *, ctx: JobContext) -> ProcessingJob:
+        """Verify *job*'s displayed state against Auphonic + the filesystem.
+
+        Resolution order:
+
+        1. **Local final present** — if ``final_path`` exists and is non-
+           empty, the work is effectively done. Archive the raw (if still
+           in ``to-process/``) and mark the job ``COMPLETED``. Cheapest
+           and safest win: a completed file on disk is ground truth.
+        2. **Upstream UUID** — when ``backend_ref`` is set, call
+           ``get_production(uuid)``. If the production is ``DONE``,
+           finalize it; if ``ERROR``, fail the job; otherwise resurrect
+           to ``PROCESSING`` (clearing any stale error/timeout markers).
+        3. **Title-based fallback** — when the UUID is missing (the
+           server crashed before persisting it, or the original
+           submission failed partway through), search Auphonic for a
+           production whose title matches the raw filename's stem. A
+           single match is adopted as the new ``backend_ref``; zero or
+           multiple matches leaves the job alone but records a message
+           the user can act on.
+
+        Safe to call on any state, including terminal. Network errors
+        are surfaced on ``last_poll_error`` — callers rely on the
+        returned job, not exceptions, to communicate status.
+        """
+        # 1. Filesystem check — cheap, always-correct recovery.
+        if job.final_path.exists() and job.final_path.stat().st_size > 0:
+            if job.raw_path.exists():
+                try:
+                    self._archive_raw(job)
+                except Exception as exc:  # pragma: no cover — defensive
+                    logger.warning("reconcile: archive_raw failed for {}: {}", job.id, exc)
+            job.state = JobState.COMPLETED
+            job.progress = 1.0
+            job.message = "Recovered: final already on disk"
+            job.error = None
+            job.last_poll_error = None
+            job.stale = False
+            if job.completed_at is None:
+                job.completed_at = datetime.now(timezone.utc)
+            ctx.report(job)
+            return job
+
+        # 2. Upstream UUID — let Auphonic tell us where the production is.
+        if job.backend_ref:
+            try:
+                production = self._client.get_production(job.backend_ref)
+            except AuphonicError as exc:
+                # Network blip or schema drift — record and leave the
+                # job alone. The caller can retry the reconcile.
+                job.last_poll_error = str(exc)
+                ctx.report(job)
+                return job
+
+            if production.status == AuphonicStatus.DONE:
+                return self._finalize(job, production, ctx)
+            if production.status == AuphonicStatus.ERROR:
+                self._fail(
+                    job,
+                    production.error_message or "Auphonic reported ERROR",
+                    ctx,
+                )
+                return job
+
+            # Still in-flight upstream — resurrect from whatever local
+            # state we had (FAILED, stuck, stale) back into PROCESSING.
+            job.state = JobState.PROCESSING
+            job.error = None
+            job.last_poll_error = None
+            job.stale = False
+            job.message = self._message_for(production, job)
+            job.progress = self._progress_for(production.status, job.progress)
+            ctx.report(job)
+            return job
+
+        # 3. Title-based fallback — the UUID was lost; search by title.
+        title = self._title_for(job.raw_path)
+        try:
+            candidates = self._client.list_productions(title=title)
+        except AuphonicError as exc:
+            job.last_poll_error = str(exc)
+            ctx.report(job)
+            return job
+
+        if len(candidates) == 1:
+            job.backend_ref = candidates[0].uuid
+            ctx.report(job)
+            # Recurse into branch 2 now that we have a UUID.
+            return self.reconcile(job, ctx=ctx)
+        if len(candidates) > 1:
+            job.message = f"Multiple Auphonic productions match {title!r} — resolve manually"
+            ctx.report(job)
+            return job
+
+        # No match upstream and no local final. Leave the job in its
+        # current state and surface an actionable message.
+        job.message = f"Nothing to reconcile: no production matches {title!r}"
+        ctx.report(job)
+        return job
 
     # ------------------------------------------------------------------
     # Finalization / state transitions
@@ -530,11 +654,14 @@ class AuphonicBackend:
         base, _ = parse_raw_stem(raw.stem, self._raw_suffix)
         return base or raw.stem
 
-    def _has_timed_out(self, job: ProcessingJob) -> bool:
-        """True if *job* has been in-flight longer than the configured timeout.
+    def _has_hit_stale_warn(self, job: ProcessingJob) -> bool:
+        """True once *job* has exceeded the configured stale-warning window.
 
-        Uses ``started_at`` as the anchor (set when the job first enters
-        ``PROCESSING``). Falls back to ``created_at`` if somehow unset.
+        Used as a *soft* signal: the job's ``stale`` flag flips to True
+        so the UI can surface a warning badge, but the job is NOT
+        failed. ``started_at`` is the primary anchor; we fall back to
+        ``created_at`` if the job never managed to transition to
+        ``PROCESSING`` upstream.
         """
         anchor = job.started_at or job.created_at
         if anchor is None:  # pragma: no cover — both defaulted in the model
@@ -543,6 +670,27 @@ class AuphonicBackend:
             anchor = anchor.replace(tzinfo=timezone.utc)
         deadline = anchor + timedelta(minutes=self._poll_timeout_minutes)
         return datetime.now(timezone.utc) > deadline
+
+    def _has_hit_hard_giveup(self, job: ProcessingJob) -> bool:
+        """True once *job* has exceeded the hard giveup window.
+
+        This is the only time-based failure the backend applies — past
+        :data:`AUPHONIC_HARD_GIVEUP_DAYS` the production has almost
+        certainly been pruned upstream, so keeping the job "alive" is
+        pointless. Deliberately much longer than :meth:`_has_hit_stale_warn`
+        so healthy long-running jobs aren't auto-failed.
+        """
+        anchor = job.started_at or job.created_at
+        if anchor is None:  # pragma: no cover — both defaulted
+            return False
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=timezone.utc)
+        deadline = anchor + timedelta(days=AUPHONIC_HARD_GIVEUP_DAYS)
+        return datetime.now(timezone.utc) > deadline
+
+    # Deprecated alias: older tests refer to ``_has_timed_out``. The
+    # same semantics now live on ``_has_hit_stale_warn``.
+    _has_timed_out = _has_hit_stale_warn
 
     @staticmethod
     def _message_for(
@@ -589,10 +737,12 @@ class AuphonicBackend:
 
 
 __all__ = [
+    "AUPHONIC_HARD_GIVEUP_DAYS",
     "AUPHONIC_POLL_BACKOFF_AFTER_MINUTES",
     "AUPHONIC_POLL_INITIAL_SECONDS",
     "AUPHONIC_POLL_LONG_SECONDS",
     "AUPHONIC_POLL_TIMEOUT_MINUTES",
+    "AUPHONIC_STALE_WARN_MINUTES",
     "DEFAULT_CUT_LIST_OUTPUT",
     "DEFAULT_INLINE_ALGORITHMS",
     "DEFAULT_MANAGED_PRESET_NAME",

--- a/src/clm/recordings/workflow/backends/auphonic_client.py
+++ b/src/clm/recordings/workflow/backends/auphonic_client.py
@@ -30,6 +30,7 @@ background) and §6.8 (backend usage).
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -44,6 +45,14 @@ DEFAULT_BASE_URL = "https://auphonic.com"
 
 #: Default streaming upload chunk size (8 MiB).
 DEFAULT_UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024
+
+#: Minimum interval between consecutive ``on_progress`` callbacks in
+#: :meth:`AuphonicClient.upload_input`. The callback is otherwise chunk-
+#: granular — gating it on wall-clock time prevents the dashboard from
+#: being flooded on fast uplinks while still letting a slow uplink tick
+#: at its natural chunk cadence (the gate is a no-op when chunks take
+#: longer than the interval). A final ``1.0`` tick is always delivered.
+UPLOAD_PROGRESS_MIN_INTERVAL = 0.25
 
 #: Default HTTP timeout for non-upload requests, in seconds.
 DEFAULT_REQUEST_TIMEOUT = 30.0
@@ -389,15 +398,16 @@ class AuphonicClient:
         """Upload *file_path* as the production's input (step 2 of 3).
 
         Streams the file in ``self._chunk_size`` chunks. If *on_progress*
-        is supplied, it is called with a fraction in ``[0.0, 1.0]`` after
-        each chunk is sent. The last call is always ``1.0`` on success.
+        is supplied, it is called with a fraction in ``[0.0, 1.0]``; the
+        call rate is gated by :data:`UPLOAD_PROGRESS_MIN_INTERVAL` so
+        fast uplinks don't flood the dashboard with updates. The final
+        ``1.0`` call is always delivered on success.
 
         Args:
             uuid: Production UUID returned by :meth:`create_production`.
             file_path: Local file to upload.
             on_progress: Optional progress callback.
         """
-
         url = f"{self._base_url}/api/production/{uuid}/upload.json"
         total_size = file_path.stat().st_size
         filename = file_path.name
@@ -414,6 +424,7 @@ class AuphonicClient:
             tail = b"\r\n--" + boundary + b"--\r\n"
 
             sent = 0
+            last_report = time.monotonic()
             yield head
             with file_path.open("rb") as fh:
                 while True:
@@ -423,7 +434,12 @@ class AuphonicClient:
                     sent += len(chunk)
                     yield chunk
                     if on_progress is not None and total_size > 0:
-                        on_progress(min(sent / total_size, 1.0))
+                        now = time.monotonic()
+                        if (
+                            now - last_report
+                        ) >= UPLOAD_PROGRESS_MIN_INTERVAL or sent == total_size:
+                            on_progress(min(sent / total_size, 1.0))
+                            last_report = now
             yield tail
 
         # Compute content-length for the multipart payload so the server
@@ -454,8 +470,10 @@ class AuphonicClient:
             self._raise_for_status("POST", response)
             payload = response.json()
 
-        # Guarantee a final 1.0 tick in case the file was 0 bytes.
-        if on_progress is not None:
+        # Guarantee a final 1.0 tick — the inner loop only runs when the
+        # file has at least one chunk, so zero-byte uploads still need the
+        # UI to see an end-of-upload event.
+        if on_progress is not None and total_size == 0:
             on_progress(1.0)
 
         return AuphonicProduction.model_validate(self._unwrap(payload))

--- a/src/clm/recordings/workflow/backends/auphonic_client.py
+++ b/src/clm/recordings/workflow/backends/auphonic_client.py
@@ -388,6 +388,55 @@ class AuphonicClient:
             payload = response.json()
         return AuphonicProduction.model_validate(self._unwrap(payload))
 
+    def list_productions(
+        self,
+        *,
+        title: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuphonicProduction]:
+        """List productions on the account, optionally filtered by title.
+
+        Used by :meth:`AuphonicBackend.reconcile` to find a production
+        whose UUID was lost (e.g. the server crashed before persisting
+        ``backend_ref``). Auphonic's search API matches the substring in
+        ``metadata.title`` case-insensitively.
+
+        Args:
+            title: Optional substring to filter by. When ``None``, returns
+                the most recent productions on the account.
+            limit: Optional cap on the number of results. When ``None``,
+                the server default applies (usually 100).
+
+        Returns:
+            A list of :class:`AuphonicProduction` objects. Empty when no
+            productions match. Unknown fields in the server response are
+            ignored, so the list is robust to schema drift.
+        """
+        params: dict[str, str] = {}
+        if title is not None:
+            params["title"] = title
+        if limit is not None:
+            params["limit"] = str(limit)
+
+        url = f"{self._base_url}/api/productions.json"
+        with self._client(timeout=self._timeout) as client:
+            response = client.get(url, headers=self._headers(), params=params)
+            self._raise_for_status("GET", response)
+            payload = response.json()
+
+        # Auphonic list endpoints return ``{"data": [...]}`` in current
+        # versions; older responses may use a bare list or a single dict.
+        # Normalise to a list of dicts for uniform parsing.
+        if isinstance(payload, dict) and "data" in payload:
+            body = payload["data"]
+        else:
+            body = payload
+        if isinstance(body, dict):
+            body = [body]
+        if not isinstance(body, list):
+            raise AuphonicError(f"Unexpected Auphonic list response shape: {type(body).__name__}")
+        return [AuphonicProduction.model_validate(p) for p in body]
+
     def upload_input(
         self,
         uuid: str,

--- a/src/clm/recordings/workflow/backends/base.py
+++ b/src/clm/recordings/workflow/backends/base.py
@@ -123,3 +123,30 @@ class ProcessingBackend(Protocol):
         regardless of whether the remote work actually stopped.
         """
         ...
+
+    def reconcile(self, job: ProcessingJob, *, ctx: JobContext) -> ProcessingJob:
+        """Verify a job's displayed state against upstream + filesystem reality.
+
+        Called when the user explicitly asks the dashboard to double-check
+        a job — typically because the job is stuck or FAILED for reasons
+        unrelated to the actual work (server restart during upload, timed
+        out on a long production, etc.). The returned job replaces the
+        currently-tracked one and is published on the event bus.
+
+        Required contract:
+
+        * Safe to call on any state, including terminal. A ``FAILED`` job
+          whose work actually completed upstream should be resurrected
+          to ``COMPLETED``.
+        * Must not raise for transient upstream errors — callers rely on
+          the returned job's ``last_poll_error`` (or ``error``) to surface
+          any network/API blips.
+        * May mutate ``job`` in place; return the same object.
+
+        The default :class:`~clm.recordings.workflow.backends.audio_first.AudioFirstBackend`
+        and any other audio-first backend inherit a filesystem-only check
+        (promote to COMPLETED if ``final_path`` exists and is non-empty).
+        Backends that talk to a remote service (Auphonic) override with
+        a richer implementation.
+        """
+        ...

--- a/src/clm/recordings/workflow/backends/base.py
+++ b/src/clm/recordings/workflow/backends/base.py
@@ -35,6 +35,17 @@ class JobContext(Protocol):
         """Persist the job and publish a progress event."""
         ...
 
+    def request_poll_soon(self) -> None:
+        """Ask the manager's poller to run again on the next scheduler tick.
+
+        Async backends call this after a phase transition (typically
+        ``submit`` → ``PROCESSING``) so the UI sees the first upstream
+        status within a second instead of waiting for the normal poll
+        interval. Safe to call from any state and any thread; manager
+        implementations without a poller may ignore it.
+        """
+        ...
+
     @property
     def work_dir(self) -> Path:
         """Scratch directory the backend may use for intermediate files."""

--- a/src/clm/recordings/workflow/directories.py
+++ b/src/clm/recordings/workflow/directories.py
@@ -1,12 +1,17 @@
 """Directory structure management for the recording workflow.
 
-Manages the four-tier directory layout under the recordings root::
+Manages the five-tier directory layout under the recordings root::
 
     <root>/
     +-- to-process/   # Raw recordings and externally processed audio
     +-- final/        # Muxed output (video + processed audio)
     +-- archive/      # Originals moved here after successful assembly
-    +-- superseded/   # Displaced recordings (re-recorded or overwritten)
+    +-- takes/        # Fully-processed takes replaced by a later take (history)
+    +-- superseded/   # Displaced recordings (re-recorded before processing)
+
+``takes/`` holds **processed** takes preserved for history — these cost
+Auphonic credits to produce, so they are kept deliberately. ``superseded/``
+holds **pre-processing garbage** (zero-length OBS outputs, abandoned takes).
 """
 
 from __future__ import annotations
@@ -20,7 +25,7 @@ from clm.recordings.processing.batch import VIDEO_EXTENSIONS
 
 from .naming import DEFAULT_RAW_SUFFIX, parse_raw_stem
 
-SUBDIRS = ("to-process", "final", "archive", "superseded")
+SUBDIRS = ("to-process", "final", "archive", "takes", "superseded")
 
 
 class PendingPair(BaseModel):
@@ -74,6 +79,11 @@ def archive_dir(root_dir: Path) -> Path:
 
 def superseded_dir(root_dir: Path) -> Path:
     return root_dir / "superseded"
+
+
+def takes_dir(root_dir: Path) -> Path:
+    """Return the ``takes/`` directory — history of superseded processed takes."""
+    return root_dir / "takes"
 
 
 def find_pending_pairs(

--- a/src/clm/recordings/workflow/job_manager.py
+++ b/src/clm/recordings/workflow/job_manager.py
@@ -109,6 +109,10 @@ class _DefaultJobContext:
         self._manager._store_job(job)
         self._bus.publish(JOB_EVENT_TOPIC, job)
 
+    def request_poll_soon(self) -> None:
+        """Wake the manager's poller loop — see :meth:`JobManager.request_poll_soon`."""
+        self._manager.request_poll_soon()
+
 
 class JobManager:
     """Coordinates triggers and a single backend.
@@ -155,6 +159,10 @@ class JobManager:
         self._lock = threading.RLock()
         self._poller: threading.Thread | None = None
         self._stop = threading.Event()
+        # Fires when a backend calls ``request_poll_soon`` — or on
+        # shutdown, so the poller wakes promptly instead of sleeping
+        # out the remainder of its interval.
+        self._wake = threading.Event()
 
         # Rehydrate in-flight jobs from disk. PROCESSING jobs will be
         # re-polled on the next poller tick; UPLOADING jobs are stale
@@ -320,9 +328,26 @@ class JobManager:
         Safe to call multiple times and from any thread.
         """
         self._stop.set()
+        # Also wake the poller so it doesn't sit out the rest of its
+        # sleep interval before seeing ``_stop``.
+        self._wake.set()
         poller = self._poller
         if poller is not None and poller.is_alive():
             poller.join(timeout=timeout)
+
+    def request_poll_soon(self) -> None:
+        """Ask the poller to run again on the next scheduler tick.
+
+        Called by async backends (via :class:`JobContext`) after an
+        in-band state transition so the dashboard sees the new state
+        without waiting out the full ``poll_interval``. Safe to call
+        before the poller has started — the wake flag stays set until
+        the first loop iteration consumes it. No-op when the backend
+        is synchronous.
+        """
+        if self._backend.capabilities.is_synchronous:
+            return
+        self._wake.set()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -365,6 +390,7 @@ class JobManager:
         if self._poller is not None:
             return
         self._stop.clear()
+        self._wake.clear()
         self._poller = threading.Thread(
             target=self._poller_loop,
             name="clm-job-poller",
@@ -376,7 +402,12 @@ class JobManager:
     def _poller_loop(self) -> None:
         while not self._stop.is_set():
             self.poll_once()
-            self._stop.wait(self._poll_interval)
+            # Wait for the normal interval, an explicit wake-up, or
+            # shutdown — whichever comes first. ``_wake`` is shared by
+            # ``request_poll_soon`` and ``shutdown``; inspecting
+            # ``_stop`` at the top of the loop distinguishes them.
+            self._wake.wait(self._poll_interval)
+            self._wake.clear()
 
     def poll_once(self, *, job_id: str | None = None) -> list[ProcessingJob]:
         """Run a single poll cycle and return the jobs that were polled.

--- a/src/clm/recordings/workflow/job_manager.py
+++ b/src/clm/recordings/workflow/job_manager.py
@@ -165,16 +165,29 @@ class JobManager:
         self._wake = threading.Event()
 
         # Rehydrate in-flight jobs from disk. PROCESSING jobs will be
-        # re-polled on the next poller tick; UPLOADING jobs are stale
-        # (the upload endpoint isn't resumable), so we fail them with
-        # a clear message. COMPLETED/FAILED/CANCELLED jobs are loaded
-        # into memory too so list_jobs() can surface recent history.
+        # re-polled on the next poller tick; UPLOADING jobs need to be
+        # classified by whether a production already exists upstream.
+        # COMPLETED/FAILED/CANCELLED jobs are loaded into memory too so
+        # ``list_jobs()`` can surface recent history.
         for job in store.load_all():
             if job.state == JobState.UPLOADING:
-                job.state = JobState.FAILED
-                job.error = (
-                    "Upload was interrupted by a process restart. Please re-submit the recording."
-                )
+                if job.backend_ref:
+                    # A production was created upstream before the crash.
+                    # Move to PROCESSING so the next poll (or a user-
+                    # triggered Verify) can pick the state back up from
+                    # the backend rather than assuming the work is lost.
+                    job.state = JobState.PROCESSING
+                    job.message = "Resumed after restart — checking upstream"
+                    job.last_poll_error = None
+                else:
+                    # No upstream handle: the upload never made it past
+                    # step 1. The raw is still on disk, so this is a
+                    # genuine "please retry" case.
+                    job.state = JobState.FAILED
+                    job.error = (
+                        "Upload was interrupted before the production was created. "
+                        "Please re-submit the recording."
+                    )
                 job.touch()
                 self._store.save(job)
             self._jobs[job.id] = job
@@ -252,6 +265,50 @@ class JobManager:
         self._store_job(job)
         self._bus.publish(JOB_EVENT_TOPIC, job)
         return job
+
+    def reconcile(self, job_id: str) -> ProcessingJob | None:
+        """Run the backend's reconcile hook for *job_id*.
+
+        Returns the updated job, or ``None`` if the id is unknown.
+        Works on any state (including terminal) so a stuck ``FAILED``
+        job whose work actually completed upstream can be resurrected.
+        Any exception from the backend is classified like a poll:
+        permanent errors drive the job to ``FAILED``; transient ones
+        are recorded on ``last_poll_error`` and the state is left alone.
+        """
+        with self._lock:
+            job = self._jobs.get(job_id)
+        if job is None:
+            return None
+
+        ctx = self._make_context()
+        try:
+            updated = self._backend.reconcile(job, ctx=ctx)
+        except Exception as exc:
+            if _is_permanent_poll_error(exc):
+                logger.error(
+                    "Permanent reconcile error for {}, marking FAILED: {}",
+                    job.id,
+                    exc,
+                )
+                job.state = JobState.FAILED
+                job.error = str(exc)
+                job.last_poll_error = None
+            else:
+                logger.warning(
+                    "Transient reconcile error for {} (caller can retry): {}",
+                    job.id,
+                    exc,
+                )
+                job.last_poll_error = str(exc)
+            job.touch()
+            self._store_job(job)
+            self._bus.publish(JOB_EVENT_TOPIC, job)
+            return job
+
+        self._store_job(updated)
+        self._bus.publish(JOB_EVENT_TOPIC, updated)
+        return updated
 
     def mark_failed(self, job_id: str, *, reason: str) -> ProcessingJob | None:
         """Manually transition *job_id* to :attr:`JobState.FAILED`.

--- a/src/clm/recordings/workflow/jobs.py
+++ b/src/clm/recordings/workflow/jobs.py
@@ -169,6 +169,17 @@ class ProcessingJob(BaseModel):
     failed.
     """
 
+    stale: bool = False
+    """True when the job has exceeded the backend's stale-warning window.
+
+    Used by Auphonic (and any other async backend with a wall-clock
+    progress budget) as a *soft* flag: the production has been running
+    longer than expected, but no upstream ERROR has been reported and
+    the local work hasn't failed either. The UI surfaces a warning
+    badge and a Verify button; the user can still cancel or wait.
+    Cleared by a successful poll or reconciliation.
+    """
+
     artifacts: dict[str, Path] = Field(default_factory=dict)
     """Extra outputs keyed by kind (``"cut_list"``, ``"transcript"``, …)."""
 

--- a/src/clm/recordings/workflow/naming.py
+++ b/src/clm/recordings/workflow/naming.py
@@ -24,6 +24,8 @@ from clm.core.utils.text_utils import sanitize_file_name
 DEFAULT_RAW_SUFFIX = "--RAW"
 
 _PART_RE = re.compile(r"^(.*?) \((?:part|Teil) (\d+)\)$")
+_PART_TAKE_RE = re.compile(r"^(.*?) \((?:part|Teil) (\d+), take (\d+)\)$")
+_TAKE_ONLY_RE = re.compile(r"^(.*?) \(take (\d+)\)$")
 
 _PART_LABELS: dict[str, str] = {"de": "Teil", "en": "part"}
 
@@ -42,6 +44,19 @@ def _part_suffix(part: int, lang: str = "en") -> str:
         return ""
     label = _PART_LABELS.get(lang, "part")
     return f" ({label} {part})"
+
+
+def _part_take_suffix(part: int, take: int, lang: str = "en") -> str:
+    """Return the combined ``(part N, take K)`` suffix for superseded takes.
+
+    When ``part == 0``, the single-part form ``(take K)`` is used.  Always
+    English-labelled ``take`` regardless of ``lang`` — users never see this
+    suffix outside the ``takes/`` history shelf.
+    """
+    if part <= 0:
+        return f" (take {take})"
+    label = _PART_LABELS.get(lang, "part")
+    return f" ({label} {part}, take {take})"
 
 
 def raw_filename(
@@ -107,6 +122,56 @@ def parse_part(base_name: str) -> tuple[str, int]:
     if m:
         return m.group(1), int(m.group(2))
     return base_name, 0
+
+
+def parse_part_take(base_name: str) -> tuple[str, int, int]:
+    """Split a ``(part N, take K)`` or ``(take K)`` suffix from *base_name*.
+
+    Returns ``(deck_name, part_number, take_number)`` where a zero
+    ``take_number`` means "no take suffix found". Part 0 with take>0 means
+    a single-part recording's take, e.g. ``(take 2)`` without ``(part ...)``.
+
+    >>> parse_part_take("03 Intro (part 2, take 3)")
+    ('03 Intro', 2, 3)
+    >>> parse_part_take("03 Intro (take 2)")
+    ('03 Intro', 0, 2)
+    >>> parse_part_take("03 Intro (part 2)")
+    ('03 Intro', 2, 0)
+    >>> parse_part_take("03 Intro")
+    ('03 Intro', 0, 0)
+    """
+    m = _PART_TAKE_RE.match(base_name)
+    if m:
+        return m.group(1), int(m.group(2)), int(m.group(3))
+    m = _TAKE_ONLY_RE.match(base_name)
+    if m:
+        return m.group(1), 0, int(m.group(2))
+    base, part = parse_part(base_name)
+    return base, part, 0
+
+
+def take_filename(
+    deck_name: str,
+    ext: str = ".mp4",
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+    *,
+    part: int = 0,
+    take: int,
+    is_raw: bool = False,
+    lang: str = "en",
+) -> str:
+    """Build a filename for a superseded take under ``takes/``.
+
+    >>> take_filename("03 Intro", part=2, take=1)
+    '03 Intro (part 2, take 1).mp4'
+    >>> take_filename("03 Intro", part=0, take=2)
+    '03 Intro (take 2).mp4'
+    >>> take_filename("03 Intro", part=2, take=1, is_raw=True)
+    '03 Intro (part 2, take 1)--RAW.mp4'
+    """
+    suffix = _part_take_suffix(part, take, lang)
+    raw = raw_suffix if is_raw else ""
+    return f"{sanitize_file_name(deck_name)}{suffix}{raw}{ext}"
 
 
 def find_existing_recordings(

--- a/src/clm/recordings/workflow/obs.py
+++ b/src/clm/recordings/workflow/obs.py
@@ -189,6 +189,46 @@ class ObsClient:
         resp = req.get_record_directory()
         return Path(resp.record_directory)
 
+    def start_record(self) -> None:
+        """Tell OBS to begin recording.
+
+        Thin wrapper around ``obsws-python``'s ``start_record`` request.
+        The STARTED event arrives asynchronously via the EventClient; do
+        not rely on this call blocking until the recording is actually
+        running. OBS itself rejects the request if a recording is already
+        in progress — the underlying library surfaces that as an
+        exception, which we re-raise as :class:`ConnectionError` with a
+        friendly message so the web layer can present it cleanly.
+
+        Raises:
+            ConnectionError: If not connected to OBS or if OBS rejected
+                the request (e.g. already recording, no scene configured).
+        """
+        req = self._require_connected()
+        try:
+            req.start_record()
+        except Exception as exc:
+            raise ConnectionError(f"OBS rejected start_record: {exc}") from exc
+        logger.info("Requested OBS to start recording")
+
+    def stop_record(self) -> None:
+        """Tell OBS to stop the current recording.
+
+        The STOPPED event arrives asynchronously; the existing session
+        state machine handles the rename. Raises if OBS rejects the
+        request — typically because no recording is in progress.
+
+        Raises:
+            ConnectionError: If not connected to OBS or if OBS rejected
+                the request.
+        """
+        req = self._require_connected()
+        try:
+            req.stop_record()
+        except Exception as exc:
+            raise ConnectionError(f"OBS rejected stop_record: {exc}") from exc
+        logger.info("Requested OBS to stop recording")
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -316,6 +316,47 @@ class RecordingSession:
 
         self._notify()
 
+    def record(
+        self,
+        course_slug: str,
+        section_name: str,
+        deck_name: str,
+        *,
+        part_number: int = 0,
+        lang: str = "en",
+    ) -> None:
+        """Arm a deck and start OBS recording in one operation.
+
+        The two steps are deliberately *not* atomic: ``arm`` succeeds
+        under the session lock, then ``obs.start_record`` is invoked
+        outside the lock (OBS I/O must not block other callers).
+
+        If OBS rejects the start request, the deck is left **armed** on
+        purpose: the user can switch to OBS and start recording manually,
+        or retry the Record button once OBS is reachable. The caller is
+        responsible for surfacing the error in the UI.
+
+        Raises:
+            RuntimeError: If ``arm`` fails (already recording or mid-rename).
+            ConnectionError: If OBS rejects the start request. The deck
+                remains armed — callers should present a recoverable error.
+        """
+        self.arm(course_slug, section_name, deck_name, part_number=part_number, lang=lang)
+        self._obs.start_record()
+
+    def stop(self) -> None:
+        """Ask OBS to stop the current recording.
+
+        Pure convenience so the dashboard can offer a Stop button without
+        leaving the web UI. The rest of the stop flow (STOPPED event →
+        rename → transition to IDLE) is handled by the existing event
+        pipeline.
+
+        Raises:
+            ConnectionError: If OBS is not connected or rejects the request.
+        """
+        self._obs.stop_record()
+
     # ------------------------------------------------------------------
     # OBS event handling
     # ------------------------------------------------------------------

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -6,10 +6,23 @@ into the structured directory layout.
 
 State transitions::
 
-    idle ──arm()──► armed ──OBS starts──► recording ──OBS stops──► renaming ──done──► idle
-      ▲               │                                                                │
-      └──disarm()─────┘                                                                │
-      └────────────────────────────────────────────────────────────────────────────────┘
+    idle ──arm()──► armed ──OBS starts──► recording ──OBS stops──► renaming ──done──┐
+      ▲               │                      ▲                                       │
+      │               │                      │                                       ▼
+      │               │                      └── OBS starts ── armed_after_take ◄────┤
+      │               │                                             │                │
+      │               │                                             ▼                │
+      └──disarm()─────┴────────────────── timer expires ────────────┴────────────────┘
+
+A "short take" (OBS stops within ``short_take_seconds`` of starting) is
+treated as an accidental start-then-stop: the output goes to
+``superseded/`` and the session returns to ``ARMED`` with the same deck
+intact, so the user can start again without re-arming.
+
+A "retake" starts when OBS begins recording again inside the
+``retake_window_seconds`` after a normal take completes. The new
+recording is associated with the same armed deck; the old raw is
+superseded via the existing ``_prepare_target_slot`` cascade.
 
 The session manager is **thread-safe**.  OBS events arrive on a background
 thread (from ``obsws-python``), while :meth:`arm` / :meth:`disarm` are
@@ -45,6 +58,13 @@ class SessionState(enum.Enum):
     ARMED = "armed"
     RECORDING = "recording"
     RENAMING = "renaming"
+    ARMED_AFTER_TAKE = "armed_after_take"
+    """A take has completed and the deck remains armed for a short window.
+
+    A new OBS recording that begins before the window expires is
+    treated as a retake of the same deck. The window expiring
+    transitions the session to :attr:`IDLE` and clears the armed deck.
+    """
 
 
 @dataclass(frozen=True)
@@ -166,6 +186,28 @@ def _rename_final_to_part1(
             break
 
 
+def _move_to_superseded_dir(src: Path, dest_dir: Path) -> Path:
+    """Move *src* into *dest_dir*, appending ``(2)``, ``(3)``, … on collision.
+
+    Creates *dest_dir* if needed. Returns the final resolved destination
+    path. Shared by :func:`_supersede_file` (replacing a processed take
+    that's being re-recorded) and :meth:`RecordingSession._handle_short_take`
+    (moving an accidental zero-length take out of OBS's default dir).
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / src.name
+    if dest.exists():
+        stem = src.stem
+        ext = src.suffix
+        counter = 2
+        while dest.exists():
+            dest = dest_dir / f"{stem} ({counter}){ext}"
+            counter += 1
+    shutil.move(str(src), str(dest))
+    logger.info("Superseded {} → {}", src.name, dest)
+    return dest
+
+
 def _supersede_file(existing: Path, recordings_root: Path) -> None:
     """Move *existing* (and any companion ``.wav``) into ``superseded/``.
 
@@ -180,26 +222,12 @@ def _supersede_file(existing: Path, recordings_root: Path) -> None:
         rel = Path(".")
 
     dest_dir = superseded_dir(recordings_root) / str(rel)
-    dest_dir.mkdir(parents=True, exist_ok=True)
-
-    def _move_to_superseded(src: Path) -> None:
-        dest = dest_dir / src.name
-        if dest.exists():
-            stem = src.stem
-            ext = src.suffix
-            counter = 2
-            while dest.exists():
-                dest = dest_dir / f"{stem} ({counter}){ext}"
-                counter += 1
-        shutil.move(str(src), str(dest))
-        logger.info("Superseded {} → {}", src.name, dest)
-
-    _move_to_superseded(existing)
+    _move_to_superseded_dir(existing, dest_dir)
 
     # Also move companion .wav if present
     companion = existing.with_suffix(".wav")
     if companion.exists():
-        _move_to_superseded(companion)
+        _move_to_superseded_dir(companion, dest_dir)
 
 
 class RecordingSession:
@@ -214,6 +242,20 @@ class RecordingSession:
             for the recording file to stabilise after OBS stops.
         stability_checks: Number of consecutive identical size readings
             required before considering the file stable.
+        short_take_seconds: A recording that stops within this many seconds
+            of starting is treated as an accidental short take: its output
+            is moved to ``superseded/`` and the session remains armed.
+            Default 5 seconds.
+        retake_window_seconds: After a successful take, the deck stays
+            armed for this many seconds. A new OBS recording that begins
+            within the window is associated with the same armed deck as
+            a retake. When the window expires, the session transitions
+            to :attr:`SessionState.IDLE` and clears the armed deck.
+            Default 60 seconds.
+        rename_timeout_seconds: Total wall-clock budget for
+            :meth:`_wait_for_stable` to wait for OBS to finish writing
+            the file. A wedged encoder won't freeze the session forever.
+            Default 600 seconds (10 minutes).
         on_state_change: Optional callback invoked (outside the lock)
             after every state transition.  Receives a :class:`SessionSnapshot`.
     """
@@ -226,6 +268,9 @@ class RecordingSession:
         raw_suffix: str = DEFAULT_RAW_SUFFIX,
         stability_interval: float = 1.0,
         stability_checks: int = 3,
+        short_take_seconds: float = 5.0,
+        retake_window_seconds: float = 60.0,
+        rename_timeout_seconds: float = 600.0,
         on_state_change: Callable[[SessionSnapshot], None] | None = None,
     ) -> None:
         self._obs = obs
@@ -233,6 +278,9 @@ class RecordingSession:
         self._raw_suffix = raw_suffix
         self._stability_interval = stability_interval
         self._stability_checks = stability_checks
+        self._short_take_seconds = short_take_seconds
+        self._retake_window_seconds = retake_window_seconds
+        self._rename_timeout_seconds = rename_timeout_seconds
         self._on_state_change = on_state_change
 
         self._state = SessionState.IDLE
@@ -240,6 +288,10 @@ class RecordingSession:
         self._last_output: Path | None = None
         self._error: str | None = None
         self._lock = threading.Lock()
+
+        # Retake machinery (guarded by the session lock).
+        self._recording_started_at: float | None = None
+        self._retake_timer: threading.Timer | None = None
 
         # Wire up OBS events
         self._obs.on_record_state_changed(self._handle_record_event)
@@ -283,17 +335,26 @@ class RecordingSession:
     ) -> None:
         """Arm a slide deck for the next recording.
 
-        Can be called from ``IDLE`` or ``ARMED`` (to switch decks).
+        Can be called from ``IDLE``, ``ARMED``, or ``ARMED_AFTER_TAKE``
+        (to switch decks mid-retake-window). Calling from
+        ``ARMED_AFTER_TAKE`` cancels the retake timer — the window is
+        specific to the deck that just finished, and switching decks
+        means the user is moving on.
 
         Raises:
             RuntimeError: If a recording or rename is in progress.
         """
         with self._lock:
-            if self._state not in (SessionState.IDLE, SessionState.ARMED):
+            if self._state not in (
+                SessionState.IDLE,
+                SessionState.ARMED,
+                SessionState.ARMED_AFTER_TAKE,
+            ):
                 raise RuntimeError(
                     f"Cannot arm while in state '{self._state.value}'. "
                     "Wait for the current recording to finish."
                 )
+            self._cancel_retake_timer_locked()
             self._armed = ArmedDeck(course_slug, section_name, deck_name, part_number, lang)
             self._error = None
             self._state = SessionState.ARMED
@@ -303,6 +364,9 @@ class RecordingSession:
     def disarm(self) -> None:
         """Disarm the currently armed topic, returning to ``IDLE``.
 
+        Can be called from ``ARMED`` or ``ARMED_AFTER_TAKE`` (the latter
+        cancels the retake window early).
+
         Raises:
             RuntimeError: If a recording is in progress.
         """
@@ -311,6 +375,7 @@ class RecordingSession:
                 raise RuntimeError("Cannot disarm while recording is in progress.")
             if self._state == SessionState.RENAMING:
                 raise RuntimeError("Cannot disarm while rename is in progress.")
+            self._cancel_retake_timer_locked()
             self._armed = None
             self._state = SessionState.IDLE
 
@@ -376,14 +441,24 @@ class RecordingSession:
         We must ignore the intermediate STOPPING event and only act on
         the definitive STOPPED event, otherwise the session transitions
         to ``IDLE`` before the output path is available.
+
+        OBS START during ``ARMED_AFTER_TAKE`` is treated as a retake of
+        the same armed deck. OBS STOP within ``short_take_seconds`` of
+        the start is treated as an accidental take: the file is moved
+        to ``superseded/`` and the deck stays armed.
         """
         rename_args: tuple[Path, ArmedDeck] | None = None
+        short_take_args: tuple[Path, ArmedDeck] | None = None
 
         with self._lock:
             if event.output_active:
-                # Recording started
-                if self._state == SessionState.ARMED:
+                # Recording started (STARTED)
+                if self._state in (SessionState.ARMED, SessionState.ARMED_AFTER_TAKE):
+                    if self._state == SessionState.ARMED_AFTER_TAKE:
+                        logger.info("Retake detected for {} (within window)", self._armed)
+                    self._cancel_retake_timer_locked()
                     self._state = SessionState.RECORDING
+                    self._recording_started_at = time.monotonic()
                     logger.info("Recording started for {}", self._armed)
                 else:
                     logger.info("Recording started (state={}, no auto-rename)", self._state.value)
@@ -397,7 +472,21 @@ class RecordingSession:
 
                 # Recording stopped (definitive STOPPED event)
                 if self._state == SessionState.RECORDING and self._armed is not None:
-                    if event.output_path:
+                    elapsed = self._elapsed_since_start_locked()
+                    is_short_take = elapsed is not None and elapsed < self._short_take_seconds
+                    self._recording_started_at = None
+
+                    if is_short_take and event.output_path:
+                        # Accidental start-then-stop — move to superseded/
+                        # and stay armed on the same deck.
+                        logger.info(
+                            "Short take ({:.1f}s < {:.1f}s) — superseding and staying armed",
+                            elapsed,
+                            self._short_take_seconds,
+                        )
+                        self._state = SessionState.ARMED
+                        short_take_args = (Path(event.output_path), self._armed)
+                    elif event.output_path:
                         self._state = SessionState.RENAMING
                         rename_args = (Path(event.output_path), self._armed)
                     else:
@@ -408,12 +497,20 @@ class RecordingSession:
                 elif self._state == SessionState.RECORDING:
                     # Was recording but nothing armed — just go back to idle
                     self._state = SessionState.IDLE
+                    self._recording_started_at = None
                 else:
                     logger.debug("Recording stopped event ignored (state={})", self._state.value)
 
         self._notify()
 
-        if rename_args:
+        if short_take_args:
+            threading.Thread(
+                target=self._handle_short_take,
+                args=short_take_args,
+                daemon=True,
+                name="recording-short-take",
+            ).start()
+        elif rename_args:
             threading.Thread(
                 target=self._rename_recording,
                 args=rename_args,
@@ -426,7 +523,12 @@ class RecordingSession:
     # ------------------------------------------------------------------
 
     def _rename_recording(self, obs_output: Path, deck: ArmedDeck) -> None:
-        """Move the OBS output file into the structured ``to-process/`` tree."""
+        """Move the OBS output file into the structured ``to-process/`` tree.
+
+        On success, transitions the session to :attr:`ARMED_AFTER_TAKE`
+        and starts a timer that will disarm the deck if no retake
+        arrives within ``retake_window_seconds``.
+        """
         try:
             self._wait_for_stable(obs_output)
 
@@ -449,8 +551,9 @@ class RecordingSession:
 
             with self._lock:
                 self._last_output = target
-                self._armed = None
-                self._state = SessionState.IDLE
+                # Keep _armed so a retake within the window can re-use it.
+                self._state = SessionState.ARMED_AFTER_TAKE
+                self._start_retake_timer_locked()
 
         except Exception as exc:
             logger.error("Failed to rename recording: {}", exc)
@@ -461,16 +564,50 @@ class RecordingSession:
 
         self._notify()
 
+    def _handle_short_take(self, obs_output: Path, deck: ArmedDeck) -> None:
+        """Move an accidental short take to ``superseded/`` and log it.
+
+        The session has already transitioned back to :attr:`ARMED` under
+        the event-handler lock; this thread exists only to do the
+        filesystem I/O without blocking the OBS callback thread.
+        """
+        try:
+            self._wait_for_stable(obs_output)
+        except Exception as exc:
+            logger.warning(
+                "Short-take file {} did not stabilise: {}. Leaving in place.",
+                obs_output,
+                exc,
+            )
+            return
+
+        rel_dir = recording_relative_dir(deck.course_slug, deck.section_name)
+        dest_dir = superseded_dir(self._root) / str(rel_dir)
+        try:
+            dest = _move_to_superseded_dir(obs_output, dest_dir)
+            logger.info("Short take moved to {}", dest)
+        except Exception as exc:
+            logger.warning("Failed to move short-take {} to superseded/: {}", obs_output, exc)
+
     def _wait_for_stable(self, path: Path) -> None:
         """Poll file size until it stops changing.
 
+        Bounded by :attr:`_rename_timeout_seconds` so a wedged encoder
+        cannot freeze the session forever.
+
         Raises:
             FileNotFoundError: If the file does not exist.
+            TimeoutError: If the file has not stabilised within the timeout.
         """
         prev_size = -1
         stable_count = 0
+        deadline = time.monotonic() + self._rename_timeout_seconds
 
         while stable_count < self._stability_checks:
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"File {path} did not stabilise within {self._rename_timeout_seconds:.0f}s"
+                )
             if not path.exists():
                 raise FileNotFoundError(f"Recording file not found: {path}")
 
@@ -495,3 +632,54 @@ class RecordingSession:
                 self._on_state_change(self.snapshot())
             except Exception:
                 logger.exception("Error in state change callback")
+
+    def _elapsed_since_start_locked(self) -> float | None:
+        """Seconds since the most recent OBS STARTED event, or None if unknown.
+
+        The caller must hold :attr:`_lock`.
+        """
+        if self._recording_started_at is None:
+            return None
+        return time.monotonic() - self._recording_started_at
+
+    def _cancel_retake_timer_locked(self) -> None:
+        """Cancel the retake-window timer if one is running.
+
+        The caller must hold :attr:`_lock`. Safe to call when no timer
+        is active.
+        """
+        timer = self._retake_timer
+        self._retake_timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _start_retake_timer_locked(self) -> None:
+        """Arm a timer that will fire :meth:`_on_retake_window_expired`.
+
+        The caller must hold :attr:`_lock`. Cancels any prior timer
+        first so there is only ever one pending.
+        """
+        self._cancel_retake_timer_locked()
+        timer = threading.Timer(self._retake_window_seconds, self._on_retake_window_expired)
+        timer.daemon = True
+        timer.name = "recording-retake-window"
+        self._retake_timer = timer
+        timer.start()
+
+    def _on_retake_window_expired(self) -> None:
+        """Fire when the retake window elapses without a new OBS recording.
+
+        Transitions ``ARMED_AFTER_TAKE`` → ``IDLE``. Silently does
+        nothing if the session has already moved on (e.g. the user
+        disarmed, armed a different deck, or a retake arrived just
+        before the timer fired).
+        """
+        with self._lock:
+            if self._state != SessionState.ARMED_AFTER_TAKE:
+                return
+            logger.info("Retake window expired; disarming {}", self._armed)
+            self._armed = None
+            self._state = SessionState.IDLE
+            self._retake_timer = None
+
+        self._notify()

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -38,15 +38,26 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from clm.recordings.state import CourseRecordingState
 
 from loguru import logger
 
-from .directories import final_dir, superseded_dir, to_process_dir
+from clm.core.utils.text_utils import sanitize_file_name
+
+from .directories import archive_dir, final_dir, superseded_dir, takes_dir, to_process_dir
 from .naming import (
     DEFAULT_RAW_SUFFIX,
+    final_filename,
     find_existing_recordings,
+    parse_part,
+    parse_part_take,
+    parse_raw_stem,
     raw_filename,
     recording_relative_dir,
+    take_filename,
 )
 from .obs import ObsClient, RecordingEvent
 
@@ -98,6 +109,195 @@ class SessionSnapshot:
         return self.armed_deck
 
 
+def _next_take_number(
+    takes_subtree: Path,
+    deck_name: str,
+    part: int,
+) -> int:
+    """Return the next take number to assign when demoting the active take.
+
+    Scans *takes_subtree* for files named ``deck (part N, take K).*`` (or
+    ``deck (take K).*`` for single-part lectures) and returns ``max(K) + 1``.
+    Returns ``1`` if no historical takes exist — i.e., the take being
+    demoted right now is the first one to enter the history shelf.
+    """
+    if not takes_subtree.is_dir():
+        return 1
+
+    sanitized = sanitize_file_name(deck_name)
+    highest = 0
+    for child in takes_subtree.iterdir():
+        if not child.is_file():
+            continue
+        stem = child.stem
+        base_with, is_raw = parse_raw_stem(stem)
+        if is_raw:
+            base, p, take = parse_part_take(base_with)
+        else:
+            base, p, take = parse_part_take(stem)
+        if take == 0:
+            continue
+        if p != part:
+            continue
+        if base != sanitized:
+            continue
+        highest = max(highest, take)
+    return highest + 1
+
+
+def _scan_active_take_files(
+    *,
+    recordings_root: Path,
+    rel_dir: str,
+    deck_name: str,
+    part: int,
+    raw_suffix: str,
+    lang: str,
+) -> list[Path]:
+    """Collect the filesystem paths that belong to the active take of *part*.
+
+    Returns a list of existing paths across ``to-process/``, ``archive/``,
+    and ``final/`` that would collide with a new recording of the same
+    part. Includes both video and companion ``.wav`` files in the raw
+    directories. For ``final/`` the extension is not known a priori, so
+    any video-extension file matching the deck+part slot is returned.
+
+    Files are returned in a deterministic order for reproducibility.
+    """
+    from clm.recordings.processing.batch import VIDEO_EXTENSIONS
+
+    sanitized = sanitize_file_name(deck_name)
+    result: list[Path] = []
+
+    # Raw candidates in to-process/ and archive/. Filter by extension —
+    # both the video and the companion .wav share the ``--RAW`` stem so
+    # a generic scan can't distinguish them on its own.
+    for base_dir in (to_process_dir(recordings_root), archive_dir(recordings_root)):
+        subtree = base_dir / rel_dir
+        if not subtree.is_dir():
+            continue
+        for child in subtree.iterdir():
+            if not child.is_file():
+                continue
+            if child.suffix.lower() not in VIDEO_EXTENSIONS:
+                continue
+            base_with, is_raw = parse_raw_stem(child.stem, raw_suffix)
+            if not is_raw:
+                continue
+            base, p = parse_part(base_with)
+            if base != sanitized or p != part:
+                continue
+            result.append(child)
+            wav = child.with_suffix(".wav")
+            if wav.is_file():
+                result.append(wav)
+
+    # Final/ candidate — must scan because we don't know the extension.
+    final_subtree = final_dir(recordings_root) / rel_dir
+    if final_subtree.is_dir():
+        for child in final_subtree.iterdir():
+            if not child.is_file():
+                continue
+            if child.suffix.lower() not in VIDEO_EXTENSIONS:
+                continue
+            base, p = parse_part(child.stem)
+            if base == sanitized and p == part:
+                result.append(child)
+
+    return result
+
+
+def _classify_retake_source(path: Path, recordings_root: Path) -> str:
+    """Return ``"raw"`` for to-process/archive files, ``"final"`` otherwise."""
+    try:
+        path.relative_to(final_dir(recordings_root))
+        return "final"
+    except ValueError:
+        return "raw"
+
+
+def _preserve_active_take(
+    *,
+    recordings_root: Path,
+    rel_dir: str,
+    deck_name: str,
+    part: int,
+    raw_suffix: str,
+    lang: str,
+) -> list[tuple[Path, Path]]:
+    """Move the active take's files into ``takes/`` with ``(part N, take K)`` suffixes.
+
+    Returns the list of ``(old_path, new_path)`` pairs actually performed.
+    If no active-take files are present, returns an empty list.
+
+    The take number is chosen as ``max(existing_takes_for_part) + 1`` and
+    applied uniformly across all files moved in this call so that the
+    historical raw + final pair keeps the same ``K``.
+    """
+    files = _scan_active_take_files(
+        recordings_root=recordings_root,
+        rel_dir=rel_dir,
+        deck_name=deck_name,
+        part=part,
+        raw_suffix=raw_suffix,
+        lang=lang,
+    )
+    if not files:
+        return []
+
+    takes_subtree = takes_dir(recordings_root) / rel_dir
+    take_number = _next_take_number(takes_subtree, deck_name, part)
+    takes_subtree.mkdir(parents=True, exist_ok=True)
+
+    renames: list[tuple[Path, Path]] = []
+    for src in files:
+        kind = _classify_retake_source(src, recordings_root)
+        ext = src.suffix
+        if kind == "raw" and ext.lower() == ".wav":
+            name = take_filename(
+                deck_name,
+                ext=".wav",
+                raw_suffix=raw_suffix,
+                part=part,
+                take=take_number,
+                is_raw=True,
+                lang=lang,
+            )
+        elif kind == "raw":
+            name = take_filename(
+                deck_name,
+                ext=ext,
+                raw_suffix=raw_suffix,
+                part=part,
+                take=take_number,
+                is_raw=True,
+                lang=lang,
+            )
+        else:  # final
+            name = take_filename(
+                deck_name,
+                ext=ext,
+                raw_suffix=raw_suffix,
+                part=part,
+                take=take_number,
+                is_raw=False,
+                lang=lang,
+            )
+        dest = takes_subtree / name
+        # Should be clean because `take_number` is strictly greater than
+        # every existing take; defensive collision-handling is still cheap.
+        if dest.exists():
+            counter = 2
+            while dest.exists():
+                dest = takes_subtree / f"{dest.stem} ({counter}){dest.suffix}"
+                counter += 1
+        shutil.move(str(src), str(dest))
+        logger.info("Preserved active take {} → {}", src.name, dest)
+        renames.append((src, dest))
+
+    return renames
+
+
 def _prepare_target_slot(
     target_dir: Path,
     deck_name: str,
@@ -106,7 +306,7 @@ def _prepare_target_slot(
     raw_suffix: str,
     recordings_root: Path,
     lang: str = "en",
-) -> Path:
+) -> tuple[Path, list[tuple[Path, Path]]]:
     """Ensure the target slot is clear and handle dynamic part renaming.
 
     Implements these rules:
@@ -117,8 +317,11 @@ def _prepare_target_slot(
     - If the computed target already exists, supersede it.
     - Single recording = no suffix; multiple parts = all get ``(part N)``.
 
-    Returns the final target :class:`Path` for the new recording.
+    Returns the final target :class:`Path` for the new recording along with
+    the list of ``(old_path, new_path)`` pairs renamed on disk so that
+    callers can update any external path index (e.g. ``state.json``).
     """
+    renames: list[tuple[Path, Path]] = []
     existing = find_existing_recordings(target_dir, deck_name, raw_suffix)
 
     # If user is adding a new part (part>0) and an unsuffixed file exists,
@@ -132,6 +335,7 @@ def _prepare_target_slot(
         if not part1_target.exists():
             shutil.move(str(unsuffixed), str(part1_target))
             logger.info("Renamed {} → {} (multi-part cascade)", unsuffixed.name, part1_target.name)
+            renames.append((unsuffixed, part1_target))
 
             # Also rename companion .wav
             wav = unsuffixed.with_suffix(".wav")
@@ -141,9 +345,14 @@ def _prepare_target_slot(
                 )
                 shutil.move(str(wav), str(wav_target))
                 logger.info("Renamed {} → {} (companion)", wav.name, wav_target.name)
+                renames.append((wav, wav_target))
 
             # Also rename in final/
-            _rename_final_to_part1(deck_name, unsuffixed.suffix, recordings_root, target_dir, lang)
+            final_rename = _rename_final_to_part1(
+                deck_name, unsuffixed.suffix, recordings_root, target_dir, lang
+            )
+            if final_rename is not None:
+                renames.append(final_rename)
 
     target_name = raw_filename(deck_name, ext=ext, raw_suffix=raw_suffix, part=part, lang=lang)
     target = target_dir / target_name
@@ -151,39 +360,41 @@ def _prepare_target_slot(
     if target.exists():
         _supersede_file(target, recordings_root)
 
-    return target
+    return target, renames
 
 
 def _rename_final_to_part1(
     deck_name: str, ext: str, recordings_root: Path, target_dir: Path, lang: str = "en"
-) -> None:
-    """Rename unsuffixed final output to ``(part 1)`` when a multi-part cascade happens."""
+) -> tuple[Path, Path] | None:
+    """Rename unsuffixed final output to ``(part 1)`` when a multi-part cascade happens.
+
+    Returns the ``(old_path, new_path)`` pair when a rename happened, or
+    ``None`` if no unsuffixed final was found.
+    """
     tp = to_process_dir(recordings_root)
     try:
         rel = target_dir.relative_to(tp)
     except ValueError:
-        return
+        return None
 
     fd = final_dir(recordings_root) / str(rel)
     if not fd.is_dir():
-        return
-
-    from .naming import final_filename, parse_part
+        return None
 
     # Look for unsuffixed final file (any video extension)
     for child in fd.iterdir():
         if not child.is_file():
             continue
         base, part_num = parse_part(child.stem)
-        from clm.core.utils.text_utils import sanitize_file_name
-
         if base == sanitize_file_name(deck_name) and part_num == 0:
             new_name = final_filename(deck_name, ext=child.suffix, part=1, lang=lang)
             new_path = fd / new_name
             if not new_path.exists():
                 shutil.move(str(child), str(new_path))
                 logger.info("Renamed final {} → {}", child.name, new_path)
-            break
+                return (child, new_path)
+            return None
+    return None
 
 
 def _move_to_superseded_dir(src: Path, dest_dir: Path) -> Path:
@@ -258,6 +469,13 @@ class RecordingSession:
             Default 600 seconds (10 minutes).
         on_state_change: Optional callback invoked (outside the lock)
             after every state transition.  Receives a :class:`SessionSnapshot`.
+        state: Optional per-course recording state. When provided, each
+            filesystem rename performed by the session (retake pre-move,
+            multi-part cascade) is paired with a call to
+            :meth:`CourseRecordingState.rename_recording_paths` so the
+            state's ``raw_file``/``processed_file`` indices stay in sync
+            with disk. Pass ``None`` in tests that don't care about
+            state tracking — the filesystem behaviour is unchanged.
     """
 
     def __init__(
@@ -272,6 +490,7 @@ class RecordingSession:
         retake_window_seconds: float = 60.0,
         rename_timeout_seconds: float = 600.0,
         on_state_change: Callable[[SessionSnapshot], None] | None = None,
+        state: CourseRecordingState | None = None,
     ) -> None:
         self._obs = obs
         self._root = recordings_root
@@ -282,6 +501,7 @@ class RecordingSession:
         self._retake_window_seconds = retake_window_seconds
         self._rename_timeout_seconds = rename_timeout_seconds
         self._on_state_change = on_state_change
+        self._course_state = state
 
         self._state = SessionState.IDLE
         self._armed: ArmedDeck | None = None
@@ -525,6 +745,11 @@ class RecordingSession:
     def _rename_recording(self, obs_output: Path, deck: ArmedDeck) -> None:
         """Move the OBS output file into the structured ``to-process/`` tree.
 
+        Before landing the new raw, any existing active-take files for the
+        same ``(deck, part)`` are demoted into ``takes/`` with a
+        ``(part N, take K)`` suffix. This preserves previously-processed
+        finals and their matching raws without overwriting.
+
         On success, transitions the session to :attr:`ARMED_AFTER_TAKE`
         and starts a timer that will disarm the deck if no retake
         arrives within ``retake_window_seconds``.
@@ -536,7 +761,19 @@ class RecordingSession:
             target_dir = to_process_dir(self._root) / str(rel_dir)
             target_dir.mkdir(parents=True, exist_ok=True)
 
-            target = _prepare_target_slot(
+            # Retake pre-move: demote the active take's files into takes/
+            # before the new recording claims their slots.
+            preserved = _preserve_active_take(
+                recordings_root=self._root,
+                rel_dir=str(rel_dir),
+                deck_name=deck.deck_name,
+                part=deck.part_number,
+                raw_suffix=self._raw_suffix,
+                lang=deck.lang,
+            )
+            self._apply_renames_to_state(preserved)
+
+            target, cascade_renames = _prepare_target_slot(
                 target_dir,
                 deck.deck_name,
                 obs_output.suffix,
@@ -545,6 +782,7 @@ class RecordingSession:
                 self._root,
                 lang=deck.lang,
             )
+            self._apply_renames_to_state(cascade_renames)
 
             shutil.move(str(obs_output), str(target))
             logger.info("Renamed {} → {}", obs_output.name, target)
@@ -563,6 +801,30 @@ class RecordingSession:
                 self._state = SessionState.IDLE
 
         self._notify()
+
+    def _apply_renames_to_state(self, renames: list[tuple[Path, Path]]) -> None:
+        """Forward disk renames to the course state index when wired up.
+
+        No-op if ``state`` was not provided at construction. Swallows
+        exceptions so state tracking never blocks a successful rename on
+        disk — a stale state entry is recoverable; losing the recording
+        is not.
+        """
+        if self._course_state is None or not renames:
+            return
+        try:
+            for old, new in renames:
+                self._course_state.rename_recording_paths(str(old), str(new))
+                # The moved file may also be referenced as a processed_file
+                # when it lived under ``final/``; rename that column too.
+                self._course_state.rename_recording_paths(
+                    str(old),
+                    str(old),
+                    old_processed=str(old),
+                    new_processed=str(new),
+                )
+        except Exception as exc:
+            logger.warning("Failed to propagate rename to course state: {}", exc)
 
     def _handle_short_take(self, obs_output: Path, deck: ArmedDeck) -> None:
         """Move an accidental short take to ``superseded/`` and log it.

--- a/tests/recordings/test_audio_first_backend.py
+++ b/tests/recordings/test_audio_first_backend.py
@@ -32,6 +32,10 @@ class _RecordingContext:
     def report(self, job: ProcessingJob) -> None:
         self.reports.append((job.state, job.progress, job.message))
 
+    def request_poll_soon(self) -> None:
+        # No poller in this synchronous-backend test harness.
+        pass
+
 
 class _StubAudioBackend(AudioFirstBackend):
     """Audio-first backend for tests that writes a placeholder WAV."""

--- a/tests/recordings/test_auphonic_backend.py
+++ b/tests/recordings/test_auphonic_backend.py
@@ -46,6 +46,7 @@ class _RecordingContext:
     def __init__(self, work_dir: Path) -> None:
         self._work_dir = work_dir
         self.reports: list[ProcessingJob] = []
+        self.poll_soon_calls = 0
 
     @property
     def work_dir(self) -> Path:
@@ -55,6 +56,9 @@ class _RecordingContext:
         # Record a snapshot so downstream assertions see each transition,
         # not just the final state of the shared mutable job object.
         self.reports.append(job.model_copy(deep=True))
+
+    def request_poll_soon(self) -> None:
+        self.poll_soon_calls += 1
 
 
 class _FakeAuphonicClient:
@@ -536,3 +540,72 @@ class TestCancel:
 
         assert not client.deleted
         assert not client.calls
+
+
+class TestMessageElapsed:
+    """``_message_for`` appends elapsed time when a job is provided."""
+
+    def test_without_job_argument_returns_bare_status(self) -> None:
+        production = AuphonicProduction(
+            uuid="p",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        assert AuphonicBackend._message_for(production) == "Auphonic: Audio Processing"
+
+    def test_with_job_appends_elapsed_time(self, raw_file: Path, root: Path) -> None:
+        production = AuphonicProduction(
+            uuid="p",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        job = ProcessingJob(
+            backend_name="auphonic",
+            raw_path=raw_file,
+            final_path=_final_path_for(root, raw_file),
+            relative_dir=Path(),
+            started_at=datetime.now(timezone.utc) - timedelta(minutes=3, seconds=47),
+        )
+        msg = AuphonicBackend._message_for(production, job)
+        assert msg.startswith("Auphonic: Audio Processing — ")
+        # Minute/second boundaries drift by a few ms during the test,
+        # but the "3m Ns" shape should hold.
+        assert "3m" in msg and msg.endswith("s")
+
+    def test_with_job_without_started_at_is_bare(self, raw_file: Path, root: Path) -> None:
+        production = AuphonicProduction(
+            uuid="p",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        job = ProcessingJob(
+            backend_name="auphonic",
+            raw_path=raw_file,
+            final_path=_final_path_for(root, raw_file),
+            relative_dir=Path(),
+            # started_at left at default None.
+        )
+        assert AuphonicBackend._message_for(production, job) == "Auphonic: Audio Processing"
+
+    def test_humanize_duration_formats(self) -> None:
+        from clm.recordings.workflow.backends.auphonic import _humanize_duration
+
+        assert _humanize_duration(timedelta(seconds=45)) == "45s"
+        assert _humanize_duration(timedelta(minutes=3, seconds=47)) == "3m 47s"
+        assert _humanize_duration(timedelta(hours=1, minutes=5)) == "1h 5m"
+        assert _humanize_duration(timedelta(seconds=-10)) == "0s"
+
+
+class TestSubmitRequestsPollSoon:
+    """After transitioning to PROCESSING, submit nudges the poller."""
+
+    def test_submit_calls_request_poll_soon(self, root: Path, raw_file: Path, ctx) -> None:
+        backend = _make_backend(_FakeAuphonicClient(), root)
+        options = ProcessingOptions()
+        backend.submit(
+            raw_file,
+            _final_path_for(root, raw_file),
+            options=options,
+            ctx=ctx,
+        )
+        assert ctx.poll_soon_calls == 1

--- a/tests/recordings/test_auphonic_backend.py
+++ b/tests/recordings/test_auphonic_backend.py
@@ -75,11 +75,13 @@ class _FakeAuphonicClient:
         *,
         production_uuid: str = "prod-1",
         get_responses: list[AuphonicProduction] | None = None,
+        list_responses: list[list[AuphonicProduction]] | None = None,
         download_fn: Callable[[str, Path], None] | None = None,
     ) -> None:
         self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
         self._production_uuid = production_uuid
         self._get_responses = list(get_responses or [])
+        self._list_responses = list(list_responses or [])
         self._download_fn = download_fn or (lambda url, dest: dest.write_bytes(b"fake-video"))
         # Track state for optional multi-call scripts.
         self.deleted = False
@@ -108,6 +110,12 @@ class _FakeAuphonicClient:
         if not self._get_responses:
             raise AssertionError("No scripted get_production responses remain")
         return self._get_responses.pop(0)
+
+    def list_productions(self, *, title=None, limit=None):
+        self._record("list_productions", (), {"title": title, "limit": limit})
+        if not self._list_responses:
+            return []
+        return self._list_responses.pop(0)
 
     def download(self, url, dest, *, on_progress=None):
         self._record("download", (url, dest), {})
@@ -463,19 +471,72 @@ class TestPoll:
         assert updated.state == JobState.PROCESSING
         assert "network blip" in updated.message
 
-    def test_timeout_fails_job(self, root: Path, raw_file: Path, ctx: _RecordingContext) -> None:
-        client = _FakeAuphonicClient()
+    def test_stale_warn_flags_but_does_not_fail(
+        self, root: Path, raw_file: Path, ctx: _RecordingContext
+    ) -> None:
+        """Past the stale-warn window the job gets flagged, not failed.
+
+        Auphonic credits and time are too expensive to discard; a soft
+        warning lets the user click Verify while the production keeps
+        running upstream.
+        """
+        still_going = AuphonicProduction(
+            uuid="prod-x",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        client = _FakeAuphonicClient(get_responses=[still_going])
         backend = _make_backend(client, root, poll_timeout_minutes=1)
         job = self._make_in_flight_job(root, raw_file)
-        # Pretend the job started 2 minutes ago.
         job.started_at = datetime.now(timezone.utc) - timedelta(minutes=2)
 
         updated = backend.poll(job, ctx=ctx)
 
+        assert updated.state == JobState.PROCESSING
+        assert updated.stale is True
+        # Upstream was still contacted — we don't short-circuit anymore.
+        assert any(name == "get_production" for name, _, _ in client.calls)
+
+    def test_hard_giveup_fails_job(
+        self, root: Path, raw_file: Path, ctx: _RecordingContext
+    ) -> None:
+        """Past the hard giveup window the job is auto-failed as a safety net.
+
+        At this point the Auphonic production has almost certainly been
+        garbage-collected, so keeping the job alive is pointless.
+        """
+        from clm.recordings.workflow.backends.auphonic import AUPHONIC_HARD_GIVEUP_DAYS
+
+        client = _FakeAuphonicClient()
+        backend = _make_backend(client, root)
+        job = self._make_in_flight_job(root, raw_file)
+        job.started_at = datetime.now(timezone.utc) - timedelta(days=AUPHONIC_HARD_GIVEUP_DAYS + 1)
+
+        updated = backend.poll(job, ctx=ctx)
+
         assert updated.state == JobState.FAILED
-        assert "timed out" in (updated.error or "")
-        # Poll must short-circuit before talking to Auphonic on timeout.
+        assert "unfinished" in (updated.error or "").lower() or "days" in (updated.error or "")
+        # Hard-giveup must short-circuit before talking to Auphonic.
         assert not any(name == "get_production" for name, _, _ in client.calls)
+
+    def test_successful_poll_clears_stale_flag(
+        self, root: Path, raw_file: Path, ctx: _RecordingContext
+    ) -> None:
+        """A fresh poll within the stale window leaves the flag off."""
+        still_going = AuphonicProduction(
+            uuid="prod-x",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        client = _FakeAuphonicClient(get_responses=[still_going])
+        backend = _make_backend(client, root, poll_timeout_minutes=60)
+        job = self._make_in_flight_job(root, raw_file)
+        job.stale = True  # lingering from a prior poll
+        job.started_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+        updated = backend.poll(job, ctx=ctx)
+
+        assert updated.stale is False
 
     def test_missing_backend_ref_fails_immediately(
         self, root: Path, raw_file: Path, ctx: _RecordingContext
@@ -594,6 +655,191 @@ class TestMessageElapsed:
         assert _humanize_duration(timedelta(minutes=3, seconds=47)) == "3m 47s"
         assert _humanize_duration(timedelta(hours=1, minutes=5)) == "1h 5m"
         assert _humanize_duration(timedelta(seconds=-10)) == "0s"
+
+
+class TestReconcile:
+    """``AuphonicBackend.reconcile`` rescues jobs whose displayed state drifted."""
+
+    def _make_job(
+        self,
+        root: Path,
+        raw_file: Path,
+        *,
+        state: JobState = JobState.FAILED,
+        backend_ref: str | None = None,
+        error: str | None = None,
+    ) -> ProcessingJob:
+        return ProcessingJob(
+            backend_name="auphonic",
+            raw_path=raw_file,
+            final_path=_final_path_for(root, raw_file),
+            relative_dir=Path(),
+            state=state,
+            backend_ref=backend_ref,
+            error=error,
+            started_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+
+    def test_local_final_already_exists_marks_completed(
+        self, root: Path, raw_file: Path, ctx
+    ) -> None:
+        """Filesystem check is the cheapest and highest-priority signal."""
+        backend = _make_backend(_FakeAuphonicClient(), root)
+        job = self._make_job(root, raw_file, backend_ref="prod-1")
+
+        job.final_path.parent.mkdir(parents=True, exist_ok=True)
+        job.final_path.write_bytes(b"final-bytes")
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.state == JobState.COMPLETED
+        assert updated.progress == 1.0
+        assert "Recovered" in updated.message
+        assert updated.error is None
+        assert updated.completed_at is not None
+        # Raw should be archived if it was still present.
+        archived = (
+            root / "archive" / raw_file.parent.relative_to(root / "to-process") / raw_file.name
+        )
+        assert archived.exists() or not raw_file.exists()
+
+    def test_backend_ref_done_triggers_finalize(self, root: Path, raw_file: Path, ctx) -> None:
+        """A DONE Auphonic production drives full finalization."""
+        done_production = AuphonicProduction(
+            uuid="prod-x",
+            status=AuphonicStatus.DONE,
+            output_files=[
+                AuphonicOutputFile(
+                    format="video",
+                    ending="mp4",
+                    download_url="https://cdn.test/p.mp4",
+                )
+            ],
+        )
+        client = _FakeAuphonicClient(get_responses=[done_production])
+        backend = _make_backend(client, root)
+        job = self._make_job(root, raw_file, backend_ref="prod-x")
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.state == JobState.COMPLETED
+        # Final should now exist on disk (downloaded by _finalize).
+        assert updated.final_path.exists()
+        call_names = [c[0] for c in client.calls]
+        assert "get_production" in call_names
+        assert "download" in call_names
+
+    def test_backend_ref_error_fails_job(self, root: Path, raw_file: Path, ctx) -> None:
+        """A production in ERROR state transitions the job to FAILED with a clear message."""
+        err_production = AuphonicProduction(
+            uuid="prod-x",
+            status=AuphonicStatus.ERROR,
+            error_message="Upload truncated",
+        )
+        client = _FakeAuphonicClient(get_responses=[err_production])
+        backend = _make_backend(client, root)
+        job = self._make_job(root, raw_file, state=JobState.PROCESSING, backend_ref="prod-x")
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.state == JobState.FAILED
+        assert updated.error == "Upload truncated"
+
+    def test_resurrects_failed_job_when_upstream_still_processing(
+        self, root: Path, raw_file: Path, ctx
+    ) -> None:
+        """A FAILED local job whose upstream is still working comes back to PROCESSING."""
+        still_going = AuphonicProduction(
+            uuid="prod-x",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        client = _FakeAuphonicClient(get_responses=[still_going])
+        backend = _make_backend(client, root)
+        job = self._make_job(
+            root,
+            raw_file,
+            state=JobState.FAILED,
+            backend_ref="prod-x",
+            error="120-min timeout",
+        )
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.state == JobState.PROCESSING
+        assert updated.error is None
+        assert updated.last_poll_error is None
+        assert updated.stale is False
+        assert "Audio Processing" in updated.message
+
+    def test_backend_ref_network_error_records_last_poll_error(
+        self, root: Path, raw_file: Path, ctx
+    ) -> None:
+        """Transient errors are surfaced on last_poll_error, not raised."""
+
+        class _FlakyClient(_FakeAuphonicClient):
+            def get_production(self, uuid):
+                raise AuphonicError("network unreachable")
+
+        backend = _make_backend(_FlakyClient(), root)
+        job = self._make_job(root, raw_file, backend_ref="prod-x")
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.last_poll_error == "network unreachable"
+        # State unchanged (still FAILED from the fixture) — caller decides.
+        assert updated.state == JobState.FAILED
+
+    def test_title_fallback_single_match_adopts_uuid(self, root: Path, raw_file: Path, ctx) -> None:
+        """When backend_ref is missing, a single title match is adopted."""
+        match = AuphonicProduction(
+            uuid="found-uuid",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        still_going = AuphonicProduction(
+            uuid="found-uuid",
+            status=AuphonicStatus.AUDIO_PROCESSING,
+            status_string="Audio Processing",
+        )
+        client = _FakeAuphonicClient(
+            get_responses=[still_going],
+            list_responses=[[match]],
+        )
+        backend = _make_backend(client, root)
+        job = self._make_job(root, raw_file, backend_ref=None)
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.backend_ref == "found-uuid"
+        assert updated.state == JobState.PROCESSING
+
+    def test_title_fallback_multiple_matches_leaves_alone(
+        self, root: Path, raw_file: Path, ctx
+    ) -> None:
+        """Ambiguous title matches stay a no-op with a resolvable message."""
+        match_a = AuphonicProduction(uuid="a", status=AuphonicStatus.DONE)
+        match_b = AuphonicProduction(uuid="b", status=AuphonicStatus.DONE)
+        client = _FakeAuphonicClient(list_responses=[[match_a, match_b]])
+        backend = _make_backend(client, root)
+        job = self._make_job(root, raw_file, backend_ref=None)
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.backend_ref is None  # unchanged — ambiguous
+        assert "Multiple" in updated.message
+
+    def test_title_fallback_no_matches_is_noop_with_message(
+        self, root: Path, raw_file: Path, ctx
+    ) -> None:
+        client = _FakeAuphonicClient(list_responses=[[]])
+        backend = _make_backend(client, root)
+        job = self._make_job(root, raw_file, backend_ref=None, state=JobState.FAILED)
+
+        updated = backend.reconcile(job, ctx=ctx)
+
+        assert updated.state == JobState.FAILED  # untouched
+        assert "Nothing to reconcile" in updated.message
 
 
 class TestSubmitRequestsPollSoon:

--- a/tests/recordings/test_auphonic_client.py
+++ b/tests/recordings/test_auphonic_client.py
@@ -435,6 +435,74 @@ class TestUpload:
         # clears the upload bar.
         assert progress == [1.0]
 
+    def test_progress_is_time_gated(
+        self, client: AuphonicClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fast-uplink spam is suppressed: progress only fires on the gate.
+
+        Five chunks upload in <10 ms wall-clock; without the time gate the
+        old client fired progress five times. With the gate, intermediate
+        ticks are coalesced and only the forced final ``1.0`` fires.
+        """
+        from clm.recordings.workflow import backends as backends_module
+
+        payload = b"x" * (4096 * 5)
+        source = tmp_path / "raw.mp4"
+        source.write_bytes(payload)
+
+        # Freeze the clock so the gate is never satisfied.
+        frozen_t = [1000.0]
+        monkeypatch.setattr(
+            backends_module.auphonic_client.time,
+            "monotonic",
+            lambda: frozen_t[0],
+            raising=False,
+        )
+
+        progress: list[float] = []
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.post("/api/production/prod-3/upload.json").mock(
+                return_value=httpx.Response(200, json={"data": {"uuid": "prod-3"}})
+            )
+            client.upload_input("prod-3", source, on_progress=progress.append)
+
+        # Only the final forced 1.0 tick is emitted because the wall
+        # clock never advanced past the 250 ms gate.
+        assert progress == [1.0]
+
+    def test_progress_fires_on_interval_when_clock_advances(
+        self, client: AuphonicClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When at least one gate-interval elapses between chunks, the
+        intermediate progress tick is delivered.
+        """
+        from clm.recordings.workflow import backends as backends_module
+
+        payload = b"x" * (4096 * 3)
+        source = tmp_path / "raw.mp4"
+        source.write_bytes(payload)
+
+        # Advance the clock by 300 ms on every lookup so every chunk
+        # clears the gate.
+        counter = iter(i * 0.3 + 1000 for i in range(100))
+        monkeypatch.setattr(
+            backends_module.auphonic_client.time,
+            "monotonic",
+            lambda: next(counter),
+            raising=False,
+        )
+
+        progress: list[float] = []
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.post("/api/production/prod-4/upload.json").mock(
+                return_value=httpx.Response(200, json={"data": {"uuid": "prod-4"}})
+            )
+            client.upload_input("prod-4", source, on_progress=progress.append)
+
+        # At least the intermediate ticks plus a final 1.0.
+        assert len(progress) >= 2
+        assert progress[-1] == pytest.approx(1.0)
+
 
 # ---------------------------------------------------------------------
 # download

--- a/tests/recordings/test_auphonic_client.py
+++ b/tests/recordings/test_auphonic_client.py
@@ -350,6 +350,64 @@ class TestGetProduction:
         assert production.output_files[0].download_url.endswith("out.mp4")
 
 
+class TestListProductions:
+    def test_filters_by_title(self, client: AuphonicClient) -> None:
+        with respx.mock(base_url=BASE_URL) as mock:
+            route = mock.get("/api/productions.json").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {"uuid": "p-1", "status": AuphonicStatus.DONE},
+                            {"uuid": "p-2", "status": AuphonicStatus.AUDIO_PROCESSING},
+                        ]
+                    },
+                )
+            )
+            productions = client.list_productions(title="lecture 03")
+
+        assert [p.uuid for p in productions] == ["p-1", "p-2"]
+        assert route.called
+        assert route.calls[0].request.url.params.get("title") == "lecture 03"
+
+    def test_no_title_omits_query_param(self, client: AuphonicClient) -> None:
+        with respx.mock(base_url=BASE_URL) as mock:
+            route = mock.get("/api/productions.json").mock(
+                return_value=httpx.Response(200, json={"data": []})
+            )
+            result = client.list_productions()
+        assert result == []
+        assert route.called
+        assert "title" not in route.calls[0].request.url.params
+
+    def test_empty_list(self, client: AuphonicClient) -> None:
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.get("/api/productions.json").mock(
+                return_value=httpx.Response(200, json={"data": []})
+            )
+            assert client.list_productions(title="nothing-matches") == []
+
+    def test_limit_param_passed_through(self, client: AuphonicClient) -> None:
+        with respx.mock(base_url=BASE_URL) as mock:
+            route = mock.get("/api/productions.json").mock(
+                return_value=httpx.Response(200, json={"data": []})
+            )
+            client.list_productions(title="t", limit=5)
+        assert route.calls[0].request.url.params.get("limit") == "5"
+
+    def test_bare_dict_response_treated_as_single_entry(self, client: AuphonicClient) -> None:
+        """Older Auphonic responses wrap a single result as a dict, not a list."""
+        with respx.mock(base_url=BASE_URL) as mock:
+            mock.get("/api/productions.json").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"data": {"uuid": "only-one", "status": AuphonicStatus.DONE}},
+                )
+            )
+            productions = client.list_productions(title="x")
+        assert [p.uuid for p in productions] == ["only-one"]
+
+
 class TestStartProduction:
     def test_posts_start_endpoint(self, client: AuphonicClient) -> None:
         with respx.mock(base_url=BASE_URL) as mock:

--- a/tests/recordings/test_directories.py
+++ b/tests/recordings/test_directories.py
@@ -14,6 +14,7 @@ from clm.recordings.workflow.directories import (
     final_dir,
     find_pending_pairs,
     superseded_dir,
+    takes_dir,
     to_process_dir,
     validate_root,
 )
@@ -57,9 +58,10 @@ class TestValidateRoot:
     def test_missing_subdir(self, tmp_path: Path):
         root = tmp_path / "recordings"
         root.mkdir()
-        (root / "to-process").mkdir()
-        (root / "final").mkdir()
-        (root / "superseded").mkdir()
+        for name in SUBDIRS:
+            if name == "archive":
+                continue
+            (root / name).mkdir()
         # archive/ intentionally missing
         errors = validate_root(root)
         assert len(errors) == 1
@@ -69,7 +71,7 @@ class TestValidateRoot:
         root = tmp_path / "recordings"
         root.mkdir()
         errors = validate_root(root)
-        assert len(errors) == 4
+        assert len(errors) == len(SUBDIRS)
 
 
 class TestDirHelpers:
@@ -84,6 +86,14 @@ class TestDirHelpers:
 
     def test_superseded_dir(self, tmp_path: Path):
         assert superseded_dir(tmp_path) == tmp_path / "superseded"
+
+    def test_takes_dir(self, tmp_path: Path):
+        assert takes_dir(tmp_path) == tmp_path / "takes"
+
+    def test_ensure_root_creates_takes(self, tmp_path: Path):
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        assert takes_dir(root).is_dir()
 
 
 class TestPendingPair:
@@ -186,3 +196,24 @@ class TestFindPendingPairs:
         pairs = find_pending_pairs(tp)
         assert len(pairs) == 1
         assert pairs[0].relative_dir == Path(".")
+
+    def test_ignores_takes_sibling_directory(self, tmp_path: Path):
+        """Files under a sibling ``takes/`` tree are never returned.
+
+        ``find_pending_pairs`` only ever scans the ``to-process/`` root it's
+        given, but the regression guard documents the guarantee: putting a
+        raw file in ``takes/`` never makes it eligible for processing.
+        """
+        root = tmp_path / "recordings"
+        ensure_root(root)
+        tp = to_process_dir(root)
+        self._make_pair(tp, "course/section", "topic")
+
+        takes = takes_dir(root) / "course" / "section"
+        takes.mkdir(parents=True)
+        (takes / "topic (part 1, take 1)--RAW.mp4").write_bytes(b"v")
+        (takes / "topic (part 1, take 1)--RAW.wav").write_bytes(b"a")
+
+        pairs = find_pending_pairs(tp)
+        assert len(pairs) == 1
+        assert pairs[0].base_name == "topic"

--- a/tests/recordings/test_external_audio_first.py
+++ b/tests/recordings/test_external_audio_first.py
@@ -36,6 +36,10 @@ class _RecordingContext:
     def report(self, job: ProcessingJob) -> None:
         self.reports.append((job.state, job.progress, job.message))
 
+    def request_poll_soon(self) -> None:
+        # No poller in this synchronous-backend test harness.
+        pass
+
 
 @pytest.fixture()
 def fake_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/recordings/test_job_manager.py
+++ b/tests/recordings/test_job_manager.py
@@ -61,6 +61,9 @@ class _SyncFakeBackend:
     def cancel(self, job, *, ctx):
         self.cancels.append(job.id)
 
+    def reconcile(self, job, *, ctx):
+        return job
+
 
 class _AsyncFakeBackend:
     """Async fake that advances one step each poll call.
@@ -115,6 +118,11 @@ class _AsyncFakeBackend:
 
     def cancel(self, job, *, ctx):
         self.cancels.append(job.id)
+
+    def reconcile(self, job, *, ctx):
+        self.reconciles = getattr(self, "reconciles", [])
+        self.reconciles.append(job.id)
+        return job
 
 
 class _RaisingAsyncBackend(_AsyncFakeBackend):
@@ -687,6 +695,81 @@ class TestRequestPollSoon:
         assert manager._wake.is_set()
 
 
+class TestReconcile:
+    """``JobManager.reconcile`` routes to the backend and persists the result."""
+
+    def test_reconcile_routes_to_backend(self, tmp_path: Path):
+        backend = _AsyncFakeBackend()
+        manager, _, _ = _make_manager(tmp_path, backend)
+        raw = _make_raw_path(tmp_path)
+        job = manager.submit(raw)
+
+        try:
+            updated = manager.reconcile(job.id)
+            assert updated is not None
+            # The fake's reconcile records the call.
+            assert getattr(backend, "reconciles", []) == [job.id]
+        finally:
+            manager.shutdown(timeout=2.0)
+
+    def test_reconcile_unknown_id_returns_none(self, tmp_path: Path):
+        manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
+        assert manager.reconcile("no-such-job") is None
+
+    def test_reconcile_persists_and_publishes(self, tmp_path: Path):
+        backend = _SyncFakeBackend()
+        manager, _, events = _make_manager(tmp_path, backend)
+        raw = _make_raw_path(tmp_path)
+        job = manager.submit(raw)
+
+        # Clear events from submit so we only see the reconcile-generated ones.
+        events.clear()
+        updated = manager.reconcile(job.id)
+
+        assert updated is not None
+        # Reconcile must publish at least one job event on the bus.
+        assert any(topic == JOB_EVENT_TOPIC for (topic, _) in events)
+
+    def test_reconcile_classifies_permanent_backend_error(self, tmp_path: Path):
+        """Permanent HTTP errors from reconcile mark the job FAILED."""
+        from clm.recordings.workflow.backends.auphonic_client import AuphonicHTTPError
+
+        class _PermanentFailBackend(_SyncFakeBackend):
+            # Synchronous backend: no poller to race against.
+            def reconcile(self, job, *, ctx):
+                raise AuphonicHTTPError("GET", "https://x", 404, "Not Found")
+
+        backend = _PermanentFailBackend()
+        manager, _, _ = _make_manager(tmp_path, backend)
+        raw = _make_raw_path(tmp_path)
+        job = manager.submit(raw)
+
+        updated = manager.reconcile(job.id)
+        assert updated is not None
+        assert updated.state == JobState.FAILED
+        assert "404" in (updated.error or "") or "Not Found" in (updated.error or "")
+
+    def test_reconcile_classifies_transient_backend_error(self, tmp_path: Path):
+        """Transient errors don't change state; last_poll_error is set."""
+
+        class _TransientBackend(_SyncFakeBackend):
+            # Synchronous backend avoids the poller racing and clearing
+            # ``last_poll_error`` via a background successful poll.
+            def reconcile(self, job, *, ctx):
+                raise RuntimeError("temporary network hiccup")
+
+        backend = _TransientBackend()
+        manager, _, _ = _make_manager(tmp_path, backend)
+        raw = _make_raw_path(tmp_path)
+        job = manager.submit(raw)
+
+        pre_state = manager.get(job.id).state
+        updated = manager.reconcile(job.id)
+        assert updated is not None
+        assert updated.state == pre_state
+        assert "temporary" in (updated.last_poll_error or "")
+
+
 class TestJobManagerCancel:
     def test_cancel_sync_job_sets_cancelled_state(self, tmp_path: Path):
         """Cancel of an already-terminal job is a no-op that preserves state."""
@@ -740,8 +823,8 @@ class TestJobManagerRehydration:
 
         assert manager.get(old_job.id) is not None
 
-    def test_uploading_jobs_become_failed_on_startup(self, tmp_path: Path):
-        """Per design doc Q5, interrupted uploads cannot be resumed."""
+    def test_uploading_without_backend_ref_fails_on_startup(self, tmp_path: Path):
+        """When no production was ever created, the upload is genuinely lost."""
         ensure_root(tmp_path)
         store_path = tmp_path / ".clm" / "jobs.json"
         pre = JsonFileJobStore(store_path)
@@ -752,6 +835,7 @@ class TestJobManagerRehydration:
             relative_dir=Path(),
             state=JobState.UPLOADING,
             message="Uploading",
+            backend_ref=None,
         )
         pre.save(in_flight)
 
@@ -766,6 +850,41 @@ class TestJobManagerRehydration:
         assert rehydrated is not None
         assert rehydrated.state == JobState.FAILED
         assert "re-submit" in (rehydrated.error or "")
+
+    def test_uploading_with_backend_ref_resumes_as_processing(self, tmp_path: Path):
+        """When a production exists upstream, resume instead of failing.
+
+        The crash might have happened mid-upload *after* the production
+        was created — Auphonic likely has the file. Transition to
+        PROCESSING so the next poll (or the user's Verify action) can
+        settle the real state.
+        """
+        ensure_root(tmp_path)
+        store_path = tmp_path / ".clm" / "jobs.json"
+        pre = JsonFileJobStore(store_path)
+        in_flight = ProcessingJob(
+            backend_name="auphonic",
+            raw_path=tmp_path / "a--RAW.mp4",
+            final_path=tmp_path / "final" / "a.mp4",
+            relative_dir=Path(),
+            state=JobState.UPLOADING,
+            message="Uploading",
+            backend_ref="prod-uuid-7",
+        )
+        pre.save(in_flight)
+
+        manager = JobManager(
+            backend=_SyncFakeBackend(),
+            root_dir=tmp_path,
+            store=JsonFileJobStore(store_path),
+            bus=EventBus(),
+        )
+
+        rehydrated = manager.get(in_flight.id)
+        assert rehydrated is not None
+        assert rehydrated.state == JobState.PROCESSING
+        assert rehydrated.error is None
+        assert "Resumed" in rehydrated.message
 
 
 class TestJobManagerShutdown:

--- a/tests/recordings/test_job_manager.py
+++ b/tests/recordings/test_job_manager.py
@@ -627,6 +627,66 @@ class TestJobManagerAsynchronousBackend:
             manager.shutdown(timeout=2.0)
 
 
+class TestRequestPollSoon:
+    """Backends can nudge the poller loop without waiting out the interval."""
+
+    def test_wake_runs_poll_sooner_than_interval(self, tmp_path: Path):
+        """After a wake signal, poll_once is driven before the sleep elapses."""
+        # Keep the job alive for many polls so we can observe repeat cycles.
+        backend = _AsyncFakeBackend(poll_completes_after_calls=100)
+        manager, _, _ = _make_manager(tmp_path, backend, poll_interval=30.0)
+        raw = _make_raw_path(tmp_path)
+
+        try:
+            manager.submit(raw)
+
+            # The first poller iteration runs poll_once immediately (no
+            # wait yet), then blocks on _wake for poll_interval seconds.
+            assert backend.poll_event.wait(timeout=2.0), "initial poll didn't fire"
+
+            # Reset and wake. Without the signal the next poll would wait
+            # the full 30s; with it, the poller reacts within a second.
+            backend.poll_event.clear()
+            manager.request_poll_soon()
+            assert backend.poll_event.wait(timeout=2.0), (
+                "poller did not react to request_poll_soon within 2s "
+                "(poll_interval=30s so this would take 30s without the wake)"
+            )
+        finally:
+            manager.shutdown(timeout=2.0)
+
+    def test_wake_is_no_op_for_synchronous_backend(self, tmp_path: Path):
+        """Synchronous backends don't have a poller — the call must not raise."""
+        manager, _, _ = _make_manager(tmp_path, _SyncFakeBackend())
+        # Explicitly safe to call even with no poller running.
+        manager.request_poll_soon()
+
+    def test_shutdown_wakes_poller_promptly(self, tmp_path: Path):
+        """Shutdown must not sit out the remainder of the poll interval."""
+        backend = _AsyncFakeBackend(poll_completes_after_calls=10)
+        manager, bus, _ = _make_manager(tmp_path, backend, poll_interval=30.0)
+        raw = _make_raw_path(tmp_path)
+
+        job = manager.submit(raw)
+        _wait_for_state(manager, bus, job.id, JobState.PROCESSING)
+
+        started = time.monotonic()
+        manager.shutdown(timeout=5.0)
+        elapsed = time.monotonic() - started
+        assert elapsed < 5.0, f"shutdown took {elapsed:.1f}s — poller wasn't woken on stop"
+
+    def test_context_request_poll_soon_delegates_to_manager(self, tmp_path: Path):
+        """JobContext.request_poll_soon must reach the manager."""
+        backend = _AsyncFakeBackend(poll_completes_after_calls=1)
+        manager, _, _ = _make_manager(tmp_path, backend, poll_interval=30.0)
+        # Build a context without going through submit so we can call it
+        # directly. The manager isn't running a poller yet, so we just
+        # verify the call doesn't raise and sets the wake flag.
+        ctx = manager._make_context()
+        ctx.request_poll_soon()
+        assert manager._wake.is_set()
+
+
 class TestJobManagerCancel:
     def test_cancel_sync_job_sets_cancelled_state(self, tmp_path: Path):
         """Cancel of an already-terminal job is a no-op that preserves state."""

--- a/tests/recordings/test_naming.py
+++ b/tests/recordings/test_naming.py
@@ -11,9 +11,11 @@ from clm.recordings.workflow.naming import (
     final_filename,
     find_existing_recordings,
     parse_part,
+    parse_part_take,
     parse_raw_stem,
     raw_filename,
     recording_relative_dir,
+    take_filename,
 )
 
 
@@ -230,3 +232,47 @@ class TestFindExistingRecordings:
         result = find_existing_recordings(tmp_path, "03 Intro")
         assert 2 in result
         assert result[2].name == "03 Intro (Teil 2)--RAW.mkv"
+
+
+class TestParsePartTake:
+    def test_no_suffix(self):
+        assert parse_part_take("03 Intro") == ("03 Intro", 0, 0)
+
+    def test_part_only(self):
+        assert parse_part_take("03 Intro (part 2)") == ("03 Intro", 2, 0)
+
+    def test_take_only(self):
+        assert parse_part_take("03 Intro (take 3)") == ("03 Intro", 0, 3)
+
+    def test_part_and_take(self):
+        assert parse_part_take("03 Intro (part 2, take 3)") == ("03 Intro", 2, 3)
+
+    def test_german_part_and_take(self):
+        assert parse_part_take("03 Intro (Teil 2, take 4)") == ("03 Intro", 2, 4)
+
+
+class TestTakeFilename:
+    def test_part_and_take(self):
+        assert take_filename("03 Intro", part=2, take=1) == "03 Intro (part 2, take 1).mp4"
+
+    def test_single_part_take(self):
+        assert take_filename("03 Intro", part=0, take=2) == "03 Intro (take 2).mp4"
+
+    def test_raw_variant(self):
+        assert (
+            take_filename("03 Intro", part=2, take=1, is_raw=True)
+            == "03 Intro (part 2, take 1)--RAW.mp4"
+        )
+
+    def test_german_label(self):
+        assert (
+            take_filename("03 Intro", part=1, take=2, lang="de") == "03 Intro (Teil 1, take 2).mp4"
+        )
+
+    def test_round_trip(self):
+        name = take_filename("03 Intro", part=2, take=3, is_raw=True, ext=".mkv")
+        stem = name.removesuffix(".mkv")
+        base_with, is_raw = parse_raw_stem(stem)
+        assert is_raw is True
+        deck, part, take = parse_part_take(base_with)
+        assert (deck, part, take) == ("03 Intro", 2, 3)

--- a/tests/recordings/test_obs.py
+++ b/tests/recordings/test_obs.py
@@ -164,6 +164,49 @@ class TestObsClientQueries:
 
 
 # ---------------------------------------------------------------------------
+# Recording control
+# ---------------------------------------------------------------------------
+
+
+class TestObsClientRecordingControl:
+    def test_start_record_delegates_to_req(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        client.start_record()
+        mock_obsws["req"].start_record.assert_called_once_with()
+
+    def test_start_record_not_connected(self):
+        client = ObsClient()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.start_record()
+
+    def test_start_record_wraps_obsws_error(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        mock_obsws["req"].start_record.side_effect = RuntimeError("already recording")
+        with pytest.raises(ConnectionError, match="OBS rejected start_record"):
+            client.start_record()
+
+    def test_stop_record_delegates_to_req(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        client.stop_record()
+        mock_obsws["req"].stop_record.assert_called_once_with()
+
+    def test_stop_record_not_connected(self):
+        client = ObsClient()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.stop_record()
+
+    def test_stop_record_wraps_obsws_error(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        mock_obsws["req"].stop_record.side_effect = RuntimeError("not recording")
+        with pytest.raises(ConnectionError, match="OBS rejected stop_record"):
+            client.stop_record()
+
+
+# ---------------------------------------------------------------------------
 # Event dispatching
 # ---------------------------------------------------------------------------
 

--- a/tests/recordings/test_onnx_audio_first.py
+++ b/tests/recordings/test_onnx_audio_first.py
@@ -29,6 +29,10 @@ class _RecordingContext:
     def report(self, job: ProcessingJob) -> None:
         self.reports.append((job.state, job.progress, job.message))
 
+    def request_poll_soon(self) -> None:
+        # No poller in this synchronous-backend test harness.
+        pass
+
 
 def _setup_tree(tmp_path: Path) -> tuple[Path, Path]:
     ensure_root(tmp_path)

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -644,10 +644,16 @@ class TestSupersede:
         assert (sup / "deck--RAW.mkv").exists()
         assert not (sup / "deck--RAW.wav").exists()
 
-    def test_rename_supersedes_existing_target(
+    def test_rename_preserves_existing_target_as_take(
         self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path
     ):
-        """When the target file already exists, it is moved to superseded/."""
+        """When the target file already exists, it is preserved under takes/.
+
+        Phase 3 change: a retake now demotes the existing raw into
+        ``takes/`` with a ``(take K)`` suffix rather than discarding it
+        to ``superseded/``. Previously-processed takes (and their raws)
+        are too expensive to throw away.
+        """
         tp = to_process_dir(recording_root) / "c" / "s"
         tp.mkdir(parents=True)
         existing = tp / "t--RAW.mkv"
@@ -674,10 +680,12 @@ class TestSupersede:
         assert target.exists()
         assert target.read_bytes() == b"new recording"
 
-        # Old recording moved to superseded
-        sup = superseded_dir(recording_root) / "c" / "s" / "t--RAW.mkv"
-        assert sup.exists()
-        assert sup.read_bytes() == b"old recording"
+        # Old recording preserved under takes/ with take-1 suffix
+        from clm.recordings.workflow.directories import takes_dir
+
+        preserved = takes_dir(recording_root) / "c" / "s" / "t (take 1)--RAW.mkv"
+        assert preserved.exists()
+        assert preserved.read_bytes() == b"old recording"
 
 
 # ---------------------------------------------------------------------------
@@ -690,8 +698,9 @@ class TestDynamicPartNaming:
         """No files exist, part 0 → unsuffixed target."""
         td = to_process_dir(recording_root) / "c" / "s"
         td.mkdir(parents=True)
-        target = _prepare_target_slot(td, "deck", ".mkv", 0, "--RAW", recording_root)
+        target, renames = _prepare_target_slot(td, "deck", ".mkv", 0, "--RAW", recording_root)
         assert target.name == "deck--RAW.mkv"
+        assert renames == []
 
     def test_part_2_renames_unsuffixed_to_part_1(self, recording_root: Path):
         """Existing unsuffixed file renamed to (part 1) when part 2 is recorded."""
@@ -699,12 +708,13 @@ class TestDynamicPartNaming:
         td.mkdir(parents=True)
         (td / "deck--RAW.mkv").write_bytes(b"old")
 
-        target = _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
+        target, renames = _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
 
         assert target.name == "deck (part 2)--RAW.mkv"
         assert not (td / "deck--RAW.mkv").exists()
         assert (td / "deck (part 1)--RAW.mkv").exists()
         assert (td / "deck (part 1)--RAW.mkv").read_bytes() == b"old"
+        assert (td / "deck--RAW.mkv", td / "deck (part 1)--RAW.mkv") in renames
 
     def test_part_2_renames_companion_audio(self, recording_root: Path):
         """Companion .wav is also renamed to (part 1)."""
@@ -739,7 +749,7 @@ class TestDynamicPartNaming:
         td.mkdir(parents=True)
         (td / "deck--RAW.mkv").write_bytes(b"old")
 
-        target = _prepare_target_slot(td, "deck", ".mkv", 0, "--RAW", recording_root)
+        target, _renames = _prepare_target_slot(td, "deck", ".mkv", 0, "--RAW", recording_root)
 
         assert target.name == "deck--RAW.mkv"
         assert not (td / "deck--RAW.mkv").exists()  # superseded
@@ -753,7 +763,7 @@ class TestDynamicPartNaming:
         (td / "deck (part 1)--RAW.mkv").write_bytes(b"p1")
         (td / "deck (part 2)--RAW.mkv").write_bytes(b"old p2")
 
-        target = _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
+        target, _renames = _prepare_target_slot(td, "deck", ".mkv", 2, "--RAW", recording_root)
 
         assert target.name == "deck (part 2)--RAW.mkv"
         # Part 1 untouched
@@ -770,12 +780,13 @@ class TestDynamicPartNaming:
         (td / "deck (part 1)--RAW.mkv").write_bytes(b"p1")
         (td / "deck (part 2)--RAW.mkv").write_bytes(b"p2")
 
-        target = _prepare_target_slot(td, "deck", ".mkv", 3, "--RAW", recording_root)
+        target, renames = _prepare_target_slot(td, "deck", ".mkv", 3, "--RAW", recording_root)
 
         assert target.name == "deck (part 3)--RAW.mkv"
         # Existing parts untouched
         assert (td / "deck (part 1)--RAW.mkv").read_bytes() == b"p1"
         assert (td / "deck (part 2)--RAW.mkv").read_bytes() == b"p2"
+        assert renames == []
 
 
 # ---------------------------------------------------------------------------
@@ -1104,6 +1115,318 @@ class TestRenameTimeout:
         finally:
             stop.set()
             t.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: retake pre-move + state wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRetakePreMove:
+    """The session demotes existing active-take files into ``takes/``.
+
+    Each scenario exercises one arm of the ``_preserve_active_take`` logic
+    so a future refactor cannot silently regress one path while the others
+    still pass.
+    """
+
+    def _stop(self, mock_obs, obs_output: Path) -> None:
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+
+    def test_retake_moves_final_and_archive_to_takes(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Happy path: processed part gets demoted; new raw lands cleanly."""
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        fin.mkdir(parents=True)
+        (arc / "t--RAW.mkv").write_bytes(b"old-raw")
+        (fin / "t.mp4").write_bytes(b"old-final")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new-raw")
+
+        session.arm("c", "s", "t")
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        takes = takes_dir(recording_root) / rel
+        assert (takes / "t (take 1)--RAW.mkv").read_bytes() == b"old-raw"
+        assert (takes / "t (take 1).mp4").read_bytes() == b"old-final"
+        # Archive/final slots are clear — ready for the new take to process.
+        assert not (arc / "t--RAW.mkv").exists()
+        assert not (fin / "t.mp4").exists()
+
+        tp = to_process_dir(recording_root) / rel
+        assert (tp / "t--RAW.mkv").read_bytes() == b"new-raw"
+
+    def test_retake_when_only_raw_exists(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Processing failed before retake — only a raw in archive/."""
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        (arc / "t--RAW.mkv").write_bytes(b"old-raw")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new-raw")
+
+        session.arm("c", "s", "t")
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        takes = takes_dir(recording_root) / rel
+        assert (takes / "t (take 1)--RAW.mkv").read_bytes() == b"old-raw"
+
+    def test_retake_when_only_final_exists(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Raw manually deleted after processing — only a final to preserve."""
+        from clm.recordings.workflow.directories import takes_dir
+
+        rel = Path("c") / "s"
+        fin = final_dir(recording_root) / rel
+        fin.mkdir(parents=True)
+        (fin / "t.mp4").write_bytes(b"old-final")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new-raw")
+
+        session.arm("c", "s", "t")
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        takes = takes_dir(recording_root) / rel
+        assert (takes / "t (take 1).mp4").read_bytes() == b"old-final"
+
+    def test_retake_when_nothing_exists_yet(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Retake fires before first processing finished — nothing to demote."""
+        from clm.recordings.workflow.directories import takes_dir
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"first-take")
+
+        session.arm("c", "s", "t")
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        takes = takes_dir(recording_root) / "c" / "s"
+        assert not takes.exists() or list(takes.iterdir()) == []
+
+    def test_retake_increments_take_number(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Second retake writes ``(take 2)``; existing ``(take 1)`` is untouched."""
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        takes = takes_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        takes.mkdir(parents=True)
+        # Pretend a prior retake already demoted take 1.
+        (takes / "t (take 1)--RAW.mkv").write_bytes(b"take-1")
+        (arc / "t--RAW.mkv").write_bytes(b"take-2-active")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"take-3")
+
+        session.arm("c", "s", "t")
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        assert (takes / "t (take 1)--RAW.mkv").read_bytes() == b"take-1"
+        assert (takes / "t (take 2)--RAW.mkv").read_bytes() == b"take-2-active"
+
+    def test_retake_companion_wav_also_preserved(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """``.wav`` companion in archive/ gets the same ``(take K)`` suffix."""
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        (arc / "t--RAW.mkv").write_bytes(b"raw-video")
+        (arc / "t--RAW.wav").write_bytes(b"raw-audio")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new")
+
+        session.arm("c", "s", "t")
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        takes = takes_dir(recording_root) / rel
+        assert (takes / "t (take 1)--RAW.mkv").read_bytes() == b"raw-video"
+        assert (takes / "t (take 1)--RAW.wav").read_bytes() == b"raw-audio"
+
+    def test_new_part_after_processed_parts_preserves_existing(
+        self, session: RecordingSession, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Regression guard: adding part 2 while part 1 is already processed.
+
+        The existing part-1 files live under ``archive/`` and ``final/``
+        (not ``to-process/``), so the scanner should leave them untouched
+        when the armed part is 2.
+        """
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        fin.mkdir(parents=True)
+        (arc / "t (part 1)--RAW.mkv").write_bytes(b"p1-raw")
+        (fin / "t (part 1).mp4").write_bytes(b"p1-final")
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"p2-raw")
+
+        session.arm("c", "s", "t", part_number=2)
+        self._stop(mock_obs, obs_output)
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        assert (arc / "t (part 1)--RAW.mkv").read_bytes() == b"p1-raw"
+        assert (fin / "t (part 1).mp4").read_bytes() == b"p1-final"
+
+        takes = takes_dir(recording_root) / rel
+        assert not takes.exists() or list(takes.iterdir()) == []
+
+
+class TestStateWiring:
+    """When a ``CourseRecordingState`` is injected, disk renames sync to state."""
+
+    def test_cascade_updates_state_paths(self, mock_obs, recording_root: Path, tmp_path: Path):
+        """Multi-part cascade rename propagates to state.json."""
+        from clm.recordings.state import CourseRecordingState, LectureState, RecordingPart
+
+        tp = to_process_dir(recording_root) / "c" / "s"
+        tp.mkdir(parents=True)
+        unsuffixed = tp / "t--RAW.mkv"
+        unsuffixed.write_bytes(b"old-p0")
+
+        state = CourseRecordingState(
+            course_id="cid",
+            lectures=[
+                LectureState(
+                    lecture_id="l1",
+                    display_name="L1",
+                    parts=[RecordingPart(part=1, raw_file=str(unsuffixed))],
+                )
+            ],
+        )
+
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new-p2")
+
+        session.arm("c", "s", "t", part_number=2)
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        # state.json's raw_file updated from the unsuffixed path to (part 1).
+        expected = tp / "t (part 1)--RAW.mkv"
+        assert state.lectures[0].parts[0].raw_file == str(expected)
+
+    def test_retake_updates_state_paths(self, mock_obs, recording_root: Path, tmp_path: Path):
+        """Retake pre-move propagates to state.json processed_file pointer."""
+        from clm.recordings.state import CourseRecordingState, LectureState, RecordingPart
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        fin.mkdir(parents=True)
+        old_raw = arc / "t--RAW.mkv"
+        old_final = fin / "t.mp4"
+        old_raw.write_bytes(b"old-raw")
+        old_final.write_bytes(b"old-final")
+
+        state = CourseRecordingState(
+            course_id="cid",
+            lectures=[
+                LectureState(
+                    lecture_id="l1",
+                    display_name="L1",
+                    parts=[
+                        RecordingPart(
+                            part=1,
+                            raw_file=str(old_raw),
+                            processed_file=str(old_final),
+                            status="processed",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"new-raw")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+        _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        takes = takes_dir(recording_root) / rel
+        expected_raw = takes / "t (take 1)--RAW.mkv"
+        expected_final = takes / "t (take 1).mp4"
+        part = state.lectures[0].parts[0]
+        assert part.raw_file == str(expected_raw)
+        assert part.processed_file == str(expected_final)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -162,6 +162,57 @@ class TestArmDisarm:
 
 
 # ---------------------------------------------------------------------------
+# One-click record / stop (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAndStop:
+    def test_record_arms_and_starts_obs(self, session: RecordingSession, mock_obs):
+        session.record("c", "s", "01 Deck")
+        assert session.state is SessionState.ARMED
+        assert session.armed_deck == ArmedDeck("c", "s", "01 Deck")
+        mock_obs.start_record.assert_called_once_with()
+
+    def test_record_passes_part_number_and_lang(self, session: RecordingSession, mock_obs):
+        session.record("c", "s", "01 Deck", part_number=2, lang="de")
+        assert session.armed_deck.part_number == 2
+        assert session.armed_deck.lang == "de"
+        mock_obs.start_record.assert_called_once_with()
+
+    def test_record_obs_failure_leaves_deck_armed(self, session: RecordingSession, mock_obs):
+        """If OBS rejects the start, the deck stays armed so the user can
+        start recording manually or retry once OBS is reachable."""
+        mock_obs.start_record.side_effect = ConnectionError("OBS not running")
+
+        with pytest.raises(ConnectionError):
+            session.record("c", "s", "01 Deck")
+
+        assert session.state is SessionState.ARMED
+        assert session.armed_deck == ArmedDeck("c", "s", "01 Deck")
+
+    def test_record_while_recording_raises(self, session: RecordingSession, mock_obs):
+        """Trying to start a new recording while one is in flight is a
+        RuntimeError from arm(); OBS is never contacted."""
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        mock_obs.start_record.reset_mock()
+
+        with pytest.raises(RuntimeError, match="Cannot arm"):
+            session.record("c", "s", "other")
+
+        mock_obs.start_record.assert_not_called()
+
+    def test_stop_calls_obs_stop_record(self, session: RecordingSession, mock_obs):
+        session.stop()
+        mock_obs.stop_record.assert_called_once_with()
+
+    def test_stop_propagates_obs_error(self, session: RecordingSession, mock_obs):
+        mock_obs.stop_record.side_effect = ConnectionError("OBS not connected")
+        with pytest.raises(ConnectionError):
+            session.stop()
+
+
+# ---------------------------------------------------------------------------
 # Recording start event
 # ---------------------------------------------------------------------------
 

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -53,12 +53,21 @@ def recording_root(tmp_path: Path) -> Path:
 
 @pytest.fixture()
 def session(mock_obs: MagicMock, recording_root: Path) -> RecordingSession:
-    """A session with short stability checks for fast tests."""
+    """A session with short stability checks for fast tests.
+
+    Short-take detection and the retake window are disabled by default
+    (``short_take_seconds=0.0``, ``retake_window_seconds=0.0``) so that
+    existing tests which fire STARTED/STOPPED back-to-back still exercise
+    the normal rename path. Phase 2 tests that want to exercise those
+    features construct their own session with explicit values.
+    """
     return RecordingSession(
         mock_obs,
         recording_root,
         stability_interval=0.01,
         stability_checks=1,
+        short_take_seconds=0.0,
+        retake_window_seconds=0.0,
     )
 
 
@@ -767,6 +776,334 @@ class TestDynamicPartNaming:
         # Existing parts untouched
         assert (td / "deck (part 1)--RAW.mkv").read_bytes() == b"p1"
         assert (td / "deck (part 2)--RAW.mkv").read_bytes() == b"p2"
+
+
+# ---------------------------------------------------------------------------
+# Short-take detection and retake window (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def _phase2_session(
+    mock_obs: MagicMock,
+    root: Path,
+    *,
+    short_take_seconds: float = 5.0,
+    retake_window_seconds: float = 60.0,
+) -> RecordingSession:
+    """Build a session with Phase 2 features enabled for explicit testing."""
+    return RecordingSession(
+        mock_obs,
+        root,
+        stability_interval=0.01,
+        stability_checks=1,
+        short_take_seconds=short_take_seconds,
+        retake_window_seconds=retake_window_seconds,
+    )
+
+
+class TestShortTake:
+    def test_short_take_goes_to_superseded(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """A stop within short_take_seconds moves the file to superseded/
+        and leaves the session in ARMED with the same deck intact."""
+        sess = _phase2_session(mock_obs, recording_root, short_take_seconds=5.0)
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"tiny take")
+
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert sess.state is SessionState.RECORDING
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+
+        # Wait for the background short-take thread to finish.
+        import time
+
+        deadline = time.monotonic() + 5.0
+        while obs_out.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        # File moved to superseded/<course>/<section>/
+        sup = superseded_dir(recording_root) / "c" / "s" / "rec.mkv"
+        assert sup.exists(), f"short take should be at {sup}"
+        # Deck stays armed on the same ArmedDeck
+        assert sess.state is SessionState.ARMED
+        assert sess.armed_deck == ArmedDeck("c", "s", "01 Deck")
+
+    def test_short_take_can_be_followed_by_real_take(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """After a short take, a subsequent normal recording should
+        complete the usual rename flow (the deck was never disarmed)."""
+        sess = _phase2_session(
+            mock_obs,
+            recording_root,
+            short_take_seconds=0.05,
+            retake_window_seconds=0.01,
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        # First take: short.
+        short_out = tmp_path / "short.mkv"
+        short_out.write_bytes(b"x")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(short_out),
+            ),
+        )
+        _wait_for_state(sess, SessionState.ARMED, timeout=5.0)
+
+        # Second take: wait past the short threshold before stopping.
+        import time
+
+        real_out = tmp_path / "real.mkv"
+        real_out.write_bytes(b"real take data")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        time.sleep(0.1)  # exceed short_take_seconds=0.05
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(real_out),
+            ),
+        )
+
+        # Rename should produce a file in to-process/<course>/<section>/
+        _wait_for_state(sess, SessionState.IDLE, timeout=5.0)
+        renamed = to_process_dir(recording_root) / "c" / "s" / "01 Deck--RAW.mkv"
+        assert renamed.exists()
+
+    def test_short_take_threshold_zero_never_fires(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """``short_take_seconds=0.0`` means no elapsed duration can be
+        'short', so the rename path is always taken."""
+        sess = _phase2_session(
+            mock_obs,
+            recording_root,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"content")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+        _wait_for_state(sess, SessionState.IDLE, timeout=5.0)
+        renamed = to_process_dir(recording_root) / "c" / "s" / "01 Deck--RAW.mkv"
+        assert renamed.exists()
+
+
+class TestRetakeWindow:
+    def test_rename_transitions_to_armed_after_take(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """After a normal take, the session lands in ARMED_AFTER_TAKE
+        with the same deck preserved for a potential retake."""
+        sess = _phase2_session(
+            mock_obs, recording_root, short_take_seconds=0.0, retake_window_seconds=5.0
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"real")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+
+        _wait_for_state(sess, SessionState.ARMED_AFTER_TAKE, timeout=5.0)
+        assert sess.armed_deck == ArmedDeck("c", "s", "01 Deck")
+
+    def test_retake_window_expires_to_idle(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """When no retake arrives before the window elapses, the session
+        returns to IDLE and the deck is cleared."""
+        sess = _phase2_session(
+            mock_obs,
+            recording_root,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.1,
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"real")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+
+        _wait_for_state(sess, SessionState.IDLE, timeout=5.0)
+        assert sess.armed_deck is None
+
+    def test_retake_within_window_rearms_same_deck(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """A new OBS STARTED during the retake window is treated as a
+        retake of the same armed deck (back to RECORDING)."""
+        sess = _phase2_session(
+            mock_obs,
+            recording_root,
+            short_take_seconds=0.0,
+            retake_window_seconds=60.0,
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"real")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+        _wait_for_state(sess, SessionState.ARMED_AFTER_TAKE, timeout=5.0)
+
+        # New STARTED → retake of same deck.
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert sess.state is SessionState.RECORDING
+        assert sess.armed_deck == ArmedDeck("c", "s", "01 Deck")
+
+    def test_disarm_during_window_cancels(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """Disarm during ARMED_AFTER_TAKE cancels the timer and goes IDLE
+        immediately."""
+        sess = _phase2_session(
+            mock_obs,
+            recording_root,
+            short_take_seconds=0.0,
+            retake_window_seconds=60.0,
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"real")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+        _wait_for_state(sess, SessionState.ARMED_AFTER_TAKE, timeout=5.0)
+
+        sess.disarm()
+        assert sess.state is SessionState.IDLE
+        assert sess.armed_deck is None
+
+    def test_arm_different_deck_during_window_switches(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """Arming a different deck during ARMED_AFTER_TAKE cancels the
+        timer and arms the new deck."""
+        sess = _phase2_session(
+            mock_obs,
+            recording_root,
+            short_take_seconds=0.0,
+            retake_window_seconds=60.0,
+        )
+        sess.arm("c", "s", "01 Deck")
+
+        obs_out = tmp_path / "rec.mkv"
+        obs_out.write_bytes(b"real")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                output_path=str(obs_out),
+            ),
+        )
+        _wait_for_state(sess, SessionState.ARMED_AFTER_TAKE, timeout=5.0)
+
+        sess.arm("c", "s", "02 Other Deck")
+        assert sess.state is SessionState.ARMED
+        assert sess.armed_deck == ArmedDeck("c", "s", "02 Other Deck")
+
+
+class TestRenameTimeout:
+    def test_wait_for_stable_honors_timeout(
+        self, mock_obs: MagicMock, recording_root: Path, tmp_path: Path
+    ):
+        """A file whose size keeps growing should cause _wait_for_stable
+        to raise TimeoutError once the rename budget elapses."""
+        growing = tmp_path / "growing.mkv"
+        growing.write_bytes(b"seed")
+
+        sess = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.05,
+            stability_checks=10,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            rename_timeout_seconds=0.2,
+        )
+
+        # Spawn a thread that keeps changing the file size so it never
+        # stabilises; _wait_for_stable must give up after the timeout.
+        import time as _time
+
+        stop = threading.Event()
+
+        def grow():
+            i = 1
+            while not stop.is_set():
+                try:
+                    growing.write_bytes(b"x" * i)
+                except OSError:
+                    return
+                i += 1
+                _time.sleep(0.01)
+
+        t = threading.Thread(target=grow, daemon=True)
+        t.start()
+        try:
+            with pytest.raises(TimeoutError, match="did not stabilise"):
+                sess._wait_for_stable(growing)
+        finally:
+            stop.set()
+            t.join(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recordings/test_state.py
+++ b/tests/recordings/test_state.py
@@ -10,6 +10,7 @@ from clm.recordings.state import (
     CourseRecordingState,
     LectureState,
     RecordingPart,
+    TakeRecord,
 )
 
 
@@ -196,3 +197,210 @@ class TestLectureState:
 
         lecture.parts.append(RecordingPart(part=2, raw_file="/obs/rec2.mkv", status="processed"))
         assert lecture.latest_status == "processed"
+
+
+class TestTakeSchemaDefaults:
+    def test_new_part_has_empty_takes_and_active_1(self):
+        part = RecordingPart(part=1, raw_file="/obs/rec1.mkv")
+        assert part.takes == []
+        assert part.active_take == 1
+
+    def test_state_json_without_takes_field_loads(self, tmp_path: Path):
+        """Old schema state.json must still load (backcompat)."""
+        path = tmp_path / "old.json"
+        path.write_text(
+            """
+            {
+                "course_id": "legacy",
+                "lectures": [
+                    {
+                        "lecture_id": "010-intro",
+                        "display_name": "Intro",
+                        "parts": [
+                            {
+                                "part": 1,
+                                "raw_file": "/obs/rec1.mkv",
+                                "processed_file": "/out/rec1.mp4",
+                                "status": "processed"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """,
+            encoding="utf-8",
+        )
+        loaded = CourseRecordingState.load(path)
+        part = loaded.lectures[0].parts[0]
+        assert part.takes == []
+        assert part.active_take == 1
+
+
+class TestRecordRetake:
+    def test_demotes_active_to_takes(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording(
+            "/obs/rec1.mkv", lecture_id="010-intro", git_commit="old-commit"
+        )
+        sample_state.update_recording_status(
+            "/obs/rec1.mkv", "processed", processed_file="/final/rec1.mp4"
+        )
+
+        demoted = sample_state.record_retake(
+            "010-intro",
+            1,
+            "/obs/rec1-take2.mkv",
+            git_commit="new-commit",
+            git_dirty=True,
+        )
+
+        assert demoted.take == 1
+        assert demoted.raw_file == "/obs/rec1.mkv"
+        assert demoted.processed_file == "/final/rec1.mp4"
+        assert demoted.status == "processed"
+        assert demoted.superseded_at != ""
+
+        part = sample_state.lectures[0].parts[0]
+        assert len(part.takes) == 1
+        assert part.takes[0].take == 1
+        assert part.active_take == 2
+        assert part.raw_file == "/obs/rec1-take2.mkv"
+        assert part.processed_file is None
+        assert part.git_commit == "new-commit"
+        assert part.git_dirty is True
+        assert part.status == "pending"
+
+    def test_multiple_retakes_append_in_order(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv", lecture_id="010-intro")
+        sample_state.record_retake("010-intro", 1, "/obs/rec1-t2.mkv")
+        sample_state.record_retake("010-intro", 1, "/obs/rec1-t3.mkv")
+
+        part = sample_state.lectures[0].parts[0]
+        assert [t.take for t in part.takes] == [1, 2]
+        assert part.active_take == 3
+        assert part.raw_file == "/obs/rec1-t3.mkv"
+
+    def test_rejects_unknown_lecture(self, sample_state: CourseRecordingState):
+        with pytest.raises(ValueError, match="Lecture not found"):
+            sample_state.record_retake("999-missing", 1, "/obs/x.mkv")
+
+    def test_rejects_unknown_part(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv", lecture_id="010-intro")
+        with pytest.raises(ValueError, match="Part 99 not found"):
+            sample_state.record_retake("010-intro", 99, "/obs/x.mkv")
+
+
+class TestRestoreTake:
+    def test_swaps_active_and_history(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv", lecture_id="010-intro")
+        sample_state.update_recording_status(
+            "/obs/rec1.mkv", "processed", processed_file="/final/rec1-t1.mp4"
+        )
+        sample_state.record_retake("010-intro", 1, "/obs/rec1-t2.mkv")
+        sample_state.update_recording_status(
+            "/obs/rec1-t2.mkv", "processed", processed_file="/final/rec1-t2.mp4"
+        )
+
+        sample_state.restore_take("010-intro", 1, 1)
+
+        part = sample_state.lectures[0].parts[0]
+        assert part.active_take == 1
+        assert part.raw_file == "/obs/rec1.mkv"
+        assert part.processed_file == "/final/rec1-t1.mp4"
+        # The previously-active take 2 now lives in history.
+        assert len(part.takes) == 1
+        assert part.takes[0].take == 2
+        assert part.takes[0].raw_file == "/obs/rec1-t2.mkv"
+
+    def test_rejects_already_active_take(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv", lecture_id="010-intro")
+        with pytest.raises(ValueError, match="already active"):
+            sample_state.restore_take("010-intro", 1, 1)
+
+    def test_rejects_unknown_take(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec1.mkv", lecture_id="010-intro")
+        with pytest.raises(ValueError, match="Take 99 not found"):
+            sample_state.restore_take("010-intro", 1, 99)
+
+
+class TestRenameRecordingPaths:
+    def test_renames_active_raw(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/old.mkv", lecture_id="010-intro")
+        sample_state.rename_recording_paths("/obs/old.mkv", "/obs/new.mkv")
+
+        assert sample_state.lectures[0].parts[0].raw_file == "/obs/new.mkv"
+
+    def test_renames_processed_path(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec.mkv", lecture_id="010-intro")
+        sample_state.update_recording_status(
+            "/obs/rec.mkv", "processed", processed_file="/final/old.mp4"
+        )
+        sample_state.rename_recording_paths(
+            "/obs/rec.mkv",
+            "/obs/rec.mkv",
+            old_processed="/final/old.mp4",
+            new_processed="/final/new.mp4",
+        )
+
+        part = sample_state.lectures[0].parts[0]
+        assert part.processed_file == "/final/new.mp4"
+
+    def test_renames_inside_takes(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec.mkv", lecture_id="010-intro")
+        sample_state.update_recording_status(
+            "/obs/rec.mkv", "processed", processed_file="/final/t1.mp4"
+        )
+        sample_state.record_retake("010-intro", 1, "/obs/rec-t2.mkv")
+
+        sample_state.rename_recording_paths(
+            "/obs/rec.mkv",
+            "/takes/rec (take 1).mkv",
+            old_processed="/final/t1.mp4",
+            new_processed="/takes/t1 (take 1).mp4",
+        )
+
+        take = sample_state.lectures[0].parts[0].takes[0]
+        assert take.raw_file == "/takes/rec (take 1).mkv"
+        assert take.processed_file == "/takes/t1 (take 1).mp4"
+
+    def test_noop_when_old_path_absent(self, sample_state: CourseRecordingState):
+        sample_state.assign_recording("/obs/rec.mkv", lecture_id="010-intro")
+        sample_state.rename_recording_paths("/obs/nothing.mkv", "/obs/elsewhere.mkv")
+
+        # Unchanged — no match found anywhere.
+        assert sample_state.lectures[0].parts[0].raw_file == "/obs/rec.mkv"
+
+
+class TestTakeRecordModel:
+    def test_round_trip_serialization(self, tmp_path: Path):
+        state = CourseRecordingState(
+            course_id="serial",
+            lectures=[
+                LectureState(
+                    lecture_id="010",
+                    display_name="A",
+                    parts=[
+                        RecordingPart(
+                            part=1,
+                            raw_file="/raw.mkv",
+                            active_take=2,
+                            takes=[
+                                TakeRecord(
+                                    take=1,
+                                    raw_file="/takes/t1.mkv",
+                                    processed_file="/takes/t1.mp4",
+                                    status="processed",
+                                    superseded_at="2026-04-17T10:00:00",
+                                ),
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+        path = tmp_path / "s.json"
+        state.save(path)
+        loaded = CourseRecordingState.load(path)
+        part = loaded.lectures[0].parts[0]
+        assert part.active_take == 2
+        assert len(part.takes) == 1
+        assert part.takes[0].processed_file == "/takes/t1.mp4"

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -279,6 +279,103 @@ class TestArmDisarm:
 
 
 # ---------------------------------------------------------------------------
+# Record / Stop (one-click, Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordStop:
+    def test_record_arms_and_starts_obs(self, app, client: TestClient):
+        resp = client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
+        assert resp.status_code == 200
+
+        session = app.state.session
+        assert session.state is SessionState.ARMED
+        assert session.armed_deck is not None
+        assert session.armed_deck.deck_name == "01 Deck"
+        app.state.obs.start_record.assert_called_once_with()
+
+    def test_record_passes_part_number(self, app, client: TestClient):
+        client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "03 Intro",
+                "part_number": "2",
+            },
+        )
+        session = app.state.session
+        assert session.armed_deck.part_number == 2
+
+    def test_record_obs_failure_returns_502_but_leaves_armed(self, app, client: TestClient):
+        """If OBS rejects start_record, /record returns 502 but the deck
+        stays armed so the user can start recording manually or retry."""
+        app.state.obs.start_record.side_effect = ConnectionError("OBS not connected")
+
+        resp = client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
+        assert resp.status_code == 502
+        assert "OBS" in resp.text
+
+        session = app.state.session
+        assert session.state is SessionState.ARMED
+        assert session.armed_deck.deck_name == "01 Deck"
+
+    def test_record_while_recording_returns_409(self, app, client: TestClient):
+        """Re-recording while one is in flight is a state-machine conflict."""
+        # Arm + simulate OBS STARTED to reach RECORDING state.
+        client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        for cb in app.state.obs._record_callbacks:
+            cb(RecordingEvent(output_active=True, output_state="started"))
+
+        resp = client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "02 Other",
+                "part_number": "0",
+            },
+        )
+        assert resp.status_code == 409
+
+    def test_stop_calls_obs(self, app, client: TestClient):
+        resp = client.post("/stop")
+        assert resp.status_code == 200
+        app.state.obs.stop_record.assert_called_once_with()
+
+    def test_stop_obs_failure_returns_502(self, app, client: TestClient):
+        app.state.obs.stop_record.side_effect = ConnectionError("not recording")
+        resp = client.post("/stop")
+        assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
 # Status
 # ---------------------------------------------------------------------------
 

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -461,6 +461,40 @@ class TestSSEEvents:
         queue = app.state.sse_queue
         assert not queue.empty()
 
+    def test_job_payloads_map_to_event_job(self):
+        """Job-prefixed SSE payloads are classified as ``event: job``.
+
+        Splitting event names lets the dashboard bind refreshes on a per-
+        panel basis instead of flooding every panel on every tick. The
+        helper is unit-tested directly so we don't have to stream the
+        open-ended ``/events`` endpoint from a test client.
+        """
+        from clm.recordings.web.routes import _sse_event_name_for
+
+        assert _sse_event_name_for("job") == "job"
+        assert _sse_event_name_for("job:abc-123") == "job"
+        assert _sse_event_name_for("submitted:abc-123") == "job"
+
+    def test_status_payloads_map_to_event_status(self):
+        """Non-job payloads stay on ``event: status`` — status panel binding."""
+        from clm.recordings.web.routes import _sse_event_name_for
+
+        assert _sse_event_name_for("state_changed") == "status"
+        assert _sse_event_name_for("watcher_error") == "status"
+
+    def test_jobs_panel_refreshes_on_sse_job(self, client: TestClient):
+        """The jobs-panel must bind its refresh to ``sse:job`` (new) in
+        addition to the legacy ``sse:status`` so per-job ticks don't
+        require every panel to refresh.
+        """
+        html = client.get("/").text
+        assert 'id="jobs-panel"' in html
+        panel_idx = html.index('id="jobs-panel"')
+        tag_start = html.rfind("<", 0, panel_idx)
+        tag_end = html.index(">", panel_idx)
+        panel_tag = html[tag_start : tag_end + 1]
+        assert "sse:job" in panel_tag
+
 
 # ---------------------------------------------------------------------------
 # Pending pairs display

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -501,6 +501,39 @@ class TestSSEEvents:
 # ---------------------------------------------------------------------------
 
 
+class TestReconcileRoute:
+    """``POST /jobs/{id}/reconcile`` drives the backend's reconcile hook."""
+
+    def test_reconcile_requires_known_job_id(self, client: TestClient):
+        resp = client.post("/jobs/no-such-job/reconcile")
+        assert resp.status_code == 404
+
+    def test_reconcile_returns_updated_partial(self, app, client: TestClient):
+        """Submitting a reconcile route re-renders the jobs panel."""
+        from pathlib import Path as _Path
+
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        # Inject a fake job directly into the manager so we don't need
+        # to run a full backend submit flow.
+        manager = app.state.job_manager
+        job = ProcessingJob(
+            backend_name="onnx",
+            raw_path=_Path("/tmp/raw--RAW.mp4"),
+            final_path=_Path("/tmp/final.mp4"),
+            relative_dir=_Path(),
+            state=JobState.FAILED,
+            error="to-be-reconciled",
+        )
+        manager._store_job(job)
+
+        resp = client.post(f"/jobs/{job.id}/reconcile")
+        assert resp.status_code == 200
+        # The response is the jobs panel partial — contains the Jobs
+        # header when any jobs are present.
+        assert "Processing Jobs" in resp.text
+
+
 class TestPendingPairsDisplay:
     def test_dashboard_shows_no_pairs(self, client: TestClient):
         resp = client.get("/")


### PR DESCRIPTION
## Summary

Overhauls the recordings dashboard and workflow to address five concrete pain points from production use. Ships as five independently-shippable phases, each already reviewed-in-passing via pre-commit hooks (ruff + ruff format + mypy + fast pytest). 554 recordings tests green; design docs and handover doc cover the whole thing.

- **Phase 1 — One-click Record**: `POST /record` + `POST /stop` drive OBS over the WebSocket so the user never has to alt-tab to start a take. `/arm` + `/disarm` stay as primitives under an "Advanced" disclosure. `RecordingSession.record/stop`, `ObsClient.start_record/stop_record`.
- **Phase 2 — Retake handling**: New `SessionState.ARMED_AFTER_TAKE` keeps the deck armed for `retake_window_seconds` (default 60) after a take stops; a new OBS recording within the window is associated with the same deck as a retake. Short takes (< `short_take_seconds`, default 5) auto-supersede and keep the deck armed. Rename thread bounded by `rename_timeout_seconds` (default 10 min).
- **Phase 3 — Part/take model + `takes/` directory**: `TakeRecord` schema with backward-compat defaults; `CourseRecordingState.record_retake` / `restore_take` / `rename_recording_paths`. New `takes/` subtree holds superseded processed takes with `(part N, take K)` suffix so Auphonic-paid finals are never overwritten. Session retake pre-move demotes existing `final/` + `archive/` files before the new raw lands; optional state injection keeps `state.json` paths in sync with disk cascades.
- **Phase 4 — Live job progress**: `UPLOAD_PROGRESS_MIN_INTERVAL = 0.25` gates upload callbacks to prevent flooding. `JobManager.request_poll_soon()` + `JobContext.request_poll_soon()` collapse the 30 s post-upload gap to ~1 s. `_message_for` appends an elapsed-time heartbeat so every poll publishes a visibly different message. `/events` emits `event: job` vs `event: status` so the jobs panel and status panel can refresh independently.
- **Phase 5 — Reconcile + softer timeouts**: Generic `ProcessingBackend.reconcile(job, ctx)` Protocol method; `AuphonicBackend.reconcile` does filesystem → `get_production(uuid)` → title-based `list_productions` fallback. `POST /jobs/{id}/reconcile` + per-row "Verify" button + stale badge. `AUPHONIC_POLL_TIMEOUT_MINUTES` → `AUPHONIC_STALE_WARN_MINUTES` (alias kept): flag `job.stale` instead of failing; `AUPHONIC_HARD_GIVEUP_DAYS = 7` is the only wall-clock auto-fail. `UPLOADING`-on-restart now resumes as `PROCESSING` when `backend_ref` is set.

## Design docs

- `docs/claude/design/recordings-workflow-ux-redesign.md`
- `docs/claude/design/recordings-parts-and-takes.md`
- `docs/claude/design/recordings-job-progress-and-reconciliation.md`
- `docs/claude/recordings-ux-redesign-handover.md` (implementation status + follow-ups)

## Test plan

- [ ] Click **Record** on a lecture. OBS starts recording without switching focus; dashboard shows `recording`.
- [ ] Click **Stop** in the dashboard. OBS stops, raw lands in `to-process/`, dashboard shows the new "Ready for retake" state; after 60 s it goes to `idle`.
- [ ] Start a take, stop within 2 s. File moves to `superseded/`, dashboard unchanged, deck still armed.
- [ ] With a part already processed, click Record for the same part. Old `final/…deck.mp4` and `archive/…deck--RAW.mp4` should move to `takes/…deck (take 1).*`; new raw processes normally to fresh `final/` + `archive/` slots.
- [ ] With a part already processed, click Record for `part_number=2`. Existing files stay in `archive/` and `final/` untouched; new file becomes `part 2`.
- [ ] Verify an old state.json file without `takes` / `active_take` loads without error.
- [ ] Upload a ~500 MB file to Auphonic. Progress bar ticks smoothly (no multi-second freezes on fast uplinks).
- [ ] After upload finishes the first "Audio Processing" message appears within a couple of seconds (was 30 s).
- [ ] During Auphonic processing the "— 3m 47s" elapsed heartbeat increments every poll even when upstream status is unchanged.
- [ ] Stop the CLM server while an Auphonic job is UPLOADING. Restart. If `backend_ref` was already set, the job should come back as `PROCESSING` (not `FAILED`).
- [ ] Let an Auphonic job run past the stale-warn window (120 min). Job should show a "stale" badge but stay in `processing`; clicking Verify resolves to current upstream state.
- [ ] For a stuck `FAILED` job whose Auphonic production is actually `DONE`, click Verify. Job should transition to `COMPLETED` with the finalized output on disk.
- [ ] Run the full fast suite: `pytest` — expect 3361+ passing with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)