### PR TITLE
feat(voiceover): backfill pipeline (PRs 1-5)

### DIFF
--- a/docs/proposals/VOICEOVER_BACKFILL.md
+++ b/docs/proposals/VOICEOVER_BACKFILL.md
@@ -1,0 +1,403 @@
+# Proposal: `clm voiceover backfill` — Extract voiceover from historical recordings
+
+**Status:** Design — ready for phased implementation
+**Scope:** New CLI feature that composes existing voiceover machinery with
+git-history analysis. Also absorbs infrastructure pieces from
+`CLM_VOICEOVER_COMPARE_SPEC.md` (artifact cache, trace-log schema, shared
+prompt scaffolding) that both features need.
+
+This document is the source of truth for implementation. It evolved in a
+design discussion (April 2026) between the user and the CLM agent; open
+questions resolved in that discussion are noted inline.
+
+---
+
+## 1. Motivation
+
+We have ~400 existing OBS lecture recordings (per
+`PythonCourses/planning/VIDEO_TO_SLIDE_MAPPING.md`) recorded against slide
+decks that have since been revised — sometimes slightly, often
+significantly. We want to ingest voiceover content from those recordings
+into the current slide files, without manual re-transcription.
+
+`clm voiceover sync` handles the video-to-notes step but presumes the slide
+file on disk matches what was recorded. For outdated recordings it
+produces notes that refer to content that no longer exists, and misses
+material that was on the slides during recording but has been removed.
+
+The proposal: a **three-step pipeline** that identifies a likely historical
+slide revision, runs sync against that revision, and ports the resulting
+voiceover onto the current HEAD slides.
+
+## 2. User-visible commands
+
+Each step is separately invocable (useful for debugging and incremental
+rollout) plus a one-shot wrapper.
+
+```bash
+# Step 1 — identify a likely historical slide revision from the video
+clm voiceover identify-rev <slide-file> <video>...
+    [--lang de|en] [--top 5] [--since <date>]
+
+# Step 2 — run the existing sync pipeline against a historical revision
+clm voiceover sync-at-rev <slide-file> <video>...
+    --rev <sha> --output <scratch-path>
+
+# Step 3 — port voiceover from one slide file onto another
+#   (file-to-file; no git involvement here)
+clm voiceover port-voiceover <source> <target>
+    [--dry-run] [--lang de|en]
+
+# One-shot wrapper
+clm voiceover backfill <slide-file> <video>...
+    [--rev <sha>]       # skip Step 1 if user supplies the revision
+    [--top 5]           # how many candidates to show
+    [--auto]            # pick top candidate without prompting (Step 1)
+    [--dry-run]         # emit unified diff only
+    [--apply]           # REQUIRED to mutate the working tree (default: patch only)
+    [--keep-scratch]
+
+# Spike / debug tool (throwaway; informs Step 1 scoring)
+clm voiceover debug voiceover-commits <slide-file>
+    [--since <date>] [--threshold 0.7]
+```
+
+**Patch-by-default policy.** `backfill` writes
+`.clm/voiceover-backfill/<topic>-<YYYYMMDD-HHMMSS>/port.patch` and prints
+the unified diff to stdout. Mutation of the working tree requires
+`--apply`. Auto-mode (`--auto`) governs Step 1 candidate selection only,
+not writes.
+
+**Scope.** One slide file at a time. No batch operations; the use cases
+are too variable to invest in that up front. Part-based recordings
+(`Teil 1.mp4`, `Teil 2.mp4`) are supported because the underlying `sync`
+already supports them.
+
+## 3. Step-by-step design
+
+### 3.1 Step 1 — Identify a likely git revision
+
+**Approach.**
+
+For each commit touching the slide file
+(`git log --follow --format=%H -- <path>`), compute a cheap **slide
+fingerprint**: the ordered list of slide titles (reuse `_extract_title`
+from `src/clm/notebooks/slide_parser.py`). The video gives an analogous
+fingerprint via the existing `matcher.py` OCR path: detected keyframe
+texts in temporal order.
+
+Score each candidate revision by sequence similarity (LCS with fuzzy title
+equality, `rapidfuzz.fuzz.token_set_ratio` threshold). Return the top-N
+revisions with scores — not just "the" answer. The user should see
+`rev A: 0.93, rev B: 0.88, rev C: 0.41` and pick.
+
+**Narrative-commit prior.** A commit whose diff is dominated by
+additions/edits to cells tagged `voiceover` or `notes` is a strong signal
+that a recording session happened around that time. Both `voiceover` and
+`notes` count (pre-voiceover-era commits used `notes`). The heuristic
+applies to **narrative runs** — consecutive narrative-heavy commits
+collapsed into a single run — and evaluates **both endpoints** of each
+run, because recording order varies:
+
+- **Pre-run** — the parent of the run's earliest commit (slides as they
+  were going into the recording-and-note-taking session).
+- **Post-run** — the run's latest commit (slides as they were when
+  note-taking finished; may include minor slide edits made while
+  authoring voiceover).
+
+Score both candidates against the video fingerprint; pick the higher
+scorer, break ties toward pre-run. A spike (§6.2) validates whether the
+narrative-commit signal is strong enough to fold into the main scorer as
+a multiplicative prior.
+
+**Problems and mitigations.**
+
+- **Search space.** Cap at 50 most recent candidates before video mtime +
+  buffer. Each scoring is just fingerprint LCS (no LLM, no full pipeline
+  run), so brute force is fine.
+- **`--follow` only tracks single renames.** If the slide file was
+  split/merged from ancestors, we miss history. Accept
+  `--since-path <old-path>` as an override; union histories when given.
+- **OCR noise in video titles.** Reuse `matcher.py` normalization.
+  When available, use `slide_id="..."` attributes as the primary key
+  (more stable than titles); fall back to titles, then first content
+  line.
+- **Untitled code slides.** Weight by title-bearing slides only.
+- **No revision matches well.** If the top score is below threshold
+  (≈0.6), refuse to proceed without `--force-rev <sha>`.
+
+### 3.2 Step 2 — Sync at the identified revision
+
+Export the slide file at the chosen revision to a scratch location with
+`git show <rev>:<path>` (safer than `git checkout`; no working-tree
+mutation). Run the existing `clm voiceover sync` against that file plus
+the video. Write output to a scratch file — never the working copy.
+
+**Notes.**
+
+- Related files (helper modules, images) may have changed too. For
+  voiceover sync alone this does not matter; if we later evaluate content
+  rendering, `git worktree add` would be more honest.
+- Bilingual files require `--lang`, same as today.
+- The new `--transcript PATH` / `--alignment PATH` override flags (see
+  §4.2) are useful here when iterating: run sync once to populate the
+  cache, iterate on the port step without re-running ASR.
+
+### 3.3 Step 3 — Port forward to HEAD
+
+**Inputs.**
+
+- `slides@rev-with-voiceover` (from Step 2) — call it **B**
+- `slides@HEAD` as-is — may already have hand-written voiceover — call it **C**
+- Optional: `slides@rev` pre-sync — the ancestor, **A** (rarely needed)
+
+**Slide matching (B↔C).** Primary key: `slide_id` attribute (parsed at
+`slide_parser.py:30`). Fallback: fuzzy title match, then content-
+fingerprint similarity. Produce explicit buckets:
+
+- `unchanged` — same id/title, content diff below threshold
+- `modified` — same id, content diff significant
+- `new_at_head` — in C, no match in B
+- `removed_at_head` — in B, no match in C
+
+**Per-slide transform.**
+
+- `unchanged` + C empty → insert B's voiceover verbatim.
+- `unchanged` + C has baseline → `polish_and_port(baseline=C,
+  prior_voiceover=B, slide_content=HEAD)`.
+- `modified` → same, but also pass old slide content; flag output for
+  review.
+- `new_at_head` → no transfer; list in report.
+- `removed_at_head` → drop; list in report.
+- Split/merged slides → `manual review` bucket (no cleverness in MVP).
+
+**The new primitive.**
+
+```python
+# in src/clm/notebooks/polish.py
+async def polish_and_port(
+    baseline_bullets: str,            # HEAD voiceover (may be empty)
+    prior_voiceover: str,             # video-derived bullets from old rev
+    slide_content_head: str,
+    slide_content_prior: str | None,  # None if unresolvable
+    language: str,
+    content_changed: bool,
+    *,
+    model: str = "gpt-4o-mini",
+) -> PortResult:
+```
+
+Sibling to `polish_and_merge`. Different invariants (no noise filter —
+input is already clean), same structured output. Shares the per-slide
+input packing and the `covered/dropped/added/rewritten` status enum with
+the future `compare` judge (see §4.4).
+
+**Problems and mitigations.**
+
+- **`slide_id` is optional.** Many existing slides lack one. → Run
+  `clm normalize-slides --operations slide_ids <path>` first (already
+  shipped; see §6.1). Improves matching quality for every later port.
+- **Reordered slides.** Title/id matching handles this; no positional
+  assumptions.
+- **Duplicate titles.** Disambiguate with content fingerprint when titles
+  collide. If still ambiguous → `manual review`.
+- **Notes already at HEAD.** Default must preserve C and augment from B.
+  Never silently overwrite. Inherit the merge mode semantics.
+
+## 4. Absorbed from the compare spec
+
+The user's `PythonCourses/planning/CLM_VOICEOVER_COMPARE_SPEC.md` proposes
+three pieces (artifact cache, `compare` command, MCP exposure). Three of
+those are **infrastructure that both features need** and are absorbed
+into this work. The compare **command** itself is deferred to a capstone
+follow-up PR because it's a small wrapper once the infrastructure exists.
+
+**Absorbed (implemented as part of backfill work):**
+
+### 4.1 Artifact cache
+
+Full implementation per compare spec §2.
+
+Layout: `<repo>/.clm/voiceover-cache/` with `transcripts/`,
+`transitions/`, `timelines/`, `alignments/` subdirectories. Keys:
+
+- **`video_hash`** = `sha1(abspath + str(mtime_ns) + str(size))[:16]`
+  (cheap; no full-file hash for GB-scale videos).
+- **`slides_hash`** = `sha1(normalized_source_bytes)[:16]` with trailing
+  whitespace stripped per line.
+- Cache entries embed the operation config (for transcripts:
+  `(backend, model, lang, device_class)`) — config mismatch is a miss,
+  not an error.
+
+API: `clm/voiceover/cache.py` with `VideoKey`, `SlidesKey`,
+`TranscribeConfig`, and the four artifact kinds. Atomic writes (temp +
+rename). `None` on miss; corrupt JSON = miss + overwrite.
+
+Retrofit `transcribe` / `detect` / `identify` / `sync` to read and write.
+New flags on the `voiceover` group: `--cache-root PATH`, `--no-cache`,
+`--refresh-cache`. New subgroup: `clm voiceover cache list/prune/clear`.
+
+**Acceptance** (from compare spec §8):
+
+- `clm voiceover transcribe VIDEO -o t.json` second call with identical
+  inputs returns in <1s.
+- `clm voiceover sync SLIDES VIDEO --dry-run` second invocation completes
+  in ~15s on a 120 MB video (was minutes).
+
+### 4.2 Override flags on `sync`
+
+`sync --transcript PATH` and `sync --alignment PATH` skip ASR/alignment
+respectively when a precomputed artifact is supplied. Useful for
+iterating on the merge step without re-running the full pipeline, and
+required by `backfill` when iterating on port.
+
+### 4.3 Trace-log schema v1
+
+Per compare spec §5. Promote `.clm/voiceover-traces/<stem>-<ts>.jsonl` to
+a versioned schema. Top-level field `"schema": "clm.voiceover.trace/1"`;
+per-slide fields `slide_id`, `cell_index`, `baseline`,
+`transcript_segments`, `llm_merged`, `dropped_from_transcript`,
+`added_from_baseline`, `model`, `mode`, `timestamp`. Add
+`clm voiceover trace show PATH`.
+
+### 4.4 Shared judge/port scaffolding + prompts
+
+A common module for per-slide LLM-input packing and a shared structured-
+response schema (bullet ids, per-bullet status enum). Both `compare`'s
+judge and `polish_and_port` consume it.
+
+Author both prompt sets now (`compare_{de,en}.md`, `port_{de,en}.md`)
+while context is loaded. Prompts diverge (compare is evaluative/read-
+only; port is constructive), but plumbing converges.
+
+**Deferred:**
+
+- **`clm voiceover compare` command** (compare spec §3) — the wrapper
+  itself. Lands after backfill as a capstone PR.
+- **MCP exposure** (compare spec §6) — trivial once the command exists.
+- **LLM-output caching keyed on prompt hash** (compare spec §4.2
+  option 2) — optional in the spec; defer unless dry-run iteration is
+  still too slow after the artifact cache lands.
+
+## 5. PR layout
+
+1. **PR 1 — Cache + trace schema + override flags.**
+   Pure infrastructure; no new user-facing commands.
+   Acceptance: compare spec §8 criteria 1–2.
+2. **PR 2 — `identify-rev` + narrative-commit heuristic.**
+   Includes the shippable outcome of the spike (§6.2) if it validates.
+3. **PR 3 — Shared scaffolding + `polish_and_port` + `port-voiceover` +
+   prompts for both port and compare.**
+4. **PR 4 — `backfill`.** Thin composition; patch-by-default.
+5. **PR 5 (follow-up) — `compare` command** wrapping the existing
+   scaffolding. May be picked up by CLM or handed back to the original
+   spec owner.
+
+## 6. Preparatory work
+
+### 6.1 `assign-ids` — already shipped
+
+The `_apply_slide_ids` normalizer operation
+(`src/clm/slides/normalizer.py:603`) auto-generates `slide_id` metadata:
+markdown heading → slug, code `def`/`class` → name, fallback
+`<stem>-cell-<n>`. DE/EN pairs get the same id; collisions resolved with
+`-2/-3` suffixes; idempotent.
+
+Exposed as `clm normalize-slides --operations slide_ids <path>`
+(see `info_topics/commands.md:245`). No new command needed. The backfill
+docs and the pre-recording workflow should point users here.
+
+**Action:** add a note in `clm info commands` that running
+`clm normalize-slides --operations slide_ids` on newly-written slide
+files improves future port/backfill matching quality.
+
+### 6.2 Narrative-commit spike
+
+Throwaway prototype that validates (or rejects) the narrative-commit
+prior before we wire it into `identify-rev`.
+
+**Command:**
+`clm voiceover debug voiceover-commits <slide-file> [--since DATE] [--threshold 0.7]`
+
+**Algorithm:**
+
+1. `git log --follow --format="%H|%ai|%s" -- <path>`, optionally filtered
+   by `--since`.
+2. For each commit, `git show <commit>:<path>` and
+   `git show <parent>:<path>`; parse both with `parse_cells`.
+3. Classify cells by `metadata.is_narrative` (true for `notes` or
+   `voiceover` tagged cells — see `slide_parser.py:46`). Compute
+   character totals per class for both versions; delta = absolute
+   difference.
+4. `ratio = narrative_delta / (narrative_delta + content_delta + 1)`.
+   Commit is narrative-heavy if `ratio >= threshold` AND
+   `narrative_delta >= FLOOR` (filters trivial whitespace commits).
+5. Collapse **consecutive** narrative-heavy commits in file-history order
+   into **runs**.
+6. For each run: emit pre-run SHA (parent of oldest commit) and post-run
+   SHA (latest commit). Print run metadata.
+
+**Outputs:**
+
+- A Rich table with columns `SHA, date, ratio, nar-Δ, con-Δ, heavy?,
+  run-id`.
+- Run summary: `run #1 length=2 pre-run=abc123 post-run=def456`.
+
+**Decision point after spike.** Run against a real AZAV slide file with
+a known recording. If the narrative-commit ratio cleanly distinguishes
+recording sessions from content edits, fold into `identify-rev` as a
+multiplicative prior alongside fingerprint matching. If noisy, drop and
+keep pure fingerprint scoring.
+
+**First-run finding (2026-04-21).** The naive implementation compares
+total characters in narrative vs content cells between parent and commit
+(`abs(after − before)` per class). Run against
+`slides_010v_streaming_generators.py` (recent history, 20 commits) it
+rejected the "finish Phase 4 W04 punch list — EN voiceover" commit:
+narrative-Δ 13921 vs content-Δ 15473, ratio 0.47, below the 0.7
+threshold. That commit reorganized *both* narrative and content
+substantially; net-char-delta cannot distinguish "recording-session
+note addition" from "general rewrite". Most other commits show 0/0
+(rename-only churn from module renumbering).
+
+**Implication.** A hunk-based classifier is needed before the prior is
+useful. Proposed upgrade: for each commit, parse the unified diff, map
+each +/- line to the cell it belongs to in the relevant file version
+(via `parse_cells` line offsets), and sum added+removed lines per
+class. This double-counts churn on both sides of a rewrite and
+preserves the signal we want. Keep the spike module as the
+ratio-computation scaffold; the upgrade is the hunk classifier that
+feeds better inputs into the same scoring function. Revisit the
+decision point after the fingerprint scorer is in place — the prior
+may not be needed at all if fingerprint matching alone is decisive.
+
+## 7. Open questions (resolved in discussion)
+
+- **Output mode for `backfill`.** Patch-by-default; `--apply` required
+  for working-tree mutation.
+- **Scope.** One slide file at a time.
+- **Scratch location.** `.clm/voiceover-backfill/<topic>-<ts>/`,
+  gitignored.
+- **`port-voiceover` git integration.** Keep file-to-file for now; let
+  `backfill` handle git extraction.
+- **Compare-tool ownership.** Absorb infrastructure (cache, trace
+  schema, scaffolding, prompts); defer `compare` command itself to a
+  follow-up PR.
+- **Narrative tags.** Both `voiceover` and `notes` count as narrative
+  for the commit heuristic (pre-voiceover-era used `notes`).
+- **Narrative-run endpoints.** Score both pre-run and post-run; pick
+  higher; tie-break toward pre-run.
+
+## 8. Unresolved / deferred
+
+- **Compare-output performance acceptance** (compare spec §8 criterion
+  for <10s compare re-run): cross-check as part of PR 1 that the cache
+  covers everything except the LLM judge step.
+- **Split/merged slide detection** in port Step 3: MVP dumps to
+  `manual review`; revisit after real-world use.
+- **Modified-slide LLM adaptation** (second LLM pass that sees both
+  content versions): deferred to PR 4 polish if needed.
+- **Integration with `VIDEO_TO_SLIDE_MAPPING.md`**: `identify-rev`
+  output should be compatible with the mapping doc's schema so the
+  course-side tool can consume it. Detailed mapping deferred until
+  after PR 2.

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -1027,6 +1027,163 @@ def identify_rev_cmd(ctx, slide_file, videos, lang, top, since, limit, as_json):
         )
 
 
+@voiceover_group.command("port-voiceover")
+@click.argument("source", type=click.Path(exists=True, path_type=Path))
+@click.argument("target", type=click.Path(exists=True, path_type=Path))
+@click.option("--lang", required=True, type=click.Choice(["de", "en"]), help="Slide language.")
+@click.option("--dry-run", is_flag=True, help="Print a unified diff instead of writing TARGET.")
+@click.option(
+    "--tag",
+    default="voiceover",
+    help="Cell tag to read/write: 'voiceover' (default) or 'notes'.",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="Override the LLM model (defaults to anthropic/claude-sonnet-4-6).",
+)
+@click.option(
+    "--api-base",
+    default=None,
+    help="Override the LLM API base URL (e.g. https://openrouter.ai/api/v1).",
+)
+def port_voiceover_cmd(source, target, lang, dry_run, tag, model, api_base):
+    """Port voiceover from SOURCE slide file onto TARGET slide file.
+
+    File-to-file transfer with no git involvement — use `clm voiceover
+    backfill` when you want history-aware extraction. SOURCE typically
+    comes from `clm voiceover sync-at-rev` against an older revision;
+    TARGET is the current HEAD version.
+
+    Slide matching uses slide_id as the primary key, falling back to
+    fuzzy title match, then content fingerprint for ambiguous cases.
+    New-at-HEAD and removed-at-HEAD slides are reported but never
+    edited. The LLM is called per matched slide to merge prior bullets
+    into any existing baseline.
+
+    \b
+    Examples:
+        clm voiceover port-voiceover /tmp/slides-at-abc123.py slides.py --lang de
+        clm voiceover port-voiceover old.py new.py --lang en --dry-run
+    """
+    import asyncio
+
+    from clm.notebooks.slide_parser import parse_slides
+    from clm.notebooks.slide_writer import update_narrative
+    from clm.voiceover.port import polish_and_port
+    from clm.voiceover.slide_matcher import MatchKind, match_slides
+
+    source_groups = parse_slides(source, lang, include_header=True)
+    target_groups = parse_slides(target, lang, include_header=True)
+
+    matches = match_slides(source_groups, target_groups)
+
+    summary: dict[MatchKind, int] = {}
+    for m in matches:
+        summary[m.kind] = summary.get(m.kind, 0) + 1
+
+    console.print(
+        f"[bold]Matched {len(target_groups)} target slides "
+        f"against {len(source_groups)} source slides[/bold]"
+    )
+    for kind in MatchKind:
+        if summary.get(kind):
+            console.print(f"  {kind.value}: {summary[kind]}")
+
+    port_kwargs: dict = {}
+    if model:
+        port_kwargs["model"] = model
+    if api_base:
+        port_kwargs["api_base"] = api_base
+
+    async def _run() -> dict[int, str]:
+        notes_map: dict[int, str] = {}
+        for match in matches:
+            if match.kind is MatchKind.REMOVED_AT_HEAD:
+                console.print(f"  [dim]removed at head:[/dim] {match.key} (source slide dropped)")
+                continue
+            if match.kind is MatchKind.NEW_AT_HEAD:
+                console.print(f"  [dim]new at head:[/dim] {match.key} (no prior voiceover)")
+                continue
+            if match.kind is MatchKind.MANUAL_REVIEW:
+                console.print(
+                    f"  [yellow]manual review:[/yellow] {match.key} (ambiguous source match)"
+                )
+                continue
+
+            assert match.target_index is not None
+            assert match.target_group is not None
+            assert match.source_group is not None
+
+            baseline = match.target_group.notes_text
+            prior = match.source_group.notes_text
+            if not prior.strip() and not baseline.strip():
+                continue
+
+            result = await polish_and_port(
+                baseline_bullets=baseline,
+                prior_voiceover=prior,
+                slide_content_head=match.target_group.text_content,
+                slide_content_prior=(
+                    match.source_group.text_content if match.content_changed else None
+                ),
+                language=lang,
+                content_changed=match.content_changed,
+                slide_id=f"{target.stem}/{match.target_index}",
+                **port_kwargs,
+            )
+            if result.error:
+                console.print(f"  [red]error porting {match.key}:[/red] {result.error}")
+            elif match.content_changed:
+                console.print(
+                    f"  [yellow]modified:[/yellow] {match.key} "
+                    f"(content similarity {match.content_similarity:.0f})"
+                )
+            else:
+                console.print(f"  [green]unchanged:[/green] {match.key}")
+
+            if result.bullets.strip():
+                notes_map[match.target_index] = result.bullets
+        return notes_map
+
+    notes_map = asyncio.run(_run())
+
+    if not notes_map:
+        console.print("\n[dim]Nothing to port (no matched slides had prior voiceover).[/dim]")
+        return
+
+    original_text = target.read_text(encoding="utf-8")
+    updated_text = update_narrative(original_text, notes_map, lang, tag=tag)
+
+    if dry_run:
+        if original_text == updated_text:
+            console.print("\n[dim]No changes — merged output matches baseline.[/dim]")
+            return
+        diff = difflib.unified_diff(
+            original_text.splitlines(keepends=True),
+            updated_text.splitlines(keepends=True),
+            fromfile=f"a/{target.name}",
+            tofile=f"b/{target.name}",
+        )
+        console.print()
+        for line in diff:
+            line = line.rstrip("\n")
+            if line.startswith("+++") or line.startswith("---"):
+                console.print(f"[bold]{line}[/bold]")
+            elif line.startswith("+"):
+                console.print(f"[green]{line}[/green]")
+            elif line.startswith("-"):
+                console.print(f"[red]{line}[/red]")
+            elif line.startswith("@@"):
+                console.print(f"[cyan]{line}[/cyan]")
+            else:
+                console.print(line)
+        return
+
+    target.write_text(updated_text, encoding="utf-8")
+    console.print(f"\n[bold green]Wrote {len(notes_map)} voiceover cells to {target}[/bold green]")
+
+
 @voiceover_group.command("extract-training-data")
 @click.argument("trace_log", type=click.Path(exists=True, path_type=Path))
 @click.option(

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -886,6 +886,147 @@ def identify(ctx, video, slides, lang, output):
         console.print(table)
 
 
+@voiceover_group.command("identify-rev")
+@click.argument("slide_file", type=click.Path(exists=True, path_type=Path))
+@click.argument("videos", nargs=-1, required=True, type=click.Path(exists=True, path_type=Path))
+@click.option("--lang", required=True, type=click.Choice(["de", "en"]))
+@click.option(
+    "--top",
+    default=5,
+    show_default=True,
+    type=int,
+    help="How many top-ranked revisions to display.",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="git log --since filter (e.g. '6 months ago', '2025-01-01').",
+)
+@click.option(
+    "--limit",
+    default=50,
+    show_default=True,
+    type=int,
+    help="Maximum number of commits to score (most recent first).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON instead of a table.",
+)
+@click.pass_context
+def identify_rev_cmd(ctx, slide_file, videos, lang, top, since, limit, as_json):
+    """Identify which historical SLIDE_FILE revision a VIDEO was recorded against.
+
+    Builds an OCR fingerprint from the video's keyframe transitions and
+    scores each recent git revision of SLIDE_FILE by fuzzy longest-
+    common-subsequence matching. Narrative-heavy commit endpoints (likely
+    recording-session markers) receive a multiplicative prior.
+
+    Useful as a standalone diagnostic before running the full backfill
+    pipeline, or when handing a revision to `clm voiceover sync` manually.
+
+    \b
+    Examples:
+        clm voiceover identify-rev slides/topic_045/slides.py part1.mp4 part2.mp4 --lang de
+        clm voiceover identify-rev slides/topic_045/slides.py recording.mp4 --lang en --top 10
+    """
+    from clm.voiceover.cache import CachePolicy, cached_detect
+    from clm.voiceover.keyframes import detect_transitions, get_frame_at
+    from clm.voiceover.matcher import ocr_frame
+    from clm.voiceover.rev_scorer import DEFAULT_ACCEPT_THRESHOLD, score_revisions
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+
+    console.print(f"[bold]Building video fingerprint from {len(videos)} part(s)...[/bold]")
+    labels: list[str] = []
+    ocr_lang = "deu+eng" if lang == "de" else "eng+deu"
+    for video in videos:
+
+        def _do_detect(v=video):
+            return detect_transitions(v)[0]
+
+        events, det_hit = cached_detect(
+            video,
+            policy=policy,
+            base_dir=slide_file.parent,
+            detect_fn=_do_detect,
+        )
+        if det_hit:
+            console.print(f"  [dim]{video.name}: transitions cache hit[/dim]")
+        for event in events:
+            try:
+                frame = get_frame_at(video, event.timestamp, offset=1.0)
+                text = ocr_frame(frame, lang=ocr_lang).strip()
+            except (ValueError, FileNotFoundError) as e:
+                logger.warning("Skipping frame at %.1fs: %s", event.timestamp, e)
+                continue
+            if text:
+                labels.append(text)
+
+    if not labels:
+        raise click.ClickException("video fingerprint is empty (no OCR text extracted)")
+
+    console.print(
+        f"[bold]Scoring up to {limit} candidate revisions against {len(labels)} keyframes...[/bold]"
+    )
+    scored = score_revisions(slide_file, labels, lang=lang, limit=limit, since=since)
+    top_n = scored[:top]
+
+    if not top_n:
+        console.print("[yellow]No historical revisions found for this file.[/yellow]")
+        return
+
+    if as_json:
+        payload = [
+            {
+                "rev": r.rev,
+                "date": r.date.isoformat() if r.date else None,
+                "subject": r.subject,
+                "base_score": r.base_score,
+                "narrative_prior": r.narrative_prior,
+                "score": r.score,
+                "is_narrative_candidate": r.is_narrative_candidate,
+                "run_id": r.run_id,
+                "run_position": r.run_position,
+            }
+            for r in top_n
+        ]
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    table = Table(title=f"Top {len(top_n)} revisions for {slide_file.name}")
+    table.add_column("SHA", style="cyan")
+    table.add_column("Date")
+    table.add_column("Base", justify="right")
+    table.add_column("Prior", justify="right")
+    table.add_column("Score", justify="right", style="green")
+    table.add_column("Endpoint")
+    table.add_column("Subject")
+    for r in top_n:
+        endpoint = f"#{r.run_id} {r.run_position}" if r.is_narrative_candidate else ""
+        table.add_row(
+            r.rev[:10],
+            r.date.strftime("%Y-%m-%d") if r.date else "",
+            f"{r.base_score:.3f}",
+            f"{r.narrative_prior:.2f}x",
+            f"{r.score:.3f}",
+            endpoint,
+            (r.subject or "")[:50],
+        )
+    console.print(table)
+
+    top_score = top_n[0].score
+    if top_score < DEFAULT_ACCEPT_THRESHOLD:
+        console.print()
+        console.print(
+            f"[yellow]Top score {top_score:.3f} is below the acceptance threshold "
+            f"{DEFAULT_ACCEPT_THRESHOLD}. Re-run `sync`/`backfill` with an explicit "
+            f"--rev if you want to force this revision.[/yellow]"
+        )
+
+
 @voiceover_group.command("extract-training-data")
 @click.argument("trace_log", type=click.Path(exists=True, path_type=Path))
 @click.option(
@@ -1269,10 +1410,10 @@ def debug_group():
 )
 @click.option(
     "--floor",
-    default=50,
+    default=5,
     show_default=True,
     type=int,
-    help="Minimum narrative char-delta required for 'heavy' classification.",
+    help="Minimum narrative-line-delta required for 'heavy' classification.",
 )
 @click.option(
     "--json",

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -841,3 +841,168 @@ def _display_notes_summary(notes_map: dict[int, str], slide_groups: list):
         table.add_row(str(idx), title, f"{len(text)} chars", preview)
 
     console.print(table)
+
+
+@voiceover_group.group("debug", hidden=True)
+def debug_group():
+    """Diagnostic tools (unstable; hidden from --help).
+
+    These commands expose internal signals used by higher-level features
+    (e.g. the backfill / identify-rev pipeline). They are authoring-tool
+    development aids, not part of the stable CLI surface, and may change
+    or be removed without notice. Invoke by name explicitly:
+    ``clm voiceover debug <subcommand>``.
+    """
+
+
+@debug_group.command("voiceover-commits")
+@click.argument("slide_file", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--since",
+    default=None,
+    help="git log --since filter (e.g. '6 months ago', '2025-01-01').",
+)
+@click.option(
+    "--limit",
+    default=50,
+    show_default=True,
+    type=int,
+    help="Maximum number of commits to examine (most recent first).",
+)
+@click.option(
+    "--threshold",
+    default=0.7,
+    show_default=True,
+    type=float,
+    help="Narrative-churn ratio cutoff for 'heavy' classification.",
+)
+@click.option(
+    "--floor",
+    default=50,
+    show_default=True,
+    type=int,
+    help="Minimum narrative char-delta required for 'heavy' classification.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON instead of tables.",
+)
+def voiceover_commits_cmd(slide_file, since, limit, threshold, floor, as_json):
+    """Walk git history and flag narrative-heavy commits for SLIDE_FILE.
+
+    Throwaway spike informing the identify-rev scorer in the backfill
+    feature. For each commit touching the file, computes narrative-cell
+    (voiceover/notes) vs content-cell character churn. Consecutive
+    narrative-heavy commits are collapsed into 'runs' and each run yields
+    two candidate recording revisions: the pre-run parent (slides as they
+    were going into the recording session) and the post-run tip (slides
+    after note-taking finished).
+
+    \b
+    Examples:
+        clm voiceover debug voiceover-commits slides/topic_045/slides.py
+        clm voiceover debug voiceover-commits slides/topic_045/slides.py \\
+            --since '6 months ago' --threshold 0.6
+    """
+    from clm.voiceover.narrative_commits import NarrativeRun, scan_slide_file
+
+    metrics, runs = scan_slide_file(
+        slide_file,
+        since=since,
+        limit=limit,
+        threshold=threshold,
+        floor=floor,
+    )
+
+    if not metrics:
+        console.print(f"[yellow]No history found for {slide_file}[/yellow]")
+        return
+
+    if as_json:
+        import json as jsonlib
+
+        payload = {
+            "slide_file": str(slide_file),
+            "threshold": threshold,
+            "floor": floor,
+            "commits": [
+                {
+                    "sha": m.commit.sha,
+                    "parent": m.commit.parent_sha,
+                    "date": m.commit.date.isoformat(),
+                    "subject": m.commit.subject,
+                    "narrative_delta": m.narrative_delta,
+                    "content_delta": m.content_delta,
+                    "ratio": m.ratio,
+                    "heavy": m.is_narrative_heavy,
+                }
+                for m in metrics
+            ],
+            "runs": [
+                {
+                    "id": r.run_id,
+                    "length": len(r.commit_metrics),
+                    "pre_run_sha": r.pre_run_sha,
+                    "post_run_sha": r.post_run_sha,
+                    "commits": [m.commit.sha for m in r.commit_metrics],
+                    "narrative_delta_sum": sum(m.narrative_delta for m in r.commit_metrics),
+                }
+                for r in runs
+            ],
+        }
+        click.echo(jsonlib.dumps(payload, indent=2))
+        return
+
+    sha_to_run: dict[str, NarrativeRun] = {m.commit.sha: r for r in runs for m in r.commit_metrics}
+
+    table = Table(title=f"Narrative-commit scan: {slide_file.name}")
+    table.add_column("SHA", style="cyan")
+    table.add_column("Date")
+    table.add_column("nar-Δ", justify="right", style="magenta")
+    table.add_column("con-Δ", justify="right", style="blue")
+    table.add_column("ratio", justify="right")
+    table.add_column("heavy", justify="center")
+    table.add_column("run")
+    table.add_column("subject")
+
+    for m in metrics:
+        run = sha_to_run.get(m.commit.sha)
+        table.add_row(
+            m.commit.sha[:10],
+            m.commit.date.strftime("%Y-%m-%d"),
+            str(m.narrative_delta),
+            str(m.content_delta),
+            f"{m.ratio:.2f}",
+            "[green]Y[/green]" if m.is_narrative_heavy else "",
+            f"#{run.run_id}" if run else "",
+            m.commit.subject[:60],
+        )
+
+    console.print(table)
+
+    if runs:
+        console.print()
+        console.print("[bold]Narrative runs (candidate recording revisions):[/bold]")
+        run_table = Table()
+        run_table.add_column("Run", style="cyan")
+        run_table.add_column("Len", justify="right")
+        run_table.add_column("Pre-run SHA", style="yellow")
+        run_table.add_column("Post-run SHA", style="green")
+        run_table.add_column("Nar Δ sum", justify="right")
+        run_table.add_column("Subjects")
+        for r in runs:
+            subjects = " | ".join(m.commit.subject[:35] for m in r.commit_metrics)
+            nar_sum = sum(m.narrative_delta for m in r.commit_metrics)
+            run_table.add_row(
+                f"#{r.run_id}",
+                str(len(r.commit_metrics)),
+                (r.pre_run_sha or "<root>")[:10],
+                r.post_run_sha[:10],
+                str(nar_sum),
+                subjects,
+            )
+        console.print(run_table)
+    else:
+        console.print("[yellow]No narrative-heavy commits found.[/yellow]")

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -22,7 +22,26 @@ console = Console()
 
 
 @click.group("voiceover")
-def voiceover_group():
+@click.option(
+    "--cache-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Override the cache location (default: ./.clm/voiceover-cache).",
+)
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Disable the artifact cache for this invocation.",
+)
+@click.option(
+    "--refresh-cache",
+    is_flag=True,
+    default=False,
+    help="Force recomputation and overwrite existing cache entries.",
+)
+@click.pass_context
+def voiceover_group(ctx, cache_root, no_cache, refresh_cache):
     """Video-to-speaker-notes synchronization.
 
     Transcribe a video recording and align the transcript to slides,
@@ -30,6 +49,14 @@ def voiceover_group():
 
     Requires: pip install clm[voiceover]
     """
+    from clm.voiceover.cache import CachePolicy
+
+    ctx.ensure_object(dict)
+    ctx.obj["cache_policy"] = CachePolicy(
+        enabled=not no_cache,
+        refresh=refresh_cache,
+        cache_root=cache_root,
+    )
 
 
 @voiceover_group.command()
@@ -72,7 +99,31 @@ def voiceover_group():
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None, help="Output file.")
 @click.option("--keep-audio", is_flag=True, help="Keep extracted audio files.")
 @click.option("--model", default=None, help="LLM model for polished/merge mode.")
