### PR TITLE
feat(recordings): Phase C — UI parts-inline chip strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Recordings web UI: per-part chip strip in the lectures page.** Each
+  deck row's Status column now renders one chip per existing part (color-
+  coded: amber `recorded`, green `processed`, purple `processing`, red
+  `failed`) plus a trailing `+ N` chip for "record the next part". The
+  chip strip doubles as the part selector — clicking a chip targets the
+  Record/Arm/Process/Advance buttons at that part, and selecting an
+  existing chip swaps Record/Arm labels to Retake/Re-arm with a ⚠ icon
+  warning that the current take will be moved to `takes/`. A
+  `Process all` button appears only when ≥2 unprocessed parts exist on
+  the deck. Right-click a chip to reveal an inline take-history panel
+  below the deck row, lazy-fetched from a new
+  `GET /decks/{course}/{section}/{deck}/takes` route and refreshed on
+  job SSE events. Selection state lives in client-side `sessionStorage`
+  keyed by `(course, section, deck)` so swaps no longer wipe the user's
+  choice — incidentally fixing the long-standing `part_number`
+  snap-back bug as a side-effect of removing the input. Restore-take
+  action is intentionally absent and ships with the next phase.
+
 ## [1.3.2] - 2026-05-02
 
 ### Added

--- a/docs/claude/recordings-ux-followups-handover.md
+++ b/docs/claude/recordings-ux-followups-handover.md
@@ -398,6 +398,26 @@ so the history in `takes/` is complete.
 - **Tests baseline**: 786 recordings tests green at the end of
   Phase C (2026-05-03).
 
+### Open Design Questions (consolidated)
+
+Quick index for future sessions — full context lives in each phase's
+body above. Resolve these before opening an implementation branch.
+
+| Phase | Question | Status |
+|---|---|---|
+| D | Gesture: single click vs. confirm modal? | OPEN |
+| D | Where does the file-swap helper live (session.py vs new helper)? | OPEN |
+| D | Should backend file moves be atomic with `state.restore_take`, or two-phase with rollback? | OPEN |
+| D | After-swap display: does the previously-active take reappear in history with a new take number? | OPEN |
+| E | Concrete sidecar file-extension list (EDL only? FCP XML? subtitles?) | OPEN |
+| E | Discovery strategy: glob beside the video/wav, or a known sidecar subdir? | OPEN |
+| E | Backend-specific scanner (Auphonic only) vs. generic in `session.py`? | OPEN |
+| F | Scope flag: `--course`, `--lecture`, or global? | OPEN |
+| F | Retention semantics: mtime vs `state.json` `superseded_at`? | OPEN |
+| F | Safety: dry-run mode? Interactive confirmation? | OPEN |
+| F | Orphan handling: delete vs warn for state-without-disk and disk-without-state? | OPEN |
+| F | Backend quota awareness: also delete the upstream Auphonic production? (lean: no) | OPEN |
+
 ## 5. Next Steps
 
 1. **Phase D** (Restore-take UI) is the natural next step now that

--- a/docs/claude/recordings-ux-followups-handover.md
+++ b/docs/claude/recordings-ux-followups-handover.md
@@ -75,7 +75,7 @@ the shipped summary. Decisions taken: 5 s ping interval, 1 → 2 → 4 →
 check, both warning banner and disabled Record/Arm buttons,
 `obs:<state>` SSE events routed onto the existing `status` channel.
 
-### Phase C — UI parts-inline display [DESIGN LOCKED 2026-05-03]
+### Phase C — UI parts-inline display [SHIPPED 2026-05-03]
 
 **Goal**: Replace the bare `<input name="part_number">` selector with
 a per-part chip strip that doubles as the part selector and the
@@ -388,25 +388,23 @@ so the history in `takes/` is complete.
 
 ## 4. Current Status
 
