### PR TITLE
feat(build): output-write deduplication and conflict warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `--gitignore` (idempotent per-topic `.gitignore` rules for
   materialized includes), `--dry-run`. See `clm info commands` and
   `clm info spec-files` for the full reference.
+- **Output-write deduplication and conflict warnings on `clm build`.**
+  Builds that legitimately produce identical writes to the same output
+  path (e.g. multiple topics that share an `<include>`-sourced file,
+  or the C# course's repeated `NUnitTestRunner.cs`) now collapse to a
+  single write, with the remaining writes reported as a dedup count
+  in the build summary. Differing-content writes to the same output
+  path still proceed with last-writer-wins (preserving previous
+  behavior) but now surface a per-conflict `output_path_conflict`
+  warning naming both source paths and a structured
+  `output_conflicts` entry in the JSON summary, so authoring drift no
+  longer hides silently. Image-path collisions continue to go through
+  the existing `image_collision` channel — no double-warning. Tunable
+  via `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` (default 50 MB; files above
+  this size skip hashing and are reported as a single summary
+  collision count).
+- **`output_dedup_count`, `output_conflicts`, and
+  `output_large_file_collision_count` keys on the `clm build` JSON
+  summary.** Emitted unconditionally so machine consumers don't have
+  to special-case the absence of registry events on clean builds.
+  `output_conflicts` is a list of
+  `{output_path, first_writer, last_writer, first_hash, last_hash,
+  conflict_count}` records.
 - **`--http-replay=new-episodes` build mode.** Replays every request
   that is in the existing cassette and records only the genuinely new
   ones into the same file. Fixes the case where an edited notebook now

--- a/docs/claude/shared-source-includes-handover.md
+++ b/docs/claude/shared-source-includes-handover.md
@@ -2,62 +2,58 @@
 
 Companion to
 [`docs/claude/design/shared-source-includes-and-output-dedup.md`](design/shared-source-includes-and-output-dedup.md)
-(locked 2026-05-10). Tracks implementation progress across two PRs.
+(locked 2026-05-10). Tracks implementation across two PRs:
+
+- **Feature 1 — shared-source `<include>` + `clm sync-includes`.** Shipped
+  via [PR #61](https://github.com/hoelzl/clm/pull/61), merged 2026-05-11
+  (master tip `f86c36d`). See "PR 1 — Shipped (reference card)" below for
+  the eight-phase summary; full per-phase detail preserved in the
+  historical sections after the active PR 2 table.
+- **Feature 2 — output-write dedup + collision warning.** This handover's
+  current focus; not started.
 
 ---
 
 ## Start here (fresh session)
 
-**Worktree**: `C:\Users\tc\Programming\Python\Projects\clm\.claude\worktrees\curious-twirling-owl`
+**Worktree**: `C:\Users\tc\Programming\Python\Projects\clm\.claude\worktrees\methodical-writing-registry`
 (do all work from there; do NOT `cd` to the main repo).
 
-**Branch**: `claude/shared-source-includes` (already checked out in the worktree).
+**Branch**: `claude/output-write-dedup` (already checked out in the
+worktree; tracks `origin/master`, created off `f86c36d`).
 
-**Last commits on the branch**:
+**Last commits visible from the branch**:
 
 ```
+f86c36d  Merge pull request #61 from hoelzl/claude/shared-source-includes  <-- master tip / PR 1 merged
+4a22ed6  fix(includes): Linux backslash normalization + Click 8.1/8.2 CliRunner
+efaf051  Merge remote-tracking branch 'origin/master' into claude/shared-source-includes
+c820699  docs(handover): mark PR1.8 complete; PR 1 ready for review
+aadacc6  docs(handover): record PR1.7 commit hash
 9cd89bd  fix(core): exclude .clm-include ledger from topic file map  <-- PR1.7
-1a9c967  docs(handover): mark PR1.6 complete; pivot to PR1.7 smoke test
-1835064  docs: document <include> element and clm sync-includes  <-- PR1.6
-e98faaa  docs(handover): record PR1.5 commit hash
-72289b1  feat(cli): add clm sync-includes command            <-- PR1.5
-af3b61e  feat(validate-spec): surface <include> spec issues
-10321a5  docs(handover): record PR1.3 commit hash
-0f4185b  feat(course): resolve <include> entries during section build
-c122608  feat(spec): add <include> element with virtual file splice
-1866962  build(uv): refresh uv.lock for exclude-newer=2026-04-20
-27042ca  build(uv): bump exclude-newer to 2026-04-20   <-- master tip
 ```
 
-**Test command**: `uv run pytest -x -q` (fast suite, ~62s, runs via pre-commit too).
-Last green: 4639 passed at PR1.6 (docs-only commit). One known flaky session
-test (`tests/recordings/test_session.py::TestShortTake::test_short_take_can_be_followed_by_real_take`)
-times out under xdist load but passes in isolation — unrelated to this feature.
+**Test command**: `uv run pytest -x -q` (fast suite, ~60s, runs via
+pre-commit too). Master baseline at `f86c36d` should be all-green
+(verified by CI on the PR1 merge). One known-flaky session test —
+`tests/recordings/test_session.py::TestShortTake::test_short_take_can_be_followed_by_real_take`
+— times out under xdist load but passes in isolation; unrelated.
 
-**Auto Mode is on**: user prefers continuous execution. Don't re-ask the
-locked design questions; they're listed under "Decisions log" below. Course
-corrections will arrive as user messages.
+**Auto Mode is on**: user prefers continuous execution. Don't re-ask
+the locked design questions; they're listed under "Decisions log"
+below. Course corrections will arrive as user messages.
 
-**Status**: PR 1 is **feature-complete and locally green** as of
-commit `aadacc6`. All eight phases ticked. Branch waiting for the
-user's go-ahead to push and open a PR against `master`.
+**Status**: PR 2 not started. The worktree was just created off the
+post-PR1-merge master tip; only this handover refresh sits on the
+branch so far.
 
-- PR1.7 + PR1.7a (smoke test + `.clm-include` filter bugfix) landed in
-  commit `9cd89bd`; see the PR1.7/PR1.7a rows in the phases table
-  below, and "PR1.7 smoke test outcome" for the diff methodology.
-- PR1.8 pre-PR checks all clean — `pytest -m "not docker"`: 4751
-  passed / 12 skipped / 4 xfailed in 156.73s; `ruff check`: clean;
-  `ruff format --check`: clean; mypy: clean (verified by pre-commit
-  on commit `9cd89bd`).
-
-**Next phase**: push `claude/shared-source-includes` and open the PR.
-After the user authorizes push, the typical move is
-`git push -u origin claude/shared-source-includes` then
-`gh pr create --base master`. PR body should summarize the eight
-phases and link the design doc
-[`docs/claude/design/shared-source-includes-and-output-dedup.md`](design/shared-source-includes-and-output-dedup.md).
-Feature 2 (output-write dedup) starts on a separate branch after PR 1
-merges.
+**Next phase to pick up**: PR2.1 — `OutputWriteRegistry` module +
+content-hashing helper as a standalone unit-testable thing, no
+integration yet. See the PR 2 phase table below for the full sequence
+and design-doc references. Each phase gets its own commit, matching
+PR 1's pattern; PR1.7's bisect-friendly history made the `.clm-include`
+bug (caught by the smoke test) much easier to reason about, so keep
+the per-phase shape unless a phase is genuinely trivial.
 
 ---
 
@@ -83,7 +79,49 @@ topics legitimately produce the same output paths).
 
 ---
 
-## PR 1 — Feature 1 phases
+## PR 2 — Feature 2 phases
+
+Branch: `claude/output-write-dedup`. Design doc §"Feature 2: Output-Write
+Deduplication and Collision Warning" (lines 337–407 of
+`design/shared-source-includes-and-output-dedup.md`) is the authoritative
+spec; the rows below break it into incremental commits.
+
+| # | Phase | Status | Notes |
+|---|---|---|---|
+| 1 | `OutputWriteRegistry` module + content-hashing helper | [ ] | Standalone unit-testable module; no integration with the build pipeline yet. Probable home: `src/clm/core/output_write_registry.py` (sibling to `image_registry.py`). Per-build singleton recording, for each absolute output path: `(content_hash, first_writer_source_path, dedup_count, conflict_count)`. Hash: BLAKE2b-128 or SHA-256-truncated (speed > cryptographic strength). Path-equality fast path for files >50 MB (skip hashing, log a single `output_large_file_collision` summary). Size threshold should be configurable via env var or build flag — pick the same plumbing pattern as `CLM_HTTP_REPLAY_MODE` etc. Unit tests live in `tests/core/test_output_write_registry.py`: record first write, dedup identical second write, conflict on differing second write, large-file path-equality fast path. **Decision (locked):** no persistence across builds — registry is per-build only. |
+| 2 | Hook into `backend.copy_file_to_output()` and the notebook output writer | [ ] | Two real choke points (jupyterlite + plantuml outputs funnel through these). `backend.copy_file_to_output()` lives at `src/clm/core/operations/copy_file.py` + the backend impl; the notebook output writer is `src/clm/workers/notebook/notebook_processor.py:write_other_files_sync` (~line 1529 at PR1 tip; check current line numbers). **Crucial: skip paths owned by `ImageRegistry`** (`src/clm/core/image_registry.py`) so the existing `image_collision` warning channel stays the sole reporter for image paths — no double-warn. Behavior on second write: same hash → increment count + **skip the actual write** + debug-log; different hash → write file (current behavior preserved), emit `output_path_conflict` warning naming both source files + the output path + both hashes, replace registry's first-writer with the latest, increment `conflict_count`. **Watch for the `.clm-include` class of bug from PR1.7**: the `CopyFileOperation` path picks up files that authors don't expect — make sure the registry only logs the files we mean to log, not build-internal artifacts. |
+| 3 | `BuildReporter` integration (counts + JSON `output_conflicts` key) | [ ] | Existing reporter at `src/clm/cli/build_reporter.py`. End-of-build summary line: "{N} output paths written multiple times with identical content (deduplicated); {M} output paths had conflicting writes (last writer won)." JSON output gets a new `output_conflicts` key — machine-readable list of `{output_path, first_writer, second_writer, first_hash, second_hash}` entries. Exit code unchanged (warnings, not errors); the `--strict` promotion to errors is captured in "Out-of-scope" below for a future PR. |
+| 4 | Tests | [ ] | **Unit** (in addition to phase 1 tests): registry skips `ImageRegistry`-owned paths; `BuildReporter` JSON has the right keys when no conflicts (empty list, not missing). **Integration** (new file `tests/integration/test_output_dedup.py` or similar): build a synthetic course where two topics produce the same path with identical content — verify single write + counted dedup; same path with differing content — verify warning + last-writer-wins + JSON entry. **C# case (most-likely-to-bite real example)**: the C# course's repeated `NUnitTestRunner.cs` pattern (see "Out-of-scope, captured for future" → Feature 2 motivating cases) — build a synthetic miniature with N topics that produce the same runner file, verify `dedup_count == N-1`. **Regression**: existing `ImageRegistry` collision tests must still fire `image_collision` (not the new `output_path_conflict`) for shared images. |
+| 5 | Docs + CHANGELOG | [ ] | `clm info commands` mentions the new warning + JSON key on `clm build`; `CHANGELOG.md` `[Unreleased] > ### Added` gets bullets for the dedup + the new reporter key. No new info-topic file — this is a build-time behavior, not a user-facing command. If the size-threshold flag/env-var lands, document it next to existing build flags. |
+| 6 | Pre-PR checks | [ ] | `uv run pytest -m "not docker"`, `uv run ruff check src/ tests/`, `uv run ruff format src/ tests/`, mypy via pre-commit. Per CLAUDE.md release rules. |
+| 7 | Smoke validation against the AZAV ML build | [ ] | Optional but high-value (mirrors PR1.7). Run a full course build with the new dedup hook enabled; expect the now-deduped writes from the `<include>`-shared `simple_chatbot/` (60 output variants × 7 files = 420 dedup events) to show up in the reporter summary, and zero `output_path_conflict` warnings on a clean course. Don't commit course-repo state; record the dedup-count outcome in the PR body. |
+
+---
+
+## PR 1 — Shipped (reference card)
+
+Feature 1 shipped in [PR #61](https://github.com/hoelzl/clm/pull/61),
+merged 2026-05-11 as commit `f86c36d`. The eight-phase summary:
+
+| Phase | Commit | What |
+|---|---|---|
+| 1.1 spec parsing | `c122608` | `IncludeSpec`, `_parse_includes`, `_normalize_include_path` in `course_spec.py`; 12 tests in `course_spec_test.py` |
+| 1.2 file discovery | `c122608` | `source_origin` + `from_virtual` in `course_file.py`; `apply_includes`, `add_virtual_file` in `topic.py`; `source_path` reads in `copy_file.py`, `process_notebook.py`, `convert_drawio_file.py`, `convert_plantuml_file.py`; 6 tests in `topic_test.py` |
+| 1.3 build-pipeline integration | `0f4185b` | `Course._build_topics` calls `SectionSpec.includes_for`; 6 integration tests in `course_test.py` |
+| 1.4 validation | `af3b61e` | `spec_validator._validate_includes` + helpers; 5 finding categories; 17 tests in `test_spec_validator.py` |
+| 1.5 `clm sync-includes` CLI | `72289b1` | `cli/commands/sync_includes.py` (~470 LOC); copy/symlink/hardlink modes with Windows-friendly fallbacks; per-topic `.clm-include` JSON ledger; 18 tests in `test_sync_includes.py` |
+| 1.6 docs | `1835064` | `info_topics/spec-files.md`, `info_topics/commands.md`, `docs/user-guide/spec-file-reference.md`, `CHANGELOG.md` |
+| 1.7 smoke + `.clm-include` filter bugfix | `9cd89bd` | Migrated AZAV ML gradio topics, diffed builds, caught 60-file output leak; fixed via `SKIP_FILE_NAMES` in `path_utils.py` + top-level filter in `topic.add_files_in_dir`. Full methodology in "PR1.7 smoke test outcome" below. |
+| 1.7c CI fix on Linux | `4a22ed6` | `_normalize_include_path` POSIX backslash handling + Click 8.1/8.2 `CliRunner(mix_stderr=...)` compat |
+| 1.8 pre-PR | (no code) | `pytest -m "not docker"`: 4751 passed / 12 skipped / 4 xfailed; ruff + mypy clean |
+
+Full per-phase notes (with the original rationale for each decision)
+remain under "PR 1 — Feature 1 phases (historical detail)" further down
+in this doc.
+
+---
+
+## PR 1 — Feature 1 phases (historical detail)
 
 | # | Phase | Status | Notes |
 |---|---|---|---|
@@ -96,19 +134,58 @@ topics legitimately produce the same output paths).
 | 7 | Smoke test: migrate ML AZAV `topic_040_gradio_intro` and `topic_041_gradio_deep_dive` per design doc; full build + diff against pre-migration | [x] 2026-05-10 | See "PR1.7 smoke test outcome" below. Migration produces byte-identical output for all 420 spliced `simple_chatbot` files across every output target × language × kind × format. Course-repo migration was reverted (not committed) per design. **Caught a real bug:** the `.clm-include` per-topic ledger was leaking into student/trainer/speaker output as 60 stray files; fixed in this row's work — see PR1.7a below. |
 | 7a | Bugfix: filter `.clm-include` (sync-includes ledger) from `Topic.build_file_map` and output | [x] 2026-05-10 (commit 9cd89bd) | `src/clm/infrastructure/utils/path_utils.py`: new `SKIP_FILE_NAMES = frozenset({".clm-include"})` constant; `is_ignored_file_for_course` now also rejects names in this set. `src/clm/core/topic.py`: `Topic.add_files_in_dir` was only filtering subdir descendants — added the same `is_ignored_file_for_course` check to top-level files so the ledger at the topic root is excluded. Two new tests: `path_utils_test.py::test_is_ignored_file_for_course_skips_sync_includes_ledger` and `topic_test.py::test_build_file_map_skips_sync_includes_ledger`. Verified end-to-end by re-running the smoke build: `.clm-include` leak count dropped from 60 → 0. |
 | 8 | Pre-PR: `uv run pytest -m "not docker"`, `uv run ruff check`, `uv run ruff format`, mypy via pre-commit | [x] 2026-05-10 | `pytest -m "not docker"`: **4751 passed, 12 skipped, 4 xfailed** in 156.73s (only 3 pre-existing voiceover `--mode` deprecation warnings). `ruff check src/ tests/`: clean. `ruff format --check src/ tests/`: 508 files already formatted. mypy: clean via pre-commit hook on commit `9cd89bd`. Branch is ready for PR creation; user has not authorized push yet. |
+| 9 | Post-merge: Linux/Click 8.2 CI fixes | [x] 2026-05-11 (commit 4a22ed6) | After the master merge into the branch, CI revealed two platform-only failures: (a) `_normalize_include_path` returned backslashes unchanged on POSIX because `Path("a\\b")` is a single component there — fixed by explicit `cleaned.replace("\\", "/")` before constructing the Path; (b) `CliRunner(mix_stderr=False)` is rejected by Click 8.2+ (parameter removed, stderr now always separate) — wrapped the constructor in try/except so Click 8.1 and 8.2 both work. Verified locally; PR #61 then merged as `f86c36d`. |
 
-## PR 2 — Feature 2 phases
+---
 
-Starts after PR 1 merges. Branch name TBD.
+## Lessons from PR 1 worth carrying into PR 2
 
