### PR TITLE
feat(http-replay): allow section-level default

### DIFF
--- a/docs/user-guide/http-replay.md
+++ b/docs/user-guide/http-replay.md
@@ -31,6 +31,24 @@ Mark the topic in your course spec:
 Default is `"no"`. The attribute accepts the usual truthy/falsy values
 (`yes`/`no`, `true`/`false`, `1`/`0`).
 
+### Opting in a whole section
+
+`http-replay` is also accepted on `<section>` and acts as the default
+for every child `<topic>`. Topics may still override it with their own
+`http-replay="yes"`/`"no"` — same precedence rule as `module`. Useful
+when a whole week of material talks to an LLM API:
+
+```xml
+<section http-replay="yes">
+    <name><de>Woche 03: LLM-APIs</de><en>Week 03: LLM APIs</en></name>
+    <topics>
+        <topic>llm_apis</topic>           <!-- inherits yes -->
+        <topic>openai_library_azav</topic> <!-- inherits yes -->
+        <topic http-replay="no">offline_intro</topic> <!-- explicit opt-out -->
+    </topics>
+</section>
+```
+
 ## First run — recording a cassette
 
 On a local build, the default mode is `new-episodes`:

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -592,6 +592,7 @@ class Course(NotebookMixin):
                 section=section,
                 path=topic_path,
                 includes=resolved_includes,
+                http_replay=section_spec.http_replay_for(topic_spec),
             )
             topic.build_file_map()
             section.topics.append(topic)

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -160,10 +160,12 @@ class TopicSpec:
     # ``evaluate="no"`` on the topic.
     skip_evaluation: bool = False
     skip_errors: bool = False
-    # When True, this topic opts in to HTTP replay (cassette-backed
-    # request recording/playback via ``vcrpy``). The global record mode
-    # is chosen at build time by ``--http-replay`` or ``CLM_HTTP_REPLAY_MODE``.
-    http_replay: bool = False
+    # When set, this topic opts in to (True) or out of (False) HTTP replay
+    # (cassette-backed request recording/playback via ``vcrpy``). ``None``
+    # means "inherit from the section default" — see
+    # :meth:`SectionSpec.http_replay_for`. The global record mode is chosen
+    # at build time by ``--http-replay`` or ``CLM_HTTP_REPLAY_MODE``.
+    http_replay: bool | None = None
     author: str = ""
     prog_lang: str = ""
     # Optional module binding. When set, resolution is restricted to the
@@ -190,6 +192,10 @@ class SectionSpec:
     # inherits these unless the topic declares its own ``<include>`` with
     # the same ``as_path``.
     includes: list[IncludeSpec] = Factory(list)
