### PR TITLE
fix(recordings): close ObsClient disconnect/reconnect state race

### DIFF
--- a/docs/claude/TODO.md
+++ b/docs/claude/TODO.md
@@ -28,33 +28,47 @@ proposal doc for evidence, root-cause analysis, and an implementation plan.
 
 ---
 
-### Flaky Test: `test_reconnect_loop_aborts_when_watchdog_stopped`
+### ~~Flaky Test: `test_reconnect_loop_aborts_when_watchdog_stopped`~~ (FIXED)
 
-**Status**: 🟡 Intermittent flake (first seen 2026-04-20)
+**Status**: ✅ FIXED (2026-04-20)
 
 **Location**: `tests/recordings/test_obs.py::TestObsClientWatchdog::test_reconnect_loop_aborts_when_watchdog_stopped`
 
 **Symptom**: Under xdist load (32 workers) the assertion
-`connection_state == 'disconnected'` occasionally observes
-`'reconnecting'` instead, because the watchdog reconnect loop has not
-yet noticed the `_watchdog_stop` event and transitioned back to the
-terminal state.
+`connection_state == 'disconnected'` occasionally observed
+`'reconnecting'`.
 
-```
-assert 'reconnecting' == 'disconnected'
-```
+**Root Cause**: Two independent bugs combined.
 
-Passes immediately on re-run and when the class is run in isolation —
-consistent with a scheduling race between the test's
-`_stop_watchdog()` call and the watchdog thread's next
-`_watchdog_stop.wait()` tick.
+1. **Implementation race in `ObsClient`.** `_enter_reconnect_loop()`
+   called `_set_state("reconnecting")` unconditionally at the top of
+   the loop, with no check against `_watchdog_stop`. `disconnect()`
+   does `_stop_watchdog()` (signals the event, `join(timeout=2.0)`),
+   then `_disconnect_clients()`, then `_set_state("disconnected")`. If
+   the watchdog thread was pre-empted between `_disconnect_clients()`
+   and `_set_state("reconnecting")` — or the 2s join timed out under
+   load — the watchdog's "reconnecting" write could land *after* the
+   caller's "disconnected" write, leaving the wrong terminal state.
 
-**Likely fix**: the test should poll for the expected
-`connection_state` with a short timeout (matching the existing
-`_wait_for_state` helper used in the session tests) instead of
-asserting immediately after the stop call. Cross-references the
-`worker test polling` feedback memory — fixed-time sleeps / immediate
-assertions on background-thread state are the recurring root cause.
+2. **Fixed `time.sleep(0.1)` precondition in the test.** The test used
+   a fixed sleep to give the watchdog time to enter the reconnect
+   loop. Under xdist this window wasn't always long enough, so
+   `disconnect()` could fire before the race conditions above were
+   actually exercised.
+
+**Fix Applied**:
+
+- `_set_state()` now ignores `"reconnecting"` transitions when
+  `_watchdog_stop.is_set()` — once `disconnect()` has signalled the
+  stop, the caller owns the terminal state.
+- The test polls for `connection_state == "reconnecting"` (via a new
+  `_poll_until` helper) instead of sleeping a fixed amount.
+- The sibling `test_probe_failure_triggers_reconnect_and_state_transitions`
+  was also refactored to use `_poll_until` for consistency.
+
+Cross-reference: `worker test polling` feedback memory — fixed-time
+sleeps / immediate assertions on background-thread state are the
+recurring root cause.
 
 ---
 
@@ -187,4 +201,4 @@ See `docs/developer-guide/architecture.md` for potential future enhancements.
 
 ---
 
-**Last Updated**: 2026-04-20 (Added watchdog reconnect flake entry)
+**Last Updated**: 2026-04-20 (Fixed watchdog reconnect flake — `_set_state` guard + poll)

--- a/src/clm/recordings/workflow/obs.py
+++ b/src/clm/recordings/workflow/obs.py
@@ -135,6 +135,14 @@ class ObsClient:
 
     def _set_state(self, new_state: ObsConnectionState) -> None:
         with self._lock:
+            # Ignore "reconnecting" once the watchdog has been asked to stop.
+            # Why: disconnect() signals the stop event and then sets state to
+            # "disconnected" as the final call, but the watchdog thread may
+            # still be mid-`_enter_reconnect_loop` and can race past the
+            # event check. Without this guard, a late watchdog transition
+            # overwrites the caller's intended terminal state.
+            if new_state == "reconnecting" and self._watchdog_stop.is_set():
+                return
             changed = self._state != new_state
             self._state = new_state
         if not changed:

--- a/tests/recordings/test_obs.py
+++ b/tests/recordings/test_obs.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import time
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +16,28 @@ from clm.recordings.workflow.obs import ObsClient, RecordingEvent
 # Skip the entire module if it is not installed so that CI environments
 # without the extra don't fail on patch targets.
 pytest.importorskip("obsws_python", reason="obsws-python not installed")
