### PR TITLE
feat(recordings): handle OBS pause/resume in session and web UI

### DIFF
--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -7,6 +7,8 @@ Provides:
 - ``POST /disarm`` — Disarm the current deck (low-level primitive)
 - ``POST /record`` — Arm + start OBS recording in one step
 - ``POST /stop`` — Tell OBS to stop the current recording
+- ``POST /pause`` — Tell OBS to pause the current recording
+- ``POST /resume`` — Tell OBS to resume a paused recording
 - ``GET /status`` — JSON session status snapshot
 - ``GET /events`` — SSE stream for real-time updates
 - ``GET /pairs`` — Pending pairs list (HTMX partial)
@@ -396,6 +398,46 @@ async def stop_recording(request: Request):
     return await status_partial(request)
 
 
+@router.post("/pause", response_class=HTMLResponse)
+async def pause_recording(request: Request):
+    """Tell OBS to pause the current recording.
+
+    The session's ``RecordStateChanged`` handler transitions to
+    :class:`SessionState.PAUSED` when OBS confirms the pause.
+    """
+    session = _get_session(request)
+    try:
+        session.pause()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ConnectionError as exc:
+        logger.warning("OBS rejected pause_record: {}", exc)
+        _push_notice(request, "error", f"OBS rejected pause: {exc}")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if _from_lectures(request):
+        return _lectures_refresh_response()
+    return await status_partial(request)
+
+
+@router.post("/resume", response_class=HTMLResponse)
+async def resume_recording(request: Request):
+    """Tell OBS to resume a paused recording."""
+    session = _get_session(request)
+    try:
+        session.resume()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ConnectionError as exc:
+        logger.warning("OBS rejected resume_record: {}", exc)
+        _push_notice(request, "error", f"OBS rejected resume: {exc}")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if _from_lectures(request):
+        return _lectures_refresh_response()
+    return await status_partial(request)
+
+
 @router.post("/process", response_class=HTMLResponse)
 async def process_file(request: Request):
     """Manually submit one or more files for backend processing."""
@@ -774,6 +816,7 @@ def _snapshot_to_dict(snap: SessionSnapshot) -> dict:
         "last_output": str(snap.last_output) if snap.last_output else None,
         "error": snap.error,
         "recording_elapsed_seconds": snap.recording_elapsed_seconds,
+        "paused": snap.paused,
     }
 
 

