### PR TITLE
fix(backend): close Stage 4 cache gap in Docker / API mode

### DIFF
--- a/src/clm/infrastructure/api/api_executed_notebook_cache.py
+++ b/src/clm/infrastructure/api/api_executed_notebook_cache.py
@@ -1,0 +1,97 @@
+"""API-backed adapter for the executed_notebooks cache.
+
+In Docker / API mode, notebook workers cannot open ``clm_cache.db``
+directly (SQLite WAL mode is unreliable over Windows bind-mounts, and the
+host owns the cache). This adapter satisfies the same surface as
+:class:`ExecutedNotebookCache` (``get`` and ``store``) by going through the
+Worker REST API instead of a local SQLite connection.
+
+The host's :class:`WorkerApiServer` exposes
+``GET /api/worker/cache/executed_notebook`` and
+``POST /api/worker/cache/executed_notebook`` for these reads/writes; the
+on-the-wire payload is gzip-compressed pickle bytes.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle
+from typing import TYPE_CHECKING, cast
+
+from clm.infrastructure.api.client import WorkerApiClient
+
+if TYPE_CHECKING:
+    from nbformat import NotebookNode
+
+logger = logging.getLogger(__name__)
+
+
+class ApiExecutedNotebookCache:
+    """``ExecutedNotebookCache``-shaped adapter that hits the Worker API.
+
+    Only the ``get`` and ``store`` methods are implemented — these are the
+    only entry points :class:`NotebookProcessor` uses on its ``cache``
+    attribute. The other ``ExecutedNotebookCache`` methods (clear, vacuum,
+    stats) are host-side maintenance and have no Docker-side analog.
+
+    Usage::
+
+        client = WorkerApiClient(api_url)
+        cache = ApiExecutedNotebookCache(client)
+        processor = NotebookProcessor(output_spec, cache=cache)
+    """
+
+    def __init__(self, client: WorkerApiClient):
+        self._client = client
+
+    def get(
+        self,
+        input_file: str,
+        content_hash: str,
+        language: str,
+        prog_lang: str,
+    ) -> NotebookNode | None:
+        """Fetch a cached executed notebook from the host via the REST API.
+
+        Returns ``None`` on cache miss or transport failure — both are
+        treated as "fall back to direct execution" by the caller.
+        """
+        pickle_bytes = self._client.get_executed_notebook(
+            input_file=input_file,
+            content_hash=content_hash,
+            language=language,
+            prog_lang=prog_lang,
+        )
+        if pickle_bytes is None:
+            return None
+        try:
+            return cast("NotebookNode", pickle.loads(pickle_bytes))
+        except Exception as e:
+            logger.warning(
+                f"Failed to unpickle executed_notebook for {input_file} "
+                f"({language}, {prog_lang}); treating as cache miss: {e}"
+            )
+            return None
+
+    def store(
+        self,
+        input_file: str,
+        content_hash: str,
+        language: str,
+        prog_lang: str,
+        executed_notebook: NotebookNode,
+    ) -> None:
+        """Send an executed notebook to the host's cache.
+
+        Pickles the notebook locally and ships the bytes via the REST API.
+        Failures are logged inside ``WorkerApiClient.store_executed_notebook``
+        but do not raise — caching is best-effort.
+        """
+        pickle_bytes = pickle.dumps(executed_notebook)
+        self._client.store_executed_notebook(
+            input_file=input_file,
+            content_hash=content_hash,
+            language=language,
+            prog_lang=prog_lang,
+            pickle_bytes=pickle_bytes,
+        )

--- a/src/clm/infrastructure/api/client.py
+++ b/src/clm/infrastructure/api/client.py
@@ -4,6 +4,7 @@ This module provides a client that Docker workers use to communicate
 with the CLM job queue via REST API instead of direct SQLite access.
 """
 
+import gzip
 import logging
 import os
 import time
@@ -95,6 +96,10 @@ class WorkerApiClient:
         path: str,
         json_data: dict | None = None,
         retry_on_connect: bool = True,
