### PR TITLE
v1.4.1: ledger-aware shadow suppression + always-visible dedup summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [1.4.0] - 2026-05-13
+## [1.4.1] - 2026-05-13
+
+### Changed
+- **`include_shadowed_by_local` / `include_shadowed` warnings now check the
+  topic's `.clm-include` ledger before firing.** When a real file at
+  `<topic-dir>/<as_path>` matches a ledger entry (same `as_path` *and*
+  resolved `source`), the shadowing is `clm sync-includes`'s own
+  materialization, not an ad-hoc local override — so the warning is
+  suppressed. Without this, any course adopting `<include>` would see one
+  HIGH warning per materialized file on every build (16 per build in the
+  AZAV ML migration). Unauthorized shadowings — real local files with no
+  matching ledger entry, or stale ledgers pointing at a different source —
+  still warn as before. Both the build-time path (`Topic.apply_includes`)
+  and `clm validate-spec` apply the same check. Ledger reader extracted to
+  `clm.core.include_ledger` so build and sync-includes share one
+  implementation.
+- **Build summary always shows the output-write registry counts.** The
+  `N duplicate output writes deduplicated; N output paths had conflicting
+  writes` line now appears unconditionally alongside files-processed,
+  errors, and warnings — previously it was suppressed when both counts
+  were zero, which left users unable to confirm the registry had run.
 
 ### Changed
 - **`clm sync-includes --gitignore` replaced with `--print-gitignore`.** The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Draw.io diagrams) into multiple output formats (HTML slides, executed
 notebooks, extracted code) for multiple audiences (students, solutions,
 speaker notes).
 