+@click.option(
+    "--transcript",
+    "transcript_override",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help=(
+        "Skip ASR and load a precomputed transcript from PATH (JSON produced "
+        "by `clm voiceover transcribe -o ...`). Must be a single-part JSON; "
+        "combine with a single VIDEO argument."
+    ),
+)
+@click.option(
+    "--alignment",
+    "alignment_override",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help=(
+        "Skip ASR, detection, and matching; load a precomputed alignment "
+        "from PATH. The alignment JSON is produced by a prior sync run "
+        "(cached under .clm/voiceover-cache/alignments/)."
+    ),
+)
+@click.pass_context
 def sync(
+    ctx,
     slides,
     videos,
     lang,
@@ -87,6 +138,8 @@ def sync(
     output,
     keep_audio,
     model,
+    transcript_override,
+    alignment_override,
 ):
     """Synchronize speaker notes from one or more video recordings.
 
@@ -117,6 +170,13 @@ def sync(
     from clm.notebooks.slide_parser import parse_slides
     from clm.notebooks.slide_writer import write_narrative
     from clm.voiceover.aligner import align_transcript
+    from clm.voiceover.cache import (
+        CachePolicy,
+        cached_alignment,
+        cached_detect,
+        cached_timeline,
+        cached_transcribe,
+    )
     from clm.voiceover.keyframes import TransitionEvent, detect_transitions
     from clm.voiceover.matcher import match_events_to_slides
     from clm.voiceover.timeline import (
@@ -127,6 +187,8 @@ def sync(
     )
     from clm.voiceover.transcribe import transcribe_video
 
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+
     video_paths = [Path(v) for v in videos]
     multi_part = len(video_paths) > 1
 
@@ -135,73 +197,159 @@ def sync(
     slide_groups = parse_slides(slides, lang)
     console.print(f"  Found {len(slide_groups)} slide groups")
 
-    # Probe durations and build parts
-    if multi_part:
-        console.print(f"[bold]Probing {len(video_paths)} video parts...[/bold]")
-    parts = build_parts(video_paths)
-    total_duration = sum(p.duration for p in parts)
-    if multi_part:
-        for part in parts:
-            console.print(
-                f"  Part {part.index}: {part.path.name} "
-                f"({part.duration:.0f}s, offset={part.offset:.0f}s)"
+    # --alignment short-circuits everything before the merge step.
+    if alignment_override is not None:
+        if multi_part:
+            raise click.UsageError(
+                "--alignment is incompatible with multi-part videos; "
+                "the override encodes a single pre-computed alignment."
             )
-        console.print(f"  Total duration: {total_duration:.0f}s")
+        console.print(f"[bold]Loading alignment:[/bold] {alignment_override}")
+        alignment = _load_alignment_override(alignment_override)
+    else:
+        # Probe durations and build parts
+        if multi_part:
+            console.print(f"[bold]Probing {len(video_paths)} video parts...[/bold]")
+        parts = build_parts(video_paths)
+        total_duration = sum(p.duration for p in parts)
+        if multi_part:
+            for part in parts:
+                console.print(
+                    f"  Part {part.index}: {part.path.name} "
+                    f"({part.duration:.0f}s, offset={part.offset:.0f}s)"
+                )
+            console.print(f"  Total duration: {total_duration:.0f}s")
 
-    # Per-part transcription and transition detection
-    all_transcripts = []
-    all_events: list[TransitionEvent] = []
+        if transcript_override is not None and multi_part:
+            raise click.UsageError(
+                "--transcript is incompatible with multi-part videos; "
+                "supply a precomputed single-part transcript only."
+            )
 
-    for part in parts:
-        part_label = f" (part {part.index})" if multi_part else ""
-        console.print(
-            f"[bold]Transcribing{part_label}:[/bold] {part.path.name} "
-            f"(backend={backend_name}, device={device})"
-        )
-        transcript = transcribe_video(
-            part.path,
-            language=lang,
-            backend_name=backend_name,
-            model_size=whisper_model,
-            device=device,
-            keep_audio=keep_audio,
-        )
-        console.print(
-            f"  {len(transcript.segments)} segments, "
-            f"{transcript.duration:.0f}s, language={transcript.language}"
-        )
+        # Per-part transcription and transition detection
+        all_transcripts = []
+        all_events: list[TransitionEvent] = []
 
-        console.print(f"[bold]Detecting slide transitions{part_label}...[/bold]")
-        events, _diffs = detect_transitions(part.path)
-        console.print(f"  {len(events)} transitions detected")
+        for part in parts:
+            part_label = f" (part {part.index})" if multi_part else ""
+            if transcript_override is not None:
+                console.print(f"[bold]Loading transcript:[/bold] {transcript_override}")
+                transcript = _load_transcript_override(transcript_override)
+            else:
+                console.print(
+                    f"[bold]Transcribing{part_label}:[/bold] {part.path.name} "
+                    f"(backend={backend_name}, device={device})"
+                )
 
-        # Apply offsets and tag with part index
-        all_transcripts.append(offset_transcript(transcript, part))
-        all_events.extend(offset_events(events, part))
+                def _do_transcribe(part=part):
+                    return transcribe_video(
+                        part.path,
+                        language=lang,
+                        backend_name=backend_name,
+                        model_size=whisper_model,
+                        device=device,
+                        keep_audio=keep_audio,
+                    )
 
-    # Merge transcripts
-    merged_transcript = merge_transcripts(all_transcripts)
-    if multi_part:
-        console.print(
-            f"[bold]Merged:[/bold] {len(merged_transcript.segments)} segments, "
-            f"{merged_transcript.duration:.0f}s total"
-        )
+                transcript, tx_hit = cached_transcribe(
+                    part.path,
+                    policy=policy,
+                    base_dir=slides.parent,
+                    transcribe_fn=_do_transcribe,
+                    backend_name=backend_name,
+                    model_size=whisper_model,
+                    language=lang,
+                    device=device,
+                )
+                if tx_hit:
+                    console.print("  [dim]transcript: cache hit[/dim]")
+            console.print(
+                f"  {len(transcript.segments)} segments, "
+                f"{transcript.duration:.0f}s, language={transcript.language}"
+            )
 
-    # Match to slides
-    console.print("[bold]Matching transitions to slides...[/bold]")
-    match_result = match_events_to_slides(
-        all_events,
-        slide_groups,
-        video_paths[0],
-        video_paths=video_paths if multi_part else None,
-        total_duration=total_duration,
-        lang=lang,
-    )
-    console.print(f"  {len(match_result.timeline)} timeline entries")
+            console.print(f"[bold]Detecting slide transitions{part_label}...[/bold]")
 
-    # Align transcript to slides
-    console.print("[bold]Aligning transcript to slides...[/bold]")
-    alignment = align_transcript(merged_transcript, match_result.timeline)
+            def _do_detect(part=part):
+                return detect_transitions(part.path)[0]
+
+            events, det_hit = cached_detect(
+                part.path,
+                policy=policy,
+                base_dir=slides.parent,
+                detect_fn=_do_detect,
+            )
+            if det_hit:
+                console.print("  [dim]transitions: cache hit[/dim]")
+            console.print(f"  {len(events)} transitions detected")
+
+            # Apply offsets and tag with part index
+            all_transcripts.append(offset_transcript(transcript, part))
+            all_events.extend(offset_events(events, part))
+
+        # Merge transcripts
+        merged_transcript = merge_transcripts(all_transcripts)
+        if multi_part:
+            console.print(
+                f"[bold]Merged:[/bold] {len(merged_transcript.segments)} segments, "
+                f"{merged_transcript.duration:.0f}s total"
+            )
+
+        # Match to slides (cache scoped to single-part runs only; multi-part
+        # timelines stitch across several videos and need a composite key we
+        # don't yet model).
+        console.print("[bold]Matching transitions to slides...[/bold]")
+        timeline_cfg = {
+            "lang": lang,
+            "frame_offset": 1.0,
+            "multi_part": multi_part,
+        }
+
+        def _run_match():
+            return match_events_to_slides(
+                all_events,
+                slide_groups,
+                video_paths[0],
+                video_paths=video_paths if multi_part else None,
+                total_duration=total_duration,
+                lang=lang,
+            ).timeline
+
+        if multi_part:
+            timeline = _run_match()
+        else:
+            timeline, tl_hit = cached_timeline(
+                video_paths[0],
+                slides,
+                policy=policy,
+                base_dir=slides.parent,
+                timeline_fn=_run_match,
+                cfg=timeline_cfg,
+            )
+            if tl_hit:
+                console.print("  [dim]timeline: cache hit[/dim]")
+        console.print(f"  {len(timeline)} timeline entries")
+
+        # Align transcript to slides
+        console.print("[bold]Aligning transcript to slides...[/bold]")
+        alignment_cfg = {"lang": lang, "multi_part": multi_part}
+
+        def _run_align():
+            return align_transcript(merged_transcript, timeline)
+
+        if multi_part:
+            alignment = _run_align()
+        else:
+            alignment, al_hit = cached_alignment(
+                video_paths[0],
+                slides,
+                policy=policy,
+                base_dir=slides.parent,
+                alignment_fn=_run_align,
+                cfg=alignment_cfg,
+            )
+            if al_hit:
+                console.print("  [dim]alignment: cache hit[/dim]")
 
     # Apply slide range filter
     slide_indices = set(alignment.slide_notes.keys())
@@ -567,18 +715,32 @@ def _emit_dry_run_diff(
     help="Device for transcription: auto (default), cpu, or cuda.",
 )
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
-def transcribe(video, lang, whisper_model, backend_name, device, output):
+@click.pass_context
+def transcribe(ctx, video, lang, whisper_model, backend_name, device, output):
     """Transcribe a video file and output the transcript."""
+    from clm.voiceover.cache import CachePolicy, cached_transcribe
     from clm.voiceover.transcribe import transcribe_video
 
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+
     console.print(f"[bold]Transcribing:[/bold] {video} (backend={backend_name}, device={device})")
-    transcript = transcribe_video(
+    transcript, hit = cached_transcribe(
         video,
-        language=lang,
+        policy=policy,
+        transcribe_fn=lambda: transcribe_video(
+            video,
+            language=lang,
+            backend_name=backend_name,
+            model_size=whisper_model,
+            device=device,
+        ),
         backend_name=backend_name,
         model_size=whisper_model,
+        language=lang,
         device=device,
     )
+    if hit:
+        console.print("  [dim]cache hit[/dim]")
 
     data = {
         "language": transcript.language,
@@ -596,12 +758,22 @@ def transcribe(video, lang, whisper_model, backend_name, device, output):
 @voiceover_group.command()
 @click.argument("video", type=click.Path(exists=True, path_type=Path))
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
-def detect(video, output):
+@click.pass_context
+def detect(ctx, video, output):
     """Detect slide transitions in a video file."""
+    from clm.voiceover.cache import CachePolicy, cached_detect
     from clm.voiceover.keyframes import detect_transitions
 
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+
     console.print(f"[bold]Detecting transitions:[/bold] {video}")
-    events, _diffs = detect_transitions(video)
+    events, hit = cached_detect(
+        video,
+        policy=policy,
+        detect_fn=lambda: detect_transitions(video)[0],
+    )
+    if hit:
+        console.print("  [dim]cache hit[/dim]")
 
     data = [
         {
@@ -636,22 +808,47 @@ def detect(video, output):
 @click.argument("slides", type=click.Path(exists=True, path_type=Path))
 @click.option("--lang", required=True, type=click.Choice(["de", "en"]))
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
-def identify(video, slides, lang, output):
+@click.pass_context
+def identify(ctx, video, slides, lang, output):
     """Identify which slides appear in a video (OCR + matching)."""
     from clm.notebooks.slide_parser import parse_slides
+    from clm.voiceover.cache import CachePolicy, cached_detect, cached_timeline
     from clm.voiceover.keyframes import detect_transitions
     from clm.voiceover.matcher import match_events_to_slides
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
 
     console.print(f"[bold]Parsing slides:[/bold] {slides}")
     slide_groups = parse_slides(slides, lang)
 
     console.print(f"[bold]Detecting transitions:[/bold] {video}")
-    events, _ = detect_transitions(video)
+    events, det_hit = cached_detect(
+        video,
+        policy=policy,
+        base_dir=slides.parent,
+        detect_fn=lambda: detect_transitions(video)[0],
+    )
+    if det_hit:
+        console.print("  [dim]transitions: cache hit[/dim]")
 
     console.print(
         f"[bold]Matching {len(events)} transitions to {len(slide_groups)} slides...[/bold]"
     )
-    result = match_events_to_slides(events, slide_groups, video, lang=lang)
+    timeline_cfg = {"lang": lang, "frame_offset": 1.0, "multi_part": False}
+
+    def _run_match():
+        return match_events_to_slides(events, slide_groups, video, lang=lang).timeline
+
+    timeline, tl_hit = cached_timeline(
+        video,
+        slides,
+        policy=policy,
+        base_dir=slides.parent,
+        timeline_fn=_run_match,
+        cfg=timeline_cfg,
+    )
+    if tl_hit:
+        console.print("  [dim]timeline: cache hit[/dim]")
 
     data = [
         {
@@ -660,7 +857,7 @@ def identify(video, slides, lang, output):
             "end_time": e.end_time,
             "match_score": e.match_score,
         }
-        for e in result.timeline
+        for e in timeline
     ]
 
     if output:
@@ -673,7 +870,7 @@ def identify(video, slides, lang, output):
         table.add_column("End", style="green")
         table.add_column("Score", style="yellow")
         table.add_column("Title")
-        for e in result.timeline:
+        for e in timeline:
             title = ""
             for sg in slide_groups:
                 if sg.index == e.slide_index:
@@ -775,6 +972,46 @@ def _parse_range(range_str: str) -> tuple[int, int]:
     return n, n
 
 
+def _load_transcript_override(path: Path):
+    """Load a JSON transcript produced by ``clm voiceover transcribe -o``.
+
+    Accepts both the flat CLI output format (``{"language", "duration",
+    "segments": [...]}``) and the canonical ``Transcript.to_dict()`` form,
+    so users can pass either.
+    """
+    from clm.voiceover.transcribe import Transcript
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise click.UsageError(f"Transcript override {path} is not a JSON object.")
+    if "segments" not in data or "language" not in data or "duration" not in data:
+        raise click.UsageError(
+            f"Transcript override {path} is missing required fields (segments, language, duration)."
+        )
+    return Transcript.from_dict(data)
+
+
+def _load_alignment_override(path: Path):
+    """Load a precomputed :class:`AlignmentResult` from JSON.
+
+    Expects the shape written by :func:`clm.voiceover.cache._encode_alignment`
+    (as stored under ``.clm/voiceover-cache/alignments/``). Accepts either
+    the inner artifact object or the full cache payload (with ``artifact``
+    wrapper).
+    """
+    from clm.voiceover.cache import _decode_alignment
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise click.UsageError(f"Alignment override {path} is not a JSON object.")
+    # Cache files wrap the artifact; accept either form
+    if "artifact" in data and isinstance(data["artifact"], dict):
+        data = data["artifact"]
+    if "slide_notes" not in data:
+        raise click.UsageError(f"Alignment override {path} is missing the 'slide_notes' field.")
+    return _decode_alignment(data)
+
+
 async def _polish_notes(
     notes_map: dict[int, str],
     slide_groups: list,
@@ -840,6 +1077,160 @@ def _display_notes_summary(notes_map: dict[int, str], slide_groups: list):
         preview = text[:60].replace("\n", " ") + ("..." if len(text) > 60 else "")
         table.add_row(str(idx), title, f"{len(text)} chars", preview)
 
+    console.print(table)
+
+
+@voiceover_group.group("cache")
+def cache_group():
+    """Inspect and manage the voiceover artifact cache.
+
+    The cache speeds up repeat runs of ``transcribe``/``detect``/
+    ``identify``/``sync`` by persisting their intermediate outputs under
+    ``.clm/voiceover-cache/``. Entries are keyed by cheap fingerprints of
+    the video (path+mtime+size) and slide file (content hash), and stale
+    entries are harmless — they become misses automatically when the
+    corresponding inputs change.
+    """
+
+
+@cache_group.command("list")
+@click.pass_context
+def cache_list_cmd(ctx):
+    """List cache entries (grouped by kind) with file sizes."""
+    from clm.voiceover.cache import CachePolicy, iter_entries
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+    root = policy.resolve_root()
+
+    if not root.exists():
+        console.print(f"[yellow]Cache is empty (no directory at {root}).[/yellow]")
+        return
+
+    entries = iter_entries(root)
+    if not entries:
+        console.print(f"[yellow]Cache is empty at {root}.[/yellow]")
+        return
+
+    table = Table(title=f"Voiceover cache at {root}")
+    table.add_column("Kind", style="cyan")
+    table.add_column("Key", style="magenta")
+    table.add_column("Size", justify="right", style="green")
+    table.add_column("Path")
+    total = 0
+    for entry in entries:
+        total += entry.size
+        table.add_row(
+            entry.subdir,
+            entry.key,
+            f"{entry.size:,} B",
+            str(entry.path),
+        )
+    console.print(table)
+    console.print(f"[dim]{len(entries)} entries, {total:,} bytes[/dim]")
+
+
+@cache_group.command("prune")
+@click.option(
+    "--max-age-days",
+    type=float,
+    required=True,
+    help="Delete cache entries older than this many days.",
+)
+@click.pass_context
+def cache_prune_cmd(ctx, max_age_days):
+    """Delete cache entries older than --max-age-days."""
+    from clm.voiceover.cache import CachePolicy, prune
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+    root = policy.resolve_root()
+
+    removed = prune(root, max_age_days=max_age_days)
+    console.print(f"[green]Pruned {removed} cache entries older than {max_age_days}d.[/green]")
+
+
+@cache_group.command("clear")
+@click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
+@click.pass_context
+def cache_clear_cmd(ctx, yes):
+    """Delete every entry in the cache."""
+    from clm.voiceover.cache import CachePolicy, clear
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+    root = policy.resolve_root()
+
+    if not yes:
+        click.confirm(
+            f"Delete all cache entries under {root}?",
+            abort=True,
+        )
+
+    removed = clear(root)
+    console.print(f"[green]Removed {removed} cache entries from {root}.[/green]")
+
+
+@voiceover_group.group("trace")
+def trace_group():
+    """Inspect voiceover merge trace logs.
+
+    Trace logs are JSONL files under ``.clm/voiceover-traces/`` produced
+    by every ``sync`` invocation. They record every LLM merge call with
+    enough context to replay or evaluate it later (see schema
+    ``clm.voiceover.trace/1``).
+    """
+
+
+@trace_group.command("show")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit the full entries as JSON instead of a summary table.",
+)
+def trace_show_cmd(path, as_json):
+    """Render a trace log in a human-readable summary."""
+    from clm.voiceover.trace_log import read_trace_entries
+
+    entries = read_trace_entries(path)
+    if not entries:
+        console.print(f"[yellow]No entries in {path}.[/yellow]")
+        return
+
+    if as_json:
+        click.echo(json.dumps(entries, indent=2, ensure_ascii=False))
+        return
+
+    schema_tags = {e.get("schema", "<v0>") for e in entries}
+    console.print(
+        f"[bold]Trace log:[/bold] {path}  "
+        f"([cyan]{len(entries)}[/cyan] entries; schema={', '.join(sorted(schema_tags))})"
+    )
+
+    table = Table()
+    table.add_column("#", justify="right", style="dim")
+    table.add_column("Slide", style="cyan")
+    table.add_column("Lang")
+    table.add_column("Baseline", justify="right", style="blue")
+    table.add_column("Transcript", justify="right", style="magenta")
+    table.add_column("Merged", justify="right", style="green")
+    table.add_column("Rewrites", justify="right", style="yellow")
+    table.add_column("Dropped", justify="right")
+    table.add_column("Model")
+
+    for i, entry in enumerate(entries):
+        rewrites = entry.get("rewrites") or []
+        dropped = entry.get("dropped_from_transcript") or []
+        table.add_row(
+            str(i + 1),
+            str(entry.get("slide_id", "?")),
+            str(entry.get("language", "")),
+            str(len(entry.get("baseline", ""))),
+            str(len(entry.get("transcript", ""))),
+            str(len(entry.get("llm_merged", ""))),
+            str(len(rewrites)) if rewrites else "",
+            str(len(dropped)) if dropped else "",
+            str(entry.get("model") or ""),
+        )
     console.print(table)
 
 

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -12,10 +12,14 @@ import difflib
 import json
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from clm.voiceover.compare import CompareReport
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -1356,6 +1360,236 @@ def _emit_unified_diff(target: Path, original_text: str, updated_text: str) -> N
             console.print(f"[cyan]{line}[/cyan]")
         else:
             console.print(line)
+
+
+@voiceover_group.command("compare")
+@click.argument("source", type=click.Path(exists=True, path_type=Path))
+@click.argument("target", type=click.Path(exists=True, path_type=Path))
+@click.option("--lang", required=True, type=click.Choice(["de", "en"]), help="Slide language.")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a structured JSON report instead of the Rich table.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the report to this path (default: stdout).",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="Override the LLM model (defaults to anthropic/claude-sonnet-4-6).",
+)
+@click.option(
+    "--api-base",
+    default=None,
+    help="Override the LLM API base URL (e.g. https://openrouter.ai/api/v1).",
+)
+def compare_cmd(source, target, lang, as_json, output, model, api_base):
+    """Evaluate voiceover differences between SOURCE and TARGET slide files.
+
+    Read-only sibling to ``port-voiceover``. SOURCE typically comes
+    from ``clm voiceover sync-at-rev`` against an older revision;
+    TARGET is the current HEAD version. For each matched slide pair,
+    the LLM labels every bullet as ``covered`` / ``rewritten`` /
+    ``added`` / ``dropped`` / ``manual_review``. Neither file is
+    modified.
+
+    \b
+    Examples:
+        clm voiceover compare /tmp/slides-at-abc123.py slides.py --lang de
+        clm voiceover compare old.py new.py --lang en --json -o report.json
+    """
+    report = _run_compare(
+        source=source,
+        target=target,
+        lang=lang,
+        model=model,
+        api_base=api_base,
+    )
+
+    if as_json:
+        payload = json.dumps(report.to_json(), indent=2, ensure_ascii=False)
+        if output is not None:
+            output.write_text(payload + "\n", encoding="utf-8")
+            console.print(f"\n[bold green]Wrote JSON report to {output}[/bold green]")
+        else:
+            click.echo(payload)
+        return
+
+    _render_compare_report(report)
+    if output is not None:
+        lines = _compare_report_lines(report)
+        output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        console.print(f"\n[bold green]Wrote report to {output}[/bold green]")
+
+
+def _run_compare(
+    *,
+    source: Path,
+    target: Path,
+    lang: str,
+    model: str | None,
+    api_base: str | None,
+) -> CompareReport:
+    """Match slides between ``source`` and ``target`` and judge each pair."""
+    import asyncio
+
+    from clm.notebooks.slide_parser import parse_slides
+    from clm.voiceover.compare import CompareReport, SlideComparison, judge_slide_pair
+    from clm.voiceover.slide_matcher import MatchKind, match_slides
+
+    source_groups = parse_slides(source, lang, include_header=True)
+    target_groups = parse_slides(target, lang, include_header=True)
+    matches = match_slides(source_groups, target_groups)
+
+    console.print(
+        f"[bold]Comparing {target.name} against {source.name} "
+        f"({len(target_groups)} target / {len(source_groups)} source slides)[/bold]"
+    )
+
+    judge_kwargs: dict = {}
+    if model:
+        judge_kwargs["model"] = model
+    if api_base:
+        judge_kwargs["api_base"] = api_base
+
+    async def _run() -> list[SlideComparison]:
+        slides: list[SlideComparison] = []
+        for match in matches:
+            if match.kind in (
+                MatchKind.REMOVED_AT_HEAD,
+                MatchKind.NEW_AT_HEAD,
+                MatchKind.MANUAL_REVIEW,
+            ):
+                slides.append(
+                    SlideComparison(
+                        key=match.key,
+                        kind=match.kind,
+                        target_index=match.target_index,
+                        source_index=match.source_index,
+                        content_similarity=match.content_similarity,
+                    )
+                )
+                continue
+
+            assert match.target_group is not None
+            assert match.source_group is not None
+
+            baseline = match.target_group.notes_text
+            prior = match.source_group.notes_text
+            outcomes, notes, err = await judge_slide_pair(
+                prior_bullets=prior,
+                baseline_bullets=baseline,
+                slide_content_head=match.target_group.text_content,
+                slide_content_prior=(
+                    match.source_group.text_content if match.content_changed else None
+                ),
+                language=lang,
+                content_changed=match.content_changed,
+                slide_id=f"{target.stem}/{match.target_index}",
+                **judge_kwargs,
+            )
+            slides.append(
+                SlideComparison(
+                    key=match.key,
+                    kind=match.kind,
+                    target_index=match.target_index,
+                    source_index=match.source_index,
+                    content_similarity=match.content_similarity,
+                    outcomes=outcomes,
+                    notes=notes,
+                    error=err,
+                )
+            )
+        return slides
+
+    slides = asyncio.run(_run())
+    return CompareReport(source=source, target=target, language=lang, slides=slides)
+
+
+def _render_compare_report(report: CompareReport) -> None:
+    """Render a :class:`CompareReport` as a Rich table."""
+    from clm.voiceover.bullet_schema import BulletStatus
+    from clm.voiceover.slide_matcher import MatchKind
+
+    table = Table(title=f"Compare {report.target.name} vs {report.source.name} ({report.language})")
+    table.add_column("Slide", style="cyan")
+    table.add_column("Kind")
+    table.add_column("Sim", justify="right")
+    for status in BulletStatus:
+        table.add_column(status.value, justify="right")
+    table.add_column("Notes")
+
+    for comp in report.slides:
+        counts = comp.status_counts()
+        sim = (
+            f"{comp.content_similarity:.0f}"
+            if comp.kind
+            in (
+                MatchKind.UNCHANGED,
+                MatchKind.MODIFIED,
+            )
+            else ""
+        )
+        note_cell = comp.error or (comp.notes or "")
+        table.add_row(
+            comp.key,
+            comp.kind.value,
+            sim,
+            *(str(counts[s]) if counts[s] else "" for s in BulletStatus),
+            (note_cell[:60] + "…") if len(note_cell) > 60 else note_cell,
+        )
+    console.print(table)
+
+    status_totals = report.status_totals()
+    kind_totals = report.kind_totals()
+    status_line = "  ".join(
+        f"[bold]{s.value}[/bold]={status_totals[s]}" for s in BulletStatus if status_totals[s]
+    )
+    kind_line = "  ".join(f"{k.value}={kind_totals[k]}" for k in MatchKind if kind_totals[k])
+    console.print(f"\n[bold]Status totals:[/bold] {status_line or '(all zero)'}")
+    console.print(f"[bold]Slide buckets:[/bold] {kind_line}")
+
+
+def _compare_report_lines(report: CompareReport) -> list[str]:
+    """Plain-text rendering of a compare report for ``--output`` without ``--json``."""
+    from clm.voiceover.bullet_schema import BulletStatus
+    from clm.voiceover.slide_matcher import MatchKind
+
+    lines: list[str] = [
+        f"# Compare report: {report.target.name} vs {report.source.name} ({report.language})",
+        "",
+        f"source: {report.source}",
+        f"target: {report.target}",
+        "",
+    ]
+
+    status_totals = report.status_totals()
+    kind_totals = report.kind_totals()
+    lines.append("## Totals")
+    for s in BulletStatus:
+        lines.append(f"- {s.value}: {status_totals[s]}")
+    lines.append("")
+    lines.append("## Slide buckets")
+    for k in MatchKind:
+        lines.append(f"- {k.value}: {kind_totals[k]}")
+    lines.append("")
+    lines.append("## Per-slide")
+    for comp in report.slides:
+        counts = comp.status_counts()
+        count_str = ", ".join(f"{s.value}={counts[s]}" for s in BulletStatus if counts[s])
+        line = f"- {comp.key} [{comp.kind.value}]"
+        if count_str:
+            line += f" — {count_str}"
+        if comp.error:
+            line += f" (ERROR: {comp.error})"
+        lines.append(line)
+    return lines
 
 
 @voiceover_group.command("backfill")

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -1027,6 +1027,151 @@ def identify_rev_cmd(ctx, slide_file, videos, lang, top, since, limit, as_json):
         )
 
 
+@voiceover_group.command("sync-at-rev")
+@click.argument("slide_file", type=click.Path(exists=True, path_type=Path))
+@click.argument("videos", nargs=-1, required=True, type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--rev", required=True, help="Git revision (SHA, tag, or branch) to export SLIDE_FILE at."
+)
+@click.option(
+    "--output",
+    "-o",
+    "output",
+    required=True,
+    type=click.Path(path_type=Path),
+    help="Destination for the sync output (must not be the working-copy slide file).",
+)
+@click.option("--lang", required=True, type=click.Choice(["de", "en"]), help="Video language.")
+@click.option(
+    "--mode",
+    default="polished",
+    type=click.Choice(["verbatim", "polished"]),
+)
+@click.option("--overwrite", is_flag=True, default=False)
+@click.option("--whisper-model", default="large-v3")
+@click.option(
+    "--backend",
+    "backend_name",
+    default="faster-whisper",
+    type=click.Choice(["faster-whisper", "cohere", "granite"]),
+)
+@click.option(
+    "--device",
+    default="auto",
+    type=click.Choice(["auto", "cpu", "cuda"]),
+)
+@click.option("--tag", default="voiceover")
+@click.option("--dry-run", is_flag=True)
+@click.option("--keep-audio", is_flag=True)
+@click.option("--model", default=None)
+@click.option(
+    "--transcript",
+    "transcript_override",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+)
+@click.option(
+    "--alignment",
+    "alignment_override",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+)
+@click.option(
+    "--scratch-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the exported slide file into this directory instead of a fresh scratch dir.",
+)
+@click.pass_context
+def sync_at_rev_cmd(
+    ctx,
+    slide_file,
+    videos,
+    rev,
+    output,
+    lang,
+    mode,
+    overwrite,
+    whisper_model,
+    backend_name,
+    device,
+    tag,
+    dry_run,
+    keep_audio,
+    model,
+    transcript_override,
+    alignment_override,
+    scratch_dir,
+):
+    """Run ``clm voiceover sync`` against SLIDE_FILE as it existed at --rev.
+
+    Exports the historical version of SLIDE_FILE to a scratch location
+    via ``git show`` (never touches the working tree) and then runs the
+    full sync pipeline against that file plus the VIDEO parts. Output is
+    written to --output so the working-copy slide file is preserved.
+
+    Typical use is the middle step of the backfill pipeline:
+
+    \b
+    1. ``clm voiceover identify-rev`` suggests a SHA
+    2. ``clm voiceover sync-at-rev --rev <sha> -o scratch.py`` produces
+       voiceover cells against the historical slides
+    3. ``clm voiceover port-voiceover scratch.py slide.py`` ports forward
+
+    \b
+    Examples:
+        clm voiceover sync-at-rev slides.py video.mp4 --rev abc1234 \\
+            --lang de -o /tmp/slides-at-abc1234-with-voiceover.py
+    """
+    from clm.voiceover.backfill import (
+        extract_slide_file_at_rev,
+        plan_scratch_dir,
+        resolve_rev,
+    )
+
+    target_output = Path(output)
+    if target_output.resolve() == slide_file.resolve():
+        raise click.UsageError(
+            "--output must not equal SLIDE_FILE; sync-at-rev refuses to mutate the working copy."
+        )
+
+    try:
+        full_rev = resolve_rev(slide_file, rev)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    scratch = Path(scratch_dir) if scratch_dir else plan_scratch_dir(slide_file)
+    scratch.mkdir(parents=True, exist_ok=True)
+    try:
+        scratch_slide_path = extract_slide_file_at_rev(slide_file, full_rev, scratch)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(
+        f"[bold]Exported {slide_file.name} @ {full_rev[:10]}[/bold] -> {scratch_slide_path}"
+    )
+
+    ctx.invoke(
+        sync,
+        slides=scratch_slide_path,
+        videos=tuple(videos),
+        lang=lang,
+        mode=mode,
+        overwrite=overwrite,
+        whisper_model=whisper_model,
+        backend_name=backend_name,
+        device=device,
+        tag=tag,
+        slides_range=None,
+        dry_run=dry_run,
+        output=target_output,
+        keep_audio=keep_audio,
+        model=model,
+        transcript_override=transcript_override,
+        alignment_override=alignment_override,
+    )
+
+
 @voiceover_group.command("port-voiceover")
 @click.argument("source", type=click.Path(exists=True, path_type=Path))
 @click.argument("target", type=click.Path(exists=True, path_type=Path))
@@ -1066,16 +1211,54 @@ def port_voiceover_cmd(source, target, lang, dry_run, tag, model, api_base):
         clm voiceover port-voiceover /tmp/slides-at-abc123.py slides.py --lang de
         clm voiceover port-voiceover old.py new.py --lang en --dry-run
     """
+    notes_map = _port_voiceover_notes(
+        source=source,
+        target=target,
+        lang=lang,
+        model=model,
+        api_base=api_base,
+    )
+
+    if not notes_map:
+        console.print("\n[dim]Nothing to port (no matched slides had prior voiceover).[/dim]")
+        return
+
+    from clm.notebooks.slide_writer import update_narrative
+
+    original_text = target.read_text(encoding="utf-8")
+    updated_text = update_narrative(original_text, notes_map, lang, tag=tag)
+
+    if dry_run:
+        _emit_unified_diff(target, original_text, updated_text)
+        return
+
+    target.write_text(updated_text, encoding="utf-8")
+    console.print(f"\n[bold green]Wrote {len(notes_map)} voiceover cells to {target}[/bold green]")
+
+
+def _port_voiceover_notes(
+    *,
+    source: Path,
+    target: Path,
+    lang: str,
+    model: str | None,
+    api_base: str | None,
+) -> dict[int, str]:
+    """Run the per-slide match + polish_and_port loop.
+
+    Returns a ``notes_map`` keyed by target-group index suitable for
+    passing to :func:`clm.notebooks.slide_writer.update_narrative`.
+    Shared by ``port-voiceover`` and ``backfill`` so both commands use
+    identical LLM orchestration and reporting.
+    """
     import asyncio
 
     from clm.notebooks.slide_parser import parse_slides
-    from clm.notebooks.slide_writer import update_narrative
     from clm.voiceover.port import polish_and_port
     from clm.voiceover.slide_matcher import MatchKind, match_slides
 
     source_groups = parse_slides(source, lang, include_header=True)
     target_groups = parse_slides(target, lang, include_header=True)
-
     matches = match_slides(source_groups, target_groups)
 
     summary: dict[MatchKind, int] = {}
@@ -1146,42 +1329,350 @@ def port_voiceover_cmd(source, target, lang, dry_run, tag, model, api_base):
                 notes_map[match.target_index] = result.bullets
         return notes_map
 
-    notes_map = asyncio.run(_run())
+    return asyncio.run(_run())
 
-    if not notes_map:
-        console.print("\n[dim]Nothing to port (no matched slides had prior voiceover).[/dim]")
+
+def _emit_unified_diff(target: Path, original_text: str, updated_text: str) -> None:
+    """Render a coloured unified diff for ``original_text`` -> ``updated_text``."""
+    if original_text == updated_text:
+        console.print("\n[dim]No changes — merged output matches baseline.[/dim]")
         return
+    diff = difflib.unified_diff(
+        original_text.splitlines(keepends=True),
+        updated_text.splitlines(keepends=True),
+        fromfile=f"a/{target.name}",
+        tofile=f"b/{target.name}",
+    )
+    console.print()
+    for line in diff:
+        line = line.rstrip("\n")
+        if line.startswith("+++") or line.startswith("---"):
+            console.print(f"[bold]{line}[/bold]")
+        elif line.startswith("+"):
+            console.print(f"[green]{line}[/green]")
+        elif line.startswith("-"):
+            console.print(f"[red]{line}[/red]")
+        elif line.startswith("@@"):
+            console.print(f"[cyan]{line}[/cyan]")
+        else:
+            console.print(line)
 
-    original_text = target.read_text(encoding="utf-8")
-    updated_text = update_narrative(original_text, notes_map, lang, tag=tag)
 
-    if dry_run:
-        if original_text == updated_text:
+@voiceover_group.command("backfill")
+@click.argument("slide_file", type=click.Path(exists=True, path_type=Path))
+@click.argument("videos", nargs=-1, required=True, type=click.Path(exists=True, path_type=Path))
+@click.option("--lang", required=True, type=click.Choice(["de", "en"]), help="Video language.")
+@click.option("--rev", default=None, help="Skip identify-rev and use this git revision directly.")
+@click.option(
+    "--top",
+    default=5,
+    show_default=True,
+    type=int,
+    help="How many top-ranked revisions to consider in Step 1 (identify-rev).",
+)
+@click.option(
+    "--auto",
+    is_flag=True,
+    default=False,
+    help="Pick the top-ranked revision automatically (Step 1) instead of requiring --rev.",
+)
+@click.option(
+    "--force-rev",
+    is_flag=True,
+    default=False,
+    help="Proceed even when the identified rev's score is below the accept threshold.",
+)
+@click.option("--dry-run", is_flag=True, help="Print the diff only; do not write the port.patch.")
+@click.option(
+    "--apply",
+    "apply_patch",
+    is_flag=True,
+    default=False,
+    help="Mutate SLIDE_FILE with the ported voiceover (default: write patch only).",
+)
+@click.option(
+    "--keep-scratch",
+    is_flag=True,
+    default=False,
+    help="Do not delete the .clm/voiceover-backfill/<topic>-<ts>/ scratch directory on exit.",
+)
+@click.option("--tag", default="voiceover", help="Cell tag: 'voiceover' (default) or 'notes'.")
+@click.option("--whisper-model", default="large-v3")
+@click.option(
+    "--backend",
+    "backend_name",
+    default="faster-whisper",
+    type=click.Choice(["faster-whisper", "cohere", "granite"]),
+)
+@click.option(
+    "--device",
+    default="auto",
+    type=click.Choice(["auto", "cpu", "cuda"]),
+)
+@click.option(
+    "--model",
+    default=None,
+    help="Override the LLM model for the polish + port steps.",
+)
+@click.option(
+    "--api-base",
+    default=None,
+    help="Override the LLM API base URL (passed through to port-voiceover).",
+)
+@click.pass_context
+def backfill_cmd(
+    ctx,
+    slide_file,
+    videos,
+    lang,
+    rev,
+    top,
+    auto,
+    force_rev,
+    dry_run,
+    apply_patch,
+    keep_scratch,
+    tag,
+    whisper_model,
+    backend_name,
+    device,
+    model,
+    api_base,
+):
+    """Extract voiceover from old recordings onto the current SLIDE_FILE.
+
+    Composes the three-step pipeline:
+
+    \b
+    1. identify-rev — find the git revision SLIDE_FILE was recorded at
+       (skipped if --rev is supplied)
+    2. sync-at-rev — export that revision to scratch and run sync
+       against it
+    3. port-voiceover — port the resulting voiceover cells onto the
+       current HEAD SLIDE_FILE
+    \b
+
+    Patch-by-default: the command writes a unified diff to
+    ``.clm/voiceover-backfill/<topic>-<ts>/port.patch`` and prints it.
+    Pass --apply to mutate the working-copy SLIDE_FILE. --dry-run
+    suppresses patch writing and shows the diff only.
+
+    \b
+    Examples:
+        clm voiceover backfill slides.py video.mp4 --lang de --auto
+        clm voiceover backfill slides.py video.mp4 --lang en --rev abc1234
+        clm voiceover backfill slides.py "Teil 1.mp4" "Teil 2.mp4" \\
+            --lang de --auto --apply
+    """
+    import shutil
+
+    from clm.voiceover.backfill import (
+        compute_port_patch,
+        extract_slide_file_at_rev,
+        plan_scratch_dir,
+        resolve_rev,
+    )
+
+    if dry_run and apply_patch:
+        raise click.UsageError("--dry-run and --apply are mutually exclusive.")
+
+    scratch = plan_scratch_dir(slide_file)
+    console.print(f"[bold]Scratch dir:[/bold] {scratch}")
+
+    cleanup_scratch = not keep_scratch
+    try:
+        # Step 1 — identify-rev (unless the caller supplied --rev).
+        if rev is None:
+            picked_rev = _backfill_identify_rev(
+                ctx=ctx,
+                slide_file=slide_file,
+                videos=list(videos),
+                lang=lang,
+                top=top,
+                auto=auto,
+                force_rev=force_rev,
+            )
+        else:
+            try:
+                picked_rev = resolve_rev(slide_file, rev)
+            except ValueError as exc:
+                raise click.ClickException(str(exc)) from exc
+        console.print(f"[bold]Using revision:[/bold] {picked_rev[:10]}")
+
+        # Step 2 — export the slide file at that rev and run sync into scratch.
+        try:
+            scratch_slides = extract_slide_file_at_rev(slide_file, picked_rev, scratch)
+        except FileNotFoundError as exc:
+            raise click.ClickException(str(exc)) from exc
+        synced_output = scratch / f"{slide_file.stem}-at-{picked_rev[:10]}-synced.py"
+
+        console.print(
+            f"[bold]Step 2:[/bold] sync {slide_file.name}@{picked_rev[:10]} -> {synced_output.name}"
+        )
+        ctx.invoke(
+            sync,
+            slides=scratch_slides,
+            videos=tuple(videos),
+            lang=lang,
+            mode="polished",
+            overwrite=False,
+            whisper_model=whisper_model,
+            backend_name=backend_name,
+            device=device,
+            tag=tag,
+            slides_range=None,
+            dry_run=False,
+            output=synced_output,
+            keep_audio=False,
+            model=model,
+            transcript_override=None,
+            alignment_override=None,
+        )
+
+        # Step 3 — port synced voiceover forward to HEAD.
+        console.print(f"[bold]Step 3:[/bold] port {synced_output.name} -> {slide_file.name}")
+        notes_map = _port_voiceover_notes(
+            source=synced_output,
+            target=slide_file,
+            lang=lang,
+            model=model,
+            api_base=api_base,
+        )
+
+        if not notes_map:
+            console.print("\n[yellow]Nothing to port — leaving SLIDE_FILE untouched.[/yellow]")
+            return
+
+        from clm.notebooks.slide_writer import update_narrative
+
+        original_text = slide_file.read_text(encoding="utf-8")
+        updated_text = update_narrative(original_text, notes_map, lang, tag=tag)
+        patch_text = compute_port_patch(slide_file, updated_text, original_text=original_text)
+
+        if not patch_text:
             console.print("\n[dim]No changes — merged output matches baseline.[/dim]")
             return
-        diff = difflib.unified_diff(
-            original_text.splitlines(keepends=True),
-            updated_text.splitlines(keepends=True),
-            fromfile=f"a/{target.name}",
-            tofile=f"b/{target.name}",
-        )
-        console.print()
-        for line in diff:
-            line = line.rstrip("\n")
-            if line.startswith("+++") or line.startswith("---"):
-                console.print(f"[bold]{line}[/bold]")
-            elif line.startswith("+"):
-                console.print(f"[green]{line}[/green]")
-            elif line.startswith("-"):
-                console.print(f"[red]{line}[/red]")
-            elif line.startswith("@@"):
-                console.print(f"[cyan]{line}[/cyan]")
-            else:
-                console.print(line)
-        return
 
-    target.write_text(updated_text, encoding="utf-8")
-    console.print(f"\n[bold green]Wrote {len(notes_map)} voiceover cells to {target}[/bold green]")
+        _emit_unified_diff(slide_file, original_text, updated_text)
+
+        if dry_run:
+            console.print("\n[yellow]Dry run — no patch written.[/yellow]")
+        else:
+            patch_path = scratch / "port.patch"
+            patch_path.write_text(patch_text, encoding="utf-8")
+            console.print(f"\n[bold]Patch written:[/bold] {patch_path}")
+            # We intentionally keep the scratch dir whenever a patch was
+            # written, so the user can re-apply it later or audit the
+            # scratch slides. Explicit --keep-scratch is honored for the
+            # no-patch path.
+            cleanup_scratch = False
+
+        if apply_patch:
+            slide_file.write_text(updated_text, encoding="utf-8")
+            console.print(
+                f"[bold green]Applied {len(notes_map)} voiceover cells to {slide_file}[/bold green]"
+            )
+        elif not dry_run:
+            console.print(
+                "[dim]Review the patch above and re-run with --apply to update SLIDE_FILE.[/dim]"
+            )
+    finally:
+        if cleanup_scratch and scratch.exists():
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _backfill_identify_rev(
+    *,
+    ctx,
+    slide_file: Path,
+    videos: list[Path],
+    lang: str,
+    top: int,
+    auto: bool,
+    force_rev: bool,
+) -> str:
+    """Run identify-rev internally and pick a candidate SHA.
+
+    Honors ``--auto`` (take the highest-scoring rev without prompting),
+    ``--force-rev`` (bypass the accept threshold), and otherwise aborts
+    with a message asking the caller to rerun with --rev.
+    """
+    from clm.voiceover.cache import CachePolicy, cached_detect
+    from clm.voiceover.keyframes import detect_transitions, get_frame_at
+    from clm.voiceover.matcher import ocr_frame
+    from clm.voiceover.rev_scorer import DEFAULT_ACCEPT_THRESHOLD, score_revisions
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+    ocr_lang = "deu+eng" if lang == "de" else "eng+deu"
+
+    console.print("[bold]Step 1:[/bold] identifying recording revision...")
+    labels: list[str] = []
+    for video in videos:
+
+        def _do_detect(v=video):
+            return detect_transitions(v)[0]
+
+        events, det_hit = cached_detect(
+            video,
+            policy=policy,
+            base_dir=slide_file.parent,
+            detect_fn=_do_detect,
+        )
+        if det_hit:
+            console.print(f"  [dim]{video.name}: transitions cache hit[/dim]")
+        for event in events:
+            try:
+                frame = get_frame_at(video, event.timestamp, offset=1.0)
+                text = ocr_frame(frame, lang=ocr_lang).strip()
+            except (ValueError, FileNotFoundError) as exc:
+                logger.warning("Skipping frame at %.1fs: %s", event.timestamp, exc)
+                continue
+            if text:
+                labels.append(text)
+
+    if not labels:
+        raise click.ClickException(
+            "video fingerprint is empty (no OCR text extracted) — cannot identify revision"
+        )
+
+    scored = score_revisions(slide_file, labels, lang=lang, limit=50)
+    top_n = scored[:top]
+    if not top_n:
+        raise click.ClickException("no historical revisions found for this file")
+
+    table = Table(title=f"Top {len(top_n)} revisions for {slide_file.name}")
+    table.add_column("SHA", style="cyan")
+    table.add_column("Date")
+    table.add_column("Base", justify="right")
+    table.add_column("Prior", justify="right")
+    table.add_column("Score", justify="right", style="green")
+    table.add_column("Subject")
+    for r in top_n:
+        table.add_row(
+            r.rev[:10],
+            r.date.strftime("%Y-%m-%d") if r.date else "",
+            f"{r.base_score:.3f}",
+            f"{r.narrative_prior:.2f}x",
+            f"{r.score:.3f}",
+            (r.subject or "")[:50],
+        )
+    console.print(table)
+
+    picked = top_n[0]
+    if picked.score < DEFAULT_ACCEPT_THRESHOLD and not force_rev:
+        raise click.ClickException(
+            f"top score {picked.score:.3f} is below the accept threshold "
+            f"{DEFAULT_ACCEPT_THRESHOLD}. Re-run with --force-rev to accept it, "
+            f"or pass --rev <sha> to pick a different candidate."
+        )
+
+    if not auto:
+        raise click.ClickException(
+            "multiple candidates shown above; re-run with --auto to pick the top-ranked "
+            "revision, or --rev <sha> to select one explicitly."
+        )
+
+    return picked.rev
 
 
 @voiceover_group.command("extract-training-data")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -600,6 +600,19 @@ clm summarize course.xml --audience client --style bullets
 Synchronize video recordings with slide files to generate speaker notes.
 Requires `clm[voiceover]` extra.
 
+**Group-level cache flags** (accepted by every `voiceover` subcommand):
+
+| Option | Description |
+|--------|-------------|
+| `--cache-root PATH` | Override the cache location (default: `./.clm/voiceover-cache`) |
+| `--no-cache` | Disable the artifact cache for this invocation |
+| `--refresh-cache` | Force recomputation and overwrite existing cache entries |
+
+The cache stores intermediate pipeline artifacts (transcripts, transitions,
+timelines, alignments) keyed by video and slide-file fingerprints, so
+repeat invocations skip the expensive ASR/detection steps when inputs are
+unchanged. Manage the cache with `clm voiceover cache list/prune/clear`.
+
 #### `clm voiceover sync`
 
 Full pipeline: transcribe one or more video parts, detect transitions, match
@@ -633,6 +646,8 @@ Part ordering is authoritative — pass parts in the order they should be stitch
 | `-o, --output PATH` | Output file |
 | `--keep-audio` | Keep extracted audio files |
 | `--model TEXT` | LLM model for merge/polished mode (default: `anthropic/claude-sonnet-4-6` via OpenRouter) |
+| `--transcript PATH` | Skip ASR; load precomputed transcript JSON (single-part only) |
+| `--alignment PATH` | Skip ASR, detection, matching; load precomputed alignment JSON |
 
 **Merge behavior (default):**
 - Existing voiceover cells are read as baseline; transcript additions are
@@ -712,6 +727,33 @@ Output fields per JSONL line: `input.baseline`, `input.transcript`,
 `llm_output`, `human_final`, `delta_vs_llm` (empty = no hand edits, valid
 positive training example).
 
+#### `clm voiceover cache`
+
+Inspect and manage the voiceover artifact cache.
+
+```
+clm voiceover cache list
+clm voiceover cache prune --max-age-days DAYS
+clm voiceover cache clear [--yes]
+```
+
+`list` groups entries by kind (`transcripts`, `transitions`, `timelines`,
+`alignments`) and shows the on-disk path and size. `prune` removes entries
+older than the given number of days. `clear` removes every entry (prompts
+for confirmation unless `--yes` is passed).
+
+#### `clm voiceover trace show`
+
+Render a trace log (`.clm/voiceover-traces/<stem>-<ts>.jsonl`) in a
+human-readable summary table, or dump the raw entries with `--json`.
+
+```
+clm voiceover trace show PATH [--json]
+```
+
+The trace log schema is documented in `docs/claude/voiceover-design.md`
+(schema tag `clm.voiceover.trace/1`).
+
 Examples:
 
 ```bash
@@ -726,6 +768,10 @@ clm voiceover extract-training-data trace.jsonl -o training.jsonl --no-check-git
 clm voiceover transcribe video.mp4 --lang de -o transcript.txt
 clm voiceover detect video.mp4 -o transitions.txt
 clm voiceover identify video.mp4 slides.py --lang de
+clm voiceover cache list
+clm voiceover cache prune --max-age-days 30
+clm voiceover --no-cache sync slides.py video.mp4 --lang de
+clm voiceover trace show .clm/voiceover-traces/slides_intro-20260412-012020.jsonl
 ```
 
 ### `clm polish`

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -735,6 +735,76 @@ warning suggesting you force a specific revision downstream. Re-using
 the transitions cache (written by `detect`/`sync`/`identify`) keeps
 repeated runs fast.
 
+#### `clm voiceover sync-at-rev`
+
+Middle step of the backfill pipeline. Exports SLIDE_FILE as it existed
+at `--rev` to a scratch location via `git show` (never touches the
+working tree) and runs the full `sync` pipeline against that historical
+version plus the supplied VIDEO parts. Output is written to `--output`.
+
+```
+clm voiceover sync-at-rev SLIDE_FILE VIDEO... --rev SHA -o PATH --lang {de|en} [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--rev TEXT` | Git revision (SHA, tag, or branch) to export SLIDE_FILE at (required) |
+| `-o, --output PATH` | Sync output path; must not equal SLIDE_FILE (required) |
+| `--lang TEXT` | Video language, `de` or `en` (required) |
+| `--mode {polished,verbatim}` | Verbatim keeps transcript as-is; polished (default) runs LLM cleanup |
+| `--overwrite` | Overwrite existing voiceover cells instead of merging |
+| `--whisper-model TEXT` | Whisper model size (default: `large-v3`) |
+| `--backend TEXT` | Transcription backend (`faster-whisper`/`cohere`/`granite`) |
+| `--device {auto,cpu,cuda}` | Device for transcription |
+| `--tag TEXT` | Cell tag to write: `voiceover` (default) or `notes` |
+| `--dry-run` | Parse and report without running the LLM merge |
+| `--keep-audio` | Keep extracted audio files for debugging |
+| `--model TEXT` | Override the LLM merge model |
+| `--transcript PATH` | Skip ASR; load transcript JSON |
+| `--alignment PATH` | Skip ASR + detection + matching; load alignment JSON |
+| `--scratch-dir PATH` | Use this directory for the exported slide file (default: fresh `.clm/voiceover-backfill/<topic>-<ts>/`) |
+
+Use `clm voiceover backfill` to chain Step 1 (identify-rev), this
+command (Step 2), and Step 3 (port-voiceover) in one shot.
+
+#### `clm voiceover backfill`
+
+One-shot wrapper that extracts voiceover content from old recordings
+onto the current SLIDE_FILE. Chains `identify-rev` → `sync-at-rev` →
+`port-voiceover`. **Patch-by-default:** writes a unified diff to
+`.clm/voiceover-backfill/<topic>-<ts>/port.patch` and prints it;
+`--apply` is required to mutate the working-copy SLIDE_FILE.
+
+```
+clm voiceover backfill SLIDE_FILE VIDEO... --lang {de|en} [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--lang TEXT` | Video language, `de` or `en` (required) |
+| `--rev TEXT` | Skip identify-rev and use this revision directly |
+| `--top N` | How many top-ranked candidates to display (default: 5) |
+| `--auto` | Pick the top-ranked revision automatically (Step 1) |
+| `--force-rev` | Accept the identified rev even if its score is below the threshold |
+| `--dry-run` | Print the diff only; do not write `port.patch` |
+| `--apply` | Mutate SLIDE_FILE with the ported voiceover (default: patch-only) |
+| `--keep-scratch` | Retain `.clm/voiceover-backfill/<topic>-<ts>/` on exit |
+| `--tag TEXT` | Cell tag: `voiceover` (default) or `notes` |
+| `--whisper-model TEXT` | Whisper model size (default: `large-v3`) |
+| `--backend TEXT` | Transcription backend (`faster-whisper`/`cohere`/`granite`) |
+| `--device {auto,cpu,cuda}` | Device for transcription |
+| `--model TEXT` | Override the LLM model for the polish + port steps |
+| `--api-base TEXT` | Override the LLM API base URL |
+
+Without `--rev`, Step 1 scores candidate revisions and displays them.
+If `--auto` is also set, the top-ranked candidate is used; otherwise
+the command exits with the table shown and asks you to rerun with
+`--rev <sha>`. Scores below ~0.6 require `--force-rev` to proceed.
+
+The scratch directory is kept when a patch was written (so you can
+re-apply or audit it later) and deleted otherwise, unless
+`--keep-scratch` forces it to stick around.
+
 #### `clm voiceover port-voiceover`
 
 Port polished voiceover content from one slide file onto another,
@@ -831,6 +901,9 @@ clm voiceover identify-rev slides.py part1.mp4 part2.mp4 --lang de
 clm voiceover identify-rev slides.py recording.mp4 --lang en --top 10 --json
 clm voiceover port-voiceover /tmp/slides-at-abc123.py slides.py --lang de --dry-run
 clm voiceover port-voiceover old.py new.py --lang en
+clm voiceover sync-at-rev slides.py video.mp4 --rev abc1234 --lang de -o /tmp/synced.py
+clm voiceover backfill slides.py video.mp4 --lang de --auto
+clm voiceover backfill slides.py video.mp4 --lang en --rev abc1234 --apply
 clm voiceover cache list
 clm voiceover cache prune --max-age-days 30
 clm voiceover --no-cache sync slides.py video.mp4 --lang de

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -835,6 +835,35 @@ Prefer `clm voiceover backfill` when you want one-shot extraction plus
 porting in a single command with automatic git-revision detection;
 `port-voiceover` is the file-to-file primitive that `backfill` composes.
 
+#### `clm voiceover compare`
+
+Evaluate bullet-level differences between two slide-file revisions
+without modifying either one. Read-only sibling to `port-voiceover`:
+the LLM labels each bullet on each side as `covered`, `rewritten`,
+`added`, `dropped`, or `manual_review`. Useful for auditing a port
+(`source = sync-at-rev output`, `target = slides@HEAD` after a port)
+or for reviewing how voiceover drifted between two hand-edited
+revisions.
+
+```
+clm voiceover compare SOURCE TARGET --lang {de|en} [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--lang TEXT` | Slide language (`de` or `en`) (required) |
+| `--json` | Emit a structured JSON report instead of the Rich table |
+| `-o, --output PATH` | Write the report to this path (default: stdout) |
+| `--model TEXT` | Override the LLM model (default: `anthropic/claude-sonnet-4-6`) |
+| `--api-base TEXT` | Override the LLM API base URL |
+
+Slide matching uses the same `slide_id`/title/content pipeline as
+`port-voiceover`. Slides present on only one side appear in the
+report under their `new_at_head` / `removed_at_head` bucket with no
+LLM call. The JSON schema mirrors the in-memory `CompareReport`:
+top-level `status_totals` and `kind_totals`, plus a `slides[]` list
+with per-slide outcomes.
+
 #### `clm voiceover extract-training-data`
 
 Extract training data from a voiceover merge trace log. Reads a JSONL trace
@@ -904,6 +933,8 @@ clm voiceover port-voiceover old.py new.py --lang en
 clm voiceover sync-at-rev slides.py video.mp4 --rev abc1234 --lang de -o /tmp/synced.py
 clm voiceover backfill slides.py video.mp4 --lang de --auto
 clm voiceover backfill slides.py video.mp4 --lang en --rev abc1234 --apply
+clm voiceover compare /tmp/slides-at-abc123.py slides.py --lang de
+clm voiceover compare old.py new.py --lang en --json -o report.json
 clm voiceover cache list
 clm voiceover cache prune --max-age-days 30
 clm voiceover --no-cache sync slides.py video.mp4 --lang de

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -706,6 +706,35 @@ clm voiceover identify VIDEO SLIDES --lang {de|en} [OPTIONS]
 | `--lang TEXT` | Video language (`de` or `en`) (required) |
 | `-o, --output PATH` | Output file |
 
+#### `clm voiceover identify-rev`
+
+Identify which historical revision of a slide file a recording was made
+against. Walks the git history of the slide file, builds a fingerprint
+from the OCR of the video's keyframe transitions, and ranks each
+candidate revision by fuzzy longest-common-subsequence similarity.
+Revisions at the boundary of a narrative-heavy commit run (likely
+recording-session markers) receive a multiplicative prior.
+
+Used standalone as a diagnostic, or as the first step of the backfill
+pipeline before `clm voiceover sync` is run against a specific revision.
+
+```
+clm voiceover identify-rev SLIDE_FILE VIDEO... --lang {de|en} [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--lang TEXT` | Video language (`de` or `en`) (required) |
+| `--top N` | How many top-ranked revisions to display (default: 5) |
+| `--since TEXT` | `git log --since` filter (e.g. `'6 months ago'`, `'2025-01-01'`) |
+| `--limit N` | Maximum number of commits to score, most recent first (default: 50) |
+| `--json` | Emit machine-readable JSON instead of a table |
+
+If the top-ranked revision scores below ~0.6 the command prints a
+warning suggesting you force a specific revision downstream. Re-using
+the transitions cache (written by `detect`/`sync`/`identify`) keeps
+repeated runs fast.
+
 #### `clm voiceover extract-training-data`
 
 Extract training data from a voiceover merge trace log. Reads a JSONL trace
@@ -768,6 +797,8 @@ clm voiceover extract-training-data trace.jsonl -o training.jsonl --no-check-git
 clm voiceover transcribe video.mp4 --lang de -o transcript.txt
 clm voiceover detect video.mp4 -o transitions.txt
 clm voiceover identify video.mp4 slides.py --lang de
+clm voiceover identify-rev slides.py part1.mp4 part2.mp4 --lang de
+clm voiceover identify-rev slides.py recording.mp4 --lang en --top 10 --json
 clm voiceover cache list
 clm voiceover cache prune --max-age-days 30
 clm voiceover --no-cache sync slides.py video.mp4 --lang de

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -735,6 +735,36 @@ warning suggesting you force a specific revision downstream. Re-using
 the transitions cache (written by `detect`/`sync`/`identify`) keeps
 repeated runs fast.
 
+#### `clm voiceover port-voiceover`
+
+Port polished voiceover content from one slide file onto another,
+file-to-file. Typical use: after running `clm voiceover sync` against
+a historical revision exported to a scratch location, port the
+resulting voiceover cells onto the current HEAD slide file.
+
+Slide matching uses `slide_id` metadata as the primary key, falling
+back to fuzzy title match and then content fingerprint when titles
+collide. Slides present only on one side are reported but never
+edited. The LLM merges prior bullets around any voiceover already
+present on the target; baseline content is preserved unless directly
+contradicted.
+
+```
+clm voiceover port-voiceover SOURCE TARGET --lang {de|en} [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--lang TEXT` | Slide language (`de` or `en`) (required) |
+| `--dry-run` | Print a unified diff instead of writing TARGET |
+| `--tag TEXT` | Cell tag to read/write: `voiceover` (default) or `notes` |
+| `--model TEXT` | Override the LLM model (default: `anthropic/claude-sonnet-4-6`) |
+| `--api-base TEXT` | Override the LLM API base URL |
+
+Prefer `clm voiceover backfill` when you want one-shot extraction plus
+porting in a single command with automatic git-revision detection;
+`port-voiceover` is the file-to-file primitive that `backfill` composes.
+
 #### `clm voiceover extract-training-data`
 
 Extract training data from a voiceover merge trace log. Reads a JSONL trace
@@ -799,6 +829,8 @@ clm voiceover detect video.mp4 -o transitions.txt
 clm voiceover identify video.mp4 slides.py --lang de
 clm voiceover identify-rev slides.py part1.mp4 part2.mp4 --lang de
 clm voiceover identify-rev slides.py recording.mp4 --lang en --top 10 --json
+clm voiceover port-voiceover /tmp/slides-at-abc123.py slides.py --lang de --dry-run
+clm voiceover port-voiceover old.py new.py --lang en
 clm voiceover cache list
 clm voiceover cache prune --max-age-days 30
 clm voiceover --no-cache sync slides.py video.mp4 --lang de

--- a/src/clm/voiceover/backfill.py
+++ b/src/clm/voiceover/backfill.py
@@ -1,0 +1,106 @@
+"""Scratch-dir and git-extraction helpers for ``clm voiceover backfill``.
+
+The command itself is a thin composition of ``identify-rev`` →
+``sync-at-rev`` → ``port-voiceover`` (see
+``docs/proposals/VOICEOVER_BACKFILL.md`` §3). The helpers here handle
+the filesystem plumbing so the CLI layer stays readable:
+
+* :func:`extract_slide_file_at_rev` — ``git show <rev>:<path>`` into a
+  scratch file, no working-tree mutation.
+* :func:`plan_scratch_dir` — create
+  ``.clm/voiceover-backfill/<topic>-<YYYYMMDD-HHMMSS>/`` (gitignored via
+  the project-wide ``.clm/`` rule).
+* :func:`compute_port_patch` — unified-diff text between the current
+  target file and the ported result, suitable for ``git apply``.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from clm.voiceover.narrative_commits import _git_toplevel, get_file_at_rev
+
+logger = logging.getLogger(__name__)
+
+
+def plan_scratch_dir(slide_path: Path, *, base_dir: Path | None = None) -> Path:
+    """Create and return a fresh ``.clm/voiceover-backfill/<topic>-<ts>/`` directory.
+
+    ``base_dir`` defaults to the slide file's parent (so the directory
+    sits next to the slides, inside whatever project rooted them).
+    Timestamped so repeated runs do not clobber each other, which also
+    makes ``--keep-scratch`` forensics readable.
+    """
+    anchor = base_dir if base_dir is not None else slide_path.parent
+    topic = slide_path.stem
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    scratch = anchor / ".clm" / "voiceover-backfill" / f"{topic}-{stamp}"
+    scratch.mkdir(parents=True, exist_ok=True)
+    return scratch
+
+
+def extract_slide_file_at_rev(slide_path: Path, rev: str, scratch_dir: Path) -> Path:
+    """Export ``slide_path`` as it existed at ``rev`` into ``scratch_dir``.
+
+    Uses ``git show`` rather than ``git checkout`` so the working tree is
+    never touched. Raises :class:`FileNotFoundError` when the file did
+    not exist at that revision — callers should surface this cleanly.
+    """
+    content = get_file_at_rev(rev, slide_path)
+    if content is None:
+        raise FileNotFoundError(f"{slide_path.name} does not exist at revision {rev[:10]}")
+    # Use a short SHA suffix so multiple sync-at-rev invocations against
+    # the same scratch dir stay distinguishable.
+    out = scratch_dir / f"{slide_path.stem}-at-{rev[:10]}.py"
+    out.write_text(content, encoding="utf-8")
+    return out
+
+
+def compute_port_patch(
+    target_path: Path,
+    updated_text: str,
+    *,
+    original_text: str | None = None,
+) -> str:
+    """Return a unified diff from ``target_path``'s current content to ``updated_text``.
+
+    The result uses ``a/<name>`` / ``b/<name>`` paths so it applies
+    cleanly via ``git apply`` when run from the file's directory.
+    ``original_text`` can be supplied when the caller has already read
+    the file (avoids re-reading on very large slide decks).
+    """
+    if original_text is None:
+        original_text = target_path.read_text(encoding="utf-8")
+    if original_text == updated_text:
+        return ""
+    diff_lines = difflib.unified_diff(
+        original_text.splitlines(keepends=True),
+        updated_text.splitlines(keepends=True),
+        fromfile=f"a/{target_path.name}",
+        tofile=f"b/{target_path.name}",
+    )
+    return "".join(diff_lines)
+
+
+def resolve_rev(slide_path: Path, rev: str) -> str:
+    """Resolve a rev-ish (tag, branch, short SHA) to a full SHA.
+
+    Validates that the rev exists in the repo that owns ``slide_path``
+    so we fail fast before the heavier sync step runs.
+    """
+    import subprocess
+
+    repo_root = _git_toplevel(slide_path)
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{rev}^{{commit}}"],
+            text=True,
+            encoding="utf-8",
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"unknown revision {rev!r}: {exc.stderr.strip()}") from exc
+    return out.strip()

--- a/src/clm/voiceover/bullet_schema.py
+++ b/src/clm/voiceover/bullet_schema.py
@@ -1,0 +1,208 @@
+"""Shared structured-output schema for the per-slide LLM operations.
+
+Both the future ``clm voiceover compare`` judge and the
+``polish_and_port`` primitive (backing ``clm voiceover port-voiceover``
+and ``clm voiceover backfill``) need to reason about bullet-level
+provenance: for every bullet in an output or target, did it survive
+untouched, get modified, appear from nowhere, or vanish from the source?
+
+This module centralizes:
+
+* the canonical :class:`BulletStatus` enum and its JSON spelling,
+* :class:`BulletOutcome` — one row of structured bullet-level feedback,
+* :class:`PerSlidePack` — the shared input packer that both the port
+  and compare per-slide prompts consume, so the two prompt files diverge
+  only in tone and instructions, never in field names, and
+* ``parse_structured_response`` — the forgiving JSON reader used by
+  both call sites.
+
+Keeping this separate from ``clm/voiceover/merge.py`` preserves that
+module's single-purpose narrative (merge transcript + baseline) while
+giving port/compare their own symmetric home.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class BulletStatus(str, Enum):
+    """Per-bullet outcome, shared by port and compare.
+
+    * ``covered`` — the bullet is present in both source and target with
+      essentially the same content (modulo style).
+    * ``rewritten`` — the bullet is present in both but substantively
+      edited (a correction, clarification, or merge).
+    * ``added`` — the bullet is new in the output and has no counterpart
+      in the prior side.
+    * ``dropped`` — the bullet existed on the prior side and is
+      intentionally absent from the output.
+    * ``manual_review`` — the model could not confidently classify the
+      bullet; callers should surface these for human judgment.
+    """
+
+    COVERED = "covered"
+    REWRITTEN = "rewritten"
+    ADDED = "added"
+    DROPPED = "dropped"
+    MANUAL_REVIEW = "manual_review"
+
+
+@dataclass
+class BulletOutcome:
+    """One row of structured feedback about a single bullet.
+
+    ``source`` and ``target`` are optional because ``added`` entries have
+    no source bullet and ``dropped`` entries have no target bullet.
+    """
+
+    status: BulletStatus
+    target: str | None = None
+    source: str | None = None
+    note: str | None = None
+
+    def to_json(self) -> dict:
+        payload: dict = {"status": self.status.value}
+        if self.target is not None:
+            payload["target"] = self.target
+        if self.source is not None:
+            payload["source"] = self.source
+        if self.note is not None:
+            payload["note"] = self.note
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict) -> BulletOutcome:
+        raw_status = data.get("status", "")
+        try:
+            status = BulletStatus(raw_status)
+        except ValueError:
+            logger.debug("Unknown bullet status %r, mapping to manual_review", raw_status)
+            status = BulletStatus.MANUAL_REVIEW
+        return cls(
+            status=status,
+            target=data.get("target"),
+            source=data.get("source"),
+            note=data.get("note"),
+        )
+
+
+@dataclass
+class PerSlidePack:
+    """Per-slide input packet for a port or compare LLM call.
+
+    All three text fields use the same packing so both prompt families
+    see identical structure. ``slide_content_prior`` is omitted when the
+    slide wasn't modified between the two revisions.
+    """
+
+    slide_id: str
+    language: str
+    baseline_bullets: str
+    prior_bullets: str
+    slide_content_head: str
+    slide_content_prior: str | None = None
+    content_changed: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def estimate_chars(self) -> int:
+        total = len(self.baseline_bullets) + len(self.prior_bullets) + len(self.slide_content_head)
+        if self.slide_content_prior:
+            total += len(self.slide_content_prior)
+        return total
+
+    def build_user_message(self) -> str:
+        """Render the per-slide user message.
+
+        The same layout is consumed by ``port_{lang}.md`` (constructive)
+        and ``compare_{lang}.md`` (evaluative) — the prompts differ in
+        what they ask the model to *do* with the fields, not in how
+        those fields are named or ordered.
+        """
+        parts: list[str] = [f"SLIDE ID: {self.slide_id}"]
+
+        if self.slide_content_head.strip():
+            parts.append(
+                "SLIDE CONTENT (current HEAD version; do not include in output):\n"
+                f"{self.slide_content_head.strip()}"
+            )
+        if self.content_changed and self.slide_content_prior is not None:
+            parts.append(
+                "SLIDE CONTENT (prior/source version; for matching context only):\n"
+                f"{self.slide_content_prior.strip()}"
+            )
+        elif self.content_changed:
+            parts.append(
+                "NOTE: The slide content changed between the source and target "
+                "revisions, but the prior slide text is not available."
+            )
+
+        prior_label = "PRIOR BULLETS (from the video-derived voiceover on the source revision):"
+        parts.append(f"{prior_label}\n{self.prior_bullets.strip() or '(empty)'}")
+
+        baseline_label = "BASELINE BULLETS (already present at HEAD; preserve unless contradicted):"
+        parts.append(
+            f"{baseline_label}\n{self.baseline_bullets.strip() or '(empty -- no existing voiceover at HEAD)'}"
+        )
+
+        for note in self.notes:
+            parts.append(f"NOTE: {note}")
+
+        return "\n\n".join(parts)
+
+
+def parse_structured_response(
+    raw: str,
+    *,
+    default_bullets: str = "",
+) -> tuple[str, list[BulletOutcome], str | None]:
+    """Parse a port/compare structured response into its three pieces.
+
+    Returns ``(bullets, outcomes, notes)`` where ``bullets`` is the
+    merged-or-critiqued bullet text, ``outcomes`` is a list of
+    :class:`BulletOutcome`, and ``notes`` is an optional free-text
+    summary the model may include.
+
+    The parser is forgiving: it strips markdown fences, accepts either a
+    bare JSON object or one wrapped in ``{"result": {...}}``, and
+    returns ``default_bullets`` with an empty outcome list when the
+    response isn't parseable. Callers may log or reject on an empty
+    outcome list.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        if len(lines) >= 2 and lines[-1].strip().startswith("```"):
+            text = "\n".join(lines[1:-1]).strip()
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("LLM response is not valid JSON: %s", exc)
+        return default_bullets, [], None
+
+    if isinstance(data, dict) and "result" in data and isinstance(data["result"], dict):
+        data = data["result"]
+
+    if not isinstance(data, dict):
+        logger.warning("LLM response is not a JSON object (got %s)", type(data).__name__)
+        return default_bullets, [], None
+
+    bullets = str(data.get("bullets") or data.get("merged_bullets") or default_bullets)
+
+    outcomes_raw = data.get("outcomes") or data.get("bullet_outcomes") or []
+    outcomes: list[BulletOutcome] = []
+    if isinstance(outcomes_raw, list):
+        for row in outcomes_raw:
+            if isinstance(row, dict):
+                outcomes.append(BulletOutcome.from_json(row))
+
+    notes_value = data.get("notes")
+    notes = str(notes_value) if isinstance(notes_value, str) and notes_value.strip() else None
+
+    return bullets, outcomes, notes

--- a/src/clm/voiceover/cache.py
+++ b/src/clm/voiceover/cache.py
@@ -1,0 +1,771 @@
+"""Artifact cache for the voiceover pipeline.
+
+Stages in the voiceover pipeline — transcription, transition detection,
+OCR-based timeline matching, and transcript-to-slide alignment — produce
+intermediate artifacts that are deterministic with respect to their inputs.
+Re-running the pipeline with the same inputs is expensive (especially ASR on
+multi-GB videos) but should produce identical results, which makes these
+artifacts good cache candidates.
+
+This module provides a local filesystem cache layered under the working
+directory's ``.clm/voiceover-cache/`` tree. Keys are derived from cheap
+fingerprints (path + mtime + size for videos; normalized source hash for
+slide files) so cache writes/reads stay fast even on large inputs.
+
+The cache is consulted at four points:
+
+- :class:`TranscriptsCache` — keyed by ``video_hash`` and backend config.
+- :class:`TransitionsCache` — keyed by ``video_hash`` and detection config.
+- :class:`TimelinesCache` — keyed by ``video_hash`` + ``slides_hash``.
+- :class:`AlignmentsCache` — keyed by ``video_hash`` + ``slides_hash``.
+
+Corrupt or unreadable entries are treated as a miss (the cache overwrites on
+the next successful write). Config mismatch is likewise a miss, not an
+error — callers may cache alternate configurations side by side.
+
+Usage::
+
+    cache_root = resolve_cache_root()                   # .clm/voiceover-cache/
+    video_key = VideoKey.from_path(video_path)
+    slides_key = SlidesKey.from_path(slide_path)
+    tx_cfg = TranscribeConfig(backend="faster-whisper", model="large-v3",
+                              language="de", device_class="cuda")
+
+    store = TranscriptsCache(cache_root)
+    cached = store.get(video_key, tx_cfg)
+    if cached is None:
+        transcript = transcribe_video(...)
+        store.put(video_key, tx_cfg, transcript)
+    else:
+        transcript = cached
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIRNAME = ".clm/voiceover-cache"
+CACHE_SUBDIRS = ("transcripts", "transitions", "timelines", "alignments")
+
+
+# ---------------------------------------------------------------------------
+# Keys and configs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VideoKey:
+    """Fingerprint for a video file used as a cache key.
+
+    Uses path + mtime + size rather than full-file SHA because videos can
+    be several GB; hashing the entire file on every invocation would defeat
+    the cache. The fingerprint is stable across invocations of the same
+    file and invalidates cleanly when the file is replaced or edited.
+    """
+
+    abspath: str
+    mtime_ns: int
+    size: int
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> VideoKey:
+        p = Path(path).resolve()
+        stat = p.stat()
+        return cls(abspath=str(p), mtime_ns=stat.st_mtime_ns, size=stat.st_size)
+
+    @property
+    def hash(self) -> str:
+        h = hashlib.sha1(
+            f"{self.abspath}|{self.mtime_ns}|{self.size}".encode(),
+            usedforsecurity=False,
+        )
+        return h.hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class SlidesKey:
+    """Fingerprint for a slide source file used as a cache key.
+
+    Hashes the file's bytes after stripping trailing whitespace per line.
+    This ignores line-ending churn and trailing-space edits (which don't
+    change pipeline outputs) without being so aggressive that semantic
+    changes get lost.
+    """
+
+    hash: str
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> SlidesKey:
+        text = Path(path).read_text(encoding="utf-8")
+        return cls.from_text(text)
+
+    @classmethod
+    def from_text(cls, text: str) -> SlidesKey:
+        normalized = "\n".join(line.rstrip() for line in text.splitlines())
+        h = hashlib.sha1(normalized.encode("utf-8"), usedforsecurity=False)
+        return cls(hash=h.hexdigest()[:16])
+
+
+@dataclass(frozen=True)
+class TranscribeConfig:
+    """Subset of transcription parameters that affect the output.
+
+    Device is collapsed to a coarse class ("cuda"/"cpu") rather than the
+    exact device string because "auto" and "cuda:0" should share cache
+    entries on the same machine.
+    """
+
+    backend: str
+    model: str
+    language: str | None
+    device_class: str
+
+    @classmethod
+    def normalize_device(cls, device: str) -> str:
+        d = device.lower()
+        if d.startswith("cuda"):
+            return "cuda"
+        if d == "auto":
+            # "auto" resolves at runtime; we treat it as a separate class
+            # so cached cuda entries aren't incorrectly served for
+            # explicit cpu calls on the same machine.
+            return "auto"
+        return "cpu"
+
+
+@dataclass(frozen=True)
+class DetectConfig:
+    """Parameters that affect transition detection output."""
+
+    sample_fps: float
+    threshold_factor: float
+    percentile: float
+    merge_window: float
+
+
+# ---------------------------------------------------------------------------
+# Cache primitives
+# ---------------------------------------------------------------------------
+
+
+def resolve_cache_root(base_dir: str | Path | None = None) -> Path:
+    """Resolve the default cache root under ``base_dir`` (or cwd)."""
+    base = Path(base_dir) if base_dir is not None else Path.cwd()
+    return base / CACHE_DIRNAME
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    """Write JSON to *path* atomically via temp-file + rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # NamedTemporaryFile keeps the file open on Windows, which blocks
+    # rename; use mkstemp + manual write instead.
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _read_json(path: Path) -> dict | None:
+    """Read JSON from *path*. Returns None on miss or corruption."""
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Corrupt cache entry %s: %s — treating as miss", path, exc)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Unexpected cache payload %s (not a dict) — treating as miss", path)
+        return None
+    return data
+
+
+T = TypeVar("T")
+
+
+class _JsonCache(Generic[T]):
+    """Base class for JSON-backed caches under a named subdirectory."""
+
+    subdir: str
+
+    def __init__(
+        self,
+        cache_root: Path,
+        *,
+        encoder: Callable[[T], Any],
+        decoder: Callable[[Any], T],
+    ):
+        self._root = cache_root / self.subdir
+        self._encoder = encoder
+        self._decoder = decoder
+
+    @property
+    def directory(self) -> Path:
+        return self._root
+
+    def _entry_path(self, key: str) -> Path:
+        return self._root / f"{key}.json"
+
+    def _load(self, key: str) -> dict | None:
+        return _read_json(self._entry_path(key))
+
+    def _store(self, key: str, payload: dict) -> None:
+        _atomic_write_json(self._entry_path(key), payload)
+
+    def _config_matches(self, entry: dict, expected: dict) -> bool:
+        stored = entry.get("config")
+        if not isinstance(stored, dict):
+            return False
+        return stored == expected
+
+
+# ---------------------------------------------------------------------------
+# Typed caches
+# ---------------------------------------------------------------------------
+
+
+class TranscriptsCache(_JsonCache):
+    """Cache for :class:`clm.voiceover.transcribe.Transcript` artifacts."""
+
+    subdir = "transcripts"
+
+    def __init__(self, cache_root: Path):
+        from clm.voiceover.transcribe import Transcript
+
+        super().__init__(
+            cache_root,
+            encoder=lambda t: t.to_dict(),
+            decoder=Transcript.from_dict,
+        )
+
+    def get(self, video: VideoKey, cfg: TranscribeConfig):
+        entry = self._load(video.hash)
+        if entry is None:
+            return None
+        if not self._config_matches(entry, asdict(cfg)):
+            return None
+        artifact = entry.get("artifact")
+        if not isinstance(artifact, dict):
+            return None
+        try:
+            return self._decoder(artifact)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("Cannot decode cached transcript %s: %s", video.hash, exc)
+            return None
+
+    def put(self, video: VideoKey, cfg: TranscribeConfig, transcript) -> None:
+        payload = {
+            "version": 1,
+            "kind": "transcript",
+            "video": asdict(video),
+            "config": asdict(cfg),
+            "artifact": self._encoder(transcript),
+        }
+        self._store(video.hash, payload)
+
+
+class TransitionsCache(_JsonCache):
+    """Cache for lists of :class:`TransitionEvent`."""
+
+    subdir = "transitions"
+
+    def __init__(self, cache_root: Path):
+        super().__init__(
+            cache_root,
+            encoder=_encode_transitions,
+            decoder=_decode_transitions,
+        )
+
+    def get(self, video: VideoKey, cfg: DetectConfig):
+        entry = self._load(video.hash)
+        if entry is None:
+            return None
+        if not self._config_matches(entry, asdict(cfg)):
+            return None
+        artifact = entry.get("artifact")
+        if not isinstance(artifact, list):
+            return None
+        try:
+            return self._decoder(artifact)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("Cannot decode cached transitions %s: %s", video.hash, exc)
+            return None
+
+    def put(self, video: VideoKey, cfg: DetectConfig, events) -> None:
+        payload = {
+            "version": 1,
+            "kind": "transitions",
+            "video": asdict(video),
+            "config": asdict(cfg),
+            "artifact": self._encoder(events),
+        }
+        self._store(video.hash, payload)
+
+
+class TimelinesCache(_JsonCache):
+    """Cache for slide-timelines (output of ``match_events_to_slides``)."""
+
+    subdir = "timelines"
+
+    def __init__(self, cache_root: Path):
+        super().__init__(
+            cache_root,
+            encoder=_encode_timeline,
+            decoder=_decode_timeline,
+        )
+
+    @staticmethod
+    def _compose_key(video: VideoKey, slides: SlidesKey) -> str:
+        return f"{video.hash}_{slides.hash}"
+
+    def get(self, video: VideoKey, slides: SlidesKey, cfg: dict[str, Any]):
+        entry = self._load(self._compose_key(video, slides))
+        if entry is None:
+            return None
+        if not self._config_matches(entry, cfg):
+            return None
+        artifact = entry.get("artifact")
+        if not isinstance(artifact, list):
+            return None
+        try:
+            return self._decoder(artifact)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Cannot decode cached timeline %s: %s",
+                self._compose_key(video, slides),
+                exc,
+            )
+            return None
+
+    def put(
+        self,
+        video: VideoKey,
+        slides: SlidesKey,
+        cfg: dict[str, Any],
+        timeline,
+    ) -> None:
+        payload = {
+            "version": 1,
+            "kind": "timeline",
+            "video": asdict(video),
+            "slides": asdict(slides),
+            "config": cfg,
+            "artifact": self._encoder(timeline),
+        }
+        self._store(self._compose_key(video, slides), payload)
+
+
+class AlignmentsCache(_JsonCache):
+    """Cache for :class:`AlignmentResult` objects."""
+
+    subdir = "alignments"
+
+    def __init__(self, cache_root: Path):
+        super().__init__(
+            cache_root,
+            encoder=_encode_alignment,
+            decoder=_decode_alignment,
+        )
+
+    @staticmethod
+    def _compose_key(video: VideoKey, slides: SlidesKey) -> str:
+        return f"{video.hash}_{slides.hash}"
+
+    def get(self, video: VideoKey, slides: SlidesKey, cfg: dict[str, Any]):
+        entry = self._load(self._compose_key(video, slides))
+        if entry is None:
+            return None
+        if not self._config_matches(entry, cfg):
+            return None
+        artifact = entry.get("artifact")
+        if not isinstance(artifact, dict):
+            return None
+        try:
+            return self._decoder(artifact)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Cannot decode cached alignment %s: %s",
+                self._compose_key(video, slides),
+                exc,
+            )
+            return None
+
+    def put(
+        self,
+        video: VideoKey,
+        slides: SlidesKey,
+        cfg: dict[str, Any],
+        alignment,
+    ) -> None:
+        payload = {
+            "version": 1,
+            "kind": "alignment",
+            "video": asdict(video),
+            "slides": asdict(slides),
+            "config": cfg,
+            "artifact": self._encoder(alignment),
+        }
+        self._store(self._compose_key(video, slides), payload)
+
+
+# ---------------------------------------------------------------------------
+# Cache inspection / housekeeping
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CacheEntrySummary:
+    """Describes a single cache entry for the ``cache list`` command."""
+
+    subdir: str
+    key: str
+    path: Path
+    size: int
+
+
+def iter_entries(cache_root: Path) -> list[CacheEntrySummary]:
+    """Return a flat list of cache entries across all known subdirectories."""
+    summaries: list[CacheEntrySummary] = []
+    for sub in CACHE_SUBDIRS:
+        d = cache_root / sub
+        if not d.exists():
+            continue
+        for entry in sorted(d.glob("*.json")):
+            try:
+                size = entry.stat().st_size
+            except OSError:
+                continue
+            summaries.append(CacheEntrySummary(subdir=sub, key=entry.stem, path=entry, size=size))
+    return summaries
+
+
+def clear(cache_root: Path) -> int:
+    """Remove all cache entries. Returns the number of files deleted."""
+    removed = 0
+    for entry in iter_entries(cache_root):
+        try:
+            entry.path.unlink()
+            removed += 1
+        except OSError as exc:
+            logger.warning("Cannot remove %s: %s", entry.path, exc)
+    return removed
+
+
+def prune(cache_root: Path, *, max_age_days: float | None = None) -> int:
+    """Remove cache entries older than *max_age_days*.
+
+    If *max_age_days* is ``None`` the function is a no-op and returns 0.
+    """
+    if max_age_days is None:
+        return 0
+
+    import time
+
+    cutoff = time.time() - max_age_days * 86400.0
+    removed = 0
+    for entry in iter_entries(cache_root):
+        try:
+            if entry.path.stat().st_mtime < cutoff:
+                entry.path.unlink()
+                removed += 1
+        except OSError as exc:
+            logger.warning("Cannot prune %s: %s", entry.path, exc)
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Encode/decode helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode_transitions(events) -> list[dict]:
+    return [
+        {
+            "timestamp": e.timestamp,
+            "peak_diff": e.peak_diff,
+            "confidence": e.confidence,
+            "num_frames": e.num_frames,
+            "source_part_index": e.source_part_index,
+            "local_timestamp": e.local_timestamp,
+        }
+        for e in events
+    ]
+
+
+def _decode_transitions(data: list[dict]):
+    from clm.voiceover.keyframes import TransitionEvent
+
+    return [
+        TransitionEvent(
+            timestamp=d["timestamp"],
+            peak_diff=d["peak_diff"],
+            confidence=d["confidence"],
+            num_frames=d["num_frames"],
+            source_part_index=d.get("source_part_index", 0),
+            local_timestamp=d.get("local_timestamp"),
+        )
+        for d in data
+    ]
+
+
+def _encode_timeline(timeline) -> list[dict]:
+    return [
+        {
+            "slide_index": e.slide_index,
+            "start_time": e.start_time,
+            "end_time": e.end_time,
+            "match_score": e.match_score,
+            "is_header": e.is_header,
+        }
+        for e in timeline
+    ]
+
+
+def _decode_timeline(data: list[dict]):
+    from clm.voiceover.matcher import TimelineEntry
+
+    return [
+        TimelineEntry(
+            slide_index=d["slide_index"],
+            start_time=d["start_time"],
+            end_time=d["end_time"],
+            match_score=d["match_score"],
+            is_header=d.get("is_header", False),
+        )
+        for d in data
+    ]
+
+
+def _encode_alignment(alignment) -> dict:
+    return {
+        "slide_notes": {
+            str(idx): {
+                "slide_index": notes.slide_index,
+                "segments": list(notes.segments),
+                "revisited_segments": [list(r) for r in notes.revisited_segments],
+            }
+            for idx, notes in alignment.slide_notes.items()
+        },
+        "unassigned_segments": [
+            {
+                "start": s.start,
+                "end": s.end,
+                "text": s.text,
+                "source_part_index": s.source_part_index,
+            }
+            for s in alignment.unassigned_segments
+        ],
+    }
+
+
+def _decode_alignment(data: dict):
+    from clm.voiceover.aligner import AlignmentResult, SlideNotes
+    from clm.voiceover.transcribe import TranscriptSegment
+
+    slide_notes = {}
+    for idx_str, payload in data.get("slide_notes", {}).items():
+        idx = int(idx_str)
+        slide_notes[idx] = SlideNotes(
+            slide_index=payload["slide_index"],
+            segments=list(payload.get("segments", [])),
+            revisited_segments=[list(r) for r in payload.get("revisited_segments", [])],
+        )
+
+    unassigned = [
+        TranscriptSegment(
+            start=s["start"],
+            end=s["end"],
+            text=s["text"],
+            source_part_index=s.get("source_part_index", 0),
+        )
+        for s in data.get("unassigned_segments", [])
+    ]
+
+    return AlignmentResult(slide_notes=slide_notes, unassigned_segments=unassigned)
+
+
+# ---------------------------------------------------------------------------
+# Policy + cache-aware pipeline helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CachePolicy:
+    """Controls cache participation during a pipeline invocation.
+
+    - ``enabled=False`` bypasses the cache entirely (no reads, no writes).
+    - ``refresh=True`` forces a miss on read but still writes the new result.
+    - ``cache_root`` overrides the default ``.clm/voiceover-cache/`` location.
+    """
+
+    enabled: bool = True
+    refresh: bool = False
+    cache_root: Path | None = None
+
+    @classmethod
+    def disabled(cls) -> CachePolicy:
+        return cls(enabled=False)
+
+    def resolve_root(self, base_dir: str | Path | None = None) -> Path:
+        if self.cache_root is not None:
+            return self.cache_root
+        return resolve_cache_root(base_dir)
+
+
+def cached_transcribe(
+    video_path: str | Path,
+    *,
+    policy: CachePolicy,
+    base_dir: str | Path | None = None,
+    transcribe_fn: Callable[[], Any],
+    backend_name: str,
+    model_size: str,
+    language: str | None,
+    device: str,
+):
+    """Run transcription with cache lookup + write-back.
+
+    ``transcribe_fn`` is a thunk that returns a fresh ``Transcript`` when
+    invoked. It's only called on a miss. Keeps this helper agnostic to
+    the underlying ASR backend.
+    """
+    cfg = TranscribeConfig(
+        backend=backend_name,
+        model=model_size,
+        language=language,
+        device_class=TranscribeConfig.normalize_device(device),
+    )
+
+    if not policy.enabled:
+        return transcribe_fn(), False
+
+    video_key = VideoKey.from_path(video_path)
+    cache = TranscriptsCache(policy.resolve_root(base_dir))
+
+    if not policy.refresh:
+        hit = cache.get(video_key, cfg)
+        if hit is not None:
+            logger.info("Transcript cache hit for %s", Path(video_path).name)
+            return hit, True
+
+    transcript = transcribe_fn()
+    cache.put(video_key, cfg, transcript)
+    return transcript, False
+
+
+def cached_detect(
+    video_path: str | Path,
+    *,
+    policy: CachePolicy,
+    base_dir: str | Path | None = None,
+    detect_fn: Callable[[], Any],
+    sample_fps: float = 2.0,
+    threshold_factor: float = 3.0,
+    percentile: float = 95.0,
+    merge_window: float = 3.0,
+):
+    """Run transition detection with cache lookup + write-back.
+
+    ``detect_fn`` returns the list of :class:`TransitionEvent` objects on a
+    cache miss.
+    """
+    cfg = DetectConfig(
+        sample_fps=sample_fps,
+        threshold_factor=threshold_factor,
+        percentile=percentile,
+        merge_window=merge_window,
+    )
+
+    if not policy.enabled:
+        return detect_fn(), False
+
+    video_key = VideoKey.from_path(video_path)
+    cache = TransitionsCache(policy.resolve_root(base_dir))
+
+    if not policy.refresh:
+        hit = cache.get(video_key, cfg)
+        if hit is not None:
+            logger.info("Transitions cache hit for %s", Path(video_path).name)
+            return hit, True
+
+    events = detect_fn()
+    cache.put(video_key, cfg, events)
+    return events, False
+
+
+def cached_timeline(
+    video_path: str | Path,
+    slide_path: str | Path,
+    *,
+    policy: CachePolicy,
+    base_dir: str | Path | None = None,
+    timeline_fn: Callable[[], Any],
+    cfg: dict[str, Any],
+):
+    """Run timeline matching with cache lookup + write-back.
+
+    The cache key combines video and slides fingerprints. ``cfg`` is the
+    match configuration (lang, frame_offset, etc.) serialized as a dict.
+    """
+    if not policy.enabled:
+        return timeline_fn(), False
+
+    video_key = VideoKey.from_path(video_path)
+    slides_key = SlidesKey.from_path(slide_path)
+    cache = TimelinesCache(policy.resolve_root(base_dir))
+
+    if not policy.refresh:
+        hit = cache.get(video_key, slides_key, cfg)
+        if hit is not None:
+            logger.info("Timeline cache hit for %s", Path(video_path).name)
+            return hit, True
+
+    timeline = timeline_fn()
+    cache.put(video_key, slides_key, cfg, timeline)
+    return timeline, False
+
+
+def cached_alignment(
+    video_path: str | Path,
+    slide_path: str | Path,
+    *,
+    policy: CachePolicy,
+    base_dir: str | Path | None = None,
+    alignment_fn: Callable[[], Any],
+    cfg: dict[str, Any],
+):
+    """Run transcript-to-slide alignment with cache lookup + write-back."""
+    if not policy.enabled:
+        return alignment_fn(), False
+
+    video_key = VideoKey.from_path(video_path)
+    slides_key = SlidesKey.from_path(slide_path)
+    cache = AlignmentsCache(policy.resolve_root(base_dir))
+
+    if not policy.refresh:
+        hit = cache.get(video_key, slides_key, cfg)
+        if hit is not None:
+            logger.info("Alignment cache hit for %s", Path(video_path).name)
+            return hit, True
+
+    alignment = alignment_fn()
+    cache.put(video_key, slides_key, cfg, alignment)
+    return alignment, False

--- a/src/clm/voiceover/compare.py
+++ b/src/clm/voiceover/compare.py
@@ -1,0 +1,192 @@
+"""Evaluate voiceover content between two slide-file revisions.
+
+Read-only sibling to :mod:`clm.voiceover.port`. Matches slides between
+source and target, then asks the LLM to label the bullet-level
+relationship on each matched pair (``covered`` / ``rewritten`` /
+``added`` / ``dropped`` / ``manual_review``). The primitive here is
+:func:`judge_slide_pair`; the higher-level ``clm voiceover compare``
+CLI command composes it across an entire file and aggregates
+:class:`CompareReport`.
+
+Shares the per-slide packing and structured-response schema with
+:mod:`clm.voiceover.port` via :mod:`clm.voiceover.bullet_schema` — the
+only things that differ between port and compare are the prompt
+(``compare_{lang}.md`` vs. ``port_{lang}.md``) and the disposition of
+the result (written vs. reported).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.voiceover.bullet_schema import (
+    BulletOutcome,
+    BulletStatus,
+    PerSlidePack,
+    parse_structured_response,
+)
+from clm.voiceover.slide_matcher import MatchKind
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMPARE_MODEL = "anthropic/claude-sonnet-4-6"
+
+
+@dataclass
+class SlideComparison:
+    """Per-slide result of a compare run.
+
+    ``outcomes`` is empty when no LLM call happened (both sides empty,
+    unmatched slide, or an error). ``error`` records a non-raising
+    LLM failure so the report can flag it without aborting.
+    """
+
+    key: str
+    kind: MatchKind
+    target_index: int | None
+    source_index: int | None
+    content_similarity: float = 0.0
+    outcomes: list[BulletOutcome] = field(default_factory=list)
+    notes: str | None = None
+    error: str | None = None
+
+    def status_counts(self) -> dict[BulletStatus, int]:
+        tot: dict[BulletStatus, int] = dict.fromkeys(BulletStatus, 0)
+        for outcome in self.outcomes:
+            tot[outcome.status] = tot.get(outcome.status, 0) + 1
+        return tot
+
+    def to_json(self) -> dict:
+        return {
+            "key": self.key,
+            "kind": self.kind.value,
+            "target_index": self.target_index,
+            "source_index": self.source_index,
+            "content_similarity": self.content_similarity,
+            "outcomes": [o.to_json() for o in self.outcomes],
+            "notes": self.notes,
+            "error": self.error,
+        }
+
+
+@dataclass
+class CompareReport:
+    """Aggregated result of ``clm voiceover compare``."""
+
+    source: Path
+    target: Path
+    language: str
+    slides: list[SlideComparison] = field(default_factory=list)
+
+    def status_totals(self) -> dict[BulletStatus, int]:
+        tot: dict[BulletStatus, int] = dict.fromkeys(BulletStatus, 0)
+        for comp in self.slides:
+            for outcome in comp.outcomes:
+                tot[outcome.status] = tot.get(outcome.status, 0) + 1
+        return tot
+
+    def kind_totals(self) -> dict[MatchKind, int]:
+        tot: dict[MatchKind, int] = dict.fromkeys(MatchKind, 0)
+        for comp in self.slides:
+            tot[comp.kind] = tot.get(comp.kind, 0) + 1
+        return tot
+
+    def to_json(self) -> dict:
+        totals = self.status_totals()
+        kinds = self.kind_totals()
+        return {
+            "source": str(self.source),
+            "target": str(self.target),
+            "language": self.language,
+            "slide_count": len(self.slides),
+            "status_totals": {s.value: totals[s] for s in BulletStatus},
+            "kind_totals": {k.value: kinds[k] for k in MatchKind},
+            "slides": [c.to_json() for c in self.slides],
+        }
+
+
+def _load_compare_prompt(language: str) -> str:
+    prompt_dir = Path(__file__).parent / "prompts"
+    candidate = prompt_dir / f"compare_{language}.md"
+    if candidate.exists():
+        return candidate.read_text(encoding="utf-8")
+    fallback = prompt_dir / "compare_en.md"
+    if fallback.exists():
+        return fallback.read_text(encoding="utf-8")
+    raise FileNotFoundError(f"No compare prompt found for language '{language}'")
+
+
+async def judge_slide_pair(
+    prior_bullets: str,
+    baseline_bullets: str,
+    slide_content_head: str,
+    slide_content_prior: str | None,
+    language: str,
+    content_changed: bool,
+    *,
+    slide_id: str = "",
+    model: str = DEFAULT_COMPARE_MODEL,
+    temperature: float = 0.1,
+    api_base: str | None = None,
+    api_key: str | None = None,
+    langfuse_context: dict | None = None,
+) -> tuple[list[BulletOutcome], str | None, str | None]:
+    """Ask the LLM to label the relationship between two bullet sets.
+
+    Returns ``(outcomes, notes, error)``. When both sides are empty,
+    no LLM call is made and the outcomes list is empty. ``error`` is
+    populated on non-raising failures (network, malformed JSON); the
+    caller should surface it in the final report rather than abort.
+    """
+    from clm.infrastructure.llm.client import LLMError, _build_client
+
+    if not prior_bullets.strip() and not baseline_bullets.strip():
+        return [], None, None
+
+    pack = PerSlidePack(
+        slide_id=slide_id,
+        language=language,
+        baseline_bullets=baseline_bullets,
+        prior_bullets=prior_bullets,
+        slide_content_head=slide_content_head,
+        slide_content_prior=slide_content_prior if content_changed else None,
+        content_changed=content_changed,
+    )
+    system_prompt = _load_compare_prompt(language)
+    user_message = pack.build_user_message()
+
+    client = _build_client(api_base=api_base, api_key=api_key)
+
+    logger.debug(
+        "judge_slide_pair slide=%s baseline=%d chars prior=%d chars changed=%s",
+        slide_id,
+        len(baseline_bullets),
+        len(prior_bullets),
+        content_changed,
+    )
+
+    create_kwargs: dict = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+        "temperature": temperature,
+    }
+    if langfuse_context:
+        create_kwargs.update(langfuse_context)
+
+    try:
+        response = await client.chat.completions.create(**create_kwargs)
+    except Exception as exc:
+        err = f"Compare LLM call failed for slide {slide_id}: {exc}"
+        logger.warning("%s", err)
+        if isinstance(exc, LLMError):
+            raise
+        return [], None, err
+
+    raw = str(response.choices[0].message.content).strip()
+    _, outcomes, notes = parse_structured_response(raw, default_bullets="")
+    return outcomes, notes, None

