### PR TITLE
fix(notebooks): partial HTML reuses Speaker cache instead of re-executing

### DIFF
--- a/src/clm/core/execution_dependencies.py
+++ b/src/clm/core/execution_dependencies.py
@@ -53,11 +53,12 @@ EXECUTION_REQUIREMENTS: dict[tuple[str, str], ExecutionRequirement] = {
     ("html", "completed"): ExecutionRequirement.REUSES_CACHE,
     ("notebook", "completed"): ExecutionRequirement.NONE,
     ("code", "completed"): ExecutionRequirement.NONE,
-    # Partial: executes independently for HTML (post-workshop cells are
-    # blanked before execution so they produce no outputs). It does not
-    # share a cache with Speaker because Speaker's cached notebook
-    # contains outputs for post-workshop cells that Partial must not show.
-    ("html", "partial"): ExecutionRequirement.NONE,
+    # Partial: HTML reuses Speaker's cached executed notebook and
+    # post-processes it — pre-workshop cells keep their Speaker-executed
+    # outputs; post-workshop cells are blanked and their outputs cleared,
+    # so no workshop code is ever executed. Notebook/code formats are
+    # produced by the per-cell filter without execution.
+    ("html", "partial"): ExecutionRequirement.REUSES_CACHE,
     ("notebook", "partial"): ExecutionRequirement.NONE,
     ("code", "partial"): ExecutionRequirement.NONE,
 }
@@ -88,6 +89,7 @@ class ExecutionDependencyResolver:
     CACHE_PROVIDERS: dict[tuple[str, str], tuple[str, str]] = {
         # (consumer_format, consumer_kind) -> (provider_format, provider_kind)
         ("html", "completed"): ("html", "speaker"),
+        ("html", "partial"): ("html", "speaker"),
     }
 
     def resolve_implicit_executions(

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -25,7 +25,12 @@ from nbformat.validator import normalize
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
 from clm.infrastructure.workers.process_reaper import terminate_then_kill_procs
 
-from .output_spec import POST_WORKSHOP_TAG, OutputSpec
+from .output_spec import (
+    POST_WORKSHOP_TAG,
+    OutputSpec,
+    PartialOutput,
+    find_workshop_start_index,
+)
 
 if TYPE_CHECKING:
     from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
@@ -447,10 +452,14 @@ class NotebookProcessor:
 
         logger.info(f"{cid}:Cache hit - reusing executed notebook for '{payload.input_file_name}'")
 
-        # Filter out notes cells from the cached notebook
-        # The cached notebook is from Speaker, which includes notes cells
-        # For Completed, we need to remove notes cells
-        filtered_nb = self._filter_notes_cells_from_cached(cached_nb)
+        # Translate the cached Speaker notebook into the consuming kind.
+        # Completed drops notes/voiceover; Partial additionally blanks and
+        # clears outputs for every cell at or after the workshop boundary so
+        # no workshop code is ever executed under the Partial kind.
+        if isinstance(self.output_spec, PartialOutput):
+            filtered_nb = self._filter_cached_notebook_for_partial(cached_nb)
+        else:
+            filtered_nb = self._filter_notes_cells_from_cached(cached_nb)
 
         # Export to HTML (no execution needed)
         traitlets_logger = traitlets.log.get_logger()
@@ -476,6 +485,55 @@ class NotebookProcessor:
             for cell in filtered_nb.get("cells", [])
             if not {"notes", "voiceover"}.intersection(get_tags(cell))
         ]
