### PR TITLE
fix(monitor): populate header, surface job metadata, sub-second durations

### DIFF
--- a/src/clm/cli/monitor/app.py
+++ b/src/clm/cli/monitor/app.py
@@ -26,8 +26,12 @@ class CLMMonitorApp(App):
         height: 5;
         background: $panel;
         border: solid $primary;
-        padding: 1;
-        content-align: center middle;
+        padding: 0 1;
+    }
+
+    #status-header-line {
+        height: auto;
+        width: 100%;
     }
 
     #main-content {

--- a/src/clm/cli/monitor/data_provider.py
+++ b/src/clm/cli/monitor/data_provider.py
@@ -1,5 +1,6 @@
 """Data provider for monitor TUI application."""
 
+import json
 import logging
 import os
 from datetime import datetime
@@ -10,6 +11,29 @@ from clm.cli.status.models import StatusInfo
 from clm.infrastructure.database.job_queue import JobQueue
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_payload_fields(job_type: str, payload_json: str | None) -> dict[str, str | None]:
+    """Pull display-relevant fields out of a job payload JSON blob.
+
+    Mirrors :meth:`StatusCollector._parse_job_payload` but lives at module
+    level so the activity-log path doesn't need a collector instance.
+    """
+    if not payload_json:
+        return {}
+    try:
+        payload = json.loads(payload_json)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+    if job_type == "notebook":
+        return {
+            "output_format": payload.get("format"),
+            "language": payload.get("language"),
+            "kind": payload.get("kind"),
+        }
+    if job_type in ("plantuml", "drawio"):
+        return {"output_format": payload.get("output_format", "png")}
+    return {}
 
 
 def _find_common_prefix(paths: list[str]) -> str:
@@ -77,8 +101,12 @@ class ActivityEvent:
         job_id: str | None = None,
         worker_id: str | None = None,
         document_path: str | None = None,
-        duration_seconds: int | None = None,
+        duration_seconds: float | None = None,
         error_message: str | None = None,
+        job_type: str | None = None,
+        output_format: str | None = None,
+        language: str | None = None,
+        kind: str | None = None,
     ):
         """Initialize activity event."""
         self.timestamp = timestamp
@@ -88,6 +116,10 @@ class ActivityEvent:
         self.document_path = document_path
         self.duration_seconds = duration_seconds
         self.error_message = error_message
+        self.job_type = job_type
+        self.output_format = output_format
+        self.language = language
+        self.kind = kind
 
 
 class DataProvider:
@@ -139,12 +171,13 @@ class DataProvider:
                     j.id,
                     j.status,
                     j.input_file,
-                    j.created_at,
                     j.started_at,
                     j.completed_at,
                     w.container_id,
-                    CAST((julianday(j.completed_at) - julianday(j.started_at)) * 86400 AS INTEGER) as duration,
-                    j.error
+                    ROUND((julianday(j.completed_at) - julianday(j.started_at)) * 86400, 2) as duration,
+                    j.error,
+                    j.job_type,
+                    j.payload
                 FROM jobs j
                 LEFT JOIN workers w ON w.id = j.worker_id
                 WHERE j.status IN ('processing', 'completed', 'failed')
@@ -159,12 +192,13 @@ class DataProvider:
                 job_id = row[0]
                 status = row[1]
                 document_path = row[2]
-                row[3]
-                started_at = row[4]
-                completed_at = row[5]
-                worker_id = row[6]
-                duration = row[7]
-                error_message = row[8]
+                started_at = row[3]
+                completed_at = row[4]
+                worker_id = row[5]
+                duration = row[6]
+                error_message = row[7]
+                job_type = row[8]
+                payload_json = row[9]
 
                 # Determine event type and timestamp
                 if status == "processing" and started_at:
@@ -180,6 +214,8 @@ class DataProvider:
                     # Skip if we can't determine proper event
                     continue
 