--- a/src/clm/voiceover/narrative_commits.py
+++ b/src/clm/voiceover/narrative_commits.py
@@ -1,0 +1,247 @@
+"""Narrative-commit heuristic spike.
+
+Throwaway module for the ``clm voiceover debug voiceover-commits``
+subcommand. Walks the git history of a slide file and flags commits whose
+diff is dominated by changes to narrative cells (tagged ``voiceover`` or
+``notes``). Consecutive narrative-heavy commits are collapsed into
+"runs", and each run yields two candidate revisions (pre-run parent and
+post-run tip) that identify-rev can score against the video fingerprint.
+
+Promoted from spike to production if the heuristic proves useful on real
+course history; see ``docs/proposals/VOICEOVER_BACKFILL.md`` §6.2.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from clm.notebooks.slide_parser import Cell, parse_cells
+
+
+@dataclass(frozen=True)
+class CommitInfo:
+    sha: str
+    parent_sha: str | None
+    date: datetime
+    subject: str
+
+
+@dataclass(frozen=True)
+class CommitMetrics:
+    commit: CommitInfo
+    narrative_delta: int
+    content_delta: int
+    ratio: float
+    is_narrative_heavy: bool
+
+
+@dataclass(frozen=True)
+class NarrativeRun:
+    run_id: int
+    commit_metrics: list[CommitMetrics]
+    pre_run_sha: str | None
+    post_run_sha: str
+
+
+def classify_cells(cells: list[Cell]) -> tuple[int, int]:
+    """Return ``(narrative_chars, content_chars)`` summed across cells.
+
+    Narrative = cells tagged ``voiceover`` or ``notes`` (both count, since
+    pre-voiceover-era commits used ``notes``). Content = everything else.
+    j2 directives are skipped (they rarely carry recording-relevant churn).
+    """
+    narrative = 0
+    content = 0
+    for cell in cells:
+        if cell.metadata.is_j2:
+            continue
+        chars = len(cell.content)
+        if cell.metadata.is_narrative:
+            narrative += chars
+        else:
+            content += chars
+    return narrative, content
+
+
+def compute_ratio(narrative_delta: int, content_delta: int) -> float:
+    """Narrative share of total churn, with a +1 denominator guard."""
+    return narrative_delta / (narrative_delta + content_delta + 1)
+
+
+def compute_commit_metrics(
+    commit: CommitInfo,
+    parent_text: str | None,
+    commit_text: str | None,
+    *,
+    threshold: float = 0.7,
+    floor: int = 50,
+) -> CommitMetrics:
+    """Compare parent-vs-commit cell character totals.
+
+    ``parent_text`` may be None (root commit or file added this commit).
+    ``commit_text`` may be None (file deleted this commit) — uncommon for
+    slide files but we tolerate it.
+
+    The delta is a signed-magnitude approximation of churn: we compare
+    total characters in narrative vs content cells between the two
+    versions. This undercounts reshuffling (cells moved without edits
+    show zero delta), but for the spike that's acceptable — recording
+    sessions produce substantive narrative additions, not reshuffles.
+    """
+    parent_cells = parse_cells(parent_text) if parent_text else []
+    commit_cells = parse_cells(commit_text) if commit_text else []
+
+    n_before, c_before = classify_cells(parent_cells)
+    n_after, c_after = classify_cells(commit_cells)
+
+    narrative_delta = abs(n_after - n_before)
+    content_delta = abs(c_after - c_before)
+    ratio = compute_ratio(narrative_delta, content_delta)
+    heavy = ratio >= threshold and narrative_delta >= floor
+
+    return CommitMetrics(
+        commit=commit,
+        narrative_delta=narrative_delta,
+        content_delta=content_delta,
+        ratio=ratio,
+        is_narrative_heavy=heavy,
+    )
+
+
+def collapse_runs(metrics: list[CommitMetrics]) -> list[NarrativeRun]:
+    """Collapse consecutive narrative-heavy commits into runs.
+
+    ``metrics`` must be in chronological order (oldest → newest). Returns
+    runs in the same order, each with its pre-run parent and post-run tip.
+    """
+    runs: list[NarrativeRun] = []
+    current: list[CommitMetrics] = []
+    next_id = 1
+
+    def flush() -> None:
+        nonlocal next_id
+        if not current:
+            return
+        runs.append(
+            NarrativeRun(
+                run_id=next_id,
+                commit_metrics=list(current),
+                pre_run_sha=current[0].commit.parent_sha,
+                post_run_sha=current[-1].commit.sha,
+            )
+        )
+        next_id += 1
+        current.clear()
+
+    for m in metrics:
+        if m.is_narrative_heavy:
+            current.append(m)
+        else:
+            flush()
+    flush()
+
+    return runs
+
+
+def _git_toplevel(path: Path) -> Path:
+    target = path.resolve()
+    cwd = target.parent if target.is_file() else target
+    out = subprocess.check_output(
+        ["git", "-C", str(cwd), "rev-parse", "--show-toplevel"],
+        text=True,
+        encoding="utf-8",
+    ).strip()
+    return Path(out)
+
+
+def walk_file_history(
+    path: Path,
+    *,
+    since: str | None = None,
+    limit: int | None = None,
+) -> list[CommitInfo]:
+    """Return commits touching ``path``, chronological (oldest → newest)."""
+    repo_root = _git_toplevel(path)
+    rel = path.resolve().relative_to(repo_root)
+
+    cmd = [
+        "git",
+        "-C",
+        str(repo_root),
+        "log",
+        "--follow",
+        "--format=%H|%P|%aI|%s",
+    ]
+    if since:
+        cmd.append(f"--since={since}")
+    if limit:
+        cmd.extend(["-n", str(limit)])
+    cmd.append("--")
+    cmd.append(rel.as_posix())
+
+    out = subprocess.check_output(cmd, text=True, encoding="utf-8")
+    commits: list[CommitInfo] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("|", 3)
+        if len(parts) != 4:
+            continue
+        sha, parents, date_str, subject = parts
+        parent_sha = parents.split()[0] if parents.strip() else None
+        try:
+            date = datetime.fromisoformat(date_str)
+        except ValueError:
+            continue
+        commits.append(CommitInfo(sha=sha, parent_sha=parent_sha, date=date, subject=subject))
+
+    return list(reversed(commits))
+
+
+def get_file_at_rev(rev: str, path: Path) -> str | None:
+    """Return the file's content at ``rev``, or None if it doesn't exist there."""
+    repo_root = _git_toplevel(path)
+    rel = path.resolve().relative_to(repo_root)
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{rev}:{rel.as_posix()}"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def scan_slide_file(
+    path: Path,
+    *,
+    since: str | None = None,
+    limit: int = 50,
+    threshold: float = 0.7,
+    floor: int = 50,
+) -> tuple[list[CommitMetrics], list[NarrativeRun]]:
+    """End-to-end scan: walk history, score each commit, collapse runs.
+
+    Convenience entry point for the CLI and integration tests.
+    """
+    commits = walk_file_history(path, since=since, limit=limit)
+    metrics: list[CommitMetrics] = []
+    for c in commits:
+        parent_text = get_file_at_rev(c.parent_sha, path) if c.parent_sha else None
+        commit_text = get_file_at_rev(c.sha, path)
+        metrics.append(
+            compute_commit_metrics(
+                c,
+                parent_text,
+                commit_text,
+                threshold=threshold,
+                floor=floor,
+            )
+        )
+    runs = collapse_runs(metrics)
+    return metrics, runs

--- a/src/clm/voiceover/narrative_commits.py
+++ b/src/clm/voiceover/narrative_commits.py
@@ -1,14 +1,19 @@
-"""Narrative-commit heuristic spike.
+"""Narrative-commit heuristic.
 
-Throwaway module for the ``clm voiceover debug voiceover-commits``
-subcommand. Walks the git history of a slide file and flags commits whose
-diff is dominated by changes to narrative cells (tagged ``voiceover`` or
+Walks the git history of a slide file and flags commits whose diff is
+dominated by changes to narrative cells (tagged ``voiceover`` or
 ``notes``). Consecutive narrative-heavy commits are collapsed into
 "runs", and each run yields two candidate revisions (pre-run parent and
-post-run tip) that identify-rev can score against the video fingerprint.
+post-run tip) that ``identify-rev`` scores against the video fingerprint
+as a multiplicative prior alongside sequence-based slide matching.
 
-Promoted from spike to production if the heuristic proves useful on real
-course history; see ``docs/proposals/VOICEOVER_BACKFILL.md`` §6.2.
+Classifier is hunk-based: diff lines are mapped to the owning cell via
+``parse_cells`` line offsets, and added+removed lines are both counted
+per class. This preserves churn signal on rewrites (where a block of
+narrative is replaced by a different block of narrative) that a
+net-char-delta approach loses. See
+``docs/proposals/VOICEOVER_BACKFILL.md`` §6.2 for the empirical finding
+that motivated the upgrade.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
+from difflib import SequenceMatcher
 from pathlib import Path
 
 from clm.notebooks.slide_parser import Cell, parse_cells
@@ -52,6 +58,9 @@ def classify_cells(cells: list[Cell]) -> tuple[int, int]:
     Narrative = cells tagged ``voiceover`` or ``notes`` (both count, since
     pre-voiceover-era commits used ``notes``). Content = everything else.
     j2 directives are skipped (they rarely carry recording-relevant churn).
+
+    Retained as a helper for callers that want aggregate sizes; the
+    commit-level scorer uses :func:`compute_hunk_deltas` instead.
     """
     narrative = 0
     content = 0