+        return filtered_nb
+
+    def _filter_cached_notebook_for_partial(self, nb: NotebookNode) -> NotebookNode:
+        """Translate Speaker's cached executed notebook into Partial HTML.
+
+        Pre-workshop: drop ``notes``/``voiceover`` (Completed-style).
+        Post-workshop: drop ``alt``/``completed``/``notes``/``voiceover``/``del``;
+        blank code source for cells without ``keep``/``start``; blank
+        ``answer`` markdown; and clear ``outputs`` for every remaining
+        post-workshop code cell so no workshop code is ever presented as
+        executed — even ``keep``-tagged cells render as unevaluated.
+
+        This post-processing replaces the previous approach of letting
+        Partial execute the notebook with blanked post-workshop sources,
+        which raised NameErrors whenever a post-workshop ``keep`` cell
+        referenced symbols defined in the blanked non-``keep`` cells.
+        """
+        filtered_nb = copy.deepcopy(nb)
+        cells = filtered_nb.get("cells", [])
+        workshop_start = find_workshop_start_index(cells)
+
+        pre_drop = {"notes", "voiceover"}
+        post_drop = {"alt", "completed", "del", "notes", "voiceover"}
+        post_retain_code = {"keep", "start"}
+        post_blank_markdown = {"answer"}
+
+        new_cells: list[NotebookNode] = []
+        for idx, cell in enumerate(cells):
+            tags = set(get_tags(cell))
+            in_workshop = workshop_start is not None and idx >= workshop_start
+
+            drop_tags = post_drop if in_workshop else pre_drop
+            if drop_tags.intersection(tags):
+                continue
+
+            if in_workshop:
+                if is_code_cell(cell):
+                    if not post_retain_code.intersection(tags):
+                        cell["source"] = ""
+                    cell["outputs"] = []
+                    if "execution_count" in cell:
+                        cell["execution_count"] = None
+                elif is_markdown_cell(cell):
+                    if post_blank_markdown.intersection(tags):
+                        cell["source"] = ""
+
+            new_cells.append(cell)
+
+        filtered_nb.cells = new_cells
         return filtered_nb
 
     async def load_and_expand_jinja_template(

--- a/src/clm/workers/notebook/output_spec.py
+++ b/src/clm/workers/notebook/output_spec.py
@@ -33,6 +33,22 @@ from .utils.prog_lang_utils import jupytext_format_for, suffix_for
 POST_WORKSHOP_TAG = "_post_workshop"
 
 
+def find_workshop_start_index(cells: Iterable[Cell]) -> int | None:
+    """Return the index of the first markdown cell tagged ``workshop``.
+
+    The workshop section runs from this cell to end-of-notebook; a value
+    of ``None`` means no workshop heading is present. Shared between the
+    per-cell filter path (``PartialOutput.annotate_cells``) and the
+    Partial HTML cache-reuse post-processor in the notebook processor.
+    """
+    for i, cell in enumerate(cells):
+        if cell.get("cell_type") != "markdown":
+            continue
+        if "workshop" in cell.get("metadata", {}).get("tags", []):
+            return i
+    return None
+
+
 @define
 class OutputSpec(ABC):
     """Description of the kind of output that should be created.
@@ -112,8 +128,9 @@ class OutputSpec(ABC):
     def can_reuse_execution(self) -> bool:
         """Whether this spec can reuse a cached executed notebook.
 
-        Only Completed HTML can reuse, since it's a subset of Speaker HTML
-        (same content minus "notes" cells).
+        Completed HTML reuses Speaker's cached notebook (same content minus
+        ``notes``/``voiceover`` cells). Partial HTML also reuses it via a
+        dedicated post-processing step that blanks post-workshop cells.
 
         Returns:
             True if a cached executed notebook can be reused.
@@ -343,19 +360,37 @@ class PartialOutput(OutputSpec):
     _post_retain_code: frozenset[str] = frozenset({"keep", "start"})
     _post_delete_markdown: frozenset[str] = frozenset({"answer"})
 