-- **Shipped**: Phases A and B (folded into Recordings App Hardening
-  PR #42, 2026-04-19).
-- **Design locked**: Phase C (2026-05-03) — ready for implementation.
+- **Shipped**: Phases A, B, and C (Phases A+B folded into Recordings
+  App Hardening PR #42 on 2026-04-19; Phase C shipped on
+  branch `claude/recordings-ux-followups-c-parts-inline`,
+  2026-05-03).
 - **In progress**: None.
 - **Blocked on**: User review + design decisions listed under each
   remaining phase's "Open design questions" (D, E, F).
-- **Tests baseline**: 740 recordings tests green at the end of
-  hardening + Commit-B (2026-04-20).
+- **Tests baseline**: 786 recordings tests green at the end of
+  Phase C (2026-05-03).
 
 ## 5. Next Steps
 
-1. **Implement Phase C** on a fresh
-   `claude/recordings-ux-followups-c-parts-inline` branch from master.
-   Design is locked; see §3 Phase C above.
-2. **Phases D, E, F** still need their design questions answered.
-   Suggested order:
-   - Phase D after C ships (Restore-take UI; depends on C's hooks).
-   - Phase E and F are independent; schedule by urgency.
-3. **Re-run the phase-check skill** after Phase C ships; update
+1. **Phase D** (Restore-take UI) is the natural next step now that
+   Phase C's chip strip and take-history panel exist as anchor
+   points. Open design questions still need answers — see §3 Phase D.
+2. **Phases E and F** are independent; schedule by urgency.
+3. **Re-run the phase-check skill** after each phase ships; update
    this handover's Status section.
 
 ## 6. Key Files & Architecture
@@ -451,9 +449,7 @@ Phase C's design questions were locked in a Q1–Q8 walkthrough on
 
 ---
 
-**Last updated**: 2026-05-03 (Phases A and B confirmed shipped via
-hardening PR #42; Phase C design locked).
-**Next action**: Implement Phase C on a fresh
-`claude/recordings-ux-followups-c-parts-inline` branch from master.
-Phases D, E, F still need their design questions answered before
-implementation.
+**Last updated**: 2026-05-03 (Phase C shipped: chip strip + inline
+take-history panel + /takes route; 786 recordings tests green).
+**Next action**: Phases D, E, F still need their design questions
+answered before implementation. Phase D is the natural next step.

--- a/docs/claude/recordings-ux-followups-handover.md
+++ b/docs/claude/recordings-ux-followups-handover.md
@@ -75,39 +75,212 @@ the shipped summary. Decisions taken: 5 s ping interval, 1 → 2 → 4 →
 check, both warning banner and disabled Record/Arm buttons,
 `obs:<state>` SSE events routed onto the existing `status` channel.
 
-### Phase C — UI parts-inline display [TODO]
+### Phase C — UI parts-inline display [DESIGN LOCKED 2026-05-03]
 
-**Goal**: Replace the one-row-per-deck layout with an inline per-part
-indicator (`▶ 1 │ ▶ 2 │ ▶ 3`) and a collapsible takes history.
+**Goal**: Replace the bare `<input name="part_number">` selector with
+a per-part chip strip that doubles as the part selector and the
+status display. Also fixes the `part_number` snap-back bug as a
+side-effect of removing the input. Take-history is revealed inline.
+Restore-take action stays deferred to Phase D.
 
-**Open design questions** (UX decisions — needs a wireframe or mock):
-- **Component type**: buttons, links, or custom chips?
-- **Interaction**: click a part → modal, sidebar, inline expand, or
-  HTMX fetch?
-- **Status dot semantics**: colors / icons per state
-  (pending/processing/processed/failed)?
-- **Wrapping**: how does `▶ 1 │ ▶ 2 │ ▶ 3 │ …` behave on narrow
-  screens and with many parts?
-- **Retake dropdown integration**: separate control, or folded into
-  the per-part click-through?
+**Design decisions (locked 2026-05-03)**:
+
+**Q1 — Chip purpose**: Selection + status (Option B). Chips are the
+part selector; clicking a chip writes selection state to
+`sessionStorage`. Action buttons (Record/Arm/Process/Advance) consume
+the selection. A permanent rightmost "next part" chip represents
+"create a new part" and is the default selection on every fresh
+render. Single-part recordings and multi-part recordings share the
+same mental model: "next part" is always one click away.
+
+**Q2 — Per-chip visual encoding**:
+- Status palette tracks the existing badge palette in `app.css`:
+  amber (`recorded`, `processing` with pulse), green (`processed`),
+  red (`failed`), neutral-dashed outline (next-part placeholder).
+- Processed-with-failed-retry adds a small red corner dot (matches
+  the existing `failed_job_id && state != 'failed'` heuristic in
+  `lectures.html:138-140`).
+- Selection: 2px blue outline ring on top of any fill; ring goes
+  neutral when the deck row has no valid action (already armed or
+  recording).
+- Take-count indicator: superscript number after the part number
+  (`▶ 2³`) when `takes[]` has more than one entry; absent for
+  single-take parts. Capped cosmetically at `⁹⁺`; full count lives
+  in the tooltip.
+- Tooltip via native `title` attribute, multi-line via `&#10;`:
+  ```
+  Part {N} — {state label}
+  Takes: {K}
+  Last job: {job_id_short} ({status})    # only when relevant
+  ```
+  `aria-label` mirrors the first line so screen readers don't get
+  the multi-line noise. Selection state goes into `aria-pressed` on
+  the chip button, not into the tooltip.
+
+**Q3 — Default selection + persistence**:
+- **Default**: "next part" chip is selected on first render (matches
+  current `value="0"` default semantics so the keyboard flow
+  doesn't regress).
+- **Persistence**: client-side `sessionStorage`, keyed by
+  `(course_slug, section_name, deck_name)`. Chip render reads
+  storage on first paint after every swap; no snapshot/restore
+  handler needed. Survives every kind of swap including
+  `hx-target="body"` paths that flush the entire DOM.
+- **Auto-advance**: sticky except when the previously selected chip
+  was "next part" — then re-target the new "next part" after the
+  cascade, since the chip the user selected has just become an
+  existing part and staying on it would be confusing.
+- **Stale-selection fallback**: every render validates the stored
+  selection against the actual chips present and falls back to
+  "next part" when stale (e.g. the part was deleted out from
+  underneath us via the CLI).
+- **Armed/recording deck**: chip strip is read-only until disarm /
+  stop; armed part shown with selection ring + small pulsing dot;
+  clicking another chip is suppressed (cursor `not-allowed`).
+
+**Q4 — Click semantics**:
+- **Single-click / Space / Enter on chip** = select chip
+  (client-side only, writes `sessionStorage`). No network call.
+  Re-clicking the selected chip is a no-op, never a toggle to
+  "unselected" — there is always a selection.
+- **Action buttons stay inline** next to the chip strip (no
+  per-chip overflow menu). They always operate on the selected
+  chip.
+- **Right-click / long-press / hover-revealed `⋯` button** = open
+  take-history (Q5). Falls back gracefully on touch and for users
+  who don't right-click.
+- **Tab** focuses chips and action buttons in row order; **Arrow
+  Left/Right** moves focus inside the chip strip (ARIA tablist
+  pattern).
+- **Drop** the existing "Enter inside `part_number` input triggers
+  Record" handler (`base.html:191-201`) — it has no input to
+  attach to. Optional R/A/P single-key shortcuts deferred to a
+  later pass; not in Phase C scope.
+
+**Q5 — Take-history reveal**:
+- Container: **inline expand** below the deck row (sibling `<tr>`).
+  No singleton enforcement — multiple deck panels can be open at
+  once.
+- Per-take fields: take number badge, recorded-at timestamp, file
+  stem (truncated middle), status mini-badge, optional
+  "open in Explorer" link (Windows-first, `file://` URL).
+- **No Restore button in Phase C** — Restore is Phase D's
+  headliner. Shipping a disabled placeholder would clutter the
+  panel; better to introduce the button visibly during Phase D.
+- Loading: HTMX **lazy fetch** at
+  `GET /decks/{course}/{section}/{deck}/takes` (final URL TBD
+  during implementation). Keeps `/lectures` payload lean and lets
+  the panel evolve independently (e.g. when Phase E adds
+  sidecars, only the new route changes).
+- SSE refresh: open panel piggy-backs `data-sse-refresh="job"` and
+  refetches on each `job` event; chip strip outside the panel
+  refreshes per the existing wiring.
+- Close gestures: toggle the `⋯` button, right-click the chip
+  again, or `Escape` while focus is inside the panel. Outside-
+  click does NOT close (panels are inline, not overlays).
+
+**Q6 — Wrapping / overflow**:
+- Chip strip uses `flex-wrap: wrap; gap: 0.4rem`. No horizontal
+  scroll inside the cell, no truncation. Status visibility wins
+  over row-height compactness.
+- Status column gets `min-width: ~240px`; below that the table
+  scrolls horizontally (acceptable on phones — recording is a
+  desktop activity).
+- Action buttons keep Phase 4's `flex-wrap` layout unchanged.
+- Take-count display capped at `⁹⁺`; full number stays in tooltip.
+
+**Q7 — Retake-dropdown integration**:
+- **No separate retake dropdown.** Chip selection covers it: an
+  existing chip is the retake target; the "next part" chip is the
+  fresh-record target.
+- **No confirmation modal.** When the selected chip already has
+  a take, the Record button's `title` warns
+  (`"Will move the current take to takes/ before recording"`) and
+  a small warning icon appears next to the button.
+- **Button labels swap** based on selection: Record↔Retake,
+  Arm↔Re-arm.
+- **Process targets the selected chip** by default. A separate
+  **Process all** button appears only when ≥2 unprocessed parts
+  exist on the deck — preserves the fire-and-forget batch flow
+  without breaking the chip-centric mental model.
+- **Advance targets the selected chip** (replaces the current
+  "first recorded part" probe at `lectures.html:206-207`).
+
+**Q8 — Snap-back bug**:
+- **Root cause** (most likely): the existing `_partNumberSnapshots`
+  code in `base.html:47-82` cannot bridge form-shape changes. When
+  a deck transitions Record/Arm form → Pause/Stop form (during
+  arm/recording) and back, the input does not exist in the
+  intermediate render, so the snapshot map loses the entry. On the
+  next disarm, the fresh form arrives with `value="0"` and there's
+  nothing to restore.
+- **Fix**: Phase C's chip rollout dissolves the bug — selection
+  lives in `sessionStorage`, not in a DOM input. Form-shape
+  changes are irrelevant; chip strip just reads storage on every
+  render.
+- **Cleanup in the Phase C diff**: remove `_partNumberSnapshots`,
+  `_snapshotPartNumbers`, `_restorePartNumbers`, the
+  `htmx:beforeSwap` / `htmx:afterSwap` listeners that drove them,
+  and the Enter-on-`part_number` keyboard handler.
+- **Click delegation**: single document-level click listener using
+  `event.target.closest('[data-chip]')` so swaps cannot break the
+  binding.
 
 **What it accomplishes**:
-- Lectures page shows parts inline per deck, not one row per deck.
-- Each part surfaces its current state and (if takes exist) a small
-  "N takes" indicator.
+- Lectures page shows parts inline per deck via a chip strip in
+  the Status column.
+- Each chip surfaces its current state, take count, and selection
+  status; click selects, hover/right-click/`⋯` reveals takes.
+- Action buttons (Record/Arm/Process/Advance) operate on the
+  selected chip; labels swap to Retake/Re-arm when appropriate.
+- Eliminates the `part_number` snap-back bug as a side-effect.
 
 **Files likely involved**:
-- `src/clm/recordings/web/templates/lectures.html`
-- New: `src/clm/recordings/web/templates/partials/parts.html`
-- `src/clm/recordings/web/routes.py` (if new HTMX fetch endpoints
-  are needed)
+- `src/clm/recordings/web/templates/lectures.html` — chip strip
+  in Status column, action buttons consume chip selection,
+  warning icon on Retake.
+- New: `src/clm/recordings/web/templates/partials/parts.html` —
+  chip strip partial.
+- New: `src/clm/recordings/web/templates/partials/takes.html` —
+  inline-expand take-history panel.
+- `src/clm/recordings/web/templates/base.html` — drop dead code,
+  add chip-selection JS (event delegation, sessionStorage I/O,
+  ARIA tablist focus management).
+- `src/clm/recordings/web/routes.py` — new
+  `GET /decks/{course}/{section}/{deck}/takes` route; rewire
+  `/process`, `/advance`, `/record`, `/arm` to read part from a
+  unified place (form field stays the wire format; chip JS
+  populates it before submit).
+- `src/clm/recordings/web/static/app.css` — `.chip-strip`,
+  `.chip`, `.chip-selected`, `.chip-armed`, `.chip-status-*`
+  classes; superscript take-count style.
+- Tests:
+  - `tests/recordings/test_web.py` — server-rendered HTML
+    assertions (chip elements present per part, default-selected
+    next-part chip, tooltip strings, status classes, button
+    label swap, /takes route happy path).
+  - Manual smoke test (per CLAUDE.md UI rule): record-stop-rerecord
+    sequence with intervening SSE traffic to confirm the snap-back
+    symptom is gone.
 
-**Reference**: `recordings-parts-and-takes.md` §8.
+**Reference**: `docs/claude/design/recordings-parts-and-takes.md` §8.
 
 **Acceptance criteria**:
-- Decks with multiple parts render as inline chips.
-- Clicking a part reveals its take history and per-part controls.
-- Existing single-part decks still render sensibly.
+- Decks render a chip strip with one chip per existing part plus a
+  trailing "next part" chip; default selection is the "next part"
+  chip.
+- Clicking a chip updates selection visibly and persistently
+  (survives SSE refresh, body swap, page reload within the tab).
+- Action buttons act on the selected chip; labels swap to
+  Retake/Re-arm when the selection is an existing part.
+- Right-click / `⋯` opens an inline take-history panel below the
+  deck row, lazy-fetched, refreshed on `job` SSE events.
+- Single-part recordings still render sensibly (one part chip
+  plus the next-part chip).
+- The `part_number` snap-back symptom does not reproduce in the
+  manual smoke test (record → stop → re-arm sequence).
+- Existing 740 recordings tests still pass; new HTML-render and
+  /takes-route tests added.
 
 ### Phase D — Restore-take UI [TODO]
 
@@ -217,26 +390,24 @@ so the history in `takes/` is complete.
 
 - **Shipped**: Phases A and B (folded into Recordings App Hardening
   PR #42, 2026-04-19).
+- **Design locked**: Phase C (2026-05-03) — ready for implementation.
 - **In progress**: None.
 - **Blocked on**: User review + design decisions listed under each
-  remaining phase's "Open design questions".
+  remaining phase's "Open design questions" (D, E, F).
 - **Tests baseline**: 740 recordings tests green at the end of
   hardening + Commit-B (2026-04-20).
 
 ## 5. Next Steps
 
-1. **Pick a phase to start with.** Suggested order:
-   - **Phase C** first (parts-inline UI; foundation for D).
-   - **Phase D** after C (Restore-take UI depends on C's hooks).
-   - **Phase E**, **F** are independent; schedule by urgency.
-2. **Answer the phase's "Open design questions"** — either via a
-   brief user check-in or a short design note appended to this
-   handover under the phase body. Do not implement until those are
-   answered.
-3. **Open a `claude/recordings-ux-followups-<phase-letter>-<slug>`
-   branch** from `master` per phase.
-4. **Re-run the phase check + phase-check skill** after each phase
-   ships; update this handover's Status section.
+1. **Implement Phase C** on a fresh
+   `claude/recordings-ux-followups-c-parts-inline` branch from master.
+   Design is locked; see §3 Phase C above.
+2. **Phases D, E, F** still need their design questions answered.
+   Suggested order:
+   - Phase D after C ships (Restore-take UI; depends on C's hooks).
+   - Phase E and F are independent; schedule by urgency.
+3. **Re-run the phase-check skill** after Phase C ships; update
+   this handover's Status section.
 
 ## 6. Key Files & Architecture
 
@@ -248,6 +419,7 @@ areas this follow-up set touches that weren't already mapped:
 | `src/clm/cli/commands/recordings.py` | Recordings subcommand group | F |
 | `src/clm/cli/info_topics/commands.md` | Version-accurate CLI docs (mandatory update) | F |
 | `src/clm/recordings/web/templates/partials/parts.html` *(new)* | Per-part chip rendering | C, D |
+| `src/clm/recordings/web/templates/partials/takes.html` *(new)* | Inline take-history panel | C |
 
 ## 7. Testing Approach
 
@@ -274,13 +446,14 @@ decisions that a developer cannot make unilaterally:
   gesture choice.
 - Phase E: domain discovery (which sidecar formats exist).
 
-Do not skip the design step. The original redesign's five phases each
-had a full design doc section backing them; these follow-ups do not,
-and that gap is the reason they were deferred.
+Phase C's design questions were locked in a Q1–Q8 walkthrough on
+2026-05-03 — see §3 Phase C above for the answers.
 
 ---
 
 **Last updated**: 2026-05-03 (Phases A and B confirmed shipped via
-hardening PR #42; suggested order refreshed).
-**Next action**: User to pick the starting phase (C, D, E, or F) and
-answer its open design questions.
+hardening PR #42; Phase C design locked).
+**Next action**: Implement Phase C on a fresh
+`claude/recordings-ux-followups-c-parts-inline` branch from master.
+Phases D, E, F still need their design questions answered before
+implementation.

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -175,6 +175,35 @@ Generatoren") and can be armed for the next recording with one click.
   does not trigger the rename cascade, so the part numbering will be
   inconsistent.
 
+#### Per-part chip strip (lectures page)
+
+The Status column on the Lectures page renders a per-deck **chip strip**:
+one chip per existing part (color-coded by state — amber `recorded`,
+green `processed`, purple `processing`, red `failed`) plus a trailing
+dashed `+ N` chip representing "record the next part". Clicking a chip
+selects it; the action buttons in the Actions column then operate on
+the selected part:
+
+- Selecting an existing chip swaps the **Record/Arm** labels to
+  **Retake/Re-arm** and surfaces a small ⚠ warning icon — the next
+  recording will move the current take into `takes/` before recording
+  the new one.
+- Selecting the trailing `+ N` chip records a fresh new part (the
+  default selection on every fresh render).
+- The **Process** button targets the selected chip's raw file. A
+  separate **Process all** button appears only when ≥2 unprocessed
+  parts exist on the deck.
+- **Right-click** any chip to reveal an inline take-history panel
+  below the deck row, listing every superseded take in `takes/` with
+  its file path and an "Open in Explorer" link. Press **Escape** or
+  click **Close** to dismiss it.
+
+Chip selection is remembered per `(course, section, deck)` in
+client-side `sessionStorage`, so SSE refreshes and HTMX swaps no
+longer wipe what you just chose. A part badge with a small red
+corner dot means the part is processed but a recent retry failed —
+worth a re-process or a retake.
+
 ### Dashboard Panels
 
 The main dashboard (`/`) shows:

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -175,8 +175,10 @@ async def lectures(request: Request):
 
             root = request.app.state.recordings_root
             raw_suffix = request.app.state.raw_suffix
-            failed_jobs = _get_failed_jobs_map(request)
-            active_jobs = _get_active_jobs_map(request)
+            failed_per_part = _get_failed_jobs_per_part(request)
+            active_per_part = _get_active_jobs_per_part(request)
+            failed_jobs = _deck_level_jobs(failed_per_part)
+            active_jobs = _deck_level_jobs(active_per_part)
 
             for section in course.sections:
                 decks = []
@@ -201,6 +203,8 @@ async def lectures(request: Request):
                     raw_suffix=raw_suffix,
                     failed_jobs=failed_jobs,
                     active_jobs=active_jobs,
+                    failed_jobs_per_part=failed_per_part,
+                    active_jobs_per_part=active_per_part,
                 )
                 for deck in decks:
                     deck["status"] = statuses.get(deck["deck_name"])
@@ -477,6 +481,55 @@ async def process_file(request: Request):
 
 
 # ------------------------------------------------------------------
+# Take history (Phase C — UI parts-inline display)
+# ------------------------------------------------------------------
+
+
+@router.get(
+    "/decks/{course_slug}/{section_name}/{deck_name}/takes",
+    response_class=HTMLResponse,
+)
+async def deck_takes(
+    request: Request,
+    course_slug: str,
+    section_name: str,
+    deck_name: str,
+    part: int = 0,
+):
+    """Return the inline take-history panel for ``(course, section, deck, part)``.
+
+    Lazy-fetched by the chip strip in the lectures UI. The panel
+    renders one row per superseded take found under
+    ``takes/<course>/<section>/`` matching the deck and part. The
+    Restore action is intentionally absent — that ships with Phase D.
+    """
+    from clm.recordings.workflow.deck_status import scan_take_files
+
+    templates = _get_templates(request)
+    root = request.app.state.recordings_root
+    raw_suffix = request.app.state.raw_suffix
+    takes = scan_take_files(
+        root,
+        course_slug,
+        section_name,
+        deck_name,
+        part=part,
+        raw_suffix=raw_suffix,
+    )
+    return templates.TemplateResponse(
+        request,
+        "partials/takes.html",
+        {
+            "course_slug": course_slug,
+            "section_name": section_name,
+            "deck_name": deck_name,
+            "part": part,
+            "takes": takes,
+        },
+    )
+
+
+# ------------------------------------------------------------------
 # Watcher
 # ------------------------------------------------------------------
 
@@ -740,11 +793,13 @@ def _get_lang(request: Request) -> str:
     return request.cookies.get("clm_lang", "de")
 
 
-def _get_active_jobs_map(request: Request) -> dict[str, str]:
-    """Build a mapping of deck names to active (non-terminal) job IDs.
+def _get_active_jobs_per_part(request: Request) -> dict[tuple[str, int], str]:
+    """Build a mapping of ``(deck, part) -> job_id`` for non-terminal jobs.
 
-    Scans recent jobs for those in queued/uploading/processing/downloading/
-    assembling states and maps the deck name to the job ID.
+    Used by the chip strip in the lectures UI to mark individual chips
+    as ``processing``. Newest-first iteration with per-slot dedupe so
+    the most recent job per ``(deck, part)`` wins — same scheme as
+    :func:`_get_failed_jobs_per_part` for symmetry.
     """
     from clm.recordings.workflow.jobs import JobState
     from clm.recordings.workflow.naming import parse_part, parse_raw_stem
@@ -752,33 +807,36 @@ def _get_active_jobs_map(request: Request) -> dict[str, str]:
     manager = _get_job_manager(request)
     raw_suffix = request.app.state.raw_suffix
     terminal = {JobState.COMPLETED, JobState.FAILED, JobState.CANCELLED}
-    result: dict[str, str] = {}
+    result: dict[tuple[str, int], str] = {}
     try:
         for job in manager.list_jobs():
+            base_with_part, _ = parse_raw_stem(job.raw_path.stem, raw_suffix)
+            base, part = parse_part(base_with_part)
+            slot = (base, part)
+            if slot in result:
+                continue
             if job.state not in terminal:
-                base_with_part, _ = parse_raw_stem(job.raw_path.stem, raw_suffix)
-                base, _ = parse_part(base_with_part)
-                result.setdefault(base, job.id)
+                result[slot] = job.id
     except Exception:
         pass
     return result
 
 
-def _get_failed_jobs_map(request: Request) -> dict[str, str]:
-    """Build a mapping of deck names whose most recent job for *any part* failed.
+def _get_failed_jobs_per_part(request: Request) -> dict[tuple[str, int], str]:
+    """Build a mapping of ``(deck, part) -> job_id`` for the slot's most recent FAILED job.
 
-    ``list_jobs()`` returns newest-first. We dedupe per
-    ``(deck, part)`` slot — a retake of a specific part should clear
-    the indicator for that slot, but a successful part 2 must not
-    mask an unresolved part-1 failure. Any slot whose newest job is
-    FAILED drives the deck-level badge; otherwise the deck is clean.
+    ``list_jobs()`` returns newest-first. We dedupe per ``(deck,
+    part)`` slot — a retake of a specific part should clear the
+    indicator for that slot, but a successful part 2 must not mask an
+    unresolved part-1 failure. Only slots whose newest job is FAILED
+    end up in the result.
     """
     from clm.recordings.workflow.jobs import JobState
     from clm.recordings.workflow.naming import parse_part, parse_raw_stem
 
     manager = _get_job_manager(request)
     raw_suffix = request.app.state.raw_suffix
-    result: dict[str, str] = {}
+    result: dict[tuple[str, int], str] = {}
     seen_slots: set[tuple[str, int]] = set()
     try:
         for job in manager.list_jobs():
@@ -789,10 +847,22 @@ def _get_failed_jobs_map(request: Request) -> dict[str, str]:
                 continue
             seen_slots.add(slot)
             if job.state == JobState.FAILED:
-                result.setdefault(base, job.id)
+                result[slot] = job.id
     except Exception:
         pass
     return result
+
+
+def _deck_level_jobs(per_part: dict[tuple[str, int], str]) -> dict[str, str]:
+    """Collapse a per-``(deck, part)`` map into ``deck -> first job_id``.
+
+    Used to keep the deck-level badge ("processing failed", "processing")
+    semantics unchanged when the chip strip's per-part view is added.
+    """
+    out: dict[str, str] = {}
+    for (deck, _part), job_id in per_part.items():
+        out.setdefault(deck, job_id)
+    return out
 
 
 def _snapshot_to_dict(snap: SessionSnapshot) -> dict:

--- a/src/clm/recordings/web/static/app.css
+++ b/src/clm/recordings/web/static/app.css
@@ -501,6 +501,155 @@ footer {
     to   { opacity: 1; transform: translateY(0); }
 }
 
+/* Lectures table: per-part chip strip in the Status column.
+
+   Chip = the per-part pill that doubles as the part selector and the
+   status display. ``.chip-status-*`` carries the fill color; selection
+   is a 2px outline ring; armed chips get a small pulsing dot. */
+.chip-strip {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    min-width: 240px;
+    margin-right: var(--s-2);
+    vertical-align: middle;
+}
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.18rem 0.55rem;
+    border: 1px solid var(--c-border-strong);
+    border-radius: 999px;
+    background: var(--c-surface);
+    color: var(--c-fg);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    line-height: 1.4;
+    cursor: pointer;
+    position: relative;
+    transition: box-shadow 0.12s, background 0.12s, border-color 0.12s;
+}
+.chip:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+.chip:hover:not([aria-disabled="true"]) {
+    border-color: var(--c-fg-muted);
+}
+.chip[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+.chip-label { line-height: 1; }
+.chip-takes {
+    font-size: 0.65rem;
+    margin-left: 0.05rem;
+    vertical-align: super;
+    color: var(--c-fg-muted);
+    font-weight: 700;
+}
+
+/* Status palette — tracks the badge palette in §4. */
+.chip-status-recorded   { background: var(--c-badge-recorded-bg);   color: var(--c-badge-recorded-fg); }
+.chip-status-processed  { background: var(--c-badge-completed-bg);  color: var(--c-badge-completed-fg); border-color: var(--c-badge-completed-bg); }
+.chip-status-failed     { background: var(--c-badge-failed-bg);     color: var(--c-badge-failed-fg);    border-color: var(--c-badge-failed-bg); }
+.chip-status-processing {
+    background: var(--c-badge-processing-bg);
+    color: var(--c-badge-processing-fg);
+    border-color: var(--c-badge-processing-bg);
+    animation: chip-processing-pulse 1.4s ease-in-out infinite;
+}
+@keyframes chip-processing-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+}
+
+/* Next-part placeholder: dashed neutral outline, no fill. */
+.chip-next {
+    background: transparent;
+    color: var(--c-fg-muted);
+    border-style: dashed;
+    border-color: var(--c-border-strong);
+}
+.chip-next:hover {
+    color: var(--c-fg);
+    border-color: var(--c-fg-muted);
+}
+
+/* Selection ring: 2px outline on top of any fill. */
+.chip-selected {
+    box-shadow: 0 0 0 2px var(--c-primary);
+}
+/* Armed deck: ring goes neutral (gray) — selection is locked. */
+.chip-strip[data-armed-part] .chip-selected {
+    box-shadow: 0 0 0 2px var(--c-fg-muted);
+}
+
+/* Pulsing dot on the currently armed chip. */
+.chip-armed-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--c-danger);
+    margin-left: 0.2rem;
+    animation: pulse 1.2s ease-in-out infinite;
+}
+
+/* Small red corner dot when a processed part has a failed retry. */
+.chip-has-failed-retry::after {
+    content: "";
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--c-danger);
+    border: 1px solid var(--c-surface);
+}
+
+/* Inline retake warning icon next to the Record button. */
+.chip-warning {
+    color: var(--c-warning);
+    font-size: var(--t-base);
+    cursor: help;
+}
+
+/* Inline take-history panel rendered as a sibling <tr>. */
+.takes-row .takes-cell {
+    background: var(--c-surface-alt);
+    padding: 0;
+}
+.takes-panel {
+    padding: var(--s-3) var(--s-4);
+    border-top: 1px dashed var(--c-border-strong);
+}
+.takes-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--s-2);
+}
+.takes-empty {
+    color: var(--c-fg-muted);
+    font-size: var(--t-sm);
+    margin: 0;
+}
+.takes-table {
+    width: 100%;
+}
+.takes-table th, .takes-table td {
+    padding: var(--s-1) var(--s-2);
+    border-bottom: 1px solid var(--c-border);
+}
+.take-stem {
+    background: transparent;
+    padding: 0;
+    font-size: var(--t-xs);
+}
+
 /* Lectures table: deck actions row */
 .deck-actions {
     display: flex;

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -44,42 +44,151 @@
         });
     });
 