-| # | Phase | Status | Notes |
-|---|---|---|---|
-| 1 | `OutputWriteRegistry` module + content hashing helper | [ ] | Probably under `src/clm/core/`. |
-| 2 | Hook into `backend.copy_file_to_output()` and the notebook output writer | [ ] | Skip paths owned by `ImageRegistry` (it already does this for shared images). |
-| 3 | `BuildReporter` integration (counts + JSON `output_conflicts` key) | [ ] | Existing reporter at `src/clm/cli/build_reporter.py`. |
-| 4 | Tests (unit + integration with synthetic two-topic collision; one with the C# repeated `NUnitTestRunner.cs` pattern) | [ ] | |
-| 5 | Docs + CHANGELOG | [ ] | |
-| 6 | Pre-PR checks | [ ] | |
+The full smoke-test postmortem is preserved further down ("PR1.7 smoke
+test outcome"); these are the items most likely to bite PR 2:
+
+- **`CopyFileOperation` is the choke point you're hooking, and it
+  picks up files authors didn't intend to ship.** PR1.7 found this the
+  hard way: `Topic.add_files_in_dir` filtered subdir descendants
+  through `is_ignored_file_for_course` but let top-level files at the
+  topic root through unfiltered. The `.clm-include` ledger landed in
+  every output variant as a result. For PR 2, this means the registry
+  will see paths that include build-internal artifacts (anything
+  matching `SKIP_FILE_NAMES`, `SKIP_OUTPUT_FILE_PATTERNS`, etc.). The
+  registry hook should respect those filters consistently — or, more
+  defensively, only register paths the build is actually about to
+  write, so filtered-out files never enter the registry's view.
+- **`CliRunner(mix_stderr=False)` is non-portable.** Click 8.1 needs
+  it; Click 8.2+ rejects it (stderr is always separate). `_invoke` in
+  `tests/cli/test_sync_includes.py:64` wraps the constructor in
+  try/except; copy that pattern for any new CLI tests in PR 2 (none
+  are currently planned, but the reporter could grow CLI flags).
+- **POSIX vs Windows path normalization.** `Path("a\\b")` on POSIX is
+  one component (`as_posix()` returns it unchanged), so any
+  user-supplied path string needs `cleaned.replace("\\", "/")` *before*
+  hitting `Path(...)` if you want cross-platform normalization. PR 2's
+  registry keys are absolute output paths produced by CLM itself, so
+  this is unlikely to bite — but if any test ever constructs synthetic
+  paths from string literals containing backslashes, watch for the
+  POSIX-vs-Windows split.
+- **`uv.lock` drift on `exclude-newer` bump.** Master's `1866962`
+  re-ran `uv lock` after `27042ca` bumped `pyproject.toml`'s
+  `exclude-newer` without re-locking. If a future master commit does
+  the same, the first `uv run` in this worktree will regenerate the
+  lock and dirty the tree; commit that as a separate `build(uv):
+  refresh uv.lock for exclude-newer=YYYY-MM-DD` commit on PR 2 before
+  any feature work, same pattern as `1866962`.
+- **Pre-commit hooks run ruff → ruff-format → mypy → fast pytest.** A
+  commit that fails any hook did **not** happen; fix and create a NEW
+  commit (never `--amend`). The hook order means a mypy fix landing
+  alongside the change that needed it ends up in the same commit, but
+  a ruff F821 surfacing late may need a second commit. Don't try to
+  pre-format or pre-mypy; let the hook do its job.
+- **Click + GitHub Actions runs newer Click than the worktree.**
+  `>=8.1.0` resolved locally to 8.1.8 (Windows venv pinned by
+  `uv.lock`) but CI runners installed 8.2+ via `astral-sh/setup-uv`
+  with no project lockfile honored. If PR 2 adds a new dep, sanity-check
+  the lockfile pin and the CI runner's resolution before assuming local
+  green = CI green.
 
 ---
 
@@ -254,17 +331,50 @@ future" below.
 
 ---
 
-## Key code surface (frozen at design time, with current line numbers
-where they shifted)
+## Key code surface
+
+### PR 2 entry points (verify line numbers when you start each phase)
+
+- **Backend write hook (primary integration point):**
+  `src/clm/infrastructure/backend.py:36` — abstract
+  `copy_file_to_output()`; concrete impls at
+  `src/clm/infrastructure/backends/sqlite_backend.py:985`,
+  `local_ops_backend.py:52`, `dummy_backend.py:27`. Hook the registry
+  *here* (or in a wrapper layer that sits between the operation and
+  the backend) so every backend benefits.
+- **Notebook output writer (secondary integration point):**
+  `src/clm/workers/notebook/notebook_processor.py:1529`
+  (`write_other_files_sync`). Writes notebook-generated artifacts and
+  other-files copies on the worker side; needs the same registry
+  awareness so dedup works for notebook output too.
+- **Image registry (don't double-warn):**
+  `src/clm/core/image_registry.py:61` (`class ImageRegistry`). Skip
+  paths owned by this registry in the new `OutputWriteRegistry`. Read
+  this class first — it's the closest analogue and may inform the new
+  registry's API shape.
+- **Reporter (phase 3 lands here):**
+  `src/clm/cli/build_reporter.py:13` (`class BuildReporter`). Add
+  counts to the in-memory state and an `output_conflicts` key to the
+  JSON serialization.
+- **Probable new file:** `src/clm/core/output_write_registry.py` for
+  the registry module + content-hashing helper. Sibling to
+  `image_registry.py`. Test file: `tests/core/test_output_write_registry.py`.
+
+### PR 1 surface (mostly for context now that Feature 1 has shipped)
 
 - Spec parsing: `src/clm/core/course_spec.py` — `parse_sections` (line ~875), `parse_dir_groups` (line ~864 after PR1.1 insertions). `IncludeSpec` (~46), `_parse_includes` (~112), `_normalize_include_path` (~80). `SectionSpec.includes_for` is part of the SectionSpec class (~190).
 - Topic resolution: `src/clm/core/topic_resolver.py:60` (`build_topic_map`), `src/clm/core/course.py:540+` (`_build_sections`).
-- File discovery: `src/clm/core/topic.py` — `DirectoryTopic.build_file_map`, `add_files_in_dir`, plus PR1.2 additions: `ResolvedInclude` (~32), `Topic.includes` field (~73), `add_virtual_file` (~125), `apply_includes` (~190).
+- File discovery: `src/clm/core/topic.py` — `DirectoryTopic.build_file_map`, `add_files_in_dir` (now filters top-level files too — see PR1.7a), `ResolvedInclude` (~32), `Topic.includes` field (~73), `add_virtual_file` (~125), `apply_includes` (~190).
 - CourseFile: `src/clm/core/course_file.py` — base (~25), `_find_file_class` (~134). PR1.2 additions: `source_origin` field (~38), `source_path` property (~46), `from_virtual` (~64).
-- Output write: `src/clm/core/operations/copy_file.py:20`, `backend.copy_file_to_output()`. PR1.2 changed `input_path=self.input_file.path` → `self.input_file.source_path`.
-- Notebook other-files copy: `src/clm/workers/notebook/notebook_processor.py:1529` (`write_other_files_sync`). Read in `compute_other_files` at `src/clm/core/operations/process_notebook.py:91` now uses `source_path`.
+- Output write: `src/clm/core/operations/copy_file.py:20`. PR1.2 changed `input_path=self.input_file.path` → `self.input_file.source_path`.
+- Notebook other-files copy read site: `src/clm/core/operations/process_notebook.py:91` (`compute_other_files`, now uses `source_path`).
 - Docker mounts: `src/clm/infrastructure/workers/worker_executor.py:147` (`/source` mount). Includes work over the existing single-source mount; no Docker image rebuild needed (see design doc §F1.G3).
-- Image registry (don't double-warn from PR2): `src/clm/core/image_registry.py:62`.
+- Path-filter constants for the build (relevant when deciding what
+  the registry should record): `src/clm/infrastructure/utils/path_utils.py`
+  — `SKIP_DIRS_FOR_COURSE`, `SKIP_DIRS_FOR_OUTPUT`, `SKIP_FILE_SUFFIXES`,
+  `SKIP_FILE_NAMES` (new in PR1.7a, currently `{".clm-include"}`),
+  `SKIP_OUTPUT_FILE_PATTERNS`, plus the predicates
+  `is_ignored_file_for_course` and `is_ignored_file_for_output`.
 
 ## Decisions log (locked, do not re-litigate)
 

--- a/docs/claude/shared-source-includes-handover.md
+++ b/docs/claude/shared-source-includes-handover.md
@@ -43,17 +43,22 @@ pre-commit too). Master baseline at `f86c36d` should be all-green
 the locked design questions; they're listed under "Decisions log"
 below. Course corrections will arrive as user messages.
 
-**Status**: PR 2 not started. The worktree was just created off the
-post-PR1-merge master tip; only this handover refresh sits on the
-branch so far.
+**Status**: PR2.1 shipped on `claude/output-write-dedup` as commit
+`a78cb2d`. Standalone `OutputWriteRegistry` module + 32 unit tests, all
+green; ruff + mypy clean via pre-commit. No integration with the build
+pipeline yet (that's PR2.2).
 
-**Next phase to pick up**: PR2.1 — `OutputWriteRegistry` module +
-content-hashing helper as a standalone unit-testable thing, no
-integration yet. See the PR 2 phase table below for the full sequence
-and design-doc references. Each phase gets its own commit, matching
-PR 1's pattern; PR1.7's bisect-friendly history made the `.clm-include`
-bug (caught by the smoke test) much easier to reason about, so keep
-the per-phase shape unless a phase is genuinely trivial.
+**Next phase to pick up**: PR2.2 — wire the registry into
+`backend.copy_file_to_output()` (mediated writers) and the
+sqlite-backend cache-hit replay path. **Read the "Call-path audit"
+subsection of PR 2 first** — it identifies that the design's "two
+choke points" wording is incomplete (worker processes write outputs
+themselves and bypass `copy_file_to_output`), and recommends covering
+the mediated writers first, then bringing in dir-groups and the
+worker readback site (`sqlite_backend.py:434`) as a second sub-phase.
+JupyterLite cross-process coverage is captured under "Out-of-scope".
+Each phase still gets its own commit (PR 1's `.clm-include` bug was
+easy to reason about because of that).
 
 ---
 
@@ -88,7 +93,7 @@ spec; the rows below break it into incremental commits.
 
 | # | Phase | Status | Notes |
 |---|---|---|---|
-| 1 | `OutputWriteRegistry` module + content-hashing helper | [ ] | Standalone unit-testable module; no integration with the build pipeline yet. Probable home: `src/clm/core/output_write_registry.py` (sibling to `image_registry.py`). Per-build singleton recording, for each absolute output path: `(content_hash, first_writer_source_path, dedup_count, conflict_count)`. Hash: BLAKE2b-128 or SHA-256-truncated (speed > cryptographic strength). Path-equality fast path for files >50 MB (skip hashing, log a single `output_large_file_collision` summary). Size threshold should be configurable via env var or build flag — pick the same plumbing pattern as `CLM_HTTP_REPLAY_MODE` etc. Unit tests live in `tests/core/test_output_write_registry.py`: record first write, dedup identical second write, conflict on differing second write, large-file path-equality fast path. **Decision (locked):** no persistence across builds — registry is per-build only. |
+| 1 | `OutputWriteRegistry` module + content-hashing helper | [x] 2026-05-11 (commit `a78cb2d`) | `src/clm/core/output_write_registry.py` (~245 LOC) + `tests/core/test_output_write_registry.py` (32 tests, all green). API: `OutputWriteRegistry.record_write(output_path, *, content=..., content_source=..., source=...)` returns a `WriteResult(outcome, entry)` where `outcome ∈ {FIRST_WRITE, DEDUP, CONFLICT, LARGE_FILE_COLLISION}`. Caller branches on outcome (FIRST_WRITE/CONFLICT/LARGE_FILE_COLLISION → proceed; DEDUP → skip the write). BLAKE2b with 16-byte (128-bit) digest. Size threshold: `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` env var (default 50, lower bound 0); large-file writes bypass hashing and any repeat write to the same path registers as a single `LARGE_FILE_COLLISION` summary. Registry is image-agnostic — the caller (integration phase) checks `is_image_path(source)` and routes image paths to `ImageRegistry` instead. **Watch for** the `output_path` argument: must be absolute (registry raises `ValueError` if not) — pulled this in after the audit because mixing relative and absolute paths in the same key space would silently miss dedup matches. |
 | 2 | Hook into `backend.copy_file_to_output()` and the notebook output writer | [ ] | Two real choke points (jupyterlite + plantuml outputs funnel through these). `backend.copy_file_to_output()` lives at `src/clm/core/operations/copy_file.py` + the backend impl; the notebook output writer is `src/clm/workers/notebook/notebook_processor.py:write_other_files_sync` (~line 1529 at PR1 tip; check current line numbers). **Crucial: skip paths owned by `ImageRegistry`** (`src/clm/core/image_registry.py`) so the existing `image_collision` warning channel stays the sole reporter for image paths — no double-warn. Behavior on second write: same hash → increment count + **skip the actual write** + debug-log; different hash → write file (current behavior preserved), emit `output_path_conflict` warning naming both source files + the output path + both hashes, replace registry's first-writer with the latest, increment `conflict_count`. **Watch for the `.clm-include` class of bug from PR1.7**: the `CopyFileOperation` path picks up files that authors don't expect — make sure the registry only logs the files we mean to log, not build-internal artifacts. |
 | 3 | `BuildReporter` integration (counts + JSON `output_conflicts` key) | [ ] | Existing reporter at `src/clm/cli/build_reporter.py`. End-of-build summary line: "{N} output paths written multiple times with identical content (deduplicated); {M} output paths had conflicting writes (last writer won)." JSON output gets a new `output_conflicts` key — machine-readable list of `{output_path, first_writer, second_writer, first_hash, second_hash}` entries. Exit code unchanged (warnings, not errors); the `--strict` promotion to errors is captured in "Out-of-scope" below for a future PR. |
 | 4 | Tests | [ ] | **Unit** (in addition to phase 1 tests): registry skips `ImageRegistry`-owned paths; `BuildReporter` JSON has the right keys when no conflicts (empty list, not missing). **Integration** (new file `tests/integration/test_output_dedup.py` or similar): build a synthetic course where two topics produce the same path with identical content — verify single write + counted dedup; same path with differing content — verify warning + last-writer-wins + JSON entry. **C# case (most-likely-to-bite real example)**: the C# course's repeated `NUnitTestRunner.cs` pattern (see "Out-of-scope, captured for future" → Feature 2 motivating cases) — build a synthetic miniature with N topics that produce the same runner file, verify `dedup_count == N-1`. **Regression**: existing `ImageRegistry` collision tests must still fire `image_collision` (not the new `output_path_conflict`) for shared images. |

--- a/docs/claude/shared-source-includes-handover.md
+++ b/docs/claude/shared-source-includes-handover.md
@@ -9,9 +9,14 @@ Companion to
   (master tip `f86c36d`). See "PR 1 — Shipped (reference card)" below for
   the eight-phase summary; full per-phase detail preserved in the
   historical sections after the active PR 2 table.
-- **Feature 2 — output-write dedup + collision warning.** This handover's
-  current focus; PR2.1 (standalone registry) shipped 2026-05-11; PR2.2
-  (integration) is next.
+- **Feature 2 — output-write dedup + collision warning.** All seven
+  phases shipped on `claude/output-write-dedup` (commits `a78cb2d`
+  through `bc924b1`); pre-PR gate green (4831 / 11 skipped / 4
+  xfailed; ruff + mypy clean). Branch is ready for PR creation;
+  user has not authorized push yet. See "PR 2 — Shipped (reference
+  card)" below for the per-phase summary; the original tabular
+  plan + call-path audit remain under "PR 2 — Feature 2 phases" for
+  reference.
 
 ---
 
@@ -26,8 +31,15 @@ worktree; tracks `origin/master`, originally forked off `f86c36d`).
 **Last commits visible from the branch** (newest first):
 
 ```
-af6b0bc  docs(handover): mark PR2.1 complete; pivot to PR2.2 integration
-a78cb2d  feat(core): add OutputWriteRegistry for output-write dedup  <-- PR2.1
+bc924b1  docs: output-write dedup + reporter keys                <-- PR2.5
+01d429b  test(integration): end-to-end pipeline tests             <-- PR2.4
+33283ae  feat(reporter): drain registry into build summary        <-- PR2.3
+8bb1731  feat(local-ops-backend): register <dir-group> writes     <-- PR2.2c
+c37077e  feat(sqlite-backend): register worker readback writes    <-- PR2.2b
+6b37a6d  feat(backends): wire registry into mediated writers      <-- PR2.2a
+09a4088  docs(handover): refresh fresh-session entry point
+af6b0bc  docs(handover): mark PR2.1 complete; pivot to PR2.2
+a78cb2d  feat(core): add OutputWriteRegistry                      <-- PR2.1
 782eeac  docs(handover): record call-path audit for PR 2
 36b9ac1  docs(handover): refresh for PR 2 (output-write dedup)
 f86c36d  Merge pull request #61 from hoelzl/claude/shared-source-includes  <-- master tip / PR 1 merged
@@ -68,12 +80,19 @@ did **not** happen; fix the issue and create a NEW commit (never
 the locked design questions; they're listed under "Decisions log"
 below. Course corrections will arrive as user messages.
 
-**Status**: PR2.1 shipped on `claude/output-write-dedup` as commit
-`a78cb2d`. Standalone `OutputWriteRegistry` module
-(`src/clm/core/output_write_registry.py`) + 32 unit tests in
-`tests/core/test_output_write_registry.py`, all green; ruff + mypy
-clean via pre-commit. No integration with the build pipeline yet
-(that's PR2.2).
+**Status**: PR 2 is **feature-complete** on
+`claude/output-write-dedup` (last commit `bc924b1`). The branch
+covers the standalone registry (PR2.1), the three integration hooks
+(PR2.2a mediated writers, PR2.2b worker readback, PR2.2c dir-group
+writes), the BuildReporter bridge with JSON keys (PR2.3),
+end-to-end pipeline tests (PR2.4), and docs/CHANGELOG (PR2.5). PR 2.6
+pre-PR gate is green (4831 passed / 11 skipped / 4 xfailed; ruff +
+mypy clean across the full `src/`). PR 2.7 (optional AZAV ML smoke
+validation) is not committed in this branch — capture in the PR body
+if you decide to run it.
+
+**Branch is ready for PR creation.** User has NOT authorized push
+yet; do not push without explicit confirmation.
 
 The shipped registry API in one paragraph:
 `OutputWriteRegistry.record_write(output_path, *, content=... | content_source=..., source=...)`
@@ -90,42 +109,24 @@ the integration caller is responsible for routing `img/`-segment paths
 to `ImageRegistry` instead; `is_image_path(source_path)` is exported
 for that check. `output_path` must be absolute (raises `ValueError`).
 
-**Next phase to pick up**: PR2.2 — wire the registry into the build
-pipeline. **Read the "Call-path audit" subsection of PR 2 first** — it
-identifies that the design's "two choke points" wording is incomplete
-(worker processes write outputs themselves and bypass
-`backend.copy_file_to_output`). Recommended phasing:
+**Next step if resuming**: nothing to implement. The branch is
+PR-ready. The two remaining knobs that DON'T need fresh code:
 
-1. **2.2a — mediated writers (easy):** hook into
-   `backend.copy_file_to_output` (`local_ops_backend.py:52`) and the
-   sqlite-backend cache-hit replay (`sqlite_backend.py:136`,
-   `atomic_write_bytes` call site). Both are in the orchestrator
-   process; the registry sees them directly. Skip image-path writes
-   via `is_image_path`. Each branch's `WriteOutcome` handling:
-   FIRST_WRITE proceeds, DEDUP skips the underlying `shutil.copyfile` /
-   `atomic_write_bytes`, CONFLICT proceeds and the caller emits the
-   `output_path_conflict` warning naming both source paths + hashes,
-   LARGE_FILE_COLLISION proceeds and increments the registry's summary
-   counter (no per-event warning).
-2. **2.2b — worker readback site:** hook
-   `sqlite_backend.py:434` (`result_bytes = output_path.read_bytes()` /
-   `result_text = output_path.read_text()`). This is the only point
-   where the orchestrator sees fresh worker output (notebook, plantuml,
-   drawio). Registration happens **after** the file is on disk, so the
-   dedup-skip semantics degrade to "warn only" — but conflict detection
-   still works and is the cross-cutting value.
-3. **2.2c — `<dir-group>` writes:** `copy_dir_group_to_output`
-   (`local_ops_backend.py:81`) bypasses `copy_file_to_output` entirely
-   and writes via `shutil.copytree`/`copy2`. This is the exact analogue
-   of PR1.7's "top-level filter gap". Hook in the iteration so each
-   per-file write registers individually.
-
-JupyterLite cross-process coverage is **out of scope** (workers write
-directly via `Path.write_text` from subprocesses; no in-process choke
-point to hook). Captured under "Out-of-scope, captured for future".
-
-Each phase still gets its own commit (PR 1's `.clm-include` bug was
-easy to reason about because of that).
+1. **PR creation** — `gh pr create` (when user authorizes). The PR
+   body should reference the design doc, list the seven commits, and
+   call out two caveats: (a) JupyterLite cross-process coverage is
+   deliberately out-of-scope (workers write directly via
+   `Path.write_text` from subprocesses; no in-process choke point);
+   (b) PR2.7 smoke validation against the AZAV ML build wasn't run
+   in this branch.
+2. **Optional PR2.7 smoke** — run a full build of the AZAV ML course
+   with this branch installed editably (`uv pip install --python
+   .venv\Scripts\python.exe -e ".[dev,all]"` from the worktree, then
+   `UV_NO_SYNC=1 uv run --no-sync clm build ...` from the course
+   repo). Expect non-zero `output_dedup_count` from the 60 output
+   variants × 7 files = 420 dedup events for the include-shared
+   `simple_chatbot/` package. Don't commit course-repo state; record
+   the dedup-count outcome in the PR body.
 
 ---
 
@@ -148,6 +149,33 @@ Feature 2 (PR 2) makes the build's file-writer idempotent for
 identical-content writes and warns on conflicting writes (independent of
 Feature 1, but its value is more visible after Feature 1 lands and many
 topics legitimately produce the same output paths).
+
+---
+
+## PR 2 — Shipped (reference card)
+
+Feature 2 (the OutputWriteRegistry + dedup + conflict warning + JSON
+keys) shipped as seven commits on `claude/output-write-dedup`. No PR
+opened yet; user pre-authorization is required to push. Pre-PR gate
+green: 4831 passed / 11 skipped / 4 xfailed (`pytest -m "not docker"`),
+ruff + ruff-format + mypy clean.
+
+| Phase | Commit | What |
+|---|---|---|
+| 2.1 | `a78cb2d` | Standalone `OutputWriteRegistry` module (`src/clm/core/output_write_registry.py`, ~245 LOC) + 32 unit tests. API: `record_write(output_path, *, content=... \| content_source=..., source=...)` → `WriteResult(outcome, entry)` with outcome in `{FIRST_WRITE, DEDUP, CONFLICT, LARGE_FILE_COLLISION}`. BLAKE2b-128 hash. `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` env var (default 50). |
+| 2.2a | `6b37a6d` | Hooks `LocalOpsBackend.copy_file_to_output` and the `SqliteBackend` cache-hit replay (`sqlite_backend.py:136`). Pre-write registration with dedup-skip on DEDUP; logs warning on CONFLICT. Image-path sources skipped (ImageRegistry-owned). `output_write_registry` field added to base `Backend`. |
+| 2.2b | `c37077e` | Hooks the worker readback site (`sqlite_backend.py:~426`) inside `wait_for_completion`. Registers after the file is on disk (worker subprocesses wrote it), so dedup-skip is unavailable here — conflict detection still works (the cross-cutting value). |
+| 2.2c | `8bb1731` | Hooks `copy_dir_group_to_output`. Post-copy walk runs on the event loop (registry is not thread-safe; this reuses `shutil`'s ignore-pattern handling for free). Same warn-only trade-off as PR2.2b. Covers `base_path`, recursive copytree, and non-recursive iteration paths. |
+| 2.3 | `33283ae` | `BuildReporter.report_output_writes(registry)` drains the per-build registry into `BuildSummary`: `output_dedup_count`, structured `output_conflicts` list, `output_large_file_collision_count`. One `BuildWarning` per conflict (category `output_path_conflict`) plus optional summary warning for large-file collisions. JSON formatter emits all three keys unconditionally. `OutputWriteEntry` gained a `first_writer_hash` (write-once) so conflict records can name both first and last hashes. |
+| 2.4 | `01d429b` | End-to-end pipeline tests in `tests/integration/test_output_dedup_pipeline.py` — C# `NUnitTestRunner.cs` six-topics pattern (5 dedups for 6 writes), drift creates conflict + last-writer-wins, ImageRegistry doesn't double-warn, JSON summary end-to-end, 20 concurrent `asyncio.gather`-driven copies. |
+| 2.5 | `bc924b1` | CHANGELOG bullets under `[Unreleased] > Added` (dedup + reporter keys); `docs/user-guide/configuration.md → Performance` documents `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB`; `src/clm/cli/info_topics/commands.md` adds an "Output-write deduplication and conflict warnings" subsection under `clm build`. |
+| 2.6 | (no code) | Pre-PR gate: `pytest -m "not docker"` → 4831 passed / 11 skipped / 4 xfailed; ruff check + format clean across `src/` and `tests/`; mypy clean on 248 source files. |
+| 2.7 | [optional] | AZAV ML smoke validation. Not run in this branch. Expected dedup-count for the include-shared `simple_chatbot/` package is 60 variants × 7 files = 420. |
+
+JupyterLite cross-process coverage is **out of scope** for v1 (workers
+in `clm.workers.jupyterlite` write directly via `Path.write_text` from
+subprocesses; sqlite_backend explicitly skips the DB-cache layer for
+jupyterlite, so there's no readback to piggyback on).
 
 ---
 

--- a/docs/claude/shared-source-includes-handover.md
+++ b/docs/claude/shared-source-includes-handover.md
@@ -96,6 +96,93 @@ spec; the rows below break it into incremental commits.
 | 6 | Pre-PR checks | [ ] | `uv run pytest -m "not docker"`, `uv run ruff check src/ tests/`, `uv run ruff format src/ tests/`, mypy via pre-commit. Per CLAUDE.md release rules. |
 | 7 | Smoke validation against the AZAV ML build | [ ] | Optional but high-value (mirrors PR1.7). Run a full course build with the new dedup hook enabled; expect the now-deduped writes from the `<include>`-shared `simple_chatbot/` (60 output variants × 7 files = 420 dedup events) to show up in the reporter summary, and zero `output_path_conflict` warnings on a clean course. Don't commit course-repo state; record the dedup-count outcome in the PR body. |
 
+### Call-path audit (pre-PR2.1, 2026-05-11)
+
+Re-read of design §Feature 2 against the current source. The design says
+the two real choke points are `backend.copy_file_to_output()` and "the
+notebook-output writer", and that "jupyterlite and plantuml outputs
+ultimately funnel through these". **That claim is incomplete** — the
+worker processes (notebook, plantuml, drawio, jupyterlite-builder) write
+their outputs themselves, not through the backend. PR2.2 must plan for
+this; PR2.1 (the standalone registry module) is unaffected.
+
+Concrete writers, grouped by reachability from the orchestrator:
+
+**Mediated by the backend (easy to hook):**
+
+- `src/clm/core/operations/copy_file.py:20` → `backend.copy_file_to_output(copy_data)`
+- `src/clm/infrastructure/backends/local_ops_backend.py:52` —
+  `_copy_file_to_output_sync` → `shutil.copyfile`. Single choke point
+  for copy-style writes. Hook here.
+- `src/clm/infrastructure/backends/sqlite_backend.py:136` —
+  `atomic_write_bytes(output_file, result.result_bytes())` on
+  database-cache hit, *replaying* a previously-executed worker result.
+  Hook here too (cached fresh writes get the same dedup treatment).
+- `src/clm/infrastructure/utils/path_utils.py:419` — `atomic_write_bytes`
+  helper. Only one caller today (the cache-hit replay at 136), but it's
+  the natural sink if other call sites move through it later. Hooking at
+  the call site rather than the helper is cleaner — keeps the helper
+  registry-agnostic.
+
+**NOT mediated (worker writes directly, registry blind unless we add a hook):**
+
+- `src/clm/infrastructure/backends/local_ops_backend.py:81` —
+  `copy_dir_group_to_output` uses `shutil.copytree`/`copy2` and
+  **bypasses `copy_file_to_output` entirely**. This is the exact analogue
+  of PR1.7's "top-level filter gap". `<dir-group>` writes will not be
+  in the registry unless we hook here separately. Design lists
+  dir-groups under §F2.G2 ("works for every output kind") but the call
+  path is independent.
+- `src/clm/workers/notebook/notebook_worker.py:214` —
+  `open(output_path, "w") as f` then writes notebook contents. Runs in
+  a worker subprocess (sometimes inside Docker). Orchestrator first
+  sees the bytes when sqlite_backend re-reads them at line 434 for the
+  DB cache. Practical hook point: `sqlite_backend.py:434`
+  (`output_path.read_bytes()`) — register the bytes the orchestrator
+  just read. *Tradeoff:* registry sees the write **after** disk;
+  dedup-skip is impossible for fresh worker output, only warn-on-conflict
+  works. That's acceptable per design (the dedup story shines for
+  copy-style writes; conflict warnings are the cross-cutting value).
+- `src/clm/workers/plantuml/plantuml_worker.py:195` —
+  `open(output_path, "wb") as f`. Same after-the-fact registration via
+  sqlite_backend.py:434.
+- `src/clm/workers/drawio/drawio_worker.py:189` —
+  `open(output_path, "wb") as f`. Same path.
+- `src/clm/workers/jupyterlite/builder.py:149,225,281,323`,
+  `lite_dir.py:151,254,290,323`, `miniserve.py:131,149,161` — direct
+  `Path.write_text` into the output dir, no funnel. JupyterLite outputs
+  are a directory tree; sqlite_backend.py:444 explicitly **skips** the
+  DB-cache layer for them ("queue cache is authoritative"), so there's
+  no readback to piggyback on. If PR 2 needs jupyterlite coverage, the
+  worker has to register the writes itself — likely cross-process, so
+  either a per-build registry file on disk or scope-restriction to
+  in-process orchestrator writes (acceptable for v1).
+- `src/clm/workers/notebook/notebook_processor.py:1165` — recorded
+  HTTP cassette persistence (writes to `source_topic_dir`, not output).
+  **Out of scope** for the registry (it's not an output write).
+- `src/clm/workers/notebook/notebook_processor.py:1535` —
+  `write_other_files_sync` writes supporting files to the **kernel
+  temp dir** (CWD for notebook execution), not the build output dir.
+  **Out of scope.** (The design line "notebook output writer" referred
+  to where executed notebooks land — that's the worker's
+  `notebook_worker.py:214`, not this function.)
+
+**ImageRegistry skip predicate.** `src/clm/core/image_registry.py:60`
+keys by relative-from-`img/` path, not absolute output path. The new
+registry's "skip ImageRegistry-owned paths" rule translates to:
+**skip any write whose source path contains an `img/` segment**
+(determined by walking `source_path.parts` for `"img"`, same logic as
+`get_relative_img_path`). Doing this at hook entry means the existing
+`image_collision` channel remains the sole reporter for image paths;
+the new `output_path_conflict` won't double-warn.
+
+**Recommendation for PR2.2 phasing.** Cover the mediated writers first
+(`copy_file_to_output` + sqlite cache-hit replay) — those exercise
+the registry, the BuildReporter integration, and the dedup-skip
+behavior. Bring in dir-groups and the worker readback site
+(sqlite_backend.py:434) as a second sub-phase. JupyterLite cross-process
+coverage is most likely a follow-up PR; capture under "Out-of-scope".
+
 ---
 
 ## PR 1 — Shipped (reference card)
@@ -484,6 +571,14 @@ and `topic_041_gradio_deep_dive/simple_chatbot/` are byte-identical to
   on whether topic-level author-written `.gitignore` files exist in
   practice in any course repo.
 - `--strict` flag promoting `output_path_conflict` warnings to errors.
+- **JupyterLite output coverage in `OutputWriteRegistry`.** Workers
+  in `clm.workers.jupyterlite` write directly via `Path.write_text`
+  to the output dir from a subprocess; sqlite_backend explicitly
+  skips the DB-cache layer for jupyterlite (worker_queue cache is
+  authoritative). No in-process choke point to hook. Either ship an
+  on-disk per-build registry the workers can append to, or scope v1
+  to in-process orchestrator writes only. See "Call-path audit"
+  above for details.
 - Cross-spec sharing (include in spec A pulling from spec B).
 - Auto-installation of an include's `pyproject.toml` dependencies into
   the worker environment (we surface the deps via `validate-spec` info

--- a/docs/claude/shared-source-includes-handover.md
+++ b/docs/claude/shared-source-includes-handover.md
@@ -10,7 +10,8 @@ Companion to
   the eight-phase summary; full per-phase detail preserved in the
   historical sections after the active PR 2 table.
 - **Feature 2 — output-write dedup + collision warning.** This handover's
-  current focus; not started.
+  current focus; PR2.1 (standalone registry) shipped 2026-05-11; PR2.2
+  (integration) is next.
 
 ---
 
@@ -20,43 +21,109 @@ Companion to
 (do all work from there; do NOT `cd` to the main repo).
 
 **Branch**: `claude/output-write-dedup` (already checked out in the
-worktree; tracks `origin/master`, created off `f86c36d`).
+worktree; tracks `origin/master`, originally forked off `f86c36d`).
 
-**Last commits visible from the branch**:
+**Last commits visible from the branch** (newest first):
 
 ```
