### PR TITLE
fix(http-replay): persist cassettes when kernel is killed forcibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **HTTP-replay cassettes survive forceful kernel termination.** Previously,
+  if a build hit the wait-for-completion timeout while a notebook was
+  recording HTTP interactions, the worker process was force-killed
+  (`TerminateProcess` on Windows) before vcrpy could flush the cassette to
+  disk. Every interaction recorded so far was discarded, and the next build
+  re-ran the same long-running requests from scratch — for chained-request
+  notebooks this caused the build to time out forever. The bootstrap cell
+  now writes to a per-worker staging file at an absolute path under the
+  source tree and patches `Cassette.append` to save eagerly after each
+  recorded interaction, so the cassette on disk always reflects every
+  interaction recorded up to the moment the kernel died. A post-execution
+  merge step runs in a `finally` block to fold the worker's staging file
+  (and any orphan staging files left by previously-killed workers) into the
+  canonical cassette under a cross-process file lock, deduplicating by
+  request fingerprint. This also makes concurrent builds of the same
+  notebook in different languages safe — German and English workers each
+  write to their own staging file and merge into the shared canonical
+  cassette without races. Adds `filelock` to the `[replay]` extra.
+
 ### Removed
 - **Validator: "start/completed inside workshop" warning.** The matching
   authoring guideline was retired, so the deterministic `tags`-category

--- a/docs/user-guide/http-replay.md
+++ b/docs/user-guide/http-replay.md
@@ -80,6 +80,28 @@ Cassettes are never copied to public or speaker output. They travel with
 the notebook into worker payloads and Docker source mounts so execution
 can find them, but the student-facing build tree does not contain them.
 