+                payload_fields = _extract_payload_fields(job_type, payload_json)
+
                 raw_events.append(
                     {
                         "timestamp": timestamp,
@@ -189,6 +225,10 @@ class DataProvider:
                         "document_path": document_path,
                         "duration_seconds": duration,
                         "error_message": error_message,
+                        "job_type": job_type,
+                        "output_format": payload_fields.get("output_format"),
+                        "language": payload_fields.get("language"),
+                        "kind": payload_fields.get("kind"),
                     }
                 )
 
@@ -213,6 +253,10 @@ class DataProvider:
                         document_path=rel_path,
                         duration_seconds=raw["duration_seconds"],
                         error_message=raw["error_message"],
+                        job_type=raw["job_type"],
+                        output_format=raw["output_format"],
+                        language=raw["language"],
+                        kind=raw["kind"],
                     )
                 )
 

--- a/src/clm/cli/monitor/formatters.py
+++ b/src/clm/cli/monitor/formatters.py
@@ -3,26 +3,34 @@
 from datetime import datetime
 
 
-def format_elapsed(seconds: int) -> str:
+def format_elapsed(seconds: int | float) -> str:
     """Format elapsed time in human-readable format.
 
+    Sub-second durations (e.g. 0.3 from julianday() arithmetic, or fast
+    cached jobs) render as ``"0.Xs"`` so they are not lost to integer
+    truncation. ``0`` still renders as ``"00:00"`` because that's the
+    intent for jobs whose start/end timestamps coincide exactly.
+
     Args:
-        seconds: Elapsed seconds
+        seconds: Elapsed seconds (int or float).
 
     Returns:
-        Formatted string (e.g., "02:15", "1:45:30")
+        Formatted string (e.g., "0.3s", "02:15", "1:45:30").
     """
-    if seconds < 60:
-        return f"00:{seconds:02d}"
-    elif seconds < 3600:
-        minutes = seconds // 60
-        secs = seconds % 60
+    if 0 < seconds < 1:
+        return f"{int(round(seconds * 1000))}ms"
+
+    secs_int = int(round(seconds))
+    if secs_int < 60:
+        return f"00:{secs_int:02d}"
+    if secs_int < 3600:
+        minutes = secs_int // 60
+        secs = secs_int % 60
         return f"{minutes:02d}:{secs:02d}"
-    else:
-        hours = seconds // 3600
-        minutes = (seconds % 3600) // 60
-        secs = seconds % 60
-        return f"{hours}:{minutes:02d}:{secs:02d}"
+    hours = secs_int // 3600
+    minutes = (secs_int % 3600) // 60
+    secs = secs_int % 60
+    return f"{hours}:{minutes:02d}:{secs:02d}"
 
 
 def format_timestamp(dt: datetime, relative: bool = False) -> str:

--- a/src/clm/cli/monitor/widgets/activity_panel.py
+++ b/src/clm/cli/monitor/widgets/activity_panel.py
@@ -94,21 +94,51 @@ class ActivityPanel(Static):
     def _write_event(self, log: RichLog, event: ActivityEvent) -> None:
         """Write a single event to the RichLog."""
         timestamp = format_timestamp(event.timestamp)
+        metadata = self._format_metadata(event)
 
         if event.event_type == "job_started":
-            log.write(f"{timestamp} [blue]⚙ Started[/blue]    {event.document_path}")
+            log.write(f"{timestamp} [blue]⚙ Started[/blue]    {event.document_path}{metadata}")
 
         elif event.event_type == "job_completed":
-            duration = format_elapsed(event.duration_seconds) if event.duration_seconds else "?"
+            duration = (
+                format_elapsed(event.duration_seconds)
+                if event.duration_seconds is not None
+                else "?"
+            )
             log.write(
-                f"{timestamp} [green]✓ Completed[/green]  {event.document_path}  ({duration})"
+                f"{timestamp} [green]✓ Completed[/green]  "
+                f"{event.document_path}{metadata}  ({duration})"
             )
 
         elif event.event_type == "job_failed":
-            duration = format_elapsed(event.duration_seconds) if event.duration_seconds else "?"
+            duration = (
+                format_elapsed(event.duration_seconds)
+                if event.duration_seconds is not None
+                else "?"
+            )
             error_display = self._format_error(event.error_message)