+    # Section-level ``http-replay`` default applied to all child topics
+    # that do not themselves carry an explicit ``http-replay`` attribute.
+    # Per-topic ``http-replay="yes"``/``"no"`` overrides this default.
+    http_replay: bool = False
 
     def module_for(self, topic_spec: TopicSpec) -> str | None:
         """Effective module binding for *topic_spec* under this section.
@@ -215,6 +221,14 @@ class SectionSpec:
         for inc in topic_spec.includes:
             merged[inc.key] = inc
         return list(merged.values())
+
+    def http_replay_for(self, topic_spec: TopicSpec) -> bool:
+        """Effective ``http-replay`` flag for *topic_spec* under this section.
+
+        Per-topic ``http-replay`` overrides the section default. ``None``
+        on the topic means "not set" → inherit the section value.
+        """
+        return self.http_replay if topic_spec.http_replay is None else topic_spec.http_replay
 
 
 @frozen
@@ -283,6 +297,19 @@ def _parse_bool_attr(value: str | None, *, attr_name: str) -> bool:
         f"Invalid value for {attr_name!r} attribute: {value!r}. "
         f"Expected 'true'/'yes'/'1' or 'false'/'no'/'0' (case-insensitive)."
     )
+
+
+def _parse_optional_bool_attr(value: str | None, *, attr_name: str) -> bool | None:
+    """Like :func:`_parse_bool_attr` but distinguishes "absent" from "false".
+
+    Returns ``None`` when the attribute is missing (so callers can fall
+    back to an inherited default), and ``True``/``False`` for explicit
+    truthy/falsy values. Empty string is treated as ``False`` for
+    symmetry with :func:`_parse_bool_attr`.
+    """
+    if value is None:
+        return None
+    return _parse_bool_attr(value, attr_name=attr_name)
 
 
 def _parse_disable_attr(value: str | None, *, attr_name: str) -> bool:
@@ -911,6 +938,9 @@ class CourseSpec:
 
             section_id = section_elem.attrib.get("id") or None
             section_module = section_elem.attrib.get("module") or None
+            section_http_replay = _parse_bool_attr(
+                section_elem.attrib.get("http-replay"), attr_name="http-replay"
+            )
 
             if not enabled and not keep_disabled:
                 # Skip disabled sections entirely. They may reference topics
@@ -948,7 +978,7 @@ class CourseSpec:
                                 topic_elem.attrib.get("skip-errors"),
                                 attr_name="skip-errors",
                             ),
-                            http_replay=_parse_bool_attr(
+                            http_replay=_parse_optional_bool_attr(
                                 topic_elem.attrib.get("http-replay"),
                                 attr_name="http-replay",
                             ),
@@ -966,6 +996,7 @@ class CourseSpec:
                     id=section_id,
                     module=section_module,
                     includes=section_includes,
+                    http_replay=section_http_replay,
                 )
             )
         return sections

--- a/src/clm/core/topic.py
+++ b/src/clm/core/topic.py
@@ -67,8 +67,13 @@ class Topic(NotebookMixin, ABC):
         path: Path,
         *,
         includes: "list[ResolvedInclude] | None" = None,
+        http_replay: bool | None = None,
     ):  # noqa
         cls: type[Topic] = FileTopic if path.is_file() else DirectoryTopic
+        # Caller (Course._build_topics) passes the section-resolved effective
+        # value via ``http_replay=``. When omitted (test code, direct callers),
+        # fall back to the topic spec; ``None`` there means "not set" → False.
+        effective_http_replay = http_replay if http_replay is not None else bool(spec.http_replay)
         return cls(
             id=spec.id,
             section=section,
@@ -76,7 +81,7 @@ class Topic(NotebookMixin, ABC):
             skip_html=spec.skip_html,
             skip_evaluation=spec.skip_evaluation,
             skip_errors=spec.skip_errors,
-            http_replay=spec.http_replay,
+            http_replay=effective_http_replay,
             author=spec.author,
             prog_lang_override=spec.prog_lang,
             includes=list(includes) if includes else [],

--- a/tests/core/course_spec_test.py
+++ b/tests/core/course_spec_test.py
@@ -218,7 +218,76 @@ def test_parse_topic_with_http_replay_attribute():
     assert topics[0].http_replay is True
     assert topics[1].http_replay is True
     assert topics[2].http_replay is False
-    assert topics[3].http_replay is False
+    # Absent attribute → None (inherit from section default), distinct
+    # from explicit "no" which is False.
+    assert topics[3].http_replay is None
+    # Section default is False, so resolved value is False for all four.
+    section = sections[0]
+    assert [section.http_replay_for(t) for t in topics] == [True, True, False, False]
+
+
+def test_section_http_replay_defaults_to_topics():
+    """``<section http-replay="yes">`` applies to every child topic."""
+    from xml.etree import ElementTree as ETree
+
+    xml = """
+    <course>
+        <name><de>Test</de><en>Test</en></name>
+        <prog-lang>python</prog-lang>
+        <description><de></de><en></en></description>
+        <certificate><de></de><en></en></certificate>
+        <sections>
+            <section http-replay="yes">
+                <name><de>LLM</de><en>LLM</en></name>
+                <topics>
+                    <topic>uses_llm_one</topic>
+                    <topic>uses_llm_two</topic>
+                    <topic http-replay="no">no_network_topic</topic>
+                </topics>
+            </section>
+        </sections>
+    </course>
+    """
+    root = ETree.fromstring(xml)
+    sections = CourseSpec.parse_sections(root)
+    section = sections[0]
+    assert section.http_replay is True
+    topics = section.topics
+    # Topic 0 + 1 inherit section default; topic 2 explicitly opts out.
+    assert topics[0].http_replay is None
+    assert topics[1].http_replay is None
+    assert topics[2].http_replay is False
+    assert section.http_replay_for(topics[0]) is True
+    assert section.http_replay_for(topics[1]) is True
+    assert section.http_replay_for(topics[2]) is False
+
+
+def test_section_http_replay_default_false_topic_can_opt_in():
+    """Section default False; per-topic ``http-replay="yes"`` still opts in."""
+    from xml.etree import ElementTree as ETree
+
+    xml = """
+    <course>
+        <name><de>Test</de><en>Test</en></name>
+        <prog-lang>python</prog-lang>
+        <description><de></de><en></en></description>
+        <certificate><de></de><en></en></certificate>
+        <sections>
+            <section>
+                <name><de>Mixed</de><en>Mixed</en></name>
+                <topics>
+                    <topic>plain_topic</topic>
+                    <topic http-replay="yes">opts_in_topic</topic>
+                </topics>
+            </section>
+        </sections>
+    </course>
+    """
+    root = ETree.fromstring(xml)
+    section = CourseSpec.parse_sections(root)[0]
+    assert section.http_replay is False
+    assert section.http_replay_for(section.topics[0]) is False
+    assert section.http_replay_for(section.topics[1]) is True
 
 
 def test_parse_topic_with_evaluate_attribute():


### PR DESCRIPTION
## Summary

- `<section http-replay="...">` is now parsed and acts as the default for every child `<topic>`. Per-topic `http-replay="yes"`/`"no"` still wins as an explicit override — same precedence rule as `module` and `<include>`.
- `TopicSpec.http_replay` becomes `bool | None`: `None` means "not set, inherit"; `True`/`False` are explicit overrides. `SectionSpec.http_replay_for(topic_spec)` resolves the effective value, mirroring `module_for` / `includes_for`.
- `Course._build_topics` passes the resolved value into `Topic.from_spec(..., http_replay=...)`. Downstream consumers continue to see a plain `bool` on `Topic.http_replay`.

Motivates the change: in course specs like `machine-learning-azav.xml`, whole weeks of LLM topics need replay enabled, and repeating `http-replay="true"` on every `<topic>` is noisy.

## Test plan

- [x] `tests/core/course_spec_test.py::test_parse_topic_with_http_replay_attribute` updated for the new "absent → None" semantics, including a resolution check via `http_replay_for`.
- [x] New `test_section_http_replay_defaults_to_topics` covers section default + per-topic opt-out.
- [x] New `test_section_http_replay_default_false_topic_can_opt_in` covers the inverse direction.
- [x] Full `tests/core` (449 tests) and existing `-k replay` suite (27 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)