@@ -66,6 +75,75 @@ def classify_cells(cells: list[Cell]) -> tuple[int, int]:
     return narrative, content
 
 
+def _line_to_cell(cells: list[Cell], num_lines: int) -> list[Cell | None]:
+    """Build a 0-indexed array mapping each line to its owning cell.
+
+    ``Cell.line_number`` is the 1-based line of the header. Cell *i*
+    owns lines ``[cells[i].line_number - 1, cells[i+1].line_number - 1)``;
+    the last cell owns through EOF. Lines before the first cell header
+    (rare — shebangs or leading whitespace) are unowned (``None``).
+    """
+    mapping: list[Cell | None] = [None] * num_lines
+    for i, cell in enumerate(cells):
+        start = max(cell.line_number - 1, 0)
+        end = cells[i + 1].line_number - 1 if i + 1 < len(cells) else num_lines
+        for li in range(start, min(end, num_lines)):
+            mapping[li] = cell
+    return mapping
+
+
+def _classify_line(cell: Cell | None) -> str | None:
+    """Return ``"narrative"``, ``"content"``, or ``None`` for a line."""
+    if cell is None or cell.metadata.is_j2:
+        return None
+    return "narrative" if cell.metadata.is_narrative else "content"
+
+
+def compute_hunk_deltas(
+    parent_text: str | None,
+    commit_text: str | None,
+) -> tuple[int, int]:
+    """Count added+removed lines per cell class between two file versions.
+
+    Hunk-based replacement for net-char-delta: each diff line is charged
+    against the cell it belongs to in its respective file version, and
+    both sides of a rewrite (deletes from parent + inserts in commit)
+    are counted. This preserves churn that a net-size comparison hides.
+
+    Returns ``(narrative_lines, content_lines)``.
+    """
+    parent_lines = (parent_text or "").splitlines()
+    commit_lines = (commit_text or "").splitlines()
+
+    parent_cells = parse_cells(parent_text) if parent_text else []
+    commit_cells = parse_cells(commit_text) if commit_text else []
+
+    parent_map = _line_to_cell(parent_cells, len(parent_lines))
+    commit_map = _line_to_cell(commit_cells, len(commit_lines))
+
+    narrative = 0
+    content = 0
+
+    sm = SequenceMatcher(a=parent_lines, b=commit_lines, autojunk=False)
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "equal":
+            continue
+        for li in range(i1, i2):
+            cls = _classify_line(parent_map[li])
+            if cls == "narrative":
+                narrative += 1
+            elif cls == "content":
+                content += 1
+        for lj in range(j1, j2):
+            cls = _classify_line(commit_map[lj])
+            if cls == "narrative":
+                narrative += 1
+            elif cls == "content":
+                content += 1
+
+    return narrative, content
+
+
 def compute_ratio(narrative_delta: int, content_delta: int) -> float:
     """Narrative share of total churn, with a +1 denominator guard."""
     return narrative_delta / (narrative_delta + content_delta + 1)