+### Per-worker staging files
+
+While a build is running, each worker writes its recordings to a
+*staging* file next to the canonical cassette
+(`<stem>.http-cassette.yaml.staging-<unique>`). The kernel saves to
+this file after every recorded interaction, so a worker that is killed
+mid-execution (for example by the build-level wait-for-completion
+timeout) leaves its partial recordings on disk. The next build merges
+every staging file in the directory into the canonical cassette under a
+file lock and then deletes them.
+
+Staging files are normally invisible — the merge step runs in the
+build's `finally` block on success and on failure. If you see lingering
+`*.staging-*` files in a course repo after a build, the worker was
+killed *before* the merge could acquire the lock; running any subsequent
+build for that topic will pick them up. You can also delete them by
+hand if you do not want their contents.
+
+Concurrent builds of the same notebook in different languages (German
+and English on the same topic) write to distinct staging files and are
+merged together — neither overwrites the other.
+
 ## Record modes
 
 The record mode is chosen per build. Set it via the `--http-replay` CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,8 @@ module = [
     "transformers.*",
     "vcr",
     "vcr.*",
+    "filelock",
+    "filelock.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,9 @@ slides = [
 # builds when a topic opts in via ``http-replay="yes"`` in the spec.
 replay = [
     "vcrpy>=6.0.0",
+    # Used to serialize cassette merges across concurrent workers that
+    # process the same notebook in different languages.
+    "filelock>=3.12.0",
 ]
 # MCP server for AI-assisted slide authoring
 mcp = [
@@ -333,6 +336,8 @@ module = [
     "torch.*",
     "transformers",
     "transformers.*",
+    "vcr",
+    "vcr.*",
 ]
 ignore_missing_imports = true
 

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -1,0 +1,236 @@
+"""HTTP-replay cassette persistence helpers.
+
+The notebook kernel records HTTP interactions into a per-worker *staging*
+file that lives in the same directory as the topic's canonical cassette.
+This module owns the logic that
+
+1. resolves the canonical and per-worker staging paths,
+2. seeds the staging file from the canonical cassette so already-recorded
+   interactions can be replayed without hitting the network,
+3. merges the staging file (plus any orphan staging files left behind by
+   previously-killed workers) into the canonical cassette under a
+   cross-process file lock, deduplicating by request fingerprint,
+4. writes the merged cassette atomically.
+
+The merge step runs in a ``finally`` block so it executes even when the
+notebook raised — vcrpy's eager-save patch in the bootstrap means partial
+recordings are already on disk by the time the failure propagates.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_STAGING_SUFFIX = ".staging-"
+_LOCK_SUFFIX = ".lock"
+_MERGE_LOCK_TIMEOUT_SECONDS = 300.0
+
+
+@dataclass(frozen=True)
+class CassettePaths:
+    """Resolved locations for the canonical cassette and this worker's staging file.
+
+    ``canonical`` is the path the cassette ends up at after a successful
+    merge — this is what authors commit and what subsequent builds replay
+    from. ``staging`` is unique per worker invocation so that concurrent
+    workers (e.g., German and English builds of the same notebook) do not
+    write to the same file.
+    """
+
+    canonical: Path
+    staging: Path
+
+
+def resolve_paths(target_dir: Path, cassette_name: str) -> CassettePaths:
+    """Compute the canonical and staging paths for a topic.
+
+    Args:
+        target_dir: Directory the kernel can write to that maps to the
+            source tree (host source-topic dir in direct mode, container
+            source mount in Docker mode).
+        cassette_name: Cassette name relative to ``target_dir``, possibly
+            including a ``_cassettes/`` prefix (e.g.,
+            ``_cassettes/slides.http-cassette.yaml``).
+    """
+    canonical = target_dir / cassette_name
+    unique = f"{os.getpid()}-{uuid.uuid4().hex}"
+    staging = canonical.parent / f"{canonical.name}{_STAGING_SUFFIX}{unique}"
+    return CassettePaths(canonical=canonical, staging=staging)
+
+
+def seed_staging_from_canonical(paths: CassettePaths) -> None:
+    """Sweep orphan staging files into canonical, then seed staging from canonical.
+
+    Without the orphan sweep, every failed build (e.g., one that ran
+    past the build-level timeout and was force-killed before its merge
+    finally block ran) would leave its partial recordings stranded in a
+    ``.staging-*`` file that nobody ever incorporates into the canonical
+    cassette — and the next build would re-record those interactions
+    over the network instead of replaying them. Sweeping pre-execution
+    means canonical converges across a sequence of failed builds.
+
+    The seed copy after the sweep gives vcrpy a starting point inside
+    the kernel: when the bootstrap calls ``Cassette.load``, it reads
+    every interaction in canonical (now including freshly-merged
+    orphans) so the notebook can replay them offline.
+    """
+    paths.staging.parent.mkdir(parents=True, exist_ok=True)
+    # Sweep orphans into canonical so this worker's seed picks them up.
+    # Failures here are non-fatal — we still seed from whatever
+    # canonical currently is, and the post-execution merge will retry.
+    try:
+        merge_staging_into_canonical(paths)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.warning(
+            f"Pre-execution orphan sweep failed for '{paths.canonical}' "
+            f"({type(exc).__name__}: {exc}); seeding from canonical as-is."
+        )
+    if paths.canonical.exists():
+        shutil.copy2(paths.canonical, paths.staging)
+
+
+def merge_staging_into_canonical(paths: CassettePaths) -> int:
+    """Merge this worker's staging file and any orphan staging files into canonical.
+
+    Acquires a cross-process file lock at ``<canonical>.lock`` for the
+    duration of the merge so two workers cannot corrupt the canonical
+    cassette by writing concurrently. Loads the existing canonical
+    cassette (if any), folds in interactions from every staging file in
+    the canonical's directory (this worker's plus orphans from
+    previously-killed workers), deduplicates by request fingerprint, and
+    writes the merged cassette atomically via :func:`os.replace`. The
+    staging files are deleted after a successful merge.
+
+    Returns:
+        Number of staging files merged. Zero is returned for replay-only
+        topics where no recording happened.
+    """
+    # vcrpy is an optional extra; importing here keeps the module
+    # importable for tests that exercise pure path resolution without
+    # requiring the [replay] install.
+    from filelock import FileLock, Timeout
+    from vcr.persisters.filesystem import FilesystemPersister
+    from vcr.serialize import serialize as vcr_serialize
+    from vcr.serializers import yamlserializer
+
+    canonical = paths.canonical
+    lock_path = canonical.parent / f"{canonical.name}{_LOCK_SUFFIX}"
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with FileLock(str(lock_path), timeout=_MERGE_LOCK_TIMEOUT_SECONDS):
+            staging_glob = f"{canonical.name}{_STAGING_SUFFIX}*"
+            staging_files = sorted(canonical.parent.glob(staging_glob))
+            if not staging_files:
+                return 0
+
+            canonical_requests: list = []
+            canonical_responses: list = []
+            if canonical.exists():
+                try:
+                    canonical_requests, canonical_responses = FilesystemPersister.load_cassette(
+                        canonical, serializer=yamlserializer
+                    )
+                except Exception as exc:  # noqa: BLE001 — defensive
+                    logger.warning(
+                        f"Could not load existing canonical cassette '{canonical}' "
+                        f"before merge ({type(exc).__name__}: {exc}); treating as empty."
+                    )
+
+            seen_keys = {_dedup_key(req) for req in canonical_requests}
+            merged_requests = list(canonical_requests)
+            merged_responses = list(canonical_responses)
+
+            for staging_path in staging_files:
+                try:
+                    staging_requests, staging_responses = FilesystemPersister.load_cassette(
+                        staging_path, serializer=yamlserializer
+                    )
+                except Exception as exc:  # noqa: BLE001 — defensive
+                    logger.warning(
+                        f"Could not load staging cassette '{staging_path}' "
+                        f"({type(exc).__name__}: {exc}); skipping."
+                    )
+                    continue
+                for request, response in zip(staging_requests, staging_responses, strict=False):
+                    key = _dedup_key(request)
+                    if key in seen_keys:
+                        continue
+                    merged_requests.append(request)
+                    merged_responses.append(response)
+                    seen_keys.add(key)
+
+            payload = vcr_serialize(
+                {"requests": merged_requests, "responses": merged_responses},
+                yamlserializer,
+            )
+            _atomic_write_text(canonical, payload)
+
+            for staging_path in staging_files:
+                try:
+                    staging_path.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.warning(
+                        f"Could not delete merged staging cassette '{staging_path}': {exc}"
+                    )
+
+            return len(staging_files)
+    except Timeout:
+        logger.error(
+            f"Timed out after {_MERGE_LOCK_TIMEOUT_SECONDS:.0f}s waiting for cassette "
+            f"merge lock at '{lock_path}'. Cassette '{canonical}' was not updated. "
+            f"Staging files remain on disk and will be picked up by the next build."
+        )
+        return 0
+
+
+def _dedup_key(request) -> tuple:
+    """Build a hashable fingerprint for a vcrpy request.
+
+    The dedup key is intentionally narrower than vcrpy's default matcher
+    chain — we only care that two ``append`` calls referring to the same
+    HTTP call do not produce two stored interactions, not that we
+    replicate every nuance of vcrpy's matching semantics. Method, URI,
+    and body cover the common cases (GET with query strings, POST with
+    a body, REST endpoints with different paths) for teaching material.
+    """
+    body = getattr(request, "body", None)
+    if isinstance(body, bytes):
+        body_key: object = body
+    elif body is None:
+        body_key = b""
+    else:
+        body_key = str(body).encode("utf-8", errors="replace")
+    return (
+        getattr(request, "method", ""),
+        getattr(request, "uri", ""),
+        body_key,
+    )
+
+
+def _atomic_write_text(target: Path, text: str) -> None:
+    """Write ``text`` to ``target`` atomically.
+
+    Writes to a temporary file in the same directory and then calls
+    :func:`os.replace`, which is atomic on POSIX and Windows. This
+    prevents a concurrent reader from observing a half-written cassette.
+    """
+    tmp = target.parent / f"{target.name}.tmp-{uuid.uuid4().hex}"
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -35,6 +35,8 @@ from .output_spec import (
 
 if TYPE_CHECKING:
     from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
+
+    from .http_replay_cassette import CassettePaths
 from clm.infrastructure.messaging.base_classes import ProcessingWarning
 
 from .utils.jupyter_utils import (
@@ -91,27 +93,54 @@ _clm_vcr_instance = _clm_vcr.VCR(
     filter_query_parameters=["api_key", "token"],
     decode_compressed_response=True,
 )
-_clm_ctx = _clm_vcr_instance.use_cassette({cassette!r})
-_clm_ctx.__enter__()
-# vcrpy only flushes the cassette to disk on context-manager exit. Notebook
-# kernels never exit context managers established at module level, so without
-# this atexit hook record-mode runs would buffer interactions in memory and
-# discard them at kernel shutdown.
+# The cassette path is the worker's per-invocation *staging* file (an
+# absolute path resolved on the host before the cell was injected). Each
+# concurrent worker writes to its own staging file so the German and
+# English builds of the same notebook never write to the same path; the
+# host code merges staging into the canonical cassette under a file lock
+# after execution completes.
+_clm_ctx = _clm_vcr_instance.use_cassette({cassette_path!r})
+# ``__enter__`` returns the underlying ``Cassette`` (vcrpy's
+# CassetteContextDecorator name-mangles its private ``__cassette``
+# attribute, so this is the only stable way to reach the cassette).
+_clm_cassette = _clm_ctx.__enter__()
+# vcrpy buffers recorded interactions in memory and only flushes to
+# disk in ``__exit__`` (or via the atexit fallback below). When the
+# kernel is killed forcibly — typically because the build-level
+# wait-for-completion timeout fired and the parent worker was
+# ``TerminateProcess``'d — neither path runs and every interaction
+# recorded so far is lost. Patch the cassette so each successful
+# ``append`` immediately persists to disk; the staging file then always
+# reflects every interaction recorded up to the moment the kernel died.
+_clm_orig_append = _clm_cassette.append
+def _clm_eager_append(request, response):
+    _clm_orig_append(request, response)
+    try:
+        _clm_cassette._save(force=True)
+    except Exception:
+        pass
+_clm_cassette.append = _clm_eager_append
+# Belt-and-suspenders: graceful kernel shutdown still flushes via ``__exit__``.
 _clm_atexit.register(_clm_ctx.__exit__, None, None, None)
 """
 
 
-def _inject_http_replay_bootstrap(nb: NotebookNode, cassette_name: str, mode: str) -> None:
+def _inject_http_replay_bootstrap(nb: NotebookNode, cassette_path: str, mode: str) -> None:
     """Prepend a vcrpy-activation cell to ``nb``.
 
-    The cell is tagged ``del`` and marked with
+    ``cassette_path`` must be an absolute path to the worker's staging
+    cassette file (see :mod:`clm.workers.notebook.http_replay_cassette`),
+    so the kernel does not depend on its working directory to locate the
+    file. The cell is tagged ``del`` and marked with
     ``metadata.clm_injected = "http_replay"`` so the post-execution pass
     can remove it by metadata rather than by string-matching the source.
     """
     vcr_mode = _HTTP_REPLAY_MODE_TO_VCR_MODE[mode]
     from nbformat.v4 import new_code_cell
 
-    source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(record_mode=vcr_mode, cassette=cassette_name)
+    source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
+        record_mode=vcr_mode, cassette_path=cassette_path
+    )
     cell = new_code_cell(
         source=source,
         metadata={
@@ -1123,80 +1152,123 @@ class NotebookProcessor:
             },
         )
 
