### PR TITLE
Recordings Commit-B polish: progress clamp, scroll preserve, elapsed timer, advance take

### DIFF
--- a/docs/claude/recordings-hardening-handover-archive.md
+++ b/docs/claude/recordings-hardening-handover-archive.md
@@ -1,3 +1,18 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-04-20 -->
+
+# Handover Archive: Recordings App Hardening
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
+
 # Handover: Recordings App Hardening
 
 > **Status**: Design decisions locked by user 2026-04-17. Phase 1
@@ -569,84 +584,107 @@ dedicated follow-up):
   progress bar as 0/100 on terminal states rather than stuck mid-
   arc).
 
-**Deferred to follow-up work** (surfaced during the smoke test but
-not critical enough to block Phase 4 shipping):
+**Deferred to follow-up work** (all four shipped 2026-04-20 as the
+"Commit-B" batch — see §3 Phase 4 Commit-B below):
 
-- Auphonic FAILED jobs leave the jobs-panel progress bar stuck at
-  ~40 %. Cosmetic — the badge itself flips to `failed` correctly.
-- Clicking any button scrolls the lectures page back to the top;
-  users with long lecture lists have to scroll back down. Candidate
-  fixes: collapsible sections, or preserve scroll position via an
-  HTMX swap strategy that keeps the row in view.
-- "Elapsed time" display while a deck is recording — requested
-  during the smoke test, would leverage the existing
-  `_recording_started_at` attribute on the session.
-- Manual "advance to next take" affordance (`POST /advance`) so the
-  user can slot a recording session's first take into the `takes/`
-  history without actually recording a throwaway take first.
+- ~~Auphonic FAILED jobs leave the jobs-panel progress bar stuck at
+  ~40 %. Cosmetic — the badge itself flips to `failed` correctly.~~
+- ~~Clicking any button scrolls the lectures page back to the top.~~
+- ~~"Elapsed time" display while a deck is recording.~~
+- ~~Manual "advance to next take" affordance (`POST /advance`).~~
+
+### Phase 4 Commit-B — optional polish [SHIPPED 2026-04-20]
+
+**Goal**: Pick up the four items deferred from the Phase-4 smoke test.
+Each is independent and can ship separately; they were bundled to
+keep the PR churn down.
+
+**Shipped**:
+
+- **FAILED progress bar clamped + permanent ValidationError after N
+  retries**. `ProcessingJob` gained a
+  `consecutive_validation_errors: int` counter; the JobManager's
+  poll/reconcile paths increment it on every pydantic
+  `ValidationError`, reset it on success or any non-validation
+  exception, and promote the error to *permanent* (job → FAILED)
+  after `MAX_CONSECUTIVE_VALIDATION_ERRORS = 5` consecutive hits.
+  See `src/clm/recordings/workflow/job_manager.py:55-109` for the
+  classifier. The jobs partial clamps the progress bar to 100 on
+  COMPLETED and 0 on FAILED/CANCELLED
+  (`src/clm/recordings/web/templates/partials/jobs.html:39-48`), plus
+  state-specific `.progress-failed` / `.progress-cancelled` colours
+  in `app.css`.
+- **Scroll preservation on lecture-page actions**. Every lecture
+  route that used to return `HX-Redirect: /lectures` (full-page
+  navigation, resets `window.scrollY`) now returns `HX-Location`
+  targeted at `#lectures-dynamic` with `swap=outerHTML`. HTMX fetches
+  `/lectures`, extracts the subtree, and swaps in-place — the outer
+  shell (nav, hidden SSE listener, `<h1>Lectures</h1>`) stays put
+  and the browser never scrolls. Helper is
+  `_lectures_refresh_response` in `routes.py`; applied to `/arm`,
+  `/disarm`, `/record`, `/stop`, `/process`, `/set-lang`,
+  `/lectures/refresh`, and the new `/advance`.
+- **Elapsed-time display while recording**. `SessionSnapshot` gained
+  `recording_elapsed_seconds: float | None` (populated from the
+  existing `_recording_started_at` when `state is RECORDING`). Both
+  the lectures banner, the per-row armed deck, and the dashboard
+  status partial render a
+  `<span class="elapsed-timer" data-elapsed-base-seconds="N">mm:ss</span>`.
+  The per-row timer was added after the user smoke test pointed out
+  that with scroll preservation the banner is often out of view. A
+  `setInterval` in `base.html` ticks every second using the
+  anchor-on-first-render pattern (captures `Date.now()`, extrapolates
+  `base + (now - anchor)/1000`). On each `htmx:afterSwap` the anchor
+  is reset from the fresh server value, so any drift self-corrects
+  without per-second server chatter.
+- **Manual advance-take**. New `RecordingSession.advance_take()`
+  runs the `_preserve_active_take` cascade standalone (no OBS
+  interaction), propagates the rename to `CourseRecordingState` via
+  the existing `_apply_renames_to_state` helper, and cancels the
+  retake-window timer + transitions `ARMED_AFTER_TAKE → ARMED` when
+  the advanced deck matches the currently armed one. Exposed as
+  `POST /advance` in `routes.py`; the lectures page shows an
+  "Advance" button next to Process whenever a recorded/failed raw
+  exists. Emits a `notice` toast with the file-count preserved.
+
+**User verification 2026-04-20**: full dashboard smoke test on the
+`~/Tmp/AuphonicTest` tree (state file backed up + restored so the
+prod D: state stayed untouched). User confirmed scroll preservation,
+per-row elapsed timer, and overall flow. Remaining items not
+individually re-verified but covered by tests.
+
+**Tests**: 740 recordings tests green (was 616 at end of Phase 4);
+full fast suite (4033 tests, 4 xfailed) green; ruff + mypy clean.
+Added:
+
+- `tests/recordings/test_job_manager.py::TestJobManagerAsynchronousBackend::test_validation_error_counts_up_until_permanent`
+- `tests/recordings/test_job_manager.py::TestJobManagerAsynchronousBackend::test_non_validation_error_resets_validation_counter`
+- `tests/recordings/test_web.py::TestLectureRouteScrollPreservation::*` (2 tests)
+- `tests/recordings/test_web.py::TestStatus::test_status_json_elapsed_none_when_idle`
+- `tests/recordings/test_web.py::TestStatus::test_status_json_elapsed_populated_while_recording`
+- `tests/recordings/test_web.py::TestLectures::test_lectures_row_shows_elapsed_timer_while_recording`
+- `tests/recordings/test_session.py::TestAdvanceTake::*` (5 tests)
+- `tests/recordings/test_web.py::TestAdvanceRoute::*` (4 tests)
 
 ## 4. Current Status
 