@@ -77,28 +155,21 @@ def compute_commit_metrics(
     commit_text: str | None,
     *,
     threshold: float = 0.7,
-    floor: int = 50,
+    floor: int = 5,
 ) -> CommitMetrics:
-    """Compare parent-vs-commit cell character totals.
+    """Score a commit by hunk-based narrative vs content churn.
 
     ``parent_text`` may be None (root commit or file added this commit).
     ``commit_text`` may be None (file deleted this commit) — uncommon for
     slide files but we tolerate it.
 
-    The delta is a signed-magnitude approximation of churn: we compare
-    total characters in narrative vs content cells between the two
-    versions. This undercounts reshuffling (cells moved without edits
-    show zero delta), but for the spike that's acceptable — recording
-    sessions produce substantive narrative additions, not reshuffles.
+    Deltas are counts of diff lines mapped to each class via the cell
+    they belong to, with both sides of a replace counted. A commit is
+    narrative-heavy if ``ratio >= threshold`` AND
+    ``narrative_delta >= floor`` (the floor filters trivial whitespace
+    commits while keeping small but intentional note additions).
     """
-    parent_cells = parse_cells(parent_text) if parent_text else []
-    commit_cells = parse_cells(commit_text) if commit_text else []
-
-    n_before, c_before = classify_cells(parent_cells)
-    n_after, c_after = classify_cells(commit_cells)
-
-    narrative_delta = abs(n_after - n_before)
-    content_delta = abs(c_after - c_before)
+    narrative_delta, content_delta = compute_hunk_deltas(parent_text, commit_text)
     ratio = compute_ratio(narrative_delta, content_delta)
     heavy = ratio >= threshold and narrative_delta >= floor
 
@@ -223,7 +294,7 @@ def scan_slide_file(
     since: str | None = None,
     limit: int = 50,
     threshold: float = 0.7,
-    floor: int = 50,
+    floor: int = 5,
 ) -> tuple[list[CommitMetrics], list[NarrativeRun]]:
     """End-to-end scan: walk history, score each commit, collapse runs.
 

--- a/src/clm/voiceover/port.py
+++ b/src/clm/voiceover/port.py
@@ -1,0 +1,183 @@
+"""Port voiceover content from one slide revision onto another.
+
+Sibling to :mod:`clm.voiceover.merge` with different invariants: the
+input is already clean (prior bullets were polished by an earlier sync),
+so there's no noise filtering to do — the job is integration, not
+cleanup. The module owns :func:`polish_and_port`, the primitive that
+runs one per-slide LLM call; the higher-level ``port-voiceover`` CLI
+command composes it across an entire file.
+
+Shares the per-slide input packing and the structured response schema
+with the future ``clm voiceover compare`` judge via
+:mod:`clm.voiceover.bullet_schema`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.voiceover.bullet_schema import (
+    BulletOutcome,
+    PerSlidePack,
+    parse_structured_response,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT_MODEL = "anthropic/claude-sonnet-4-6"
+
+
+@dataclass
+class PortResult:
+    """Result of porting prior voiceover onto a HEAD slide.
+
+    ``bullets`` is the merged bullet text ready to be written to the
+    voiceover cell. ``outcomes`` is the per-bullet provenance list
+    from the LLM. ``notes`` is an optional free-text summary. When the
+    LLM call fails or returns an unusable response, ``bullets`` falls
+    back to the baseline (or the prior, if baseline is empty) and
+    ``error`` describes what happened.
+    """
+
+    slide_id: str
+    bullets: str
+    outcomes: list[BulletOutcome] = field(default_factory=list)
+    notes: str | None = None
+    error: str | None = None
+
+
+def _load_system_prompt(language: str) -> str:
+    prompt_dir = Path(__file__).parent / "prompts"
+    candidate = prompt_dir / f"port_{language}.md"
+    if candidate.exists():
+        return candidate.read_text(encoding="utf-8")
+    fallback = prompt_dir / "port_en.md"
+    if fallback.exists():
+        return fallback.read_text(encoding="utf-8")
+    raise FileNotFoundError(f"No port prompt found for language '{language}'")
+
+
+def _fallback_bullets(baseline: str, prior: str) -> str:
+    """Pick the best-effort output when the LLM call is skipped or fails."""
+    base = baseline.strip()
+    pri = prior.strip()
+    if base and pri:
+        return base  # Conservative: keep HEAD, don't overwrite with unmerged prior.
+    if base:
+        return base
+    return pri
+
+
+async def polish_and_port(
+    baseline_bullets: str,
+    prior_voiceover: str,
+    slide_content_head: str,
+    slide_content_prior: str | None,
+    language: str,
+    content_changed: bool,
+    *,
+    slide_id: str = "",
+    model: str = DEFAULT_PORT_MODEL,
+    temperature: float = 0.3,
+    api_base: str | None = None,
+    api_key: str | None = None,
+    langfuse_context: dict | None = None,
+) -> PortResult:
+    """Port prior voiceover onto a HEAD slide via one LLM call.
+
+    Per the proposal §3.3: different invariants from ``polish_and_merge``
+    — no noise filtering, because the prior voiceover is already clean.
+    The call must preserve every substantive prior bullet (porting,
+    not summarising) and must respect HEAD baseline content when
+    present (merge around it rather than over it).
+
+    Args:
+        baseline_bullets: Voiceover already present at HEAD ("" when empty).
+        prior_voiceover: The polished voiceover from the source revision.
+        slide_content_head: HEAD slide text (for LLM context).
+        slide_content_prior: Source-revision slide text. ``None`` means
+            "unchanged or unavailable" — combined with ``content_changed``
+            to decide whether to pass prior content to the prompt.
+        language: Language code ("de" or "en").
+        content_changed: True when the slide's visible content changed
+            between source and target. Signals to the LLM that prior
+            bullets may no longer fit.
+        slide_id: Identifier for traceability.
+        model: LLM model identifier.
+        temperature: Sampling temperature.
+        api_base: API base URL (e.g. OpenRouter).
+        api_key: API key override.
+        langfuse_context: Optional Langfuse kwargs forwarded to ``create()``.
+
+    Returns:
+        PortResult with merged bullets and per-bullet outcomes.
+    """
+    from clm.infrastructure.llm.client import LLMError, _build_client
+
+    # No LLM call needed when both sides are empty.
+    if not prior_voiceover.strip() and not baseline_bullets.strip():
+        return PortResult(slide_id=slide_id, bullets="", outcomes=[])
+
+    # If there's nothing to port, degrade to baseline unchanged.
+    if not prior_voiceover.strip():
+        return PortResult(slide_id=slide_id, bullets=baseline_bullets.strip(), outcomes=[])
+
+    pack = PerSlidePack(
+        slide_id=slide_id,
+        language=language,
+        baseline_bullets=baseline_bullets,
+        prior_bullets=prior_voiceover,
+        slide_content_head=slide_content_head,
+        slide_content_prior=slide_content_prior if content_changed else None,
+        content_changed=content_changed,
+    )
+    system_prompt = _load_system_prompt(language)
+    user_message = pack.build_user_message()
+
+    client = _build_client(api_base=api_base, api_key=api_key)
+
+    logger.debug(
+        "polish_and_port slide=%s baseline=%d chars prior=%d chars changed=%s",
+        slide_id,
+        len(baseline_bullets),
+        len(prior_voiceover),
+        content_changed,
+    )
+
+    create_kwargs: dict = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+        "temperature": temperature,
+    }
+    if langfuse_context:
+        create_kwargs.update(langfuse_context)
+
+    try:
+        response = await client.chat.completions.create(**create_kwargs)
+    except Exception as exc:
+        err = f"Port LLM call failed for slide {slide_id}: {exc}"
+        logger.warning("%s", err)
+        fallback = _fallback_bullets(baseline_bullets, prior_voiceover)
+        if isinstance(exc, LLMError):
+            raise
+        return PortResult(slide_id=slide_id, bullets=fallback, error=err)
+
+    raw = str(response.choices[0].message.content).strip()
+    fallback = _fallback_bullets(baseline_bullets, prior_voiceover)
+    bullets, outcomes, notes = parse_structured_response(raw, default_bullets=fallback)
+
+    if not bullets.strip():
+        logger.warning("polish_and_port returned empty bullets for %s; using fallback", slide_id)
+        bullets = fallback
+
+    return PortResult(
+        slide_id=slide_id,
+        bullets=bullets,
+        outcomes=outcomes,
+        notes=notes,
+    )

--- a/src/clm/voiceover/prompts/compare_de.md
+++ b/src/clm/voiceover/prompts/compare_de.md
@@ -1,0 +1,64 @@
+Du bist ein erfahrener Reviewer und vergleichst zwei Versionen von
+Voiceover-Inhalten fuer Schulungsfolien. Du erhaeltst zwei
+Bullet-Listen pro Folie und erstellst eine strukturierte, reine
+Leseauswertung — du schreibst nichts um und merge nichts.
+
+Deine Eingaben fuer jede Folie:
+1. SLIDE CONTENT fuer das Ziel (aktuelle HEAD-Version).
+2. Optional SLIDE CONTENT fuer die Quelle (nur vorhanden, wenn sich die
+   Folie zwischen beiden Revisionen tatsaechlich geaendert hat).
+3. PRIOR BULLETS — das "Vorher"- bzw. Referenz-Voiceover.
+4. BASELINE BULLETS — das "Nachher"- bzw. aktuelle Voiceover in HEAD.
+   Das ist die Seite, die bewertet wird.
+
+Deine Aufgabe: Jeden Bullet einer Seite dem Gegenstueck auf der anderen
+Seite zuordnen (falls vorhanden) und die Beziehung klassifizieren. Das
+ist eine Auswertung, keine Ueberarbeitung — du darfst keinen gemergten
+Output erzeugen; das Feld "bullets" in der Antwort ist schlicht die
+unveraenderte BASELINE, damit die nachgelagerten Tools ein einheitliches
+Format erhalten.
+
+Kategorien:
+- `covered` — derselbe Gedanke steht auf beiden Seiten mit im
+  Wesentlichen gleichem Inhalt (abgesehen von Stil).
+- `rewritten` — derselbe Gedanke steht auf beiden Seiten, wurde aber
+  inhaltlich bearbeitet. Schreibe eine Zeile Note, die die
+  inhaltliche Aenderung beschreibt (z.B. "korrigiert: extend aendert
+  in-place, gibt keine neue Liste zurueck").
+- `added` — ein Bullet erscheint in der Baseline (HEAD), hat aber kein
+  Gegenstueck im Prior. Gib eine kurze Charakterisierung in der Note an.
+- `dropped` — ein Bullet war im Prior, erscheint aber nicht in der
+  Baseline. Kurze Charakterisierung in der Note angeben; besonders
+  flaggen, wenn das Weglassen versehentlich wirkt.
+- `manual_review` — du kannst nicht sicher klassifizieren. Erklaere in
+  der Note, was mehrdeutig ist.
+
+Regeln:
+1. Sei konservativ bei `covered` vs. `rewritten`. Rein stilistische
+   Umformulierungen sind `covered`; jede inhaltliche oder didaktische
+   Differenz ist `rewritten`.
+2. Erfinde keine Gegenstuecke. Wenn du wirklich keine Zuordnung findest,
+   nutze `added` oder `dropped` statt ein schlechtes Pairing zu erzwingen.
+3. Gleiche Sprache wie die Eingabe.
+
+Gib deine Antwort als JSON-Objekt mit folgendem Schema zurueck:
+{
+  "bullets": "- Baseline-Bullet 1\n- Baseline-Bullet 2\n...",
+  "outcomes": [
+    {
+      "status": "covered" | "rewritten" | "added" | "dropped" | "manual_review",
+      "target": "- Baseline-(HEAD-)Bullet (weglassen bei dropped)",
+      "source": "- Prior-Bullet (weglassen bei added)",
+      "note": "kurze Erklaerung, pflicht bei rewritten/added/dropped/manual_review"
+    }
+  ],
+  "notes": "optionale Freitext-Zusammenfassung der Gesamt-Diff"
+}
+
+Regeln fuer die JSON-Antwort:
+- "bullets" muss die BASELINE unveraendert wiedergeben (compare ist
+  read-only).
+- "outcomes" sollte einen Eintrag pro distinktem Mapping enthalten;
+  unveraenderte `covered`-Eintraege sind optional, aber empfohlen wenn
+  die Liste kurz ist.
+- Gib NUR das JSON-Objekt zurueck, keine Markdown-Fences, kein Kommentar.

--- a/src/clm/voiceover/prompts/compare_en.md
+++ b/src/clm/voiceover/prompts/compare_en.md
@@ -1,0 +1,63 @@
+You are an expert reviewer comparing two versions of voiceover content
+for educational course slides. You receive two sets of bullets for each
+slide and produce a structured, read-only evaluation — you do not
+rewrite or merge anything.
+
+Your inputs for each slide are:
+1. SLIDE CONTENT for the target (current HEAD version).
+2. Optionally, SLIDE CONTENT for the source (only provided when the slide
+   actually changed between the two revisions).
+3. PRIOR BULLETS — the "before" or reference voiceover.
+4. BASELINE BULLETS — the "after" or current voiceover at HEAD. This is
+   the side being evaluated.
+
+Your job is to map each bullet on each side to its counterpart on the
+other (if any) and label the relationship. This is an evaluation, not a
+revision — you must not produce merged output; the "bullets" field in
+your response is simply the BASELINE echoed back unchanged for
+downstream tooling convenience.
+
+Categories:
+- `covered` — the same thought appears on both sides with essentially
+  the same content (modulo style).
+- `rewritten` — the same thought appears on both sides but was
+  substantively edited. Include a one-line note describing the
+  substantive change (e.g. "corrected: extend mutates in place, not
+  returns new list").
+- `added` — a bullet appears in the baseline (HEAD) but has no
+  counterpart in the prior. Include a note with a short
+  characterisation.
+- `dropped` — a bullet was in the prior but does not appear in the
+  baseline. Include a note with a short characterisation; flag
+  especially if the drop seems accidental.
+- `manual_review` — you cannot confidently classify. Include a note
+  explaining what's ambiguous.
+
+Rules:
+1. Be conservative on `covered` vs `rewritten`. Reword-only changes are
+   `covered`; any factual or instructional difference is `rewritten`.
+2. Do not fabricate counterparts. If you truly can't find a match, use
+   `added` or `dropped` rather than forcing a low-quality pairing.
+3. Same language as input.
+
+Return your response as a JSON object with the following schema:
+{
+  "bullets": "- baseline bullet 1\n- baseline bullet 2\n...",
+  "outcomes": [
+    {
+      "status": "covered" | "rewritten" | "added" | "dropped" | "manual_review",
+      "target": "- baseline (HEAD) bullet (omit for dropped)",
+      "source": "- prior bullet (omit for added)",
+      "note": "short explanation, required for rewritten/added/dropped/manual_review"
+    }
+  ],
+  "notes": "optional free-text summary of the overall diff"
+}
+
+Rules for the JSON response:
+- "bullets" must echo the BASELINE content unchanged (compare is
+  read-only).
+- "outcomes" should include one entry per distinct mapping; unchanged
+  `covered` entries are optional but recommended when the list is
+  short.
+- Return ONLY the JSON object, no markdown fences, no commentary.

--- a/src/clm/voiceover/prompts/port_de.md
+++ b/src/clm/voiceover/prompts/port_de.md
@@ -1,0 +1,63 @@
+Du bist ein Experte fuer die Bearbeitung von Voiceover-Zellen in
+Schulungskursen. Du portierst Voiceover-Inhalte von einer aelteren
+Folienrevision (der "Quelle") auf die aktuelle Folie in HEAD (das "Ziel").
+Die Quellen-Bullets stammen aus einer echten Trainer-Aufnahme und sind
+bereits aufgeraeumt; deine Aufgabe ist, sie in das Ziel zu integrieren.
+
+Deine Eingaben fuer jede Folie:
+1. SLIDE CONTENT fuer das Ziel (aktuelle HEAD-Version).
+2. Optional SLIDE CONTENT fuer die Quelle (nur vorhanden, wenn sich die
+   Folie zwischen beiden Revisionen tatsaechlich geaendert hat).
+3. PRIOR BULLETS — das bereits polierte Voiceover aus der Quell-Revision.
+4. BASELINE BULLETS — bereits vorhandenes Voiceover in HEAD (kann leer sein).
+
+Invarianten:
+1. Halluziniere nicht. Jeder Bullet in deiner Ausgabe muss aus den Prior-
+   Bullets oder der Baseline stammen. Du darfst leicht umsortieren oder
+   umformulieren; du darfst keine neuen Fakten einfuehren.
+2. Baseline-Content bewahren. Wenn HEAD bereits Voiceover enthaelt, ist
+   dieser fuer die abgedeckten Themen massgeblich — integriere die
+   Prior-Bullets drumherum.
+3. Wenn ein Prior-Bullet der Baseline widerspricht (z.B. Baseline sagt
+   "extend gibt eine neue Liste zurueck", Prior sagt "extend aendert
+   in-place"), uebernimm die Prior-Version und markiere den geaenderten
+   Baseline-Bullet in den Outcomes als `rewritten`.
+4. Wenn sich die Folie zwischen Quelle und Ziel geaendert hat: Verwerfe
+   Prior-Bullets, die nicht mehr zum tatsaechlichen Inhalt der
+   Ziel-Folie passen. Markiere sie in den Outcomes als `dropped` mit
+   kurzer Begruendung.
+5. Wenn du einen Prior-Bullet nicht sicher der neuen Folie zuordnen
+   kannst (z.B. mehrdeutig, nur teilweise relevant), markiere ihn als
+   `manual_review` und behalte ihn im Output, damit ein Mensch
+   entscheiden kann.
+
+Stil:
+- Markdown-Aufzaehlung ("- " Praefix), ein Gedanke pro Bullet.
+- Direkte Studentenansprache, konsistente Zeitform (an der laengeren
+  Seite orientieren; Praesens, wenn beide leer sind).
+- Gleiche Sprache wie die Eingabe (nicht uebersetzen).
+
+Gib deine Antwort als JSON-Objekt mit folgendem Schema zurueck:
+{
+  "bullets": "- Bullet 1\n- Bullet 2\n...",
+  "outcomes": [
+    {
+      "status": "covered" | "rewritten" | "added" | "dropped" | "manual_review",
+      "target": "- Bullet-Text im Output (weglassen bei dropped)",
+      "source": "- Original-Bullet aus Prior oder Baseline (weglassen bei added)",
+      "note": "kurze Erklaerung, pflicht bei rewritten/dropped/manual_review"
+    }
+  ],
+  "notes": "optionale Freitext-Zusammenfassung"
+}
+
+Regeln fuer die JSON-Antwort:
+- "bullets" ist das finale Voiceover fuer diese Folie, ein Bullet pro
+  Zeile mit "- " Praefix. Das ist was auf die Platte geschrieben wird.
+- "outcomes" muss einen Eintrag pro Prior-Bullet UND einen pro
+  geaendertem Baseline-Bullet enthalten. `covered`-Eintraege fuer
+  unveraenderte Baseline-Bullets sind optional — wenn die Liste dadurch
+  zu geraeuschvoll wird, weglassen.
+- "notes" ist optional; nutze es, um auf etwas hinzuweisen, das der
+  Mensch pruefen sollte.
+- Gib NUR das JSON-Objekt zurueck, keine Markdown-Fences, kein Kommentar.

--- a/src/clm/voiceover/prompts/port_en.md
+++ b/src/clm/voiceover/prompts/port_en.md
@@ -1,0 +1,59 @@
+You are an expert editor for educational course voiceover cells. You are
+porting voiceover content from an older slide revision (the "source") onto
+the current slide at HEAD (the "target"). The source bullets were produced
+from a real recording of the trainer and are already cleaned up; your job
+is to integrate them into the target.
+
+Your inputs for each slide are:
+1. SLIDE CONTENT for the target (current HEAD version).
+2. Optionally, SLIDE CONTENT for the source (only provided when the slide
+   actually changed between the two revisions).
+3. PRIOR BULLETS — the already-polished voiceover from the source revision.
+4. BASELINE BULLETS — any voiceover already present at HEAD (may be empty).
+
+Invariants:
+1. Never hallucinate. Every bullet in your output must come from either
+   the prior bullets or the baseline. You may lightly re-order or
+   paraphrase for flow; you may not introduce new facts.
+2. Preserve baseline content. If HEAD already has voiceover, it is
+   authoritative for topics it covers — merge prior bullets around it.
+3. If the prior bullet contradicts the baseline (e.g. baseline says
+   "extend returns a new list", prior says "extend mutates in place"),
+   keep the prior version and mark the changed baseline bullet as
+   `rewritten` in the outcomes.
+4. When the slide changed between source and target: drop prior bullets
+   that no longer fit the target slide's actual content. Mark them
+   `dropped` in the outcomes with a brief explanation.
+5. When you cannot confidently map a prior bullet to the new slide
+   (e.g. ambiguous, partially relevant), mark it `manual_review` and
+   keep it in the output so the human can decide.
+
+Style:
+- Bulleted markdown ("- " prefix), one thought per bullet.
+- Direct student address, consistent tense (match whichever side is
+  longer; default to present tense when both are empty).
+- Same language as input (do not translate).
+
+Return your response as a JSON object with the following schema:
+{
+  "bullets": "- bullet 1\n- bullet 2\n...",
+  "outcomes": [
+    {
+      "status": "covered" | "rewritten" | "added" | "dropped" | "manual_review",
+      "target": "- bullet text in the output (omit for dropped)",
+      "source": "- original bullet from prior or baseline (omit for added)",
+      "note": "short explanation, required for rewritten/dropped/manual_review"
+    }
+  ],
+  "notes": "optional free-text summary of what you did"
+}
+
+Rules for the JSON response:
+- "bullets" is the final voiceover for this slide, one bullet per line
+  with "- " prefix. This is what lands on disk.
+- "outcomes" must include one entry per prior bullet AND one per
+  baseline bullet you changed. `covered` entries for unchanged baseline
+  bullets are optional — include them if it helps traceability, omit if
+  the list would be noisy.
+- "notes" is optional; use it to flag something the human should look at.
+- Return ONLY the JSON object, no markdown fences, no commentary.

--- a/src/clm/voiceover/rev_scorer.py
+++ b/src/clm/voiceover/rev_scorer.py
@@ -149,12 +149,18 @@ def fuzzy_lcs_score(
 
 
 def _clean_for_match(label: str) -> str:
-    """Strip prefix, lowercase, collapse whitespace for fuzzy comparison."""
+    """Strip prefix, lowercase, collapse whitespace for fuzzy comparison.
+
+    Hyphens and underscores are normalised to spaces so slug-style
+    slide ids (``rest-vs-soap``) tokenise the same way as their OCR
+    counterparts (``rest vs soap``) under ``token_set_ratio``.
+    """
     if not label:
         return ""
     # Drop the "id:"/"title:"/"text:" prefix when comparing across types.
     stripped = label.split(":", 1)[1] if ":" in label else label
-    return " ".join(stripped.lower().split())
+    normalized = stripped.lower().replace("-", " ").replace("_", " ")
+    return " ".join(normalized.split())
 
 
 def score_revisions(

--- a/src/clm/voiceover/rev_scorer.py
+++ b/src/clm/voiceover/rev_scorer.py
@@ -1,0 +1,274 @@
+"""Score historical slide revisions against a video fingerprint.
+
+Backs ``clm voiceover identify-rev``. Given a slide file path and an
+OCR-derived video fingerprint (ordered list of keyframe texts), walks
+git history and assigns each candidate revision a similarity score via
+fuzzy longest-common-subsequence matching of slide labels against video
+labels. Narrative-commit run endpoints (see ``narrative_commits``) get a
+multiplicative prior on top of the base fingerprint score, per
+``docs/proposals/VOICEOVER_BACKFILL.md`` §3.1.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from clm.notebooks.slide_parser import SlideGroup, group_slides, parse_cells
+from clm.voiceover.narrative_commits import (
+    CommitInfo,
+    NarrativeRun,
+    collapse_runs,
+    compute_commit_metrics,
+    get_file_at_rev,
+    walk_file_history,
+)
+
+logger = logging.getLogger(__name__)
+
+# Minimum fuzzy similarity for two labels to count as a match in LCS.
+DEFAULT_LABEL_MATCH = 70.0
+
+# Refuse to proceed below this score unless --force-rev is supplied.
+DEFAULT_ACCEPT_THRESHOLD = 0.6
+
+# Multiplicative boost applied to revisions that are narrative-run
+# endpoints (pre-run parent or post-run tip). Tuned to break ties
+# toward recording-session endpoints without overriding a strong
+# fingerprint match elsewhere.
+NARRATIVE_PRIOR = 1.25
+
+
+@dataclass(frozen=True)
+class RevisionScore:
+    """Scoring result for one historical revision.
+
+    ``score`` is the final, prior-multiplied score used for ranking.
+    ``base_score`` is the raw fingerprint similarity before any priors.
+    ``is_narrative_candidate`` flags revisions that sit at the boundary
+    of a narrative run.
+    """
+
+    rev: str
+    date: datetime | None
+    subject: str | None
+    base_score: float
+    narrative_prior: float
+    score: float
+    is_narrative_candidate: bool
+    run_id: int | None
+    run_position: str | None  # "pre-run" or "post-run" when is_narrative_candidate
+
+
+def slide_labels(text: str, lang: str) -> list[str]:
+    """Extract an ordered fingerprint for a slide file version.
+
+    Primary key is ``slide_id`` (stable across edits); falls back to
+    the slide title, then to the first content line. Header (j2) slides
+    are excluded because recordings rarely dwell on them and their
+    synthetic labels are brittle. Untitled code-only slides map to an
+    empty string which the scorer treats as a non-matching placeholder.
+    """
+    cells = parse_cells(text)
+    groups = group_slides(cells, lang, include_header=False)
+    labels: list[str] = []
+    for group in groups:
+        labels.append(_label_for_group(group))
+    return labels
+
+
+def _label_for_group(group: SlideGroup) -> str:
+    slide_cell = group.cells[0] if group.cells else None
+    slide_id = slide_cell.metadata.slide_id if slide_cell is not None else None
+    if slide_id:
+        return f"id:{slide_id}"
+    if group.title:
+        return f"title:{group.title}"
+    text = group.text_content
+    if text:
+        first = text.split(".")[0].strip()
+        if first:
+            return f"text:{first[:80]}"
+    return ""
+
+
+def fuzzy_lcs_score(
+    revision_labels: list[str],
+    video_labels: list[str],
+    *,
+    match_threshold: float = DEFAULT_LABEL_MATCH,
+) -> float:
+    """Longest common subsequence with fuzzy string equality.
+
+    Uses ``rapidfuzz.fuzz.token_set_ratio`` on lowercased labels. Two
+    labels are considered equal when the ratio is at or above
+    ``match_threshold``; matched pairs contribute ``ratio / 100`` to the
+    total (so close matches weigh less than exact matches).
+
+    The returned score is normalized by ``max(len(a), len(b))`` — adding
+    slides between revisions drags the score down, but reshuffling
+    within the matched set is essentially free.
+    """
+    if not revision_labels or not video_labels:
+        return 0.0
+
+    from rapidfuzz import fuzz
+
+    m = len(revision_labels)
+    n = len(video_labels)
+
+    # Precompute pairwise similarity once.
+    sims: list[list[float]] = [[0.0] * n for _ in range(m)]
+    for i, rl in enumerate(revision_labels):
+        rl_low = _clean_for_match(rl)
+        if not rl_low:
+            continue
+        for j, vl in enumerate(video_labels):
+            vl_low = _clean_for_match(vl)
+            if not vl_low:
+                continue
+            sims[i][j] = float(fuzz.token_set_ratio(rl_low, vl_low))
+
+    # DP table: dp[i][j] = best fuzzy-LCS score using first i rev labels
+    # and first j video labels.
+    dp: list[list[float]] = [[0.0] * (n + 1) for _ in range(m + 1)]
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            best = max(dp[i - 1][j], dp[i][j - 1])
+            s = sims[i - 1][j - 1]
+            if s >= match_threshold:
+                best = max(best, dp[i - 1][j - 1] + s / 100.0)
+            dp[i][j] = best
+
+    denom = max(m, n)
+    if denom == 0:
+        return 0.0
+    return dp[m][n] / denom
+
+
+def _clean_for_match(label: str) -> str:
+    """Strip prefix, lowercase, collapse whitespace for fuzzy comparison."""
+    if not label:
+        return ""
+    # Drop the "id:"/"title:"/"text:" prefix when comparing across types.
+    stripped = label.split(":", 1)[1] if ":" in label else label
+    return " ".join(stripped.lower().split())
+
+
+def score_revisions(
+    slide_path: Path,
+    video_fingerprint: list[str],
+    *,
+    lang: str,
+    limit: int = 50,
+    since: str | None = None,
+    match_threshold: float = DEFAULT_LABEL_MATCH,
+    narrative_prior: float = NARRATIVE_PRIOR,
+) -> list[RevisionScore]:
+    """Score each recent revision of ``slide_path`` against the video.
+
+    Returns a list sorted by final score descending. Narrative-run
+    endpoints (pre-run parent SHA and post-run tip SHA) receive a
+    multiplicative prior ``narrative_prior`` on top of the base LCS
+    score. Scores are not clamped — a strong fingerprint match on a
+    narrative endpoint can exceed 1.0, which is fine for ranking but
+    callers should normalise for display.
+    """
+    commits = walk_file_history(slide_path, since=since, limit=limit)
+    if not commits:
+        return []
+
+    metrics = [
+        compute_commit_metrics(
+            c,
+            get_file_at_rev(c.parent_sha, slide_path) if c.parent_sha else None,
+            get_file_at_rev(c.sha, slide_path),
+        )
+        for c in commits
+    ]
+    runs = collapse_runs(metrics)
+    endpoint_info = _endpoint_lookup(runs)
+
+    # Also score the pre-run parents (which aren't in the file-history
+    # list, because the "touched" commit is the first heavy commit in
+    # the run — its parent may not have touched the file).
+    extras: dict[str, CommitInfo] = {}
+    for run in runs:
+        if run.pre_run_sha and run.pre_run_sha not in {c.sha for c in commits}:
+            extras[run.pre_run_sha] = _synth_commit_info(run.pre_run_sha, slide_path)
+
+    all_commits: list[CommitInfo] = list(commits) + list(extras.values())
+
+    scored: list[RevisionScore] = []
+    for commit in all_commits:
+        text = get_file_at_rev(commit.sha, slide_path)
+        if text is None:
+            logger.debug("Skipping %s: file does not exist at this revision", commit.sha[:8])
+            continue
+        labels = slide_labels(text, lang)
+        base = fuzzy_lcs_score(labels, video_fingerprint, match_threshold=match_threshold)
+
+        endpoint = endpoint_info.get(commit.sha)
+        prior = narrative_prior if endpoint is not None else 1.0
+        final = base * prior
+
+        scored.append(
+            RevisionScore(
+                rev=commit.sha,
+                date=commit.date,
+                subject=commit.subject,
+                base_score=base,
+                narrative_prior=prior,
+                score=final,
+                is_narrative_candidate=endpoint is not None,
+                run_id=endpoint[0] if endpoint else None,
+                run_position=endpoint[1] if endpoint else None,
+            )
+        )
+
+    scored.sort(key=lambda r: (r.score, r.base_score), reverse=True)
+    return scored
+
+
+def _endpoint_lookup(runs: list[NarrativeRun]) -> dict[str, tuple[int, str]]:
+    """Map endpoint SHA → (run_id, 'pre-run' | 'post-run').
+
+    When a SHA is both an endpoint and appears elsewhere we keep the
+    first position seen (pre-run wins over post-run because §3.1 breaks
+    ties toward pre-run).
+    """
+    lookup: dict[str, tuple[int, str]] = {}
+    for run in runs:
+        if run.pre_run_sha:
+            lookup.setdefault(run.pre_run_sha, (run.run_id, "pre-run"))
+        lookup.setdefault(run.post_run_sha, (run.run_id, "post-run"))
+    return lookup
+
+
+def _synth_commit_info(sha: str, slide_path: Path) -> CommitInfo:
+    """Build a ``CommitInfo`` for a SHA not returned by ``walk_file_history``.
+
+    Pre-run parents may be commits that didn't touch the slide file. We
+    still want to score them, so we fetch just their metadata.
+    """
+    import subprocess
+
+    from clm.voiceover.narrative_commits import _git_toplevel
+
+    repo_root = _git_toplevel(slide_path)
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(repo_root), "show", "-s", "--format=%P|%aI|%s", sha],
+            text=True,
+            encoding="utf-8",
+        )
+        parents, date_str, subject = out.strip().split("|", 2)
+        parent_sha = parents.split()[0] if parents.strip() else None
+        date = datetime.fromisoformat(date_str)
+    except (subprocess.CalledProcessError, ValueError):
+        parent_sha = None
+        date = datetime.fromtimestamp(0)
+        subject = ""
+    return CommitInfo(sha=sha, parent_sha=parent_sha, date=date, subject=subject)