-    def _persist_recorded_cassette(
-        self, cid: str, kernel_cwd: Path, payload: NotebookPayload
-    ) -> None:
-        """Copy a freshly-recorded cassette out of the kernel's temp cwd.
+    def _resolve_cassette_paths(
+        self, payload: NotebookPayload, source_dir: Path | None
+    ) -> "CassettePaths | None":
+        """Determine where this worker will stage the cassette and the canonical target.
 
-        Direct-mode kernels run with their cwd set to a temporary directory
-        that is destroyed when control returns from the surrounding ``with``
-        block. vcrpy's atexit hook flushes the cassette to that cwd, so the
-        file lives only as long as the temp dir. Record-capable modes
-        (``once``, ``new-episodes``, and ``refresh``) need the file to land
-        in the course source tree at the topic-relative cassette path,
-        which is what this method does.
+        Returns ``None`` when the topic did not opt into replay, when the
+        mode is ``disabled``/``replay`` (no recording, so nothing to
+        stage), or when we cannot resolve a writable target directory.
 
-        ``replay`` mode never writes; ``disabled`` and absent modes are
-        no-ops here.
+        ``target_dir`` is the worker-side directory that maps to the
+        source tree: in direct mode this is ``payload.source_topic_dir``
+        (a host path readable from the same process), in Docker mode it
+        is ``source_dir`` (the container-mapped path under the source
+        mount). vcrpy inside the kernel writes to an absolute path under
+        this directory; the host code merges staging into canonical via
+        the same view of the filesystem.
         """
-        mode = payload.http_replay_mode
-        if not mode or mode in ("disabled", "replay"):
-            return
-        cassette_name = payload.http_replay_cassette_name
-        if not cassette_name:
-            return
-        if not payload.source_topic_dir:
-            logger.warning(
-                f"{cid}: cannot persist recorded cassette for "
-                f"'{payload.input_file_name}': source_topic_dir is empty."
-            )
-            return
-        recorded = kernel_cwd / cassette_name
-        if not recorded.exists():
-            # The cell that would have made the HTTP call may have errored
-            # out, or the topic may not actually issue any HTTP traffic.
-            logger.info(
-                f"{cid}: no cassette recorded for '{payload.input_file_name}' "
-                f"(expected at '{recorded}'); nothing to persist."
-            )
-            return
-        target = Path(payload.source_topic_dir) / cassette_name
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(recorded.read_bytes())
-        logger.info(
-            f"{cid}: persisted recorded cassette for '{payload.input_file_name}' to '{target}'"
-        )
+        from .http_replay_cassette import CassettePaths, resolve_paths
 
-    def _maybe_inject_http_replay(
-        self, processed_nb: NotebookNode, payload: NotebookPayload
-    ) -> bool:
-        """Inject the vcrpy bootstrap cell when the topic opted into replay.
-
-        Returns True when a cell was injected so the caller can decide
-        whether to run the strip pass.
-        """
         mode = payload.http_replay_mode
         if not mode or mode == "disabled":
-            return False
+            return None
         if mode not in _HTTP_REPLAY_MODE_TO_VCR_MODE:
             logger.warning(
                 f"{payload.correlation_id}: Unknown http_replay_mode {mode!r} "
-                f"for '{payload.input_file_name}'; skipping bootstrap injection."
+                f"for '{payload.input_file_name}'; skipping cassette resolution."
             )
-            return False
+            return None
         cassette_name = payload.http_replay_cassette_name
         if not cassette_name:
             logger.warning(
                 f"{payload.correlation_id}: http_replay_mode={mode!r} but no "
                 f"cassette was resolved for '{payload.input_file_name}'; "
-                f"skipping bootstrap injection."
+                f"skipping cassette resolution."
             )
+            return None
+        if source_dir is not None:
+            target_dir: Path = source_dir
+        elif payload.source_topic_dir:
+            target_dir = Path(payload.source_topic_dir)
+        else:
+            logger.warning(
+                f"{payload.correlation_id}: cannot resolve cassette target dir "
+                f"for '{payload.input_file_name}': source_topic_dir is empty and "
+                f"no source mount was provided; skipping bootstrap injection."
+            )
+            return None
+        paths: CassettePaths = resolve_paths(target_dir, cassette_name)
+        return paths
+
+    def _persist_recorded_cassette(
+        self, cid: str, payload: NotebookPayload, paths: "CassettePaths | None"
+    ) -> None:
+        """Merge this worker's staging cassette into the canonical cassette.
+
+        For ``replay``/``disabled`` modes (or when no paths were resolved)
+        this is a no-op. Otherwise the staging file plus any orphan
+        staging files left behind by previously-killed workers in the
+        same directory are merged into the canonical cassette under a
+        cross-process file lock, deduplicated by request fingerprint,
+        and the resulting file is written atomically. Staging files are
+        deleted after a successful merge.
+
+        Called from a ``finally`` block so it executes even when the
+        notebook raised — vcrpy's eager-save patch in the bootstrap
+        means partial recordings are already on disk in the staging
+        file before this method runs.
+        """
+        if paths is None:
+            return
+        mode = payload.http_replay_mode
+        if not mode or mode in ("disabled", "replay"):
+            return
+        from .http_replay_cassette import merge_staging_into_canonical
+
+        try:
+            merged = merge_staging_into_canonical(paths)
+        except Exception as exc:  # noqa: BLE001 — defensive: never let merge mask
+            #  the original notebook execution error.
+            logger.exception(
+                f"{cid}: cassette merge failed for '{payload.input_file_name}' "
+                f"(canonical='{paths.canonical}'): {exc}"
+            )
+            return
+        if merged == 0:
+            logger.info(
+                f"{cid}: no cassette recorded for '{payload.input_file_name}' "
+                f"(staging='{paths.staging}'); nothing to persist."
+            )
+        else:
+            logger.info(
+                f"{cid}: merged {merged} staging cassette(s) for "
+                f"'{payload.input_file_name}' into '{paths.canonical}'"
+            )
+
+    def _maybe_inject_http_replay(
+        self,
+        processed_nb: NotebookNode,
+        payload: NotebookPayload,
+        paths: "CassettePaths | None",
+    ) -> bool:
+        """Inject the vcrpy bootstrap cell when the topic opted into replay.
+
+        ``paths`` is the resolved canonical/staging pair from
+        :meth:`_resolve_cassette_paths`. Returns ``True`` when a cell was
+        injected so the caller can decide whether to run the strip pass.
+        """
+        if paths is None:
             return False
-        _inject_http_replay_bootstrap(processed_nb, cassette_name, mode)
+        mode = payload.http_replay_mode
+        if not mode or mode == "disabled" or mode not in _HTTP_REPLAY_MODE_TO_VCR_MODE:
+            return False
+        _inject_http_replay_bootstrap(processed_nb, str(paths.staging), mode)
         logger.debug(
             f"{payload.correlation_id}: Injected http-replay bootstrap "
-            f"(mode={mode}, cassette={cassette_name}) for "
-            f"'{payload.input_file_name}'"
+            f"(mode={mode}, staging='{paths.staging}', canonical='{paths.canonical}') "
+            f"for '{payload.input_file_name}'"
         )
         return True
 
@@ -1214,7 +1286,22 @@ class NotebookProcessor:
         if self.output_spec.evaluate_for_html and not payload.skip_evaluation:
             if any(is_code_cell(cell) for cell in processed_nb.get("cells", [])):
                 logger.debug(f"Evaluating and writing notebook '{payload.input_file_name}'")
-                replay_injected = self._maybe_inject_http_replay(processed_nb, payload)
+                # Resolve cassette paths up-front so the bootstrap can be
+                # injected with an absolute staging path and the finally
+                # block has the same paths to merge into canonical even
+                # when execution raised.
+                cassette_paths = self._resolve_cassette_paths(payload, source_dir)
+                if cassette_paths is not None:
+                    # Seed the worker's staging file from the canonical
+                    # cassette so already-recorded interactions can be
+                    # replayed (and so concurrent workers do not all
+                    # re-record the same traffic).
+                    from .http_replay_cassette import seed_staging_from_canonical
+
+                    seed_staging_from_canonical(cassette_paths)
+                replay_injected = self._maybe_inject_http_replay(
+                    processed_nb, payload, cassette_paths
+                )
                 try:
                     # To silence warnings about frozen modules...
                     os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
@@ -1236,20 +1323,17 @@ class NotebookProcessor:
                                 cid, path, processed_nb, payload, loop, source_dir
                             )
                         else:
-                            # Standard mode: write other_files to temp directory
+                            # Standard mode: write other_files to temp directory.
+                            # The kernel cwd is this temp dir but the http-replay
+                            # bootstrap writes its cassette to an absolute path
+                            # under the source tree, so the cassette survives
+                            # destruction of the temp dir.
                             with TemporaryDirectory() as temp_dir:
                                 path = Path(temp_dir)
                                 await self.write_other_files(cid, path, payload)
                                 await self._execute_notebook_with_path(
                                     cid, path, processed_nb, payload, loop, None
                                 )
-                                # In direct mode the kernel cwd is this temp
-                                # directory. vcrpy writes the cassette there
-                                # at kernel shutdown, so we must copy it back
-                                # to the source tree before the temp dir is
-                                # destroyed; otherwise record-mode runs leave
-                                # no artifact on disk.
-                                self._persist_recorded_cassette(cid, path, payload)
 
                 except Exception as e:
                     file_name = payload.input_file_name
@@ -1265,6 +1349,13 @@ class NotebookProcessor:
                     # when execution raised above.
                     if replay_injected:
                         _strip_injected_cells(processed_nb)
+                    # Always merge the staging cassette into the canonical
+                    # cassette, even when execution failed. The eager-save
+                    # patch in the bootstrap means partial recordings are
+                    # already on disk in the staging file; skipping the
+                    # merge would lose every interaction the kernel
+                    # successfully recorded before the failure.
+                    self._persist_recorded_cassette(cid, payload, cassette_paths)
 
                 # Cache the executed notebook for later reuse by Completed HTML
                 if self.output_spec.should_cache_execution and self.cache is not None:

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -1995,7 +1995,7 @@ class TestHttpReplayBootstrap:
 
         nb = make_notebook_node([make_cell("code", "import requests; requests.get('http://x')")])
 
-        _inject_http_replay_bootstrap(nb, "slides_test.http-cassette.yaml", "replay")
+        _inject_http_replay_bootstrap(nb, "/abs/slides_test.http-cassette.yaml", "replay")
 
         assert len(nb["cells"]) == 2
         injected = nb["cells"][0]
@@ -2005,11 +2005,15 @@ class TestHttpReplayBootstrap:
         assert "import vcr" in injected["source"]
         # record_mode maps replay -> vcrpy's "none"
         assert "'none'" in injected["source"]
-        assert "slides_test.http-cassette.yaml" in injected["source"]
+        assert "/abs/slides_test.http-cassette.yaml" in injected["source"]
         # The bootstrap must register an atexit hook so vcrpy flushes the
         # cassette to disk on kernel shutdown (refresh/once recording paths).
         assert "atexit" in injected["source"]
         assert "_clm_ctx.__exit__" in injected["source"]
+        # And it must patch Cassette.append for eager save so partial
+        # recordings survive a forceful kernel kill.
+        assert "_clm_eager_append" in injected["source"]
+        assert "_save" in injected["source"]
 
     def test_inject_uses_vcr_mode_mapping(self):
         from clm.workers.notebook.notebook_processor import (
@@ -2017,7 +2021,7 @@ class TestHttpReplayBootstrap:
         )
 
         nb = make_notebook_node([make_cell("code", "pass")])
-        _inject_http_replay_bootstrap(nb, "c.yaml", "refresh")
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "refresh")
 
         # refresh maps to vcrpy's "all"
         assert "'all'" in nb["cells"][0]["source"]
@@ -2028,7 +2032,7 @@ class TestHttpReplayBootstrap:
         )
 
         nb = make_notebook_node([make_cell("code", "pass")])
-        _inject_http_replay_bootstrap(nb, "c.yaml", "new-episodes")
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "new-episodes")
 
         # new-episodes maps to vcrpy's "new_episodes" (underscore form).
         assert "'new_episodes'" in nb["cells"][0]["source"]
@@ -2045,7 +2049,7 @@ class TestHttpReplayBootstrap:
                 make_cell("code", "x = 1"),
             ]
         )
-        _inject_http_replay_bootstrap(nb, "c.yaml", "replay")
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "replay")
         assert len(nb["cells"]) == 3
 
         _strip_injected_cells(nb)
@@ -2066,21 +2070,16 @@ class TestHttpReplayBootstrap:
         assert nb["cells"][0]["source"] == original[0]["source"]
         assert nb["cells"][1]["source"] == original[1]["source"]
 
-    def test_maybe_inject_skips_without_mode(self):
+    def test_resolve_paths_returns_none_without_mode(self):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
-        nb = make_notebook_node([make_cell("code", "x = 1")])
         payload = make_payload("", kind="speaker", format_="html")
 
-        injected = processor._maybe_inject_http_replay(nb, payload)
+        assert processor._resolve_cassette_paths(payload, source_dir=None) is None
 
-        assert injected is False
-        assert len(nb["cells"]) == 1
-
-    def test_maybe_inject_skips_disabled_mode(self):
+    def test_resolve_paths_returns_none_for_disabled_mode(self):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
-        nb = make_notebook_node([make_cell("code", "x = 1")])
         payload = make_payload("", kind="speaker", format_="html").model_copy(
             update={
                 "http_replay_mode": "disabled",
@@ -2088,193 +2087,334 @@ class TestHttpReplayBootstrap:
             }
         )
 
-        injected = processor._maybe_inject_http_replay(nb, payload)
+        assert processor._resolve_cassette_paths(payload, source_dir=None) is None
 
-        assert injected is False
-        assert len(nb["cells"]) == 1
-
-    def test_maybe_inject_skips_without_cassette_name(self):
+    def test_resolve_paths_returns_none_without_cassette_name(self):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
-        nb = make_notebook_node([make_cell("code", "x = 1")])
         payload = make_payload("", kind="speaker", format_="html").model_copy(
-            update={"http_replay_mode": "replay"}
+            update={"http_replay_mode": "replay", "source_topic_dir": "/tmp/topic"}
         )
 
-        injected = processor._maybe_inject_http_replay(nb, payload)
+        assert processor._resolve_cassette_paths(payload, source_dir=None) is None
 
-        assert injected is False
-        assert len(nb["cells"]) == 1
-
-    def test_maybe_inject_injects_when_mode_and_cassette_set(self):
+    def test_resolve_paths_returns_none_without_target_dir(self):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
-        nb = make_notebook_node([make_cell("code", "x = 1")])
         payload = make_payload("", kind="speaker", format_="html").model_copy(
             update={
                 "http_replay_mode": "once",
-                "http_replay_cassette_name": "_cassettes/slides.http-cassette.yaml",
-            }
-        )
-
-        injected = processor._maybe_inject_http_replay(nb, payload)
-
-        assert injected is True
-        assert len(nb["cells"]) == 2
-        assert nb["cells"][0]["metadata"]["clm_injected"] == "http_replay"
-        assert "_cassettes/slides.http-cassette.yaml" in nb["cells"][0]["source"]
-
-    def test_persist_recorded_cassette_copies_from_temp_to_source(self, tmp_path):
-        """Direct mode must copy the kernel's written cassette into the source tree.
-
-        vcrpy writes to the kernel cwd — a TemporaryDirectory in direct
-        mode — which is destroyed once execution returns. Without this
-        copy-back step the cassette never reaches the course repo even
-        when the atexit hook flushes it correctly.
-        """
-        spec = SpeakerOutput(format="html")
-        processor = NotebookProcessor(spec)
-
-        kernel_cwd = tmp_path / "kernel_temp"
-        kernel_cwd.mkdir()
-        (kernel_cwd / "slides.http-cassette.yaml").write_bytes(b"interactions: []\n")
-
-        source_topic_dir = tmp_path / "topic"
-        source_topic_dir.mkdir()
-
-        payload = make_payload("", kind="speaker", format_="html").model_copy(
-            update={
-                "http_replay_mode": "refresh",
                 "http_replay_cassette_name": "slides.http-cassette.yaml",
-                "source_topic_dir": str(source_topic_dir),
             }
         )
 
-        processor._persist_recorded_cassette("cid-1", kernel_cwd, payload)
+        assert processor._resolve_cassette_paths(payload, source_dir=None) is None
 
-        target = source_topic_dir / "slides.http-cassette.yaml"
-        assert target.exists()
-        assert target.read_bytes() == b"interactions: []\n"
-
-    def test_persist_recorded_cassette_creates_nested_cassettes_dir(self, tmp_path):
+    def test_resolve_paths_uses_source_topic_dir_in_direct_mode(self, tmp_path):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
-
-        kernel_cwd = tmp_path / "kernel_temp"
-        (kernel_cwd / "_cassettes").mkdir(parents=True)
-        (kernel_cwd / "_cassettes" / "slides.http-cassette.yaml").write_bytes(b"x: y\n")
-
-        source_topic_dir = tmp_path / "topic"
-        source_topic_dir.mkdir()
-
+        topic = tmp_path / "topic"
+        topic.mkdir()
         payload = make_payload("", kind="speaker", format_="html").model_copy(
             update={
                 "http_replay_mode": "once",
-                "http_replay_cassette_name": "_cassettes/slides.http-cassette.yaml",
-                "source_topic_dir": str(source_topic_dir),
+                "http_replay_cassette_name": "slides.http-cassette.yaml",
+                "source_topic_dir": str(topic),
             }
         )
 
-        processor._persist_recorded_cassette("cid-1", kernel_cwd, payload)
+        paths = processor._resolve_cassette_paths(payload, source_dir=None)
+        assert paths is not None
+        assert paths.canonical == topic / "slides.http-cassette.yaml"
+        # Staging file is in the same directory but with a unique suffix.
+        assert paths.staging.parent == paths.canonical.parent
+        assert paths.staging.name.startswith(paths.canonical.name + ".staging-")
+        assert paths.staging != paths.canonical
 
-        target = source_topic_dir / "_cassettes" / "slides.http-cassette.yaml"
-        assert target.exists()
-        assert target.read_bytes() == b"x: y\n"
-
-    def test_persist_recorded_cassette_persists_new_episodes_mode(self, tmp_path):
-        # new-episodes is record-capable: vcrpy may have appended new
-        # interactions to the kernel-cwd cassette and we must copy the
-        # merged file back into the source tree alongside ``once`` and
-        # ``refresh``.
+    def test_resolve_paths_prefers_source_dir_in_docker_mode(self, tmp_path):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
+        container_source = tmp_path / "container_source"
+        container_source.mkdir()
+        host_topic = tmp_path / "host_topic"  # different path; must NOT be used
+        host_topic.mkdir()
+        payload = make_payload("", kind="speaker", format_="html").model_copy(
+            update={
+                "http_replay_mode": "once",
+                "http_replay_cassette_name": "slides.http-cassette.yaml",
+                "source_topic_dir": str(host_topic),
+            }
+        )
 
-        kernel_cwd = tmp_path / "kernel_temp"
-        kernel_cwd.mkdir()
-        (kernel_cwd / "slides.http-cassette.yaml").write_bytes(b"interactions: [old, new]\n")
+        paths = processor._resolve_cassette_paths(payload, source_dir=container_source)
+        assert paths is not None
+        assert paths.canonical == container_source / "slides.http-cassette.yaml"
 
-        source_topic_dir = tmp_path / "topic"
-        source_topic_dir.mkdir()
-
+    def test_resolve_paths_two_workers_get_distinct_staging_paths(self, tmp_path):
+        """Concurrent workers building the same notebook must not collide on staging."""
+        spec = SpeakerOutput(format="html")
+        processor = NotebookProcessor(spec)
+        topic = tmp_path / "topic"
+        topic.mkdir()
         payload = make_payload("", kind="speaker", format_="html").model_copy(
             update={
                 "http_replay_mode": "new-episodes",
                 "http_replay_cassette_name": "slides.http-cassette.yaml",
-                "source_topic_dir": str(source_topic_dir),
+                "source_topic_dir": str(topic),
             }
         )
 
-        processor._persist_recorded_cassette("cid-1", kernel_cwd, payload)
+        paths_a = processor._resolve_cassette_paths(payload, source_dir=None)
+        paths_b = processor._resolve_cassette_paths(payload, source_dir=None)
+        assert paths_a is not None and paths_b is not None
+        assert paths_a.canonical == paths_b.canonical
+        assert paths_a.staging != paths_b.staging
 
-        target = source_topic_dir / "slides.http-cassette.yaml"
-        assert target.exists()
-        assert target.read_bytes() == b"interactions: [old, new]\n"
-
-    def test_persist_recorded_cassette_skips_replay_mode(self, tmp_path):
-        # Replay mode never writes — even if vcrpy somehow produced a file
-        # in the temp dir, we must not propagate it into the source tree.
+    def test_maybe_inject_skips_when_paths_none(self):
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
+        nb = make_notebook_node([make_cell("code", "x = 1")])
+        payload = make_payload("", kind="speaker", format_="html")
 
-        kernel_cwd = tmp_path / "kernel_temp"
-        kernel_cwd.mkdir()
-        (kernel_cwd / "slides.http-cassette.yaml").write_bytes(b"interactions: []\n")
+        injected = processor._maybe_inject_http_replay(nb, payload, paths=None)
 
-        source_topic_dir = tmp_path / "topic"
-        source_topic_dir.mkdir()
+        assert injected is False
+        assert len(nb["cells"]) == 1
 
-        payload = make_payload("", kind="speaker", format_="html").model_copy(
-            update={
-                "http_replay_mode": "replay",
-                "http_replay_cassette_name": "slides.http-cassette.yaml",
-                "source_topic_dir": str(source_topic_dir),
-            }
-        )
+    def test_maybe_inject_injects_when_paths_provided(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import CassettePaths
 
-        processor._persist_recorded_cassette("cid-1", kernel_cwd, payload)
-
-        assert not (source_topic_dir / "slides.http-cassette.yaml").exists()
-
-    def test_persist_recorded_cassette_noop_when_kernel_wrote_nothing(self, tmp_path):
-        # If the cell that would have made the HTTP call errored before
-        # issuing a request, vcrpy never writes a cassette. The persist
-        # step must silently do nothing.
         spec = SpeakerOutput(format="html")
         processor = NotebookProcessor(spec)
-
-        kernel_cwd = tmp_path / "kernel_temp"
-        kernel_cwd.mkdir()
-        # No cassette file written here.
-
-        source_topic_dir = tmp_path / "topic"
-        source_topic_dir.mkdir()
-
+        nb = make_notebook_node([make_cell("code", "x = 1")])
         payload = make_payload("", kind="speaker", format_="html").model_copy(
             update={
-                "http_replay_mode": "refresh",
-                "http_replay_cassette_name": "slides.http-cassette.yaml",
-                "source_topic_dir": str(source_topic_dir),
+                "http_replay_mode": "once",
+                "http_replay_cassette_name": "_cassettes/slides.http-cassette.yaml",
             }
         )
+        paths = CassettePaths(
+            canonical=tmp_path / "_cassettes" / "slides.http-cassette.yaml",
+            staging=tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc",
+        )
 
-        processor._persist_recorded_cassette("cid-1", kernel_cwd, payload)
+        injected = processor._maybe_inject_http_replay(nb, payload, paths)
 
-        assert not (source_topic_dir / "slides.http-cassette.yaml").exists()
+        assert injected is True
+        assert len(nb["cells"]) == 2
+        assert nb["cells"][0]["metadata"]["clm_injected"] == "http_replay"
+        # Bootstrap must reference the absolute staging path, not the
+        # relative cassette name from the payload. The path is emitted
+        # via ``repr()`` so on Windows the embedded backslashes are
+        # escaped — compare against ``repr(str(...))`` accordingly.
+        assert repr(str(paths.staging))[1:-1] in nb["cells"][0]["source"]
+        # And the canonical path's own name (which is part of the
+        # staging name) must appear too — a quick check that the
+        # canonical-to-staging mapping was honored.
+        assert paths.staging.name in nb["cells"][0]["source"]
 
-    def test_bootstrap_persists_cassette_to_disk(self, tmp_path, monkeypatch):
-        """Executing the bootstrap source in record mode must write a cassette.
 
