### PR TITLE
feat(backend): hash-aware output writes behind CLM_HASH_AWARE_WRITES flag (D1)

### DIFF
--- a/docs/claude/design/git-friendly-output-writes-gemini-conversation.md
+++ b/docs/claude/design/git-friendly-output-writes-gemini-conversation.md
@@ -1,0 +1,88 @@
+# you asked
+
+OK, that's great. For a long term solution, can you tell me whether I can modify the external program to be more "git friendly." The reason for moving the git directory is the following:
+The external program (CLM) generates lecture slides and other files in multiple languages and output formats from a common input format. In order that CLM doesn't have to track the state of the previously generated course, it does the following: When a course is recreated, it moves its `.git` directory to a temporary location, deletes the complete folder and writes if from scratch. Then it moves the `.git` directory back. This avoids any problems with renaming files or changing the order of files (which may lead to many files obtaining new names because the output files have a "serial number" at the start, e.g. "01 Introduction"). But obviously it's very bad for git performance.
+Do you see a better way to handle this. For example, could we ask git for the directory contents and content hashes of the files that are in the repository, and then actually modify the existing repository instead of the brute force approach we are using now?
+
+---
+
+# gemini response
+
+Yes, absolutely. The current "brute-force" design of the Course Lifecycle Manager (CLM) is a textbook anti-pattern for Git. By wiping and recreating the folder while hiding the `.git` directory, CLM forces Git to do a massive, expensive cryptographic re-verification of the entire project every single run.
+
+You can modify CLM to be immensely more "Git-friendly" without losing its state-free design. Here are the three best ways to refactor the tool's output engine, ranging from simple to highly optimized.
+
+---
+
+## Strategy 1: The "Smart Purge" (Easiest to implement)
+
+If you want to keep the logic where CLM doesn't track state, you can replace the `rm -rf *` step with a smart deletion that spares the `.git` folder but uses standard file system synchronization. 
+
+Instead of moving `.git` away, use an efficient synchronization utility (like `rsync` or native equivalents in Python/Go/Node) to build the new course into a separate temporary directory, and then sync it to the target directory.
+
+**The Workflow:**
+1. CLM generates the entire course into a temporary directory (e.g., `/tmp/clm-build/`).
+2. Run a synchronization command targeting the live repo:
+   ```bash
+   rsync -a --delete --exclude='.git/' /tmp/clm-build/ /path/to/your/repo/
+   ```
+3. Run Git commands normally.
+
+**Why this helps:** `rsync` will only touch files that actually changed, completely preserving the `mtime`, size, and inodes of the 90% of files that stayed the same (even if serial numbers shifted further down the line). Git's stat cache remains completely intact for unchanged files, keeping `git status` sub-second.
+
+---
+
+## Strategy 2: Query Git for the State (Your suggestion)
+
+If you want CLM to actively query Git so it can intelligently clean up after itself, Git has specific low-level plumbing commands designed exactly for scripts to read the index.
+
+Before generating anything, CLM can get a complete manifest of everything Git currently tracks using:
+```bash
+git ls-files
+```
+If you also need the content hashes (SHA-1s) of those files directly from the index without reading the files on disk, use:
+```bash
+git ls-files --stage
+```
+This outputs entries like this:
+```text
+100644 7a31b2... 0    01_Introduction/slides.html
+100644 e1a9f4... 0    02_Architecture/diagram.png
+```
+
+**The Workflow:**
+1. **Gather Manifest:** CLM runs `git ls-files` to get an in-memory list of what exists right now.
+2. **Generate Directly:** CLM overwrites files and writes new ones straight into the directory. It doesn't delete anything yet.
+3. **Reconcile and Clean Up:** CLM looks at its *old* manifest. Any file that was in the old Git manifest but was *not* recreated by CLM in this run is a stray file (e.g., due to a renaming or serial number shift). CLM explicitly deletes only those stray files.
+4. **Stage:** Run `git add -A` (which efficiently picks up the edits, creations, and deletions).
+
+---
+
+## Strategy 3: The "No-Working-Tree" Approach (Ultimate Performance)
+
+If CLM is written in a language with good scripting capabilities, you can bypass the working tree entirely during generation. Git allows you to hash files directly into its object database and write a commit **without writing files to the disk first**.
+
+If CLM computes the new slide contents, it can pass them directly to Git's plumbing:
+1. **Hash content into Git:** 
+   
+```bash
+   echo "slide content" | git hash-object -w --stdin
+   ```
+   This returns a SHA-1 hash and safely stores the object in `.git/objects`, bypassing the disk working directory.
+2. **Build the Index:** CLM can use `git update-index --index-info` to feed a list of paths and their new hashes straight into the Git staging area.
+3. **Commit:** CLM runs `git write-tree` and `git commit-tree` to cut a commit.
+4. **Checkout:** Finally, you run a single `git checkout` or `git reset --hard` to update the physical disk files to match the new commit all at once.
+
+---
+
+## Summary Comparison
+
+| Strategy | Complexity | Disk IO | Git Index Impact |
+| :--- | :--- | :--- | :--- |
+| **Current Brute-Force** | Very Low | Extremely High | **Trashes the index completely** |
+| **1. Smart Purge (`rsync`)** | Low | Low (Updates only changes) | Perfect (Preserves untouched files) |
+| **2. Query Git (`ls-files`)**| Medium | Low (Deletes strays only) | Great (Standard incremental updates) |
+| **3. Plumbing (`index-info`)**| High | Extremely Low | Perfect (Index is built directly in-memory) |
+
+**Recommendation:** Go with **Strategy 1** or **Strategy 2**. They allow CLM to remain "stateless" conceptually, but treat the filesystem and Git with the precision required to keep performance lightning-fast.
+```

--- a/docs/claude/design/git-friendly-output-writes.md
+++ b/docs/claude/design/git-friendly-output-writes.md
@@ -1,0 +1,481 @@
+# CLM Design — Git-Friendly Output Writes
+
+Status: **proposed** (2026-05-16, design only — no implementation has
+started). Targets a future minor release (likely 1.5.0). Replaces the
+"wipe and rebuild" output strategy with hash-aware writes plus a
+post-build stray-file sweep so that course output directories stay
+fast under git.
+
+Motivation captured in:
+- [`git-friendly-output-writes-gemini-conversation.md`](git-friendly-output-writes-gemini-conversation.md)
+  — the source Gemini conversation that prompted this design. The three
+  strategies Gemini proposed (rsync staging, `git ls-files` manifest,
+  pure-plumbing) are evaluated against the chosen approach in
+  [Alternatives considered](#alternatives-considered) below.
+- This design extends the [`OutputWriteRegistry`](../shared-source-includes-and-output-dedup.md#feature-2-output-write-deduplication)
+  introduced in PR #64 — same registry, new consumer at the disk-write boundary.
+
+## Problem
+
+CLM's current build flow is hostile to git in the output tree:
+
+1. `git_dir_mover` (`src/clm/cli/git_dir_mover.py:12-74`) finds every
+   nested `.git` under each output root and `shutil.move()`s it to a
+   tempdir under the context manager's `__enter__`.
+2. `build.py:802-806` then runs `shutil.rmtree(root_dir, ignore_errors=True)`
+   over the entire output tree.
+3. Everything is regenerated from scratch; mtimes/inodes change for every
+   file even when content is unchanged.
+4. `__exit__` moves the `.git` directories back.
+
+The net effect on a repo containing the output: git's stat-cache is
+invalidated for every tracked file, so the next `git status` re-hashes
+the entire tree. On the AZAV ML course (~thousands of files) this turns
+sub-second `git status` into multi-minute rebuilds of the index.
+
+Compounding factor: notebook filenames carry a serial-number prefix
+(`notebook_file.py:271`, `f"{self.number_in_section:02} {sanitized_title}{ext}"`)
+re-assigned per build (`section.py:26-28`). Inserting one topic shifts
+the prefix of every later notebook in the section, producing genuine
+renames even when content is unchanged.
+
+CLM today does have two partial mitigations:
+- `--keep-directory` (`build.py:1130`) skips both the `.git` move and
+  the rmtree.
+- `--incremental` (`build.py:961`) implies `keep_directory` and additionally
+  skips disk writes on database cache hits (`sqlite_backend.py:116-122`).
+
+Both are opt-in. `--incremental` correctness depends on the existing on-disk
+state matching the cache exactly; any drift (stale files from old names,
+hand-edits, partial wipes) produces silent inconsistency. Neither is safe
+to make the default in its current form.
+
+## Goals
+
+- **G1.** Default build flow does not invalidate git's stat-cache for
+  unchanged content. After two consecutive builds with no spec changes,
+  `git status` in the output tree is sub-second.
+- **G2.** No content drift relative to today's "wipe and rebuild" output —
+  any file produced by a clean rebuild must also be produced (with the
+  same content) by the new flow.
+- **G3.** No stale files. Renames, reorders, and deletions in the spec
+  must remove the obsolete files from the output tree, with the same
+  guarantees the rmtree-then-rebuild flow provides today.
+- **G4.** Build the feature on top of the existing `OutputWriteRegistry`
+  rather than introducing a parallel mechanism.
+- **G5.** Old behavior remains available behind an opt-in flag (`--clean`),
+  for emergency recovery and parity with current scripts that depend on it.
+
+## Non-Goals
+
+- Coupling CLM to git as a source of truth. The output tree is sometimes
+  shipped to consumers (students, instructors) who do not have a git
+  repo at all. The design must work identically whether the output dir
+  is a git repo, untracked, or anywhere else.
+- Bypassing the working tree (Gemini's Strategy 3 — `git hash-object`
+  plumbing). Worker subprocesses (`jupyter nbconvert`, the PlantUML JAR,
+  `drawio.exe`) write to disk; intercepting those writes is a worker-layer
+  rewrite out of scope for this feature.
+- Persisting a cross-build manifest. The stray-file sweep operates on
+  the current build's registry plus a filesystem walk; no separate
+  state file is required.
+- Solving the serial-number renumbering itself. Git detects renames by
+  content similarity; what matters for performance is *not modifying
+  unchanged files*, which this design delivers.
+
+## Design
+
+Four pieces, ordered by dependency.
+
+### D1. Per-write destination check at every output write site
+
+There are four registry-aware write call sites today:
+
+| # | Site | Location | Current behavior |
+|---|---|---|---|
+| 1 | `LocalOpsBackend.copy_file_to_output` | `local_ops_backend.py:53-113` | Calls `record_write(content_source=…)`. DEDUP outcome skips the `shutil.copyfile`. Other outcomes always copy. |
+| 2 | `LocalOpsBackend._register_dir_group_writes` | `local_ops_backend.py:147-` | Post-hoc registration after `shutil.copytree`. No skip path; files already on disk. |
+| 3 | `SqliteBackend.execute_operation` cache-replay | `sqlite_backend.py:115-187` | On DB cache hit, calls `record_write(content=…)`. DEDUP outcome skips `atomic_write_bytes`. Other outcomes always write. |
+| 4 | `SqliteBackend` worker-readback | `sqlite_backend.py:478-498` | Worker subprocess has already written the file. Registry registration is informational only. |
+
+Sites 1 and 3 are the high-leverage targets — sites 2 and 4 happen
+after the bytes are already on disk and cannot be skipped without
+restructuring the worker layer.
+
+**Add a `WriteOutcome.UNCHANGED_ON_DISK` variant** to
+`output_write_registry.py:98-114`. The registry doesn't decide this
+itself (it doesn't stat the disk); instead, callers check on demand
+using a new helper:
+
+```python
+class OutputWriteRegistry:
+    def is_destination_identical(
+        self,
+        output_path: Path,
+        *,
+        content: bytes | None = None,
+        content_source: Path | None = None,
+    ) -> bool:
+        """Return True iff output_path exists on disk and its content
+        is byte-identical to the supplied content / file. Cheap-path
+        first: stat size mismatch → False without hashing. Used by
+        write call sites to skip the actual disk write so mtime is
+        preserved and git's stat-cache stays valid."""
+```
+
+**Cheap-path comparison order** (each step short-circuits to "differs"):
+1. `output_path.exists()` — no → not identical.
+2. Source size vs. `output_path.stat().st_size` — mismatch → not identical.
+3. Hash both (reuse `_HASH_READ_CHUNK`, `BLAKE2b-128`, same algo as
+   `record_write`). The expensive step, but only reached when sizes match.
+
+Above `_resolve_hash_limit_bytes()` (currently 50 MB by default), fall
+back to the existing behavior — write unconditionally. The "skip" is an
+optimization, not a correctness boundary, so it's safe to give up on
+huge files.
+
+**Caller change at site 1** (`local_ops_backend.py`, after the existing
+DEDUP branch around line 71):
+
+```python
+if write_result.outcome == WriteOutcome.FIRST_WRITE:
+    if self.output_write_registry.is_destination_identical(
+        abs_output, content_source=copy_data.input_path
+    ):
+        logger.debug(f"Disk-skip: {abs_output} already has identical content")
+        return  # don't shutil.copyfile, preserve mtime
+```
+
+**Caller change at site 3** (`sqlite_backend.py`, around line 168 before
+`atomic_write_bytes`):
+
+```python
+if not skip_write:
+    if self.output_write_registry.is_destination_identical(
+        output_file, content=content_bytes
+    ):
+        logger.debug(f"Disk-skip: {output_file} already has identical content")
+    else:
+        atomic_write_bytes(output_file, content_bytes)
+```
+
+**Sites 2 and 4 are left unchanged.** Worker-readback (4) cannot help
+us — the worker has already written. Dir-group (2) uses `shutil.copytree`
+which doesn't easily support per-file skip; it's a minority of writes
+and we accept the cost. If profiling shows dir-groups are hot, we can
+revisit by replacing `_copy_dir_group_to_output_sync` with a walk that
+goes through `copy_file_to_output` per file.
+
+### D2. End-of-build stray-file sweep
+
+Once all stages complete, the build's `OutputWriteRegistry` holds the
+complete set of paths the build *intended* to populate. Anything under
+a build-owned root that's not in that set is stray.
+
+Add a new function in `src/clm/cli/output_sweep.py` (new module):
+
+```python
+def sweep_stray_files(
+    root_dirs: Iterable[Path],
+    registry: OutputWriteRegistry,
+    *,
+    keep_patterns: Iterable[str] = DEFAULT_KEEP_PATTERNS,
+    dry_run: bool = False,
+) -> SweepReport:
+    """Walk each root_dir recursively. For each file not in the
+    registry's entries and not matching keep_patterns, delete it.
+    After the file pass, remove empty directories bottom-up.
+    Returns counts and a list of deleted paths for the build summary."""
+```
+
+**Default `keep_patterns`** — paths the sweep must never touch:
+- `.git/**` (covers nested `.git` directories anywhere under each root —
+  see EC9 for the full nested-repo handling)
+
+That is the entire allow-list. The output directory's governing
+principle is **everything under a build-owned root must be produced by
+`clm build`** — authors do not hand-edit, hand-place, or commit
+auxiliary files (`.gitignore`, `README.md`, editor caches, `.DS_Store`,
+`__pycache__`, etc.) into the output tree. The sweep enforces that
+principle.
+
+Specifically, files matching `SKIP_DIRS_FOR_OUTPUT` /
+`SKIP_DIRS_PATTERNS` / `SKIP_OUTPUT_FILE_GLOBS` from `path_utils.py`
+are **not** excluded from the sweep. Those patterns are auto-generated
+junk (caches, OS metadata) or content explicitly withheld from
+students; if they appear under the output tree, they were placed by
+mistake or by manual intervention, and the sweep should remove them.
+
+If a course genuinely needs a file like `.gitignore` at the root of
+its output (e.g., to ignore a sibling build-artifact directory), the
+right answer is to teach CLM to generate it as part of the build —
+not to special-case the sweep.
+
+**Image-path handling.** The registry deliberately skips `img/`
+paths (`output_write_registry.py:17-20`) because `ImageRegistry`
+owns those. Without intervention the sweep would treat every image
+as stray. Two options:
+
+- **Option A.** Extend `ImageRegistry` to expose a `tracked_paths`
+  property; the sweep takes the union of registry paths + image
+  registry paths as "expected".
+- **Option B.** Hardcode `img/**` into `keep_patterns`.
+
+**Recommend Option A.** It correctly handles the case where an image
+is *removed* from the spec — option B would silently keep removed
+images forever. Stale-image cleanup is a real bug currently masked by
+the rmtree.
+
+**Invocation point.** In `build.py:_run_stages` (around line 762, after
+`build_reporter.report_output_writes(...)` and before `finish_build`),
+call `sweep_stray_files(root_dirs, backend.output_write_registry)`
+and feed the result into the build reporter. Skip the sweep when
+`--only-sections` mode is active — that mode has its own narrower
+cleanup scope (`build.py:770-782`), and a sweep over the full root
+would delete files for non-selected sections.
+
+**Empty-directory cleanup.** After the file pass, walk each root_dir
+bottom-up; remove any directory that is now empty (excluding the root
+itself and any `.git/` directory). This catches the case where an
+entire section was renamed `01 Intro` → `01 Introduction`: every
+file under the old `01 Intro/` is stray and gets deleted, then the
+empty dir itself gets removed.
+
+### D3. Default behavior change
+
+In `build.py:802-806`, today's logic is:
+
+```python
+with git_dir_mover(root_dirs, config.keep_directory):
+    for root_dir in root_dirs:
+        if not config.keep_directory:
+            shutil.rmtree(root_dir, ignore_errors=True)
+```
+
+Flip the default. `keep_directory` becomes the implicit normal mode;
+the wipe-and-restore branch becomes opt-in:
+
+```python
+if config.clean:
+    # Legacy / emergency-recovery path. Wipes output, preserves
+    # nested .git, regenerates from scratch. Strictly slower than
+    # the default but useful when the on-disk state is corrupt.
+    with git_dir_mover(root_dirs):
+        for root_dir in root_dirs:
+            shutil.rmtree(root_dir, ignore_errors=True)
+        course.precreate_output_directories()
+        await _run_stages()
+else:
+    # New default: do not wipe, do not move .git. Hash-aware writes
+    # (D1) preserve mtimes for unchanged files; stray-file sweep
+    # (D2) at end of build removes orphans.
+    course.precreate_output_directories()
+    await _run_stages()
+    # sweep runs inside _run_stages' finally block — see D2
+```
+
+**CLI surface:**
+- Add `--clean` flag (replaces today's implicit default).
+- Keep `--keep-directory` as a no-op alias that warns it's now the default
+  (one release of deprecation, remove in 1.6).
+- `--incremental` remains as-is but now buys less — it implies `--no-sweep`
+  on top of the new default, since `--incremental` users explicitly
+  trust the on-disk state.
+- Add `--no-sweep` for users who want hash-aware writes but no stray
+  cleanup (useful when iterating on a single section and you don't
+  want orphans from other sections deleted).
+
+**Config struct.** Add `clean: bool` and `sweep: bool` to `BuildConfig`
+(`build.py:104-`). Default `clean=False`, `sweep=True`.
+
+### D4. Status of `git_dir_mover`
+
+Keep the module, keep the implementation. It still runs under `--clean`.
+Mark its public surface as "internal, used only by `--clean`" in the
+docstring; flag in the migration info topic
+(`src/clm/cli/info_topics/migration.md`) that the default no longer
+wipes output. No deletion in this release.
+
+## Edge cases and open questions
+
+| # | Case | Resolution |
+|---|---|---|
+| EC1 | First build of a course (empty output tree). | Hash-aware check sees no destination → writes normally. Sweep walks an empty tree → no-op. Zero overhead vs. today. |
+| EC2 | User has hand-edited a generated file or hand-placed an auxiliary file (`.gitignore`, `README.md`, editor cache, …). | Sweep deletes it. This is the governing principle, not an edge case — the output tree is exclusively CLM's. `--no-sweep` exists for users who want to iterate without orphan cleanup but does not change the principle. |
+| EC3 | Worker writes a slightly different output for byte-identical input (timestamp metadata in `.ipynb`, etc.). | The hash check correctly sees a difference → writes. Mtime updates. Git sees a real change. This is correct, just not free. Worth measuring how often it triggers. |
+| EC4 | Same path written twice in one build with identical content (the existing DEDUP case). | Unchanged. Registry's existing DEDUP outcome already short-circuits. Stray sweep sees the path in `entries` → keeps it. |
+| EC5 | `--only-sections` mode. | Skip the sweep entirely (already noted in D2). `--only-sections` has its own scoped cleanup at `build.py:770-782`. Hash-aware writes (D1) still apply. |
+| EC6 | Large file (above `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB`). | `is_destination_identical` returns False → write unconditionally. Same behavior as today for large files. |
+| EC7 | Sweep runs but a stage errored out partway. | The registry only contains entries from writes that were *attempted*. If a stage fails before its writes, the sweep would mistakenly delete files from prior successful builds. **Mitigation:** skip the sweep when `build_reporter` has logged any stage-fatal errors. Add `SweepReport.skipped_due_to_errors` for the summary. |
+| EC8 | Race with watch mode (`--watch`). | Watch mode re-enters `process_course_with_backend` per file change. The sweep would delete files for sections not in the current iteration. **Resolution:** disable the sweep when `config.watch` is set. Watch mode is dev-time iteration; correctness is provided by the next full build. |
+| EC9 | Nested git repos. | The sweep excludes `.git/**` everywhere. A nested git repo's tracked files outside `.git/` would still be candidates for deletion if not in the registry. **Resolution:** if a directory contains a `.git/` entry, treat the entire directory as opaque (skip the subtree). Mirrors how `SKIP_DIRS_PATTERNS` already treats nested vcs dirs. |
+| EC10 | Symlinks under the output root. | Walk with `follow_symlinks=False`. If a symlink isn't in the registry, delete the link only (not the target). |
+
+**Resolved D1.** Hash-aware writes do **not** apply at site 4
+(worker-readback). Restoring mtime after the worker subprocess has
+written is fragile (atomic temp+rename changes inodes; `utime` works
+on Windows/Linux but requires care) and the savings depend on workers
+producing byte-identical output, which is uncommon. Re-evaluate only
+if profiling shows worker-readback as a meaningful contributor to
+git-status latency.
+
+**Resolved D2.** The registry does **not** persist across builds.
+The end-of-build walk is O(files-on-disk), comparable to one
+`git status`, and cross-build state introduces correctness risk
+(stale manifest after manual edits or interrupted builds) for a
+small performance win.
+
+**Resolved D3.** `--keep-directory` emits a deprecation warning for
+one release ("now default, will be removed in 1.6") and is removed
+in the following minor release. The flag is documented and ecosystem
+scripts may reference it, so silent no-op is unacceptable.
+
+## Test plan
+
+### Unit
+
+- `tests/core/test_output_write_registry.py` — extend with
+  `is_destination_identical` cases:
+  - dest does not exist → False
+  - dest exists, size differs → False (without hashing — verify by
+    spying on the hash function)
+  - dest exists, size matches, content differs → False
+  - dest exists, content identical → True
+  - dest above size limit → False (no skip, write proceeds)
+- `tests/cli/test_output_sweep.py` (new) — sweep semantics:
+  - empty registry, empty tree → no-op
+  - registry has paths, tree has stray file → file deleted
+  - tree has `.git/` → preserved
+  - tree has `.gitignore` at root → preserved
+  - tree has nested `.git` repo → entire repo preserved
+  - tree has stray symlink → link removed, target untouched
+  - tree has empty dir left over → removed bottom-up
+  - sweep skipped when stage errors recorded
+  - sweep skipped in `--only-sections` mode
+  - sweep skipped in `--watch` mode
+
+### Integration
+
+- `tests/cli/test_build_command.py` — extend:
+  - **The git-friendliness test.** Build a small course twice into the
+    same output dir. Capture `(path, mtime, inode)` of every output
+    file after build 1. After build 2, assert that ≥95% of files have
+    identical mtime+inode (the survivors of hash-aware skip). The
+    threshold accounts for files whose content legitimately changes
+    (e.g., notebook metadata timestamps if any).
+  - **Stale-file removal test.** Build course A with sections S1, S2.
+    Modify spec to remove S2. Rebuild. Assert S2's output directory
+    is gone after sweep.
+  - **Rename test.** Section title changes `01 Intro` → `01 Introduction`.
+    Rebuild. Assert old dir is gone, new dir is populated.
+  - **`--clean` flag works.** Asserts old wipe-and-restore path still
+    runs and produces identical output to default flow.
+- `tests/cli/test_build_only_sections.py` — assert sweep is *not*
+  invoked under `--only-sections`.
+
+### End-to-end (slow, opt-in)
+
+- `tests/e2e/test_git_friendliness.py` (new, `slow` marker) — initialize
+  an empty git repo over a real course output, run two builds, capture
+  `git status` wall time on the second run. Assert it completes under
+  some threshold (5 s for a course of N files; pick threshold by
+  measuring current `--incremental` runs).
+
+### Smoke (manual, documented)
+
+- Build AZAV ML (`machine-learning-azav.xml`) into the existing
+  `D:\CLM\Recordings` tree. Verify `git status` is sub-second.
+- Insert a topic mid-section; rebuild; verify only the renamed files
+  show up in `git status`, not the entire section.
+
+## Implementation phasing
+
+Three PRs, each independently testable and revertable.
+
+**PR 1 — Hash-aware writes (D1).** Adds `is_destination_identical`,
+`WriteOutcome.UNCHANGED_ON_DISK` (unused initially, in case we want
+to plumb it back), and the two skip sites in
+`local_ops_backend.py` and `sqlite_backend.py`. Behind a feature flag
+`CLM_HASH_AWARE_WRITES=1` initially so we can A/B perf before flipping.
+~300 LOC + 200 LOC tests.
+
+**PR 2 — Stray-file sweep (D2).** Adds `src/clm/cli/output_sweep.py`,
+extends `ImageRegistry` with `tracked_paths`, wires the sweep into
+`_run_stages`' finally block. Sweep gated on a new BuildConfig field
+`sweep: bool` that defaults to False initially. ~250 LOC + 300 LOC
+tests.
+
+**PR 3 — Default flip (D3, D4).** Flips defaults, adds `--clean` and
+`--no-sweep` flags, updates info topics (`commands.md` and
+`migration.md`), deprecates `--keep-directory` with warning, updates
+`CHANGELOG.md`. ~150 LOC + 100 LOC tests.
+
+After PR 3 lands and bakes for a release, a follow-up can remove the
+feature flag and `--keep-directory` alias.
+
+## Alternatives considered
+
+**A1. rsync-style staging (Gemini's Strategy 1).** Build into a tempdir,
+then `rsync --delete` into the live tree. Considered and rejected:
+2× disk I/O during build (write to temp, then sync to final), and
+on Windows there is no native `rsync` — we'd reimplement it. The
+hash-aware approach gets the same outcome (preserved mtimes for
+unchanged files) at 1× I/O. Kept as a fallback if the hash-aware
+approach hits unforeseen integration problems with the worker layer.
+
+**A2. `git ls-files` manifest (Gemini's Strategy 2).** Use git as the
+source of truth for what should exist. Rejected per the non-goals:
+output is sometimes shipped to non-git consumers, and git-only logic
+makes the build path bimodal.
+
+**A3. Plumbing-only (Gemini's Strategy 3).** Discussed and rejected
+in non-goals. Would require rewriting the worker subprocesses to
+stream content back rather than write to disk.
+
+**A4. Make `--incremental` the default.** Tempting but unsound. Incremental
+mode skips disk writes on cache hits *without verifying* the on-disk
+file is correct. Any drift (partial wipe, hand-edit, interrupted
+prior build) produces silent inconsistency. Hash-aware writes give us
+the same speed with a stat+hash safety check.
+
+**A5. Per-section sweep instead of per-root sweep.** Sweep only inside
+`precreate_output_directories`' set. Rejected because section
+renames leave stale directories *outside* the new precreate set —
+exactly the case we need to handle.
+
+## Estimated size
+
+| Component | LOC src | LOC tests |
+|---|---|---|
+| `is_destination_identical` + `WriteOutcome.UNCHANGED_ON_DISK` | 80 | 150 |
+| Site 1, site 3 skip paths | 40 | 50 |
+| `output_sweep.py` (sweep + report struct) | 180 | 250 |
+| `ImageRegistry.tracked_paths` | 30 | 50 |
+| Build wiring (`_run_stages`, BuildConfig) | 60 | 50 |
+| CLI flags + deprecation warning | 80 | 50 |
+| Info-topic updates | 30 | — |
+| **Total** | **~500** | **~600** |
+
+Larger than a quick fix, smaller than the PR #64 baseline (which was
+~1200 LOC). Two months of intermittent work or three weeks dedicated.
+
+## References
+
+- `src/clm/cli/git_dir_mover.py` — current `.git`-move logic.
+- `src/clm/cli/commands/build.py:104-`, `:419-`, `:700-830`, `:1130-` —
+  build entry points, BuildConfig, root_dir computation, flag wiring.
+- `src/clm/core/output_write_registry.py` — registry to extend.
+- `src/clm/infrastructure/backends/local_ops_backend.py:53-180` — write
+  sites 1 and 2.
+- `src/clm/infrastructure/backends/sqlite_backend.py:100-200`,
+  `:478-498` — write sites 3 and 4.
+- `src/clm/core/course_files/notebook_file.py:271`,
+  `src/clm/core/section.py:26-28` — serial-number naming (root cause
+  of rename churn, not addressed here).
+- `src/clm/core/image_registry.py` — sibling registry for `img/` paths;
+  needs `tracked_paths` extension for the sweep.
+- `src/clm/cli/info_topics/commands.md`,
+  `src/clm/cli/info_topics/migration.md` — info topics to update on
+  default flip (per CLAUDE.md rule).
+- [`shared-source-includes-and-output-dedup.md`](shared-source-includes-and-output-dedup.md)
+  — design of the registry this feature extends.

--- a/src/clm/core/output_write_registry.py
+++ b/src/clm/core/output_write_registry.py
@@ -36,9 +36,26 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_HASH_LIMIT_MB: Final[int] = 50
 _ENV_HASH_LIMIT_MB: Final[str] = "CLM_OUTPUT_DEDUP_HASH_LIMIT_MB"
+_ENV_HASH_AWARE_WRITES: Final[str] = "CLM_HASH_AWARE_WRITES"
 
 _HASH_DIGEST_SIZE: Final[int] = 16
 _HASH_READ_CHUNK: Final[int] = 64 * 1024
+
+
+def hash_aware_writes_enabled() -> bool:
+    """Whether write call sites should skip disk writes when the
+    destination already holds byte-identical content.
+
+    Off by default during the initial rollout (PR1, PR2 of the
+    git-friendly output design). PR3 will flip the default and
+    retire this flag.
+    """
+    return os.environ.get(_ENV_HASH_AWARE_WRITES, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def _resolve_hash_limit_bytes() -> int:
@@ -250,6 +267,50 @@ class OutputWriteRegistry:
         existing.last_writer_hash = ""
         self._large_file_collision_count += 1
         return WriteResult(outcome=WriteOutcome.LARGE_FILE_COLLISION, entry=existing)
+
+    def is_destination_identical(
+        self,
+        output_path: Path,
+        *,
+        content: bytes | None = None,
+        content_source: Path | None = None,
+    ) -> bool:
+        """Return ``True`` iff ``output_path`` exists and already contains
+        the supplied content.
+
+        Cheap-path first: a missing destination or a size mismatch returns
+        ``False`` without reading either file. Only when sizes match does
+        the function hash both sides.
+
+        Sources larger than :attr:`hash_limit_bytes` always return
+        ``False`` — the skip is an optimization, and treating big files as
+        "differs" defers to the regular write path, which is always
+        correct. ``output_path`` must be absolute, mirroring
+        :meth:`record_write`.
+
+        Exactly one of ``content`` or ``content_source`` must be supplied.
+        """
+        if not output_path.is_absolute():
+            raise ValueError(f"output_path must be absolute: {output_path}")
+        if (content is None) == (content_source is None):
+            raise ValueError("provide exactly one of content= or content_source=")
+
+        if not output_path.is_file():
+            return False
+
+        source_size = (
+            len(content) if content is not None else content_source.stat().st_size  # type: ignore[union-attr]
+        )
+        if source_size > self._hash_limit_bytes:
+            return False
+        if output_path.stat().st_size != source_size:
+            return False
+
+        dest_hash = _hash_file(output_path)
+        source_hash = (
+            _hash_bytes(content) if content is not None else _hash_file(content_source)  # type: ignore[arg-type]
+        )
+        return dest_hash == source_hash
 
     def get(self, output_path: Path) -> OutputWriteEntry | None:
         return self._entries.get(output_path)

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -34,7 +34,11 @@ from attrs import define
 
 from clm.cli.build_data_classes import BuildWarning
 from clm.core.course_file import CourseFile
-from clm.core.output_write_registry import WriteOutcome, is_image_path
+from clm.core.output_write_registry import (
+    WriteOutcome,
+    hash_aware_writes_enabled,
+    is_image_path,
+)
 from clm.infrastructure.backend import Backend
 from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
 from clm.infrastructure.utils.copy_file_data import CopyFileData
@@ -86,6 +90,16 @@ class LocalOpsBackend(Backend, ABC):
                     f"Large-file collision at {abs_output} from "
                     f"{copy_data.input_path} (over hash limit; counted as collision)"
                 )
+
+            # Hash-aware skip: if the destination already holds identical
+            # content (typically from a prior build), avoid the copy so
+            # mtime is preserved and git's stat-cache remains valid.
+            # Flag-gated until PR3 flips the default.
+            if hash_aware_writes_enabled() and self.output_write_registry.is_destination_identical(
+                abs_output, content_source=copy_data.input_path
+            ):
+                logger.debug(f"Hash-aware skip: {abs_output} already has identical content")
+                return
 
         try:
             loop = asyncio.get_running_loop()

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -13,7 +13,11 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import define, field
 
-from clm.core.output_write_registry import WriteOutcome, is_image_path
+from clm.core.output_write_registry import (
+    WriteOutcome,
+    hash_aware_writes_enabled,
+    is_image_path,
+)
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.database.job_queue import JobQueue
@@ -166,12 +170,27 @@ class SqliteBackend(LocalOpsBackend):
                                 f"collision)"
                             )
                     if not skip_write:
-                        # Atomic temp+rename with retry on transient OSError —
-                        # plain write_bytes intermittently fails with EINVAL on
-                        # Windows when AV/indexer/sync agents hold handles on
-                        # files in the same directory.
-                        atomic_write_bytes(output_file, content_bytes)
-                        logger.debug(f"Wrote cached result to {output_file}")
+                        # Hash-aware skip: when the destination already
+                        # holds byte-identical content from a prior build,
+                        # avoid the write so mtime is preserved and git's
+                        # stat-cache stays valid. Flag-gated until PR3
+                        # flips the default.
+                        if (
+                            hash_aware_writes_enabled()
+                            and self.output_write_registry.is_destination_identical(
+                                output_file, content=content_bytes
+                            )
+                        ):
+                            logger.debug(
+                                f"Hash-aware skip: {output_file} already has identical content"
+                            )
+                        else:
+                            # Atomic temp+rename with retry on transient OSError —
+                            # plain write_bytes intermittently fails with EINVAL on
+                            # Windows when AV/indexer/sync agents hold handles on
+                            # files in the same directory.
+                            atomic_write_bytes(output_file, content_bytes)
+                            logger.debug(f"Wrote cached result to {output_file}")
 
                 # Report any stored errors/warnings for this cached result
                 self._report_cached_issues(

--- a/tests/core/test_output_write_registry.py
+++ b/tests/core/test_output_write_registry.py
@@ -298,3 +298,90 @@ class TestHashLimitWiring:
         monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "10")
         registry = OutputWriteRegistry()
         assert registry.hash_limit_bytes == 10 * 1024 * 1024
+
+
+class TestIsDestinationIdentical:
+    def test_returns_false_when_dest_missing(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "missing.txt")
+        assert registry.is_destination_identical(out, content=b"hello") is False
+
+    def test_returns_false_when_dest_is_directory(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = tmp_path / "out" / "subdir"
+        out.mkdir(parents=True)
+        assert registry.is_destination_identical(out, content=b"hello") is False
+
+    def test_size_mismatch_short_circuits_without_hashing(self, tmp_path, monkeypatch):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        out.write_bytes(b"different size content")
+
+        call_count = {"n": 0}
+
+        def spy_hash_file(path):
+            call_count["n"] += 1
+            return ""
+
+        monkeypatch.setattr("clm.core.output_write_registry._hash_file", spy_hash_file)
+
+        assert registry.is_destination_identical(out, content=b"short") is False
+        assert call_count["n"] == 0
+
+    def test_size_matches_but_content_differs(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        out.write_bytes(b"hello")
+        assert registry.is_destination_identical(out, content=b"world") is False
+
+    def test_identical_via_content(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        out.write_bytes(b"hello")
+        assert registry.is_destination_identical(out, content=b"hello") is True
+
+    def test_identical_via_content_source(self, tmp_path):
+        registry = OutputWriteRegistry()
+        src = _abs(tmp_path, "src", "a.txt")
+        src.write_bytes(b"hello from disk")
+        out = _abs(tmp_path, "out", "a.txt")
+        out.write_bytes(b"hello from disk")
+        assert registry.is_destination_identical(out, content_source=src) is True
+
+    def test_above_hash_limit_returns_false(self, monkeypatch, tmp_path):
+        # Tiny limit so even a 100-byte file is "above limit".
+        monkeypatch.setenv("CLM_OUTPUT_DEDUP_HASH_LIMIT_MB", "0")
+        registry = OutputWriteRegistry()
+        # hash_limit_bytes is now 0 — every non-empty source is "above limit".
+        out = _abs(tmp_path, "out", "a.txt")
+        out.write_bytes(b"hello")
+        assert registry.is_destination_identical(out, content=b"hello") is False
+
+    def test_relative_output_path_raises(self):
+        registry = OutputWriteRegistry()
+        with pytest.raises(ValueError, match="must be absolute"):
+            registry.is_destination_identical(Path("rel/out.txt"), content=b"x")
+
+    def test_both_content_and_content_source_raises(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        src = _abs(tmp_path, "src", "a.txt")
+        src.write_bytes(b"x")
+        with pytest.raises(ValueError, match="exactly one"):
+            registry.is_destination_identical(out, content=b"x", content_source=src)
+
+    def test_neither_content_nor_content_source_raises(self, tmp_path):
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        with pytest.raises(ValueError, match="exactly one"):
+            registry.is_destination_identical(out)
+
+    def test_does_not_modify_registry_state(self, tmp_path):
+        # Pure query — must not be mistaken for a recorded write.
+        registry = OutputWriteRegistry()
+        out = _abs(tmp_path, "out", "a.txt")
+        out.write_bytes(b"hello")
+        registry.is_destination_identical(out, content=b"hello")
+        assert registry.get(out) is None
+        assert registry.total_dedups == 0
+        assert registry.total_conflicts == 0

--- a/tests/infrastructure/backends/test_local_ops_backend_extended.py
+++ b/tests/infrastructure/backends/test_local_ops_backend_extended.py
@@ -537,3 +537,102 @@ class TestTaskGroupShim:
             await backend.delete_dependencies(mock_file)
 
         assert call_count == 2  # Two files should have been "deleted"
+
+
+class TestCopyFileToOutputHashAware:
+    """Tests for the CLM_HASH_AWARE_WRITES flag-gated skip-path in
+    ``copy_file_to_output``. PR1 of the git-friendly output design."""
+
+    @pytest.mark.asyncio
+    async def test_flag_off_copies_even_when_identical(self, tmp_path, monkeypatch):
+        """With the flag unset (default), the copy always runs — same
+        behavior as before the feature was added."""
+        monkeypatch.delenv("CLM_HASH_AWARE_WRITES", raising=False)
+
+        infile = tmp_path / "input.txt"
+        outfile = tmp_path / "output.txt"
+        infile.write_bytes(b"hello")
+        outfile.write_bytes(b"hello")  # identical content already present
+
+        copy_data = CopyFileData(
+            input_path=infile,
+            output_path=outfile,
+            relative_input_path=Path("input.txt"),
+        )
+
+        with patch("clm.infrastructure.backends.local_ops_backend.shutil.copyfile") as mock_copy:
+            async with ConcreteLocalOpsBackend() as backend:
+                await backend.copy_file_to_output(copy_data)
+
+            mock_copy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_skips_when_identical(self, tmp_path, monkeypatch):
+        """With the flag set and the destination already holding identical
+        content, ``shutil.copyfile`` is never called."""
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+
+        infile = tmp_path / "input.txt"
+        outfile = tmp_path / "output.txt"
+        infile.write_bytes(b"hello")
+        outfile.write_bytes(b"hello")
+        mtime_before = outfile.stat().st_mtime_ns
+
+        copy_data = CopyFileData(
+            input_path=infile,
+            output_path=outfile,
+            relative_input_path=Path("input.txt"),
+        )
+
+        with patch("clm.infrastructure.backends.local_ops_backend.shutil.copyfile") as mock_copy:
+            async with ConcreteLocalOpsBackend() as backend:
+                await backend.copy_file_to_output(copy_data)
+
+            mock_copy.assert_not_called()
+
+        assert outfile.stat().st_mtime_ns == mtime_before
+        assert outfile.read_bytes() == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_copies_when_content_differs(self, tmp_path, monkeypatch):
+        """With the flag set but the destination's content differs, the
+        copy still runs."""
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+
+        infile = tmp_path / "input.txt"
+        outfile = tmp_path / "output.txt"
+        infile.write_bytes(b"new content")
+        outfile.write_bytes(b"old content")
+
+        copy_data = CopyFileData(
+            input_path=infile,
+            output_path=outfile,
+            relative_input_path=Path("input.txt"),
+        )
+
+        async with ConcreteLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(copy_data)
+
+        assert outfile.read_bytes() == b"new content"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_copies_when_dest_does_not_exist(self, tmp_path, monkeypatch):
+        """First-time write to a missing destination is unaffected by
+        the flag."""
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+
+        infile = tmp_path / "input.txt"
+        outfile = tmp_path / "subdir" / "output.txt"
+        infile.write_bytes(b"hello")
+
+        copy_data = CopyFileData(
+            input_path=infile,
+            output_path=outfile,
+            relative_input_path=Path("input.txt"),
+        )
+
+        async with ConcreteLocalOpsBackend() as backend:
+            await backend.copy_file_to_output(copy_data)
+
+        assert outfile.exists()
+        assert outfile.read_bytes() == b"hello"

--- a/tests/infrastructure/backends/test_output_dedup_integration.py
+++ b/tests/infrastructure/backends/test_output_dedup_integration.py
@@ -477,3 +477,142 @@ class TestSqliteWorkerReadbackRegistry:
             assert entry.first_writer_source == Path("src/topic_a.py")
         finally:
             await backend.shutdown()
+
+
+class TestSqliteCacheHitReplayHashAware:
+    """PR1 of git-friendly output design: hash-aware skip in cache-replay.
+
+    When the destination on disk already holds the same bytes the cache
+    replay would write (typically a leftover from a prior build),
+    ``CLM_HASH_AWARE_WRITES`` lets us skip ``atomic_write_bytes`` so the
+    file's mtime is preserved and git's stat-cache stays valid.
+    """
+
+    async def test_flag_off_writes_even_when_identical(
+        self, _sqlite_temp_db, _sqlite_workspace, monkeypatch
+    ):
+        monkeypatch.delenv("CLM_HASH_AWARE_WRITES", raising=False)
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="x",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_a.py",
+                content_hash="h1",
+            )
+
+            output_path = _sqlite_workspace / "output" / "topic.ipynb"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"cached payload")
+            mtime_before = output_path.stat().st_mtime_ns
+
+            time.sleep(0.05)
+            await backend.execute_operation(_MockOp(), _MockPayload())
+
+            assert output_path.stat().st_mtime_ns != mtime_before
+            assert output_path.read_bytes() == b"cached payload"
+        finally:
+            await backend.shutdown()
+
+    async def test_flag_on_skips_when_identical(
+        self, _sqlite_temp_db, _sqlite_workspace, monkeypatch
+    ):
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="x",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_a.py",
+                content_hash="h1",
+            )
+
+            output_path = _sqlite_workspace / "output" / "topic.ipynb"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"cached payload")
+            mtime_before = output_path.stat().st_mtime_ns
+
+            time.sleep(0.05)
+            await backend.execute_operation(_MockOp(), _MockPayload())
+
+            assert output_path.stat().st_mtime_ns == mtime_before
+            # Registry still records the intent so the future stray-file
+            # sweep knows this path was produced by the build.
+            entry = backend.output_write_registry.get(output_path)
+            assert entry is not None
+        finally:
+            await backend.shutdown()
+
+    async def test_flag_on_writes_when_content_differs(
+        self, _sqlite_temp_db, _sqlite_workspace, monkeypatch
+    ):
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="x",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_a.py",
+                content_hash="h1",
+            )
+
+            output_path = _sqlite_workspace / "output" / "topic.ipynb"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"stale content")
+
+            await backend.execute_operation(_MockOp(), _MockPayload())
+
+            assert output_path.read_bytes() == b"cached payload"
+        finally:
+            await backend.shutdown()
+
+    async def test_flag_on_writes_when_dest_missing(
+        self, _sqlite_temp_db, _sqlite_workspace, monkeypatch
+    ):
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+        backend = SqliteBackend(
+            db_path=_sqlite_temp_db,
+            workspace_path=_sqlite_workspace,
+            ignore_db=False,
+            incremental=False,
+            skip_worker_check=True,
+        )
+        try:
+            backend.db_manager = Mock()
+            backend.db_manager.get_result.return_value = _MockResult(
+                correlation_id="x",
+                output_file="output/topic.ipynb",
+                input_file="src/topic_a.py",
+                content_hash="h1",
+            )
+
+            (_sqlite_workspace / "output").mkdir(parents=True, exist_ok=True)
+            output_path = _sqlite_workspace / "output" / "topic.ipynb"
+            assert not output_path.exists()
+
+            await backend.execute_operation(_MockOp(), _MockPayload())
+
+            assert output_path.read_bytes() == b"cached payload"
+        finally:
+            await backend.shutdown()

--- a/tests/integration/test_hash_aware_writes_pipeline.py
+++ b/tests/integration/test_hash_aware_writes_pipeline.py
@@ -1,0 +1,299 @@
+"""Integration tests for the git-friendly hash-aware-writes feature (PR1).
+
+These exercise the cross-build mtime-preservation property through both
+write call sites that PR1 affects:
+
+- :meth:`LocalOpsBackend.copy_file_to_output` — used for plain file
+  copies (data files, asset files, dir-group leaf files).
+- :class:`SqliteBackend` cache-hit replay — used for processed worker
+  outputs (notebooks, plantuml, drawio) on rebuilds.
+
+The shape of each test is: do a "build 1" that populates the output
+tree, snapshot every output file's mtime_ns + size, then do a "build
+2" through the same code path with ``CLM_HASH_AWARE_WRITES=1`` set,
+and assert that unchanged files keep their mtime — the signal git
+relies on to keep its stat-cache valid.
+
+Mtime granularity on NTFS is 100ns; the tests sleep 50ms between
+builds so a real second write would visibly advance the timestamp.
+
+These run in the fast suite. They are integration-flavored (cross
+two-build flow, two backend instances, real filesystem) but they
+neither spin up workers nor invoke the CLI, so they complete in well
+under a second and provide useful pre-commit signal.
+"""
+
+from __future__ import annotations
+
+import gc
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from attrs import frozen
+
+from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
+from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+from clm.infrastructure.database.schema import init_database
+from clm.infrastructure.messaging.base_classes import Payload, Result
+from clm.infrastructure.operation import Operation
+from clm.infrastructure.utils.copy_file_data import CopyFileData
+
+
+class _Backend(LocalOpsBackend):
+    async def execute_operation(self, operation, payload):
+        pass
+
+    async def wait_for_completion(self, all_submitted=None) -> bool:
+        return True
+
+
+def _copy_data(source: Path, out: Path, base: Path) -> CopyFileData:
+    return CopyFileData(
+        input_path=source,
+        output_path=out,
+        relative_input_path=source.relative_to(base),
+    )
+
+
+def _snapshot(paths: list[Path]) -> dict[Path, tuple[int, int]]:
+    """Return {path: (size, mtime_ns)} for every existing path."""
+    return {p: (p.stat().st_size, p.stat().st_mtime_ns) for p in paths if p.exists()}
+
+
+class TestCopyFileToOutputMtimePreservation:
+    """Site 1: ``LocalOpsBackend.copy_file_to_output``. Two consecutive
+    "builds" that copy the same source files to the same outputs — with
+    the flag on, the second pass preserves mtimes."""
+
+    async def test_flag_off_rewrites_every_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLM_HASH_AWARE_WRITES", raising=False)
+        sources = []
+        outs = []
+        for i in range(8):
+            src = tmp_path / f"src_{i}.txt"
+            out = tmp_path / "out" / f"out_{i}.txt"
+            src.write_bytes(f"content {i}".encode())
+            sources.append(src)
+            outs.append(out)
+
+        async with _Backend() as build1:
+            for src, out in zip(sources, outs, strict=True):
+                await build1.copy_file_to_output(_copy_data(src, out, tmp_path))
+        before = _snapshot(outs)
+
+        time.sleep(0.05)
+
+        async with _Backend() as build2:
+            for src, out in zip(sources, outs, strict=True):
+                await build2.copy_file_to_output(_copy_data(src, out, tmp_path))
+        after = _snapshot(outs)
+
+        # Every file's mtime advanced — no hash-aware skip in play.
+        assert all(after[p][1] != before[p][1] for p in outs)
+
+    async def test_flag_on_preserves_unchanged_files(self, tmp_path, monkeypatch):
+        sources = []
+        outs = []
+        for i in range(8):
+            src = tmp_path / f"src_{i}.txt"
+            out = tmp_path / "out" / f"out_{i}.txt"
+            src.write_bytes(f"content {i}".encode())
+            sources.append(src)
+            outs.append(out)
+
+        # Build 1 populates the output tree (flag value irrelevant here —
+        # dest doesn't exist yet, so the skip path can't fire).
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+        async with _Backend() as build1:
+            for src, out in zip(sources, outs, strict=True):
+                await build1.copy_file_to_output(_copy_data(src, out, tmp_path))
+        before = _snapshot(outs)
+
+        time.sleep(0.05)
+
+        # Build 2 — every dest already holds identical content → all skips.
+        async with _Backend() as build2:
+            for src, out in zip(sources, outs, strict=True):
+                await build2.copy_file_to_output(_copy_data(src, out, tmp_path))
+        after = _snapshot(outs)
+
+        assert all(after[p] == before[p] for p in outs), (
+            f"expected every file's (size, mtime_ns) preserved, got diffs at "
+            f"{[p for p in outs if after[p] != before[p]]}"
+        )
+
+    async def test_flag_on_rewrites_only_modified_source(self, tmp_path, monkeypatch):
+        sources = []
+        outs = []
+        for i in range(5):
+            src = tmp_path / f"src_{i}.txt"
+            out = tmp_path / "out" / f"out_{i}.txt"
+            src.write_bytes(f"content {i}".encode())
+            sources.append(src)
+            outs.append(out)
+
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+        async with _Backend() as build1:
+            for src, out in zip(sources, outs, strict=True):
+                await build1.copy_file_to_output(_copy_data(src, out, tmp_path))
+        before = _snapshot(outs)
+
+        time.sleep(0.05)
+
+        # Modify just one source — its output must get a fresh mtime,
+        # the others must stay frozen.
+        sources[2].write_bytes(b"genuinely new content for #2")
+
+        async with _Backend() as build2:
+            for src, out in zip(sources, outs, strict=True):
+                await build2.copy_file_to_output(_copy_data(src, out, tmp_path))
+        after = _snapshot(outs)
+
+        modified_out = outs[2]
+        assert after[modified_out][1] != before[modified_out][1]
+        assert after[modified_out][0] != before[modified_out][0]  # size also differs
+        for i, out in enumerate(outs):
+            if i == 2:
+                continue
+            assert after[out] == before[out], f"unchanged file {out} was rewritten"
+
+
+@frozen
+class _MockOp(Operation):
+    @property
+    def service_name(self) -> str:
+        return "notebook-processor"
+
+    async def execute(self, backend, *args, **kwargs):
+        pass
+
+
+class _MockPayload(Payload):
+    correlation_id: str = "cid"
+    input_file: str = "src/topic.py"
+    input_file_name: str = "topic.py"
+    output_file: str = "output/topic.ipynb"
+    data: str = ""
+
+
+class _MockResult(Result):
+    data: bytes = b"cached notebook bytes"
+
+    def result_bytes(self) -> bytes:
+        return self.data
+
+    def output_metadata(self) -> str:
+        return "default"
+
+
+@pytest.fixture
+def _sqlite_temp_db():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = Path(f.name)
+    init_database(db_path)
+    yield db_path
+    gc.collect()
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.close()
+    except Exception:
+        pass
+    for attempt in range(3):
+        try:
+            db_path.unlink(missing_ok=True)
+            for suffix in ("-wal", "-shm"):
+                Path(str(db_path) + suffix).unlink(missing_ok=True)
+            break
+        except PermissionError:
+            if attempt < 2:
+                time.sleep(0.1)
+
+
+@pytest.fixture
+def _sqlite_workspace():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+def _new_sqlite_backend(db_path: Path, workspace: Path) -> SqliteBackend:
+    backend = SqliteBackend(
+        db_path=db_path,
+        workspace_path=workspace,
+        ignore_db=False,
+        incremental=False,
+        skip_worker_check=True,
+    )
+    backend.db_manager = Mock()
+    backend.db_manager.get_result.return_value = _MockResult(
+        correlation_id="cid",
+        output_file="output/topic.ipynb",
+        input_file="src/topic.py",
+        content_hash="h1",
+    )
+    return backend
+
+
+class TestSqliteCacheReplayMtimePreservation:
+    """Site 3: ``SqliteBackend`` cache-hit replay. The hot path for
+    rebuilds — every cached notebook/plantuml/drawio output replays
+    through here. Hash-aware skip must preserve mtime on the second
+    build."""
+
+    async def test_flag_on_preserves_mtime_when_identical(
+        self, _sqlite_temp_db, _sqlite_workspace, monkeypatch
+    ):
+        monkeypatch.setenv("CLM_HASH_AWARE_WRITES", "1")
+
+        (_sqlite_workspace / "output").mkdir(parents=True, exist_ok=True)
+        output_path = _sqlite_workspace / "output" / "topic.ipynb"
+
+        # Build 1.
+        build1 = _new_sqlite_backend(_sqlite_temp_db, _sqlite_workspace)
+        try:
+            await build1.execute_operation(_MockOp(), _MockPayload())
+        finally:
+            await build1.shutdown()
+        before = (output_path.stat().st_size, output_path.stat().st_mtime_ns)
+
+        time.sleep(0.05)
+
+        # Build 2 — fresh backend (fresh registry); dest already has
+        # the cached bytes → hash-aware skip → mtime preserved.
+        build2 = _new_sqlite_backend(_sqlite_temp_db, _sqlite_workspace)
+        try:
+            await build2.execute_operation(_MockOp(), _MockPayload())
+        finally:
+            await build2.shutdown()
+        after = (output_path.stat().st_size, output_path.stat().st_mtime_ns)
+
+        assert after == before
+
+    async def test_flag_off_rewrites_even_when_identical(
+        self, _sqlite_temp_db, _sqlite_workspace, monkeypatch
+    ):
+        monkeypatch.delenv("CLM_HASH_AWARE_WRITES", raising=False)
+
+        (_sqlite_workspace / "output").mkdir(parents=True, exist_ok=True)
+        output_path = _sqlite_workspace / "output" / "topic.ipynb"
+
+        build1 = _new_sqlite_backend(_sqlite_temp_db, _sqlite_workspace)
+        try:
+            await build1.execute_operation(_MockOp(), _MockPayload())
+        finally:
+            await build1.shutdown()
+        mtime_before = output_path.stat().st_mtime_ns
+
+        time.sleep(0.05)
+
+        build2 = _new_sqlite_backend(_sqlite_temp_db, _sqlite_workspace)
+        try:
+            await build2.execute_operation(_MockOp(), _MockPayload())
+        finally:
+            await build2.shutdown()
+
+        assert output_path.stat().st_mtime_ns != mtime_before


### PR DESCRIPTION
## Summary

PR1 of the [git-friendly output-writes design](docs/claude/design/git-friendly-output-writes.md). Adds a stat+hash check at the two registry-aware disk-write sites so the destination's mtime is preserved when the on-disk content already matches what the build would write — which is what keeps git's stat-cache valid for course output trees on rebuilds.

Ships as a runtime **no-op** unless `CLM_HASH_AWARE_WRITES=1` (also accepts `true`/`yes`/`on`) is set. Safe to land independently of PR2 (stray-file sweep) and PR3 (default flip + `--clean` flag).

## What's in the PR

- `OutputWriteRegistry.is_destination_identical()` — cheap-path query: non-existence → False, size mismatch → False (no hash), above hash limit → False, then BLAKE2b-128 compare.
- `hash_aware_writes_enabled()` helper reading `CLM_HASH_AWARE_WRITES`.
- Skip wiring at the two leveraged write sites:
  - `LocalOpsBackend.copy_file_to_output` — most data/asset file copies
  - `SqliteBackend` cache-hit replay (`execute_operation`) — every cached worker output on rebuilds (the hot path)
- Workers' direct writes (`SqliteBackend` worker-readback site) and `shutil.copytree` dir-group copies are documented as out of scope; see the design's [Resolved D1](docs/claude/design/git-friendly-output-writes.md#edge-cases-and-open-questions) for rationale.

Out of scope: end-of-build stray-file sweep (PR2), `--clean`/`--no-sweep` flags + default flip (PR3).

## Test plan

- [x] 24 new tests across:
  - `tests/core/test_output_write_registry.py::TestIsDestinationIdentical` (11) — pure-query semantics including no-hash-on-size-mismatch, above-limit short-circuit, contract errors, and "doesn't modify registry state".
  - `tests/infrastructure/backends/test_local_ops_backend_extended.py::TestCopyFileToOutputHashAware` (4) — flag off/on × identical/differing/missing-dest.
  - `tests/infrastructure/backends/test_output_dedup_integration.py::TestSqliteCacheHitReplayHashAware` (4) — same matrix at the cache-replay site.
  - `tests/integration/test_hash_aware_writes_pipeline.py` (5) — cross-build mtime preservation through both write sites.
- [x] Local `ruff check`, `ruff format --check`, `mypy src/`, fast `pytest` all green (4840 passed).
- [x] Pre-commit hook runs all of the above and passed on the commit.

## Manual smoke (after merge, before flipping default)

- [ ] Set `CLM_HASH_AWARE_WRITES=1` in a course-build environment, run two consecutive `clm build --keep-directory` invocations, verify `git status` is sub-second after the second build.
- [ ] Compare on-disk mtimes before/after the second build for a sampling of notebook outputs — expect them to be unchanged.

## Deviations from the design doc

- `WriteOutcome.UNCHANGED_ON_DISK` enum variant deferred — would be dead code without a consumer; trivial to add when a future plumbing-back design needs it.
- Cross-build mtime integration test is **not** marked `@pytest.mark.integration` — backend-level simulation runs in ~0.3s and is more valuable as pre-commit signal than as CI-gated. A real `clm build`-driven integration test is planned for PR3 once the default flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)