+
+
+def _poll_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 2.0,
+    interval: float = 0.01,
+) -> None:
+    """Block until ``predicate`` returns truthy or raise ``TimeoutError``.
+
+    Watchdog tests must never assert on state touched by a background thread
+    without polling — see the ``worker test polling`` guidance. Fixed sleeps
+    flake under parallel xdist load where the thread may not be scheduled in
+    time.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise TimeoutError(f"Predicate did not become true within {timeout}s")
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -386,8 +410,6 @@ class TestObsClientWatchdog:
 
     def test_probe_failure_triggers_reconnect_and_state_transitions(self, mock_obsws):
         """Probe raising → state goes reconnecting → connected after success."""
-        import time
-
         req = mock_obsws["req"]
         # First probe raises; subsequent calls succeed.
         call_count = {"n": 0}
@@ -409,11 +431,7 @@ class TestObsClientWatchdog:
         client.on_state_change(transitions.append)
         client.connect()
         try:
-            deadline = time.monotonic() + 2.0
-            while time.monotonic() < deadline:
-                if transitions.count("connected") >= 2:
-                    break
-                time.sleep(0.02)
+            _poll_until(lambda: transitions.count("connected") >= 2, timeout=2.0)
         finally:
             client.disconnect()
 
@@ -450,8 +468,6 @@ class TestObsClientWatchdog:
 
     def test_reconnect_loop_aborts_when_watchdog_stopped(self, mock_obsws):
         """Stopping the watchdog during reconnect breaks out of the loop."""
-        import time
-
         req = mock_obsws["req"]
         # Initial probe fails → enters reconnect loop.
         req.get_record_status.side_effect = ConnectionError("socket dead")
@@ -467,8 +483,10 @@ class TestObsClientWatchdog:
         # loop is pinned in ``reconnecting`` until the watchdog is stopped.
         mock_obsws["ReqClient"].side_effect = ConnectionError("still down")
 
-        # Give the watchdog a moment to fail its probe + attempt reconnect.
-        time.sleep(0.1)
+        # Wait for the watchdog to actually reach the reconnect loop. Polling
+        # here (instead of a fixed sleep) keeps the test deterministic under
+        # parallel xdist load where the thread may not be scheduled in time.
+        _poll_until(lambda: client.connection_state == "reconnecting", timeout=2.0)
 
         client.disconnect()
         thread = client._watchdog_thread


### PR DESCRIPTION
## Summary

- Fixes the flaky `test_reconnect_loop_aborts_when_watchdog_stopped` test tracked in `docs/claude/TODO.md` (first seen 2026-04-20 under 32-worker xdist load).
- The flake was a real data race in `ObsClient`, not just a test-timing issue — `disconnect()` could not reliably own the terminal `connection_state` because the watchdog's `_set_state(\"reconnecting\")` in `_enter_reconnect_loop()` had no guard against the stop signal.
- Also replaces the test's fixed `time.sleep(0.1)` precondition with polling, and refactors the sibling probe-failure test to share the same `_poll_until` helper.

## Root cause

Two independent bugs combined:

1. **`ObsClient._enter_reconnect_loop()` race.** The method set state to `\"reconnecting\"` at the top with no check against `_watchdog_stop`. `disconnect()` does `_stop_watchdog()` (signal + `join(timeout=2.0)`) → `_disconnect_clients()` → `_set_state(\"disconnected\")`. If the watchdog thread was pre-empted between entering the loop and its first `wait()`, or the 2 s join timed out under heavy load, the watchdog's `\"reconnecting\"` write could land *after* the caller's `\"disconnected\"` write — leaving the wrong terminal state.

2. **Fixed `time.sleep(0.1)` precondition in the test.** Meant to let the watchdog reach the reconnect loop; under xdist this window wasn't always long enough, so the interesting race wasn't always exercised and the assertion fired before the watchdog had even started its reconnect transition.

## Fix

- `_set_state()` now returns early on `\"reconnecting\"` when `_watchdog_stop.is_set()`, so once `disconnect()` has signalled stop the caller reliably owns the terminal state.
- New `_poll_until(predicate, timeout, interval)` helper at the top of `tests/recordings/test_obs.py`.
- `test_reconnect_loop_aborts_when_watchdog_stopped` now polls for `connection_state == \"reconnecting\"` as the precondition.
- `test_probe_failure_triggers_reconnect_and_state_transitions` refactored to use the same helper for consistency.
- `docs/claude/TODO.md` entry flipped from 🟡 open flake to ✅ FIXED with full root-cause writeup.

Cross-ref: the \"worker test polling\" feedback note — fixed-time sleeps / immediate assertions on background-thread state are the recurring root cause of this class of flake.

## Test plan

- [x] `uv run pytest tests/recordings/test_obs.py` — 41 passed.
- [x] `uv run pytest tests/recordings/` — 766 passed.
- [x] Ran the previously flaky test 10× in a row with xdist — all passed.
- [x] Ran the three related test modules 5× in a row with xdist — 174 passed each time.
- [x] Pre-commit hooks (ruff lint + format, mypy, pytest fast) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)