+        params: dict | None = None,
+        content: bytes | None = None,
+        headers: dict | None = None,
+        accept_404: bool = False,
     ) -> httpx.Response:
         """Make a request with retry logic.
 
@@ -103,6 +108,12 @@ class WorkerApiClient:
             path: API path
             json_data: JSON body data
             retry_on_connect: Whether to retry on connection errors
+            params: Query string parameters
+            content: Raw request body bytes (mutually exclusive with json_data)
+            headers: Extra HTTP headers to merge into the request
+            accept_404: If True, a 404 response is returned to the caller
+                instead of raised as an error. Useful for cache lookups
+                where "not found" is a normal outcome.
 
         Returns:
             Response object
@@ -114,7 +125,16 @@ class WorkerApiClient:
 
         for attempt in range(self.max_retries):
             try:
-                response = self._client.request(method, path, json=json_data)
+                response = self._client.request(
+                    method,
+                    path,
+                    json=json_data,
+                    params=params,
+                    content=content,
+                    headers=headers,
+                )
+                if accept_404 and response.status_code == 404:
+                    return response
                 response.raise_for_status()
                 return response
 
@@ -380,3 +400,94 @@ class WorkerApiClient:
         except WorkerApiError as e:
             # Log but don't fail - caching is not critical
             logger.warning(f"Failed to add cache entry for {output_file}: {e}")
+
+    def get_executed_notebook(
+        self,
+        input_file: str,
+        content_hash: str,
+        language: str,
+        prog_lang: str,
+    ) -> bytes | None:
+        """Fetch a cached executed notebook's pickle bytes.
+
+        Returns None on cache miss (HTTP 404). Network/server errors are
+        logged and swallowed — a cache lookup failure must never abort
+        notebook processing.
+
+        The response body is gzipped pickle bytes; this method decompresses
+        them before returning.
+        """
+        try:
+            response = self._request_with_retry(
+                "GET",
+                "/api/worker/cache/executed_notebook",
+                params={
+                    "input_file": input_file,
+                    "content_hash": content_hash,
+                    "language": language,
+                    "prog_lang": prog_lang,
+                },
+                accept_404=True,
+            )
+        except WorkerApiError as e:
+            logger.warning(
+                f"executed_notebook GET failed for {input_file} "
+                f"({language}, {prog_lang}); treating as cache miss: {e}"
+            )
+            return None
+
+        if response.status_code == 404:
+            return None
+
+        # httpx auto-decompresses Content-Encoding: gzip into response.content
+        # when the header is present, so the bytes we get back are already
+        # the raw pickle. Guard against servers that strip the header by
+        # detecting the gzip magic and decompressing manually.
+        body = response.content
+        if body[:2] == b"\x1f\x8b":
+            try:
+                body = gzip.decompress(body)
+            except gzip.BadGzipFile as e:
+                logger.warning(
+                    f"executed_notebook GET returned malformed gzip for {input_file}: {e}"
+                )
+                return None
+        return body
+
+    def store_executed_notebook(
+        self,
+        input_file: str,
+        content_hash: str,
+        language: str,
+        prog_lang: str,
+        pickle_bytes: bytes,
+    ) -> None:
+        """Send pickle bytes of an executed notebook to the host's cache.
+
+        The bytes MUST be the output of ``pickle.dumps(notebook_node)``.
+        They are gzip-compressed before transmission. Failures are logged
+        but not raised — caching is best-effort.
+        """
+        body = gzip.compress(pickle_bytes)
+        try:
+            self._request_with_retry(
+                "POST",
+                "/api/worker/cache/executed_notebook",
+                params={
+                    "input_file": input_file,
+                    "content_hash": content_hash,
+                    "language": language,
+                    "prog_lang": prog_lang,
+                },
+                content=body,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            logger.debug(
+                f"Stored executed_notebook for {input_file} "
+                f"({language}, {prog_lang}); {len(pickle_bytes)} bytes (pickle), "
+                f"{len(body)} bytes (gzip) via REST API"
+            )
+        except WorkerApiError as e:
+            logger.warning(
+                f"Failed to store executed_notebook for {input_file} ({language}, {prog_lang}): {e}"
+            )

--- a/src/clm/infrastructure/api/models.py
+++ b/src/clm/infrastructure/api/models.py
@@ -146,6 +146,21 @@ class CacheAddResponse(BaseModel):
     acknowledged: bool = True
 
 
+# === Executed Notebook Cache (Stage 3 producer / Stage 4 consumer) ===
+
+
+class ExecutedNotebookStoreResponse(BaseModel):
+    """Response body for executed_notebook cache store.
+
+    The store endpoint accepts gzipped pickle bytes as the raw request body,
+    so there is no Pydantic request model. The response confirms receipt and
+    reports the decompressed payload size for log/diagnostic purposes.
+    """
+
+    acknowledged: bool = True
+    bytes_stored: int = Field(..., description="Size of stored pickle bytes after decompression")
+
+
 # === Health Check ===
 
 

--- a/src/clm/infrastructure/api/server.py
+++ b/src/clm/infrastructure/api/server.py
@@ -46,17 +46,23 @@ class WorkerApiServer:
         db_path: Path,
         host: str = DEFAULT_HOST,
         port: int = DEFAULT_PORT,
+        cache_db_path: Path | None = None,
     ):
         """Initialize the Worker API server.
 
         Args:
-            db_path: Path to the SQLite database
+            db_path: Path to the SQLite job database (clm_jobs.db)
             host: Host to bind to (default: 0.0.0.0 for Docker access)
             port: Port to bind to (default: 8765)
+            cache_db_path: Path to the executed_notebooks cache database
+                (clm_cache.db). If None, the cache endpoints fall back to
+                ``db_path`` for backwards compatibility — the executed_notebooks
+                table is created on demand by ``ExecutedNotebookCache``.
         """
         self.db_path = db_path
         self.host = host
         self.port = port
+        self.cache_db_path = cache_db_path
 
         self._app: FastAPI | None = None
         self._server: uvicorn.Server | None = None
@@ -71,11 +77,13 @@ class WorkerApiServer:
         from clm import __version__
 
         db_path = self.db_path
+        cache_db_path = self.cache_db_path
 
         @asynccontextmanager
         async def lifespan(app: FastAPI):
             app.state.job_queue = JobQueue(db_path)
             app.state.db_path = db_path
+            app.state.cache_db_path = cache_db_path
             yield
             app.state.job_queue.close()
 
@@ -211,11 +219,15 @@ _server_instance: WorkerApiServer | None = None
 _server_lock = threading.Lock()
 
 
-def get_worker_api_server(db_path: Path | None = None) -> WorkerApiServer | None:
+def get_worker_api_server(
+    db_path: Path | None = None,
+    cache_db_path: Path | None = None,
+) -> WorkerApiServer | None:
     """Get the global Worker API server instance.
 
     Args:
-        db_path: Path to database (required if creating new instance)
+        db_path: Path to job database (required if creating new instance)
+        cache_db_path: Path to executed_notebooks cache database (optional)
 
     Returns:
         WorkerApiServer instance, or None if not initialized
@@ -224,19 +236,26 @@ def get_worker_api_server(db_path: Path | None = None) -> WorkerApiServer | None
 
     with _server_lock:
         if _server_instance is None and db_path is not None:
-            _server_instance = WorkerApiServer(db_path)
+            _server_instance = WorkerApiServer(db_path, cache_db_path=cache_db_path)
         return _server_instance
 
 
