### PR TITLE
feat(spec): module-bound section/topic references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Module-bound section/topic references** in course specs. `<section>` and
+  `<topic>` accept an optional `module="module_directory_name"` attribute; when
+  set, topic resolution is restricted to that specific module directory. This
+  removes the long-standing first-occurrence-wins ambiguity when two modules
+  share topic IDs, and is the supported mechanism for cohort archives or
+  course variants. Per-topic `module=` overrides the section default. The
+  `clm resolve-topic` CLI and the MCP `resolve_topic` tool gain a matching
+  `--module` / `module` argument. `clm validate-spec` reports unknown module
+  names and module-bound topics that don't exist in the named module. See
+  `clm info spec-files` for the full pattern, including the cohort-archive
+  recipe.
 - **`trainer` and `recording` output kinds** split the previous `speaker`
   kind into two named variants that match how the decks are actually used:
   - `trainer` keeps `notes` cells but strips `voiceover` cells — the
@@ -29,6 +40,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `recording`. See `clm info migration` for the spec-rewrite recipe.
 
 ### Changed
+- **Duplicate-topic-id warning is now emitted only when resolution
+  actually depended on first-occurrence-wins.** Previously the warning
+  fired for every duplicate topic ID found on disk, even when every
+  reference in the spec was bound to a specific module via the new
+  `module=` attribute. Specs that disambiguate every duplicate via
+  `module=` now produce no duplicate-id noise. Unbound references that
+  hit a duplicate still warn exactly as before — strict improvement, no
+  behaviour change for existing specs.
 - **Output paths for private kinds always include a kind subdir.**
   Previously a `speaker` build wrote to
   `output/speaker/<course>/Slides/Html/<topic>.html` (no kind subdir).

--- a/src/clm/cli/commands/resolve_topic.py
+++ b/src/clm/cli/commands/resolve_topic.py
@@ -28,11 +28,20 @@ from clm.core.topic_resolver import (
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Course data directory (contains slides/). Default: inferred from --course-spec or cwd.",
 )