-            log.write(f"{timestamp} [red]✗ Failed[/red]     {event.document_path}  ({duration})")
+            log.write(
+                f"{timestamp} [red]✗ Failed[/red]     {event.document_path}{metadata}  ({duration})"
+            )
             log.write(f"  {error_display}")
+
+    @staticmethod
+    def _format_metadata(event: ActivityEvent) -> str:
+        """Render an event's payload metadata (kind/format/language) inline.
+
+        Returns an empty string when nothing useful is available so the
+        line stays compact for plantuml/drawio jobs without metadata.
+        """
+        parts: list[str] = []
+        if event.kind:
+            parts.append(event.kind)
+        if event.output_format:
+            parts.append(event.output_format)
+        if event.language:
+            parts.append(event.language)
+        if not parts:
+            return ""
+        return f"  [dim]({', '.join(parts)})[/dim]"
 
     def _format_error(self, error_message: str | None) -> str:
         """Format error message with categorization if available.

--- a/src/clm/cli/monitor/widgets/status_header.py
+++ b/src/clm/cli/monitor/widgets/status_header.py
@@ -1,18 +1,29 @@
 """Status header widget for monitor TUI."""
 
 from rich.text import Text
+from textual.app import ComposeResult
 from textual.widgets import Static
 
 from clm.cli.status.models import StatusInfo, SystemHealth
 
 
 class StatusHeader(Static):
-    """Header showing system status summary."""
+    """Header showing system status summary.
+
+    Renders via a child Static driven from a Rich-markup string. The
+    markup-string path renders reliably under ``content-align`` and
+    nested ``padding`` declarations where directly storing a styled
+    ``Text`` on the parent widget sometimes produced an empty pane.
+    """
 
     def __init__(self, **kwargs):
         """Initialize header widget."""
-        super().__init__(Text("CLM Monitor - Loading...", style="bold"), **kwargs)
+        super().__init__(**kwargs)
         self.status: StatusInfo | None = None
+
+    def compose(self) -> ComposeResult:
+        """Create the child Static that displays the rendered header line."""
+        yield Static("[bold]CLM Monitor - Loading...[/bold]", id="status-header-line")
 
     def update_status(self, status: StatusInfo) -> None:
         """Update with new status data.
@@ -21,69 +32,79 @@ class StatusHeader(Static):
             status: System status data
         """
         self.status = status
-        self.update(self._render_content())
+        line = self.query_one("#status-header-line", Static)
+        line.update(self._build_markup())
+
+    def _build_markup(self) -> str:
+        """Build the header content as a Rich-markup string."""
+        if not self.status:
+            return "[bold]CLM Monitor - Loading...[/bold]"
+        return self._render_content().markup
 
     def _render_content(self) -> Text:  # type: ignore[override]
-        """Render header content."""
-        if not self.status:
-            return Text("CLM Monitor - Loading...", style="bold")
+        """Render header content as Rich :class:`Text`.
 