-        Regression for the bug where ``__enter__`` was called but ``__exit__``
-        was never invoked, so vcrpy buffered interactions in memory and
-        discarded them at kernel shutdown without ever calling
-        ``Cassette._save()``. The atexit hook in the bootstrap fixes this.
+# ============================================================================
+# Cassette persistence: merge, locking, durability under forceful kill.
+# ============================================================================
+
+
+_SAMPLE_CASSETTE_TEMPLATE = """interactions:
+- request:
+    method: GET
+    uri: {uri}
+    headers: {{}}
+    body: null
+  response:
+    status: {{code: 200, message: OK}}
+    headers:
+      content-type: [text/plain]
+    body: {{string: '{body}'}}
+version: 1
+"""
+
+
+def _write_cassette(path, *, uri: str, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_SAMPLE_CASSETTE_TEMPLATE.format(uri=uri, body=body), encoding="utf-8")
+
+
+class TestCassetteMerge:
+    """Locked merge of per-worker staging files into the canonical cassette."""
+
+    def test_merge_creates_canonical_when_only_staging_exists(self, tmp_path):
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker-a"
+        _write_cassette(staging, uri="http://example/a", body="A")
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merged = merge_staging_into_canonical(paths)
+
+        assert merged == 1
+        assert canonical.exists()
+        assert not staging.exists()
+        content = canonical.read_text(encoding="utf-8")
+        assert "http://example/a" in content
+
+    def test_merge_is_noop_with_no_staging_files(self, tmp_path):
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker-a"
+        # Neither file exists.
+        paths = CassettePaths(canonical=canonical, staging=staging)
+
+        merged = merge_staging_into_canonical(paths)
+
+        assert merged == 0
+        assert not canonical.exists()
+
+    def test_merge_sweeps_orphan_staging_files(self, tmp_path):
+        """Staging files from previously-killed workers must be absorbed too."""
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        orphan_one = tmp_path / "slides.http-cassette.yaml.staging-orphan-1"
+        orphan_two = tmp_path / "slides.http-cassette.yaml.staging-orphan-2"
+        own = tmp_path / "slides.http-cassette.yaml.staging-own"
+        _write_cassette(orphan_one, uri="http://example/orphan1", body="O1")
+        _write_cassette(orphan_two, uri="http://example/orphan2", body="O2")
+        _write_cassette(own, uri="http://example/own", body="OWN")
+
+        paths = CassettePaths(canonical=canonical, staging=own)
+        merged = merge_staging_into_canonical(paths)
+
+        assert merged == 3
+        assert canonical.exists()
+        assert not orphan_one.exists()
+        assert not orphan_two.exists()
+        assert not own.exists()
+        content = canonical.read_text(encoding="utf-8")
+        assert "http://example/orphan1" in content
+        assert "http://example/orphan2" in content
+        assert "http://example/own" in content
+
+    def test_merge_deduplicates_against_canonical(self, tmp_path):
+        """An interaction already present in canonical must not be appended twice."""
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(canonical, uri="http://example/same", body="SAME")
+        _write_cassette(staging, uri="http://example/same", body="SAME")
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merged = merge_staging_into_canonical(paths)
+
+        assert merged == 1
+        content = canonical.read_text(encoding="utf-8")
+        # Should appear exactly once after dedup.
+        assert content.count("http://example/same") == 1
+
+    def test_merge_appends_new_interactions_to_existing_canonical(self, tmp_path):
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(canonical, uri="http://example/old", body="OLD")
+        _write_cassette(staging, uri="http://example/new", body="NEW")
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merge_staging_into_canonical(paths)
+
+        content = canonical.read_text(encoding="utf-8")
+        assert "http://example/old" in content
+        assert "http://example/new" in content
+
+    def test_concurrent_merges_do_not_lose_interactions(self, tmp_path):
+        """Two workers merging different recordings must produce a union, not a last-writer-wins."""
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        import threading
+
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging_a = tmp_path / "slides.http-cassette.yaml.staging-worker-a"
+        staging_b = tmp_path / "slides.http-cassette.yaml.staging-worker-b"
+        _write_cassette(staging_a, uri="http://example/a", body="A-PAYLOAD")
+        _write_cassette(staging_b, uri="http://example/b", body="B-PAYLOAD")
+
+        paths_a = CassettePaths(canonical=canonical, staging=staging_a)
+        paths_b = CassettePaths(canonical=canonical, staging=staging_b)
+
+        errors: list[Exception] = []
+
+        def _run(paths):
+            try:
+                merge_staging_into_canonical(paths)
+            except Exception as exc:  # pragma: no cover — debug aid
+                errors.append(exc)
+
+        t_a = threading.Thread(target=_run, args=(paths_a,))
+        t_b = threading.Thread(target=_run, args=(paths_b,))
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=30)
+        t_b.join(timeout=30)
+
+        assert not errors, f"Merge threads raised: {errors!r}"
+        assert canonical.exists()
+        content = canonical.read_text(encoding="utf-8")
+        # The union of both workers' recordings must be present — neither
+        # may have overwritten the other.
+        assert "http://example/a" in content
+        assert "http://example/b" in content
+        assert not staging_a.exists()
+        assert not staging_b.exists()
+
+
+class TestBootstrapDurability:
+    """The bootstrap must keep the cassette current even under forceful termination."""
+
+    def test_bootstrap_eager_saves_after_each_interaction(self, tmp_path):
+        """A recorded interaction must be on disk immediately, without waiting for atexit.
+
+        Regression for the bug where vcrpy buffered every interaction in
+        memory and only wrote them on graceful kernel shutdown — so a
+        kernel killed forcibly mid-execution (typically because the
+        build-level timeout fired and the parent worker was
+        TerminateProcess'd) discarded every recording.
         """
         pytest.importorskip("vcr")