--- a/src/clm/voiceover/slide_matcher.py
+++ b/src/clm/voiceover/slide_matcher.py
@@ -1,0 +1,322 @@
+"""Match slides between two slide-file revisions.
+
+Used by ``port-voiceover`` (and the future ``compare``) to decide, for
+each slide in the target file, which slide in the source file (if any)
+it corresponds to. The matching strategy (per proposal §3.3):
+
+1. **Primary key** — ``slide_id`` metadata attribute (stable across
+   edits, written once by ``clm normalize-slides --operations slide_ids``).
+2. **Fallback** — fuzzy title match on the slide heading.
+3. **Tie-break** — content-fingerprint similarity when titles collide.
+
+The module is deliberately side-effect-free: it returns a list of
+:class:`MatchedSlide` records that the CLI then feeds to
+:func:`clm.voiceover.port.polish_and_port` one by one.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from clm.notebooks.slide_parser import SlideGroup
+
+logger = logging.getLogger(__name__)
+
+# Minimum fuzzy similarity for two titles to count as a match.
+TITLE_MATCH_THRESHOLD = 75.0
+
+# Below this content similarity, a slide pair with matching title/id is
+# still considered "modified" (content changed enough that porting needs
+# the LLM to be aware).
+CONTENT_UNCHANGED_THRESHOLD = 90.0
+
+
+class MatchKind(str, Enum):
+    """How a target slide was matched to a source slide.
+
+    * ``unchanged`` — title/id match, content essentially identical.
+    * ``modified`` — title/id match, content changed enough to warn the LLM.
+    * ``new_at_head`` — target slide has no source counterpart.
+    * ``removed_at_head`` — source slide has no target counterpart; the
+      entry appears in :func:`match_slides` output so the CLI can report
+      dropped content, but it has no target index.
+    * ``manual_review`` — ambiguous match (e.g. duplicate titles that we
+      couldn't disambiguate); the CLI should surface for human review.
+    """
+
+    UNCHANGED = "unchanged"
+    MODIFIED = "modified"
+    NEW_AT_HEAD = "new_at_head"
+    REMOVED_AT_HEAD = "removed_at_head"
+    MANUAL_REVIEW = "manual_review"
+
+
+@dataclass
+class MatchedSlide:
+    """One slide-level match result.
+
+    ``target_index`` and ``source_index`` refer to the position in the
+    respective :func:`~clm.notebooks.slide_parser.group_slides` output
+    (same scheme ``slide_writer`` uses for its notes map). Either may
+    be ``None`` for new/removed slides.
+    """
+
+    kind: MatchKind
+    target_index: int | None
+    source_index: int | None
+    target_group: SlideGroup | None
+    source_group: SlideGroup | None
+    key: str  # slide_id, title, or "<untitled>" fallback — for reports
+    content_similarity: float = 0.0
+
+    @property
+    def content_changed(self) -> bool:
+        return self.kind is MatchKind.MODIFIED
+
+
+def match_slides(
+    source_groups: list[SlideGroup],
+    target_groups: list[SlideGroup],
+) -> list[MatchedSlide]:
+    """Match ``target_groups`` against ``source_groups``.
+
+    Returns one :class:`MatchedSlide` per target slide, followed by one
+    per source slide that had no target match (with
+    ``kind=removed_at_head``). Header groups (``slide_type="header"``)
+    are ignored — they never receive voiceover.
+
+    Matching is deterministic and case-insensitive for fallback keys.
+    Duplicate source slide_ids/titles are disambiguated by first-seen
+    + content fingerprint; if still ambiguous, the match is demoted to
+    ``manual_review``.
+    """
+    source_usable = [(i, g) for i, g in enumerate(source_groups) if g.slide_type != "header"]
+    target_usable = [(i, g) for i, g in enumerate(target_groups) if g.slide_type != "header"]
+
+    source_by_id = _build_index(source_usable, key_fn=_slide_id_of)
+    source_by_title = _build_index(source_usable, key_fn=_title_key_of)
+
+    consumed: set[int] = set()
+    results: list[MatchedSlide] = []
+
+    for t_idx, t_group in target_usable:
+        match = _match_one(
+            t_idx=t_idx,
+            t_group=t_group,
+            source_by_id=source_by_id,
+            source_by_title=source_by_title,
+            source_groups=source_groups,
+            consumed=consumed,
+        )
+        results.append(match)
+
+    # Collect unmatched source slides as removed_at_head entries.
+    for s_idx, s_group in source_usable:
+        if s_idx in consumed:
+            continue
+        s_id = _slide_id_of(s_group)
+        s_title = _title_key_of(s_group)
+        if s_id:
+            key = f"id:{s_id}"
+        elif s_title:
+            key = f"title:{s_title}"
+        else:
+            key = "<untitled>"
+        results.append(
+            MatchedSlide(
+                kind=MatchKind.REMOVED_AT_HEAD,
+                target_index=None,
+                source_index=s_idx,
+                target_group=None,
+                source_group=s_group,
+                key=key,
+            )
+        )
+
+    return results
+
+
+def content_similarity(a: str, b: str) -> float:
+    """Return a 0-100 similarity score between two slide content blobs.
+
+    Uses ``fuzz.ratio`` (character-level Levenshtein) rather than
+    ``token_set_ratio`` so that *adding* content registers as a
+    difference — a slide that gained a paragraph of explanation is
+    "modified", not "unchanged".
+    """
+    from rapidfuzz import fuzz
+
+    a_norm = _normalize_content(a)
+    b_norm = _normalize_content(b)
+    if not a_norm and not b_norm:
+        return 100.0
+    if not a_norm or not b_norm:
+        return 0.0
+    return float(fuzz.ratio(a_norm, b_norm))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_index(
+    items: list[tuple[int, SlideGroup]],
+    *,
+    key_fn,
+) -> dict[str, list[tuple[int, SlideGroup]]]:
+    index: dict[str, list[tuple[int, SlideGroup]]] = {}
+    for idx, group in items:
+        key = key_fn(group)
+        if not key:
+            continue
+        index.setdefault(key, []).append((idx, group))
+    return index
+
+
+def _match_one(
+    *,
+    t_idx: int,
+    t_group: SlideGroup,
+    source_by_id: dict[str, list[tuple[int, SlideGroup]]],
+    source_by_title: dict[str, list[tuple[int, SlideGroup]]],
+    source_groups: list[SlideGroup],
+    consumed: set[int],
+) -> MatchedSlide:
+    t_id = _slide_id_of(t_group)
+    t_title = _title_key_of(t_group)
+
+    # 1. Exact slide_id match (primary).
+    if t_id and t_id in source_by_id:
+        candidates = source_by_id[t_id]
+        picked = _pick_candidate(t_group, candidates, consumed)
+        if picked is not None:
+            return _finalise_match(t_idx, t_group, picked, "id:" + t_id)
+        if len(candidates) > 1:
+            return MatchedSlide(
+                kind=MatchKind.MANUAL_REVIEW,
+                target_index=t_idx,
+                source_index=None,
+                target_group=t_group,
+                source_group=None,
+                key="id:" + t_id,
+            )
+
+    # 2. Fuzzy title match (fallback).
+    title_match = _fuzzy_title_pick(t_group, source_by_title, consumed)
+    if title_match is not None:
+        return _finalise_match(t_idx, t_group, title_match, "title:" + (t_title or ""))
+
+    # 3. No match.
+    return MatchedSlide(
+        kind=MatchKind.NEW_AT_HEAD,
+        target_index=t_idx,
+        source_index=None,
+        target_group=t_group,
+        source_group=None,
+        key=("id:" + t_id) if t_id else ("title:" + t_title if t_title else "<untitled>"),
+    )
+
+
+def _finalise_match(
+    t_idx: int,
+    t_group: SlideGroup,
+    picked: tuple[int, SlideGroup],
+    key: str,
+) -> MatchedSlide:
+    s_idx, s_group = picked
+    similarity = content_similarity(s_group.text_content, t_group.text_content)
+    kind = MatchKind.UNCHANGED if similarity >= CONTENT_UNCHANGED_THRESHOLD else MatchKind.MODIFIED
+    return MatchedSlide(
+        kind=kind,
+        target_index=t_idx,
+        source_index=s_idx,
+        target_group=t_group,
+        source_group=s_group,
+        key=key,
+        content_similarity=similarity,
+    )
+
+
+def _pick_candidate(
+    t_group: SlideGroup,
+    candidates: list[tuple[int, SlideGroup]],
+    consumed: set[int],
+) -> tuple[int, SlideGroup] | None:
+    available = [c for c in candidates if c[0] not in consumed]
+    if not available:
+        return None
+    if len(available) == 1:
+        consumed.add(available[0][0])
+        return available[0]
+
+    # Duplicate id/title: disambiguate by content similarity.
+    t_text = t_group.text_content
+    scored = [(content_similarity(g.text_content, t_text), idx, g) for idx, g in available]
+    scored.sort(reverse=True, key=lambda x: x[0])
+    top_score, top_idx, top_group = scored[0]
+    runner_up = scored[1][0] if len(scored) > 1 else 0.0
+    if top_score - runner_up < 10.0:
+        # Too close to call — let the caller flag manual_review.
+        return None
+    consumed.add(top_idx)
+    return top_idx, top_group
+
+
+def _fuzzy_title_pick(
+    t_group: SlideGroup,
+    source_by_title: dict[str, list[tuple[int, SlideGroup]]],
+    consumed: set[int],
+) -> tuple[int, SlideGroup] | None:
+    t_title = _title_key_of(t_group)
+    if not t_title:
+        return None
+
+    if t_title in source_by_title:
+        picked = _pick_candidate(t_group, source_by_title[t_title], consumed)
+        if picked is not None:
+            return picked
+
+    # Try fuzzy match across remaining titles. ``ratio`` penalises
+    # added/missing words, unlike ``token_set_ratio`` which happily
+    # matches titles that share only a single token.
+    from rapidfuzz import fuzz
+
+    best_score = 0.0
+    best_candidate: tuple[int, SlideGroup] | None = None
+    for title, entries in source_by_title.items():
+        score = fuzz.ratio(t_title, title)
+        if score < TITLE_MATCH_THRESHOLD or score <= best_score:
+            continue
+        for idx, group in entries:
+            if idx in consumed:
+                continue
+            best_score = score
+            best_candidate = (idx, group)
+            break
+
+    if best_candidate is not None:
+        consumed.add(best_candidate[0])
+    return best_candidate
+
+
+def _slide_id_of(group: SlideGroup) -> str:
+    cell = group.cells[0] if group.cells else None
+    if cell is None:
+        return ""
+    return cell.metadata.slide_id or ""
+
+
+def _title_key_of(group: SlideGroup) -> str:
+    if not group.title:
+        return ""
+    return " ".join(group.title.lower().split())
+
+
+def _normalize_content(text: str) -> str:
+    # Strip markdown syntax noise so reformatting doesn't look like a content change.
+    cleaned = re.sub(r"[*_`#>]+", " ", text)
+    return " ".join(cleaned.lower().split())

--- a/src/clm/voiceover/trace_log.py
+++ b/src/clm/voiceover/trace_log.py
@@ -3,7 +3,25 @@
 Writes one line per LLM call to
 ``.clm/voiceover-traces/<topic>-<timestamp>.jsonl`` inside the working
 directory. The log is independent of Langfuse and provides a durable,
-local-first substrate for training data extraction (Phase 4).
+local-first substrate for training-data extraction and offline analysis.
+
+Schema v1 (``clm.voiceover.trace/1``) — the first explicitly-versioned
+format — preserves every field from the original unversioned log and adds
+a few structured fields useful for the upcoming ``compare`` / ``port``
+features:
+
+- ``schema`` — constant ``"clm.voiceover.trace/1"``.
+- ``cell_index`` — per-slide index within the slide file (authoritative
+  identifier alongside ``slide_id`` for callers that need stable ordering).
+- ``transcript_segments`` — structured ``[{start, end, text}]`` rather
+  than a flat string; helps ``compare`` line up spoken content with the
+  polished baseline. Falls back to a single segment with ``start=0`` when
+  the caller only provides flat text.
+- ``added_from_baseline`` — symmetric counterpart to
+  ``dropped_from_transcript``: material the LLM kept from the written
+  baseline when it didn't appear in the transcript. Empty on legacy
+  callers; to be populated by the merge prompt in a follow-up PR.
+- ``model`` / ``mode`` — which LLM and pipeline mode produced the output.
 """
 
 from __future__ import annotations
@@ -13,8 +31,11 @@ import logging
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+SCHEMA_V1 = "clm.voiceover.trace/1"
 
 
 def _get_git_head() -> str | None:
@@ -94,18 +115,39 @@ class TraceLog:
         rewrites: list[dict],
         dropped_from_transcript: list[str],
         langfuse_trace_id: str | None = None,
+        cell_index: int | None = None,
+        transcript_segments: list[dict] | None = None,
+        added_from_baseline: list[str] | None = None,
+        model: str | None = None,
+        mode: str | None = None,
     ) -> None:
-        """Append one merge-call entry to the trace log."""
-        entry = {
+        """Append one merge-call entry to the trace log.
+
+        All new v1 fields are optional; legacy callers that don't provide
+        them get safe defaults (``cell_index=None``, a single-segment
+        ``transcript_segments``, empty ``added_from_baseline``).
+        """
+        if transcript_segments is None:
+            segments = [{"start": 0.0, "end": 0.0, "text": transcript}] if transcript else []
+        else:
+            segments = list(transcript_segments)
+
+        entry: dict[str, Any] = {
+            "schema": SCHEMA_V1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "slide_file": self._slide_file,
             "slide_id": slide_id,
+            "cell_index": cell_index,
             "language": language,
             "baseline": baseline,
             "transcript": transcript,
+            "transcript_segments": segments,
             "llm_merged": llm_merged,
             "rewrites": rewrites,
             "dropped_from_transcript": dropped_from_transcript,
+            "added_from_baseline": list(added_from_baseline) if added_from_baseline else [],
+            "model": model,
+            "mode": mode,
             "git_head": self._git_head,
         }
         if langfuse_trace_id:
@@ -113,3 +155,25 @@ class TraceLog:
 
         with self._path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def read_trace_entries(path: Path) -> list[dict]:
+    """Read a trace log file and return its entries as a list of dicts.
+
+    Entries without a ``schema`` field are returned as-is (legacy
+    ``clm.voiceover.trace/0`` format) so ``trace show`` can inspect older
+    logs alongside current ones.
+    """
+    entries: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping malformed trace line in %s: %s", path, exc)
+                continue
+            entries.append(entry)
+    return entries

--- a/tests/cli/test_voiceover_cli.py
+++ b/tests/cli/test_voiceover_cli.py
@@ -39,6 +39,19 @@ class TestVoiceoverGroup:
         assert result.exit_code == 0
         assert "--lang" in result.output
 
+    def test_debug_group_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["debug", "--help"])
+        assert result.exit_code == 0
+        assert "voiceover-commits" in result.output
+
+    def test_voiceover_commits_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["debug", "voiceover-commits", "--help"])
+        assert result.exit_code == 0
+        assert "--threshold" in result.output
+        assert "--since" in result.output
+
 
 class TestPolishCommand:
     def test_help(self):

--- a/tests/cli/test_voiceover_cli.py
+++ b/tests/cli/test_voiceover_cli.py
@@ -80,6 +80,28 @@ class TestVoiceoverGroup:
         assert "SOURCE" in result.output
         assert "TARGET" in result.output
 
+    def test_sync_at_rev_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["sync-at-rev", "--help"])
+        assert result.exit_code == 0
+        assert "--rev" in result.output
+        assert "--output" in result.output
+        assert "--lang" in result.output
+        assert "SLIDE_FILE" in result.output
+        assert "VIDEOS" in result.output
+
+    def test_backfill_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["backfill", "--help"])
+        assert result.exit_code == 0
+        assert "--lang" in result.output
+        assert "--rev" in result.output
+        assert "--auto" in result.output
+        assert "--apply" in result.output
+        assert "--dry-run" in result.output
+        assert "--keep-scratch" in result.output
+        assert "SLIDE_FILE" in result.output
+
     def test_debug_group_help(self):
         runner = CliRunner()
         result = runner.invoke(voiceover_group, ["debug", "--help"])

--- a/tests/cli/test_voiceover_cli.py
+++ b/tests/cli/test_voiceover_cli.py
@@ -21,6 +21,28 @@ class TestVoiceoverGroup:
         assert "--lang" in result.output
         assert "--mode" in result.output
         assert "--dry-run" in result.output
+        assert "--transcript" in result.output
+        assert "--alignment" in result.output
+
+    def test_group_help_shows_cache_flags(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["--help"])
+        assert result.exit_code == 0
+        assert "--cache-root" in result.output
+        assert "--no-cache" in result.output
+        assert "--refresh-cache" in result.output
+
+    def test_group_help_shows_cache_subgroup(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["--help"])
+        assert result.exit_code == 0
+        assert "cache" in result.output
+
+    def test_group_help_shows_trace_subgroup(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["--help"])
+        assert result.exit_code == 0
+        assert "trace" in result.output
 
     def test_transcribe_help(self):
         runner = CliRunner()
@@ -51,6 +73,127 @@ class TestVoiceoverGroup:
         assert result.exit_code == 0
         assert "--threshold" in result.output
         assert "--since" in result.output
+
+
+class TestCacheSubgroup:
+    def test_cache_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["cache", "--help"])
+        assert result.exit_code == 0
+        assert "list" in result.output
+        assert "prune" in result.output
+        assert "clear" in result.output
+
+    def test_cache_list_empty(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["--cache-root", str(tmp_path / "empty"), "cache", "list"],
+        )
+        assert result.exit_code == 0
+        assert "empty" in result.output.lower()
+
+    def test_cache_list_with_entry(self, tmp_path):
+        from clm.voiceover.cache import TranscribeConfig, TranscriptsCache, VideoKey
+        from clm.voiceover.transcribe import Transcript
+
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"x" * 256)
+        cache_root = tmp_path / "cache"
+        tc = TranscriptsCache(cache_root)
+        cfg = TranscribeConfig(
+            backend="faster-whisper",
+            model="large-v3",
+            language="de",
+            device_class="cpu",
+        )
+        tc.put(
+            VideoKey.from_path(video),
+            cfg,
+            Transcript(segments=[], language="de", duration=1.0),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["--cache-root", str(cache_root), "cache", "list"])
+        assert result.exit_code == 0
+        assert "transcripts" in result.output
+
+    def test_cache_clear_aborts_without_confirmation(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["--cache-root", str(tmp_path / "cache"), "cache", "clear"],
+            input="n\n",
+        )
+        assert result.exit_code != 0
+
+    def test_cache_clear_with_yes(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["--cache-root", str(tmp_path / "cache"), "cache", "clear", "--yes"],
+        )
+        assert result.exit_code == 0
+
+    def test_cache_prune_requires_max_age(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            ["--cache-root", str(tmp_path / "cache"), "cache", "prune"],
+        )
+        assert result.exit_code != 0
+
+
+class TestTraceSubgroup:
+    def test_trace_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["trace", "--help"])
+        assert result.exit_code == 0
+        assert "show" in result.output
+
+    def test_trace_show_renders_summary(self, tmp_path):
+        from clm.voiceover.trace_log import TraceLog
+
+        trace = TraceLog.create("slides.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="slides/1",
+            language="en",
+            baseline="",
+            transcript="hello world",
+            llm_merged="- hello world",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["trace", "show", str(trace.path)])
+        assert result.exit_code == 0
+        # Rich truncates long table cells, so just check the summary line
+        assert "clm.voiceover.trace/1" in result.output
+        assert "1" in result.output and "entries" in result.output
+
+    def test_trace_show_json(self, tmp_path):
+        import json as jsonlib
+
+        from clm.voiceover.trace_log import TraceLog
+
+        trace = TraceLog.create("slides.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="slides/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["trace", "show", str(trace.path), "--json"])
+        assert result.exit_code == 0
+        data = jsonlib.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["slide_id"] == "slides/1"
 
 
 class TestPolishCommand:

--- a/tests/cli/test_voiceover_cli.py
+++ b/tests/cli/test_voiceover_cli.py
@@ -70,6 +70,16 @@ class TestVoiceoverGroup:
         assert "--since" in result.output
         assert "--limit" in result.output
 
+    def test_port_voiceover_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["port-voiceover", "--help"])
+        assert result.exit_code == 0
+        assert "--lang" in result.output
+        assert "--dry-run" in result.output
+        assert "--tag" in result.output
+        assert "SOURCE" in result.output
+        assert "TARGET" in result.output
+
     def test_debug_group_help(self):
         runner = CliRunner()
         result = runner.invoke(voiceover_group, ["debug", "--help"])

--- a/tests/cli/test_voiceover_cli.py
+++ b/tests/cli/test_voiceover_cli.py
@@ -61,6 +61,15 @@ class TestVoiceoverGroup:
         assert result.exit_code == 0
         assert "--lang" in result.output
 
+    def test_identify_rev_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["identify-rev", "--help"])
+        assert result.exit_code == 0
+        assert "--lang" in result.output
+        assert "--top" in result.output
+        assert "--since" in result.output
+        assert "--limit" in result.output
+
     def test_debug_group_help(self):
         runner = CliRunner()
         result = runner.invoke(voiceover_group, ["debug", "--help"])

--- a/tests/cli/test_voiceover_cli.py
+++ b/tests/cli/test_voiceover_cli.py
@@ -102,6 +102,16 @@ class TestVoiceoverGroup:
         assert "--keep-scratch" in result.output
         assert "SLIDE_FILE" in result.output
 
+    def test_compare_help(self):
+        runner = CliRunner()
+        result = runner.invoke(voiceover_group, ["compare", "--help"])
+        assert result.exit_code == 0
+        assert "--lang" in result.output
+        assert "--json" in result.output
+        assert "-o" in result.output or "--output" in result.output
+        assert "SOURCE" in result.output
+        assert "TARGET" in result.output
+
     def test_debug_group_help(self):
         runner = CliRunner()
         result = runner.invoke(voiceover_group, ["debug", "--help"])

--- a/tests/cli/test_voiceover_command.py
+++ b/tests/cli/test_voiceover_command.py
@@ -392,7 +392,7 @@ class TestDetectCommand:
         monkeypatch.setitem(sys.modules, "clm.voiceover.keyframes", fake_keyframes)
 
         runner = CliRunner()
-        result = runner.invoke(voiceover_group, ["detect", str(video)])
+        result = runner.invoke(voiceover_group, ["--no-cache", "detect", str(video)])
 
         assert result.exit_code == 0, result.output
         assert "1 transitions" in result.output
@@ -411,7 +411,9 @@ class TestDetectCommand:
         monkeypatch.setitem(sys.modules, "clm.voiceover.keyframes", fake_keyframes)
 
         runner = CliRunner()
-        result = runner.invoke(voiceover_group, ["detect", str(video), "-o", str(out)])
+        result = runner.invoke(
+            voiceover_group, ["--no-cache", "detect", str(video), "-o", str(out)]
+        )
 
         assert result.exit_code == 0
         data = json.loads(out.read_text())
@@ -459,7 +461,16 @@ class TestIdentifyCommand:
         runner = CliRunner()
         result = runner.invoke(
             voiceover_group,
-            ["identify", str(video), str(slides), "--lang", "de", "-o", str(out)],
+            [
+                "--no-cache",
+                "identify",
+                str(video),
+                str(slides),
+                "--lang",
+                "de",
+                "-o",
+                str(out),
+            ],
         )
 
         assert result.exit_code == 0, result.output