-    evaluate_for_html = True
-    """Partial HTML is executed so pre-workshop code cells produce outputs;
-    post-workshop code cells are blanked before execution, so they produce
-    no outputs. Cache reuse is intentionally disabled because Speaker's
-    cached notebook contains outputs for post-workshop cells that Partial
-    must not show; a future optimization could add a Partial-specific
-    post-processing step on the cached notebook.
+    evaluate_for_html = False
+    """Partial never executes on its own. Pre-workshop outputs come from
+    Speaker's cached executed notebook (reused via :meth:`can_reuse_execution`),
+    and post-workshop cells are blanked with outputs cleared in the
+    post-processing step in
+    :meth:`NotebookProcessor._filter_cached_notebook_for_partial`.
+
+    Setting this to ``False`` also makes the cache-miss fallback safe:
+    ``_create_using_nbconvert`` skips execution, so no workshop code can
+    run and the NameErrors observed when ``keep`` post-workshop cells
+    reference symbols defined in blanked non-``keep`` cells are impossible.
     """
+
+    @property
+    def can_reuse_execution(self) -> bool:
+        """Partial HTML reuses Speaker's cached executed notebook.
+
+        Pre-workshop cells of Partial match Completed (a subset of Speaker),
+        so they can be taken verbatim from the cache. Post-workshop cells
+        are filtered and blanked in a dedicated post-processing pass by
+        :meth:`NotebookProcessor._filter_cached_notebook_for_partial`.
+
+        Reuse is independent of :attr:`evaluate_for_html` because the
+        post-processing step does not require execution.
+        """
+        return self.format == "html"
 
     def annotate_cells(self, cells: Iterable[Cell]) -> None:
         """Tag every cell at or after the first ``workshop`` heading."""
         cells_list = list(cells)
-        start = self._find_workshop_start(cells_list)
+        start = find_workshop_start_index(cells_list)
         if start is None:
             return
         for cell in cells_list[start:]:
@@ -363,15 +398,6 @@ class PartialOutput(OutputSpec):
             if POST_WORKSHOP_TAG not in tags:
                 tags.append(POST_WORKSHOP_TAG)
                 set_tags(cell, tags)
-
-    @staticmethod
-    def _find_workshop_start(cells: list[Cell]) -> int | None:
-        for i, cell in enumerate(cells):
-            if cell.get("cell_type") != "markdown":
-                continue
-            if "workshop" in cell.get("metadata", {}).get("tags", []):
-                return i
-        return None
 
     @staticmethod
     def _is_post_workshop(cell: Cell) -> bool:

--- a/tests/core/test_execution_dependencies.py
+++ b/tests/core/test_execution_dependencies.py
@@ -46,15 +46,13 @@ class TestExecutionRequirement:
         req = get_execution_requirement("unknown", "unknown")
         assert req == ExecutionRequirement.NONE
 
-    def test_partial_kinds_no_cache_dependency(self):
-        """Partial executes independently of Speaker — no shared cache.
-
-        Partial HTML runs its own execution with post-workshop cells
-        blanked, so it cannot reuse Speaker's cached notebook (which
-        contains outputs for those cells). Notebook/code formats don't
-        execute at all.
+    def test_partial_html_reuses_speaker_cache(self):
+        """Partial HTML reuses Speaker's cached executed notebook and
+        post-processes it — pre-workshop cells keep their executed outputs,
+        post-workshop cells are blanked with outputs cleared. Notebook/code
+        formats don't execute at all.
         """
-        assert get_execution_requirement("html", "partial") == ExecutionRequirement.NONE
+        assert get_execution_requirement("html", "partial") == ExecutionRequirement.REUSES_CACHE
         assert get_execution_requirement("notebook", "partial") == ExecutionRequirement.NONE
         assert get_execution_requirement("code", "partial") == ExecutionRequirement.NONE
 
@@ -79,6 +77,16 @@ class TestExecutionDependencyResolverImplicitExecutions:
         """Speaker HTML is implicit when only completed HTML is requested."""
         requested = {
             ("en", "html", "completed"),
+        }
+        implicit = resolver.resolve_implicit_executions(requested)
+
+        assert ("en", "html", "speaker") in implicit
+
+    def test_implicit_speaker_when_only_partial(self, resolver):
+        """Speaker HTML is implicit when only partial HTML is requested —
+        partial HTML reuses Speaker's cached executed notebook."""
+        requested = {
+            ("en", "html", "partial"),
         }
         implicit = resolver.resolve_implicit_executions(requested)
 
@@ -247,9 +255,18 @@ class TestCacheProviders:
         assert ("html", "completed") in providers
         assert providers[("html", "completed")] == ("html", "speaker")
 
-    def test_no_other_cache_dependencies(self):
-        """Only HTML completed has cache dependencies."""
+    def test_partial_html_needs_speaker_html(self):
+        """Partial HTML reuses Speaker's cached executed notebook."""
         providers = ExecutionDependencyResolver.CACHE_PROVIDERS
 
-        # Currently only one dependency
-        assert len(providers) == 1
+        assert ("html", "partial") in providers
+        assert providers[("html", "partial")] == ("html", "speaker")
+
+    def test_only_html_cache_dependencies(self):
+        """Only HTML kinds depend on the Speaker HTML cache."""
+        providers = ExecutionDependencyResolver.CACHE_PROVIDERS
+
+        for (consumer_fmt, _), (provider_fmt, provider_kind) in providers.items():
+            assert consumer_fmt == "html"
+            assert provider_fmt == "html"
+            assert provider_kind == "speaker"

--- a/tests/workers/notebook/test_cache_equivalence.py
+++ b/tests/workers/notebook/test_cache_equivalence.py
@@ -14,7 +14,7 @@ from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
 from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
 from clm.workers.notebook.notebook_processor import NotebookProcessor
-from clm.workers.notebook.output_spec import CompletedOutput, SpeakerOutput
+from clm.workers.notebook.output_spec import CompletedOutput, PartialOutput, SpeakerOutput
 
 
 @pytest.fixture
