### PR TITLE
Recordings Phase D: restore-take UI + correctness fixes

### DIFF
--- a/docs/claude/recordings-ux-followups-handover.md
+++ b/docs/claude/recordings-ux-followups-handover.md
@@ -282,40 +282,123 @@ same mental model: "next part" is always one click away.
 - Existing 740 recordings tests still pass; new HTML-render and
   /takes-route tests added.
 
-### Phase D — Restore-take UI [TODO]
+### Phase D — Restore-take UI [DESIGN LOCKED 2026-05-03]
 
 **Goal**: Expose the already-implemented
 `CourseRecordingState.restore_take` to the user. Depends on Phase C
 to have somewhere to put the control.
 
-**Open design questions**:
-- **Gesture**: single click vs. confirm modal?
-- **File handling**: does the UI request a backend swap (server-side
-  file moves), or is there a separate CLI/manual flow?
-- **After-swap display**: does the previously-active take show up
-  in the history with its old take number?
+**Design decisions (locked 2026-05-03)**:
+
+**Q1 — Gesture**: Two-step in-panel. First click on Restore morphs
+the button to "Confirm restore"; second click commits. No native
+`confirm()` modal, no toast-only path. Cheap to implement (HTMX
+partial swap), reversible by clicking elsewhere or pressing
+`Escape`. Toast on success.
+
+**Q2 — Helper location**: New `_swap_active_with_take(...)` private
+helper next to `_demote_active_to_takes` in
+`src/clm/recordings/workflow/session.py`. Reuses
+`_scan_active_take_files`, `take_filename`, `takes_dir`, and
+`_classify_retake_source`. State stays pure-data (no method on
+`CourseRecordingState`).
+
+**Q3 — Atomicity / rollback**: Mirror the existing
+`_prepare_target_slot` pattern. Plan all `(src, dst)` moves up front
+(both directions: active → `takes/` and chosen-take → active
+filenames). Execute, recording each completed rename. On any
+exception mid-execution, replay the inverse on the partial list
+and re-raise without touching `state.json`. State mutation
+(`state.restore_take(...)` + JSON dump) runs **last**, only after
+all filesystem moves succeed.
+
+**Q4 — After-swap display + take-numbering invariant**:
+- Re-render chip strip + takes panel; take numbers are stable
+  identity, so they reappear with their original `K`. A transient
+  toast (`HX-Trigger: showToast`) confirms the action.
+- **Invariant**: a retake after a restore must allocate a fresh
+  take number — `max(active_take, max(takes[].take)) + 1` — never
+  reuse an existing one. The current `state.record_retake`
+  implementation uses `demoted.take + 1`, which would collide
+  after a restore (e.g. takes [1,2,3] with active=3, restore→1
+  makes active=1; a retake would compute 1+1=2, clobbering the
+  existing take 2). Phase D fixes this in `record_retake` and
+  adds an explicit interaction test.
+
+**Q5 — Restore button placement**: New rightmost action column in
+`partials/takes.html`'s takes table, beside "Open in Explorer".
+The Phase C placeholder slot (`restore_url_for=None`) becomes the
+hook.
+
+**Q6 — Armed/recording protection**: Restore button is disabled
+(and its column header replaced by an info note) whenever the
+deck row is armed or recording. The route handler returns 409
+Conflict if called against an armed deck — defense in depth.
+
+**Q7 — Route shape**:
+`POST /decks/{course}/{section}/{deck}/takes/{take}/restore?part=N`.
+Resourceful counterpart to the Phase C
+`GET /decks/.../takes` route. Returns the re-rendered takes panel
+plus an `HX-Trigger` event that refreshes the chip strip and
+shows the success toast.
 
 **What it accomplishes**:
 - Per-take "Restore" control that swaps the chosen take back to
   active, demoting the current active take to history.
 - Corresponding backend route that orchestrates
-  `state.restore_take(...)` plus the file moves on disk.
+  `state.restore_take(...)` plus the file moves on disk with
+  rollback on failure.
+- Fixes the `record_retake` numbering collision so retake after
+  restore allocates a fresh take number.
 
 **Files likely involved**:
-- `src/clm/recordings/web/routes.py` (new restore route)
-- `src/clm/recordings/web/templates/partials/parts.html`
-- `src/clm/recordings/workflow/session.py` or a new helper for the
-  file swap (design decision: where does swap logic live?)
+- `src/clm/recordings/state.py` — fix `record_retake` numbering
+  to `max(active_take, max(takes[].take)) + 1`.
+- `src/clm/recordings/workflow/session.py` — new
+  `_swap_active_with_take` helper with planned-rename rollback.
+- `src/clm/recordings/web/routes.py` — new
+  `POST /decks/{course}/{section}/{deck}/takes/{take}/restore`
+  route; passes a real `restore_url_for` callable into the takes
+  partial.
+- `src/clm/recordings/web/templates/partials/takes.html` — add
+  Restore action column with two-step morph.
+- `src/clm/recordings/web/static/app.css` — `.btn-restore`,
+  `.btn-restore-confirm` two-state styling.
+- `src/clm/recordings/web/templates/base.html` — toast handler
+  bound to the `showToast` HX-Trigger event.
+- Tests:
+  - `tests/recordings/test_state.py::test_retake_after_restore_does_not_collide`
+    — locks the numbering invariant.
+  - `tests/recordings/test_session.py::test_swap_active_with_take_*`
+    — happy path, raw-only, final-only, missing target.
+  - `tests/recordings/test_session.py::test_swap_active_with_take_rolls_back_on_failure`
+    — patch `shutil.move` to raise mid-way; assert filesystem
+    and state are untouched.
+  - `tests/recordings/test_web.py::test_restore_route_*` — 200
+    happy path returns refreshed partial; 409 when armed; 404
+    when take missing.
+  - Manual smoke (per CLAUDE.md UI rule): record → record retake
+    → restore take 1 → record another retake; confirm chip strip
+    flips, history shows fresh take number, no clobber.
 
-**Reference**: `recordings-parts-and-takes.md` §10 step 5.
+**Reference**: `recordings-parts-and-takes.md` §10 step 5, §11
+("When restoring a take, do we keep the current active as a new
+take, or discard it?" — Phase D adopts the design doc's lean:
+always keep, restore is a swap).
 
 **Acceptance criteria**:
-- Clicking "Restore take K" on a part with multiple takes updates
-  both `state.json` and the filesystem atomically (or rolls back on
-  failure).
+- Clicking "Restore" on a take morphs to "Confirm restore"; second
+  click commits, swapping `state.json` and filesystem atomically
+  (rolls back on failure).
 - Final and archive files for the restored take become the active
   files; previously active files move to `takes/` with their own
-  suffix.
+  suffix and original take number.
+- A retake after a restore allocates a take number strictly
+  greater than every existing take in `state.json` — no overwrite.
+- Restore button is disabled and the route returns 409 while the
+  deck is armed or recording.
+- Existing 786 recordings tests still pass; new state, session,
+  and web-route tests added.
 
 ### Phase E — Cut-list artifact versioning on retake [TODO]
 
@@ -392,9 +475,10 @@ so the history in `takes/` is complete.
   App Hardening PR #42 on 2026-04-19; Phase C shipped on
   branch `claude/recordings-ux-followups-c-parts-inline`,
   2026-05-03).
-- **In progress**: None.
-- **Blocked on**: User review + design decisions listed under each
-  remaining phase's "Open design questions" (D, E, F).
+- **Design locked**: Phase D (2026-05-03) — ready for implementation.
+- **In progress**: Phase D (Restore-take UI) — implementation
+  starting on `worktree-recordings-ux-phase-c-design`.
+- **Blocked on**: User review + design decisions for Phases E and F.
 - **Tests baseline**: 786 recordings tests green at the end of
   Phase C (2026-05-03).
 
@@ -405,10 +489,10 @@ body above. Resolve these before opening an implementation branch.
 
 | Phase | Question | Status |
 |---|---|---|
-| D | Gesture: single click vs. confirm modal? | OPEN |
-| D | Where does the file-swap helper live (session.py vs new helper)? | OPEN |
-| D | Should backend file moves be atomic with `state.restore_take`, or two-phase with rollback? | OPEN |
-| D | After-swap display: does the previously-active take reappear in history with a new take number? | OPEN |
+| D | Gesture: single click vs. confirm modal? | LOCKED — two-step in-panel |
+| D | Where does the file-swap helper live (session.py vs new helper)? | LOCKED — `_swap_active_with_take` in `session.py` |
+| D | Should backend file moves be atomic with `state.restore_take`, or two-phase with rollback? | LOCKED — planned-rename rollback, state mutation last |
+| D | After-swap display: does the previously-active take reappear in history with a new take number? | LOCKED — stable take numbers + retake-after-restore numbering invariant |
 | E | Concrete sidecar file-extension list (EDL only? FCP XML? subtitles?) | OPEN |
 | E | Discovery strategy: glob beside the video/wav, or a known sidecar subdir? | OPEN |
 | E | Backend-specific scanner (Auphonic only) vs. generic in `session.py`? | OPEN |
@@ -420,9 +504,17 @@ body above. Resolve these before opening an implementation branch.
 
 ## 5. Next Steps
 
-1. **Phase D** (Restore-take UI) is the natural next step now that
-   Phase C's chip strip and take-history panel exist as anchor
-   points. Open design questions still need answers — see §3 Phase D.
+1. **Implement Phase D** on this worktree
+   (`worktree-recordings-ux-phase-c-design`). Design is locked —
+   see §3 Phase D above. Implementation order:
+   1. Fix `record_retake` numbering invariant + add
+      `test_retake_after_restore_does_not_collide`.
+   2. Add `_swap_active_with_take` helper with rollback +
+      session-level tests.
+   3. Add `POST .../takes/{take}/restore` route + web-route tests.
+   4. Wire `restore_url_for` callable through the takes partial;
+      add Restore-button two-step morph + CSS.
+   5. Manual smoke per the acceptance criteria.
 2. **Phases E and F** are independent; schedule by urgency.
 3. **Re-run the phase-check skill** after each phase ships; update
    this handover's Status section.
@@ -437,7 +529,7 @@ areas this follow-up set touches that weren't already mapped:
 | `src/clm/cli/commands/recordings.py` | Recordings subcommand group | F |
 | `src/clm/cli/info_topics/commands.md` | Version-accurate CLI docs (mandatory update) | F |
 | `src/clm/recordings/web/templates/partials/parts.html` *(new)* | Per-part chip rendering | C, D |