-def start_worker_api_server(db_path: Path, timeout: float = 5.0) -> WorkerApiServer:
+def start_worker_api_server(
+    db_path: Path,
+    timeout: float = 5.0,
+    cache_db_path: Path | None = None,
+) -> WorkerApiServer:
     """Start the global Worker API server.
 
     This is the main entry point for starting the server. It ensures
     only one server instance exists.
 
     Args:
-        db_path: Path to the SQLite database
+        db_path: Path to the SQLite job database
         timeout: Maximum time to wait for server to start
+        cache_db_path: Path to the executed_notebooks cache database
+            (clm_cache.db). Required for cache endpoints to write to the
+            real cache; falls back to ``db_path`` if not provided.
 
     Returns:
         The WorkerApiServer instance
@@ -251,7 +270,7 @@ def start_worker_api_server(db_path: Path, timeout: float = 5.0) -> WorkerApiSer
             logger.debug("Worker API server already running")
             return _server_instance
 
-        _server_instance = WorkerApiServer(db_path)
+        _server_instance = WorkerApiServer(db_path, cache_db_path=cache_db_path)
         if not _server_instance.start(timeout=timeout):
             raise RuntimeError("Failed to start Worker API server")
 

--- a/src/clm/infrastructure/api/worker_routes.py
+++ b/src/clm/infrastructure/api/worker_routes.py
@@ -4,16 +4,20 @@ These routes allow Docker containers to communicate with the CLM job queue
 without requiring direct SQLite access, solving the WAL mode issues on Windows.
 """
 
+import gzip
 import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import cast
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
 
 from clm.infrastructure.api.models import (
     CacheAddRequest,
     CacheAddResponse,
+    ExecutedNotebookStoreResponse,
     HeartbeatRequest,
     HeartbeatResponse,
     JobCancellationResponse,
@@ -29,6 +33,7 @@ from clm.infrastructure.api.models import (
     WorkerUnregisterRequest,
     WorkerUnregisterResponse,
 )
+from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
 from clm.infrastructure.database.job_queue import JobQueue
 
 logger = logging.getLogger(__name__)
@@ -286,6 +291,110 @@ async def activate_worker(request: Request, body: WorkerActivationRequest):
     except Exception as e:
         logger.error(f"Failed to activate worker: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to activate worker: {e}") from e
+
+
+def _get_cache_db_path(request: Request) -> Path:
+    """Resolve the executed_notebooks cache DB path from app state.
+
+    The executed_notebooks table lives in ``clm_cache.db``, which the host
+    server publishes on ``app.state.cache_db_path``. For backwards
+    compatibility with older test setups we fall back to the job DB path
+    (the table is created on demand by ``ExecutedNotebookCache``).
+    """
+    cache_db = getattr(request.app.state, "cache_db_path", None)
+    if cache_db is None:
+        cache_db = request.app.state.db_path
+    return Path(cache_db)
+
+
+@router.get("/cache/executed_notebook")
+async def get_executed_notebook(
+    request: Request,
+    input_file: str,
+    content_hash: str,
+    language: str,
+    prog_lang: str,
+):
+    """Fetch a pickled executed NotebookNode by cache key.
+
+    Returns the gzipped pickle bytes (octet-stream + Content-Encoding: gzip)
+    on a hit, or 404 on a miss. The payload is shipped without unpickling
+    server-side: pickled NotebookNodes can be multi-MB with image outputs,
+    so we round-trip the bytes directly.
+    """
+    cache_db_path = _get_cache_db_path(request)
+    try:
+        with ExecutedNotebookCache(cache_db_path) as cache:
+            pickle_bytes = cache.get_raw(
+                input_file=input_file,
+                content_hash=content_hash,
+                language=language,
+                prog_lang=prog_lang,
+            )
+    except Exception as e:
+        logger.error(f"Failed to read executed_notebook cache: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to read executed_notebook cache: {e}"
+        ) from e
+
+    if pickle_bytes is None:
+        raise HTTPException(status_code=404, detail="Executed notebook not cached")
+
+    gz = gzip.compress(pickle_bytes)
+    logger.debug(
+        f"REST API: executed_notebook cache hit for {input_file} "
+        f"({language}, {prog_lang}); shipping {len(gz)} bytes"
+    )
+    return Response(
+        content=gz,
+        media_type="application/octet-stream",
+        headers={"Content-Encoding": "gzip"},
+    )
+
+
+@router.post("/cache/executed_notebook", response_model=ExecutedNotebookStoreResponse)
+async def store_executed_notebook(
+    request: Request,
+    input_file: str,
+    content_hash: str,
+    language: str,
+    prog_lang: str,
+):
+    """Store a pickled executed NotebookNode under the given cache key.
+
+    The request body MUST be gzip-compressed pickle bytes — the inverse of
+    what :func:`get_executed_notebook` returns. The server stores the
+    decompressed pickle bytes verbatim so subsequent :meth:`ExecutedNotebookCache.get`
+    calls (from direct-mode workers or the Stage 4 reuse path) round-trip
+    cleanly.
+    """
+    body = await request.body()
+    try:
+        pickle_bytes = gzip.decompress(body)
+    except gzip.BadGzipFile as e:
+        raise HTTPException(status_code=400, detail=f"Body is not valid gzip: {e}") from e
+
+    cache_db_path = _get_cache_db_path(request)
+    try:
+        with ExecutedNotebookCache(cache_db_path) as cache:
+            cache.store_raw(
+                input_file=input_file,
+                content_hash=content_hash,
+                language=language,
+                prog_lang=prog_lang,
+                pickle_bytes=pickle_bytes,
+            )
+    except Exception as e:
+        logger.error(f"Failed to store executed_notebook cache: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to store executed_notebook cache: {e}"
+        ) from e
+
+    logger.debug(
+        f"REST API: executed_notebook cache store for {input_file} "
+        f"({language}, {prog_lang}); {len(pickle_bytes)} bytes (pickle)"
+    )
+    return ExecutedNotebookStoreResponse(acknowledged=True, bytes_stored=len(pickle_bytes))
 
 
 @router.post("/cache/add", response_model=CacheAddResponse)

--- a/src/clm/infrastructure/database/executed_notebook_cache.py
+++ b/src/clm/infrastructure/database/executed_notebook_cache.py
@@ -134,6 +134,87 @@ class ExecutedNotebookCache:
             )
             return None
 