-        # Health indicator
+        Kept on the public surface because unit tests assert against
+        ``_render_content().plain``. The :meth:`update_status` path
+        consumes the same Text via :attr:`Text.markup` so all callers
+        stay in sync.
+        """
+        if not self.status:
+            return Text.from_markup("[bold]CLM Monitor - Loading...[/bold]")
+
         health_icons = {
             SystemHealth.HEALTHY: "✓",
             SystemHealth.WARNING: "⚠",
             SystemHealth.ERROR: "✗",
         }
-        health_icon = health_icons.get(self.status.health, "?")
-
         health_colors = {
             SystemHealth.HEALTHY: "green",
             SystemHealth.WARNING: "yellow",
             SystemHealth.ERROR: "red",
         }
+        health_icon = health_icons.get(self.status.health, "?")
         health_color = health_colors.get(self.status.health, "white")
 
-        # Calculate worker stats
         total_workers = sum(s.total for s in self.status.workers.values())
         busy_workers = sum(s.busy for s in self.status.workers.values())
 
-        # Build header text
-        text = Text()
-        text.append(
-            f"{health_icon} {self.status.health.value.title()}",
-            style=f"bold {health_color}",
-        )
-        text.append("  |  ", style="dim")
+        segments: list[str] = []
+        segments.append(f"[bold {health_color}]{health_icon} {self.status.health.value.title()}[/]")
 
-        # Workers summary
         if total_workers > 0:
-            text.append(f"{busy_workers}/{total_workers} workers busy", style="cyan")
+            segments.append(f"[cyan]{busy_workers}/{total_workers} workers busy[/cyan]")
         else:
-            text.append("No workers", style="dim")
+            segments.append("[dim]No workers[/dim]")
 
-        text.append("  |  ", style="dim")
-
-        # Queue summary
         processing = self.status.queue.processing
         pending = self.status.queue.pending
         if processing > 0 or pending > 0:
-            text.append(f"{processing} processing", style="blue")
+            queue_bits = [f"[blue]{processing} processing[/blue]"]
             if pending > 0:
-                text.append(f", {pending} pending", style="yellow")
+                queue_bits.append(f"[yellow]{pending} pending[/yellow]")
+            segments.append(", ".join(queue_bits))
         else:
-            text.append("Queue empty", style="dim")
+            segments.append("[dim]Queue empty[/dim]")
 
-        text.append("  |  ", style="dim")
-
-        # Completed in last hour
         completed = self.status.queue.completed_last_hour
         failed = self.status.queue.failed_last_hour
         if completed > 0 or failed > 0:
-            text.append(f"{completed} done", style="green")
+            last_hour = [f"[green]{completed} done[/green]"]
             if failed > 0:
-                text.append(f", {failed} failed", style="red")
-            text.append(" (1h)", style="dim")
+                last_hour.append(f"[red]{failed} failed[/red]")
+            last_hour_text = ", ".join(last_hour) + " [dim](1h)[/dim]"
+            segments.append(last_hour_text)
         else:
-            text.append("No activity (1h)", style="dim")
+            segments.append("[dim]No activity (1h)[/dim]")
 
-        return text
+        summary_line = "  [dim]|[/dim]  ".join(segments)
+
+        # Top line: highlight the build context so the pane stops looking
+        # empty when summary stats are all dim.
+        spec = getattr(self.status, "current_course_spec", None)
+        if spec:
+            top_line = f"[bold]Building:[/bold] [magenta]{spec}[/magenta]"
+        else:
+            top_line = "[bold]CLM Monitor[/bold]"
+
+        return Text.from_markup(f"{top_line}\n{summary_line}")

--- a/src/clm/cli/monitor/widgets/workers_panel.py
+++ b/src/clm/cli/monitor/widgets/workers_panel.py
@@ -132,10 +132,12 @@ class WorkersPanel(Static):
 
         # Build compact info string
         info_parts = []
-        if worker.output_format:
-            info_parts.append(worker.output_format)
         if worker.kind:
             info_parts.append(worker.kind)
+        if worker.output_format:
+            info_parts.append(worker.output_format)
+        if worker.language:
+            info_parts.append(worker.language)
 
         if info_parts:
             info_str = f"[dim]({', '.join(info_parts)})[/dim]"

--- a/src/clm/cli/status/collector.py
+++ b/src/clm/cli/status/collector.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -115,6 +116,7 @@ class StatusCollector:
         workers = self._collect_worker_stats()
         queue = self._collect_queue_stats()
         error_stats = self._collect_error_stats()
+        current_course_spec = self._derive_current_course_spec()
 
         # Determine health and collect warnings/errors
         health, warnings, errors = self._determine_health(workers, queue, db_info)
@@ -128,6 +130,7 @@ class StatusCollector:
             warnings=warnings,
             errors=errors,
             error_stats=error_stats,
+            current_course_spec=current_course_spec,
         )
 
     def _collect_database_info(self) -> DatabaseInfo:
@@ -321,6 +324,63 @@ class StatusCollector:
                 return "mixed"
 
         except Exception:
+            return None
+
+    def _derive_current_course_spec(self) -> str | None:
+        """Best-effort label for the build currently in flight.
+
+        Falls back through processing -> recently-completed jobs. Walks up
+        the common output-path ancestor looking for a single ``.xml`` spec
+        and returns its filename; otherwise returns the ancestor directory
+        name. ``None`` means no recent activity.
+        """
+        if not self.job_queue:
+            return None
+
+        try:
+            conn = self.job_queue._get_conn()
+            cursor = conn.execute(
+                """
+                SELECT output_file FROM jobs WHERE status = 'processing' LIMIT 50
+                """
+            )
+            paths = [row[0] for row in cursor.fetchall() if row[0]]
+            if not paths:
+                cursor = conn.execute(
+                    """
+                    SELECT output_file FROM jobs
+                    WHERE completed_at > datetime('now', '-5 minutes')
+                    ORDER BY completed_at DESC
+                    LIMIT 50
+                    """
+                )
+                paths = [row[0] for row in cursor.fetchall() if row[0]]
+
+            if not paths:
+                return None
+
+            try:
+                common = os.path.commonpath(paths) if len(paths) > 1 else os.path.dirname(paths[0])
+            except ValueError:
+                # Different drives — fall back to most-frequent top directory
+                tops = Counter(Path(p).anchor or Path(p).parts[0] for p in paths)
+                return tops.most_common(1)[0][0]
+
+            candidate = Path(common) if common else None
+            for _ in range(6):
+                if not candidate or candidate == candidate.parent:
+                    break
+                if candidate.is_dir():
+                    xml_files = list(candidate.glob("*.xml"))
+                    if len(xml_files) == 1:
+                        return xml_files[0].name
+                    if len(xml_files) > 1:
+                        return candidate.name
+                candidate = candidate.parent
+
+            return Path(common).name or None
+        except Exception:
+            logger.debug("Failed to derive current course spec", exc_info=True)
             return None
 
     def _collect_error_stats(self, hours: int = 1) -> ErrorStats | None:

--- a/src/clm/cli/status/models.py
+++ b/src/clm/cli/status/models.py
@@ -103,3 +103,4 @@ class StatusInfo:
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     error_stats: ErrorStats | None = None  # Recent error statistics
+    current_course_spec: str | None = None  # Best-effort label for the active build

--- a/tests/cli/test_monitor_app.py
+++ b/tests/cli/test_monitor_app.py
@@ -2,19 +2,19 @@
 
 These tests exercise the application end-to-end through Textual's
 ``run_test`` pilot harness as well as the individual widget rendering
-routines.  They also document three currently-broken behaviors via
-``xfail`` markers so regressions in a future fix can be detected:
+routines.
 
-    * Bug #1  Stale "Started" entries and ``(?)`` durations in the
-              activity log (duration truncation + no cleanup of old
-              processing rows).
-    * Bug #2  The status-header area is empty after a build — it
-              should show the course spec currently being processed.
-    * Bug #3  Panel scrolling lags behind the mouse because every
-              refresh rebuilds the worker/queue panels from scratch.
+Two ``xfail`` markers used to live here for fixed monitor bugs:
 
-The bug descriptions in each ``xfail`` reason give future-you a
-one-line starting point when tackling the fix.
+    * Sub-second job durations rendered as ``(?)`` because of integer
+      truncation in the SQL ``CAST``; the SQL now uses ROUND() and the
+      activity panel formats sub-second values in ms.
+    * The status header was empty during a build; it now surfaces the
+      ``current_course_spec`` derived from active job paths.
+
+One known issue remains documented in
+``docs/claude/TODO.md`` (monitor-tui-followups): the workers/activity
+panels rebuild their contents on every tick, causing scrolling lag.
 """
 
 from __future__ import annotations
