### PR TITLE
test: round-2 coverage expansion (74% → 86.20%)

### DIFF
--- a/docs/claude/test-coverage-continuation-guide.md
+++ b/docs/claude/test-coverage-continuation-guide.md
@@ -3,7 +3,7 @@
 **Created**: 2025-11-25
 **Last Updated**: 2026-04-18
 **Starting Coverage**: 53%
-**Current Coverage**: 82.09%
+**Current Coverage**: 83.17%
 **Target Coverage**: 85% (round-2 goal; round-1 goal of 75% is complete)
 
 This document provides detailed instructions for continuing the test coverage improvement effort.
@@ -24,6 +24,7 @@ This document provides detailed instructions for continuing the test coverage im
 | Round 2 / PR 2: output formatter + sqlite resilience | ✅ Complete | +64 | 75.13% → 76.33% |
 | Round 2 / PR 3: MCP, JupyterLite worker, Monitor TUI | ✅ Complete | +59 | 76.33% → 78.14% |
 | Round 2 / PR 4: build/docker CLI + infrastructure/api | ✅ Complete | +205 | 78.14% → 82.09% |
+| Round 2 / PR 5: recordings/processing helpers | ✅ Complete | +56 | 82.09% → 83.17% |
 
 ### Tests Created (All Phases)
 
@@ -68,6 +69,10 @@ This document provides detailed instructions for continuing the test coverage im
 | `tests/infrastructure/api/test_job_queue_adapter.py` | 23 | `infrastructure/api/job_queue_adapter.py` | 100% |
 | `tests/infrastructure/api/test_server.py` | 17 | `infrastructure/api/server.py` | 100% |
 | `tests/infrastructure/api/test_worker_routes_endpoints.py` | 21 | `infrastructure/api/worker_routes.py` | 100% |
+| **Round 2 / PR 5** | | | |
+| `tests/recordings/test_processing_utils.py` | 28 | `recordings/processing/utils.py` | 99% |
+| `tests/recordings/test_processing_pipeline.py` (extended) | +16 | `recordings/processing/pipeline.py` | 98% |
+| `tests/recordings/test_processing_compare.py` | 9 | `recordings/processing/compare.py` | 100% |
 
 *PlantUML tests are skipped without the JAR file present
 

--- a/docs/claude/test-coverage-continuation-guide.md
+++ b/docs/claude/test-coverage-continuation-guide.md
@@ -1,9 +1,9 @@
 # Test Coverage Improvement: Continuation Guide
 
 **Created**: 2025-11-25
-**Last Updated**: 2026-04-17
+**Last Updated**: 2026-04-18
 **Starting Coverage**: 53%
-**Current Coverage**: 78.14%
+**Current Coverage**: 82.09%
 **Target Coverage**: 85% (round-2 goal; round-1 goal of 75% is complete)
 
 This document provides detailed instructions for continuing the test coverage improvement effort.
@@ -23,6 +23,7 @@ This document provides detailed instructions for continuing the test coverage im
 | Round 2 / PR 1: CLI commands + course.py | ✅ Complete | +39 | 74% → 75.13% |
 | Round 2 / PR 2: output formatter + sqlite resilience | ✅ Complete | +64 | 75.13% → 76.33% |
 | Round 2 / PR 3: MCP, JupyterLite worker, Monitor TUI | ✅ Complete | +59 | 76.33% → 78.14% |
+| Round 2 / PR 4: build/docker CLI + infrastructure/api | ✅ Complete | +205 | 78.14% → 82.09% |
 
 ### Tests Created (All Phases)
 
@@ -60,6 +61,13 @@ This document provides detailed instructions for continuing the test coverage im
 | `tests/mcp/test_server.py` | 9 | `mcp/server.py` | 82% |
 | `tests/workers/jupyterlite/test_jupyterlite_worker.py` | 14 | `workers/jupyterlite/jupyterlite_worker.py` | 100% |
 | `tests/cli/test_monitor_app.py` | 32 + 4 xfail | `cli/monitor/*` (app, widgets, data_provider) | 85-100% |
+| **Round 2 / PR 4** | | | |
+| `tests/cli/test_build_command.py` | 48 | `cli/commands/build.py` | 80% |
+| `tests/cli/test_docker_command.py` | 70 | `cli/commands/docker.py` | 99% |
+| `tests/infrastructure/api/test_client.py` | 26 | `infrastructure/api/client.py` | 99% |
+| `tests/infrastructure/api/test_job_queue_adapter.py` | 23 | `infrastructure/api/job_queue_adapter.py` | 100% |
+| `tests/infrastructure/api/test_server.py` | 17 | `infrastructure/api/server.py` | 100% |
+| `tests/infrastructure/api/test_worker_routes_endpoints.py` | 21 | `infrastructure/api/worker_routes.py` | 100% |
 
 *PlantUML tests are skipped without the JAR file present
 

--- a/docs/claude/test-coverage-continuation-guide.md
+++ b/docs/claude/test-coverage-continuation-guide.md
@@ -1,10 +1,10 @@
 # Test Coverage Improvement: Continuation Guide
 
 **Created**: 2025-11-25
-**Last Updated**: 2025-11-26
+**Last Updated**: 2026-04-17
 **Starting Coverage**: 53%
-**Current Coverage**: 69%
-**Target Coverage**: 75%+
+**Current Coverage**: 78.14%
+**Target Coverage**: 85% (round-2 goal; round-1 goal of 75% is complete)
 
 This document provides detailed instructions for continuing the test coverage improvement effort.
 
@@ -20,6 +20,9 @@ This document provides detailed instructions for continuing the test coverage im
 | Phase 2: Infrastructure | ✅ Complete | ~100 | 61% → 63% |
 | Phase 3: Worker Modules | ✅ Complete | ~200 | 63% → 68% |
 | Phase 4: Complex Modules | ✅ Complete | ~80 | 68% → 69% |
+| Round 2 / PR 1: CLI commands + course.py | ✅ Complete | +39 | 74% → 75.13% |
+| Round 2 / PR 2: output formatter + sqlite resilience | ✅ Complete | +64 | 75.13% → 76.33% |
+| Round 2 / PR 3: MCP, JupyterLite worker, Monitor TUI | ✅ Complete | +59 | 76.33% → 78.14% |
 
 ### Tests Created (All Phases)
 
@@ -46,6 +49,17 @@ This document provides detailed instructions for continuing the test coverage im
 | `tests/workers/notebook/test_notebook_processor.py` | 41 | `notebook_processor.py` | 84% |
 | `tests/web/services/test_monitor_service.py` | 18 | `monitor_service.py` | 38% |
 | `tests/web/api/test_websocket.py` | 19 | `websocket.py` | 65% |
+| **Round 2 / PR 1** | | | |
+| `tests/cli/test_config_command.py` | 13 | `cli/commands/config.py` | 97% |
+| `tests/cli/test_db_commands.py` | 17 | `cli/commands/database.py` | 93% |
+| `tests/core/test_multi_target_course.py` (extended) | +9 | `core/course.py` (JupyterLite paths) | 69% |
+| **Round 2 / PR 2** | | | |
+| `tests/cli/test_build_output.py` (extended) | +41 | `cli/output_formatter.py` | 99% |
+| `tests/infrastructure/backends/test_sqlite_backend_resilience.py` | 23 | `infrastructure/backends/sqlite_backend.py` | 82% |
+| **Round 2 / PR 3** | | | |
+| `tests/mcp/test_server.py` | 9 | `mcp/server.py` | 82% |
+| `tests/workers/jupyterlite/test_jupyterlite_worker.py` | 14 | `workers/jupyterlite/jupyterlite_worker.py` | 100% |
+| `tests/cli/test_monitor_app.py` | 32 + 4 xfail | `cli/monitor/*` (app, widgets, data_provider) | 85-100% |
 
 *PlantUML tests are skipped without the JAR file present
 
@@ -64,6 +78,29 @@ This document provides detailed instructions for continuing the test coverage im
 2. **monitor_service.py** - Fixed SQL query using incorrect column names:
    - `w.worker_id` → `w.container_id`
    - `w.created_at` → `w.started_at`
+
+3. **job_queue.py** (Round 2, PR 1) - `vacuum()` crashed on Python 3.13 because
+   `conn.execute("COMMIT")` is rejected on an autocommit connection when no
+   transaction is active. Guarded with `if conn.in_transaction:`.
+
+---
+
+## Round 2 Bug Documentation (via xfail tests)
+
+PR 3 introduced three `xfail(strict=True)` tests that document currently-broken
+Monitor TUI behaviors. Fixing any of them will cause the test to XPASS and the
+run to fail — this is the intended regression alarm.
+
+| Test | File | Bug |
+|---|---|---|
+| `test_one_second_duration_should_not_report_zero` | `tests/cli/test_monitor_app.py::TestDataProviderEventDuration` | `julianday()` subtraction in `data_provider.get_recent_events` loses precision: 1s → 0.9999945s → `CAST(... AS INTEGER) = 0`. 8,236 completed jobs in the user's production DB hit this. |
+| `test_zero_duration_renders_as_instant_not_question_mark` | `...::TestActivityPanelViaPilot` | Presentation-side of the same bug: `_write_event` treats `duration_seconds = 0` as falsy and renders `(?)`. |
+| `test_completing_a_job_removes_its_started_entry` | `...::TestActivityPanelViaPilot` | Once a `job_started` line is appended to the `RichLog`, it is never removed when the job later completes → panel fills with ghost "Started" lines. |
+| `test_header_shows_current_course_spec` | `...::TestStatusHeaderEmptyTitleBug` | Header does not surface the current course spec; the big top panel sits informationless during a build. |
+
+The sluggish-scrolling bug (bug #3 from the user's report) is documented in a
+module-level comment in `tests/cli/test_monitor_app.py` rather than as an
+xfail test, because a meaningful perf assertion would be too flaky for CI.
 
 ---
 
@@ -1077,11 +1114,17 @@ python -m pytest -x
 
 ## Coverage Goals
 
-| Phase | Target Coverage | Modules |
-|-------|-----------------|---------|
-| After Phase 3 | 70% | Worker modules |
-| After Phase 4 | 75% | Complex modules (processor, CLI) |
-| After Phase 5 | 78%+ | TUI, pool manager |
+| Phase | Target Coverage | Achieved | Modules |
+|-------|-----------------|----------|---------|
+| After Phase 3 | 70% | 68% | Worker modules |
+| After Phase 4 | 75% | 69% | Complex modules (processor, CLI) |
+| After Phase 5 | 78% | — | TUI, pool manager (superseded by Round 2) |
+| Round 2 / PR 1 | ~75.5% | 75.13% | CLI config/database, course.py JupyterLite |
+| Round 2 / PR 2 | ~77% | 76.33% | output formatter, sqlite resilience |
+| Round 2 / PR 3 | ~77.8% | 78.14% | MCP, JupyterLite worker, Monitor TUI |
+| Round 2 / PR 4 (pending) | ~82% | — | build/docker commands, infrastructure/api |
+| Round 2 / PR 5 (pending) | ~83.5% | — | recordings/processing |
+| Round 2 target | 85% | — | — |
 
 ---
 

--- a/docs/claude/test-coverage-continuation-guide.md
+++ b/docs/claude/test-coverage-continuation-guide.md
@@ -1,10 +1,10 @@
 # Test Coverage Improvement: Continuation Guide
 
 **Created**: 2025-11-25
-**Last Updated**: 2026-04-18
+**Last Updated**: 2026-04-18 (PR 6 shipped — round-2 target met)
 **Starting Coverage**: 53%
-**Current Coverage**: 83.17%
-**Target Coverage**: 85% (round-2 goal; round-1 goal of 75% is complete)
+**Current Coverage**: 86.20%
+**Target Coverage**: ✅ **≥ 85% met** (round-2 complete; round-1 goal of 75% is complete)
 
 This document provides detailed instructions for continuing the test coverage improvement effort.
 
@@ -25,6 +25,7 @@ This document provides detailed instructions for continuing the test coverage im
 | Round 2 / PR 3: MCP, JupyterLite worker, Monitor TUI | ✅ Complete | +59 | 76.33% → 78.14% |
 | Round 2 / PR 4: build/docker CLI + infrastructure/api | ✅ Complete | +205 | 78.14% → 82.09% |
 | Round 2 / PR 5: recordings/processing helpers | ✅ Complete | +56 | 82.09% → 83.17% |
+| Round 2 / PR 6: remaining CLI + processing/batch.py | ✅ Complete | +180 | 83.17% → 86.20% |
 
 ### Tests Created (All Phases)
 
@@ -73,6 +74,14 @@ This document provides detailed instructions for continuing the test coverage im
 | `tests/recordings/test_processing_utils.py` | 28 | `recordings/processing/utils.py` | 99% |
 | `tests/recordings/test_processing_pipeline.py` (extended) | +16 | `recordings/processing/pipeline.py` | 98% |
 | `tests/recordings/test_processing_compare.py` | 9 | `recordings/processing/compare.py` | 100% |
+| **Round 2 / PR 6** | | | |
+| `tests/recordings/test_recordings_command.py` | 42 | `cli/commands/recordings.py` | 91% |
+| `tests/cli/test_voiceover_command.py` | 38 | `cli/commands/voiceover.py` | 59% |
+| `tests/cli/test_zip_ops.py` (extended) | +17 | `cli/commands/zip_ops.py` | 100% |
+| `tests/cli/test_monitoring_command.py` | 16 | `cli/commands/monitoring.py` | 90% |
+| `tests/cli/test_polish_command.py` | 14 | `cli/commands/polish.py` | 100% |
+| `tests/cli/test_jupyterlite_command.py` | 15 | `cli/commands/jupyterlite.py` | 94% |
+| `tests/recordings/test_batch.py` (extended) | +14 | `recordings/processing/batch.py` | 100% |
 
 *PlantUML tests are skipped without the JAR file present
 

--- a/docs/claude/test-coverage-expansion-handover.md
+++ b/docs/claude/test-coverage-expansion-handover.md
@@ -1,7 +1,9 @@
 # Handover: Test Coverage Expansion (Round 2)
 
 **Created**: 2026-04-17
+**Last Updated**: 2026-04-18 (PR 4 shipped)
 **Starting coverage (fast suite)**: **74%** (5,264 / 20,037 statements missed, 3,311 tests)
+**Current coverage (fast suite)**: **82.09%** (after PR 4; 3,647 tests passing + 4 xfailed)
 **Measurement command**: `pytest -m "not docker and not slow and not integration and not e2e" --cov=src/clm`
 **Target**: raise overall fast-suite coverage to **≥ 85%**, concentrating on user-facing CLI surface,
   resilience paths in persistence/worker orchestration, and newly-added features that shipped without
@@ -10,6 +12,19 @@
 Prior coverage effort (53% → 69%, Phases 1–4) is archived in
 `docs/claude/test-coverage-continuation-guide.md`. **This document does not re-plan that work** — it
 plans the next round, incorporating explicit decisions from the maintainer (see §3).
+
+## PR status (round 2)
+
+| PR | Focus | Planned Δ | Actual Δ | Status |
+|---|---|---:|---:|---|
+| 1 | `cli/commands/{database,config}.py` + `core/course.py` JupyterLite paths | +1.5% | +1.13% | ✅ shipped |
+| 2 | `cli/output_formatter.py` verbose + `sqlite_backend.py` resilience | +1.5% | +1.20% | ✅ shipped |
+| 3 | MCP server, JupyterLite worker, Monitor TUI smoke/diagnostic tests | +1.5% | +1.81% | ✅ shipped (4 xfail bugs documented) |
+| 4 | `cli/commands/build.py`, `cli/commands/docker.py`, `infrastructure/api/*` | +4.0% | +3.95% | ✅ shipped |
+| 5 | `recordings/processing/{utils,pipeline,compare}.py` | +1.5% | — | ⏳ remaining — see §5.5 |
+
+**Round 2 to date**: 74% → 82.09% (+8.09pp across PRs 1–4). PR 5 is the remaining work to hit the
+85% target.
 
 ---
 
@@ -112,26 +127,17 @@ recipe.
 
 ## 4. PR plan
 
-Five PRs in order. Each is sized to roughly one session; the dependency graph is:
+Five PRs in order. PRs 1–4 are shipped; only PR 5 remains.
 
 ```
-PR 1  (small)  ──►  PR 2  (medium)
-PR 3  (smoke tests, independent)
-PR 4  (CLI + API, independent of 1-3)
-PR 5  (processing, depends only on tooling)
+PR 1  ✅ shipped     ──►  PR 2  ✅ shipped
+PR 3  ✅ shipped     (smoke tests, independent)
+PR 4  ✅ shipped     (CLI + API, independent of 1-3)
+PR 5  ⏳ remaining   (processing, depends only on tooling)
 ```
 
-Estimated coverage deltas are indicative, computed from the current missing-line counts assuming
-the target per-file percentages hold.
-
-| PR | Focus | Expected Δ coverage |
-|---|---|---:|
-| 1 | `cli/commands/{database,config}.py` + `core/course.py` JupyterLite paths | +1.5% |
-| 2 | `cli/output_formatter.py` verbose + `sqlite_backend.py` resilience | +1.5% |
-| 3 | MCP server, JupyterLite worker, Monitor TUI smoke/diagnostic tests | +1.5% |
-| 4 | `cli/commands/build.py`, `cli/commands/docker.py`, `infrastructure/api/*` | +4.0% |
-| 5 | `recordings/processing/{utils,pipeline,compare}.py` | +1.5% |
-| **Total** | | **≥ 10%**, lands ≥ 85% |
+Actual coverage deltas recorded per PR (see the status table at the top of this doc). PR 5 has a
+planned delta of +1.5pp that should land the round at or above the 85% target.
 
 Rules for every PR:
 
@@ -150,7 +156,10 @@ Rules for every PR:
 
 ## 5. PR-by-PR recipes
 
-### PR 1 — Small, high-ROI CLI + core coverage
+> **PRs 1–4 are shipped.** Their recipes remain below as historical reference for what was built
+> and how. Only §5.5 (PR 5) is still actionable work.
+
+### PR 1 — Small, high-ROI CLI + core coverage ✅ shipped (2026-04-17)
 
 **Goal**: cover unit-testable user-facing commands and the new JupyterLite build path.
 
@@ -194,7 +203,7 @@ Rules for every PR:
 
 ---
 
-### PR 2 — Formatting and persistence resilience
+### PR 2 — Formatting and persistence resilience ✅ shipped (2026-04-17)
 
 **Goal**: lock down user-facing error output and the SQLite backend's recovery paths.
 
@@ -231,7 +240,27 @@ Rules for every PR:
 
 ---
 
-### PR 3 — Smoke + diagnostic tests (MCP, JupyterLite worker, Monitor TUI)
+### PR 3 — Smoke + diagnostic tests (MCP, JupyterLite worker, Monitor TUI) ✅ shipped (2026-04-17)
+
+**Outcome**: 55 pass + 4 xfail tests across three files (`test_server.py`, `test_jupyterlite_worker.py`,
+`test_monitor_app.py`). Coverage 76.33% → 78.14% (+1.81pp). Actual per-file: mcp/server.py 82.2%,
+jupyterlite_worker.py 100%, monitor/app.py 97.6%, activity_panel.py 83.5%, status_header.py 100%,
+workers_panel.py 100%, queue_panel.py 94.9%, data_provider.py 84.6%.
+
+**Monitor TUI bugs documented as strict xfail tests** (still unfixed at end of PR 3 — fixing these
+is separate follow-up work):
+- Bug #1 — `(?)` duration for 1-second jobs: `julianday()` rounding loses 1s → `CAST(... AS INTEGER) = 0`
+  in `data_provider.get_recent_events`; `format_elapsed(0)` renders `"?"` because 0 is falsy in
+  `activity_panel._write_event`. Two xfail tests reproduce the data-layer and presentation-layer
+  halves of the bug.
+- Bug #1 — stale "Started" entries: an xfail test documents that completing a job should remove
+  its "Started" entry from the activity log; currently it doesn't.
+- Bug #2 — empty title area: `status_header._render_content` uses only health/workers/queue/
+  completed-last-hour; has no course-spec tracking. An xfail test asserts the header should show
+  the currently-processing course spec name.
+- Bug #3 — scroll lag: `WorkersPanel._render_workers` calls `content_widget.remove_children()`
+  every tick, forcing Textual to reconstruct the scroll layout. Documented as a module-level
+  comment (not a perf test — too flaky for CI).
 
 **Goal**: fill the three zero-coverage surfaces the maintainer flagged, and give the monitor team
 a foothold for tracking the known display bugs.
@@ -330,7 +359,36 @@ Target: each widget ≥ 60%, `data_provider.py` ≥ 80%. Overall monitor subtree
 
 ---
 
-### PR 4 — Build CLI, Docker CLI, and API layer
+### PR 4 — Build CLI, Docker CLI, and API layer ✅ shipped (2026-04-18)
+
+**Outcome**: 205 new tests across 6 files. Coverage 78.14% → 82.09% (+3.95pp, essentially on plan).
+
+**Per-file actuals**:
+- `cli/commands/build.py`: 43.6% → **80%** (48 tests in `test_build_command.py`)
+- `cli/commands/docker.py`: 11.8% → **99%** (70 tests in `test_docker_command.py`)
+- `infrastructure/api/client.py`: 50% → **99%** (26 tests in `test_client.py`)
+- `infrastructure/api/job_queue_adapter.py`: 27% → **100%** (23 tests in `test_job_queue_adapter.py`)
+- `infrastructure/api/server.py`: 49% → **100%** (17 tests in `test_server.py`)
+- `infrastructure/api/worker_routes.py`: 35% → **100%** (21 tests in `test_worker_routes_endpoints.py`;
+  original `test_worker_routes.py` kept as-is)
+
+**Testing patterns worth knowing for future work in these areas**:
+- **Rich console capture**: both `build.py` and `docker.py` bind `console = Console(file=sys.stderr)`
+  at import time, so CliRunner stream isolation does *not* capture their output. Swap the module's
+  `console` / `cli_console` for a `Console(file=StringIO(), force_terminal=False, no_color=True)`
+  and assert on `buf.getvalue()`. Used in both `test_docker_command.py::captured_console` fixture
+  and `test_build_command.py::TestReportValidationErrors::test_quiet_mode_emits_short_message`.
+- **FastAPI 500 paths**: `TestClient(app, raise_server_exceptions=False)` lets the test observe the
+  500 response instead of re-raising. Also, patch a method used *inside* each handler's
+  `try`/`except` (e.g. `JobQueue._get_conn`, `JobQueue.get_next_job`) so the handler's generic
+  `Exception → HTTPException(500)` conversion runs.
+- **Fake uvicorn**: `WorkerApiServer._run_server` is tested with a `FakeUvicornServer` stand-in that
+  mimics `should_exit` / `run()`; lets lifecycle, idempotent-start, and stop-on-stubborn-thread
+  paths run without opening a socket. One real-uvicorn smoke test exists on port 0 and is
+  marked `@pytest.mark.slow`.
+- **`build` CLI wrapper tests**: the command reads `ctx.obj["CACHE_DB_PATH"]` / `["JOBS_DB_PATH"]`
+  set by the top-level `clm` group. Provide them via `CliRunner().invoke(build, args, obj={...})`
+  (the `_invoke_build` helper in `test_build_command.py`).
 
 **Goal**: the big three CLI surfaces that dominate the `cli/commands/` missed-line count, plus the
 FastAPI boundary that's currently only reached through docker-marked tests.
@@ -374,7 +432,12 @@ FastAPI boundary that's currently only reached through docker-marked tests.
 
 ---
 
-### PR 5 — Recordings processing helpers
+### PR 5 — Recordings processing helpers ⏳ remaining (next)
+
+**Coverage baseline at start of PR 5** (2026-04-18): project 82.09%. PR 5's +1.5pp lifts us to
+~83.6%, within striking distance of the 85% target. If PR 5 overshoots its plan, the round is
+done; if it underdelivers, consider a small PR 6 focused on remaining zero/low-coverage files
+discovered by the post-PR-5 coverage diff.
 
 **Goal**: cover the shared processing layer that underpins `clm recordings serve`, `clm recordings
 process`, and the workflow backends.
@@ -425,40 +488,60 @@ process`, and the workflow backends.
 
 ## 7. Session-start checklist for picking up this work
 
+PRs 1–4 are shipped. The next (and currently only) actionable PR is **PR 5** — see §5.5.
+
 1. Read this document plus §3 of `docs/claude/test-coverage-continuation-guide.md` for historical
    context.
-2. Ask the user: "Which PR am I working on, and is there an updated list of monitor TUI bugs?"
-   (PR 3 specifically needs the latest bug list.)
-3. Regenerate the coverage baseline (command in §1) and diff against the numbers in §2. If the
-   baseline has drifted significantly, re-triage before starting.
-4. Follow the PR recipe in §5. Each recipe lists its "Done when" criteria — don't declare done
-   without hitting them.
-5. After the PR merges, update §4 with the actual Δ coverage and add a row to
-   `docs/claude/test-coverage-continuation-guide.md` Phase 5+ table.
+2. Regenerate the coverage baseline (command in §1) and compare against 82.09%. If it has drifted,
+   re-triage before starting PR 5.
+3. Follow the PR 5 recipe in §5.5. "Done when" criteria are listed there.
+4. After PR 5 merges, update the PR status table at the top of this doc with the actual Δ
+   coverage, and add a row to `docs/claude/test-coverage-continuation-guide.md`.
+5. If the 85% target has been hit, archive this handover alongside the prior round-1 guide. If it
+   hasn't, triage the remaining gap and decide whether a PR 6 is warranted.
+
+### Separate follow-up: Monitor TUI bugs (PR 3 xfails)
+
+PR 3 documented four Monitor TUI bugs as `xfail(strict=True)` tests. These are *not* coverage work
+— they are real display bugs in production code. Fixing them requires separate design work
+(especially bug #2, which needs a new `StatusInfo.current_course_spec` field). When the maintainer
+chooses to address them, flipping the xfail → pass in the same commit is the easy part; the
+upstream work is:
+
+- **Bug #1 duration rounding**: change `data_provider.get_recent_events` to use
+  `(strftime('%s', completed_at) - strftime('%s', started_at))` instead of `julianday()`
+  arithmetic, *and* change `activity_panel._write_event` to test `is not None` instead of
+  truthiness on `event.duration_seconds`.
+- **Bug #1 stale "Started" entries**: dedup key currently combines `job_id` and `event_type`;
+  needs to be `job_id` alone, with the latest event wins (or emit an explicit "remove" event
+  on job completion).
+- **Bug #2 empty title**: add `current_course_spec` to `StatusInfo` (populated from the
+  corresponding CLI flag or from the in-progress job's payload) and render it in
+  `status_header._render_content`.
+- **Bug #3 scroll lag**: `WorkersPanel._render_workers` should update children in place
+  (mutate existing Static widgets) rather than `remove_children()` + mount each tick.
 
 ## 8. File map
 
-Where to put the new tests:
-
-| PR | New / extended test file | Source under test |
-|---|---|---|
-| 1 | `tests/cli/test_config_command.py` (new) | `cli/commands/config.py` |
-| 1 | `tests/cli/test_db_commands.py` (new) | `cli/commands/database.py` |
-| 1 | `tests/core/test_multi_target_course.py` (extend) | `core/course.py` JupyterLite paths |
-| 2 | `tests/cli/test_build_output.py` (extend) | `cli/output_formatter.py` (verbose) |
-| 2 | `tests/infrastructure/backends/test_sqlite_backend_resilience.py` (new) | `sqlite_backend.py` |
-| 3 | `tests/mcp/test_server.py` (new) | `mcp/server.py` |
-| 3 | `tests/workers/jupyterlite/test_jupyterlite_worker.py` (new) | `workers/jupyterlite/jupyterlite_worker.py` |
-| 3 | `tests/cli/test_monitor_unit.py` (extend) | `cli/monitor/widgets/*` |
-| 3 | `tests/cli/test_monitor_app.py` (new) | `cli/monitor/app.py`, `data_provider.py` |
-| 4 | `tests/cli/test_build_command.py` (new) | `cli/commands/build.py` |
-| 4 | `tests/cli/test_docker_command.py` (new) | `cli/commands/docker.py` |
-| 4 | `tests/infrastructure/api/test_server_routes.py` (new) | `infrastructure/api/server.py`, `worker_routes.py` |
-| 4 | `tests/infrastructure/api/test_client.py` (new) | `infrastructure/api/client.py` |
-| 4 | `tests/infrastructure/api/test_job_queue_adapter.py` (new) | `infrastructure/api/job_queue_adapter.py` |
-| 5 | `tests/recordings/test_processing_utils.py` (new) | `recordings/processing/utils.py` |
-| 5 | `tests/recordings/test_processing_pipeline.py` (extend) | `recordings/processing/pipeline.py` |
-| 5 | `tests/recordings/test_processing_compare.py` (new) | `recordings/processing/compare.py` |
+| PR | Test file | Source under test | Status |
+|---|---|---|---|
+| 1 | `tests/cli/test_config_command.py` | `cli/commands/config.py` | ✅ shipped |
+| 1 | `tests/cli/test_db_commands.py` | `cli/commands/database.py` | ✅ shipped |
+| 1 | `tests/core/test_multi_target_course.py` (extended) | `core/course.py` JupyterLite paths | ✅ shipped |
+| 2 | `tests/cli/test_build_output.py` (extended) | `cli/output_formatter.py` (verbose) | ✅ shipped |
+| 2 | `tests/infrastructure/backends/test_sqlite_backend_resilience.py` | `sqlite_backend.py` | ✅ shipped |
+| 3 | `tests/mcp/test_server.py` | `mcp/server.py` | ✅ shipped |
+| 3 | `tests/workers/jupyterlite/test_jupyterlite_worker.py` | `workers/jupyterlite/jupyterlite_worker.py` | ✅ shipped |
+| 3 | `tests/cli/test_monitor_app.py` | `cli/monitor/app.py`, widgets, `data_provider.py` | ✅ shipped (+ 4 xfail bugs) |
+| 4 | `tests/cli/test_build_command.py` | `cli/commands/build.py` | ✅ shipped |
+| 4 | `tests/cli/test_docker_command.py` | `cli/commands/docker.py` | ✅ shipped |
+| 4 | `tests/infrastructure/api/test_worker_routes_endpoints.py` | `worker_routes.py` endpoints + 500s | ✅ shipped |
+| 4 | `tests/infrastructure/api/test_server.py` | `infrastructure/api/server.py` (WorkerApiServer) | ✅ shipped |
+| 4 | `tests/infrastructure/api/test_client.py` | `infrastructure/api/client.py` | ✅ shipped |
+| 4 | `tests/infrastructure/api/test_job_queue_adapter.py` | `infrastructure/api/job_queue_adapter.py` | ✅ shipped |
+| 5 | `tests/recordings/test_processing_utils.py` (new) | `recordings/processing/utils.py` | ⏳ remaining |
+| 5 | `tests/recordings/test_processing_pipeline.py` (extend) | `recordings/processing/pipeline.py` | ⏳ remaining |
+| 5 | `tests/recordings/test_processing_compare.py` (new) | `recordings/processing/compare.py` | ⏳ remaining |
 
 Existing fixture files worth reusing:
 
@@ -468,3 +551,10 @@ Existing fixture files worth reusing:
 - `tests/recordings/test_web.py::app` — FastAPI TestClient + mocked OBS.
 - `tests/core/test_multi_target_course.py` — multi-target + DummyBackend fixture.
 - `tests/cli/test_build_output.py` — `Console(record=True)` pattern.
+- **New (PR 4)** `tests/cli/test_docker_command.py::captured_console` — fixture for intercepting
+  module-level Rich Console output; copy-paste for any future tests on modules that bind a
+  console at import.
+- **New (PR 4)** `tests/cli/test_build_command.py::_invoke_build` — helper that supplies
+  `ctx.obj` so the `build` command can be driven without wiring up the parent `clm` group.
+- **New (PR 4)** `tests/infrastructure/api/test_server.py::FakeUvicornServer` — fake uvicorn for
+  lifecycle testing of `WorkerApiServer` without opening a real socket.

--- a/docs/claude/test-coverage-expansion-handover.md
+++ b/docs/claude/test-coverage-expansion-handover.md
@@ -1,13 +1,11 @@
 # Handover: Test Coverage Expansion (Round 2)
 
 **Created**: 2026-04-17
-**Last Updated**: 2026-04-18 (PR 5 shipped; PR 6 scoped)
+**Last Updated**: 2026-04-18 (PR 6 shipped — round 2 target met)
 **Starting coverage (fast suite)**: **74%** (5,264 / 20,037 statements missed, 3,311 tests)
-**Current coverage (fast suite)**: **83.17%** (after PR 5; 3,723 tests passing + 4 xfailed)
+**Current coverage (fast suite)**: **86.20%** (after PR 6; 3,882 tests passing + 4 xfailed, 20,038 statements)
 **Measurement command**: `pytest -m "not docker and not slow and not integration and not e2e" --cov=src/clm`
-**Target**: raise overall fast-suite coverage to **≥ 85%**, concentrating on user-facing CLI surface,
-  resilience paths in persistence/worker orchestration, and newly-added features that shipped without
-  direct tests.
+**Target**: ✅ **≥ 85% achieved** — round 2 is complete.
 
 Prior coverage effort (53% → 69%, Phases 1–4) is archived in
 `docs/claude/test-coverage-continuation-guide.md`. **This document does not re-plan that work** — it
@@ -22,10 +20,9 @@ plans the next round, incorporating explicit decisions from the maintainer (see 
 | 3 | MCP server, JupyterLite worker, Monitor TUI smoke/diagnostic tests | +1.5% | +1.81% | ✅ shipped (4 xfail bugs documented) |
 | 4 | `cli/commands/build.py`, `cli/commands/docker.py`, `infrastructure/api/*` | +4.0% | +3.95% | ✅ shipped |
 | 5 | `recordings/processing/{utils,pipeline,compare}.py` | +1.5% | +1.08% | ✅ shipped |
-| 6 | Remaining low-hanging CLI + `recordings/processing/batch.py` | +2.0% | — | ⏳ remaining — see §5.6 |
+| 6 | Remaining low-hanging CLI + `recordings/processing/batch.py` | +2.0% | +3.03% | ✅ shipped |
 
-**Round 2 to date**: 74% → 83.17% (+9.17pp across PRs 1–5). PR 6 is the remaining work to hit the
-85% target.
+**Round 2 final**: 74% → 86.20% (+12.20pp across PRs 1–6). **Target met** (≥ 85%).
 
 ---
 
@@ -460,42 +457,57 @@ overshoots produced a modest total lift).
   that records the real return value lets tests assert `keep_temp=True` preserves the temp dir
   (and `False` removes it), without stubbing out disk writes.
 
-### PR 6 — Remaining gap to 85% ⏳ remaining (next)
+### PR 6 — Remaining gap to 85% ✅ shipped (2026-04-18)
 
-**Baseline at start of PR 6**: project 83.17% (3,372 / 20,038 missed). Target +1.83pp to hit 85%
-(≈ 367 statements to cover).
+**Outcome**: 180 new tests across 7 files. Coverage 83.17% → **86.20%** (+3.03pp, well over the
+~+2.1pp plan). Round-2 target (≥ 85%) achieved.
 
-**Scope** — chosen from the post-PR-5 coverage diff, prioritized by (a) user-facing surface and
-(b) cost to test. All live in `cli/commands/*` or `recordings/processing/batch.py`; they are
-testable with the same `click.testing.CliRunner` + narrow-seam mocks that PR 4 used.
+**Per-file actuals** (target → actual, where *actual* is the per-file coverage measured across
+the full fast suite):
+- `cli/commands/jupyterlite.py`: 23% → **94%** (15 tests in `test_jupyterlite_command.py`)
+- `cli/commands/monitoring.py`: 23% → **90%** (16 tests in `test_monitoring_command.py`)
+- `cli/commands/polish.py`: 28% → **100%** (14 tests in `test_polish_command.py`)
+- `cli/commands/recordings.py`: 52% → **91%** (42 tests in `test_recordings_command.py`; existing
+  `test_cli_recordings.py` / `test_recordings_auphonic_cli.py` stay in place)
+- `cli/commands/voiceover.py`: 26% → **59%** (38 tests in `test_voiceover_command.py`; 1pp under
+  the 60% target because the `sync` command's `_merge_notes` helper and the multi-part
+  orchestration loop are integration-shaped and were not unit-mocked here)
+- `cli/commands/zip_ops.py`: 46% → **100%** (31 tests extending `test_zip_ops.py`)
+- `recordings/processing/batch.py`: 49% → **100%** (24 tests extending `test_batch.py`)
 
-1. **`cli/commands/recordings.py`** (612 stmts, 293 miss, 52% → target 75%, ~140 stmts). The
-   biggest single gap; huge user-facing surface (serve, process, batch, compare, record). Mock
-   `ProcessingPipeline`, `OBSClient`, and file I/O at narrow seams.
-2. **`cli/commands/voiceover.py`** (362 stmts, 269 miss, 26% → target 60%, ~120 stmts). The CLI
-   layer only — keep the `voiceover/*` backend paths `integration`-marked per §6. Mock
-   `transcribe`/`matcher`/`aligner` at the module-level import in the command file.
-3. **`cli/commands/zip_ops.py`** (113, 61 miss, 46% → target 80%). Small, contained.
-4. **`cli/commands/monitoring.py`** (73, 56 miss, 23% → target 70%). Small.
-5. **`cli/commands/polish.py`** (64, 46 miss, 28% → target 70%). Small; LLM-adjacent, mock the
-   `polish()` function.
-6. **`cli/commands/jupyterlite.py`** (71, 55 miss, 23% → target 70%). Small; JupyterLite CLI.
-7. **`recordings/processing/batch.py`** (53, 27 miss, 49% → target 80%). Natural adjunct to PR 5
-   — actively used by `recordings serve`, follows the same mocking patterns.
+**Testing patterns worth knowing for future work in these areas**:
+- **`sys.modules` injection for lazy imports**: `monitoring.serve`, `monitoring.monitor`,
+  `recordings.process`/`batch`/`assemble`/`serve_recordings`, and the `voiceover.*` commands do
+  their heavy imports *inside* the command body, so the mocks must be installed on `sys.modules`
+  *before* `runner.invoke(...)`. `monkeypatch.setitem(sys.modules, "clm.web.app", fake_module)`
+  is the pattern.
+- **Real `JobManager` + stub `ProcessingBackend`**: `TestWaitJobCommand` reuses
+  `test_cli_recordings.py`'s pattern — constructing an actual `JobManager(root_dir, store, bus)`
+  with a hand-written `ProcessingBackend` subclass whose `poll()` flips the job's state on the
+  first tick. Patching `time.sleep` keeps the wait loop fast without flakiness.
+- **`_get_*_config` helper fallbacks**: each helper has a `try/except → defaults` path. Test the
+  happy path by patching `sys.modules["clm.infrastructure.config"]` with a `MagicMock`, and the
+  fallback by setting `get_config.side_effect = RuntimeError`.
+- **`zip create` CLI**: `find_output_directories` is the natural narrow seam — patch it to return
+  a fixed list of `OutputDirectory` objects and let the command drive the archive creation. The
+  archive path is predictable via `_archive_name(output_dir)`.
+- **Language filter in `jupyterlite._find_site_dirs`**: looks for `/{lang}/` as a *posix path
+  segment*, so fixtures must use real `/de/` directories (not `course-de`) to exercise the
+  filter path. When no paths match, it falls back to returning the unfiltered list.
 
-**Expected lift**: ≈ 420 stmts → ~+2.1pp → ~85.3%. Comfortable margin over the 85% target.
-
-**Out of scope for PR 6** (still deferred):
-- `cli/commands/git_ops.py`, `cli/commands/summarize.py`, `cli/commands/workers.py` — larger; keep
-  for a potential PR 7 if needed.
+**Out of scope for PR 6** (still deferred — could be a future PR 7 if needed):
+- `cli/commands/git_ops.py`, `cli/commands/summarize.py`, `cli/commands/workers.py` — larger; not
+  required to hit 85%.
 - `infrastructure/workers/pool_manager.py` — docker-marked branches dominate the gap per §6.
-- `workers/notebook/notebook_processor.py` — already at 76% after earlier rounds; remaining gap is
-  integration-shaped.
+- `workers/notebook/notebook_processor.py` — already at 76% after earlier rounds; remaining gap
+  is integration-shaped.
+- `cli/commands/voiceover.py` sync merge/multi-part paths — would need full `merge_batch` and
+  `build_parts` stubs; easier as integration tests.
 
-**Test-infrastructure note**: `tests/cli/test_cli_unit.py` passes relative `custom_cache.db` /
-`custom_jobs.db` paths to `--cache-db-path` / `--jobs-db-path`, causing those SQLite files to
-leak into the caller's cwd. Wrap those invocations in a `tmp_path` sandbox (or use
-`CliRunner().isolated_filesystem()`) as part of PR 6 cleanup.
+**Test-infrastructure note (still open)**: `tests/cli/test_cli_unit.py` passes relative
+`custom_cache.db` / `custom_jobs.db` paths to `--cache-db-path` / `--jobs-db-path`, causing
+those SQLite files to leak into the caller's cwd. Wrap those invocations in a `tmp_path`
+sandbox (or use `CliRunner().isolated_filesystem()`) when convenient — not urgent.
 
 ---
 
@@ -514,19 +526,27 @@ leak into the caller's cwd. Wrap those invocations in a `tmp_path` sandbox (or u
 
 ## 7. Session-start checklist for picking up this work
 
-PRs 1–5 are shipped. The next actionable PR is **PR 6** — see §5.6.
+**Round 2 is complete** (86.20% fast-suite coverage, target ≥ 85% met). This document can be
+archived alongside the round-1 continuation guide once a follow-up session opens PR 7 or the
+maintainer decides no further coverage work is planned.
+
+If a **follow-up PR 7** is later needed (e.g. to push into the 88-90% range), the largest
+remaining gaps in the fast suite as of PR 6 are:
+
+- `cli/commands/voiceover.py` — `sync` command's multi-part / merge path (~149 miss).
+- `cli/commands/git_ops.py`, `cli/commands/summarize.py`, `cli/commands/workers.py` — larger
+  CLI surfaces not touched in PR 6.
+- `workers/notebook/notebook_processor.py` — 76%; remaining gap is integration-shaped.
+
+Session-start recipe:
 
 1. Read this document plus §3 of `docs/claude/test-coverage-continuation-guide.md` for historical
-   context.
-2. Regenerate the coverage baseline (command in §1) and compare against 83.17%. If it has drifted,
-   re-triage before starting PR 6.
-3. Follow the PR 6 recipe in §5.6. The targets are listed with per-file miss counts and expected
-   lift — reuse the CliRunner + narrow-seam mocking patterns from PR 4 (see the "Testing patterns"
-   notes in §5.4).
-4. After PR 6 merges, update the PR status table at the top of this doc with the actual Δ
-   coverage, and add a row to `docs/claude/test-coverage-continuation-guide.md`.
-5. If the 85% target has been hit, archive this handover alongside the prior round-1 guide. If it
-   hasn't, triage the remaining gap and decide whether a PR 7 is warranted.
+   context on testing patterns (Console capture, `JobManager` stubs, `sys.modules` injection).
+2. Regenerate the coverage baseline (command in §1) and compare against 86.20%. If it has
+   regressed, investigate before starting new work.
+3. Pick one or two high-miss files from the list above, apply the PR-6 patterns (§5.6), and land
+   the tests in a focused PR.
+4. Keep updating the continuation guide's phase table so the historical record stays complete.
 
 ### Separate follow-up: Monitor TUI bugs (PR 3 xfails)
 
@@ -570,13 +590,13 @@ upstream work is:
 | 5 | `tests/recordings/test_processing_utils.py` | `recordings/processing/utils.py` | ✅ shipped |
 | 5 | `tests/recordings/test_processing_pipeline.py` (extended) | `recordings/processing/pipeline.py` | ✅ shipped |
 | 5 | `tests/recordings/test_processing_compare.py` | `recordings/processing/compare.py` | ✅ shipped |
-| 6 | `tests/cli/test_recordings_command.py` (new) | `cli/commands/recordings.py` | ⏳ remaining |
-| 6 | `tests/cli/test_voiceover_command.py` (new) | `cli/commands/voiceover.py` | ⏳ remaining |
-| 6 | `tests/cli/test_zip_ops_command.py` (new) | `cli/commands/zip_ops.py` | ⏳ remaining |
-| 6 | `tests/cli/test_monitoring_command.py` (new) | `cli/commands/monitoring.py` | ⏳ remaining |
-| 6 | `tests/cli/test_polish_command.py` (new) | `cli/commands/polish.py` | ⏳ remaining |
-| 6 | `tests/cli/test_jupyterlite_command.py` (new) | `cli/commands/jupyterlite.py` | ⏳ remaining |
-| 6 | `tests/recordings/test_processing_batch.py` (new) | `recordings/processing/batch.py` | ⏳ remaining |
+| 6 | `tests/recordings/test_recordings_command.py` (new) | `cli/commands/recordings.py` | ✅ shipped |
+| 6 | `tests/cli/test_voiceover_command.py` (new) | `cli/commands/voiceover.py` | ✅ shipped |
+| 6 | `tests/cli/test_zip_ops.py` (extended) | `cli/commands/zip_ops.py` | ✅ shipped |
+| 6 | `tests/cli/test_monitoring_command.py` (new) | `cli/commands/monitoring.py` | ✅ shipped |
+| 6 | `tests/cli/test_polish_command.py` (new) | `cli/commands/polish.py` | ✅ shipped |
+| 6 | `tests/cli/test_jupyterlite_command.py` (new) | `cli/commands/jupyterlite.py` | ✅ shipped |
+| 6 | `tests/recordings/test_batch.py` (extended) | `recordings/processing/batch.py` | ✅ shipped |
 
 Existing fixture files worth reusing:
 

--- a/docs/claude/test-coverage-expansion-handover.md
+++ b/docs/claude/test-coverage-expansion-handover.md
@@ -1,9 +1,9 @@
 # Handover: Test Coverage Expansion (Round 2)
 
 **Created**: 2026-04-17
-**Last Updated**: 2026-04-18 (PR 4 shipped)
+**Last Updated**: 2026-04-18 (PR 5 shipped; PR 6 scoped)
 **Starting coverage (fast suite)**: **74%** (5,264 / 20,037 statements missed, 3,311 tests)
-**Current coverage (fast suite)**: **82.09%** (after PR 4; 3,647 tests passing + 4 xfailed)
+**Current coverage (fast suite)**: **83.17%** (after PR 5; 3,723 tests passing + 4 xfailed)
 **Measurement command**: `pytest -m "not docker and not slow and not integration and not e2e" --cov=src/clm`
 **Target**: raise overall fast-suite coverage to **≥ 85%**, concentrating on user-facing CLI surface,
   resilience paths in persistence/worker orchestration, and newly-added features that shipped without
@@ -21,9 +21,10 @@ plans the next round, incorporating explicit decisions from the maintainer (see 
 | 2 | `cli/output_formatter.py` verbose + `sqlite_backend.py` resilience | +1.5% | +1.20% | ✅ shipped |
 | 3 | MCP server, JupyterLite worker, Monitor TUI smoke/diagnostic tests | +1.5% | +1.81% | ✅ shipped (4 xfail bugs documented) |
 | 4 | `cli/commands/build.py`, `cli/commands/docker.py`, `infrastructure/api/*` | +4.0% | +3.95% | ✅ shipped |
-| 5 | `recordings/processing/{utils,pipeline,compare}.py` | +1.5% | — | ⏳ remaining — see §5.5 |
+| 5 | `recordings/processing/{utils,pipeline,compare}.py` | +1.5% | +1.08% | ✅ shipped |
+| 6 | Remaining low-hanging CLI + `recordings/processing/batch.py` | +2.0% | — | ⏳ remaining — see §5.6 |
 
-**Round 2 to date**: 74% → 82.09% (+8.09pp across PRs 1–4). PR 5 is the remaining work to hit the
+**Round 2 to date**: 74% → 83.17% (+9.17pp across PRs 1–5). PR 6 is the remaining work to hit the
 85% target.
 
 ---
@@ -432,44 +433,69 @@ FastAPI boundary that's currently only reached through docker-marked tests.
 
 ---
 
-### PR 5 — Recordings processing helpers ⏳ remaining (next)
+### PR 5 — Recordings processing helpers ✅ shipped (2026-04-18)
 
-**Coverage baseline at start of PR 5** (2026-04-18): project 82.09%. PR 5's +1.5pp lifts us to
-~83.6%, within striking distance of the 85% target. If PR 5 overshoots its plan, the round is
-done; if it underdelivers, consider a small PR 6 focused on remaining zero/low-coverage files
-discovered by the post-PR-5 coverage diff.
+**Outcome**: 56 new tests across three files. Coverage 82.09% → 83.17% (+1.08pp, slightly under
+plan — the processing files were smaller than the CLI surfaces of PR 4, so per-file coverage
+overshoots produced a modest total lift).
 
-**Goal**: cover the shared processing layer that underpins `clm recordings serve`, `clm recordings
-process`, and the workflow backends.
+**Per-file actuals**:
+- `recordings/processing/utils.py`: 22% → **99%** (28 tests in `test_processing_utils.py`)
+- `recordings/processing/pipeline.py`: 37% → **98%** (extended `test_processing_pipeline.py`; 19 total)
+- `recordings/processing/compare.py`: 0% → **100%** (9 tests in `test_processing_compare.py`)
 
-**Context**: see §3.3. This module is actively used, not legacy.
+**Testing patterns worth knowing for future work in these areas**:
+- **ONNX denoise trims the algorithmic delay from the front of the buffer**: test assertions on
+  `sf.write` output length must use `n_samples - delay` (where `delay = ONNX_FFT_SIZE - ONNX_HOP_SIZE`,
+  i.e., 480 at 48 kHz) instead of the original sample count. Input length must also be a multiple
+  of `ONNX_HOP_SIZE` or padding is added; mock-friendly test inputs pick a clean hop multiple.
+- **`find_binary` Windows fallback**: patch both `shutil.which` *and* `Path.is_file` to exercise the
+  `sys.prefix / "Scripts"` branch. `monkeypatch.setattr(sys, "platform", "win32")` is enough to
+  swap the platform check — the function reads `sys.platform` at call time.
+- **Pipeline end-to-end happy path**: patch `run_subprocess`, `run_onnx_denoise`, and
+  `get_audio_duration` at `pipeline_module` (the `from .utils import …` imports rebind into the
+  pipeline namespace). Return a loudnorm JSON on the `null` (measure pass) invocation and a plain
+  completed-process on all others — the apply-pass picks up the measured values.
+- **`tempfile.mkdtemp` inspection**: patching `pipeline_module.tempfile.mkdtemp` with a side_effect
+  that records the real return value lets tests assert `keep_temp=True` preserves the temp dir
+  (and `False` removes it), without stubbing out disk writes.
 
-**Scope**:
+### PR 6 — Remaining gap to 85% ⏳ remaining (next)
 
-1. **`recordings/processing/utils.py`** (114 stmts, 89 miss → target 80%).
-   - `find_ffmpeg` / `find_ffprobe`: patch `shutil.which` and `Path.is_file`; cover found, not
-     found, and platform-specific fallback paths (`ffmpeg.exe` on Windows).
-   - `run_subprocess`: mock `subprocess.run`; cover success, nonzero exit, logging of stdout/stderr,
-     timeout, and `check_returncode=False` mode.
-   - `check_dependencies`: cover ffmpeg-present / ONNX-model-present / neither.
-   - `ensure_onnx_model`: mock `urllib.request.urlretrieve`; cover cache hit, cache miss (downloads),
-     and the `BinaryNotFoundError` branch.
-   - Downloads should never hit the real network — if any test would, add a monkeypatch in the
-     test module's `conftest.py`.
+**Baseline at start of PR 6**: project 83.17% (3,372 / 20,038 missed). Target +1.83pp to hit 85%
+(≈ 367 statements to cover).
 
-2. **`recordings/processing/pipeline.py`** (101 stmts, 64 miss → target 70%).
-   - Existing tests cover `_parse_loudnorm_json`. Extend to cover `ProcessingPipeline.run` by
-     mocking `run_subprocess` and asserting the pipeline step sequence.
-   - Cover the `keep_temp` and cleanup paths, and the "already-processed" short-circuit.
+**Scope** — chosen from the post-PR-5 coverage diff, prioritized by (a) user-facing surface and
+(b) cost to test. All live in `cli/commands/*` or `recordings/processing/batch.py`; they are
+testable with the same `click.testing.CliRunner` + narrow-seam mocks that PR 4 used.
 
-3. **`recordings/processing/compare.py`** (20 stmts, 0% → target 90%).
-   - Small file. Mock `run_subprocess` for `extract_audio_segment`; cover the HTML-generation
-     function against a fixture pair of WAV paths.
-   - Use `tmp_path` for outputs.
+1. **`cli/commands/recordings.py`** (612 stmts, 293 miss, 52% → target 75%, ~140 stmts). The
+   biggest single gap; huge user-facing surface (serve, process, batch, compare, record). Mock
+   `ProcessingPipeline`, `OBSClient`, and file I/O at narrow seams.
+2. **`cli/commands/voiceover.py`** (362 stmts, 269 miss, 26% → target 60%, ~120 stmts). The CLI
+   layer only — keep the `voiceover/*` backend paths `integration`-marked per §6. Mock
+   `transcribe`/`matcher`/`aligner` at the module-level import in the command file.
+3. **`cli/commands/zip_ops.py`** (113, 61 miss, 46% → target 80%). Small, contained.
+4. **`cli/commands/monitoring.py`** (73, 56 miss, 23% → target 70%). Small.
+5. **`cli/commands/polish.py`** (64, 46 miss, 28% → target 70%). Small; LLM-adjacent, mock the
+   `polish()` function.
+6. **`cli/commands/jupyterlite.py`** (71, 55 miss, 23% → target 70%). Small; JupyterLite CLI.
+7. **`recordings/processing/batch.py`** (53, 27 miss, 49% → target 80%). Natural adjunct to PR 5
+   — actively used by `recordings serve`, follows the same mocking patterns.
 
-**Done when**:
-- `utils.py` ≥ 80%, `pipeline.py` ≥ 70%, `compare.py` ≥ 90%.
-- Overall coverage rises by ≈ 1.5 percentage points.
+**Expected lift**: ≈ 420 stmts → ~+2.1pp → ~85.3%. Comfortable margin over the 85% target.
+
+**Out of scope for PR 6** (still deferred):
+- `cli/commands/git_ops.py`, `cli/commands/summarize.py`, `cli/commands/workers.py` — larger; keep
+  for a potential PR 7 if needed.
+- `infrastructure/workers/pool_manager.py` — docker-marked branches dominate the gap per §6.
+- `workers/notebook/notebook_processor.py` — already at 76% after earlier rounds; remaining gap is
+  integration-shaped.
+
+**Test-infrastructure note**: `tests/cli/test_cli_unit.py` passes relative `custom_cache.db` /
+`custom_jobs.db` paths to `--cache-db-path` / `--jobs-db-path`, causing those SQLite files to
+leak into the caller's cwd. Wrap those invocations in a `tmp_path` sandbox (or use
+`CliRunner().isolated_filesystem()`) as part of PR 6 cleanup.
 
 ---
 
@@ -488,17 +514,19 @@ process`, and the workflow backends.
 
 ## 7. Session-start checklist for picking up this work
 
-PRs 1–4 are shipped. The next (and currently only) actionable PR is **PR 5** — see §5.5.
+PRs 1–5 are shipped. The next actionable PR is **PR 6** — see §5.6.
 
 1. Read this document plus §3 of `docs/claude/test-coverage-continuation-guide.md` for historical
    context.
-2. Regenerate the coverage baseline (command in §1) and compare against 82.09%. If it has drifted,
-   re-triage before starting PR 5.
-3. Follow the PR 5 recipe in §5.5. "Done when" criteria are listed there.
-4. After PR 5 merges, update the PR status table at the top of this doc with the actual Δ
+2. Regenerate the coverage baseline (command in §1) and compare against 83.17%. If it has drifted,
+   re-triage before starting PR 6.
+3. Follow the PR 6 recipe in §5.6. The targets are listed with per-file miss counts and expected
+   lift — reuse the CliRunner + narrow-seam mocking patterns from PR 4 (see the "Testing patterns"
+   notes in §5.4).
+4. After PR 6 merges, update the PR status table at the top of this doc with the actual Δ
    coverage, and add a row to `docs/claude/test-coverage-continuation-guide.md`.
 5. If the 85% target has been hit, archive this handover alongside the prior round-1 guide. If it
-   hasn't, triage the remaining gap and decide whether a PR 6 is warranted.
+   hasn't, triage the remaining gap and decide whether a PR 7 is warranted.
 
 ### Separate follow-up: Monitor TUI bugs (PR 3 xfails)
 
@@ -539,9 +567,16 @@ upstream work is:
 | 4 | `tests/infrastructure/api/test_server.py` | `infrastructure/api/server.py` (WorkerApiServer) | ✅ shipped |
 | 4 | `tests/infrastructure/api/test_client.py` | `infrastructure/api/client.py` | ✅ shipped |
 | 4 | `tests/infrastructure/api/test_job_queue_adapter.py` | `infrastructure/api/job_queue_adapter.py` | ✅ shipped |
-| 5 | `tests/recordings/test_processing_utils.py` (new) | `recordings/processing/utils.py` | ⏳ remaining |
-| 5 | `tests/recordings/test_processing_pipeline.py` (extend) | `recordings/processing/pipeline.py` | ⏳ remaining |
-| 5 | `tests/recordings/test_processing_compare.py` (new) | `recordings/processing/compare.py` | ⏳ remaining |
+| 5 | `tests/recordings/test_processing_utils.py` | `recordings/processing/utils.py` | ✅ shipped |
+| 5 | `tests/recordings/test_processing_pipeline.py` (extended) | `recordings/processing/pipeline.py` | ✅ shipped |
+| 5 | `tests/recordings/test_processing_compare.py` | `recordings/processing/compare.py` | ✅ shipped |
+| 6 | `tests/cli/test_recordings_command.py` (new) | `cli/commands/recordings.py` | ⏳ remaining |
+| 6 | `tests/cli/test_voiceover_command.py` (new) | `cli/commands/voiceover.py` | ⏳ remaining |
+| 6 | `tests/cli/test_zip_ops_command.py` (new) | `cli/commands/zip_ops.py` | ⏳ remaining |
+| 6 | `tests/cli/test_monitoring_command.py` (new) | `cli/commands/monitoring.py` | ⏳ remaining |
+| 6 | `tests/cli/test_polish_command.py` (new) | `cli/commands/polish.py` | ⏳ remaining |
+| 6 | `tests/cli/test_jupyterlite_command.py` (new) | `cli/commands/jupyterlite.py` | ⏳ remaining |
+| 6 | `tests/recordings/test_processing_batch.py` (new) | `recordings/processing/batch.py` | ⏳ remaining |
 
 Existing fixture files worth reusing:
 

--- a/docs/claude/test-coverage-expansion-handover.md
+++ b/docs/claude/test-coverage-expansion-handover.md
@@ -1,0 +1,470 @@
+# Handover: Test Coverage Expansion (Round 2)
+
+**Created**: 2026-04-17
+**Starting coverage (fast suite)**: **74%** (5,264 / 20,037 statements missed, 3,311 tests)
+**Measurement command**: `pytest -m "not docker and not slow and not integration and not e2e" --cov=src/clm`
+**Target**: raise overall fast-suite coverage to **≥ 85%**, concentrating on user-facing CLI surface,
+  resilience paths in persistence/worker orchestration, and newly-added features that shipped without
+  direct tests.
+
+Prior coverage effort (53% → 69%, Phases 1–4) is archived in
+`docs/claude/test-coverage-continuation-guide.md`. **This document does not re-plan that work** — it
+plans the next round, incorporating explicit decisions from the maintainer (see §3).
+
+---
+
+## 1. How to reproduce the baseline
+
+```powershell
+# from worktree or main repo
+uv run pytest -m "not docker and not slow and not integration and not e2e" `
+  --cov=src/clm --cov-report=term-missing --cov-report=json:coverage.json -q
+```
+
+The JSON report drives the per-file numbers below. Regenerate after each PR and diff against
+`coverage.json` to confirm the expected lift.
+
+Do **not** chase the Docker/integration-only paths in the fast suite — many low numbers in
+`infrastructure/api/*` and `cli/commands/docker.py` look worse than they are in CI because the
+corresponding test files are marked `docker`/`integration` and skipped.
+
+---
+
+## 2. Where the gaps are
+
+Ranked by absolute missed lines in the fast suite. Numbers are from the 2026-04-17 run.
+
+| Area | Miss | Cov | Read as |
+|---|---:|---:|---|
+| `cli/commands/*` (29 files) | 2,207 | 47.6% | Biggest single area; user-facing |
+| `infrastructure/workers/*` | 421 | 78% | Critical; docker paths inflate gap |
+| `cli/monitor/*` (Textual TUI) | 343 | 27% | Has display bugs — see §3.4 |
+| `cli/output_formatter.py` | 142 | 61% | VerboseOutputFormatter detail paths |
+| `infrastructure/api/*` | 224 | 50% | Reachable via FastAPI TestClient |
+| `recordings/processing/*` | 200 | 36% | **Not legacy** — see §3.3 |
+| `infrastructure/backends/sqlite_backend.py` | 178 | 58% | Resilience / dead-worker recovery |
+| `core/course.py` | 140 | 59% | New JupyterLite flow (see §3.2) |
+| `voiceover/*` | 197 | 79% | Backend-gated (Whisper/HF/Mistral) |
+
+### 2.1 Files completely uncovered (0%)
+
+| File | Stmts | Notes |
+|---|---:|---|
+| `cli/monitor/app.py` | 84 | TUI shell — tests in PR 3 |
+| `cli/monitor/widgets/workers_panel.py` | 77 | Display bugs live here |
+| `cli/monitor/widgets/queue_panel.py` | 39 | Display bugs live here |
+| `workers/jupyterlite/jupyterlite_worker.py` | 62 | **Not docker-only** — see §3.1 |
+| `mcp/server.py` | 45 | Thin FastMCP registration layer — see §3.1 |
+| `recordings/processing/compare.py` | 20 | Used by `clm recordings compare` |
+| `cli/commands/*/__main__.py` | 1–1 | Entry shims; skip |
+
+---
+
+## 3. Maintainer decisions and clarifications (2026-04-17)
+
+These override the initial triage.
+
+### 3.1 MCP server and JupyterLite worker: both need smoke tests
+
+- **MCP server** (`src/clm/mcp/server.py`). `mcp/tools.py` is already 90% covered; only the FastMCP
+  wiring in `create_server(data_dir)` is untested. A smoke test that calls `create_server()` and
+  inspects the registered tools is enough to catch registration regressions and argument-drift
+  between the `@mcp.tool()` wrappers and the underlying `handle_*` functions.
+- **JupyterLite worker** (`src/clm/workers/jupyterlite/jupyterlite_worker.py`). It is **not**
+  docker-only — JupyterLite sites build on host Python when the `[jupyterlite]` extra is installed.
+  Unit tests should construct a `JupyterLiteWorker` against an in-memory SQLite job queue, stub
+  `builder.build_site`, and assert that `_process_job_async` correctly unpacks the payload into
+  `BuildArgs` and writes a cache entry.
+
+### 3.2 `core/course.py`: new code landed without direct tests
+
+Missed lines 420–481 and 490–515 implement `process_jupyterlite_for_targets` and related per-target
+aggregation introduced in commits `e0a2a2d` (`feat(jupyterlite): report JupyterLite generation as
+its own build phase`) and `d3da1a3` (`refactor(jupyterlite): one site per (target, language), not
+per kind`). This is a user-visible build phase with no direct test coverage today. Extend the
+existing multi-target / `DummyBackend` patterns in `tests/core/test_multi_target_course.py`.
+
+### 3.3 `recordings/processing/*` is actively used — not legacy
+
+Verified imports (2026-04-17): the module is a shared helper layer for the recordings pipeline,
+imported from
+
+- `cli/commands/recordings.py` — `pipeline`, `compare`, `utils`, `batch`, `config`
+- `recordings/workflow/assembler.py` — `utils.find_ffmpeg`, `utils.run_subprocess`
+- `recordings/workflow/backends/{onnx,external,auphonic}.py` — `batch.VIDEO_EXTENSIONS`,
+  `config.PipelineConfig`, `utils`
+- `recordings/workflow/directories.py` — `batch.VIDEO_EXTENSIONS`
+
+The `clm recordings serve` command (currently being significantly extended) depends on this layer
+transitively via `recordings/web/app.py` and the workflow backends. Keep coverage here as a
+priority (PR 5), and do **not** omit the module from coverage.
+
+### 3.4 Monitor TUI has display bugs — tests should find them
+
+The TUI is in active use but has known display bugs. The testing goal is **diagnostic** (reproduce
+bugs in a test so they can be fixed and regressions caught), not just chasing line coverage. Use
+Textual's built-in `App.run_test()` pilot harness plus direct unit-level calls into
+`ActivityPanel.update_events`, `WorkersPanel.update_workers`, `QueuePanel.update_queue`, and
+`StatusHeader.update_status` with synthesized `StatusInfo` / `ActivityEvent` data. See §5.3 for
+recipe.
+
+---
+
+## 4. PR plan
+
+Five PRs in order. Each is sized to roughly one session; the dependency graph is:
+
+```
+PR 1  (small)  ──►  PR 2  (medium)
+PR 3  (smoke tests, independent)
+PR 4  (CLI + API, independent of 1-3)
+PR 5  (processing, depends only on tooling)
+```
+
+Estimated coverage deltas are indicative, computed from the current missing-line counts assuming
+the target per-file percentages hold.
+
+| PR | Focus | Expected Δ coverage |
+|---|---|---:|
+| 1 | `cli/commands/{database,config}.py` + `core/course.py` JupyterLite paths | +1.5% |
+| 2 | `cli/output_formatter.py` verbose + `sqlite_backend.py` resilience | +1.5% |
+| 3 | MCP server, JupyterLite worker, Monitor TUI smoke/diagnostic tests | +1.5% |
+| 4 | `cli/commands/build.py`, `cli/commands/docker.py`, `infrastructure/api/*` | +4.0% |
+| 5 | `recordings/processing/{utils,pipeline,compare}.py` | +1.5% |
+| **Total** | | **≥ 10%**, lands ≥ 85% |
+
+Rules for every PR:
+
+- All new tests run in the fast suite (`pytest -m "not docker and not slow and not integration and not e2e"`).
+- Follow existing patterns — don't invent a new harness when `click.testing.CliRunner`,
+  `fastapi.testclient.TestClient`, `textual.app.App.run_test()`, or `DummyBackend` fits.
+- If a module has a genuine external dependency (ffmpeg, Whisper, Docker daemon), mock at the
+  narrowest stable seam (e.g., `subprocess.run`, `builder.build_site`).
+- Update `docs/claude/test-coverage-continuation-guide.md` with a new Phase 5+ row per PR so the
+  historical log stays complete.
+- Never loosen existing coverage thresholds to mask regressions.
+- Pre-commit hooks run ruff, mypy, and the fast suite. If a hook fails the commit did **not**
+  happen — fix, re-stage, make a **new** commit (no `--amend`).
+
+---
+
+## 5. PR-by-PR recipes
+
+### PR 1 — Small, high-ROI CLI + core coverage
+
+**Goal**: cover unit-testable user-facing commands and the new JupyterLite build path.
+
+**Scope**:
+
+1. **`cli/commands/config.py`** (78 stmts, 67 miss → target 90%).
+   - Subcommands: `clm config init` (`--location {user,project}`, `--force`),
+     `clm config show`.
+   - Test via `click.testing.CliRunner` + `tmp_path`; patch `platformdirs.user_config_dir` to
+     redirect the user-level path into `tmp_path`.
+   - Assert that `init` writes a TOML file with the documented keys, respects `--force`, and
+     refuses to overwrite without it.
+   - Assert that `show` prints the resolved merged config (user + project layers) — verify
+     precedence when both files exist.
+
+2. **`cli/commands/database.py`** (206 stmts, 164 miss → target 85%).
+   Commands: `stats`, `prune`, `vacuum`, `clean`.
+   - `stats`: construct a `JobQueue(tmp_db)` with a couple of jobs, run `clm db stats`, assert the
+     row counts in the output.
+   - `prune`: seed old completed jobs (backdate `completed_at`), run `clm db prune --older-than 7d`,
+     assert row count and that the `--dry-run` path does not modify the DB.
+   - `vacuum`: assert it runs to completion on `jobs` and `cache` DBs and logs expected output.
+   - `clean`: with `--force`, verify it removes orphaned rows; without `--force`, verify prompts /
+     dry-run behavior. `--remove-missing` should delete cache rows whose files are gone.
+   - Existing smoke test lives in `tests/cli/test_workers_reap.py::test_clean_db_clean_processes` —
+     follow its pattern for DB setup.
+
+3. **`core/course.py` JupyterLite aggregation** (lines 420–481, 490–515).
+   - Extend `tests/core/test_multi_target_course.py` with fixtures that include a target with
+     `format="jupyterlite"` and an effective `<jupyterlite>` config.
+   - Use a `DummyBackend` that records every submitted operation; assert that
+     `process_jupyterlite_for_targets` produces exactly one `BuildJupyterLiteSiteOperation` per
+     `(target, language)` pair and that `notebook_trees` contains one entry per kind.
+   - Add a negative test for the "no config → skip" path and the `opted_in_jupyterlite_site_count`
+     accessor.
+
+**Done when**:
+- `cli/commands/config.py` and `cli/commands/database.py` reach ≥ 85% each.
+- `core/course.py` missing-lines list no longer includes 420–481, 490–515.
+- Overall coverage rises by ≈ 1.5 percentage points.
+
+---
+
+### PR 2 — Formatting and persistence resilience
+
+**Goal**: lock down user-facing error output and the SQLite backend's recovery paths.
+
+**Scope**:
+
+1. **`cli/output_formatter.py`** (360 stmts, 142 miss → target 85%).
+   Missed blocks are the verbose renderer's detail sections (lines 289–342, 355–468, 640–746).
+   Add table-driven tests over `VerboseOutputFormatter`:
+   - `_show_error_detail(index, error)` for each `BuildError` severity / source-type combination.
+   - `show_summary(summary)` with: zero errors, only warnings, mixed, and an overflow summary where
+     error/warning lists are truncated.
+   - `show_file_completed` and `show_stage_start` when invoked with unusual file counts (0, 1, 1000).
+   - Capture `rich` output via `Console(record=True)` and diff against approval fixtures (or assert
+     substrings — approval fixtures are fine but keep them small).
+   - Existing file `tests/cli/test_build_output.py` (64 tests) is the model; extend the same
+     `Console(record=True)` fixture.
+
+2. **`infrastructure/backends/sqlite_backend.py`** (424 stmts, 178 miss → target 80%).
+   Prioritize resilience paths — these are the bugs that silently leak jobs.
+   - `_cleanup_dead_worker_jobs` (lines 236–291): seed a job in state `processing` whose worker is
+     `dead`, call the method, assert the job is reset to `pending` with `worker_id` cleared and
+     `started_at = NULL`; also assert the early-return when no stuck jobs exist and the exception
+     rollback path (inject a `conn.execute` that raises).
+   - `wait_for_completion` edge cases (lines 329–337, 368–477): empty queue + `all_submitted` set,
+     queue drained while events still pending, mid-flight cancellation.
+   - `submit_*` error paths (lines 744–815, 838–846, 870–919): assert exceptions are logged and
+     surfaced, and that retry bookkeeping stays consistent.
+   - Use `tmp_path / "jobs.db"` + `init_database`, not `:memory:` (the code paths open their own
+     connections and the operations rely on filesystem-backed SQLite).
+
+**Done when**:
+- `cli/output_formatter.py` ≥ 85%, `sqlite_backend.py` ≥ 80%.
+- Overall coverage rises by ≈ 1.5 percentage points.
+
+---
+
+### PR 3 — Smoke + diagnostic tests (MCP, JupyterLite worker, Monitor TUI)
+
+**Goal**: fill the three zero-coverage surfaces the maintainer flagged, and give the monitor team
+a foothold for tracking the known display bugs.
+
+This PR is **independent of PR 1/PR 2** and can land in parallel.
+
+#### 3A. MCP server (`src/clm/mcp/server.py`)
+
+Pattern: call `create_server(data_dir)` and introspect the registered tools. No stdio transport.
+
+- Create `tests/mcp/test_server.py`.
+- Reuse `course_tree` fixture from `tests/mcp/test_tools.py` (import or duplicate minimally).
+- Test 1: `create_server(data_dir)` returns a `FastMCP` instance named `"clm"`.
+- Test 2: the expected tool set is registered:
+  `{resolve_topic, search_slides, course_outline, validate_spec, validate_slides,
+    normalize_slides, get_language_view, suggest_sync, extract_voiceover, inline_voiceover,
+    course_authoring_rules}` (11 tools; exact list derived from `server.py`).
+- Test 3: each registered tool's call signature matches its underlying `handle_*` function for
+  required arguments. Use `inspect.signature` on the handler vs. the tool's declared parameters
+  (FastMCP exposes these via `mcp._tools` or `await mcp.list_tools()` — check the installed
+  `mcp` SDK version; prefer the async `list_tools` accessor if present).
+- Test 4: one end-to-end smoke — call the `course_outline` tool through `mcp.call_tool(...)` (or
+  whatever the SDK's in-process dispatch is called) against the fixture course and assert the JSON
+  shape. This catches wiring bugs that the handler-level tests in `test_tools.py` cannot.
+- Also cover the thin `run_server(data_dir)` helper: patch `FastMCP.run` and assert it was called
+  with `transport="stdio"`.
+
+Target: `mcp/server.py` ≥ 80%.
+
+#### 3B. JupyterLite worker (`src/clm/workers/jupyterlite/jupyterlite_worker.py`)
+
+Pattern: construct a worker against a real tmpdir SQLite DB with `init_database`, stub
+`clm.workers.jupyterlite.builder.build_site`, enqueue a synthetic job via `JobQueue.submit_job`,
+call `_process_job_async` directly.
+
+- Create `tests/workers/jupyterlite/test_jupyterlite_worker.py`.
+- Test 1 — payload unpacking: build a `payload` dict with `notebook_trees`, `output_dir`, `kernel`,
+  `wheels`, `environment_yml`, optional branding fields; assert `build_site` receives a `BuildArgs`
+  with the right types (`Path` for wheels / env file, stringy fields preserved).
+- Test 2 — cache write: stub `build_site` to return a `BuildResult(cache_key="abc", files_count=3,
+  site_dir=...)` and assert `JobQueue.add_to_cache` is called with
+  `(job.output_file, job.content_hash, {"cache_key": "abc", "files_count": 3, "summary": ...})`.
+- Test 3 — cancelled job: set `is_job_cancelled` to `True` via the real queue and assert
+  `build_site` is not called.
+- Test 4 — error handling: have `build_site` raise; assert the worker surfaces the exception to
+  the caller (so the base `Worker.run` marks the job failed).
+- Test 5 — `main()` smoke: patch `Worker.get_or_register_worker`, `JupyterLiteWorker.run`,
+  `init_database`, and run `main()` with `DB_PATH` / `CLM_API_URL` combinations; assert the SQLite
+  vs. API branches choose correctly.
+- Do **not** add this to the `docker` mark; it runs on host Python.
+
+Target: `jupyterlite_worker.py` ≥ 80%.
+
+#### 3C. Monitor TUI diagnostic tests
+
+Goal: turn the known display bugs into failing or parameterized tests so they can be fixed and
+locked in. The user has observed bugs — write tests that reproduce them, confirm with the user,
+then fix.
+
+Prep step (do this first so PR 3 can be reviewed as green):
+
+1. Open an issue or TODO.md entry listing the observed display bugs (ask the user for the current
+   list; do not invent symptoms).
+2. For each bug, add a test that reproduces it (marked `@pytest.mark.xfail(reason=...)` if not
+   fixed in this PR) so the signal is preserved even when the test cannot yet pass.
+3. Bugs you fix in this PR: flip the test from xfail to passing in the same commit.
+
+Test harness:
+
+- **Unit level** (fast, deterministic): call widget methods directly.
+  - `ActivityPanel`: mount via a tiny host `App`, call `update_events(events)` with synthesized
+    `ActivityEvent` lists, then introspect the `RichLog` contents. The event dedup key is
+    `f"{job_id}:{event_type}"` — test that (a) duplicates are dropped, (b) ordering is
+    chronological (oldest → newest), (c) scroll position is preserved when user has scrolled away.
+  - `WorkersPanel`: call `update_workers(stats)` with `WorkerTypeStats` including edge cases
+    `total=0`, all-dead, mixed busy/idle, and long `input_file` paths (check truncation).
+  - `QueuePanel`: call `update_queue(stats)` with pending/processing/retry mixes.
+  - `StatusHeader`: call `update_status(info)` with a `StatusInfo` built from
+    `tests/cli/test_monitor_unit.py` fixtures; include extremes (1 worker vs. 100 workers).
+- **Integration level** (driving the app):
+  ```python
+  async with CLMMonitorApp(db_path=tmp_db).run_test() as pilot:
+      await pilot.pause()
+      # introspect widgets: pilot.app.query_one(ActivityPanel) …
+  ```
+  Use Textual's `App.run_test()` (no real terminal). Assert widget state after simulated key
+  presses (refresh, quit) and after the data provider is poked with fake events.
+
+- **Data provider** (`cli/monitor/data_provider.py`, currently 45%): seed a `JobQueue` with a
+  realistic sequence of jobs (pending → processing → completed / failed), call
+  `DataProvider.get_activity_events()`, `.get_queue_stats()`, `.get_worker_stats()`, and assert the
+  `StatusInfo` model fields. Most of the missing lines (123–223) are aggregation branches that a
+  handful of seeded fixtures can exercise.
+
+Target: each widget ≥ 60%, `data_provider.py` ≥ 80%. Overall monitor subtree lifts from 27% → 60%.
+
+---
+
+### PR 4 — Build CLI, Docker CLI, and API layer
+
+**Goal**: the big three CLI surfaces that dominate the `cli/commands/` missed-line count, plus the
+FastAPI boundary that's currently only reached through docker-marked tests.
+
+**Scope**:
+
+1. **`cli/commands/build.py`** (530 stmts, 299 miss → target 80%).
+   - Test with `CliRunner` + a stub `Backend` that records submitted operations (pattern from
+     `tests/core/*`).
+   - Cover the main flag matrix: `--targets`, `--languages`, `--kinds`, `--formats`,
+     `--only-sections`, `--watch-only-sections` (watch tests already exist; extend them),
+     `--clean`, `--force-rebuild`, `--dry-run`, reporter selection flags.
+   - Assert the expected phase sequence (`discover → notebook → plantuml → drawio → jupyterlite →
+     dir-groups → copy`) and that `--only-sections` correctly filters.
+   - Edge cases: missing spec file, invalid target name, no work to do.
+
+2. **`cli/commands/docker.py`** (424 stmts, 374 miss → target 70%).
+   - This shells out; **do not** invoke real `docker`. Mock `subprocess.run` and
+     `subprocess.Popen` at the boundary.
+   - Cover `build`, `push`, `pull`, `prune`, cache-stage logic for each service in
+     `SERVICE_NAME_MAP`, `get_project_root()`, version string composition.
+   - Assert the exact argv list passed to each `docker` invocation (this is how real regressions
+     bite — a flag typo). Use a helper like
+     `assert called_docker_with(["buildx", "build", "--cache-to", ...])`.
+   - Use `runner.invoke(cli, [...], catch_exceptions=False)` so tracebacks aren't swallowed.
+
+3. **`infrastructure/api/*`** (444 stmts, 224 miss; server 49%, client 50%, worker_routes 35%,
+   job_queue_adapter 27% → target 80% each).
+   - Use `fastapi.testclient.TestClient` against `create_app(job_queue=…)` to exercise
+     `worker_routes` in-process.
+   - Pattern is already in `tests/recordings/test_web.py`; import `TestClient` the same way.
+   - Cover each route with happy path + one error: register worker, heartbeat, claim job, report
+     progress, complete job, fail job, list workers.
+   - For the `ApiClient` side, drive it against the same test app (`TestClient` can serve as an
+     `httpx` transport), so client + server contract-test together.
+   - `job_queue_adapter.py` is thin — one test per public method should lift it to > 85%.
+
+**Done when**:
+- All three areas reach the stated thresholds.
+- Overall coverage rises by ≈ 4 percentage points.
+
+---
+
+### PR 5 — Recordings processing helpers
+
+**Goal**: cover the shared processing layer that underpins `clm recordings serve`, `clm recordings
+process`, and the workflow backends.
+
+**Context**: see §3.3. This module is actively used, not legacy.
+
+**Scope**:
+
+1. **`recordings/processing/utils.py`** (114 stmts, 89 miss → target 80%).
+   - `find_ffmpeg` / `find_ffprobe`: patch `shutil.which` and `Path.is_file`; cover found, not
+     found, and platform-specific fallback paths (`ffmpeg.exe` on Windows).
+   - `run_subprocess`: mock `subprocess.run`; cover success, nonzero exit, logging of stdout/stderr,
+     timeout, and `check_returncode=False` mode.
+   - `check_dependencies`: cover ffmpeg-present / ONNX-model-present / neither.
+   - `ensure_onnx_model`: mock `urllib.request.urlretrieve`; cover cache hit, cache miss (downloads),
+     and the `BinaryNotFoundError` branch.
+   - Downloads should never hit the real network — if any test would, add a monkeypatch in the
+     test module's `conftest.py`.
+
+2. **`recordings/processing/pipeline.py`** (101 stmts, 64 miss → target 70%).
+   - Existing tests cover `_parse_loudnorm_json`. Extend to cover `ProcessingPipeline.run` by
+     mocking `run_subprocess` and asserting the pipeline step sequence.
+   - Cover the `keep_temp` and cleanup paths, and the "already-processed" short-circuit.
+
+3. **`recordings/processing/compare.py`** (20 stmts, 0% → target 90%).
+   - Small file. Mock `run_subprocess` for `extract_audio_segment`; cover the HTML-generation
+     function against a fixture pair of WAV paths.
+   - Use `tmp_path` for outputs.
+
+**Done when**:
+- `utils.py` ≥ 80%, `pipeline.py` ≥ 70%, `compare.py` ≥ 90%.
+- Overall coverage rises by ≈ 1.5 percentage points.
+
+---
+
+## 6. Non-goals
+
+- **Textual TUI visual regression.** PR 3 writes diagnostic tests, not full visual snapshots.
+  Don't introduce a snapshot library for this round.
+- **Docker integration tests.** These are CI-only by design (per CLAUDE.md). No change.
+- **Voiceover backends** (Whisper, HF, Mistral paths in `voiceover/transcribe.py`). Each backend
+  has environment requirements; leave them `integration`-marked.
+- **Worker pool docker branches** in `pool_manager.py`. Covered in docker-marked tests.
+- **Deleting the `recordings/processing/` module.** It is still imported from `cli`, `workflow`,
+  and `backends` (verified 2026-04-17). Do not remove.
+
+---
+
+## 7. Session-start checklist for picking up this work
+
+1. Read this document plus §3 of `docs/claude/test-coverage-continuation-guide.md` for historical
+   context.
+2. Ask the user: "Which PR am I working on, and is there an updated list of monitor TUI bugs?"
+   (PR 3 specifically needs the latest bug list.)
+3. Regenerate the coverage baseline (command in §1) and diff against the numbers in §2. If the
+   baseline has drifted significantly, re-triage before starting.
+4. Follow the PR recipe in §5. Each recipe lists its "Done when" criteria — don't declare done
+   without hitting them.
+5. After the PR merges, update §4 with the actual Δ coverage and add a row to
+   `docs/claude/test-coverage-continuation-guide.md` Phase 5+ table.
+
+## 8. File map
+
+Where to put the new tests:
+
+| PR | New / extended test file | Source under test |
+|---|---|---|
+| 1 | `tests/cli/test_config_command.py` (new) | `cli/commands/config.py` |
+| 1 | `tests/cli/test_db_commands.py` (new) | `cli/commands/database.py` |
+| 1 | `tests/core/test_multi_target_course.py` (extend) | `core/course.py` JupyterLite paths |
+| 2 | `tests/cli/test_build_output.py` (extend) | `cli/output_formatter.py` (verbose) |
+| 2 | `tests/infrastructure/backends/test_sqlite_backend_resilience.py` (new) | `sqlite_backend.py` |
+| 3 | `tests/mcp/test_server.py` (new) | `mcp/server.py` |
+| 3 | `tests/workers/jupyterlite/test_jupyterlite_worker.py` (new) | `workers/jupyterlite/jupyterlite_worker.py` |
+| 3 | `tests/cli/test_monitor_unit.py` (extend) | `cli/monitor/widgets/*` |
+| 3 | `tests/cli/test_monitor_app.py` (new) | `cli/monitor/app.py`, `data_provider.py` |
+| 4 | `tests/cli/test_build_command.py` (new) | `cli/commands/build.py` |
+| 4 | `tests/cli/test_docker_command.py` (new) | `cli/commands/docker.py` |
+| 4 | `tests/infrastructure/api/test_server_routes.py` (new) | `infrastructure/api/server.py`, `worker_routes.py` |
+| 4 | `tests/infrastructure/api/test_client.py` (new) | `infrastructure/api/client.py` |
+| 4 | `tests/infrastructure/api/test_job_queue_adapter.py` (new) | `infrastructure/api/job_queue_adapter.py` |
+| 5 | `tests/recordings/test_processing_utils.py` (new) | `recordings/processing/utils.py` |
+| 5 | `tests/recordings/test_processing_pipeline.py` (extend) | `recordings/processing/pipeline.py` |
+| 5 | `tests/recordings/test_processing_compare.py` (new) | `recordings/processing/compare.py` |
+
+Existing fixture files worth reusing:
+
+- `tests/conftest.py` — top-level fixtures; respects the WorkerApiServer port-collision guidance
+  in CLAUDE.md memory.
+- `tests/mcp/test_tools.py::course_tree` — minimal bilingual course tree.
+- `tests/recordings/test_web.py::app` — FastAPI TestClient + mocked OBS.
+- `tests/core/test_multi_target_course.py` — multi-target + DummyBackend fixture.
+- `tests/cli/test_build_output.py` — `Console(record=True)` pattern.

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -987,8 +987,12 @@ class JobQueue:
         Note: VACUUM requires exclusive access and can be slow for large databases.
         """
         conn = self._get_conn()
-        # VACUUM cannot run inside a transaction, so we need to commit first
-        conn.execute("COMMIT")
+        # VACUUM cannot run inside a transaction. Python 3.12+ raises
+        # ``OperationalError: cannot commit - no transaction is active``
+        # when COMMIT is issued on an autocommit connection with no
+        # open transaction, so check in_transaction before committing.
+        if conn.in_transaction:
+            conn.execute("COMMIT")
         conn.execute("VACUUM")
         logger.info(f"Vacuumed database: {self.db_path}")
 

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1,0 +1,967 @@
+"""Unit tests for ``clm.cli.commands.build`` helpers and the ``list_targets`` CLI.
+
+The ``build`` command itself orchestrates the entire course pipeline and
+is exercised end-to-end by the integration tests (test_build_output,
+test_cli_subprocess, test_watch_mode, etc.). These tests cover the
+building blocks that orchestration composes — helpers like
+``_find_env_file``, ``create_output_formatter``, ``configure_workers``,
+``_report_duplicate_file_warnings``, etc. — plus the ``clm targets``
+subcommand which has almost no integration coverage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.build_data_classes import BuildError, BuildWarning
+from clm.cli.commands import build as build_module
+from clm.cli.commands.build import (
+    BuildConfig,
+    _compute_section_dirs_for_cleanup,
+    _find_env_file,
+    _report_duplicate_file_warnings,
+    _report_image_collisions,
+    _report_loading_issues,
+    configure_workers,
+    create_output_formatter,
+    enable_jupyterlite_workers_if_needed,
+    initialize_paths_and_course,
+    list_targets,
+    report_validation_errors,
+    start_managed_workers,
+)
+from clm.cli.output_formatter import (
+    DefaultOutputFormatter,
+    JSONOutputFormatter,
+    QuietOutputFormatter,
+    VerboseOutputFormatter,
+)
+from clm.core.course_spec import CourseSpecError
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides) -> BuildConfig:
+    """Build a minimal ``BuildConfig`` with sensible defaults for tests."""
+    defaults: dict = {
+        "spec_file": Path("spec.xml"),
+        "data_dir": Path("data"),
+        "output_dir": Path("out"),
+        "log_level": "INFO",
+        "cache_db_path": Path("cache.db"),
+        "jobs_db_path": Path("jobs.db"),
+        "ignore_cache": False,
+        "clear_cache": False,
+        "keep_directory": False,
+        "watch": False,
+        "print_correlation_ids": False,
+        "workers": None,
+        "notebook_workers": None,
+        "plantuml_workers": None,
+        "drawio_workers": None,
+        "notebook_image": None,
+    }
+    defaults.update(overrides)
+    return BuildConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _find_env_file
+# ---------------------------------------------------------------------------
+
+
+class TestFindEnvFile:
+    def test_finds_env_in_same_directory(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("", encoding="utf-8")
+        assert _find_env_file(tmp_path) == env
+
+    def test_walks_up_to_find_env(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("", encoding="utf-8")
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        assert _find_env_file(nested) == env
+
+    def test_returns_none_when_no_env(self, tmp_path: Path) -> None:
+        # An isolated tmp_path tree will only hit its own root and then
+        # stop (path.parent == path at the filesystem root).
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        # Guard against an ancestor having a .env on the dev machine
+        # by checking behaviour relative to tmp_path itself.
+        assert _find_env_file(nested) is None or _find_env_file(nested).parent != tmp_path
+
+
+# ---------------------------------------------------------------------------
+# create_output_formatter
+# ---------------------------------------------------------------------------
+
+
+class TestCreateOutputFormatter:
+    def test_json_mode(self) -> None:
+        config = _make_config(output_mode="json")
+        assert isinstance(create_output_formatter(config), JSONOutputFormatter)
+
+    def test_quiet_mode(self) -> None:
+        config = _make_config(output_mode="quiet")
+        assert isinstance(create_output_formatter(config), QuietOutputFormatter)
+
+    def test_verbose_mode(self) -> None:
+        config = _make_config(output_mode="verbose")
+        assert isinstance(create_output_formatter(config), VerboseOutputFormatter)
+
+    def test_default_mode(self) -> None:
+        config = _make_config(output_mode="default")
+        assert isinstance(create_output_formatter(config), DefaultOutputFormatter)
+
+    def test_unknown_mode_falls_back_to_default(self) -> None:
+        config = _make_config(output_mode="something-weird")
+        assert isinstance(create_output_formatter(config), DefaultOutputFormatter)
+
+    def test_output_mode_is_case_insensitive(self) -> None:
+        config = _make_config(output_mode="JSON")
+        assert isinstance(create_output_formatter(config), JSONOutputFormatter)
+
+
+# ---------------------------------------------------------------------------
+# report_validation_errors
+# ---------------------------------------------------------------------------
+
+
+class TestReportValidationErrors:
+    def test_json_mode_prints_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        report_validation_errors(
+            ["Missing element", "Bad attribute"],
+            spec_file=Path("course.xml"),
+            output_mode="json",
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "validation_failed"
+        assert data["error_count"] == 2
+        assert len(data["errors"]) == 2
+        assert data["errors"][0]["category"] == "spec_validation"
+
+    def test_quiet_mode_emits_short_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``cli_console`` is a Rich Console bound to ``sys.stderr`` at
+        import time, so neither capsys nor capfd see its output reliably
+        under xdist. Swap it for a Console writing to an in-memory buffer."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        buf = StringIO()
+        fake_console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+        monkeypatch.setattr(build_module, "cli_console", fake_console)
+
+        report_validation_errors(
+            ["err1"],
+            spec_file=Path("course.xml"),
+            output_mode="quiet",
+        )
+
+        assert "Spec validation failed with 1 error(s)" in buf.getvalue()
+
+    def test_default_mode_emits_full_report(self, capfd: pytest.CaptureFixture[str]) -> None:
+        report_validation_errors(
+            ["err1", "err2"],
+            spec_file=Path("course.xml"),
+            output_mode="default",
+        )
+
+        captured = capfd.readouterr()
+        combined = captured.out + captured.err
+        assert "Course spec validation failed" in combined
+        assert "err1" in combined
+        assert "err2" in combined
+
+    def test_verbose_mode_includes_log_dir(self, capfd: pytest.CaptureFixture[str]) -> None:
+        report_validation_errors(
+            ["err1"],
+            spec_file=Path("course.xml"),
+            output_mode="verbose",
+        )
+
+        captured = capfd.readouterr()
+        combined = captured.out + captured.err
+        assert "Full logs available in" in combined
+
+
+# ---------------------------------------------------------------------------
+# configure_workers
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureWorkers:
+    def test_no_overrides_returns_defaults(self) -> None:
+        config = _make_config()
+        worker_config = configure_workers(config)
+        # Defaults resolve to direct execution with no explicit worker counts.
+        assert worker_config.default_execution_mode == "direct"
+        assert worker_config.notebook.count is None
+
+    def test_all_overrides_are_forwarded(self) -> None:
+        config = _make_config(
+            workers="docker",
+            notebook_workers=4,
+            plantuml_workers=2,
+            drawio_workers=1,
+            max_workers=8,
+            notebook_image="myimage:tag",
+        )
+        worker_config = configure_workers(config)
+
+        assert worker_config.default_execution_mode == "docker"
+        assert worker_config.notebook.count == 4
+        assert worker_config.plantuml.count == 2
+        assert worker_config.drawio.count == 1
+        assert worker_config.max_workers_cap == 8
+        assert worker_config.notebook.image == "myimage:tag"
+
+
+# ---------------------------------------------------------------------------
+# enable_jupyterlite_workers_if_needed
+# ---------------------------------------------------------------------------
+
+
+class TestEnableJupyterLiteWorkersIfNeeded:
+    def _target(self, *, with_jl: bool) -> SimpleNamespace:
+        return SimpleNamespace(includes_format=lambda fmt: with_jl and fmt == "jupyterlite")
+
+    def test_no_targets_request_jupyterlite_leaves_count_none(self) -> None:
+        worker_config = configure_workers(_make_config())
+        course = SimpleNamespace(output_targets=[self._target(with_jl=False)])
+
+        enable_jupyterlite_workers_if_needed(course, worker_config)
+
+        assert worker_config.jupyterlite.count is None
+
+    def test_any_target_requests_jl_bumps_count_to_one(self) -> None:
+        worker_config = configure_workers(_make_config())
+        course = SimpleNamespace(
+            output_targets=[
+                self._target(with_jl=False),
+                self._target(with_jl=True),
+            ]
+        )
+
+        enable_jupyterlite_workers_if_needed(course, worker_config)
+
+        assert worker_config.jupyterlite.count == 1
+
+    def test_preserves_explicit_higher_count(self) -> None:
+        worker_config = configure_workers(_make_config())
+        worker_config.jupyterlite.count = 3
+        course = SimpleNamespace(output_targets=[self._target(with_jl=True)])
+
+        enable_jupyterlite_workers_if_needed(course, worker_config)
+
+        # Explicit setting wins.
+        assert worker_config.jupyterlite.count == 3
+
+
+# ---------------------------------------------------------------------------
+# start_managed_workers
+# ---------------------------------------------------------------------------
+
+
+class TestStartManagedWorkers:
+    def test_no_op_when_should_start_false(self) -> None:
+        manager = MagicMock()
+        manager.should_start_workers.return_value = False
+
+        result = start_managed_workers(manager, worker_config=MagicMock())
+
+        assert result == []
+        manager.start_managed_workers.assert_not_called()
+
+    def test_returns_workers_when_started(self) -> None:
+        manager = MagicMock()
+        manager.should_start_workers.return_value = True
+        manager.start_managed_workers.return_value = ["w1", "w2", "w3"]
+
+        result = start_managed_workers(manager, worker_config=MagicMock())
+
+        assert result == ["w1", "w2", "w3"]
+
+    def test_raises_when_start_fails(self) -> None:
+        manager = MagicMock()
+        manager.should_start_workers.return_value = True
+        manager.start_managed_workers.side_effect = RuntimeError("nope")
+
+        with pytest.raises(RuntimeError, match="nope"):
+            start_managed_workers(manager, worker_config=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# _report_duplicate_file_warnings
+# ---------------------------------------------------------------------------
+
+
+class TestReportDuplicateFileWarnings:
+    def test_reports_each_duplicate_as_warning(self) -> None:
+        course = MagicMock()
+        course.detect_duplicate_output_files.return_value = [
+            {
+                "output_name": "a.ipynb",
+                "language": "en",
+                "format": "ipynb",
+                "kind": "completed",
+                "files": [Path("x/a.py"), Path("y/a.py")],
+            }
+        ]
+
+        reporter = MagicMock()
+        _report_duplicate_file_warnings(course, reporter)
+
+        reporter.report_warning.assert_called_once()
+        warning = reporter.report_warning.call_args[0][0]
+        assert isinstance(warning, BuildWarning)
+        assert "a.ipynb" in warning.message
+
+    def test_no_duplicates_no_calls(self) -> None:
+        course = MagicMock()
+        course.detect_duplicate_output_files.return_value = []
+
+        reporter = MagicMock()
+        _report_duplicate_file_warnings(course, reporter)
+
+        reporter.report_warning.assert_not_called()
+
+    def test_swallows_exceptions_from_detect(self) -> None:
+        """A failing detector must not crash the build — it only warns."""
+        course = MagicMock()
+        course.detect_duplicate_output_files.side_effect = RuntimeError("oops")
+
+        reporter = MagicMock()
+        # Should not raise
+        _report_duplicate_file_warnings(course, reporter)
+
+        reporter.report_warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _report_image_collisions
+# ---------------------------------------------------------------------------
+
+
+class TestReportImageCollisions:
+    def test_duplicated_mode_always_returns_false(self) -> None:
+        course = MagicMock()
+        course.image_mode = "duplicated"
+
+        reporter = MagicMock()
+        assert _report_image_collisions(course, reporter) is False
+        reporter.report_error.assert_not_called()
+
+    def test_shared_mode_no_collisions_returns_false(self) -> None:
+        course = MagicMock()
+        course.image_mode = "shared"
+        course.image_registry.collisions = []
+
+        reporter = MagicMock()
+        assert _report_image_collisions(course, reporter) is False
+        reporter.report_error.assert_not_called()
+
+    def test_shared_mode_with_collisions_returns_true_and_reports(self) -> None:
+        course = MagicMock()
+        course.image_mode = "shared"
+        collision = SimpleNamespace(
+            relative_path="foo/bar.png",
+            paths=[Path("a/foo/bar.png"), Path("b/foo/bar.png")],
+        )
+        course.image_registry.collisions = [collision]
+
+        reporter = MagicMock()
+        assert _report_image_collisions(course, reporter) is True
+
+        reporter.report_error.assert_called_once()
+        error = reporter.report_error.call_args[0][0]
+        assert isinstance(error, BuildError)
+        assert "foo/bar.png" in error.message
+
+
+# ---------------------------------------------------------------------------
+# _report_loading_issues
+# ---------------------------------------------------------------------------
+
+
+class TestReportLoadingIssues:
+    def _course(self, errors=None, warnings=None) -> MagicMock:
+        course = MagicMock()
+        course.loading_errors = errors or []
+        course.loading_warnings = warnings or []
+        return course
+
+    def test_no_errors_no_warnings_no_calls(self) -> None:
+        reporter = MagicMock()
+        _report_loading_issues(self._course(), reporter)
+        reporter.report_error.assert_not_called()
+        reporter.report_warning.assert_not_called()
+
+    def test_topic_not_found_error_with_available_list(self) -> None:
+        reporter = MagicMock()
+        course = self._course(
+            errors=[
+                {
+                    "category": "topic_not_found",
+                    "message": "Topic xyz not found",
+                    "details": {
+                        "file_path": "course.xml",
+                        "available_topics": ["topic_010", "topic_020"],
+                    },
+                }
+            ]
+        )
+
+        _report_loading_issues(course, reporter)
+
+        reporter.report_error.assert_called_once()
+        error = reporter.report_error.call_args[0][0]
+        assert error.error_type == "configuration"
+        assert "Available topic IDs" in error.message
+        assert "topic_010" in error.message
+
+    def test_file_load_error_is_user_type(self) -> None:
+        reporter = MagicMock()
+        course = self._course(
+            errors=[
+                {
+                    "category": "file_load_error",
+                    "message": "UTF-8 decode failed",
+                    "details": {"file_path": "bad.py"},
+                }
+            ]
+        )
+
+        _report_loading_issues(course, reporter)
+        error = reporter.report_error.call_args[0][0]
+        assert error.error_type == "user"
+
+    def test_unknown_error_category_is_infrastructure(self) -> None:
+        reporter = MagicMock()
+        course = self._course(
+            errors=[
+                {
+                    "category": "something_weird",
+                    "message": "Internal error",
+                    "details": {},
+                }
+            ]
+        )
+
+        _report_loading_issues(course, reporter)
+        error = reporter.report_error.call_args[0][0]
+        assert error.error_type == "infrastructure"
+
+    def test_missing_file_path_defaults_to_unknown(self) -> None:
+        reporter = MagicMock()
+        course = self._course(errors=[{"category": "other", "message": "m", "details": {}}])
+
+        _report_loading_issues(course, reporter)
+        error = reporter.report_error.call_args[0][0]
+        assert error.file_path == "unknown"
+
+    def test_duplicate_topic_id_warning_gets_paths_appended(self) -> None:
+        reporter = MagicMock()
+        course = self._course(
+            warnings=[
+                {
+                    "category": "duplicate_topic_id",
+                    "message": "Duplicate 'intro'",
+                    "details": {
+                        "first_path": "a/intro",
+                        "duplicate_path": "b/intro",
+                    },
+                }
+            ]
+        )
+
+        _report_loading_issues(course, reporter)
+        warning = reporter.report_warning.call_args[0][0]
+        assert "a/intro" in warning.message
+        assert "b/intro" in warning.message
+
+
+# ---------------------------------------------------------------------------
+# _compute_section_dirs_for_cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSectionDirsForCleanup:
+    def test_returns_product_of_outputs_and_sections(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        course = MagicMock()
+        # Two targets, two sections → several output specs × sections.
+        target1 = MagicMock()
+        target2 = MagicMock()
+        course.output_targets = [target1, target2]
+        course.sections = [
+            SimpleNamespace(name={"en": "Section A", "de": "Abschnitt A"}),
+            SimpleNamespace(name={"en": "Section B", "de": "Abschnitt B"}),
+        ]
+
+        # Monkeypatch output_specs to return a deterministic, small iterable.
+        def fake_output_specs(course, output_root, skip_html, target):
+            return [
+                SimpleNamespace(language="en", output_dir=tmp_path / "out_en"),
+                SimpleNamespace(language="de", output_dir=tmp_path / "out_de"),
+            ]
+
+        monkeypatch.setattr(
+            "clm.infrastructure.utils.path_utils.output_specs",
+            fake_output_specs,
+        )
+        # sanitize_file_name is called per section.name[lang]; default is fine.
+
+        dirs = _compute_section_dirs_for_cleanup(course)
+
+        # 2 output specs × 2 sections × 2 targets = 8 unique tuples,
+        # but the code dedups by Path, and the fake returns the same
+        # 2 output_dirs for each target. So we should see each of the
+        # (output_dir, section) combos once = 4 dirs.
+        assert len(dirs) == 4
+        names = {d.name for d in dirs}
+        assert "Section_A" in names or any("Section" in d.name for d in dirs)
+
+
+# ---------------------------------------------------------------------------
+# initialize_paths_and_course
+# ---------------------------------------------------------------------------
+
+
+class TestInitializePathsAndCourse:
+    """Coverage for error paths in ``initialize_paths_and_course``.
+
+    The happy path is better exercised by the end-to-end build tests
+    that actually load real course trees.
+    """
+
+    def _config(self, tmp_path: Path, **overrides) -> BuildConfig:
+        data = tmp_path / "data"
+        data.mkdir(exist_ok=True)
+        spec_file = tmp_path / "course.xml"
+        defaults = {
+            "spec_file": spec_file,
+            "data_dir": data,
+            "output_dir": tmp_path / "out",
+            "log_level": "INFO",
+            "cache_db_path": tmp_path / "cache.db",
+            "jobs_db_path": tmp_path / "jobs.db",
+            "ignore_cache": False,
+            "clear_cache": False,
+            "keep_directory": False,
+            "watch": False,
+            "print_correlation_ids": False,
+            "workers": None,
+            "notebook_workers": None,
+            "plantuml_workers": None,
+            "drawio_workers": None,
+            "notebook_image": None,
+        }
+        defaults.update(overrides)
+        return BuildConfig(**defaults)
+
+    def test_spec_parsing_error_json_mode_exits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        config = self._config(tmp_path, output_mode="json")
+        config.spec_file.write_text("not-xml", encoding="utf-8")
+
+        def fail(*args, **kwargs):
+            raise CourseSpecError("bad xml")
+
+        monkeypatch.setattr("clm.core.course_spec.CourseSpec.from_file", fail)
+
+        with pytest.raises(SystemExit):
+            initialize_paths_and_course(config)
+
+        captured = capsys.readouterr()
+        # JSON mode prints a JSON error to stdout.
+        assert '"status": "error"' in captured.out
+        assert '"error_type": "spec_parsing"' in captured.out
+
+    def test_spec_parsing_error_default_mode_exits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config = self._config(tmp_path, output_mode="default")
+        config.spec_file.write_text("not-xml", encoding="utf-8")
+
+        def fail(*args, **kwargs):
+            raise CourseSpecError("bad xml")
+
+        monkeypatch.setattr("clm.core.course_spec.CourseSpec.from_file", fail)
+
+        with pytest.raises(SystemExit):
+            initialize_paths_and_course(config)
+
+    def test_spec_validation_errors_raise_click_exception(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config = self._config(tmp_path, output_mode="default")
+        config.spec_file.write_text("<course/>", encoding="utf-8")
+
+        fake_spec = MagicMock()
+        fake_spec.validate.return_value = ["err1", "err2"]
+
+        monkeypatch.setattr(
+            "clm.core.course_spec.CourseSpec.from_file",
+            lambda *args, **kwargs: fake_spec,
+        )
+
+        with pytest.raises(click.ClickException, match="Course spec validation failed"):
+            initialize_paths_and_course(config)
+
+    def test_spec_validation_errors_json_mode_exits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config = self._config(tmp_path, output_mode="json")
+        config.spec_file.write_text("<course/>", encoding="utf-8")
+
+        fake_spec = MagicMock()
+        fake_spec.validate.return_value = ["err"]
+
+        monkeypatch.setattr(
+            "clm.core.course_spec.CourseSpec.from_file",
+            lambda *args, **kwargs: fake_spec,
+        )
+
+        with pytest.raises(SystemExit):
+            initialize_paths_and_course(config)
+
+
+# ---------------------------------------------------------------------------
+# list_targets CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_spec(path: Path, *, with_targets: bool = True) -> Path:
+    if with_targets:
+        content = """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <output-targets>
+        <output-target name="public">
+            <path>public</path>
+            <kinds><kind>code-along</kind></kinds>
+            <formats><format>html</format></formats>
+            <languages><language>en</language></languages>
+        </output-target>
+    </output-targets>
+    <sections/>
+</course>
+"""
+    else:
+        content = """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <sections/>
+</course>
+"""
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _invoke_build(args, tmp_path: Path | None = None):
+    """Invoke the ``build`` command with a parent-context ``obj`` dict.
+
+    The top-level ``clm`` group seeds ``ctx.obj`` with the DB paths; when
+    we invoke ``build`` directly via CliRunner, we need to provide the
+    same dict or the command fails on ``ctx.obj["CACHE_DB_PATH"]``.
+    """
+    obj = {
+        "CACHE_DB_PATH": Path(str(tmp_path or Path("."))) / "cache.db",
+        "JOBS_DB_PATH": Path(str(tmp_path or Path("."))) / "jobs.db",
+    }
+    return CliRunner().invoke(build_module.build, args, obj=obj)
+
+
+class TestListTargetsCli:
+    def test_table_format_prints_each_target(self, tmp_path: Path) -> None:
+        spec = _write_spec(tmp_path / "course.xml", with_targets=True)
+        result = CliRunner().invoke(list_targets, [str(spec)])
+
+        assert result.exit_code == 0
+        assert "public" in result.output
+        assert "Path:" in result.output
+        assert "Kinds:" in result.output
+
+    def test_json_format_returns_json(self, tmp_path: Path) -> None:
+        spec = _write_spec(tmp_path / "course.xml", with_targets=True)
+        result = CliRunner().invoke(list_targets, [str(spec), "--format=json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert data[0]["name"] == "public"
+
+    def test_no_targets_prints_default_behavior_note(self, tmp_path: Path) -> None:
+        spec = _write_spec(tmp_path / "course.xml", with_targets=False)
+        result = CliRunner().invoke(list_targets, [str(spec)])
+
+        assert result.exit_code == 0
+        assert "No output targets" in result.output
+
+    def test_parse_error_table_format(self, tmp_path: Path) -> None:
+        spec = tmp_path / "broken.xml"
+        spec.write_text("<not-valid", encoding="utf-8")
+
+        result = CliRunner().invoke(list_targets, [str(spec)])
+
+        assert result.exit_code == 1
+        assert "Error" in (result.output + (result.stderr if result.stderr_bytes else ""))
+
+    def test_parse_error_json_format(self, tmp_path: Path) -> None:
+        spec = tmp_path / "broken.xml"
+        spec.write_text("<not-valid", encoding="utf-8")
+
+        result = CliRunner().invoke(list_targets, [str(spec), "--format=json"])
+
+        assert result.exit_code == 1
+        # Either stdout (JSON error) or stderr (error text).
+        combined = result.output
+        if combined.strip().startswith("{"):
+            data = json.loads(combined)
+            assert data["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# build CLI wrapper: asyncio.run + .env loading + signal-handler surface
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCliWrapper:
+    """End-to-end tests for the ``clm build`` CLI entry point.
+
+    We stub ``asyncio.run`` so the heavy ``main_build`` coroutine never
+    actually runs, then verify that the wrapper (a) wires arguments
+    correctly into the coroutine, (b) installs signal handlers, and
+    (c) loads the .env when one is present next to the spec.
+    """
+
+    def _make_spec(self, tmp_path: Path) -> Path:
+        spec = tmp_path / "course.xml"
+        _write_spec(spec, with_targets=False)
+        return spec
+
+    def test_only_sections_whitespace_is_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--only-sections`` validation happens inside the orchestrator
+        coroutine, so we run it fully with a real event loop."""
+        import asyncio
+
+        spec = self._make_spec(tmp_path)
+        monkeypatch.setattr(build_module.asyncio, "run", asyncio.run)
+
+        result = _invoke_build([str(spec), "--only-sections", "  "], tmp_path=tmp_path)
+
+        assert result.exit_code != 0
+        # Output or exception message should mention the whitespace error.
+        combined = result.output + (str(result.exception) if result.exception else "")
+        assert "empty or whitespace-only value" in combined
+
+    def test_explicit_env_file_is_loaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--env-file with an existing file is forwarded to load_dotenv."""
+        spec = self._make_spec(tmp_path)
+        env_file = tmp_path / "my.env"
+        env_file.write_text("FOO=bar\n", encoding="utf-8")
+        ran: list[object] = []
+        loaded: list[object] = []
+
+        def fake_run(coro) -> None:
+            ran.append(coro)
+            coro.close()
+
+        def fake_load_dotenv(path, override: bool = False) -> bool:
+            loaded.append(path)
+            return True
+
+        monkeypatch.setattr(build_module.asyncio, "run", fake_run)
+        monkeypatch.setattr("dotenv.load_dotenv", fake_load_dotenv)
+
+        result = _invoke_build(["--env-file", str(env_file), str(spec)], tmp_path=tmp_path)
+
+        assert result.exit_code == 0
+        assert len(ran) == 1
+        # load_dotenv called with the explicit env file.
+        assert any(str(env_file) in str(p) for p in loaded)
+
+    def test_no_env_file_flag_short_circuits_dotenv(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With --no-env-file, neither the auto-lookup nor --env-file runs."""
+        spec = self._make_spec(tmp_path)
+
+        # Seed a .env next to the spec — it should be ignored.
+        (tmp_path / ".env").write_text("FOO=bar\n", encoding="utf-8")
+
+        # If dotenv.load_dotenv is called we fail loudly.
+        def should_not_call(*args, **kwargs):
+            raise AssertionError("load_dotenv should not be called with --no-env-file")
+
+        monkeypatch.setattr("dotenv.load_dotenv", should_not_call)
+        monkeypatch.setattr(build_module.asyncio, "run", lambda coro: coro.close())
+
+        result = _invoke_build(["--no-env-file", str(spec)], tmp_path=tmp_path)
+
+        assert result.exit_code == 0
+
+    def test_build_runs_main_build_with_mocked_pipeline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full path through ``build`` → ``asyncio.run(main_build(...))``
+        with every pipeline step replaced by a stub.
+
+        This covers argument-to-config translation, formatter/worker/DB
+        setup and the happy-path finally block, exercising ``main_build``
+        line-by-line.
+        """
+        import asyncio
+
+        # Make a real spec + data dir so resolve_course_paths doesn't explode.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        spec = _write_spec(tmp_path / "course.xml", with_targets=False)
+
+        monkeypatch.setattr(build_module.asyncio, "run", asyncio.run)
+
+        # Stub out every heavy dep used by main_build.
+        fake_course = MagicMock()
+        fake_course.output_targets = []
+        fake_course.sections = []
+        fake_course.files = []
+        fake_course.output_root = tmp_path / "out"
+        fake_course.name = SimpleNamespace(en="Course")
+        fake_course.image_mode = "duplicated"
+        fake_course.image_registry = SimpleNamespace(collisions=[])
+        fake_course.output_dir_name = {"en": "Course", "de": "Kurs"}
+        fake_course.loading_errors = []
+        fake_course.loading_warnings = []
+        fake_course.detect_duplicate_output_files.return_value = []
+        fake_course.count_jupyterlite_operations.return_value = 0
+        fake_course.precreate_output_directories = MagicMock()
+
+        async def _noop_async_method(*args, **kwargs):
+            return None
+
+        fake_course.count_stage_operations = MagicMock(side_effect=_noop_async_method)
+        fake_course.process_stage = MagicMock(side_effect=_noop_async_method)
+        fake_course.process_dir_group = MagicMock(side_effect=_noop_async_method)
+        fake_course.process_jupyterlite_for_targets = MagicMock(side_effect=_noop_async_method)
+
+        monkeypatch.setattr(
+            build_module,
+            "initialize_paths_and_course",
+            lambda config: (fake_course, [tmp_path / "out" / "En"], data_dir),
+        )
+
+        fake_lifecycle = MagicMock()
+        fake_lifecycle.should_start_workers.return_value = False
+        monkeypatch.setattr(
+            "clm.infrastructure.workers.lifecycle_manager.WorkerLifecycleManager",
+            lambda **kwargs: fake_lifecycle,
+        )
+
+        monkeypatch.setattr(
+            "clm.infrastructure.database.schema.init_database",
+            lambda *args, **kwargs: None,
+        )
+
+        # Stub the DB manager and backend so the async-with chains no-op.
+        class FakeDbManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class FakeBackend:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def shutdown(self):
+                pass
+
+        monkeypatch.setattr(build_module, "DatabaseManager", FakeDbManager)
+        monkeypatch.setattr(build_module, "SqliteBackend", FakeBackend)
+
+        # Avoid real git_dir_mover context manager side effects.
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_mover(root_dirs, keep_directory):
+            yield
+
+        monkeypatch.setattr(build_module, "git_dir_mover", fake_mover)
+
+        # BuildReporter: trivial stub.
+        monkeypatch.setattr(build_module, "BuildReporter", lambda formatter: MagicMock())
+
+        # Avoid real execution stages (already mocked on fake_course).
+        monkeypatch.setattr(
+            "clm.core.utils.execution_utils.execution_stages",
+            lambda: [],
+        )
+
+        result = _invoke_build([str(spec)], tmp_path=tmp_path)
+
+        assert result.exit_code == 0, result.exception
+
+    def test_auto_detects_env_next_to_spec(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --env-file or --no-env-file, the wrapper walks up from
+        the spec file looking for a ``.env`` and forwards it to
+        ``load_dotenv``."""
+        spec = self._make_spec(tmp_path)
+        env = tmp_path / ".env"
+        env.write_text("X=1\n", encoding="utf-8")
+
+        loaded: list[Path] = []
+
+        def fake_load_dotenv(path, override: bool = False) -> bool:
+            loaded.append(Path(str(path)))
+            return True
+
+        monkeypatch.setattr("dotenv.load_dotenv", fake_load_dotenv)
+        monkeypatch.setattr(build_module.asyncio, "run", lambda coro: coro.close())
+
+        result = _invoke_build([str(spec)], tmp_path=tmp_path)
+
+        assert result.exit_code == 0
+        assert env in loaded

--- a/tests/cli/test_build_output.py
+++ b/tests/cli/test_build_output.py
@@ -1135,3 +1135,436 @@ class TestBuildReporterFileEvents:
         # doesn't track file events
         reporter.report_file_started("test.ipynb", "notebook", job_id=123)
         reporter.report_file_completed("test.ipynb", "notebook", job_id=123, success=True)
+
+
+# ---------------------------------------------------------------------------
+# PR 2: additional coverage for verbose formatter detail paths, default
+# summary rendering, quiet + JSON formatters.
+# ---------------------------------------------------------------------------
+
+
+def _make_error(
+    *,
+    error_type: str = "user",
+    severity: str = "error",
+    category: str = "notebook_compilation",
+    file_path: str = "slides/ex.py",
+    message: str = "boom",
+    actionable_guidance: str = "Fix the cell that is failing",
+    details: dict | None = None,
+    job_id: int | None = None,
+    correlation_id: str | None = None,
+) -> BuildError:
+    return BuildError(
+        error_type=error_type,
+        category=category,
+        severity=severity,
+        file_path=file_path,
+        message=message,
+        actionable_guidance=actionable_guidance,
+        details=details or {},
+        job_id=job_id,
+        correlation_id=correlation_id,
+    )
+
+
+class TestVerboseShowErrorDetail:
+    """Exercise every branch of ``VerboseOutputFormatter._show_error_detail``."""
+
+    def _capture(self, formatter, error, index=1):
+        formatter._show_error_detail(index, error)
+
+    def test_cell_and_line_number_both_rendered(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"cell_number": 7, "line_number": 42})
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "cell #7" in out
+        assert "line 42" in out
+
+    def test_cell_only_renders_without_line(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"cell_number": 3})
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "cell #3" in out
+        assert "line" not in out
+
+    def test_error_class_and_short_message(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(
+            details={
+                "error_class": "SyntaxError",
+                "short_message": "invalid syntax at col 4",
+            }
+        )
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "SyntaxError" in out
+        assert "invalid syntax at col 4" in out
+
+    def test_error_class_without_short_message(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"error_class": "ValueError"})
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "ValueError" in out
+
+    def test_fallback_message_when_no_error_class(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(message="plain old error message")
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "plain old error message" in out
+
+    def test_code_snippet_rendered_when_present(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"code_snippet": "def foo():\n    return 1/0"})
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "Code context" in out
+
+    def test_empty_code_snippet_suppresses_context_header(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"code_snippet": ""})
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "Code context" not in out
+
+    def test_job_and_correlation_ids_rendered(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(job_id=99, correlation_id="abc-123")
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert "Job ID: #99" in out
+        assert "Correlation ID: abc-123" in out
+
+    @pytest.mark.parametrize(
+        "error_type",
+        ["user", "configuration", "infrastructure"],
+    )
+    def test_all_error_types_supported(self, capsys, error_type):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(error_type=error_type)
+        self._capture(formatter, err)
+        out = capsys.readouterr().err
+        assert error_type.title() in out
+
+
+class TestVerboseShowFileCompletedEdgeCases:
+    """Cover the duration + started/not-started branches of show_file_completed."""
+
+    def test_completed_without_prior_started(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        # No show_file_started call — duration_str stays empty.
+        formatter.show_file_completed("orphan.ipynb", "notebook", success=True)
+        assert formatter._files_completed == 1
+
+    def test_completed_with_prior_started_includes_duration(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_file_started("t.ipynb", "notebook", job_id=5)
+        formatter.show_file_completed("t.ipynb", "notebook", job_id=5, success=True)
+        out = capsys.readouterr().err
+        # Duration marker "(0.00s)" format — at least one digit + s.
+        assert "s)" in out
+
+    def test_failed_without_job_id(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_file_completed("x.ipynb", "notebook", success=False)
+        out = capsys.readouterr().err
+        assert "Failed notebook" in out
+        # No " (job #" fragment because job_id is None.
+        assert "job #" not in out
+
+
+class TestVerboseShowStageStart:
+    """Cover the verbose-specific show_stage_start printout."""
+
+    def test_with_cached_jobs(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_stage_start("Notebooks", 2, 4, num_jobs=10, num_cached=3)
+        out = capsys.readouterr().err
+        assert "Stage 2/4" in out
+        assert "Notebooks" in out
+        assert "3 from cache" in out
+
+    def test_without_cached_jobs(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_stage_start("Plantuml", 1, 3, num_jobs=5, num_cached=0)
+        out = capsys.readouterr().err
+        assert "Stage 1/3" in out
+        assert "from cache" not in out
+
+
+class TestDefaultFormatterSummary:
+    """Exercise DefaultOutputFormatter.show_summary across error/warning mixes."""
+
+    def _make_errors(self, n, error_type="user"):
+        return [
+            _make_error(
+                error_type=error_type,
+                file_path=f"file{i}.py",
+                message=f"err {i}",
+                actionable_guidance=("x" * 30),  # >20 chars so branch triggers
+            )
+            for i in range(n)
+        ]
+
+    def _make_warnings(self, n, severity="medium"):
+        return [
+            BuildWarning(
+                category="c",
+                message=f"warn {i}",
+                severity=severity,
+                file_path=f"w{i}.py" if i % 2 else None,
+            )
+            for i in range(n)
+        ]
+
+    def test_summary_all_clean(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        summary = BuildSummary(duration=1.0, total_files=5)
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "successfully" in out
+        assert "5 files processed" in out
+        assert "0 errors" in out
+
+    def test_summary_errors_over_cap_shows_overflow(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        errors = self._make_errors(12)
+        summary = BuildSummary(duration=2.5, total_files=12, errors=errors)
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "and 2 more errors" in out
+        assert "verbose" in out
+
+    @pytest.mark.parametrize("severity", ["high", "medium", "low"])
+    def test_summary_warning_severity_branches(self, capsys, severity):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        warnings = self._make_warnings(2, severity=severity)
+        summary = BuildSummary(duration=1.0, total_files=2, errors=[], warnings=warnings)
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        # File-path location branch is exercised for the odd-indexed warning.
+        assert "w1.py" in out
+
+    def test_summary_warnings_over_cap_shows_overflow(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        warnings = self._make_warnings(8, severity="high")
+        summary = BuildSummary(duration=1.0, total_files=8, errors=[], warnings=warnings)
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "more warnings" in out
+
+    def test_summary_error_without_long_guidance_uses_error_class(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(
+            actionable_guidance="short",  # <20 chars, falls through
+            details={"error_class": "ValueError", "short_message": "bad input"},
+        )
+        summary = BuildSummary(duration=1.0, total_files=1, errors=[err])
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "ValueError" in out
+        assert "bad input" in out
+
+    def test_summary_error_with_cell_number_adds_location(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(
+            actionable_guidance="s",
+            details={"cell_number": 4},
+            message="something failed",
+        )
+        summary = BuildSummary(duration=1.0, total_files=1, errors=[err])
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "cell #4" in out
+
+
+class TestDefaultShowError:
+    """Exercise DefaultOutputFormatter.show_error detail branches (lines 289-342)."""
+
+    def test_show_error_with_cell_and_line(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"cell_number": 2, "line_number": 17})
+        formatter.show_error(err)
+        out = capsys.readouterr().err
+        assert "#2" in out
+        assert "line 17" in out
+
+    def test_show_error_with_error_class(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"error_class": "RuntimeError", "short_message": "kaboom"})
+        formatter.show_error(err)
+        out = capsys.readouterr().err
+        assert "RuntimeError" in out
+        assert "kaboom" in out
+
+    def test_show_error_with_code_snippet(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(details={"code_snippet": "x = 1 / 0"})
+        formatter.show_error(err)
+        out = capsys.readouterr().err
+        assert "Code context" in out
+
+    def test_show_error_with_job_id(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        err = _make_error(job_id=77)
+        formatter.show_error(err)
+        out = capsys.readouterr().err
+        assert "Job ID: #77" in out
+
+    def test_show_error_configuration_and_infrastructure_colors(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        for t in ("configuration", "infrastructure"):
+            formatter.show_error(_make_error(error_type=t))
+        out = capsys.readouterr().err
+        assert "Configuration Error" in out
+        assert "Infrastructure Error" in out
+
+    def test_show_warning(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        w = BuildWarning(category="c", message="hey", severity="high")
+        formatter.show_warning(w)
+        out = capsys.readouterr().err
+        assert "hey" in out
+
+
+class TestQuietFormatter:
+    """QuietOutputFormatter has large no-op surface — cover every method."""
+
+    def test_all_noop_methods_run(self):
+        from clm.cli.output_formatter import QuietOutputFormatter
+
+        formatter = QuietOutputFormatter()
+        # These should all be silent and not raise.
+        formatter.show_build_start("course", 10, ["out1", "out2"])
+        formatter.show_stage_start("Stage", 1, 2, num_jobs=5, num_cached=1)
+        formatter.update_progress(3, 5, active_workers=1, cached=1)
+        formatter.show_warning(BuildWarning(category="c", message="m", severity="low"))
+        assert (
+            formatter.should_show_warning(BuildWarning(category="c", message="m", severity="high"))
+            is False
+        )
+        formatter.cleanup()
+
+    def test_show_error_only_for_error_and_fatal(self, capsys):
+        from clm.cli.output_formatter import QuietOutputFormatter
+
+        formatter = QuietOutputFormatter()
+        err = _make_error(severity="error", file_path="q.py", message="die")
+        assert formatter.should_show_error(err)
+        formatter.show_error(err)
+        out = capsys.readouterr().err
+        assert "ERROR" in out
+        assert "die" in out
+
+    def test_show_error_skipped_for_warning_severity(self):
+        from clm.cli.output_formatter import QuietOutputFormatter
+
+        formatter = QuietOutputFormatter()
+        err = _make_error(severity="warning")
+        assert not formatter.should_show_error(err)
+
+    def test_summary_with_errors_prints_red_line_and_log_dir(self, capsys):
+        from clm.cli.output_formatter import QuietOutputFormatter
+
+        formatter = QuietOutputFormatter()
+        summary = BuildSummary(duration=1.5, total_files=1, errors=[_make_error()])
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "Build failed" in out
+        assert "logs" in out.lower()
+
+    def test_summary_without_errors(self, capsys):
+        from clm.cli.output_formatter import QuietOutputFormatter
+
+        formatter = QuietOutputFormatter()
+        summary = BuildSummary(duration=0.5, total_files=0)
+        formatter.show_summary(summary)
+        out = capsys.readouterr().err
+        assert "successfully" in out
+
+
+class TestJSONFormatter:
+    """JSONOutputFormatter structured output shape."""
+
+    def test_full_roundtrip(self, capsys):
+        formatter = JSONOutputFormatter()
+        formatter.show_build_start("course-x", 3, ["out-de", "out-en"])
+        formatter.show_stage_start("Notebooks", 1, 2, num_jobs=3, num_cached=1)
+        formatter.update_progress(2, 3, active_workers=1, cached=1)
+
+        # These are silent but must not raise.
+        formatter.show_error(_make_error())
+        formatter.show_warning(BuildWarning(category="c", message="w", severity="low"))
+        assert not formatter.should_show_error(_make_error())
+        assert not formatter.should_show_warning(
+            BuildWarning(category="c", message="w", severity="high")
+        )
+
+        summary = BuildSummary(
+            duration=1.0,
+            total_files=3,
+            errors=[_make_error(details={"a_string": "x", "a_number": 42})],
+            warnings=[BuildWarning(category="c", message="w", severity="low", file_path="w.py")],
+            start_time=datetime(2026, 4, 17, 10, 0, 0),
+            end_time=datetime(2026, 4, 17, 10, 0, 1),
+        )
+        formatter.show_summary(summary)
+        formatter.cleanup()
+
+        captured = capsys.readouterr().out
+        data = json.loads(captured)
+        assert data["status"] == "failed"
+        assert data["course_name"] == "course-x"
+        assert data["output_dirs"] == ["out-de", "out-en"]
+        assert data["stages"][0]["num_cached"] == 1
+        assert data["stages"][0]["cached_completed"] == 1
+        assert data["error_count"] == 1
+        assert data["warning_count"] == 1
+        assert "log_directory" in data
+        assert "start_time" in data and "end_time" in data
+        # Non-string details preserved verbatim; strings ANSI-stripped.
+        assert data["errors"][0]["details"]["a_number"] == 42
+
+    def test_status_success_when_no_errors(self, capsys):
+        formatter = JSONOutputFormatter()
+        formatter.show_build_start("ok", 1)
+        summary = BuildSummary(duration=0.1, total_files=1)
+        formatter.show_summary(summary)
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "success"
+
+    def test_status_fatal_when_fatal_error(self, capsys):
+        formatter = JSONOutputFormatter()
+        formatter.show_build_start("x", 1)
+        fatal = _make_error(severity="fatal")
+        summary = BuildSummary(duration=0.1, total_files=1, errors=[fatal])
+        formatter.show_summary(summary)
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "fatal"
+
+
+class TestDefaultFormatterMisc:
+    """Small remaining DefaultOutputFormatter branches."""
+
+    def test_show_build_start_prints_output_dirs(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_build_start("C", 2, output_dirs=["a", "b"])
+        out = capsys.readouterr().err
+        assert "a" in out and "b" in out
+
+    def test_stage_start_without_progress_prints_line(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_stage_start("S", 1, 1, num_jobs=4, num_cached=2)
+        out = capsys.readouterr().err
+        assert "4 jobs" in out
+        assert "2 cached" in out
+
+    def test_startup_message(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_startup_message("warming up")
+        out = capsys.readouterr().err
+        assert "warming up" in out

--- a/tests/cli/test_config_command.py
+++ b/tests/cli/test_config_command.py
@@ -1,0 +1,189 @@
+"""Tests for ``clm config`` commands.
+
+Covers ``clm config init`` (both locations + --force), ``clm config show``,
+and ``clm config locate``. All tests redirect ``platformdirs.user_config_dir``
+into ``tmp_path`` so the user's real config file is never touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+
+@pytest.fixture
+def isolated_config_dirs(tmp_path, monkeypatch):
+    """Redirect user + project config dirs into tmp_path.
+
+    Patches:
+    - ``platformdirs.user_config_dir`` → ``tmp_path/user``
+    - cwd → ``tmp_path/project`` (so project config lives under that)
+    """
+    user_dir = tmp_path / "user"
+    project_dir = tmp_path / "project"
+    user_dir.mkdir()
+    project_dir.mkdir()
+
+    # platformdirs is imported by clm.infrastructure.config; patch it there too.
+    monkeypatch.setattr(
+        "clm.infrastructure.config.platformdirs.user_config_dir",
+        lambda *a, **kw: str(user_dir),
+    )
+    # Some code paths call Path.cwd() directly.
+    monkeypatch.chdir(project_dir)
+
+    return {
+        "user": user_dir / "config.toml",
+        "project": project_dir / ".clm" / "config.toml",
+        "user_dir": user_dir,
+        "project_dir": project_dir,
+    }
+
+
+class TestConfigInit:
+    def test_init_creates_user_config_by_default(self, isolated_config_dirs):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "init"])
+        assert result.exit_code == 0, result.output
+        assert isolated_config_dirs["user"].exists()
+        assert "Created configuration file" in result.output
+        content = isolated_config_dirs["user"].read_text()
+        # Example config must document a handful of expected sections.
+        assert "[paths]" in content
+        assert "[logging]" in content
+        assert "[worker_management]" in content
+
+    def test_init_creates_project_config(self, isolated_config_dirs):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "init", "--location", "project"])
+        assert result.exit_code == 0, result.output
+        assert isolated_config_dirs["project"].exists()
+
+    def test_init_refuses_to_overwrite_without_force(self, isolated_config_dirs):
+        cfg = isolated_config_dirs["user"]
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text("# existing\n")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "init"])
+
+        assert result.exit_code == 0
+        assert "already exists" in result.output
+        assert "Use --force" in result.output
+        # File content is untouched.
+        assert cfg.read_text() == "# existing\n"
+
+    def test_init_with_force_overwrites(self, isolated_config_dirs):
+        cfg = isolated_config_dirs["user"]
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text("# existing\n")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "init", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert "Created configuration file" in result.output
+        # Now contains the templated content, not the sentinel.
+        assert cfg.read_text() != "# existing\n"
+        assert "[paths]" in cfg.read_text()
+
+    def test_init_reports_permission_error(self, isolated_config_dirs):
+        runner = CliRunner()
+        with patch(
+            "clm.infrastructure.config.write_example_config",
+            side_effect=PermissionError("denied"),
+        ):
+            result = runner.invoke(cli, ["config", "init"])
+        assert result.exit_code == 0  # command echoes error, doesn't raise
+        assert "Permission denied" in result.output
+
+    def test_init_reports_generic_error(self, isolated_config_dirs):
+        runner = CliRunner()
+        with patch(
+            "clm.infrastructure.config.write_example_config",
+            side_effect=RuntimeError("broke"),
+        ):
+            result = runner.invoke(cli, ["config", "init"])
+        assert "Error creating configuration file" in result.output
+
+
+class TestConfigShow:
+    def test_show_prints_all_sections(self, isolated_config_dirs):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "show"])
+        assert result.exit_code == 0, result.output
+        assert "Current CLM Configuration" in result.output
+        for header in (
+            "[Paths]",
+            "[External Tools]",
+            "[Logging]",
+            "[Jupyter]",
+            "[Workers]",
+        ):
+            assert header in result.output
+
+    def test_show_reflects_project_config_values(self, isolated_config_dirs):
+        project_cfg = isolated_config_dirs["project"]
+        project_cfg.parent.mkdir(parents=True, exist_ok=True)
+        project_cfg.write_text(
+            '[logging]\nlog_level = "DEBUG"\n[paths]\ncache_db_path = "custom_cache.db"\n'
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "show"])
+        assert result.exit_code == 0, result.output
+        assert "DEBUG" in result.output
+        assert "custom_cache.db" in result.output
+
+
+class TestConfigLocate:
+    def test_locate_shows_all_locations(self, isolated_config_dirs):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "locate"])
+        assert result.exit_code == 0, result.output
+        assert "System config" in result.output
+        assert "User config" in result.output
+        assert "Project config" in result.output
+        assert "Priority order" in result.output
+
+    def test_locate_marks_existing_config_files(self, isolated_config_dirs):
+        # Create a user config so locate detects it.
+        cfg = isolated_config_dirs["user"]
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text("# dummy\n")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "locate"])
+        assert result.exit_code == 0
+        # User line should say "Exists"; project line "Not found".
+        output = result.output
+        user_idx = output.index("User config:")
+        project_idx = output.index("Project config")
+        assert "Exists" in output[user_idx:project_idx]
+        assert "Not found" in output[project_idx:]
+
+
+class TestConfigHelp:
+    def test_group_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "--help"])
+        assert result.exit_code == 0
+        for sub in ("init", "show", "locate"):
+            assert sub in result.output
+
+    def test_init_help_lists_flags(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "init", "--help"])
+        assert result.exit_code == 0
+        assert "--location" in result.output
+        assert "--force" in result.output
+
+    def test_init_rejects_invalid_location(self, isolated_config_dirs):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "init", "--location", "bogus"])
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "bogus" in result.output

--- a/tests/cli/test_db_commands.py
+++ b/tests/cli/test_db_commands.py
@@ -1,0 +1,244 @@
+"""Tests for ``clm db`` commands.
+
+Covers ``stats``, ``prune``, ``vacuum``, ``clean``, and the legacy
+``delete-database`` command. Each test seeds a real tmp_path SQLite DB
+via ``init_database`` + ``JobQueue`` / ``DatabaseManager`` so the CLI
+paths exercise the real schema.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+from clm.infrastructure.database.db_operations import DatabaseManager
+from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.database.schema import init_database
+
+
+@pytest.fixture
+def db_paths(tmp_path):
+    jobs = tmp_path / "clm_jobs.db"
+    cache = tmp_path / "clm_cache.db"
+    return {"jobs": jobs, "cache": cache, "root": tmp_path}
+
+
+@pytest.fixture
+def initialized_dbs(db_paths):
+    init_database(db_paths["jobs"])
+    # DatabaseManager initialises its own schema on first use.
+    with DatabaseManager(db_paths["cache"]):
+        pass
+    return db_paths
+
+
+def _invoke(db_paths, *args, input: str | None = None):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        [
+            "--jobs-db-path",
+            str(db_paths["jobs"]),
+            "--cache-db-path",
+            str(db_paths["cache"]),
+            *args,
+        ],
+        input=input,
+    )
+
+
+def _seed_job(db_path: Path, *, status: str = "completed", input_file: str = "a.py") -> int:
+    with JobQueue(db_path) as jq:
+        job_id = jq.add_job(
+            job_type="notebook",
+            input_file=input_file,
+            output_file=input_file.replace(".py", ".ipynb"),
+            content_hash=f"hash-{input_file}",
+            payload={},
+        )
+        conn = jq._get_conn()
+        if status == "completed":
+            conn.execute(
+                "UPDATE jobs SET status = 'completed', "
+                "completed_at = datetime('now', '-60 days') WHERE id = ?",
+                (job_id,),
+            )
+        elif status == "failed":
+            conn.execute(
+                "UPDATE jobs SET status = 'failed', "
+                "created_at = datetime('now', '-60 days') WHERE id = ?",
+                (job_id,),
+            )
+        elif status == "processing":
+            conn.execute(
+                "UPDATE jobs SET status = 'processing', "
+                "started_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (job_id,),
+            )
+        conn.commit()
+    return job_id
+
+
+# ---------------------------------------------------------------------------
+# db stats
+# ---------------------------------------------------------------------------
+
+
+class TestDbStats:
+    def test_stats_missing_dbs(self, db_paths):
+        result = _invoke(db_paths, "db", "stats")
+        assert result.exit_code == 0, result.output
+        assert "not found" in result.output
+
+    def test_stats_with_seeded_dbs(self, initialized_dbs):
+        _seed_job(initialized_dbs["jobs"], status="completed", input_file="x.py")
+        _seed_job(initialized_dbs["jobs"], status="failed", input_file="y.py")
+
+        result = _invoke(initialized_dbs, "db", "stats")
+        assert result.exit_code == 0, result.output
+        assert "Jobs Database" in result.output
+        assert "Cache Database" in result.output
+        # jobs_by_status breakdown should list both statuses.
+        assert "completed" in result.output
+        assert "failed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# db prune
+# ---------------------------------------------------------------------------
+
+
+class TestDbPrune:
+    def test_prune_dry_run_no_mutation(self, initialized_dbs):
+        job_id = _seed_job(initialized_dbs["jobs"], status="completed")
+
+        result = _invoke(initialized_dbs, "db", "prune", "--completed-days=7", "--dry-run")
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+
+        # Job survives.
+        with JobQueue(initialized_dbs["jobs"]) as jq:
+            assert jq.get_job(job_id) is not None
+
+    def test_prune_deletes_old_completed_jobs(self, initialized_dbs):
+        job_id = _seed_job(initialized_dbs["jobs"], status="completed")
+
+        result = _invoke(initialized_dbs, "db", "prune", "--completed-days=7")
+        assert result.exit_code == 0, result.output
+        assert "Prune complete" in result.output
+
+        with JobQueue(initialized_dbs["jobs"]) as jq:
+            assert jq.get_job(job_id) is None
+
+    def test_prune_missing_dbs_no_error(self, db_paths):
+        result = _invoke(db_paths, "db", "prune", "--completed-days=7")
+        assert result.exit_code == 0, result.output
+        assert "not found" in result.output
+
+    def test_prune_remove_missing_deletes_jobs_for_missing_files(self, initialized_dbs):
+        # Job references a file that doesn't exist on disk.
+        _seed_job(initialized_dbs["jobs"], status="completed", input_file="ghost.py")
+
+        result = _invoke(initialized_dbs, "db", "prune", "--remove-missing")
+        assert result.exit_code == 0, result.output
+        assert "missing source files" in result.output.lower()
+
+    def test_prune_remove_missing_dry_run_preserves(self, initialized_dbs):
+        _seed_job(initialized_dbs["jobs"], status="completed", input_file="ghost.py")
+        result = _invoke(initialized_dbs, "db", "prune", "--remove-missing", "--dry-run")
+        assert result.exit_code == 0, result.output
+        # Job still present after dry-run.
+        with JobQueue(initialized_dbs["jobs"]) as jq:
+            stats = jq.get_database_stats()
+            assert stats["jobs_count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# db vacuum
+# ---------------------------------------------------------------------------
+
+
+class TestDbVacuum:
+    def test_vacuum_both(self, initialized_dbs):
+        result = _invoke(initialized_dbs, "db", "vacuum")
+        assert result.exit_code == 0, result.output
+        assert "Vacuuming jobs database" in result.output
+        assert "Vacuuming cache database" in result.output
+
+    def test_vacuum_only_jobs(self, initialized_dbs):
+        result = _invoke(initialized_dbs, "db", "vacuum", "--which=jobs")
+        assert result.exit_code == 0, result.output
+        assert "Vacuuming jobs database" in result.output
+        assert "Vacuuming cache database" not in result.output
+
+    def test_vacuum_missing_dbs(self, db_paths):
+        result = _invoke(db_paths, "db", "vacuum")
+        assert result.exit_code == 0, result.output
+        assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# db clean
+# ---------------------------------------------------------------------------
+
+
+class TestDbClean:
+    def test_clean_cancel_at_prompt(self, initialized_dbs):
+        result = _invoke(initialized_dbs, "db", "clean", input="n\n")
+        assert result.exit_code == 0, result.output
+        assert "Cancelled" in result.output
+
+    def test_clean_force_runs_prune_and_vacuum(self, initialized_dbs):
+        result = _invoke(initialized_dbs, "db", "clean", "--force")
+        assert result.exit_code == 0, result.output
+        # prune and vacuum both run.
+        assert "Pruning jobs database" in result.output
+        assert "Vacuuming jobs database" in result.output
+        assert "Cleanup complete" in result.output
+
+    def test_clean_remove_missing_passthrough(self, initialized_dbs):
+        _seed_job(initialized_dbs["jobs"], status="completed", input_file="gone.py")
+        result = _invoke(initialized_dbs, "db", "clean", "--force", "--remove-missing")
+        assert result.exit_code == 0, result.output
+        assert "missing source files" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# legacy delete-database command
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteDatabase:
+    def test_delete_both_when_present(self, initialized_dbs):
+        result = _invoke(initialized_dbs, "delete-database", "--which=both")
+        assert result.exit_code == 0, result.output
+        assert not initialized_dbs["jobs"].exists()
+        assert not initialized_dbs["cache"].exists()
+
+    def test_delete_only_jobs(self, initialized_dbs):
+        result = _invoke(initialized_dbs, "delete-database", "--which=jobs")
+        assert result.exit_code == 0, result.output
+        assert not initialized_dbs["jobs"].exists()
+        assert initialized_dbs["cache"].exists()
+
+    def test_delete_when_absent(self, db_paths):
+        result = _invoke(db_paths, "delete-database", "--which=both")
+        assert result.exit_code == 0, result.output
+        assert "No databases found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# help
+# ---------------------------------------------------------------------------
+
+
+class TestDbHelp:
+    def test_group_help_lists_subcommands(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["db", "--help"])
+        assert result.exit_code == 0
+        for sub in ("stats", "prune", "vacuum", "clean"):
+            assert sub in result.output

--- a/tests/cli/test_docker_command.py
+++ b/tests/cli/test_docker_command.py
@@ -1,0 +1,828 @@
+"""Tests for ``clm.cli.commands.docker``.
+
+Exercises helper functions (project root lookup, cache args, login
+check, image-exists) and the four click subcommands (build,
+build-quick, push, pull, list, cache-info) via ``CliRunner`` with
+``subprocess.run`` mocked so we never actually touch ``docker``.
+"""
+
+from __future__ import annotations
+
+import json as json_module
+import subprocess
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from clm.cli.commands import docker as docker_cmd
+from clm.cli.commands.docker import (
+    AVAILABLE_SERVICES,
+    CACHE_DIR_NAME,
+    HUB_NAMESPACE,
+    REGISTRY,
+    SERVICE_NAME_MAP,
+    build_notebook,
+    build_notebook_variant,
+    build_service,
+    check_docker_login,
+    docker_build,
+    docker_build_quick,
+    docker_cache_info,
+    docker_list,
+    docker_pull,
+    docker_push,
+    ensure_cache_dir,
+    get_cache_args,
+    get_cache_dir,
+    get_project_root,
+    get_version,
+    image_exists_locally,
+    pull_service,
+    push_service,
+)
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_project_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a temp directory that looks like a project root.
+
+    Contains a ``docker/`` directory with one subdirectory per service
+    (each with a ``Dockerfile``) and a ``pyproject.toml`` marker file.
+    """
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='clm'\n", encoding="utf-8")
+    docker_dir = tmp_path / "docker"
+    docker_dir.mkdir()
+    for service in AVAILABLE_SERVICES:
+        svc_dir = docker_dir / service
+        svc_dir.mkdir()
+        (svc_dir / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def mock_run_docker() -> MagicMock:
+    """Patch ``run_docker_command`` to a mock returning a successful CompletedProcess."""
+    with patch.object(docker_cmd, "run_docker_command") as mock:
+        mock.return_value = subprocess.CompletedProcess([], 0, "", "")
+        yield mock
+
+
+@pytest.fixture
+def captured_console() -> StringIO:
+    """Redirect docker.py's module-level Rich console to a StringIO buffer.
+
+    docker.py binds ``console = Console(file=sys.stderr)`` at import time, so
+    CliRunner's stream isolation does not capture its output. We swap the
+    console for one writing to an in-memory buffer for the duration of
+    each test, and hand the buffer to the test so it can assert on the
+    text that docker.py emitted.
+    """
+    buf = StringIO()
+    fake = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    with patch.object(docker_cmd, "console", fake):
+        yield buf
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersion:
+    def test_returns_clm_version(self) -> None:
+        from clm import __version__
+
+        assert get_version() == __version__
+
+
+class TestGetProjectRoot:
+    def test_returns_root_when_markers_present(self, fake_project_root: Path) -> None:
+        assert get_project_root() == fake_project_root
+
+    def test_returns_root_from_nested_directory(
+        self, fake_project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nested = fake_project_root / "docker" / "plantuml"
+        monkeypatch.chdir(nested)
+        # Should walk up and find the root.
+        assert get_project_root() == fake_project_root
+
+    def test_returns_none_when_no_markers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.chdir(empty)
+        # Walk up eventually hits a drive root that has no docker/
+        # or pyproject.toml. On systems where an ancestor happens to
+        # contain those markers this would return that directory —
+        # guard against that by using an isolated tmp_path tree.
+        assert get_project_root() != empty
+
+
+class TestImageExistsLocally:
+    def test_returns_true_when_inspect_succeeds(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            assert image_exists_locally("my-image:tag") is True
+
+    def test_returns_false_when_inspect_fails(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 1, "", "not found")
+            assert image_exists_locally("missing:tag") is False
+
+
+class TestGetCacheDir:
+    def test_service_without_variant(self) -> None:
+        assert get_cache_dir("plantuml") == Path(CACHE_DIR_NAME) / "plantuml"
+
+    def test_notebook_with_variant(self) -> None:
+        assert get_cache_dir("notebook", "lite") == (Path(CACHE_DIR_NAME) / "notebook" / "lite")
+
+    def test_notebook_without_variant(self) -> None:
+        assert get_cache_dir("notebook") == Path(CACHE_DIR_NAME) / "notebook"
+
+
+class TestGetCacheArgs:
+    def test_cache_disabled_returns_empty(self) -> None:
+        cache_from, cache_to = get_cache_args("plantuml", use_cache=False)
+        assert cache_from == []
+        assert cache_to == []
+
+    def test_cache_enabled_with_existing_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / CACHE_DIR_NAME / "plantuml").mkdir(parents=True)
+
+        cache_from, cache_to = get_cache_args("plantuml", use_cache=True)
+
+        assert cache_from == [
+            "--cache-from",
+            f"type=local,src={Path(CACHE_DIR_NAME) / 'plantuml'}",
+        ]
+        assert cache_to == [
+            "--cache-to",
+            f"type=local,dest={Path(CACHE_DIR_NAME) / 'plantuml'},mode=max",
+        ]
+
+    def test_cache_enabled_without_existing_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        cache_from, cache_to = get_cache_args("plantuml", use_cache=True)
+
+        # No cache-from when directory does not exist yet
+        assert cache_from == []
+        # But still a cache-to so the first build populates it
+        assert cache_to == [
+            "--cache-to",
+            f"type=local,dest={Path(CACHE_DIR_NAME) / 'plantuml'},mode=max",
+        ]
+
+
+class TestEnsureCacheDir:
+    def test_creates_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = ensure_cache_dir("plantuml")
+        assert result.is_dir()
+        assert result == Path(CACHE_DIR_NAME) / "plantuml"
+
+    def test_creates_notebook_variant_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = ensure_cache_dir("notebook", "full")
+        assert result.is_dir()
+        assert result == Path(CACHE_DIR_NAME) / "notebook" / "full"
+
+
+# ---------------------------------------------------------------------------
+# check_docker_login
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDockerLogin:
+    def test_no_config_file_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert check_docker_login() is False
+
+    def test_malformed_json_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        docker_dir = tmp_path / ".docker"
+        docker_dir.mkdir()
+        (docker_dir / "config.json").write_text("{ invalid json", encoding="utf-8")
+
+        assert check_docker_login() is False
+
+    def test_direct_auth_entry_returns_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        docker_dir = tmp_path / ".docker"
+        docker_dir.mkdir()
+        (docker_dir / "config.json").write_text(
+            json_module.dumps({"auths": {"https://index.docker.io/v1/": {"auth": "sometoken"}}}),
+            encoding="utf-8",
+        )
+
+        assert check_docker_login() is True
+
+    def test_credstore_with_auth_entry_returns_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        docker_dir = tmp_path / ".docker"
+        docker_dir.mkdir()
+        (docker_dir / "config.json").write_text(
+            json_module.dumps(
+                {
+                    "auths": {"https://index.docker.io/v1/": {}},
+                    "credsStore": "desktop",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert check_docker_login() is True
+
+    def test_empty_config_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        docker_dir = tmp_path / ".docker"
+        docker_dir.mkdir()
+        (docker_dir / "config.json").write_text("{}", encoding="utf-8")
+
+        assert check_docker_login() is False
+
+    def test_credshelpers_alone_without_hub_entry_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        docker_dir = tmp_path / ".docker"
+        docker_dir.mkdir()
+        (docker_dir / "config.json").write_text(
+            json_module.dumps(
+                {
+                    "credsHelpers": {"other-registry.io": "helper"},
+                    "auths": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert check_docker_login() is False
+
+
+# ---------------------------------------------------------------------------
+# build_service / build_notebook_variant / build_notebook / push_service /
+# pull_service helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBuildService:
+    def test_missing_dockerfile_fails(self, fake_project_root: Path) -> None:
+        docker_path = fake_project_root / "docker" / "plantuml"
+        (docker_path / "Dockerfile").unlink()
+
+        assert build_service("plantuml", "1.0.0", docker_path) is False
+
+    def test_successful_build(self, fake_project_root: Path, mock_run_docker: MagicMock) -> None:
+        docker_path = fake_project_root / "docker" / "plantuml"
+        assert build_service("plantuml", "1.2.3", docker_path, use_cache=True) is True
+
+        # Verify docker invocation
+        cmd = mock_run_docker.call_args[0][0]
+        assert "buildx" in cmd
+        assert "build" in cmd
+        assert f"{REGISTRY}/{HUB_NAMESPACE}/clm-plantuml-converter:1.2.3" in cmd
+        assert f"{REGISTRY}/{HUB_NAMESPACE}/clm-plantuml-converter:latest" in cmd
+
+    def test_build_failure_returns_false(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+        docker_path = fake_project_root / "docker" / "plantuml"
+        assert build_service("plantuml", "1.0.0", docker_path) is False
+
+    def test_build_without_cache_skips_cache_from(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        docker_path = fake_project_root / "docker" / "plantuml"
+        assert build_service("plantuml", "1.0.0", docker_path, use_cache=False) is True
+
+        cmd = mock_run_docker.call_args[0][0]
+        assert "--cache-from" not in cmd
+
+
+class TestBuildNotebookVariant:
+    def test_lite_variant_adds_four_tags(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        docker_path = fake_project_root / "docker" / "notebook"
+        assert build_notebook_variant("lite", "1.0.0", docker_path) is True
+
+        cmd = mock_run_docker.call_args[0][0]
+        image = f"{REGISTRY}/{HUB_NAMESPACE}/clm-notebook-processor"
+        assert f"{image}:1.0.0" in cmd
+        assert f"{image}:1.0.0-lite" in cmd
+        assert f"{image}:latest" in cmd
+        assert f"{image}:lite" in cmd
+
+    def test_full_variant_adds_two_tags(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        docker_path = fake_project_root / "docker" / "notebook"
+        assert build_notebook_variant("full", "1.0.0", docker_path) is True
+
+        cmd = mock_run_docker.call_args[0][0]
+        image = f"{REGISTRY}/{HUB_NAMESPACE}/clm-notebook-processor"
+        assert f"{image}:1.0.0-full" in cmd
+        assert f"{image}:full" in cmd
+        # Lite-only tags must not appear
+        assert f"{image}:latest" not in cmd
+
+    def test_notebook_variant_failure(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+        docker_path = fake_project_root / "docker" / "notebook"
+        assert build_notebook_variant("lite", "1.0.0", docker_path) is False
+
+
+class TestBuildNotebook:
+    def test_builds_both_variants_when_none(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        docker_path = fake_project_root / "docker" / "notebook"
+        assert build_notebook(None, "1.0.0", docker_path) is True
+
+        # Two builds invoked (one for lite, one for full)
+        assert mock_run_docker.call_count == 2
+
+    def test_builds_only_requested_variant(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        docker_path = fake_project_root / "docker" / "notebook"
+        assert build_notebook("lite", "1.0.0", docker_path) is True
+
+        assert mock_run_docker.call_count == 1
+
+    def test_build_both_returns_false_if_any_fails(
+        self, fake_project_root: Path, mock_run_docker: MagicMock
+    ) -> None:
+        # First call succeeds (lite), second fails (full).
+        calls = [
+            subprocess.CompletedProcess([], 0, "", ""),
+            subprocess.CalledProcessError(1, ["docker"]),
+        ]
+
+        def side_effect(*args, **kwargs):
+            result = calls.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        mock_run_docker.side_effect = side_effect
+
+        docker_path = fake_project_root / "docker" / "notebook"
+        assert build_notebook(None, "1.0.0", docker_path) is False
+
+
+class TestPushService:
+    def test_image_not_found_fails(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 1, "", "")
+            assert push_service("plantuml-converter", "1.0.0") is False
+
+    def test_successful_push(self, mock_run_docker: MagicMock) -> None:
+        with patch("subprocess.run") as mock_inspect:
+            mock_inspect.return_value = subprocess.CompletedProcess([], 0, "", "")
+
+            assert push_service("plantuml-converter", "1.0.0") is True
+
+            # Two pushes: version and latest
+            assert mock_run_docker.call_count == 2
+            args_first = mock_run_docker.call_args_list[0][0][0]
+            args_second = mock_run_docker.call_args_list[1][0][0]
+            assert "push" in args_first
+            assert "push" in args_second
+
+    def test_push_failure(self, mock_run_docker: MagicMock) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+
+        with patch("subprocess.run") as mock_inspect:
+            mock_inspect.return_value = subprocess.CompletedProcess([], 0, "", "")
+
+            assert push_service("plantuml-converter", "1.0.0") is False
+
+
+class TestPullService:
+    def test_successful_pull(self, mock_run_docker: MagicMock) -> None:
+        assert pull_service("plantuml-converter", "latest") is True
+        mock_run_docker.assert_called_once()
+        cmd = mock_run_docker.call_args[0][0]
+        assert cmd[0] == "pull"
+
+    def test_failed_pull(self, mock_run_docker: MagicMock) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+        assert pull_service("plantuml-converter") is False
+
+
+# ---------------------------------------------------------------------------
+# Click CLI subcommands
+# ---------------------------------------------------------------------------
+
+
+class TestDockerBuildCli:
+    def test_build_all_by_default(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        result = CliRunner().invoke(docker_build, [])
+        assert result.exit_code == 0
+        # plantuml + drawio + notebook(lite+full) = 4 invocations
+        assert mock_run_docker.call_count == 4
+
+    def test_build_single_service(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        result = CliRunner().invoke(docker_build, ["plantuml"])
+        assert result.exit_code == 0
+        assert mock_run_docker.call_count == 1
+
+    def test_build_notebook_variant(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        result = CliRunner().invoke(docker_build, ["notebook:full"])
+        assert result.exit_code == 0
+        assert mock_run_docker.call_count == 1
+
+    def test_build_unknown_notebook_variant_fails(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_build, ["notebook:weird"])
+        assert result.exit_code == 1
+        assert "Unknown notebook variant" in captured_console.getvalue()
+
+    def test_build_unknown_service_fails(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        (fake_project_root / "docker" / "nosuch").mkdir()
+        result = CliRunner().invoke(docker_build, ["nosuch"])
+        assert result.exit_code == 1
+        assert "Unknown service" in captured_console.getvalue()
+
+    def test_build_service_with_variant_rejected(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_build, ["plantuml:some"])
+        assert result.exit_code == 1
+        assert "does not support variants" in captured_console.getvalue()
+
+    def test_build_missing_docker_dir_fails(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        import shutil
+
+        shutil.rmtree(fake_project_root / "docker" / "plantuml")
+        result = CliRunner().invoke(docker_build, ["plantuml"])
+        assert result.exit_code == 1
+        assert "Docker directory" in captured_console.getvalue()
+
+    def test_build_no_project_root_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        captured_console: StringIO,
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.chdir(empty)
+        monkeypatch.setattr(docker_cmd, "get_project_root", lambda: None)
+
+        result = CliRunner().invoke(docker_build, [])
+        assert result.exit_code == 1
+        assert "Could not find project root" in captured_console.getvalue()
+
+    def test_build_some_failed_exits_nonzero(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+        result = CliRunner().invoke(docker_build, ["plantuml"])
+        assert result.exit_code == 1
+        assert "Some services failed" in captured_console.getvalue()
+
+    def test_build_no_cache(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        result = CliRunner().invoke(docker_build, ["--no-cache", "plantuml"])
+        assert result.exit_code == 0
+        assert "Cache disabled" in captured_console.getvalue()
+
+
+class TestDockerBuildQuickCli:
+    def test_build_quick_all(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        result = CliRunner().invoke(docker_build_quick, [])
+        assert result.exit_code == 0
+        # plantuml + drawio + notebook:lite + notebook:full
+        assert mock_run_docker.call_count == 4
+
+    def test_build_quick_single_service(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        result = CliRunner().invoke(docker_build_quick, ["plantuml"])
+        assert result.exit_code == 0
+
+    def test_build_quick_unknown_service_fails(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_build_quick, ["nosuch"])
+        assert result.exit_code == 1
+        assert "Unknown service" in captured_console.getvalue()
+
+    def test_build_quick_notebook_requires_variant(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_build_quick, ["notebook"])
+        assert result.exit_code == 1
+        assert "requires a variant" in captured_console.getvalue()
+
+    def test_build_quick_notebook_bad_variant(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_build_quick, ["notebook:weird"])
+        assert result.exit_code == 1
+        assert "Unknown notebook variant" in captured_console.getvalue()
+
+    def test_build_quick_service_with_variant_rejected(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_build_quick, ["plantuml:something"])
+        assert result.exit_code == 1
+        assert "does not support variants" in captured_console.getvalue()
+
+    def test_build_quick_no_project_root(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        captured_console: StringIO,
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.chdir(empty)
+        monkeypatch.setattr(docker_cmd, "get_project_root", lambda: None)
+
+        result = CliRunner().invoke(docker_build_quick, ["plantuml"])
+        assert result.exit_code == 1
+        assert "Could not find project root" in captured_console.getvalue()
+
+    def test_build_quick_warns_when_cache_missing(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        """With a single service and no cache, the helper warns loudly."""
+        result = CliRunner().invoke(docker_build_quick, ["plantuml"])
+        assert result.exit_code == 0
+        assert "Warning: Local cache not found" in captured_console.getvalue()
+
+    def test_build_quick_all_failure_exits_nonzero(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+        result = CliRunner().invoke(docker_build_quick, ["plantuml"])
+        assert result.exit_code == 1
+
+
+class TestDockerCacheInfoCli:
+    def test_shows_cache_status(self, fake_project_root: Path, captured_console: StringIO) -> None:
+        with patch.object(docker_cmd, "image_exists_locally", return_value=False):
+            result = CliRunner().invoke(docker_cache_info, [])
+
+        assert result.exit_code == 0
+        output = captured_console.getvalue()
+        assert "Docker Build Cache Status" in output
+        # All services rendered
+        for svc in AVAILABLE_SERVICES:
+            assert svc in output
+
+    def test_shows_cache_and_image_present(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        # Make the cache dirs exist.
+        (fake_project_root / CACHE_DIR_NAME / "plantuml").mkdir(parents=True)
+        (fake_project_root / CACHE_DIR_NAME / "drawio").mkdir(parents=True)
+        (fake_project_root / CACHE_DIR_NAME / "notebook" / "lite").mkdir(parents=True)
+        (fake_project_root / CACHE_DIR_NAME / "notebook" / "full").mkdir(parents=True)
+
+        with patch.object(docker_cmd, "image_exists_locally", return_value=True):
+            result = CliRunner().invoke(docker_cache_info, [])
+
+        assert result.exit_code == 0
+
+
+class TestDockerPushCli:
+    def test_push_all_default(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        with (
+            patch.object(docker_cmd, "check_docker_login", return_value=True),
+            patch("subprocess.run") as mock_sub,
+        ):
+            mock_sub.return_value = subprocess.CompletedProcess([], 0, "", "")
+            result = CliRunner().invoke(docker_push, [])
+
+        assert result.exit_code == 0
+        # 3 services × 2 tags = 6 docker pushes
+        assert mock_run_docker.call_count == 6
+
+    def test_push_unknown_service_fails(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        with patch.object(docker_cmd, "check_docker_login", return_value=True):
+            result = CliRunner().invoke(docker_push, ["nosuch"])
+
+        assert result.exit_code == 1
+        assert "Unknown service" in captured_console.getvalue()
+
+    def test_push_no_project_root(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        captured_console: StringIO,
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.chdir(empty)
+        monkeypatch.setattr(docker_cmd, "get_project_root", lambda: None)
+
+        result = CliRunner().invoke(docker_push, [])
+        assert result.exit_code == 1
+        assert "Could not find project root" in captured_console.getvalue()
+
+    def test_push_declines_confirm_when_not_logged_in(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        with patch.object(docker_cmd, "check_docker_login", return_value=False):
+            # Provide 'n' to the confirm prompt.
+            result = CliRunner().invoke(docker_push, ["plantuml-converter"], input="n\n")
+
+        assert result.exit_code == 1
+        assert "Not logged in" in captured_console.getvalue()
+
+    def test_push_force_skips_login_check(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        with patch("subprocess.run") as mock_sub:
+            mock_sub.return_value = subprocess.CompletedProcess([], 0, "", "")
+            result = CliRunner().invoke(docker_push, ["--force", "plantuml-converter"])
+
+        assert result.exit_code == 0
+
+    def test_push_failure_exits_nonzero(
+        self,
+        fake_project_root: Path,
+        mock_run_docker: MagicMock,
+        captured_console: StringIO,
+    ) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+
+        with (
+            patch.object(docker_cmd, "check_docker_login", return_value=True),
+            patch("subprocess.run") as mock_sub,
+        ):
+            mock_sub.return_value = subprocess.CompletedProcess([], 0, "", "")
+            result = CliRunner().invoke(docker_push, ["plantuml-converter"])
+
+        assert result.exit_code == 1
+        assert "Some services failed" in captured_console.getvalue()
+
+
+class TestDockerPullCli:
+    def test_pull_all_default(self, mock_run_docker: MagicMock, captured_console: StringIO) -> None:
+        result = CliRunner().invoke(docker_pull, [])
+        assert result.exit_code == 0
+        # 3 services, 1 tag each = 3 pulls
+        assert mock_run_docker.call_count == 3
+
+    def test_pull_custom_tag(self, mock_run_docker: MagicMock, captured_console: StringIO) -> None:
+        result = CliRunner().invoke(docker_pull, ["--tag", "1.2.3", "plantuml-converter"])
+
+        assert result.exit_code == 0
+        cmd = mock_run_docker.call_args[0][0]
+        # The pulled image tag should contain "1.2.3"
+        assert any("1.2.3" in part for part in cmd)
+
+    def test_pull_unknown_service_fails(self, captured_console: StringIO) -> None:
+        result = CliRunner().invoke(docker_pull, ["nosuch"])
+        assert result.exit_code == 1
+        assert "Unknown service" in captured_console.getvalue()
+
+    def test_pull_failure_exits_nonzero(
+        self, mock_run_docker: MagicMock, captured_console: StringIO
+    ) -> None:
+        mock_run_docker.side_effect = subprocess.CalledProcessError(1, ["docker"])
+        result = CliRunner().invoke(docker_pull, ["plantuml-converter"])
+        assert result.exit_code == 1
+        assert "Some services failed" in captured_console.getvalue()
+
+
+class TestDockerListCli:
+    def test_list_without_project_root(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        captured_console: StringIO,
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.chdir(empty)
+        monkeypatch.setattr(docker_cmd, "get_project_root", lambda: None)
+
+        result = CliRunner().invoke(docker_list, [])
+        assert result.exit_code == 0
+        # All services still listed, without Dockerfile paths.
+        output = captured_console.getvalue()
+        for svc in AVAILABLE_SERVICES:
+            assert svc in output
+
+    def test_list_with_project_root(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        result = CliRunner().invoke(docker_list, [])
+        assert result.exit_code == 0
+        output = captured_console.getvalue()
+        for svc in AVAILABLE_SERVICES:
+            assert svc in output
+
+    def test_list_reports_missing_dockerfile(
+        self, fake_project_root: Path, captured_console: StringIO
+    ) -> None:
+        """If a service has no docker directory, list flags it red."""
+        import shutil
+
+        shutil.rmtree(fake_project_root / "docker" / "plantuml")
+
+        result = CliRunner().invoke(docker_list, [])
+
+        assert result.exit_code == 0
+        assert "Not found" in captured_console.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Constants sanity
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_service_name_map_covers_all_services(self) -> None:
+        for svc in AVAILABLE_SERVICES:
+            assert svc in SERVICE_NAME_MAP

--- a/tests/cli/test_jupyterlite_command.py
+++ b/tests/cli/test_jupyterlite_command.py
@@ -1,0 +1,281 @@
+"""Tests for the ``clm jupyterlite`` CLI command group."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import jupyterlite as jupyterlite_module
+from clm.cli.commands.jupyterlite import _find_site_dirs, jupyterlite_group
+
+
+def _make_output_target(name: str, output_root: Path, formats: list[str]):
+    """Build a MagicMock that quacks like OutputTarget for the command."""
+    target = MagicMock()
+    target.name = name
+    target.output_root = output_root
+    target.formats = formats
+    return target
+
+
+class TestFindSiteDirs:
+    def test_returns_empty_when_no_jupyterlite_output(self, tmp_path: Path):
+        result = _find_site_dirs(tmp_path, kind=None, language=None)
+        assert result == []
+
+    def test_finds_site_with_index_html(self, tmp_path: Path):
+        site = tmp_path / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        site.mkdir(parents=True)
+        (site / "index.html").write_text("<html></html>")
+
+        result = _find_site_dirs(tmp_path, kind=None, language=None)
+
+        assert len(result) == 1
+        assert result[0] == site
+
+    def test_skips_site_without_index_html(self, tmp_path: Path):
+        site = tmp_path / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        site.mkdir(parents=True)
+        # No index.html — should be skipped.
+
+        result = _find_site_dirs(tmp_path, kind=None, language=None)
+        assert result == []
+
+    def test_sorted_by_mtime_newest_first(self, tmp_path: Path):
+        site_old = tmp_path / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        site_new = tmp_path / "course-de" / "Slides" / "JupyterLite" / "CodeAlong" / "_output"
+        for site in (site_old, site_new):
+            site.mkdir(parents=True)
+            (site / "index.html").write_text("x")
+
+        # Make site_new newer by touching.
+        older = time.time() - 100
+        os.utime(site_old, (older, older))
+
+        result = _find_site_dirs(tmp_path, kind=None, language=None)
+        assert result[0] == site_new
+
+    def test_language_filter_falls_back_when_no_match(self, tmp_path: Path):
+        # The language filter only narrows results when at least one path
+        # contains the /{lang}/ segment. When no path matches, it falls
+        # back to returning all results.
+        de = tmp_path / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        de.mkdir(parents=True)
+        (de / "index.html").write_text("x")
+
+        result = _find_site_dirs(tmp_path, kind=None, language="zh")
+        # "zh" doesn't appear in the path, so fall back to unfiltered list.
+        assert len(result) == 1
+        assert result[0] == de
+
+    def test_language_filter_matches_posix_segment(self, tmp_path: Path):
+        # When paths contain /de/ as an actual path segment, the filter matches.
+        de_site = tmp_path / "out" / "de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        en_site = tmp_path / "out" / "en" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        for site in (de_site, en_site):
+            site.mkdir(parents=True)
+            (site / "index.html").write_text("x")
+
+        result = _find_site_dirs(tmp_path, kind=None, language="de")
+        assert len(result) == 1
+        assert result[0] == de_site
+
+
+def _patch_course(monkeypatch, targets):
+    """Patch CourseSpec.from_file and Course.from_spec to return a course with the
+    given output targets."""
+    fake_spec = MagicMock()
+    fake_course = MagicMock()
+    fake_course.output_targets = targets
+
+    fake_course_spec_module = MagicMock()
+    fake_course_spec_module.CourseSpec.from_file = MagicMock(return_value=fake_spec)
+
+    fake_course_module = MagicMock()
+    fake_course_module.Course.from_spec = MagicMock(return_value=fake_course)
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "clm.core.course", fake_course_module)
+    monkeypatch.setitem(sys.modules, "clm.core.course_spec", fake_course_spec_module)
+
+
+class TestPreviewCommand:
+    def test_group_help(self):
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["--help"])
+        assert result.exit_code == 0
+
+    def test_preview_help(self):
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", "--help"])
+        assert result.exit_code == 0
+        assert "--target" in result.output
+
+    def test_unknown_target_errors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        output_root.mkdir()
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["jupyterlite"])],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            jupyterlite_group, ["preview", str(spec_file), "--target", "nonexistent"]
+        )
+
+        assert result.exit_code != 0
+        assert "No target named" in result.output
+        # The error lists available targets.
+        assert "public" in result.output
+
+    def test_target_without_jupyterlite_format_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        output_root.mkdir()
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["html"])],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", str(spec_file), "--target", "public"])
+
+        assert result.exit_code != 0
+        assert "does not include 'jupyterlite'" in result.output
+
+    def test_no_built_site_errors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        output_root.mkdir()
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["jupyterlite"])],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", str(spec_file), "--target", "public"])
+
+        assert result.exit_code != 0
+        assert "No built JupyterLite site" in result.output
+
+    def test_multiple_sites_require_narrowing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        # Create two sites that both have index.html.
+        completed = output_root / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        codealong = output_root / "course-de" / "Slides" / "JupyterLite" / "CodeAlong" / "_output"
+        for site in (completed, codealong):
+            site.mkdir(parents=True)
+            (site / "index.html").write_text("x")
+
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["jupyterlite"])],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", str(spec_file), "--target", "public"])
+
+        assert result.exit_code != 0
+        assert "Multiple sites found" in result.output
+        assert "Specify --kind" in result.output
+
+    def test_invokes_launch_py_when_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        site = output_root / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        site.mkdir(parents=True)
+        (site / "index.html").write_text("x")
+        (site.parent / "launch.py").write_text("print('hi')")
+
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["jupyterlite"])],
+        )
+
+        fake_run = MagicMock()
+        monkeypatch.setattr(jupyterlite_module.subprocess, "run", fake_run)
+
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", str(spec_file), "--target", "public"])
+
+        assert result.exit_code == 0, result.output
+        fake_run.assert_called_once()
+        args = fake_run.call_args.args[0]
+        assert args[1] == str(site.parent / "launch.py")
+        assert fake_run.call_args.kwargs["check"] is True
+
+    def test_falls_back_to_miniserve_launchers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        site = output_root / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        site.mkdir(parents=True)
+        (site / "index.html").write_text("x")
+        # No launch.py, but a launch.bat and launch.sh.
+        (site.parent / "launch.bat").write_text("echo windows")
+        (site.parent / "launch.sh").write_text("echo linux")
+
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["jupyterlite"])],
+        )
+
+        fake_run = MagicMock()
+        monkeypatch.setattr(jupyterlite_module.subprocess, "run", fake_run)
+
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", str(spec_file), "--target", "public"])
+
+        assert result.exit_code == 0, result.output
+        assert "miniserve launcher" in result.output
+        assert "launch.bat" in result.output
+        assert "launch.sh" in result.output
+        # Miniserve launcher mode does not shell out.
+        fake_run.assert_not_called()
+
+    def test_no_launcher_errors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text("<course/>")
+
+        output_root = tmp_path / "output"
+        site = output_root / "course-de" / "Slides" / "JupyterLite" / "Completed" / "_output"
+        site.mkdir(parents=True)
+        (site / "index.html").write_text("x")
+        # No launch.py, no launchers.
+
+        _patch_course(
+            monkeypatch,
+            targets=[_make_output_target("public", output_root, ["jupyterlite"])],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(jupyterlite_group, ["preview", str(spec_file), "--target", "public"])
+
+        assert result.exit_code != 0
+        assert "No launcher found" in result.output

--- a/tests/cli/test_monitor_app.py
+++ b/tests/cli/test_monitor_app.py
@@ -1,0 +1,819 @@
+"""Tests for the Monitor TUI CLMMonitorApp and its widgets.
+
+These tests exercise the application end-to-end through Textual's
+``run_test`` pilot harness as well as the individual widget rendering
+routines.  They also document three currently-broken behaviors via
+``xfail`` markers so regressions in a future fix can be detected:
+
+    * Bug #1  Stale "Started" entries and ``(?)`` durations in the
+              activity log (duration truncation + no cleanup of old
+              processing rows).
+    * Bug #2  The status-header area is empty after a build — it
+              should show the course spec currently being processed.
+    * Bug #3  Panel scrolling lags behind the mouse because every
+              refresh rebuilds the worker/queue panels from scratch.
+
+The bug descriptions in each ``xfail`` reason give future-you a
+one-line starting point when tackling the fix.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from clm.cli.monitor.data_provider import ActivityEvent, DataProvider
+from clm.cli.monitor.widgets.activity_panel import ActivityPanel
+from clm.cli.monitor.widgets.queue_panel import QueuePanel
+from clm.cli.monitor.widgets.status_header import StatusHeader
+from clm.cli.monitor.widgets.workers_panel import WorkersPanel
+from clm.cli.status.models import (
+    BusyWorkerInfo,
+    DatabaseInfo,
+    QueueStats,
+    StatusInfo,
+    SystemHealth,
+    WorkerTypeStats,
+)
+from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.database.schema import init_database
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jobs_db(tmp_path: Path) -> Path:
+    """Initialize an empty jobs DB for tests."""
+    db = tmp_path / "jobs.db"
+    init_database(db)
+    return db
+
+
+def _status(
+    *,
+    health: SystemHealth = SystemHealth.HEALTHY,
+    workers: dict[str, WorkerTypeStats] | None = None,
+    queue: QueueStats | None = None,
+) -> StatusInfo:
+    return StatusInfo(
+        timestamp=datetime(2026, 4, 17, 21, 0, 0),
+        health=health,
+        database=DatabaseInfo(path="/tmp/x.db", accessible=True, exists=True, size_bytes=0),
+        workers=workers or {},
+        queue=queue
+        or QueueStats(pending=0, processing=0, completed_last_hour=0, failed_last_hour=0),
+    )
+
+
+def _event(
+    event_type: str,
+    *,
+    job_id: str = "1",
+    document_path: str = "topic_x/slides.py",
+    duration_seconds: int | None = None,
+    timestamp: datetime | None = None,
+    error_message: str | None = None,
+) -> ActivityEvent:
+    return ActivityEvent(
+        timestamp=timestamp or datetime(2026, 4, 17, 21, 0, 0),
+        event_type=event_type,
+        job_id=job_id,
+        document_path=document_path,
+        duration_seconds=duration_seconds,
+        error_message=error_message,
+    )
+
+
+def _rendered_activity_text(panel: ActivityPanel) -> str:
+    """Return the plain-text content of the activity panel's RichLog.
+
+    The RichLog's ``lines`` are Strip objects; ``Strip.text`` gives the
+    user-visible text without style markup.
+    """
+    from textual.widgets import RichLog
+
+    log = panel.query_one("#activity-log", RichLog)
+    return "\n".join(line.text for line in log.lines)
+
+
+def _rendered_mounted_children_text(panel, content_id: str) -> str:
+    """Concatenate the rendered text of every child Static in a scroll pane.
+
+    Workers and queue panels dynamically mount Static widgets carrying
+    Rich-markup strings; render them and strip markup by going through
+    ``rich.text.Text.from_markup``.
+    """
+    from rich.text import Text as RichText
+    from textual.containers import VerticalScroll
+
+    content = panel.query_one(f"#{content_id}", VerticalScroll)
+    parts: list[str] = []
+    for child in content.children:
+        rendered = child.render()
+        if isinstance(rendered, str):
+            parts.append(RichText.from_markup(rendered).plain)
+        else:
+            parts.append(str(rendered))
+    return " ".join(parts)
+
+
+def _rendered_workers_text(panel: WorkersPanel) -> str:
+    return _rendered_mounted_children_text(panel, "workers-content")
+
+
+def _rendered_queue_text(panel: QueuePanel) -> str:
+    return _rendered_mounted_children_text(panel, "queue-content")
+
+
+# ---------------------------------------------------------------------------
+# DataProvider: duration precision bug
+# ---------------------------------------------------------------------------
+
+
+class TestDataProviderEventDuration:
+    """Cover the duration field on events returned by get_recent_events."""
+
+    def _seed_completed_job(
+        self,
+        db_path: Path,
+        *,
+        started_at: str,
+        completed_at: str,
+    ) -> int:
+        with JobQueue(db_path) as jq:
+            job_id = jq.add_job(
+                job_type="notebook",
+                input_file="topic_x/slides.py",
+                output_file="out/x.ipynb",
+                content_hash="hash",
+                payload={},
+            )
+            conn = jq._get_conn()
+            conn.execute(
+                """
+                UPDATE jobs
+                SET status='completed', started_at=?, completed_at=?
+                WHERE id=?
+                """,
+                (started_at, completed_at, job_id),
+            )
+            conn.commit()
+        return job_id
+
+    def test_multi_second_duration_is_reported(self, jobs_db: Path) -> None:
+        """Completed jobs with a multi-second gap produce a non-zero duration."""
+        self._seed_completed_job(
+            jobs_db,
+            started_at="2026-04-17 21:00:00",
+            completed_at="2026-04-17 21:00:10",
+        )
+        provider = DataProvider(db_path=jobs_db)
+        events = provider.get_recent_events(limit=5)
+        provider.close()
+
+        completed = [e for e in events if e.event_type == "job_completed"]
+        assert len(completed) == 1
+        assert completed[0].duration_seconds is not None
+        assert completed[0].duration_seconds >= 9  # allow 1s julianday slack
+
+    @pytest.mark.xfail(
+        reason=(
+            "Monitor bug #1: julianday() subtraction in get_recent_events loses "
+            "precision (1s → 0.9999945s → CAST(.. AS INTEGER) = 0), so sub-2s "
+            "jobs report duration=0 which the activity panel renders as '(?)'. "
+            "Fix: round or use the ROUND() SQL function, or read duration_ms "
+            "from a stored column."
+        ),
+        strict=True,
+    )
+    def test_one_second_duration_should_not_report_zero(self, jobs_db: Path) -> None:
+        """A completed job with a 1-second gap should not report 0 duration."""
+        self._seed_completed_job(
+            jobs_db,
+            started_at="2026-04-17 21:00:00",
+            completed_at="2026-04-17 21:00:01",
+        )
+        provider = DataProvider(db_path=jobs_db)
+        events = provider.get_recent_events(limit=5)
+        provider.close()
+
+        completed = [e for e in events if e.event_type == "job_completed"]
+        assert len(completed) == 1
+        # Expected: ~1. Actual due to bug: 0.
+        assert completed[0].duration_seconds is not None
+        assert completed[0].duration_seconds >= 1
+
+
+# ---------------------------------------------------------------------------
+# ActivityPanel: stale "Started" entries and duration rendering
+# ---------------------------------------------------------------------------
+
+
+class TestActivityPanelUnit:
+    """Directly call ActivityPanel helpers on real widget instances."""
+
+    def test_event_key_differs_by_event_type(self) -> None:
+        started = _event("job_started", job_id="42")
+        completed = _event("job_completed", job_id="42", duration_seconds=5)
+        assert ActivityPanel._event_key(started) != ActivityPanel._event_key(completed)
+
+    def test_format_error_plain_string(self) -> None:
+        panel = ActivityPanel(id="ap")
+        formatted = panel._format_error("boom")
+        assert "boom" in formatted
+
+    def test_format_error_truncated(self) -> None:
+        panel = ActivityPanel(id="ap")
+        formatted = panel._format_error("x" * 200)
+        assert formatted.endswith("...")
+
+    def test_format_error_categorized_json(self) -> None:
+        panel = ActivityPanel(id="ap")
+        msg = (
+            '{"error_type": "user", "category": "syntax", '
+            '"error_message": "Unexpected EOF", '
+            '"actionable_guidance": "Add a closing brace", '
+            '"details": {"cell_number": 3}}'
+        )
+        formatted = panel._format_error(msg)
+        assert "User" in formatted or "user" in formatted
+        assert "syntax" in formatted
+        assert "Unexpected EOF" in formatted
+        assert "Cell #3" in formatted
+
+    def test_format_error_none_returns_unknown(self) -> None:
+        panel = ActivityPanel(id="ap")
+        assert "unknown" in panel._format_error(None)
+
+    def test_format_error_json_without_categorization(self) -> None:
+        panel = ActivityPanel(id="ap")
+        msg = '{"error_message": "Something went wrong"}'
+        formatted = panel._format_error(msg)
+        assert "Something went wrong" in formatted
+
+
+class TestActivityPanelViaPilot:
+    """Drive ActivityPanel through a real Textual App using run_test()."""
+
+    async def test_completed_event_renders_duration(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            events = [
+                _event("job_completed", job_id="1", duration_seconds=42),
+            ]
+            panel.update_events(events)
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            assert "Completed" in rendered
+            assert "00:42" in rendered
+
+    async def test_empty_events_shows_placeholder(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            panel.update_events([])
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            assert "No recent activity" in rendered
+
+    async def test_duplicate_events_not_double_written(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            event = _event("job_completed", job_id="1", duration_seconds=5)
+            panel.update_events([event])
+            panel.update_events([event])
+            panel.update_events([event])
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            assert rendered.count("Completed") == 1
+
+    async def test_full_refresh_clears_seen_keys(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            event = _event("job_completed", job_id="1", duration_seconds=5)
+            panel.update_events([event])
+            # Full refresh should redraw the same event rather than skip it
+            panel.full_refresh_events([event])
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            # After clear + repopulate there is exactly one line.
+            assert rendered.count("Completed") == 1
+
+    @pytest.mark.xfail(
+        reason=(
+            "Monitor bug #1 (presentation half): events with "
+            "duration_seconds=0 render '(?)' because the widget tests "
+            "`if event.duration_seconds` — this is the downstream side of "
+            "the julianday precision loss and also fires for legitimately "
+            "instantaneous jobs (cached skips). Fix: render '00:00' when "
+            "duration_seconds is 0, reserve '?' only for None."
+        ),
+        strict=True,
+    )
+    async def test_zero_duration_renders_as_instant_not_question_mark(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            panel.update_events([_event("job_completed", job_id="1", duration_seconds=0)])
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            # Expected: shows a real duration like 00:00. Actual: shows '?'.
+            assert "(?)" not in rendered
+            assert "00:00" in rendered
+
+    @pytest.mark.xfail(
+        reason=(
+            "Monitor bug #1 (stale Started lines): once a job emits its "
+            "'job_started' line, the widget keeps that line forever even "
+            "after the job reaches 'job_completed'. With many fast jobs "
+            "the panel fills with ghost 'Started' entries that never get "
+            "replaced. Fix: when a job_completed/failed arrives, remove "
+            "the matching job_started line from the log, or coalesce both "
+            "into a single entry."
+        ),
+        strict=True,
+    )
+    async def test_completing_a_job_removes_its_started_entry(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            # First poll: saw the job as started.
+            panel.update_events([_event("job_started", job_id="42", document_path="a.py")])
+            # Second poll: same job is now completed.
+            panel.update_events(
+                [
+                    _event(
+                        "job_completed",
+                        job_id="42",
+                        document_path="a.py",
+                        duration_seconds=3,
+                    )
+                ]
+            )
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            # Expected: no stale 'Started' line remains.
+            assert "Started" not in rendered
+            assert "Completed" in rendered
+
+
+# ---------------------------------------------------------------------------
+# StatusHeader: empty title bug
+# ---------------------------------------------------------------------------
+
+
+class TestStatusHeaderEmptyTitleBug:
+    """The header area remains empty after a build completes."""
+
+    def test_loading_state_has_placeholder_text(self) -> None:
+        header = StatusHeader(id="h")
+        # Initial render: even before data arrives the header should have
+        # some placeholder text.
+        rendered = header._render_content()
+        assert rendered.plain.strip() != ""
+
+    def test_idle_state_shows_no_activity(self) -> None:
+        header = StatusHeader(id="h")
+        header.status = _status()
+        rendered = header._render_content().plain
+        assert "No activity" in rendered or "done" in rendered
+
+    @pytest.mark.xfail(
+        reason=(
+            "Monitor bug #2: the header does not surface the course spec "
+            "that is currently being processed, so during a large build "
+            "the big top panel is visually empty / uninformative. Fix: "
+            "track the active course spec in the data_provider (either "
+            "via a dedicated table, an env stamp, or the most-frequent "
+            "spec among processing jobs) and render it here."
+        ),
+        strict=True,
+    )
+    def test_header_shows_current_course_spec(self) -> None:
+        header = StatusHeader(id="h")
+        # Hypothetical future field — not present yet.
+        status = _status(
+            queue=QueueStats(pending=0, processing=2, completed_last_hour=100, failed_last_hour=0)
+        )
+        # Attach ad-hoc attribute for forward-compat: the real fix would
+        # add current_course_spec to StatusInfo and _render_content would
+        # use it.
+        setattr(status, "current_course_spec", "python-best-practice.xml")
+        header.status = status
+        rendered = header._render_content().plain
+        assert "python-best-practice" in rendered
+
+
+class TestStatusHeaderRenderBranches:
+    """Exercise the remaining render branches for coverage."""
+
+    def test_warning_health_renders_warning_icon(self) -> None:
+        header = StatusHeader(id="h")
+        header.status = _status(health=SystemHealth.WARNING)
+        plain = header._render_content().plain
+        assert "Warning" in plain
+
+    def test_error_health_renders_error_icon(self) -> None:
+        header = StatusHeader(id="h")
+        header.status = _status(health=SystemHealth.ERROR)
+        plain = header._render_content().plain
+        assert "Error" in plain
+
+    def test_queue_with_processing_and_pending(self) -> None:
+        header = StatusHeader(id="h")
+        header.status = _status(
+            queue=QueueStats(pending=3, processing=1, completed_last_hour=0, failed_last_hour=0)
+        )
+        plain = header._render_content().plain
+        assert "1 processing" in plain
+        assert "3 pending" in plain
+
+    def test_queue_with_failures(self) -> None:
+        header = StatusHeader(id="h")
+        header.status = _status(
+            queue=QueueStats(pending=0, processing=0, completed_last_hour=10, failed_last_hour=2)
+        )
+        plain = header._render_content().plain
+        assert "10 done" in plain
+        assert "2 failed" in plain
+
+
+# ---------------------------------------------------------------------------
+# WorkersPanel rendering via pilot
+# ---------------------------------------------------------------------------
+
+
+class TestWorkersPanelPilot:
+    async def test_no_workers_registered_placeholder(self) -> None:
+        """Status with empty workers dict shows the registration warning."""
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield WorkersPanel(id="workers-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(WorkersPanel)
+            panel.update_status(_status())
+            await pilot.pause()
+            text = _rendered_workers_text(panel)
+            assert "No workers registered" in text
+
+    async def test_zero_worker_types_show_not_started_messages(self) -> None:
+        """When a worker type has total=0, show 'No workers started'."""
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield WorkersPanel(id="workers-panel", classes="panel")
+
+        workers = {
+            "notebook": WorkerTypeStats(
+                worker_type="notebook",
+                execution_mode=None,
+                total=0,
+                idle=0,
+                busy=0,
+                hung=0,
+                dead=0,
+                busy_workers=[],
+            ),
+        }
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(WorkersPanel)
+            panel.update_status(_status(workers=workers))
+            await pilot.pause()
+            text = _rendered_workers_text(panel)
+            assert "No workers started" in text
+
+    async def test_busy_workers_list_entries(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield WorkersPanel(id="workers-panel", classes="panel")
+
+        workers = {
+            "notebook": WorkerTypeStats(
+                worker_type="notebook",
+                execution_mode="direct",
+                total=2,
+                idle=0,
+                busy=2,
+                hung=0,
+                dead=0,
+                busy_workers=[
+                    BusyWorkerInfo(
+                        worker_id="w1",
+                        job_id="1",
+                        document_path="module/topic/slides_intro.ipynb",
+                        elapsed_seconds=30,
+                        output_format="html",
+                        kind="completed",
+                    ),
+                ],
+            ),
+        }
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(WorkersPanel)
+            panel.update_status(_status(workers=workers))
+            await pilot.pause()
+            text = _rendered_workers_text(panel)
+            assert "Notebook" in text
+            assert "2 busy" in text
+            assert "slides_intro" in text
+
+    async def test_hung_and_dead_workers_surfaced(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield WorkersPanel(id="workers-panel", classes="panel")
+
+        workers = {
+            "notebook": WorkerTypeStats(
+                worker_type="notebook",
+                execution_mode="docker",
+                total=4,
+                idle=1,
+                busy=0,
+                hung=1,
+                dead=2,
+                busy_workers=[],
+            ),
+        }
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(WorkersPanel)
+            panel.update_status(_status(workers=workers))
+            await pilot.pause()
+            text = _rendered_workers_text(panel)
+            assert "1 idle" in text
+            assert "1 hung" in text
+            assert "2 dead" in text
+
+
+class TestWorkersPanelFormatBusyWorker:
+    """Unit-test the private _format_busy_worker string builder."""
+
+    def test_windows_path_strips_to_filename(self) -> None:
+        panel = WorkersPanel(id="wp")
+        worker = BusyWorkerInfo(
+            worker_id="w1",
+            job_id="1",
+            document_path=r"C:\repo\topic\slides.ipynb",
+            elapsed_seconds=10,
+        )
+        text = panel._format_busy_worker(worker, "direct")
+        assert "slides" in text
+        assert "topic" not in text  # only filename remains
+
+    def test_long_document_name_truncated(self) -> None:
+        panel = WorkersPanel(id="wp")
+        worker = BusyWorkerInfo(
+            worker_id="w1",
+            job_id="1",
+            document_path="x" * 80 + ".ipynb",
+            elapsed_seconds=5,
+        )
+        text = panel._format_busy_worker(worker, "direct")
+        assert "..." in text
+
+    def test_format_includes_elapsed_time(self) -> None:
+        panel = WorkersPanel(id="wp")
+        worker = BusyWorkerInfo(
+            worker_id="w1",
+            job_id="1",
+            document_path="slides.py",
+            elapsed_seconds=125,
+        )
+        text = panel._format_busy_worker(worker, "direct")
+        assert "02:05" in text
+
+
+# ---------------------------------------------------------------------------
+# QueuePanel pilot tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueuePanelPilot:
+    async def test_warns_on_old_pending(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield QueuePanel(id="queue-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(QueuePanel)
+            panel.update_status(
+                _status(
+                    queue=QueueStats(
+                        pending=3,
+                        processing=0,
+                        completed_last_hour=0,
+                        failed_last_hour=0,
+                        oldest_pending_seconds=600,
+                    )
+                )
+            )
+            await pilot.pause()
+            text = _rendered_queue_text(panel)
+            assert "oldest:" in text
+            assert "3 jobs" in text
+
+    async def test_high_failure_rate_flagged(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield QueuePanel(id="queue-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(QueuePanel)
+            panel.update_status(
+                _status(
+                    queue=QueueStats(
+                        pending=0,
+                        processing=0,
+                        completed_last_hour=2,
+                        failed_last_hour=8,
+                    )
+                )
+            )
+            await pilot.pause()
+            text = _rendered_queue_text(panel)
+            assert "80.0%" in text  # 8 / 10 = 80%
+
+    async def test_empty_queue_shows_zero_stats(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield QueuePanel(id="queue-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(QueuePanel)
+            panel.update_status(_status())
+            await pilot.pause()
+            text = _rendered_queue_text(panel)
+            assert "Pending:" in text
+            assert "0 jobs" in text
+
+
+# ---------------------------------------------------------------------------
+# CLMMonitorApp: run_test() smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorAppRun:
+    async def test_app_starts_and_refreshes(
+        self, jobs_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clm.cli.monitor.app import CLMMonitorApp
+
+        app = CLMMonitorApp(db_path=jobs_db, refresh_interval=1)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # App should have mounted successfully and populated widget refs.
+            assert app.workers_panel is not None
+            assert app.queue_panel is not None
+            assert app.activity_panel is not None
+            assert app.status_header is not None
+            assert app.title == "CLM Monitor"
+            assert "1" in app.sub_title
+
+    async def test_pause_resume_toggles_paused_flag(self, jobs_db: Path) -> None:
+        from clm.cli.monitor.app import CLMMonitorApp
+
+        app = CLMMonitorApp(db_path=jobs_db, refresh_interval=2)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.paused is False
+            await pilot.press("p")
+            await pilot.pause()
+            assert app.paused is True
+            assert app.sub_title == "PAUSED"
+            await pilot.press("p")
+            await pilot.pause()
+            assert app.paused is False
+
+    async def test_pause_short_circuits_refresh(self, jobs_db: Path) -> None:
+        from clm.cli.monitor.app import CLMMonitorApp
+
+        app = CLMMonitorApp(db_path=jobs_db, refresh_interval=2)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("p")
+            await pilot.pause()
+
+            # While paused, refresh_data should be a no-op (no exception).
+            app.refresh_data()
+            app.action_refresh()
+
+    async def test_manual_refresh_runs_full_refresh_on_activity(
+        self, jobs_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clm.cli.monitor.app import CLMMonitorApp
+
+        app = CLMMonitorApp(db_path=jobs_db, refresh_interval=2)
+        full_refresh_called: list[list[ActivityEvent]] = []
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.activity_panel is not None
+            monkeypatch.setattr(
+                app.activity_panel,
+                "full_refresh_events",
+                lambda events: full_refresh_called.append(events),
+            )
+            await pilot.press("r")
+            await pilot.pause()
+            assert len(full_refresh_called) == 1
+
+    async def test_refresh_error_notifies_without_crash(
+        self, jobs_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clm.cli.monitor.app import CLMMonitorApp
+
+        app = CLMMonitorApp(db_path=jobs_db, refresh_interval=2)
+
+        def fake_get_status():
+            raise RuntimeError("db gone")
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            monkeypatch.setattr(app.data_provider, "get_status", fake_get_status)
+            # Should not raise — the exception handler inside refresh_data
+            # notifies instead.
+            app.refresh_data()
+            app.action_refresh()
+
+
+# ---------------------------------------------------------------------------
+# Scrolling sluggishness (bug #3) — documented, not tested
+# ---------------------------------------------------------------------------
+#
+# Bug #3 describes observable lag (1-2s) between the mouse and the
+# scrollbar indicator on the workers/activity panels, becoming severe
+# while refresh_data is rebuilding the workers panel every 2 seconds.
+#
+# The root cause lives in WorkersPanel._render_workers which calls
+# content_widget.remove_children() on every tick — Textual then has to
+# reconstruct the scroll layout, which interrupts ongoing mouse
+# interaction.
+#
+# A meaningful perf test would need wall-clock timing that is too
+# flaky for CI and too environment-dependent for the fast suite.
+# Tracking it in docs/claude/TODO.md (see monitor-tui-followups
+# section) instead of as a failing unit test — the fix itself is
+# "diff the WorkerTypeStats and only remount the changed lines".

--- a/tests/cli/test_monitoring_command.py
+++ b/tests/cli/test_monitoring_command.py
@@ -1,0 +1,319 @@
+"""Tests for the ``clm monitor`` and ``clm serve`` CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import monitoring as monitoring_module
+from clm.cli.commands.monitoring import monitor, serve
+
+
+class TestMonitorCommand:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(monitor, ["--help"])
+        assert result.exit_code == 0
+        assert "--refresh" in result.output
+        assert "--jobs-db-path" in result.output
+        assert "--log-file" in result.output
+
+    def test_refresh_range_validated(self):
+        runner = CliRunner()
+        # Click's IntRange validator should reject values outside [1, 10].
+        result = runner.invoke(monitor, ["--refresh", "0"])
+        assert result.exit_code != 0
+
+        result = runner.invoke(monitor, ["--refresh", "11"])
+        assert result.exit_code != 0
+
+    def test_missing_db_exits_with_code_2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # Stub CLMMonitorApp import so the try/except doesn't fail;
+        # the command should exit with code 2 before it runs.
+        fake_app_cls = MagicMock(name="CLMMonitorApp")
+        fake_module = MagicMock()
+        fake_module.CLMMonitorApp = fake_app_cls
+        monkeypatch.setitem(__import__("sys").modules, "clm.cli.monitor.app", fake_module)
+
+        missing_db = tmp_path / "does_not_exist.db"
+
+        runner = CliRunner()
+        result = runner.invoke(monitor, ["--jobs-db-path", str(missing_db)])
+
+        assert result.exit_code == 2
+        assert "not found" in result.output
+
+    def test_runs_app_when_db_exists(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_app = MagicMock()
+        fake_app_cls = MagicMock(return_value=fake_app)
+        fake_module = MagicMock()
+        fake_module.CLMMonitorApp = fake_app_cls
+        monkeypatch.setitem(__import__("sys").modules, "clm.cli.monitor.app", fake_module)
+
+        runner = CliRunner()
+        result = runner.invoke(monitor, ["--jobs-db-path", str(db_path), "--refresh", "3"])
+
+        assert result.exit_code == 0, result.output
+        fake_app_cls.assert_called_once()
+        kwargs = fake_app_cls.call_args.kwargs
+        assert kwargs["db_path"] == db_path
+        assert kwargs["refresh_interval"] == 3
+        fake_app.run.assert_called_once()
+
+    def test_auto_detects_db_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "auto_detected.db"
+        db_path.touch()
+
+        fake_app = MagicMock()
+        fake_module = MagicMock()
+        fake_module.CLMMonitorApp = MagicMock(return_value=fake_app)
+        monkeypatch.setitem(__import__("sys").modules, "clm.cli.monitor.app", fake_module)
+
+        # Patch StatusCollector so the module's .db_path lookup returns our db.
+        fake_collector_cls = MagicMock()
+        fake_collector = MagicMock()
+        fake_collector.db_path = db_path
+        fake_collector_cls.return_value = fake_collector
+        collector_module = MagicMock()
+        collector_module.StatusCollector = fake_collector_cls
+        monkeypatch.setitem(__import__("sys").modules, "clm.cli.status.collector", collector_module)
+
+        runner = CliRunner()
+        result = runner.invoke(monitor, [])
+
+        assert result.exit_code == 0, result.output
+        fake_module.CLMMonitorApp.assert_called_once()
+        assert fake_module.CLMMonitorApp.call_args.kwargs["db_path"] == db_path
+
+    def test_import_error_reports_tui_extra(self, monkeypatch: pytest.MonkeyPatch):
+        import sys
+
+        fake_module = MagicMock()
+        del fake_module.CLMMonitorApp  # Accessing it should raise AttributeError.
+
+        monkeypatch.setitem(sys.modules, "clm.cli.monitor.app", None)  # triggers ImportError
+
+        runner = CliRunner()
+        result = runner.invoke(monitor, [])
+
+        assert result.exit_code == 1
+        assert "TUI dependencies" in result.output
+
+    def test_app_run_exception_reports_and_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_app = MagicMock()
+        fake_app.run.side_effect = RuntimeError("boom")
+        fake_module = MagicMock()
+        fake_module.CLMMonitorApp = MagicMock(return_value=fake_app)
+        monkeypatch.setitem(__import__("sys").modules, "clm.cli.monitor.app", fake_module)
+
+        runner = CliRunner()
+        result = runner.invoke(monitor, ["--jobs-db-path", str(db_path)])
+
+        assert result.exit_code == 1
+        assert "Error running monitor" in result.output
+        assert "boom" in result.output
+
+    def test_log_file_option_mentioned_in_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+        log_file = tmp_path / "err.log"
+
+        fake_app = MagicMock()
+        fake_app.run.side_effect = RuntimeError("crash")
+        fake_module = MagicMock()
+        fake_module.CLMMonitorApp = MagicMock(return_value=fake_app)
+        monkeypatch.setitem(__import__("sys").modules, "clm.cli.monitor.app", fake_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            monitor,
+            ["--jobs-db-path", str(db_path), "--log-file", str(log_file)],
+        )
+
+        assert result.exit_code == 1
+        assert "See" in result.output
+        assert str(log_file) in result.output
+
+
+class TestServeCommand:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--help"])
+        assert result.exit_code == 0
+        assert "--host" in result.output
+        assert "--port" in result.output
+        assert "--no-browser" in result.output
+        assert "--cors-origin" in result.output
+
+    def test_starts_server_with_existing_db(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_uvicorn = MagicMock()
+        fake_create_app = MagicMock(return_value="fastapi_app")
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = fake_create_app
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            serve,
+            [
+                "--jobs-db-path",
+                str(db_path),
+                "--port",
+                "9001",
+                "--host",
+                "127.0.0.1",
+                "--no-browser",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        fake_create_app.assert_called_once()
+        # create_app call includes db path and cors origins.
+        kwargs = fake_create_app.call_args.kwargs
+        assert kwargs["db_path"] == db_path
+        assert kwargs["host"] == "127.0.0.1"
+        assert kwargs["port"] == 9001
+        assert kwargs["cors_origins"] is None
+        fake_uvicorn.run.assert_called_once()
+
+    def test_warns_when_db_missing_but_still_starts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        missing_db = tmp_path / "nope.db"
+
+        fake_uvicorn = MagicMock()
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--jobs-db-path", str(missing_db), "--no-browser"])
+
+        assert result.exit_code == 0, result.output
+        assert "Warning" in result.output
+        assert "not found" in result.output
+        fake_uvicorn.run.assert_called_once()
+
+    def test_cors_origin_list_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_create_app = MagicMock(return_value="app")
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = fake_create_app
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            serve,
+            [
+                "--jobs-db-path",
+                str(db_path),
+                "--no-browser",
+                "--cors-origin",
+                "https://a.example",
+                "--cors-origin",
+                "https://b.example",
+            ],
+        )
+
+        assert result.exit_code == 0
+        kwargs = fake_create_app.call_args.kwargs
+        assert kwargs["cors_origins"] == ["https://a.example", "https://b.example"]
+
+    def test_opens_browser_by_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_webbrowser = MagicMock()
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+        monkeypatch.setitem(sys.modules, "webbrowser", fake_webbrowser)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            serve,
+            ["--jobs-db-path", str(db_path), "--host", "127.0.0.1", "--port", "4242"],
+        )
+
+        assert result.exit_code == 0
+        fake_webbrowser.open.assert_called_once_with("http://127.0.0.1:4242")
+
+    def test_no_browser_skips_webbrowser(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_webbrowser = MagicMock()
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+        monkeypatch.setitem(sys.modules, "webbrowser", fake_webbrowser)
+
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--jobs-db-path", str(db_path), "--no-browser"])
+
+        assert result.exit_code == 0
+        fake_webbrowser.open.assert_not_called()
+
+    def test_uvicorn_error_reports_and_exits(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_uvicorn = MagicMock()
+        fake_uvicorn.run.side_effect = RuntimeError("port in use")
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--jobs-db-path", str(db_path), "--no-browser"])
+
+        assert result.exit_code == 1
+        assert "Error running server" in result.output
+        assert "port in use" in result.output
+
+
+def test_module_logger_name():
+    # Confirm the module exposes a logger with the expected name.
+    assert monitoring_module.logger.name == "clm.cli.commands.monitoring"

--- a/tests/cli/test_polish_command.py
+++ b/tests/cli/test_polish_command.py
@@ -1,0 +1,254 @@
+"""Tests for the ``clm polish`` CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import polish as polish_module
+from clm.cli.commands.polish import _parse_range, polish
+
+
+class TestParseRange:
+    def test_single_number(self):
+        assert _parse_range("7") == (7, 7)
+
+    def test_range_pair(self):
+        assert _parse_range("5-10") == (5, 10)
+
+    def test_range_single_digit(self):
+        assert _parse_range("1-2") == (1, 2)
+
+
+def _make_slide_group(index: int, has_notes: bool, notes_text: str = "", title: str = ""):
+    """Build a minimal SlideGroup-like object for polish tests."""
+    sg = MagicMock()
+    sg.index = index
+    sg.has_notes = has_notes
+    sg.notes_text = notes_text
+    sg.text_content = f"slide content {index}"
+    sg.title = title or f"Slide {index}"
+    return sg
+
+
+class TestPolishCommand:
+    def test_no_notes_found_early_return(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text('# %% [markdown] lang="de" tags=["slide"]\n# Hello\n')
+
+        groups = [_make_slide_group(1, has_notes=False)]
+        fake_parse_slides = MagicMock(return_value=groups)
+        fake_write_narrative = MagicMock()
+        fake_polish_text = AsyncMock(return_value="should-not-run")
+
+        monkeypatch.setattr("clm.notebooks.slide_parser.parse_slides", fake_parse_slides)
+        monkeypatch.setattr("clm.notebooks.slide_writer.write_narrative", fake_write_narrative)
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "de"])
+
+        assert result.exit_code == 0, result.output
+        assert "No notes found" in result.output
+        fake_polish_text.assert_not_called()
+        fake_write_narrative.assert_not_called()
+
+    def test_polishes_each_slide_with_notes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        groups = [
+            _make_slide_group(1, has_notes=True, notes_text="raw notes 1"),
+            _make_slide_group(2, has_notes=False),
+            _make_slide_group(3, has_notes=True, notes_text="raw notes 3"),
+        ]
+        fake_parse_slides = MagicMock(return_value=groups)
+        fake_polish_text = AsyncMock(side_effect=lambda notes, content, **_: f"polished({notes})")
+        fake_write_narrative = MagicMock(return_value=slides)
+
+        monkeypatch.setattr("clm.notebooks.slide_parser.parse_slides", fake_parse_slides)
+        monkeypatch.setattr("clm.notebooks.slide_writer.write_narrative", fake_write_narrative)
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "en"])
+
+        assert result.exit_code == 0, result.output
+        # Only slides 1 and 3 have notes; slide 2 should not have been polished.
+        polished_args = [call.args[0] for call in fake_polish_text.call_args_list]
+        assert polished_args == ["raw notes 1", "raw notes 3"]
+
+        written_map = fake_write_narrative.call_args.args[1]
+        assert written_map == {
+            1: "polished(raw notes 1)",
+            3: "polished(raw notes 3)",
+        }
+
+    def test_slides_range_filters(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        groups = [
+            _make_slide_group(i, has_notes=True, notes_text=f"notes {i}") for i in [1, 3, 5, 7]
+        ]
+        fake_polish_text = AsyncMock(side_effect=lambda notes, content, **_: notes.upper())
+        fake_write_narrative = MagicMock(return_value=slides)
+
+        monkeypatch.setattr(
+            "clm.notebooks.slide_parser.parse_slides", MagicMock(return_value=groups)
+        )
+        monkeypatch.setattr("clm.notebooks.slide_writer.write_narrative", fake_write_narrative)
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "en", "--slides-range", "3-5"])
+
+        assert result.exit_code == 0, result.output
+        # Only slides 3 and 5 fall in range.
+        polished_args = [call.args[0] for call in fake_polish_text.call_args_list]
+        assert polished_args == ["notes 3", "notes 5"]
+
+    def test_single_number_range(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        groups = [_make_slide_group(i, has_notes=True, notes_text=f"notes {i}") for i in [1, 2, 3]]
+        fake_polish_text = AsyncMock(side_effect=lambda notes, content, **_: notes.upper())
+        fake_write_narrative = MagicMock(return_value=slides)
+
+        monkeypatch.setattr(
+            "clm.notebooks.slide_parser.parse_slides", MagicMock(return_value=groups)
+        )
+        monkeypatch.setattr("clm.notebooks.slide_writer.write_narrative", fake_write_narrative)
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "en", "--slides-range", "2"])
+
+        assert result.exit_code == 0, result.output
+        polished_args = [call.args[0] for call in fake_polish_text.call_args_list]
+        assert polished_args == ["notes 2"]
+
+    def test_dry_run_skips_write(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        groups = [_make_slide_group(1, has_notes=True, notes_text="hello")]
+        fake_write_narrative = MagicMock()
+        fake_polish_text = AsyncMock(return_value="polished hello")
+
+        monkeypatch.setattr(
+            "clm.notebooks.slide_parser.parse_slides", MagicMock(return_value=groups)
+        )
+        monkeypatch.setattr("clm.notebooks.slide_writer.write_narrative", fake_write_narrative)
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "de", "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        fake_write_narrative.assert_not_called()
+        fake_polish_text.assert_awaited_once()
+
+    def test_model_option_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        groups = [_make_slide_group(1, has_notes=True, notes_text="hello")]
+        fake_polish_text = AsyncMock(return_value="polished")
+
+        monkeypatch.setattr(
+            "clm.notebooks.slide_parser.parse_slides", MagicMock(return_value=groups)
+        )
+        monkeypatch.setattr(
+            "clm.notebooks.slide_writer.write_narrative", MagicMock(return_value=slides)
+        )
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            polish,
+            [str(slides), "--lang", "de", "--model", "gpt-fake"],
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = fake_polish_text.call_args.kwargs
+        assert call_kwargs == {"model": "gpt-fake"}
+
+    def test_no_model_option_gives_empty_kwargs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        groups = [_make_slide_group(1, has_notes=True, notes_text="hello")]
+        fake_polish_text = AsyncMock(return_value="polished")
+
+        monkeypatch.setattr(
+            "clm.notebooks.slide_parser.parse_slides", MagicMock(return_value=groups)
+        )
+        monkeypatch.setattr(
+            "clm.notebooks.slide_writer.write_narrative", MagicMock(return_value=slides)
+        )
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "de"])
+
+        assert result.exit_code == 0, result.output
+        # No --model flag → polish_text called without a "model" kwarg.
+        call_kwargs = fake_polish_text.call_args.kwargs
+        assert call_kwargs == {}
+
+    def test_output_path_forwarded_to_writer(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+        output_path = tmp_path / "out.py"
+
+        groups = [_make_slide_group(1, has_notes=True, notes_text="hello")]
+        fake_write_narrative = MagicMock(return_value=output_path)
+        fake_polish_text = AsyncMock(return_value="polished")
+
+        monkeypatch.setattr(
+            "clm.notebooks.slide_parser.parse_slides", MagicMock(return_value=groups)
+        )
+        monkeypatch.setattr("clm.notebooks.slide_writer.write_narrative", fake_write_narrative)
+        monkeypatch.setattr("clm.notebooks.polish.polish_text", fake_polish_text)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            polish,
+            [str(slides), "--lang", "de", "-o", str(output_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = fake_write_narrative.call_args.kwargs
+        assert kwargs["output_path"] == output_path
+        assert kwargs["tag"] == "notes"
+
+    def test_rejects_invalid_lang(self, tmp_path: Path):
+        slides = tmp_path / "deck.py"
+        slides.write_text("placeholder")
+
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(slides), "--lang", "fr"])
+
+        assert result.exit_code != 0
+
+    def test_missing_slides_path_errors(self, tmp_path: Path):
+        runner = CliRunner()
+        result = runner.invoke(polish, [str(tmp_path / "missing.py"), "--lang", "en"])
+
+        assert result.exit_code != 0
+
+
+def test_module_exposes_logger_and_console():
+    assert polish_module.logger.name == "clm.cli.commands.polish"
+    # console is a rich.console.Console instance
+    from rich.console import Console
+
+    assert isinstance(polish_module.console, Console)

--- a/tests/cli/test_voiceover_command.py
+++ b/tests/cli/test_voiceover_command.py
@@ -1,0 +1,559 @@
+"""Tests for the ``clm voiceover`` CLI command group.
+
+These tests focus on the command layer itself (argument parsing, option
+handling, flow control). The voiceover backend implementations (Whisper,
+Cohere, Granite, OCR, LLM merge) are stubbed via ``sys.modules`` so the
+tests run fast and do not require the ``[voiceover]`` extra dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import voiceover as voiceover_module
+from clm.cli.commands.voiceover import (
+    _display_merge_summary,
+    _display_notes_summary,
+    _emit_dry_run_diff,
+    _extract_baseline,
+    _get_git_user_name,
+    _has_boundary,
+    _parse_range,
+    _polish_notes,
+    voiceover_group,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers — easy targets for unit tests.
+# ---------------------------------------------------------------------------
+
+
+class TestParseRange:
+    def test_single_number(self):
+        assert _parse_range("7") == (7, 7)
+
+    def test_pair(self):
+        assert _parse_range("5-12") == (5, 12)
+
+
+class TestExtractBaseline:
+    def _cell(self, tags: list[str], text: str):
+        cell = MagicMock()
+        cell.metadata.tags = tags
+        cell.text_content = MagicMock(return_value=text)
+        return cell
+
+    def test_extracts_tagged_cells_only(self):
+        sg = MagicMock()
+        sg.notes_cells = [
+            self._cell(["voiceover"], "voice line"),
+            self._cell(["notes"], "notes line"),
+        ]
+        assert _extract_baseline(sg, tag="voiceover") == "voice line"
+        assert _extract_baseline(sg, tag="notes") == "notes line"
+
+    def test_joins_multiple_cells_with_newlines(self):
+        sg = MagicMock()
+        sg.notes_cells = [
+            self._cell(["voiceover"], "first"),
+            self._cell(["voiceover"], "second"),
+        ]
+        assert _extract_baseline(sg, tag="voiceover") == "first\nsecond"
+
+    def test_ignores_empty_text(self):
+        sg = MagicMock()
+        sg.notes_cells = [
+            self._cell(["voiceover"], ""),
+            self._cell(["voiceover"], "actual"),
+        ]
+        assert _extract_baseline(sg, tag="voiceover") == "actual"
+
+    def test_no_matching_tag_returns_empty(self):
+        sg = MagicMock()
+        sg.notes_cells = [self._cell(["notes"], "x")]
+        assert _extract_baseline(sg, tag="voiceover") == ""
+
+
+class TestHasBoundary:
+    def test_returns_false_when_slide_not_in_alignment(self):
+        alignment = MagicMock(slide_notes={})
+        assert _has_boundary(alignment, 5) is False
+
+    def test_returns_true_when_slide_present(self):
+        alignment = MagicMock(slide_notes={5: []})
+        assert _has_boundary(alignment, 5) is True
+
+
+class TestGetGitUserName:
+    def test_returns_name_on_success(self, monkeypatch: pytest.MonkeyPatch):
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "Jane Doe\n"
+        fake_run = MagicMock(return_value=fake_result)
+        monkeypatch.setattr(voiceover_module, "__name__", voiceover_module.__name__)
+        # The helper imports subprocess locally — patch globally.
+        import subprocess
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert _get_git_user_name() == "Jane Doe"
+
+    def test_returns_none_when_git_missing(self, monkeypatch: pytest.MonkeyPatch):
+        import subprocess
+
+        def raise_fnf(*_a, **_kw):
+            raise FileNotFoundError
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        assert _get_git_user_name() is None
+
+    def test_returns_none_on_timeout(self, monkeypatch: pytest.MonkeyPatch):
+        import subprocess
+
+        def raise_timeout(*_a, **_kw):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        assert _get_git_user_name() is None
+
+    def test_returns_none_on_nonzero_exit(self, monkeypatch: pytest.MonkeyPatch):
+        import subprocess
+
+        fake_result = MagicMock(returncode=1, stdout="")
+        monkeypatch.setattr(subprocess, "run", MagicMock(return_value=fake_result))
+        assert _get_git_user_name() is None
+
+    def test_returns_none_on_empty_name(self, monkeypatch: pytest.MonkeyPatch):
+        import subprocess
+
+        fake_result = MagicMock(returncode=0, stdout="   \n")
+        monkeypatch.setattr(subprocess, "run", MagicMock(return_value=fake_result))
+        assert _get_git_user_name() is None
+
+
+class TestDisplaySummaries:
+    """Smoke tests for the display helpers — they should not raise."""
+
+    def test_display_notes_summary_empty_map(self):
+        _display_notes_summary({}, [])
+
+    def test_display_notes_summary_with_data(self):
+        sg = MagicMock()
+        sg.index = 1
+        sg.title = "Intro"
+        _display_notes_summary({1: "body"}, [sg])
+
+    def test_display_merge_summary_empty(self):
+        _display_merge_summary([], [])
+
+    def test_display_merge_summary_with_rewrites(self):
+        result = MagicMock()
+        result.slide_id = "deck/3"
+        result.merged_bullets = "merged body " * 10
+        result.rewrites = [{"original": "a", "revised": "b"}]
+        sg = MagicMock()
+        sg.index = 3
+        sg.title = "Slide 3"
+        _display_merge_summary([result], [sg])
+
+    def test_display_merge_summary_bad_slide_id(self):
+        result = MagicMock()
+        result.slide_id = "no-slash-no-number"
+        result.merged_bullets = "text"
+        result.rewrites = []
+        _display_merge_summary([result], [])
+
+
+class TestPolishNotes:
+    @pytest.mark.asyncio
+    async def test_polishes_each_slide(self, monkeypatch):
+        sg1 = MagicMock()
+        sg1.index = 1
+        sg1.text_content = "content 1"
+        sg2 = MagicMock()
+        sg2.index = 2
+        sg2.text_content = "content 2"
+
+        async def fake_polish(text, content, **_):
+            return text.upper()
+
+        fake_polish_module = MagicMock()
+        fake_polish_module.polish_text = fake_polish
+        monkeypatch.setitem(sys.modules, "clm.notebooks.polish", fake_polish_module)
+
+        notes = {1: "alpha", 2: "beta"}
+        result = await _polish_notes(notes, [sg1, sg2], lang="de")
+
+        assert result == {1: "ALPHA", 2: "BETA"}
+
+    @pytest.mark.asyncio
+    async def test_model_kwarg_forwarded(self, monkeypatch):
+        captured_kwargs: list[dict] = []
+
+        sg = MagicMock()
+        sg.index = 1
+        sg.text_content = "c"
+
+        async def fake_polish(text, content, **kwargs):
+            captured_kwargs.append(kwargs)
+            return text
+
+        fake_polish_module = MagicMock()
+        fake_polish_module.polish_text = fake_polish
+        monkeypatch.setitem(sys.modules, "clm.notebooks.polish", fake_polish_module)
+
+        await _polish_notes({1: "hello"}, [sg], model="my-model", lang="en")
+        assert captured_kwargs == [{"model": "my-model"}]
+
+
+class TestEmitDryRunDiff:
+    def test_no_change_short_circuits(self, tmp_path: Path, monkeypatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("original")
+
+        fake_writer_module = MagicMock()
+        fake_writer_module.update_narrative = MagicMock(return_value="original")
+        monkeypatch.setitem(sys.modules, "clm.notebooks.slide_writer", fake_writer_module)
+
+        # Should not raise; produces "No changes" message via console.
+        _emit_dry_run_diff(slides, {1: "x"}, "de", "voiceover", [])
+
+    def test_diff_output_and_rewrite_warning(self, tmp_path: Path, monkeypatch):
+        slides = tmp_path / "deck.py"
+        slides.write_text("line one\nline two\n")
+
+        fake_writer_module = MagicMock()
+        fake_writer_module.update_narrative = MagicMock(return_value="line one\nupdated two\n")
+        monkeypatch.setitem(sys.modules, "clm.notebooks.slide_writer", fake_writer_module)
+
+        result = MagicMock()
+        result.slide_id = "deck/1"
+        result.rewrites = [{"original": "foo", "revised": "bar"}]
+
+        # Just verify it runs without error.
+        _emit_dry_run_diff(slides, {1: "x"}, "de", "voiceover", [result])
+
+
+# ---------------------------------------------------------------------------
+# Top-level group help.
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceoverGroupHelp:
+    def test_group_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["--help"])
+        assert result.exit_code == 0
+
+    def test_sync_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["sync", "--help"])
+        assert result.exit_code == 0
+        assert "--mode" in result.output
+        assert "--overwrite" in result.output
+        assert "--whisper-model" in result.output
+
+    def test_transcribe_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["transcribe", "--help"])
+        assert result.exit_code == 0
+
+    def test_detect_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["detect", "--help"])
+        assert result.exit_code == 0
+
+    def test_identify_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["identify", "--help"])
+        assert result.exit_code == 0
+
+    def test_extract_training_data_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["extract-training-data", "--help"])
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# sync command — UsageError and mode gating.
+# ---------------------------------------------------------------------------
+
+
+class TestSyncUsageErrors:
+    def test_verbatim_without_overwrite_errors(self, tmp_path: Path):
+        slides = tmp_path / "deck.py"
+        slides.write_text("# slide")
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"fake")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync",
+                str(slides),
+                str(video),
+                "--lang",
+                "de",
+                "--mode",
+                "verbatim",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "verbatim" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# transcribe command — stub out the backend.
+# ---------------------------------------------------------------------------
+
+
+def _make_transcript(language: str = "de", duration: float = 12.5, text: str = "hello world"):
+    from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+    return Transcript(
+        language=language,
+        duration=duration,
+        segments=[TranscriptSegment(start=0.0, end=duration, text=text)],
+    )
+
+
+class TestTranscribeCommand:
+    def test_prints_json_when_no_output(self, tmp_path: Path, monkeypatch):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"fake")
+
+        fake = MagicMock(return_value=_make_transcript())
+        # transcribe_video is imported at call time from clm.voiceover.transcribe;
+        # stub the module entry.
+        fake_module = MagicMock()
+        fake_module.transcribe_video = fake
+        monkeypatch.setitem(sys.modules, "clm.voiceover.transcribe", fake_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["transcribe", str(video), "--lang", "de"],
+        )
+
+        assert result.exit_code == 0, result.output
+        fake.assert_called_once()
+        # The output contains JSON with the language field.
+        assert '"language"' in result.output
+        assert '"de"' in result.output
+
+    def test_writes_output_file(self, tmp_path: Path, monkeypatch):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"fake")
+        out_file = tmp_path / "transcript.json"
+
+        fake = MagicMock(return_value=_make_transcript(text="bonjour"))
+        fake_module = MagicMock()
+        fake_module.transcribe_video = fake
+        monkeypatch.setitem(sys.modules, "clm.voiceover.transcribe", fake_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["transcribe", str(video), "-o", str(out_file)],
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert data["language"] == "de"
+        assert data["segments"][0]["text"] == "bonjour"
+
+
+# ---------------------------------------------------------------------------
+# detect command — stub detect_transitions.
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCommand:
+    def test_prints_table_when_no_output(self, tmp_path: Path, monkeypatch):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"fake")
+
+        event = MagicMock()
+        event.timestamp = 10.0
+        event.peak_diff = 0.5
+        event.confidence = 0.9
+        fake_detect = MagicMock(return_value=([event], []))
+
+        fake_keyframes = MagicMock()
+        fake_keyframes.detect_transitions = fake_detect
+        monkeypatch.setitem(sys.modules, "clm.voiceover.keyframes", fake_keyframes)
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["detect", str(video)])
+
+        assert result.exit_code == 0, result.output
+        assert "1 transitions" in result.output
+
+    def test_writes_json_to_output_file(self, tmp_path: Path, monkeypatch):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"fake")
+        out = tmp_path / "events.json"
+
+        event = MagicMock()
+        event.timestamp = 5.0
+        event.peak_diff = 0.1
+        event.confidence = 0.8
+        fake_keyframes = MagicMock()
+        fake_keyframes.detect_transitions = MagicMock(return_value=([event], []))
+        monkeypatch.setitem(sys.modules, "clm.voiceover.keyframes", fake_keyframes)
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["detect", str(video), "-o", str(out)])
+
+        assert result.exit_code == 0
+        data = json.loads(out.read_text())
+        assert len(data) == 1
+        assert data[0]["timestamp"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# identify command.
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyCommand:
+    def test_writes_timeline_to_output(self, tmp_path: Path, monkeypatch):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"fake")
+        slides = tmp_path / "deck.py"
+        slides.write_text("# slide")
+        out = tmp_path / "timeline.json"
+
+        # Fake slide_parser module
+        slide_mock = MagicMock()
+        slide_mock.index = 1
+        slide_mock.title = "Title"
+        fake_parser = MagicMock()
+        fake_parser.parse_slides = MagicMock(return_value=[slide_mock])
+        monkeypatch.setitem(sys.modules, "clm.notebooks.slide_parser", fake_parser)
+
+        # Fake keyframes
+        fake_keyframes = MagicMock()
+        fake_keyframes.detect_transitions = MagicMock(return_value=([MagicMock()], []))
+        monkeypatch.setitem(sys.modules, "clm.voiceover.keyframes", fake_keyframes)
+
+        # Fake matcher
+        timeline_entry = MagicMock()
+        timeline_entry.slide_index = 1
+        timeline_entry.start_time = 0.0
+        timeline_entry.end_time = 10.0
+        timeline_entry.match_score = 90.0
+        match_result = MagicMock(timeline=[timeline_entry])
+        fake_matcher = MagicMock()
+        fake_matcher.match_events_to_slides = MagicMock(return_value=match_result)
+        monkeypatch.setitem(sys.modules, "clm.voiceover.matcher", fake_matcher)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["identify", str(video), str(slides), "--lang", "de", "-o", str(out)],
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert data[0]["slide_index"] == 1
+        assert data[0]["match_score"] == 90.0
+
+
+# ---------------------------------------------------------------------------
+# extract-training-data command.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTrainingDataCommand:
+    def test_no_triples_returns_zero(self, tmp_path: Path, monkeypatch):
+        trace_log = tmp_path / "trace.jsonl"
+        trace_log.write_text("")
+
+        fake_training = MagicMock()
+        fake_training.extract_training_data = MagicMock(return_value=[])
+        monkeypatch.setitem(sys.modules, "clm.voiceover.training_export", fake_training)
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["extract-training-data", str(trace_log)])
+
+        assert result.exit_code == 0, result.output
+        assert "No training triples" in result.output
+
+    def test_writes_triples_to_output(self, tmp_path: Path, monkeypatch):
+        trace_log = tmp_path / "trace.jsonl"
+        trace_log.write_text("")
+        out = tmp_path / "train.jsonl"
+
+        triple = MagicMock()
+        triple.delta_vs_llm = ""
+        triple.to_dict = MagicMock(return_value={"baseline": "a", "llm_output": "b"})
+
+        edited_triple = MagicMock()
+        edited_triple.delta_vs_llm = "diff"
+        edited_triple.to_dict = MagicMock(return_value={"baseline": "c", "llm_output": "d"})
+
+        fake_training = MagicMock()
+        fake_training.extract_training_data = MagicMock(return_value=[triple, edited_triple])
+        monkeypatch.setitem(sys.modules, "clm.voiceover.training_export", fake_training)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["extract-training-data", str(trace_log), "-o", str(out)],
+        )
+
+        assert result.exit_code == 0, result.output
+        lines = out.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["baseline"] == "a"
+        # Counts are reported.
+        assert "2 training triple" in result.output
+        assert "1 positive" in result.output
+        assert "1 with hand edits" in result.output
+
+    def test_no_output_and_no_output_file(self, tmp_path: Path, monkeypatch):
+        trace_log = tmp_path / "trace.jsonl"
+        trace_log.write_text("")
+
+        triple = MagicMock()
+        triple.delta_vs_llm = "diff"
+        triple.to_dict = MagicMock(return_value={"slide_id": "a/2"})
+
+        fake_training = MagicMock()
+        fake_training.extract_training_data = MagicMock(return_value=[triple])
+        monkeypatch.setitem(sys.modules, "clm.voiceover.training_export", fake_training)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["extract-training-data", str(trace_log), "--no-check-git", "--tag", "notes"],
+        )
+
+        assert result.exit_code == 0, result.output
+
+    def test_prints_to_stdout_when_no_output(self, tmp_path: Path, monkeypatch):
+        trace_log = tmp_path / "trace.jsonl"
+        trace_log.write_text("")
+
+        triple = MagicMock()
+        triple.delta_vs_llm = ""
+        triple.to_dict = MagicMock(return_value={"slide_id": "a/1"})
+
+        fake_training = MagicMock()
+        fake_training.extract_training_data = MagicMock(return_value=[triple])
+        monkeypatch.setitem(sys.modules, "clm.voiceover.training_export", fake_training)
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["extract-training-data", str(trace_log)])
+
+        assert result.exit_code == 0, result.output
+        assert '"slide_id": "a/1"' in result.output

--- a/tests/cli/test_zip_ops.py
+++ b/tests/cli/test_zip_ops.py
@@ -2,10 +2,19 @@
 
 import zipfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from click.testing import CliRunner
 
-from clm.cli.commands.zip_ops import zip_directory
+from clm.cli.commands import zip_ops as zip_ops_module
+from clm.cli.commands.zip_ops import (
+    OutputDirectory,
+    _archive_name,
+    find_output_directories,
+    zip_directory,
+    zip_group,
+)
 
 
 @pytest.fixture
@@ -152,3 +161,293 @@ class TestZipDirectory:
         zip_directory(sample_tree, archive)
 
         assert archive.exists()
+
+
+class TestOutputDirectory:
+    def test_display_name_combines_target_and_language(self, tmp_path: Path):
+        od = OutputDirectory(path=tmp_path, target_name="public", language="de")
+        assert od.display_name == "public/de"
+
+    def test_exists_true_when_directory_present(self, tmp_path: Path):
+        (tmp_path / "built").mkdir()
+        od = OutputDirectory(path=tmp_path / "built", target_name="x", language="en")
+        assert od.exists is True
+
+    def test_exists_false_when_missing(self, tmp_path: Path):
+        od = OutputDirectory(path=tmp_path / "never_created", target_name="x", language="en")
+        assert od.exists is False
+
+    def test_exists_false_when_path_is_file(self, tmp_path: Path):
+        file_path = tmp_path / "a_file.txt"
+        file_path.write_text("not a dir")
+        od = OutputDirectory(path=file_path, target_name="x", language="en")
+        assert od.exists is False
+
+
+class TestArchiveName:
+    def test_archive_name_format(self, tmp_path: Path):
+        od = OutputDirectory(
+            path=tmp_path / "my-course-de",
+            target_name="public",
+            language="de",
+        )
+        assert _archive_name(od) == "my-course-de_public_de.zip"
+
+
+def _make_spec(output_targets=None):
+    """Build a MagicMock that quacks like a CourseSpec."""
+    spec = MagicMock()
+    spec.output_targets = output_targets or []
+    spec.output_dir_name = {"de": "course-de", "en": "course-en"}
+    return spec
+
+
+class TestFindOutputDirectoriesWithTargets:
+    def test_returns_entry_per_target_and_language(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        target_a = MagicMock(name="public", path="out/public", languages=["de", "en"])
+        target_a.name = "public"
+        target_b = MagicMock(name="speaker", path="out/speaker", languages=["de"])
+        target_b.name = "speaker"
+        spec = _make_spec(output_targets=[target_a, target_b])
+
+        monkeypatch.setattr(zip_ops_module.CourseSpec, "from_file", lambda _: spec)
+        monkeypatch.setattr(
+            zip_ops_module,
+            "resolve_course_paths",
+            lambda _: (tmp_path, tmp_path / "output"),
+        )
+
+        result = find_output_directories(tmp_path / "spec.xml")
+
+        names = {(d.target_name, d.language) for d in result}
+        assert names == {
+            ("public", "de"),
+            ("public", "en"),
+            ("speaker", "de"),
+        }
+
+    def test_target_filter_narrows_results(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        target_a = MagicMock(path="out/public", languages=["de"])
+        target_a.name = "public"
+        target_b = MagicMock(path="out/speaker", languages=["de"])
+        target_b.name = "speaker"
+        spec = _make_spec(output_targets=[target_a, target_b])
+
+        monkeypatch.setattr(zip_ops_module.CourseSpec, "from_file", lambda _: spec)
+        monkeypatch.setattr(
+            zip_ops_module,
+            "resolve_course_paths",
+            lambda _: (tmp_path, tmp_path / "output"),
+        )
+
+        result = find_output_directories(tmp_path / "spec.xml", target_filter="public")
+
+        assert len(result) == 1
+        assert result[0].target_name == "public"
+
+    def test_absolute_target_path_is_preserved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        absolute_path = (tmp_path / "elsewhere").resolve()
+        target = MagicMock(path=str(absolute_path), languages=["en"])
+        target.name = "public"
+        spec = _make_spec(output_targets=[target])
+
+        monkeypatch.setattr(zip_ops_module.CourseSpec, "from_file", lambda _: spec)
+        monkeypatch.setattr(
+            zip_ops_module,
+            "resolve_course_paths",
+            lambda _: (tmp_path, tmp_path / "output"),
+        )
+
+        result = find_output_directories(tmp_path / "spec.xml")
+
+        assert result[0].path == absolute_path / "course-en"
+
+    def test_default_languages_when_none_specified(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        target = MagicMock(path="out", languages=None)
+        target.name = "public"
+        spec = _make_spec(output_targets=[target])
+
+        monkeypatch.setattr(zip_ops_module.CourseSpec, "from_file", lambda _: spec)
+        monkeypatch.setattr(
+            zip_ops_module,
+            "resolve_course_paths",
+            lambda _: (tmp_path, tmp_path / "output"),
+        )
+
+        result = find_output_directories(tmp_path / "spec.xml")
+
+        assert {d.language for d in result} == {"de", "en"}
+
+
+class TestFindOutputDirectoriesNoTargets:
+    def test_falls_back_to_public_and_speaker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        spec = _make_spec(output_targets=[])
+
+        monkeypatch.setattr(zip_ops_module.CourseSpec, "from_file", lambda _: spec)
+        monkeypatch.setattr(
+            zip_ops_module,
+            "resolve_course_paths",
+            lambda _: (tmp_path, tmp_path / "output"),
+        )
+
+        result = find_output_directories(tmp_path / "spec.xml")
+
+        names = {(d.target_name, d.language) for d in result}
+        assert names == {
+            ("public", "de"),
+            ("public", "en"),
+            ("speaker", "de"),
+            ("speaker", "en"),
+        }
+
+    def test_target_filter_with_fallback_targets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        spec = _make_spec(output_targets=[])
+
+        monkeypatch.setattr(zip_ops_module.CourseSpec, "from_file", lambda _: spec)
+        monkeypatch.setattr(
+            zip_ops_module,
+            "resolve_course_paths",
+            lambda _: (tmp_path, tmp_path / "output"),
+        )
+
+        result = find_output_directories(tmp_path / "spec.xml", target_filter="speaker")
+
+        assert len(result) == 2
+        assert {d.language for d in result} == {"de", "en"}
+        assert {d.target_name for d in result} == {"speaker"}
+
+
+def _patch_find_output_directories(monkeypatch, directories):
+    monkeypatch.setattr(
+        zip_ops_module, "find_output_directories", lambda spec, target_filter=None: directories
+    )
+
+
+class TestZipGroupListCommand:
+    def test_reports_existing_and_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / "spec.xml").touch()
+        exists_dir = tmp_path / "built"
+        exists_dir.mkdir()
+
+        dirs = [
+            OutputDirectory(path=exists_dir, target_name="public", language="de"),
+            OutputDirectory(path=tmp_path / "missing", target_name="public", language="en"),
+        ]
+        _patch_find_output_directories(monkeypatch, dirs)
+
+        runner = CliRunner()
+        result = runner.invoke(zip_group, ["list", str(tmp_path / "spec.xml")])
+
+        assert result.exit_code == 0, result.output
+        assert "public/de" in result.output
+        assert "exists" in result.output
+        assert "public/en" in result.output
+        assert "not built" in result.output
+
+    def test_reports_no_directories(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / "spec.xml").touch()
+        _patch_find_output_directories(monkeypatch, [])
+
+        runner = CliRunner()
+        result = runner.invoke(zip_group, ["list", str(tmp_path / "spec.xml")])
+
+        assert result.exit_code == 0
+        assert "No output directories found" in result.output
+
+
+class TestZipGroupCreateCommand:
+    def test_no_directories_early_return(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / "spec.xml").touch()
+        _patch_find_output_directories(monkeypatch, [])
+
+        runner = CliRunner()
+        result = runner.invoke(zip_group, ["create", str(tmp_path / "spec.xml")])
+
+        assert result.exit_code == 0
+        assert "No output directories found" in result.output
+
+    def test_no_existing_directories(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / "spec.xml").touch()
+        missing_dir = tmp_path / "missing"
+        dirs = [
+            OutputDirectory(path=missing_dir, target_name="public", language="de"),
+        ]
+        _patch_find_output_directories(monkeypatch, dirs)
+
+        runner = CliRunner()
+        result = runner.invoke(zip_group, ["create", str(tmp_path / "spec.xml")])
+
+        assert result.exit_code == 0
+        assert "No built output directories found" in result.output
+
+    def test_dry_run_does_not_create_archives(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        (tmp_path / "spec.xml").touch()
+        built = tmp_path / "built_de"
+        built.mkdir()
+        dirs = [OutputDirectory(path=built, target_name="public", language="de")]
+        _patch_find_output_directories(monkeypatch, dirs)
+
+        runner = CliRunner()
+        result = runner.invoke(zip_group, ["create", str(tmp_path / "spec.xml"), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "dry-run" in result.output.lower()
+        # No zip files should exist anywhere under tmp_path.
+        assert list(tmp_path.rglob("*.zip")) == []
+
+    def test_creates_archive_for_existing_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        (tmp_path / "spec.xml").touch()
+        built = tmp_path / "course-de"
+        built.mkdir()
+        (built / "content.html").write_text("<html></html>")
+
+        dirs = [OutputDirectory(path=built, target_name="public", language="de")]
+        _patch_find_output_directories(monkeypatch, dirs)
+
+        runner = CliRunner()
+        result = runner.invoke(zip_group, ["create", str(tmp_path / "spec.xml")])
+
+        assert result.exit_code == 0, result.output
+        archive_path = tmp_path / _archive_name(dirs[0])
+        assert archive_path.is_file()
+
+    def test_custom_output_dir_for_archives(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        (tmp_path / "spec.xml").touch()
+        built = tmp_path / "course-de"
+        built.mkdir()
+        (built / "content.html").write_text("<html></html>")
+        archives_root = tmp_path / "archives"
+
+        dirs = [OutputDirectory(path=built, target_name="public", language="de")]
+        _patch_find_output_directories(monkeypatch, dirs)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            zip_group,
+            [
+                "create",
+                str(tmp_path / "spec.xml"),
+                "--output-dir",
+                str(archives_root),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # Archive lands in the custom directory, not next to the source.
+        expected = archives_root / _archive_name(dirs[0])
+        assert expected.is_file()
+        assert not (built.parent / _archive_name(dirs[0])).exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1141,8 +1141,8 @@ def mock_notebook_workers(mock_worker_pool):
     Returns a list of 2 MockWorker instances already started and ready
     to process jobs.
     """
-    import time
-
     workers = mock_worker_pool.start_workers("notebook", count=2)
-    time.sleep(0.1)  # Give workers time to register
+    assert mock_worker_pool.wait_for_workers_registered(timeout=5.0), (
+        "Mock notebook workers did not register within 5s"
+    )
     return workers

--- a/tests/core/test_multi_target_course.py
+++ b/tests/core/test_multi_target_course.py
@@ -1,13 +1,25 @@
 """Integration tests for multi-target course processing."""
 
+import asyncio
 import io
 from pathlib import Path
 
 import pytest
 
 from clm.core.course import Course
-from clm.core.course_spec import CourseSpec, GitHubSpec, OutputTargetSpec
-from clm.core.output_target import ALL_KINDS, ALL_LANGUAGES, DEFAULT_FORMATS, OutputTarget
+from clm.core.course_spec import (
+    CourseSpec,
+    GitHubSpec,
+    JupyterLiteConfig,
+    OutputTargetSpec,
+)
+from clm.core.output_target import (
+    ALL_KINDS,
+    ALL_LANGUAGES,
+    DEFAULT_FORMATS,
+    OutputTarget,
+)
+from clm.core.utils.text_utils import Text
 
 
 class TestCourseFromSpecWithTargets:
@@ -446,3 +458,300 @@ class TestDirGroupMultiTarget:
         for target in course.output_targets:
             assert target.languages == frozenset({"de"})
             assert "en" not in target.languages
+
+
+class _RecordingBackend:
+    """Minimal ``Backend`` stub that records what got submitted.
+
+    ``process_jupyterlite_for_targets`` runs an outer ``TaskGroup`` that
+    contains two tasks: one submits per-``(target, language)`` jobs, the
+    other awaits ``backend.wait_for_completion(all_submitted)``. We only
+    need to drain the first; ``wait_for_completion`` just has to return
+    once the submitter sets ``all_submitted``.
+    """
+
+    def __init__(self) -> None:
+        self.operations: list[object] = []
+
+    async def wait_for_completion(self, all_submitted=None) -> bool:
+        if all_submitted is not None:
+            await all_submitted.wait()
+        return True
+
+
+class TestCountJupyterLiteOperations:
+    """Tests for ``Course.count_jupyterlite_operations``."""
+
+    @pytest.fixture
+    def course_root(self, tmp_path):
+        (tmp_path / "slides").mkdir()
+        return tmp_path
+
+    def _course_with_targets(self, course_root, targets, course_jupyterlite=None):
+        spec = CourseSpec(
+            name=Text(de="Test", en="Test"),
+            prog_lang="python",
+            description=Text(de="D", en="D"),
+            certificate=Text(de="C", en="C"),
+            sections=[],
+            github=GitHubSpec(),
+            output_targets=targets,
+            jupyterlite=course_jupyterlite,
+        )
+        return Course.from_spec(spec, course_root, output_root=None)
+
+    def test_count_zero_when_no_target_opts_in(self, course_root):
+        course = self._course_with_targets(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="students",
+                    path="./students",
+                    kinds=["code-along"],
+                    formats=["html", "notebook"],
+                ),
+            ],
+        )
+        assert course.count_jupyterlite_operations() == 0
+
+    def test_count_one_per_language_on_course_level_config(self, course_root):
+        course = self._course_with_targets(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="playground",
+                    path="./playground",
+                    kinds=["completed"],
+                    formats=["notebook", "jupyterlite"],
+                    # languages unspecified = both de + en = 2 jobs
+                ),
+            ],
+            course_jupyterlite=JupyterLiteConfig(kernel="pyodide"),
+        )
+        assert course.count_jupyterlite_operations() == 2
+
+    def test_count_sums_across_multiple_opted_in_targets(self, course_root):
+        course = self._course_with_targets(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="en-playground",
+                    path="./en",
+                    kinds=["completed"],
+                    formats=["notebook", "jupyterlite"],
+                    languages=["en"],
+                    jupyterlite=JupyterLiteConfig(kernel="pyodide"),
+                ),
+                OutputTargetSpec(
+                    name="bilingual",
+                    path="./bi",
+                    kinds=["completed"],
+                    formats=["notebook", "jupyterlite"],
+                    jupyterlite=JupyterLiteConfig(kernel="xeus-python"),
+                ),
+                OutputTargetSpec(
+                    name="not-jl",
+                    path="./n",
+                    kinds=["code-along"],
+                    formats=["html"],
+                ),
+            ],
+        )
+        # 1 (en-only) + 2 (both langs) + 0 (no jl format) = 3
+        assert course.count_jupyterlite_operations() == 3
+
+
+class TestProcessJupyterLiteForTargets:
+    """Tests for ``Course.process_jupyterlite_for_targets``.
+
+    We monkeypatch ``BuildJupyterLiteSiteOperation.execute`` so the test
+    never has to produce a real notebook tree on disk — the operation
+    otherwise ``rglob(*.ipynb)`` inside ``collect_notebook_trees``.
+    """
+
+    @pytest.fixture
+    def course_root(self, tmp_path):
+        (tmp_path / "slides").mkdir()
+        return tmp_path
+
+    @pytest.fixture
+    def captured_ops(self, monkeypatch):
+        captured: list[object] = []
+
+        async def fake_execute(self, backend, *args, **kwargs):
+            captured.append(self)
+
+        monkeypatch.setattr(
+            "clm.core.operations.build_jupyterlite_site.BuildJupyterLiteSiteOperation.execute",
+            fake_execute,
+            raising=True,
+        )
+        return captured
+
+    def _course(self, course_root, targets, course_jupyterlite=None):
+        spec = CourseSpec(
+            name=Text(de="T", en="T"),
+            prog_lang="python",
+            description=Text(de="D", en="D"),
+            certificate=Text(de="C", en="C"),
+            sections=[],
+            github=GitHubSpec(),
+            output_targets=targets,
+            jupyterlite=course_jupyterlite,
+        )
+        return Course.from_spec(spec, course_root, output_root=None)
+
+    def test_no_ops_when_no_target_opts_in(self, course_root, captured_ops):
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="students",
+                    path="./students",
+                    kinds=["code-along"],
+                    formats=["html"],
+                ),
+            ],
+        )
+        backend = _RecordingBackend()
+        asyncio.run(course.process_jupyterlite_for_targets(backend))
+        assert captured_ops == []
+
+    def test_one_op_per_target_language_pair(self, course_root, captured_ops):
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="playground",
+                    path="./playground",
+                    kinds=["completed", "code-along"],
+                    formats=["notebook", "jupyterlite"],
+                    # Both languages de + en → 2 ops
+                ),
+            ],
+            course_jupyterlite=JupyterLiteConfig(kernel="pyodide"),
+        )
+        backend = _RecordingBackend()
+        asyncio.run(course.process_jupyterlite_for_targets(backend))
+
+        assert len(captured_ops) == 2
+        languages = {op.language for op in captured_ops}  # type: ignore[attr-defined]
+        assert languages == {"de", "en"}
+        # kinds list merges all kinds from the target, sorted.
+        for op in captured_ops:
+            assert op.kinds == ["code-along", "completed"]  # type: ignore[attr-defined]
+            # notebook_trees contains one entry per kind.
+            assert set(op.notebook_trees.keys()) == {  # type: ignore[attr-defined]
+                "code-along",
+                "completed",
+            }
+            assert op.target_name == "playground"  # type: ignore[attr-defined]
+            assert op.config.kernel == "pyodide"  # type: ignore[attr-defined]
+
+    def test_target_level_config_overrides_course_level(self, course_root, captured_ops):
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="xeus-only",
+                    path="./x",
+                    kinds=["completed"],
+                    formats=["jupyterlite"],
+                    languages=["en"],
+                    jupyterlite=JupyterLiteConfig(kernel="xeus-python"),
+                ),
+            ],
+            # Course level says pyodide — target override must win.
+            course_jupyterlite=JupyterLiteConfig(kernel="pyodide"),
+        )
+        backend = _RecordingBackend()
+        asyncio.run(course.process_jupyterlite_for_targets(backend))
+
+        assert len(captured_ops) == 1
+        assert captured_ops[0].config.kernel == "xeus-python"  # type: ignore[attr-defined]
+
+    def test_missing_config_is_skipped_with_warning(self, course_root, captured_ops, caplog):
+        """Target opts into format='jupyterlite' but the runtime target has
+        no ``<jupyterlite>`` config resolved.
+
+        CourseSpec validation normally rejects this, so we bypass by
+        assembling the ``Course`` and overwriting the output target's
+        ``course_jupyterlite`` attribute manually.
+        """
+        spec = CourseSpec(
+            name=Text(de="T", en="T"),
+            prog_lang="python",
+            description=Text(de="D", en="D"),
+            certificate=Text(de="C", en="C"),
+            sections=[],
+            github=GitHubSpec(),
+            # No output targets so CourseSpec validation doesn't reject.
+        )
+        course = Course.from_spec(spec, course_root, output_root=None)
+        # Build a single target directly and attach it — this bypasses
+        # CourseSpec's opt-in validation. Both jupyterlite attrs are
+        # None so ``effective_jupyterlite_config`` returns None.
+        bad_target = OutputTarget(
+            name="broken",
+            output_root=course_root / "broken",
+            kinds=frozenset({"completed"}),
+            formats=frozenset({"jupyterlite"}),
+            languages=frozenset({"en"}),
+            is_explicit=True,
+            jupyterlite=None,
+            course_jupyterlite=None,
+        )
+        course.output_targets = [bad_target]
+
+        backend = _RecordingBackend()
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="clm.core.course"):
+            asyncio.run(course.process_jupyterlite_for_targets(backend))
+
+        assert captured_ops == []
+        assert any("no effective <jupyterlite> config" in rec.message for rec in caplog.records)
+
+    def test_returns_early_when_no_jupyterlite_targets(self, course_root, captured_ops):
+        """Early-return branch: no target lists 'jupyterlite' at all."""
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="html-only",
+                    path="./h",
+                    kinds=["code-along"],
+                    formats=["html"],
+                ),
+            ],
+        )
+        backend = _RecordingBackend()
+        # Should return immediately without constructing the outer TaskGroup.
+        asyncio.run(course.process_jupyterlite_for_targets(backend))
+        assert captured_ops == []
+
+    def test_output_dir_uses_parent_of_jupyterlite_spec(self, course_root, captured_ops):
+        """The per-op ``output_dir`` should be the parent of the jupyterlite
+        OutputSpec output_dir, so the site lands at the target's jupyterlite
+        directory level (not inside a per-kind subfolder).
+        """
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(
+                    name="p",
+                    path="./p",
+                    kinds=["completed"],
+                    formats=["jupyterlite", "notebook"],
+                    languages=["en"],
+                ),
+            ],
+            course_jupyterlite=JupyterLiteConfig(kernel="pyodide"),
+        )
+        backend = _RecordingBackend()
+        asyncio.run(course.process_jupyterlite_for_targets(backend))
+        assert len(captured_ops) == 1
+        op = captured_ops[0]
+        # output_dir is the parent of the jupyterlite spec's output_dir
+        # (i.e. not inside a per-kind subfolder).
+        assert "completed" not in op.output_dir.parts  # type: ignore[attr-defined]

--- a/tests/infrastructure/api/test_client.py
+++ b/tests/infrastructure/api/test_client.py
@@ -1,0 +1,415 @@
+"""Tests for ``clm.infrastructure.api.client``.
+
+Covers ``WorkerApiClient``'s HTTP operations and retry loop:
+registration, job lifecycle (claim/complete/fail/cancel), heartbeat,
+activation, unregistration, cache, plus the retry/error paths for
+``ConnectError``, 4xx/5xx ``HTTPStatusError``, and timeouts.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from clm.infrastructure.api.client import JobInfo, WorkerApiClient, WorkerApiError
+
+
+def _make_response(
+    status_code: int = 200,
+    json_payload: dict | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a mock httpx.Response."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.text = text
+    response.json.return_value = json_payload or {}
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.fixture
+def patched_request():
+    """Patch ``httpx.Client.request`` and hand back the mock."""
+    with patch("httpx.Client.request") as mock_request:
+        yield mock_request
+
+
+@pytest.fixture
+def client() -> WorkerApiClient:
+    """A client with a tiny retry delay so failure paths finish fast."""
+    return WorkerApiClient(
+        "http://localhost:8765",
+        timeout=1.0,
+        max_retries=3,
+        initial_retry_delay=0.001,
+    )
+
+
+class TestConstruction:
+    """WorkerApiClient basic construction and context manager."""
+
+    def test_strips_trailing_slash_from_base_url(self) -> None:
+        c = WorkerApiClient("http://localhost:8765/")
+        assert c.base_url == "http://localhost:8765"
+        c.close()
+
+    def test_stores_timeout_and_retry_settings(self) -> None:
+        c = WorkerApiClient(
+            "http://host:1",
+            timeout=7.5,
+            max_retries=10,
+            initial_retry_delay=2.0,
+        )
+        assert c.timeout == 7.5
+        assert c.max_retries == 10
+        assert c.initial_retry_delay == 2.0
+        c.close()
+
+    def test_context_manager_closes_client(self) -> None:
+        with WorkerApiClient("http://localhost:8765") as c:
+            assert c._client is not None
+        # httpx.Client.close() has been called; a second close is a no-op.
+        c.close()
+
+
+class TestRegister:
+    """WorkerApiClient.register()."""
+
+    def test_returns_worker_id_from_response(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"worker_id": 42})
+
+        worker_id = client.register("notebook", container_id="container-abc", parent_pid=123)
+
+        assert worker_id == 42
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/register")
+        body = call[1]["json"]
+        assert body == {
+            "worker_type": "notebook",
+            "container_id": "container-abc",
+            "parent_pid": 123,
+        }
+
+    def test_defaults_container_id_to_hostname_env(
+        self,
+        client: WorkerApiClient,
+        patched_request: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HOSTNAME", "my-host")
+        patched_request.return_value = _make_response(json_payload={"worker_id": 7})
+
+        client.register("plantuml")
+
+        body = patched_request.call_args[1]["json"]
+        assert body["container_id"] == "my-host"
+        assert body["parent_pid"] is None
+
+    def test_defaults_container_id_to_unknown_when_no_env(
+        self,
+        client: WorkerApiClient,
+        patched_request: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("HOSTNAME", raising=False)
+        patched_request.return_value = _make_response(json_payload={"worker_id": 1})
+
+        client.register("drawio")
+
+        body = patched_request.call_args[1]["json"]
+        assert body["container_id"] == "unknown"
+
+
+class TestClaimJob:
+    """WorkerApiClient.claim_job()."""
+
+    def test_returns_none_when_no_jobs_available(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"job": None})
+
+        result = client.claim_job(worker_id=1, job_type="notebook")
+
+        assert result is None
+
+    def test_returns_job_info_when_job_claimed(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(
+            json_payload={
+                "job": {
+                    "id": 99,
+                    "job_type": "notebook",
+                    "input_file": "in.py",
+                    "output_file": "out.html",
+                    "content_hash": "abc",
+                    "payload": {"x": 1},
+                    "correlation_id": "corr-1",
+                }
+            }
+        )
+
+        job = client.claim_job(worker_id=2, job_type="notebook")
+
+        assert isinstance(job, JobInfo)
+        assert job.id == 99
+        assert job.job_type == "notebook"
+        assert job.payload == {"x": 1}
+        assert job.correlation_id == "corr-1"
+
+    def test_missing_correlation_id_is_none(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(
+            json_payload={
+                "job": {
+                    "id": 1,
+                    "job_type": "plantuml",
+                    "input_file": "a",
+                    "output_file": "b",
+                    "content_hash": "c",
+                    "payload": {},
+                }
+            }
+        )
+
+        job = client.claim_job(worker_id=1, job_type="plantuml")
+
+        assert job is not None
+        assert job.correlation_id is None
+
+
+class TestJobStatusUpdates:
+    """WorkerApiClient.complete_job() / fail_job()."""
+
+    def test_complete_job_posts_completed_status(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"acknowledged": True})
+
+        client.complete_job(job_id=5, worker_id=1, result={"warnings": 0})
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/jobs/5/status")
+        body = call[1]["json"]
+        assert body == {"worker_id": 1, "status": "completed", "result": {"warnings": 0}}
+
+    def test_complete_job_with_none_result(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"acknowledged": True})
+
+        client.complete_job(job_id=5, worker_id=1, result=None)
+
+        body = patched_request.call_args[1]["json"]
+        assert body["result"] is None
+
+    def test_fail_job_posts_failed_status(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"acknowledged": True})
+
+        client.fail_job(job_id=9, worker_id=2, error={"type": "ExecutionError"})
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/jobs/9/status")
+        body = call[1]["json"]
+        assert body == {
+            "worker_id": 2,
+            "status": "failed",
+            "error": {"type": "ExecutionError"},
+        }
+
+
+class TestHeartbeatAndCancellation:
+    def test_heartbeat_sends_worker_id(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(
+            json_payload={"acknowledged": True, "timestamp": "2024-01-01T00:00:00Z"}
+        )
+
+        client.heartbeat(worker_id=3)
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/heartbeat")
+        assert call[1]["json"] == {"worker_id": 3}
+
+    def test_is_job_cancelled_true(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"cancelled": True})
+
+        assert client.is_job_cancelled(42) is True
+        call = patched_request.call_args
+        assert call[0] == ("GET", "/api/worker/jobs/42/cancelled")
+
+    def test_is_job_cancelled_false_when_missing_key(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={})
+
+        assert client.is_job_cancelled(42) is False
+
+
+class TestActivateAndUnregister:
+    def test_activate_posts_worker_id(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(
+            json_payload={"acknowledged": True, "activated_at": "2024-01-01T00:00:00Z"}
+        )
+
+        client.activate(55)
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/activate")
+        assert call[1]["json"] == {"worker_id": 55}
+
+    def test_unregister_posts_reason(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"acknowledged": True})
+
+        client.unregister(worker_id=11, reason="shutdown")
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/unregister")
+        assert call[1]["json"] == {"worker_id": 11, "reason": "shutdown"}
+
+    def test_unregister_swallows_api_error(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        """Unregistration must not raise even if the server is gone."""
+        # ConnectError is wrapped in WorkerApiError by _request_with_retry;
+        # but unregister uses retry_on_connect=False, so connect errors raise
+        # immediately — and unregister must catch them.
+        patched_request.side_effect = httpx.ConnectError("server gone")
+
+        # Should not raise
+        client.unregister(worker_id=11)
+
+
+class TestAddToCache:
+    def test_add_to_cache_posts_metadata(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.return_value = _make_response(json_payload={"acknowledged": True})
+
+        client.add_to_cache(
+            output_file="out.html",
+            content_hash="deadbeef",
+            result_metadata={"size": 100},
+        )
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/cache/add")
+        body = call[1]["json"]
+        assert body == {
+            "output_file": "out.html",
+            "content_hash": "deadbeef",
+            "result_metadata": {"size": 100},
+        }
+
+    def test_add_to_cache_swallows_api_error(
+        self,
+        client: WorkerApiClient,
+        patched_request: MagicMock,
+    ) -> None:
+        """Cache errors should be logged but not propagate."""
+        response = _make_response(status_code=500, text="boom")
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=response
+        )
+        patched_request.return_value = response
+
+        # Should not raise
+        client.add_to_cache("f", "h", {"k": "v"})
+
+
+class TestRetryLoop:
+    """_request_with_retry retry semantics."""
+
+    def test_retries_on_connect_error_then_succeeds(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        success = _make_response(json_payload={"worker_id": 1})
+        patched_request.side_effect = [
+            httpx.ConnectError("no route"),
+            success,
+        ]
+
+        worker_id = client.register("notebook", container_id="c")
+
+        assert worker_id == 1
+        assert patched_request.call_count == 2
+
+    def test_raises_after_max_retries_on_connect_error(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.side_effect = httpx.ConnectError("refused")
+
+        with pytest.raises(WorkerApiError, match="Failed to connect"):
+            client.register("notebook", container_id="c")
+
+        assert patched_request.call_count == client.max_retries
+
+    def test_retries_on_5xx_then_succeeds(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        fail = _make_response(status_code=502, text="bad gateway")
+        fail.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "502", request=MagicMock(), response=fail
+        )
+        success = _make_response(json_payload={"worker_id": 7})
+
+        patched_request.side_effect = [fail, success]
+
+        worker_id = client.register("notebook", container_id="c")
+
+        assert worker_id == 7
+        assert patched_request.call_count == 2
+
+    def test_does_not_retry_on_4xx(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        fail = _make_response(status_code=400, text="bad request")
+        fail.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400", request=MagicMock(), response=fail
+        )
+        patched_request.return_value = fail
+
+        with pytest.raises(WorkerApiError, match="API error: 400"):
+            client.register("notebook", container_id="c")
+
+        # Exactly one attempt — no retry for client error.
+        assert patched_request.call_count == 1
+
+    def test_retries_on_timeout_then_raises(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        patched_request.side_effect = httpx.TimeoutException("timeout")
+
+        with pytest.raises(WorkerApiError, match="Request timeout"):
+            client.register("notebook", container_id="c")
+
+        assert patched_request.call_count == client.max_retries
+
+    def test_5xx_exhausts_retries(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        fail = _make_response(status_code=500, text="boom")
+        fail.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=fail
+        )
+        patched_request.return_value = fail
+
+        with pytest.raises(WorkerApiError, match="API error after"):
+            client.register("notebook", container_id="c")
+
+        assert patched_request.call_count == client.max_retries

--- a/tests/infrastructure/api/test_job_queue_adapter.py
+++ b/tests/infrastructure/api/test_job_queue_adapter.py
@@ -1,0 +1,199 @@
+"""Tests for ``clm.infrastructure.api.job_queue_adapter``.
+
+``ApiJobQueue`` wraps ``WorkerApiClient`` with the JobQueue-like interface
+used by workers. These tests substitute a fake client so we exercise the
+adapter logic without real HTTP traffic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from clm.infrastructure.api.client import JobInfo, WorkerApiError
+from clm.infrastructure.api.job_queue_adapter import ApiJobQueue
+
+
+@pytest.fixture
+def fake_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def adapter(fake_client: MagicMock) -> ApiJobQueue:
+    """Adapter wired to a fake client, with a pre-set worker_id."""
+    q = ApiJobQueue("http://host:1", worker_id=42)
+    q._client = fake_client
+    return q
+
+
+class TestConstructionAndClose:
+    def test_stores_api_url_and_worker_id(self) -> None:
+        q = ApiJobQueue("http://localhost:8765/", worker_id=7)
+        assert q.api_url == "http://localhost:8765/"
+        assert q.worker_id == 7
+        q.close()
+
+    def test_close_delegates_to_client(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        adapter.close()
+        fake_client.close.assert_called_once()
+
+
+class TestGetNextJob:
+    def test_returns_none_when_no_jobs(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        fake_client.claim_job.return_value = None
+        assert adapter.get_next_job("notebook") is None
+
+    def test_returns_job_when_claimed(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        fake_client.claim_job.return_value = JobInfo(
+            id=1,
+            job_type="notebook",
+            input_file="in.py",
+            output_file="out.html",
+            content_hash="abc",
+            payload={"k": "v"},
+            correlation_id="c-1",
+        )
+
+        job = adapter.get_next_job("notebook")
+
+        assert job is not None
+        assert job.id == 1
+        assert job.job_type == "notebook"
+        assert job.status == "processing"
+        assert job.worker_id == 42
+        assert job.correlation_id == "c-1"
+
+    def test_explicit_worker_id_overrides_default(
+        self, adapter: ApiJobQueue, fake_client: MagicMock
+    ) -> None:
+        fake_client.claim_job.return_value = None
+
+        adapter.get_next_job("notebook", worker_id=99)
+
+        fake_client.claim_job.assert_called_once_with(99, "notebook")
+
+    def test_raises_if_no_worker_id(self, fake_client: MagicMock) -> None:
+        q = ApiJobQueue("http://host", worker_id=None)
+        q._client = fake_client
+
+        with pytest.raises(ValueError, match="worker_id"):
+            q.get_next_job("notebook")
+
+    def test_propagates_worker_api_error(
+        self, adapter: ApiJobQueue, fake_client: MagicMock
+    ) -> None:
+        fake_client.claim_job.side_effect = WorkerApiError("boom")
+
+        with pytest.raises(WorkerApiError):
+            adapter.get_next_job("notebook")
+
+
+class TestUpdateJobStatus:
+    def test_completed_parses_result_json(
+        self, adapter: ApiJobQueue, fake_client: MagicMock
+    ) -> None:
+        adapter.update_job_status(
+            job_id=5,
+            status="completed",
+            result='{"warnings": 1}',
+        )
+
+        fake_client.complete_job.assert_called_once_with(5, 42, {"warnings": 1})
+
+    def test_completed_with_none_result(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        adapter.update_job_status(job_id=5, status="completed", result=None)
+
+        fake_client.complete_job.assert_called_once_with(5, 42, None)
+
+    def test_failed_parses_error_json(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        adapter.update_job_status(
+            job_id=7,
+            status="failed",
+            error='{"type": "ExecError"}',
+        )
+
+        fake_client.fail_job.assert_called_once_with(7, 42, {"type": "ExecError"})
+
+    def test_failed_with_none_error_uses_default(
+        self, adapter: ApiJobQueue, fake_client: MagicMock
+    ) -> None:
+        adapter.update_job_status(job_id=7, status="failed", error=None)
+
+        fake_client.fail_job.assert_called_once_with(7, 42, {"error_message": "Unknown error"})
+
+    def test_invalid_status_raises(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        with pytest.raises(ValueError, match="Invalid status"):
+            adapter.update_job_status(job_id=1, status="bogus")
+
+    def test_requires_worker_id(self, fake_client: MagicMock) -> None:
+        q = ApiJobQueue("http://host", worker_id=None)
+        q._client = fake_client
+
+        with pytest.raises(ValueError, match="worker_id"):
+            q.update_job_status(job_id=1, status="completed")
+
+    def test_propagates_worker_api_error(
+        self, adapter: ApiJobQueue, fake_client: MagicMock
+    ) -> None:
+        fake_client.complete_job.side_effect = WorkerApiError("boom")
+
+        with pytest.raises(WorkerApiError):
+            adapter.update_job_status(job_id=1, status="completed")
+
+
+class TestIsJobCancelled:
+    def test_returns_client_result(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        fake_client.is_job_cancelled.return_value = True
+        assert adapter.is_job_cancelled(1) is True
+
+    def test_returns_false_on_error(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        fake_client.is_job_cancelled.side_effect = WorkerApiError("boom")
+        assert adapter.is_job_cancelled(1) is False
+
+
+class TestUpdateHeartbeat:
+    def test_uses_explicit_worker_id(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        adapter.update_heartbeat(worker_id=99)
+        fake_client.heartbeat.assert_called_once_with(99)
+
+    def test_falls_back_to_instance_worker_id(
+        self, adapter: ApiJobQueue, fake_client: MagicMock
+    ) -> None:
+        adapter.update_heartbeat()
+        fake_client.heartbeat.assert_called_once_with(42)
+
+    def test_requires_worker_id(self, fake_client: MagicMock) -> None:
+        q = ApiJobQueue("http://host", worker_id=None)
+        q._client = fake_client
+
+        with pytest.raises(ValueError, match="worker_id"):
+            q.update_heartbeat()
+
+    def test_swallows_api_error(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        """Heartbeat failures must not stop job processing."""
+        fake_client.heartbeat.side_effect = WorkerApiError("boom")
+
+        # Should not raise
+        adapter.update_heartbeat()
+
+
+class TestAddToCache:
+    def test_forwards_to_client(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        adapter.add_to_cache("out.html", "abc", {"size": 10})
+        fake_client.add_to_cache.assert_called_once_with("out.html", "abc", {"size": 10})
+
+    def test_swallows_api_error(self, adapter: ApiJobQueue, fake_client: MagicMock) -> None:
+        fake_client.add_to_cache.side_effect = WorkerApiError("boom")
+
+        # Should not raise
+        adapter.add_to_cache("f", "h", {})
+
+
+class TestGetConn:
+    """_get_conn must raise — the API adapter has no direct SQLite access."""
+
+    def test_raises_not_implemented(self, adapter: ApiJobQueue) -> None:
+        with pytest.raises(NotImplementedError, match="Direct database access"):
+            adapter._get_conn()

--- a/tests/infrastructure/api/test_server.py
+++ b/tests/infrastructure/api/test_server.py
@@ -1,0 +1,351 @@
+"""Tests for ``clm.infrastructure.api.server``.
+
+Covers ``WorkerApiServer`` lifecycle (``start``, ``stop``,
+``is_running``, URL properties, health route) and the module-level
+singleton helpers (``start_worker_api_server``,
+``stop_worker_api_server``, ``get_worker_api_server``).
+
+Server start paths are tested in two regimes:
+
+- **Fake uvicorn** — we monkeypatch ``uvicorn.Server`` so we can
+  synchronously inject start/stop behavior, including the "failed to
+  start" timeout path and the clean shutdown path, without opening a
+  real socket.
+- **Real uvicorn** — one integration-style test that binds the server
+  to port 0 and exercises the health endpoint, proving the full
+  threading/startup path works end to end.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.infrastructure.api import server as server_module
+from clm.infrastructure.api.server import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    WorkerApiServer,
+    get_worker_api_server,
+    start_worker_api_server,
+    stop_worker_api_server,
+)
+from clm.infrastructure.database.schema import init_database
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "workers.db"
+    init_database(path)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Ensure the module-level singleton is cleared around every test."""
+    server_module._server_instance = None
+    yield
+    if server_module._server_instance is not None:
+        server_module._server_instance.stop(timeout=2.0)
+        server_module._server_instance = None
+
+
+def _free_port() -> int:
+    """Bind to port 0, read the assigned port, release it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Construction, URLs, FastAPI app setup
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_defaults_to_standard_host_port(self, db_path: Path) -> None:
+        server = WorkerApiServer(db_path)
+        assert server.db_path == db_path
+        assert server.host == DEFAULT_HOST
+        assert server.port == DEFAULT_PORT
+
+    def test_custom_host_and_port(self, db_path: Path) -> None:
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=9999)
+        assert server.host == "127.0.0.1"
+        assert server.port == 9999
+
+    def test_url_and_docker_url(self, db_path: Path) -> None:
+        server = WorkerApiServer(db_path, host="0.0.0.0", port=8888)
+        assert server.url == "http://0.0.0.0:8888"
+        assert server.docker_url == "http://host.docker.internal:8888"
+
+
+class TestCreateApp:
+    """_create_app returns a FastAPI app wired with health + worker routes."""
+
+    def test_health_endpoint(self, db_path: Path) -> None:
+        server = WorkerApiServer(db_path)
+        app = server._create_app()
+
+        with TestClient(app) as client:
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["api_version"] == "1.0"
+        assert data["database"] == str(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Fake-uvicorn lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class FakeUvicornServer:
+    """Tiny stand-in for ``uvicorn.Server`` that mimics its control surface.
+
+    ``run()`` blocks until ``should_exit`` is set; this lets the test
+    exercise the real threading code in ``WorkerApiServer._run_server``
+    without opening a socket. Tests can flip instance flags to drive the
+    "failed to start" path as well.
+    """
+
+    def __init__(self, config: object, *, fail_to_start: bool = False) -> None:
+        self.config = config
+        self.should_exit = False
+        self.fail_to_start = fail_to_start
+        self.ran = False
+
+    def run(self) -> None:
+        self.ran = True
+        if self.fail_to_start:
+            # Simulate crashing during startup, before the parent's
+            # ``_started`` event is already set.
+            return
+        while not self.should_exit:
+            time.sleep(0.01)
+
+
+class TestStartAndStop:
+    """start() spins up the thread; stop() winds it down."""
+
+    def test_start_and_stop_cycle(self, db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server_module.uvicorn, "Server", FakeUvicornServer)
+
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=_free_port())
+
+        assert server.start(timeout=2.0) is True
+        assert server.is_running is True
+        assert server._thread is not None
+        assert server._thread.is_alive()
+
+        server.stop(timeout=2.0)
+
+        assert server.is_running is False
+        assert server._thread is None
+        assert server._server is None
+
+    def test_start_is_idempotent(self, db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server_module.uvicorn, "Server", FakeUvicornServer)
+
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=_free_port())
+        assert server.start(timeout=2.0) is True
+
+        # Second start should be a no-op and return True.
+        first_thread = server._thread
+        assert server.start(timeout=2.0) is True
+        assert server._thread is first_thread
+
+        server.stop(timeout=2.0)
+
+    def test_stop_when_never_started_is_noop(self, db_path: Path) -> None:
+        server = WorkerApiServer(db_path)
+        # No exception, no state change.
+        server.stop(timeout=1.0)
+        assert server._server is None
+
+    def test_start_timeout_returns_false(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the started-event is never set, start() returns False."""
+
+        class NeverStartsServer(FakeUvicornServer):
+            pass
+
+        monkeypatch.setattr(server_module.uvicorn, "Server", NeverStartsServer)
+
+        # Patch _run_server to *not* set the started event.
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=_free_port())
+
+        original_run = server._run_server
+
+        def run_without_signaling() -> None:
+            # Mimic the real _run_server up to the point where it would
+            # set _started, but skip the set() to force the timeout.
+            server._app = server._create_app()
+            while not server._shutdown_requested.is_set():
+                time.sleep(0.01)
+
+        server._run_server = run_without_signaling  # type: ignore[method-assign]
+        try:
+            assert server.start(timeout=0.1) is False
+        finally:
+            server._shutdown_requested.set()
+            if server._thread is not None:
+                server._thread.join(timeout=1.0)
+            server._run_server = original_run  # type: ignore[method-assign]
+
+
+class TestIsRunning:
+    def test_false_before_start(self, db_path: Path) -> None:
+        server = WorkerApiServer(db_path)
+        assert server.is_running is False
+
+    def test_false_after_shutdown_requested(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even if the thread lives briefly, ``is_running`` flips false
+        as soon as ``_shutdown_requested`` is set."""
+        monkeypatch.setattr(server_module.uvicorn, "Server", FakeUvicornServer)
+
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=_free_port())
+        server.start(timeout=2.0)
+        try:
+            assert server.is_running is True
+            server._shutdown_requested.set()
+            assert server.is_running is False
+        finally:
+            server.stop(timeout=2.0)
+
+
+class TestStopWarnsOnStubbornThread:
+    """If the worker thread refuses to die, stop() still clears state."""
+
+    def test_unresponsive_thread_is_logged(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(server_module.uvicorn, "Server", FakeUvicornServer)
+
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=_free_port())
+        server.start(timeout=2.0)
+
+        # Swap the thread with one that ignores the shutdown signal.
+        fake_thread = MagicMock(spec=threading.Thread)
+        fake_thread.is_alive.return_value = True
+        server._thread = fake_thread
+
+        with caplog.at_level("WARNING"):
+            server.stop(timeout=0.1)
+
+        assert any("did not stop cleanly" in rec.message for rec in caplog.records), (
+            "Expected a warning about unresponsive thread"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalSingleton:
+    def test_get_worker_api_server_returns_none_initially(self) -> None:
+        assert get_worker_api_server() is None
+
+    def test_get_worker_api_server_lazy_creation(self, db_path: Path) -> None:
+        server = get_worker_api_server(db_path)
+        assert server is not None
+        assert server.db_path == db_path
+
+        # A second call without db_path returns the same instance.
+        second = get_worker_api_server()
+        assert second is server
+
+    def test_start_worker_api_server_creates_and_returns(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_module.uvicorn, "Server", FakeUvicornServer)
+
+        server = start_worker_api_server(db_path, timeout=2.0)
+        try:
+            assert server is not None
+            assert server.is_running is True
+            assert get_worker_api_server() is server
+        finally:
+            stop_worker_api_server(timeout=2.0)
+
+    def test_start_worker_api_server_idempotent_when_running(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_module.uvicorn, "Server", FakeUvicornServer)
+
+        first = start_worker_api_server(db_path, timeout=2.0)
+        try:
+            # Second call returns the existing running instance.
+            second = start_worker_api_server(db_path, timeout=2.0)
+            assert second is first
+        finally:
+            stop_worker_api_server(timeout=2.0)
+
+    def test_start_worker_api_server_raises_on_failure(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force start() to return False by swapping the instance method.
+        def never_start(self: WorkerApiServer, timeout: float = 5.0) -> bool:
+            return False
+
+        monkeypatch.setattr(WorkerApiServer, "start", never_start)
+
+        with pytest.raises(RuntimeError, match="Failed to start Worker API server"):
+            start_worker_api_server(db_path, timeout=0.1)
+
+    def test_stop_worker_api_server_when_never_started(self) -> None:
+        # No exception when global instance is None.
+        stop_worker_api_server(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Real-uvicorn integration smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestRealUvicornStartup:
+    """Bind an actual uvicorn server; hit /health; ensure clean shutdown.
+
+    This is the one place that exercises the real threading path
+    end-to-end. It's marked ``slow`` so the fast suite skips it.
+    """
+
+    def test_real_server_serves_health(self, db_path: Path) -> None:
+        port = _free_port()
+        server = WorkerApiServer(db_path, host="127.0.0.1", port=port)
+
+        assert server.start(timeout=5.0) is True
+        try:
+            # Poll for readiness — uvicorn's port binding happens shortly
+            # after the started event is set.
+            response = None
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                try:
+                    response = httpx.get(f"{server.url}/health", timeout=1.0)
+                    break
+                except httpx.ConnectError:
+                    time.sleep(0.05)
+
+            assert response is not None, "Server did not accept connections"
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+        finally:
+            server.stop(timeout=5.0)
+
+        assert server.is_running is False

--- a/tests/infrastructure/api/test_worker_routes_endpoints.py
+++ b/tests/infrastructure/api/test_worker_routes_endpoints.py
@@ -1,0 +1,442 @@
+"""Endpoint tests for ``clm.infrastructure.api.worker_routes``.
+
+Exercises every route except ``activate`` (already covered by
+``test_worker_routes.py``): register, claim, status, heartbeat, cancelled,
+unregister, and cache endpoints, plus their error paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.infrastructure.api.server import WorkerApiServer
+from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.database.schema import init_database
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "workers.db"
+    init_database(path)
+    return path
+
+
+@pytest.fixture
+def client(db_path: Path):
+    server = WorkerApiServer(db_path)
+    app = server._create_app()
+    # raise_server_exceptions=False lets us observe the 500 that FastAPI
+    # would return to a real HTTP client instead of re-raising the
+    # exception through TestClient.
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def _seed_pending_job(db_path: Path, job_type: str = "notebook") -> int:
+    queue = JobQueue(db_path)
+    try:
+        conn = queue._get_conn()
+        cursor = conn.execute(
+            """
+            INSERT INTO jobs (
+                job_type, input_file, output_file, content_hash,
+                payload, status, priority, attempts
+            ) VALUES (?, ?, ?, ?, ?, 'pending', 0, 0)
+            """,
+            (job_type, "in.py", "out.html", "hash", "{}"),
+        )
+        job_id = cursor.lastrowid
+        assert job_id is not None
+        return job_id
+    finally:
+        queue.close()
+
+
+# ---------------------------------------------------------------------------
+# /register
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterEndpoint:
+    def test_register_inserts_worker_and_returns_id(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/worker/register",
+            json={
+                "worker_type": "notebook",
+                "container_id": "c1",
+                "parent_pid": 1234,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["worker_id"] >= 1
+        assert "registered_at" in data
+
+    def test_register_returns_500_on_db_error(self, client: TestClient) -> None:
+        # Patch a method used *inside* the try/except so the handler's
+        # generic Exception -> HTTPException(500) path is exercised.
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue._get_conn",
+            side_effect=RuntimeError("db gone"),
+        ):
+            response = client.post(
+                "/api/worker/register",
+                json={
+                    "worker_type": "notebook",
+                    "container_id": "c1",
+                    "parent_pid": None,
+                },
+            )
+
+        assert response.status_code == 500
+        assert "db gone" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /jobs/claim
+# ---------------------------------------------------------------------------
+
+
+class TestClaimJobEndpoint:
+    def test_claim_returns_null_when_no_jobs(self, client: TestClient, db_path: Path) -> None:
+        queue = JobQueue(db_path)
+        try:
+            cursor = queue._get_conn().execute(
+                "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, 'idle')",
+                ("notebook", "c1"),
+            )
+            worker_id = cursor.lastrowid
+        finally:
+            queue.close()
+
+        response = client.post(
+            "/api/worker/jobs/claim",
+            json={"worker_id": worker_id, "job_type": "notebook"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["job"] is None
+
+    def test_claim_returns_job_data(self, client: TestClient, db_path: Path) -> None:
+        job_id = _seed_pending_job(db_path)
+        queue = JobQueue(db_path)
+        try:
+            cursor = queue._get_conn().execute(
+                "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, 'idle')",
+                ("notebook", "c1"),
+            )
+            worker_id = cursor.lastrowid
+        finally:
+            queue.close()
+
+        response = client.post(
+            "/api/worker/jobs/claim",
+            json={"worker_id": worker_id, "job_type": "notebook"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["job"] is not None
+        assert data["job"]["id"] == job_id
+
+    def test_claim_returns_500_on_error(self, client: TestClient) -> None:
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue.get_next_job",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post(
+                "/api/worker/jobs/claim",
+                json={"worker_id": 1, "job_type": "notebook"},
+            )
+
+        assert response.status_code == 500
+        assert "boom" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /jobs/{id}/status
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStatusEndpoint:
+    def test_completed_status_is_acknowledged(self, client: TestClient, db_path: Path) -> None:
+        job_id = _seed_pending_job(db_path)
+
+        # Put job into 'processing' so the completion transition is valid.
+        queue = JobQueue(db_path)
+        try:
+            queue._get_conn().execute("UPDATE jobs SET status='processing' WHERE id=?", (job_id,))
+        finally:
+            queue.close()
+
+        response = client.post(
+            f"/api/worker/jobs/{job_id}/status",
+            json={
+                "worker_id": 1,
+                "status": "completed",
+                "result": {"warnings": 0},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["acknowledged"] is True
+
+    def test_failed_status_is_acknowledged(self, client: TestClient, db_path: Path) -> None:
+        job_id = _seed_pending_job(db_path)
+        queue = JobQueue(db_path)
+        try:
+            queue._get_conn().execute("UPDATE jobs SET status='processing' WHERE id=?", (job_id,))
+        finally:
+            queue.close()
+
+        response = client.post(
+            f"/api/worker/jobs/{job_id}/status",
+            json={
+                "worker_id": 1,
+                "status": "failed",
+                "error": {"type": "ExecError", "message": "oops"},
+            },
+        )
+
+        assert response.status_code == 200
+
+    def test_invalid_status_returns_400(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/worker/jobs/1/status",
+            json={"worker_id": 1, "status": "bogus"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid status" in response.json()["detail"]
+
+    def test_update_returns_500_on_db_error(self, client: TestClient) -> None:
+        # Valid status, but the underlying job_queue operation blows up.
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue.update_job_status",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post(
+                "/api/worker/jobs/1/status",
+                json={"worker_id": 1, "status": "completed", "result": {}},
+            )
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatEndpoint:
+    def test_heartbeat_acknowledges(self, client: TestClient, db_path: Path) -> None:
+        queue = JobQueue(db_path)
+        try:
+            cursor = queue._get_conn().execute(
+                "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, 'idle')",
+                ("notebook", "c1"),
+            )
+            worker_id = cursor.lastrowid
+        finally:
+            queue.close()
+
+        response = client.post(
+            "/api/worker/heartbeat",
+            json={"worker_id": worker_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["acknowledged"] is True
+        assert "timestamp" in data
+
+    def test_heartbeat_returns_500_on_error(self, client: TestClient) -> None:
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue._get_conn",
+            side_effect=RuntimeError("db gone"),
+        ):
+            response = client.post(
+                "/api/worker/heartbeat",
+                json={"worker_id": 1},
+            )
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /jobs/{id}/cancelled
+# ---------------------------------------------------------------------------
+
+
+class TestCancelledEndpoint:
+    def test_not_cancelled_pending_job(self, client: TestClient, db_path: Path) -> None:
+        job_id = _seed_pending_job(db_path)
+
+        response = client.get(f"/api/worker/jobs/{job_id}/cancelled")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["cancelled"] is False
+
+    def test_cancelled_job(self, client: TestClient, db_path: Path) -> None:
+        job_id = _seed_pending_job(db_path)
+        queue = JobQueue(db_path)
+        try:
+            queue._get_conn().execute(
+                """
+                UPDATE jobs
+                SET status='cancelled',
+                    cancelled_at=CURRENT_TIMESTAMP,
+                    cancelled_by='test'
+                WHERE id=?
+                """,
+                (job_id,),
+            )
+        finally:
+            queue.close()
+
+        response = client.get(f"/api/worker/jobs/{job_id}/cancelled")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["cancelled"] is True
+        assert data["cancelled_by"] == "test"
+        assert data["cancelled_at"] is not None
+
+    def test_not_found_returns_404(self, client: TestClient) -> None:
+        response = client.get("/api/worker/jobs/9999/cancelled")
+
+        assert response.status_code == 404
+
+    def test_returns_500_on_error(self, client: TestClient) -> None:
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue.get_job",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.get("/api/worker/jobs/1/cancelled")
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /unregister
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisterEndpoint:
+    def test_unregister_marks_worker_dead(self, client: TestClient, db_path: Path) -> None:
+        queue = JobQueue(db_path)
+        try:
+            cursor = queue._get_conn().execute(
+                "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, 'idle')",
+                ("notebook", "c1"),
+            )
+            worker_id = cursor.lastrowid
+        finally:
+            queue.close()
+
+        response = client.post(
+            "/api/worker/unregister",
+            json={"worker_id": worker_id, "reason": "test"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["acknowledged"] is True
+
+        queue = JobQueue(db_path)
+        try:
+            row = (
+                queue._get_conn()
+                .execute("SELECT status FROM workers WHERE id=?", (worker_id,))
+                .fetchone()
+            )
+        finally:
+            queue.close()
+        assert row[0] == "dead"
+
+    def test_unregister_returns_500_on_error(self, client: TestClient) -> None:
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue._get_conn",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post(
+                "/api/worker/unregister",
+                json={"worker_id": 1, "reason": "test"},
+            )
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /activate (error paths not yet covered)
+# ---------------------------------------------------------------------------
+
+
+class TestActivateErrorPath:
+    def test_activate_returns_500_on_unexpected_error(self, client: TestClient) -> None:
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue._get_conn",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post(
+                "/api/worker/activate",
+                json={"worker_id": 1},
+            )
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /cache/add
+# ---------------------------------------------------------------------------
+
+
+class TestCacheAddEndpoint:
+    def test_cache_add_acknowledged(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/worker/cache/add",
+            json={
+                "output_file": "out.html",
+                "content_hash": "abc",
+                "result_metadata": {"size": 100},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["acknowledged"] is True
+
+    def test_cache_add_returns_500_on_error(self, client: TestClient) -> None:
+        with patch(
+            "clm.infrastructure.database.job_queue.JobQueue.add_to_cache",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post(
+                "/api/worker/cache/add",
+                json={
+                    "output_file": "out.html",
+                    "content_hash": "abc",
+                    "result_metadata": {},
+                },
+            )
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /health (server-level, defined on the FastAPI app itself)
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    def test_health_returns_status_ok(self, client: TestClient) -> None:
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["api_version"] == "1.0"

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -1,0 +1,754 @@
+"""Resilience tests for SqliteBackend.
+
+Focus areas (lines that are not exercised by ``test_sqlite_backend.py``):
+
+- ``_cleanup_dead_worker_jobs`` — orphan recovery from dead workers.
+- ``wait_for_completion`` edge cases (all_submitted gating, missing job row,
+  TimeoutError, failed job path through error categorizer + db_manager).
+- ``cancel_jobs_for_file`` watch-mode cancellation.
+- ``_perform_session_start_cleanup`` and ``_perform_build_end_cleanup``.
+- ``_get_available_workers`` (activated path, no activation, pre-registered wait).
+- ``_get_output_metadata`` for every job type.
+- ``_extract_and_report_job_warnings`` happy path.
+- ``_report_cached_issues`` when stored issues exist.
+
+All jobs are driven by poking the SQLite tables directly rather than running
+real workers. ``skip_worker_check=True`` so the availability gate doesn't
+fire, except on the dedicated worker-availability tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import json
+import sqlite3
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from attrs import frozen
+
+from clm.cli.build_data_classes import BuildError
+from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+from clm.infrastructure.database.db_operations import DatabaseManager
+from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.database.schema import init_database
+from clm.infrastructure.messaging.base_classes import Payload
+from clm.infrastructure.operation import Operation
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@frozen
+class _MockOp(Operation):
+    service_name_value: str = "notebook-processor"
+
+    @property
+    def service_name(self) -> str:
+        return self.service_name_value
+
+    async def execute(self, backend, *args, **kwargs):
+        pass
+
+
+class _MockPayload(Payload):
+    correlation_id: str = "cid"
+    input_file: str = "in.py"
+    input_file_name: str = "in.py"
+    output_file: str = "out.ipynb"
+    data: str = "data"
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = Path(f.name)
+    init_database(db_path)
+
+    yield db_path
+
+    gc.collect()
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.close()
+    except Exception:
+        pass
+    for attempt in range(3):
+        try:
+            db_path.unlink(missing_ok=True)
+            for suffix in ["-wal", "-shm"]:
+                Path(str(db_path) + suffix).unlink(missing_ok=True)
+            break
+        except PermissionError:
+            if attempt < 2:
+                time.sleep(0.1)
+
+
+@pytest.fixture
+def temp_workspace():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+def _backend(db, ws, **kwargs) -> SqliteBackend:
+    return SqliteBackend(
+        db_path=db,
+        workspace_path=ws,
+        skip_worker_check=True,
+        poll_interval=0.02,
+        max_wait_for_completion_duration=5.0,
+        **kwargs,
+    )
+
+
+def _seed_job_processing_with_dead_worker(db_path: Path) -> int:
+    """Insert a worker row in 'dead' state and a job in 'processing' bound to it."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, parent_pid)
+            VALUES ('notebook', 'dead-worker', 'dead', 1234)
+            """
+        )
+        worker_id = cur.lastrowid
+        cur = conn.execute(
+            """
+            INSERT INTO jobs (
+                job_type, status, input_file, output_file, content_hash,
+                payload, worker_id, started_at
+            )
+            VALUES ('notebook', 'processing', 'f.py', 'f.ipynb', 'h',
+                    '{}', ?, CURRENT_TIMESTAMP)
+            """,
+            (worker_id,),
+        )
+        conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+    finally:
+        conn.close()
+
+
+_container_id_counter = [0]
+
+
+def _seed_activated_worker(db_path: Path, worker_type: str = "notebook") -> int:
+    _container_id_counter[0] += 1
+    cid = f"live-{worker_type}-{_container_id_counter[0]}"
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, last_heartbeat)
+            VALUES (?, ?, 'idle', CURRENT_TIMESTAMP)
+            """,
+            (worker_type, cid),
+        )
+        conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+    finally:
+        conn.close()
+
+
+def _seed_created_worker(db_path: Path, worker_type: str = "notebook") -> int:
+    _container_id_counter[0] += 1
+    cid = f"pending-{worker_type}-{_container_id_counter[0]}"
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status)
+            VALUES (?, ?, 'created')
+            """,
+            (worker_type, cid),
+        )
+        conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+    finally:
+        conn.close()
+
+
+class _StubReporter:
+    """Minimal BuildReporter-shaped double (has every method backend calls)."""
+
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+        self.cache_hits = []
+        self.started = []
+        self.completed = []
+        self.progress_updates = []
+
+    def on_progress_update(self, update):
+        self.progress_updates.append(update)
+
+    def report_cache_hit(self, file_path, job_type):
+        self.cache_hits.append((file_path, job_type))
+
+    def report_file_started(self, file_path, job_type, job_id=None):
+        self.started.append((file_path, job_type, job_id))
+
+    def report_file_completed(self, file_path, job_type, job_id=None, success=True):
+        self.completed.append((file_path, job_type, job_id, success))
+
+    def report_error(self, error):
+        self.errors.append(error)
+
+    def report_warning(self, warning):
+        self.warnings.append(warning)
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_dead_worker_jobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_worker_jobs_resets_stuck_jobs(temp_db, temp_workspace):
+    job_id = _seed_job_processing_with_dead_worker(temp_db)
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        count = backend._cleanup_dead_worker_jobs()
+        assert count == 1
+
+        # DB state: job reset to pending with worker_id NULL.
+        conn = sqlite3.connect(temp_db)
+        try:
+            row = conn.execute(
+                "SELECT status, worker_id, started_at FROM jobs WHERE id = ?",
+                (job_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == ("pending", None, None)
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_worker_jobs_no_stuck_is_noop(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        assert backend._cleanup_dead_worker_jobs() == 0
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_worker_jobs_handles_sql_error(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        # Patch _get_conn to raise on execute so the except-branch fires.
+        with patch.object(backend.job_queue, "_get_conn", side_effect=RuntimeError("db gone")):
+            assert backend._cleanup_dead_worker_jobs() == 0
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_worker_jobs_no_queue_returns_zero(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        backend.job_queue = None  # type: ignore[assignment]
+        assert backend._cleanup_dead_worker_jobs() == 0
+    finally:
+        pass  # shutdown will try to use job_queue; bypass.
+
+
+# ---------------------------------------------------------------------------
+# wait_for_completion edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_honours_all_submitted_gate(temp_db, temp_workspace):
+    """With no active jobs, returns True immediately if all_submitted is set
+    (or None); waits while empty otherwise."""
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        evt = asyncio.Event()
+
+        # Submit a job *after* wait_for_completion starts polling.
+        async def submit_later():
+            await asyncio.sleep(0.05)
+            await backend.execute_operation(_MockOp(), _MockPayload())
+            job_id = next(iter(backend.active_jobs))
+            await asyncio.sleep(0.05)
+            # Mark it completed.
+            jq = JobQueue(temp_db)
+            try:
+                jq.update_job_status(job_id, "completed")
+            finally:
+                jq.close()
+            evt.set()
+
+        submitter = asyncio.create_task(submit_later())
+        result = await backend.wait_for_completion(all_submitted=evt)
+        await submitter
+        assert result is True
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_missing_job_row_treated_as_done(temp_db, temp_workspace):
+    """When a job disappears from the DB mid-wait, it is logged + removed."""
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        await backend.execute_operation(_MockOp(), _MockPayload())
+        job_id = next(iter(backend.active_jobs))
+
+        # Delete the row before the next poll.
+        conn = sqlite3.connect(temp_db)
+        try:
+            conn.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = await backend.wait_for_completion()
+        # All "active" jobs drained; wait returns successfully.
+        assert result is True
+        assert len(backend.active_jobs) == 0
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_timeout(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    backend.max_wait_for_completion_duration = 0.1
+    try:
+        await backend.execute_operation(_MockOp(), _MockPayload())
+        with pytest.raises(TimeoutError):
+            await backend.wait_for_completion()
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_failed_job_reports_error(temp_db, temp_workspace, tmp_path):
+    """A failed notebook job with a user-type error is stored in db_manager."""
+    cache_db = tmp_path / "cache.db"
+
+    backend = _backend(temp_db, temp_workspace)
+    backend.db_manager = DatabaseManager(cache_db)
+    backend.db_manager.__enter__()
+    try:
+        await backend.execute_operation(_MockOp(), _MockPayload())
+        job_id = next(iter(backend.active_jobs))
+
+        # Mark failed with a notebook-style syntax error so the categorizer
+        # tags it as "user" and db_manager.store_error is invoked.
+        jq = JobQueue(temp_db)
+        try:
+            jq.update_job_status(job_id, "failed", error="SyntaxError: invalid syntax")
+        finally:
+            jq.close()
+
+        result = await backend.wait_for_completion()
+        assert result is False  # failed_jobs non-empty → False
+    finally:
+        backend.active_jobs.clear()
+        backend.db_manager.__exit__(None, None, None)
+        await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# cancel_jobs_for_file (watch mode)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_jobs_for_file_removes_from_active(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        await backend.execute_operation(_MockOp(), _MockPayload(input_file="a.py"))
+        await backend.execute_operation(
+            _MockOp(), _MockPayload(input_file="a.py", output_file="a.html")
+        )
+        assert len(backend.active_jobs) == 2
+
+        count = await backend.cancel_jobs_for_file(Path("a.py"))
+        assert count == 2
+        assert backend.active_jobs == {}
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancel_jobs_for_file_no_queue_returns_zero(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        backend.job_queue = None  # type: ignore[assignment]
+        assert await backend.cancel_jobs_for_file(Path("a.py")) == 0
+    finally:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _perform_session_start_cleanup / _perform_build_end_cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_start_cleanup_resets_hung(temp_db, temp_workspace, caplog):
+    # Seed a hung job: started_at older than the timeout.
+    conn = sqlite3.connect(temp_db)
+    try:
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                job_type, status, input_file, output_file, content_hash,
+                payload, started_at
+            ) VALUES ('notebook', 'processing', 'h.py', 'h.ipynb', 'x', '{}',
+                      datetime('now', '-1 hour'))
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        import logging as _logging
+
+        with caplog.at_level(_logging.INFO, logger="clm.infrastructure.backends.sqlite_backend"):
+            backend._perform_session_start_cleanup()
+        assert any("hung job" in rec.message for rec in caplog.records)
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_session_start_cleanup_handles_exception(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        with patch.object(backend.job_queue, "reset_hung_jobs", side_effect=RuntimeError("boom")):
+            # Should not raise.
+            backend._perform_session_start_cleanup()
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_build_end_cleanup_prunes_and_vacuums(temp_db, temp_workspace, tmp_path, monkeypatch):
+    # Point config cache_db_path at tmp_path so ExecutedNotebookCache works.
+    from clm.infrastructure import config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "_config",
+        None,
+    )
+    monkeypatch.setenv("CLM_RETENTION__AUTO_VACUUM_AFTER_CLEANUP", "true")
+    monkeypatch.setenv("CLM_PATHS__CACHE_DB_PATH", str(tmp_path / "cache.db"))
+
+    cache_db = tmp_path / "cache.db"
+    backend = _backend(temp_db, temp_workspace)
+    backend.db_manager = DatabaseManager(cache_db)
+    backend.db_manager.__enter__()
+    try:
+        # Should not raise — exercises both job_queue + db_manager cleanup
+        # and the vacuum branch.
+        backend._perform_build_end_cleanup()
+    finally:
+        backend.db_manager.__exit__(None, None, None)
+        await backend.shutdown()
+        # Reset the cached config.
+        config_mod._config = None
+
+
+@pytest.mark.asyncio
+async def test_build_end_cleanup_handles_exception(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        with patch.object(backend.job_queue, "cleanup_all", side_effect=RuntimeError("nope")):
+            # Top-level except swallows the error.
+            backend._perform_build_end_cleanup()
+    finally:
+        await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# _get_available_workers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_available_workers_counts_activated(temp_db, temp_workspace):
+    _seed_activated_worker(temp_db, "notebook")
+    _seed_activated_worker(temp_db, "notebook")
+    _seed_activated_worker(temp_db, "plantuml")  # different type
+
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        assert backend._get_available_workers("notebook") == 2
+        assert backend._get_available_workers("plantuml") == 1
+        # No drawio workers — with wait_for_activation=False to skip the 30s sleep.
+        assert backend._get_available_workers("drawio", wait_for_activation=False) == 0
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_available_workers_waits_for_pre_registered(temp_db, temp_workspace):
+    """A 'created' worker is pre-registered; the backend polls until it activates."""
+    _seed_created_worker(temp_db, "notebook")
+
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        # Activate the worker after a short delay (from another thread).
+        import threading
+
+        def activate_later():
+            time.sleep(0.1)
+            conn = sqlite3.connect(temp_db)
+            try:
+                conn.execute(
+                    "UPDATE workers SET status='idle', "
+                    "last_heartbeat=CURRENT_TIMESTAMP WHERE worker_type='notebook'"
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        thread = threading.Thread(target=activate_later)
+        thread.start()
+        try:
+            # Shorten module-level sleeps so the test finishes fast.
+            real_sleep = time.sleep
+
+            def short_sleep(*_a, **_kw):
+                real_sleep(0.02)
+
+            with patch(
+                "clm.infrastructure.backends.sqlite_backend.time.sleep",
+                side_effect=short_sleep,
+            ):
+                count = backend._get_available_workers("notebook")
+            assert count >= 1
+        finally:
+            thread.join()
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_available_workers_no_queue(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        backend.job_queue = None  # type: ignore[assignment]
+        assert backend._get_available_workers("notebook") == 0
+    finally:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _get_output_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_output_metadata_all_types(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        assert backend._get_output_metadata(
+            "notebook",
+            {
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "notebook",
+            },
+        ) == str(("completed", "python", "en", "notebook"))
+
+        assert backend._get_output_metadata("plantuml", {"output_format": "svg"}) == "svg"
+        assert backend._get_output_metadata("drawio", {"output_format": "png"}) == "png"
+
+        jl_meta = backend._get_output_metadata(
+            "jupyterlite",
+            {
+                "target_name": "playground",
+                "language": "en",
+                "kinds": ["completed", "code-along"],
+                "kernel": "pyodide",
+            },
+        )
+        assert jl_meta == "jupyterlite:playground:en:code-along+completed:pyodide"
+
+        # Unknown job type → empty string.
+        assert backend._get_output_metadata("unknown", {}) == ""
+    finally:
+        await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# _extract_and_report_job_warnings and _report_cached_issues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_and_report_job_warnings_happy_path(temp_db, temp_workspace, tmp_path):
+    cache_db = tmp_path / "cache.db"
+    backend = _backend(temp_db, temp_workspace, build_reporter=_StubReporter())
+    backend.db_manager = DatabaseManager(cache_db)
+    backend.db_manager.__enter__()
+
+    try:
+        # Submit + immediately stash a result JSON with warnings.
+        await backend.execute_operation(_MockOp(), _MockPayload())
+        job_id = next(iter(backend.active_jobs))
+
+        result_payload = {
+            "warnings": [
+                {
+                    "category": "duplicate",
+                    "message": "duplicate topic",
+                    "severity": "high",
+                }
+            ]
+        }
+        conn = sqlite3.connect(temp_db)
+        try:
+            conn.execute(
+                "UPDATE jobs SET result = ? WHERE id = ?",
+                (json.dumps(result_payload), job_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        backend._extract_and_report_job_warnings(job_id, backend.active_jobs[job_id])
+        assert len(backend.build_reporter.warnings) == 1
+        assert backend.build_reporter.warnings[0].category == "duplicate"
+    finally:
+        backend.active_jobs.clear()
+        backend.db_manager.__exit__(None, None, None)
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_extract_and_report_job_warnings_no_row(temp_db, temp_workspace):
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        # Returns silently when no row found.
+        backend._extract_and_report_job_warnings(
+            999999, {"input_file": "x.py", "job_type": "notebook"}
+        )
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_report_cached_issues_reports_stored_errors_and_warnings(
+    temp_db, temp_workspace, tmp_path
+):
+    cache_db = tmp_path / "cache.db"
+    backend = _backend(temp_db, temp_workspace, build_reporter=_StubReporter())
+    backend.db_manager = DatabaseManager(cache_db)
+    backend.db_manager.__enter__()
+    try:
+        from clm.cli.build_data_classes import BuildWarning
+
+        backend.db_manager.store_error(
+            file_path="f.py",
+            content_hash="hh",
+            output_metadata="('x','python','en','notebook')",
+            error=BuildError(
+                error_type="user",
+                category="c",
+                severity="error",
+                file_path="f.py",
+                message="m",
+                actionable_guidance="fix",
+            ),
+        )
+        backend.db_manager.store_warning(
+            file_path="f.py",
+            content_hash="hh",
+            output_metadata="('x','python','en','notebook')",
+            warning=BuildWarning(category="c", message="w", severity="low"),
+        )
+
+        backend._report_cached_issues("f.py", "hh", "('x','python','en','notebook')")
+        assert len(backend.build_reporter.errors) == 1
+        assert backend.build_reporter.errors[0].details.get("from_cache") is True
+        assert len(backend.build_reporter.warnings) == 1
+    finally:
+        backend.db_manager.__exit__(None, None, None)
+        await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# copy_dir_group_to_output warning forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_copy_dir_group_forwards_warnings_to_reporter(temp_db, temp_workspace, tmp_path):
+    """When ``LocalOpsBackend.copy_dir_group_to_output`` returns warnings,
+    they must be forwarded to the build reporter.
+
+    Exercised by pointing the dir group at a non-existent source dir.
+    """
+    from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+    backend = _backend(temp_db, temp_workspace, build_reporter=_StubReporter())
+    try:
+        missing = tmp_path / "does-not-exist"
+        out = tmp_path / "out"
+        out.mkdir()
+        copy_data = CopyDirGroupData(
+            name="missing",
+            source_dirs=(missing,),
+            relative_paths=(Path("."),),
+            output_dir=out,
+            lang="en",
+        )
+        result = await backend.copy_dir_group_to_output(copy_data)
+        # Warnings forwarded; same list returned.
+        assert len(result) == len(backend.build_reporter.warnings)
+    finally:
+        await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Incremental copy_file_to_output skip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_incremental_copy_skips_existing_output(temp_db, temp_workspace, tmp_path):
+    from clm.infrastructure.utils.copy_file_data import CopyFileData
+
+    src = tmp_path / "src.txt"
+    src.write_text("hello")
+    dest = tmp_path / "out" / "src.txt"
+    dest.parent.mkdir()
+    dest.write_text("already here")
+
+    backend = _backend(temp_db, temp_workspace)
+    backend.incremental = True
+    try:
+        data = CopyFileData(
+            input_path=src,
+            output_path=dest,
+            relative_input_path=Path("src.txt"),
+        )
+        await backend.copy_file_to_output(data)
+        # File content unchanged — incremental skipped the copy.
+        assert dest.read_text() == "already here"
+    finally:
+        await backend.shutdown()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,212 @@
+"""Smoke tests for the MCP server wiring.
+
+These tests exercise ``create_server`` and verify that every expected
+tool is registered with the correct handler, schema fields, and default
+arguments.  Individual tool behavior is already covered by
+``tests/mcp/test_tools.py`` — here we only assert the server glue.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clm.mcp import server as server_module
+from clm.mcp.server import create_server, run_server
+
+EXPECTED_TOOLS = {
+    "resolve_topic",
+    "search_slides",
+    "course_outline",
+    "validate_spec",
+    "validate_slides",
+    "normalize_slides",
+    "get_language_view",
+    "suggest_sync",
+    "extract_voiceover",
+    "inline_voiceover",
+    "course_authoring_rules",
+}
+
+
+@pytest.fixture()
+def tmp_data_dir(tmp_path: Path) -> Path:
+    """Provide an empty data directory."""
+    return tmp_path
+
+
+@pytest.fixture()
+def course_tree(tmp_path: Path) -> Path:
+    """Minimal course tree with one topic and one spec."""
+    slides = tmp_path / "slides"
+    topic = slides / "module_100_basics" / "topic_010_intro"
+    topic.mkdir(parents=True)
+    (topic / "slides_intro.py").write_text(
+        '# %% [markdown]\n# {{ header("Einführung", "Introduction") }}\n',
+        encoding="utf-8",
+    )
+
+    specs = tmp_path / "course-specs"
+    specs.mkdir()
+    (specs / "course.xml").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <sections>
+        <section>
+            <name><de>S1</de><en>S1</en></name>
+            <topics>
+                <dir-group>
+                    <dir>module_100_basics</dir>
+                    <topic>topic_010_intro</topic>
+                </dir-group>
+            </topics>
+        </section>
+    </sections>
+</course>
+""",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+class TestCreateServer:
+    """create_server should return a configured FastMCP with every CLM tool."""
+
+    def test_returns_fastmcp_instance(self, tmp_data_dir: Path) -> None:
+        server = create_server(tmp_data_dir)
+        assert server.name == "clm"
+
+    def test_all_expected_tools_registered(self, tmp_data_dir: Path) -> None:
+        server = create_server(tmp_data_dir)
+        registered = set(server._tool_manager._tools.keys())
+        assert registered == EXPECTED_TOOLS
+
+    async def test_list_tools_exposes_all(self, tmp_data_dir: Path) -> None:
+        server = create_server(tmp_data_dir)
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert names == EXPECTED_TOOLS
+
+    def test_tool_schemas_have_descriptions(self, tmp_data_dir: Path) -> None:
+        """Every tool should have a non-trivial docstring-derived description."""
+        server = create_server(tmp_data_dir)
+        for name in EXPECTED_TOOLS:
+            tool = server._tool_manager.get_tool(name)
+            assert tool is not None, f"{name} missing from tool manager"
+            assert tool.description, f"{name} has no description"
+            # Should mention its primary subject in the first line
+            first_line = tool.description.splitlines()[0]
+            assert len(first_line) > 10, f"{name} description too short"
+
+    def test_tools_accept_expected_parameters(self, tmp_data_dir: Path) -> None:
+        """Spot-check parameter schemas for a handful of tools."""
+        server = create_server(tmp_data_dir)
+
+        resolve = server._tool_manager.get_tool("resolve_topic")
+        assert "topic_id" in resolve.parameters["properties"]
+
+        search = server._tool_manager.get_tool("search_slides")
+        search_props = search.parameters["properties"]
+        assert "query" in search_props
+        assert "max_results" in search_props
+
+        outline = server._tool_manager.get_tool("course_outline")
+        outline_props = outline.parameters["properties"]
+        assert "spec_file" in outline_props
+        assert "language" in outline_props
+        assert "include_disabled" in outline_props
+
+
+class TestServerDispatch:
+    """Smoke-call selected tools through the MCP dispatch path.
+
+    This verifies that the closures created by ``create_server`` actually
+    bind ``data_dir`` correctly and forward arguments to the handler.
+    """
+
+    async def test_call_resolve_topic(self, course_tree: Path) -> None:
+        server = create_server(course_tree)
+        result = await server._tool_manager.call_tool("resolve_topic", {"topic_id": "intro"})
+        payload = _extract_text_payload(result)
+        data = json.loads(payload)
+        assert data["topic_id"] == "intro"
+        assert "topic_010_intro" in (data.get("path") or "")
+
+    async def test_call_course_outline(self, course_tree: Path) -> None:
+        server = create_server(course_tree)
+        result = await server._tool_manager.call_tool(
+            "course_outline",
+            {"spec_file": "course-specs/course.xml", "language": "en"},
+        )
+        payload = _extract_text_payload(result)
+        data = json.loads(payload)
+        assert data["course_name"] == "Course"
+        assert data["language"] == "en"
+
+    async def test_call_search_slides_forwards_max_results(self, course_tree: Path) -> None:
+        server = create_server(course_tree)
+        result = await server._tool_manager.call_tool(
+            "search_slides", {"query": "intro", "max_results": 1}
+        )
+        payload = _extract_text_payload(result)
+        data = json.loads(payload)
+        assert "results" in data
+        assert len(data["results"]) <= 1
+
+
+class TestRunServer:
+    """run_server should configure the server and invoke stdio transport."""
+
+    def test_run_server_uses_stdio_transport(
+        self, tmp_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[dict[str, object]] = []
+
+        real_create_server = server_module.create_server
+
+        def fake_create_server(data_dir: Path):
+            srv = real_create_server(data_dir)
+
+            def fake_run(*args, **kwargs) -> None:
+                calls.append({"args": args, "kwargs": kwargs})
+
+            srv.run = fake_run  # type: ignore[method-assign]
+            return srv
+
+        monkeypatch.setattr(server_module, "create_server", fake_create_server)
+        run_server(tmp_data_dir)
+
+        assert len(calls) == 1
+        assert calls[0]["kwargs"].get("transport") == "stdio"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_text_payload(result: object) -> str:
+    """Pull the ``.text`` payload out of an MCP tool-call result.
+
+    FastMCP's ``call_tool`` may return either a raw string, a list of
+    content objects, or a tuple ``(content, structured)`` depending on
+    version.  We accept all three and return the first text chunk.
+    """
+    if isinstance(result, str):
+        return result
+    if isinstance(result, tuple) and result:
+        return _extract_text_payload(result[0])
+    if isinstance(result, list) and result:
+        first = result[0]
+        text = getattr(first, "text", None)
+        if text is not None:
+            return text
+        return str(first)
+    text = getattr(result, "text", None)
+    if text is not None:
+        return text
+    return str(result)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -13,8 +13,14 @@ from pathlib import Path
 
 import pytest
 
-from clm.mcp import server as server_module
-from clm.mcp.server import create_server, run_server
+# ``clm.mcp.server`` imports ``mcp.server.fastmcp`` at module level, so the
+# whole file is unimportable without the ``[mcp]`` extra.  Skip collection
+# cleanly in environments that don't install it (e.g. the Docker integration
+# CI job, which only installs the default extras).
+pytest.importorskip("mcp.server.fastmcp", reason="mcp SDK not installed (needs [mcp] extra)")
+
+from clm.mcp import server as server_module  # noqa: E402
+from clm.mcp.server import create_server, run_server  # noqa: E402
 
 EXPECTED_TOOLS = {
     "resolve_topic",

--- a/tests/recordings/test_batch.py
+++ b/tests/recordings/test_batch.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
-from clm.recordings.processing.batch import BatchResult, find_video_files
+import pytest
+
+from clm.recordings.processing import batch as batch_module
+from clm.recordings.processing.batch import (
+    VIDEO_EXTENSIONS,
+    BatchResult,
+    find_video_files,
+    process_batch,
+)
 
 
 class TestFindVideoFiles:
@@ -83,3 +92,286 @@ class TestBatchResult:
         result = BatchResult()
         summary = result.summary()
         assert "0 files" in summary
+
+    def test_summary_mentions_each_category(self):
+        from clm.recordings.processing.pipeline import ProcessingResult
+
+        result = BatchResult(
+            succeeded=[
+                ProcessingResult(input_file=Path("a.mkv"), output_file=Path("a.mp4"), success=True),
+                ProcessingResult(input_file=Path("b.mkv"), output_file=Path("b.mp4"), success=True),
+            ],
+            skipped=[Path("c.mkv")],
+        )
+        summary = result.summary()
+        assert "3 files" in summary
+        assert "Succeeded: 2" in summary
+        assert "Skipped:   1" in summary
+        assert "Failed:    0" in summary
+        # No failure detail section when there are no failures.
+        assert "Failed files:" not in summary
+
+    def test_summary_includes_failure_details(self):
+        from clm.recordings.processing.pipeline import ProcessingResult
+
+        result = BatchResult(
+            failed=[
+                ProcessingResult(
+                    input_file=Path("broken.mkv"),
+                    output_file=Path("broken.mp4"),
+                    success=False,
+                    error="ffmpeg exited 1",
+                ),
+            ],
+        )
+        summary = result.summary()
+        assert "Failed files:" in summary
+        assert "broken.mkv" in summary
+        assert "ffmpeg exited 1" in summary
+
+    def test_total_zero(self):
+        assert BatchResult().total == 0
+
+
+class TestFindVideoFilesExtensions:
+    """Test the extensions parameter of find_video_files."""
+
+    def test_default_matches_video_extensions_constant(self, tmp_path: Path):
+        # Create one file per default extension and a non-video.
+        for ext in VIDEO_EXTENSIONS:
+            (tmp_path / f"clip{ext}").touch()
+        (tmp_path / "notes.txt").touch()
+
+        files = find_video_files(tmp_path)
+        assert len(files) == len(VIDEO_EXTENSIONS)
+        assert all(f.suffix.lower() in VIDEO_EXTENSIONS for f in files)
+
+    def test_custom_extensions_overrides_default(self, tmp_path: Path):
+        (tmp_path / "clip.mkv").touch()
+        (tmp_path / "clip.wav").touch()
+        (tmp_path / "clip.flac").touch()
+
+        files = find_video_files(tmp_path, extensions={".wav", ".flac"})
+        names = sorted(f.name for f in files)
+        assert names == ["clip.flac", "clip.wav"]
+
+
+@pytest.fixture
+def fake_pipeline(monkeypatch: pytest.MonkeyPatch):
+    """Replace ProcessingPipeline with a fake so process_batch doesn't touch binaries."""
+    from clm.recordings.processing.pipeline import ProcessingResult
+
+    instances: list[MagicMock] = []
+
+    def _make_result(input_file: Path, output_file: Path, *, success: bool = True, error=None):
+        return ProcessingResult(
+            input_file=input_file,
+            output_file=output_file,
+            success=success,
+            duration_seconds=1.0,
+            error=error,
+        )
+
+    class FakePipeline:
+        def __init__(self, config):
+            self.config = config
+            self._process = MagicMock()
+            # Default: every process() call succeeds and creates an empty output file.
+            self._process.side_effect = self._default_process
+            instances.append(self)
+
+        def _default_process(self, input_file: Path, output_file: Path, *, on_step=None):
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_bytes(b"processed")
+            return _make_result(input_file, output_file, success=True)
+
+        def process(self, input_file: Path, output_file: Path, *, on_step=None):
+            return self._process(input_file, output_file, on_step=on_step)
+
+    monkeypatch.setattr(batch_module, "ProcessingPipeline", FakePipeline)
+    return instances
+
+
+class TestProcessBatch:
+    def test_empty_directory_returns_empty_result(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        output_dir = tmp_path / "out"
+
+        result = process_batch(input_dir, output_dir)
+
+        assert result.total == 0
+        assert result.succeeded == []
+        assert result.failed == []
+        assert result.skipped == []
+
+    def test_creates_output_directory(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        output_dir = tmp_path / "nested" / "out"
+
+        process_batch(input_dir, output_dir)
+
+        assert output_dir.is_dir()
+
+    def test_processes_all_videos(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "a.mkv").touch()
+        (input_dir / "b.mp4").touch()
+        output_dir = tmp_path / "out"
+
+        result = process_batch(input_dir, output_dir)
+
+        assert len(result.succeeded) == 2
+        assert len(result.failed) == 0
+        assert len(result.skipped) == 0
+
+    def test_output_filename_uses_suffix_and_extension(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "lecture.mkv").touch()
+        output_dir = tmp_path / "out"
+
+        result = process_batch(input_dir, output_dir, suffix="_clean")
+
+        expected = output_dir / "lecture_clean.mp4"
+        assert result.succeeded[0].output_file == expected
+        assert expected.is_file()
+
+    def test_skips_when_output_already_exists(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "video.mkv").touch()
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        # Pre-create output with the default suffix.
+        (output_dir / "video_final.mp4").write_bytes(b"already done")
+
+        result = process_batch(input_dir, output_dir)
+
+        assert result.skipped == [input_dir / "video.mkv"]
+        assert result.succeeded == []
+        # The fake pipeline's process method should not have been invoked.
+        assert fake_pipeline[0]._process.call_count == 0
+
+    def test_collects_failures_separately(self, tmp_path: Path, fake_pipeline):
+        from clm.recordings.processing.pipeline import ProcessingResult
+
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        good = input_dir / "good.mkv"
+        bad = input_dir / "bad.mkv"
+        good.touch()
+        bad.touch()
+        output_dir = tmp_path / "out"
+
+        def side_effect(input_file, output_file, *, on_step=None):
+            if input_file.name == "bad.mkv":
+                return ProcessingResult(
+                    input_file=input_file,
+                    output_file=output_file,
+                    success=False,
+                    error="boom",
+                )
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_bytes(b"ok")
+            return ProcessingResult(
+                input_file=input_file,
+                output_file=output_file,
+                success=True,
+            )
+
+        # Patch the fake pipeline instance AFTER process_batch constructs it —
+        # actually, fake_pipeline is constructed inside process_batch. Patch the
+        # class's _default_process via side_effect upfront by subclassing is
+        # hard; simpler: patch ProcessingPipeline itself.
+        from clm.recordings.processing import batch as batch_module_inner
+
+        class PipelineWithFailure:
+            def __init__(self, config):
+                self.config = config
+
+            def process(self, input_file, output_file, *, on_step=None):
+                return side_effect(input_file, output_file, on_step=on_step)
+
+        # Replace the monkeypatched class from the fixture.
+        batch_module_inner.ProcessingPipeline = PipelineWithFailure
+
+        result = process_batch(input_dir, output_dir)
+
+        succeeded_inputs = {r.input_file.name for r in result.succeeded}
+        failed_inputs = {r.input_file.name for r in result.failed}
+        assert succeeded_inputs == {"good.mkv"}
+        assert failed_inputs == {"bad.mkv"}
+
+    def test_on_file_callback_invoked_per_file(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "a.mkv").touch()
+        (input_dir / "b.mkv").touch()
+        output_dir = tmp_path / "out"
+
+        calls: list[tuple[int, str, int]] = []
+
+        def on_file(i: int, f: Path, total: int) -> None:
+            calls.append((i, f.name, total))
+
+        process_batch(input_dir, output_dir, on_file=on_file)
+
+        assert calls == [(0, "a.mkv", 2), (1, "b.mkv", 2)]
+
+    def test_on_step_passed_through_to_pipeline(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "a.mkv").touch()
+        output_dir = tmp_path / "out"
+
+        def on_step(step: int, name: str, total: int) -> None:
+            pass
+
+        process_batch(input_dir, output_dir, on_step=on_step)
+
+        # The fake pipeline recorded the on_step kwarg.
+        args, kwargs = fake_pipeline[0]._process.call_args
+        assert kwargs["on_step"] is on_step
+
+    def test_recursive_flag_descends_subdirs(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        sub = input_dir / "sub"
+        sub.mkdir(parents=True)
+        (input_dir / "top.mkv").touch()
+        (sub / "nested.mkv").touch()
+        output_dir = tmp_path / "out"
+
+        result = process_batch(input_dir, output_dir, recursive=True)
+
+        assert len(result.succeeded) == 2
+
+    def test_uses_default_config_when_none_passed(self, tmp_path: Path, fake_pipeline):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "a.mkv").touch()
+        output_dir = tmp_path / "out"
+
+        process_batch(input_dir, output_dir)
+
+        # The fake pipeline instance received a PipelineConfig (the default).
+        from clm.recordings.processing.config import PipelineConfig
+
+        assert isinstance(fake_pipeline[0].config, PipelineConfig)
+
+    def test_custom_config_is_used(self, tmp_path: Path, fake_pipeline):
+        from clm.recordings.processing.config import PipelineConfig
+
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        (input_dir / "a.mkv").touch()
+        output_dir = tmp_path / "out"
+        config = PipelineConfig(output_extension="mkv")
+
+        result = process_batch(input_dir, output_dir, config=config)
+
+        assert fake_pipeline[0].config is config
+        # The output file name reflects the custom extension.
+        assert result.succeeded[0].output_file.suffix == ".mkv"

--- a/tests/recordings/test_processing_compare.py
+++ b/tests/recordings/test_processing_compare.py
@@ -1,0 +1,144 @@
+"""Unit tests for ``clm.recordings.processing.compare``.
+
+The FFmpeg extraction is stubbed; only argv construction, base64 framing,
+and HTML rendering are checked here.
+"""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clm.recordings.processing import compare as compare_module
+from clm.recordings.processing.compare import (
+    audio_to_base64,
+    extract_audio_segment,
+    generate_comparison_html,
+)
+
+
+class TestExtractAudioSegment:
+    def _fake_result(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    def test_argv_without_segment_flags(self, tmp_path: Path):
+        with patch(
+            "clm.recordings.processing.compare.run_subprocess",
+            return_value=self._fake_result(),
+        ) as mock_run:
+            extract_audio_segment(
+                ffmpeg=Path("/usr/bin/ffmpeg"),
+                input_file=tmp_path / "in.mp4",
+                output_file=tmp_path / "out.wav",
+                start_seconds=0,
+                duration_seconds=0,
+            )
+
+        args, _ = mock_run.call_args
+        argv = args[0]
+        assert argv[0] == Path("/usr/bin/ffmpeg")
+        assert "-i" in argv
+        # Without start/duration, -ss and -t must be absent.
+        assert "-ss" not in argv
+        assert "-t" not in argv
+        # WAV output codec is always set.
+        assert "pcm_s16le" in argv
+        assert argv[-1] == tmp_path / "out.wav"
+
+    def test_argv_with_segment_flags(self, tmp_path: Path):
+        with patch(
+            "clm.recordings.processing.compare.run_subprocess",
+            return_value=self._fake_result(),
+        ) as mock_run:
+            extract_audio_segment(
+                ffmpeg=Path("/usr/bin/ffmpeg"),
+                input_file=tmp_path / "in.mp4",
+                output_file=tmp_path / "out.wav",
+                start_seconds=15,
+                duration_seconds=30,
+            )
+
+        args, _ = mock_run.call_args
+        argv = args[0]
+        assert "-ss" in argv
+        assert argv[argv.index("-ss") + 1] == "15"
+        assert "-t" in argv
+        assert argv[argv.index("-t") + 1] == "30"
+
+
+class TestAudioToBase64:
+    def test_encodes_round_trip(self, tmp_path: Path):
+        raw = b"RIFF\x00fake-wav\xff\xaa"
+        f = tmp_path / "clip.wav"
+        f.write_bytes(raw)
+
+        encoded = audio_to_base64(f)
+        assert isinstance(encoded, str)
+        assert base64.b64decode(encoded) == raw
+
+    def test_empty_file(self, tmp_path: Path):
+        f = tmp_path / "empty.wav"
+        f.write_bytes(b"")
+        assert audio_to_base64(f) == ""
+
+
+class TestGenerateComparisonHtml:
+    def test_without_original(self):
+        html = generate_comparison_html(
+            original_b64=None,
+            version_a_b64="AAAA",
+            version_b_b64="BBBB",
+            label_a="iZotope RX",
+            label_b="DeepFilterNet",
+        )
+        assert "<!DOCTYPE html>" in html
+        assert "iZotope RX" in html
+        assert "DeepFilterNet" in html
+        assert "AAAA" in html
+        assert "BBBB" in html
+        # No "Original" card when no original is supplied.
+        assert "Original (unprocessed)" not in html
+
+    def test_with_original(self):
+        html = generate_comparison_html(
+            original_b64="ORIG",
+            version_a_b64="AAAA",
+            version_b_b64="BBBB",
+            label_a="A-label",
+            label_b="B-label",
+        )
+        assert "Original (unprocessed)" in html
+        assert "ORIG" in html
+        assert "A-label" in html
+        assert "B-label" in html
+
+    def test_labels_appear_in_reveal_script(self):
+        """Reveal-text substitution must bake both labels into the JS block."""
+        html = generate_comparison_html(
+            original_b64=None,
+            version_a_b64="aa",
+            version_b_b64="bb",
+            label_a="Variant-A",
+            label_b="Variant-B",
+        )
+        # The reveal script references labels twice each (swap vs. no-swap).
+        assert html.count("Variant-A") >= 2
+        assert html.count("Variant-B") >= 2
+
+    @pytest.mark.parametrize(
+        "label_a,label_b",
+        [("", ""), ("a" * 200, "b" * 200)],
+    )
+    def test_accepts_edge_case_labels(self, label_a: str, label_b: str):
+        html = generate_comparison_html(
+            original_b64=None,
+            version_a_b64="x",
+            version_b_b64="y",
+            label_a=label_a,
+            label_b=label_b,
+        )
+        assert "<html" in html

--- a/tests/recordings/test_processing_pipeline.py
+++ b/tests/recordings/test_processing_pipeline.py
@@ -7,12 +7,27 @@ marked with @pytest.mark.recordings.
 
 from __future__ import annotations
 
+import subprocess
 import textwrap
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from clm.recordings.processing import pipeline as pipeline_module
+from clm.recordings.processing.config import PipelineConfig
 from clm.recordings.processing.pipeline import ProcessingPipeline, ProcessingResult
+
+
+@pytest.fixture
+def mock_binaries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend ffmpeg/ffprobe exist so ProcessingPipeline() can be constructed."""
+    monkeypatch.setattr(pipeline_module, "find_ffmpeg", lambda: Path("/mock/ffmpeg"))
+    monkeypatch.setattr(pipeline_module, "find_ffprobe", lambda: Path("/mock/ffprobe"))
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 class TestLoudnormParsing:
@@ -100,3 +115,278 @@ class TestProcessingResult:
         assert not r.success
         assert r.error == "Something went wrong"
         assert r.duration_seconds == 0.0
+
+
+class TestProcessingPipelineInit:
+    def test_locates_binaries(self, mock_binaries: None):
+        pipeline = ProcessingPipeline()
+        assert pipeline.ffmpeg == Path("/mock/ffmpeg")
+        assert pipeline.ffprobe == Path("/mock/ffprobe")
+        assert isinstance(pipeline.config, PipelineConfig)
+
+    def test_accepts_custom_config(self, mock_binaries: None):
+        cfg = PipelineConfig(keep_temp=True, sample_rate=44100)
+        pipeline = ProcessingPipeline(config=cfg)
+        assert pipeline.config.keep_temp is True
+        assert pipeline.config.sample_rate == 44100
+
+
+class TestProcessingPipelineProcess:
+    """Exercise ProcessingPipeline.process with all external calls mocked."""
+
+    @pytest.fixture
+    def loudnorm_stderr(self) -> str:
+        return textwrap.dedent("""\
+            {
+                "input_i" : "-24.00",
+                "input_tp" : "-3.00",
+                "input_lra" : "8.00",
+                "input_thresh" : "-35.00",
+                "output_i" : "-16.00",
+                "output_tp" : "-1.50",
+                "output_lra" : "7.80",
+                "output_thresh" : "-26.50",
+                "normalization_type" : "dynamic",
+                "target_offset" : "0.00"
+            }
+        """)
+
+    def test_missing_input_returns_failed_result(self, mock_binaries: None, tmp_path: Path):
+        pipeline = ProcessingPipeline()
+        out = tmp_path / "out.mp4"
+        result = pipeline.process(tmp_path / "missing.mkv", out)
+        assert result.success is False
+        assert result.error is not None
+        assert "not found" in result.error
+
+    def test_happy_path_invokes_all_steps(
+        self,
+        mock_binaries: None,
+        tmp_path: Path,
+        loudnorm_stderr: str,
+    ):
+        input_file = tmp_path / "raw.mkv"
+        input_file.write_bytes(b"fake-video")
+        output_file = tmp_path / "out" / "final.mp4"
+
+        steps: list[tuple[int, str, int]] = []
+
+        def on_step(step: int, name: str, total: int) -> None:
+            steps.append((step, name, total))
+
+        # Two-pass loudnorm: first pass returns the JSON above on stderr,
+        # subsequent calls return empty (they don't inspect output).
+        run_calls: list[list] = []
+
+        def fake_run_subprocess(argv, *, check: bool = True, **kwargs):
+            run_calls.append(list(argv))
+            return _completed(stderr=loudnorm_stderr if "null" in argv else "")
+
+        with (
+            patch.object(pipeline_module, "run_subprocess", side_effect=fake_run_subprocess),
+            patch.object(pipeline_module, "run_onnx_denoise") as onnx_mock,
+            patch.object(pipeline_module, "get_audio_duration", return_value=42.0) as duration_mock,
+        ):
+            pipeline = ProcessingPipeline()
+            result = pipeline.process(input_file, output_file, on_step=on_step)
+
+        assert result.success is True
+        assert result.duration_seconds == 42.0
+        assert result.output_file == output_file.resolve()
+
+        # Callback saw all five steps in order.
+        assert [s[0] for s in steps] == [1, 2, 3, 4, 5]
+        assert all(s[2] == 5 for s in steps)
+        assert "Extracting audio" in steps[0][1]
+        assert "Muxing" in steps[4][1]
+
+        # Output dir was created.
+        assert output_file.parent.exists()
+        # ONNX denoise called once.
+        onnx_mock.assert_called_once()
+        duration_mock.assert_called_once()
+
+        # run_subprocess was called for each ffmpeg step (extract, loudnorm
+        # measurement pass, loudnorm apply pass, encode, mux = 5 calls).
+        assert len(run_calls) >= 5
+        # Mux command must map video + audio and use +faststart.
+        mux_argv = run_calls[-1]
+        assert any("+faststart" == str(a) for a in mux_argv)
+        assert "-map" in [str(a) for a in mux_argv]
+
+    def test_exception_during_processing_returns_failed_result(
+        self, mock_binaries: None, tmp_path: Path
+    ):
+        input_file = tmp_path / "raw.mkv"
+        input_file.write_bytes(b"x")
+        output_file = tmp_path / "out.mp4"
+
+        with (
+            patch.object(
+                pipeline_module,
+                "run_subprocess",
+                side_effect=RuntimeError("ffmpeg exploded"),
+            ),
+            patch.object(pipeline_module, "run_onnx_denoise"),
+            patch.object(pipeline_module, "get_audio_duration", return_value=1.0),
+        ):
+            pipeline = ProcessingPipeline()
+            result = pipeline.process(input_file, output_file)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "ffmpeg exploded" in result.error
+
+    def test_keep_temp_preserves_temp_dir(
+        self, mock_binaries: None, tmp_path: Path, loudnorm_stderr: str
+    ):
+        """keep_temp=True must not remove the temp directory after processing."""
+        input_file = tmp_path / "raw.mkv"
+        input_file.write_bytes(b"x")
+        output_file = tmp_path / "out.mp4"
+
+        recorded_temp_dirs: list[Path] = []
+        original_mkdtemp = pipeline_module.tempfile.mkdtemp
+
+        def record_mkdtemp(*args, **kwargs) -> str:
+            path: str = original_mkdtemp(*args, **kwargs)
+            recorded_temp_dirs.append(Path(path))
+            return path
+
+        def fake_run_subprocess(argv, *, check: bool = True, **kwargs):
+            return _completed(stderr=loudnorm_stderr if "null" in argv else "")
+
+        cfg = PipelineConfig(keep_temp=True)
+        with (
+            patch.object(pipeline_module.tempfile, "mkdtemp", side_effect=record_mkdtemp),
+            patch.object(pipeline_module, "run_subprocess", side_effect=fake_run_subprocess),
+            patch.object(pipeline_module, "run_onnx_denoise"),
+            patch.object(pipeline_module, "get_audio_duration", return_value=1.0),
+        ):
+            pipeline = ProcessingPipeline(config=cfg)
+            result = pipeline.process(input_file, output_file)
+
+        assert result.success is True
+        assert recorded_temp_dirs
+        assert recorded_temp_dirs[0].exists()
+        # Caller is responsible for cleanup when keep_temp is set.
+        import shutil
+
+        shutil.rmtree(recorded_temp_dirs[0], ignore_errors=True)
+
+    def test_single_pass_fallback_when_loudnorm_unparseable(
+        self, mock_binaries: None, tmp_path: Path
+    ):
+        """If the first loudnorm pass produces no JSON, the second pass uses
+        ``loudnorm_filter`` directly."""
+        input_file = tmp_path / "raw.mkv"
+        input_file.write_bytes(b"x")
+        output_file = tmp_path / "out.mp4"
+
+        run_calls: list[list] = []
+
+        def fake_run_subprocess(argv, *, check: bool = True, **kwargs):
+            run_calls.append([str(a) for a in argv])
+            return _completed(stderr="no json here")  # measure pass returns garbage
+
+        with (
+            patch.object(pipeline_module, "run_subprocess", side_effect=fake_run_subprocess),
+            patch.object(pipeline_module, "run_onnx_denoise"),
+            patch.object(pipeline_module, "get_audio_duration", return_value=1.0),
+        ):
+            pipeline = ProcessingPipeline()
+            result = pipeline.process(input_file, output_file)
+
+        assert result.success is True
+        # The apply-pass ffmpeg call must use the fallback single-pass filter
+        # (no "measured_I" when measurement failed).
+        apply_calls = [c for c in run_calls if "-af" in c and "loudnorm" in " ".join(c)]
+        # Find the apply pass — it follows the measurement pass. Measurement
+        # pass outputs to "NUL" or "/dev/null"; apply pass outputs to the
+        # temp wav file.
+        apply_pass = [c for c in apply_calls if "NUL" not in c and "/dev/null" not in c]
+        assert apply_pass, "expected an apply-pass ffmpeg invocation"
+        apply_filter = apply_pass[0][apply_pass[0].index("-af") + 1]
+        assert "measured_I" not in apply_filter
+
+
+class TestPrivateArgv:
+    """Verify the argv each private step method assembles."""
+
+    @pytest.fixture
+    def pipeline(self, mock_binaries: None) -> ProcessingPipeline:
+        return ProcessingPipeline()
+
+    @staticmethod
+    def _capture_argv(captured: list[list[str]]):
+        """Build a patch side_effect that records the argv of each call."""
+
+        def _side_effect(argv, **_kwargs):
+            captured.append([str(a) for a in argv])
+            return _completed()
+
+        return _side_effect
+
+    def test_extract_audio_argv(self, pipeline: ProcessingPipeline, tmp_path: Path):
+        captured: list[list[str]] = []
+        with patch.object(
+            pipeline_module, "run_subprocess", side_effect=self._capture_argv(captured)
+        ):
+            pipeline._extract_audio(tmp_path / "in.mkv", tmp_path / "out.wav")
+
+        argv = captured[0]
+        # ffmpeg path is always the first argv element; platform separators vary.
+        assert argv[0].endswith("ffmpeg") or argv[0].endswith("ffmpeg.exe")
+        assert "-vn" in argv
+        assert "pcm_s16le" in argv
+        assert "48000" in argv  # default sample rate
+        assert argv[-1].endswith("out.wav")
+
+    def test_encode_audio_argv(self, pipeline: ProcessingPipeline, tmp_path: Path):
+        captured: list[list[str]] = []
+        with patch.object(
+            pipeline_module, "run_subprocess", side_effect=self._capture_argv(captured)
+        ):
+            pipeline._encode_audio(tmp_path / "in.wav", tmp_path / "out.aac")
+
+        argv = captured[0]
+        assert "aac" in argv
+        assert "192k" in argv  # default bitrate
+        assert argv[-1].endswith("out.aac")
+
+    def test_mux_video_argv(self, pipeline: ProcessingPipeline, tmp_path: Path):
+        captured: list[list[str]] = []
+        with patch.object(
+            pipeline_module, "run_subprocess", side_effect=self._capture_argv(captured)
+        ):
+            pipeline._mux_video(
+                tmp_path / "video.mkv",
+                tmp_path / "audio.aac",
+                tmp_path / "final.mp4",
+            )
+
+        argv = captured[0]
+        assert "copy" in argv  # default video codec
+        assert "+faststart" in argv
+        assert "0:v:0" in argv
+        assert "1:a:0" in argv
+
+    def test_run_denoise_forwards_atten(self, pipeline: ProcessingPipeline, tmp_path: Path):
+        pipeline.config.denoise_atten_lim = 42.0
+        with patch.object(pipeline_module, "run_onnx_denoise") as denoise:
+            pipeline._run_denoise(tmp_path / "a.wav", tmp_path / "b.wav")
+        denoise.assert_called_once()
+        _, kwargs = denoise.call_args
+        assert kwargs["atten_lim_db"] == 42.0
+
+    def test_measure_loudness_returns_none_on_empty_output(
+        self, pipeline: ProcessingPipeline, tmp_path: Path
+    ):
+        with patch.object(
+            pipeline_module, "run_subprocess", return_value=_completed(stderr="no json")
+        ):
+            result = pipeline._measure_loudness(
+                tmp_path / "in.wav",
+                base_filters="highpass=f=80,compand",
+            )
+        assert result is None

--- a/tests/recordings/test_processing_utils.py
+++ b/tests/recordings/test_processing_utils.py
@@ -1,0 +1,417 @@
+"""Unit tests for ``clm.recordings.processing.utils``.
+
+These tests stay on the host side of every external dependency — no real
+ffmpeg, no real network, no real ONNX inference. The ONNX path is exercised
+with heavy mocking so the function body is covered without a model file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from clm.recordings.processing import utils
+from clm.recordings.processing.utils import (
+    BinaryNotFoundError,
+    check_dependencies,
+    check_onnxruntime,
+    download_onnx_model,
+    find_binary,
+    find_ffmpeg,
+    find_ffprobe,
+    get_audio_duration,
+    run_onnx_denoise,
+    run_subprocess,
+)
+
+
+class TestBinaryNotFoundError:
+    def test_message_without_hint(self):
+        err = BinaryNotFoundError("ffmpeg")
+        assert "ffmpeg" in str(err)
+        assert "Install" not in str(err)
+        assert err.name == "ffmpeg"
+
+    def test_message_with_hint(self):
+        err = BinaryNotFoundError("ffmpeg", "winget install FFmpeg")
+        text = str(err)
+        assert "ffmpeg" in text
+        assert "Install: winget install FFmpeg" in text
+
+
+class TestFindBinary:
+    def test_returns_path_when_on_path(self):
+        with patch("clm.recordings.processing.utils.shutil.which", return_value="/usr/bin/ffmpeg"):
+            assert find_binary("ffmpeg") == Path("/usr/bin/ffmpeg")
+
+    def test_windows_scripts_fallback(self, monkeypatch: pytest.MonkeyPatch):
+        """On Windows, pip-installed scripts should be located via sys.prefix."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        with (
+            patch("clm.recordings.processing.utils.shutil.which", return_value=None),
+            patch.object(Path, "is_file", return_value=True),
+        ):
+            result = find_binary("auphonic")
+            # First candidate is sys.prefix / "Scripts" / "auphonic.exe"
+            assert result.name == "auphonic.exe"
+            assert "Scripts" in result.parts
+
+    def test_raises_when_missing(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch("clm.recordings.processing.utils.shutil.which", return_value=None):
+            with pytest.raises(BinaryNotFoundError) as exc:
+                find_binary("nonesuch")
+            assert exc.value.name == "nonesuch"
+
+    def test_raises_on_windows_when_no_candidate_exists(self, monkeypatch: pytest.MonkeyPatch):
+        """Windows fallback iterates candidates; all missing → raise."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        with (
+            patch("clm.recordings.processing.utils.shutil.which", return_value=None),
+            patch.object(Path, "is_file", return_value=False),
+        ):
+            with pytest.raises(BinaryNotFoundError):
+                find_binary("nonesuch")
+
+
+class TestFindFfmpeg:
+    def test_delegates_to_find_binary(self):
+        with patch(
+            "clm.recordings.processing.utils.find_binary",
+            return_value=Path("/opt/ffmpeg"),
+        ) as m:
+            assert find_ffmpeg() == Path("/opt/ffmpeg")
+            m.assert_called_once_with("ffmpeg")
+
+    def test_adds_windows_hint(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        with patch(
+            "clm.recordings.processing.utils.find_binary",
+            side_effect=BinaryNotFoundError("ffmpeg"),
+        ):
+            with pytest.raises(BinaryNotFoundError) as exc:
+                find_ffmpeg()
+            assert "winget install FFmpeg" in str(exc.value)
+
+    def test_adds_posix_hint(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch(
+            "clm.recordings.processing.utils.find_binary",
+            side_effect=BinaryNotFoundError("ffmpeg"),
+        ):
+            with pytest.raises(BinaryNotFoundError) as exc:
+                find_ffmpeg()
+            text = str(exc.value)
+            assert "apt install" in text or "pacman" in text
+
+
+class TestFindFfprobe:
+    def test_delegates_to_find_binary(self):
+        with patch(
+            "clm.recordings.processing.utils.find_binary",
+            return_value=Path("/opt/ffprobe"),
+        ) as m:
+            assert find_ffprobe() == Path("/opt/ffprobe")
+            m.assert_called_once_with("ffprobe")
+
+    def test_wraps_not_found_with_hint(self):
+        with patch(
+            "clm.recordings.processing.utils.find_binary",
+            side_effect=BinaryNotFoundError("ffprobe"),
+        ):
+            with pytest.raises(BinaryNotFoundError) as exc:
+                find_ffprobe()
+            assert "alongside ffmpeg" in str(exc.value)
+
+
+class TestDownloadOnnxModel:
+    def test_returns_existing_model_without_download(self, tmp_path: Path):
+        cache_dir = tmp_path / "models"
+        cache_dir.mkdir()
+        cached = cache_dir / utils.ONNX_MODEL_FILENAME
+        cached.write_bytes(b"fake-model")
+
+        with patch("clm.recordings.processing.utils.urllib.request.urlretrieve") as mock_retrieve:
+            result = download_onnx_model(cache_dir=cache_dir)
+
+        assert result == cached
+        mock_retrieve.assert_not_called()
+
+    def test_downloads_when_missing(self, tmp_path: Path):
+        cache_dir = tmp_path / "new_cache"
+
+        def fake_retrieve(url: str, dest: str) -> None:
+            Path(dest).write_bytes(b"downloaded")
+
+        with patch(
+            "clm.recordings.processing.utils.urllib.request.urlretrieve",
+            side_effect=fake_retrieve,
+        ) as mock_retrieve:
+            result = download_onnx_model(cache_dir=cache_dir)
+
+        assert result.exists()
+        assert result.read_bytes() == b"downloaded"
+        mock_retrieve.assert_called_once()
+        # URL is the first positional argument.
+        args, _ = mock_retrieve.call_args
+        assert args[0] == utils.ONNX_MODEL_URL
+
+    def test_default_cache_dir_uses_platformdirs(self, tmp_path: Path):
+        """When cache_dir is None, the function should route through platformdirs."""
+        with (
+            patch(
+                "platformdirs.user_cache_dir",
+                return_value=str(tmp_path / "user_cache"),
+            ),
+            patch("clm.recordings.processing.utils.urllib.request.urlretrieve") as mock_retrieve,
+        ):
+
+            def fake_retrieve(url: str, dest: str) -> None:
+                Path(dest).write_bytes(b"x")
+
+            mock_retrieve.side_effect = fake_retrieve
+            result = download_onnx_model()
+
+        assert result.exists()
+        assert result.parent.name == "models"
+        # Directory below the platformdirs-provided cache dir.
+        assert "user_cache" in str(result)
+
+
+class TestCheckOnnxruntime:
+    def test_returns_version_when_installed(self):
+        # onnxruntime is a real dep — the version is a non-empty string.
+        version = check_onnxruntime()
+        assert version is not None
+        assert isinstance(version, str)
+        assert version  # non-empty
+
+    def test_returns_none_on_import_error(self):
+        def fake_import(name: str, *args, **kwargs):
+            if name == "onnxruntime":
+                raise ImportError("no onnxruntime")
+            return real_import(name, *args, **kwargs)
+
+        import builtins
+
+        real_import = builtins.__import__
+        with patch("builtins.__import__", side_effect=fake_import):
+            assert check_onnxruntime() is None
+
+
+class TestCheckDependencies:
+    def test_reports_all_found(self):
+        with (
+            patch(
+                "clm.recordings.processing.utils.find_ffmpeg",
+                return_value=Path("/usr/bin/ffmpeg"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.find_ffprobe",
+                return_value=Path("/usr/bin/ffprobe"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.check_onnxruntime",
+                return_value="1.17.0",
+            ),
+        ):
+            deps = check_dependencies()
+
+        assert deps["ffmpeg"] == Path("/usr/bin/ffmpeg")
+        assert deps["ffprobe"] == Path("/usr/bin/ffprobe")
+        assert deps["onnxruntime"] == "1.17.0"
+
+    def test_reports_missing_binaries_as_none(self):
+        with (
+            patch(
+                "clm.recordings.processing.utils.find_ffmpeg",
+                side_effect=BinaryNotFoundError("ffmpeg"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.find_ffprobe",
+                side_effect=BinaryNotFoundError("ffprobe"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.check_onnxruntime",
+                return_value=None,
+            ),
+        ):
+            deps = check_dependencies()
+
+        assert deps == {"ffmpeg": None, "ffprobe": None, "onnxruntime": None}
+
+
+class TestRunSubprocess:
+    def test_success_returns_completed_process(self):
+        fake_result = subprocess.CompletedProcess(
+            args=["echo"], returncode=0, stdout="hi\n", stderr=""
+        )
+        with patch(
+            "clm.recordings.processing.utils.subprocess.run", return_value=fake_result
+        ) as mock_run:
+            result = run_subprocess(["echo", "hi"])
+        assert result.returncode == 0
+        assert result.stdout == "hi\n"
+        # args must be stringified.
+        called_args, called_kwargs = mock_run.call_args
+        assert called_args[0] == ["echo", "hi"]
+        assert called_kwargs["text"] is True
+        assert called_kwargs["check"] is True
+        assert called_kwargs["capture_output"] is True
+
+    def test_stringifies_path_arguments(self):
+        fake_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch(
+            "clm.recordings.processing.utils.subprocess.run", return_value=fake_result
+        ) as mock_run:
+            run_subprocess(["ffmpeg", Path("/tmp/in.wav"), Path("/tmp/out.wav")])
+        called_args, _ = mock_run.call_args
+        assert all(isinstance(a, str) for a in called_args[0])
+
+    def test_passes_cwd_through(self, tmp_path: Path):
+        fake_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch(
+            "clm.recordings.processing.utils.subprocess.run", return_value=fake_result
+        ) as mock_run:
+            run_subprocess(["ls"], cwd=tmp_path)
+        _, called_kwargs = mock_run.call_args
+        assert called_kwargs["cwd"] == tmp_path
+
+    def test_check_false_returns_nonzero_exit(self):
+        """When ``check=False`` and the command exits nonzero, the warning
+        branch must execute and the CompletedProcess is returned to the caller.
+        """
+        fake_result = subprocess.CompletedProcess(
+            args=["bad"], returncode=2, stdout="", stderr="kaboom"
+        )
+        with patch(
+            "clm.recordings.processing.utils.subprocess.run",
+            return_value=fake_result,
+        ):
+            result = run_subprocess(["bad"], check=False)
+        assert result.returncode == 2
+
+    def test_windows_applies_creationflags(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        fake_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch(
+            "clm.recordings.processing.utils.subprocess.run", return_value=fake_result
+        ) as mock_run:
+            run_subprocess(["echo", "hi"])
+        _, called_kwargs = mock_run.call_args
+        assert called_kwargs.get("creationflags") == 0x08000000
+
+    def test_non_windows_omits_creationflags(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        fake_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch(
+            "clm.recordings.processing.utils.subprocess.run", return_value=fake_result
+        ) as mock_run:
+            run_subprocess(["echo", "hi"])
+        _, called_kwargs = mock_run.call_args
+        assert "creationflags" not in called_kwargs
+
+
+class TestGetAudioDuration:
+    def test_parses_ffprobe_output(self):
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="123.45\n", stderr=""
+        )
+        with patch(
+            "clm.recordings.processing.utils.run_subprocess",
+            return_value=fake_result,
+        ) as mock_run:
+            duration = get_audio_duration(Path("/usr/bin/ffprobe"), Path("/tmp/x.wav"))
+        assert duration == pytest.approx(123.45)
+        # ffprobe is the first argv element.
+        called_args, _ = mock_run.call_args
+        argv = called_args[0]
+        assert argv[0] == Path("/usr/bin/ffprobe")
+        assert "-show_entries" in argv
+
+
+class TestRunOnnxDenoise:
+    """Exercise run_onnx_denoise end-to-end with heavy mocks.
+
+    Covers the happy-path happy branch (sample-rate OK, mono audio) and the
+    stereo + sample-rate-error branches. No real model file is loaded.
+    """
+
+    def _make_fake_session(self, hop_size: int = 480) -> MagicMock:
+        session = MagicMock()
+
+        def fake_run(_outputs, inputs):
+            frame = inputs["input_frame"]
+            state = inputs["states"]
+            lsnr = np.zeros(1, dtype=np.float32)
+            return [frame.copy(), state.copy(), lsnr]
+
+        session.run.side_effect = fake_run
+        return session
+
+    def test_denoises_mono_audio(self, tmp_path: Path):
+        # Length is a multiple of the hop size so no padding is added.
+        n_samples = utils.ONNX_HOP_SIZE * 100  # ~1 second at 48 kHz
+        audio = np.linspace(-0.5, 0.5, n_samples, dtype=np.float32)
+
+        with (
+            patch(
+                "clm.recordings.processing.utils.download_onnx_model",
+                return_value=tmp_path / "fake.onnx",
+            ),
+            patch("onnxruntime.InferenceSession", return_value=self._make_fake_session()),
+            patch("soundfile.read", return_value=(audio, 48000)),
+            patch("soundfile.write") as sf_write,
+        ):
+            run_onnx_denoise(tmp_path / "in.wav", tmp_path / "out.wav")
+
+        sf_write.assert_called_once()
+        args, _ = sf_write.call_args
+        written = args[1]
+        # The pipeline trims the algorithmic delay from the start.
+        delay = utils.ONNX_FFT_SIZE - utils.ONNX_HOP_SIZE
+        assert written.ndim == 1
+        assert written.shape[0] == n_samples - delay
+        # Sample rate argument is passed through.
+        assert args[2] == 48000
+
+    def test_stereo_input_uses_first_channel(self, tmp_path: Path):
+        n_samples = utils.ONNX_HOP_SIZE * 3  # multiple of hop size → no padding
+        mono = np.linspace(-0.5, 0.5, n_samples, dtype=np.float32)
+        stereo = np.stack([mono, -mono], axis=1)
+
+        with (
+            patch(
+                "clm.recordings.processing.utils.download_onnx_model",
+                return_value=tmp_path / "fake.onnx",
+            ),
+            patch("onnxruntime.InferenceSession", return_value=self._make_fake_session()),
+            patch("soundfile.read", return_value=(stereo, 48000)),
+            patch("soundfile.write") as sf_write,
+        ):
+            run_onnx_denoise(tmp_path / "in.wav", tmp_path / "out.wav")
+
+        args, _ = sf_write.call_args
+        written = args[1]
+        delay = utils.ONNX_FFT_SIZE - utils.ONNX_HOP_SIZE
+        assert written.ndim == 1
+        assert written.shape[0] == n_samples - delay
+
+    def test_rejects_non_48k_sample_rate(self, tmp_path: Path):
+        audio = np.zeros(1000, dtype=np.float32)
+        with (
+            patch(
+                "clm.recordings.processing.utils.download_onnx_model",
+                return_value=tmp_path / "fake.onnx",
+            ),
+            patch("onnxruntime.InferenceSession", return_value=self._make_fake_session()),
+            patch("soundfile.read", return_value=(audio, 44100)),
+            patch("soundfile.write"),
+        ):
+            with pytest.raises(ValueError, match="48 kHz"):
+                run_onnx_denoise(tmp_path / "in.wav", tmp_path / "out.wav")

--- a/tests/recordings/test_recordings_command.py
+++ b/tests/recordings/test_recordings_command.py
@@ -1,0 +1,1016 @@
+"""Tests for ``clm recordings`` CLI commands.
+
+Complements ``test_cli_recordings.py`` (which covers the jobs subcommand
+group) by exercising the remaining commands: check, process, batch,
+status, compare, assemble, serve, backends, and the internal config
+resolution helpers. Mocks at narrow seams so the tests don't require
+ffmpeg, OBS, uvicorn, or the Auphonic API.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import recordings as recordings_module
+from clm.cli.commands.recordings import (
+    _build_recordings_config,
+    _get_auphonic_config,
+    _get_obs_config,
+    _get_raw_suffix,
+    _get_watcher_config,
+    _load_pipeline_config,
+    _resolve_recordings_root,
+    recordings_group,
+)
+
+# ---------------------------------------------------------------------------
+# _get_*_config helpers — fallback paths (config system unavailable).
+# ---------------------------------------------------------------------------
+
+
+class TestGetObsConfig:
+    def test_returns_config_values_when_available(self, monkeypatch: pytest.MonkeyPatch):
+        fake_config_module = MagicMock()
+        fake_cfg = MagicMock()
+        fake_cfg.recordings.obs_host = "host.internal"
+        fake_cfg.recordings.obs_port = 4456
+        fake_cfg.recordings.obs_password = "secret"
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        host, port, password = _get_obs_config()
+        assert (host, port, password) == ("host.internal", 4456, "secret")
+
+    def test_falls_back_to_defaults_on_exception(self, monkeypatch: pytest.MonkeyPatch):
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(side_effect=RuntimeError)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        host, port, password = _get_obs_config()
+        assert (host, port, password) == ("localhost", 4455, "")
+
+
+class TestGetRawSuffix:
+    def test_returns_configured_value(self, monkeypatch: pytest.MonkeyPatch):
+        fake_config_module = MagicMock()
+        fake_cfg = MagicMock()
+        fake_cfg.recordings.raw_suffix = "--MY-RAW"
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        assert _get_raw_suffix() == "--MY-RAW"
+
+    def test_falls_back_to_default_when_empty(self, monkeypatch: pytest.MonkeyPatch):
+        from clm.recordings.workflow.naming import DEFAULT_RAW_SUFFIX
+
+        fake_config_module = MagicMock()
+        fake_cfg = MagicMock()
+        fake_cfg.recordings.raw_suffix = ""
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        assert _get_raw_suffix() == DEFAULT_RAW_SUFFIX
+
+    def test_falls_back_to_default_on_exception(self, monkeypatch: pytest.MonkeyPatch):
+        from clm.recordings.workflow.naming import DEFAULT_RAW_SUFFIX
+
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(side_effect=RuntimeError)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        assert _get_raw_suffix() == DEFAULT_RAW_SUFFIX
+
+
+class TestGetWatcherConfig:
+    def test_returns_config_values(self, monkeypatch: pytest.MonkeyPatch):
+        fake_cfg = MagicMock()
+        fake_cfg.recordings.processing_backend = "external"
+        fake_cfg.recordings.stability_check_interval = 5.5
+        fake_cfg.recordings.stability_check_count = 7
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        backend, interval, count = _get_watcher_config()
+        assert backend == "external"
+        assert interval == 5.5
+        assert count == 7
+
+    def test_fallback_on_exception(self, monkeypatch: pytest.MonkeyPatch):
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(side_effect=RuntimeError)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        assert _get_watcher_config() == ("onnx", 2.0, 3)
+
+
+class TestGetAuphonicConfig:
+    def test_returns_config_values(self, monkeypatch: pytest.MonkeyPatch):
+        fake_cfg = MagicMock()
+        fake_cfg.recordings.auphonic.api_key = "abc"
+        fake_cfg.recordings.auphonic.preset = "my-preset"
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        api_key, preset = _get_auphonic_config()
+        assert api_key == "abc"
+        assert preset == "my-preset"
+
+    def test_fallback_on_exception(self, monkeypatch: pytest.MonkeyPatch):
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(side_effect=RuntimeError)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        assert _get_auphonic_config() == ("", "")
+
+
+class TestLoadPipelineConfig:
+    def test_loads_from_json_file(self, tmp_path: Path):
+        config_file = tmp_path / "pipeline.json"
+        config_file.write_text(
+            '{"denoise_atten_lim": 40.0, "sample_rate": 44100, "output_extension": "mkv"}'
+        )
+
+        config = _load_pipeline_config(config_file)
+
+        assert config.denoise_atten_lim == 40.0
+        assert config.sample_rate == 44100
+        assert config.output_extension == "mkv"
+
+    def test_uses_clm_config_when_no_file(self, monkeypatch: pytest.MonkeyPatch):
+        fake_cfg = MagicMock()
+        fake_rec = MagicMock()
+        fake_rec.denoise_atten_lim = 33.0
+        fake_rec.sample_rate = 48000
+        fake_rec.audio_bitrate = "192k"
+        fake_rec.video_codec = "copy"
+        fake_rec.output_extension = "mp4"
+        fake_rec.highpass_freq = 100
+        fake_rec.loudnorm_target = -14
+        fake_cfg.recordings.processing = fake_rec
+
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        config = _load_pipeline_config(None)
+
+        assert config.denoise_atten_lim == 33.0
+        assert config.sample_rate == 48000
+
+    def test_falls_back_to_defaults(self, monkeypatch: pytest.MonkeyPatch):
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(side_effect=RuntimeError)
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        config = _load_pipeline_config(None)
+
+        # Defaults from PipelineConfig() — at least keys are present.
+        assert config.sample_rate > 0
+        assert isinstance(config.output_extension, str)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_recordings_root / _build_recordings_config
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRecordingsRoot:
+    def test_cli_root_takes_precedence(self, tmp_path: Path):
+        assert _resolve_recordings_root(tmp_path) == tmp_path
+
+    def test_uses_configured_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        fake_rec = MagicMock()
+        fake_rec.root_dir = str(tmp_path)
+        monkeypatch.setattr(recordings_module, "_build_recordings_config", lambda: fake_rec)
+
+        assert _resolve_recordings_root(None) == tmp_path
+
+    def test_raises_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch):
+        fake_rec = MagicMock()
+        fake_rec.root_dir = ""
+        monkeypatch.setattr(recordings_module, "_build_recordings_config", lambda: fake_rec)
+
+        import click
+
+        with pytest.raises(click.ClickException, match="No recordings root"):
+            _resolve_recordings_root(None)
+
+
+class TestBuildRecordingsConfig:
+    def test_returns_real_recordings_config_on_success(self, monkeypatch: pytest.MonkeyPatch):
+        from clm.infrastructure.config import RecordingsConfig
+
+        fake_cfg = MagicMock()
+        fake_rec = RecordingsConfig()
+        fake_cfg.recordings = fake_rec
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(return_value=fake_cfg)
+        fake_config_module.RecordingsConfig = RecordingsConfig
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        assert _build_recordings_config() is fake_rec
+
+    def test_returns_defaults_on_error(self, monkeypatch: pytest.MonkeyPatch):
+        from clm.infrastructure.config import RecordingsConfig
+
+        fake_config_module = MagicMock()
+        fake_config_module.get_config = MagicMock(side_effect=RuntimeError)
+        fake_config_module.RecordingsConfig = RecordingsConfig
+        monkeypatch.setitem(sys.modules, "clm.infrastructure.config", fake_config_module)
+
+        result = _build_recordings_config()
+        assert isinstance(result, RecordingsConfig)
+
+
+# ---------------------------------------------------------------------------
+# check command
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCommand:
+    def test_all_dependencies_found(self, monkeypatch: pytest.MonkeyPatch):
+        fake_utils = MagicMock()
+        fake_utils.check_dependencies = MagicMock(
+            return_value={"ffmpeg": "/usr/bin/ffmpeg", "onnxruntime": "1.17"}
+        )
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check"])
+
+        assert result.exit_code == 0, result.output
+        assert "All dependencies found" in result.output
+
+    def test_missing_dependencies_exit_1(self, monkeypatch: pytest.MonkeyPatch):
+        fake_utils = MagicMock()
+        fake_utils.check_dependencies = MagicMock(
+            return_value={"ffmpeg": "/usr/bin/ffmpeg", "onnxruntime": None}
+        )
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check"])
+
+        assert result.exit_code == 1
+        assert "Some dependencies are missing" in result.output
+
+
+# ---------------------------------------------------------------------------
+# process command
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_pipeline(monkeypatch, success: bool, error: str | None = None):
+    """Install a fake ProcessingPipeline that short-circuits .process()."""
+    fake_pipeline_module = MagicMock()
+
+    from clm.recordings.processing.pipeline import ProcessingResult
+
+    class FakePipeline:
+        def __init__(self, _config):
+            pass
+
+        def process(self, input_file: Path, output_file: Path, *, on_step=None):
+            if on_step is not None:
+                on_step(1, "doing_step", 1)
+            # Create output file so stat().st_size works in the CLI.
+            if success:
+                output_file.write_bytes(b"output")
+            return ProcessingResult(
+                input_file=input_file,
+                output_file=output_file,
+                success=success,
+                duration_seconds=5.0,
+                error=error,
+            )
+
+    fake_pipeline_module.ProcessingPipeline = FakePipeline
+    monkeypatch.setitem(sys.modules, "clm.recordings.processing.pipeline", fake_pipeline_module)
+
+
+class TestProcessCommand:
+    def test_happy_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_file = tmp_path / "lecture.mkv"
+        input_file.write_bytes(b"input")
+
+        _install_fake_pipeline(monkeypatch, success=True)
+        # Avoid the config lookup doing real work.
+        monkeypatch.setattr(
+            recordings_module,
+            "_load_pipeline_config",
+            lambda _: __import__(
+                "clm.recordings.processing.config", fromlist=["PipelineConfig"]
+            ).PipelineConfig(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["process", str(input_file)])
+
+        assert result.exit_code == 0, result.output
+        assert "Done in" in result.output
+        # Output file was placed next to input with default suffix.
+        assert (tmp_path / "lecture_final.mp4").is_file()
+
+    def test_failure_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_file = tmp_path / "lecture.mkv"
+        input_file.write_bytes(b"input")
+
+        _install_fake_pipeline(monkeypatch, success=False, error="mux failed")
+        monkeypatch.setattr(
+            recordings_module,
+            "_load_pipeline_config",
+            lambda _: __import__(
+                "clm.recordings.processing.config", fromlist=["PipelineConfig"]
+            ).PipelineConfig(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["process", str(input_file)])
+
+        assert result.exit_code == 1
+        assert "Failed" in result.output
+        assert "mux failed" in result.output
+
+    def test_custom_output_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_file = tmp_path / "lecture.mkv"
+        input_file.write_bytes(b"input")
+        output_file = tmp_path / "custom.mp4"
+
+        _install_fake_pipeline(monkeypatch, success=True)
+        monkeypatch.setattr(
+            recordings_module,
+            "_load_pipeline_config",
+            lambda _: __import__(
+                "clm.recordings.processing.config", fromlist=["PipelineConfig"]
+            ).PipelineConfig(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group, ["process", str(input_file), "-o", str(output_file)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert output_file.is_file()
+
+    def test_keep_temp_flag_sets_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_file = tmp_path / "lecture.mkv"
+        input_file.write_bytes(b"input")
+
+        captured_configs = []
+
+        from clm.recordings.processing.pipeline import ProcessingResult
+
+        class FakePipeline:
+            def __init__(self, config):
+                captured_configs.append(config)
+
+            def process(self, input_file: Path, output_file: Path, *, on_step=None):
+                output_file.write_bytes(b"x")
+                return ProcessingResult(
+                    input_file=input_file,
+                    output_file=output_file,
+                    success=True,
+                )
+
+        fake_pipeline_module = MagicMock()
+        fake_pipeline_module.ProcessingPipeline = FakePipeline
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.pipeline", fake_pipeline_module)
+
+        from clm.recordings.processing.config import PipelineConfig
+
+        monkeypatch.setattr(recordings_module, "_load_pipeline_config", lambda _: PipelineConfig())
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["process", str(input_file), "--keep-temp"])
+
+        assert result.exit_code == 0, result.output
+        assert captured_configs[0].keep_temp is True
+
+
+# ---------------------------------------------------------------------------
+# batch command
+# ---------------------------------------------------------------------------
+
+
+class TestBatchCommand:
+    def test_happy_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+
+        from clm.recordings.processing.batch import BatchResult
+
+        fake_batch_module = MagicMock()
+        fake_batch_module.process_batch = MagicMock(return_value=BatchResult())
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.batch", fake_batch_module)
+        monkeypatch.setattr(
+            recordings_module,
+            "_load_pipeline_config",
+            lambda _: __import__(
+                "clm.recordings.processing.config", fromlist=["PipelineConfig"]
+            ).PipelineConfig(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["batch", str(input_dir)])
+
+        assert result.exit_code == 0, result.output
+        # Default output is input_dir / processed
+        kwargs = fake_batch_module.process_batch.call_args.kwargs
+        assert kwargs["recursive"] is False
+        assert callable(kwargs["on_file"])
+        assert callable(kwargs["on_step"])
+
+    def test_failure_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+
+        from clm.recordings.processing.batch import BatchResult
+        from clm.recordings.processing.pipeline import ProcessingResult
+
+        fake_batch_module = MagicMock()
+        fake_batch_module.process_batch = MagicMock(
+            return_value=BatchResult(
+                failed=[
+                    ProcessingResult(
+                        input_file=input_dir / "x.mkv",
+                        output_file=tmp_path / "x.mp4",
+                        success=False,
+                        error="boom",
+                    )
+                ]
+            )
+        )
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.batch", fake_batch_module)
+        monkeypatch.setattr(
+            recordings_module,
+            "_load_pipeline_config",
+            lambda _: __import__(
+                "clm.recordings.processing.config", fromlist=["PipelineConfig"]
+            ).PipelineConfig(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["batch", str(input_dir)])
+
+        assert result.exit_code == 1
+
+    def test_recursive_flag_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+
+        from clm.recordings.processing.batch import BatchResult
+
+        fake_batch_module = MagicMock()
+        fake_batch_module.process_batch = MagicMock(return_value=BatchResult())
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.batch", fake_batch_module)
+        monkeypatch.setattr(
+            recordings_module,
+            "_load_pipeline_config",
+            lambda _: __import__(
+                "clm.recordings.processing.config", fromlist=["PipelineConfig"]
+            ).PipelineConfig(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["batch", str(input_dir), "--recursive"])
+
+        assert result.exit_code == 0
+        assert fake_batch_module.process_batch.call_args.kwargs["recursive"] is True
+
+
+# ---------------------------------------------------------------------------
+# status command
+# ---------------------------------------------------------------------------
+
+
+class TestStatusCommand:
+    def test_no_state_for_course_exits_1(self, monkeypatch: pytest.MonkeyPatch):
+        fake_state_module = MagicMock()
+        fake_state_module.load_state = MagicMock(return_value=None)
+        monkeypatch.setitem(sys.modules, "clm.recordings.state", fake_state_module)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["status", "my-course"])
+
+        assert result.exit_code == 1
+        assert "No recording state" in result.output
+
+    def test_displays_lecture_table(self, monkeypatch: pytest.MonkeyPatch):
+        # Build a fake state with different lecture statuses.
+        part_processed = MagicMock(status="processed")
+        part_failed = MagicMock(status="failed")
+        part_processing = MagicMock(status="processing")
+        part_pending = MagicMock(status="pending")
+
+        def _lecture(lecture_id: str, display_name: str, parts: list):
+            lec = MagicMock()
+            lec.lecture_id = lecture_id
+            lec.display_name = display_name
+            lec.parts = parts
+            return lec
+
+        lectures = [
+            _lecture("L1", "Intro", [part_processed]),  # all processed
+            _lecture("L2", "Two", [part_failed]),  # any failed
+            _lecture("L3", "Three", [part_processing]),  # any processing
+            _lecture("L4", "Four", [part_pending]),  # pending fallback
+            _lecture("L5", "Five", []),  # unrecorded
+        ]
+
+        fake_state = MagicMock()
+        fake_state.progress = (2, 5)
+        fake_state.continue_current_lecture = True
+        fake_state.lectures = lectures
+        fake_state.next_lecture_index = 2  # "L3" should be marked
+
+        fake_state_module = MagicMock()
+        fake_state_module.load_state = MagicMock(return_value=fake_state)
+        monkeypatch.setitem(sys.modules, "clm.recordings.state", fake_state_module)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["status", "my-course"])
+
+        assert result.exit_code == 0, result.output
+        assert "Progress:" in result.output
+        assert "2/5" in result.output
+        # At least each lecture id should appear somewhere.
+        for lid in ["L1", "L2", "L3", "L4", "L5"]:
+            assert lid in result.output
+        # The next-lecture marker is on L3 (index 2).
+        assert "*" in result.output
+
+
+# ---------------------------------------------------------------------------
+# compare command
+# ---------------------------------------------------------------------------
+
+
+class TestCompareCommand:
+    def test_writes_html(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        version_a = tmp_path / "a.mp4"
+        version_a.write_bytes(b"a")
+        version_b = tmp_path / "b.mp4"
+        version_b.write_bytes(b"b")
+        out_html = tmp_path / "cmp.html"
+
+        fake_compare = MagicMock()
+        fake_compare.audio_to_base64 = MagicMock(return_value="BASE64")
+        fake_compare.extract_audio_segment = MagicMock()
+        fake_compare.generate_comparison_html = MagicMock(return_value="<html>hi</html>")
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.compare", fake_compare)
+
+        fake_utils = MagicMock()
+        fake_utils.find_ffmpeg = MagicMock(return_value=Path("/mock/ffmpeg"))
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            ["compare", str(version_a), str(version_b), "-o", str(out_html)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert out_html.is_file()
+        assert "<html>" in out_html.read_text()
+        # generate_comparison_html called with both labels + base64.
+        kwargs = fake_compare.generate_comparison_html.call_args.kwargs
+        assert kwargs["label_a"] == "Version A"
+        assert kwargs["label_b"] == "Version B"
+        assert kwargs["original_b64"] is None
+
+    def test_includes_original(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        version_a = tmp_path / "a.mp4"
+        version_a.write_bytes(b"a")
+        version_b = tmp_path / "b.mp4"
+        version_b.write_bytes(b"b")
+        original = tmp_path / "orig.mp4"
+        original.write_bytes(b"orig")
+        out_html = tmp_path / "cmp.html"
+
+        fake_compare = MagicMock()
+        fake_compare.audio_to_base64 = MagicMock(return_value="BASE64")
+        fake_compare.extract_audio_segment = MagicMock()
+        fake_compare.generate_comparison_html = MagicMock(return_value="<html></html>")
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.compare", fake_compare)
+
+        fake_utils = MagicMock()
+        fake_utils.find_ffmpeg = MagicMock(return_value=Path("/mock/ffmpeg"))
+        monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            [
+                "compare",
+                str(version_a),
+                str(version_b),
+                "--original",
+                str(original),
+                "-o",
+                str(out_html),
+                "--label-a",
+                "Old",
+                "--label-b",
+                "New",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = fake_compare.generate_comparison_html.call_args.kwargs
+        assert kwargs["label_a"] == "Old"
+        assert kwargs["label_b"] == "New"
+        assert kwargs["original_b64"] == "BASE64"
+
+
+# ---------------------------------------------------------------------------
+# assemble command
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleCommand:
+    def test_validation_errors_exit_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        fake_directories = MagicMock()
+        fake_directories.validate_root = MagicMock(return_value=["missing to-process"])
+        fake_directories.to_process_dir = MagicMock(return_value=tmp_path / "tp")
+        fake_directories.find_pending_pairs = MagicMock(return_value=[])
+        monkeypatch.setitem(sys.modules, "clm.recordings.workflow.directories", fake_directories)
+        monkeypatch.setattr(recordings_module, "_get_raw_suffix", lambda: "--RAW")
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["assemble", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "missing to-process" in result.output
+
+    def test_no_pending_pairs_noop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        fake_directories = MagicMock()
+        fake_directories.validate_root = MagicMock(return_value=[])
+        fake_directories.to_process_dir = MagicMock(return_value=tmp_path / "tp")
+        fake_directories.find_pending_pairs = MagicMock(return_value=[])
+        monkeypatch.setitem(sys.modules, "clm.recordings.workflow.directories", fake_directories)
+        monkeypatch.setattr(recordings_module, "_get_raw_suffix", lambda: "--RAW")
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["assemble", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "No pending" in result.output
+
+    def test_dry_run_lists_pairs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        pair = MagicMock()
+        pair.relative_dir = Path("week1")
+        pair.video = MagicMock()
+        pair.video.name = "t1--RAW.mp4"
+
+        fake_directories = MagicMock()
+        fake_directories.validate_root = MagicMock(return_value=[])
+        fake_directories.to_process_dir = MagicMock(return_value=tmp_path / "tp")
+        fake_directories.find_pending_pairs = MagicMock(return_value=[pair])
+        monkeypatch.setitem(sys.modules, "clm.recordings.workflow.directories", fake_directories)
+
+        fake_assembler = MagicMock()
+        fake_assembler.assemble_all = MagicMock()
+        monkeypatch.setitem(sys.modules, "clm.recordings.workflow.assembler", fake_assembler)
+
+        monkeypatch.setattr(recordings_module, "_get_raw_suffix", lambda: "--RAW")
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["assemble", str(tmp_path), "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        fake_assembler.assemble_all.assert_not_called()
+
+    def test_failures_exit_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        pair = MagicMock()
+        pair.relative_dir = Path("week1")
+        pair.video = MagicMock()
+        pair.video.name = "t1--RAW.mp4"
+
+        fake_directories = MagicMock()
+        fake_directories.validate_root = MagicMock(return_value=[])
+        fake_directories.to_process_dir = MagicMock(return_value=tmp_path / "tp")
+        fake_directories.find_pending_pairs = MagicMock(return_value=[pair])
+        monkeypatch.setitem(sys.modules, "clm.recordings.workflow.directories", fake_directories)
+
+        fake_result = MagicMock()
+        fake_result.failed = ["something"]
+        fake_result.summary = MagicMock(return_value="failed 1")
+
+        fake_assembler = MagicMock()
+        fake_assembler.assemble_all = MagicMock(return_value=fake_result)
+        monkeypatch.setitem(sys.modules, "clm.recordings.workflow.assembler", fake_assembler)
+
+        monkeypatch.setattr(recordings_module, "_get_raw_suffix", lambda: "--RAW")
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["assemble", str(tmp_path)])
+
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# serve_recordings command (uvicorn/create_app mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestServeRecordingsCommand:
+    def _install_stubs(self, monkeypatch):
+        fake_uvicorn = MagicMock()
+        monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+
+        fake_app_module = MagicMock()
+        fake_app_module.create_app = MagicMock(return_value="app_instance")
+        monkeypatch.setitem(sys.modules, "clm.recordings.web.app", fake_app_module)
+
+        fake_webbrowser = MagicMock()
+        monkeypatch.setitem(sys.modules, "webbrowser", fake_webbrowser)
+
+        monkeypatch.setattr(
+            recordings_module,
+            "_get_obs_config",
+            lambda: ("cfg-host", 4455, ""),
+        )
+        monkeypatch.setattr(recordings_module, "_get_raw_suffix", lambda: "--RAW")
+        monkeypatch.setattr(
+            recordings_module,
+            "_get_watcher_config",
+            lambda: ("onnx", 2.0, 3),
+        )
+        monkeypatch.setattr(
+            recordings_module,
+            "_get_auphonic_config",
+            lambda: ("", ""),
+        )
+        return fake_uvicorn, fake_app_module, fake_webbrowser
+
+    def test_starts_server_with_defaults(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        fake_uvicorn, fake_app_module, _ = self._install_stubs(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["serve", str(tmp_path), "--no-browser"])
+
+        assert result.exit_code == 0, result.output
+        fake_app_module.create_app.assert_called_once()
+        # OBS fallback from config was used.
+        kwargs = fake_app_module.create_app.call_args.kwargs
+        assert kwargs["obs_host"] == "cfg-host"
+        fake_uvicorn.run.assert_called_once()
+
+    def test_cli_obs_flags_override_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _, fake_app_module, _ = self._install_stubs(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            [
+                "serve",
+                str(tmp_path),
+                "--no-browser",
+                "--obs-host",
+                "cli-host",
+                "--obs-port",
+                "4456",
+                "--obs-password",
+                "cli-pw",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = fake_app_module.create_app.call_args.kwargs
+        assert kwargs["obs_host"] == "cli-host"
+        assert kwargs["obs_port"] == 4456
+        assert kwargs["obs_password"] == "cli-pw"
+
+    def test_opens_browser_by_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _, _, fake_webbrowser = self._install_stubs(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["serve", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        fake_webbrowser.open.assert_called_once()
+
+    def test_server_exception_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        fake_uvicorn, _, _ = self._install_stubs(monkeypatch)
+        fake_uvicorn.run.side_effect = RuntimeError("boom")
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["serve", str(tmp_path), "--no-browser"])
+
+        assert result.exit_code == 1
+        assert "Server error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# backends command (list_backends)
+# ---------------------------------------------------------------------------
+
+
+class TestListBackendsCommand:
+    def test_lists_all_backends(self, monkeypatch: pytest.MonkeyPatch):
+        # Override the active backend setter.
+        fake_config = MagicMock()
+        fake_config.processing_backend = "onnx"
+        monkeypatch.setattr(recordings_module, "_build_recordings_config", lambda: fake_config)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["backends"])
+
+        assert result.exit_code == 0, result.output
+        # All three backend names appear in the table.
+        assert "onnx" in result.output
+        assert "external" in result.output
+        assert "auphonic" in result.output
+        # And the active-backend hint is printed.
+        assert "Active backend" in result.output
+
+
+# ---------------------------------------------------------------------------
+# wait_job command
+# ---------------------------------------------------------------------------
+
+
+class TestWaitJobCommand:
+    def _install_fake_manager(self, monkeypatch, tmp_path: Path):
+        from clm.cli.commands import recordings as recordings_cli
+        from clm.recordings.workflow.backends.base import (
+            BackendCapabilities,
+            ProcessingBackend,
+        )
+        from clm.recordings.workflow.directories import ensure_root
+        from clm.recordings.workflow.event_bus import EventBus
+        from clm.recordings.workflow.job_manager import JobManager
+        from clm.recordings.workflow.job_store import JsonFileJobStore
+
+        class _StubBackend(ProcessingBackend):
+            capabilities = BackendCapabilities(
+                name="stub",
+                display_name="Stub",
+                is_synchronous=False,
+            )
+
+            def accepts_file(self, path: Path) -> bool:
+                return True
+
+            def submit(self, raw_path, final_path, *, options, ctx):
+                raise NotImplementedError
+
+            def poll(self, job, *, ctx):
+                # Transition to COMPLETED on first poll.
+                from clm.recordings.workflow.jobs import JobState
+
+                job.state = JobState.COMPLETED
+                job.progress = 1.0
+                job.message = "Done"
+                return job
+
+            def cancel(self, job, *, ctx):
+                pass
+
+        ensure_root(tmp_path)
+        store = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        bus = EventBus()
+        manager = JobManager(
+            backend=_StubBackend(),
+            root_dir=tmp_path,
+            store=store,
+            bus=bus,
+        )
+        monkeypatch.setattr(
+            recordings_cli,
+            "_make_job_manager_for_root",
+            lambda root: manager,
+        )
+        monkeypatch.setattr(
+            recordings_cli,
+            "_resolve_recordings_root",
+            lambda cli_root: tmp_path,
+        )
+
+        # Patch time.sleep so the wait loop doesn't actually sleep.
+        import time as _time
+
+        monkeypatch.setattr(_time, "sleep", lambda _: None)
+        return manager
+
+    def test_wait_on_terminal_job_returns_immediately(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        done = ProcessingJob(
+            id="done-done-done-done",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "done.mp4",
+            final_path=tmp_path / "final" / "done.mp4",
+            relative_dir=Path(),
+            state=JobState.COMPLETED,
+            progress=1.0,
+            message="Done",
+        )
+        manager._store_job(done)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "wait", "done", "--interval", "0"])
+
+        assert result.exit_code == 0, result.output
+        assert "already completed" in result.output
+
+    def test_wait_for_completion(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        manager = self._install_fake_manager(monkeypatch, tmp_path)
+
+        job = ProcessingJob(
+            id="wait-wait-wait-wait",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "x.mp4",
+            final_path=tmp_path / "final" / "x.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+        )
+        manager._store_job(job)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "wait", "wait", "--interval", "0"])
+
+        assert result.exit_code == 0, result.output
+        assert "Done" in result.output
+
+    def test_wait_for_failure_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from clm.recordings.workflow.backends.base import (
+            BackendCapabilities,
+            ProcessingBackend,
+        )
+        from clm.recordings.workflow.directories import ensure_root
+        from clm.recordings.workflow.event_bus import EventBus
+        from clm.recordings.workflow.job_manager import JobManager
+        from clm.recordings.workflow.job_store import JsonFileJobStore
+        from clm.recordings.workflow.jobs import JobState, ProcessingJob
+
+        class _FailingBackend(ProcessingBackend):
+            capabilities = BackendCapabilities(
+                name="stub",
+                display_name="Stub",
+                is_synchronous=False,
+            )
+
+            def accepts_file(self, path):
+                return True
+
+            def submit(self, raw_path, final_path, *, options, ctx):
+                raise NotImplementedError
+
+            def poll(self, job, *, ctx):
+                job.state = JobState.FAILED
+                job.error = "broken"
+                return job
+
+            def cancel(self, job, *, ctx):
+                pass
+
+        ensure_root(tmp_path)
+        store = JsonFileJobStore(tmp_path / ".clm" / "jobs.json")
+        bus = EventBus()
+        manager = JobManager(
+            backend=_FailingBackend(),
+            root_dir=tmp_path,
+            store=store,
+            bus=bus,
+        )
+
+        from clm.cli.commands import recordings as recordings_cli
+
+        monkeypatch.setattr(recordings_cli, "_make_job_manager_for_root", lambda root: manager)
+        monkeypatch.setattr(recordings_cli, "_resolve_recordings_root", lambda cli_root: tmp_path)
+
+        import time as _time
+
+        monkeypatch.setattr(_time, "sleep", lambda _: None)
+
+        job = ProcessingJob(
+            id="fail-fail-fail-fail",
+            backend_name="stub",
+            raw_path=tmp_path / "to-process" / "x.mp4",
+            final_path=tmp_path / "final" / "x.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+        )
+        manager._store_job(job)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["jobs", "wait", "fail", "--interval", "0"])
+
+        assert result.exit_code == 1
+        assert "Failed" in result.output

--- a/tests/workers/jupyterlite/test_jupyterlite_worker.py
+++ b/tests/workers/jupyterlite/test_jupyterlite_worker.py
@@ -1,0 +1,533 @@
+"""Unit tests for the JupyterLite worker lifecycle.
+
+These tests cover payload unpacking, cancellation handling, cache
+writes, the sync ``process_job`` wrapper, and ``main()``'s
+SQLite-vs-API branching.  Heavy dependencies (``build_site``,
+``init_database``, ``Worker.run``) are monkeypatched so the tests
+stay in the fast suite.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import sqlite3
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clm.infrastructure.database.job_queue import Job, JobQueue
+from clm.infrastructure.database.schema import init_database
+from clm.workers.jupyterlite import jupyterlite_worker as worker_module
+from clm.workers.jupyterlite.builder import BuildResult
+from clm.workers.jupyterlite.jupyterlite_worker import JupyterLiteWorker
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Create an initialized jobs DB in a tmp dir and clean up WAL files."""
+    path = tmp_path / "jobs.db"
+    init_database(path)
+    yield path
+
+    # Windows-friendly teardown.
+    gc.collect()
+    try:
+        conn = sqlite3.connect(path)
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.close()
+    except Exception:
+        pass
+    for suffix in ["", "-wal", "-shm"]:
+        try:
+            (Path(str(path) + suffix)).unlink(missing_ok=True)
+        except PermissionError:
+            time.sleep(0.1)
+            try:
+                (Path(str(path) + suffix)).unlink(missing_ok=True)
+            except Exception:
+                pass
+
+
+@pytest.fixture
+def worker_id(db_path: Path) -> int:
+    """Register a jupyterlite worker row and return its id."""
+    with JobQueue(db_path) as queue:
+        conn = queue._get_conn()
+        cursor = conn.execute(
+            "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, ?)",
+            ("jupyterlite", "test-container-jlw", "idle"),
+        )
+        conn.commit()
+        return cursor.lastrowid  # type: ignore[return-value]
+
+
+def _make_job(
+    *,
+    job_id: int = 1,
+    payload: dict[str, Any] | None = None,
+    output_file: str = "/out/site",
+    content_hash: str = "hash-abc",
+) -> Job:
+    return Job(
+        id=job_id,
+        job_type="jupyterlite",
+        status="processing",
+        input_file="course-spec.xml",
+        output_file=output_file,
+        content_hash=content_hash,
+        payload=payload or {},
+        created_at=datetime.now(),
+    )
+
+
+def _fake_build_result(site_dir: Path) -> BuildResult:
+    manifest = site_dir / "_output" / "manifest.json"
+    return BuildResult(
+        site_dir=site_dir / "_output",
+        manifest_path=manifest,
+        cache_key="deadbeef" * 8,  # 64-char hex
+        files_count=42,
+    )
+
+
+class TestJupyterLiteWorkerInit:
+    """Worker identifies itself correctly in both modes."""
+
+    def test_sqlite_mode_initializes(self, worker_id: int, db_path: Path) -> None:
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        assert worker.worker_type == "jupyterlite"
+        assert worker.db_path == db_path
+        assert worker.api_url is None
+        assert worker._api_mode is False
+
+    def test_api_mode_initializes(self, monkeypatch: pytest.MonkeyPatch, worker_id: int) -> None:
+        # ApiJobQueue is constructed in __init__; stub it out so we don't
+        # need a live HTTP server.
+        class _StubApi:
+            def __init__(self, url: str, wid: int) -> None:  # noqa: D401
+                self.url = url
+                self.wid = wid
+
+        monkeypatch.setattr("clm.infrastructure.api.job_queue_adapter.ApiJobQueue", _StubApi)
+        worker = JupyterLiteWorker(worker_id, api_url="http://localhost:1234")
+        assert worker._api_mode is True
+        assert worker.api_url == "http://localhost:1234"
+
+
+class TestProcessJobAsync:
+    """_process_job_async should unpack the payload and call build_site."""
+
+    async def test_unpacks_payload_and_caches_result(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+
+        captured: dict[str, Any] = {}
+
+        def fake_build_site(args):
+            captured["args"] = args
+            return _fake_build_result(site_dir)
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        wheels_dir = tmp_path / "wheels"
+        wheels_dir.mkdir()
+        wheel1 = wheels_dir / "pkg-1.0-py3-none-any.whl"
+        wheel1.write_bytes(b"")
+
+        env_yml = tmp_path / "environment.yml"
+        env_yml.write_text("name: base\n", encoding="utf-8")
+
+        nb_tree_dir = tmp_path / "notebooks"
+        nb_tree_dir.mkdir()
+
+        payload: dict[str, Any] = {
+            "input_file_name": "python-best-practice/en/completed",
+            "wheels": [str(wheel1)],
+            "environment_yml": str(env_yml),
+            "notebook_trees": {"code-along": str(nb_tree_dir)},
+            "output_dir": str(site_dir),
+            "kernel": "pyodide",
+            "app_archive": "offline",
+            "launcher": "python",
+            "jupyterlite_core_version": "0.7.4",
+            "branding_theme": "clm",
+            "branding_logo": "",
+            "branding_site_name": "CLM",
+        }
+
+        job = _make_job(
+            job_id=7,
+            payload=payload,
+            output_file="/out/py-best-practice-site",
+            content_hash="hash-7",
+        )
+
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        await worker._process_job_async(job)
+
+        args = captured["args"]
+        # Primitive fields forward verbatim.
+        assert args.kernel == "pyodide"
+        assert args.app_archive == "offline"
+        assert args.launcher == "python"
+        assert args.jupyterlite_core_version == "0.7.4"
+        assert args.branding_theme == "clm"
+        assert args.branding_site_name == "CLM"
+        # String paths get coerced to Path.
+        assert args.output_dir == site_dir
+        assert args.environment_yml == env_yml
+        assert args.wheels == [wheel1]
+        assert args.notebook_trees == {"code-along": nb_tree_dir}
+        # target_label falls back to input_file_name when set.
+        assert args.target_label == payload["input_file_name"]
+
+        # Cache was written with summary JSON.
+        conn = worker.job_queue._get_conn()
+        row = conn.execute(
+            "SELECT result_metadata FROM results_cache WHERE output_file = ?",
+            ("/out/py-best-practice-site",),
+        ).fetchone()
+        assert row is not None
+        cached = json.loads(row[0])
+        assert cached["cache_key"].startswith("deadbeef")
+        assert cached["files_count"] == 42
+        assert json.loads(cached["summary"])["files_count"] == 42
+
+    async def test_missing_input_file_name_uses_job_id(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+        captured: dict[str, Any] = {}
+
+        def fake_build_site(args):
+            captured["args"] = args
+            return _fake_build_result(site_dir)
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        job = _make_job(
+            job_id=99,
+            payload={
+                "wheels": [],
+                "notebook_trees": {},
+                "output_dir": str(site_dir),
+                "kernel": "python",
+            },
+        )
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        await worker._process_job_async(job)
+        assert captured["args"].target_label == "99"
+
+    async def test_empty_environment_yml_becomes_none(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+        captured: dict[str, Any] = {}
+
+        def fake_build_site(args):
+            captured["args"] = args
+            return _fake_build_result(site_dir)
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        job = _make_job(
+            payload={
+                "wheels": [],
+                "notebook_trees": {},
+                "output_dir": str(site_dir),
+                "kernel": "pyodide",
+                "environment_yml": "",  # empty string
+            },
+        )
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        await worker._process_job_async(job)
+        assert captured["args"].environment_yml is None
+
+    async def test_defaults_for_optional_fields(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+        captured: dict[str, Any] = {}
+
+        def fake_build_site(args):
+            captured["args"] = args
+            return _fake_build_result(site_dir)
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        # Payload with only required fields.
+        job = _make_job(
+            payload={
+                "output_dir": str(site_dir),
+                "kernel": "pyodide",
+            },
+        )
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        await worker._process_job_async(job)
+        args = captured["args"]
+        assert args.wheels == []
+        assert args.notebook_trees == {}
+        assert args.environment_yml is None
+        assert args.app_archive == "offline"
+        assert args.launcher == "python"
+        assert args.jupyterlite_core_version == ""
+        assert args.branding_theme == ""
+        assert args.branding_logo == ""
+        assert args.branding_site_name == ""
+
+    async def test_cancelled_job_skips_build(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        build_calls: list[Any] = []
+
+        def fake_build_site(args):
+            build_calls.append(args)
+            return _fake_build_result(tmp_path)
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        monkeypatch.setattr(worker.job_queue, "is_job_cancelled", lambda _jid: True)
+        job = _make_job(payload={"output_dir": str(tmp_path), "kernel": "pyodide"})
+        await worker._process_job_async(job)
+
+        assert build_calls == [], "build_site must not run for cancelled job"
+
+    async def test_build_error_propagates(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_build_site(_args):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        job = _make_job(payload={"output_dir": str(tmp_path), "kernel": "pyodide"})
+        with pytest.raises(RuntimeError, match="boom"):
+            await worker._process_job_async(job)
+
+
+class TestProcessJobSync:
+    """process_job (sync wrapper) drives the async variant."""
+
+    def test_sync_wrapper_runs_async(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+
+        monkeypatch.setattr(
+            "clm.workers.jupyterlite.builder.build_site",
+            lambda _args: _fake_build_result(site_dir),
+        )
+
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        job = _make_job(payload={"output_dir": str(site_dir), "kernel": "pyodide"})
+        # Should return without error.
+        worker.process_job(job)
+
+    def test_sync_wrapper_reraises_on_failure(
+        self,
+        worker_id: int,
+        db_path: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_build_site(_args):
+            raise ValueError("fail")
+
+        monkeypatch.setattr("clm.workers.jupyterlite.builder.build_site", fake_build_site)
+
+        worker = JupyterLiteWorker(worker_id, db_path=db_path)
+        job = _make_job(payload={"output_dir": str(tmp_path), "kernel": "pyodide"})
+        with pytest.raises(ValueError, match="fail"):
+            worker.process_job(job)
+
+
+class TestMainEntryPoint:
+    """main() routes between SQLite and API modes based on env."""
+
+    def test_main_sqlite_mode_initializes_db(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "new-jobs.db"
+        init_calls: list[Path] = []
+        register_calls: list[dict[str, Any]] = []
+        run_calls: list[JupyterLiteWorker] = []
+
+        def fake_init_database(path: Path) -> None:
+            init_calls.append(path)
+
+        def fake_register(*, db_path, api_url, worker_type):
+            register_calls.append(
+                {"db_path": db_path, "api_url": api_url, "worker_type": worker_type}
+            )
+            return 42
+
+        # Don't actually start the run loop.
+        def fake_run(self: JupyterLiteWorker) -> None:
+            run_calls.append(self)
+
+        def fake_cleanup(self: JupyterLiteWorker) -> None:
+            pass
+
+        monkeypatch.setattr(worker_module, "init_database", fake_init_database)
+        monkeypatch.setattr(worker_module, "API_URL", None, raising=True)
+        monkeypatch.setattr(worker_module, "DB_PATH", db_path, raising=True)
+        monkeypatch.setattr(
+            "clm.infrastructure.workers.worker_base.Worker.get_or_register_worker",
+            staticmethod(fake_register),
+        )
+        monkeypatch.setattr(JupyterLiteWorker, "run", fake_run, raising=False)
+        monkeypatch.setattr(JupyterLiteWorker, "cleanup", fake_cleanup, raising=False)
+
+        # DB doesn't exist yet — init_database should be called.
+        worker_module.main()
+
+        assert init_calls == [db_path]
+        assert register_calls[0]["db_path"] == db_path
+        assert register_calls[0]["api_url"] is None
+        assert register_calls[0]["worker_type"] == "jupyterlite"
+        assert len(run_calls) == 1
+
+    def test_main_api_mode_skips_db_init(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        init_calls: list[Path] = []
+        register_calls: list[dict[str, Any]] = []
+
+        def fake_init_database(path: Path) -> None:
+            init_calls.append(path)
+
+        def fake_register(*, db_path, api_url, worker_type):
+            register_calls.append(
+                {"db_path": db_path, "api_url": api_url, "worker_type": worker_type}
+            )
+            return 7
+
+        class _StubApi:
+            def __init__(self, url: str, wid: int) -> None:  # noqa: D401
+                self.url = url
+
+        monkeypatch.setattr(worker_module, "init_database", fake_init_database)
+        monkeypatch.setattr(worker_module, "API_URL", "http://api", raising=True)
+        monkeypatch.setattr("clm.infrastructure.api.job_queue_adapter.ApiJobQueue", _StubApi)
+        monkeypatch.setattr(
+            "clm.infrastructure.workers.worker_base.Worker.get_or_register_worker",
+            staticmethod(fake_register),
+        )
+        monkeypatch.setattr(JupyterLiteWorker, "run", lambda self: None, raising=False)
+        monkeypatch.setattr(JupyterLiteWorker, "cleanup", lambda self: None, raising=False)
+
+        worker_module.main()
+
+        assert init_calls == [], "API mode must not initialize a local DB"
+        assert register_calls[0]["api_url"] == "http://api"
+        assert register_calls[0]["db_path"] is None
+
+    def test_main_keyboard_interrupt_stops_worker(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "jobs.db"
+        init_database(db_path)
+
+        stop_calls: list[JupyterLiteWorker] = []
+        cleanup_calls: list[JupyterLiteWorker] = []
+
+        def fake_register(*, db_path, api_url, worker_type):
+            return 1
+
+        def fake_run(self: JupyterLiteWorker) -> None:
+            raise KeyboardInterrupt
+
+        def fake_stop(self: JupyterLiteWorker) -> None:
+            stop_calls.append(self)
+
+        def fake_cleanup(self: JupyterLiteWorker) -> None:
+            cleanup_calls.append(self)
+
+        monkeypatch.setattr(worker_module, "API_URL", None, raising=True)
+        monkeypatch.setattr(worker_module, "DB_PATH", db_path, raising=True)
+        monkeypatch.setattr(
+            "clm.infrastructure.workers.worker_base.Worker.get_or_register_worker",
+            staticmethod(fake_register),
+        )
+        monkeypatch.setattr(JupyterLiteWorker, "run", fake_run, raising=False)
+        monkeypatch.setattr(JupyterLiteWorker, "stop", fake_stop, raising=False)
+        monkeypatch.setattr(JupyterLiteWorker, "cleanup", fake_cleanup, raising=False)
+
+        # Should not raise — KeyboardInterrupt is swallowed.
+        worker_module.main()
+
+        assert len(stop_calls) == 1
+        assert len(cleanup_calls) == 1
+
+    def test_main_unexpected_exception_reraises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "jobs.db"
+        init_database(db_path)
+
+        def fake_register(*, db_path, api_url, worker_type):
+            return 1
+
+        def fake_run(self: JupyterLiteWorker) -> None:
+            raise RuntimeError("unexpected crash")
+
+        cleanup_calls: list[JupyterLiteWorker] = []
+
+        monkeypatch.setattr(worker_module, "API_URL", None, raising=True)
+        monkeypatch.setattr(worker_module, "DB_PATH", db_path, raising=True)
+        monkeypatch.setattr(
+            "clm.infrastructure.workers.worker_base.Worker.get_or_register_worker",
+            staticmethod(fake_register),
+        )
+        monkeypatch.setattr(JupyterLiteWorker, "run", fake_run, raising=False)
+        monkeypatch.setattr(
+            JupyterLiteWorker,
+            "cleanup",
+            lambda self: cleanup_calls.append(self),
+            raising=False,
+        )
+
+        with pytest.raises(RuntimeError, match="unexpected crash"):
+            worker_module.main()
+
+        # Cleanup still runs via the `finally` block.
+        assert len(cleanup_calls) == 1

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1173,8 +1173,27 @@ public:
             workers = manager.start_managed_workers()
             assert len(workers) > 0, "No workers started"
 
-            # Wait for worker registration
-            time.sleep(5)
+            # Poll the workers table until the docker worker activates
+            # (status transitions from 'created' → 'idle'). A fixed
+            # time.sleep here is flake-prone under xdist load — activation
+            # is subprocess-gated and non-deterministic.
+            expected = len(workers)
+            deadline = time.monotonic() + 30.0
+            active = 0
+            while time.monotonic() < deadline:
+                conn = sqlite3.connect(env["db_path"])
+                try:
+                    cursor = conn.execute(
+                        "SELECT COUNT(*) FROM workers WHERE status IN ('idle', 'busy')"
+                    )
+                    active = cursor.fetchone()[0]
+                finally:
+                    conn.close()
+                if active >= expected:
+                    break
+                time.sleep(0.25)
+            else:
+                raise TimeoutError(f"Expected {expected} active workers within 30s; got {active}")
 
             # Add the C++ notebook job to the queue
             queue = JobQueue(env["db_path"])


### PR DESCRIPTION
## Summary

Consolidated PR covering all 6 PRs of the round-2 test-coverage expansion. Lifts fast-suite
coverage from **74% → 86.20%** (+12.20pp), meeting the ≥85% target documented in
\`docs/claude/test-coverage-expansion-handover.md\`.

| PR | Focus | Δ |
|---|---|---:|
| 1 | \`cli/commands/{database,config}.py\` + \`core/course.py\` JupyterLite paths | +1.13% |
| 2 | \`cli/output_formatter.py\` verbose + \`sqlite_backend.py\` resilience | +1.20% |
| 3 | MCP server, JupyterLite worker, Monitor TUI diagnostic tests | +1.81% |
| 4 | \`cli/commands/build.py\`, \`cli/commands/docker.py\`, \`infrastructure/api/*\` | +3.95% |
| 5 | \`recordings/processing/{utils,pipeline,compare}.py\` | +1.08% |
| 6 | Remaining CLI commands + \`recordings/processing/batch.py\` | +3.03% |

**Totals**: +571 tests (3,311 → 3,882), +4 documented xfail tests for existing Monitor TUI
display bugs (see handover §7 for the deferred fix work).

**Peripheral bug fixes landed along the way**:
- \`job_queue.py\`: guard \`VACUUM\` against Python 3.13 autocommit quirk (commit \`0c65547\`)
- \`output_spec.py\`: fix attrs \`@define\` field override in subclasses
- \`monitor_service.py\`: fix SQL column names (\`worker_id\` → \`container_id\`)

## Key testing patterns introduced

- **Console capture**: modules that bind \`console = Console(file=sys.stderr)\` at import time
  require swapping the module-level console for a \`Console(file=StringIO(), force_terminal=False,
  no_color=True)\` — CliRunner's stream isolation doesn't capture them. Used in
  \`test_docker_command.py::captured_console\` and \`test_build_command.py\`.
- **\`sys.modules\` injection**: commands that lazy-import heavy deps inside the function body
  (\`monitoring.serve\`, \`recordings.process/batch/assemble\`, \`voiceover.*\`) need their mocks
  installed on \`sys.modules\` *before* \`runner.invoke(...)\`.
- **Real \`JobManager\` + stub \`ProcessingBackend\`**: for recordings \`jobs\` subcommands,
  constructing an actual \`JobManager(root_dir, store, bus)\` with a hand-written
  \`ProcessingBackend\` subclass produces much stronger tests than mocking the manager.
- **Fake uvicorn for \`WorkerApiServer\`**: \`FakeUvicornServer\` stand-in that mimics
  \`should_exit\`/\`run()\` lets lifecycle tests run without opening a real socket.

## Deliberately-deferred work

- **Monitor TUI display bugs (PR 3)**: 4 \`xfail(strict=True)\` tests document known bugs
  (\`julianday()\` duration rounding, stale \"Started\" entries, empty title header, scroll lag).
  Fixing them needs separate design work — handover §7 has the upstream-fix recipes.
- **\`cli/commands/voiceover.py\` sync merge path**: landed at 59% vs 60% target; the multi-part
  merge orchestration is integration-shaped and deferred.
- **\`cli/commands/{git_ops,summarize,workers}.py\`**: larger surfaces; not required for the 85%
  goal and candidates for a future PR 7.

## Measurement

\`\`\`
uv run pytest -m \"not docker and not slow and not integration and not e2e\" \
  --cov=src/clm --cov-report=term-missing
\`\`\`

Last run: 3,882 passed, 4 xfailed, 83 warnings in 77s. TOTAL coverage 20,038 stmts / 2,766 miss /
**86%**.

## Test plan

- [ ] CI fast suite passes (\`not docker and not slow and not integration and not e2e\`).
- [ ] CI Docker-marked suite passes unchanged (no test files in this PR introduce docker
      dependencies).
- [ ] Spot-check: the 4 xfail tests in \`tests/cli/test_monitor_app.py\` remain \`xfailed\`, not
      \`xpassed\` (bugs not accidentally fixed).
- [ ] Local coverage run confirms ≥86% overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)