@@ -422,3 +422,141 @@ class TestCacheEquivalence:
 
             # Completed output should NOT contain the notes cell
             assert "Speaker notes" not in completed_result
+
+
+class TestPartialCacheFilter:
+    """Unit tests for NotebookProcessor._filter_cached_notebook_for_partial.
+
+    The filter transforms Speaker's executed notebook into Partial HTML by
+    preserving pre-workshop outputs and blanking post-workshop cells (source
+    and outputs) so that no workshop code is presented as executed — not
+    even ``keep``-tagged cells that would otherwise raise NameError in the
+    old execution path.
+    """
+
+    @pytest.fixture
+    def processor(self):
+        spec = PartialOutput(format="html", language="en", prog_lang="python")
+        return NotebookProcessor(spec, cache=None)
+
+    @pytest.fixture
+    def cached_speaker_nb(self):
+        """Build a cached Speaker-like executed notebook with pre- and
+        post-workshop cells, including the kinds of cells that triggered
+        NameErrors in the old path (``keep`` post-workshop code cells that
+        reference symbols defined in non-``keep`` cells)."""
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell("# Intro"),
+            new_markdown_cell("speaker note", metadata={"tags": ["notes"]}),
+            new_code_cell(
+                "class Foo: pass",
+                outputs=[],
+                execution_count=1,
+            ),
+            new_markdown_cell("## Workshop: Foo", metadata={"tags": ["workshop"]}),
+            # Non-keep post-workshop cell with setup code (gets blanked)
+            new_code_cell(
+                "foo = Foo()",
+                outputs=[],
+                execution_count=2,
+            ),
+            # keep-tagged post-workshop cell — would have NameError'd under
+            # the old execute-with-blanked-sources path if ``foo`` vanished.
+            new_code_cell(
+                "print(foo)",
+                metadata={"tags": ["keep"]},
+                outputs=[{"output_type": "stream", "name": "stdout", "text": "<Foo>"}],
+                execution_count=3,
+            ),
+            # Alt-tagged post-workshop cell (CodeAlong-style drop)
+            new_code_cell(
+                "alternative = True",
+                metadata={"tags": ["alt"]},
+                outputs=[],
+                execution_count=4,
+            ),
+            # Answer-tagged markdown post-workshop (contents blanked)
+            new_markdown_cell("The answer is 42", metadata={"tags": ["answer"]}),
+            # Post-workshop notes (dropped)
+            new_markdown_cell("post-workshop note", metadata={"tags": ["notes"]}),
+        ]
+        return nb
+
+    def test_pre_workshop_preserves_outputs(self, processor, cached_speaker_nb):
+        filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        # The pre-workshop code cell must keep its source and execution_count.
+        code_cells = [c for c in filtered.cells if c.get("cell_type") == "code"]
+        pre = code_cells[0]
+        assert pre["source"] == "class Foo: pass"
+        assert pre.get("execution_count") == 1
+
+    def test_notes_dropped_pre_and_post(self, processor, cached_speaker_nb):
+        filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        for cell in filtered.cells:
+            assert "notes" not in cell.get("metadata", {}).get("tags", [])
+
+    def test_post_workshop_non_keep_code_source_blanked(self, processor, cached_speaker_nb):
+        filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        # Find the post-workshop, non-keep code cell (originally "foo = Foo()").
+        candidates = [
+            c
+            for c in filtered.cells
+            if c.get("cell_type") == "code" and not c.get("metadata", {}).get("tags")
+        ]
+        post_non_keep = next(c for c in candidates if c is not filtered.cells[1])
+        assert post_non_keep["source"] == ""
+        assert post_non_keep["outputs"] == []
+        assert post_non_keep.get("execution_count") is None
+
+    def test_post_workshop_keep_retains_source_but_clears_outputs(
+        self, processor, cached_speaker_nb
+    ):
+        """keep cells show their source but render as unevaluated — this
+        is the core fix: no workshop code is presented as executed."""
+        filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        keep_cell = next(
+            c
+            for c in filtered.cells
+            if c.get("cell_type") == "code" and "keep" in c.get("metadata", {}).get("tags", [])
+        )
+        assert keep_cell["source"] == "print(foo)"
+        assert keep_cell["outputs"] == []
+        assert keep_cell.get("execution_count") is None
+
+    def test_post_workshop_alt_cells_dropped(self, processor, cached_speaker_nb):
+        filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        for cell in filtered.cells:
+            assert "alt" not in cell.get("metadata", {}).get("tags", [])
+
+    def test_post_workshop_answer_markdown_blanked(self, processor, cached_speaker_nb):
+        filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        answer_cell = next(
+            c
+            for c in filtered.cells
+            if c.get("cell_type") == "markdown"
+            and "answer" in c.get("metadata", {}).get("tags", [])
+        )
+        assert answer_cell["source"] == ""
+
+    def test_no_workshop_heading_matches_completed_filter(self, processor):
+        """Without a workshop heading, Partial's filter degenerates to the
+        Completed filter — only notes/voiceover dropped, nothing blanked."""
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell("# Intro"),
+            new_markdown_cell("note", metadata={"tags": ["notes"]}),
+            new_code_cell("x = 1", outputs=[], execution_count=1),
+        ]
+        filtered = processor._filter_cached_notebook_for_partial(nb)
+        assert len(filtered.cells) == 2
+        code = next(c for c in filtered.cells if c.get("cell_type") == "code")
+        assert code["source"] == "x = 1"
+        assert code.get("execution_count") == 1
+
+    def test_does_not_mutate_cached_notebook(self, processor, cached_speaker_nb):
+        """The filter must deep-copy to avoid poisoning the cache for other
+        consumers (e.g., Completed HTML built from the same cache entry)."""
+        original_source = cached_speaker_nb.cells[4]["source"]
+        processor._filter_cached_notebook_for_partial(cached_speaker_nb)
+        assert cached_speaker_nb.cells[4]["source"] == original_source