-- **Shipped (merged to master)**: Phase 1 (`submit_async`
-  non-blocking `/process`). User-verified 2026-04-17.
-- **Implemented on branch** (`claude/recordings-hardening`,
-  smoke-tested by user on Windows 2026-04-19, ready for PR):
-  - Phase 2 — web state wiring (2026-04-18).
-  - Phase 3 — OBS auto-reconnect + connection-aware buttons
-    (2026-04-18).
-  - Phase 4 — UI feedback, design-system migration, SSE toasts,
-    cascade rename for all companions, Auphonic schema-drift
-    hardening (2026-04-19).
-- **Next up**: open the single PR for `claude/recordings-hardening`
-  against master; then pick up the Commit-B follow-ups listed in
-  §3 Phase 4's post-implementation notes.
-- **Tests**: 616 recordings tests green (up from 554); full fast
-  suite (3445 tests) green; ruff + mypy clean on changed files.
+- **Shipped (merged to master via PR #42 2026-04-19)**: Phases 1–4
+  of the hardening plan.
+- **Shipped on master** (2026-04-20, follow-up PR): Phase 4
+  Commit-B polish — FAILED progress-bar clamp + permanent
+  ValidationError classification, lecture-page scroll preservation
+  (HX-Location), elapsed-time timer in the recording banners and
+  per-row status, manual `POST /advance` route +
+  `RecordingSession.advance_take()`. User-verified 2026-04-20.
+- **Tests**: 740 recordings tests green (up from 616 end of Phase 4);
+  full fast suite (4033 tests, 4 xfailed) green; ruff + mypy clean on
+  changed files.
 
 ## 5. Next Steps
 
-All design questions for Phase 2 are locked (see §3 Phase 2). A
-fresh session can go straight to implementation. The order of
-operations below assumes a clean slate on the hardening branch.
-
-**Phase 2 entry checklist** (for the new session):
-
-1. Read this handover top to bottom (it's the source of truth for
-   design decisions — CLAUDE.md and the archived redesign handover
-   cover everything else).
-2. Read `src/clm/recordings/state.py` to understand
-   `CourseRecordingState`, `record_retake`, and
-   `rename_recording_paths` — these are the APIs Phase 2 wires up.
-3. Read `src/clm/recordings/workflow/session.py` — identify the
-   retake pre-move branch (this is where `state.record_retake(...)`
-   must be called before files land).
-4. Read `src/clm/recordings/web/app.py` — identify where `Course`
-   is loaded and where the session is constructed; this is where
-   the `app.state.recording_states` cache lives.
-5. Read `src/clm/recordings/web/routes.py` `/arm` and `/record`
-   handlers — these need to resolve `lecture_id` from the Course
-   spec and pass it into `ArmedDeck`.
-6. Write tests first for the bug scenario (see Phase 2 acceptance
-   criteria in §3).
-7. Implement: Course-to-lecture-id resolver → state cache in
-   `app.py` → `ArmedDeck.lecture_id` field → session
-   `record_retake` call at pre-move.
-8. Run `tests/recordings/` fast, then full fast suite. Green is
-   the bar.
-9. Manual smoke: replay the original bug scenario (record part 0 →
-   start processing → bump part to 2 → record → stop) and confirm
-   `(part 1)` rename and `state.json` both update correctly.
-10. Update this handover: mark Phase 2 as shipped with a summary
-    block like Phase 1's, update §4 Current Status, hand off to the
-    user for Phase 3.
-
-**Subsequent phases** (no session-boundary checklist — the user
-may decide to overlap or re-order):
-
-- Phase 3: connection-aware UI + OBS auto-reconnect.
-- Phase 4: start with a brief design-system evaluation (Tailwind
-  CDN vs. shadcn-style static) and capture the choice in a short
-  note appended to §3 Phase 4 before coding.
+No active work on this feature. The follow-ups handover
+(`docs/claude/recordings-ux-followups-handover.md`) retains
+Phases C/D/E/F for a future pass.
 
 ## 6. Key Files & Architecture
 
@@ -655,11 +693,12 @@ New touch-points unique to this plan:
 
 | File | Role | Phase |
 |---|---|---|
-| `src/clm/recordings/workflow/job_manager.py` | New `submit_async` + swap context (shipped) | 1 |
+| `src/clm/recordings/workflow/job_manager.py` | New `submit_async` + swap context; ValidationError retry classifier | 1, 4 Commit-B |
 | `src/clm/recordings/web/app.py` | Recording-state cache (Phase 2), obs_state subscription (Phase 3), notice wiring (Phase 4) | 2, 3, 4 |
 | `src/clm/recordings/workflow/obs.py` | Watchdog + reconnect | 3 |
-| `src/clm/recordings/web/templates/base.html` *(rewrite)* | Design-system migration | 4 |
+| `src/clm/recordings/web/templates/base.html` *(rewrite)* | Design-system migration; elapsed-timer ticker | 4, 4 Commit-B |
 | `src/clm/recordings/web/static/` *(new)* | Custom stylesheet / bundled assets | 4 |
+| `src/clm/recordings/workflow/session.py` | `advance_take()` method; `recording_elapsed_seconds` snapshot field | 4 Commit-B |
 
 ## 7. Testing Approach
 
@@ -692,10 +731,4 @@ for a later pass.
 
 ---
 
-**Last updated**: 2026-04-19 (Phase 4 implemented, all phases
-smoke-tested, branch ready for PR)
-**Next action**: Open a single PR for `claude/recordings-hardening`
-bundling Phases 2 + 3 + 4 against master. The Commit-B follow-ups
-(progress-bar cosmetics on FAILED, scroll preservation, elapsed-
-time indicator, manual "advance take" button) are optional and can
-follow later.
+**Last updated**: 2026-04-20 (Commit-B shipped and smoke-tested).

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -181,12 +181,29 @@ The main dashboard (`/`) shows:
 
 - **Session Status** — current state (idle / armed / recording / renaming),
   OBS connection status, the armed slide deck (if any), and last output path.
+  While a recording is in progress, an elapsed-time counter (`mm:ss`) ticks
+  alongside the armed deck so you always know how long the take has been
+  running.
 - **File Watcher** — start/stop controls and the active processing backend.
 - **Pending Pairs** — raw video + audio file pairs awaiting processing.
 - **Processing Jobs** — status of submitted processing jobs with progress
-  bars and cancel buttons.
+  bars and cancel buttons.  Failed jobs reset the bar to 0 (rather than
+  freezing wherever the failure happened); completed jobs show 100.
 
-All panels update in real time via Server-Sent Events (SSE).
+All panels update in real time via Server-Sent Events (SSE).  Button
+clicks on the Lectures page swap only the dynamic subtree (not the whole
+page), so your scroll position is preserved — handy for courses with
+many lectures.
+
+### Advance Take (demote the active take without re-recording)
+
+Use the **Advance** button next to **Process** when you want to slot
+the current raw into `takes/` history without recording a throwaway.
+Typical scenario: the current recording has a defect you caught before
+processing; click Advance to move `deck--RAW.mp4` (and any `.wav`
+companion) to `takes/deck (take 1)--RAW.mp4`, freeing the slot for the
+next proper take. `state.json` is updated to keep the UI in sync. Not
+available while a recording is in progress — stop first.
 
 ## Recording State
 

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -24,6 +24,7 @@ Provides:
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import cast
 
 from fastapi import APIRouter, Form, HTTPException, Request
@@ -58,6 +59,33 @@ def _get_backend(request: Request) -> ProcessingBackend:
 
 def _get_templates(request: Request):
     return request.app.state.templates
+
+
+#: HX-Location payload that re-fetches ``/lectures`` and swaps only the
+#: ``#lectures-dynamic`` subtree. Used by every lecture-page action
+#: instead of ``HX-Redirect: /lectures``. ``HX-Redirect`` triggers a
+#: full browser navigation, which resets ``window.scrollY`` to 0 — the
+#: user had to scroll back to their deck after every click. ``HX-Location``
+#: stays on the same document and swaps only the dynamic content, so
+#: scroll position is preserved naturally.
+_LECTURES_REFRESH_LOCATION = json.dumps(
+    {
+        "path": "/lectures",
+        "target": "#lectures-dynamic",
+        "select": "#lectures-dynamic",
+        "swap": "outerHTML",
+    }
+)
+
+
+def _lectures_refresh_response() -> HTMLResponse:
+    """Return a response that refreshes ``#lectures-dynamic`` in-place.
+
+    Replacement for ``HTMLResponse("", headers={"HX-Redirect": "/lectures"})``
+    on routes invoked from the lectures page. Preserves scroll position
+    because no full-page navigation happens.
+    """
+    return HTMLResponse("", headers={"HX-Location": _LECTURES_REFRESH_LOCATION})
 
 
 def _resolve_lecture_id(section_name: str, deck_name: str) -> str:
@@ -238,7 +266,7 @@ async def arm_deck(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     if _from_lectures(request):
-        return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+        return _lectures_refresh_response()
     return await status_partial(request)
 
 
@@ -252,7 +280,7 @@ async def disarm(request: Request):
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     if _from_lectures(request):
-        return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+        return _lectures_refresh_response()
     return await status_partial(request)
 
 
@@ -295,7 +323,56 @@ async def record_deck(
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     if _from_lectures(request):
-        return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+        return _lectures_refresh_response()
+    return await status_partial(request)
+
+
+@router.post("/advance", response_class=HTMLResponse)
+async def advance_take(
+    request: Request,
+    course_slug: str = Form(...),
+    section_name: str = Form(...),
+    deck_name: str = Form(...),
+    part_number: int = Form(0),
+):
+    """Demote the active take for ``(deck, part)`` into ``takes/`` without recording.
+
+    Runs :meth:`RecordingSession.advance_take` — the same preserve-take
+    cascade a retake would trigger, but without starting a new OBS
+    recording. Lets the user slot the current recording into the take
+    history (e.g. because they noticed a mistake mid-session) without
+    having to record a throwaway just to trigger the demote.
+    """
+    session = _get_session(request)
+    lang = _get_lang(request)
+    lecture_id = _resolve_lecture_id(section_name, deck_name)
+    try:
+        preserved = session.advance_take(
+            course_slug,
+            section_name,
+            deck_name,
+            part_number=part_number,
+            lang=lang,
+            lecture_id=lecture_id,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    if preserved:
+        _push_notice(
+            request,
+            "success",
+            f"Advanced take: demoted {len(preserved)} file{'s' if len(preserved) != 1 else ''} to takes/",
+        )
+    else:
+        _push_notice(
+            request,
+            "info",
+            f"No active take to advance for {deck_name}",
+        )
+
+    if _from_lectures(request):
+        return _lectures_refresh_response()
     return await status_partial(request)
 
 
@@ -315,7 +392,7 @@ async def stop_recording(request: Request):
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     if _from_lectures(request):
-        return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+        return _lectures_refresh_response()
     return await status_partial(request)
 
 
@@ -354,7 +431,7 @@ async def process_file(request: Request):
             "success",
             f"Submitted {submitted} file{'s' if submitted != 1 else ''} for processing",
         )
-    return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+    return _lectures_refresh_response()
 
 
 # ------------------------------------------------------------------
@@ -415,7 +492,7 @@ async def set_lang(request: Request, lang: str = Form(...)):
     """Set the recording language cookie and redirect back to lectures."""
     if lang not in ("de", "en"):
         lang = "de"
-    response = HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+    response = _lectures_refresh_response()
     response.set_cookie("clm_lang", lang, max_age=365 * 24 * 3600)
     return response
 
@@ -433,7 +510,7 @@ async def refresh_lectures(request: Request):
     spec_file = request.app.state.spec_file
     if spec_file is not None:
         request.app.state.course = _build_course(spec_file)
-    return HTMLResponse("", headers={"HX-Redirect": "/lectures"})
+    return _lectures_refresh_response()
 
 
 # ------------------------------------------------------------------
@@ -696,6 +773,7 @@ def _snapshot_to_dict(snap: SessionSnapshot) -> dict:
         "obs_state": snap.obs_state,
         "last_output": str(snap.last_output) if snap.last_output else None,
         "error": snap.error,
+        "recording_elapsed_seconds": snap.recording_elapsed_seconds,
     }
 
 

--- a/src/clm/recordings/web/static/app.css
+++ b/src/clm/recordings/web/static/app.css
@@ -209,6 +209,10 @@ progress {
 progress::-webkit-progress-bar { background: var(--c-border); }
 progress::-webkit-progress-value { background: var(--c-primary); }
 progress::-moz-progress-bar { background: var(--c-primary); }
+.progress-failed::-webkit-progress-value   { background: var(--c-badge-failed-bg); }
+.progress-failed::-moz-progress-bar        { background: var(--c-badge-failed-bg); }
+.progress-cancelled::-webkit-progress-value { background: var(--c-fg-muted); }
+.progress-cancelled::-moz-progress-bar      { background: var(--c-fg-muted); }
 
 /* ======================================================================
  * 3. Layout
@@ -430,6 +434,20 @@ footer {
 .banner-warning { background: var(--c-obs-banner-bg); color: var(--c-obs-banner-fg); border-color: var(--c-obs-banner-bd); }
 .banner-error   { background: var(--c-error-bg);      color: var(--c-error-fg);      border-color: var(--c-error-bd); }
 .banner-info    { background: var(--c-armed-bg);      color: #1e3a8a;                border-color: var(--c-armed-bd); }
+
+.elapsed-timer {
+    display: inline-block;
+    margin-left: var(--s-2);
+    padding: 0 var(--s-2);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: var(--t-sm);
+    color: var(--c-fg-muted);
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 3px;
+    min-width: 3.5em;
+    text-align: center;
+}
 
 /* Toasts (notice SSE topic) */
 .toast-region {

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -81,6 +81,44 @@
     document.addEventListener('htmx:beforeSwap', _snapshotPartNumbers);
     document.addEventListener('htmx:afterSwap', _restorePartNumbers);
 
+    /* Elapsed-time ticker.
+       Any element carrying `data-elapsed-base-seconds="N"` is anchored
+       on render (we capture Date.now() at anchor time) and re-rendered
+       every second as `mm:ss` using `N + (now - anchor)/1000`.
+       New swaps reset the anchor from the fresh server value, so any
+       drift gets corrected on the next SSE refresh without server-side
+       per-second chatter. */
+    function _formatElapsed(totalSeconds) {
+        totalSeconds = Math.max(0, Math.floor(totalSeconds));
+        var m = Math.floor(totalSeconds / 60);
+        var s = totalSeconds % 60;
+        return m + ':' + (s < 10 ? '0' : '') + s;
+    }
+    function _tickElapsedTimers() {
+        var now = Date.now();
+        document.querySelectorAll('.elapsed-timer[data-elapsed-base-seconds]').forEach(function (el) {
+            var base = parseInt(el.getAttribute('data-elapsed-base-seconds'), 10);
+            if (isNaN(base)) return;
+            var anchor = el._elapsedAnchor;
+            if (anchor == null) {
+                el._elapsedAnchor = now;
+                anchor = now;
+            }
+            var seconds = base + (now - anchor) / 1000;
+            el.textContent = _formatElapsed(seconds);
+        });
+    }
+    setInterval(_tickElapsedTimers, 1000);
+    /* Reset each timer's anchor after an htmx swap so the fresh server
+       value takes effect immediately instead of continuing to tick from
+       the previous anchor. */
+    document.addEventListener('htmx:afterSwap', function () {
+        document.querySelectorAll('.elapsed-timer[data-elapsed-base-seconds]').forEach(function (el) {
+            el._elapsedAnchor = null;
+        });
+        _tickElapsedTimers();
+    });
+
     /* Toast construction helper. Adds a dismissible toast node and
        auto-removes after `ttl` ms (default 6000). */
     function showToast(message, level, ttl) {

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -55,6 +55,16 @@
     {% if snapshot.armed_deck.part_number > 0 %}
     ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
     {% endif %}
+    {% if snapshot.state.value == 'recording' and snapshot.recording_elapsed_seconds is not none %}
+    <span class="elapsed-timer"
+          data-elapsed-base-seconds="{{ snapshot.recording_elapsed_seconds | int }}"
+          aria-label="Elapsed recording time">
+        {{ '%d:%02d' | format(
+            (snapshot.recording_elapsed_seconds | int) // 60,
+            (snapshot.recording_elapsed_seconds | int) % 60
+        ) }}
+    </span>
+    {% endif %}
     {% if snapshot.state.value == 'recording' %}
     <form hx-post="/stop" hx-target="body" hx-disabled-elt="find button" class="u-inline u-ml-auto">
         <button type="submit" class="btn btn-sm btn-danger">Stop</button>
@@ -90,6 +100,16 @@
                 <td>
                     {% if is_armed and snapshot.state.value == 'recording' %}
                     <span class="badge badge-recording">recording</span>
+                    {% if snapshot.recording_elapsed_seconds is not none %}
+                    <span class="elapsed-timer"
+                          data-elapsed-base-seconds="{{ snapshot.recording_elapsed_seconds | int }}"
+                          aria-label="Elapsed recording time">
+                        {{ '%d:%02d' | format(
+                            (snapshot.recording_elapsed_seconds | int) // 60,
+                            (snapshot.recording_elapsed_seconds | int) % 60
+                        ) }}
+                    </span>
+                    {% endif %}
                     {% endif %}
                     {% if deck.status %}
                     {% set st = deck.status.state.value %}
@@ -150,6 +170,19 @@
                             <input type="hidden" name="raw_path" value="{{ rp }}">
                             {% endfor %}
                             <button type="submit" class="btn btn-sm">Process</button>
+                        </form>
+                        <form hx-post="/advance" hx-target="body" hx-disabled-elt="find button">
+                            <input type="hidden" name="course_slug" value="{{ course_slug }}">
+                            <input type="hidden" name="section_name" value="{{ section.name }}">
+                            <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
+                            {# Advance operates on whichever part is currently
+                               unsuffixed on disk; use the first recorded part
+                               (matches the _preserve_active_take probe). #}
+                            <input type="hidden" name="part_number" value="{{ deck.status.parts[0] if deck.status.parts else 0 }}">
+                            <button type="submit" class="btn btn-sm btn-ghost"
+                                    title="Move this take into takes/ without recording a throwaway">
+                                Advance
+                            </button>
                         </form>
                         {% elif deck.status and deck.status.state.value == 'processing' %}
                         <span class="badge badge-processing">processing…</span>

--- a/src/clm/recordings/web/templates/partials/jobs.html
+++ b/src/clm/recordings/web/templates/partials/jobs.html
@@ -37,8 +37,15 @@
                     {% endif %}
                 </td>
                 <td>
-                    <progress value="{{ (job.progress * 100) | int }}" max="100">
-                        {{ (job.progress * 100) | int }}%
+                    {% if job.state.value == 'completed' %}
+                        {% set pct = 100 %}
+                    {% elif job.state.value in ('failed', 'cancelled') %}
+                        {% set pct = 0 %}
+                    {% else %}
+                        {% set pct = (job.progress * 100) | int %}
+                    {% endif %}
+                    <progress value="{{ pct }}" max="100" class="progress-{{ job.state.value }}">
+                        {{ pct }}%
                     </progress>
                 </td>
                 <td>

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -44,6 +44,16 @@
         {% if snapshot.armed_deck.part_number > 0 %}
         ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
         {% endif %}
+        {% if snapshot.state.value == 'recording' and snapshot.recording_elapsed_seconds is not none %}
+        <span class="elapsed-timer"
+              data-elapsed-base-seconds="{{ snapshot.recording_elapsed_seconds | int }}"
+              aria-label="Elapsed recording time">
+            {{ '%d:%02d' | format(
+                (snapshot.recording_elapsed_seconds | int) // 60,
+                (snapshot.recording_elapsed_seconds | int) % 60
+            ) }}
+        </span>
+        {% endif %}
         {% if snapshot.state.value == 'recording' %}
         <form hx-post="/stop" hx-target="#status-panel" hx-swap="innerHTML"
               hx-disabled-elt="find button" class="u-inline u-ml-auto">

--- a/src/clm/recordings/workflow/job_manager.py
+++ b/src/clm/recordings/workflow/job_manager.py
@@ -53,8 +53,26 @@ DEFAULT_POLL_INTERVAL_SECONDS = 30.0
 #: * 410 Gone — same as 404 but upstream is explicit about it.
 _PERMANENT_POLL_HTTP_STATUSES = frozenset({401, 403, 404, 410})
 
+#: Number of consecutive ``pydantic.ValidationError`` poll failures
+#: after which the schema-drift is treated as permanent. Real-world
+#: trigger: Auphonic returned a non-string scalar for a field the
+#: coercer couldn't handle, and the job retried forever pinned near
+#: 40 % progress. Five retries at the default 30 s poll interval is
+#: ~2.5 minutes of grace before the job flips to FAILED so the user
+#: can act on it.
+MAX_CONSECUTIVE_VALIDATION_ERRORS = 5
 
-def _is_permanent_poll_error(exc: BaseException) -> bool:
+
+def _is_validation_error(exc: BaseException) -> bool:
+    """Return ``True`` if *exc* is a pydantic schema-validation failure."""
+    try:
+        from pydantic import ValidationError
+    except ImportError:  # pragma: no cover — pydantic is a hard dep
+        return False
+    return isinstance(exc, ValidationError)
+
+
+def _is_permanent_poll_error(exc: BaseException, job: ProcessingJob) -> bool:
     """Return ``True`` if *exc* will not be fixed by retrying the poll.
 
     Used by :meth:`JobManager._poll_once` to decide whether a poll
@@ -64,20 +82,30 @@ def _is_permanent_poll_error(exc: BaseException) -> bool:
     so the next tick can retry. The rationale for the specific
     classification lives on :data:`_PERMANENT_POLL_HTTP_STATUSES`.
 
-    We deliberately treat **unknown exceptions** as transient: losing
-    a completed Auphonic production to an unhandled blip is worse
-    than leaving a stuck job in the list for a user to notice. The
-    ``last_poll_error`` field makes the stuck state visible.
+    Persistent schema drift is also treated as permanent once the
+    counter on *job* has crossed
+    :data:`MAX_CONSECUTIVE_VALIDATION_ERRORS` — see the field docstring
+    on :attr:`ProcessingJob.consecutive_validation_errors`.
+
+    We deliberately treat **other unknown exceptions** as transient:
+    losing a completed Auphonic production to an unhandled blip is
+    worse than leaving a stuck job in the list for a user to notice.
+    The ``last_poll_error`` field makes the stuck state visible.
     """
     # Lazy import to avoid a hard dependency on the auphonic backend
     # from the manager module (other backends may not be installed).
     try:
         from clm.recordings.workflow.backends.auphonic_client import AuphonicHTTPError
-    except ImportError:  # pragma: no cover — defensive
-        return False
 
-    if isinstance(exc, AuphonicHTTPError):
-        return exc.status_code in _PERMANENT_POLL_HTTP_STATUSES
+        if isinstance(exc, AuphonicHTTPError):
+            return exc.status_code in _PERMANENT_POLL_HTTP_STATUSES
+    except ImportError:  # pragma: no cover — defensive
+        pass
+
+    if _is_validation_error(exc):
+        # +1 because this tick's error hasn't been counted yet.
+        return job.consecutive_validation_errors + 1 >= MAX_CONSECUTIVE_VALIDATION_ERRORS
+
     return False
 
 
@@ -380,7 +408,7 @@ class JobManager:
         try:
             updated = self._backend.reconcile(job, ctx=ctx)
         except Exception as exc:
-            if _is_permanent_poll_error(exc):
+            if _is_permanent_poll_error(exc, job):
                 logger.error(
                     "Permanent reconcile error for {}, marking FAILED: {}",
                     job.id,
@@ -389,6 +417,7 @@ class JobManager:
                 job.state = JobState.FAILED
                 job.error = str(exc)
                 job.last_poll_error = None
+                job.consecutive_validation_errors = 0
             else:
                 logger.warning(
                     "Transient reconcile error for {} (caller can retry): {}",
@@ -396,11 +425,16 @@ class JobManager:
                     exc,
                 )
                 job.last_poll_error = str(exc)
+                if _is_validation_error(exc):
+                    job.consecutive_validation_errors += 1
+                else:
+                    job.consecutive_validation_errors = 0
             job.touch()
             self._store_job(job)
             self._bus.publish(JOB_EVENT_TOPIC, job)
             return job
 
+        updated.consecutive_validation_errors = 0
         self._store_job(updated)
         self._bus.publish(JOB_EVENT_TOPIC, updated)
         return updated
@@ -725,7 +759,7 @@ class JobManager:
             try:
                 updated = self._backend.poll(job, ctx=ctx)
             except Exception as exc:
-                if _is_permanent_poll_error(exc):
+                if _is_permanent_poll_error(exc, job):
                     logger.error(
                         "Permanent poll error for {}, marking FAILED: {}",
                         job.id,
@@ -734,6 +768,7 @@ class JobManager:
                     job.state = JobState.FAILED
                     job.error = str(exc)
                     job.last_poll_error = None
+                    job.consecutive_validation_errors = 0
                 else:
                     logger.warning(
                         "Transient poll error for {} (will retry next tick): {}",
@@ -741,6 +776,10 @@ class JobManager:
                         exc,
                     )
                     job.last_poll_error = str(exc)
+                    if _is_validation_error(exc):
+                        job.consecutive_validation_errors += 1
+                    else:
+                        job.consecutive_validation_errors = 0
                 job.touch()
                 self._store_job(job)
                 self._bus.publish(JOB_EVENT_TOPIC, job)
@@ -751,6 +790,7 @@ class JobManager:
             # marker so the user sees a clean state next time they
             # run `clm recordings jobs list`.
             updated.last_poll_error = None
+            updated.consecutive_validation_errors = 0
             self._store_job(updated)
             self._bus.publish(JOB_EVENT_TOPIC, updated)
             polled.append(updated)

--- a/src/clm/recordings/workflow/jobs.py
+++ b/src/clm/recordings/workflow/jobs.py
@@ -169,6 +169,20 @@ class ProcessingJob(BaseModel):
     failed.
     """
 
+    consecutive_validation_errors: int = 0
+    """Count of back-to-back ``pydantic.ValidationError`` poll failures.
+
+    Incremented by the :class:`JobManager` each time the backend's
+    ``poll``/``reconcile`` raises a pydantic validation error (schema
+    drift from upstream). Reset to 0 on a successful poll or on any
+    non-validation exception. Once the counter reaches
+    ``MAX_CONSECUTIVE_VALIDATION_ERRORS`` the next validation error is
+    classified as **permanent** — the job transitions to ``FAILED``
+    rather than retrying forever. Prevents the pathology where an
+    upstream response that Pydantic cannot parse wedges the job at
+    mid-progress until the user cancels manually.
+    """
+
     stale: bool = False
     """True when the job has exceeded the backend's stale-warning window.
 

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -110,6 +110,14 @@ class SessionSnapshot:
     obs_state: str = "disconnected"
     last_output: Path | None = None
     error: str | None = None
+    recording_elapsed_seconds: float | None = None
+    """Seconds since the most recent OBS STARTED event, or ``None``.
+
+    ``None`` when no recording is active. When a recording is in
+    progress, the UI captures this value on render and extrapolates
+    client-side via ``setInterval`` so the elapsed-time display ticks
+    smoothly without per-second server chatter.
+    """
 
     @property
     def armed_topic(self) -> ArmedDeck | None:
@@ -610,6 +618,11 @@ class RecordingSession:
                 obs_state=getattr(self._obs, "connection_state", "disconnected"),
                 last_output=self._last_output,
                 error=self._error,
+                recording_elapsed_seconds=(
+                    self._elapsed_since_start_locked()
+                    if self._state is SessionState.RECORDING
+                    else None
+                ),
             )
 
     def arm(
@@ -712,6 +725,82 @@ class RecordingSession:
             lecture_id=lecture_id,
         )
         self._obs.start_record()
+
+    def advance_take(
+        self,
+        course_slug: str,
+        section_name: str,
+        deck_name: str,
+        *,
+        part_number: int = 0,
+        lang: str = "en",
+        lecture_id: str | None = None,
+    ) -> list[tuple[Path, Path]]:
+        """Demote the active take for ``(deck, part)`` into ``takes/`` without recording.
+
+        Runs the same ``_preserve_active_take`` cascade that a retake
+        would trigger, but without starting a new OBS recording. Useful
+        when the user realises mid-session that the current recording
+        is wrong and wants to slot it into the take history before
+        moving on — without first recording a throwaway just to demote
+        the previous take.
+
+        If any files were preserved, also propagates the rename to
+        ``state.json`` so the dashboard reflects the move. If the
+        session was in :attr:`ARMED_AFTER_TAKE` for this deck, the
+        retake-window timer is cancelled (the active-take slot is now
+        empty, so the retake-window semantics no longer apply) and the
+        state transitions back to :attr:`ARMED`.
+
+        Returns the list of ``(old_path, new_path)`` pairs actually
+        moved. Empty if no active-take files existed.
+
+        Raises:
+            RuntimeError: If a recording or rename is currently in
+                progress — the caller should stop first.
+        """
+        with self._lock:
+            if self._state in (SessionState.RECORDING, SessionState.RENAMING):
+                raise RuntimeError(f"Cannot advance take while in state '{self._state.value}'.")
+            was_armed_after_take = (
+                self._state is SessionState.ARMED_AFTER_TAKE
+                and self._armed is not None
+                and self._armed.course_slug == course_slug
+                and self._armed.section_name == section_name
+                and self._armed.deck_name == deck_name
+                and self._armed.part_number == part_number
+            )
+            if was_armed_after_take:
+                self._cancel_retake_timer_locked()
+                self._state = SessionState.ARMED
+
+        rel_dir = recording_relative_dir(course_slug, section_name)
+        preserved = _preserve_active_take(
+            recordings_root=self._root,
+            rel_dir=str(rel_dir),
+            deck_name=deck_name,
+            part=part_number,
+            raw_suffix=self._raw_suffix,
+            lang=lang,
+        )
+
+        if preserved:
+            deck = ArmedDeck(
+                course_slug=course_slug,
+                section_name=section_name,
+                deck_name=deck_name,
+                part_number=part_number,
+                lang=lang,
+                lecture_id=lecture_id,
+            )
+            course_state = self._resolve_course_state(deck)
+            self._apply_renames_to_state(preserved, course_state)
+            self._notify_path_renames(preserved)
+
+        if was_armed_after_take or preserved:
+            self._notify()
+
+        return preserved
 
     def stop(self) -> None:
         """Ask OBS to stop the current recording.

--- a/tests/recordings/test_job_manager.py
+++ b/tests/recordings/test_job_manager.py
@@ -620,6 +620,121 @@ class TestJobManagerAsynchronousBackend:
         finally:
             manager.shutdown(timeout=2.0)
 
+    def test_validation_error_counts_up_until_permanent(self, tmp_path: Path):
+        """Persistent pydantic.ValidationError flips the job to FAILED after N retries.
+
+        Real-world trigger: Auphonic returned a response shape the
+        coercer couldn't handle, and poll() raised ValidationError
+        every tick. Before this, the manager classified it as
+        transient forever and the job stayed pinned mid-progress.
+        """
+        from pydantic import BaseModel
+
+        class _Tiny(BaseModel):
+            name: str
+
+        try:
+            _Tiny.model_validate({"name": 123})
+        except Exception as exc:  # noqa: BLE001 — we want the actual ValidationError
+            validation_exc = exc
+        else:  # pragma: no cover — pydantic would have raised
+            pytest.fail("expected ValidationError")
+
+        from clm.recordings.workflow.job_manager import (
+            MAX_CONSECUTIVE_VALIDATION_ERRORS,
+        )
+
+        backend = _RaisingAsyncBackend(exc=validation_exc)
+        # Pre-seed so we drive polls deterministically instead of racing
+        # a background poller.
+        manager, _, _ = _make_manager(tmp_path, backend)
+        raw = _make_raw_path(tmp_path)
+        seeded = ProcessingJob(
+            id="val-err-job",
+            backend_name="async-fake",
+            raw_path=raw,
+            final_path=tmp_path / "final" / "lecture.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.4,
+            message="Processing",
+            backend_ref="fake-ref",
+        )
+        manager._store_job(seeded)
+
+        # First N-1 ticks stay transient.
+        for tick in range(MAX_CONSECUTIVE_VALIDATION_ERRORS - 1):
+            polled = manager.poll_once(job_id=seeded.id)
+            assert len(polled) == 1
+            current = polled[0]
+            assert current.state == JobState.PROCESSING, (
+                f"tick {tick}: expected transient, got {current.state}"
+            )
+            assert current.consecutive_validation_errors == tick + 1
+            assert current.last_poll_error is not None
+
+        # The Nth tick flips to FAILED.
+        polled = manager.poll_once(job_id=seeded.id)
+        assert len(polled) == 1
+        final = polled[0]
+        assert final.state == JobState.FAILED
+        assert final.error is not None
+        assert final.last_poll_error is None
+        assert final.consecutive_validation_errors == 0
+
+    def test_non_validation_error_resets_validation_counter(self, tmp_path: Path):
+        """A network blip between validation errors resets the counter.
+
+        We only treat *consecutive* ValidationErrors as schema drift.
+        A generic RuntimeError interleaved between them signals the
+        upstream is flaky, not that the schema is wrong, so the
+        counter must reset.
+        """
+        from pydantic import BaseModel
+
+        class _Tiny(BaseModel):
+            name: str
+
+        try:
+            _Tiny.model_validate({"name": 123})
+        except Exception as exc:  # noqa: BLE001
+            validation_exc = exc
+        else:  # pragma: no cover
+            pytest.fail("expected ValidationError")
+
+        class _AlternatingBackend(_AsyncFakeBackend):
+            def __init__(self) -> None:
+                super().__init__(poll_completes_after_calls=100)
+                self._tick = 0
+
+            def poll(self, job, *, ctx):
+                self._tick += 1
+                if self._tick % 2 == 1:
+                    raise validation_exc
+                raise RuntimeError("network blip")
+
+        backend = _AlternatingBackend()
+        manager, _, _ = _make_manager(tmp_path, backend)
+        raw = _make_raw_path(tmp_path)
+        seeded = ProcessingJob(
+            id="alternating-job",
+            backend_name="async-fake",
+            raw_path=raw,
+            final_path=tmp_path / "final" / "lecture.mp4",
+            relative_dir=Path(),
+            state=JobState.PROCESSING,
+            progress=0.4,
+            backend_ref="fake-ref",
+        )
+        manager._store_job(seeded)
+
+        # Drive 10 ticks: should never flip to FAILED because each
+        # ValidationError is followed by a RuntimeError that resets.
+        for _ in range(10):
+            polled = manager.poll_once(job_id=seeded.id)
+            assert polled[0].state == JobState.PROCESSING
+        assert polled[0].consecutive_validation_errors <= 1
+
     def test_poller_is_started_only_once(self, tmp_path: Path):
         backend = _AsyncFakeBackend(poll_completes_after_calls=10)
         manager, _, _ = _make_manager(tmp_path, backend, poll_interval=0.05)

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -1777,6 +1777,129 @@ class TestStateWiring:
 
 # ---------------------------------------------------------------------------
 # Helpers
+class TestAdvanceTake:
+    """`session.advance_take` demotes the active take into takes/ without recording.
+
+    Companion to :class:`TestRetakePreMove`: those tests fire a real
+    STARTED/STOPPED pair, this one runs the preserve cascade as a
+    standalone operation.
+    """
+
+    def test_advance_moves_raw_and_final_to_takes(
+        self,
+        session: RecordingSession,
+        recording_root: Path,
+    ):
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        fin.mkdir(parents=True)
+        (arc / "t--RAW.mkv").write_bytes(b"raw")
+        (fin / "t.mp4").write_bytes(b"final")
+
+        preserved = session.advance_take("c", "s", "t")
+
+        assert len(preserved) == 2
+        takes = takes_dir(recording_root) / rel
+        assert (takes / "t (take 1)--RAW.mkv").read_bytes() == b"raw"
+        assert (takes / "t (take 1).mp4").read_bytes() == b"final"
+        assert not (arc / "t--RAW.mkv").exists()
+        assert not (fin / "t.mp4").exists()
+
+    def test_advance_with_nothing_to_preserve_is_noop(
+        self,
+        session: RecordingSession,
+        recording_root: Path,
+    ):
+        preserved = session.advance_take("c", "s", "t")
+        assert preserved == []
+
+    def test_advance_refuses_while_recording(self, session: RecordingSession, mock_obs):
+        """Cannot demote an active take while a recording is in progress."""
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert session.state is SessionState.RECORDING
+        with pytest.raises(RuntimeError, match="Cannot advance take"):
+            session.advance_take("c", "s", "t")
+
+    def test_advance_transitions_armed_after_take_back_to_armed(
+        self, mock_obs, recording_root: Path, tmp_path: Path
+    ):
+        """Advancing the current active take while ARMED_AFTER_TAKE returns to ARMED.
+
+        Rationale: once the active-take slot is empty the retake-window
+        semantics no longer apply; the user is implicitly opting to
+        continue rather than retake.
+        """
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=30.0,
+        )
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"first")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="stopped",
+                output_path=str(obs_output),
+            ),
+        )
+        _wait_for_state(session, SessionState.ARMED_AFTER_TAKE, timeout=15.0)
+
+        preserved = session.advance_take("c", "s", "t")
+        assert len(preserved) >= 1
+        assert session.state is SessionState.ARMED
+
+    def test_advance_updates_state_paths(self, mock_obs, recording_root: Path):
+        """Preserved renames propagate to CourseRecordingState."""
+        from clm.recordings.state import CourseRecordingState, LectureState, RecordingPart
+        from clm.recordings.workflow.directories import archive_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        raw = arc / "t--RAW.mkv"
+        raw.write_bytes(b"raw")
+
+        state = CourseRecordingState(
+            course_id="cid",
+            lectures=[
+                LectureState(
+                    lecture_id="l1",
+                    display_name="L1",
+                    parts=[RecordingPart(part=1, raw_file=str(raw))],
+                )
+            ],
+        )
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+
+        session.advance_take("c", "s", "t", lecture_id="l1")
+
+        # State's raw_file pointer updated to the takes/ location.
+        new_path = state.lectures[0].parts[0].raw_file
+        assert "takes" in new_path
+        assert "(take 1)--RAW.mkv" in new_path
+
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -171,6 +171,46 @@ class TestLectures:
             resp = c.get("/lectures")
         assert 'value="kurs-de"' in resp.text
 
+    def test_lectures_row_shows_elapsed_timer_while_recording(self, app, recording_root: Path):
+        """The currently-recording deck row carries its own elapsed-time timer.
+
+        Surfaced during the smoke test: the banner timer scrolls out of
+        view on long lecture lists, so a per-row timer is needed so the
+        counter stays visible regardless of scroll.
+        """
+        import time as _time
+
+        from clm.core.utils.text_utils import Text
+        from clm.recordings.workflow.session import SessionState
+
+        mock_course = MagicMock()
+        mock_section = MagicMock()
+        mock_section.name = Text(de="Woche 1", en="Week 1")
+        mock_nb = MagicMock()
+        mock_nb.title = Text(de="Intro", en="Intro")
+        mock_nb.number_in_section = 1
+        mock_nb.file_name.return_value = "01 Intro"
+        mock_section.notebooks = [mock_nb]
+        mock_course.sections = [mock_section]
+        mock_course.output_dir_name = Text(de="kurs-de", en="course-en")
+        app.state.course = mock_course
+
+        # Arm and move the session into RECORDING with a known start time.
+        session = app.state.session
+        session.arm("kurs-de", "Woche 1", "01 Intro")
+        with session._lock:
+            session._state = SessionState.RECORDING
+            session._recording_started_at = _time.monotonic() - 12.0
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        # The page contains two elapsed-timer spans: one in the top
+        # banner (existing), one in the recording row (new). Both
+        # should have a ``data-elapsed-base-seconds`` anchor.
+        assert html.count('class="elapsed-timer"') >= 2
+        assert html.count("data-elapsed-base-seconds=") >= 2
+
     def test_successful_part_2_does_not_mask_failed_part_1(self, app, recording_root: Path):
         """An unresolved failure on part 1 stays visible even when part 2 succeeds.
 
@@ -353,7 +393,11 @@ class TestLanguageSelection:
     def test_set_lang_de(self, client: TestClient):
         resp = client.post("/set-lang", data={"lang": "de"}, follow_redirects=False)
         assert resp.status_code == 200
-        assert resp.headers.get("hx-redirect") == "/lectures"
+        # HX-Location swaps #lectures-dynamic in-place (scroll preserved);
+        # HX-Redirect would trigger a full navigation and reset scroll.
+        location = resp.headers.get("hx-location", "")
+        assert "/lectures" in location
+        assert "#lectures-dynamic" in location
         assert "clm_lang" in resp.cookies
         assert resp.cookies["clm_lang"] == "de"
 
@@ -380,7 +424,9 @@ class TestLecturesRefresh:
             mock_build.return_value = MagicMock()
             resp = client.post("/lectures/refresh", follow_redirects=False)
         assert resp.status_code == 200
-        assert resp.headers.get("hx-redirect") == "/lectures"
+        location = resp.headers.get("hx-location", "")
+        assert "/lectures" in location
+        assert "#lectures-dynamic" in location
         mock_build.assert_called_once_with(app.state.spec_file)
 
     def test_refresh_without_spec_file(self, app, client: TestClient):
@@ -392,6 +438,49 @@ class TestLecturesRefresh:
 # ---------------------------------------------------------------------------
 # Arm / Disarm
 # ---------------------------------------------------------------------------
+
+
+class TestLectureRouteScrollPreservation:
+    """Lecture-page actions must use HX-Location, not HX-Redirect.
+
+    HX-Redirect triggers a full browser navigation, which resets
+    ``window.scrollY`` to 0 so the user lands back at the top of the
+    lectures page after every click. HX-Location swaps only
+    ``#lectures-dynamic`` in-place, preserving scroll position.
+    """
+
+    _LECTURES_HEADER = {"HX-Current-URL": "http://testserver/lectures"}
+
+    def test_arm_from_lectures_returns_hx_location(self, client: TestClient):
+        resp = client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "intro",
+                "deck_name": "01 Hello",
+                "part_number": "0",
+            },
+            headers=self._LECTURES_HEADER,
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("hx-redirect") is None
+        location = resp.headers.get("hx-location", "")
+        assert "/lectures" in location
+        assert "#lectures-dynamic" in location
+
+    def test_disarm_from_lectures_returns_hx_location(self, app, client: TestClient):
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
+        resp = client.post("/disarm", headers=self._LECTURES_HEADER)
+        assert resp.status_code == 200
+        assert "#lectures-dynamic" in resp.headers.get("hx-location", "")
 
 
 class TestArmDisarm:
@@ -608,6 +697,101 @@ class TestRecordStop:
 
 
 # ---------------------------------------------------------------------------
+# Advance (manual "demote active take" without recording)
+# ---------------------------------------------------------------------------
+
+
+class TestAdvanceRoute:
+    def test_advance_moves_active_take_into_takes_dir(
+        self, app, client: TestClient, recording_root: Path
+    ):
+        from clm.recordings.workflow.directories import archive_dir, takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        (arc / "t--RAW.mkv").write_bytes(b"raw")
+
+        resp = client.post(
+            "/advance",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "t",
+                "part_number": "0",
+            },
+        )
+        assert resp.status_code == 200
+        takes = takes_dir(recording_root) / rel
+        assert (takes / "t (take 1)--RAW.mkv").read_bytes() == b"raw"
+        assert not (arc / "t--RAW.mkv").exists()
+
+    def test_advance_with_nothing_to_preserve_returns_200(self, client: TestClient):
+        """No active-take files → route still succeeds (no-op)."""
+        resp = client.post(
+            "/advance",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "nothing-to-demote",
+                "part_number": "0",
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_advance_refuses_during_recording(self, app, client: TestClient):
+        """Cannot advance while a recording is in progress — 409 Conflict."""
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "t",
+                "part_number": "0",
+            },
+        )
+        for cb in app.state.obs._record_callbacks:
+            cb(RecordingEvent(output_active=True, output_state="started"))
+
+        resp = client.post(
+            "/advance",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "t",
+                "part_number": "0",
+            },
+        )
+        assert resp.status_code == 409
+
+    def test_advance_from_lectures_returns_hx_location(
+        self, app, client: TestClient, recording_root: Path
+    ):
+        from clm.recordings.workflow.directories import archive_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        arc.mkdir(parents=True)
+        (arc / "t--RAW.mkv").write_bytes(b"raw")
+
+        resp = client.post(
+            "/advance",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "t",
+                "part_number": "0",
+            },
+            headers={"HX-Current-URL": "http://testserver/lectures"},
+        )
+        assert resp.status_code == 200
+        # Scroll-preserving swap, not a full-page redirect.
+        assert "#lectures-dynamic" in resp.headers.get("hx-location", "")
+
+
+# ---------------------------------------------------------------------------
 # Status
 # ---------------------------------------------------------------------------
 
@@ -636,6 +820,32 @@ class TestStatus:
         assert data["state"] == "armed"
         assert data["armed_deck"]["deck_name"] == "01 Deck"
         assert data["armed_deck"]["part_number"] == 0
+
+    def test_status_json_elapsed_none_when_idle(self, client: TestClient):
+        """/status exposes recording_elapsed_seconds as None when not recording."""
+        data = client.get("/status").json()
+        assert "recording_elapsed_seconds" in data
+        assert data["recording_elapsed_seconds"] is None
+
+    def test_status_json_elapsed_populated_while_recording(
+        self, app, client: TestClient, monkeypatch
+    ):
+        """When a recording is in progress, elapsed seconds is exposed as a number."""
+        import time as _time
+
+        from clm.recordings.workflow.session import SessionState
+
+        session = app.state.session
+        # Fake the session into RECORDING state with a known start time.
+        with session._lock:
+            session._state = SessionState.RECORDING
+            session._recording_started_at = _time.monotonic() - 7.5
+
+        data = client.get("/status").json()
+        elapsed = data["recording_elapsed_seconds"]
+        assert elapsed is not None
+        assert elapsed >= 7.0  # tolerate a little clock drift from the test harness
+        assert elapsed < 30.0
 
     def test_status_json_backward_compat(self, client: TestClient):
         """The JSON response still includes armed_topic for backward compat."""
@@ -964,7 +1174,9 @@ class TestProcessRoute:
         resp = client.post("/process", data={"raw_path": str(raw)})
 
         assert resp.status_code == 200
-        assert resp.headers.get("HX-Redirect") == "/lectures"
+        location = resp.headers.get("hx-location", "")
+        assert "/lectures" in location
+        assert "#lectures-dynamic" in location
 
     def test_process_skips_missing_files(self, app, client: TestClient, monkeypatch):
         """Non-existent raw_path is logged and skipped, not submitted."""


### PR DESCRIPTION
## Summary

The four optional polish items deferred from the Phase-4 smoke test of the Recordings App Hardening work (PR #42), bundled into a single follow-up PR on top of master:

- **Clamp FAILED progress bar + permanent ValidationError retry cap.** `ProcessingJob.consecutive_validation_errors` tracks back-to-back pydantic `ValidationError`s; the JobManager promotes to FAILED after `MAX_CONSECUTIVE_VALIDATION_ERRORS = 5`. The jobs template clamps the progress bar to 100 on COMPLETED and 0 on FAILED/CANCELLED, with state-specific colours in `app.css`.
- **Scroll preservation on lecture-page actions.** Every lecture route that used to return `HX-Redirect: /lectures` now returns `HX-Location` targeted at `#lectures-dynamic` (swap=outerHTML), so only the dynamic subtree swaps in-place and scroll position is preserved.
- **Elapsed-time timer while recording.** `SessionSnapshot.recording_elapsed_seconds` is populated from the existing `_recording_started_at`; both the top banner and the per-row armed deck render a `mm:ss` timer that ticks client-side via `setInterval` and re-anchors on every swap. Per-row placement was added after the user pointed out that the banner timer goes out of view once you scroll down.
- **Manual advance-take.** `RecordingSession.advance_take()` runs the `_preserve_active_take` cascade standalone (no OBS interaction), updates `state.json`, and transitions `ARMED_AFTER_TAKE → ARMED` when the advanced deck matches the armed one. Exposed as `POST /advance`; the lectures page shows an Advance button next to Process whenever a recorded/failed raw exists.

Also retires the hardening handover (`docs/claude/recordings-hardening-handover.md → recordings-hardening-handover-archive.md`) now that all phases plus Commit-B are shipped, and adds a short user-guide section covering the new dashboard behaviours.

**Tests**: 740 recordings tests green (was 616); full fast suite (4033, 4 xfailed) green; ruff + mypy clean.

## Test plan

- [x] Full recordings test suite passes (`pytest tests/recordings/`)
- [x] Full fast test suite passes (`pytest`)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `mypy` clean on `src/clm/recordings`
- [x] Manual dashboard smoke test on `~/Tmp/AuphonicTest` tree (prod `D:\CLM` state file backed up + restored); user verified scroll preservation, per-row elapsed timer, and overall flow on 2026-04-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)