-| `src/clm/recordings/web/templates/partials/takes.html` *(new)* | Inline take-history panel | C |
+| `src/clm/recordings/web/templates/partials/takes.html` *(new)* | Inline take-history panel | C, D |
 
 ## 7. Testing Approach
 
@@ -465,11 +557,16 @@ decisions that a developer cannot make unilaterally:
 - Phase E: domain discovery (which sidecar formats exist).
 
 Phase C's design questions were locked in a Q1–Q8 walkthrough on
-2026-05-03 — see §3 Phase C above for the answers.
+2026-05-03 — see §3 Phase C above for the answers. Phase D's
+questions were locked in a Q1–Q7 walkthrough on the same day; the
+user added the take-numbering invariant under Q4 (a retake after
+restore must allocate `max(active_take, max(takes[].take)) + 1`
+to avoid clobbering existing history).
 
 ---
 
-**Last updated**: 2026-05-03 (Phase C shipped: chip strip + inline
-take-history panel + /takes route; 786 recordings tests green).
-**Next action**: Phases D, E, F still need their design questions
-answered before implementation. Phase D is the natural next step.
+**Last updated**: 2026-05-03 (Phase D design locked; Phase C
+shipped earlier the same day — chip strip + inline take-history
+panel + /takes route; 786 recordings tests green).
+**Next action**: Implement Phase D on this worktree. See §5
+Next Steps for the implementation order.

--- a/src/clm/recordings/state.py
+++ b/src/clm/recordings/state.py
@@ -357,7 +357,7 @@ class CourseRecordingState(BaseModel):
         )
         part.takes.append(demoted)
 
-        part.active_take = demoted.take + 1
+        part.active_take = max(t.take for t in part.takes) + 1
         part.raw_file = new_raw_file
         part.processed_file = new_processed_file
         part.git_commit = git_commit