--- a/src/clm/recordings/web/static/app.css
+++ b/src/clm/recordings/web/static/app.css
@@ -60,6 +60,8 @@ button, input, select, textarea {
     --c-badge-armed-fg:         #ffffff;
     --c-badge-recording-bg:     #dc2626;
     --c-badge-recording-fg:     #ffffff;
+    --c-badge-paused-bg:        #f59e0b;
+    --c-badge-paused-fg:        #78350f;
     --c-badge-renaming-bg:      #d97706;
     --c-badge-renaming-fg:      #ffffff;
     --c-badge-connected-bg:     #16a34a;
@@ -399,6 +401,7 @@ footer {
 .badge-armed        { background: var(--c-badge-armed-bg);        color: var(--c-badge-armed-fg); }
 .badge-armed_after_take { background: var(--c-badge-armed-bg);    color: var(--c-badge-armed-fg); }
 .badge-recording    { background: var(--c-badge-recording-bg);    color: var(--c-badge-recording-fg); }
+.badge-paused       { background: var(--c-badge-paused-bg);       color: var(--c-badge-paused-fg); }
 .badge-renaming     { background: var(--c-badge-renaming-bg);     color: var(--c-badge-renaming-fg); }
 .badge-connected    { background: var(--c-badge-connected-bg);    color: var(--c-badge-connected-fg); }
 .badge-disconnected { background: var(--c-badge-disconnected-bg); color: var(--c-badge-disconnected-fg); }

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -99,6 +99,13 @@
         document.querySelectorAll('.elapsed-timer[data-elapsed-base-seconds]').forEach(function (el) {
             var base = parseInt(el.getAttribute('data-elapsed-base-seconds'), 10);
             if (isNaN(base)) return;
+            /* When the session is paused the server renders a frozen
+               base value and sets `data-elapsed-paused`; just display it
+               without advancing so the timer does not tick. */
+            if (el.hasAttribute('data-elapsed-paused')) {
+                el.textContent = _formatElapsed(base);
+                return;
+            }
             var anchor = el._elapsedAnchor;
             if (anchor == null) {
                 el._elapsedAnchor = now;

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -47,7 +47,7 @@
 {% if snapshot.armed_deck %}
 <div class="banner banner-info">
     <strong>
-        {% if snapshot.state.value == 'recording' %}Recording{% elif snapshot.state.value == 'armed_after_take' %}Ready for retake{% else %}Armed{% endif %}:
+        {% if snapshot.state.value == 'recording' %}Recording{% elif snapshot.state.value == 'paused' %}Paused{% elif snapshot.state.value == 'armed_after_take' %}Ready for retake{% else %}Armed{% endif %}:
     </strong>
     {{ snapshot.armed_deck.course_slug }} /
     {{ snapshot.armed_deck.section_name }} /
@@ -55,9 +55,10 @@
     {% if snapshot.armed_deck.part_number > 0 %}
     ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
     {% endif %}
-    {% if snapshot.state.value == 'recording' and snapshot.recording_elapsed_seconds is not none %}
+    {% if snapshot.state.value in ('recording', 'paused') and snapshot.recording_elapsed_seconds is not none %}
     <span class="elapsed-timer"
           data-elapsed-base-seconds="{{ snapshot.recording_elapsed_seconds | int }}"
+          {% if snapshot.paused %}data-elapsed-paused="true"{% endif %}
           aria-label="Elapsed recording time">
         {{ '%d:%02d' | format(
             (snapshot.recording_elapsed_seconds | int) // 60,
@@ -66,7 +67,17 @@
     </span>
     {% endif %}
     {% if snapshot.state.value == 'recording' %}
-    <form hx-post="/stop" hx-target="body" hx-disabled-elt="find button" class="u-inline u-ml-auto">
+    <form hx-post="/pause" hx-target="body" hx-disabled-elt="find button" class="u-inline u-ml-auto">
+        <button type="submit" class="btn btn-sm">Pause</button>
+    </form>
+    <form hx-post="/stop" hx-target="body" hx-disabled-elt="find button" class="u-inline">
+        <button type="submit" class="btn btn-sm btn-danger">Stop</button>
+    </form>
+    {% elif snapshot.state.value == 'paused' %}
+    <form hx-post="/resume" hx-target="body" hx-disabled-elt="find button" class="u-inline u-ml-auto">
+        <button type="submit" class="btn btn-sm btn-primary">Resume</button>
+    </form>
+    <form hx-post="/stop" hx-target="body" hx-disabled-elt="find button" class="u-inline">
         <button type="submit" class="btn btn-sm btn-danger">Stop</button>
     </form>
     {% else %}
@@ -98,11 +109,16 @@
             <tr{% if is_armed %} class="row-armed"{% endif %}>
                 <td>{{ deck.display_name }}</td>
                 <td>
-                    {% if is_armed and snapshot.state.value == 'recording' %}
+                    {% if is_armed and snapshot.state.value in ('recording', 'paused') %}
+                    {% if snapshot.state.value == 'paused' %}
+                    <span class="badge badge-paused">paused</span>
+                    {% else %}
                     <span class="badge badge-recording">recording</span>
+                    {% endif %}
                     {% if snapshot.recording_elapsed_seconds is not none %}
                     <span class="elapsed-timer"
                           data-elapsed-base-seconds="{{ snapshot.recording_elapsed_seconds | int }}"
+                          {% if snapshot.paused %}data-elapsed-paused="true"{% endif %}
                           aria-label="Elapsed recording time">
                         {{ '%d:%02d' | format(
                             (snapshot.recording_elapsed_seconds | int) // 60,
@@ -134,6 +150,16 @@
                 <td>
                     <div class="deck-actions">
                         {% if is_armed and snapshot.state.value == 'recording' %}
+                        <form hx-post="/pause" hx-target="body" hx-disabled-elt="find button">
+                            <button type="submit" class="btn btn-sm">Pause</button>
+                        </form>
+                        <form hx-post="/stop" hx-target="body" hx-disabled-elt="find button">
+                            <button type="submit" class="btn btn-sm btn-danger">Stop</button>
+                        </form>
+                        {% elif is_armed and snapshot.state.value == 'paused' %}
+                        <form hx-post="/resume" hx-target="body" hx-disabled-elt="find button">
+                            <button type="submit" class="btn btn-sm btn-primary">Resume</button>
+                        </form>
                         <form hx-post="/stop" hx-target="body" hx-disabled-elt="find button">
                             <button type="submit" class="btn btn-sm btn-danger">Stop</button>
                         </form>

--- a/src/clm/recordings/web/templates/partials/status.html
+++ b/src/clm/recordings/web/templates/partials/status.html
@@ -36,7 +36,7 @@
     {% if snapshot.armed_deck %}
     <div class="banner banner-info">
         <strong>
-            {% if snapshot.state.value == 'recording' %}Recording{% elif snapshot.state.value == 'armed_after_take' %}Ready for retake{% else %}Armed{% endif %}:
+            {% if snapshot.state.value == 'recording' %}Recording{% elif snapshot.state.value == 'paused' %}Paused{% elif snapshot.state.value == 'armed_after_take' %}Ready for retake{% else %}Armed{% endif %}:
         </strong>
         {{ snapshot.armed_deck.course_slug }} /
         {{ snapshot.armed_deck.section_name }} /
@@ -44,9 +44,13 @@
         {% if snapshot.armed_deck.part_number > 0 %}
         ({% if snapshot.armed_deck.lang == 'de' %}Teil{% else %}part{% endif %} {{ snapshot.armed_deck.part_number }})
         {% endif %}
-        {% if snapshot.state.value == 'recording' and snapshot.recording_elapsed_seconds is not none %}
+        {% if snapshot.state.value in ('recording', 'paused') and snapshot.recording_elapsed_seconds is not none %}
+        {# During PAUSED the timer is frozen: ``data-elapsed-paused`` tells the
+           client-side ticker not to advance. Resuming re-renders without the
+           attribute so ticking picks up automatically. #}
         <span class="elapsed-timer"
               data-elapsed-base-seconds="{{ snapshot.recording_elapsed_seconds | int }}"
+              {% if snapshot.paused %}data-elapsed-paused="true"{% endif %}
               aria-label="Elapsed recording time">
             {{ '%d:%02d' | format(
                 (snapshot.recording_elapsed_seconds | int) // 60,
@@ -55,8 +59,21 @@
         </span>
         {% endif %}
         {% if snapshot.state.value == 'recording' %}
-        <form hx-post="/stop" hx-target="#status-panel" hx-swap="innerHTML"
+        <form hx-post="/pause" hx-target="#status-panel" hx-swap="innerHTML"
               hx-disabled-elt="find button" class="u-inline u-ml-auto">
+            <button type="submit" class="btn btn-sm">Pause</button>
+        </form>
+        <form hx-post="/stop" hx-target="#status-panel" hx-swap="innerHTML"
+              hx-disabled-elt="find button" class="u-inline">
+            <button type="submit" class="btn btn-sm btn-danger">Stop</button>
+        </form>
+        {% elif snapshot.state.value == 'paused' %}
+        <form hx-post="/resume" hx-target="#status-panel" hx-swap="innerHTML"
+              hx-disabled-elt="find button" class="u-inline u-ml-auto">
+            <button type="submit" class="btn btn-sm btn-primary">Resume</button>
+        </form>
+        <form hx-post="/stop" hx-target="#status-panel" hx-swap="innerHTML"
+              hx-disabled-elt="find button" class="u-inline">
             <button type="submit" class="btn btn-sm btn-danger">Stop</button>
         </form>
         {% else %}

--- a/src/clm/recordings/workflow/obs.py
+++ b/src/clm/recordings/workflow/obs.py
@@ -298,6 +298,42 @@ class ObsClient:
             raise ConnectionError(f"OBS rejected stop_record: {exc}") from exc
         logger.info("Requested OBS to stop recording")
 
+    def pause_record(self) -> None:
+        """Tell OBS to pause the current recording.
+
+        OBS emits a ``RecordStateChanged`` event with
+        ``output_state=OBS_WEBSOCKET_OUTPUT_PAUSED`` asynchronously.
+        The session state machine tracks the pause so the dashboard can
+        reflect it without forgetting the armed deck.
+
+        Raises:
+            ConnectionError: If not connected to OBS or if OBS rejected
+                the request (e.g. no recording in progress, already paused).
+        """
+        req = self._require_connected()
+        try:
+            req.pause_record()
+        except Exception as exc:
+            raise ConnectionError(f"OBS rejected pause_record: {exc}") from exc
+        logger.info("Requested OBS to pause recording")
+
+    def resume_record(self) -> None:
+        """Tell OBS to resume a paused recording.
+
+        OBS emits a ``RecordStateChanged`` event with
+        ``output_state=OBS_WEBSOCKET_OUTPUT_RESUMED`` asynchronously.
+
+        Raises:
+            ConnectionError: If not connected to OBS or if OBS rejected
+                the request (e.g. not paused).
+        """
+        req = self._require_connected()
+        try:
+            req.resume_record()
+        except Exception as exc:
+            raise ConnectionError(f"OBS rejected resume_record: {exc}") from exc
+        logger.info("Requested OBS to resume recording")
+
     # ------------------------------------------------------------------
     # Watchdog / reconnect
     # ------------------------------------------------------------------

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -7,12 +7,15 @@ into the structured directory layout.
 State transitions::
 
     idle ──arm()──► armed ──OBS starts──► recording ──OBS stops──► renaming ──done──┐
-      ▲               │                      ▲                                       │
-      │               │                      │                                       ▼
-      │               │                      └── OBS starts ── armed_after_take ◄────┤
-      │               │                                             │                │
-      │               │                                             ▼                │
-      └──disarm()─────┴────────────────── timer expires ────────────┴────────────────┘
+      ▲               │                    ▲  │ ▲                                    │
+      │               │                    │  │ │ OBS resumes                        ▼
+      │               │                    │  ▼ │                                    │
+      │               │                    │ paused ─ OBS stops ──────► renaming ────┤
+      │               │                    │                                          │
+      │               │                    └── OBS starts ── armed_after_take ◄───────┤
+      │               │                                         │                    │
+      │               │                                         ▼                    │
+      └──disarm()─────┴────────────────── timer expires ────────┴────────────────────┘
 
 A "short take" (OBS stops within ``short_take_seconds`` of starting) is
 treated as an accidental start-then-stop: the output goes to
@@ -68,6 +71,14 @@ class SessionState(enum.Enum):
     IDLE = "idle"
     ARMED = "armed"
     RECORDING = "recording"
+    PAUSED = "paused"
+    """OBS has paused the recording — output file is still open.
+
+    The armed deck is kept intact; a subsequent OBS
+    ``OBS_WEBSOCKET_OUTPUT_RESUMED`` event returns the session to
+    :attr:`RECORDING`, while a ``OBS_WEBSOCKET_OUTPUT_STOPPED`` triggers
+    the normal rename path as if the pause had not happened.
+    """
     RENAMING = "renaming"
     ARMED_AFTER_TAKE = "armed_after_take"
     """A take has completed and the deck remains armed for a short window.
@@ -111,12 +122,20 @@ class SessionSnapshot:
     last_output: Path | None = None
     error: str | None = None
     recording_elapsed_seconds: float | None = None
-    """Seconds since the most recent OBS STARTED event, or ``None``.
+    """Seconds of *actual recording time* so far, excluding pause windows.
 
     ``None`` when no recording is active. When a recording is in
     progress, the UI captures this value on render and extrapolates
     client-side via ``setInterval`` so the elapsed-time display ticks
-    smoothly without per-second server chatter.
+    smoothly without per-second server chatter. During :attr:`SessionState.PAUSED`
+    the value is frozen at the moment OBS paused so the displayed timer
+    does not tick; resuming unfreezes it.
+    """
+    paused: bool = False
+    """``True`` while the session is in :attr:`SessionState.PAUSED`.
+
+    Exposed as a plain boolean rather than requiring callers to compare
+    against the enum so templates can use the flag directly.
     """
 
     @property
@@ -588,6 +607,13 @@ class RecordingSession:
         self._recording_started_at: float | None = None
         self._retake_timer: threading.Timer | None = None
 
+        # Pause tracking (guarded by the session lock). ``_paused_elapsed``
+        # captures how much recording time had accumulated when OBS
+        # paused, so the UI can display a frozen elapsed value during
+        # PAUSED and we can resume the timer on RESUMED by rebasing
+        # ``_recording_started_at`` to ``now - paused_elapsed``.
+        self._paused_elapsed: float | None = None
+
         # Wire up OBS events
         self._obs.on_record_state_changed(self._handle_record_event)
 
@@ -611,6 +637,12 @@ class RecordingSession:
     def snapshot(self) -> SessionSnapshot:
         """Thread-safe snapshot of the current session state."""
         with self._lock:
+            if self._state is SessionState.RECORDING:
+                elapsed: float | None = self._elapsed_since_start_locked()
+            elif self._state is SessionState.PAUSED:
+                elapsed = self._paused_elapsed
+            else:
+                elapsed = None
             return SessionSnapshot(
                 state=self._state,
                 armed_deck=self._armed,
@@ -618,11 +650,8 @@ class RecordingSession:
                 obs_state=getattr(self._obs, "connection_state", "disconnected"),
                 last_output=self._last_output,
                 error=self._error,
-                recording_elapsed_seconds=(
-                    self._elapsed_since_start_locked()
-                    if self._state is SessionState.RECORDING
-                    else None
-                ),
+                recording_elapsed_seconds=elapsed,
+                paused=self._state is SessionState.PAUSED,
             )
 
     def arm(
@@ -682,6 +711,10 @@ class RecordingSession:
         with self._lock:
             if self._state == SessionState.RECORDING:
                 raise RuntimeError("Cannot disarm while recording is in progress.")
+            if self._state == SessionState.PAUSED:
+                raise RuntimeError(
+                    "Cannot disarm while recording is paused. Resume and stop first."
+                )
             if self._state == SessionState.RENAMING:
                 raise RuntimeError("Cannot disarm while rename is in progress.")
             self._cancel_retake_timer_locked()
@@ -760,7 +793,11 @@ class RecordingSession:
                 progress — the caller should stop first.
         """
         with self._lock:
-            if self._state in (SessionState.RECORDING, SessionState.RENAMING):
+            if self._state in (
+                SessionState.RECORDING,
+                SessionState.PAUSED,
+                SessionState.RENAMING,
+            ):
                 raise RuntimeError(f"Cannot advance take while in state '{self._state.value}'.")
             was_armed_after_take = (
                 self._state is SessionState.ARMED_AFTER_TAKE
@@ -808,12 +845,53 @@ class RecordingSession:
         Pure convenience so the dashboard can offer a Stop button without
         leaving the web UI. The rest of the stop flow (STOPPED event →
         rename → transition to IDLE) is handled by the existing event
-        pipeline.
+        pipeline. Works both from :attr:`SessionState.RECORDING` and
+        :attr:`SessionState.PAUSED` — OBS accepts ``StopRecord`` while
+        paused and will emit the normal STOPPED event.
 
         Raises:
             ConnectionError: If OBS is not connected or rejects the request.
         """
         self._obs.stop_record()
+
+    def pause(self) -> None:
+        """Ask OBS to pause the current recording.
+
+        The PAUSED event arrives asynchronously via the OBS event
+        client and drives the actual state transition in
+        :meth:`_handle_record_event`. This method is a thin wrapper so
+        the dashboard can offer a Pause button without leaving the web
+        UI.
+
+        Raises:
+            RuntimeError: If the session is not in :attr:`SessionState.RECORDING`.
+            ConnectionError: If OBS is not connected or rejects the request.
+        """
+        with self._lock:
+            if self._state is not SessionState.RECORDING:
+                raise RuntimeError(
+                    f"Cannot pause while in state '{self._state.value}'. "
+                    "Recording must be in progress."
+                )
+        self._obs.pause_record()
+
+    def resume(self) -> None:
+        """Ask OBS to resume a paused recording.
+
+        The RESUMED event arrives asynchronously and drives the
+        transition back to :attr:`SessionState.RECORDING` in
+        :meth:`_handle_record_event`.
+
+        Raises:
+            RuntimeError: If the session is not in :attr:`SessionState.PAUSED`.
+            ConnectionError: If OBS is not connected or rejects the request.
+        """
+        with self._lock:
+            if self._state is not SessionState.PAUSED:
+                raise RuntimeError(
+                    f"Cannot resume while in state '{self._state.value}'. Recording must be paused."
+                )
+        self._obs.resume_record()
 
     # ------------------------------------------------------------------
     # OBS event handling
@@ -835,6 +913,15 @@ class RecordingSession:
         the definitive STOPPED event, otherwise the session transitions
         to ``IDLE`` before the output path is available.
 
+        Pause handling: OBS emits ``OBS_WEBSOCKET_OUTPUT_PAUSED`` /
+        ``OBS_WEBSOCKET_OUTPUT_RESUMED`` with ``output_active=False`` /
+        ``True`` respectively. We key on the explicit ``output_state`` so
+        the session can expose a visible paused state without mistaking
+        it for a stop — previously the paused event fell into the
+        stopped branch, had no ``output_path``, and silently disarmed
+        the deck, leaving the user to manually move the recording once
+        OBS finally stopped.
+
         OBS START during ``ARMED_AFTER_TAKE`` is treated as a retake of
         the same armed deck. OBS STOP within ``short_take_seconds`` of
         the start is treated as an accidental take: the file is moved
@@ -844,7 +931,33 @@ class RecordingSession:
         short_take_args: tuple[Path, ArmedDeck] | None = None
 
         with self._lock:
-            if event.output_active:
+            # Pause / resume are dispatched explicitly before the
+            # active/inactive split so the PAUSED event (which carries
+            # output_active=False and no output_path) is not confused
+            # with a stop.
+            if event.output_state == "OBS_WEBSOCKET_OUTPUT_PAUSED":
+                if self._state is SessionState.RECORDING:
+                    elapsed = self._elapsed_since_start_locked() or 0.0
+                    self._paused_elapsed = elapsed
+                    self._recording_started_at = None
+                    self._state = SessionState.PAUSED
+                    logger.info("Recording paused for {} after {:.1f}s", self._armed, elapsed)
+                else:
+                    logger.debug("OBS paused event ignored (state={})", self._state.value)
+                    return
+            elif event.output_state == "OBS_WEBSOCKET_OUTPUT_RESUMED":
+                if self._state is SessionState.PAUSED:
+                    resumed_from = self._paused_elapsed or 0.0
+                    # Re-base the start timestamp so elapsed picks up
+                    # where pause froze it, ignoring the paused window.
+                    self._recording_started_at = time.monotonic() - resumed_from
+                    self._paused_elapsed = None
+                    self._state = SessionState.RECORDING
+                    logger.info("Recording resumed for {}", self._armed)
+                else:
+                    logger.debug("OBS resumed event ignored (state={})", self._state.value)
+                    return
+            elif event.output_active:
                 # Recording started (STARTED)
                 if self._state in (SessionState.ARMED, SessionState.ARMED_AFTER_TAKE):
                     if self._state == SessionState.ARMED_AFTER_TAKE:
@@ -852,6 +965,7 @@ class RecordingSession:
                     self._cancel_retake_timer_locked()
                     self._state = SessionState.RECORDING
                     self._recording_started_at = time.monotonic()
+                    self._paused_elapsed = None
                     logger.info("Recording started for {}", self._armed)
                 else:
                     logger.info("Recording started (state={}, no auto-rename)", self._state.value)
@@ -863,18 +977,29 @@ class RecordingSession:
                     logger.debug("Intermediate STOPPING event, waiting for STOPPED")
                     return
 
-                # Recording stopped (definitive STOPPED event)
-                if self._state == SessionState.RECORDING and self._armed is not None:
-                    elapsed = self._elapsed_since_start_locked()
-                    is_short_take = elapsed is not None and elapsed < self._short_take_seconds
+                # Recording stopped (definitive STOPPED event). A stop
+                # arriving while PAUSED is the user ending the take from
+                # OBS without resuming first — handle it on the same
+                # rename path as a stop from RECORDING.
+                active_states = (SessionState.RECORDING, SessionState.PAUSED)
+                if self._state in active_states and self._armed is not None:
+                    stop_elapsed: float | None
+                    if self._state is SessionState.PAUSED:
+                        stop_elapsed = self._paused_elapsed
+                    else:
+                        stop_elapsed = self._elapsed_since_start_locked()
+                    is_short_take = (
+                        stop_elapsed is not None and stop_elapsed < self._short_take_seconds
+                    )
                     self._recording_started_at = None
+                    self._paused_elapsed = None
 
                     if is_short_take and event.output_path:
                         # Accidental start-then-stop — move to superseded/
                         # and stay armed on the same deck.
                         logger.info(
                             "Short take ({:.1f}s < {:.1f}s) — superseding and staying armed",
-                            elapsed,
+                            stop_elapsed,
                             self._short_take_seconds,
                         )
                         self._state = SessionState.ARMED
@@ -887,10 +1012,11 @@ class RecordingSession:
                         self._error = "OBS did not report the output file path"
                         self._armed = None
                         self._state = SessionState.IDLE
-                elif self._state == SessionState.RECORDING:
-                    # Was recording but nothing armed — just go back to idle
+                elif self._state in active_states:
+                    # Was recording/paused but nothing armed — just go back to idle
                     self._state = SessionState.IDLE
                     self._recording_started_at = None
+                    self._paused_elapsed = None
                 else:
                     logger.debug("Recording stopped event ignored (state={})", self._state.value)
 

--- a/tests/recordings/test_obs.py
+++ b/tests/recordings/test_obs.py
@@ -205,6 +205,42 @@ class TestObsClientRecordingControl:
         with pytest.raises(ConnectionError, match="OBS rejected stop_record"):
             client.stop_record()
 
+    def test_pause_record_delegates_to_req(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        client.pause_record()
+        mock_obsws["req"].pause_record.assert_called_once_with()
+
+    def test_pause_record_not_connected(self):
+        client = ObsClient()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.pause_record()
+
+    def test_pause_record_wraps_obsws_error(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        mock_obsws["req"].pause_record.side_effect = RuntimeError("already paused")
+        with pytest.raises(ConnectionError, match="OBS rejected pause_record"):
+            client.pause_record()
+
+    def test_resume_record_delegates_to_req(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        client.resume_record()
+        mock_obsws["req"].resume_record.assert_called_once_with()
+
+    def test_resume_record_not_connected(self):
+        client = ObsClient()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.resume_record()
+
+    def test_resume_record_wraps_obsws_error(self, mock_obsws):
+        client = ObsClient()
+        client.connect()
+        mock_obsws["req"].resume_record.side_effect = RuntimeError("not paused")
+        with pytest.raises(ConnectionError, match="OBS rejected resume_record"):
+            client.resume_record()
+
 
 # ---------------------------------------------------------------------------
 # Event dispatching

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -223,6 +223,206 @@ class TestRecordAndStop:
 
 
 # ---------------------------------------------------------------------------
+# Pause / resume
+# ---------------------------------------------------------------------------
+
+
+def _start_recording(session: RecordingSession, mock_obs: MagicMock) -> None:
+    """Helper that drives the session from IDLE to RECORDING."""
+    session.arm("c", "s", "t")
+    _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+    assert session.state is SessionState.RECORDING
+
+
+class TestPauseResume:
+    """OBS pause/resume events must be surfaced, not mistaken for a stop.
+
+    Regression for the bug where a pause during an active recording
+    produced a ``RecordStateChanged`` event with ``output_active=False``
+    and no ``output_path``; the old handler fell into the stopped
+    branch, set an error, and disarmed the deck — leaving the user to
+    manually move the recording file into ``to-process/`` once OBS
+    finally stopped.
+    """
+
+    def test_paused_event_transitions_to_paused_state(
+        self, session: RecordingSession, mock_obs: MagicMock
+    ):
+        _start_recording(session, mock_obs)
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+                output_path=None,
+            ),
+        )
+        assert session.state is SessionState.PAUSED
+        assert session.armed_deck is not None  # deck must be preserved
+
+    def test_paused_event_does_not_set_error(self, session: RecordingSession, mock_obs: MagicMock):
+        """The old handler misread pause as a missing-path stop."""
+        _start_recording(session, mock_obs)
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+                output_path=None,
+            ),
+        )
+        assert session.snapshot().error is None
+
+    def test_resumed_event_returns_to_recording(
+        self, session: RecordingSession, mock_obs: MagicMock
+    ):
+        _start_recording(session, mock_obs)
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=False,
+                output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+            ),
+        )
+        assert session.state is SessionState.PAUSED
+
+        _fire_event(
+            mock_obs,
+            RecordingEvent(
+                output_active=True,
+                output_state="OBS_WEBSOCKET_OUTPUT_RESUMED",
+            ),
+        )
+        assert session.state is SessionState.RECORDING
+        assert session.armed_deck is not None
+
+    def test_stop_after_pause_renames_file(
+        self,
+        mock_obs: MagicMock,
+        recording_root: Path,
+        tmp_path: Path,
+    ):
+        """Pause → Stop from OBS must still trigger the normal rename."""
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+        )
+        obs_output = tmp_path / "rec.mkv"
+        obs_output.write_bytes(b"video data")
+
+        session.arm("c", "s", "t")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="OBS_WEBSOCKET_OUTPUT_PAUSED"),
+        )
+        assert session.state is SessionState.PAUSED
+
+        with patch("clm.recordings.workflow.session.shutil.move"):
+            _fire_event(
+                mock_obs,
+                RecordingEvent(
+                    output_active=False,
+                    output_state="OBS_WEBSOCKET_OUTPUT_STOPPED",
+                    output_path=str(obs_output),
+                ),
+            )
+            _wait_for_state(session, SessionState.IDLE, timeout=15.0)
+
+        assert session.state is SessionState.IDLE
+        assert session.armed_deck is None
+        assert session.snapshot().error is None
+
+    def test_paused_event_outside_recording_is_ignored(
+        self, session: RecordingSession, mock_obs: MagicMock
+    ):
+        """A PAUSED event arriving while IDLE must not disturb the session."""
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="OBS_WEBSOCKET_OUTPUT_PAUSED"),
+        )
+        assert session.state is SessionState.IDLE
+        assert session.armed_deck is None
+
+    def test_resumed_event_outside_pause_is_ignored(
+        self, session: RecordingSession, mock_obs: MagicMock
+    ):
+        """A stray RESUMED while IDLE must not start fabricated recording."""
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=True, output_state="OBS_WEBSOCKET_OUTPUT_RESUMED"),
+        )
+        assert session.state is SessionState.IDLE
+
+    def test_pause_calls_obs_pause_record(self, session: RecordingSession, mock_obs: MagicMock):
+        _start_recording(session, mock_obs)
+        session.pause()
+        mock_obs.pause_record.assert_called_once_with()
+
+    def test_pause_raises_when_not_recording(self, session: RecordingSession, mock_obs: MagicMock):
+        with pytest.raises(RuntimeError, match="Cannot pause"):
+            session.pause()
+        mock_obs.pause_record.assert_not_called()
+
+    def test_resume_calls_obs_resume_record(self, session: RecordingSession, mock_obs: MagicMock):
+        _start_recording(session, mock_obs)
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="OBS_WEBSOCKET_OUTPUT_PAUSED"),
+        )
+        session.resume()
+        mock_obs.resume_record.assert_called_once_with()
+
+    def test_resume_raises_when_not_paused(self, session: RecordingSession, mock_obs: MagicMock):
+        _start_recording(session, mock_obs)
+        with pytest.raises(RuntimeError, match="Cannot resume"):
+            session.resume()
+        mock_obs.resume_record.assert_not_called()
+
+    def test_disarm_while_paused_raises(self, session: RecordingSession, mock_obs: MagicMock):
+        _start_recording(session, mock_obs)
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="OBS_WEBSOCKET_OUTPUT_PAUSED"),
+        )
+        with pytest.raises(RuntimeError, match="Cannot disarm"):
+            session.disarm()
+
+    def test_snapshot_paused_flag(self, session: RecordingSession, mock_obs: MagicMock):
+        _start_recording(session, mock_obs)
+        assert session.snapshot().paused is False
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="OBS_WEBSOCKET_OUTPUT_PAUSED"),
+        )
+        snap = session.snapshot()
+        assert snap.paused is True
+        assert snap.state is SessionState.PAUSED
+        # Paused elapsed is frozen — present as a non-None float.
+        assert snap.recording_elapsed_seconds is not None
+
+    def test_pause_freezes_elapsed_timer(self, session: RecordingSession, mock_obs: MagicMock):
+        """Elapsed reads must not advance while paused."""
+        _start_recording(session, mock_obs)
+        _fire_event(
+            mock_obs,
+            RecordingEvent(output_active=False, output_state="OBS_WEBSOCKET_OUTPUT_PAUSED"),
+        )
+        first = session.snapshot().recording_elapsed_seconds
+        # Sleep briefly — in paused state the elapsed must not tick.
+        import time as _time
+
+        _time.sleep(0.05)
+        second = session.snapshot().recording_elapsed_seconds
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
 # Recording start event
 # ---------------------------------------------------------------------------
 

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -697,6 +697,119 @@ class TestRecordStop:
 
 
 # ---------------------------------------------------------------------------