+@click.option(
+    "--module",
+    "module",
+    default=None,
+    help="Restrict resolution to topics in the named module directory "
+    "(e.g., 'module_545_ml_azav_cohort_2026_04'). Useful when a topic ID "
+    "exists in multiple modules and you need to disambiguate.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
 def resolve_topic_cmd(
     topic_id: str,
     course_spec: Path | None,
     data_dir: Path | None,
+    module: str | None,
     as_json: bool,
 ):
     """Resolve a topic ID to its filesystem path.
@@ -46,6 +55,7 @@ def resolve_topic_cmd(
         clm resolve-topic what_is_ml
         clm resolve-topic "decorators*"
         clm resolve-topic intro --course-spec course-specs/python.xml
+        clm resolve-topic intro --module module_545_ml_azav_cohort_2026_04
     """
     slides_dir = _resolve_slides_dir(data_dir, course_spec)
 
@@ -57,7 +67,7 @@ def resolve_topic_cmd(
         except CourseSpecError as e:
             raise click.ClickException(f"Failed to parse course spec: {e}") from None
 
-    result = _resolve_topic(topic_id, slides_dir, course_topic_ids=course_topic_ids)
+    result = _resolve_topic(topic_id, slides_dir, course_topic_ids=course_topic_ids, module=module)
 
     if as_json:
         click.echo(json.dumps(_result_to_dict(result), indent=2))
@@ -72,8 +82,11 @@ def resolve_topic_cmd(
         lines = [f"Topic '{topic_id}' is ambiguous — found in multiple modules:"]
         for alt in result.alternatives:
             lines.append(f"  {alt.module}: {alt.path}")
+        lines.append("  (use --module=<module_name> to restrict resolution to one module)")
         raise click.ClickException("\n".join(lines))
     elif result.path is None:
+        if module:
+            raise click.ClickException(f"Topic '{topic_id}' not found in module '{module}'")
         raise click.ClickException(f"Topic '{topic_id}' not found")
     else:
         click.echo(result.path)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -146,6 +146,7 @@ clm resolve-topic [OPTIONS] TOPIC_ID
 |--------|-------------|
 | `--course-spec FILE` | Scope resolution to topics in this course spec |
 | `--data-dir DIR` | Course data directory (contains slides/) |
+| `--module NAME` | Restrict resolution to topics in the named module directory (e.g., `module_545_ml_azav_cohort_2026_04`). Use this when a topic ID exists in multiple modules — for example, a frozen-cohort archive that shares topic IDs with the live module. |
 | `--json` | Output as JSON |
 
 Examples:
@@ -154,6 +155,7 @@ Examples:
 clm resolve-topic what_is_ml
 clm resolve-topic "decorators*"
 clm resolve-topic intro --course-spec course-specs/python.xml
+clm resolve-topic intro --module module_545_ml_azav_cohort_2026_04
 ```
 
 ### `clm search-slides`

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -100,6 +100,7 @@ Optional `<section>` attributes:
 |-----------|-------------|
 | `enabled` | `"true"` (default) or `"false"`, case-insensitive. A disabled section is dropped from the parsed spec entirely, so `clm build`, `clm outline`, `clm validate-spec`, and all MCP tools ignore it without needing code changes. Disabled sections may omit `<topics>` or reference topic IDs that do not yet exist — they are never built or validated, which lets a full roadmap spec live as a single file instead of carrying a separate `-build.xml` subset. |
 | `id` | Optional stable identifier for the section (e.g. `id="w03"`). Recommended for courses that are frequently filtered, because IDs are stable under reordering and renaming. |
+| `module` | Optional module-directory binding (e.g. `module="module_545_ml_azav_cohort_2026_04"`). When set, every `<topic>` inside this section resolves only against that module — duplicate topic IDs in other modules are ignored. This is the supported mechanism for cohort archives or course variants that share topic IDs with the live module. The value is the literal directory name under `slides/`. Per-topic `module=` (see below) overrides the section default for individual topics. |
 
 Example of a roadmap section deferred until its topics exist:
 
@@ -115,6 +116,37 @@ Example of a roadmap section deferred until its topics exist:
 </section>
 ```
 
+Example of a frozen-cohort archive sharing topic IDs with the live module:
+
+```xml
+<!-- New unified content for the next cohort, currently disabled -->
+<section id="w01" enabled="false">
+    <name><de>Woche 1</de><en>Week 1</en></name>
+    <topics>
+        <topic>introduction</topic>
+        <topic>python_setup</topic>
+    </topics>
+</section>
+
+<!-- Frozen materials shipped to the current cohort, bound to the
+     archive module so they resolve regardless of duplicate topic IDs
+     in the live module. -->
+<section id="w01-cohort-2026-04" enabled="true"
+         module="module_545_ml_azav_cohort_2026_04">
+    <name>
+        <de>Woche 1 (Kohorte 2026-04)</de>
+        <en>Week 1 (cohort 2026-04)</en>
+    </name>
+    <topics>
+        <topic>introduction</topic>
+        <topic>python_setup</topic>
+    </topics>
+</section>
+```
+
+When the next cohort starts, flip `enabled="true"` on the live section and
+`enabled="false"` on the frozen one — no topic-directory renames required.
+
 Optional `<topic>` attributes:
 
 | Attribute | Description |
@@ -124,6 +156,7 @@ Optional `<topic>` attributes:
 | `http-replay` | `"true"`/`"yes"`/`"1"` or `"false"`/`"no"`/`"0"` (case-insensitive; default `false`). Opts the topic in to HTTP replay: live `requests` / `httpx` / `urllib3` / `aiohttp` calls are intercepted by `vcrpy` and recorded to a cassette file next to the source (or under a sibling `_cassettes/` directory), then replayed on subsequent builds. The replay record mode is chosen at build time via `--http-replay=<replay\|once\|refresh\|disabled>` or `CLM_HTTP_REPLAY_MODE`; CI defaults to strict `replay` mode, local builds default to `once`. Cassettes are version-controlled alongside source but excluded from student output. Requires the `[replay]` extra (`pip install -e .[replay]`). |
 | `author` | Override the course-level author for this topic |
 | `prog-lang` | Override the course-level programming language for this topic |
+| `module` | Optional module-directory binding for this single topic, overriding the section's `module=` default. Use sparingly — usually the section-level `module=` is enough. |
 
 The `prog-lang` attribute is useful for `.md` notebook files where the language
 cannot be inferred from the file extension. For `.md` files, the programming

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -549,6 +549,11 @@ class Course(NotebookMixin):
         if self.section_selection is not None:
             selected = set(self.section_selection.resolved_indices)
 
+        # Track which topic IDs were resolved in unbound mode (no module=)
+        # so the duplicate-id warning can be emitted only for IDs whose
+        # disambiguation actually depended on first-occurrence-wins.
+        self._unbound_resolved_ids: set[str] = set()
+
         for i, section_spec in enumerate(self.spec.sections):
             if selected is not None and i not in selected:
                 continue
@@ -557,34 +562,113 @@ class Course(NotebookMixin):
             section.add_notebook_numbers()
             self.sections.append(section)
 
+        self._emit_unbound_duplicate_warnings()
+
     def _build_topics(self, section, section_spec):
         for topic_spec in section_spec.topics:
-            topic_path = self._topic_path_map.get(topic_spec.id)
+            # Effective module: per-topic override beats section default.
+            effective_module = topic_spec.module or section_spec.module
+            topic_path = self._resolve_topic_path(
+                topic_spec.id, module=effective_module, section_spec=section_spec
+            )
             if not topic_path:
-                logger.error(f"Topic not found: {topic_spec.id}")
-                # Track for later reporting to user
+                # Error already recorded by _resolve_topic_path
+                continue
+            topic = Topic.from_spec(spec=topic_spec, section=section, path=topic_path)
+            topic.build_file_map()
+            section.topics.append(topic)
+
+    def _resolve_topic_path(
+        self,
+        topic_id: str,
+        *,
+        module: str | None,
+        section_spec,
+    ):
+        """Resolve a single topic ID to a path, honoring an optional module binding.
+
+        Falls back to the cached, filesystem-wide ``_topic_path_map`` for the
+        unbound case so existing behavior (and its first-occurrence-wins
+        warning) is preserved verbatim. When ``module`` is set, scans the
+        full topic map directly so we can pick the entry whose parent
+        module matches.
+        """
+        if not module:
+            self._unbound_resolved_ids.add(topic_id)
+            topic_path = self._topic_path_map.get(topic_id)
+            if not topic_path:
+                logger.error(f"Topic not found: {topic_id}")
                 self.loading_errors.append(
                     {
                         "category": "topic_not_found",
-                        "message": f"Topic '{topic_spec.id}' not found in filesystem",
+                        "message": f"Topic '{topic_id}' not found in filesystem",
                         "details": {
-                            "topic_id": topic_spec.id,
+                            "topic_id": topic_id,
                             "section": section_spec.name.en,
                             "available_topics": list(self._topic_path_map.keys())[:10],
                         },
                     }
                 )
-                continue
-            topic = Topic.from_spec(spec=topic_spec, section=section, path=topic_path)
-            topic.build_file_map()
-            section.topics.append(topic)
+                return None
+            return topic_path
+
+        # Module-bound resolution. Use the full topic map (includes every
+        # occurrence) so we can pick the one in the requested module even
+        # when other modules share the topic ID.
+        from clm.core.topic_resolver import build_topic_map
+
+        slides_dir = self.course_root / "slides"
+        full_map = build_topic_map(slides_dir)
+        candidates = [m for m in full_map.get(topic_id, []) if m.module == module]
+
+        if not candidates:
+            logger.error(f"Topic not found: {topic_id} in module {module}")
+            self.loading_errors.append(
+                {
+                    "category": "topic_not_found",
+                    "message": (f"Topic '{topic_id}' not found in module '{module}'"),
+                    "details": {
+                        "topic_id": topic_id,
+                        "module": module,
+                        "section": section_spec.name.en,
+                    },
+                }
+            )
+            return None
+
+        if len(candidates) > 1:
+            # Same ID twice within the same module is itself a filesystem
+            # bug; pick the first (sort-order) and surface a warning.
+            logger.warning(
+                f"Topic '{topic_id}' has multiple entries in module '{module}'; "
+                f"using {candidates[0].path}"
+            )
+            self.loading_warnings.append(
+                {
+                    "category": "duplicate_topic_id",
+                    "message": (
+                        f"Topic '{topic_id}' has multiple entries in module "
+                        f"'{module}' - using first occurrence"
+                    ),
+                    "details": {
+                        "topic_id": topic_id,
+                        "module": module,
+                        "first_path": str(candidates[0].path),
+                        "duplicate_paths": [str(c.path) for c in candidates[1:]],
+                    },
+                }
+            )
+
+        return candidates[0].path
 
     def _build_topic_map(self, rebuild: bool = False):
         """Build map from topic IDs to topic paths.
 
         Delegates to :func:`clm.core.topic_resolver.build_topic_map` for
         the actual filesystem scan, then applies first-occurrence logic
-        and tracks warnings for duplicates.
+        and **records** (does not yet emit) duplicates so the warning can
+        be filtered to IDs whose resolution actually depended on
+        first-occurrence-wins. See :meth:`_emit_unbound_duplicate_warnings`.
 
         Args:
             rebuild: If True, force rebuild even if map already exists
@@ -598,6 +682,11 @@ class Course(NotebookMixin):
             return
 
         self._topic_path_map.clear()
+        # Stash duplicates by topic_id so we can decide later whether to
+        # warn — only IDs resolved in unbound mode get a warning. IDs whose
+        # references all carry an explicit ``module=`` are unambiguous and
+        # should not produce noise.
+        self._duplicate_topic_records: dict[str, list[tuple[str, str]]] = {}
 
         slides_dir = self.course_root / "slides"
         if not slides_dir.is_dir():
@@ -606,24 +695,41 @@ class Course(NotebookMixin):
 
         for topic_id, matches in full_map.items():
             if len(matches) > 1:
-                first_path = matches[0].path
-                for dup in matches[1:]:
-                    logger.warning(f"Duplicate topic id: {topic_id}: {dup.path} and {first_path}")
-                    self.loading_warnings.append(
-                        {
-                            "category": "duplicate_topic_id",
-                            "message": f"Duplicate topic ID '{topic_id}' - using first occurrence",
-                            "details": {
-                                "topic_id": topic_id,
-                                "first_path": str(first_path),
-                                "duplicate_path": str(dup.path),
-                            },
-                        }
-                    )
-
+                first_path = str(matches[0].path)
+                self._duplicate_topic_records[topic_id] = [
+                    (first_path, str(dup.path)) for dup in matches[1:]
+                ]
             self._topic_path_map[topic_id] = matches[0].path
 
         logger.debug(f"Built topic map with {len(self._topic_path_map)} topics")
+
+    def _emit_unbound_duplicate_warnings(self):
+        """Emit duplicate-topic-id warnings for IDs that were resolved unbound.
+
+        A duplicate topic ID is only problematic when at least one
+        reference relied on first-occurrence-wins (i.e., was resolved
+        without an explicit ``module=`` binding). Specs that bind every
+        reference to a specific module produce no warning here because
+        the duplicate is no longer ambiguous in practice.
+        """
+        unbound: set[str] = getattr(self, "_unbound_resolved_ids", set())
+        records: dict[str, list[tuple[str, str]]] = getattr(self, "_duplicate_topic_records", {})
+        for topic_id, dup_pairs in records.items():
+            if topic_id not in unbound:
+                continue
+            for first_path, dup_path in dup_pairs:
+                logger.warning(f"Duplicate topic id: {topic_id}: {dup_path} and {first_path}")
+                self.loading_warnings.append(
+                    {
+                        "category": "duplicate_topic_id",
+                        "message": f"Duplicate topic ID '{topic_id}' - using first occurrence",
+                        "details": {
+                            "topic_id": topic_id,
+                            "first_path": first_path,
+                            "duplicate_path": dup_path,
+                        },
+                    }
+                )
 
     def _build_dir_groups(self):
         for dictionary_spec in self.spec.dictionaries:

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -53,6 +53,11 @@ class TopicSpec:
     http_replay: bool = False
     author: str = ""
     prog_lang: str = ""
+    # Optional module binding. When set, resolution is restricted to the
+    # named module directory (e.g., ``"module_545_ml_azav_cohort_2026_04"``).
+    # ``None`` means "use the section default if any, otherwise unbound".
+    # Empty string is treated as None for tolerance with XML defaults.
+    module: str | None = None
 
 
 @frozen
@@ -61,6 +66,9 @@ class SectionSpec:
     topics: list[TopicSpec] = Factory(list)
     enabled: bool = True
     id: str | None = None
+    # Optional module binding applied as a default to all child topics that
+    # do not themselves carry an explicit ``module`` attribute.
+    module: str | None = None
 
 
 @frozen
@@ -682,6 +690,7 @@ class CourseSpec:
                     )
 
             section_id = section_elem.attrib.get("id") or None
+            section_module = section_elem.attrib.get("module") or None
 
             if not enabled and not keep_disabled:
                 # Skip disabled sections entirely. They may reference topics
@@ -707,10 +716,19 @@ class CourseSpec:
                         ),
                         author=topic_elem.attrib.get("author", ""),
                         prog_lang=topic_elem.attrib.get("prog-lang", ""),
+                        module=topic_elem.attrib.get("module") or None,
                     )
                     for topic_elem in topics_elem.findall("topic")
                 ]
-            sections.append(SectionSpec(name=name, topics=topics, enabled=enabled, id=section_id))
+            sections.append(
+                SectionSpec(
+                    name=name,
+                    topics=topics,
+                    enabled=enabled,
+                    id=section_id,
+                    module=section_module,
+                )
+            )
         return sections
 
     @staticmethod

--- a/src/clm/core/topic_resolver.py
+++ b/src/clm/core/topic_resolver.py
@@ -135,6 +135,7 @@ def resolve_topic(
     slides_dir: Path,
     *,
     course_topic_ids: set[str] | None = None,
+    module: str | None = None,
 ) -> ResolutionResult:
     """Resolve a topic ID (or glob pattern) to filesystem path(s).
 
@@ -145,6 +146,12 @@ def resolve_topic(
       :func:`simplify_ordered_name`).
     - **Glob match**: If the query contains ``*`` or ``?``, all topic IDs
       matching the pattern are returned.
+    - **Module binding**: When ``module`` is provided, resolution is
+      restricted to topics whose parent module directory equals ``module``.
+      This is used by course specs that bind ``<section>`` or ``<topic>``
+      references to a specific module so duplicate topic IDs across modules
+      are unambiguous (e.g., frozen-cohort archives that share topic IDs
+      with the live module).
 
     Args:
         topic_id: Topic identifier or glob pattern (e.g., ``"what_is_ml"``
@@ -153,6 +160,9 @@ def resolve_topic(
         course_topic_ids: When provided, only topics whose ID is in this
             set are considered.  Use this to scope resolution to topics
             referenced by a particular course spec.
+        module: When provided, only topics whose parent module directory
+            equals this name are considered. Used for module-bound topic
+            references in course specs.
 
     Returns:
         A :class:`ResolutionResult` describing the match outcome.
@@ -164,6 +174,14 @@ def resolve_topic(
     # Filter to course-scoped topics if requested.
     if course_topic_ids is not None:
         full_map = {tid: matches for tid, matches in full_map.items() if tid in course_topic_ids}
+
+    # Filter to a specific module if requested. Drop entries whose match
+    # list becomes empty so resolution treats them as not-found.
+    if module is not None:
+        full_map = {
+            tid: [m for m in matches if m.module == module] for tid, matches in full_map.items()
+        }
+        full_map = {tid: matches for tid, matches in full_map.items() if matches}
 
     if is_glob:
         return _resolve_glob(topic_id, full_map)

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -51,6 +51,7 @@ def create_server(data_dir: Path) -> FastMCP:
     async def resolve_topic(
         topic_id: str,
         course_spec: str | None = None,
+        module: str | None = None,
     ) -> str:
         """Resolve a topic ID or glob pattern to its filesystem path.
 
@@ -59,8 +60,17 @@ def create_server(data_dir: Path) -> FastMCP:
                 pattern (e.g. "what_is_ml*").
             course_spec: Optional path to a course spec file to scope
                 resolution to topics referenced by that course.
+            module: Optional module directory name (e.g.
+                "module_545_ml_azav_cohort_2026_04"). When set,
+                resolution is restricted to topics in that module —
+                useful when a topic ID exists in multiple modules.
         """
-        return await handle_resolve_topic(topic_id, data_dir, course_spec=course_spec)
+        return await handle_resolve_topic(
+            topic_id,
+            data_dir,
+            course_spec=course_spec,
+            module=module,
+        )
 
     @mcp.tool()
     async def search_slides(

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -130,6 +130,7 @@ async def handle_resolve_topic(
     data_dir: Path,
     *,
     course_spec: str | None = None,
+    module: str | None = None,
 ) -> str:
     """Resolve a topic ID or glob pattern to filesystem path(s).
 
@@ -137,6 +138,11 @@ async def handle_resolve_topic(
         topic_id: Topic identifier or glob pattern.
         data_dir: Root data directory (contains ``slides/``).
         course_spec: Optional path to a course spec file to scope resolution.
+        module: Optional module directory name (e.g.,
+            ``"module_545_ml_azav_cohort_2026_04"``). When set, resolution
+            is restricted to topics in that module — useful when a topic
+            ID exists in multiple modules (e.g., a frozen-cohort archive
+            shares topic IDs with the live module).
 
     Returns:
         JSON string with resolution result.
@@ -151,7 +157,12 @@ async def handle_resolve_topic(
         except CourseSpecError:
             logger.warning("Failed to parse course spec: %s", course_spec)
 
-    result = _resolve_topic(topic_id, slides_dir, course_topic_ids=course_topic_ids)
+    result = _resolve_topic(
+        topic_id,
+        slides_dir,
+        course_topic_ids=course_topic_ids,
+        module=module,
+    )
     return json.dumps(_resolution_to_dict(result), indent=2)
 
 

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -82,11 +82,21 @@ def validate_spec(
     topic_map = build_topic_map(slides_dir)
     all_topic_ids = list(topic_map.keys())
 
+    # Set of module directory names (the immediate children of slides/).
+    # Used to validate ``module=`` attributes on sections and topics.
+    available_modules: set[str] = set()
+    if slides_dir.is_dir():
+        available_modules = {p.name for p in slides_dir.iterdir() if p.is_dir()}
+
     findings: list[SpecFinding] = []
     topics_total = sum(len(s.topics) for s in spec.sections)
 
     # Track seen topic IDs for duplicate detection: topic_id -> list of section names
     seen_topics: dict[str, list[str]] = {}
+    # Track which (topic_id, module) pairs have been bound so the
+    # cross-section "duplicate reference" warning can ignore deliberate
+    # cohort duplication (same topic ID in two different modules).
+    seen_bound: dict[tuple[str, str | None], list[str]] = {}
 
     def _suffix(section_is_disabled: bool, msg: str) -> str:
         return f"{msg} (disabled)" if section_is_disabled else msg
@@ -94,6 +104,25 @@ def validate_spec(
     for section in spec.sections:
         section_name = section.name.en or section.name.de
         section_disabled = not section.enabled
+
+        # Validate section-level module binding (if any).
+        if section.module and section.module not in available_modules:
+            findings.append(
+                SpecFinding(
+                    severity="error",
+                    type="unknown_module",
+                    section=section_name,
+                    message=_suffix(
+                        section_disabled,
+                        f"Section '{section_name}' references unknown module '{section.module}'",
+                    ),
+                    suggestion=(
+                        "Check the module attribute on this section. The value "
+                        "must be the literal module directory name under slides/ "
+                        "(e.g., 'module_545_ml_azav_cohort_2026_04')."
+                    ),
+                )
+            )
 
         # Empty section check
         if not section.topics:
@@ -112,12 +141,39 @@ def validate_spec(
 
         for topic_spec in section.topics:
             tid = topic_spec.id
+            # Effective module: per-topic override beats section default.
+            effective_module = topic_spec.module or section.module
 
-            # Track for duplicate detection
+            # Track for duplicate detection. Key by (id, module) so the
+            # same topic ID resolved in two different modules is treated
+            # as two distinct bindings, not a duplicate reference.
             seen_topics.setdefault(tid, []).append(section_name)
+            seen_bound.setdefault((tid, effective_module), []).append(section_name)
 
-            # Resolution check
+            # Validate per-topic module if it differs from the section default.
+            if (
+                topic_spec.module
+                and topic_spec.module != section.module
+                and topic_spec.module not in available_modules
+            ):
+                findings.append(
+                    SpecFinding(
+                        severity="error",
+                        type="unknown_module",
+                        topic_id=tid,
+                        section=section_name,
+                        message=_suffix(
+                            section_disabled,
+                            f"Topic '{tid}' references unknown module '{topic_spec.module}'",
+                        ),
+                    )
+                )
+                continue
+
+            # Resolution check, honoring the effective module if set.
             matches = topic_map.get(tid, [])
+            if effective_module:
+                matches = [m for m in matches if m.module == effective_module]
 
             if not matches:
                 # Unresolved — try to suggest near matches
@@ -127,22 +183,26 @@ def validate_spec(
                     near = topic_map[close[0]]
                     suggestion = f"Did you mean '{close[0]}'? Found: {near[0].path}"
 
+                msg = (
+                    f"Topic '{tid}' not found in module '{effective_module}'"
+                    if effective_module
+                    else f"Topic '{tid}' does not match any topic directory or file"
+                )
                 findings.append(
                     SpecFinding(
                         severity="error",
                         type="unresolved_topic",
                         topic_id=tid,
                         section=section_name,
-                        message=_suffix(
-                            section_disabled,
-                            f"Topic '{tid}' does not match any topic directory or file",
-                        ),
+                        message=_suffix(section_disabled, msg),
                         suggestion=suggestion,
                     )
                 )
 
             elif len(matches) > 1:
-                # Ambiguous — same ID in multiple modules
+                # Ambiguous — same ID in multiple modules. Only fires for
+                # unbound references; module-bound references will have
+                # filtered down to one match (or zero, handled above).
                 match_paths = [str(m.path) for m in matches]
                 findings.append(
                     SpecFinding(
@@ -156,22 +216,26 @@ def validate_spec(
                         ),
                         matches=match_paths,
                         suggestion=(
-                            "Qualify the topic ID to make it unique, "
-                            "or move one variant to a different name"
+                            "Bind the section or topic to a specific module with "
+                            'module="...", or move one variant to a different name'
                         ),
                     )
                 )
 
-    # Duplicate topic references (same topic in multiple sections)
-    for tid, section_names in seen_topics.items():
+    # Duplicate topic references (same topic resolved to the same target
+    # in multiple sections). Module-bound references that share an ID but
+    # point at different modules are intentionally NOT flagged here —
+    # cohort archives commonly do exactly that.
+    for (tid, mod), section_names in seen_bound.items():
         if len(section_names) > 1:
+            qualifier = f" (module: {mod})" if mod else ""
             findings.append(
                 SpecFinding(
                     severity="warning",
                     type="duplicate_topic",
                     topic_id=tid,
                     sections=section_names,
-                    message=f"Topic '{tid}' is referenced in multiple sections",
+                    message=(f"Topic '{tid}'{qualifier} is referenced in multiple sections"),
                 )
             )
 

--- a/tests/core/course_spec_test.py
+++ b/tests/core/course_spec_test.py
@@ -1053,6 +1053,102 @@ class TestSectionEnabledAndId:
             CourseSpec.from_file(io.StringIO(xml))
 
 
+class TestSectionAndTopicModuleBinding:
+    """Tests for the optional ``module`` attribute on ``<section>`` and
+    ``<topic>`` elements (cohort-versioning support)."""
+
+    @staticmethod
+    def _parse(xml: str, *, keep_disabled: bool = False):
+        from xml.etree import ElementTree as ETree
+
+        root = ETree.fromstring(xml)
+        return CourseSpec.parse_sections(root, keep_disabled=keep_disabled)
+
+    def test_section_module_default_none(self):
+        xml = """
+        <course>
+            <sections>
+                <section>
+                    <name><de>W1</de><en>W1</en></name>
+                    <topics><topic>t1</topic></topics>
+                </section>
+            </sections>
+        </course>
+        """
+        sections = self._parse(xml)
+        assert sections[0].module is None
+        assert sections[0].topics[0].module is None
+
+    def test_section_module_attribute_parsed(self):
+        xml = """
+        <course>
+            <sections>
+                <section module="module_545_frozen">
+                    <name><de>W1 (frozen)</de><en>W1 (frozen)</en></name>
+                    <topics>
+                        <topic>t1</topic>
+                        <topic>t2</topic>
+                    </topics>
+                </section>
+            </sections>
+        </course>
+        """
+        sections = self._parse(xml)
+        assert sections[0].module == "module_545_frozen"
+        # Per-topic module remains None — the section default applies.
+        assert sections[0].topics[0].module is None
+        assert sections[0].topics[1].module is None
+
+    def test_topic_module_overrides_section(self):
+        xml = """
+        <course>
+            <sections>
+                <section module="module_545_frozen">
+                    <name><de>Mixed</de><en>Mixed</en></name>
+                    <topics>
+                        <topic>t1</topic>
+                        <topic module="module_550_live">t2</topic>
+                    </topics>
+                </section>
+            </sections>
+        </course>
+        """
+        sections = self._parse(xml)
+        assert sections[0].module == "module_545_frozen"
+        assert sections[0].topics[0].module is None
+        assert sections[0].topics[1].module == "module_550_live"
+
+    def test_empty_module_treated_as_none(self):
+        xml = """
+        <course>
+            <sections>
+                <section module="">
+                    <name><de>X</de><en>X</en></name>
+                    <topics><topic module="">t1</topic></topics>
+                </section>
+            </sections>
+        </course>
+        """
+        sections = self._parse(xml)
+        assert sections[0].module is None
+        assert sections[0].topics[0].module is None
+
+    def test_module_persists_through_disabled_sections(self):
+        """Disabled sections retain their ``module`` when keep_disabled=True."""
+        xml = """
+        <course>
+            <sections>
+                <section enabled="false" module="module_545_frozen">
+                    <name><de>W1</de><en>W1</en></name>
+                    <topics><topic>t1</topic></topics>
+                </section>
+            </sections>
+        </course>
+        """
+        sections = self._parse(xml, keep_disabled=True)
+        assert sections[0].module == "module_545_frozen"
+
+
 # ---------------------------------------------------------------------------
 # JupyterLite spec parsing + cross-validation (Phase 1)
 # ---------------------------------------------------------------------------

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -350,3 +350,163 @@ def test_get_stage_name_returns_fallback_for_unknown_stage():
     """Test that get_stage_name returns a fallback for unknown stages."""
     assert get_stage_name(99) == "Stage 99"
     assert get_stage_name(0) == "Stage 0"
+
+
+# ---------------------------------------------------------------------------
+# Module-bound topic resolution
+# ---------------------------------------------------------------------------
+
+
+def _make_topic_dir(course_root: Path, module: str, topic: str) -> Path:
+    topic_dir = course_root / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    (topic_dir / "slides_intro.py").write_text("# %% [markdown]\n# Hello\n", encoding="utf-8")
+    return topic_dir
+
+
+def _build_course(course_root: Path, sections_xml: str):
+    """Construct a Course from a tmp_path course root and an inline sections XML."""
+    import io
+
+    from clm.core.course import Course
+    from clm.core.course_spec import CourseSpec
+
+    spec_xml = f"""
+    <course>
+      <name><de>Test</de><en>Test</en></name>
+      <prog-lang>python</prog-lang>
+      <description><de></de><en></en></description>
+      <certificate><de></de><en></en></certificate>
+      <project-slug>test-course</project-slug>
+      {sections_xml}
+    </course>
+    """
+    spec = CourseSpec.from_file(io.StringIO(spec_xml))
+    return Course.from_spec(spec, course_root, course_root / "_out")
+
+
+def test_module_bound_section_resolves_to_named_module(tmp_path):
+    """A section with module= picks the topic from that specific module
+    even when another module has the same topic ID."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    _make_topic_dir(tmp_path, "module_545_frozen", "topic_010_intro")
+
+    sections_xml = """
+    <sections>
+      <section module="module_545_frozen">
+        <name><de>Frozen</de><en>Frozen</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+
+    assert len(course.sections) == 1
+    topic = course.sections[0].topics[0]
+    assert "module_545_frozen" in str(topic.path)
+    # No loading errors — the topic was resolved.
+    assert not [e for e in course.loading_errors if e.get("category") == "topic_not_found"]
+
+
+def test_module_bound_two_sections_resolve_independently(tmp_path):
+    """Two enabled sections binding the same topic ID to different modules
+    each resolve to their own copy."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    _make_topic_dir(tmp_path, "module_545_frozen", "topic_010_intro")
+
+    sections_xml = """
+    <sections>
+      <section module="module_100_live">
+        <name><de>Live</de><en>Live</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+      <section module="module_545_frozen">
+        <name><de>Frozen</de><en>Frozen</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+    assert len(course.sections) == 2
+    assert "module_100_live" in str(course.sections[0].topics[0].path)
+    assert "module_545_frozen" in str(course.sections[1].topics[0].path)
+
+
+def test_topic_module_override_wins_over_section_default(tmp_path):
+    """Per-topic ``module=`` overrides the section default."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    _make_topic_dir(tmp_path, "module_545_frozen", "topic_010_intro")
+
+    sections_xml = """
+    <sections>
+      <section module="module_545_frozen">
+        <name><de>Mixed</de><en>Mixed</en></name>
+        <topics>
+          <topic>intro</topic>
+          <topic module="module_100_live">intro</topic>
+        </topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+    topics = course.sections[0].topics
+    assert "module_545_frozen" in str(topics[0].path)
+    assert "module_100_live" in str(topics[1].path)
+
+
+def test_module_bound_resolution_silences_duplicate_warning(tmp_path):
+    """When all references to a duplicate topic ID are module-bound, no
+    duplicate-id warning is emitted (the duplicate is unambiguous in
+    practice)."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    _make_topic_dir(tmp_path, "module_545_frozen", "topic_010_intro")
+
+    sections_xml = """
+    <sections>
+      <section module="module_545_frozen">
+        <name><de>Frozen</de><en>Frozen</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+    dup_warnings = [w for w in course.loading_warnings if w.get("category") == "duplicate_topic_id"]
+    assert dup_warnings == []
+
+
+def test_unbound_resolution_still_warns_about_duplicates(tmp_path):
+    """An unbound section that hits a duplicate ID still triggers the
+    duplicate-id warning (existing behavior preserved)."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    _make_topic_dir(tmp_path, "module_545_frozen", "topic_010_intro")
+
+    sections_xml = """
+    <sections>
+      <section>
+        <name><de>Live</de><en>Live</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+    dup_warnings = [w for w in course.loading_warnings if w.get("category") == "duplicate_topic_id"]
+    assert len(dup_warnings) >= 1
+
+
+def test_module_bound_unknown_module_is_topic_not_found(tmp_path):
+    """A section binding to a non-existent module yields a topic_not_found
+    error (with the module name in the message)."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+
+    sections_xml = """
+    <sections>
+      <section module="module_999_nope">
+        <name><de>X</de><en>X</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+    nf = [e for e in course.loading_errors if e.get("category") == "topic_not_found"]
+    assert len(nf) == 1
+    assert "module_999_nope" in nf[0]["message"]

--- a/tests/core/test_topic_resolver.py
+++ b/tests/core/test_topic_resolver.py
@@ -239,6 +239,69 @@ class TestResolveTopic:
         assert result.path is not None
         assert result.path_type == "file"
 
+    def test_module_filter_picks_intended_match(self, slides_dir):
+        """A duplicate ID is unambiguous when ``module`` is specified."""
+        m200_dec = slides_dir / "module_200_oop" / "topic_030_decorators"
+        m200_dec.mkdir(parents=True)
+        (m200_dec / "slides_decorators.py").write_text("# oop dec", encoding="utf-8")
+
+        # Without module: ambiguous.
+        result = resolve_topic("decorators", slides_dir)
+        assert result.ambiguous
+
+        # With module=module_200_oop: resolves to that module's copy.
+        result = resolve_topic("decorators", slides_dir, module="module_200_oop")
+        assert not result.ambiguous
+        assert result.path is not None
+        assert "module_200_oop" in str(result.path)
+
+        # With module=module_300_advanced: resolves to that module's copy.
+        result = resolve_topic("decorators", slides_dir, module="module_300_advanced")
+        assert not result.ambiguous
+        assert result.path is not None
+        assert "module_300_advanced" in str(result.path)
+
+    def test_module_filter_not_in_module(self, slides_dir):
+        """Topic exists, but not in the named module → not found."""
+        result = resolve_topic("intro", slides_dir, module="module_300_advanced")
+        assert result.path is None
+        assert not result.ambiguous
+
+    def test_module_filter_no_such_module(self, slides_dir):
+        """Module name doesn't match any directory → not found."""
+        result = resolve_topic("intro", slides_dir, module="module_999_does_not_exist")
+        assert result.path is None
+        assert not result.ambiguous
+
+    def test_module_filter_with_glob(self, slides_dir):
+        """Module filter narrows glob matches to the specified module."""
+        m200_dec = slides_dir / "module_200_oop" / "topic_030_decorators"
+        m200_dec.mkdir(parents=True)
+        (m200_dec / "slides_decorators.py").write_text("# oop dec", encoding="utf-8")
+
+        result = resolve_topic("decorators*", slides_dir, module="module_200_oop")
+        assert result.glob
+        # Only the module_200 entry should be returned.
+        modules = {m.module for m in result.matches}
+        assert modules == {"module_200_oop"}
+
+    def test_module_filter_combines_with_course_scoping(self, slides_dir):
+        """Both course_topic_ids and module filters apply."""
+        m200_dec = slides_dir / "module_200_oop" / "topic_030_decorators"
+        m200_dec.mkdir(parents=True)
+        (m200_dec / "slides_decorators.py").write_text("# oop dec", encoding="utf-8")
+
+        # Course-scoped to {decorators}, module-bound to module_300_advanced
+        # — should resolve to the module_300 copy.
+        result = resolve_topic(
+            "decorators",
+            slides_dir,
+            course_topic_ids={"decorators"},
+            module="module_300_advanced",
+        )
+        assert result.path is not None
+        assert "module_300_advanced" in str(result.path)
+
 
 class TestGetCourseTopicIds:
     def test_extracts_ids(self):

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -401,3 +401,116 @@ class TestValidateSpecIncludeDisabled:
         empty_findings = [f for f in result.findings if f.type == "empty_section"]
         assert len(empty_findings) == 1
         assert empty_findings[0].message.endswith("(disabled)")
+
+
+class TestModuleBindingValidation:
+    """Validation behaviour for the optional ``module=`` attribute on
+    ``<section>`` and ``<topic>``."""
+
+    def test_module_bound_section_resolves_correctly(self, tmp_path):
+        """Section with ``module=`` resolves to the named module's copy
+        even when the topic ID exists in another module."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="module_545_frozen">
+                <name><de>Frozen</de><en>Frozen</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+            </sections>""",
+        )
+        result = validate_spec(spec_file, tmp_path / "slides")
+        # No ambiguity finding because the module binding disambiguates.
+        assert [f for f in result.findings if f.type == "ambiguous_topic"] == []
+        assert [f for f in result.findings if f.type == "unresolved_topic"] == []
+
+    def test_module_bound_two_sections_no_duplicate_warning(self, tmp_path):
+        """Two sections binding the same topic ID to different modules
+        should NOT produce a duplicate-reference warning."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="module_545_frozen">
+                <name><de>Frozen</de><en>Frozen</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+              <section enabled="false">
+                <name><de>Live</de><en>Live</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+            </sections>""",
+        )
+        result = validate_spec(spec_file, tmp_path / "slides", include_disabled=True)
+        assert [f for f in result.findings if f.type == "duplicate_topic"] == []
+
+    def test_unknown_section_module_error(self, tmp_path):
+        """Section ``module=`` referencing a non-existent directory errors out."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="module_999_nope">
+                <name><de>X</de><en>X</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+            </sections>""",
+        )
+        result = validate_spec(spec_file, tmp_path / "slides")
+        unknown = [f for f in result.findings if f.type == "unknown_module"]
+        assert len(unknown) == 1
+        assert "module_999_nope" in unknown[0].message
+
+    def test_topic_module_override_resolves(self, tmp_path):
+        """Per-topic ``module=`` overrides the section default."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="module_545_frozen">
+                <name><de>Mixed</de><en>Mixed</en></name>
+                <topics>
+                  <topic>intro</topic>
+                  <topic module="module_100_live">intro</topic>
+                </topics>
+              </section>
+            </sections>""",
+        )
+        result = validate_spec(spec_file, tmp_path / "slides")
+        # No ambiguity, no unknown_module, no duplicate (different modules
+        # → distinct bindings).
+        assert [f for f in result.findings if f.severity == "error"] == []
+        assert [f for f in result.findings if f.type == "duplicate_topic"] == []
+
+    def test_module_bound_topic_not_in_module(self, tmp_path):
+        """``module=`` topic that doesn't exist in the named module errors."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro")
+        # Create the frozen module, but with a different topic
+        _make_topic(tmp_path, "module_545_frozen", "topic_020_variables")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="module_545_frozen">
+                <name><de>X</de><en>X</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+            </sections>""",
+        )
+        result = validate_spec(spec_file, tmp_path / "slides")
+        unresolved = [f for f in result.findings if f.type == "unresolved_topic"]
+        assert len(unresolved) == 1
+        assert "module_545_frozen" in unresolved[0].message


### PR DESCRIPTION
## Summary

Adds an optional `module` attribute on `<section>` and `<topic>` elements in course specs. When set, topic resolution is restricted to the named module directory — eliminating the silent first-occurrence-wins ambiguity that fires when two modules share a topic ID.

## Motivation

Course specs select topics by ID (the suffix after `topic_NNN_`), but the resolver scans every `module_*/` under `slides/` and collapses duplicate IDs to `matches[0]` by sort order, with a `duplicate_topic_id` warning. The spec layer's `enabled="false"` flag controls *whether a section is built* but not *how its refs resolve* — so two sections (one enabled, one disabled) referencing the same topic ID in different modules silently both pick the alphabetically-first module.

This blocks legitimate use cases:

- **Cohort archives** — freezing the materials shipped to the current cohort while developing the next version of the same topics in parallel
- **Course variants** — A/B experiments, audience-specific decks
- **Migration paths** — old/new content side-by-side during a refactor

The previous workaround (suffix every topic directory with a cohort tag) couples the workaround to topic IDs forever and pollutes paths, MCP calls, and planning docs.

## Design

```xml
<section module="module_545_ml_azav_cohort_2026_04">
  <topic>introduction</topic>
  <topic module="module_550_live">special_case</topic>  <!-- per-topic override -->
</section>
```

- `module=` on `<section>` is a default for all child topic refs
- `module=` on `<topic>` overrides the section default
- Absent → current behaviour (filesystem scan, first-occurrence-wins, duplicate warning)
- Backwards-compatible: existing specs build identically

The duplicate-id warning was moved out of `_build_topic_map` and into a post-section-build pass so it only fires for IDs whose resolution actually depended on first-occurrence-wins. Specs that bind every duplicate via `module=` produce zero noise.

## Surface

- `topic_resolver.resolve_topic(...)` gains `module: str | None`
- `Course._build_topics` honors per-topic and per-section bindings
- `clm resolve-topic --module NAME` flag
- MCP `resolve_topic` tool gains a `module` parameter
- `clm validate-spec` reports unknown module names and module-bound topics that don't exist in the named module
- The "duplicate topic reference across sections" warning is keyed by `(topic_id, module)` so two sections binding the same ID to different modules aren't flagged

## Docs

- `clm info spec-files`: new attribute documented on `<section>` and `<topic>`, with a cohort-archive example showing how to flip `enabled` flags between cohorts
- `clm info commands`: `--module` flag documented for `resolve-topic`
- `CHANGELOG.md`: entry under `[Unreleased]`

## Test plan

- [x] `tests/core/test_topic_resolver.py` — module filter, glob+module, course-scope+module, not-found-in-module, no-such-module
- [x] `tests/core/course_spec_test.py::TestSectionAndTopicModuleBinding` — section default, per-topic override, empty-string tolerance, persistence through disabled sections
- [x] `tests/core/course_test.py` — independent two-section resolution, override semantics, silenced duplicate warning when bound, preserved warning when unbound, unknown-module yields topic_not_found
- [x] `tests/slides/test_spec_validator.py::TestModuleBindingValidation` — clean module-bound spec, no false-positive duplicate_topic, unknown_module error, override resolution, module-bound topic missing in module
- [x] Existing tests (366 across resolver/spec/course/validator/cli/mcp): all pass
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run mypy` clean on touched modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)