+    def get_raw(
+        self,
+        input_file: str,
+        content_hash: str,
+        language: str,
+        prog_lang: str,
+    ) -> bytes | None:
+        """Retrieve the raw pickled bytes for a cached executed notebook.
+
+        Unlike :meth:`get`, this does not unpickle the payload. Used by the
+        Worker API to ship cache hits to remote workers without round-tripping
+        the NotebookNode through pickle twice.
+
+        Args:
+            input_file: Path to the source notebook file
+            content_hash: SHA hash of the notebook content
+            language: Output language ("de" or "en")
+            prog_lang: Programming language ("python", "cpp", etc.)
+
+        Returns:
+            The raw pickle bytes (as written by :meth:`store`), or None if not
+            found.
+        """
+        if not self.conn:
+            logger.warning("ExecutedNotebookCache not initialized (use with statement)")
+            return None
+
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT executed_notebook FROM executed_notebooks
+            WHERE input_file = ? AND content_hash = ? AND language = ? AND prog_lang = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (str(input_file), content_hash, language, prog_lang),
+        )
+        row = cursor.fetchone()
+        if row:
+            return cast(bytes, row[0])
+        return None
+
+    def store_raw(
+        self,
+        input_file: str,
+        content_hash: str,
+        language: str,
+        prog_lang: str,
+        pickle_bytes: bytes,
+    ) -> None:
+        """Store pre-pickled bytes in the cache.
+
+        Mirrors :meth:`store` but accepts already-pickled bytes. Used by the
+        Worker API to land a remote worker's executed notebook into the
+        host's cache without unpickling the payload on the server.
+
+        The bytes MUST be the output of ``pickle.dumps(notebook_node)`` so
+        :meth:`get` can round-trip them.
+        """
+        if not self.conn:
+            logger.warning("ExecutedNotebookCache not initialized (use with statement)")
+            return
+
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO executed_notebooks
+            (input_file, content_hash, language, prog_lang, executed_notebook)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                str(input_file),
+                content_hash,
+                language,
+                prog_lang,
+                pickle_bytes,
+            ),
+        )
+        self.conn.commit()
+        logger.debug(f"Cached executed notebook (raw): {input_file} ({language}, {prog_lang})")
+
     def store(
         self,
         input_file: str,

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -469,7 +469,9 @@ class WorkerPoolManager:
             return
 
         try:
-            self._api_server = start_worker_api_server(self.db_path)
+            self._api_server = start_worker_api_server(
+                self.db_path, cache_db_path=self.cache_db_path
+            )
             logger.info(
                 f"Worker API server started for Docker communication "
                 f"(Docker URL: {self._api_server.docker_url})"

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -34,9 +34,37 @@ from .output_spec import (
 )
 
 if TYPE_CHECKING:
-    from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
+    from typing import Protocol
 
     from .http_replay_cassette import CassettePaths
+
+    class ExecutedNotebookCacheLike(Protocol):
+        """Structural interface for the executed_notebooks cache.
+
+        Both the SQLite-backed :class:`ExecutedNotebookCache` (direct mode)
+        and ``ApiExecutedNotebookCache`` (Docker mode) satisfy this shape.
+        Only ``get`` and ``store`` are required — the maintenance methods on
+        the SQLite implementation are not used inside ``NotebookProcessor``.
+        """
+
+        def get(
+            self,
+            input_file: str,
+            content_hash: str,
+            language: str,
+            prog_lang: str,
+        ) -> "NotebookNode | None": ...
+
+        def store(
+            self,
+            input_file: str,
+            content_hash: str,
+            language: str,
+            prog_lang: str,
+            executed_notebook: "NotebookNode",
+        ) -> None: ...
+
+
 from clm.infrastructure.messaging.base_classes import ProcessingWarning
 
 from .utils.jupyter_utils import (
@@ -361,7 +389,7 @@ class NotebookProcessor:
     def __init__(
         self,
         output_spec: OutputSpec,
-        cache: "ExecutedNotebookCache | None" = None,
+        cache: "ExecutedNotebookCacheLike | None" = None,
     ):
         self.output_spec = output_spec
         self.id_generator = CellIdGenerator()

--- a/src/clm/workers/notebook/notebook_worker.py
+++ b/src/clm/workers/notebook/notebook_worker.py
@@ -14,6 +14,8 @@ import logging
 import os
 from pathlib import Path
 
+from clm.infrastructure.api.api_executed_notebook_cache import ApiExecutedNotebookCache
+from clm.infrastructure.api.client import WorkerApiClient
 from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
 from clm.infrastructure.database.job_queue import Job
 from clm.infrastructure.database.schema import init_database
@@ -52,28 +54,47 @@ class NotebookWorker(Worker):
             worker_id: Worker ID from database
             db_path: Path to SQLite database (required for direct mode)
             cache_db_path: Path to executed notebook cache database
-            api_url: URL of the Worker API (for Docker mode)
+                (direct mode only — ignored in API mode)
+            api_url: URL of the Worker API (for Docker mode); cache requests
+                go over this URL via :class:`ApiExecutedNotebookCache`.
         """
         super().__init__(worker_id, "notebook", db_path=db_path, api_url=api_url)
         self.cache_db_path = cache_db_path
-        self._cache: ExecutedNotebookCache | None = None
+        self.api_url = api_url
+        self._cache: ExecutedNotebookCache | ApiExecutedNotebookCache | None = None
+        self._api_cache_client: WorkerApiClient | None = None
         mode = "API" if api_url else "SQLite"
         logger.info(f"NotebookWorker {worker_id} initialized in {mode} mode")
 
-    def _ensure_cache_initialized(self) -> ExecutedNotebookCache | None:
+    def _ensure_cache_initialized(
+        self,
+    ) -> "ExecutedNotebookCache | ApiExecutedNotebookCache | None":
         """Ensure the executed notebook cache is initialized.
 
+        In API mode, returns an :class:`ApiExecutedNotebookCache` that
+        proxies reads/writes through the Worker REST API to the host's
+        ``clm_cache.db``. In direct mode, opens a local SQLite connection.
+
         Returns:
-            The cache instance, or None if no cache path configured.
+            The cache instance, or None if no cache backend can be opened
+            (direct mode without a ``cache_db_path``).
         """
+        if self._cache is not None:
+            return self._cache
+
+        if self.api_url is not None:
+            self._api_cache_client = WorkerApiClient(self.api_url)
+            self._cache = ApiExecutedNotebookCache(self._api_cache_client)
+            logger.info(f"Initialized API-backed executed notebook cache (via {self.api_url})")
+            return self._cache
+
         if self.cache_db_path is None:
             return None
 
-        if self._cache is None:
-            self._cache = ExecutedNotebookCache(self.cache_db_path)
-            self._cache.__enter__()
-            logger.info(f"Initialized executed notebook cache at {self.cache_db_path}")
-
+        sqlite_cache = ExecutedNotebookCache(self.cache_db_path)
+        sqlite_cache.__enter__()
+        self._cache = sqlite_cache
+        logger.info(f"Initialized executed notebook cache at {self.cache_db_path}")
         return self._cache
 
     def process_job(self, job: Job):
@@ -235,14 +256,22 @@ class NotebookWorker(Worker):
 
     def cleanup(self):
         """Clean up resources including the executed notebook cache."""
-        # Close the cache if it was initialized
-        if self._cache is not None:
+        # Close the SQLite cache if it was initialized (API cache has no
+        # connection to close — it's stateless aside from the httpx client).
+        if isinstance(self._cache, ExecutedNotebookCache):
             try:
                 self._cache.__exit__(None, None, None)
                 logger.info("Closed executed notebook cache")
             except Exception as e:
                 logger.warning(f"Error closing cache: {e}")
-            self._cache = None
+        self._cache = None
+
+        if self._api_cache_client is not None:
+            try:
+                self._api_cache_client.close()
+            except Exception as e:
+                logger.warning(f"Error closing API cache client: {e}")
+            self._api_cache_client = None
 
         # Call parent cleanup
         super().cleanup()
@@ -260,8 +289,10 @@ def main():
             db_path=None, api_url=API_URL, worker_type="notebook"
         )
 
-        # Create worker in API mode (no database access)
-        # Note: cache_db_path is not used in API mode as cache is handled by host
+        # Create worker in API mode. The executed_notebooks cache is reached
+        # via the Worker API (``ApiExecutedNotebookCache``) — the worker
+        # never opens ``clm_cache.db`` directly in this mode, so
+        # ``cache_db_path`` is intentionally left unset.
         worker = NotebookWorker(worker_id, api_url=API_URL)
     else:
         logger.info("Starting notebook worker in SQLite mode")

--- a/tests/infrastructure/api/test_api_executed_notebook_cache.py
+++ b/tests/infrastructure/api/test_api_executed_notebook_cache.py
@@ -1,0 +1,87 @@
+"""Tests for ApiExecutedNotebookCache (the Docker-side cache adapter).
+
+The adapter satisfies the same ``get``/``store`` shape as the SQLite
+:class:`ExecutedNotebookCache` so :class:`NotebookProcessor` can use either
+backend transparently. These tests exercise the pickle and transport
+boundary against a mocked ``WorkerApiClient`` — the real over-HTTP
+round-trip is covered by ``test_executed_notebook_cache_endpoints``.
+"""
+
+from __future__ import annotations
+
+import pickle
+from unittest.mock import MagicMock
+
+from nbformat.v4 import new_code_cell, new_notebook
+
+from clm.infrastructure.api.api_executed_notebook_cache import (
+    ApiExecutedNotebookCache,
+)
+
+
+def _sample_nb():
+    nb = new_notebook()
+    nb.cells.append(new_code_cell(source="z = 42"))
+    return nb
+
+
+def _key():
+    return {
+        "input_file": "/tmp/foo.py",
+        "content_hash": "deadbeef",
+        "language": "en",
+        "prog_lang": "python",
+    }
+
+
+class TestGet:
+    def test_returns_none_on_miss(self):
+        client = MagicMock()
+        client.get_executed_notebook.return_value = None
+        cache = ApiExecutedNotebookCache(client)
+
+        result = cache.get(**_key())
+
+        assert result is None
+        client.get_executed_notebook.assert_called_once_with(**_key())
+
+    def test_unpickles_pickle_bytes_on_hit(self):
+        client = MagicMock()
+        nb = _sample_nb()
+        client.get_executed_notebook.return_value = pickle.dumps(nb)
+        cache = ApiExecutedNotebookCache(client)
+
+        result = cache.get(**_key())
+
+        assert result is not None
+        assert result.cells[0].source == "z = 42"
+
+    def test_returns_none_on_malformed_pickle(self):
+        """A corrupted cache entry must not abort notebook processing —
+        falling back to direct execution is always safe."""
+        client = MagicMock()
+        client.get_executed_notebook.return_value = b"not a pickle"
+        cache = ApiExecutedNotebookCache(client)
+
+        result = cache.get(**_key())
+
+        assert result is None
+
+
+class TestStore:
+    def test_pickles_notebook_and_forwards_to_client(self):
+        client = MagicMock()
+        cache = ApiExecutedNotebookCache(client)
+        nb = _sample_nb()
+
+        cache.store(executed_notebook=nb, **_key())
+
+        client.store_executed_notebook.assert_called_once()
+        kwargs = client.store_executed_notebook.call_args.kwargs
+        assert kwargs["input_file"] == "/tmp/foo.py"
+        assert kwargs["content_hash"] == "deadbeef"
+        assert kwargs["language"] == "en"
+        assert kwargs["prog_lang"] == "python"
+
+        round_tripped = pickle.loads(kwargs["pickle_bytes"])
+        assert round_tripped.cells[0].source == "z = 42"

--- a/tests/infrastructure/api/test_client.py
+++ b/tests/infrastructure/api/test_client.py
@@ -332,6 +332,107 @@ class TestAddToCache:
         client.add_to_cache("f", "h", {"k": "v"})
 
 
+class TestExecutedNotebookCacheClient:
+    """WorkerApiClient.get_executed_notebook / store_executed_notebook."""
+
+    def _key(self) -> dict[str, str]:
+        return {
+            "input_file": "/tmp/foo.py",
+            "content_hash": "abc",
+            "language": "en",
+            "prog_lang": "python",
+        }
+
+    def test_get_returns_pickle_bytes_on_hit(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        # httpx auto-decompresses gzip Content-Encoding into ``.content`` for
+        # us, so simulate the post-decompression body.
+        response = _make_response()
+        response.content = b"\x80\x04pretend-pickle-bytes"
+        patched_request.return_value = response
+
+        body = client.get_executed_notebook(**self._key())
+
+        assert body == b"\x80\x04pretend-pickle-bytes"
+        call = patched_request.call_args
+        assert call[0] == ("GET", "/api/worker/cache/executed_notebook")
+        assert call[1]["params"] == self._key()
+        # accept_404 must be on so a miss doesn't raise.
+        assert call[1].get("json") is None
+
+    def test_get_returns_none_on_404(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        response = _make_response(status_code=404)
+        patched_request.return_value = response
+
+        result = client.get_executed_notebook(**self._key())
+
+        assert result is None
+
+    def test_get_returns_none_on_transport_error(
+        self,
+        client: WorkerApiClient,
+        patched_request: MagicMock,
+    ) -> None:
+        """Cache lookup failures must not propagate."""
+        patched_request.side_effect = httpx.ConnectError("no route")
+
+        result = client.get_executed_notebook(**self._key())
+
+        assert result is None
+
+    def test_get_decompresses_unwrapped_gzip(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        """Defensive path: if a proxy strips Content-Encoding so httpx
+        doesn't auto-decompress, the gzip magic bytes still let the client
+        recover."""
+        import gzip as _gz
+
+        raw_pickle = b"\x80\x04N."  # pickle of None
+        response = _make_response()
+        response.content = _gz.compress(raw_pickle)
+        patched_request.return_value = response
+
+        body = client.get_executed_notebook(**self._key())
+
+        assert body == raw_pickle
+
+    def test_store_posts_gzipped_body(
+        self, client: WorkerApiClient, patched_request: MagicMock
+    ) -> None:
+        import gzip as _gz
+
+        patched_request.return_value = _make_response(
+            json_payload={"acknowledged": True, "bytes_stored": 5}
+        )
+
+        client.store_executed_notebook(pickle_bytes=b"hello", **self._key())
+
+        call = patched_request.call_args
+        assert call[0] == ("POST", "/api/worker/cache/executed_notebook")
+        assert call[1]["params"] == self._key()
+        sent = call[1]["content"]
+        assert _gz.decompress(sent) == b"hello"
+        assert call[1]["headers"]["Content-Type"] == "application/octet-stream"
+
+    def test_store_swallows_api_error(
+        self,
+        client: WorkerApiClient,
+        patched_request: MagicMock,
+    ) -> None:
+        """Caching is best-effort; a failed POST must not raise."""
+        response = _make_response(status_code=500, text="boom")
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=response
+        )
+        patched_request.return_value = response
+
+        client.store_executed_notebook(pickle_bytes=b"hi", **self._key())
+
+
 class TestRetryLoop:
     """_request_with_retry retry semantics."""
 

--- a/tests/infrastructure/api/test_executed_notebook_cache_endpoints.py
+++ b/tests/infrastructure/api/test_executed_notebook_cache_endpoints.py
@@ -1,0 +1,165 @@
+"""Tests for the executed_notebooks cache REST endpoints.
+
+These endpoints close the Docker/API-mode gap that previously left
+``NotebookWorker`` without a cache: in API mode the worker now reads and
+writes ``executed_notebooks`` over the Worker API instead of opening
+``clm_cache.db`` directly. Without these endpoints (and the adapter that
+calls them), Stage 4 Completed/Trainer/Partial HTML jobs would
+unconditionally re-execute their notebooks under Docker — the same bug
+that PR #71 fixed for direct mode.
+"""
+
+from __future__ import annotations
+
+import gzip
+import pickle
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from nbformat.v4 import new_code_cell, new_notebook
+
+from clm.infrastructure.api.server import WorkerApiServer
+from clm.infrastructure.database.executed_notebook_cache import ExecutedNotebookCache
+from clm.infrastructure.database.schema import init_database
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test_jobs.db"
+    init_database(path)
+    return path
+
+
+@pytest.fixture
+def cache_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "test_clm_cache.db"
+
+
+@pytest.fixture
+def client(db_path: Path, cache_db_path: Path):
+    server = WorkerApiServer(db_path, cache_db_path=cache_db_path)
+    app = server._create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _sample_nb():
+    nb = new_notebook()
+    nb.cells.append(new_code_cell(source="print('hi')"))
+    return nb
+
+
+def _params() -> dict[str, str]:
+    return {
+        "input_file": "/tmp/foo.py",
+        "content_hash": "abc123",
+        "language": "en",
+        "prog_lang": "python",
+    }
+
+
+class TestExecutedNotebookCacheEndpoints:
+    def test_get_miss_returns_404(self, client):
+        response = client.get("/api/worker/cache/executed_notebook", params=_params())
+        assert response.status_code == 404
+
+    def test_post_then_get_round_trips_notebook(self, client, cache_db_path):
+        nb = _sample_nb()
+        pickle_bytes = pickle.dumps(nb)
+        body = gzip.compress(pickle_bytes)
+
+        post_response = client.post(
+            "/api/worker/cache/executed_notebook",
+            params=_params(),
+            content=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert post_response.status_code == 200
+        assert post_response.json()["acknowledged"] is True
+        assert post_response.json()["bytes_stored"] == len(pickle_bytes)
+
+        # Direct verification: the host's SQLite cache has the entry now,
+        # which is exactly the state Stage 4 direct-mode consumers need.
+        with ExecutedNotebookCache(cache_db_path) as cache:
+            cached_nb = cache.get(**_params())
+        assert cached_nb is not None
+        assert cached_nb.cells[0].source == "print('hi')"
+
+        # GET round-trip: httpx auto-decompresses gzip on the way back, so
+        # response.content is already the raw pickle bytes.
+        get_response = client.get("/api/worker/cache/executed_notebook", params=_params())
+        assert get_response.status_code == 200
+        round_tripped = pickle.loads(get_response.content)
+        assert round_tripped.cells[0].source == "print('hi')"
+
+    def test_post_with_non_gzip_body_returns_400(self, client):
+        response = client.post(
+            "/api/worker/cache/executed_notebook",
+            params=_params(),
+            content=b"not gzip",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert response.status_code == 400
+        assert "gzip" in response.json()["detail"].lower()
+
+    def test_get_requires_all_key_parts(self, client):
+        # FastAPI returns 422 when a required query param is missing.
+        partial = dict(_params())
+        partial.pop("language")
+        response = client.get("/api/worker/cache/executed_notebook", params=partial)
+        assert response.status_code == 422
+
+    def test_overwrite_replaces_existing_entry(self, client, cache_db_path):
+        nb1 = _sample_nb()
+        nb1.cells.append(new_code_cell(source="x = 1"))
+        client.post(
+            "/api/worker/cache/executed_notebook",
+            params=_params(),
+            content=gzip.compress(pickle.dumps(nb1)),
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+        nb2 = _sample_nb()
+        nb2.cells.append(new_code_cell(source="y = 2"))
+        client.post(
+            "/api/worker/cache/executed_notebook",
+            params=_params(),
+            content=gzip.compress(pickle.dumps(nb2)),
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+        # ExecutedNotebookCache.get uses ORDER BY created_at DESC LIMIT 1,
+        # so we should see nb2. The UNIQUE(input_file, content_hash, language,
+        # prog_lang) constraint plus INSERT OR REPLACE keeps row count at 1.
+        with ExecutedNotebookCache(cache_db_path) as cache:
+            cached_nb = cache.get(**_params())
+            stats = cache.get_stats()
+        assert cached_nb is not None
+        assert cached_nb.cells[-1].source == "y = 2"
+        assert stats["total_entries"] == 1
+
+    def test_falls_back_to_job_db_when_no_cache_db_path(self, db_path: Path, tmp_path: Path):
+        """Backwards-compat: callers that constructed WorkerApiServer without
+        a cache_db_path should still see endpoint behavior — the cache table
+        gets created on-demand in the job DB."""
+        server = WorkerApiServer(db_path)  # no cache_db_path
+        app = server._create_app()
+        with TestClient(app) as fallback_client:
+            response = fallback_client.get("/api/worker/cache/executed_notebook", params=_params())
+            assert response.status_code == 404
+
+            nb = _sample_nb()
+            post = fallback_client.post(
+                "/api/worker/cache/executed_notebook",
+                params=_params(),
+                content=gzip.compress(pickle.dumps(nb)),
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            assert post.status_code == 200
+
+            # Entry landed in the job DB (which has the executed_notebooks
+            # table auto-created by ExecutedNotebookCache).
+            with ExecutedNotebookCache(db_path) as cache:
+                cached = cache.get(**_params())
+            assert cached is not None

--- a/tests/workers/notebook/test_notebook_worker.py
+++ b/tests/workers/notebook/test_notebook_worker.py
@@ -177,6 +177,56 @@ class TestNotebookWorkerCache:
             MockCache.assert_called_once()  # Only called once
             assert result1 == result2
 
+    def test_api_mode_builds_api_backed_cache(self, worker_id):
+        """In API mode the worker must construct an ApiExecutedNotebookCache.
+
+        This is the Docker-mode fix for the Stage 4 re-execution bug: prior
+        to this wiring, ``_ensure_cache_initialized`` returned ``None`` in
+        API mode (cache_db_path is unused), and
+        ``NotebookProcessor._try_reuse_cached_execution`` short-circuited on
+        ``self.cache is not None`` — forcing every Completed/Trainer/Partial
+        HTML job to spawn a fresh kernel.
+        """
+        from clm.infrastructure.api.api_executed_notebook_cache import (
+            ApiExecutedNotebookCache,
+        )
+        from clm.workers.notebook.notebook_worker import NotebookWorker
+
+        with patch("clm.workers.notebook.notebook_worker.Worker.__init__", return_value=None):
+            worker = NotebookWorker(worker_id, api_url="http://host.docker.internal:8765")
+            # Worker.__init__ is mocked, so the attributes it normally sets
+            # are absent — restore the ones _ensure_cache_initialized reads.
+            worker.api_url = "http://host.docker.internal:8765"
+            worker.cache_db_path = None
+            worker._cache = None
+            worker._api_cache_client = None
+
+        with patch("clm.workers.notebook.notebook_worker.WorkerApiClient") as MockClient:
+            MockClient.return_value = MagicMock()
+            cache = worker._ensure_cache_initialized()
+
+        assert isinstance(cache, ApiExecutedNotebookCache)
+        MockClient.assert_called_once_with("http://host.docker.internal:8765")
+
+    def test_api_mode_reuses_existing_cache(self, worker_id):
+        """Subsequent calls in API mode must return the same adapter."""
+        from clm.workers.notebook.notebook_worker import NotebookWorker
+
+        with patch("clm.workers.notebook.notebook_worker.Worker.__init__", return_value=None):
+            worker = NotebookWorker(worker_id, api_url="http://host.docker.internal:8765")
+            worker.api_url = "http://host.docker.internal:8765"
+            worker.cache_db_path = None
+            worker._cache = None
+            worker._api_cache_client = None
+
+        with patch("clm.workers.notebook.notebook_worker.WorkerApiClient") as MockClient:
+            MockClient.return_value = MagicMock()
+            first = worker._ensure_cache_initialized()
+            second = worker._ensure_cache_initialized()
+
+        assert first is second
+        MockClient.assert_called_once()
+
 
 class TestNotebookWorkerProcessJob:
     """Test job processing functionality."""
@@ -482,13 +532,21 @@ class TestNotebookWorkerCleanup:
     """Test cleanup functionality."""
 
     def test_cleanup_closes_cache(self, worker_id, db_path, cache_db_path):
-        """cleanup should close the cache if initialized."""
+        """cleanup should close the SQLite cache if initialized.
+
+        Cleanup distinguishes the SQLite-backed ``ExecutedNotebookCache``
+        (which holds a connection that needs closing) from the API-backed
+        ``ApiExecutedNotebookCache`` (stateless aside from the httpx
+        client); only the former gets ``__exit__``'d.
+        """
+        from clm.infrastructure.database.executed_notebook_cache import (
+            ExecutedNotebookCache,
+        )
         from clm.workers.notebook.notebook_worker import NotebookWorker
 
         worker = NotebookWorker(worker_id, db_path, cache_db_path=cache_db_path)
 
-        # Initialize cache
-        mock_cache = MagicMock()
+        mock_cache = MagicMock(spec=ExecutedNotebookCache)
         mock_cache.__enter__ = MagicMock(return_value=mock_cache)
         mock_cache.__exit__ = MagicMock()
         worker._cache = mock_cache
@@ -500,11 +558,14 @@ class TestNotebookWorkerCleanup:
 
     def test_cleanup_handles_cache_error(self, worker_id, db_path, cache_db_path):
         """cleanup should handle errors when closing cache."""
+        from clm.infrastructure.database.executed_notebook_cache import (
+            ExecutedNotebookCache,
+        )
         from clm.workers.notebook.notebook_worker import NotebookWorker
 
         worker = NotebookWorker(worker_id, db_path, cache_db_path=cache_db_path)
 
-        mock_cache = MagicMock()
+        mock_cache = MagicMock(spec=ExecutedNotebookCache)
         mock_cache.__exit__ = MagicMock(side_effect=RuntimeError("Close error"))
         worker._cache = mock_cache
 
@@ -512,6 +573,26 @@ class TestNotebookWorkerCleanup:
         worker.cleanup()
 
         assert worker._cache is None
+
+    def test_cleanup_closes_api_cache_client(self, worker_id, db_path):
+        """In API mode, cleanup must close the underlying httpx client."""
+        from clm.workers.notebook.notebook_worker import NotebookWorker
+
+        worker = NotebookWorker(worker_id, db_path)
+        # Simulate an API-mode cache: adapter doesn't need __exit__, but the
+        # client it wraps must be closed.
+        api_cache = MagicMock()  # NOT spec'd as ExecutedNotebookCache
+        api_client = MagicMock()
+        worker._cache = api_cache
+        worker._api_cache_client = api_client
+
+        worker.cleanup()
+
+        # Adapter must NOT have been __exit__'d (it isn't a context manager).
+        api_cache.__exit__.assert_not_called()
+        api_client.close.assert_called_once()
+        assert worker._cache is None
+        assert worker._api_cache_client is None
 
     def test_cleanup_without_cache(self, worker_id, db_path):
         """cleanup should work without cache."""


### PR DESCRIPTION
## Summary

- In direct mode, PR #71 fixed the Stage 4 re-execution bug by gating ``processed_files`` short-circuits on a fresh ``executed_notebooks`` peek. Docker/API mode had a worse, permanent variant: ``NotebookWorker.__init__`` never constructed a cache in API mode (the "cache is handled by host" comment was not wired up), so ``NotebookProcessor._try_reuse_cached_execution`` short-circuited on ``self.cache is not None`` for every Completed/Trainer/Partial HTML job and unconditionally re-executed each notebook.
- Routes the ``executed_notebooks`` cache over the existing Worker REST API: two new endpoints (``GET``/``POST /api/worker/cache/executed_notebook``) ship gzipped pickle bytes; new ``ExecutedNotebookCache.get_raw``/``store_raw`` helpers let the server avoid an unpickle+repickle round-trip (pickled NotebookNodes are typically multi-MB with image outputs).
- New ``ApiExecutedNotebookCache`` adapter satisfies the ``get``/``store`` shape ``NotebookProcessor`` expects; a structural ``ExecutedNotebookCacheLike`` Protocol lets the processor accept either backend. ``NotebookWorker`` builds the adapter in API mode and the SQLite cache in direct mode.
- ``WorkerApiServer`` accepts an optional ``cache_db_path`` (defaults to ``db_path``, backwards-compatible); pool manager wires it through.

## Test plan

- [x] ``tests/infrastructure/api/test_executed_notebook_cache_endpoints.py`` — endpoint round-trip via FastAPI ``TestClient``: cold miss → 404, store → 200, warm hit → pickle bytes round-trip, bad-gzip body → 400, missing query param → 422, overwrite replaces existing row, fallback-DB-path when ``cache_db_path`` is None.
- [x] ``tests/infrastructure/api/test_api_executed_notebook_cache.py`` — adapter: miss returns None, hit unpickles, malformed pickle → cache miss (not crash), store pickles + forwards.
- [x] ``tests/infrastructure/api/test_client.py::TestExecutedNotebookCacheClient`` — client: 200/404/connect-error paths, gzip body shape, store swallows server errors.
- [x] ``tests/workers/notebook/test_notebook_worker.py::TestNotebookWorkerCache`` — wiring: API mode builds ``ApiExecutedNotebookCache``, second call reuses it. ``TestNotebookWorkerCleanup`` distinguishes SQLite cache (closed via ``__exit__``) from adapter (only the underlying httpx client is closed).
- [x] Full non-docker suite: ``4925 passed, 19 skipped, 1 xfailed`` (193s).
- [ ] Docker integration build to confirm Stage 4 Completed/Trainer/Partial HTML jobs no longer re-execute when Recording HTML produced a cache entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)