### PR TITLE
fix(notebooks): move partial HTML to completed stage (it reuses the cache)

### DIFF
--- a/src/clm/core/course_files/notebook_file.py
+++ b/src/clm/core/course_files/notebook_file.py
@@ -29,9 +29,9 @@ def _get_operation_stage(format_: str, kind: str) -> int:
 
     Staging:
     - Stage 1: Non-HTML operations (notebook, code formats) and code-along HTML
-    - Stage 2 (HTML_SPEAKER_STAGE): Speaker HTML (executes and caches) and
-      Partial HTML (executes independently — does not share Speaker's cache)
-    - Stage 3 (HTML_COMPLETED_STAGE): Completed HTML (reuses cache)
+    - Stage 2 (HTML_SPEAKER_STAGE): Speaker HTML (executes and caches)
+    - Stage 3 (HTML_COMPLETED_STAGE): Completed HTML and Partial HTML (both
+      reuse Speaker's cached executed notebook)
     """
     if format_ != "html":
         return FIRST_EXECUTION_STAGE
@@ -40,7 +40,7 @@ def _get_operation_stage(format_: str, kind: str) -> int:
     if kind == "completed":
         return HTML_COMPLETED_STAGE
     if kind == "partial":
-        return HTML_SPEAKER_STAGE
+        return HTML_COMPLETED_STAGE
     # code-along HTML doesn't need execution, can run in first stage
     return FIRST_EXECUTION_STAGE
 

--- a/src/clm/core/utils/execution_utils.py
+++ b/src/clm/core/utils/execution_utils.py
@@ -17,7 +17,8 @@ import logging
 #   - Speaker HTML runs first, caching executed notebooks
 #
 # Stage 4 (HTML_COMPLETED_STAGE):
-#   - Completed HTML runs second, reusing cached executed notebooks
+#   - Completed HTML and Partial HTML run second, reusing cached
+#     executed notebooks from Stage 3
 #
 FIRST_EXECUTION_STAGE = 1
 COPY_GENERATED_IMAGES_STAGE = 2
@@ -37,7 +38,7 @@ STAGE_NAMES: dict[int, str] = {
     FIRST_EXECUTION_STAGE: "Processing",
     COPY_GENERATED_IMAGES_STAGE: "Images",
     HTML_SPEAKER_STAGE: "HTML Speaker",
-    HTML_COMPLETED_STAGE: "HTML Completed",
+    HTML_COMPLETED_STAGE: "HTML Completed/Partial",
     JUPYTERLITE_STAGE: "JupyterLite",
 }
 

--- a/tests/core/course_files/notebook_file_test.py
+++ b/tests/core/course_files/notebook_file_test.py
@@ -362,3 +362,58 @@ class TestProcessNotebookOperationHttpReplay:
         op, _ = self._make_operation(course_1, tmp_path, mode="replay", with_cassette=False)
         other = op.compute_other_files()
         assert "slides_replay.http-cassette.yaml" not in other
+
+
+class TestGetOperationStage:
+    """Stage assignment controls per-file dispatch order during a build.
+
+    Speaker HTML must finish (populating the executed-notebook cache)
+    before Completed HTML and Partial HTML can reuse it. If Partial were
+    put in the Speaker stage it would race with Speaker and often hit a
+    cache miss, silently falling back to a no-execute path that renders
+    HTML without the pre-workshop executed outputs.
+    """
+
+    @pytest.mark.parametrize(
+        "format_,kind",
+        [
+            ("notebook", "speaker"),
+            ("notebook", "completed"),
+            ("notebook", "code-along"),
+            ("notebook", "partial"),
+            ("code", "completed"),
+        ],
+    )
+    def test_non_html_formats_are_stage_1(self, format_, kind):
+        from clm.core.course_files.notebook_file import _get_operation_stage
+        from clm.core.utils.execution_utils import FIRST_EXECUTION_STAGE
+
+        assert _get_operation_stage(format_, kind) == FIRST_EXECUTION_STAGE
+
+    def test_html_speaker_runs_in_speaker_stage(self):
+        from clm.core.course_files.notebook_file import _get_operation_stage
+        from clm.core.utils.execution_utils import HTML_SPEAKER_STAGE
+
+        assert _get_operation_stage("html", "speaker") == HTML_SPEAKER_STAGE
+
+    def test_html_completed_runs_in_completed_stage(self):
+        from clm.core.course_files.notebook_file import _get_operation_stage
+        from clm.core.utils.execution_utils import HTML_COMPLETED_STAGE
+
+        assert _get_operation_stage("html", "completed") == HTML_COMPLETED_STAGE
+
+    def test_html_partial_runs_in_completed_stage(self):
+        """Partial HTML reuses Speaker's cache and must run AFTER the
+        speaker stage, alongside completed. Running in the speaker stage
+        would race with speaker and cache-miss."""
+        from clm.core.course_files.notebook_file import _get_operation_stage
+        from clm.core.utils.execution_utils import HTML_COMPLETED_STAGE
+
+        assert _get_operation_stage("html", "partial") == HTML_COMPLETED_STAGE
+
+    def test_html_code_along_runs_in_stage_1(self):
+        """Code-along HTML doesn't execute and has no cache dependency."""
+        from clm.core.course_files.notebook_file import _get_operation_stage
+        from clm.core.utils.execution_utils import FIRST_EXECUTION_STAGE
+
+        assert _get_operation_stage("html", "code-along") == FIRST_EXECUTION_STAGE

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -343,7 +343,7 @@ def test_get_stage_name_returns_correct_names():
     assert get_stage_name(FIRST_EXECUTION_STAGE) == "Processing"
     assert get_stage_name(COPY_GENERATED_IMAGES_STAGE) == "Images"
     assert get_stage_name(HTML_SPEAKER_STAGE) == "HTML Speaker"
-    assert get_stage_name(HTML_COMPLETED_STAGE) == "HTML Completed"
+    assert get_stage_name(HTML_COMPLETED_STAGE) == "HTML Completed/Partial"
 
 
 def test_get_stage_name_returns_fallback_for_unknown_stage():


### PR DESCRIPTION
## Summary

- Follow-up to #51. When partial was a cache-reuser, its build stage was still `HTML_SPEAKER_STAGE`, so partial jobs raced speaker jobs in the same stage.
- Cache-miss races silently degraded output: the fallback path renders HTML without execution (`evaluate_for_html=False` after #51), so pre-workshop cells in affected notebooks lost their executed outputs. This also explained why partial showed no progress bar and "no noticeable delay" — its jobs vanished into the speaker stage's counter and most of them short-circuited.
- Move partial HTML to `HTML_COMPLETED_STAGE` so it runs after all speaker executions, with the same cache-availability guarantee completed already has.

## Test plan

- [x] `pytest tests/core/course_files/notebook_file_test.py tests/core/course_test.py` — 40 passed (new `TestGetOperationStage` pins the stage assignment for all format/kind combos)
- [x] Fast suite: `pytest -q` — 4417 passed, 4 xfailed
- [x] ruff + mypy clean
- [ ] Manually verify on the AZAV ML course: partial HTML now appears in the "HTML Completed/Partial" progress bar and pre-workshop cells consistently have executed outputs even on a fresh cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)