@@ -24,7 +24,11 @@ from pathlib import Path
 
 import pytest
 
-from clm.cli.monitor.data_provider import ActivityEvent, DataProvider
+from clm.cli.monitor.data_provider import (
+    ActivityEvent,
+    DataProvider,
+    _extract_payload_fields,
+)
 from clm.cli.monitor.widgets.activity_panel import ActivityPanel
 from clm.cli.monitor.widgets.queue_panel import QueuePanel
 from clm.cli.monitor.widgets.status_header import StatusHeader
@@ -74,9 +78,13 @@ def _event(
     *,
     job_id: str = "1",
     document_path: str = "topic_x/slides.py",
-    duration_seconds: int | None = None,
+    duration_seconds: float | None = None,
     timestamp: datetime | None = None,
     error_message: str | None = None,
+    job_type: str | None = None,
+    output_format: str | None = None,
+    language: str | None = None,
+    kind: str | None = None,
 ) -> ActivityEvent:
     return ActivityEvent(
         timestamp=timestamp or datetime(2026, 4, 17, 21, 0, 0),
@@ -85,6 +93,10 @@ def _event(
         document_path=document_path,
         duration_seconds=duration_seconds,
         error_message=error_message,
+        job_type=job_type,
+        output_format=output_format,
+        language=language,
+        kind=kind,
     )
 
 
@@ -180,18 +192,12 @@ class TestDataProviderEventDuration:
         assert completed[0].duration_seconds is not None
         assert completed[0].duration_seconds >= 9  # allow 1s julianday slack
 
-    @pytest.mark.xfail(
-        reason=(
-            "Monitor bug #1: julianday() subtraction in get_recent_events loses "
-            "precision (1s → 0.9999945s → CAST(.. AS INTEGER) = 0), so sub-2s "
-            "jobs report duration=0 which the activity panel renders as '(?)'. "
-            "Fix: round or use the ROUND() SQL function, or read duration_ms "
-            "from a stored column."
-        ),
-        strict=True,
-    )
     def test_one_second_duration_should_not_report_zero(self, jobs_db: Path) -> None:
-        """A completed job with a 1-second gap should not report 0 duration."""
+        """A completed job with a 1-second gap reports a non-zero duration.
+
+        Previously the SQL ``CAST(... AS INTEGER)`` truncated the
+        julianday-derived 0.9999945s to 0; ROUND() preserves it as 1.0.
+        """
         self._seed_completed_job(
             jobs_db,
             started_at="2026-04-17 21:00:00",
@@ -203,7 +209,6 @@ class TestDataProviderEventDuration:
 
         completed = [e for e in events if e.event_type == "job_completed"]
         assert len(completed) == 1
-        # Expected: ~1. Actual due to bug: 0.
         assert completed[0].duration_seconds is not None
         assert completed[0].duration_seconds >= 1
 
@@ -330,17 +335,6 @@ class TestActivityPanelViaPilot:
             # After clear + repopulate there is exactly one line.
             assert rendered.count("Completed") == 1
 
-    @pytest.mark.xfail(
-        reason=(
-            "Monitor bug #1 (presentation half): events with "
-            "duration_seconds=0 render '(?)' because the widget tests "
-            "`if event.duration_seconds` — this is the downstream side of "
-            "the julianday precision loss and also fires for legitimately "
-            "instantaneous jobs (cached skips). Fix: render '00:00' when "
-            "duration_seconds is 0, reserve '?' only for None."
-        ),
-        strict=True,
-    )
     async def test_zero_duration_renders_as_instant_not_question_mark(self) -> None:
         from textual.app import App, ComposeResult
 
@@ -421,27 +415,13 @@ class TestStatusHeaderEmptyTitleBug:
         rendered = header._render_content().plain
         assert "No activity" in rendered or "done" in rendered
 
-    @pytest.mark.xfail(
-        reason=(
-            "Monitor bug #2: the header does not surface the course spec "
-            "that is currently being processed, so during a large build "
-            "the big top panel is visually empty / uninformative. Fix: "
-            "track the active course spec in the data_provider (either "
-            "via a dedicated table, an env stamp, or the most-frequent "
-            "spec among processing jobs) and render it here."
-        ),
-        strict=True,
-    )
     def test_header_shows_current_course_spec(self) -> None:
+        """When a build is in flight, the header surfaces its spec file."""
         header = StatusHeader(id="h")
-        # Hypothetical future field — not present yet.
         status = _status(
             queue=QueueStats(pending=0, processing=2, completed_last_hour=100, failed_last_hour=0)
         )
-        # Attach ad-hoc attribute for forward-compat: the real fix would
-        # add current_course_spec to StatusInfo and _render_content would
-        # use it.
-        setattr(status, "current_course_spec", "python-best-practice.xml")
+        status.current_course_spec = "python-best-practice.xml"
         header.status = status
         rendered = header._render_content().plain
         assert "python-best-practice" in rendered
@@ -797,6 +777,121 @@ class TestMonitorAppRun:
             # notifies instead.
             app.refresh_data()
             app.action_refresh()
+
+
+# ---------------------------------------------------------------------------
+# Payload metadata extraction + activity-log surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPayloadFields:
+    """Cover _extract_payload_fields for each job_type."""
+
+    def test_notebook_payload(self) -> None:
+        payload = '{"format": "html", "language": "de", "kind": "recording"}'
+        fields = _extract_payload_fields("notebook", payload)
+        assert fields["output_format"] == "html"
+        assert fields["language"] == "de"
+        assert fields["kind"] == "recording"
+
+    def test_plantuml_payload_defaults_to_png(self) -> None:
+        assert _extract_payload_fields("plantuml", "{}")["output_format"] == "png"
+
+    def test_drawio_payload_with_explicit_format(self) -> None:
+        fields = _extract_payload_fields("drawio", '{"output_format": "svg"}')
+        assert fields["output_format"] == "svg"
+
+    def test_invalid_json_returns_empty(self) -> None:
+        assert _extract_payload_fields("notebook", "not json") == {}
+
+    def test_none_payload_returns_empty(self) -> None:
+        assert _extract_payload_fields("notebook", None) == {}
+
+    def test_unknown_job_type_returns_empty(self) -> None:
+        assert _extract_payload_fields("mystery", '{"format": "x"}') == {}
+
+
+class TestActivityPanelMetadataRendering:
+    """ActivityPanel surfaces kind/format/language on the completed line."""
+
+    async def test_completed_event_shows_metadata(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            panel.update_events(
+                [
+                    _event(
+                        "job_completed",
+                        job_id="1",
+                        duration_seconds=2.5,
+                        kind="recording",
+                        output_format="html",
+                        language="de",
+                    )
+                ]
+            )
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            assert "recording" in rendered
+            assert "html" in rendered
+            assert "de" in rendered
+
+    async def test_subsecond_duration_renders_in_ms(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            panel.update_events([_event("job_completed", job_id="1", duration_seconds=0.5)])
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            assert "500ms" in rendered
+            assert "(?)" not in rendered
+
+    async def test_none_duration_still_shows_question_mark(self) -> None:
+        from textual.app import App, ComposeResult
+
+        class _TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ActivityPanel(id="activity-panel", classes="panel")
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ActivityPanel)
+            panel.update_events([_event("job_completed", job_id="1", duration_seconds=None)])
+            await pilot.pause()
+            rendered = _rendered_activity_text(panel)
+            assert "(?)" in rendered
+
+
+class TestWorkersPanelLanguage:
+    """The busy-worker line includes natural language alongside format/kind."""
+
+    def test_format_includes_language(self) -> None:
+        panel = WorkersPanel(id="wp")
+        worker = BusyWorkerInfo(
+            worker_id="w1",
+            job_id="1",
+            document_path="slides.ipynb",
+            elapsed_seconds=5,
+            output_format="html",
+            kind="recording",
+            language="de",
+        )
+        text = panel._format_busy_worker(worker, "direct")
+        assert "de" in text
+        assert "html" in text
+        assert "recording" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_status_collector.py
+++ b/tests/cli/test_status_collector.py
@@ -341,3 +341,60 @@ class TestStatusCollector:
         # Should count the recent completed and failed jobs, but not the old one
         assert status.queue.completed_last_hour == 1, "Should count 1 completed job from last hour"
         assert status.queue.failed_last_hour == 1, "Should count 1 failed job from last hour"
+
+
+class TestDeriveCurrentCourseSpec:
+    """Verify the heuristic that drives the monitor's header label."""
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        db = tmp_path / "test_status.db"
+        init_database(db)
+        return db
+
+    def _register_idle_worker(self, db_path: Path) -> None:
+        """Keep the collector out of the no-workers ERROR short-circuit."""
+        with JobQueue(db_path) as queue:
+            conn = queue._get_conn()
+            conn.execute(
+                """
+                INSERT INTO workers (worker_type, container_id, status, execution_mode)
+                VALUES ('notebook', 'nb-1', 'idle', 'direct')
+                """
+            )
+            conn.commit()
+
+    def test_returns_none_for_quiet_database(self, db_path):
+        self._register_idle_worker(db_path)
+        with StatusCollector(db_path=db_path) as collector:
+            status = collector.collect()
+        assert status.current_course_spec is None
+
+    def test_picks_up_xml_spec_from_processing_outputs(self, tmp_path, db_path):
+        # Make a fake course-spec layout so the heuristic has something to find.
+        course_dir = tmp_path / "course"
+        course_dir.mkdir()
+        spec = course_dir / "python-best-practice.xml"
+        spec.write_text("<course/>")
+        out_dir = course_dir / "build" / "html" / "de"
+        out_dir.mkdir(parents=True)
+
+        self._register_idle_worker(db_path)
+        with JobQueue(db_path) as queue:
+            jid = queue.add_job(
+                job_type="notebook",
+                input_file="anything.py",
+                output_file=str(out_dir / "lesson_1.ipynb"),
+                content_hash="h",
+                payload={},
+            )
+            conn = queue._get_conn()
+            conn.execute(
+                "UPDATE jobs SET status='processing', started_at=datetime('now') WHERE id=?",
+                (jid,),
+            )
+            conn.commit()
+
+        with StatusCollector(db_path=db_path) as collector:
+            status = collector.collect()
+        assert status.current_course_spec == "python-best-practice.xml"


### PR DESCRIPTION
## Summary

Three rough edges in `clm monitor` are addressed:

- **(a) Empty top header pane.** `StatusHeader` now composes a child `Static` driven from a Rich-markup string (the direct `Static.update(Text(...))` path was silently producing nothing under `content-align`, so the pane rendered blank). It also surfaces a new `current_course_spec` field that `StatusCollector` derives by walking up the common ancestor of active / recently-completed output paths and matching a single `.xml` spec. Top line reads `Building: <spec>.xml` when active, generic title otherwise.
- **(b) `(?)` durations and missing per-job metadata.** SQL switched from `CAST(... AS INTEGER)` to `ROUND(..., 2)` so julianday's `1s → 0.9999945s` no longer truncates to 0. Panel uses `duration is not None` instead of truthiness, so a legitimate 0 renders as `00:00`; sub-second values format as `Nms`. Completed / failed / started lines now include each job's kind, output format, and language (parsed from the job payload).
- **(c) Workers pane missing language.** Busy-worker line now includes language (de/en) alongside kind and format.

The two `xfail(strict=True)` markers that documented these bugs are removed; new tests cover the metadata path, sub-second rendering, and the course-spec derivation heuristic.

## Test plan

- [x] `pytest tests/cli/test_status_collector.py tests/cli/test_monitor_app.py tests/cli/test_monitor_unit.py` — 87 passed, 1 xfailed (unrelated)
- [x] Full fast CLI suite (`pytest tests/cli/ -m "not slow and not docker and not integration and not e2e"`) — 1034 passed
- [x] `ruff check`, `ruff format`, `mypy` clean on `src/clm/cli/monitor/` and `src/clm/cli/status/`
- [ ] Manual smoke: run `clm monitor` against a live build; verify the top pane shows `Building: <spec>.xml`, completed lines show duration in ms / s plus `(kind, format, language)`, and the workers pane shows language for busy notebook workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)