-        import atexit
+        import atexit as _atexit_module
         import socket
         import urllib.request
-
-        # Bind a tiny HTTP server so the recorded interaction is real but local.
         from http.server import BaseHTTPRequestHandler, HTTPServer
         from threading import Thread
 
@@ -2302,33 +2442,92 @@ class TestHttpReplayBootstrap:
         thread.start()
 
         cassette_path = tmp_path / "test.http-cassette.yaml"
-        # Mirror what NotebookProcessor would emit for ``refresh`` mode.
         source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
             record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["refresh"],
-            cassette=str(cassette_path),
+            cassette_path=str(cassette_path),
         )
 
-        # Capture atexit registrations so the test runs them deterministically
-        # rather than waiting for interpreter shutdown.
+        # Capture atexit registrations so we can verify the cassette was
+        # written BEFORE we ever ran them — the eager-save patch is the
+        # only path that could have produced the file.
         registered: list = []
-        monkeypatch.setattr(atexit, "register", lambda fn, *a, **kw: registered.append((fn, a, kw)))
 
-        ns: dict = {}
-        try:
-            exec(compile(source, "<bootstrap>", "exec"), ns, ns)
-            urllib.request.urlopen(f"http://127.0.0.1:{port}/").read()
-        finally:
-            server.shutdown()
-            thread.join(timeout=2)
+        def _capture(fn, *a, **kw):
+            registered.append((fn, a, kw))
 