+# Pause / resume
+# ---------------------------------------------------------------------------
+
+
+class TestPauseResumeRoutes:
+    """HTTP-level regression coverage for the pause/resume workflow.
+
+    Covers the bug where pausing from OBS made the dashboard forget the
+    armed deck (``/stop`` button disappeared, no rename at final stop).
+    """
+
+    def _drive_to_recording(self, app, client: TestClient) -> None:
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "01 Deck",
+                "part_number": "0",
+            },
+        )
+        for cb in app.state.obs._record_callbacks:
+            cb(RecordingEvent(output_active=True, output_state="started"))
+
+    def test_pause_event_keeps_deck_armed(self, app, client: TestClient):
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        self._drive_to_recording(app, client)
+        for cb in app.state.obs._record_callbacks:
+            cb(
+                RecordingEvent(
+                    output_active=False,
+                    output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+                    output_path=None,
+                )
+            )
+        snap = app.state.session.snapshot()
+        assert snap.state is SessionState.PAUSED
+        assert snap.armed_deck is not None
+        assert snap.error is None
+
+    def test_status_partial_shows_paused_and_resume_button(self, app, client: TestClient):
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        self._drive_to_recording(app, client)
+        for cb in app.state.obs._record_callbacks:
+            cb(
+                RecordingEvent(
+                    output_active=False,
+                    output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+                )
+            )
+        resp = client.get("/status-partial")
+        assert resp.status_code == 200
+        assert "Paused" in resp.text
+        assert '"/resume"' in resp.text or "/resume" in resp.text
+        # The Disarm button must NOT appear — the deck is still active.
+        assert "data-disarm-shortcut" not in resp.text
+
+    def test_pause_route_calls_obs_pause_record(self, app, client: TestClient):
+        self._drive_to_recording(app, client)
+        resp = client.post("/pause")
+        assert resp.status_code == 200
+        app.state.obs.pause_record.assert_called_once_with()
+
+    def test_pause_route_conflict_when_not_recording(self, app, client: TestClient):
+        resp = client.post("/pause")
+        assert resp.status_code == 409
+        app.state.obs.pause_record.assert_not_called()
+
+    def test_resume_route_calls_obs_resume_record(self, app, client: TestClient):
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        self._drive_to_recording(app, client)
+        for cb in app.state.obs._record_callbacks:
+            cb(
+                RecordingEvent(
+                    output_active=False,
+                    output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+                )
+            )
+        resp = client.post("/resume")
+        assert resp.status_code == 200
+        app.state.obs.resume_record.assert_called_once_with()
+
+    def test_resume_route_conflict_when_not_paused(self, app, client: TestClient):
+        resp = client.post("/resume")
+        assert resp.status_code == 409
+        app.state.obs.resume_record.assert_not_called()
+
+    def test_status_json_includes_paused_flag(self, app, client: TestClient):
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        self._drive_to_recording(app, client)
+        resp = client.get("/status")
+        assert resp.json()["paused"] is False
+
+        for cb in app.state.obs._record_callbacks:
+            cb(
+                RecordingEvent(
+                    output_active=False,
+                    output_state="OBS_WEBSOCKET_OUTPUT_PAUSED",
+                )
+            )
+        resp = client.get("/status")
+        data = resp.json()
+        assert data["paused"] is True
+        assert data["state"] == "paused"
+
+
+# ---------------------------------------------------------------------------
 # Advance (manual "demote active take" without recording)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds an explicit `SessionState.PAUSED` and routes the OBS `OBS_WEBSOCKET_OUTPUT_PAUSED` / `RESUMED` events into it, so pausing from OBS no longer disarms the dashboard or strands the recording in OBS's default output directory.