--- a/tests/voiceover/test_backfill.py
+++ b/tests/voiceover/test_backfill.py
@@ -1,0 +1,248 @@
+"""Tests for the ``clm voiceover backfill`` scratch/git helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.voiceover.backfill import (
+    compute_port_patch,
+    extract_slide_file_at_rev,
+    plan_scratch_dir,
+    resolve_rev,
+)
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Minimal git repo with two revisions of a slide-shaped .py file."""
+    _run(["git", "init", "-q", "-b", "main"], tmp_path)
+    _run(["git", "config", "user.email", "t@t"], tmp_path)
+    _run(["git", "config", "user.name", "T"], tmp_path)
+
+    slides = tmp_path / "slides.py"
+    slides.write_text("# rev 1\n", encoding="utf-8")
+    _run(["git", "add", "slides.py"], tmp_path)
+    _run(["git", "commit", "-q", "-m", "rev 1"], tmp_path)
+
+    slides.write_text("# rev 2\n", encoding="utf-8")
+    _run(["git", "commit", "-q", "-am", "rev 2"], tmp_path)
+
+    return tmp_path
+
+
+class TestPlanScratchDir:
+    def test_creates_dir_next_to_slides(self, tmp_path: Path):
+        slides = tmp_path / "topic.py"
+        slides.write_text("", encoding="utf-8")
+        scratch = plan_scratch_dir(slides)
+        assert scratch.exists()
+        assert scratch.is_dir()
+        assert scratch.parent.name == "voiceover-backfill"
+        assert scratch.parent.parent.name == ".clm"
+        assert scratch.name.startswith("topic-")
+
+    def test_repeated_calls_do_not_collide(self, tmp_path: Path):
+        slides = tmp_path / "topic.py"
+        slides.write_text("", encoding="utf-8")
+        import time
+
+        a = plan_scratch_dir(slides)
+        time.sleep(1.01)  # timestamps are per-second
+        b = plan_scratch_dir(slides)
+        assert a != b
+
+
+class TestExtractSlideFileAtRev:
+    def test_exports_rev1_into_scratch(self, repo: Path):
+        slides = repo / "slides.py"
+        rev1 = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD~1"],
+            text=True,
+        ).strip()
+        scratch = repo / "scratch"
+        scratch.mkdir()
+        out = extract_slide_file_at_rev(slides, rev1, scratch)
+        assert out.exists()
+        assert out.read_text(encoding="utf-8") == "# rev 1\n"
+        # HEAD stays untouched.
+        assert slides.read_text(encoding="utf-8") == "# rev 2\n"
+
+    def test_file_missing_at_rev_raises(self, repo: Path):
+        new_file = repo / "new.py"
+        new_file.write_text("# added later\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "new.py"], check=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-q", "-m", "add new"],
+            check=True,
+        )
+
+        rev1 = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD~2"],
+            text=True,
+        ).strip()
+        scratch = repo / "scratch"
+        scratch.mkdir()
+        with pytest.raises(FileNotFoundError):
+            extract_slide_file_at_rev(new_file, rev1, scratch)
+
+
+class TestResolveRev:
+    def test_resolves_short_sha(self, repo: Path):
+        slides = repo / "slides.py"
+        full = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+        ).strip()
+        short = full[:7]
+        assert resolve_rev(slides, short) == full
+
+    def test_unknown_rev_raises(self, repo: Path):
+        slides = repo / "slides.py"
+        with pytest.raises(ValueError):
+            resolve_rev(slides, "deadbeef" * 5)
+
+
+class TestSyncAtRevGuards:
+    """CLI-level guards on ``sync-at-rev`` that short-circuit before any sync runs."""
+
+    def test_rejects_output_equal_to_slide_file(self, repo: Path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        slides = repo / "slides.py"
+        video = repo / "video.mp4"
+        video.write_bytes(b"\x00")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync-at-rev",
+                str(slides),
+                str(video),
+                "--rev",
+                "HEAD",
+                "--output",
+                str(slides),
+                "--lang",
+                "de",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "working copy" in result.output.lower()
+
+    def test_rejects_unknown_rev(self, repo: Path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        slides = repo / "slides.py"
+        video = repo / "video.mp4"
+        video.write_bytes(b"\x00")
+        output = repo / "scratch-out.py"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "sync-at-rev",
+                str(slides),
+                str(video),
+                "--rev",
+                "deadbeef" * 5,
+                "--output",
+                str(output),
+                "--lang",
+                "de",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "unknown revision" in result.output.lower()
+
+
+class TestBackfillGuards:
+    def test_dry_run_and_apply_are_mutually_exclusive(self, repo: Path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        slides = repo / "slides.py"
+        video = repo / "video.mp4"
+        video.write_bytes(b"\x00")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "backfill",
+                str(slides),
+                str(video),
+                "--lang",
+                "de",
+                "--rev",
+                "HEAD",
+                "--dry-run",
+                "--apply",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_rejects_unknown_rev(self, repo: Path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        slides = repo / "slides.py"
+        video = repo / "video.mp4"
+        video.write_bytes(b"\x00")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            voiceover_group,
+            [
+                "backfill",
+                str(slides),
+                str(video),
+                "--lang",
+                "de",
+                "--rev",
+                "deadbeef" * 5,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "unknown revision" in result.output.lower()
+
+
+class TestComputePortPatch:
+    def test_identical_returns_empty(self, tmp_path: Path):
+        target = tmp_path / "t.py"
+        target.write_text("hello\n", encoding="utf-8")
+        assert compute_port_patch(target, "hello\n") == ""
+
+    def test_emits_unified_diff(self, tmp_path: Path):
+        target = tmp_path / "t.py"
+        target.write_text("line1\nline2\n", encoding="utf-8")
+        patch = compute_port_patch(target, "line1\nline2-edited\n")
+        assert patch.startswith("--- a/t.py")
+        assert "+++ b/t.py" in patch
+        assert "-line2" in patch
+        assert "+line2-edited" in patch
+
+    def test_accepts_explicit_original_text(self, tmp_path: Path):
+        target = tmp_path / "t.py"
+        # target file intentionally not present — original_text supplied directly.
+        patch = compute_port_patch(
+            target,
+            "two\n",
+            original_text="one\n",
+        )
+        assert "-one" in patch
+        assert "+two" in patch

--- a/tests/voiceover/test_bullet_schema.py
+++ b/tests/voiceover/test_bullet_schema.py
@@ -1,0 +1,168 @@
+"""Tests for the shared bullet schema used by port and compare."""
+
+from __future__ import annotations
+
+import json
+
+from clm.voiceover.bullet_schema import (
+    BulletOutcome,
+    BulletStatus,
+    PerSlidePack,
+    parse_structured_response,
+)
+
+
+class TestBulletStatus:
+    def test_values_are_strings(self):
+        assert BulletStatus.COVERED.value == "covered"
+        assert BulletStatus.REWRITTEN.value == "rewritten"
+        assert BulletStatus.ADDED.value == "added"
+        assert BulletStatus.DROPPED.value == "dropped"
+        assert BulletStatus.MANUAL_REVIEW.value == "manual_review"
+
+    def test_roundtrip_through_string(self):
+        for status in BulletStatus:
+            assert BulletStatus(status.value) is status
+
+
+class TestBulletOutcome:
+    def test_to_json_omits_none_fields(self):
+        outcome = BulletOutcome(status=BulletStatus.ADDED, target="- new bullet")
+        payload = outcome.to_json()
+        assert payload == {"status": "added", "target": "- new bullet"}
+
+    def test_to_json_includes_all_fields(self):
+        outcome = BulletOutcome(
+            status=BulletStatus.REWRITTEN,
+            target="- corrected bullet",
+            source="- original bullet",
+            note="factual correction",
+        )
+        payload = outcome.to_json()
+        assert payload["status"] == "rewritten"
+        assert payload["note"] == "factual correction"
+
+    def test_from_json_recognised_status(self):
+        outcome = BulletOutcome.from_json({"status": "covered", "target": "- x"})
+        assert outcome.status is BulletStatus.COVERED
+        assert outcome.target == "- x"
+
+    def test_from_json_unknown_status_maps_to_manual_review(self):
+        outcome = BulletOutcome.from_json({"status": "bogus"})
+        assert outcome.status is BulletStatus.MANUAL_REVIEW
+
+
+class TestPerSlidePack:
+    def test_build_user_message_includes_all_sections(self):
+        pack = PerSlidePack(
+            slide_id="topic/3",
+            language="de",
+            baseline_bullets="- existing point",
+            prior_bullets="- prior point",
+            slide_content_head="## Head Title\nsome text",
+        )
+        msg = pack.build_user_message()
+        assert "SLIDE ID: topic/3" in msg
+        assert "Head Title" in msg
+        assert "PRIOR BULLETS" in msg
+        assert "prior point" in msg
+        assert "BASELINE BULLETS" in msg
+        assert "existing point" in msg
+
+    def test_prior_content_shown_only_when_changed(self):
+        pack = PerSlidePack(
+            slide_id="x/1",
+            language="en",
+            baseline_bullets="",
+            prior_bullets="- prior",
+            slide_content_head="head content",
+            slide_content_prior="prior content",
+            content_changed=True,
+        )
+        msg = pack.build_user_message()
+        assert "prior content" in msg
+        assert "prior/source version" in msg
+
+    def test_prior_content_hidden_when_unchanged(self):
+        pack = PerSlidePack(
+            slide_id="x/1",
+            language="en",
+            baseline_bullets="",
+            prior_bullets="- prior",
+            slide_content_head="head content",
+            slide_content_prior="prior content",
+            content_changed=False,
+        )
+        msg = pack.build_user_message()
+        assert "prior content" not in msg
+
+    def test_empty_bullets_placeholder(self):
+        pack = PerSlidePack(
+            slide_id="x/1",
+            language="en",
+            baseline_bullets="",
+            prior_bullets="",
+            slide_content_head="",
+        )
+        msg = pack.build_user_message()
+        assert "(empty)" in msg
+        assert "empty -- no existing voiceover" in msg
+
+
+class TestParseStructuredResponse:
+    def test_basic_response(self):
+        raw = json.dumps(
+            {
+                "bullets": "- a\n- b",
+                "outcomes": [
+                    {"status": "covered", "target": "- a", "source": "- a"},
+                    {"status": "added", "target": "- b"},
+                ],
+                "notes": "Straightforward port.",
+            }
+        )
+        bullets, outcomes, notes = parse_structured_response(raw)
+        assert bullets == "- a\n- b"
+        assert len(outcomes) == 2
+        assert outcomes[0].status is BulletStatus.COVERED
+        assert outcomes[1].status is BulletStatus.ADDED
+        assert notes == "Straightforward port."
+
+    def test_strips_code_fences(self):
+        raw = "```json\n" + json.dumps({"bullets": "- x"}) + "\n```"
+        bullets, _, _ = parse_structured_response(raw)
+        assert bullets == "- x"
+
+    def test_accepts_merged_bullets_alias(self):
+        raw = json.dumps({"merged_bullets": "- alias"})
+        bullets, _, _ = parse_structured_response(raw)
+        assert bullets == "- alias"
+
+    def test_accepts_wrapped_result(self):
+        raw = json.dumps({"result": {"bullets": "- wrapped"}})
+        bullets, _, _ = parse_structured_response(raw)
+        assert bullets == "- wrapped"
+
+    def test_invalid_json_returns_default(self):
+        bullets, outcomes, notes = parse_structured_response(
+            "not json at all", default_bullets="- fallback"
+        )
+        assert bullets == "- fallback"
+        assert outcomes == []
+        assert notes is None
+
+    def test_non_object_returns_default(self):
+        raw = json.dumps(["a", "list", "not", "an", "object"])
+        bullets, outcomes, notes = parse_structured_response(raw, default_bullets="")
+        assert bullets == ""
+        assert outcomes == []
+
+    def test_notes_missing_returns_none(self):
+        raw = json.dumps({"bullets": "- x", "outcomes": []})
+        _, _, notes = parse_structured_response(raw)
+        assert notes is None
+
+    def test_empty_notes_returns_none(self):
+        raw = json.dumps({"bullets": "- x", "notes": "   "})
+        _, _, notes = parse_structured_response(raw)
+        assert notes is None

--- a/tests/voiceover/test_cache.py
+++ b/tests/voiceover/test_cache.py
@@ -1,0 +1,560 @@
+"""Tests for the voiceover artifact cache module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.voiceover.cache import (
+    CACHE_DIRNAME,
+    AlignmentsCache,
+    CachePolicy,
+    DetectConfig,
+    SlidesKey,
+    TimelinesCache,
+    TranscribeConfig,
+    TranscriptsCache,
+    TransitionsCache,
+    VideoKey,
+    cached_alignment,
+    cached_detect,
+    cached_timeline,
+    cached_transcribe,
+    clear,
+    iter_entries,
+    prune,
+    resolve_cache_root,
+)
+
+
+def _touch_video(tmp_path: Path, name: str = "video.mp4", size: int = 1024) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"x" * size)
+    return p
+
+
+class TestVideoKey:
+    def test_from_path_produces_stable_hash(self, tmp_path):
+        video = _touch_video(tmp_path)
+        k1 = VideoKey.from_path(video)
+        k2 = VideoKey.from_path(video)
+        assert k1 == k2
+        assert k1.hash == k2.hash
+
+    def test_hash_changes_when_content_changes(self, tmp_path):
+        video = _touch_video(tmp_path, size=1024)
+        hash1 = VideoKey.from_path(video).hash
+
+        # Rewrite with different size
+        video.write_bytes(b"y" * 2048)
+        hash2 = VideoKey.from_path(video).hash
+
+        assert hash1 != hash2
+
+    def test_hash_length(self, tmp_path):
+        video = _touch_video(tmp_path)
+        assert len(VideoKey.from_path(video).hash) == 16
+
+
+class TestSlidesKey:
+    def test_from_text_ignores_trailing_whitespace(self):
+        k1 = SlidesKey.from_text("line one\nline two\n")
+        k2 = SlidesKey.from_text("line one   \nline two   \n")
+        assert k1 == k2
+
+    def test_distinguishes_content_changes(self):
+        k1 = SlidesKey.from_text("line one\n")
+        k2 = SlidesKey.from_text("line two\n")
+        assert k1 != k2
+
+    def test_from_path(self, tmp_path):
+        p = tmp_path / "slides.py"
+        p.write_text("x = 1\n", encoding="utf-8")
+        key = SlidesKey.from_path(p)
+        assert key == SlidesKey.from_text("x = 1\n")
+
+
+class TestTranscribeConfig:
+    def test_normalize_device(self):
+        assert TranscribeConfig.normalize_device("cuda") == "cuda"
+        assert TranscribeConfig.normalize_device("cuda:0") == "cuda"
+        assert TranscribeConfig.normalize_device("CPU") == "cpu"
+        assert TranscribeConfig.normalize_device("auto") == "auto"
+
+
+class TestResolveCacheRoot:
+    def test_default_uses_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        root = resolve_cache_root()
+        assert root == tmp_path / CACHE_DIRNAME
+
+    def test_explicit_base_dir(self, tmp_path):
+        root = resolve_cache_root(tmp_path)
+        assert root == tmp_path / CACHE_DIRNAME
+
+
+class TestTranscriptsCache:
+    def test_round_trip(self, tmp_path):
+        from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg = TranscribeConfig(
+            backend="faster-whisper",
+            model="large-v3",
+            language="de",
+            device_class="cuda",
+        )
+
+        transcript = Transcript(
+            segments=[
+                TranscriptSegment(start=0.0, end=2.0, text="hallo"),
+                TranscriptSegment(start=2.0, end=4.0, text="welt", source_part_index=1),
+            ],
+            language="de",
+            duration=4.0,
+        )
+
+        cache = TranscriptsCache(tmp_path / "cache")
+        assert cache.get(video_key, cfg) is None
+
+        cache.put(video_key, cfg, transcript)
+        loaded = cache.get(video_key, cfg)
+        assert loaded is not None
+        assert loaded.language == "de"
+        assert loaded.duration == 4.0
+        assert len(loaded.segments) == 2
+        assert loaded.segments[0].text == "hallo"
+        assert loaded.segments[1].source_part_index == 1
+
+    def test_config_mismatch_is_miss(self, tmp_path):
+        from clm.voiceover.transcribe import Transcript
+
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg_de = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="de", device_class="cuda"
+        )
+        cfg_en = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="en", device_class="cuda"
+        )
+
+        cache = TranscriptsCache(tmp_path / "cache")
+        cache.put(video_key, cfg_de, Transcript(segments=[], language="de", duration=1.0))
+
+        assert cache.get(video_key, cfg_en) is None
+        assert cache.get(video_key, cfg_de) is not None
+
+    def test_corrupt_entry_is_miss(self, tmp_path):
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="de", device_class="cuda"
+        )
+        cache = TranscriptsCache(tmp_path / "cache")
+
+        # Write garbage at the expected entry path
+        cache.directory.mkdir(parents=True, exist_ok=True)
+        (cache.directory / f"{video_key.hash}.json").write_text("not json{", encoding="utf-8")
+
+        assert cache.get(video_key, cfg) is None
+
+
+class TestTransitionsCache:
+    def test_round_trip(self, tmp_path):
+        from clm.voiceover.keyframes import TransitionEvent
+
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg = DetectConfig(sample_fps=2.0, threshold_factor=3.0, percentile=95.0, merge_window=3.0)
+
+        events = [
+            TransitionEvent(
+                timestamp=10.0,
+                peak_diff=0.5,
+                confidence=2.0,
+                num_frames=3,
+                source_part_index=0,
+                local_timestamp=10.0,
+            ),
+            TransitionEvent(timestamp=20.0, peak_diff=0.6, confidence=3.0, num_frames=2),
+        ]
+
+        cache = TransitionsCache(tmp_path / "cache")
+        assert cache.get(video_key, cfg) is None
+
+        cache.put(video_key, cfg, events)
+        loaded = cache.get(video_key, cfg)
+        assert loaded is not None
+        assert len(loaded) == 2
+        assert loaded[0].timestamp == 10.0
+        assert loaded[0].num_frames == 3
+        assert loaded[0].local_timestamp == 10.0
+        assert loaded[1].local_timestamp is None
+
+    def test_config_mismatch_is_miss(self, tmp_path):
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg_a = DetectConfig(
+            sample_fps=2.0, threshold_factor=3.0, percentile=95.0, merge_window=3.0
+        )
+        cfg_b = DetectConfig(
+            sample_fps=4.0, threshold_factor=3.0, percentile=95.0, merge_window=3.0
+        )
+        cache = TransitionsCache(tmp_path / "cache")
+        cache.put(video_key, cfg_a, [])
+        assert cache.get(video_key, cfg_b) is None
+
+
+class TestTimelinesCache:
+    def test_round_trip(self, tmp_path):
+        from clm.voiceover.matcher import TimelineEntry
+
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        slides_key = SlidesKey.from_text("x = 1\n")
+        cfg = {"lang": "de"}
+
+        timeline = [
+            TimelineEntry(
+                slide_index=1,
+                start_time=0.0,
+                end_time=10.0,
+                match_score=95.0,
+                is_header=False,
+            ),
+            TimelineEntry(
+                slide_index=0,
+                start_time=10.0,
+                end_time=20.0,
+                match_score=88.0,
+                is_header=True,
+            ),
+        ]
+
+        cache = TimelinesCache(tmp_path / "cache")
+        assert cache.get(video_key, slides_key, cfg) is None
+
+        cache.put(video_key, slides_key, cfg, timeline)
+        loaded = cache.get(video_key, slides_key, cfg)
+        assert loaded is not None
+        assert len(loaded) == 2
+        assert loaded[0].slide_index == 1
+        assert loaded[1].is_header is True
+
+    def test_slides_hash_scopes_key(self, tmp_path):
+        from clm.voiceover.matcher import TimelineEntry
+
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        slides_v1 = SlidesKey.from_text("version one")
+        slides_v2 = SlidesKey.from_text("version two")
+        cfg = {"lang": "de"}
+
+        timeline = [TimelineEntry(slide_index=1, start_time=0.0, end_time=5.0, match_score=90.0)]
+        cache = TimelinesCache(tmp_path / "cache")
+        cache.put(video_key, slides_v1, cfg, timeline)
+
+        assert cache.get(video_key, slides_v1, cfg) is not None
+        assert cache.get(video_key, slides_v2, cfg) is None
+
+
+class TestAlignmentsCache:
+    def test_round_trip(self, tmp_path):
+        from clm.voiceover.aligner import AlignmentResult, SlideNotes
+        from clm.voiceover.transcribe import TranscriptSegment
+
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        slides_key = SlidesKey.from_text("x = 1")
+        cfg = {"bias": 0.4}
+
+        alignment = AlignmentResult(
+            slide_notes={
+                1: SlideNotes(
+                    slide_index=1,
+                    segments=["first", "second"],
+                    revisited_segments=[["third"]],
+                ),
+            },
+            unassigned_segments=[
+                TranscriptSegment(start=0.0, end=1.0, text="noise"),
+            ],
+        )
+
+        cache = AlignmentsCache(tmp_path / "cache")
+        cache.put(video_key, slides_key, cfg, alignment)
+        loaded = cache.get(video_key, slides_key, cfg)
+
+        assert loaded is not None
+        assert set(loaded.slide_notes) == {1}
+        notes = loaded.slide_notes[1]
+        assert notes.segments == ["first", "second"]
+        assert notes.revisited_segments == [["third"]]
+        assert len(loaded.unassigned_segments) == 1
+        assert loaded.unassigned_segments[0].text == "noise"
+
+
+class TestHousekeeping:
+    def test_iter_entries_lists_all_subdirs(self, tmp_path):
+        from clm.voiceover.transcribe import Transcript
+
+        cache_root = tmp_path / "cache"
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="de", device_class="cpu"
+        )
+
+        tc = TranscriptsCache(cache_root)
+        tc.put(video_key, cfg, Transcript(segments=[], language="de", duration=1.0))
+
+        entries = iter_entries(cache_root)
+        assert len(entries) == 1
+        assert entries[0].subdir == "transcripts"
+        assert entries[0].size > 0
+
+    def test_clear_removes_entries(self, tmp_path):
+        from clm.voiceover.transcribe import Transcript
+
+        cache_root = tmp_path / "cache"
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="de", device_class="cpu"
+        )
+        tc = TranscriptsCache(cache_root)
+        tc.put(video_key, cfg, Transcript(segments=[], language="de", duration=1.0))
+
+        removed = clear(cache_root)
+        assert removed == 1
+        assert iter_entries(cache_root) == []
+
+    def test_prune_respects_max_age(self, tmp_path):
+        import os
+        import time
+
+        from clm.voiceover.transcribe import Transcript
+
+        cache_root = tmp_path / "cache"
+        video = _touch_video(tmp_path)
+        video_key = VideoKey.from_path(video)
+        cfg = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="de", device_class="cpu"
+        )
+        tc = TranscriptsCache(cache_root)
+        tc.put(video_key, cfg, Transcript(segments=[], language="de", duration=1.0))
+
+        entry_path = iter_entries(cache_root)[0].path
+        # Backdate the file by 10 days
+        old = time.time() - 10 * 86400
+        os.utime(entry_path, (old, old))
+
+        # 7-day window: removes it
+        assert prune(cache_root, max_age_days=7) == 1
+        assert iter_entries(cache_root) == []
+
+    def test_prune_none_is_noop(self, tmp_path):
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        assert prune(cache_root, max_age_days=None) == 0
+
+
+class TestCachePolicy:
+    def test_disabled_factory(self):
+        policy = CachePolicy.disabled()
+        assert policy.enabled is False
+
+    def test_resolve_root_uses_override(self, tmp_path):
+        override = tmp_path / "explicit-cache"
+        policy = CachePolicy(cache_root=override)
+        assert policy.resolve_root(Path("/some/other/base")) == override
+
+    def test_resolve_root_falls_back_to_base_dir(self, tmp_path):
+        policy = CachePolicy()
+        assert policy.resolve_root(tmp_path) == tmp_path / CACHE_DIRNAME
+
+
+class TestCachedTranscribe:
+    def _make(self, tmp_path):
+        from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+        return Transcript(
+            segments=[TranscriptSegment(start=0.0, end=1.0, text="hi")],
+            language="de",
+            duration=1.0,
+        )
+
+    def test_miss_invokes_backend_and_writes(self, tmp_path):
+        video = _touch_video(tmp_path)
+        calls = {"n": 0}
+
+        def fake_transcribe():
+            calls["n"] += 1
+            return self._make(tmp_path)
+
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+        transcript, hit = cached_transcribe(
+            video,
+            policy=policy,
+            transcribe_fn=fake_transcribe,
+            backend_name="faster-whisper",
+            model_size="large-v3",
+            language="de",
+            device="cuda:0",
+        )
+        assert hit is False
+        assert calls["n"] == 1
+        assert transcript.duration == 1.0
+
+    def test_second_call_is_cache_hit(self, tmp_path):
+        video = _touch_video(tmp_path)
+        calls = {"n": 0}
+
+        def fake_transcribe():
+            calls["n"] += 1
+            return self._make(tmp_path)
+
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+        kwargs = {
+            "policy": policy,
+            "transcribe_fn": fake_transcribe,
+            "backend_name": "faster-whisper",
+            "model_size": "large-v3",
+            "language": "de",
+            "device": "cuda",
+        }
+
+        cached_transcribe(video, **kwargs)
+        _, hit = cached_transcribe(video, **kwargs)
+
+        assert hit is True
+        assert calls["n"] == 1
+
+    def test_disabled_policy_skips_cache(self, tmp_path):
+        video = _touch_video(tmp_path)
+        calls = {"n": 0}
+
+        def fake_transcribe():
+            calls["n"] += 1
+            return self._make(tmp_path)
+
+        policy = CachePolicy.disabled()
+        cached_transcribe(
+            video,
+            policy=policy,
+            transcribe_fn=fake_transcribe,
+            backend_name="faster-whisper",
+            model_size="large-v3",
+            language="de",
+            device="cpu",
+        )
+        cached_transcribe(
+            video,
+            policy=policy,
+            transcribe_fn=fake_transcribe,
+            backend_name="faster-whisper",
+            model_size="large-v3",
+            language="de",
+            device="cpu",
+        )
+        assert calls["n"] == 2
+
+    def test_refresh_forces_miss_but_writes(self, tmp_path):
+        video = _touch_video(tmp_path)
+        calls = {"n": 0}
+
+        def fake_transcribe():
+            calls["n"] += 1
+            return self._make(tmp_path)
+
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+        kwargs = {
+            "transcribe_fn": fake_transcribe,
+            "backend_name": "faster-whisper",
+            "model_size": "large-v3",
+            "language": "de",
+            "device": "cpu",
+        }
+
+        cached_transcribe(video, policy=policy, **kwargs)
+        cached_transcribe(
+            video, policy=CachePolicy(cache_root=tmp_path / "cache", refresh=True), **kwargs
+        )
+        # Third call with normal policy should hit (refresh wrote the entry)
+        _, hit = cached_transcribe(video, policy=policy, **kwargs)
+        assert calls["n"] == 2
+        assert hit is True
+
+
+class TestCachedDetect:
+    def test_round_trip(self, tmp_path):
+        from clm.voiceover.keyframes import TransitionEvent
+
+        video = _touch_video(tmp_path)
+        calls = {"n": 0}
+
+        def fake_detect():
+            calls["n"] += 1
+            return [TransitionEvent(timestamp=5.0, peak_diff=0.4, confidence=2.0, num_frames=2)]
+
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+
+        events, hit = cached_detect(video, policy=policy, detect_fn=fake_detect)
+        assert hit is False
+        _, hit2 = cached_detect(video, policy=policy, detect_fn=fake_detect)
+        assert hit2 is True
+        assert calls["n"] == 1
+        assert events[0].timestamp == 5.0
+
+
+class TestCachedTimelineAndAlignment:
+    def test_timeline_cached(self, tmp_path):
+        from clm.voiceover.matcher import TimelineEntry
+
+        video = _touch_video(tmp_path)
+        slides = tmp_path / "slides.py"
+        slides.write_text("x = 1\n", encoding="utf-8")
+        calls = {"n": 0}
+
+        def fake_timeline():
+            calls["n"] += 1
+            return [TimelineEntry(slide_index=1, start_time=0.0, end_time=5.0, match_score=90.0)]
+
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+        cfg = {"lang": "de", "frame_offset": 1.0}
+
+        cached_timeline(video, slides, policy=policy, timeline_fn=fake_timeline, cfg=cfg)
+        _, hit = cached_timeline(video, slides, policy=policy, timeline_fn=fake_timeline, cfg=cfg)
+        assert hit is True
+        assert calls["n"] == 1
+
+    def test_alignment_cached(self, tmp_path):
+        from clm.voiceover.aligner import AlignmentResult, SlideNotes
+
+        video = _touch_video(tmp_path)
+        slides = tmp_path / "slides.py"
+        slides.write_text("x = 1\n", encoding="utf-8")
+        calls = {"n": 0}
+
+        def fake_align():
+            calls["n"] += 1
+            return AlignmentResult(
+                slide_notes={1: SlideNotes(slide_index=1, segments=["hi"])},
+                unassigned_segments=[],
+            )
+
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+        cfg = {"bias": 0.4}
+
+        cached_alignment(video, slides, policy=policy, alignment_fn=fake_align, cfg=cfg)
+        _, hit = cached_alignment(video, slides, policy=policy, alignment_fn=fake_align, cfg=cfg)
+        assert hit is True
+        assert calls["n"] == 1
+
+
+@pytest.fixture(autouse=True)
+def _no_cv2_required():
+    """Cache tests don't need cv2; importing keyframes/matcher lazily is fine."""
+    yield

--- a/tests/voiceover/test_compare.py
+++ b/tests/voiceover/test_compare.py
@@ -1,0 +1,337 @@
+"""Tests for clm.voiceover.compare.judge_slide_pair and CompareReport."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clm.voiceover.bullet_schema import BulletOutcome, BulletStatus
+from clm.voiceover.compare import (
+    CompareReport,
+    SlideComparison,
+    judge_slide_pair,
+)
+from clm.voiceover.slide_matcher import MatchKind
+
+
+def _mock_response(content: str):
+    choice = MagicMock()
+    choice.message.content = content
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+class TestJudgeSlidePair:
+    @pytest.mark.asyncio
+    async def test_both_empty_skips_llm(self):
+        outcomes, notes, err = await judge_slide_pair(
+            prior_bullets="",
+            baseline_bullets="",
+            slide_content_head="# Slide",
+            slide_content_prior=None,
+            language="en",
+            content_changed=False,
+            slide_id="s/1",
+        )
+        assert outcomes == []
+        assert notes is None
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_parses_structured_response(self):
+        mock_llm = _mock_response(
+            json.dumps(
+                {
+                    "bullets": "- a\n- b",
+                    "outcomes": [
+                        {"status": "covered", "target": "- a", "source": "- a"},
+                        {
+                            "status": "rewritten",
+                            "target": "- b",
+                            "source": "- b old",
+                            "note": "clarified wording",
+                        },
+                    ],
+                    "notes": "Minor rewording only.",
+                }
+            )
+        )
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_llm)
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            outcomes, notes, err = await judge_slide_pair(
+                prior_bullets="- a\n- b old",
+                baseline_bullets="- a\n- b",
+                slide_content_head="# Head",
+                slide_content_prior=None,
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+        assert err is None
+        assert notes == "Minor rewording only."
+        assert len(outcomes) == 2
+        assert outcomes[0].status is BulletStatus.COVERED
+        assert outcomes[1].status is BulletStatus.REWRITTEN
+        assert outcomes[1].note == "clarified wording"
+
+    @pytest.mark.asyncio
+    async def test_non_llmerror_exception_reported_as_error(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("network"))
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            outcomes, notes, err = await judge_slide_pair(
+                prior_bullets="- a",
+                baseline_bullets="- b",
+                slide_content_head="",
+                slide_content_prior=None,
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+        assert outcomes == []
+        assert err is not None
+        assert "network" in err
+
+    @pytest.mark.asyncio
+    async def test_content_changed_includes_prior_slide(self):
+        captured: list[dict] = []
+
+        async def capture_create(**kwargs):
+            captured.extend(kwargs["messages"])
+            return _mock_response(json.dumps({"bullets": "", "outcomes": []}))
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=capture_create)
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            await judge_slide_pair(
+                prior_bullets="- a",
+                baseline_bullets="- b",
+                slide_content_head="# New",
+                slide_content_prior="# Old",
+                language="en",
+                content_changed=True,
+                slide_id="s/1",
+            )
+        user_msg = next(m["content"] for m in captured if m["role"] == "user")
+        assert "# Old" in user_msg
+        assert "prior/source version" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_uses_compare_prompt_not_port_prompt(self):
+        captured_system: list[str] = []
+
+        async def capture_create(**kwargs):
+            for m in kwargs["messages"]:
+                if m["role"] == "system":
+                    captured_system.append(m["content"])
+            return _mock_response(json.dumps({"bullets": "", "outcomes": []}))
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=capture_create)
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            await judge_slide_pair(
+                prior_bullets="- a",
+                baseline_bullets="- b",
+                slide_content_head="",
+                slide_content_prior=None,
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+        assert captured_system, "system prompt not captured"
+        # The compare prompt has evaluative language; the port prompt is constructive.
+        assert "read-only" in captured_system[0] or "evaluation" in captured_system[0]
+
+
+class TestCompareReport:
+    def _sample(self) -> CompareReport:
+        return CompareReport(
+            source=Path("old.py"),
+            target=Path("new.py"),
+            language="en",
+            slides=[
+                SlideComparison(
+                    key="id:s1",
+                    kind=MatchKind.UNCHANGED,
+                    target_index=0,
+                    source_index=0,
+                    content_similarity=100.0,
+                    outcomes=[
+                        BulletOutcome(status=BulletStatus.COVERED, target="- x", source="- x"),
+                        BulletOutcome(status=BulletStatus.REWRITTEN, target="- y", source="- y'"),
+                    ],
+                ),
+                SlideComparison(
+                    key="id:s2",
+                    kind=MatchKind.NEW_AT_HEAD,
+                    target_index=1,
+                    source_index=None,
+                ),
+                SlideComparison(
+                    key="id:s3",
+                    kind=MatchKind.MODIFIED,
+                    target_index=2,
+                    source_index=1,
+                    content_similarity=70.0,
+                    outcomes=[
+                        BulletOutcome(status=BulletStatus.DROPPED, source="- dropped"),
+                    ],
+                ),
+            ],
+        )
+
+    def test_status_totals(self):
+        report = self._sample()
+        totals = report.status_totals()
+        assert totals[BulletStatus.COVERED] == 1
+        assert totals[BulletStatus.REWRITTEN] == 1
+        assert totals[BulletStatus.DROPPED] == 1
+        assert totals[BulletStatus.ADDED] == 0
+
+    def test_kind_totals(self):
+        report = self._sample()
+        kinds = report.kind_totals()
+        assert kinds[MatchKind.UNCHANGED] == 1
+        assert kinds[MatchKind.MODIFIED] == 1
+        assert kinds[MatchKind.NEW_AT_HEAD] == 1
+
+    def test_to_json_roundtrips_fields(self):
+        report = self._sample()
+        payload = report.to_json()
+        assert payload["language"] == "en"
+        assert payload["slide_count"] == 3
+        assert payload["status_totals"]["covered"] == 1
+        assert payload["status_totals"]["rewritten"] == 1
+        assert payload["status_totals"]["dropped"] == 1
+        assert payload["kind_totals"]["unchanged"] == 1
+        assert len(payload["slides"]) == 3
+        assert payload["slides"][0]["outcomes"][0]["status"] == "covered"
+
+    def test_slide_comparison_status_counts_empty_when_no_outcomes(self):
+        comp = SlideComparison(
+            key="id:x",
+            kind=MatchKind.NEW_AT_HEAD,
+            target_index=0,
+            source_index=None,
+        )
+        counts = comp.status_counts()
+        assert all(v == 0 for v in counts.values())
+
+
+_SOURCE_SLIDES = """# %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+# Intro
+
+Explain what we are going to learn.
+
+# %% [markdown] lang="en" tags=["voiceover"]
+- talk about goals
+- emphasise practice over theory
+"""
+
+_TARGET_SLIDES = """# %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+# Intro
+
+Explain what we are going to learn.
+
+# %% [markdown] lang="en" tags=["voiceover"]
+- talk about goals
+- mention the syllabus
+"""
+
+
+class TestCompareCLI:
+    def test_runs_and_emits_json(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        source = tmp_path / "old.py"
+        target = tmp_path / "new.py"
+        source.write_text(_SOURCE_SLIDES, encoding="utf-8")
+        target.write_text(_TARGET_SLIDES, encoding="utf-8")
+
+        llm_payload = json.dumps(
+            {
+                "bullets": "- talk about goals\n- mention the syllabus",
+                "outcomes": [
+                    {
+                        "status": "covered",
+                        "target": "- talk about goals",
+                        "source": "- talk about goals",
+                    },
+                    {
+                        "status": "rewritten",
+                        "target": "- mention the syllabus",
+                        "source": "- emphasise practice over theory",
+                        "note": "substantive rewording",
+                    },
+                ],
+                "notes": "One bullet rewritten.",
+            }
+        )
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_mock_response(llm_payload))
+
+        runner = CliRunner()
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = runner.invoke(
+                voiceover_group,
+                [
+                    "compare",
+                    str(source),
+                    str(target),
+                    "--lang",
+                    "en",
+                    "--json",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        # Output begins with rich-console lines, but --json prints the payload via click.echo.
+        # Find the first `{` and parse from there.
+        start = result.output.find("{")
+        assert start >= 0, f"No JSON found in output: {result.output!r}"
+        data = json.loads(result.output[start:])
+        assert data["language"] == "en"
+        assert data["status_totals"]["covered"] == 1
+        assert data["status_totals"]["rewritten"] == 1
+
+    def test_writes_json_to_output(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.voiceover import voiceover_group
+
+        source = tmp_path / "old.py"
+        target = tmp_path / "new.py"
+        source.write_text(_SOURCE_SLIDES, encoding="utf-8")
+        target.write_text(_TARGET_SLIDES, encoding="utf-8")
+        out = tmp_path / "report.json"
+
+        llm_payload = json.dumps({"bullets": "", "outcomes": []})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_mock_response(llm_payload))
+
+        runner = CliRunner()
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = runner.invoke(
+                voiceover_group,
+                [
+                    "compare",
+                    str(source),
+                    str(target),
+                    "--lang",
+                    "en",
+                    "--json",
+                    "-o",
+                    str(out),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["target"].endswith("new.py")
+        assert data["source"].endswith("old.py")

--- a/tests/voiceover/test_narrative_commits.py
+++ b/tests/voiceover/test_narrative_commits.py
@@ -19,6 +19,7 @@ from clm.voiceover.narrative_commits import (
     classify_cells,
     collapse_runs,
     compute_commit_metrics,
+    compute_hunk_deltas,
     compute_ratio,
     scan_slide_file,
 )
@@ -163,6 +164,73 @@ class TestComputeRatio:
         assert compute_ratio(0, 0) == 0.0
 
 
+SLIDE_FILE_REWRITTEN_NOTES = '''\
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## Einführung
+Hier eine Einführung in Web Services.
+"""
+
+# %% [markdown] lang="de" tags=["notes"]
+"""
+- Komplett andere Formulierungen für die gleiche Idee.
+- Anderer Blickwinkel auf lose Kopplung.
+- Drittes neues Stichwort zum gleichen Thema.
+"""
+
+# %% [markdown] lang="en" tags=["slide"]
+"""
+## Introduction
+An introduction to web services.
+"""
+
+# %% [markdown] lang="en" tags=["notes"]
+"""
+- Entirely different wording for the same idea.
+- Different angle on loose coupling.
+- Third new talking point on the same topic.
+"""
+
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## REST vs SOAP
+REST ist der moderne Ansatz.
+"""
+'''
+
+
+class TestHunkDeltas:
+    def test_noop_is_zero(self):
+        n, c = compute_hunk_deltas(SLIDE_FILE_WITH_NOTES, SLIDE_FILE_WITH_NOTES)
+        assert n == 0
+        assert c == 0
+
+    def test_none_parent_charges_additions_only(self):
+        n, c = compute_hunk_deltas(None, SLIDE_FILE_PRE_NOTES)
+        # No narrative cells in pre-notes file, many content lines added.
+        assert n == 0
+        assert c > 0
+
+    def test_adding_notes_is_narrative(self):
+        n, c = compute_hunk_deltas(SLIDE_FILE_PRE_NOTES, SLIDE_FILE_WITH_NOTES)
+        assert n > 0
+        # No content cells edited — same 3 slide cells in both files.
+        assert n > c
+
+    def test_content_rewrite_is_content(self):
+        n, c = compute_hunk_deltas(SLIDE_FILE_PRE_NOTES, SLIDE_FILE_CONTENT_CHANGED)
+        assert c > n
+
+    def test_narrative_rewrite_double_counts(self):
+        # Hunk classifier counts both the removed and added narrative lines;
+        # a net-char classifier would see zero delta when sizes happen to
+        # balance. With 3 bullets replaced by 3 bullets of similar size,
+        # char-delta ≈ small noise; hunk classifier sees ~6 lines of churn.
+        n, c = compute_hunk_deltas(SLIDE_FILE_WITH_NOTES, SLIDE_FILE_REWRITTEN_NOTES)
+        assert n >= 6  # 3 removed + 3 added across both languages
+        assert c == 0  # slide cells untouched
+
+
 class TestComputeCommitMetrics:
     def _commit(self) -> CommitInfo:
         return CommitInfo(
@@ -220,7 +288,7 @@ class TestComputeCommitMetrics:
             self._commit(),
             tiny_before,
             tiny_after,
-            floor=50,
+            floor=50,  # 50 lines >> 2-line edit
         )
         assert not m.is_narrative_heavy
 

--- a/tests/voiceover/test_narrative_commits.py
+++ b/tests/voiceover/test_narrative_commits.py
@@ -1,0 +1,393 @@
+"""Tests for the narrative-commit heuristic spike.
+
+Covers the pure-logic functions with unit tests and the end-to-end walk
+with a smoke test against a temporary git repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from clm.notebooks.slide_parser import parse_cells
+from clm.voiceover.narrative_commits import (
+    CommitInfo,
+    CommitMetrics,
+    classify_cells,
+    collapse_runs,
+    compute_commit_metrics,
+    compute_ratio,
+    scan_slide_file,
+)
+
+SLIDE_FILE_PRE_NOTES = '''\
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## Einführung
+Hier eine Einführung in Web Services.
+"""
+
+# %% [markdown] lang="en" tags=["slide"]
+"""
+## Introduction
+An introduction to web services.
+"""
+
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## REST vs SOAP
+REST ist der moderne Ansatz.
+"""
+'''
+
+
+SLIDE_FILE_WITH_NOTES = '''\
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## Einführung
+Hier eine Einführung in Web Services.
+"""
+
+# %% [markdown] lang="de" tags=["notes"]
+"""
+- Web Services erlauben lose Kopplung zwischen Systemen.
+- Sie sind die Grundlage moderner verteilter Architekturen.
+- Wir werden REST-APIs detailliert untersuchen.
+"""
+
+# %% [markdown] lang="en" tags=["slide"]
+"""
+## Introduction
+An introduction to web services.
+"""
+
+# %% [markdown] lang="en" tags=["notes"]
+"""
+- Web services enable loose coupling across systems.
+- They are the foundation of modern distributed architectures.
+- We will examine REST APIs in detail.
+"""
+
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## REST vs SOAP
+REST ist der moderne Ansatz.
+"""
+'''
+
+
+SLIDE_FILE_WITH_VOICEOVER = '''\
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## Einführung
+Hier eine Einführung in Web Services.
+"""
+
+# %% [markdown] lang="de" tags=["voiceover"]
+"""
+- Web Services erlauben lose Kopplung zwischen Systemen.
+- Sie sind die Grundlage moderner verteilter Architekturen.
+- Wir werden REST-APIs detailliert untersuchen.
+"""
+'''
+
+
+SLIDE_FILE_CONTENT_CHANGED = '''\
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## Einführung in verteilte Systeme und Web Services
+Eine ausführliche Einführung in die Welt der Web Services
+mit vielen Beispielen und Erklärungen zur Architektur,
+Geschichte und aktuellen Best Practices in der Industrie.
+"""
+
+# %% [markdown] lang="en" tags=["slide"]
+"""
+## Introduction to Distributed Systems and Web Services
+A detailed introduction to the world of web services with
+many examples and explanations about architecture, history,
+and current best practices in the industry.
+"""
+
+# %% [markdown] lang="de" tags=["slide"]
+"""
+## REST vs SOAP — Eine Gegenüberstellung
+REST ist der moderne Ansatz, aber SOAP existiert noch.
+Hier eine ausführliche Gegenüberstellung beider Ansätze
+mit Blick auf Performance, Tooling und Wartbarkeit.
+"""
+'''
+
+
+class TestClassifyCells:
+    def test_pure_content(self):
+        cells = parse_cells(SLIDE_FILE_PRE_NOTES)
+        narrative, content = classify_cells(cells)
+        assert narrative == 0
+        assert content > 0
+
+    def test_notes_count_as_narrative(self):
+        cells = parse_cells(SLIDE_FILE_WITH_NOTES)
+        narrative, content = classify_cells(cells)
+        assert narrative > 0
+        assert content > 0
+
+    def test_voiceover_count_as_narrative(self):
+        cells = parse_cells(SLIDE_FILE_WITH_VOICEOVER)
+        narrative, content = classify_cells(cells)
+        assert narrative > 0
+
+    def test_empty(self):
+        assert classify_cells([]) == (0, 0)
+
+
+class TestComputeRatio:
+    def test_pure_narrative(self):
+        # narrative_delta=100, content_delta=0 → ~1.0
+        r = compute_ratio(100, 0)
+        assert r > 0.9
+
+    def test_pure_content(self):
+        r = compute_ratio(0, 100)
+        assert r < 0.1
+
+    def test_balanced(self):
+        r = compute_ratio(100, 100)
+        assert 0.4 < r < 0.6
+
+    def test_zero_zero_safe(self):
+        # +1 guard prevents division by zero
+        assert compute_ratio(0, 0) == 0.0
+
+
+class TestComputeCommitMetrics:
+    def _commit(self) -> CommitInfo:
+        return CommitInfo(
+            sha="a" * 40,
+            parent_sha="b" * 40,
+            date=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            subject="test commit",
+        )
+
+    def test_adding_notes_is_narrative_heavy(self):
+        m = compute_commit_metrics(
+            self._commit(),
+            SLIDE_FILE_PRE_NOTES,
+            SLIDE_FILE_WITH_NOTES,
+        )
+        assert m.is_narrative_heavy
+        assert m.narrative_delta > 0
+        assert m.ratio >= 0.7
+
+    def test_content_edit_is_not_narrative_heavy(self):
+        m = compute_commit_metrics(
+            self._commit(),
+            SLIDE_FILE_PRE_NOTES,
+            SLIDE_FILE_CONTENT_CHANGED,
+        )
+        assert not m.is_narrative_heavy
+        assert m.content_delta > 0
+        assert m.ratio < 0.7
+
+    def test_new_file_no_parent(self):
+        m = compute_commit_metrics(
+            self._commit(),
+            parent_text=None,
+            commit_text=SLIDE_FILE_PRE_NOTES,
+        )
+        assert m.narrative_delta == 0
+        assert m.content_delta > 0
+        assert not m.is_narrative_heavy
+
+    def test_identical_is_zero(self):
+        m = compute_commit_metrics(
+            self._commit(),
+            SLIDE_FILE_WITH_NOTES,
+            SLIDE_FILE_WITH_NOTES,
+        )
+        assert m.narrative_delta == 0
+        assert m.content_delta == 0
+        assert not m.is_narrative_heavy
+
+    def test_floor_rejects_tiny_narrative_commit(self):
+        # narrative_delta below floor → not heavy even if ratio is high
+        tiny_before = '# %% [markdown] lang="de" tags=["notes"]\n"""\n- a\n"""'
+        tiny_after = '# %% [markdown] lang="de" tags=["notes"]\n"""\n- ab\n"""'
+        m = compute_commit_metrics(
+            self._commit(),
+            tiny_before,
+            tiny_after,
+            floor=50,
+        )
+        assert not m.is_narrative_heavy
+
+    def test_threshold_is_adjustable(self):
+        # A borderline change ranks heavy at threshold=0.5, not at 0.9
+        m_loose = compute_commit_metrics(
+            self._commit(),
+            SLIDE_FILE_PRE_NOTES,
+            SLIDE_FILE_WITH_NOTES,
+            threshold=0.5,
+        )
+        m_strict = compute_commit_metrics(
+            self._commit(),
+            SLIDE_FILE_PRE_NOTES,
+            SLIDE_FILE_WITH_NOTES,
+            threshold=0.99,
+        )
+        assert m_loose.is_narrative_heavy
+        # Same commit: ratio is identical; only the heavy flag differs
+        assert m_strict.ratio == m_loose.ratio
+
+
+def _make_metric(
+    sha: str,
+    parent: str | None,
+    heavy: bool,
+) -> CommitMetrics:
+    return CommitMetrics(
+        commit=CommitInfo(
+            sha=sha,
+            parent_sha=parent,
+            date=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            subject=f"commit {sha[:4]}",
+        ),
+        narrative_delta=100 if heavy else 10,
+        content_delta=10 if heavy else 100,
+        ratio=0.9 if heavy else 0.1,
+        is_narrative_heavy=heavy,
+    )
+
+
+class TestCollapseRuns:
+    def test_empty(self):
+        assert collapse_runs([]) == []
+
+    def test_no_heavy_commits(self):
+        metrics = [
+            _make_metric("a", "p", False),
+            _make_metric("b", "a", False),
+        ]
+        assert collapse_runs(metrics) == []
+
+    def test_single_heavy_commit_becomes_a_run(self):
+        metrics = [
+            _make_metric("a", "p", False),
+            _make_metric("b", "a", True),
+            _make_metric("c", "b", False),
+        ]
+        runs = collapse_runs(metrics)
+        assert len(runs) == 1
+        assert runs[0].run_id == 1
+        assert runs[0].pre_run_sha == "a"
+        assert runs[0].post_run_sha == "b"
+        assert len(runs[0].commit_metrics) == 1
+
+    def test_consecutive_heavy_commits_collapse(self):
+        metrics = [
+            _make_metric("a", "p", False),
+            _make_metric("b", "a", True),
+            _make_metric("c", "b", True),
+            _make_metric("d", "c", True),
+            _make_metric("e", "d", False),
+        ]
+        runs = collapse_runs(metrics)
+        assert len(runs) == 1
+        assert runs[0].pre_run_sha == "a"
+        assert runs[0].post_run_sha == "d"
+        assert len(runs[0].commit_metrics) == 3
+
+    def test_multiple_runs(self):
+        metrics = [
+            _make_metric("a", "p", True),
+            _make_metric("b", "a", False),
+            _make_metric("c", "b", True),
+            _make_metric("d", "c", True),
+        ]
+        runs = collapse_runs(metrics)
+        assert len(runs) == 2
+        assert runs[0].post_run_sha == "a"
+        assert runs[1].pre_run_sha == "b"
+        assert runs[1].post_run_sha == "d"
+
+    def test_root_commit_has_none_pre_run(self):
+        metrics = [_make_metric("a", None, True)]
+        runs = collapse_runs(metrics)
+        assert runs[0].pre_run_sha is None
+
+
+@pytest.mark.integration
+class TestScanSlideFile:
+    """Smoke test against a real temp git repo."""
+
+    def _git(self, repo: Path, *args: str, check: bool = True) -> str:
+        env = {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_AUTHOR_DATE": "2026-04-01T00:00:00+0000",
+            "GIT_COMMITTER_DATE": "2026-04-01T00:00:00+0000",
+        }
+        import os
+
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            env={**os.environ, **env},
+            check=check,
+        )
+        return result.stdout
+
+    def test_end_to_end(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._git(repo, "init", "-q", "-b", "main")
+
+        slide = repo / "slides.py"
+
+        # Commit 1: initial slides, no notes.
+        slide.write_text(SLIDE_FILE_PRE_NOTES, encoding="utf-8")
+        self._git(repo, "add", "slides.py")
+        self._git(repo, "commit", "-q", "-m", "initial slides")
+
+        # Commit 2: add notes (narrative-heavy).
+        slide.write_text(SLIDE_FILE_WITH_NOTES, encoding="utf-8")
+        self._git(repo, "add", "slides.py")
+        self._git(repo, "commit", "-q", "-m", "add recording notes")
+
+        # Commit 3: rewrite slide content substantively (not narrative-heavy).
+        slide.write_text(SLIDE_FILE_CONTENT_CHANGED, encoding="utf-8")
+        self._git(repo, "add", "slides.py")
+        self._git(repo, "commit", "-q", "-m", "expand slide explanations")
+
+        metrics, runs = scan_slide_file(slide)
+
+        assert len(metrics) == 3
+        # Oldest → newest order.
+        subjects = [m.commit.subject for m in metrics]
+        assert subjects == [
+            "initial slides",
+            "add recording notes",
+            "expand slide explanations",
+        ]
+
+        # Initial commit classified as content (no parent, all content chars
+        # appear as additions).
+        assert not metrics[0].is_narrative_heavy
+
+        # Note-addition commit should be narrative-heavy.
+        assert metrics[1].is_narrative_heavy
+
+        # Slide-content-expansion should not.
+        assert not metrics[2].is_narrative_heavy
+
+        # One run, containing only the note-addition commit.
+        assert len(runs) == 1
+        assert len(runs[0].commit_metrics) == 1
+        assert runs[0].pre_run_sha == metrics[0].commit.sha
+        assert runs[0].post_run_sha == metrics[1].commit.sha

--- a/tests/voiceover/test_port.py
+++ b/tests/voiceover/test_port.py
@@ -1,0 +1,180 @@
+"""Tests for clm.voiceover.port.polish_and_port."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clm.voiceover.bullet_schema import BulletStatus
+from clm.voiceover.port import PortResult, polish_and_port
+
+
+def _mock_response(content: str):
+    choice = MagicMock()
+    choice.message.content = content
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+class TestPolishAndPortShortcuts:
+    @pytest.mark.asyncio
+    async def test_both_empty_returns_empty_without_llm(self):
+        result = await polish_and_port(
+            baseline_bullets="",
+            prior_voiceover="",
+            slide_content_head="# Slide",
+            slide_content_prior=None,
+            language="en",
+            content_changed=False,
+            slide_id="s/1",
+        )
+        assert isinstance(result, PortResult)
+        assert result.bullets == ""
+        assert result.outcomes == []
+
+    @pytest.mark.asyncio
+    async def test_empty_prior_returns_baseline_without_llm(self):
+        result = await polish_and_port(
+            baseline_bullets="- existing\n- two",
+            prior_voiceover="",
+            slide_content_head="",
+            slide_content_prior=None,
+            language="en",
+            content_changed=False,
+            slide_id="s/1",
+        )
+        assert result.bullets == "- existing\n- two"
+
+
+class TestPolishAndPortLLM:
+    @pytest.mark.asyncio
+    async def test_successful_port(self):
+        mock_llm = _mock_response(
+            json.dumps(
+                {
+                    "bullets": "- existing\n- new from prior",
+                    "outcomes": [
+                        {"status": "covered", "target": "- existing", "source": "- existing"},
+                        {
+                            "status": "added",
+                            "target": "- new from prior",
+                            "source": "- new from prior",
+                        },
+                    ],
+                    "notes": "Clean port.",
+                }
+            )
+        )
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_llm)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_port(
+                baseline_bullets="- existing",
+                prior_voiceover="- new from prior",
+                slide_content_head="# Head",
+                slide_content_prior=None,
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+
+        assert "new from prior" in result.bullets
+        assert result.notes == "Clean port."
+        assert len(result.outcomes) == 2
+        assert result.outcomes[0].status is BulletStatus.COVERED
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_falls_back_to_baseline(self):
+        mock_llm = _mock_response("this is not JSON")
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_llm)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_port(
+                baseline_bullets="- baseline",
+                prior_voiceover="- prior",
+                slide_content_head="",
+                slide_content_prior=None,
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+
+        # Invalid JSON -> fallback to baseline (preferred over unmerged prior).
+        assert result.bullets == "- baseline"
+        assert result.outcomes == []
+
+    @pytest.mark.asyncio
+    async def test_llm_client_failure_non_llmerror_returns_fallback(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("network down"))
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            result = await polish_and_port(
+                baseline_bullets="- baseline",
+                prior_voiceover="- prior",
+                slide_content_head="",
+                slide_content_prior=None,
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+        assert result.error is not None
+        assert "network down" in result.error
+        assert result.bullets == "- baseline"
+
+    @pytest.mark.asyncio
+    async def test_content_changed_passes_prior_slide_text(self):
+        """When content_changed=True the LLM must receive the prior slide text."""
+        captured_messages: list[dict] = []
+
+        async def capture_create(**kwargs):
+            captured_messages.extend(kwargs["messages"])
+            return _mock_response(json.dumps({"bullets": "- x", "outcomes": []}))
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=capture_create)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            await polish_and_port(
+                baseline_bullets="",
+                prior_voiceover="- prior",
+                slide_content_head="# Head",
+                slide_content_prior="# Prior",
+                language="en",
+                content_changed=True,
+                slide_id="s/1",
+            )
+
+        user_content = next(m["content"] for m in captured_messages if m["role"] == "user")
+        assert "# Prior" in user_content
+        assert "prior/source version" in user_content
+
+    @pytest.mark.asyncio
+    async def test_content_unchanged_hides_prior_slide_text(self):
+        captured_messages: list[dict] = []
+
+        async def capture_create(**kwargs):
+            captured_messages.extend(kwargs["messages"])
+            return _mock_response(json.dumps({"bullets": "- x", "outcomes": []}))
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=capture_create)
+
+        with patch("clm.infrastructure.llm.client._build_client", return_value=mock_client):
+            await polish_and_port(
+                baseline_bullets="",
+                prior_voiceover="- prior",
+                slide_content_head="# Same",
+                slide_content_prior="# Same",
+                language="en",
+                content_changed=False,
+                slide_id="s/1",
+            )
+
+        user_content = next(m["content"] for m in captured_messages if m["role"] == "user")
+        assert "prior/source version" not in user_content

--- a/tests/voiceover/test_rev_scorer.py
+++ b/tests/voiceover/test_rev_scorer.py
@@ -1,0 +1,238 @@
+"""Tests for the identify-rev fingerprint scorer."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.voiceover.rev_scorer import (
+    NARRATIVE_PRIOR,
+    fuzzy_lcs_score,
+    score_revisions,
+    slide_labels,
+)
+
+SLIDES_V1 = '''\
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+"""
+## Einführung
+Willkommen.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="rest-vs-soap"
+"""
+## REST vs SOAP
+REST ist der moderne Ansatz.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="graphql"
+"""
+## GraphQL
+Flexible Abfragen.
+"""
+'''
+
+SLIDES_V2_NOTES_ADDED = '''\
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+"""
+## Einführung
+Willkommen.
+"""
+
+# %% [markdown] lang="de" tags=["notes"]
+"""
+- Erster Aufhänger für die Einführung.
+- Zweiter Aufhänger mit mehr Kontext.
+- Dritter Punkt für den Übergang.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="rest-vs-soap"
+"""
+## REST vs SOAP
+REST ist der moderne Ansatz.
+"""
+
+# %% [markdown] lang="de" tags=["notes"]
+"""
+- Historischer Kontext zu SOAP.
+- Warum REST gewonnen hat.
+- Wann SOAP noch sinnvoll ist.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="graphql"
+"""
+## GraphQL
+Flexible Abfragen.
+"""
+'''
+
+SLIDES_V3_RENAMED = '''\
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+"""
+## Einführung in Web APIs
+Willkommen zum Kurs.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="rest-vs-soap"
+"""
+## REST vs SOAP
+REST ist der moderne Ansatz.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="graphql"
+"""
+## GraphQL und moderne Query-Languages
+Flexible Abfragen.
+"""
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="grpc"
+"""
+## gRPC
+Binäres RPC-Protokoll.
+"""
+'''
+
+
+class TestSlideLabels:
+    def test_uses_slide_id_when_present(self):
+        labels = slide_labels(SLIDES_V1, "de")
+        assert labels == ["id:intro", "id:rest-vs-soap", "id:graphql"]
+
+    def test_falls_back_to_title_without_slide_id(self):
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Titel'
+        labels = slide_labels(text, "de")
+        assert labels == ["title:Mein Titel"]
+
+    def test_empty_file(self):
+        assert slide_labels("", "de") == []
+
+    def test_notes_cells_excluded(self):
+        labels = slide_labels(SLIDES_V2_NOTES_ADDED, "de")
+        # Same three slide labels; notes cells don't contribute.
+        assert labels == ["id:intro", "id:rest-vs-soap", "id:graphql"]
+
+
+class TestFuzzyLcsScore:
+    def test_empty_inputs(self):
+        assert fuzzy_lcs_score([], []) == 0.0
+        assert fuzzy_lcs_score(["a"], []) == 0.0
+        assert fuzzy_lcs_score([], ["a"]) == 0.0
+
+    def test_exact_match_is_one(self):
+        labels = ["title:Intro", "title:REST", "title:GraphQL"]
+        score = fuzzy_lcs_score(labels, labels)
+        assert score == pytest.approx(1.0, abs=0.01)
+
+    def test_complete_mismatch(self):
+        # Very different tokens — below the default 70 threshold.
+        score = fuzzy_lcs_score(["title:xxxx"], ["title:yyyy"])
+        assert score == 0.0
+
+    def test_partial_order_preserved(self):
+        # Video saw 2 of 3 slides in order → partial credit.
+        rev = ["title:Intro", "title:REST", "title:GraphQL"]
+        vid = ["title:Intro", "title:GraphQL"]
+        score = fuzzy_lcs_score(rev, vid)
+        # 2 exact matches (worth ~2.0), normalised by max(3,2)=3.
+        assert 0.6 < score < 0.7
+
+    def test_out_of_order_video_still_scores(self):
+        # LCS picks the best in-order subsequence.
+        rev = ["title:A", "title:B", "title:C"]
+        vid = ["title:C", "title:A", "title:B"]
+        # Best in-order subsequence is A,B or C alone or A alone.
+        # A,B matches: 2 contributions normalised by max(3,3)=3 → ~0.67.
+        score = fuzzy_lcs_score(rev, vid)
+        assert 0.6 < score < 0.75
+
+    def test_fuzzy_matching_handles_ocr_noise(self):
+        # OCR mangles 'REST' → 'RE5T' but token_set_ratio still matches.
+        rev = ["title:REST vs SOAP"]
+        vid = ["title:RE5T vs SOAP"]
+        score = fuzzy_lcs_score(rev, vid)
+        assert score > 0.7
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_AUTHOR_DATE": "2026-04-01T00:00:00+0000",
+        "GIT_COMMITTER_DATE": "2026-04-01T00:00:00+0000",
+    }
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
+        check=True,
+    )
+    return result.stdout
+
+
+@pytest.mark.integration
+class TestScoreRevisionsIntegration:
+    """End-to-end scoring against a real temp git repo."""
+
+    def _make_repo(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+
+        slide = repo / "slides.py"
+
+        slide.write_text(SLIDES_V1, encoding="utf-8")
+        _git(repo, "add", "slides.py")
+        _git(repo, "commit", "-q", "-m", "initial slides")
+
+        slide.write_text(SLIDES_V2_NOTES_ADDED, encoding="utf-8")
+        _git(repo, "add", "slides.py")
+        _git(repo, "commit", "-q", "-m", "record notes for session 1")
+
+        slide.write_text(SLIDES_V3_RENAMED, encoding="utf-8")
+        _git(repo, "add", "slides.py")
+        _git(repo, "commit", "-q", "-m", "add gRPC + rename intro")
+
+        return slide
+
+    def test_matching_fingerprint_ranks_correct_rev_first(self, tmp_path):
+        slide = self._make_repo(tmp_path)
+        # Video fingerprint matching the v1/v2 slide labels (which share
+        # the same three slide_ids).
+        video_fp = ["Einführung", "REST vs SOAP", "GraphQL"]
+
+        scored = score_revisions(slide, video_fp, lang="de")
+        assert len(scored) >= 3
+        # Top score should be meaningful (not zero).
+        assert scored[0].score > 0.5
+        # v1 and v2 both have the matching 3 slide_ids; v3 renamed intro
+        # and adds gRPC which has no video-side match — v3 should score
+        # strictly lower than the others.
+        v3_subject = "add gRPC + rename intro"
+        v3_score = next(r.score for r in scored if r.subject == v3_subject)
+        other_scores = [r.score for r in scored if r.subject != v3_subject]
+        assert all(s >= v3_score for s in other_scores)
+
+    def test_narrative_prior_applied_to_run_endpoints(self, tmp_path):
+        slide = self._make_repo(tmp_path)
+        video_fp = ["Einführung", "REST vs SOAP", "GraphQL"]
+
+        scored = score_revisions(slide, video_fp, lang="de")
+        # The notes-adding commit is narrative-heavy; its post-run tip
+        # and the pre-run parent (initial commit) should be endpoints.
+        endpoints = [r for r in scored if r.is_narrative_candidate]
+        assert endpoints, "expected at least one narrative-run endpoint"
+        for r in endpoints:
+            assert r.narrative_prior == NARRATIVE_PRIOR
+            # base_score * prior == final score
+            assert r.score == pytest.approx(r.base_score * r.narrative_prior)
+
+    def test_empty_video_fingerprint_returns_zero_scores(self, tmp_path):
+        slide = self._make_repo(tmp_path)
+        scored = score_revisions(slide, [], lang="de")
+        assert all(r.base_score == 0.0 for r in scored)

--- a/tests/voiceover/test_slide_matcher.py
+++ b/tests/voiceover/test_slide_matcher.py
@@ -1,0 +1,192 @@
+"""Tests for slide matching between two slide-file revisions."""
+
+from __future__ import annotations
+
+from clm.notebooks.slide_parser import group_slides, parse_cells
+from clm.voiceover.slide_matcher import MatchKind, content_similarity, match_slides
+
+
+def _parse(text: str, lang: str = "de"):
+    return group_slides(parse_cells(text), lang, include_header=False)
+
+
+SOURCE_TEXT = """\
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+#
+# ## Einführung
+# Willkommen zum Kurs.
+
+# %% [markdown] lang="de" tags=["voiceover"]
+#
+# - Begruessung und Ueberblick.
+# - Was euch heute erwartet.
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="rest-vs-soap"
+#
+# ## REST vs SOAP
+# REST ist der moderne Ansatz.
+
+# %% [markdown] lang="de" tags=["voiceover"]
+#
+# - REST ist leichtgewichtig.
+# - SOAP ist heute eher Legacy.
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="gone"
+#
+# ## Ein altes Thema
+# Dieser Abschnitt wurde entfernt.
+"""
+
+TARGET_TEXT_UNCHANGED = """\
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+#
+# ## Einführung
+# Willkommen zum Kurs.
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="rest-vs-soap"
+#
+# ## REST vs SOAP
+# REST ist der moderne Ansatz.
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="new-topic"
+#
+# ## Neues Thema
+# Ein ganz neuer Abschnitt.
+"""
+
+TARGET_TEXT_MODIFIED = """\
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+#
+# ## Einführung
+# Willkommen zum Kurs. Heute: Web APIs im Detail.
+# Zusaetzlich eine ganz neue Einleitung mit viel mehr Text, damit
+# die Content-Aehnlichkeit deutlich unter 90 Prozent faellt.
+# Noch mehr Text um sicherzustellen, dass sich der Content
+# substantiell unterscheidet. Noch ein ganzer Absatz Text.
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="rest-vs-soap"
+#
+# ## REST vs SOAP
+# REST ist der moderne Ansatz.
+"""
+
+
+class TestSlideIdMatching:
+    def test_exact_id_match_with_unchanged_content(self):
+        source = _parse(SOURCE_TEXT)
+        target = _parse(TARGET_TEXT_UNCHANGED)
+
+        matches = match_slides(source, target)
+        # 3 target slides (unchanged/unchanged/new) + 1 removed_at_head = 4 entries
+        by_key = {m.key: m for m in matches}
+
+        assert by_key["id:intro"].kind is MatchKind.UNCHANGED
+        assert by_key["id:rest-vs-soap"].kind is MatchKind.UNCHANGED
+        assert by_key["id:new-topic"].kind is MatchKind.NEW_AT_HEAD
+        assert by_key["id:gone"].kind is MatchKind.REMOVED_AT_HEAD
+
+    def test_target_indices_match_group_order(self):
+        source = _parse(SOURCE_TEXT)
+        target = _parse(TARGET_TEXT_UNCHANGED)
+        matches = match_slides(source, target)
+
+        intro = next(m for m in matches if m.key == "id:intro")
+        assert intro.target_index == 0
+        rest = next(m for m in matches if m.key == "id:rest-vs-soap")
+        assert rest.target_index == 1
+
+
+class TestModifiedDetection:
+    def test_modified_when_content_diverges(self):
+        source = _parse(SOURCE_TEXT)
+        target = _parse(TARGET_TEXT_MODIFIED)
+
+        matches = match_slides(source, target)
+        intro = next(m for m in matches if m.key == "id:intro")
+
+        assert intro.kind is MatchKind.MODIFIED
+        assert intro.content_similarity < 90.0
+
+
+class TestTitleFallback:
+    def test_fallback_to_title_when_ids_absent(self):
+        source_text = """\
+# %% [markdown] lang="de" tags=["slide"]
+# ## Einführung
+"""
+        target_text = """\
+# %% [markdown] lang="de" tags=["slide"]
+# ## Einführung
+"""
+        source = _parse(source_text)
+        target = _parse(target_text)
+
+        matches = match_slides(source, target)
+        assert len(matches) == 1
+        assert matches[0].kind is MatchKind.UNCHANGED
+        assert matches[0].key.startswith("title:einführung") or matches[0].key.startswith(
+            "title:einf"
+        )
+
+    def test_fuzzy_title_match_when_title_slightly_changed(self):
+        source_text = """\
+# %% [markdown] lang="de" tags=["slide"]
+# ## REST vs SOAP
+"""
+        target_text = """\
+# %% [markdown] lang="de" tags=["slide"]
+# ## REST versus SOAP
+"""
+        source = _parse(source_text)
+        target = _parse(target_text)
+
+        matches = match_slides(source, target)
+        # Should fuzzy-match the slightly-renamed title.
+        assert any(
+            m.kind in (MatchKind.UNCHANGED, MatchKind.MODIFIED) and m.source_index is not None
+            for m in matches
+        )
+
+
+class TestContentSimilarity:
+    def test_identical_is_100(self):
+        assert content_similarity("hello world", "hello world") == 100.0
+
+    def test_both_empty_is_100(self):
+        assert content_similarity("", "") == 100.0
+
+    def test_one_empty_is_zero(self):
+        assert content_similarity("", "hello") == 0.0
+
+    def test_disjoint_content_is_low(self):
+        score = content_similarity("apple banana cherry", "xylophone zebra quartz")
+        assert score < 50.0
+
+    def test_markdown_formatting_ignored(self):
+        a = "## **Bold** _italic_ `code`"
+        b = "Bold italic code"
+        # Similarity should be very high after normalization.
+        assert content_similarity(a, b) > 80.0
+
+
+class TestHeaderSlidesIgnored:
+    def test_header_groups_do_not_match(self):
+        # j2-based headers (if present) would have slide_type="header".
+        # parse_slides excludes them when include_header=False; for this
+        # test we verify match_slides filters them when include_header=True.
+        source_text = """\
+# %% [markdown] lang="de" tags=["slide"] slide_id="a"
+# ## A
+"""
+        target_text = """\
+# %% [markdown] lang="de" tags=["slide"] slide_id="a"
+# ## A
+"""
+        source = group_slides(parse_cells(source_text), "de", include_header=True)
+        target = group_slides(parse_cells(target_text), "de", include_header=True)
+
+        matches = match_slides(source, target)
+        for m in matches:
+            # No header groups should appear as matches.
+            assert m.target_group is None or m.target_group.slide_type != "header"
+            assert m.source_group is None or m.source_group.slide_type != "header"

--- a/tests/voiceover/test_trace_log.py
+++ b/tests/voiceover/test_trace_log.py
@@ -197,15 +197,21 @@ class TestTraceLogRequiredFields:
     """Verify all required fields are present in every log entry."""
 
     REQUIRED_FIELDS = {
+        "schema",
         "timestamp",
         "slide_file",
         "slide_id",
+        "cell_index",
         "language",
         "baseline",
         "transcript",
+        "transcript_segments",
         "llm_merged",
         "rewrites",
         "dropped_from_transcript",
+        "added_from_baseline",
+        "model",
+        "mode",
         "git_head",
     }
 
@@ -226,3 +232,138 @@ class TestTraceLogRequiredFields:
         entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
         missing = self.REQUIRED_FIELDS - set(entry.keys())
         assert not missing, f"Missing required fields: {missing}"
+
+
+class TestTraceLogV1Fields:
+    def test_schema_tag(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["schema"] == "clm.voiceover.trace/1"
+
+    def test_transcript_segments_default_wraps_text(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="hello world",
+            llm_merged="",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["transcript_segments"] == [{"start": 0.0, "end": 0.0, "text": "hello world"}]
+
+    def test_transcript_segments_passed_through(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        segments = [
+            {"start": 0.0, "end": 2.0, "text": "guten"},
+            {"start": 2.0, "end": 4.0, "text": "tag"},
+        ]
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="de",
+            baseline="",
+            transcript="guten tag",
+            llm_merged="- hello",
+            rewrites=[],
+            dropped_from_transcript=[],
+            transcript_segments=segments,
+        )
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["transcript_segments"] == segments
+
+    def test_added_from_baseline_default_empty(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="x",
+            llm_merged="- x",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["added_from_baseline"] == []
+
+    def test_optional_v1_fields_pass_through(self, tmp_path):
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            cell_index=3,
+            language="en",
+            baseline="- baseline bullet",
+            transcript="spoken material",
+            llm_merged="- merged",
+            rewrites=[],
+            dropped_from_transcript=["noise"],
+            added_from_baseline=["- baseline bullet"],
+            model="gpt-4o-mini",
+            mode="merge",
+        )
+        entry = json.loads(trace.path.read_text(encoding="utf-8").strip())
+        assert entry["cell_index"] == 3
+        assert entry["added_from_baseline"] == ["- baseline bullet"]
+        assert entry["model"] == "gpt-4o-mini"
+        assert entry["mode"] == "merge"
+
+
+class TestReadTraceEntries:
+    def test_reads_valid_entries(self, tmp_path):
+        from clm.voiceover.trace_log import read_trace_entries
+
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="hello",
+            llm_merged="- hello",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+        trace.log_merge_call(
+            slide_id="s/2",
+            language="en",
+            baseline="",
+            transcript="world",
+            llm_merged="- world",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+
+        entries = read_trace_entries(trace.path)
+        assert len(entries) == 2
+        assert entries[0]["slide_id"] == "s/1"
+        assert entries[1]["slide_id"] == "s/2"
+
+    def test_skips_malformed_lines(self, tmp_path):
+        from clm.voiceover.trace_log import read_trace_entries
+
+        trace = TraceLog.create("slides_test.py", base_dir=tmp_path)
+        trace.log_merge_call(
+            slide_id="s/1",
+            language="en",
+            baseline="",
+            transcript="hello",
+            llm_merged="- hello",
+            rewrites=[],
+            dropped_from_transcript=[],
+        )
+        # Append garbage
+        with trace.path.open("a", encoding="utf-8") as f:
+            f.write("not json{\n")
+            f.write("\n")
+
+        entries = read_trace_entries(trace.path)
+        assert len(entries) == 1


### PR DESCRIPTION
## Summary

Ships the full `clm voiceover backfill` pipeline from
[`docs/proposals/VOICEOVER_BACKFILL.md`](docs/proposals/VOICEOVER_BACKFILL.md):
extract voiceover from historical OBS recordings against an older slide
revision, then port the result onto the current HEAD slides. Also
absorbs infrastructure the compare spec needed (artifact cache, trace
schema, shared prompt scaffolding) and lands the capstone `compare`
command that reuses that scaffolding.

Five sequential phases, one PR. Commits are kept separate so `git log` /
bisect preserves the phased structure — merge with rebase-and-merge (or
rebase) to keep them on master.

## Phases

- **PR 1 — `75449c0`** — Artifact cache (`.clm/voiceover-cache/`) with
  `VideoKey`/`SlidesKey`/`TranscribeConfig`, trace-log schema v1
  (`clm.voiceover.trace/1`), and `--transcript` / `--alignment`
  override flags on `sync`. Pure infrastructure.
- **PR 2 — `9a16c5c`** — `clm voiceover identify-rev` (OCR
  fingerprint → per-revision LCS scorer) plus a hunk-based narrative-
  commit classifier driving a multiplicative prior on the scorer.
- **PR 3 — `b77d7c3`** — Shared `bullet_schema` module (`BulletStatus`,
  `BulletOutcome`, `PerSlidePack`, `parse_structured_response`),
  `polish_and_port` primitive, `port-voiceover` CLI, and both
  `port_{de,en}.md` + `compare_{de,en}.md` prompts.
- **PR 4 — `49b5446`** — `sync-at-rev` (git-show export to scratch,
  never touches the working tree) and the `backfill` one-shot wrapper
  with patch-by-default policy (`--apply` required for mutation).
- **PR 5 — `087b64f`** — `clm voiceover compare` command wrapping the
  shared scaffolding; read-only bullet-level judge producing Rich
  table or JSON reports.

Info topics (`commands.md`) updated for every new command; design
doc (`VOICEOVER_BACKFILL.md`) shipped in the base commit.

## Test plan

- [x] Unit tests for every new module (cache, trace schema, rev scorer,
      narrative classifier, slide matcher, port, compare, backfill
      helpers) — +~100 tests across `tests/voiceover/` and `tests/cli/`.
- [x] Full fast suite: 4212 passed, 4 xfailed, ~95s.
- [x] Pre-commit hooks (ruff lint, ruff format, mypy, pytest fast)
      pass on every commit.
- [ ] CI green on this PR before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)