+af6b0bc  docs(handover): mark PR2.1 complete; pivot to PR2.2 integration
+a78cb2d  feat(core): add OutputWriteRegistry for output-write dedup  <-- PR2.1
+782eeac  docs(handover): record call-path audit for PR 2
+36b9ac1  docs(handover): refresh for PR 2 (output-write dedup)
 f86c36d  Merge pull request #61 from hoelzl/claude/shared-source-includes  <-- master tip / PR 1 merged
-4a22ed6  fix(includes): Linux backslash normalization + Click 8.1/8.2 CliRunner
-efaf051  Merge remote-tracking branch 'origin/master' into claude/shared-source-includes
-c820699  docs(handover): mark PR1.8 complete; PR 1 ready for review
-aadacc6  docs(handover): record PR1.7 commit hash
-9cd89bd  fix(core): exclude .clm-include ledger from topic file map  <-- PR1.7
 ```
 
-**Test command**: `uv run pytest -x -q` (fast suite, ~60s, runs via
-pre-commit too). Master baseline at `f86c36d` should be all-green
-(verified by CI on the PR1 merge). One known-flaky session test —
-`tests/recordings/test_session.py::TestShortTake::test_short_take_can_be_followed_by_real_take`
-— times out under xdist load but passes in isolation; unrelated.
+**First-time env setup (do this once per fresh worktree)**: the venv
+that `uv run` creates on first invocation does NOT install the project
+in editable mode by itself, and `uv run` will keep rebuilding the env
+in ways that undo a manual `uv pip install -e .`. The reliable recipe:
+
+```powershell
+# from the worktree root
+uv pip install --python .venv\Scripts\python.exe -e ".[dev,all]"
+```
+
+After that, run tests with the venv's pytest directly (bypassing
+`uv run` so it doesn't try to re-sync):
+
+```powershell
+.venv\Scripts\python.exe -m pytest tests/core/test_output_write_registry.py -x -q
+.venv\Scripts\python.exe -m ruff check src/ tests/
+.venv\Scripts\python.exe -m ruff format --check src/ tests/
+.venv\Scripts\python.exe -m mypy src/clm/core/output_write_registry.py
+```
+
+For the full pre-PR test pass: `.venv\Scripts\python.exe -m pytest -m "not docker" -q`.
+One known-flaky session test
+(`tests/recordings/test_session.py::TestShortTake::test_short_take_can_be_followed_by_real_take`)
+times out under xdist load but passes in isolation; ignore unless it's
+the only failure.
+
+Pre-commit hooks (ruff → ruff-format → mypy → fast pytest) run on
+commit and are the authoritative gate. A commit that fails any hook
+did **not** happen; fix the issue and create a NEW commit (never
+`--amend`).
 
 **Auto Mode is on**: user prefers continuous execution. Don't re-ask
 the locked design questions; they're listed under "Decisions log"
 below. Course corrections will arrive as user messages.
 
 **Status**: PR2.1 shipped on `claude/output-write-dedup` as commit
-`a78cb2d`. Standalone `OutputWriteRegistry` module + 32 unit tests, all
-green; ruff + mypy clean via pre-commit. No integration with the build
-pipeline yet (that's PR2.2).
+`a78cb2d`. Standalone `OutputWriteRegistry` module
+(`src/clm/core/output_write_registry.py`) + 32 unit tests in
+`tests/core/test_output_write_registry.py`, all green; ruff + mypy
+clean via pre-commit. No integration with the build pipeline yet
+(that's PR2.2).
 
-**Next phase to pick up**: PR2.2 — wire the registry into
-`backend.copy_file_to_output()` (mediated writers) and the
-sqlite-backend cache-hit replay path. **Read the "Call-path audit"
-subsection of PR 2 first** — it identifies that the design's "two
-choke points" wording is incomplete (worker processes write outputs
-themselves and bypass `copy_file_to_output`), and recommends covering
-the mediated writers first, then bringing in dir-groups and the
-worker readback site (`sqlite_backend.py:434`) as a second sub-phase.
-JupyterLite cross-process coverage is captured under "Out-of-scope".
+The shipped registry API in one paragraph:
+`OutputWriteRegistry.record_write(output_path, *, content=... | content_source=..., source=...)`
+→ `WriteResult(outcome, entry)` where
+`outcome ∈ {FIRST_WRITE, DEDUP, CONFLICT, LARGE_FILE_COLLISION}`. The
+caller (PR2.2 integration) branches on outcome: DEDUP means **skip the
+actual write**; the others mean **proceed**. The entry carries
+`first_writer_source`, `last_writer_source`, `dedup_count`,
+`conflict_count`, and the current `content_hash`. Hash is BLAKE2b-128.
+Files larger than 50 MB (configurable via
+`CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` env var, lower bound 0) bypass hashing
+and use a path-equality fast path. The registry is image-agnostic —
+the integration caller is responsible for routing `img/`-segment paths
+to `ImageRegistry` instead; `is_image_path(source_path)` is exported
+for that check. `output_path` must be absolute (raises `ValueError`).
+
+**Next phase to pick up**: PR2.2 — wire the registry into the build
+pipeline. **Read the "Call-path audit" subsection of PR 2 first** — it
+identifies that the design's "two choke points" wording is incomplete
+(worker processes write outputs themselves and bypass
+`backend.copy_file_to_output`). Recommended phasing:
+
+1. **2.2a — mediated writers (easy):** hook into
+   `backend.copy_file_to_output` (`local_ops_backend.py:52`) and the
+   sqlite-backend cache-hit replay (`sqlite_backend.py:136`,
+   `atomic_write_bytes` call site). Both are in the orchestrator
+   process; the registry sees them directly. Skip image-path writes
+   via `is_image_path`. Each branch's `WriteOutcome` handling:
+   FIRST_WRITE proceeds, DEDUP skips the underlying `shutil.copyfile` /
+   `atomic_write_bytes`, CONFLICT proceeds and the caller emits the
+   `output_path_conflict` warning naming both source paths + hashes,
+   LARGE_FILE_COLLISION proceeds and increments the registry's summary
+   counter (no per-event warning).
+2. **2.2b — worker readback site:** hook
+   `sqlite_backend.py:434` (`result_bytes = output_path.read_bytes()` /
+   `result_text = output_path.read_text()`). This is the only point
+   where the orchestrator sees fresh worker output (notebook, plantuml,
+   drawio). Registration happens **after** the file is on disk, so the
+   dedup-skip semantics degrade to "warn only" — but conflict detection
+   still works and is the cross-cutting value.
+3. **2.2c — `<dir-group>` writes:** `copy_dir_group_to_output`
+   (`local_ops_backend.py:81`) bypasses `copy_file_to_output` entirely
+   and writes via `shutil.copytree`/`copy2`. This is the exact analogue
+   of PR1.7's "top-level filter gap". Hook in the iteration so each
+   per-file write registers individually.
+
+JupyterLite cross-process coverage is **out of scope** (workers write
+directly via `Path.write_text` from subprocesses; no in-process choke
+point to hook). Captured under "Out-of-scope, captured for future".
+
 Each phase still gets its own commit (PR 1's `.clm-include` bug was
 easy to reason about because of that).
 
@@ -278,6 +345,42 @@ test outcome"); these are the items most likely to bite PR 2:
   with no project lockfile honored. If PR 2 adds a new dep, sanity-check
   the lockfile pin and the CI runner's resolution before assuming local
   green = CI green.
+
+---
+
+## Lessons from PR 2.1 worth carrying into PR 2.2
+
+- **Fresh worktree venv ≠ editable install.** The `.venv` that
+  `uv run` auto-creates on first invocation does not install the
+  project in editable mode, so `from clm.core.X import Y` fails
+  immediately in conftest. Worse, `uv run` re-syncs the env on every
+  invocation, *undoing* a manual `uv pip install -e .`. The only
+  recipe that holds is `uv pip install --python .venv\Scripts\python.exe -e ".[dev,all]"`
+  and then running pytest/ruff/mypy via the venv's python directly
+  (`.venv\Scripts\python.exe -m pytest …`), not through `uv run`.
+  This is recorded under "First-time env setup" at the top of this
+  handover.
+- **`@frozen` vs `@define` for registry entries.** The first cut tried
+  `@frozen` for `OutputWriteEntry` but the registry mutates
+  `dedup_count`/`conflict_count` in place on every recorded write.
+  `@frozen` forces dict-key replacement on every update — verbose for
+  no real benefit. Used `@define` for the entry (mutable in-place)
+  and `@frozen` only for the `WriteResult` return value (immutable
+  snapshot the caller reads once). General rule: entries that
+  accumulate state want `@define`; values returned to callers want
+  `@frozen`.
+- **Absolute-path assertion is cheap insurance.** `record_write`
+  raises `ValueError` if `output_path` isn't absolute. Mixing
+  relative and absolute keys in the same dict would silently miss
+  dedup matches — exactly the class of bug that's invisible until a
+  smoke test catches it (and even then, hard to attribute). The
+  audit-driven decision to assert at the entry point removes the
+  whole failure mode.
+- **Image-skip is a caller concern, not a registry concern.** Pulled
+  the `img/`-segment filter out of the registry and into the
+  integration call site (PR2.2). Keeps the registry single-purpose
+  and lets tests reason about it without `ImageRegistry` mocks.
+  Exported `is_image_path` from the module for the caller to use.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -218,6 +218,7 @@ and `CLM_LLM__API_KEY` (or `OPENAI_API_KEY`) to authenticate.
 |----------|-------------|---------|
 | `CLM_MAX_CONCURRENCY` | Max concurrent operations | `50` |
 | `CLM_MAX_WORKER_STARTUP_CONCURRENCY` | Max concurrent worker starts | `10` |
+| `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` | Skip output-write deduplication for files larger than this many megabytes. Repeat writes to a large-file output are reported as a single summary collision counter rather than per-event warnings. Set to `0` to force every write through the large-file fast path (useful for tests). | `50` |
 
 ### MCP Server
 

--- a/src/clm/cli/build_data_classes.py
+++ b/src/clm/cli/build_data_classes.py
@@ -93,6 +93,28 @@ class BuildWarning:
 
 
 @dataclass
+class OutputConflictInfo:
+    """One output-path conflict surfaced by :class:`OutputWriteRegistry`.
+
+    Attributes:
+        output_path: Absolute output path that received conflicting writes.
+        first_writer: Source path of the first writer (None if unknown).
+        last_writer: Source path of the most recent writer (None if unknown).
+        first_hash: BLAKE2b-128 hash of the first writer's content.
+        last_hash: BLAKE2b-128 hash of the last writer's content.
+        conflict_count: Number of additional writes after the first that
+            produced differing content for this output path.
+    """
+
+    output_path: str
+    first_writer: str | None
+    last_writer: str | None
+    first_hash: str
+    last_hash: str
+    conflict_count: int
+
+
+@dataclass
 class BuildSummary:
     """Summary of a build execution.
 
@@ -104,6 +126,14 @@ class BuildSummary:
         warnings: List of warnings encountered
         start_time: Build start timestamp
         end_time: Build end timestamp
+        output_dedup_count: Number of output writes that were skipped
+            because a previous writer had produced byte-identical content
+        output_conflicts: One entry per output path that received
+            conflicting writes within the build (last writer won)
+        output_large_file_collision_count: Number of repeated writes to
+            large-file outputs (over the configured hash limit) — these
+            cannot be deduplicated reliably and are reported as a single
+            summary value rather than per-event warnings.
     """
 
     duration: float
@@ -112,6 +142,9 @@ class BuildSummary:
     warnings: list[BuildWarning] = field(default_factory=list)
     start_time: datetime | None = None
     end_time: datetime | None = None
+    output_dedup_count: int = 0
+    output_conflicts: list[OutputConflictInfo] = field(default_factory=list)
+    output_large_file_collision_count: int = 0
 
     @property
     def successful_files(self) -> int:
@@ -142,6 +175,11 @@ class BuildSummary:
         parts.append(f"  {self.total_files} files processed")
         parts.append(f"  {len(self.errors)} errors")
         parts.append(f"  {len(self.warnings)} warnings")
+        if self.output_dedup_count or self.output_conflicts:
+            parts.append(
+                f"  {self.output_dedup_count} duplicate output writes deduplicated; "
+                f"{len(self.output_conflicts)} output paths had conflicting writes"
+            )
 
         if self.errors:
             parts.append("")

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -5,9 +5,19 @@ reporting, error collection, and summary generation during course builds.
 """
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
-from clm.cli.build_data_classes import BuildError, BuildSummary, BuildWarning, ProgressUpdate
+from clm.cli.build_data_classes import (
+    BuildError,
+    BuildSummary,
+    BuildWarning,
+    OutputConflictInfo,
+    ProgressUpdate,
+)
 from clm.cli.output_formatter import OutputFormatter
+
+if TYPE_CHECKING:
+    from clm.core.output_write_registry import OutputWriteRegistry
 
 
 class BuildReporter:
@@ -45,6 +55,12 @@ class BuildReporter:
         # This prevents spurious errors from being displayed during worker shutdown
         self._build_finished: bool = False
 
+        # Output-write registry summary, populated by
+        # :meth:`report_output_writes` shortly before ``finish_build``.
+        self._output_dedup_count: int = 0
+        self._output_conflicts: list[OutputConflictInfo] = []
+        self._output_large_file_collision_count: int = 0
+
     def start_build(
         self,
         course_name: str,
@@ -78,6 +94,11 @@ class BuildReporter:
 
         # Reset build finished flag
         self._build_finished = False
+
+        # Reset output-write registry summary
+        self._output_dedup_count = 0
+        self._output_conflicts = []
+        self._output_large_file_collision_count = 0
 
         self.formatter.show_build_start(course_name, total_files, output_dirs)
 
@@ -316,12 +337,78 @@ class BuildReporter:
             warnings=deduplicated_warnings,
             start_time=self.start_time,
             end_time=self.end_time,
+            output_dedup_count=self._output_dedup_count,
+            output_conflicts=list(self._output_conflicts),
+            output_large_file_collision_count=self._output_large_file_collision_count,
         )
 
         # Display summary
         self.formatter.show_summary(summary)
 
         return summary
+
+    def report_output_writes(self, registry: "OutputWriteRegistry") -> None:
+        """Drain an :class:`OutputWriteRegistry` into the build summary.
+
+        Builds one :class:`BuildWarning` per conflict (so it appears in the
+        deduplicated warning list and in any per-warning display channel),
+        and stores the aggregate counts + structured conflict list for
+        the final :class:`BuildSummary`. Call this once, after the last
+        write hook has had a chance to fire and before :meth:`finish_build`.
+
+        This is idempotent in practice but not in form — calling it twice
+        would double-count. The build command calls it exactly once per
+        build.
+        """
+        self._output_dedup_count = registry.total_dedups
+        self._output_large_file_collision_count = registry.large_file_collision_count
+
+        conflicts: list[OutputConflictInfo] = []
+        for entry in registry.conflict_entries:
+            conflict = OutputConflictInfo(
+                output_path=str(entry.output_path),
+                first_writer=(
+                    str(entry.first_writer_source)
+                    if entry.first_writer_source is not None
+                    else None
+                ),
+                last_writer=(
+                    str(entry.last_writer_source) if entry.last_writer_source is not None else None
+                ),
+                first_hash=entry.first_writer_hash,
+                last_hash=entry.last_writer_hash or entry.content_hash,
+                conflict_count=entry.conflict_count,
+            )
+            conflicts.append(conflict)
+            self.report_warning(
+                BuildWarning(
+                    category="output_path_conflict",
+                    severity="medium",
+                    file_path=conflict.output_path,
+                    message=(
+                        f"Multiple writers produced different content for "
+                        f"{conflict.output_path}: first writer "
+                        f"{conflict.first_writer}, last writer "
+                        f"{conflict.last_writer} (last writer won)"
+                    ),
+                )
+            )
+        self._output_conflicts = conflicts
+
+        if registry.large_file_collision_count > 0:
+            self.report_warning(
+                BuildWarning(
+                    category="output_large_file_collision",
+                    severity="low",
+                    file_path=None,
+                    message=(
+                        f"{registry.large_file_collision_count} write(s) targeted "
+                        f"output paths over the dedup hash limit; dedup was "
+                        f"skipped for these (set CLM_OUTPUT_DEDUP_HASH_LIMIT_MB "
+                        f"higher to include larger files)."
+                    ),
+                )
+            )
 
     def cleanup(self) -> None:
         """Clean up reporter resources."""

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -753,6 +753,12 @@ async def process_course_with_backend(
                 await course.process_jupyterlite_for_targets(backend)
 
         finally:
+            # Drain the backend's OutputWriteRegistry into the summary
+            # before finish_build serializes it. This is the single
+            # call site for the registry → reporter bridge so the
+            # totals (and any output_path_conflict warnings) appear
+            # exactly once per build.
+            build_reporter.report_output_writes(backend.output_write_registry)
             build_reporter.finish_build()
             build_reporter.cleanup()
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -100,6 +100,38 @@ What `--only-sections` does **not** do:
   top-level course files (README, `pyproject.toml`, etc.), or any git
   metadata.
 
+#### Output-write deduplication and conflict warnings
+
+`clm build` records every output write to a per-build registry keyed
+by absolute output path. Two write semantics surface in the build
+summary:
+
+- **Identical-content re-writes are deduplicated.** When multiple
+  topics produce the same output path with byte-identical content
+  (common for `<include>`-shared files and the C# course's repeated
+  `NUnitTestRunner.cs`), only the first write touches disk. The
+  others are counted as dedups and surfaced as
+  `N duplicate output writes deduplicated` in the human summary and
+  `output_dedup_count: N` in the JSON summary.
+- **Differing-content writes to the same output path are flagged.**
+  The build proceeds (last writer wins, preserving previous
+  behavior) and emits one warning per conflicting output path
+  (category `output_path_conflict`, severity `medium`) naming the
+  first and last writers. The JSON summary records each conflict
+  under the `output_conflicts` key as
+  `{output_path, first_writer, last_writer, first_hash, last_hash,
+  conflict_count}`.
+
+Image paths under an `img/` segment are owned by the existing
+`ImageRegistry` collision channel (category `image_collision`) and
+are skipped by the output-write registry — no double-warning.
+
+Tunable via the `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` environment
+variable (default 50 MB; see `docs/user-guide/configuration.md` →
+Performance). Files larger than the limit skip hashing and are
+reported as a single `output_large_file_collision_count` summary
+value rather than per-event warnings.
+
 ### `clm targets`
 
 List output targets defined in a course spec file.

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -376,6 +376,13 @@ class DefaultOutputFormatter(OutputFormatter):
         self.console.print(f"  {summary.total_files} files processed")
         self.console.print(f"  [red]{len(summary.errors)} errors[/red]")
         self.console.print(f"  [yellow]{len(summary.warnings)} warnings[/yellow]")
+        if summary.output_dedup_count or summary.output_conflicts:
+            conflict_color = "yellow" if summary.output_conflicts else "cyan"
+            self.console.print(
+                f"  [{conflict_color}]{summary.output_dedup_count} duplicate output "
+                f"writes deduplicated; {len(summary.output_conflicts)} output paths "
+                f"had conflicting writes[/{conflict_color}]"
+            )
 
         # Show errors (up to 10)
         max_errors_to_show = 10
@@ -839,6 +846,25 @@ class JSONOutputFormatter(OutputFormatter):
         # Add counts for convenience
         self.output_data["error_count"] = len(summary.errors)
         self.output_data["warning_count"] = len(summary.warnings)
+
+        # Output-write registry summary (PR 2.3). Always emit the keys
+        # so machine consumers don't have to special-case their absence
+        # on builds that produced no dedup events.
+        self.output_data["output_dedup_count"] = summary.output_dedup_count
+        self.output_data["output_large_file_collision_count"] = (
+            summary.output_large_file_collision_count
+        )
+        self.output_data["output_conflicts"] = [
+            {
+                "output_path": c.output_path,
+                "first_writer": c.first_writer,
+                "last_writer": c.last_writer,
+                "first_hash": c.first_hash,
+                "last_hash": c.last_hash,
+                "conflict_count": c.conflict_count,
+            }
+            for c in summary.output_conflicts
+        ]
 
         # Add timestamps if available
         if summary.start_time:

--- a/src/clm/core/output_write_registry.py
+++ b/src/clm/core/output_write_registry.py
@@ -120,7 +120,15 @@ class OutputWriteEntry:
 
     output_path: Path
     content_hash: str
+    """Hash of the *most recent* writer's content. Used for dedup checks
+    against the next write. May change on every CONFLICT outcome."""
+
     first_writer_source: Path | None = None
+    first_writer_hash: str = ""
+    """Hash captured at the first write; never overwritten. Retained
+    purely for diagnostics (the build reporter names both first and
+    last writer's hashes in conflict records)."""
+
     last_writer_source: Path | None = None
     last_writer_hash: str = ""
     dedup_count: int = 0
@@ -199,6 +207,7 @@ class OutputWriteRegistry:
                 output_path=output_path,
                 content_hash=new_hash,
                 first_writer_source=source,
+                first_writer_hash=new_hash,
                 last_writer_source=source,
                 last_writer_hash=new_hash,
             )
@@ -228,6 +237,7 @@ class OutputWriteRegistry:
                 output_path=output_path,
                 content_hash="",
                 first_writer_source=source,
+                first_writer_hash="",
                 last_writer_source=source,
                 is_large_file=True,
             )

--- a/src/clm/core/output_write_registry.py
+++ b/src/clm/core/output_write_registry.py
@@ -1,0 +1,275 @@
+"""Per-build output-write registry for deduplication and collision warning.
+
+The build can legitimately produce identical writes to the same output path
+(e.g., two topics that share a ``<include>``-sourced file), and it can also
+produce *different* writes to the same path silently (the historical last-
+writer-wins behavior). The :class:`OutputWriteRegistry` is a per-build
+singleton that records every write the build is about to make, decides
+whether the new write is a duplicate of a previous one, and surfaces
+conflicts so the build report can name both source files.
+
+This module is standalone; it has no dependency on the backend, the build
+reporter, or the workers. Integration with the build pipeline is done by
+the call sites (the backend's copy hook and the notebook-output writer)
+which call :meth:`OutputWriteRegistry.record_write` and act on the
+returned :class:`WriteOutcome`.
+
+Image paths (anything under an ``img/`` segment) are intentionally not
+handled here — the existing :class:`clm.core.image_registry.ImageRegistry`
+remains the sole reporter for image collisions. Use :func:`is_image_path`
+to test a source path before deciding which registry to use.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Final
+
+from attrs import Factory, define, field, frozen
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_HASH_LIMIT_MB: Final[int] = 50
+_ENV_HASH_LIMIT_MB: Final[str] = "CLM_OUTPUT_DEDUP_HASH_LIMIT_MB"
+
+_HASH_DIGEST_SIZE: Final[int] = 16
+_HASH_READ_CHUNK: Final[int] = 64 * 1024
+
+
+def _resolve_hash_limit_bytes() -> int:
+    """Resolve the byte threshold above which content hashing is skipped.
+
+    Reads ``CLM_OUTPUT_DEDUP_HASH_LIMIT_MB`` (megabytes) from the
+    environment, falling back to :data:`DEFAULT_HASH_LIMIT_MB`. A negative
+    or non-numeric value logs a warning and uses the default.
+    """
+    raw = os.environ.get(_ENV_HASH_LIMIT_MB)
+    if raw is None:
+        return DEFAULT_HASH_LIMIT_MB * 1024 * 1024
+    try:
+        mb = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; falling back to default %d MB",
+            _ENV_HASH_LIMIT_MB,
+            raw,
+            DEFAULT_HASH_LIMIT_MB,
+        )
+        return DEFAULT_HASH_LIMIT_MB * 1024 * 1024
+    if mb < 0:
+        logger.warning(
+            "Negative %s=%r; falling back to default %d MB",
+            _ENV_HASH_LIMIT_MB,
+            raw,
+            DEFAULT_HASH_LIMIT_MB,
+        )
+        return DEFAULT_HASH_LIMIT_MB * 1024 * 1024
+    return mb * 1024 * 1024
+
+
+def _hash_bytes(data: bytes) -> str:
+    return hashlib.blake2b(data, digest_size=_HASH_DIGEST_SIZE).hexdigest()
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.blake2b(digest_size=_HASH_DIGEST_SIZE)
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(_HASH_READ_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def is_image_path(source_path: Path) -> bool:
+    """Return ``True`` iff this source is owned by :class:`ImageRegistry`.
+
+    The new registry skips these paths so the existing ``image_collision``
+    warning channel remains the sole reporter for image-path conflicts.
+    Mirrors :func:`clm.core.image_registry.get_relative_img_path`'s detection
+    rule (presence of an ``img`` segment in the path).
+    """
+    return "img" in source_path.parts
+
+
+class WriteOutcome(Enum):
+    """What the caller should do about an attempted write."""
+
+    FIRST_WRITE = "first_write"
+    """No prior entry for this output path; caller proceeds with the write."""
+
+    DEDUP = "dedup"
+    """A previous write produced byte-identical content; caller skips."""
+
+    CONFLICT = "conflict"
+    """A previous write produced different content; caller proceeds (last-
+    writer-wins) and the caller should surface the conflict warning."""
+
+    LARGE_FILE_COLLISION = "large_file_collision"
+    """Either the previous or the new write is over the hash size limit;
+    the caller proceeds (last-writer-wins) and the reporter emits a single
+    summary at end-of-build instead of per-conflict warnings."""
+
+
+@define
+class OutputWriteEntry:
+    """Cumulative state for one absolute output path."""
+
+    output_path: Path
+    content_hash: str
+    first_writer_source: Path | None = None
+    last_writer_source: Path | None = None
+    last_writer_hash: str = ""
+    dedup_count: int = 0
+    conflict_count: int = 0
+    is_large_file: bool = False
+
+
+@frozen
+class WriteResult:
+    """Return value of :meth:`OutputWriteRegistry.record_write`."""
+
+    outcome: WriteOutcome
+    entry: OutputWriteEntry
+
+
+@define
+class OutputWriteRegistry:
+    """Per-build registry tracking output writes.
+
+    The registry is keyed by absolute output path. For each path it records
+    the content hash, the source of the first writer, and counts of subsequent
+    identical (``dedup_count``) and differing (``conflict_count``) writes.
+    Hashing is BLAKE2b-128, chosen for speed; the rare hash collision is not
+    a correctness concern (the cost is a false-dedup-skip).
+
+    Files larger than :data:`DEFAULT_HASH_LIMIT_MB` (configurable via the
+    ``CLM_OUTPUT_DEDUP_HASH_LIMIT_MB`` environment variable) bypass hashing.
+    Repeat writes to a large-file path are reported as a single
+    :data:`WriteOutcome.LARGE_FILE_COLLISION` summary rather than per-path
+    warnings.
+    """
+
+    _entries: dict[Path, OutputWriteEntry] = Factory(dict)
+    _hash_limit_bytes: int = field(factory=_resolve_hash_limit_bytes)
+    _large_file_collision_count: int = 0
+
+    def record_write(
+        self,
+        output_path: Path,
+        *,
+        content: bytes | None = None,
+        content_source: Path | None = None,
+        source: Path | None = None,
+    ) -> WriteResult:
+        """Record an intended write and return what the caller should do.
+
+        Exactly one of ``content`` or ``content_source`` must be supplied.
+        ``output_path`` must be absolute — the dedup key needs a canonical
+        form, and resolving relative paths here would hide caller bugs.
+
+        Args:
+            output_path: Absolute destination of the write.
+            content: In-memory bytes that will be written.
+            content_source: Source file whose bytes will be copied verbatim
+                (avoids reading the file into memory just to hash it).
+            source: Logical ``CourseFile`` source path used in conflict
+                diagnostics. Optional — purely informational.
+        """
+        if not output_path.is_absolute():
+            raise ValueError(f"output_path must be absolute: {output_path}")
+        if (content is None) == (content_source is None):
+            raise ValueError("provide exactly one of content= or content_source=")
+
+        size = len(content) if content is not None else content_source.stat().st_size  # type: ignore[union-attr]
+        is_large = size > self._hash_limit_bytes
+
+        existing = self._entries.get(output_path)
+
+        if is_large or (existing is not None and existing.is_large_file):
+            return self._record_large_file_write(output_path, source, existing)
+
+        new_hash = _hash_bytes(content) if content is not None else _hash_file(content_source)  # type: ignore[arg-type]
+
+        if existing is None:
+            entry = OutputWriteEntry(
+                output_path=output_path,
+                content_hash=new_hash,
+                first_writer_source=source,
+                last_writer_source=source,
+                last_writer_hash=new_hash,
+            )
+            self._entries[output_path] = entry
+            return WriteResult(outcome=WriteOutcome.FIRST_WRITE, entry=entry)
+
+        if existing.content_hash == new_hash:
+            existing.dedup_count += 1
+            existing.last_writer_source = source
+            existing.last_writer_hash = new_hash
+            return WriteResult(outcome=WriteOutcome.DEDUP, entry=existing)
+
+        existing.conflict_count += 1
+        existing.last_writer_source = source
+        existing.last_writer_hash = new_hash
+        existing.content_hash = new_hash
+        return WriteResult(outcome=WriteOutcome.CONFLICT, entry=existing)
+
+    def _record_large_file_write(
+        self,
+        output_path: Path,
+        source: Path | None,
+        existing: OutputWriteEntry | None,
+    ) -> WriteResult:
+        if existing is None:
+            entry = OutputWriteEntry(
+                output_path=output_path,
+                content_hash="",
+                first_writer_source=source,
+                last_writer_source=source,
+                is_large_file=True,
+            )
+            self._entries[output_path] = entry
+            return WriteResult(outcome=WriteOutcome.FIRST_WRITE, entry=entry)
+
+        existing.is_large_file = True
+        existing.last_writer_source = source
+        existing.content_hash = ""
+        existing.last_writer_hash = ""
+        self._large_file_collision_count += 1
+        return WriteResult(outcome=WriteOutcome.LARGE_FILE_COLLISION, entry=existing)
+
+    def get(self, output_path: Path) -> OutputWriteEntry | None:
+        return self._entries.get(output_path)
+
+    @property
+    def entries(self) -> dict[Path, OutputWriteEntry]:
+        """Snapshot of all recorded entries (copy; safe to mutate)."""
+        return dict(self._entries)
+
+    @property
+    def total_dedups(self) -> int:
+        return sum(e.dedup_count for e in self._entries.values())
+
+    @property
+    def total_conflicts(self) -> int:
+        return sum(e.conflict_count for e in self._entries.values())
+
+    @property
+    def conflict_entries(self) -> list[OutputWriteEntry]:
+        """Entries that have at least one recorded conflict."""
+        return [e for e in self._entries.values() if e.conflict_count > 0]
+
+    @property
+    def large_file_collision_count(self) -> int:
+        return self._large_file_collision_count
+
+    @property
+    def hash_limit_bytes(self) -> int:
+        return self._hash_limit_bytes
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self._large_file_collision_count = 0

--- a/src/clm/infrastructure/backend.py
+++ b/src/clm/infrastructure/backend.py
@@ -5,7 +5,9 @@ from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from attrs import define
+from attrs import define, field
+
+from clm.core.output_write_registry import OutputWriteRegistry
 
 if TYPE_CHECKING:
     from clm.cli.build_data_classes import BuildWarning
@@ -20,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 @define
 class Backend(AbstractAsyncContextManager):
+    output_write_registry: OutputWriteRegistry = field(factory=OutputWriteRegistry)
+
     @abstractmethod
     async def execute_operation(self, operation: "Operation", payload: "Payload") -> None: ...
 

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -34,6 +34,7 @@ from attrs import define
 
 from clm.cli.build_data_classes import BuildWarning
 from clm.core.course_file import CourseFile
+from clm.core.output_write_registry import WriteOutcome, is_image_path
 from clm.infrastructure.backend import Backend
 from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
 from clm.infrastructure.utils.copy_file_data import CopyFileData
@@ -53,6 +54,39 @@ class LocalOpsBackend(Backend, ABC):
         input_path = copy_data.relative_input_path
         output_path = copy_data.output_path
         logger.info(f"Copying {input_path} to {output_path}")
+
+        # Register with OutputWriteRegistry before the copy so dedup can
+        # short-circuit byte-identical re-writes and so conflicts are
+        # recorded for the build summary. Images are excluded — they
+        # have their own collision channel via ImageRegistry. The source
+        # must exist; if not, defer the FileNotFoundError to the sync
+        # path so the error message stays consistent.
+        if copy_data.input_path.exists() and not is_image_path(copy_data.input_path):
+            abs_output = output_path if output_path.is_absolute() else output_path.resolve()
+            write_result = self.output_write_registry.record_write(
+                abs_output,
+                content_source=copy_data.input_path,
+                source=copy_data.input_path,
+            )
+            if write_result.outcome == WriteOutcome.DEDUP:
+                logger.debug(
+                    f"Output dedup: skipping copy to {abs_output} (identical "
+                    f"content already written from "
+                    f"{write_result.entry.first_writer_source})"
+                )
+                return
+            if write_result.outcome == WriteOutcome.CONFLICT:
+                logger.warning(
+                    f"Output path conflict at {abs_output}: prior writer "
+                    f"{write_result.entry.first_writer_source}, new writer "
+                    f"{copy_data.input_path} (last writer wins)"
+                )
+            elif write_result.outcome == WriteOutcome.LARGE_FILE_COLLISION:
+                logger.debug(
+                    f"Large-file collision at {abs_output} from "
+                    f"{copy_data.input_path} (over hash limit; counted as collision)"
+                )
+
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, self._copy_file_to_output_sync, copy_data)

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -127,13 +127,65 @@ class LocalOpsBackend(Backend, ABC):
             warnings = await loop.run_in_executor(
                 None, self._copy_dir_group_to_output_sync, copy_data
             )
-            return warnings
         except Exception as e:
             logger.error(
                 f"Error while copying '{copy_data.name}' to output for {copy_data.lang}: {e}"
             )
             logger.debug(f"Error traceback for '{copy_data.name}':", exc_info=e)
             raise
+
+        # Register each per-file write after the copy completes. Walking
+        # the output tree post-hoc keeps registry access on the event
+        # loop (the registry is not thread-safe) and reuses shutil's
+        # ignore-pattern handling for free. The dedup-skip semantic
+        # therefore doesn't apply to <dir-group> writes — but conflict
+        # detection across overlapping dir-group writes still works,
+        # matching the worker-readback hook's "warn-only" trade-off.
+        self._register_dir_group_writes(copy_data)
+        return warnings
+
+    def _register_dir_group_writes(self, copy_data: "CopyDirGroupData") -> None:
+        if copy_data.base_path is not None and copy_data.base_path.exists():
+            for item in copy_data.base_path.iterdir():
+                if item.is_file():
+                    dest = copy_data.output_dir / item.name
+                    self._record_dir_group_write(source=item, dest=dest)
+
+        for source_dir, relative_path in zip(
+            copy_data.source_dirs, copy_data.relative_paths, strict=False
+        ):
+            if not source_dir.exists():
+                continue
+            target_dir = copy_data.output_dir / relative_path
+            if not target_dir.exists():
+                continue
+            if copy_data.recursive:
+                for out_file in target_dir.rglob("*"):
+                    if not out_file.is_file():
+                        continue
+                    rel = out_file.relative_to(target_dir)
+                    source_file = source_dir / rel
+                    self._record_dir_group_write(source=source_file, dest=out_file)
+            else:
+                for item in source_dir.iterdir():
+                    if not item.is_file():
+                        continue
+                    dest = target_dir / item.name
+                    if dest.exists():
+                        self._record_dir_group_write(source=item, dest=dest)
+
+    def _record_dir_group_write(self, *, source: Path, dest: Path) -> None:
+        if is_image_path(source):
+            return
+        abs_dest = dest if dest.is_absolute() else dest.resolve()
+        try:
+            self.output_write_registry.record_write(
+                abs_dest,
+                content_source=dest,
+                source=source,
+            )
+        except Exception as exc:
+            logger.debug(f"Could not register dir-group write {abs_dest} from {source}: {exc}")
 
     @staticmethod
     def _copy_dir_group_to_output_sync(

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import define, field
 
+from clm.core.output_write_registry import WriteOutcome, is_image_path
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.database.job_queue import JobQueue
@@ -129,12 +130,48 @@ class SqliteBackend(LocalOpsBackend):
                     # Make path absolute relative to workspace if not already absolute
                     if not output_file.is_absolute():
                         output_file = self.workspace_path / output_file
-                    # Atomic temp+rename with retry on transient OSError —
-                    # plain write_bytes intermittently fails with EINVAL on
-                    # Windows when AV/indexer/sync agents hold handles on
-                    # files in the same directory.
-                    atomic_write_bytes(output_file, result.result_bytes())
-                    logger.debug(f"Wrote cached result to {output_file}")
+                    # Register the planned write so identical-content
+                    # re-emissions (common when many output variants share
+                    # an include-sourced file) collapse to one write, and
+                    # path conflicts surface in the build summary. Source
+                    # paths under img/ are owned by ImageRegistry and
+                    # skipped here so the existing image_collision channel
+                    # remains the sole reporter.
+                    content_bytes = result.result_bytes()
+                    source_path = Path(payload.input_file)
+                    skip_write = False
+                    if not is_image_path(source_path):
+                        write_result = self.output_write_registry.record_write(
+                            output_file,
+                            content=content_bytes,
+                            source=source_path,
+                        )
+                        if write_result.outcome == WriteOutcome.DEDUP:
+                            logger.debug(
+                                f"Output dedup: skipping cache-hit replay to "
+                                f"{output_file} (identical content already written "
+                                f"from {write_result.entry.first_writer_source})"
+                            )
+                            skip_write = True
+                        elif write_result.outcome == WriteOutcome.CONFLICT:
+                            logger.warning(
+                                f"Output path conflict at {output_file}: prior "
+                                f"writer {write_result.entry.first_writer_source}, "
+                                f"new writer {source_path} (last writer wins)"
+                            )
+                        elif write_result.outcome == WriteOutcome.LARGE_FILE_COLLISION:
+                            logger.debug(
+                                f"Large-file collision at {output_file} from "
+                                f"{source_path} (over hash limit; counted as "
+                                f"collision)"
+                            )
+                    if not skip_write:
+                        # Atomic temp+rename with retry on transient OSError —
+                        # plain write_bytes intermittently fails with EINVAL on
+                        # Windows when AV/indexer/sync agents hold handles on
+                        # files in the same directory.
+                        atomic_write_bytes(output_file, content_bytes)
+                        logger.debug(f"Wrote cached result to {output_file}")
 
                 # Report any stored errors/warnings for this cached result
                 self._report_cached_issues(

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -424,6 +424,26 @@ class SqliteBackend(LocalOpsBackend):
                             output_path = self.workspace_path / output_path
 
                         if output_path.exists():
+                            # Register the worker's output write with the
+                            # registry. The file is already on disk (the
+                            # worker subprocess wrote it), so dedup-skip
+                            # is not meaningful here — but conflict
+                            # detection across worker outputs in the same
+                            # build still works. Image-path sources are
+                            # owned by ImageRegistry and skipped.
+                            source_for_registry = Path(job_info["input_file"])
+                            if not is_image_path(source_for_registry):
+                                try:
+                                    self.output_write_registry.record_write(
+                                        output_path,
+                                        content_source=output_path,
+                                        source=source_for_registry,
+                                    )
+                                except Exception as reg_exc:
+                                    logger.debug(
+                                        f"Could not register worker output {output_path}: {reg_exc}"
+                                    )
+
                             # Read output file and reconstruct Result object to store in database
                             try:
                                 # Get the payload from the job to determine job type and metadata

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -970,7 +970,11 @@ class TestBuildCliWrapper:
 
         class FakeBackend:
             def __init__(self, *args, **kwargs):
-                pass
+                # PR 2.3: build command drains backend.output_write_registry
+                # at end-of-build, so the fake must expose one.
+                from clm.core.output_write_registry import OutputWriteRegistry
+
+                self.output_write_registry = OutputWriteRegistry()
 
             async def __aenter__(self):
                 return self

--- a/tests/cli/test_build_reporter_output_writes.py
+++ b/tests/cli/test_build_reporter_output_writes.py
@@ -1,0 +1,222 @@
+"""Tests for BuildReporter.report_output_writes (PR 2.3).
+
+These cover the registry → reporter bridge: how a populated
+:class:`OutputWriteRegistry` is drained into the :class:`BuildSummary`
+counters, the structured ``output_conflicts`` list, and the standard
+``BuildWarning`` channel.
+
+The standalone registry semantics are covered by
+``tests/core/test_output_write_registry.py``; these tests only assert
+the bridge.
+"""
+
+from pathlib import Path
+
+from clm.cli.build_data_classes import BuildSummary
+from clm.cli.build_reporter import BuildReporter
+from clm.cli.output_formatter import QuietOutputFormatter
+from clm.core.output_write_registry import OutputWriteRegistry
+
+
+def _make_reporter() -> BuildReporter:
+    reporter = BuildReporter(QuietOutputFormatter())
+    reporter.start_build(course_name="test", total_files=0, total_stages=1)
+    return reporter
+
+
+class TestEmptyRegistry:
+    def test_empty_registry_produces_zero_summary(self, tmp_path):
+        reporter = _make_reporter()
+        registry = OutputWriteRegistry()
+
+        reporter.report_output_writes(registry)
+        summary = reporter.finish_build()
+
+        assert summary.output_dedup_count == 0
+        assert summary.output_conflicts == []
+        assert summary.output_large_file_collision_count == 0
+        # No new warnings emitted for an empty registry.
+        assert all(w.category != "output_path_conflict" for w in summary.warnings)
+
+
+class TestDedupCount:
+    def test_dedup_count_propagates_to_summary(self, tmp_path):
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        src_a.write_text("same", encoding="utf-8")
+        src_b.write_text("same", encoding="utf-8")
+        out = tmp_path / "out.txt"
+
+        registry = OutputWriteRegistry()
+        registry.record_write(out, content_source=src_a, source=src_a)
+        registry.record_write(out, content_source=src_b, source=src_b)
+
+        reporter = _make_reporter()
+        reporter.report_output_writes(registry)
+        summary = reporter.finish_build()
+
+        assert summary.output_dedup_count == 1
+        assert summary.output_conflicts == []
+
+
+class TestConflictsBecomeWarnings:
+    def test_conflict_added_as_warning_and_to_summary(self, tmp_path):
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        src_a.write_text("first", encoding="utf-8")
+        src_b.write_text("second", encoding="utf-8")
+        out = tmp_path / "out.txt"
+
+        registry = OutputWriteRegistry()
+        registry.record_write(out, content_source=src_a, source=src_a)
+        registry.record_write(out, content_source=src_b, source=src_b)
+
+        reporter = _make_reporter()
+        reporter.report_output_writes(registry)
+        summary = reporter.finish_build()
+
+        assert len(summary.output_conflicts) == 1
+        conflict = summary.output_conflicts[0]
+        assert conflict.output_path == str(out)
+        assert conflict.first_writer == str(src_a)
+        assert conflict.last_writer == str(src_b)
+        assert conflict.conflict_count == 1
+        assert conflict.first_hash != conflict.last_hash
+
+        # The conflict also shows up via the standard warning channel.
+        path_conflicts = [w for w in summary.warnings if w.category == "output_path_conflict"]
+        assert len(path_conflicts) == 1
+        assert path_conflicts[0].file_path == str(out)
+        assert "first writer" in path_conflicts[0].message.lower()
+
+
+class TestLargeFileSummary:
+    def test_large_file_collision_count_propagates(self, tmp_path, monkeypatch):
+        # Force every write through the large-file fast path.
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+
+        out = tmp_path / "big.bin"
+        src_a = tmp_path / "a.bin"
+        src_b = tmp_path / "b.bin"
+        src_a.write_bytes(b"first")
+        src_b.write_bytes(b"second")
+
+        registry.record_write(out, content_source=src_a, source=src_a)
+        registry.record_write(out, content_source=src_b, source=src_b)
+
+        reporter = _make_reporter()
+        reporter.report_output_writes(registry)
+        summary = reporter.finish_build()
+
+        assert summary.output_large_file_collision_count == 1
+        # Surfaces as one summary-level low-severity warning, not per event.
+        large_warnings = [
+            w for w in summary.warnings if w.category == "output_large_file_collision"
+        ]
+        assert len(large_warnings) == 1
+
+
+class TestStartBuildResetsState:
+    def test_second_build_does_not_carry_over_first(self, tmp_path):
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        src_a.write_text("first", encoding="utf-8")
+        src_b.write_text("second", encoding="utf-8")
+        out = tmp_path / "out.txt"
+
+        reporter = BuildReporter(QuietOutputFormatter())
+        reporter.start_build(course_name="run1", total_files=0)
+
+        registry = OutputWriteRegistry()
+        registry.record_write(out, content_source=src_a, source=src_a)
+        registry.record_write(out, content_source=src_b, source=src_b)
+        reporter.report_output_writes(registry)
+        summary1 = reporter.finish_build()
+        assert len(summary1.output_conflicts) == 1
+
+        # Start a second build with an empty registry; no state should
+        # carry over.
+        reporter.start_build(course_name="run2", total_files=0)
+        empty_registry = OutputWriteRegistry()
+        reporter.report_output_writes(empty_registry)
+        summary2 = reporter.finish_build()
+        assert summary2.output_dedup_count == 0
+        assert summary2.output_conflicts == []
+        assert summary2.output_large_file_collision_count == 0
+
+
+class TestSummaryStringIncludesCounts:
+    def test_str_summary_includes_dedup_line_when_nonzero(self, tmp_path):
+        summary = BuildSummary(
+            duration=1.0,
+            total_files=3,
+            output_dedup_count=4,
+        )
+        text = str(summary)
+        assert "duplicate output writes deduplicated" in text
+
+    def test_str_summary_omits_dedup_line_when_zero(self, tmp_path):
+        summary = BuildSummary(
+            duration=1.0,
+            total_files=3,
+            output_dedup_count=0,
+            output_conflicts=[],
+        )
+        text = str(summary)
+        assert "duplicate output writes deduplicated" not in text
+
+
+class TestJsonFormatterIncludesOutputKeys:
+    def test_json_formatter_emits_keys_even_when_empty(self, tmp_path, capsys):
+        from clm.cli.output_formatter import JSONOutputFormatter
+
+        formatter = JSONOutputFormatter()
+        formatter.show_build_start("test", total_files=0, output_dirs=[])
+        summary = BuildSummary(duration=0.1, total_files=0)
+        formatter.show_summary(summary)
+        captured = capsys.readouterr().out
+
+        import json as _json
+
+        data = _json.loads(captured)
+        assert data["output_dedup_count"] == 0
+        assert data["output_large_file_collision_count"] == 0
+        assert data["output_conflicts"] == []
+
+    def test_json_formatter_emits_conflict_records(self, tmp_path, capsys):
+        from clm.cli.build_data_classes import OutputConflictInfo
+        from clm.cli.output_formatter import JSONOutputFormatter
+
+        formatter = JSONOutputFormatter()
+        formatter.show_build_start("test", total_files=0, output_dirs=[])
+
+        summary = BuildSummary(
+            duration=0.1,
+            total_files=0,
+            output_dedup_count=2,
+            output_conflicts=[
+                OutputConflictInfo(
+                    output_path=str(Path("/tmp/out.txt")),
+                    first_writer="src_a",
+                    last_writer="src_b",
+                    first_hash="h1",
+                    last_hash="h2",
+                    conflict_count=1,
+                )
+            ],
+        )
+        formatter.show_summary(summary)
+        captured = capsys.readouterr().out
+
+        import json as _json
+
+        data = _json.loads(captured)
+        assert data["output_dedup_count"] == 2
+        assert len(data["output_conflicts"]) == 1
+        record = data["output_conflicts"][0]
+        assert record["first_writer"] == "src_a"
+        assert record["last_writer"] == "src_b"
+        assert record["first_hash"] == "h1"
+        assert record["last_hash"] == "h2"
+        assert record["conflict_count"] == 1

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -311,6 +311,7 @@ async def test_count_stage_operations_matches_worker_jobs(course_1_spec, tmp_pat
 
     class WorkerJobCountingBackend(LocalOpsBackend):
         def __init__(self):
+            super().__init__()
             self.worker_job_count = 0
 
         async def execute_operation(self, operation: Operation, payload: Payload) -> None:

--- a/tests/core/test_output_write_registry.py
+++ b/tests/core/test_output_write_registry.py
@@ -1,0 +1,300 @@
+"""Tests for :mod:`clm.core.output_write_registry`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.core.output_write_registry import (
+    DEFAULT_HASH_LIMIT_MB,
+    OutputWriteRegistry,
+    WriteOutcome,
+    _resolve_hash_limit_bytes,
+    is_image_path,
+)
+
+
+def _abs(tmp_path: Path, *parts: str) -> Path:
+    p = tmp_path.joinpath(*parts)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+class TestIsImagePath:
+    def test_img_segment_in_middle(self):
+        assert is_image_path(Path("/course/topic_x/img/diagram.png"))
+
+    def test_img_segment_at_start(self):
+        assert is_image_path(Path("img/diagram.png"))
+
+    def test_no_img_segment(self):
+        assert not is_image_path(Path("/course/topic_x/data/notes.md"))
+
+    def test_substring_match_does_not_count(self):
+        # "imgur" contains "img" as a substring, but parts split on separator
+        assert not is_image_path(Path("/course/topic_x/imgur/diagram.png"))
+
+    def test_nested_img(self):
+        assert is_image_path(Path("/course/topic_x/img/charts/diagram.png"))
+
+
+class TestResolveHashLimitBytes:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", raising=False)
+        assert _resolve_hash_limit_bytes() == DEFAULT_HASH_LIMIT_MB * 1024 * 1024
+
+    def test_explicit_value(self, monkeypatch):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "10")
+        assert _resolve_hash_limit_bytes() == 10 * 1024 * 1024
+
+    def test_zero_disables_hashing(self, monkeypatch):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        assert _resolve_hash_limit_bytes() == 0
+
+    def test_invalid_falls_back_to_default(self, monkeypatch, caplog):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "not-a-number")
+        assert _resolve_hash_limit_bytes() == DEFAULT_HASH_LIMIT_MB * 1024 * 1024
+
+    def test_negative_falls_back_to_default(self, monkeypatch, caplog):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "-5")
+        assert _resolve_hash_limit_bytes() == DEFAULT_HASH_LIMIT_MB * 1024 * 1024
+
+
+class TestRecordWriteBytes:
+    def test_first_write(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        result = registry.record_write(out, content=b"hello", source=Path("/src/a.txt"))
+
+        assert result.outcome is WriteOutcome.FIRST_WRITE
+        assert result.entry.output_path == out
+        assert result.entry.first_writer_source == Path("/src/a.txt")
+        assert result.entry.last_writer_source == Path("/src/a.txt")
+        assert result.entry.dedup_count == 0
+        assert result.entry.conflict_count == 0
+        assert result.entry.content_hash  # non-empty hex string
+        assert registry.total_dedups == 0
+        assert registry.total_conflicts == 0
+
+    def test_dedup_identical_second_write(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"hello", source=Path("/src/topic_1/a.txt"))
+        result = registry.record_write(out, content=b"hello", source=Path("/src/topic_2/a.txt"))
+
+        assert result.outcome is WriteOutcome.DEDUP
+        assert result.entry.first_writer_source == Path("/src/topic_1/a.txt")
+        assert result.entry.last_writer_source == Path("/src/topic_2/a.txt")
+        assert result.entry.dedup_count == 1
+        assert result.entry.conflict_count == 0
+        assert registry.total_dedups == 1
+        assert registry.total_conflicts == 0
+
+    def test_conflict_on_differing_second_write(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"version 1", source=Path("/src/topic_1/a.txt"))
+        result = registry.record_write(out, content=b"version 2", source=Path("/src/topic_2/a.txt"))
+
+        assert result.outcome is WriteOutcome.CONFLICT
+        # first_writer_source preserved; last_writer reflects the conflicting write
+        assert result.entry.first_writer_source == Path("/src/topic_1/a.txt")
+        assert result.entry.last_writer_source == Path("/src/topic_2/a.txt")
+        assert result.entry.conflict_count == 1
+        assert result.entry.dedup_count == 0
+        assert registry.total_conflicts == 1
+        assert registry.total_dedups == 0
+        # content_hash now reflects last-writer-wins
+        assert result.entry.content_hash == result.entry.last_writer_hash
+
+    def test_three_writes_dedup_then_conflict(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        r1 = registry.record_write(out, content=b"A", source=Path("/s1"))
+        r2 = registry.record_write(out, content=b"A", source=Path("/s2"))
+        r3 = registry.record_write(out, content=b"B", source=Path("/s3"))
+
+        assert r1.outcome is WriteOutcome.FIRST_WRITE
+        assert r2.outcome is WriteOutcome.DEDUP
+        assert r3.outcome is WriteOutcome.CONFLICT
+        assert registry.total_dedups == 1
+        assert registry.total_conflicts == 1
+
+    def test_conflict_then_dedup_against_new_winner(self, tmp_path):
+        # Once a conflict happens, the registry tracks the *latest* hash.
+        # A subsequent write that matches the latest hash is a dedup, not a conflict.
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"A", source=Path("/s1"))
+        registry.record_write(out, content=b"B", source=Path("/s2"))
+        result = registry.record_write(out, content=b"B", source=Path("/s3"))
+
+        assert result.outcome is WriteOutcome.DEDUP
+        assert result.entry.dedup_count == 1
+        assert result.entry.conflict_count == 1
+
+    def test_distinct_output_paths_are_independent(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out1 = _abs(tmp_path, "out", "a.txt")
+        out2 = _abs(tmp_path, "out", "b.txt")
+        r1 = registry.record_write(out1, content=b"same", source=Path("/s"))
+        r2 = registry.record_write(out2, content=b"same", source=Path("/s"))
+        assert r1.outcome is WriteOutcome.FIRST_WRITE
+        assert r2.outcome is WriteOutcome.FIRST_WRITE
+        assert len(registry.entries) == 2
+
+
+class TestRecordWriteContentSource:
+    def test_hashes_from_disk(self, tmp_path):
+        registry = OutputWriteRegistry()
+        src = _abs(tmp_path, "src", "a.txt")
+        src.write_bytes(b"hello from disk")
+        out = _abs(tmp_path, "out", "a.txt")
+        result = registry.record_write(out, content_source=src, source=src)
+
+        assert result.outcome is WriteOutcome.FIRST_WRITE
+        assert result.entry.content_hash
+
+    def test_dedup_across_content_and_content_source(self, tmp_path):
+        # An in-memory write and an on-disk write with identical bytes must dedup.
+        registry = OutputWriteRegistry()
+        src = _abs(tmp_path, "src", "a.txt")
+        src.write_bytes(b"hello")
+        out = _abs(tmp_path, "out", "a.txt")
+
+        r1 = registry.record_write(out, content=b"hello", source=Path("/mem"))
+        r2 = registry.record_write(out, content_source=src, source=src)
+
+        assert r1.outcome is WriteOutcome.FIRST_WRITE
+        assert r2.outcome is WriteOutcome.DEDUP
+
+
+class TestArgumentValidation:
+    def test_requires_absolute_output_path(self, tmp_path):
+        registry = OutputWriteRegistry()
+        with pytest.raises(ValueError, match="absolute"):
+            registry.record_write(Path("out/a.txt"), content=b"x")
+
+    def test_requires_exactly_one_content_source(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        with pytest.raises(ValueError, match="exactly one"):
+            registry.record_write(out)
+        src = _abs(tmp_path, "src", "a.txt")
+        src.write_bytes(b"x")
+        with pytest.raises(ValueError, match="exactly one"):
+            registry.record_write(out, content=b"x", content_source=src)
+
+
+class TestLargeFileFastPath:
+    def test_large_in_memory_skips_hashing(self, tmp_path, monkeypatch):
+        # Drop the limit to 1 byte so anything triggers the large-file path.
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.bin")
+        result = registry.record_write(out, content=b"big payload", source=Path("/s"))
+
+        assert result.outcome is WriteOutcome.FIRST_WRITE
+        assert result.entry.is_large_file
+        assert result.entry.content_hash == ""
+
+    def test_second_large_write_is_collision_not_dedup(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.bin")
+        registry.record_write(out, content=b"payload-A", source=Path("/s1"))
+        result = registry.record_write(out, content=b"payload-A", source=Path("/s2"))
+
+        # We can't compare contents above the limit, so even byte-identical
+        # writes register as collisions (paranoid by design).
+        assert result.outcome is WriteOutcome.LARGE_FILE_COLLISION
+        assert result.entry.is_large_file
+        assert registry.large_file_collision_count == 1
+
+    def test_large_file_collision_counts_increment(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.bin")
+        registry.record_write(out, content=b"A", source=Path("/s1"))
+        registry.record_write(out, content=b"B", source=Path("/s2"))
+        registry.record_write(out, content=b"C", source=Path("/s3"))
+        assert registry.large_file_collision_count == 2
+
+    def test_path_equality_fast_path_via_content_source(self, tmp_path, monkeypatch):
+        # Real on-disk file; threshold is bytes, not megabytes.
+        # Use a 1 KB file and set the limit to 0 to force the large-file branch.
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+        src = _abs(tmp_path, "src", "big.bin")
+        src.write_bytes(b"x" * 1024)
+        out = _abs(tmp_path, "out", "big.bin")
+
+        result = registry.record_write(out, content_source=src, source=src)
+        assert result.outcome is WriteOutcome.FIRST_WRITE
+        assert result.entry.is_large_file
+
+
+class TestSnapshotsAndClear:
+    def test_entries_returns_copy(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"x", source=Path("/s"))
+
+        snapshot = registry.entries
+        snapshot[Path("/fake")] = snapshot[out]
+        assert Path("/fake") not in registry.entries
+
+    def test_conflict_entries_empty_when_none(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"x", source=Path("/s"))
+        registry.record_write(out, content=b"x", source=Path("/s"))
+        assert registry.conflict_entries == []
+
+    def test_conflict_entries_contains_conflicts(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"x", source=Path("/s1"))
+        registry.record_write(out, content=b"y", source=Path("/s2"))
+        conflicts = registry.conflict_entries
+        assert len(conflicts) == 1
+        assert conflicts[0].output_path == out
+
+    def test_clear_resets_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.bin")
+        registry.record_write(out, content=b"A", source=Path("/s1"))
+        registry.record_write(out, content=b"B", source=Path("/s2"))
+
+        assert registry.large_file_collision_count == 1
+        assert len(registry.entries) == 1
+
+        registry.clear()
+        assert registry.large_file_collision_count == 0
+        assert registry.entries == {}
+        assert registry.total_dedups == 0
+        assert registry.total_conflicts == 0
+
+    def test_get_returns_none_for_unknown_path(self, tmp_path):
+        registry = OutputWriteRegistry()
+        assert registry.get(_abs(tmp_path, "out", "missing.txt")) is None
+
+    def test_get_returns_entry_for_known_path(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        registry.record_write(out, content=b"x", source=Path("/s"))
+        assert registry.get(out) is not None
+
+
+class TestHashLimitWiring:
+    def test_default_limit_is_50_mb(self, monkeypatch):
+        monkeypatch.delenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", raising=False)
+        registry = OutputWriteRegistry()
+        assert registry.hash_limit_bytes == 50 * 1024 * 1024
+
+    def test_env_override_is_picked_up_at_construction(self, monkeypatch):
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "10")
+        registry = OutputWriteRegistry()
+        assert registry.hash_limit_bytes == 10 * 1024 * 1024

--- a/tests/infrastructure/backends/test_output_dedup_integration.py
+++ b/tests/infrastructure/backends/test_output_dedup_integration.py
@@ -1,25 +1,40 @@
-"""Integration tests for OutputWriteRegistry wiring in LocalOpsBackend.
+"""Integration tests for OutputWriteRegistry wiring in the backends.
 
-These exercise the registry hook in
-:meth:`LocalOpsBackend.copy_file_to_output` end-to-end against the
-filesystem: that a first write proceeds and registers, a second
-byte-identical write from a different source dedups (no overwrite), a
-second differing-content write registers a conflict and overwrites
-(last-writer-wins), source paths under ``img/`` bypass the registry,
-and a missing source never produces a registry entry.
+These exercise the registry hooks end-to-end:
 
-The standalone registry semantics are covered by
+- :meth:`LocalOpsBackend.copy_file_to_output` (PR 2.2a) — pre-write
+  registration, dedup-skip on identical content, last-writer-wins on
+  conflict, image-path skip, missing-source no-register, and distinct
+  output paths registering independently.
+- :class:`SqliteBackend` cache-hit replay (PR 2.2a) — when a cached
+  result is replayed to disk, the registry sees it and a second
+  identical replay to the same output path dedups.
+- :class:`SqliteBackend` worker readback (PR 2.2b) — after a worker
+  subprocess writes its output and the orchestrator reads it back for
+  DB caching, the registry sees the write so cross-worker output
+  conflicts surface in the build summary.
+
+Standalone registry semantics are covered by
 ``tests/core/test_output_write_registry.py``; the tests here only assert
-the hook's plumbing.
+the hooks' plumbing.
 """
 
+import asyncio
+import gc
+import sqlite3
+import tempfile
 import time
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
+from attrs import frozen
 
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
-from clm.infrastructure.messaging.base_classes import Payload
+from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.database.schema import init_database
+from clm.infrastructure.messaging.base_classes import Payload, Result
 from clm.infrastructure.operation import Operation
 from clm.infrastructure.utils.copy_file_data import CopyFileData
 
@@ -128,3 +143,187 @@ class TestCopyFileDedup:
 
             assert backend.output_write_registry.total_dedups == 0
             assert len(backend.output_write_registry.entries) == 2
+
+
+@frozen
+class _MockOp(Operation):
+    service_name_value: str = "notebook-processor"
+
+    @property
+    def service_name(self) -> str:
+        return self.service_name_value
+
+    async def execute(self, backend, *args, **kwargs):
+        pass
+
+
+class _MockPayload(Payload):
+    correlation_id: str = "test-correlation-id"
+    input_file: str = "src/topic_a.py"
+    input_file_name: str = "topic_a.py"
+    output_file: str = "output/topic.ipynb"
+    data: str = "test content"
+
+
+class _MockResult(Result):
+    """In-memory cached result; ``data`` is the bytes to replay."""
+
+    data: bytes = b"cached payload"
+
+    def result_bytes(self) -> bytes:
+        return self.data
+
+    def output_metadata(self) -> str:
+        return "default"
+
+
+@pytest.fixture
+def _sqlite_temp_db():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = Path(f.name)
+    init_database(db_path)
+    yield db_path
+    gc.collect()
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.close()
+    except Exception:
+        pass
+    for attempt in range(3):
+        try:
+            db_path.unlink(missing_ok=True)
+            for suffix in ("-wal", "-shm"):
+                Path(str(db_path) + suffix).unlink(missing_ok=True)
+            break
+        except PermissionError:
+            if attempt < 2:
+                time.sleep(0.1)
+
+
+@pytest.fixture
+def _sqlite_workspace():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+class TestSqliteCacheHitReplayRegistry:
+    """PR 2.2a: cache-hit replay path registers writes."""
+
+    async def test_cache_hit_replay_registers_first_write(self, _sqlite_temp_db, _sqlite_workspace):
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="x",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_a.py",
+                content_hash="h1",
+            )
+
+            payload = _MockPayload()
+            (_sqlite_workspace / "output").mkdir(parents=True, exist_ok=True)
+
+            await backend.execute_operation(_MockOp(), payload)
+
+            written = _sqlite_workspace / payload.output_file
+            assert written.read_bytes() == b"cached payload"
+            entry = backend.output_write_registry.get(written)
+            assert entry is not None
+            assert entry.first_writer_source == Path("src/topic_a.py")
+        finally:
+            await backend.shutdown()
+
+    async def test_second_identical_cache_hit_dedups(self, _sqlite_temp_db, _sqlite_workspace):
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="x",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_a.py",
+                content_hash="h1",
+            )
+            (_sqlite_workspace / "output").mkdir(parents=True, exist_ok=True)
+
+            await backend.execute_operation(_MockOp(), _MockPayload())
+            written = _sqlite_workspace / "output" / "topic.ipynb"
+            mtime_after_first = written.stat().st_mtime_ns
+
+            # Second execute with same bytes but different source: identical
+            # content → dedup → no second write.
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="y",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_b.py",
+                content_hash="h1",
+            )
+            payload2 = _MockPayload()
+            object.__setattr__(payload2, "input_file", "src/topic_b.py")
+            time.sleep(0.05)
+            await backend.execute_operation(_MockOp(), payload2)
+
+            assert written.stat().st_mtime_ns == mtime_after_first
+            assert backend.output_write_registry.total_dedups == 1
+        finally:
+            await backend.shutdown()
+
+
+class TestSqliteWorkerReadbackRegistry:
+    """PR 2.2b: completed-job readback path registers worker outputs."""
+
+    async def test_worker_readback_registers_output(self, _sqlite_temp_db, _sqlite_workspace):
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            # Real db_manager mock so the cache-storage block runs and the
+            # registry hook fires. get_result returns None so execute_operation
+            # falls through to the worker-submission path (we want to exercise
+            # the readback hook, not the cache-hit-replay hook).
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = None
+
+            payload = _MockPayload()
+            await backend.execute_operation(_MockOp(), payload)
+            job_id = next(iter(backend.active_jobs.keys()))
+
+            # Simulate the worker writing its output, then completing the
+            # job in the queue.
+            output_path = _sqlite_workspace / payload.output_file
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("worker output", encoding="utf-8")
+
+            async def _complete():
+                await asyncio.sleep(0.1)
+                jq = JobQueue(_sqlite_temp_db)
+                try:
+                    jq.update_job_status(job_id, "completed")
+                finally:
+                    jq.close()
+
+            done = asyncio.create_task(_complete())
+            assert await backend.wait_for_completion() is True
+            await done
+
+            entry = backend.output_write_registry.get(output_path)
+            assert entry is not None
+            assert entry.first_writer_source == Path("src/topic_a.py")
+        finally:
+            await backend.shutdown()

--- a/tests/infrastructure/backends/test_output_dedup_integration.py
+++ b/tests/infrastructure/backends/test_output_dedup_integration.py
@@ -145,6 +145,156 @@ class TestCopyFileDedup:
             assert len(backend.output_write_registry.entries) == 2
 
 
+class TestCopyDirGroupRegistry:
+    """PR 2.2c: <dir-group> writes register per-file post-copy."""
+
+    async def test_recursive_copy_registers_each_file(self, tmp_path):
+        from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+        src_root = tmp_path / "src"
+        (src_root / "sub").mkdir(parents=True)
+        (src_root / "a.txt").write_text("alpha", encoding="utf-8")
+        (src_root / "b.txt").write_text("beta", encoding="utf-8")
+        (src_root / "sub" / "c.txt").write_text("gamma", encoding="utf-8")
+
+        output_dir = tmp_path / "out"
+        copy_data = CopyDirGroupData(
+            name="grp",
+            source_dirs=(src_root,),
+            relative_paths=(Path("grp"),),
+            lang="en",
+            output_dir=output_dir,
+            recursive=True,
+        )
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_dir_group_to_output(copy_data)
+
+            entries = backend.output_write_registry.entries
+            written = set(entries)
+            expected_files = {
+                (output_dir / "grp" / "a.txt").resolve(),
+                (output_dir / "grp" / "b.txt").resolve(),
+                (output_dir / "grp" / "sub" / "c.txt").resolve(),
+            }
+            assert expected_files <= written
+            assert backend.output_write_registry.total_dedups == 0
+
+    async def test_non_recursive_copy_registers_top_level_only(self, tmp_path):
+        from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+        src_root = tmp_path / "src"
+        (src_root / "sub").mkdir(parents=True)
+        (src_root / "a.txt").write_text("alpha", encoding="utf-8")
+        (src_root / "sub" / "c.txt").write_text("gamma", encoding="utf-8")
+
+        output_dir = tmp_path / "out"
+        copy_data = CopyDirGroupData(
+            name="grp",
+            source_dirs=(src_root,),
+            relative_paths=(Path("grp"),),
+            lang="en",
+            output_dir=output_dir,
+            recursive=False,
+        )
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_dir_group_to_output(copy_data)
+
+            keys = set(backend.output_write_registry.entries)
+            assert (output_dir / "grp" / "a.txt").resolve() in keys
+            assert (output_dir / "grp" / "sub" / "c.txt").resolve() not in keys
+
+    async def test_recursive_copy_image_paths_skipped(self, tmp_path):
+        from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+        src_root = tmp_path / "src"
+        (src_root / "img").mkdir(parents=True)
+        (src_root / "a.txt").write_text("alpha", encoding="utf-8")
+        (src_root / "img" / "diagram.png").write_bytes(b"PNG bytes")
+
+        output_dir = tmp_path / "out"
+        copy_data = CopyDirGroupData(
+            name="grp",
+            source_dirs=(src_root,),
+            relative_paths=(Path("grp"),),
+            lang="en",
+            output_dir=output_dir,
+            recursive=True,
+        )
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_dir_group_to_output(copy_data)
+
+            keys = set(backend.output_write_registry.entries)
+            assert (output_dir / "grp" / "a.txt").resolve() in keys
+            assert (output_dir / "grp" / "img" / "diagram.png").resolve() not in keys
+
+    async def test_two_overlapping_dir_groups_detect_conflict(self, tmp_path):
+        from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+        src_a = tmp_path / "src_a"
+        src_b = tmp_path / "src_b"
+        src_a.mkdir()
+        src_b.mkdir()
+        (src_a / "shared.txt").write_text("version A", encoding="utf-8")
+        (src_b / "shared.txt").write_text("version B", encoding="utf-8")
+
+        output_dir = tmp_path / "out"
+        cd_a = CopyDirGroupData(
+            name="a",
+            source_dirs=(src_a,),
+            relative_paths=(Path("grp"),),
+            lang="en",
+            output_dir=output_dir,
+            recursive=False,
+        )
+        cd_b = CopyDirGroupData(
+            name="b",
+            source_dirs=(src_b,),
+            relative_paths=(Path("grp"),),
+            lang="en",
+            output_dir=output_dir,
+            recursive=False,
+        )
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_dir_group_to_output(cd_a)
+            await backend.copy_dir_group_to_output(cd_b)
+
+            assert backend.output_write_registry.total_conflicts == 1
+            conflicts = backend.output_write_registry.conflict_entries
+            assert len(conflicts) == 1
+            assert conflicts[0].first_writer_source == src_a / "shared.txt"
+            assert conflicts[0].last_writer_source == src_b / "shared.txt"
+
+    async def test_base_path_files_registered(self, tmp_path):
+        from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+        base = tmp_path / "base"
+        base.mkdir()
+        (base / "README.md").write_text("hello", encoding="utf-8")
+        (base / "VERSION").write_text("1.0", encoding="utf-8")
+
+        output_dir = tmp_path / "out"
+        copy_data = CopyDirGroupData(
+            name="grp",
+            source_dirs=(),
+            relative_paths=(),
+            lang="en",
+            output_dir=output_dir,
+            recursive=False,
+            base_path=base,
+        )
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_dir_group_to_output(copy_data)
+
+            keys = set(backend.output_write_registry.entries)
+            assert (output_dir / "README.md").resolve() in keys
+            assert (output_dir / "VERSION").resolve() in keys
+
+
 @frozen
 class _MockOp(Operation):
     service_name_value: str = "notebook-processor"

--- a/tests/infrastructure/backends/test_output_dedup_integration.py
+++ b/tests/infrastructure/backends/test_output_dedup_integration.py
@@ -1,0 +1,130 @@
+"""Integration tests for OutputWriteRegistry wiring in LocalOpsBackend.
+
+These exercise the registry hook in
+:meth:`LocalOpsBackend.copy_file_to_output` end-to-end against the
+filesystem: that a first write proceeds and registers, a second
+byte-identical write from a different source dedups (no overwrite), a
+second differing-content write registers a conflict and overwrites
+(last-writer-wins), source paths under ``img/`` bypass the registry,
+and a missing source never produces a registry entry.
+
+The standalone registry semantics are covered by
+``tests/core/test_output_write_registry.py``; the tests here only assert
+the hook's plumbing.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
+from clm.infrastructure.messaging.base_classes import Payload
+from clm.infrastructure.operation import Operation
+from clm.infrastructure.utils.copy_file_data import CopyFileData
+
+
+class PytestLocalOpsBackend(LocalOpsBackend):
+    async def execute_operation(self, operation: Operation, payload: Payload) -> None:
+        pass
+
+    async def wait_for_completion(self, all_submitted=None) -> bool:
+        return True
+
+
+def _copy_data(source: Path, out: Path, base: Path) -> CopyFileData:
+    return CopyFileData(
+        input_path=source,
+        output_path=out,
+        relative_input_path=source.relative_to(base),
+    )
+
+
+class TestCopyFileDedup:
+    async def test_first_write_registers_and_copies(self, tmp_path):
+        src = tmp_path / "src.txt"
+        out = tmp_path / "out.txt"
+        src.write_text("hello", encoding="utf-8")
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(_copy_data(src, out, tmp_path))
+
+            assert out.read_text(encoding="utf-8") == "hello"
+            assert backend.output_write_registry.total_dedups == 0
+            entry = backend.output_write_registry.get(out.resolve())
+            assert entry is not None
+            assert entry.first_writer_source == src
+
+    async def test_second_identical_write_dedups(self, tmp_path):
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        out = tmp_path / "out.txt"
+        src_a.write_text("same", encoding="utf-8")
+        src_b.write_text("same", encoding="utf-8")
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(_copy_data(src_a, out, tmp_path))
+            mtime_after_first = out.stat().st_mtime_ns
+            # Sleep past filesystem timestamp resolution so a real second
+            # write would visibly advance mtime.
+            time.sleep(0.05)
+            await backend.copy_file_to_output(_copy_data(src_b, out, tmp_path))
+
+            assert out.stat().st_mtime_ns == mtime_after_first
+            assert backend.output_write_registry.total_dedups == 1
+            assert backend.output_write_registry.total_conflicts == 0
+
+    async def test_second_differing_write_records_conflict(self, tmp_path):
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        out = tmp_path / "out.txt"
+        src_a.write_text("first", encoding="utf-8")
+        src_b.write_text("second", encoding="utf-8")
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(_copy_data(src_a, out, tmp_path))
+            await backend.copy_file_to_output(_copy_data(src_b, out, tmp_path))
+
+            assert out.read_text(encoding="utf-8") == "second"
+            assert backend.output_write_registry.total_conflicts == 1
+            entries = backend.output_write_registry.conflict_entries
+            assert len(entries) == 1
+            assert entries[0].first_writer_source == src_a
+            assert entries[0].last_writer_source == src_b
+
+    async def test_image_path_skipped(self, tmp_path):
+        img_dir = tmp_path / "topic" / "img"
+        img_dir.mkdir(parents=True)
+        src = img_dir / "diagram.png"
+        out = tmp_path / "out.png"
+        src.write_bytes(b"PNG bytes")
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(_copy_data(src, out, tmp_path))
+            await backend.copy_file_to_output(_copy_data(src, out, tmp_path))
+
+            assert backend.output_write_registry.entries == {}
+            assert out.read_bytes() == b"PNG bytes"
+
+    async def test_missing_source_not_registered(self, tmp_path):
+        src = tmp_path / "missing.txt"
+        out = tmp_path / "out.txt"
+
+        async with PytestLocalOpsBackend() as backend:
+            with pytest.raises(FileNotFoundError):
+                await backend.copy_file_to_output(_copy_data(src, out, tmp_path))
+
+            assert backend.output_write_registry.entries == {}
+
+    async def test_distinct_output_paths_independent(self, tmp_path):
+        src = tmp_path / "src.txt"
+        out_a = tmp_path / "a" / "out.txt"
+        out_b = tmp_path / "b" / "out.txt"
+        src.write_text("payload", encoding="utf-8")
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(_copy_data(src, out_a, tmp_path))
+            await backend.copy_file_to_output(_copy_data(src, out_b, tmp_path))
+
+            assert backend.output_write_registry.total_dedups == 0
+            assert len(backend.output_write_registry.entries) == 2

--- a/tests/integration/test_output_dedup_pipeline.py
+++ b/tests/integration/test_output_dedup_pipeline.py
@@ -1,0 +1,219 @@
+"""End-to-end pipeline tests for OutputWriteRegistry (PR 2.4).
+
+These tests stitch the per-component coverage together at the
+build-pipeline level:
+
+- Many topics producing the same output path with identical content
+  (the C# NUnitTestRunner pattern) collapse to one write with the
+  remaining N-1 counted as dedups.
+- Differing-content writes to the same output path surface as one
+  ``output_path_conflict`` warning (plus an ``OutputConflictInfo``
+  entry) with last-writer-wins semantics on disk.
+- ImageRegistry-owned paths still produce ``image_collision`` and do
+  NOT produce ``output_path_conflict`` (no double-warning).
+- The JSON formatter end-to-end shows the registry totals after a
+  build summary is finalized.
+"""
+
+import json as _json
+from pathlib import Path
+
+from clm.cli.build_data_classes import BuildSummary
+from clm.cli.build_reporter import BuildReporter
+from clm.cli.output_formatter import JSONOutputFormatter, QuietOutputFormatter
+from clm.core.image_registry import ImageRegistry
+from clm.core.output_write_registry import OutputWriteRegistry
+from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
+from clm.infrastructure.messaging.base_classes import Payload
+from clm.infrastructure.operation import Operation
+from clm.infrastructure.utils.copy_file_data import CopyFileData
+
+
+class PytestLocalOpsBackend(LocalOpsBackend):
+    async def execute_operation(self, operation: Operation, payload: Payload) -> None:
+        pass
+
+    async def wait_for_completion(self, all_submitted=None) -> bool:
+        return True
+
+
+def _make_copy_data(source: Path, out: Path, base: Path) -> CopyFileData:
+    return CopyFileData(
+        input_path=source,
+        output_path=out,
+        relative_input_path=source.relative_to(base),
+    )
+
+
+class TestNUnitTestRunnerPattern:
+    """N topics that produce the same shared output file (the C#
+    course's NUnitTestRunner.cs pattern). Identical bytes → first
+    write proceeds; remaining N-1 dedup-skip."""
+
+    async def test_six_topics_same_runner_file(self, tmp_path):
+        # Simulate six topic source directories each holding a byte-
+        # identical copy of NUnitTestRunner.cs.
+        sources: list[Path] = []
+        for i in range(6):
+            src_dir = tmp_path / f"topic_{i:03d}" / "src"
+            src_dir.mkdir(parents=True)
+            runner = src_dir / "NUnitTestRunner.cs"
+            runner.write_text(
+                "// shared test runner — identical across topics\n",
+                encoding="utf-8",
+            )
+            sources.append(runner)
+
+        # All six writes target the same shared output path (typical
+        # for course-wide shared runner files).
+        out = tmp_path / "out" / "NUnitTestRunner.cs"
+
+        async with PytestLocalOpsBackend() as backend:
+            for src in sources:
+                await backend.copy_file_to_output(_make_copy_data(src, out, tmp_path))
+
+            registry = backend.output_write_registry
+            assert registry.total_dedups == 5
+            assert registry.total_conflicts == 0
+
+            reporter = BuildReporter(QuietOutputFormatter())
+            reporter.start_build(course_name="cs-course", total_files=6)
+            reporter.report_output_writes(registry)
+            summary = reporter.finish_build()
+
+            assert summary.output_dedup_count == 5
+            assert summary.output_conflicts == []
+            assert "duplicate output writes deduplicated" in str(summary)
+
+    async def test_drift_creates_conflict(self, tmp_path):
+        # Same pattern, but topic 3 ships a drifted version.
+        sources: list[Path] = []
+        for i in range(5):
+            src_dir = tmp_path / f"topic_{i:03d}" / "src"
+            src_dir.mkdir(parents=True)
+            runner = src_dir / "NUnitTestRunner.cs"
+            payload = "// drifted on topic 3\n" if i == 3 else "// shared canonical runner\n"
+            runner.write_text(payload, encoding="utf-8")
+            sources.append(runner)
+
+        out = tmp_path / "out" / "NUnitTestRunner.cs"
+
+        async with PytestLocalOpsBackend() as backend:
+            for src in sources:
+                await backend.copy_file_to_output(_make_copy_data(src, out, tmp_path))
+
+            registry = backend.output_write_registry
+            assert registry.total_conflicts >= 1
+
+            reporter = BuildReporter(QuietOutputFormatter())
+            reporter.start_build(course_name="cs-course", total_files=5)
+            reporter.report_output_writes(registry)
+            summary = reporter.finish_build()
+
+            # Last-writer-wins: the file on disk should reflect topic 4's
+            # (the last) version. Since 3 is drifted and 4 is canonical,
+            # the final state is the canonical text again.
+            assert out.read_text(encoding="utf-8") == "// shared canonical runner\n"
+
+            # At least one output_path_conflict warning surfaced.
+            assert any(w.category == "output_path_conflict" for w in summary.warnings)
+
+
+class TestImageRegistryDoesNotDoubleWarn:
+    """Image-path collisions continue to fire image_collision via
+    ImageRegistry, and the new output_path_conflict channel does NOT
+    fire for the same paths."""
+
+    async def test_image_collision_only_in_image_registry(self, tmp_path):
+        # Two topics, both with img/diagram.png but DIFFERENT content
+        # (an ImageRegistry collision).
+        topic_a = tmp_path / "topic_a"
+        topic_b = tmp_path / "topic_b"
+        (topic_a / "img").mkdir(parents=True)
+        (topic_b / "img").mkdir(parents=True)
+        img_a = topic_a / "img" / "diagram.png"
+        img_b = topic_b / "img" / "diagram.png"
+        img_a.write_bytes(b"PNG A")
+        img_b.write_bytes(b"PNG B")
+
+        image_registry = ImageRegistry()
+        image_registry.register(img_a)
+        image_registry.register(img_b)
+        assert image_registry.has_collisions()
+
+        # Now hypothetically copy both into the same output path. The
+        # output registry SHOULD NOT register them at all.
+        out = tmp_path / "out" / "img" / "diagram.png"
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(_make_copy_data(img_a, out, tmp_path))
+            await backend.copy_file_to_output(_make_copy_data(img_b, out, tmp_path))
+
+            out_registry = backend.output_write_registry
+            assert out_registry.entries == {}
+            assert out_registry.total_conflicts == 0
+
+            reporter = BuildReporter(QuietOutputFormatter())
+            reporter.start_build(course_name="course", total_files=2)
+            reporter.report_output_writes(out_registry)
+            summary = reporter.finish_build()
+
+            assert all(w.category != "output_path_conflict" for w in summary.warnings)
+
+
+class TestJsonEndToEnd:
+    def test_json_summary_carries_registry_data(self, tmp_path, capsys):
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        src_a.write_text("same payload", encoding="utf-8")
+        src_b.write_text("same payload", encoding="utf-8")
+        out = tmp_path / "out.txt"
+
+        # First, populate a registry via real copy_file_to_output calls.
+        # We need a separate event loop here so we can drive the rest of
+        # the assertions synchronously; pytest-asyncio handles this for
+        # us when the test function is async — but capsys interacts with
+        # stdout so keep the JSON section sync after the copies.
+        registry = OutputWriteRegistry()
+        # Two identical writes to the same output.
+        registry.record_write(out, content_source=src_a, source=src_a)
+        registry.record_write(out, content_source=src_b, source=src_b)
+
+        reporter = BuildReporter(JSONOutputFormatter())
+        reporter.start_build(course_name="json-course", total_files=2)
+        reporter.report_output_writes(registry)
+        summary: BuildSummary = reporter.finish_build()
+        assert summary.output_dedup_count == 1
+
+        captured = capsys.readouterr().out
+        data = _json.loads(captured)
+        assert data["output_dedup_count"] == 1
+        assert data["output_conflicts"] == []
+        assert data["output_large_file_collision_count"] == 0
+
+
+class TestConcurrentMediatedWrites:
+    """Sanity check that even with many concurrent copy_file_to_output
+    awaits, the registry sees the right total events (the per-call
+    record_write runs on the event loop, not the executor, so no real
+    threading concern — but worth pinning behavior)."""
+
+    async def test_many_concurrent_writes_count_correctly(self, tmp_path):
+        import asyncio
+
+        sources = []
+        for i in range(20):
+            src = tmp_path / f"src_{i}.txt"
+            src.write_text("identical", encoding="utf-8")
+            sources.append(src)
+
+        out = tmp_path / "out.txt"
+        async with PytestLocalOpsBackend() as backend:
+            await asyncio.gather(
+                *[backend.copy_file_to_output(_make_copy_data(s, out, tmp_path)) for s in sources]
+            )
+
+            # 1 first write + 19 dedups, regardless of scheduling order.
+            registry = backend.output_write_registry
+            assert registry.total_dedups == 19
+            assert registry.total_conflicts == 0
+            assert len(registry.entries) == 1


### PR DESCRIPTION
## Summary

Feature 2 of the [shared-source includes & output-write dedup design](docs/claude/design/shared-source-includes-and-output-dedup.md) (locked 2026-05-10). Companion to PR #61 (Feature 1, merged 2026-05-11).

Builds that produce identical writes to the same output path — common when many topics share an `<include>`-sourced file (PR #61), or for the C# course's repeated `NUnitTestRunner.cs` — now collapse to one write, with the rest counted as dedups. Differing-content writes to the same output path still proceed (last-writer-wins, preserving previous behavior) but now surface a per-conflict `output_path_conflict` warning and a structured `output_conflicts` entry in the JSON summary, so authoring drift no longer hides silently.

Image-path collisions remain owned by the existing `ImageRegistry` channel (category `image_collision`) — no double-warning.

## What ships

- **`OutputWriteRegistry`** (`src/clm/core/output_write_registry.py`) — per-build, keyed by absolute output path. BLAKE2b-128 hash; `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` env var (default 50) bypasses hashing for large files.
- **Three write hooks** wire the registry into every output-write path the orchestrator can see:
  - `LocalOpsBackend.copy_file_to_output` and `SqliteBackend` cache-hit replay — pre-write registration with **dedup-skip** on DEDUP.
  - `SqliteBackend` worker readback (`wait_for_completion`) — register-after-write for fresh worker output (notebook, plantuml, drawio); warn-only.
  - `LocalOpsBackend.copy_dir_group_to_output` — post-copy walk on the event loop (registry is not thread-safe; this reuses `shutil`'s ignore-pattern handling); warn-only.
- **`BuildReporter.report_output_writes`** drains the registry into `BuildSummary`: `output_dedup_count`, structured `output_conflicts` list, `output_large_file_collision_count`. One `BuildWarning` per conflict via the standard channel.
- **JSON summary** (`--output-mode json`) emits the three new keys unconditionally so machine consumers don't have to special-case clean builds. Conflict records are `{output_path, first_writer, last_writer, first_hash, last_hash, conflict_count}`.
- **Rich + `__str__` summary** add a one-line counts row when dedup_count or conflicts is nonzero.

## Commits (per-phase)

| Phase | Commit | What |
|---|---|---|
| 2.1 | `a78cb2d` | Standalone registry module + 32 unit tests |
| 2.2a | `6b37a6d` | Hooks `copy_file_to_output` + sqlite cache-hit replay |
| 2.2b | `c37077e` | Hooks worker readback |
| 2.2c | `8bb1731` | Hooks `<dir-group>` writes |
| 2.3 | `33283ae` | Reporter bridge + JSON keys |
| 2.4 | `01d429b` | End-to-end pipeline tests |
| 2.5 | `bc924b1` | CHANGELOG + configuration + info topic |

(plus handover commits)

## Out of scope (deferred)

- **JupyterLite cross-process coverage.** Workers in `clm.workers.jupyterlite` write directly via `Path.write_text` from subprocesses, and `SqliteBackend` explicitly skips the DB-cache layer for jupyterlite. No in-process choke point to hook. See the "Call-path audit" subsection of `docs/claude/shared-source-includes-handover.md` for the full reasoning.
- **`--strict` flag promoting `output_path_conflict` to errors.** Captured in the design doc; deferred until the warning is visible enough in practice to justify a flag.
- **PR2.7 — AZAV ML smoke validation.** Not run in this branch. Expected dedup-count for the include-shared `simple_chatbot/` package on the canonical course is ~420 events (60 output variants × 7 files).

## Pre-PR gate (PR 2.6)

- `pytest -m "not docker"` → **4831 passed / 11 skipped / 4 xfailed** in 2:55
- `ruff check src/ tests/` clean
- `ruff format --check src/ tests/` — 515 files already formatted
- `mypy src/clm` clean on 248 source files

## Test plan

- [ ] Reviewer skim of `output_write_registry.py` API + `report_output_writes` bridge
- [ ] Run `pytest tests/core/test_output_write_registry.py tests/infrastructure/backends/test_output_dedup_integration.py tests/cli/test_build_reporter_output_writes.py tests/integration/test_output_dedup_pipeline.py` (55 tests)
- [ ] Optionally run a real `clm build` against a small course with `<include>`-shared files and confirm `output_dedup_count` is non-zero
- [ ] Confirm JSON output (`-O json`) carries `output_dedup_count`, `output_conflicts`, `output_large_file_collision_count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)