### PR TITLE
feat(spec): honor section/topic module= bindings across all spec consumers

### DIFF
--- a/src/clm/cli/commands/resolve_topic.py
+++ b/src/clm/cli/commands/resolve_topic.py
@@ -9,9 +9,6 @@ import click
 
 from clm.core.course_spec import CourseSpec, CourseSpecError
 from clm.core.topic_resolver import (
-    get_course_topic_ids,
-)
-from clm.core.topic_resolver import (
     resolve_topic as _resolve_topic,
 )
 
@@ -59,15 +56,20 @@ def resolve_topic_cmd(
     """
     slides_dir = _resolve_slides_dir(data_dir, course_spec)
 
-    course_topic_ids = None
+    course_topic_bindings = None
     if course_spec:
         try:
             spec = CourseSpec.from_file(course_spec)
-            course_topic_ids = get_course_topic_ids(spec)
+            course_topic_bindings = spec.topic_bindings()
         except CourseSpecError as e:
             raise click.ClickException(f"Failed to parse course spec: {e}") from None
 
-    result = _resolve_topic(topic_id, slides_dir, course_topic_ids=course_topic_ids, module=module)
+    result = _resolve_topic(
+        topic_id,
+        slides_dir,
+        course_topic_bindings=course_topic_bindings,
+        module=module,
+    )
 
     if as_json:
         click.echo(json.dumps(_result_to_dict(result), indent=2))

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -566,8 +566,8 @@ class Course(NotebookMixin):
 
     def _build_topics(self, section, section_spec):
         for topic_spec in section_spec.topics:
-            # Effective module: per-topic override beats section default.
-            effective_module = topic_spec.module or section_spec.module
+            # Per-topic override beats section default — see SectionSpec.module_for.
+            effective_module = section_spec.module_for(topic_spec)
             topic_path = self._resolve_topic_path(
                 topic_spec.id, module=effective_module, section_spec=section_spec
             )
@@ -615,11 +615,11 @@ class Course(NotebookMixin):
         # Module-bound resolution. Use the full topic map (includes every
         # occurrence) so we can pick the one in the requested module even
         # when other modules share the topic ID.
-        from clm.core.topic_resolver import build_topic_map
+        from clm.core.topic_resolver import build_topic_map, matches_for_binding
 
         slides_dir = self.course_root / "slides"
         full_map = build_topic_map(slides_dir)
-        candidates = [m for m in full_map.get(topic_id, []) if m.module == module]
+        candidates = matches_for_binding(full_map, topic_id, module)
 
         if not candidates:
             logger.error(f"Topic not found: {topic_id} in module {module}")

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -70,6 +70,34 @@ class SectionSpec:
     # do not themselves carry an explicit ``module`` attribute.
     module: str | None = None
 
+    def module_for(self, topic_spec: TopicSpec) -> str | None:
+        """Effective module binding for *topic_spec* under this section.
+
+        Per-topic ``module=`` overrides the section default. Returns
+        ``None`` when neither side specifies a module (unbound — resolution
+        falls back to first-occurrence-wins across modules).
+        """
+        return topic_spec.module or self.module
+
+
+@frozen
+class TopicBinding:
+    """A single (section, topic, effective module) triple from a course spec.
+
+    Yielded by :meth:`CourseSpec.iter_topic_bindings` so callers do not need
+    to repeat the per-topic / section-default override logic. The
+    ``effective_module`` field is what every spec-aware resolver/validator
+    should pass to topic resolution.
+    """
+
+    section: SectionSpec
+    topic_spec: TopicSpec
+    effective_module: str | None
+
+    @property
+    def topic_id(self) -> str:
+        return self.topic_spec.id
+
 
 @frozen
 class SectionSelection:
@@ -638,6 +666,40 @@ class CourseSpec:
     @property
     def topics(self) -> list[TopicSpec]:
         return [topic for section in self.sections for topic in section.topics]
+
+    def iter_topic_bindings(self):
+        """Iterate every topic in declared order with its effective module.
+
+        Replaces the doubly-nested ``for section in spec.sections: for
+        topic_spec in section.topics:`` pattern. Each yielded
+        :class:`TopicBinding` carries the section, topic spec, and the
+        effective module computed via :meth:`SectionSpec.module_for` (per-
+        topic override beats section default; ``None`` means unbound).
+
+        Use this in every consumer that walks the spec to reach the
+        filesystem — ``normalize-slides``, ``validate-slides``, the spec
+        validator, and ``Course._build_topics`` all share this contract so
+        module-bound cohort archives resolve uniformly.
+        """
+        for section in self.sections:
+            for topic_spec in section.topics:
+                yield TopicBinding(
+                    section=section,
+                    topic_spec=topic_spec,
+                    effective_module=section.module_for(topic_spec),
+                )
+
+    def topic_bindings(self) -> set[tuple[str, str | None]]:
+        """Module-aware companion to :func:`get_course_topic_ids`.
+
+        Returns the set of ``(topic_id, effective_module)`` pairs the spec
+        actually references. Use this when scoping resolution or search to
+        a course spec — a bare topic-ID set incorrectly conflates the
+        live-module copy of ``intro`` with a frozen-cohort copy of the
+        same ID, even when the spec deliberately binds each section to a
+        different module.
+        """
+        return {(b.topic_id, b.effective_module) for b in self.iter_topic_bindings()}
 
     @property
     def output_dir_name(self) -> Text:

--- a/src/clm/core/topic_resolver.py
+++ b/src/clm/core/topic_resolver.py
@@ -172,6 +172,7 @@ def resolve_topic(
     slides_dir: Path,
     *,
     course_topic_ids: set[str] | None = None,
+    course_topic_bindings: set[tuple[str, str | None]] | None = None,
     module: str | None = None,
 ) -> ResolutionResult:
     """Resolve a topic ID (or glob pattern) to filesystem path(s).
@@ -195,8 +196,16 @@ def resolve_topic(
             or ``"what_is_ml*"``).
         slides_dir: Path to the ``slides/`` directory.
         course_topic_ids: When provided, only topics whose ID is in this
-            set are considered.  Use this to scope resolution to topics
-            referenced by a particular course spec.
+            set are considered. Drops module bindings — kept for backward
+            compatibility; new callers should pass ``course_topic_bindings``
+            so cohort archives that share topic IDs with the live module
+            are correctly disambiguated.
+        course_topic_bindings: When provided, only topics whose
+            ``(topic_id, module)`` is referenced by the spec are returned.
+            A spec entry ``(tid, None)`` (unbound) matches any module of
+            ``tid``; a bound entry ``(tid, X)`` matches only matches in
+            module ``X``. Takes precedence over ``course_topic_ids`` if
+            both are supplied.
         module: When provided, only topics whose parent module directory
             equals this name are considered. Used for module-bound topic
             references in course specs.
@@ -208,8 +217,20 @@ def resolve_topic(
 
     full_map = build_topic_map(slides_dir)
 
-    # Filter to course-scoped topics if requested.
-    if course_topic_ids is not None:
+    # Filter to course-scoped topics if requested. Module-aware bindings
+    # win over the legacy ID-only set so cohort archives are correctly
+    # disambiguated.
+    if course_topic_bindings is not None:
+        full_map = {
+            tid: [
+                m
+                for m in matches
+                if (tid, m.module) in course_topic_bindings or (tid, None) in course_topic_bindings
+            ]
+            for tid, matches in full_map.items()
+        }
+        full_map = {tid: matches for tid, matches in full_map.items() if matches}
+    elif course_topic_ids is not None:
         full_map = {tid: matches for tid, matches in full_map.items() if tid in course_topic_ids}
 
     # Filter to a specific module if requested. Drop entries whose match
@@ -275,6 +296,12 @@ def _resolve_glob(pattern: str, topic_map: dict[str, list[TopicMatch]]) -> Resol
 def get_course_topic_ids(course_spec) -> set[str]:
     """Extract the set of topic IDs referenced by a course spec.
 
+    Drops module bindings — two sections that bind the same topic ID to
+    different modules collapse into a single entry. Use
+    :meth:`clm.core.course_spec.CourseSpec.topic_bindings` instead when
+    cohort archives or per-section ``module=`` bindings need to be
+    respected.
+
     Args:
         course_spec: A :class:`CourseSpec` instance.
 
@@ -282,3 +309,23 @@ def get_course_topic_ids(course_spec) -> set[str]:
         Set of topic ID strings from all sections in the spec.
     """
     return {topic.id for section in course_spec.sections for topic in section.topics}
+
+
+def matches_for_binding(
+    topic_map: dict[str, list[TopicMatch]],
+    topic_id: str,
+    module: str | None,
+) -> list[TopicMatch]:
+    """Look up *topic_id* in *topic_map*, optionally filtered by *module*.
+
+    Centralizes the "filter ``topic_map[id]`` by effective module" step so
+    every spec consumer (build, validate, normalize, search) applies it
+    consistently. When *module* is ``None`` the binding is unbound and
+    every match is returned (the caller then deals with ambiguity per its
+    own policy — e.g. first-occurrence-wins for build, or an "ambiguous"
+    finding for the spec validator).
+    """
+    matches = topic_map.get(topic_id, [])
+    if module is not None:
+        matches = [m for m in matches if m.module == module]
+    return matches

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -15,7 +15,6 @@ from clm.core.course_paths import resolve_course_paths
 from clm.core.course_spec import CourseSpec, CourseSpecError
 from clm.core.topic_resolver import (
     ResolutionResult,
-    get_course_topic_ids,
 )
 from clm.core.topic_resolver import (
     resolve_topic as _resolve_topic,
@@ -149,18 +148,18 @@ async def handle_resolve_topic(
     """
     slides_dir = data_dir / "slides"
 
-    course_topic_ids: set[str] | None = None
+    course_topic_bindings: set[tuple[str, str | None]] | None = None
     if course_spec:
         try:
             spec = CourseSpec.from_file(Path(course_spec))
-            course_topic_ids = get_course_topic_ids(spec)
+            course_topic_bindings = spec.topic_bindings()
         except CourseSpecError:
             logger.warning("Failed to parse course spec: %s", course_spec)
 
     result = _resolve_topic(
         topic_id,
         slides_dir,
-        course_topic_ids=course_topic_ids,
+        course_topic_bindings=course_topic_bindings,
         module=module,
     )
     return json.dumps(_resolution_to_dict(result), indent=2)

--- a/src/clm/slides/authoring_rules.py
+++ b/src/clm/slides/authoring_rules.py
@@ -138,8 +138,9 @@ def _resolve_slide_to_courses(slide_path: str, data_dir: Path) -> list[str]:
     """Resolve a slide file path to the course(s) that reference its topic.
 
     Walks up from the slide file to find the topic directory, extracts the
-    topic ID, then scans all course spec XML files to find which ones
-    reference that topic.
+    topic ID *and module*, then scans all course spec XML files to find
+    which ones bind that topic to that module (or reference it without a
+    module binding).
     """
     slides_dir = data_dir / "slides"
     specs_dir = data_dir / "course-specs"
@@ -148,26 +149,26 @@ def _resolve_slide_to_courses(slide_path: str, data_dir: Path) -> list[str]:
     if not slide.is_absolute():
         slide = data_dir / slide
 
-    # Find the topic ID for this slide file
-    topic_id = _find_topic_id_for_path(slide, slides_dir)
-    if not topic_id:
+    located = _locate_topic_for_path(slide, slides_dir)
+    if not located:
         return []
+    topic_id, module = located
 
-    # Scan all course specs for this topic
-    return _find_courses_with_topic(topic_id, specs_dir)
+    return _find_courses_with_topic(topic_id, module, specs_dir)
 
 
-def _find_topic_id_for_path(slide: Path, slides_dir: Path) -> str | None:
-    """Find the topic ID that contains the given slide file.
+def _locate_topic_for_path(slide: Path, slides_dir: Path) -> tuple[str, str] | None:
+    """Find the (topic_id, module) for the given slide file.
 
-    Walks up from the slide path to find a directory that matches a
-    topic in the topic map.
+    Walks up from the slide path to find a topic directory; the parent of
+    that directory is the module directory under ``slides/``. Returning
+    the module is what lets the caller distinguish a slide in the live
+    module from the same-named slide in a frozen-cohort archive.
     """
     from clm.infrastructure.utils.path_utils import simplify_ordered_name
 
     topic_map = build_topic_map(slides_dir)
 
-    # Try the file's parent directory as a topic dir
     # Typical structure: slides/module_XXX/topic_YYY/slides_foo.py
     candidate = slide.parent
     resolved_slide = slide.resolve()
@@ -176,10 +177,9 @@ def _find_topic_id_for_path(slide: Path, slides_dir: Path) -> str | None:
     for _ in range(3):
         name = simplify_ordered_name(candidate.name)
         if name and name in topic_map:
-            # Verify the slide is actually inside this topic
             for match in topic_map[name]:
                 if resolved_slide == match.path.resolve() or _is_under(resolved_slide, match.path):
-                    return name
+                    return name, match.module
         candidate = candidate.parent
         if candidate == slides_dir or candidate == slides_dir.parent:
             break
@@ -196,8 +196,15 @@ def _is_under(child: Path, parent: Path) -> bool:
         return False
 
 
-def _find_courses_with_topic(topic_id: str, specs_dir: Path) -> list[str]:
-    """Scan all course spec XML files for ones that reference *topic_id*."""
+def _find_courses_with_topic(topic_id: str, module: str, specs_dir: Path) -> list[str]:
+    """Scan course specs for ones that reference *topic_id* in *module*.
+
+    A spec is considered to reference the slide if it has either a
+    binding ``(topic_id, module)`` (explicit cohort binding) or a binding
+    ``(topic_id, None)`` (unbound — first-occurrence-wins resolution may
+    land on this slide). Specs that bind ``topic_id`` to a different
+    module are correctly excluded.
+    """
     if not specs_dir.is_dir():
         return []
 
@@ -209,8 +216,8 @@ def _find_courses_with_topic(topic_id: str, specs_dir: Path) -> list[str]:
             logger.debug("Skipping unparseable spec: %s", xml_file)
             continue
 
-        spec_topic_ids = {t.id for section in spec.sections for t in section.topics}
-        if topic_id in spec_topic_ids:
+        bindings = spec.topic_bindings()
+        if (topic_id, module) in bindings or (topic_id, None) in bindings:
             courses.append(xml_file.stem)
 
     return courses

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -20,7 +20,12 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from clm.core.topic_resolver import build_topic_map, find_slide_files, find_slide_files_recursive
+from clm.core.topic_resolver import (
+    build_topic_map,
+    find_slide_files,
+    find_slide_files_recursive,
+    matches_for_binding,
+)
 from clm.notebooks.slide_parser import CellMetadata, parse_cell_header
 
 # ---------------------------------------------------------------------------
@@ -843,15 +848,14 @@ def normalize_course(
     topic_map = build_topic_map(slides_dir)
     combined = NormalizationResult()
 
-    for section in spec.sections:
-        for topic_spec in section.topics:
-            matches = topic_map.get(topic_spec.id, [])
-            for match in matches:
-                slide_files = find_slide_files(match.path)
-                for sf in slide_files:
-                    result = normalize_file(sf, operations=operations, dry_run=dry_run)
-                    combined.files_modified += result.files_modified
-                    combined.changes.extend(result.changes)
-                    combined.review_items.extend(result.review_items)
+    for binding in spec.iter_topic_bindings():
+        matches = matches_for_binding(topic_map, binding.topic_id, binding.effective_module)
+        for match in matches:
+            slide_files = find_slide_files(match.path)
+            for sf in slide_files:
+                result = normalize_file(sf, operations=operations, dry_run=dry_run)
+                combined.files_modified += result.files_modified
+                combined.changes.extend(result.changes)
+                combined.review_items.extend(result.review_items)
 
     return combined

--- a/src/clm/slides/search.py
+++ b/src/clm/slides/search.py
@@ -10,7 +10,6 @@ from clm.core.course_spec import CourseSpec, CourseSpecError
 from clm.core.topic_resolver import (
     TopicMatch,
     build_topic_map,
-    get_course_topic_ids,
 )
 from clm.core.utils.notebook_utils import find_notebook_titles
 
@@ -82,29 +81,34 @@ def search_slides(
     """
     topic_map = build_topic_map(slides_dir)
 
-    # Load course spec for scoping and course-membership info
-    course_topic_ids: set[str] | None = None
-    spec_topic_courses: dict[str, list[str]] = {}
+    # Load course spec for scoping and course-membership info. ``scope`` is
+    # the set of (topic_id, module) pairs the spec actually references —
+    # using bare topic IDs would let cohort-archive copies leak into
+    # results when the spec deliberately binds sections to one module.
+    scope: set[tuple[str, str | None]] | None = None
 
     if course_spec_path:
         try:
             spec = CourseSpec.from_file(course_spec_path)
-            course_topic_ids = get_course_topic_ids(spec)
+            scope = spec.topic_bindings()
         except CourseSpecError:
             logger.warning("Failed to parse course spec: %s", course_spec_path)
 
-    # Also scan all spec files to build course membership
+    # Also scan all spec files to build course membership, keyed by
+    # ``(topic_id, module)`` so a course bound to module X is not listed
+    # for the same topic ID found in module Y.
+    membership: dict[tuple[str, str | None], list[str]] = {}
     specs_dir = slides_dir.parent / "course-specs"
     if specs_dir.is_dir():
-        spec_topic_courses = _build_course_membership(specs_dir)
+        membership = _build_course_membership(specs_dir)
 
     results: list[SearchResult] = []
 
     for topic_id, matches in topic_map.items():
-        if course_topic_ids is not None and topic_id not in course_topic_ids:
-            continue
-
         for match in matches:
+            if scope is not None and not _binding_in_scope(scope, topic_id, match.module):
+                continue
+
             score, slides = _score_topic(query, match, language)
             if score < 20.0:
                 continue
@@ -115,12 +119,27 @@ def search_slides(
                     topic_id=topic_id,
                     directory=str(match.path),
                     slides=slides,
-                    courses=spec_topic_courses.get(topic_id, []),
+                    courses=_courses_for_match(membership, topic_id, match.module),
                 )
             )
 
     results.sort(key=lambda r: r.score, reverse=True)
     return results[:max_results]
+
+
+def _binding_in_scope(
+    scope: set[tuple[str, str | None]],
+    topic_id: str,
+    module: str,
+) -> bool:
+    """Match a filesystem topic against a spec's ``topic_bindings()`` set.
+
+    A bound entry ``(tid, X)`` matches the *specific* module ``X``. An
+    unbound entry ``(tid, None)`` matches *any* module — preserves the
+    long-standing first-occurrence-wins resolution for specs that don't
+    pin their topics to a module.
+    """
+    return (topic_id, module) in scope or (topic_id, None) in scope
 
 
 def _score_topic(
@@ -166,18 +185,51 @@ def _score_topic(
     return best_score, slide_infos
 
 
-def _build_course_membership(specs_dir: Path) -> dict[str, list[str]]:
-    """Scan course spec XMLs and return topic_id -> list of spec filenames."""
-    membership: dict[str, list[str]] = {}
+def _build_course_membership(specs_dir: Path) -> dict[tuple[str, str | None], list[str]]:
+    """Scan course spec XMLs and return ``(topic_id, module) -> spec names``.
+
+    Module-aware so a search hit in module X does not list courses that
+    bind the same topic ID to module Y. Unbound bindings get a ``None``
+    module entry that :func:`_courses_for_match` treats as wildcard.
+    """
+    membership: dict[tuple[str, str | None], list[str]] = {}
 
     for spec_file in sorted(specs_dir.iterdir()):
         if not spec_file.suffix == ".xml":
             continue
         try:
             spec = CourseSpec.from_file(spec_file)
-            for tid in get_course_topic_ids(spec):
-                membership.setdefault(tid, []).append(spec_file.name)
+            for tid, module in spec.topic_bindings():
+                membership.setdefault((tid, module), []).append(spec_file.name)
         except Exception:
             logger.debug("Skipping unparseable spec: %s", spec_file)
 
     return membership
+
+
+def _courses_for_match(
+    membership: dict[tuple[str, str | None], list[str]],
+    topic_id: str,
+    module: str,
+) -> list[str]:
+    """Combine bound (``topic_id``, ``module``) and unbound entries.
+
+    A course's binding ``(tid, X)`` is listed only for matches in module
+    ``X``. An unbound binding ``(tid, None)`` is listed for every match
+    of ``tid`` since unbound resolution can land in any module
+    (first-occurrence-wins).
+    """
+    bound = membership.get((topic_id, module), [])
+    unbound = membership.get((topic_id, None), [])
+    if not unbound:
+        return bound
+    if not bound:
+        return unbound
+    seen: set[str] = set()
+    combined: list[str] = []
+    for name in (*bound, *unbound):
+        if name in seen:
+            continue
+        seen.add(name)
+        combined.append(name)
+    return combined

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from clm.core.course_spec import CourseSpec
-from clm.core.topic_resolver import build_topic_map
+from clm.core.topic_resolver import build_topic_map, matches_for_binding
 
 
 @dataclass
@@ -142,7 +142,7 @@ def validate_spec(
         for topic_spec in section.topics:
             tid = topic_spec.id
             # Effective module: per-topic override beats section default.
-            effective_module = topic_spec.module or section.module
+            effective_module = section.module_for(topic_spec)
 
             # Track for duplicate detection. Key by (id, module) so the
             # same topic ID resolved in two different modules is treated
@@ -171,9 +171,7 @@ def validate_spec(
                 continue
 
             # Resolution check, honoring the effective module if set.
-            matches = topic_map.get(tid, [])
-            if effective_module:
-                matches = [m for m in matches if m.module == effective_module]
+            matches = matches_for_binding(topic_map, tid, effective_module)
 
             if not matches:
                 # Unresolved — try to suggest near matches

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -13,7 +13,12 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from clm.core.topic_resolver import build_topic_map, find_slide_files, find_slide_files_recursive
+from clm.core.topic_resolver import (
+    build_topic_map,
+    find_slide_files,
+    find_slide_files_recursive,
+    matches_for_binding,
+)
 from clm.notebooks.slide_parser import Cell, parse_cells
 from clm.slides.tags import ALL_VALID_TAGS, EXPECTED_CODE_TAGS, EXPECTED_MARKDOWN_TAGS
 from clm.slides.workshop_scope import find_workshop_ranges
@@ -892,17 +897,16 @@ def validate_course(
     files_checked = 0
     combined_review = ReviewMaterial() if (not checks or set(checks) & ALL_REVIEW_CHECKS) else None
 
-    for section in spec.sections:
-        for topic_spec in section.topics:
-            matches = topic_map.get(topic_spec.id, [])
-            for match in matches:
-                slide_files = find_slide_files(match.path)
-                for sf in slide_files:
-                    result = validate_file(sf, checks=checks)
-                    all_findings.extend(result.findings)
-                    files_checked += 1
-                    if combined_review is not None and result.review_material is not None:
-                        _merge_review_material(combined_review, result.review_material)
+    for binding in spec.iter_topic_bindings():
+        matches = matches_for_binding(topic_map, binding.topic_id, binding.effective_module)
+        for match in matches:
+            slide_files = find_slide_files(match.path)
+            for sf in slide_files:
+                result = validate_file(sf, checks=checks)
+                all_findings.extend(result.findings)
+                files_checked += 1
+                if combined_review is not None and result.review_material is not None:
+                    _merge_review_material(combined_review, result.review_material)
 
     return ValidationResult(
         files_checked=files_checked,

--- a/tests/core/test_module_bindings.py
+++ b/tests/core/test_module_bindings.py
@@ -1,0 +1,199 @@
+"""Tests for module-aware spec helpers added on CourseSpec/SectionSpec.
+
+The build pipeline (``Course._build_topics``) and the spec validator
+already honoured per-section / per-topic ``module=`` attributes. These
+tests cover the helpers that other consumers (normalize-slides,
+validate-slides, search-slides, resolve-topic with --course-spec,
+authoring-rules) now share so cohort-archive scenarios resolve uniformly
+across the codebase.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from clm.core.course_spec import CourseSpec, SectionSpec, TopicBinding, TopicSpec
+from clm.core.topic_resolver import (
+    TopicMatch,
+    matches_for_binding,
+)
+
+
+def _write_spec(tmp_path: Path, sections_xml: str) -> Path:
+    spec_file = tmp_path / "course-specs" / "test.xml"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>Test</de><en>Test</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          {sections_xml}
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+class TestSectionSpecModuleFor:
+    """``SectionSpec.module_for(topic_spec)`` resolves the effective module."""
+
+    def test_topic_module_overrides_section(self):
+        section = SectionSpec(
+            name=None,  # type: ignore[arg-type]
+            topics=[],
+            module="module_section",
+        )
+        topic = TopicSpec(id="t", module="module_topic")
+        assert section.module_for(topic) == "module_topic"
+
+    def test_section_module_used_when_topic_unbound(self):
+        section = SectionSpec(name=None, topics=[], module="module_section")  # type: ignore[arg-type]
+        topic = TopicSpec(id="t")
+        assert section.module_for(topic) == "module_section"
+
+    def test_neither_set_returns_none(self):
+        section = SectionSpec(name=None, topics=[])  # type: ignore[arg-type]
+        topic = TopicSpec(id="t")
+        assert section.module_for(topic) is None
+
+
+class TestIterTopicBindings:
+    """``CourseSpec.iter_topic_bindings`` yields one TopicBinding per topic."""
+
+    def test_no_modules_yields_unbound(self, tmp_path):
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic><topic>variables</topic></topics>
+            </section></sections>""",
+        )
+        spec = CourseSpec.from_file(spec_file)
+        bindings = list(spec.iter_topic_bindings())
+
+        assert len(bindings) == 2
+        assert all(isinstance(b, TopicBinding) for b in bindings)
+        assert [b.topic_id for b in bindings] == ["intro", "variables"]
+        assert all(b.effective_module is None for b in bindings)
+
+    def test_section_module_propagates(self, tmp_path):
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section module="module_545_frozen">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+        spec = CourseSpec.from_file(spec_file)
+        bindings = list(spec.iter_topic_bindings())
+
+        assert bindings[0].effective_module == "module_545_frozen"
+
+    def test_topic_module_overrides_section_module(self, tmp_path):
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section module="module_section">
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <topic>intro</topic>
+                <topic module="module_topic">advanced</topic>
+              </topics>
+            </section></sections>""",
+        )
+        spec = CourseSpec.from_file(spec_file)
+        bindings = list(spec.iter_topic_bindings())
+
+        assert bindings[0].effective_module == "module_section"
+        assert bindings[1].effective_module == "module_topic"
+
+
+class TestTopicBindings:
+    """``CourseSpec.topic_bindings`` returns ``(topic_id, module)`` pairs."""
+
+    def test_two_sections_different_modules(self, tmp_path):
+        """Same topic ID bound to two modules yields two distinct entries.
+
+        This is the cohort-archive scenario: the live module and a frozen
+        copy share topic IDs but are deliberately bound to different
+        module directories. ``get_course_topic_ids`` collapses them — the
+        new ``topic_bindings`` keeps them apart.
+        """
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="module_100_live">
+                <name><de>L</de><en>L</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+              <section module="module_545_frozen">
+                <name><de>F</de><en>F</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+            </sections>""",
+        )
+        spec = CourseSpec.from_file(spec_file)
+        assert spec.topic_bindings() == {
+            ("intro", "module_100_live"),
+            ("intro", "module_545_frozen"),
+        }
+
+    def test_unbound_topic(self, tmp_path):
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+        spec = CourseSpec.from_file(spec_file)
+        assert spec.topic_bindings() == {("intro", None)}
+
+
+class TestMatchesForBinding:
+    """``matches_for_binding`` filters topic_map results by module."""
+
+    def _make_topic_map(self) -> dict[str, list[TopicMatch]]:
+        return {
+            "intro": [
+                TopicMatch(
+                    topic_id="intro",
+                    path=Path("/x/module_100_live/topic_010_intro"),
+                    path_type="directory",
+                    module="module_100_live",
+                ),
+                TopicMatch(
+                    topic_id="intro",
+                    path=Path("/x/module_545_frozen/topic_010_intro"),
+                    path_type="directory",
+                    module="module_545_frozen",
+                ),
+            ]
+        }
+
+    def test_unbound_returns_all(self):
+        topic_map = self._make_topic_map()
+        result = matches_for_binding(topic_map, "intro", None)
+        assert len(result) == 2
+
+    def test_bound_filters_to_module(self):
+        topic_map = self._make_topic_map()
+        result = matches_for_binding(topic_map, "intro", "module_545_frozen")
+        assert len(result) == 1
+        assert result[0].module == "module_545_frozen"
+
+    def test_unknown_topic_returns_empty(self):
+        topic_map = self._make_topic_map()
+        assert matches_for_binding(topic_map, "missing", None) == []
+
+    def test_bound_to_unknown_module_returns_empty(self):
+        topic_map = self._make_topic_map()
+        assert matches_for_binding(topic_map, "intro", "module_nonexistent") == []

--- a/tests/slides/test_module_aware_consumers.py
+++ b/tests/slides/test_module_aware_consumers.py
@@ -1,0 +1,289 @@
+"""Cohort-archive scenario tests for spec-consuming commands.
+
+Each test below builds a slides tree containing the same topic ID in two
+modules (the live module and a frozen-cohort archive), writes a course
+spec that binds one section to each module, then exercises a command and
+asserts that the module binding is honoured.
+
+Before this fix:
+
+* ``validate-slides course.xml`` and ``normalize-slides course.xml``
+  visited *every* filesystem match for each topic ID, processing the
+  cohort archive even when the spec scoped the section to the live
+  module.
+* ``search-slides --course-spec`` returned matches in the cohort archive
+  module for a spec that bound itself to the live module.
+* ``resolve-topic --course-spec`` returned a path in the wrong module if
+  it happened to win first-occurrence ordering.
+* ``authoring-rules --slide-path=…`` listed every course that mentioned
+  the topic ID, regardless of which module each spec was bound to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.commands.resolve_topic import resolve_topic_cmd
+from clm.slides.authoring_rules import get_authoring_rules
+from clm.slides.normalizer import normalize_course
+from clm.slides.search import search_slides
+from clm.slides.validator import validate_course
+
+SLIDE_TEMPLATE = (
+    '# %% [markdown] lang="de"\n# {heading}\n\n# %% [markdown] lang="en"\n# {heading}\n'
+)
+
+
+def _make_topic(tmp_path: Path, module: str, topic: str, heading: str) -> Path:
+    """Create slides/{module}/{topic}/slides_intro.py and return its path."""
+    topic_dir = tmp_path / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    slide = topic_dir / "slides_intro.py"
+    slide.write_text(SLIDE_TEMPLATE.format(heading=heading), encoding="utf-8")
+    return slide
+
+
+def _write_spec(tmp_path: Path, name: str, sections_xml: str) -> Path:
+    """Write a course spec under course-specs/ with the supplied sections."""
+    specs_dir = tmp_path / "course-specs"
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    spec_file = specs_dir / f"{name}.xml"
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>{name}</de><en>{name}</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          {sections_xml}
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+class TestValidateCourseModuleAware:
+    """``validate-slides COURSE.xml`` must respect ``module=`` bindings."""
+
+    def test_section_module_filters_to_one_copy(self, tmp_path):
+        # Two modules, same topic ID.
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro", "Live")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "Frozen")
+
+        # Spec binds to the live module only.
+        spec_file = _write_spec(
+            tmp_path,
+            "live",
+            """\
+            <sections><section module="module_100_live">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        result = validate_course(spec_file, tmp_path / "slides")
+
+        # Only the live copy should have been validated, not both.
+        assert result.files_checked == 1
+
+
+class TestNormalizeCourseModuleAware:
+    """``normalize-slides COURSE.xml`` must respect ``module=`` bindings."""
+
+    def test_section_module_normalizes_only_bound_copy(self, tmp_path):
+        live = _make_topic(tmp_path, "module_100_live", "topic_010_intro", "Live")
+        frozen = _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "Frozen")
+        live_before = live.read_text(encoding="utf-8")
+        frozen_before = frozen.read_text(encoding="utf-8")
+
+        spec_file = _write_spec(
+            tmp_path,
+            "live",
+            """\
+            <sections><section module="module_545_frozen">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        result = normalize_course(spec_file, tmp_path / "slides", dry_run=True)
+
+        # The dry-run should only have inspected the frozen module's slide
+        # (heading "Frozen"). Tracking the change list by file path proves
+        # the bound copy was the *only* thing the normalizer touched.
+        touched = {Path(c.file).resolve() for c in result.changes}
+        # Even without changes, no inspection of the live file should
+        # have occurred — assert via filesystem mtimes / contents.
+        assert live.read_text(encoding="utf-8") == live_before
+        assert frozen.read_text(encoding="utf-8") == frozen_before
+        # If the normalizer inspected the live file we'd see its path
+        # show up among the operations it considered.
+        assert all(p == frozen.resolve() for p in touched) or not touched
+
+
+class TestSearchSlidesModuleAware:
+    """``search-slides --course-spec`` should not return cohort copies."""
+
+    def test_module_bound_spec_excludes_other_module(self, tmp_path):
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro", "Introduction")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "Introduction")
+
+        spec_file = _write_spec(
+            tmp_path,
+            "live",
+            """\
+            <sections><section module="module_100_live">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        results = search_slides(
+            "Introduction",
+            tmp_path / "slides",
+            course_spec_path=spec_file,
+        )
+
+        # Only the live module's copy should be returned.
+        assert len(results) == 1
+        assert "module_100_live" in results[0].directory
+        assert "module_545_frozen" not in results[0].directory
+
+    def test_unbound_spec_returns_all(self, tmp_path):
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro", "Introduction")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "Introduction")
+
+        spec_file = _write_spec(
+            tmp_path,
+            "live",
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        results = search_slides(
+            "Introduction",
+            tmp_path / "slides",
+            course_spec_path=spec_file,
+        )
+
+        modules = {Path(r.directory).parent.name for r in results}
+        assert modules == {"module_100_live", "module_545_frozen"}
+
+    def test_courses_field_excludes_other_module_specs(self, tmp_path):
+        """A spec bound to module X should not be listed for hits in Y."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro", "Introduction")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "Introduction")
+
+        # Two specs: one bound to live, one bound to frozen.
+        _write_spec(
+            tmp_path,
+            "live-course",
+            """\
+            <sections><section module="module_100_live">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+        _write_spec(
+            tmp_path,
+            "frozen-course",
+            """\
+            <sections><section module="module_545_frozen">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        results = search_slides("Introduction", tmp_path / "slides")
+        by_module = {Path(r.directory).parent.name: r.courses for r in results}
+
+        assert by_module["module_100_live"] == ["live-course.xml"]
+        assert by_module["module_545_frozen"] == ["frozen-course.xml"]
+
+
+class TestResolveTopicModuleAware:
+    """``resolve-topic --course-spec`` must respect spec module bindings."""
+
+    def test_course_spec_filters_by_module(self, tmp_path):
+        live = _make_topic(tmp_path, "module_100_live", "topic_010_intro", "L")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "F")
+
+        spec_file = _write_spec(
+            tmp_path,
+            "live",
+            """\
+            <sections><section module="module_100_live">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            resolve_topic_cmd,
+            [
+                "intro",
+                "--course-spec",
+                str(spec_file),
+                "--data-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # Should resolve to the live copy, not the frozen one.
+        assert str(live.parent.resolve()) in result.output
+        assert "module_545_frozen" not in result.output
+
+
+class TestAuthoringRulesModuleAware:
+    """``authoring-rules --slide-path`` should match by (topic_id, module)."""
+
+    def test_slide_in_live_module_only_lists_live_course(self, tmp_path):
+        live = _make_topic(tmp_path, "module_100_live", "topic_010_intro", "L")
+        _make_topic(tmp_path, "module_545_frozen", "topic_010_intro", "F")
+
+        # Two specs, each bound to a different module. Only the live one
+        # has authoring rules — but the broken behaviour would also
+        # return "frozen" as a referencing course.
+        _write_spec(
+            tmp_path,
+            "live-course",
+            """\
+            <sections><section module="module_100_live">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+        _write_spec(
+            tmp_path,
+            "frozen-course",
+            """\
+            <sections><section module="module_545_frozen">
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        # Drop authoring rules for both courses so we can check which
+        # gets picked up (the lookup also reports "no rules" for missing
+        # files, but the count of CourseRulesEntry items is what we care
+        # about).
+        (tmp_path / "course-specs" / "live-course.authoring.md").write_text(
+            "# Live rules\n", encoding="utf-8"
+        )
+        (tmp_path / "course-specs" / "frozen-course.authoring.md").write_text(
+            "# Frozen rules\n", encoding="utf-8"
+        )
+
+        result = get_authoring_rules(tmp_path, slide_path=str(live))
+
+        course_names = [e.course_spec for e in result.course_rules]
+        assert course_names == ["live-course"]


### PR DESCRIPTION
## Summary

The course spec format gained `module=` attributes on `<section>` and `<topic>` so cohort archives can share topic IDs with the live module. `clm build` already respected these bindings, but several other commands silently ignored them and processed every filesystem match for a topic ID — the cohort archive copy leaked into the live module''s output.

This PR centralizes the effective-module logic on `CourseSpec` / `SectionSpec` / `topic_resolver` and refactors every spec consumer to use it.

### Bugs fixed (commands that now honor `module=`)
- `clm validate-slides COURSE.xml` — `slides/validator.py` `validate_course`
- `clm normalize-slides COURSE.xml` — `slides/normalizer.py` `normalize_course`
- `clm search-slides --course-spec` — scope and the `courses` membership field
- `clm resolve-topic --course-spec` (CLI + MCP) — `course_spec` scoping
- `clm authoring-rules --slide-path` — module-distinguishes which courses include a slide

### New helpers
- `SectionSpec.module_for(topic_spec) -> str | None` — single source of truth for "topic.module or section.module"
- `CourseSpec.iter_topic_bindings()` yielding `TopicBinding(section, topic_spec, effective_module)` triples
- `CourseSpec.topic_bindings() -> set[tuple[str, str | None]]` — module-aware companion to `get_course_topic_ids`
- `topic_resolver.matches_for_binding(topic_map, topic_id, module)` — shared filter helper
- `topic_resolver.resolve_topic(..., course_topic_bindings=...)` — module-aware scoping parameter (back-compat with `course_topic_ids`)

### Already-correct sites refactored to use the helpers
- `Course._build_topics` / `_resolve_topic_path` (build pipeline)
- `validate_spec` (full spec validator)

No user-visible behavior change in those — they share the same logic now.

## Test plan
- [x] 19 new tests in `tests/core/test_module_bindings.py` (helper unit tests) and `tests/slides/test_module_aware_consumers.py` (cohort-archive scenarios for each fixed consumer)
- [x] Full suite: 4546 passed, 4 xfailed
- [x] `ruff check` + `ruff format` clean
- [x] mypy clean (pre-commit gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)