-**Version**: 1.4.0 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.4.1 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hoelzl/clm/actions/workflows/ci.yml/badge.svg)](https://github.com/hoelzl/clm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hoelzl/clm/branch/master/graph/badge.svg)](https://codecov.io/gh/hoelzl/clm)
 
-**Version**: 1.4.0 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.4.1 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 CLM is a course content processing system that converts educational materials (Jupyter notebooks, PlantUML diagrams, Draw.io diagrams) into multiple output formats.
 

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -47,7 +47,7 @@ On Windows (PowerShell):
 ### PlantUML Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.4.0`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.4.1`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -70,7 +70,7 @@ docker build -f docker/plantuml/Dockerfile -t docker.io/mhoelzl/clm-plantuml-con
 ### Draw.io Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-drawio-converter:1.4.0`
+- `docker.io/mhoelzl/clm-drawio-converter:1.4.1`
 - `docker.io/mhoelzl/clm-drawio-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -104,7 +104,7 @@ The notebook processor has **two variants** to support different use cases:
 **Best for:** Courses without deep learning, or running on Apple Silicon Macs.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.4.0-lite`
+- `docker.io/mhoelzl/clm-notebook-processor:1.4.1-lite`
 - `docker.io/mhoelzl/clm-notebook-processor:lite`
 
 **Base Image:** `python:3.11-slim` (multi-arch: amd64, arm64)
@@ -136,8 +136,8 @@ docker build -f docker/notebook/Dockerfile \
 **Best for:** Deep learning courses, CUDA-accelerated processing.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.4.0` (default)
-- `docker.io/mhoelzl/clm-notebook-processor:1.4.0-full`
+- `docker.io/mhoelzl/clm-notebook-processor:1.4.1` (default)
+- `docker.io/mhoelzl/clm-notebook-processor:1.4.1-full`
 - `docker.io/mhoelzl/clm-notebook-processor:latest`
 - `docker.io/mhoelzl/clm-notebook-processor:full`
 
@@ -169,7 +169,7 @@ docker build -f docker/notebook/Dockerfile -t docker.io/mhoelzl/clm-notebook-pro
 - .NET SDK 10.0 (C# and F# kernels)
 - Deno (TypeScript/JavaScript kernel)
 - Java JDK (Java kernel)
-- IJava 1.4.0 (Java Jupyter kernel)
+- IJava 1.4.1 (Java Jupyter kernel)
 - micromamba + xeus-cpp (C++ kernel)
 
 **Jupyter Kernels:**
@@ -220,12 +220,12 @@ The build scripts automatically set these arguments.
 All images use the Hub namespace (`docker.io/mhoelzl/clm-*`) for consistency:
 
 **PlantUML/DrawIO:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.4.0`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.4.1`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Notebook (with variants):**
-- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.4.0`, `:full`, `:1.4.0-full`
-- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.4.0-lite`
+- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.4.1`, `:full`, `:1.4.1-full`
+- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.4.1-lite`
 
 ### BuildKit Cache Mounts
 
@@ -261,7 +261,7 @@ Several large binary files are stored in Git LFS and must be present before buil
 
 ### Notebook Worker
 - `docker/notebook/deno-x86_64-unknown-linux-gnu.zip` (~40MB) - **LFS**
-- `docker/notebook/ijava-1.4.0.zip` (~6MB) - **LFS**
+- `docker/notebook/ijava-1.4.1.zip` (~6MB) - **LFS**
 - `docker/notebook/packages-microsoft-prod.deb` (~3KB) - **LFS**
 
 To ensure all LFS files are downloaded:

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,6 +1,6 @@
 # CLM Architecture
 
-This document describes the current architecture of the CLM system (v1.4.0).
+This document describes the current architecture of the CLM system (v1.4.1).
 
 ## Overview
 
@@ -42,7 +42,7 @@ CLM is a course content processing system that converts educational materials (J
                          │
 ┌────────────────────────▼──────────────────────────────────┐
 │          clm.workers (Worker Implementations)              │
-│                                (v1.4.0)             │
+│                                (v1.4.1)             │
 │  ├── notebook/ (NotebookWorker, templates, processors)    │
 │  ├── plantuml/ (PlantUmlWorker, converter)                │
 │  └── drawio/ (DrawioWorker, converter)                    │
@@ -196,7 +196,7 @@ class Worker(ABC):
 
 ### Layer 3: Workers (Worker Implementations)
 
-**Purpose**: Concrete worker implementations for different file types (v1.4.0)
+**Purpose**: Concrete worker implementations for different file types (v1.4.1)
 
 Workers are now integrated into the main `clm` package under `clm.workers/`. Previously they were separate packages in the `services/` directory.
 
@@ -551,7 +551,7 @@ CLM has evolved significantly:
 - No message broker required
 - Reduced from 8 Docker services to 3
 
-**v0.6.2 → v1.4.0** (2025): Integrated workers
+**v0.6.2 → v1.4.1** (2025): Integrated workers
 - Workers integrated into main package (`clm.workers`)
 - Optional dependencies for each worker
 - Four-layer architecture (core, infrastructure, workers, cli)
@@ -1097,4 +1097,4 @@ Potential improvements (not currently planned):
 ---
 
 **Last Updated**: 2026-02-13
-**Version**: 1.4.0
+**Version**: 1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-academy-lecture-manager"
-version = "1.4.0"
+version = "1.4.1"
 description = "Coding-Academy Lecture Manager - A course content processing system"
 authors = [
     {name = "Dr. Matthias Hölzl", email = "tc@xantira.com"},
@@ -373,7 +373,7 @@ ignore = [
 known-first-party = ["clm"]
 
 [tool.bumpversion]
-current_version = "1.4.0"
+current_version = "1.4.1"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/src/clm/__version__.py
+++ b/src/clm/__version__.py
@@ -1,3 +1,3 @@
 """Version information for CLM."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/src/clm/cli/build_data_classes.py
+++ b/src/clm/cli/build_data_classes.py
@@ -175,11 +175,10 @@ class BuildSummary:
         parts.append(f"  {self.total_files} files processed")
         parts.append(f"  {len(self.errors)} errors")
         parts.append(f"  {len(self.warnings)} warnings")
-        if self.output_dedup_count or self.output_conflicts:
-            parts.append(
-                f"  {self.output_dedup_count} duplicate output writes deduplicated; "
-                f"{len(self.output_conflicts)} output paths had conflicting writes"
-            )
+        parts.append(
+            f"  {self.output_dedup_count} duplicate output writes deduplicated; "
+            f"{len(self.output_conflicts)} output paths had conflicting writes"
+        )
 
         if self.errors:
             parts.append("")

--- a/src/clm/cli/commands/sync_includes.py
+++ b/src/clm/cli/commands/sync_includes.py
@@ -31,13 +31,22 @@ import logging
 import os
 import shutil
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
 import click
 
 from clm.core.course_spec import CourseSpec, CourseSpecError, IncludeSpec
+from clm.core.include_ledger import (
+    LEDGER_NAME,
+)
+from clm.core.include_ledger import (
+    Ledger as _Ledger,
+)
+from clm.core.include_ledger import (
+    LedgerEntry as _LedgerEntry,
+)
 from clm.core.topic_resolver import build_topic_map, matches_for_binding
 from clm.infrastructure.utils.path_utils import (
     is_ignored_dir_for_course,
@@ -46,73 +55,7 @@ from clm.infrastructure.utils.path_utils import (
 
 logger = logging.getLogger(__name__)
 
-LEDGER_NAME = ".clm-include"
-LEDGER_VERSION = 1
 SUPPORTED_MODES = ("copy", "symlink", "hardlink")
-
-
-@dataclass
-class _LedgerEntry:
-    """One materialized include recorded in a topic's ledger."""
-
-    as_path: str
-    source: str
-    mode: str
-
-    def to_dict(self) -> dict:
-        return {"as_path": self.as_path, "source": self.source, "mode": self.mode}
-
-    @classmethod
-    def from_dict(cls, data: dict) -> _LedgerEntry:
-        return cls(
-            as_path=str(data["as_path"]),
-            source=str(data.get("source", "")),
-            mode=str(data.get("mode", "copy")),
-        )
-
-
-@dataclass
-class _Ledger:
-    """Per-topic record of materializations made by ``clm sync-includes``.
-
-    Persisted as JSON at ``<topic-dir>/.clm-include``. The ledger is the
-    sole source of truth for ``--remove``: only paths it lists are
-    deleted, so untracked files in the topic dir are safe.
-    """
-
-    entries: list[_LedgerEntry] = field(default_factory=list)
-
-    def upsert(self, entry: _LedgerEntry) -> None:
-        for i, existing in enumerate(self.entries):
-            if existing.as_path == entry.as_path:
-                self.entries[i] = entry
-                return
-        self.entries.append(entry)
-
-    def to_dict(self) -> dict:
-        return {
-            "version": LEDGER_VERSION,
-            "entries": [e.to_dict() for e in self.entries],
-        }
-
-    @classmethod
-    def load(cls, path: Path) -> _Ledger:
-        if not path.is_file():
-            return cls()
-        try:
-            with path.open(encoding="utf-8") as f:
-                data = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            logger.warning("Ignoring unreadable ledger '%s': %s", path, e)
-            return cls()
-        raw_entries = data.get("entries") if isinstance(data, dict) else None
-        if not isinstance(raw_entries, list):
-            return cls()
-        entries: list[_LedgerEntry] = []
-        for raw in raw_entries:
-            if isinstance(raw, dict) and "as_path" in raw:
-                entries.append(_LedgerEntry.from_dict(raw))
-        return cls(entries=entries)
 
 
 @dataclass

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -396,6 +396,11 @@ parent element.
   `<topic-dir>/<as>`, the local file wins and the included file is
   shadowed. The build emits an `include_shadowed_by_local` warning and
   `validate-spec` surfaces the same condition as `include_shadowed`.
+  *Exception* (CLM {version}+): when the shadowing file was materialized
+  by `clm sync-includes` — i.e., the topic's `.clm-include` ledger lists
+  a matching `as_path` + `source` entry — the warning is suppressed, since
+  the on-disk copy *is* the include's authorized output rather than an
+  ad-hoc override.
 - **Collisions inside one parent.** Two `<include>` elements on the same
   `<topic>` or the same `<section>` with the same `as` target are a
   spec error reported at parse time (you cannot pick two sources for
@@ -416,7 +421,7 @@ per-topic `.clm-include` ledger so it can clean up safely later. See
 | Category | Severity | When it fires |
 |----------|----------|---------------|
 | `include_source_missing` | Error | `source` path does not exist under the course root and the include is not `optional`. |
-| `include_shadowed` | Warning | A real file/directory already occupies `<topic-dir>/<as>` — the local copy will be used, the include will not. |
+| `include_shadowed` | Warning | A real file/directory already occupies `<topic-dir>/<as>` — the local copy will be used, the include will not. Suppressed when the topic's `.clm-include` ledger lists a matching entry (sync-includes-managed materialization). |
 | `include_source_is_topic_dir` | Warning | `source` resolves into another `slides/.../topic_*` directory. Allowed but fragile; prefer pulling from a stable location like `examples/`. |
 | `include_dependencies` | Info | One per unique include source — lists the source's `pyproject.toml` `[project] dependencies` so authors can confirm the worker environment satisfies them. |
 | `include_section_inheritance` | Info | One per section-level include — lists every topic that inherits it and any topic that overrides it with a different source. |

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -376,13 +376,25 @@ class DefaultOutputFormatter(OutputFormatter):
         self.console.print(f"  {summary.total_files} files processed")
         self.console.print(f"  [red]{len(summary.errors)} errors[/red]")
         self.console.print(f"  [yellow]{len(summary.warnings)} warnings[/yellow]")
-        if summary.output_dedup_count or summary.output_conflicts:
-            conflict_color = "yellow" if summary.output_conflicts else "cyan"
-            self.console.print(
-                f"  [{conflict_color}]{summary.output_dedup_count} duplicate output "
-                f"writes deduplicated; {len(summary.output_conflicts)} output paths "
-                f"had conflicting writes[/{conflict_color}]"
-            )
+        # Output-write registry stats: always visible so users can
+        # confirm the registry ran, mirroring the unconditional errors
+        # and warnings lines above. Color cues elevate non-zero values.
+        dedup_count = summary.output_dedup_count
+        conflict_count = len(summary.output_conflicts)
+        if conflict_count:
+            color = "yellow"
+        elif dedup_count:
+            color = "cyan"
+        else:
+            color = None
+        dedup_line = (
+            f"  {dedup_count} duplicate output writes deduplicated; "
+            f"{conflict_count} output paths had conflicting writes"
+        )
+        if color:
+            self.console.print(f"[{color}]{dedup_line}[/{color}]")
+        else:
+            self.console.print(dedup_line)
 
         # Show errors (up to 10)
         max_errors_to_show = 10

--- a/src/clm/core/include_ledger.py
+++ b/src/clm/core/include_ledger.py
@@ -1,0 +1,105 @@
+"""Per-topic ledger of include materializations.
+
+Written by ``clm sync-includes`` to ``<topic-dir>/.clm-include``. Two
+consumers read it:
+
+1. ``clm sync-includes --remove``: only paths listed in the ledger are
+   deleted, so untracked user files in the topic dir are never touched.
+2. ``Topic.apply_includes`` at build time: a real on-disk file that
+   matches a ledger entry (same ``as_path`` *and* same ``source``) is the
+   include's authorized materialization, not an ad-hoc override — so the
+   shadow warning is suppressed for it.
+
+The schema is intentionally tiny and additive. Unknown keys are ignored
+on read; older readers tolerate newer writers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+LEDGER_NAME = ".clm-include"
+LEDGER_VERSION = 1
+
+
+@dataclass
+class LedgerEntry:
+    """One materialized include recorded in a topic's ledger."""
+
+    as_path: str
+    source: str
+    mode: str
+
+    def to_dict(self) -> dict:
+        return {"as_path": self.as_path, "source": self.source, "mode": self.mode}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> LedgerEntry:
+        return cls(
+            as_path=str(data["as_path"]),
+            source=str(data.get("source", "")),
+            mode=str(data.get("mode", "copy")),
+        )
+
+
+@dataclass
+class Ledger:
+    """Per-topic record of materializations made by ``clm sync-includes``."""
+
+    entries: list[LedgerEntry] = field(default_factory=list)
+
+    def upsert(self, entry: LedgerEntry) -> None:
+        for i, existing in enumerate(self.entries):
+            if existing.as_path == entry.as_path:
+                self.entries[i] = entry
+                return
+        self.entries.append(entry)
+
+    def to_dict(self) -> dict:
+        return {
+            "version": LEDGER_VERSION,
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+    @classmethod
+    def load(cls, path: Path) -> Ledger:
+        if not path.is_file():
+            return cls()
+        try:
+            with path.open(encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Ignoring unreadable ledger '%s': %s", path, e)
+            return cls()
+        raw_entries = data.get("entries") if isinstance(data, dict) else None
+        if not isinstance(raw_entries, list):
+            return cls()
+        entries: list[LedgerEntry] = []
+        for raw in raw_entries:
+            if isinstance(raw, dict) and "as_path" in raw:
+                entries.append(LedgerEntry.from_dict(raw))
+        return cls(entries=entries)
+
+    def authorizes(self, *, as_path: str, source_root: Path, course_root: Path) -> bool:
+        """Whether the ledger lists this include's materialization.
+
+        Comparison uses resolved absolute paths so that platform-style
+        and relative-vs-absolute differences in the recorded ``source``
+        do not produce false negatives.
+        """
+        target = source_root.resolve()
+        for entry in self.entries:
+            if entry.as_path != as_path:
+                continue
+            try:
+                entry_resolved = (course_root / entry.source).resolve()
+            except OSError:
+                continue
+            if entry_resolved == target:
+                return True
+        return False

--- a/src/clm/core/topic.py
+++ b/src/clm/core/topic.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from attr import Factory, frozen
 
 from clm.core.course_file import CourseFile
+from clm.core.include_ledger import LEDGER_NAME, Ledger
 from clm.core.utils.notebook_mixin import NotebookMixin
 from clm.core.utils.notebook_utils import find_images, find_imports
 from clm.infrastructure.utils.path_utils import (
@@ -134,7 +135,13 @@ class Topic(NotebookMixin, ABC):
                 }
             )
 
-    def add_virtual_file(self, *, virtual_path: Path, source_origin: Path) -> bool:
+    def add_virtual_file(
+        self,
+        *,
+        virtual_path: Path,
+        source_origin: Path,
+        ledger_authorized: bool = False,
+    ) -> bool:
         """Splice a file in from outside the topic directory.
 
         Used by ``build_file_map`` to materialize ``<include>`` entries
@@ -142,29 +149,33 @@ class Topic(NotebookMixin, ABC):
         logical position inside the topic (used for ``relative_path`` and
         output mapping); ``source_origin`` is where the bytes actually
         live. If a real file already occupies ``virtual_path``, the real
-        file wins and a structured warning is recorded — this preserves
-        the pre-include "drop a file, it ships" override path.
+        file wins — this preserves the pre-include "drop a file, it
+        ships" override path. A structured warning is recorded *unless*
+        ``ledger_authorized`` is True (i.e., the caller verified that
+        the topic's ``.clm-include`` ledger lists this include as a
+        legitimate materialization).
 
         Returns True when the virtual file was added; False when it was
         shadowed by a real file or otherwise rejected.
         """
         if self.file_for_path(virtual_path):
-            self.course.loading_warnings.append(
-                {
-                    "category": "include_shadowed_by_local",
-                    "message": (
-                        f"Topic '{self.id}': a real file at "
-                        f"'{virtual_path}' shadows the include from "
-                        f"'{source_origin}'. The local file wins; the "
-                        f"include is ignored for this path."
-                    ),
-                    "details": {
-                        "topic_id": self.id,
-                        "virtual_path": str(virtual_path),
-                        "source_origin": str(source_origin),
-                    },
-                }
-            )
+            if not ledger_authorized:
+                self.course.loading_warnings.append(
+                    {
+                        "category": "include_shadowed_by_local",
+                        "message": (
+                            f"Topic '{self.id}': a real file at "
+                            f"'{virtual_path}' shadows the include from "
+                            f"'{source_origin}'. The local file wins; the "
+                            f"include is ignored for this path."
+                        ),
+                        "details": {
+                            "topic_id": self.id,
+                            "virtual_path": str(virtual_path),
+                            "source_origin": str(source_origin),
+                        },
+                    }
+                )
             return False
         try:
             self._file_map[virtual_path] = CourseFile.from_virtual(
@@ -210,7 +221,14 @@ class Topic(NotebookMixin, ABC):
         ``topic.path / include.as_path / <relative-to-source-root>``.
         Single-file includes register a single entry at
         ``topic.path / include.as_path``.
+
+        Files materialized on disk by ``clm sync-includes`` (recorded in
+        the topic's ``.clm-include`` ledger) shadow the virtual entry by
+        design — the shadow warning is suppressed for those, since they
+        *are* the include's output, not competing overrides.
         """
+        ledger = Ledger.load(self.path / LEDGER_NAME)
+        course_root = self.course.course_root
         for include in self.includes:
             source = include.source_root
             if not source.exists():
@@ -241,9 +259,18 @@ class Topic(NotebookMixin, ABC):
                     }
                 )
                 continue
+            authorized = ledger.authorizes(
+                as_path=include.as_path,
+                source_root=source,
+                course_root=course_root,
+            )
             target_root = self.path / include.as_path
             if source.is_file():
-                self.add_virtual_file(virtual_path=target_root, source_origin=source)
+                self.add_virtual_file(
+                    virtual_path=target_root,
+                    source_origin=source,
+                    ledger_authorized=authorized,
+                )
                 continue
             for sub in source.rglob("*"):
                 if not sub.is_file():
@@ -257,7 +284,11 @@ class Topic(NotebookMixin, ABC):
                 ):
                     continue
                 rel = sub.relative_to(source)
-                self.add_virtual_file(virtual_path=target_root / rel, source_origin=sub)
+                self.add_virtual_file(
+                    virtual_path=target_root / rel,
+                    source_origin=sub,
+                    ledger_authorized=authorized,
+                )
 
     @abstractmethod
     def matches_path(self, path: Path, check_is_file: bool = True) -> bool:

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import tomllib
 
 from clm.core.course_spec import CourseSpec, IncludeSpec, SectionSpec
+from clm.core.include_ledger import LEDGER_NAME, Ledger
 from clm.core.topic_resolver import TopicMatch, build_topic_map, matches_for_binding
 
 
@@ -371,27 +372,33 @@ def _validate_includes(
                 if topic_path is not None and source_exists:
                     shadow_path = topic_path / Path(inc.as_path)
                     if shadow_path.exists():
-                        findings.append(
-                            SpecFinding(
-                                severity="warning",
-                                type="include_shadowed",
-                                topic_id=topic_spec.id,
-                                section=section_name,
-                                message=suffix(
-                                    section_disabled,
-                                    f"Topic '{topic_spec.id}': include target "
-                                    f"'{inc.as_path}' is shadowed by a real "
-                                    f"file/directory in the topic dir. The "
-                                    f"local copy wins at build time; the "
-                                    f"include is ignored for shadowed paths.",
-                                ),
-                                suggestion=(
-                                    f"Delete '{inc.as_path}' under the topic "
-                                    f"directory, or remove the <include> "
-                                    f"from this topic."
-                                ),
+                        ledger = Ledger.load(topic_path / LEDGER_NAME)
+                        if not ledger.authorizes(
+                            as_path=inc.as_path,
+                            source_root=source_path,
+                            course_root=course_root,
+                        ):
+                            findings.append(
+                                SpecFinding(
+                                    severity="warning",
+                                    type="include_shadowed",
+                                    topic_id=topic_spec.id,
+                                    section=section_name,
+                                    message=suffix(
+                                        section_disabled,
+                                        f"Topic '{topic_spec.id}': include target "
+                                        f"'{inc.as_path}' is shadowed by a real "
+                                        f"file/directory in the topic dir. The "
+                                        f"local copy wins at build time; the "
+                                        f"include is ignored for shadowed paths.",
+                                    ),
+                                    suggestion=(
+                                        f"Delete '{inc.as_path}' under the topic "
+                                        f"directory, or remove the <include> "
+                                        f"from this topic."
+                                    ),
+                                )
                             )
-                        )
 
                 if inc.source not in seen_topic_dir_sources and _is_inside_topic_dir(inc):
                     seen_topic_dir_sources.add(inc.source)

--- a/tests/cli/test_build_reporter_output_writes.py
+++ b/tests/cli/test_build_reporter_output_writes.py
@@ -156,7 +156,10 @@ class TestSummaryStringIncludesCounts:
         text = str(summary)
         assert "duplicate output writes deduplicated" in text
 
-    def test_str_summary_omits_dedup_line_when_zero(self, tmp_path):
+    def test_str_summary_includes_dedup_line_when_zero(self, tmp_path):
+        # Always-visible since v1.4.1: lets users confirm the output-
+        # write registry ran, mirroring the unconditional errors and
+        # warnings counts.
         summary = BuildSummary(
             duration=1.0,
             total_files=3,
@@ -164,7 +167,8 @@ class TestSummaryStringIncludesCounts:
             output_conflicts=[],
         )
         text = str(summary)
-        assert "duplicate output writes deduplicated" not in text
+        assert "0 duplicate output writes deduplicated" in text
+        assert "0 output paths had conflicting writes" in text
 
 
 class TestJsonFormatterIncludesOutputKeys:

--- a/tests/core/topic_test.py
+++ b/tests/core/topic_test.py
@@ -174,6 +174,95 @@ def test_real_local_file_shadows_virtual_include(tmp_path):
     assert "include_shadowed_by_local" in categories
 
 
+def test_ledger_authorized_shadow_suppresses_warning(tmp_path):
+    """Files materialized by `clm sync-includes` shadow the include but
+    are listed in the topic's `.clm-include` ledger — those shadowings
+    are authorized and must not emit the include_shadowed_by_local
+    warning."""
+    import json as _json
+
+    from clm.core.topic import ResolvedInclude
+
+    course, topic, course_root = _make_isolated_topic(tmp_path)
+
+    src = course_root / "examples" / "SimpleChatbot" / "src" / "simple_chatbot"
+    src.mkdir(parents=True)
+    (src / "main.py").write_text("ORIGIN = 'canonical'\n")
+
+    # The materialized copy that `sync-includes` would have placed.
+    materialized = topic.path / "simple_chatbot" / "main.py"
+    materialized.parent.mkdir(parents=True)
+    materialized.write_text("ORIGIN = 'canonical'\n")
+
+    # Ledger entry pointing at this include.
+    ledger_path = topic.path / ".clm-include"
+    ledger_path.write_text(
+        _json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "as_path": "simple_chatbot",
+                        "source": "examples/SimpleChatbot/src/simple_chatbot",
+                        "mode": "copy",
+                    }
+                ],
+            }
+        )
+    )
+
+    topic.includes.append(ResolvedInclude(source_root=src, as_path="simple_chatbot"))
+    before = list(course.loading_warnings)
+    topic.build_file_map()
+    new_warnings = [
+        w
+        for w in course.loading_warnings
+        if w not in before and w["category"] == "include_shadowed_by_local"
+    ]
+    assert new_warnings == [], (
+        f"Ledger-authorized materialization should not warn, but got: {new_warnings}"
+    )
+
+
+def test_unauthorized_shadow_still_warns_when_ledger_missing_entry(tmp_path):
+    """An on-disk override with no matching ledger entry still warns —
+    only `sync-includes`-managed materializations get the pass."""
+    import json as _json
+
+    from clm.core.topic import ResolvedInclude
+
+    course, topic, course_root = _make_isolated_topic(tmp_path)
+
+    src = course_root / "examples" / "SimpleChatbot" / "src" / "simple_chatbot"
+    src.mkdir(parents=True)
+    (src / "main.py").write_text("ORIGIN = 'canonical'\n")
+
+    override = topic.path / "simple_chatbot" / "main.py"
+    override.parent.mkdir(parents=True)
+    override.write_text("ORIGIN = 'local-override'\n")
+
+    # Ledger exists but lists a *different* include — does not authorize.
+    (topic.path / ".clm-include").write_text(
+        _json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "as_path": "something_else",
+                        "source": "examples/Other/src",
+                        "mode": "copy",
+                    }
+                ],
+            }
+        )
+    )
+
+    topic.includes.append(ResolvedInclude(source_root=src, as_path="simple_chatbot"))
+    topic.build_file_map()
+    categories = [w["category"] for w in course.loading_warnings]
+    assert "include_shadowed_by_local" in categories
+
+
 def test_optional_include_with_missing_source_is_silent(tmp_path):
     from clm.core.topic import ResolvedInclude
 

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -655,6 +655,86 @@ class TestIncludeShadowed:
 
         assert [f for f in result.findings if f.type == "include_shadowed"] == []
 
+    def test_ledger_authorized_shadow_does_not_warn(self, tmp_path):
+        """A `.clm-include` ledger entry matching the include suppresses
+        the warning — those files are sync-includes' materialization,
+        not an ad-hoc local override."""
+        import json as _json
+
+        topic_dir = _make_topic(tmp_path, "module_100_basics", "topic_010_intro")
+        (topic_dir / "pkg").mkdir()
+        (topic_dir / "pkg" / "main.py").write_text("# materialized\n")
+        _write_include_source_dir(tmp_path, "examples/pkg")
+        (topic_dir / ".clm-include").write_text(
+            _json.dumps(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "as_path": "pkg",
+                            "source": "examples/pkg",
+                            "mode": "copy",
+                        }
+                    ],
+                }
+            )
+        )
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <topic>intro<include source="examples/pkg" as="pkg"/></topic>
+              </topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+
+        assert [f for f in result.findings if f.type == "include_shadowed"] == []
+
+    def test_ledger_with_mismatched_source_still_warns(self, tmp_path):
+        """Ledger lists a different source for the same as_path — that
+        is a stale or unrelated entry; the shadow is unauthorized."""
+        import json as _json
+
+        topic_dir = _make_topic(tmp_path, "module_100_basics", "topic_010_intro")
+        (topic_dir / "pkg").mkdir()
+        (topic_dir / "pkg" / "main.py").write_text("# local override\n")
+        _write_include_source_dir(tmp_path, "examples/pkg")
+        _write_include_source_dir(tmp_path, "examples/other")
+        (topic_dir / ".clm-include").write_text(
+            _json.dumps(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "as_path": "pkg",
+                            "source": "examples/other",
+                            "mode": "copy",
+                        }
+                    ],
+                }
+            )
+        )
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <topic>intro<include source="examples/pkg" as="pkg"/></topic>
+              </topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+        warnings = [f for f in result.findings if f.type == "include_shadowed"]
+        assert len(warnings) == 1
+
 
 class TestIncludeSourceIsTopicDir:
     """Source pointing inside slides/.../topic_* warns once per unique source."""

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1009,7 +1009,7 @@ def _is_cpp_image_available() -> bool:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.4.0-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.4.1-full",
         ]:
             try:
                 client.images.get(tag)
@@ -1030,7 +1030,7 @@ def _get_full_image_name() -> str | None:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.4.0-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.4.1-full",
         ]:
             try:
                 client.images.get(tag)

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "coding-academy-lecture-manager"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Two related polish items surfaced by the AZAV ML PythonCourses
migration to `<include>` (hoelzl/PythonCourses#8):

1. **Suppress shadow warnings for sync-includes-managed
   materializations.** `Topic.apply_includes` and `clm validate-spec`
   both load the topic's `.clm-include` ledger and skip the
   `include_shadowed_by_local` / `include_shadowed` warning when a
   real file at `<topic-dir>/<as_path>` matches a ledger entry (same
   `as_path` *and* resolved `source`). Without this, the AZAV build
   emits 16 HIGH warnings per run — one per materialized file — even
   though the shadowing files *are* the include's authorized output.
   Unauthorized shadowings still warn.

   Ledger reader extracted from `sync_includes.py` to a new public
   `clm.core.include_ledger` module so build and sync-includes share
   one implementation.

2. **Build summary always shows output-write registry counts.** The
   `N duplicate output writes deduplicated; N output paths had
   conflicting writes` line now appears unconditionally, alongside
   the always-visible files/errors/warnings counts. Previously
   suppressed at zero, which left users unable to confirm the
   registry had run.

## Tagged

`v1.4.1` already created locally on `f230b0a` (the bump commit). I'll
push the tag after the merge so PyPI publish runs against
post-merge master.

## Test plan

- [x] `pytest -m "not docker"`: 4869 passed, 11 skipped, 4 xfailed
- [x] `mypy src/`: 250 source files clean
- [x] `ruff check src/ tests/`: clean
- [ ] CI green (Python 3.11/3.12/3.13)
- [ ] After merge: rebuild AZAV ML migration and confirm 0 shadow
      warnings; bump course repo pin to 1.4.1
- [ ] `clm build` summary line "0 duplicate output writes
      deduplicated; 0 output paths had conflicting writes" visible on
      zero-dedup builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)