--- a/src/clm/recordings/web/app.py
+++ b/src/clm/recordings/web/app.py
@@ -353,6 +353,23 @@ def create_app(
 
     app.state.templates = Jinja2Templates(directory=str(templates_dir))
 
+    def _format_mtime(value: float | int | None) -> str:
+        """Render a POSIX timestamp as ``YYYY-MM-DD HH:MM`` in local time.
+
+        Used by the take-history panel so the Recorded column shows a
+        human-readable datetime instead of a raw integer.
+        """
+        from datetime import datetime
+
+        if value is None:
+            return "—"
+        try:
+            return datetime.fromtimestamp(float(value)).strftime("%Y-%m-%d %H:%M")
+        except (OSError, ValueError):
+            return "—"
+
+    app.state.templates.env.filters["mtime"] = _format_mtime
+
     if static_dir.is_dir():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -102,6 +102,88 @@ def _resolve_lecture_id(section_name: str, deck_name: str) -> str:
     return f"{section_name}::{deck_name}"
 
 
+def _scan_active_take_for_panel(
+    *,
+    root,
+    course_slug: str,
+    section_name: str,
+    deck_name: str,
+    part: int,
+    raw_suffix: str,
+):
+    """Build a ``TakeFileInfo`` for the active (unsuffixed) take from disk.
+
+    Returns ``None`` when neither a raw nor a final file exists for
+    this (deck, part) — i.e. nothing has been recorded yet. The take
+    number is left at ``0`` and the route handler patches it from
+    ``state.json``; filesystem alone can't reveal the right number
+    after a restore (the active slot's filename has no take suffix).
+    """
+    from clm.core.utils.text_utils import sanitize_file_name
+    from clm.recordings.processing.batch import VIDEO_EXTENSIONS
+    from clm.recordings.workflow.deck_status import TakeFileInfo
+    from clm.recordings.workflow.directories import (
+        archive_dir,
+        final_dir,
+        to_process_dir,
+    )
+    from clm.recordings.workflow.naming import parse_part, parse_raw_stem
+
+    sanitized = sanitize_file_name(deck_name)
+    rel = f"{sanitize_file_name(course_slug)}/{sanitize_file_name(section_name)}"
+
+    raw_path = None
+    raw_mtime: float | None = None
+    for base_dir in (to_process_dir(root), archive_dir(root)):
+        subtree = base_dir / rel
+        if not subtree.is_dir():
+            continue
+        for child in subtree.iterdir():
+            if not child.is_file() or child.suffix.lower() not in VIDEO_EXTENSIONS:
+                continue
+            base_with, is_raw = parse_raw_stem(child.stem, raw_suffix)
+            if not is_raw:
+                continue
+            base, p = parse_part(base_with)
+            if base != sanitized or p != part:
+                continue
+            raw_path = child
+            try:
+                raw_mtime = child.stat().st_mtime
+            except OSError:
+                pass
+            break
+        if raw_path is not None:
+            break
+
+    final_path = None
+    final_mtime: float | None = None
+    final_subtree = final_dir(root) / rel
+    if final_subtree.is_dir():
+        for child in final_subtree.iterdir():
+            if not child.is_file() or child.suffix.lower() not in VIDEO_EXTENSIONS:
+                continue
+            base, p = parse_part(child.stem)
+            if base == sanitized and p == part:
+                final_path = child
+                try:
+                    final_mtime = child.stat().st_mtime
+                except OSError:
+                    pass
+                break
+
+    if raw_path is None and final_path is None:
+        return None
+
+    recorded_at = max(m for m in (raw_mtime, final_mtime) if m is not None)
+    return TakeFileInfo(
+        take=0,
+        raw_path=raw_path,
+        final_path=final_path,
+        recorded_at=recorded_at,
+    )
+
+
 def _get_or_load_course_state(request: Request, course_slug: str) -> CourseRecordingState:
     """Return the cached :class:`CourseRecordingState` for *course_slug*.
 
@@ -499,11 +581,23 @@ async def deck_takes(
     """Return the inline take-history panel for ``(course, section, deck, part)``.
 
     Lazy-fetched by the chip strip in the lectures UI. The panel
-    renders one row per superseded take found under
+    renders the active take as the first row (badged "Active") so the
+    user has a single place for every take's metadata and Open
+    affordance, followed by one row per superseded take from
     ``takes/<course>/<section>/`` matching the deck and part. The
-    Restore action is intentionally absent — that ships with Phase D.
+    Restore button on history rows is disabled when the session has
+    this exact deck armed/recording (defense in depth alongside the
+    409 returned by the restore route).
+
+    Filesystem is the source of truth for the active row's paths and
+    status — the manual ``/process`` flow doesn't update
+    ``state.json`` so a state-only view would still show ``recorded``
+    after Auphonic finished. We scan ``to-process/``, ``archive/`` and
+    ``final/`` for files in the unsuffixed (active) slot and only fall
+    back to ``state.json`` for the take number, which is the one
+    thing the filesystem can't tell us correctly post-restore.
     """
-    from clm.recordings.workflow.deck_status import scan_take_files
+    from clm.recordings.workflow.deck_status import TakeFileInfo, scan_take_files
 
     templates = _get_templates(request)
     root = request.app.state.recordings_root
@@ -516,6 +610,45 @@ async def deck_takes(
         part=part,
         raw_suffix=raw_suffix,
     )
+    session = _get_session(request)
+    armed = session.armed_deck
+    panel_locked = (
+        armed is not None
+        and armed.course_slug == course_slug
+        and armed.section_name == section_name
+        and armed.deck_name == deck_name
+    )
+
+    active = _scan_active_take_for_panel(
+        root=root,
+        course_slug=course_slug,
+        section_name=section_name,
+        deck_name=deck_name,
+        part=part,
+        raw_suffix=raw_suffix,
+    )
+    if active is not None:
+        # Take number lives in state.json — filesystem can't recover it
+        # post-restore. Falls back to None when no state exists, which
+        # the template renders as a "?" placeholder.
+        course_state = _get_or_load_course_state(request, course_slug)
+        state_part = part if part > 0 else 1
+        lecture = course_state.get_lecture(_resolve_lecture_id(section_name, deck_name))
+        part_obj = (
+            next((p for p in lecture.parts if p.part == state_part), None)
+            if lecture is not None
+            else None
+        )
+        if part_obj is not None:
+            active = TakeFileInfo(
+                take=part_obj.active_take,
+                raw_path=active.raw_path,
+                final_path=active.final_path,
+                raw_size=active.raw_size,
+                final_size=active.final_size,
+                recorded_at=active.recorded_at,
+            )
+
     return templates.TemplateResponse(
         request,
         "partials/takes.html",
@@ -525,8 +658,135 @@ async def deck_takes(
             "deck_name": deck_name,
             "part": part,
             "takes": takes,
+            "active": active,
+            "panel_locked": panel_locked,
+            "restore_url_for": lambda t: (
+                f"/decks/{course_slug}/{section_name}/{deck_name}/takes/{t.take}/restore?part={part}"
+            ),
         },
     )
+
+
+@router.post(
+    "/decks/{course_slug}/{section_name}/{deck_name}/takes/{take}/restore",
+    response_class=HTMLResponse,
+)
+async def restore_take(
+    request: Request,
+    course_slug: str,
+    section_name: str,
+    deck_name: str,
+    take: int,
+    part: int = 0,
+):
+    """Promote historical take *take* back to active for ``(deck, part)``.
+
+    Runs :meth:`RecordingSession.restore_take`, which performs the
+    filesystem swap with planned-rename rollback and updates the
+    course-state index. The previously active take becomes a history
+    entry under its existing take number, so a subsequent retake on the
+    restored slot allocates a fresh take number rather than clobbering
+    history.
+
+    Returns the lectures-page refresh response so the chip strip and
+    take history panel reflect the new active take.
+
+    Status codes:
+    - 200: Restore completed.
+    - 404: ``take`` does not exist for this part, or the part has no
+      state record.
+    - 409: Session is busy (recording, paused, or renaming).
+    """
+    session = _get_session(request)
+    lang = _get_lang(request)
+    lecture_id = _resolve_lecture_id(section_name, deck_name)
+    try:
+        session.restore_take(
+            course_slug,
+            section_name,
+            deck_name,
+            take,
+            part_number=part,
+            lang=lang,
+            lecture_id=lecture_id,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (ValueError, FileNotFoundError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    _push_notice(
+        request,
+        "success",
+        f"Restored take {take} for {deck_name}",
+    )
+
+    if _from_lectures(request):
+        return _lectures_refresh_response()
+    return await status_partial(request)
+
+
+# ------------------------------------------------------------------
+# Open in OS file browser (replacement for blocked file:/// links)
+# ------------------------------------------------------------------
+
+
+@router.post("/open-explorer", response_class=HTMLResponse)
+async def open_explorer(request: Request, path: str = Form(...)):
+    """Open the OS file browser pointed at *path* (file selected).
+
+    Replaces ``<a href="file:///...">`` from the take-history panel —
+    modern browsers refuse to follow ``file://`` links from an
+    ``http://`` origin, so the Open button needs a server-side
+    detour. The path must resolve under the configured recordings
+    root (defense against an attacker submitting an arbitrary path
+    via a forged form).
+
+    On Windows we use ``explorer /select,<path>`` so the file is
+    pre-selected; macOS uses ``open -R``; Linux falls back to
+    ``xdg-open`` on the parent directory (no built-in "select"
+    semantics across desktops).
+    """
+    import subprocess
+    import sys
+    from pathlib import Path as _Path
+
+    target = _Path(path)
+    try:
+        target_resolved = target.resolve(strict=True)
+    except (OSError, FileNotFoundError) as exc:
+        raise HTTPException(status_code=404, detail=f"Path not found: {path}") from exc
+
+    root = _Path(request.app.state.recordings_root).resolve()
+    try:
+        target_resolved.relative_to(root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Path is outside the recordings root") from exc
+
+    try:
+        if sys.platform == "win32":
+            # explorer.exe parses its own command line and is finicky:
+            # passing ``["/select,", path]`` via the argv list inserts a
+            # space after the comma, which makes Explorer fall back to
+            # opening Documents instead of selecting the file. The
+            # documented workaround is to pass a single command string
+            # with the path quoted inline. ``resolve(strict=True)``
+            # above guarantees the path is absolute and points at an
+            # existing file under the recordings root, and Windows
+            # disallows ``"`` in filenames, so embedding the path in
+            # double quotes is safe here.
+            subprocess.Popen(  # noqa: S603 - explorer is trusted, path is validated
+                f'explorer /select,"{target_resolved}"'
+            )
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", "-R", str(target_resolved)])  # noqa: S603, S607
+        else:
+            subprocess.Popen(["xdg-open", str(target_resolved.parent)])  # noqa: S603, S607
+    except Exception as exc:
+        logger.warning("Failed to open file browser for {}: {}", target_resolved, exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return HTMLResponse("")
 
 
 # ------------------------------------------------------------------

--- a/src/clm/recordings/web/static/app.css
+++ b/src/clm/recordings/web/static/app.css
@@ -650,6 +650,59 @@ footer {
     font-size: var(--t-xs);
 }
 
+/* Restore-take button: two-state morph. The base style mirrors
+   `.btn-ghost`; when `.btn-restore-confirm` is added (after the first
+   click), the button visually escalates to a warning palette so the
+   user clearly notices the state change before clicking again. */
+.btn-restore {
+    background: transparent;
+    border: 1px solid var(--c-border);
+    color: var(--c-fg);
+}
+.btn-restore:hover:not(:disabled) {
+    background: var(--c-bg-soft);
+}
+.btn-restore-confirm {
+    background: var(--c-warn-bg, #fff3cd);
+    border-color: var(--c-warn-border, #ffeaa7);
+    color: var(--c-warn-fg, #664d03);
+    font-weight: 600;
+}
+.btn-restore-confirm:hover {
+    background: var(--c-warn-bg-hover, #ffeaa7);
+}
+.takes-locked-note {
+    color: var(--c-fg-muted);
+    font-size: var(--t-xs);
+    font-style: italic;
+}
+
+/* Active take row in the panel — visually distinct from history.
+   The badge uses a slightly bolder palette and the row gets a left
+   accent so it reads as "current" at a glance. */
+.take-row-active {
+    background: var(--c-bg-soft, #f6faff);
+    box-shadow: inset 3px 0 0 var(--c-accent, #2563eb);
+}
+.badge-active {
+    background: var(--c-accent, #2563eb);
+    color: #fff;
+    font-weight: 700;
+}
+.take-active-label {
+    color: var(--c-accent, #2563eb);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    margin-left: var(--s-1);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.take-active-marker {
+    color: var(--c-fg-muted);
+    font-size: var(--t-xs);
+    font-style: italic;
+}
+
 /* Lectures table: deck actions row */
 .deck-actions {
     display: flex;

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -315,6 +315,58 @@
         }
     });
 
+    /* Restore-take button: two-step morph.
+       First click on a `.btn-restore` swaps the button into a confirm
+       state (text → "Confirm restore", `.btn-restore-confirm` class
+       added). A second click commits via HTMX POST. Clicking elsewhere
+       or pressing Escape cancels. The success path shows a toast via
+       the existing notice SSE bridge — the restore route calls
+       `_push_notice("success", ...)` which arrives as an SSE event. */
+    function _resetRestoreButtons(except) {
+        document.querySelectorAll('.btn-restore.btn-restore-confirm').forEach(function (btn) {
+            if (btn === except) return;
+            btn.classList.remove('btn-restore-confirm');
+            var idle = btn.querySelector('[data-restore-label-idle]');
+            var confirm = btn.querySelector('[data-restore-label-confirm]');
+            if (idle) idle.hidden = false;
+            if (confirm) confirm.hidden = true;
+        });
+    }
+    document.addEventListener('click', function (evt) {
+        var btn = evt.target.closest('.btn-restore');
+        if (!btn) {
+            _resetRestoreButtons(null);
+            return;
+        }
+        if (btn.disabled) return;
+        evt.preventDefault();
+        if (btn.classList.contains('btn-restore-confirm')) {
+            // Second click — commit.
+            var url = btn.getAttribute('data-restore-url');
+            if (!url || !window.htmx) return;
+            window.htmx.ajax('POST', url, {
+                source: btn,
+                target: 'body',
+                swap: 'none'
+            });
+            _resetRestoreButtons(null);
+        } else {
+            // First click — morph to confirm. Reset other confirming buttons.
+            _resetRestoreButtons(btn);
+            btn.classList.add('btn-restore-confirm');
+            var idle = btn.querySelector('[data-restore-label-idle]');
+            var confirm = btn.querySelector('[data-restore-label-confirm]');
+            if (idle) idle.hidden = true;
+            if (confirm) confirm.hidden = false;
+            btn.focus();
+        }
+    });
+    document.addEventListener('keydown', function (evt) {
+        if (evt.key === 'Escape') {
+            _resetRestoreButtons(null);
+        }
+    });
+
     /* Take-history reveal: right-click a chip to toggle the inline
        panel below the deck row. Lazy-fetched from
        GET /decks/{course}/{section}/{deck}/takes. */

--- a/src/clm/recordings/web/templates/partials/parts.html
+++ b/src/clm/recordings/web/templates/partials/parts.html
@@ -3,8 +3,8 @@
    Inputs:
      deck            — the dict assembled in routes.lectures (deck_name,
                        display_name, status, …).
-     section_name    — the section's display name (used as the
-                       sessionStorage selection key).
+     section         — the parent section (used for ``section.name`` as
+                       the sessionStorage selection key).
      course_slug     — the course's output_dir_name for the active lang.
      is_armed        — whether this deck is the currently armed/recording
                        deck (used to disable selection clicks).
@@ -40,7 +40,7 @@
      role="tablist"
      aria-label="Parts for {{ deck.deck_name }}"
      data-chip-strip
-     data-deck-key="{{ course_slug }}::{{ section_name }}::{{ deck.deck_name }}"
+     data-deck-key="{{ course_slug }}::{{ section.name }}::{{ deck.deck_name }}"
      data-default-part="{{ next_part }}"
      {% if is_armed %}data-armed-part="{{ armed_part }}"{% endif %}>
     {% for ps in parts_status %}

--- a/src/clm/recordings/web/templates/partials/takes.html
+++ b/src/clm/recordings/web/templates/partials/takes.html
@@ -9,11 +9,72 @@
    Inputs:
      deck_name        — original (un-sanitized) deck name; rendered in the header
      part             — part number this panel is showing
-     takes            — list of TakeFileInfo
-     restore_url_for  — callable(take) → URL placeholder for the Phase D
-                        Restore button. None in Phase C — the action is
-                        deferred so we render a disabled informational note.
+     active           — ``TakeFileInfo`` for the active take, or None when
+                        no state record exists for this part (the panel
+                        then renders only superseded history).
+     takes            — list of TakeFileInfo for superseded takes
+     panel_locked     — True when the session has this exact deck armed/
+                        recording. Restore buttons render disabled and
+                        the column header is replaced by an info note.
+     restore_url_for  — callable(take) → URL for the restore POST.
 #}
+{% macro take_row(take, is_active, panel_locked, restore_url_for) -%}
+{% set explorer_path = take.final_path or take.raw_path %}
+<tr {% if is_active %}class="take-row-active" title="Active take — currently in to-process/archive/final"{% else %}title="Superseded take — preserved in takes/"{% endif %}>
+    <td>
+        <span class="badge {% if is_active %}badge-active{% else %}badge-armed{% endif %}">
+            {{ take.take if take.take else '?' }}
+        </span>
+        {% if is_active %}<span class="take-active-label">active</span>{% endif %}
+    </td>
+    <td>
+        <span class="badge badge-{% if take.kind == 'processed' %}completed{% else %}recorded{% endif %}">
+            {{ take.kind }}
+        </span>
+    </td>
+    <td><code class="take-stem">{{ take.display_stem }}</code></td>
+    <td class="take-mtime"
+        {% if take.recorded_at %}data-mtime="{{ take.recorded_at | int }}"
+        title="Unix epoch {{ take.recorded_at | int }}"{% endif %}>
+        {{ take.recorded_at | mtime }}
+    </td>
+    <td>
+        {% if explorer_path %}
+        <form hx-post="/open-explorer" hx-swap="none" class="u-inline">
+            <input type="hidden" name="path" value="{{ explorer_path }}">
+            <button type="submit" class="btn btn-sm btn-ghost"
+                    title="Open in Explorer (file pre-selected)">
+                Open
+            </button>
+        </form>
+        {% endif %}
+    </td>
+    <td>
+        {% if is_active %}
+        <span class="take-active-marker"
+              title="This is the active take — restore from a history row to swap.">
+            current
+        </span>
+        {% else %}
+        {% set restore_url = restore_url_for(take) if restore_url_for else None %}
+        {% if restore_url %}
+        <button type="button"
+                class="btn btn-sm btn-restore"
+                data-restore-url="{{ restore_url }}"
+                data-take="{{ take.take }}"
+                {% if panel_locked %}disabled aria-disabled="true"
+                title="Disarm or stop recording first."
+                {% else %}
+                title="Restore this take as the active recording."
+                {% endif %}>
+            <span data-restore-label-idle>Restore</span>
+            <span data-restore-label-confirm hidden>Confirm restore</span>
+        </button>
+        {% endif %}
+        {% endif %}
+    </td>
+</tr>
+{%- endmacro %}
 <tr class="takes-row"
     data-takes-panel
     data-deck-key="{{ course_slug }}::{{ section_name }}::{{ deck_name }}"
@@ -34,10 +95,9 @@
                     Close
                 </button>
             </div>
-            {% if not takes %}
+            {% if not active and not takes %}
             <p class="takes-empty">
-                Only the active take exists. Superseded takes (after
-                a retake) appear here.
+                No takes recorded yet for this part.
             </p>
             {% else %}
             <table class="takes-table">
@@ -48,33 +108,24 @@
                         <th>File</th>
                         <th>Recorded</th>
                         <th></th>
+                        <th>
+                            {% if panel_locked %}
+                            <span class="takes-locked-note"
+                                  title="Restore is unavailable while this deck is armed or recording.">
+                                Locked
+                            </span>
+                            {% else %}
+                            Action
+                            {% endif %}
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
+                    {% if active %}
+                    {{ take_row(active, True, panel_locked, restore_url_for) }}
+                    {% endif %}
                     {% for take in takes %}
-                    <tr>
-                        <td><span class="badge badge-armed">{{ take.take }}</span></td>
-                        <td>
-                            <span class="badge badge-{% if take.kind == 'processed' %}completed{% else %}recorded{% endif %}">
-                                {{ take.kind }}
-                            </span>
-                        </td>
-                        <td><code class="take-stem">{{ take.display_stem }}</code></td>
-                        <td class="take-mtime"
-                            {% if take.recorded_at %}data-mtime="{{ take.recorded_at | int }}"{% endif %}>
-                            {% if take.recorded_at %}{{ take.recorded_at | int }}{% else %}—{% endif %}
-                        </td>
-                        <td>
-                            {% set explorer_path = take.final_path or take.raw_path %}
-                            {% if explorer_path %}
-                            <a href="file:///{{ explorer_path | string | replace('\\', '/') }}"
-                               class="btn btn-sm btn-ghost"
-                               title="Open in Explorer">
-                                Open
-                            </a>
-                            {% endif %}
-                        </td>
-                    </tr>
+                    {{ take_row(take, False, panel_locked, restore_url_for) }}
                     {% endfor %}
                 </tbody>
             </table>

--- a/src/clm/recordings/workflow/deck_status.py
+++ b/src/clm/recordings/workflow/deck_status.py
@@ -260,7 +260,7 @@ def scan_section_takes(
     sanitized_to_name = {sanitize_file_name(n): n for n in deck_names}
     out: dict[str, dict[int, set[int]]] = {n: {} for n in deck_names}
 
-    subtree = takes_dir(root) / course_slug / section_name
+    subtree = takes_dir(root) / sanitize_file_name(course_slug) / sanitize_file_name(section_name)
     if not subtree.is_dir():
         return {n: {} for n in deck_names}
 
@@ -336,7 +336,7 @@ def scan_take_files(
     from clm.recordings.processing.batch import VIDEO_EXTENSIONS
 
     sanitized = sanitize_file_name(deck_name)
-    subtree = takes_dir(root) / course_slug / section_name
+    subtree = takes_dir(root) / sanitize_file_name(course_slug) / sanitize_file_name(section_name)
     if not subtree.is_dir():
         return []
 

--- a/src/clm/recordings/workflow/session.py
+++ b/src/clm/recordings/workflow/session.py
@@ -193,9 +193,11 @@ def _scan_active_take_files(
 
     Returns a list of existing paths across ``to-process/``, ``archive/``,
     and ``final/`` that would collide with a new recording of the same
-    part. Includes both video and companion ``.wav`` files in the raw
-    directories. For ``final/`` the extension is not known a priori, so
-    any video-extension file matching the deck+part slot is returned.
+    part. Anchors on the video file in each location and then sweeps in
+    every sibling that shares its stem — picks up companions like the
+    raw ``.wav`` and the final ``.edl`` cut list, and any future sidecar
+    Auphonic emits (``.vtt``/``.srt``/``.json``/``.html``) without
+    needing a hard-coded extension list.
 
     Files are returned in a deterministic order for reproducibility.
     """
@@ -204,17 +206,17 @@ def _scan_active_take_files(
     sanitized = sanitize_file_name(deck_name)
     result: list[Path] = []
 
-    # Raw candidates in to-process/ and archive/. Filter by extension —
-    # both the video and the companion .wav share the ``--RAW`` stem so
-    # a generic scan can't distinguish them on its own.
+    # Raw candidates in to-process/ and archive/. Anchor on the --RAW
+    # video file matching deck+part, then collect every sibling that
+    # shares its stem (the .wav companion today; future raw sidecars
+    # tomorrow).
     for base_dir in (to_process_dir(recordings_root), archive_dir(recordings_root)):
         subtree = base_dir / rel_dir
         if not subtree.is_dir():
             continue
+        anchor_stems: set[str] = set()
         for child in subtree.iterdir():
-            if not child.is_file():
-                continue
-            if child.suffix.lower() not in VIDEO_EXTENSIONS:
+            if not child.is_file() or child.suffix.lower() not in VIDEO_EXTENSIONS:
                 continue
             base_with, is_raw = parse_raw_stem(child.stem, raw_suffix)
             if not is_raw:
@@ -222,22 +224,27 @@ def _scan_active_take_files(
             base, p = parse_part(base_with)
             if base != sanitized or p != part:
                 continue
-            result.append(child)
-            wav = child.with_suffix(".wav")
-            if wav.is_file():
-                result.append(wav)
+            anchor_stems.add(child.stem)
+        if anchor_stems:
+            for child in subtree.iterdir():
+                if child.is_file() and child.stem in anchor_stems:
+                    result.append(child)
 
-    # Final/ candidate — must scan because we don't know the extension.
+    # Final/: anchor on the video, then sweep every sibling sharing its
+    # stem (the Auphonic .edl, future .vtt/.srt/.json/.html outputs).
     final_subtree = final_dir(recordings_root) / rel_dir
     if final_subtree.is_dir():
+        anchor_stems = set()
         for child in final_subtree.iterdir():
-            if not child.is_file():
-                continue
-            if child.suffix.lower() not in VIDEO_EXTENSIONS:
+            if not child.is_file() or child.suffix.lower() not in VIDEO_EXTENSIONS:
                 continue
             base, p = parse_part(child.stem)
             if base == sanitized and p == part:
-                result.append(child)
+                anchor_stems.add(child.stem)
+        if anchor_stems:
+            for child in final_subtree.iterdir():
+                if child.is_file() and child.stem in anchor_stems:
+                    result.append(child)
 
     return result
 
@@ -259,15 +266,23 @@ def _preserve_active_take(
     part: int,
     raw_suffix: str,
     lang: str,
+    take_number: int | None = None,
 ) -> list[tuple[Path, Path]]:
     """Move the active take's files into ``takes/`` with ``(part N, take K)`` suffixes.
 
     Returns the list of ``(old_path, new_path)`` pairs actually performed.
     If no active-take files are present, returns an empty list.
 
-    The take number is chosen as ``max(existing_takes_for_part) + 1`` and
-    applied uniformly across all files moved in this call so that the
-    historical raw + final pair keeps the same ``K``.
+    When *take_number* is given (recommended path: caller has access to
+    ``state.json``'s ``active_take`` for this part), the demoted files
+    use that exact ``K`` so the filename matches the take's stable
+    identity. After a restore-then-retake sequence, the filesystem max
+    diverges from the state's view (state still calls the restored take
+    "1" while ``takes/`` already holds "(take 2)"), so trusting the FS
+    heuristic would produce a "(take 3)" filename for what state names
+    take 1 — breaking the take-number-as-identity invariant. Callers
+    without state access (CLI flows) fall back to the FS heuristic
+    ``max(existing_takes_for_part) + 1``.
     """
     files = _scan_active_take_files(
         recordings_root=recordings_root,
@@ -281,7 +296,8 @@ def _preserve_active_take(
         return []
 
     takes_subtree = takes_dir(recordings_root) / rel_dir
-    take_number = _next_take_number(takes_subtree, deck_name, part)
+    if take_number is None:
+        take_number = _next_take_number(takes_subtree, deck_name, part)
     takes_subtree.mkdir(parents=True, exist_ok=True)
 
     renames: list[tuple[Path, Path]] = []
@@ -331,6 +347,172 @@ def _preserve_active_take(
         renames.append((src, dest))
 
     return renames
+
+
+def _scan_takes_for(
+    takes_subtree: Path,
+    deck_name: str,
+    part: int,
+    take: int,
+    raw_suffix: str,
+) -> tuple[list[Path], list[Path]]:
+    """Find all files in *takes_subtree* belonging to the given (deck, part, take).
+
+    Returns ``(raw_files, final_files)``. Raw files have the ``--RAW`` suffix
+    in their stem (video + companion ``.wav`` share the stem and both end up
+    here); final files have no raw suffix. Either list may be empty when only
+    one variant was preserved.
+    """
+    raw_files: list[Path] = []
+    final_files: list[Path] = []
+    if not takes_subtree.is_dir():
+        return raw_files, final_files
+
+    sanitized = sanitize_file_name(deck_name)
+    for child in takes_subtree.iterdir():
+        if not child.is_file():
+            continue
+        base_with, is_raw = parse_raw_stem(child.stem, raw_suffix)
+        base, p, k = parse_part_take(base_with if is_raw else child.stem)
+        if base != sanitized or p != part or k != take:
+            continue
+        (raw_files if is_raw else final_files).append(child)
+    return raw_files, final_files
+
+
+def _swap_active_with_take(
+    *,
+    recordings_root: Path,
+    rel_dir: str,
+    deck_name: str,
+    part: int,
+    active_take: int,
+    target_take: int,
+    raw_suffix: str = DEFAULT_RAW_SUFFIX,
+    lang: str = "en",
+) -> list[tuple[Path, Path]]:
+    """Swap the active take's files with the historical take *target_take*.
+
+    The active take's files (raw in ``to-process/`` or ``archive/`` plus a
+    companion ``.wav``; final in ``final/``) are moved into ``takes/`` with
+    a ``(part N, take active_take)`` suffix, while the target take's files
+    move out of ``takes/`` into the active slots:
+
+    * Target raw → ``archive/`` when a target-final exists in ``takes/``
+      (the take had been processed), else ``to-process/``. Companion
+      ``.wav`` goes alongside.
+    * Target final → ``final/``.
+
+    Whether the target take was previously processed is detected from
+    the filesystem (presence of a final-shaped file in ``takes/``) and
+    not from ``state.json`` — the manual ``/process`` route doesn't
+    update ``processed_file`` on the active part, so trusting state
+    here would dump processed raws back into ``to-process/`` and make
+    the chip flip back to amber after a restore.
+
+    Implements a planned-rename rollback: phase A moves active → takes/,
+    phase B moves takes/ → active. If any move fails, every completed
+    move (in either phase) is reversed in LIFO order before the original
+    exception is re-raised. If rollback itself fails, the rollback error
+    is logged and the original exception still propagates.
+
+    Raises:
+        FileNotFoundError: If no target-take files exist in ``takes/``.
+        FileExistsError: If a destination already exists at plan time.
+    """
+    takes_subtree = takes_dir(recordings_root) / rel_dir
+    target_raws, target_finals = _scan_takes_for(
+        takes_subtree, deck_name, part, target_take, raw_suffix
+    )
+    if not target_raws and not target_finals:
+        raise FileNotFoundError(
+            f"No files for take {target_take} of {deck_name} part {part} in {takes_subtree}"
+        )
+    # Filesystem-derived: a target final in takes/ means the take had
+    # been processed and its raw belongs back in archive/, not to-process/.
+    target_processed = bool(target_finals)
+
+    active_files = _scan_active_take_files(
+        recordings_root=recordings_root,
+        rel_dir=rel_dir,
+        deck_name=deck_name,
+        part=part,
+        raw_suffix=raw_suffix,
+        lang=lang,
+    )
+
+    # Phase A plan: active → takes/ with (part N, take active_take) suffix.
+    plan_a: list[tuple[Path, Path]] = []
+    takes_subtree.mkdir(parents=True, exist_ok=True)
+    for src in active_files:
+        kind = _classify_retake_source(src, recordings_root)
+        ext = src.suffix
+        is_raw = kind == "raw"
+        dst_name = take_filename(
+            deck_name,
+            ext=ext,
+            raw_suffix=raw_suffix,
+            part=part,
+            take=active_take,
+            is_raw=is_raw,
+            lang=lang,
+        )
+        plan_a.append((src, takes_subtree / dst_name))
+
+    # Phase B plan: target files (in takes/) → active slots.
+    raw_dest_dir = (
+        archive_dir(recordings_root) / rel_dir
+        if target_processed
+        else to_process_dir(recordings_root) / rel_dir
+    )
+    final_dest_dir = final_dir(recordings_root) / rel_dir
+    plan_b: list[tuple[Path, Path]] = []
+    for src in target_raws:
+        # Both the video and the companion ``.wav`` (same stem, different
+        # ext) get the active-slot raw name with their own extension.
+        dst_name = raw_filename(
+            deck_name, ext=src.suffix, raw_suffix=raw_suffix, part=part, lang=lang
+        )
+        plan_b.append((src, raw_dest_dir / dst_name))
+    for src in target_finals:
+        ext = src.suffix
+        dst_name = final_filename(deck_name, ext=ext, part=part, lang=lang)
+        plan_b.append((src, final_dest_dir / dst_name))
+
+    # Pre-flight: phase B destinations must be free *after* phase A runs,
+    # which happens iff each phase B destination is either empty now or
+    # only occupied by an active-take source we are about to move out.
+    phase_a_sources = {src for src, _ in plan_a}
+    for _src, dst in plan_b:
+        if dst.exists() and dst not in phase_a_sources:
+            raise FileExistsError(f"Destination {dst} is occupied by an unexpected file")
+    # Phase A destinations should never collide either.
+    for _src, dst in plan_a:
+        if dst.exists():
+            raise FileExistsError(f"Take slot {dst} already exists in takes/")
+
+    completed: list[tuple[Path, Path]] = []
+    try:
+        for src, dst in plan_a:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            logger.info("Demoted active → takes/: {} → {}", src.name, dst)
+            completed.append((src, dst))
+        for src, dst in plan_b:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            logger.info("Restored take {} → active: {} → {}", target_take, src.name, dst)
+            completed.append((src, dst))
+    except Exception:
+        for src, dst in reversed(completed):
+            try:
+                shutil.move(str(dst), str(src))
+                logger.warning("Rolled back swap: {} → {}", dst, src)
+            except Exception as roll_exc:
+                logger.error("Rollback failed for {} → {}: {}", dst, src, roll_exc)
+        raise
+
+    return completed
 
 
 def _prepare_target_slot(
@@ -812,6 +994,15 @@ class RecordingSession:
                 self._state = SessionState.ARMED
 
         rel_dir = recording_relative_dir(course_slug, section_name)
+        deck = ArmedDeck(
+            course_slug=course_slug,
+            section_name=section_name,
+            deck_name=deck_name,
+            part_number=part_number,
+            lang=lang,
+            lecture_id=lecture_id,
+        )
+        active_take = self._lookup_active_take(deck)
         preserved = _preserve_active_take(
             recordings_root=self._root,
             rel_dir=str(rel_dir),
@@ -819,17 +1010,10 @@ class RecordingSession:
             part=part_number,
             raw_suffix=self._raw_suffix,
             lang=lang,
+            take_number=active_take,
         )
 
         if preserved:
-            deck = ArmedDeck(
-                course_slug=course_slug,
-                section_name=section_name,
-                deck_name=deck_name,
-                part_number=part_number,
-                lang=lang,
-                lecture_id=lecture_id,
-            )
             course_state = self._resolve_course_state(deck)
             self._apply_renames_to_state(preserved, course_state)
             self._notify_path_renames(preserved)
@@ -838,6 +1022,113 @@ class RecordingSession:
             self._notify()
 
         return preserved
+
+    def restore_take(
+        self,
+        course_slug: str,
+        section_name: str,
+        deck_name: str,
+        target_take: int,
+        *,
+        part_number: int = 0,
+        lang: str = "en",
+        lecture_id: str,
+    ) -> list[tuple[Path, Path]]:
+        """Promote historical take *target_take* back to active and demote the current active.
+
+        Runs :func:`_swap_active_with_take` to perform the filesystem
+        swap with planned-rename rollback, then mutates the resolved
+        :class:`CourseRecordingState` to match (path migrations applied
+        before :meth:`CourseRecordingState.restore_take` swaps the data
+        fields, so no temporary path duplicates exist).
+
+        The session must be quiescent (``IDLE``, ``ARMED``, or
+        ``ARMED_AFTER_TAKE``); a recording or rename in flight blocks
+        the swap to avoid clobbering the file OBS is still writing.
+
+        Returns the list of ``(old_path, new_path)`` pairs moved on
+        disk, in execution order. Empty only when nothing existed to
+        swap, which is itself an error (we already required at least
+        one target file to exist).
+
+        Raises:
+            RuntimeError: If the session is recording, paused, or renaming.
+            ValueError: If the resolved state has no record of the part
+                or the requested take.
+            FileNotFoundError: If no files for *target_take* exist in
+                ``takes/``.
+        """
+        with self._lock:
+            if self._state in (
+                SessionState.RECORDING,
+                SessionState.PAUSED,
+                SessionState.RENAMING,
+            ):
+                raise RuntimeError(f"Cannot restore take while in state '{self._state.value}'.")
+
+        deck = ArmedDeck(
+            course_slug=course_slug,
+            section_name=section_name,
+            deck_name=deck_name,
+            part_number=part_number,
+            lang=lang,
+            lecture_id=lecture_id,
+        )
+        course_state = self._resolve_course_state(deck)
+        if course_state is None:
+            raise ValueError(f"No course state resolved for {course_slug}")
+
+        state_part = part_number if part_number > 0 else 1
+        lecture = course_state.get_lecture(lecture_id)
+        if lecture is None:
+            raise ValueError(f"Lecture not found: {lecture_id}")
+        part_obj = next((p for p in lecture.parts if p.part == state_part), None)
+        if part_obj is None:
+            raise ValueError(f"Part {state_part} not found in lecture {lecture_id}")
+        active_take = part_obj.active_take
+        target = next((t for t in part_obj.takes if t.take == target_take), None)
+        if target is None:
+            raise ValueError(f"Take {target_take} not found in part {state_part} of {lecture_id}")
+
+        rel_dir = recording_relative_dir(course_slug, section_name)
+        renames = _swap_active_with_take(
+            recordings_root=self._root,
+            rel_dir=str(rel_dir),
+            deck_name=deck_name,
+            part=part_number,
+            active_take=active_take,
+            target_take=target_take,
+            raw_suffix=self._raw_suffix,
+            lang=lang,
+        )
+
+        # Update state paths to match the post-swap filesystem reality
+        # *before* swapping the data fields, so no two records ever hold
+        # the same path simultaneously (which would confuse the
+        # string-equality match in :meth:`rename_recording_paths`).
+        try:
+            for old, new in renames:
+                course_state.rename_recording_paths(str(old), str(new))
+                course_state.rename_recording_paths(
+                    str(old),
+                    str(old),
+                    old_processed=str(old),
+                    new_processed=str(new),
+                )
+            course_state.restore_take(lecture_id, state_part, target_take)
+        except Exception as exc:
+            logger.error(
+                "State update failed after FS swap for {} part {} take {}: {}",
+                lecture_id,
+                state_part,
+                target_take,
+                exc,
+            )
+            raise
+
+        self._persist_state(course_state)
+        self._notify_path_renames(renames)
+        return renames
 
     def stop(self) -> None:
         """Ask OBS to stop the current recording.
@@ -1063,7 +1354,10 @@ class RecordingSession:
             course_state = self._resolve_course_state(deck)
 
             # Retake pre-move: demote the active take's files into takes/
-            # before the new recording claims their slots.
+            # before the new recording claims their slots. Pull the
+            # take number from state so the demoted filename matches
+            # the take's stable identity (FS max+1 diverges from state
+            # after a restore).
             preserved = _preserve_active_take(
                 recordings_root=self._root,
                 rel_dir=str(rel_dir),
@@ -1071,6 +1365,7 @@ class RecordingSession:
                 part=deck.part_number,
                 raw_suffix=self._raw_suffix,
                 lang=deck.lang,
+                take_number=self._lookup_active_take(deck, course_state=course_state),
             )
             self._apply_renames_to_state(preserved, course_state)
 
@@ -1109,6 +1404,34 @@ class RecordingSession:
                 self._state = SessionState.IDLE
 
         self._notify()
+
+    def _lookup_active_take(
+        self,
+        deck: ArmedDeck,
+        *,
+        course_state: CourseRecordingState | None = None,
+    ) -> int | None:
+        """Return ``part.active_take`` from state for *deck* if available.
+
+        Used by the demote-on-retake path so the ``(take K)`` suffix
+        matches the take's stable identity in ``state.json`` rather
+        than the filesystem heuristic ``max(takes/) + 1`` — they
+        diverge after a restore. Returns ``None`` when no state is
+        wired (CLI/tests that don't track state) or the part is not
+        yet registered, in which case the FS heuristic is the right
+        fallback.
+        """
+        state = course_state if course_state is not None else self._resolve_course_state(deck)
+        if state is None or deck.lecture_id is None:
+            return None
+        lecture = state.get_lecture(deck.lecture_id)
+        if lecture is None:
+            return None
+        state_part = deck.part_number if deck.part_number > 0 else 1
+        for part in lecture.parts:
+            if part.part == state_part:
+                return part.active_take
+        return None
 
     def _resolve_course_state(self, deck: ArmedDeck) -> CourseRecordingState | None:
         """Look up the :class:`CourseRecordingState` for *deck*.

--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -2100,6 +2100,469 @@ class TestAdvanceTake:
         assert "(take 1)--RAW.mkv" in new_path
 
 
+class TestSwapActiveWithTake:
+    """Tests for the pure module-level :func:`_swap_active_with_take` helper."""
+
+    def _layout(
+        self,
+        recording_root: Path,
+        rel: Path,
+        *,
+        active_in_archive: bool = False,
+        active_has_final: bool = False,
+        active_wav: bool = False,
+        target_take: int = 1,
+        target_has_final: bool = True,
+    ) -> dict[str, Path]:
+        """Materialise a deck with one active take and one historical take on disk.
+
+        Returns a dict of named paths the test can assert against.
+        """
+        from clm.recordings.workflow.directories import takes_dir
+
+        arc = archive_dir(recording_root) / rel
+        tp = to_process_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        takes = takes_dir(recording_root) / rel
+        for d in (arc, tp, fin, takes):
+            d.mkdir(parents=True, exist_ok=True)
+
+        active_raw_dir = arc if active_in_archive else tp
+        active_raw = active_raw_dir / "deck--RAW.mkv"
+        active_raw.write_bytes(b"active-raw")
+        result = {"active_raw": active_raw}
+
+        if active_wav:
+            active_wav_path = active_raw_dir / "deck--RAW.wav"
+            active_wav_path.write_bytes(b"active-wav")
+            result["active_wav"] = active_wav_path
+
+        if active_has_final:
+            active_final = fin / "deck.mp4"
+            active_final.write_bytes(b"active-final")
+            result["active_final"] = active_final
+
+        target_raw = takes / f"deck (take {target_take})--RAW.mkv"
+        target_raw.write_bytes(b"target-raw")
+        result["target_raw"] = target_raw
+
+        if target_has_final:
+            target_final = takes / f"deck (take {target_take}).mp4"
+            target_final.write_bytes(b"target-final")
+            result["target_final"] = target_final
+
+        result["takes"] = takes
+        result["arc"] = arc
+        result["tp"] = tp
+        result["fin"] = fin
+        return result
+
+    def test_happy_path_processed_target(self, recording_root: Path):
+        """Active processed deck swaps with a processed historical take."""
+        from clm.recordings.workflow.session import _swap_active_with_take
+
+        rel = Path("c") / "s"
+        paths = self._layout(
+            recording_root,
+            rel,
+            active_in_archive=True,
+            active_has_final=True,
+            target_take=1,
+            target_has_final=True,
+        )
+
+        renames = _swap_active_with_take(
+            recordings_root=recording_root,
+            rel_dir=str(rel),
+            deck_name="deck",
+            part=0,
+            active_take=3,
+            target_take=1,
+        )
+
+        # Active take 3 went to takes/ with the (take 3) suffix.
+        assert (paths["takes"] / "deck (take 3)--RAW.mkv").read_bytes() == b"active-raw"
+        assert (paths["takes"] / "deck (take 3).mp4").read_bytes() == b"active-final"
+        # Target take 1 became active — same paths as before, new content.
+        assert (paths["arc"] / "deck--RAW.mkv").read_bytes() == b"target-raw"
+        assert (paths["fin"] / "deck.mp4").read_bytes() == b"target-final"
+        # The take-1 slots in takes/ are now empty.
+        assert not paths["target_raw"].exists()
+        assert not paths["target_final"].exists()
+        # Returned renames are non-empty and ordered: phase A first, then phase B.
+        assert len(renames) == 4
+
+    def test_pending_active_pending_target_to_process_only(self, recording_root: Path):
+        """Pending → pending swap leaves both raws in to-process/, never archive/."""
+        from clm.recordings.workflow.session import _swap_active_with_take
+
+        rel = Path("c") / "s"
+        paths = self._layout(
+            recording_root,
+            rel,
+            active_in_archive=False,
+            active_has_final=False,
+            target_take=1,
+            target_has_final=False,
+        )
+
+        _swap_active_with_take(
+            recordings_root=recording_root,
+            rel_dir=str(rel),
+            deck_name="deck",
+            part=0,
+            active_take=2,
+            target_take=1,
+        )
+
+        assert (paths["tp"] / "deck--RAW.mkv").read_bytes() == b"target-raw"
+        assert (paths["takes"] / "deck (take 2)--RAW.mkv").read_bytes() == b"active-raw"
+        # Archive must remain empty — neither take was processed.
+        assert not list(paths["arc"].iterdir())
+
+    def test_final_edl_sidecar_moves_with_swap(self, recording_root: Path):
+        """An ``.edl`` (or any sidecar sharing the final video stem) is preserved.
+
+        Before ``_scan_active_take_files`` was widened to a stem sweep,
+        non-video sidecars (Auphonic's ``.edl`` cut list, future
+        ``.vtt``/``.srt``/``.json``/``.html`` outputs) got left behind
+        on every retake and never came back on restore. The fix anchors
+        on the video file and sweeps every sibling sharing its stem.
+        """
+        from clm.recordings.workflow.session import _swap_active_with_take
+
+        rel = Path("c") / "s"
+        paths = self._layout(
+            recording_root,
+            rel,
+            active_in_archive=True,
+            active_has_final=True,
+            target_take=1,
+            target_has_final=True,
+        )
+        active_edl = paths["fin"] / "deck.edl"
+        active_edl.write_bytes(b"active-edl")
+        target_edl = paths["takes"] / "deck (take 1).edl"
+        target_edl.write_bytes(b"target-edl")
+
+        _swap_active_with_take(
+            recordings_root=recording_root,
+            rel_dir=str(rel),
+            deck_name="deck",
+            part=0,
+            active_take=3,
+            target_take=1,
+        )
+
+        assert (paths["takes"] / "deck (take 3).edl").read_bytes() == b"active-edl"
+        assert (paths["fin"] / "deck.edl").read_bytes() == b"target-edl"
+
+    def test_companion_wav_moves_with_raw(self, recording_root: Path):
+        """A ``.wav`` companion in the active slot rides along to takes/."""
+        from clm.recordings.workflow.session import _swap_active_with_take
+
+        rel = Path("c") / "s"
+        paths = self._layout(
+            recording_root,
+            rel,
+            active_wav=True,
+            target_take=1,
+            target_has_final=False,
+        )
+
+        _swap_active_with_take(
+            recordings_root=recording_root,
+            rel_dir=str(rel),
+            deck_name="deck",
+            part=0,
+            active_take=2,
+            target_take=1,
+        )
+
+        assert (paths["takes"] / "deck (take 2)--RAW.wav").read_bytes() == b"active-wav"
+        # Active wav slot now holds the restored target raw (no companion wav existed).
+        assert not (paths["tp"] / "deck--RAW.wav").exists()
+
+    def test_missing_target_raises(self, recording_root: Path):
+        """Empty takes/ subtree → :class:`FileNotFoundError`."""
+        from clm.recordings.workflow.session import _swap_active_with_take
+
+        rel = Path("c") / "s"
+        tp = to_process_dir(recording_root) / rel
+        tp.mkdir(parents=True)
+        (tp / "deck--RAW.mkv").write_bytes(b"active")
+
+        with pytest.raises(FileNotFoundError, match="No files for take"):
+            _swap_active_with_take(
+                recordings_root=recording_root,
+                rel_dir=str(rel),
+                deck_name="deck",
+                part=0,
+                active_take=2,
+                target_take=99,
+            )
+
+    def test_rollback_on_phase_b_failure(
+        self, recording_root: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A failure during phase B reverses every completed move."""
+        from clm.recordings.workflow import session as session_mod
+
+        rel = Path("c") / "s"
+        paths = self._layout(
+            recording_root,
+            rel,
+            active_in_archive=True,
+            active_has_final=True,
+            target_take=1,
+            target_has_final=True,
+        )
+
+        original_move = session_mod.shutil.move
+        call_count = {"n": 0}
+
+        def flaky_move(src, dst, *args, **kwargs):
+            call_count["n"] += 1
+            # Fail on the third move (first phase B move) — phase A has
+            # 2 moves (raw + final → takes/), phase B starts at call 3.
+            if call_count["n"] == 3:
+                raise OSError("simulated failure")
+            return original_move(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr(session_mod.shutil, "move", flaky_move)
+
+        with pytest.raises(OSError, match="simulated"):
+            session_mod._swap_active_with_take(
+                recordings_root=recording_root,
+                rel_dir=str(rel),
+                deck_name="deck",
+                part=0,
+                active_take=3,
+                target_take=1,
+            )
+
+        # After rollback the original layout must be restored.
+        assert paths["active_raw"].read_bytes() == b"active-raw"
+        assert paths["active_final"].read_bytes() == b"active-final"
+        assert paths["target_raw"].read_bytes() == b"target-raw"
+        assert paths["target_final"].read_bytes() == b"target-final"
+        assert not (paths["takes"] / "deck (take 3)--RAW.mkv").exists()
+        assert not (paths["takes"] / "deck (take 3).mp4").exists()
+
+
+class TestSessionRestoreTake:
+    """Integration tests for :meth:`RecordingSession.restore_take`."""
+
+    def _build_state_with_history(self, recording_root: Path):  # type: ignore[no-untyped-def]
+        """Build state matching a deck with active take 3 and history takes 1, 2."""
+        from clm.recordings.state import (
+            CourseRecordingState,
+            LectureState,
+            RecordingPart,
+            TakeRecord,
+        )
+        from clm.recordings.workflow.directories import takes_dir
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        takes = takes_dir(recording_root) / rel
+        for d in (arc, fin, takes):
+            d.mkdir(parents=True, exist_ok=True)
+
+        active_raw = arc / "deck--RAW.mkv"
+        active_final = fin / "deck.mp4"
+        active_raw.write_bytes(b"a3-raw")
+        active_final.write_bytes(b"a3-final")
+
+        t1_raw = takes / "deck (take 1)--RAW.mkv"
+        t1_final = takes / "deck (take 1).mp4"
+        t1_raw.write_bytes(b"t1-raw")
+        t1_final.write_bytes(b"t1-final")
+        t2_raw = takes / "deck (take 2)--RAW.mkv"
+        t2_final = takes / "deck (take 2).mp4"
+        t2_raw.write_bytes(b"t2-raw")
+        t2_final.write_bytes(b"t2-final")
+
+        state = CourseRecordingState(
+            course_id="c",
+            lectures=[
+                LectureState(
+                    lecture_id="l1",
+                    display_name="L1",
+                    parts=[
+                        RecordingPart(
+                            part=1,
+                            active_take=3,
+                            raw_file=str(active_raw),
+                            processed_file=str(active_final),
+                            status="processed",
+                            takes=[
+                                TakeRecord(
+                                    take=1,
+                                    raw_file=str(t1_raw),
+                                    processed_file=str(t1_final),
+                                    status="processed",
+                                ),
+                                TakeRecord(
+                                    take=2,
+                                    raw_file=str(t2_raw),
+                                    processed_file=str(t2_final),
+                                    status="processed",
+                                ),
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+        return state, {
+            "active_raw": active_raw,
+            "active_final": active_final,
+            "t1_raw": t1_raw,
+            "t1_final": t1_final,
+            "t2_raw": t2_raw,
+            "t2_final": t2_final,
+            "arc": arc,
+            "fin": fin,
+            "takes": takes,
+            "rel": rel,
+        }
+
+    def test_restore_swaps_state_and_filesystem(self, mock_obs: MagicMock, recording_root: Path):
+        """End-to-end: state + FS both reflect the swap."""
+        state, paths = self._build_state_with_history(recording_root)
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+
+        session.restore_take("c", "s", "deck", 1, lecture_id="l1")
+
+        # Active is now take 1 with the original take-1 paths in the active slot.
+        part = state.lectures[0].parts[0]
+        assert part.active_take == 1
+        assert part.raw_file == str(paths["arc"] / "deck--RAW.mkv")
+        assert part.processed_file == str(paths["fin"] / "deck.mp4")
+        # History now contains takes 2 (untouched) and 3 (the demoted ex-active).
+        assert sorted(t.take for t in part.takes) == [2, 3]
+        take3 = next(t for t in part.takes if t.take == 3)
+        assert "(take 3)--RAW.mkv" in take3.raw_file
+        # Filesystem reflects the swap.
+        assert (paths["arc"] / "deck--RAW.mkv").read_bytes() == b"t1-raw"
+        assert (paths["fin"] / "deck.mp4").read_bytes() == b"t1-final"
+        assert (paths["takes"] / "deck (take 3)--RAW.mkv").read_bytes() == b"a3-raw"
+        assert (paths["takes"] / "deck (take 3).mp4").read_bytes() == b"a3-final"
+        # Take 2 untouched.
+        assert (paths["takes"] / "deck (take 2)--RAW.mkv").read_bytes() == b"t2-raw"
+
+    def test_advance_after_restore_uses_state_take_number(
+        self, mock_obs: MagicMock, recording_root: Path
+    ):
+        """advance_take must demote with the state's ``active_take`` number.
+
+        After a restore, ``state.active_take`` and the filesystem max
+        in ``takes/`` diverge: state still calls the restored take "1"
+        while ``takes/`` already holds "(take 2)" and "(take 3)". The
+        pre-fix demote path used FS max+1 = 4 (or, mid-state, a number
+        that collided with an existing entry), producing two rows
+        labeled with the same take number in the panel. This test
+        pins the fix: the demoted file is named with the take's
+        stable identity, "(take 1)".
+        """
+        state, paths = self._build_state_with_history(recording_root)
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+        session.restore_take("c", "s", "deck", 1, lecture_id="l1")
+
+        # advance_take demotes the active slot without recording a
+        # new file — exercises the same _preserve_active_take path
+        # the OBS rename thread uses on a real retake.
+        session.advance_take("c", "s", "deck", lecture_id="l1")
+
+        # The demoted file is named with the restored take's number (1),
+        # not the FS max+1 (which would be 4 — and any FS-derived
+        # number ≤3 would collide with an existing entry).
+        assert (paths["takes"] / "deck (take 1)--RAW.mkv").exists()
+        # Pre-existing takes 2 and 3 (from the swap) are untouched.
+        assert (paths["takes"] / "deck (take 2)--RAW.mkv").exists()
+        assert (paths["takes"] / "deck (take 3)--RAW.mkv").exists()
+
+    def test_retake_after_restore_does_not_clobber_history(
+        self, mock_obs: MagicMock, recording_root: Path
+    ):
+        """The Phase D correctness invariant: restore + retake → take 4, not take 2 overwrite."""
+        state, paths = self._build_state_with_history(recording_root)
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+
+        session.restore_take("c", "s", "deck", 1, lecture_id="l1")
+
+        # Now record a fresh retake on top of the restored take 1.
+        new_raw = "/obs/new-take.mkv"
+        state.record_retake("l1", 1, new_raw)
+
+        part = state.lectures[0].parts[0]
+        assert part.active_take == 4
+        assert part.raw_file == new_raw
+        # Takes 1, 2, 3 all present and intact.
+        assert sorted(t.take for t in part.takes) == [1, 2, 3]
+        take2 = next(t for t in part.takes if t.take == 2)
+        assert take2.raw_file == str(paths["t2_raw"])
+
+    def test_restore_refuses_while_recording(self, mock_obs: MagicMock, recording_root: Path):
+        state, _ = self._build_state_with_history(recording_root)
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+        session.arm("c", "s", "deck", lecture_id="l1")
+        _fire_event(mock_obs, RecordingEvent(output_active=True, output_state="started"))
+        assert session.state is SessionState.RECORDING
+
+        with pytest.raises(RuntimeError, match="Cannot restore take"):
+            session.restore_take("c", "s", "deck", 1, lecture_id="l1")
+
+    def test_restore_unknown_take_raises(self, mock_obs: MagicMock, recording_root: Path):
+        state, _ = self._build_state_with_history(recording_root)
+        session = RecordingSession(
+            mock_obs,
+            recording_root,
+            stability_interval=0.01,
+            stability_checks=1,
+            short_take_seconds=0.0,
+            retake_window_seconds=0.0,
+            state=state,
+        )
+
+        with pytest.raises(ValueError, match="Take 99 not found"):
+            session.restore_take("c", "s", "deck", 99, lecture_id="l1")
+
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/recordings/test_state.py
+++ b/tests/recordings/test_state.py
@@ -321,6 +321,32 @@ class TestRestoreTake:
         with pytest.raises(ValueError, match="Take 99 not found"):
             sample_state.restore_take("010-intro", 1, 99)
 
+    def test_retake_after_restore_does_not_collide(self, sample_state: CourseRecordingState):
+        # Build history: takes 1, 2, 3 with 3 active.
+        sample_state.assign_recording("/obs/rec1-t1.mkv", lecture_id="010-intro")
+        sample_state.record_retake("010-intro", 1, "/obs/rec1-t2.mkv")
+        sample_state.record_retake("010-intro", 1, "/obs/rec1-t3.mkv")
+
+        part = sample_state.lectures[0].parts[0]
+        assert part.active_take == 3
+        assert [t.take for t in part.takes] == [1, 2]
+
+        # Restore take 1 → active=1, history holds 2 and 3.
+        sample_state.restore_take("010-intro", 1, 1)
+        assert part.active_take == 1
+        assert sorted(t.take for t in part.takes) == [2, 3]
+
+        # New retake must allocate take 4, not overwrite take 2.
+        sample_state.record_retake("010-intro", 1, "/obs/rec1-t4.mkv")
+
+        assert part.active_take == 4
+        assert part.raw_file == "/obs/rec1-t4.mkv"
+        assert sorted(t.take for t in part.takes) == [1, 2, 3]
+        # The historical takes 2 and 3 are intact (not clobbered).
+        history_by_take = {t.take: t for t in part.takes}
+        assert history_by_take[2].raw_file == "/obs/rec1-t2.mkv"
+        assert history_by_take[3].raw_file == "/obs/rec1-t3.mkv"
+
 
 class TestRenameRecordingPaths:
     def test_renames_active_raw(self, sample_state: CourseRecordingState):

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -1657,7 +1657,8 @@ class TestTakesRoute:
         resp = client.get("/decks/c/s/Intro/takes?part=1")
         assert resp.status_code == 200
         assert "data-takes-panel" in resp.text
-        assert "Only the active take" in resp.text
+        # No state record + no take history → empty-state copy.
+        assert "No takes recorded yet" in resp.text
 
     def test_returns_panel_with_take_rows(self, client: TestClient, recording_root: Path):
         from clm.recordings.workflow.directories import takes_dir
@@ -1670,14 +1671,192 @@ class TestTakesRoute:
         resp = client.get("/decks/c/s/Intro/takes?part=1")
         assert resp.status_code == 200
         assert "Intro (part 1, take 1)" in resp.text
-        # Phase D will add the Restore button; Phase C must not.
-        assert "Restore" not in resp.text
+        # Phase D adds the Restore action column; the button is visible
+        # by default (panel not locked) and points at the restore route.
+        assert "btn-restore" in resp.text
+        assert "/decks/c/s/Intro/takes/1/restore" in resp.text
 
     def test_panel_subscribes_to_job_sse_for_refresh(
         self, client: TestClient, recording_root: Path
     ):
         resp = client.get("/decks/c/s/Intro/takes?part=1")
         assert 'data-sse-refresh="job"' in resp.text
+
+    def test_restore_button_disabled_when_deck_armed(
+        self, app, client: TestClient, recording_root: Path
+    ):
+        from clm.recordings.workflow.directories import takes_dir
+
+        tk = takes_dir(recording_root) / "c" / "s"
+        tk.mkdir(parents=True)
+        (tk / "Intro (part 1, take 1)--RAW.mp4").write_bytes(b"raw")
+
+        client.post(
+            "/arm",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "Intro",
+                "part_number": "0",
+            },
+        )
+        resp = client.get("/decks/c/s/Intro/takes?part=1")
+        assert resp.status_code == 200
+        # The button is rendered with `disabled` and the locked-note
+        # replaces the column header.
+        assert "btn-restore" in resp.text
+        assert "disabled" in resp.text
+        assert "takes-locked-note" in resp.text
+
+
+class TestRestoreTakeRoute:
+    """``POST /decks/{course}/{section}/{deck}/takes/{take}/restore?part=N``."""
+
+    @pytest.fixture(autouse=True)
+    def _no_state_persistence(self, app):
+        """Prevent the restore route from writing state.json to the user config dir.
+
+        ``create_app`` wires the session's ``on_state_mutation`` to
+        :func:`save_state`, which writes to
+        ``~/.config/clm/recordings/<slug>.json``. That path persists
+        across tests and leaks state into other test cases (e.g. seeing
+        extra lectures from prior runs). Nulling the callback keeps the
+        in-memory mutation but skips the disk write.
+        """
+        app.state.session._on_state_mutation = None
+
+    def _seed(self, app, recording_root: Path) -> dict[str, Path]:
+        """Build state + on-disk layout: active take 3 (processed), history takes 1 and 2."""
+        from clm.recordings.state import (
+            CourseRecordingState,
+            LectureState,
+            RecordingPart,
+            TakeRecord,
+        )
+        from clm.recordings.workflow.directories import (
+            archive_dir,
+            final_dir,
+            takes_dir,
+        )
+
+        rel = Path("c") / "s"
+        arc = archive_dir(recording_root) / rel
+        fin = final_dir(recording_root) / rel
+        takes = takes_dir(recording_root) / rel
+        for d in (arc, fin, takes):
+            d.mkdir(parents=True, exist_ok=True)
+
+        active_raw = arc / "Intro--RAW.mkv"
+        active_final = fin / "Intro.mp4"
+        active_raw.write_bytes(b"a3-raw")
+        active_final.write_bytes(b"a3-final")
+
+        t1_raw = takes / "Intro (take 1)--RAW.mkv"
+        t1_final = takes / "Intro (take 1).mp4"
+        t1_raw.write_bytes(b"t1-raw")
+        t1_final.write_bytes(b"t1-final")
+        t2_raw = takes / "Intro (take 2)--RAW.mkv"
+        t2_raw.write_bytes(b"t2-raw")
+
+        state = CourseRecordingState(
+            course_id="c",
+            lectures=[
+                LectureState(
+                    lecture_id="s::Intro",
+                    display_name="Intro",
+                    parts=[
+                        RecordingPart(
+                            part=1,
+                            active_take=3,
+                            raw_file=str(active_raw),
+                            processed_file=str(active_final),
+                            status="processed",
+                            takes=[
+                                TakeRecord(
+                                    take=1,
+                                    raw_file=str(t1_raw),
+                                    processed_file=str(t1_final),
+                                    status="processed",
+                                ),
+                                TakeRecord(
+                                    take=2,
+                                    raw_file=str(t2_raw),
+                                    status="pending",
+                                ),
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+        app.state.recording_states["c"] = state
+        return {
+            "active_raw": active_raw,
+            "active_final": active_final,
+            "t1_raw": t1_raw,
+            "t1_final": t1_final,
+            "t2_raw": t2_raw,
+            "arc": arc,
+            "fin": fin,
+            "takes": takes,
+        }
+
+    def test_restore_swaps_active_with_take(self, app, client: TestClient, recording_root: Path):
+        paths = self._seed(app, recording_root)
+
+        resp = client.post("/decks/c/s/Intro/takes/1/restore?part=0")
+        assert resp.status_code == 200
+
+        # Filesystem reflects the swap.
+        assert (paths["arc"] / "Intro--RAW.mkv").read_bytes() == b"t1-raw"
+        assert (paths["fin"] / "Intro.mp4").read_bytes() == b"t1-final"
+        assert (paths["takes"] / "Intro (take 3)--RAW.mkv").read_bytes() == b"a3-raw"
+        assert (paths["takes"] / "Intro (take 3).mp4").read_bytes() == b"a3-final"
+        # State reflects the swap.
+        state = app.state.recording_states["c"]
+        part = state.lectures[0].parts[0]
+        assert part.active_take == 1
+        assert sorted(t.take for t in part.takes) == [2, 3]
+
+    def test_restore_returns_409_while_recording(
+        self, app, client: TestClient, recording_root: Path
+    ):
+        from clm.recordings.workflow.obs import RecordingEvent
+
+        self._seed(app, recording_root)
+
+        client.post(
+            "/record",
+            data={
+                "course_slug": "c",
+                "section_name": "s",
+                "deck_name": "Intro",
+                "part_number": "0",
+            },
+        )
+        for cb in app.state.obs._record_callbacks:
+            cb(RecordingEvent(output_active=True, output_state="started"))
+
+        resp = client.post("/decks/c/s/Intro/takes/1/restore?part=0")
+        assert resp.status_code == 409
+
+    def test_restore_returns_404_when_take_missing(
+        self, app, client: TestClient, recording_root: Path
+    ):
+        self._seed(app, recording_root)
+        resp = client.post("/decks/c/s/Intro/takes/99/restore?part=0")
+        assert resp.status_code == 404
+
+    def test_restore_from_lectures_returns_hx_location(
+        self, app, client: TestClient, recording_root: Path
+    ):
+        self._seed(app, recording_root)
+        resp = client.post(
+            "/decks/c/s/Intro/takes/1/restore?part=0",
+            headers={"HX-Current-URL": "http://testserver/lectures"},
+        )
+        assert resp.status_code == 200
+        assert "#lectures-dynamic" in resp.headers.get("hx-location", "")
 
 
 class TestObsStateRendering:


### PR DESCRIPTION
## Summary
- Wires `CourseRecordingState.restore_take` to the dashboard behind a two-step morph button in the inline take-history panel and a `POST /decks/.../takes/{take}/restore` route that performs the filesystem swap with planned-rename rollback.
- Folds the active take into the same panel (badged "Active", row tooltip, single Open affordance for every take) and renders the Recorded column as a local datetime via a new `mtime` Jinja filter.
- Pile of correctness fixes that surfaced during the manual smoke test — `record_retake` numbering after a restore, `_preserve_active_take` filename numbering after a restore, processed-take detection on swap, sidecar (`.edl`/`.vtt`/...) preservation, the active row's status badge, and the Open-in-Explorer command line on Windows.

## What's locked behind tests
- `test_retake_after_restore_does_not_collide` — pins the `record_retake` numbering invariant (`max(takes[].take)+1`).
- `test_advance_after_restore_uses_state_take_number` — pins that the demoted file is named with state's stable take identity, not FS max+1.
- `test_final_edl_sidecar_moves_with_swap` — sidecar (Auphonic `.edl`, future `.vtt`/`.srt`/`.json`/`.html`) rides along on demote and back on restore.
- `TestSwapActiveWithTake` — happy path (processed), pending-only, `.wav` companion, missing target, rollback-on-failure.
- `TestSessionRestoreTake` — end-to-end state + filesystem swap, refuse while recording, unknown-take error.
- `TestRestoreTakeRoute` — 200 happy path, 409 while recording, 404 missing take, `HX-Location` lectures refresh.

Test totals: **803 recordings tests passing** (786 baseline → +17 new). Pre-commit clean (ruff lint+format, mypy, fast pytest).

## Notable correctness fixes
- **`record_retake` numbering** — assigned `demoted.take + 1`, which silently clobbered an existing history take after a restore. Now `max(t.take for t in part.takes) + 1`.
- **`_preserve_active_take` filename numbering** — used FS `max+1`, diverging from `state.active_take` after a restore. Now takes the number from state when wired (callers in the OBS rename thread and `advance_take` look it up); FS heuristic remains the fallback for the CLI flow.
- **`_swap_active_with_take` processed detection** — read `target.processed_file` from state, which the manual `/process` route doesn't update. Now derived from the filesystem (presence of a final-shaped sibling under `takes/`).
- **`_scan_active_take_files` sidecar coverage** — only picked up video extensions, leaving Auphonic `.edl` cut lists behind on every retake. Now anchors on the video file in each location and sweeps every sibling sharing its stem.
- **`deck_takes` route active row** — was reading status from `state.json`'s `processed_file`, which goes stale after manual processing. Now scans the filesystem for raw/final paths so the badge flips to `processed` as soon as Auphonic finishes; state is used only for the take number.
- **Open in Explorer** — `file:///` links are blocked by browsers from `http://` origins. Replaced with `POST /open-explorer` that runs `explorer /select,"<path>"` (Windows), `open -R` (macOS), or `xdg-open <parent>` (Linux), with the path validated against the recordings root. The Windows command must be a single string — passing the args as a list inserts a space after the comma and makes Explorer fall back to Documents.
- **`partials/parts.html` chip strip** — `data-deck-key` referenced an undefined `section_name`, so right-clicking a chip silently 404'd on the takes route. Switched to `section.name` to match the row's `data-deck-key`.
- **`scan_take_files` path construction** — built directories from the raw `course_slug`/`section_name` passed in the URL, so a section name containing characters stripped by `sanitize_file_name` (e.g. colons in the test course) never matched the on-disk subtree. Now sanitizes before joining.

## Test plan
- [x] `uv run pytest tests/recordings/ -q` (803 passed)
- [x] `uv run pre-commit run --files <touched>` (ruff lint+format, mypy, fast pytest all green)
- [x] Manual smoke on the live dashboard:
  - record → record retake → restore take 1 → record again. Demoted file named `(take 1)`, panel shows takes 1, 2 in history, active row badge matches `state.active_take`, no clobber.
  - Restoring an already-processed take leaves the chip green and the Process button inactive.
  - Open button opens File Explorer with the file pre-selected.
  - Recorded column renders as a local `YYYY-MM-DD HH:MM` datetime; raw epoch lives in the `data-mtime` attribute and tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)