-        assert not cassette_path.exists(), "cassette must not be written before atexit fires"
+        import unittest.mock as _mock
 
-        # Fire the registered hooks (mimicking interpreter shutdown).
-        for fn, a, kw in registered:
-            fn(*a, **kw)
+        with _mock.patch.object(_atexit_module, "register", _capture):
+            ns: dict = {}
+            try:
+                exec(compile(source, "<bootstrap>", "exec"), ns, ns)
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/").read()
+            finally:
+                server.shutdown()
+                thread.join(timeout=2)
 
+            # Cassette must already exist on disk — atexit hooks have not fired.
+            assert cassette_path.exists(), (
+                "cassette was not eagerly saved; forceful kernel kill would lose interactions"
+            )
+            body = cassette_path.read_text(encoding="utf-8")
+            assert "interactions" in body
+            assert "127.0.0.1" in body
+
+    def test_bootstrap_eager_save_survives_force_exit(self, tmp_path):
+        """A subprocess killed via os._exit (no atexit) must leave the cassette on disk."""
+        pytest.importorskip("vcr")
+        import subprocess
+        import sys
+
+        cassette_path = tmp_path / "force_exit.http-cassette.yaml"
+
+        # Set up a tiny HTTP server inside the subprocess so the test does not
+        # depend on external networking, and `os._exit(1)` after recording so
+        # neither vcrpy's __exit__ nor the bootstrap's atexit hook can run.
+        script = f"""
+import os, socket, sys, threading, urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class _H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'hi')
+    def log_message(self, *a, **kw):
+        pass
+
+s = socket.socket(); s.bind(('127.0.0.1', 0)); port = s.getsockname()[1]; s.close()
+srv = HTTPServer(('127.0.0.1', port), _H)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+from clm.workers.notebook.notebook_processor import (
+    _HTTP_REPLAY_BOOTSTRAP_TEMPLATE, _HTTP_REPLAY_MODE_TO_VCR_MODE,
+)
+source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
+    record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE['refresh'],
+    cassette_path=r'''{cassette_path}''',
+)
+ns = {{}}
+exec(compile(source, '<bootstrap>', 'exec'), ns, ns)
+urllib.request.urlopen(f'http://127.0.0.1:{{port}}/').read()
+# Force-exit so neither __exit__ nor atexit can write the cassette.
+# If the cassette is on disk after this, the eager-save patch did it.
+os._exit(0)
+"""
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
         assert cassette_path.exists(), (
-            f"cassette was not written; atexit hook missing or broken. registered={registered!r}"
+            "cassette missing after os._exit — eager-save patch did not run; "
+            "forceful kernel kills would discard every recording"
         )
         body = cassette_path.read_text(encoding="utf-8")
         assert "interactions" in body