- Surfaces pause in the UI: a paused badge, frozen elapsed timer (client-side ticker honours a `data-elapsed-paused` flag), and Pause / Resume buttons on the dashboard and lectures pages. Stop remains available from PAUSED and runs through the normal rename path.
- Adds `ObsClient.pause_record` / `resume_record`, session `pause` / `resume` methods, and `POST /pause` / `POST /resume` routes.

### Bug being fixed

OBS emits `RecordStateChanged` with `output_active=False` and no `output_path` for `OBS_WEBSOCKET_OUTPUT_PAUSED`. The previous handler treated that like a stop with a missing path: it set an error, cleared the armed deck, and went IDLE. The later real STOPPED event then found no armed deck, so the raw file was never moved into `to-process/` and the user had to copy + rename it manually.

## Test plan

- [x] `uv run pytest tests/recordings/` — 766 passed
- [x] `uv run ruff check src/clm/recordings tests/recordings`
- [x] `uv run ruff format --check src/clm/recordings tests/recordings`
- [x] `uv run mypy src/clm/recordings/workflow/session.py src/clm/recordings/workflow/obs.py src/clm/recordings/web/routes.py`
- [x] New regression coverage: pause keeps the deck armed, resume returns to RECORDING, pause→stop still renames the file into `to-process/`, paused snapshot freezes elapsed seconds, `/pause` and `/resume` routes return 200/409 appropriately
- [ ] Manual smoke: arm + record from the dashboard, press Pause in OBS, confirm the badge flips to "paused" and the deck stays in the banner; press Resume in OBS, confirm timer resumes from where it froze; press Stop in OBS, confirm the file lands in `to-process/<course>/<section>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)