--- a/tests/workers/notebook/test_output_spec.py
+++ b/tests/workers/notebook/test_output_spec.py
@@ -603,13 +603,20 @@ class TestPartialOutput:
         assert PartialOutput().get_target_subdir_fragment() == "partial"
 
     def test_evaluate_for_html(self):
-        """Partial HTML evaluates so pre-workshop code cells produce outputs."""
-        assert PartialOutput().evaluate_for_html is True
+        """Partial never executes on its own — pre-workshop outputs come from
+        Speaker's cached notebook, post-workshop cells are blanked with
+        outputs cleared in post-processing."""
+        assert PartialOutput().evaluate_for_html is False
 
-    def test_does_not_reuse_execution(self):
-        """Partial is not a cache-consumer; it executes independently so
-        post-workshop cells (blanked before execution) don't produce outputs."""
-        assert PartialOutput(format="html").can_reuse_execution is False
+    def test_reuses_speaker_execution_for_html(self):
+        """Partial HTML reuses Speaker's cached executed notebook and
+        post-processes it, so no workshop code is ever executed."""
+        assert PartialOutput(format="html").can_reuse_execution is True
+
+    def test_does_not_reuse_execution_for_non_html(self):
+        """Notebook/code formats don't execute, so cache reuse does not apply."""
+        assert PartialOutput(format="notebook").can_reuse_execution is False
+        assert PartialOutput(format="code").can_reuse_execution is False
 
     def test_does_not_populate_cache(self):
         assert PartialOutput(format="html").should_cache_execution is False


### PR DESCRIPTION
## Summary

- `partial` HTML previously ran its own notebook execution with post-workshop cells blanked; `keep`/`start` cells kept their source and got executed, raising NameError whenever they referenced symbols defined in the blanked non-`keep` cells.
- Partial HTML now reuses Speaker's cached executed notebook via a post-processing pass: pre-workshop cells keep Speaker's executed outputs; post-workshop code cells are blanked (`keep` cells retain source but outputs are cleared) so no workshop code is ever presented as executed.
- Wiring: `PartialOutput.evaluate_for_html = False` (cache-miss fallback is now safe), `can_reuse_execution = True` for HTML, and `("html", "partial")` added to `EXECUTION_REQUIREMENTS`/`CACHE_PROVIDERS` so Speaker HTML is scheduled implicitly when only Partial HTML is requested.
- Dead code removed: duplicate workshop-start scanner consolidated into a module-level `find_workshop_start_index`; defensive `POST_WORKSHOP_TAG` stripping in the cache filter dropped (Speaker never writes the synthetic tag).

## Test plan

- [x] `pytest tests/workers/notebook/test_output_spec.py tests/workers/notebook/test_cache_equivalence.py tests/core/test_execution_dependencies.py` — 135 passed
- [x] Fast suite: `pytest -q` — 4373 passed, 4 xfailed
- [x] ruff check + mypy on touched files — clean
- [ ] Manually verify: enable `<kind>partial</kind>` in `course-specs/machine-learning-azav.xml` and build; confirm no NameErrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)