--- a/uv.lock
+++ b/uv.lock
@@ -916,6 +916,7 @@ all = [
     { name = "fastai" },
     { name = "fastembed" },
     { name = "faster-whisper" },
+    { name = "filelock" },
     { name = "ftfy" },
     { name = "gradio" },
     { name = "hf-xet" },
@@ -1119,6 +1120,7 @@ recordings = [
     { name = "soundfile" },
 ]
 replay = [
+    { name = "filelock" },
     { name = "vcrpy" },
 ]
 slides = [
@@ -1194,6 +1196,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "fastembed", marker = "extra == 'ml'", specifier = ">=0.6.0" },
     { name = "faster-whisper", marker = "extra == 'voiceover'", specifier = ">=1.0.0" },
+    { name = "filelock", marker = "extra == 'replay'", specifier = ">=3.12.0" },
     { name = "ftfy", marker = "extra == 'ml'", specifier = ">=6.1.1" },
     { name = "gradio", marker = "extra == 'ml'", specifier = ">=6.5.1" },
     { name = "hf-xet", marker = "extra == 'ml'", specifier = ">=1.1.10" },


### PR DESCRIPTION
## Summary

- HTTP-replay cassettes now survive forceful kernel termination. The bootstrap cell writes to a per-worker staging file at an absolute path under the source tree and patches `Cassette.append` to save eagerly after every recorded interaction, so the cassette on disk always reflects what the kernel actually recorded — even when the worker subprocess is `TerminateProcess`'d by the build-level wait-for-completion timeout before `__exit__`/atexit could run.
- A post-execution merge step in a `finally` block folds the worker's staging file (plus any orphan staging files left by previously-killed workers) into the canonical cassette under a cross-process `FileLock`, deduplicating by request fingerprint and writing atomically via `os.replace`.
- Concurrent builds of the same notebook in different languages each write to distinct staging files and merge into the shared canonical cassette without overwriting each other.

## Background

A user reported `slides_030_chains_parallel.py` running for 18+ minutes on every build, never converging. Trace: build hits `max_wait_for_completion_duration` (1200s) → `pool_manager._emergency_stop` → `subprocess.Popen.terminate()` → `TerminateProcess` on Windows → kernel grandchild dies with all recorded interactions still buffered in vcrpy's in-memory cassette. The merge step in `_create_using_nbconvert` was also placed outside a `finally`, so any execution failure (timeout, retry exhaustion) skipped the copy-back even when the cassette did make it to the temp dir.

## Changes

- **New module** `src/clm/workers/notebook/http_replay_cassette.py` — `resolve_paths`, `seed_staging_from_canonical`, `merge_staging_into_canonical`. Locked merge dedupes by `(method, uri, body)` and is idempotent across orphan sweep + post-execution merge.
- **Bootstrap rewrite** in `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`: captures the `Cassette` returned by `__enter__` (vcrpy name-mangles its `__cassette` attr, so this is the only stable handle), monkey-patches `append` for eager save, retains the atexit hook as belt-and-suspenders.
- **`_create_using_nbconvert`**: resolves canonical+staging paths up-front, seeds staging before bootstrap injection, wraps execution in try/…/finally with the merge in the finally block. Both direct and Docker modes now go through the same path.
- **`filelock>=3.12.0`** added to the `[replay]` extra.

## Test plan

- [x] `pytest tests/workers/notebook/test_notebook_processor.py` — 93 passed
- [x] `pytest -m \"not docker\"` — 4778 passed, 11 skipped, 4 xfailed
- [x] `ruff check` and `ruff format` clean on changed files
- [x] `mypy src/clm` clean (added `vcr.*` to ignore_missing_imports)
- [x] New regression test `test_bootstrap_eager_save_survives_force_exit` spawns a subprocess that records one interaction then `os._exit(0)`s and asserts the cassette is on disk anyway — directly exercises the user-reported scenario
- [x] New `TestCassetteMerge::test_concurrent_merges_do_not_lose_interactions` runs two threads merging different recordings concurrently and asserts the canonical contains both — locks in the concurrent-worker safety guarantee
- [ ] End-to-end verification by rebuilding `slides_030_chains_parallel.py` on a real build

🤖 Generated with [Claude Code](https://claude.com/claude-code)