-    /* Preserve part-number inputs across htmx swaps.
-       The lectures page subscribes to SSE and re-fetches /lectures on
-       every status/job event. The swap replaces the inputs with their
-       server-rendered defaults (value="0"), so a value the user was in
-       the middle of typing gets clobbered — observed while a processing
-       poller ticked mid-increment and yanked the counter back to 0.
-       We snapshot (deck_name, part_number) pairs before the swap and
-       restore them on the matching fresh input afterwards. Keyed by
-       deck so a row that reshapes (armed state flip) still gets the
-       right value. */
-    var _partNumberSnapshots = {};
-    function _snapshotPartNumbers() {
-        _partNumberSnapshots = {};
-        document.querySelectorAll('input[name="part_number"]').forEach(function (input) {
-            var form = input.closest('form');
-            if (!form) return;
-            var deckInput = form.querySelector('input[name="deck_name"]');
-            if (!deckInput) return;
-            _partNumberSnapshots[deckInput.value] = input.value;
+    /* Per-deck chip selection.
+       Replaces the old <input name="part_number"> + snapshot/restore
+       dance. Selection state lives in sessionStorage keyed by
+       "<course>::<section>::<deck>" so it survives every htmx swap
+       (including hx-target="body" full re-renders), and the
+       chip strip just rehydrates from storage on every render.
+       Action buttons consume the selection by reading the chip's
+       data-part and writing it into the form's hidden part_number
+       input right before submit. */
+    var CHIP_STORAGE_PREFIX = 'clm:chipSel:';
+    function _readChipSelection(key) {
+        try { return sessionStorage.getItem(CHIP_STORAGE_PREFIX + key); }
+        catch (e) { return null; }
+    }
+    function _writeChipSelection(key, part) {
+        try { sessionStorage.setItem(CHIP_STORAGE_PREFIX + key, String(part)); }
+        catch (e) { /* private browsing / quota exceeded — ignore */ }
+    }
+    function _applyChipSelectionToRow(strip, selectedPart, isExisting) {
+        strip.querySelectorAll('[data-chip]').forEach(function (chip) {
+            var match = String(chip.getAttribute('data-part')) === String(selectedPart)
+                && (chip.hasAttribute('data-chip-next') ? !isExisting : isExisting);
+            chip.classList.toggle('chip-selected', match);
+            chip.setAttribute('aria-pressed', match ? 'true' : 'false');
+        });
+        var row = strip.closest('[data-deck-row]');
+        if (!row) return;
+        // Mirror selection into the action forms' hidden part_number
+        // inputs so submit POSTs the right value.
+        row.querySelectorAll('[data-part-input]').forEach(function (input) {
+            input.value = String(selectedPart);
+        });
+        // Mirror selection into the per-chip Process form so the
+        // selected chip's raw_path is what gets submitted.
+        var processForm = row.querySelector('[data-process-form]');
+        if (processForm) {
+            var perPart = processForm.querySelector('[data-raw-path-for="' + selectedPart + '"]');
+            var rawInput = processForm.querySelector('[data-raw-input]');
+            if (rawInput && perPart) {
+                rawInput.value = perPart.value;
+            }
+        }
+        // Swap Record/Arm button labels to Retake/Re-arm when an
+        // existing chip is selected; show the warning icon.
+        var warningEl = row.querySelector('[data-retake-warning]');
+        if (warningEl) {
+            warningEl.hidden = !isExisting;
+        }
+        row.querySelectorAll('[data-action-label-fresh]').forEach(function (el) {
+            el.hidden = isExisting;
+        });
+        row.querySelectorAll('[data-action-label-retake]').forEach(function (el) {
+            el.hidden = !isExisting;
         });
     }
-    function _restorePartNumbers() {
-        if (!_partNumberSnapshots) return;
-        document.querySelectorAll('input[name="part_number"]').forEach(function (input) {
-            var form = input.closest('form');
-            if (!form) return;
-            var deckInput = form.querySelector('input[name="deck_name"]');
-            if (!deckInput) return;
-            var saved = _partNumberSnapshots[deckInput.value];
-            if (saved !== undefined && saved !== '' && saved !== input.value) {
-                input.value = saved;
+    function _hydrateChipStrip(strip) {
+        if (!strip) return;
+        var key = strip.getAttribute('data-deck-key');
+        var defaultPart = strip.getAttribute('data-default-part') || '0';
+        var stored = _readChipSelection(key);
+        // Validate stored selection against the current chips —
+        // otherwise a deleted part leaves the row pointing nowhere.
+        var validParts = {};
+        var nextPart = null;
+        strip.querySelectorAll('[data-chip]').forEach(function (chip) {
+            var p = chip.getAttribute('data-part');
+            if (chip.hasAttribute('data-chip-next')) {
+                nextPart = p;
+            } else {
+                validParts[p] = true;
             }
         });
+        var selected;
+        var isExisting;
+        if (stored !== null && validParts[stored]) {
+            selected = stored;
+            isExisting = true;
+        } else {
+            // Default = next-part chip (Q3 in the design).
+            selected = nextPart != null ? nextPart : defaultPart;
+            isExisting = false;
+        }
+        _applyChipSelectionToRow(strip, selected, isExisting);
     }
-    document.addEventListener('htmx:beforeSwap', _snapshotPartNumbers);
-    document.addEventListener('htmx:afterSwap', _restorePartNumbers);
+    function _hydrateAllChipStrips(scope) {
+        var root = scope || document;
+        root.querySelectorAll('[data-chip-strip]').forEach(_hydrateChipStrip);
+    }
+    // Single document-level click delegate — chip elements come and
+    // go on every htmx swap, so per-element listeners would leak.
+    document.addEventListener('click', function (evt) {
+        // Take-history close button.
+        var closeBtn = evt.target.closest('[data-takes-close]');
+        if (closeBtn) {
+            evt.preventDefault();
+            var panel = closeBtn.closest('.takes-row');
+            if (panel) panel.remove();
+            return;
+        }
+        var chip = evt.target.closest('[data-chip]');
+        if (!chip) return;
+        var strip = chip.closest('[data-chip-strip]');
+        if (!strip) return;
+        // Armed strip: selection is locked.
+        if (strip.hasAttribute('data-armed-part')) return;
+        var part = chip.getAttribute('data-part');
+        var isExisting = !chip.hasAttribute('data-chip-next');
+        var key = strip.getAttribute('data-deck-key');
+        if (isExisting) {
+            _writeChipSelection(key, part);
+        } else {
+            // Selecting "next part" clears the stored selection so the
+            // row defaults back to next-part on the next render.
+            try { sessionStorage.removeItem(CHIP_STORAGE_PREFIX + key); }
+            catch (e) { /* ignore */ }
+        }
+        _applyChipSelectionToRow(strip, part, isExisting);
+    });
+    // ARIA tablist: arrow keys move focus inside a chip strip.
+    document.addEventListener('keydown', function (evt) {
+        if (evt.key !== 'ArrowLeft' && evt.key !== 'ArrowRight') return;
+        var chip = evt.target.closest('[data-chip]');
+        if (!chip) return;
+        var strip = chip.closest('[data-chip-strip]');
+        if (!strip) return;
+        var chips = Array.prototype.slice.call(strip.querySelectorAll('[data-chip]'));
+        var idx = chips.indexOf(chip);
+        if (idx < 0) return;
+        evt.preventDefault();
+        var next = evt.key === 'ArrowLeft'
+            ? chips[(idx - 1 + chips.length) % chips.length]
+            : chips[(idx + 1) % chips.length];
+        if (next) next.focus();
+    });
+    // Auto-advance bookkeeping: when the user selects "next part",
+    // the chip they clicked becomes an existing part on the next
+    // render. To honor "sticky except when selection was next-part,
+    // re-target the new next-part" (Q3), the next-part path above
+    // already removes storage so re-render defaults back to next.
+    document.addEventListener('htmx:afterSwap', function () {
+        _hydrateAllChipStrips();
+    });
+    document.addEventListener('DOMContentLoaded', function () {
+        _hydrateAllChipStrips();
+    });
 
     /* Elapsed-time ticker.
        Any element carrying `data-elapsed-base-seconds="N"` is anchored
@@ -183,31 +292,65 @@
     })();
 
     /* Keyboard affordances.
-       • Enter inside a part-number input triggers that row's submit
-         (so you can type a part and hit Enter to Record).
-       • Escape anywhere on the page disarms an armed deck if one is
-         armed (posts to /disarm). Ignored while an input/textarea is
-         focused and has text, to avoid stealing field-reset Escape. */
+       • Escape: closes an open take-history panel that contains
+         focus, otherwise disarms an armed deck if one is armed.
+         Ignored while an input/textarea is focused and has text, to
+         avoid stealing field-reset Escape. */
     document.addEventListener('keydown', function (evt) {
-        if (evt.key === 'Enter') {
-            var target = evt.target;
-            if (target && target.matches('input[name="part_number"]')) {
-                var form = target.closest('form');
-                if (form) {
-                    evt.preventDefault();
-                    var submitBtn = form.querySelector('button[type="submit"], button:not([type])');
-                    if (submitBtn && !submitBtn.disabled) submitBtn.click();
-                }
-            }
-        } else if (evt.key === 'Escape') {
-            if (evt.target && /^(INPUT|TEXTAREA|SELECT)$/.test(evt.target.tagName)) {
-                if (evt.target.value) return;
-            }
-            var disarm = document.querySelector('[data-disarm-shortcut]');
-            if (disarm) {
-                evt.preventDefault();
-                disarm.click();
-            }
+        if (evt.key !== 'Escape') return;
+        if (evt.target && /^(INPUT|TEXTAREA|SELECT)$/.test(evt.target.tagName)) {
+            if (evt.target.value) return;
+        }
+        // Close-on-Escape: only the take panel that contains focus.
+        var openPanel = evt.target.closest && evt.target.closest('.takes-row');
+        if (openPanel) {
+            evt.preventDefault();
+            openPanel.remove();
+            return;
+        }
+        var disarm = document.querySelector('[data-disarm-shortcut]');
+        if (disarm) {
+            evt.preventDefault();
+            disarm.click();
+        }
+    });
+
+    /* Take-history reveal: right-click a chip to toggle the inline
+       panel below the deck row. Lazy-fetched from
+       GET /decks/{course}/{section}/{deck}/takes. */
+    document.addEventListener('contextmenu', function (evt) {
+        var chip = evt.target.closest('[data-chip]');
+        if (!chip) return;
+        if (chip.hasAttribute('data-chip-next')) return;
+        var strip = chip.closest('[data-chip-strip]');
+        var row = chip.closest('[data-deck-row]');
+        if (!strip || !row) return;
+        evt.preventDefault();
+        var part = chip.getAttribute('data-part');
+        var key = strip.getAttribute('data-deck-key');
+        // Toggle: if a panel for the same (deck, part) is already
+        // open, close it instead of fetching again.
+        var existing = document.querySelector(
+            '[data-takes-panel][data-deck-key="' + key + '"][data-part="' + part + '"]'
+        );
+        if (existing) {
+            existing.remove();
+            return;
+        }
+        // Parse "<course>::<section>::<deck>" — colons inside the
+        // names themselves are sanitized out by sanitize_file_name
+        // before render so the simple split is safe.
+        var parts = key.split('::');
+        if (parts.length !== 3) return;
+        var url = '/decks/' + encodeURIComponent(parts[0])
+            + '/' + encodeURIComponent(parts[1])
+            + '/' + encodeURIComponent(parts[2])
+            + '/takes?part=' + encodeURIComponent(part);
+        if (window.htmx) {
+            window.htmx.ajax('GET', url, {
+                target: row,
+                swap: 'afterend'
+            });
         }
     });
     </script>

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -106,7 +106,10 @@
         <tbody>
             {% for deck in section.decks %}
             {% set is_armed = snapshot.armed_deck and snapshot.armed_deck.deck_name == deck.deck_name and snapshot.armed_deck.section_name == section.name %}
-            <tr{% if is_armed %} class="row-armed"{% endif %}>
+            {% set armed_part = snapshot.armed_deck.part_number if is_armed else 0 %}
+            {% set has_existing_parts = deck.status and deck.status.parts_status %}
+            {% set unprocessed_count = deck.status.raw_parts | length if deck.status else 0 %}
+            <tr{% if is_armed %} class="row-armed"{% endif %} data-deck-row data-deck-key="{{ course_slug }}::{{ section.name }}::{{ deck.deck_name }}">
                 <td>{{ deck.display_name }}</td>
                 <td>
                     {% if is_armed and snapshot.state.value in ('recording', 'paused') %}
@@ -127,24 +130,16 @@
                     </span>
                     {% endif %}
                     {% endif %}
-                    {% if deck.status %}
-                    {% set st = deck.status.state.value %}
-                    <span class="badge badge-{{ st }}">{{ st | replace("_", " ") }}</span>
-                    {# Surface a failed-job indicator even when the main
-                       state falls back to "recorded" (raw file still on
-                       disk after Auphonic rejected the job). Otherwise
-                       the user sees "recorded" and has no cue that the
-                       last processing attempt failed. #}
-                    {% if deck.status.failed_job_id and deck.status.state.value != 'failed' %}
+                    {# Per-part chip strip — replaces the old free-form
+                       part_number input. The chip strip itself is the
+                       part selector; action buttons in the next column
+                       read its selection from sessionStorage. #}
+                    {% include "partials/parts.html" %}
+                    {# Failed-retry indicator stays at the row level so
+                       the user notices the deck even if no chips are
+                       in the failed state. #}
+                    {% if deck.status and deck.status.failed_job_id and deck.status.state.value != 'failed' %}
                     <span class="badge badge-failed" title="Last processing job failed: {{ deck.status.failed_job_id }}">processing failed</span>
-                    {% endif %}
-                    {% if deck.status.final_parts and deck.status.raw_parts %}
-                    <small>(done: {{ deck.status.final_parts | join(", ") }}; raw: {{ deck.status.raw_parts | join(", ") }})</small>
-                    {% elif deck.status.parts | length > 1 %}
-                    <small>(parts {{ deck.status.parts | join(", ") }})</small>
-                    {% elif deck.status.parts | length == 1 and deck.status.parts[0] != 0 %}
-                    <small>(part {{ deck.status.parts[0] }})</small>
-                    {% endif %}
                     {% endif %}
                 </td>
                 <td>
@@ -165,24 +160,37 @@
                         </form>
                         {% else %}
                         {# Shared form: two submit buttons, one per action.
-                           The per-button hx-post overrides the form's so the
-                           Part input is shared but Record vs. Arm hits the
-                           right route. #}
-                        <form hx-post="/record" hx-target="body" hx-disabled-elt="find button">
+                           The hidden ``part_number`` input is populated
+                           by the chip JS in base.html on every chip
+                           click and again right before submit. Default
+                           is 0 (unsuffixed first take) — matches the
+                           previous form's default. #}
+                        <form data-action-form
+                              hx-post="/record"
+                              hx-target="body"
+                              hx-disabled-elt="find button">
                             <input type="hidden" name="course_slug" value="{{ course_slug }}">
                             <input type="hidden" name="section_name" value="{{ section.name }}">
                             <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
-                            <label>Part</label>
-                            <input type="number" name="part_number" value="0" min="0" max="20">
-                            <button type="submit" class="btn btn-sm btn-primary"
-                                {% if not snapshot.obs_connected %}disabled title="OBS not connected"{% endif %}>
-                                Record
+                            <input type="hidden" name="part_number" value="0" data-part-input>
+                            <button type="submit"
+                                    class="btn btn-sm btn-primary"
+                                    data-action-record
+                                    {% if not snapshot.obs_connected %}disabled title="OBS not connected"{% endif %}>
+                                <span data-action-label-fresh>Record</span><span data-action-label-retake hidden>Retake</span>
                             </button>
-                            <button type="submit" class="btn btn-sm btn-ghost"
-                                hx-post="/arm" hx-target="body"
-                                {% if not snapshot.obs_connected %}disabled title="OBS not connected"{% endif %}>
-                                Arm
+                            <button type="submit"
+                                    class="btn btn-sm btn-ghost"
+                                    data-action-arm
+                                    hx-post="/arm" hx-target="body"
+                                    {% if not snapshot.obs_connected %}disabled title="OBS not connected"{% endif %}>
+                                <span data-action-label-fresh>Arm</span><span data-action-label-retake hidden>Re-arm</span>
                             </button>
+                            <span class="chip-warning" data-retake-warning hidden
+                                  title="Will move the current take to takes/ before recording"
+                                  aria-label="Retake will overwrite the active take">
+                                ⚠
+                            </span>
                         </form>
                         {% if is_armed %}
                         <form hx-post="/disarm" hx-target="body" hx-disabled-elt="find button">
@@ -191,20 +199,43 @@
                         {% endif %}
                         {% endif %}
                         {% if deck.status and deck.status.state.value in ('recorded', 'failed') and deck.status.raw_paths %}
+                        {# Per-chip Process: submits the raw path of the
+                           selected chip's part. The hidden input is
+                           rewritten by the chip JS on every selection
+                           change. #}
+                        <form data-process-form
+                              hx-post="/process"
+                              hx-target="body"
+                              hx-disabled-elt="find button">
+                            {# Default raw_path = first known raw; overwritten
+                               on selection change. #}
+                            <input type="hidden" name="raw_path" value="{{ deck.status.raw_paths[0] }}" data-raw-input>
+                            {% for rp in deck.status.raw_paths %}
+                            <input type="hidden" data-raw-path-for="{{ deck.status.raw_parts[loop.index0] }}" value="{{ rp }}">
+                            {% endfor %}
+                            <button type="submit" class="btn btn-sm">Process</button>
+                        </form>
+                        {% if unprocessed_count > 1 %}
+                        {# Process all: fire-and-forget batch submit
+                           that ignores chip selection. #}
                         <form hx-post="/process" hx-target="body" hx-disabled-elt="find button">
                             {% for rp in deck.status.raw_paths %}
                             <input type="hidden" name="raw_path" value="{{ rp }}">
                             {% endfor %}
-                            <button type="submit" class="btn btn-sm">Process</button>
+                            <button type="submit" class="btn btn-sm btn-ghost"
+                                    title="Process all unprocessed parts on this deck">
+                                Process all
+                            </button>
                         </form>
-                        <form hx-post="/advance" hx-target="body" hx-disabled-elt="find button">
+                        {% endif %}
+                        <form data-advance-form
+                              hx-post="/advance"
+                              hx-target="body"
+                              hx-disabled-elt="find button">
                             <input type="hidden" name="course_slug" value="{{ course_slug }}">
                             <input type="hidden" name="section_name" value="{{ section.name }}">
                             <input type="hidden" name="deck_name" value="{{ deck.deck_name }}">
-                            {# Advance operates on whichever part is currently
-                               unsuffixed on disk; use the first recorded part
-                               (matches the _preserve_active_take probe). #}
-                            <input type="hidden" name="part_number" value="{{ deck.status.parts[0] if deck.status.parts else 0 }}">
+                            <input type="hidden" name="part_number" value="{{ deck.status.parts[0] if deck.status.parts else 0 }}" data-part-input>
                             <button type="submit" class="btn btn-sm btn-ghost"
                                     title="Move this take into takes/ without recording a throwaway">
                                 Advance

--- a/src/clm/recordings/web/templates/partials/parts.html
+++ b/src/clm/recordings/web/templates/partials/parts.html
@@ -1,0 +1,74 @@
+{# Chip strip for a single deck row.
+
+   Inputs:
+     deck            — the dict assembled in routes.lectures (deck_name,
+                       display_name, status, …).
+     section_name    — the section's display name (used as the
+                       sessionStorage selection key).
+     course_slug     — the course's output_dir_name for the active lang.
+     is_armed        — whether this deck is the currently armed/recording
+                       deck (used to disable selection clicks).
+     armed_part      — the part number of the currently armed take (if
+                       this deck is armed); used to render the pulsing
+                       dot and selection ring.
+
+   Selection state itself lives in client-side ``sessionStorage`` keyed
+   by ``"<course>::<section>::<deck>"``. The chip JS in base.html reads
+   storage on first paint after every swap, applies the
+   ``chip-selected`` class, and mirrors the choice into the hidden
+   ``part_number`` inputs of the per-row action forms.
+
+   The trailing "next part" chip is always present and is the default
+   selection on every fresh render.
+#}
+{% set parts_status = deck.status.parts_status if deck.status else [] %}
+{% set known_parts = parts_status | map(attribute='part') | list %}
+{# The trailing chip slot:
+   * No parts yet → 0 (record an unsuffixed single-part take).
+   * Only an unsuffixed part 0 exists → 2 (the cascade in
+     _prepare_target_slot will promote the existing part-0 file to
+     part 1, so the next user-visible slot is 2).
+   * Otherwise → max(part) + 1. #}
+{% if not known_parts %}
+    {% set next_part = 0 %}
+{% elif known_parts == [0] %}
+    {% set next_part = 2 %}
+{% else %}
+    {% set next_part = (known_parts | max) + 1 %}
+{% endif %}
+<div class="chip-strip"
+     role="tablist"
+     aria-label="Parts for {{ deck.deck_name }}"
+     data-chip-strip
+     data-deck-key="{{ course_slug }}::{{ section_name }}::{{ deck.deck_name }}"
+     data-default-part="{{ next_part }}"
+     {% if is_armed %}data-armed-part="{{ armed_part }}"{% endif %}>
+    {% for ps in parts_status %}
+    {% set is_armed_part = is_armed and armed_part == ps.part %}
+    <button type="button"
+            class="chip chip-status-{{ ps.state }}{% if ps.has_failed_retry %} chip-has-failed-retry{% endif %}{% if is_armed_part %} chip-armed{% endif %}"
+            role="tab"
+            aria-pressed="false"
+            aria-label="Part {{ ps.part if ps.part > 0 else 1 }} — {{ ps.state }}"
+            data-chip
+            data-part="{{ ps.part }}"
+            {% if is_armed %}aria-disabled="true" tabindex="-1"{% endif %}
+            title="Part {{ ps.part if ps.part > 0 else 1 }} — {{ ps.state }}{% if ps.take_count > 1 %}&#10;Takes: {{ ps.take_count }}{% endif %}{% if ps.job_id %}&#10;Last job: {{ ps.job_id[:8] }}{% endif %}">
+        <span class="chip-label">{{ ps.part if ps.part > 0 else 1 }}</span>
+        {% if ps.take_count > 1 %}<span class="chip-takes" aria-hidden="true">{% if ps.take_count > 9 %}9⁺{% else %}{{ ps.take_count }}{% endif %}</span>{% endif %}
+        {% if is_armed_part %}<span class="chip-armed-dot" aria-hidden="true"></span>{% endif %}
+    </button>
+    {% endfor %}
+    <button type="button"
+            class="chip chip-next"
+            role="tab"
+            aria-pressed="false"
+            aria-label="Next part — {{ next_part if next_part > 0 else 1 }}"
+            data-chip
+            data-chip-next
+            data-part="{{ next_part }}"
+            {% if is_armed %}aria-disabled="true" tabindex="-1"{% endif %}
+            title="Next part — record {{ next_part if next_part > 0 else 1 }}">
+        <span class="chip-label">+ {{ next_part if next_part > 0 else 1 }}</span>
+    </button>
+</div>

--- a/src/clm/recordings/web/templates/partials/takes.html
+++ b/src/clm/recordings/web/templates/partials/takes.html
@@ -1,0 +1,84 @@
+{# Inline take-history panel for one deck/part.
+
+   Lazy-fetched via HTMX from
+   ``GET /decks/{course}/{section}/{deck}/takes?part=N`` and rendered
+   inside an additional ``<tr>`` directly under the deck row. The panel
+   refreshes itself on ``sse:job`` events so a retake-in-progress shows
+   up without the user toggling the panel.
+
+   Inputs:
+     deck_name        — original (un-sanitized) deck name; rendered in the header
+     part             — part number this panel is showing
+     takes            — list of TakeFileInfo
+     restore_url_for  — callable(take) → URL placeholder for the Phase D
+                        Restore button. None in Phase C — the action is
+                        deferred so we render a disabled informational note.
+#}
+<tr class="takes-row"
+    data-takes-panel
+    data-deck-key="{{ course_slug }}::{{ section_name }}::{{ deck_name }}"
+    data-part="{{ part }}">
+    <td colspan="3" class="takes-cell">
+        <div class="takes-panel"
+             data-sse-refresh="job"
+             hx-get="/decks/{{ course_slug }}/{{ section_name }}/{{ deck_name }}/takes?part={{ part }}"
+             hx-trigger="sse:job"
+             hx-target="closest .takes-panel"
+             hx-swap="outerHTML">
+            <div class="takes-panel-header">
+                <strong>Takes for part {{ part if part > 0 else 1 }}</strong>
+                <button type="button"
+                        class="btn btn-sm btn-ghost"
+                        data-takes-close
+                        aria-label="Close take history">
+                    Close
+                </button>
+            </div>
+            {% if not takes %}
+            <p class="takes-empty">
+                Only the active take exists. Superseded takes (after
+                a retake) appear here.
+            </p>
+            {% else %}
+            <table class="takes-table">
+                <thead>
+                    <tr>
+                        <th>Take</th>
+                        <th>Status</th>
+                        <th>File</th>
+                        <th>Recorded</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for take in takes %}
+                    <tr>
+                        <td><span class="badge badge-armed">{{ take.take }}</span></td>
+                        <td>
+                            <span class="badge badge-{% if take.kind == 'processed' %}completed{% else %}recorded{% endif %}">
+                                {{ take.kind }}
+                            </span>
+                        </td>
+                        <td><code class="take-stem">{{ take.display_stem }}</code></td>
+                        <td class="take-mtime"
+                            {% if take.recorded_at %}data-mtime="{{ take.recorded_at | int }}"{% endif %}>
+                            {% if take.recorded_at %}{{ take.recorded_at | int }}{% else %}—{% endif %}
+                        </td>
+                        <td>
+                            {% set explorer_path = take.final_path or take.raw_path %}
+                            {% if explorer_path %}
+                            <a href="file:///{{ explorer_path | string | replace('\\', '/') }}"
+                               class="btn btn-sm btn-ghost"
+                               title="Open in Explorer">
+                                Open
+                            </a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% endif %}
+        </div>
+    </td>
+</tr>

--- a/src/clm/recordings/workflow/deck_status.py
+++ b/src/clm/recordings/workflow/deck_status.py
@@ -11,8 +11,14 @@ import enum
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .directories import final_dir, to_process_dir
-from .naming import DEFAULT_RAW_SUFFIX, find_existing_recordings, parse_part
+from .directories import final_dir, takes_dir, to_process_dir
+from .naming import (
+    DEFAULT_RAW_SUFFIX,
+    find_existing_recordings,
+    parse_part,
+    parse_part_take,
+    parse_raw_stem,
+)
 
 
 class DeckRecordingState(enum.Enum):
@@ -24,6 +30,24 @@ class DeckRecordingState(enum.Enum):
     PROCESSING = "processing"  # Job is queued or in progress
     COMPLETED = "completed"  # Final output exists
     FAILED = "failed"  # Job failed for this deck
+
+
+@dataclass
+class PartStatus:
+    """Per-part recording state used by the chip strip in the lectures UI.
+
+    The chip strip renders one chip per known part plus a trailing
+    "next part" placeholder. ``state`` drives the chip's color class
+    (``chip-status-<state>``); ``has_failed_retry`` adds the small red
+    corner dot for the "processed but the most recent retry failed"
+    case.
+    """
+
+    part: int
+    state: str  # "recorded" | "processed" | "processing" | "failed"
+    take_count: int = 1
+    has_failed_retry: bool = False
+    job_id: str | None = None
 
 
 @dataclass
@@ -39,6 +63,7 @@ class DeckStatus:
     has_raw: bool = False
     has_pair: bool = False
     failed_job_id: str | None = None
+    parts_status: list[PartStatus] = field(default_factory=list)
 
 
 def scan_deck_status(
@@ -49,6 +74,9 @@ def scan_deck_status(
     raw_suffix: str = DEFAULT_RAW_SUFFIX,
     failed_jobs: dict[str, str] | None = None,
     active_jobs: dict[str, str] | None = None,
+    failed_jobs_per_part: dict[tuple[str, int], str] | None = None,
+    active_jobs_per_part: dict[tuple[str, int], str] | None = None,
+    take_counts: dict[int, int] | None = None,
 ) -> DeckStatus:
     """Check ``to-process/`` and ``final/`` for files matching a deck.
 
@@ -59,9 +87,15 @@ def scan_deck_status(
         deck_name: The deck name (will be sanitized for matching).
         raw_suffix: Raw filename suffix.
         failed_jobs: Optional dict mapping deck names to job IDs
-            for failed jobs.
+            for failed jobs (deck-level badge).
         active_jobs: Optional dict mapping deck names to job IDs
-            for queued/in-progress jobs.
+            for queued/in-progress jobs (deck-level badge).
+        failed_jobs_per_part: Optional dict mapping ``(deck, part)``
+            to job IDs for the chip-strip per-part view.
+        active_jobs_per_part: Optional dict mapping ``(deck, part)``
+            to job IDs for the chip-strip per-part view.
+        take_counts: Optional dict mapping part numbers to total take
+            count (active + superseded). Defaults to ``{}``.
 
     Returns:
         :class:`DeckStatus` with the current state and part information.
@@ -133,6 +167,17 @@ def scan_deck_status(
     else:
         state = DeckRecordingState.NO_RECORDING
 
+    parts_status = _compute_parts_status(
+        deck_name=deck_name,
+        all_parts=all_parts,
+        raw_parts=set(parts),
+        final_parts=set(final_parts),
+        has_pair=has_pair,
+        failed_per_part=failed_jobs_per_part or {},
+        active_per_part=active_jobs_per_part or {},
+        take_counts=take_counts or {},
+    )
+
     return DeckStatus(
         state=state,
         parts=all_parts,
@@ -143,7 +188,187 @@ def scan_deck_status(
         has_raw=has_raw,
         has_pair=has_pair,
         failed_job_id=failed_id,
+        parts_status=parts_status,
     )
+
+
+def _compute_parts_status(
+    *,
+    deck_name: str,
+    all_parts: list[int],
+    raw_parts: set[int],
+    final_parts: set[int],
+    has_pair: bool,
+    failed_per_part: dict[tuple[str, int], str],
+    active_per_part: dict[tuple[str, int], str],
+    take_counts: dict[int, int],
+) -> list[PartStatus]:
+    """Build per-part chip data from scan results + per-part job/take info."""
+    out: list[PartStatus] = []
+    for part in all_parts:
+        in_raw = part in raw_parts
+        in_final = part in final_parts
+        active_id = active_per_part.get((deck_name, part))
+        failed_id = failed_per_part.get((deck_name, part))
+
+        if active_id:
+            state = "processing"
+        elif in_final and not in_raw:
+            state = "processed"
+        elif in_raw:
+            # Raw on disk and either no final yet or both — both cases
+            # surface as "recorded" so the chip color tracks "needs
+            # processing". The has_pair flag is informational only.
+            state = "recorded"
+        elif failed_id:
+            state = "failed"
+        else:
+            # Nothing on disk for this part — should not normally happen
+            # because all_parts is the union of raw + final, but be safe.
+            state = "recorded"
+
+        out.append(
+            PartStatus(
+                part=part,
+                state=state,
+                take_count=take_counts.get(part, 1),
+                has_failed_retry=in_final and bool(failed_id),
+                job_id=active_id or failed_id,
+            )
+        )
+    return out
+
+
+def scan_section_takes(
+    root: Path,
+    course_slug: str,
+    section_name: str,
+    deck_names: list[str],
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+) -> dict[str, dict[int, list[int]]]:
+    """Scan the section's ``takes/`` directory once for every deck name.
+
+    Returns a mapping of ``deck_name -> {part: [sorted take numbers]}``.
+    Decks with no superseded takes are present with an empty inner dict.
+
+    Take entries are deduped by ``(part, take)`` so that a take with
+    both raw and final files only counts once. Files without a
+    ``(take K)`` suffix are ignored — those belong to the active take.
+    """
+    from clm.core.utils.text_utils import sanitize_file_name
+
+    sanitized_to_name = {sanitize_file_name(n): n for n in deck_names}
+    out: dict[str, dict[int, set[int]]] = {n: {} for n in deck_names}
+
+    subtree = takes_dir(root) / course_slug / section_name
+    if not subtree.is_dir():
+        return {n: {} for n in deck_names}
+
+    for child in subtree.iterdir():
+        if not child.is_file():
+            continue
+        stem = child.stem
+        base_with, is_raw = parse_raw_stem(stem, raw_suffix)
+        base, part, take = parse_part_take(base_with if is_raw else stem)
+        if take == 0:
+            continue
+        deck = sanitized_to_name.get(base)
+        if deck is None:
+            continue
+        out[deck].setdefault(part, set()).add(take)
+
+    return {n: {p: sorted(ts) for p, ts in m.items()} for n, m in out.items()}
+
+
+def take_counts_from_section_takes(
+    section_takes: dict[int, list[int]],
+    *,
+    known_parts: list[int],
+) -> dict[int, int]:
+    """Combine ``takes/`` history with the active take to get a chip count.
+
+    For every known part, ``count = len(superseded_takes_for_part) + 1``
+    (the active take). Parts without a ``takes/`` entry get ``1``.
+    """
+    return {part: len(section_takes.get(part, [])) + 1 for part in known_parts}
+
+
+@dataclass
+class TakeFileInfo:
+    """One superseded take, surfaced in the inline take-history panel."""
+
+    take: int
+    raw_path: Path | None
+    final_path: Path | None
+    raw_size: int | None = None
+    final_size: int | None = None
+    recorded_at: float | None = None  # POSIX timestamp (mtime), latest of the two
+
+    @property
+    def display_stem(self) -> str:
+        path = self.final_path or self.raw_path
+        return path.stem if path else ""
+
+    @property
+    def kind(self) -> str:
+        if self.final_path is not None:
+            return "processed"
+        if self.raw_path is not None:
+            return "recorded"
+        return "unknown"
+
+
+def scan_take_files(
+    root: Path,
+    course_slug: str,
+    section_name: str,
+    deck_name: str,
+    *,
+    part: int,
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+) -> list[TakeFileInfo]:
+    """Return one ``TakeFileInfo`` per superseded take for the deck/part.
+
+    Pairs raw and final files that share the same ``(part N, take K)``
+    suffix. Returned list is sorted by take number ascending.
+    """
+    from clm.core.utils.text_utils import sanitize_file_name
+    from clm.recordings.processing.batch import VIDEO_EXTENSIONS
+
+    sanitized = sanitize_file_name(deck_name)
+    subtree = takes_dir(root) / course_slug / section_name
+    if not subtree.is_dir():
+        return []
+
+    by_take: dict[int, TakeFileInfo] = {}
+    for child in subtree.iterdir():
+        if not child.is_file():
+            continue
+        if child.suffix.lower() not in VIDEO_EXTENSIONS:
+            continue
+        stem = child.stem
+        base_with, is_raw = parse_raw_stem(stem, raw_suffix)
+        base, p, take = parse_part_take(base_with if is_raw else stem)
+        if take == 0 or p != part or base != sanitized:
+            continue
+
+        info = by_take.setdefault(take, TakeFileInfo(take=take, raw_path=None, final_path=None))
+        try:
+            size = child.stat().st_size
+            mtime = child.stat().st_mtime
+        except OSError:
+            size = None
+            mtime = None
+        if is_raw:
+            info.raw_path = child
+            info.raw_size = size
+        else:
+            info.final_path = child
+            info.final_size = size
+        if mtime is not None and (info.recorded_at is None or mtime > info.recorded_at):
+            info.recorded_at = mtime
+
+    return [by_take[k] for k in sorted(by_take)]
 
 
 def scan_section_deck_statuses(
@@ -154,14 +379,49 @@ def scan_section_deck_statuses(
     raw_suffix: str = DEFAULT_RAW_SUFFIX,
     failed_jobs: dict[str, str] | None = None,
     active_jobs: dict[str, str] | None = None,
+    failed_jobs_per_part: dict[tuple[str, int], str] | None = None,
+    active_jobs_per_part: dict[tuple[str, int], str] | None = None,
 ) -> dict[str, DeckStatus]:
     """Scan status for all decks in a section.
 
     Returns a dict mapping deck names to their :class:`DeckStatus`.
     """
-    return {
-        name: scan_deck_status(
-            root, course_slug, section_name, name, raw_suffix, failed_jobs, active_jobs
+    section_takes = scan_section_takes(root, course_slug, section_name, deck_names, raw_suffix)
+
+    result: dict[str, DeckStatus] = {}
+    for name in deck_names:
+        # First pass to know the part list — needed to compute take counts.
+        status = scan_deck_status(
+            root,
+            course_slug,
+            section_name,
+            name,
+            raw_suffix,
+            failed_jobs,
+            active_jobs,
+            failed_jobs_per_part=failed_jobs_per_part,
+            active_jobs_per_part=active_jobs_per_part,
+            take_counts=take_counts_from_section_takes(
+                section_takes.get(name, {}),
+                known_parts=[],  # patched below after we know all_parts
+            ),
         )
-        for name in deck_names
-    }
+        # Recompute take_counts now that we have the part list, then
+        # rebuild parts_status. Cheaper than running scan_deck_status
+        # twice — only the per-part view is regenerated.
+        take_counts = take_counts_from_section_takes(
+            section_takes.get(name, {}),
+            known_parts=status.parts,
+        )
+        status.parts_status = _compute_parts_status(
+            deck_name=name,
+            all_parts=status.parts,
+            raw_parts=set(status.raw_parts),
+            final_parts=set(status.final_parts),
+            has_pair=status.has_pair,
+            failed_per_part=failed_jobs_per_part or {},
+            active_per_part=active_jobs_per_part or {},
+            take_counts=take_counts,
+        )
+        result[name] = status
+    return result

--- a/tests/recordings/test_deck_status.py
+++ b/tests/recordings/test_deck_status.py
@@ -8,8 +8,15 @@ from clm.recordings.workflow.deck_status import (
     DeckRecordingState,
     scan_deck_status,
     scan_section_deck_statuses,
+    scan_section_takes,
+    scan_take_files,
 )
-from clm.recordings.workflow.directories import ensure_root, final_dir, to_process_dir
+from clm.recordings.workflow.directories import (
+    ensure_root,
+    final_dir,
+    takes_dir,
+    to_process_dir,
+)
 
 
 class TestScanDeckStatus:
@@ -207,3 +214,156 @@ class TestFinalParts:
         status = scan_deck_status(root, "course", "section", "03 Intro")
 
         assert status.final_parts == [1, 2]
+
+
+class TestPartsStatus:
+    """The chip strip in the lectures UI consumes ``DeckStatus.parts_status``.
+
+    Per-part state is computed from raw_parts/final_parts plus per-(deck,
+    part) job maps. Phase C added these fields; the legacy deck-level
+    badge is preserved for backwards compatibility.
+    """
+
+    def test_parts_status_marks_processed_part(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        fd = final_dir(root) / "c" / "s"
+        fd.mkdir(parents=True)
+        (fd / "03 Intro.mp4").write_bytes(b"final")
+
+        status = scan_deck_status(root, "c", "s", "03 Intro")
+
+        assert len(status.parts_status) == 1
+        assert status.parts_status[0].part == 0
+        assert status.parts_status[0].state == "processed"
+
+    def test_parts_status_marks_recorded_when_raw_only(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "03 Intro (part 1)--RAW.mkv").write_bytes(b"raw")
+
+        status = scan_deck_status(root, "c", "s", "03 Intro")
+
+        assert [(p.part, p.state) for p in status.parts_status] == [(1, "recorded")]
+
+    def test_parts_status_marks_per_part_processing(self, tmp_path: Path):
+        """A per-(deck, part) active job marks its chip as processing."""
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "03 Intro (part 1)--RAW.mkv").write_bytes(b"raw")
+        (td / "03 Intro (part 2)--RAW.mkv").write_bytes(b"raw")
+
+        status = scan_deck_status(
+            root,
+            "c",
+            "s",
+            "03 Intro",
+            active_jobs_per_part={("03 Intro", 1): "job-1"},
+        )
+
+        by_part = {p.part: p.state for p in status.parts_status}
+        assert by_part == {1: "processing", 2: "recorded"}
+
+    def test_parts_status_marks_failed_retry_dot(self, tmp_path: Path):
+        """A processed part with a most-recent FAILED job sets has_failed_retry."""
+        root = tmp_path / "rec"
+        ensure_root(root)
+        fd = final_dir(root) / "c" / "s"
+        fd.mkdir(parents=True)
+        (fd / "03 Intro.mp4").write_bytes(b"final")
+
+        status = scan_deck_status(
+            root,
+            "c",
+            "s",
+            "03 Intro",
+            failed_jobs_per_part={("03 Intro", 0): "job-fail"},
+        )
+
+        assert status.parts_status[0].state == "processed"
+        assert status.parts_status[0].has_failed_retry is True
+
+    def test_parts_status_take_count_includes_active(self, tmp_path: Path):
+        """A part with two superseded takes in takes/ reports take_count == 3."""
+        root = tmp_path / "rec"
+        ensure_root(root)
+        td = to_process_dir(root) / "c" / "s"
+        td.mkdir(parents=True)
+        (td / "03 Intro (part 1)--RAW.mkv").write_bytes(b"raw")
+        tk = takes_dir(root) / "c" / "s"
+        tk.mkdir(parents=True)
+        (tk / "03 Intro (part 1, take 1).mp4").write_bytes(b"old")
+        (tk / "03 Intro (part 1, take 1)--RAW.mkv").write_bytes(b"old raw")
+        (tk / "03 Intro (part 1, take 2).mp4").write_bytes(b"old")
+
+        result = scan_section_deck_statuses(root, "c", "s", ["03 Intro"])
+        status = result["03 Intro"]
+        assert status.parts_status[0].take_count == 3
+
+
+class TestScanSectionTakes:
+    def test_returns_empty_for_decks_with_no_takes(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+
+        result = scan_section_takes(root, "c", "s", ["A", "B"])
+        assert result == {"A": {}, "B": {}}
+
+    def test_collects_take_numbers_per_part(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        tk = takes_dir(root) / "c" / "s"
+        tk.mkdir(parents=True)
+        (tk / "Intro (part 1, take 1).mp4").write_bytes(b"")
+        (tk / "Intro (part 1, take 2).mp4").write_bytes(b"")
+        (tk / "Intro (part 2, take 1).mp4").write_bytes(b"")
+        (tk / "Other (take 1).mp4").write_bytes(b"")
+
+        result = scan_section_takes(root, "c", "s", ["Intro", "Other"])
+        assert result["Intro"] == {1: [1, 2], 2: [1]}
+        assert result["Other"] == {0: [1]}
+
+    def test_dedupes_raw_and_final_for_same_take(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        tk = takes_dir(root) / "c" / "s"
+        tk.mkdir(parents=True)
+        # Both raw and final for take 1 — must count once.
+        (tk / "Intro (part 1, take 1).mp4").write_bytes(b"")
+        (tk / "Intro (part 1, take 1)--RAW.mp4").write_bytes(b"")
+
+        result = scan_section_takes(root, "c", "s", ["Intro"])
+        assert result["Intro"] == {1: [1]}
+
+
+class TestScanTakeFiles:
+    def test_pairs_raw_and_final_into_one_take(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        tk = takes_dir(root) / "c" / "s"
+        tk.mkdir(parents=True)
+        (tk / "Intro (part 2, take 1).mp4").write_bytes(b"final")
+        (tk / "Intro (part 2, take 1)--RAW.mp4").write_bytes(b"raw")
+
+        takes = scan_take_files(root, "c", "s", "Intro", part=2)
+        assert len(takes) == 1
+        assert takes[0].take == 1
+        assert takes[0].final_path is not None
+        assert takes[0].raw_path is not None
+
+    def test_filters_to_requested_part(self, tmp_path: Path):
+        root = tmp_path / "rec"
+        ensure_root(root)
+        tk = takes_dir(root) / "c" / "s"
+        tk.mkdir(parents=True)
+        (tk / "Intro (part 1, take 1).mp4").write_bytes(b"")
+        (tk / "Intro (part 2, take 1).mp4").write_bytes(b"")
+
+        result = scan_take_files(root, "c", "s", "Intro", part=2)
+        assert len(result) == 1
+        assert result[0].take == 1
+        assert "part 2" in result[0].display_stem

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -381,7 +381,9 @@ class TestLectures:
             resp = c.get("/lectures")
         assert resp.status_code == 200
         assert "processing failed" in resp.text
-        assert "badge-recorded" in resp.text  # main state still recorded
+        # The deck-level main badge was replaced by per-part chips in
+        # Phase C — the recorded chip carries the same semantic.
+        assert "chip-status-recorded" in resp.text
 
 
 # ---------------------------------------------------------------------------
@@ -1528,6 +1530,154 @@ class TestNoticeEvents:
         success_notice = next((s for s in seen if s.startswith("notice:success|")), None)
         assert success_notice is not None, seen
         assert "deck--RAW" in success_notice
+
+
+class TestPartsInlineChipStrip:
+    """Phase C — chip strip in the Status column doubles as part selector.
+
+    Replaces the bare ``<input name="part_number">`` form. Selection
+    state lives in client-side ``sessionStorage`` keyed by
+    ``"<course>::<section>::<deck>"``; the action buttons read that
+    selection right before submit.
+    """
+
+    def _set_course(self, app, *, deck_name: str = "01 Hello") -> None:
+        from clm.core.utils.text_utils import Text
+
+        mock_course = MagicMock()
+        mock_section = MagicMock()
+        mock_section.name = Text(de="W1", en="W1")
+        mock_nb = MagicMock()
+        mock_nb.title = Text(de="T", en="T")
+        mock_nb.number_in_section = 1
+        mock_nb.file_name.return_value = deck_name
+        mock_section.notebooks = [mock_nb]
+        mock_course.sections = [mock_section]
+        mock_course.output_dir_name = Text(de="kurs-de", en="course-en")
+        app.state.course = mock_course
+
+    def test_chip_strip_renders_for_each_deck(self, app, recording_root: Path):
+        self._set_course(app)
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+        assert "data-chip-strip" in html
+        # The empty deck has only the trailing "next part" chip.
+        assert "data-chip-next" in html
+
+    def test_chip_strip_includes_existing_part_chips(self, app, recording_root: Path):
+        self._set_course(app)
+        td = recording_root / "to-process" / "kurs-de" / "W1"
+        td.mkdir(parents=True)
+        (td / "01 Hello (part 1)--RAW.mp4").write_bytes(b"raw")
+        (td / "01 Hello (part 2)--RAW.mp4").write_bytes(b"raw")
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        # Two existing chips + a next-part chip.
+        assert 'data-part="1"' in html
+        assert 'data-part="2"' in html
+        # Next chip would be 3.
+        assert "data-chip-next" in html
+        assert 'data-part="3"' in html
+
+    def test_no_part_number_text_input_remains(self, app, recording_root: Path):
+        """The free-form ``<input name="part_number">`` must be gone.
+
+        Phase C dissolves the snap-back bug by removing the input entirely.
+        Action forms still POST a ``part_number`` field, but it is a
+        hidden input populated by chip-selection JS.
+        """
+        self._set_course(app)
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        # No visible text/number input named part_number.
+        assert 'type="number" name="part_number"' not in html
+        # Hidden input is fine and required (chip JS writes into it).
+        assert 'name="part_number"' in html
+
+    def test_chip_strip_carries_default_next_part(self, app, recording_root: Path):
+        self._set_course(app)
+        td = recording_root / "to-process" / "kurs-de" / "W1"
+        td.mkdir(parents=True)
+        (td / "01 Hello (part 1)--RAW.mp4").write_bytes(b"raw")
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        # data-default-part is the next-part value.
+        assert 'data-default-part="2"' in html
+
+    def test_action_buttons_have_label_swap_markers(self, app, recording_root: Path):
+        """JS swaps Record↔Retake / Arm↔Re-arm markers based on selection.
+
+        The template renders both labels per button and toggles their
+        ``hidden`` attribute on selection change. Without these
+        markers, the JS swap has nowhere to land.
+        """
+        self._set_course(app)
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        assert "data-action-label-fresh" in html
+        assert "data-action-label-retake" in html
+        assert ">Record<" in html
+        assert ">Retake<" in html
+        assert ">Arm<" in html
+        assert ">Re-arm<" in html
+
+    def test_record_form_has_hidden_part_input_ready_for_chip_js(self, app, recording_root: Path):
+        self._set_course(app)
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        # The action form must carry data-action-form so JS can find
+        # it; the part_number input must carry data-part-input so JS
+        # can rewrite it.
+        assert "data-action-form" in html
+        assert "data-part-input" in html
+
+    def test_armed_strip_marks_armed_part(self, app, recording_root: Path):
+        """When a deck is armed, its chip strip carries data-armed-part."""
+        self._set_course(app)
+        session = app.state.session
+        session.arm("kurs-de", "W1", "01 Hello", part_number=2)
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+
+        assert 'data-armed-part="2"' in html
+
+
+class TestTakesRoute:
+    """``GET /decks/{course}/{section}/{deck}/takes?part=N``."""
+
+    def test_returns_panel_with_no_takes(self, client: TestClient, recording_root: Path):
+        resp = client.get("/decks/c/s/Intro/takes?part=1")
+        assert resp.status_code == 200
+        assert "data-takes-panel" in resp.text
+        assert "Only the active take" in resp.text
+
+    def test_returns_panel_with_take_rows(self, client: TestClient, recording_root: Path):
+        from clm.recordings.workflow.directories import takes_dir
+
+        tk = takes_dir(recording_root) / "c" / "s"
+        tk.mkdir(parents=True)
+        (tk / "Intro (part 1, take 1).mp4").write_bytes(b"final old")
+        (tk / "Intro (part 1, take 1)--RAW.mp4").write_bytes(b"raw old")
+
+        resp = client.get("/decks/c/s/Intro/takes?part=1")
+        assert resp.status_code == 200
+        assert "Intro (part 1, take 1)" in resp.text
+        # Phase D will add the Restore button; Phase C must not.
+        assert "Restore" not in resp.text
+
+    def test_panel_subscribes_to_job_sse_for_refresh(
+        self, client: TestClient, recording_root: Path
+    ):
+        resp = client.get("/decks/c/s/Intro/takes?part=1")
+        assert 'data-sse-refresh="job"' in resp.text
 
 
 class TestObsStateRendering:


### PR DESCRIPTION
## Summary

- Replaces the bare `<input name=\"part_number\">` selector on the lectures page with a per-deck **chip strip** in the Status column. Each chip shows its part's state (amber `recorded`, green `processed`, purple `processing`, red `failed`, neutral-dashed `next part`), take count, and selection. A trailing `+ N` chip is the default selection on every render — recording a fresh part is always one click away.
- Adds an **inline take-history panel** below the deck row, lazy-fetched from a new `GET /decks/{course}/{section}/{deck}/takes` route and refreshed on `sse:job` events. Right-click a chip to open it; Escape or Close to dismiss. Restore-take is intentionally absent and ships with Phase D.
- Action buttons consume the chip selection: Record/Arm labels swap to **Retake/Re-arm** when an existing chip is selected, with a small ⚠ icon warning that the current take will be moved to `takes/`. **Process** targets the selected chip; a separate **Process all** button appears only when ≥2 unprocessed parts exist on the deck. **Advance** also follows the selected chip.
- Selection state lives in client-side `sessionStorage` keyed by `(course, section, deck)` — swaps no longer wipe the user's choice. As a side-effect, the long-standing `part_number` snap-back bug is dissolved by removing the input entirely.

## Design

Q1–Q8 walkthrough locked 2026-05-03 — see commit `425a2d3` (`docs(recordings): lock Phase C design`).

## Test plan

- [x] `uv run pytest tests/recordings/` — **786 passed** (740 baseline + 46 new chip-strip, take-history, per-part status assertions)
- [x] `uv run pytest` — **4515 passed**
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/clm/` — clean
- [ ] Manual smoke test on Windows: record → stop → re-arm sequence to confirm the `part_number` snap-back symptom is gone (handover lists this as the qualitative gate).
- [ ] Manual smoke test: right-click a chip, observe inline take-history panel; trigger an SSE `job` tick and confirm the panel refreshes in place.

## Docs

- `CHANGELOG.md` — under Unreleased.
- `docs/user-guide/recordings.md` — new \"Per-part chip strip\" subsection.
- `docs/claude/recordings-ux-followups-handover.md` — Phase C marked SHIPPED, consolidated Open Design Questions table for Phases D/E/F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)