### PR TITLE
feat(cli): post-build stray-file sweep (PR2/3 of git-friendly output writes)

### DIFF
--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -48,6 +48,28 @@ logger = get_logger(__name__)
 VALID_HTTP_REPLAY_MODES = ("replay", "once", "new-episodes", "refresh", "disabled")
 
 
+_ENV_OUTPUT_SWEEP = "CLM_OUTPUT_SWEEP"
+
+
+def _resolve_sweep_opt_in(no_sweep: bool) -> bool:
+    """Resolve whether the post-build stray-file sweep should run.
+
+    During the D2 rollout the sweep defaults to off; opt in via
+    ``CLM_OUTPUT_SWEEP=1`` (also accepts ``true``/``yes``/``on``,
+    case-insensitive). The ``--no-sweep`` flag always wins.
+
+    When D3 flips the default this helper goes away — the CLI flag
+    will wire directly into ``BuildConfig.sweep`` and the env var
+    becomes unnecessary.
+    """
+    import os
+
+    if no_sweep:
+        return False
+    raw = os.environ.get(_ENV_OUTPUT_SWEEP, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 def _resolve_http_replay_mode(cli_value: str | None) -> str:
     """Resolve the effective HTTP replay mode for this build.
 
@@ -155,6 +177,13 @@ class BuildConfig:
 
     # Incremental build mode
     incremental: bool = False  # Only write newly processed files, skip cached ones
+
+    # Stray-file sweep at end of build (Feature D2 of git-friendly output
+    # writes). Defaults to ``False`` during rollout: the wipe-and-restore
+    # flow that runs today already removes stale files, so the sweep is
+    # only meaningful once that flow is replaced (D3). Set to ``True``
+    # opt-in via the absence of ``--no-sweep`` once D3 lands.
+    sweep: bool = False
 
     # --only-sections selector tokens (raw, with prefixes preserved for
     # error messages). None or empty list means full build. Non-empty means
@@ -693,6 +722,69 @@ def _compute_section_dirs_for_cleanup(course: Course) -> list[Path]:
     return directories
 
 
+def _maybe_run_sweep(
+    *,
+    config: BuildConfig,
+    root_dirs: list[Path],
+    backend,
+    build_reporter: BuildReporter,
+    only_sections_mode: bool,
+) -> None:
+    """Invoke the stray-file sweep when the build config opts in.
+
+    The sweep is deliberately conservative — it skips itself whenever
+    correctness would be at risk:
+
+    - ``config.sweep`` is False (the default during D2 rollout).
+    - ``--only-sections`` mode is active: that mode has its own narrower
+      cleanup scope (section subdirs only); a full-root sweep would
+      delete files for unselected sections.
+    - Watch mode (``--watch``): event-driven rebuilds populate only the
+      changed files; the sweep would delete everything else.
+    - The build recorded fatal errors: the registry is missing entries
+      for writes that never happened, so sweeping would remove valid
+      files from prior successful builds.
+    """
+    from clm.cli.output_sweep import sweep_stray_files
+
+    if not config.sweep:
+        return
+
+    skip_reason: str | None = None
+    if only_sections_mode:
+        skip_reason = "--only-sections mode has its own cleanup scope"
+    elif config.watch:
+        skip_reason = "watch mode populates only changed files"
+    elif build_reporter.errors:
+        skip_reason = (
+            f"build recorded {len(build_reporter.errors)} error(s); "
+            f"sweep skipped to avoid removing files from prior successful builds"
+        )
+
+    report = sweep_stray_files(
+        root_dirs,
+        backend.output_write_registry,
+        image_registry=getattr(backend, "image_registry", None),
+        skip_reason=skip_reason,
+    )
+
+    if report.skipped:
+        logger.info(f"Stray-file sweep skipped: {report.skip_reason}")
+        return
+
+    if report.deleted_files or report.removed_dirs:
+        logger.info(
+            f"Stray-file sweep removed {len(report.deleted_files)} file(s) "
+            f"and {len(report.removed_dirs)} empty directory/ies"
+        )
+        for path in report.deleted_files:
+            logger.debug(f"Sweep deleted file: {path}")
+        for path in report.removed_dirs:
+            logger.debug(f"Sweep removed empty dir: {path}")
+    else:
+        logger.debug("Stray-file sweep found no orphans")
+
+
 async def process_course_with_backend(
     course: Course,
     root_dirs: list[Path],
@@ -759,6 +851,13 @@ async def process_course_with_backend(
             # totals (and any output_path_conflict warnings) appear
             # exactly once per build.
             build_reporter.report_output_writes(backend.output_write_registry)
+            _maybe_run_sweep(
+                config=config,
+                root_dirs=root_dirs,
+                backend=backend,
+                build_reporter=build_reporter,
+                only_sections_mode=only_sections_mode,
+            )
             build_reporter.finish_build()
             build_reporter.cleanup()
 
@@ -916,6 +1015,7 @@ async def main_build(
     clear_cache,
     keep_directory,
     incremental,
+    no_sweep,
     only_sections,
     workers,
     notebook_workers,
@@ -1001,6 +1101,7 @@ async def main_build(
         image_format=image_format,
         inline_images=inline_images,
         incremental=incremental,
+        sweep=_resolve_sweep_opt_in(no_sweep),
         selected_sections=selected_sections,
     )
 
@@ -1048,6 +1149,7 @@ async def main_build(
                 ignore_db=config.ignore_cache,
                 build_reporter=build_reporter,
                 incremental=config.incremental,
+                image_registry=course.image_registry,
             )
 
             async with backend:
@@ -1135,6 +1237,17 @@ async def main_build(
     "--incremental",
     is_flag=True,
     help="Incremental build: keep directories and only write newly processed files (skip cached ones).",
+)
+@click.option(
+    "--no-sweep",
+    is_flag=True,
+    help=(
+        "Disable the post-build stray-file sweep. The sweep removes files "
+        "under each output root that the build did not write (e.g. orphans "
+        "from a renamed section). Currently the sweep is off by default; "
+        "this flag is the forward-compatible way to keep it off once the "
+        "default flips in a later release."
+    ),
 )
 @click.option(
     "--only-sections",
@@ -1288,6 +1401,7 @@ def build(
     clear_cache,
     keep_directory,
     incremental,
+    no_sweep,
     only_sections,
     workers,
     notebook_workers,
@@ -1366,6 +1480,7 @@ def build(
             clear_cache,
             keep_directory,
             incremental,
+            no_sweep,
             only_sections,
             workers,
             notebook_workers,

--- a/src/clm/cli/output_sweep.py
+++ b/src/clm/cli/output_sweep.py
@@ -1,0 +1,281 @@
+"""End-of-build stray-file sweep.
+
+After all build stages complete, the :class:`OutputWriteRegistry`
+plus the :class:`ImageRegistry` together describe the complete set of
+files the build *intended* to populate under each root directory.
+Anything else in the tree is a leftover from a previous build (renamed
+section, removed topic) or a hand-placed file. This module's
+:func:`sweep_stray_files` walks each root and removes those leftovers
+so that subsequent ``git status`` calls do not see a mix of current
+and stale artifacts.
+
+The sweep is intentionally strict — the design principle is that
+**everything in an output directory is owned by ``clm build``**. The
+only path the sweep refuses to touch is ``.git/`` (so a course-output
+git repo survives across builds) and any subtree that contains its
+own ``.git/`` directory (nested repos are treated as opaque). Other
+files — even ``.gitignore``, ``README.md``, editor caches — are
+swept; if a course genuinely needs an auxiliary file at the root of
+its output, the right answer is for ``clm`` to generate it.
+
+This module has no dependency on the build pipeline; the caller
+(``build.py``) decides when to invoke the sweep (e.g. skipping it in
+``--only-sections`` mode, in watch mode, or when stages have errored).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from attrs import Factory, define, field, frozen
+
+if TYPE_CHECKING:
+    from clm.core.image_registry import ImageRegistry
+    from clm.core.output_write_registry import OutputWriteRegistry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_KEEP_PATTERNS: tuple[str, ...] = (".git/**",)
+"""Only ``.git/**`` is protected from the sweep by default.
+
+The output tree is exclusively CLM's: authors should never hand-place
+auxiliary files (``.gitignore``, ``README.md``, editor caches) there.
+``SKIP_DIRS_FOR_OUTPUT``/``SKIP_DIRS_PATTERNS``/``SKIP_OUTPUT_FILE_GLOBS``
+from ``path_utils.py`` are **deliberately not included** here — those
+patterns mark auto-generated junk or content withheld from students,
+and the sweep should remove them if they appear under an output root.
+"""
+
+
+@frozen
+class SweepReport:
+    """Outcome of a single sweep run."""
+
+    deleted_files: list[Path] = Factory(list)
+    """Absolute paths of files deleted from the output tree."""
+
+    removed_dirs: list[Path] = Factory(list)
+    """Absolute paths of directories removed because they became empty."""
+
+    kept_due_to_pattern: int = 0
+    """Number of files kept solely because they matched ``keep_patterns``."""
+
+    skipped_subtrees: list[Path] = Factory(list)
+    """Subtrees skipped entirely because they contained a nested ``.git/``."""
+
+    skipped: bool = False
+    """Set to ``True`` when the sweep was a no-op (e.g. stage errors)."""
+
+    skip_reason: str | None = None
+    """Human-readable reason ``skipped`` is ``True``."""
+
+    dry_run: bool = False
+    """Set to ``True`` when no filesystem changes were performed."""
+
+
+@define
+class _SweepState:
+    """Mutable counters threaded through the recursive walk."""
+
+    deleted_files: list[Path] = field(factory=list)
+    removed_dirs: list[Path] = field(factory=list)
+    skipped_subtrees: list[Path] = field(factory=list)
+    kept_due_to_pattern: int = 0
+
+
+def _matches_keep_pattern(rel_path: str, patterns: Iterable[str]) -> bool:
+    """Return True iff ``rel_path`` matches any of ``patterns``.
+
+    Uses :func:`fnmatch.fnmatchcase` on POSIX-style paths. Both
+    ``.git/**`` and ``.git/*`` will match files anywhere under a
+    top-level ``.git`` directory.
+    """
+    # Normalize to POSIX-style separators so patterns like ".git/**"
+    # match on Windows where Path.relative_to yields backslashes.
+    posix_rel = rel_path.replace(os.sep, "/")
+    for pattern in patterns:
+        if fnmatch.fnmatchcase(posix_rel, pattern):
+            return True
+        # fnmatch's "**" does not span path segments the way glob does,
+        # so we also accept the prefix-match interpretation: a pattern
+        # ending in "/**" matches anything under that prefix.
+        if pattern.endswith("/**"):
+            prefix = pattern[:-3]
+            if posix_rel == prefix or posix_rel.startswith(prefix + "/"):
+                return True
+    return False
+
+
+def _has_nested_git(directory: Path) -> bool:
+    """Return True iff ``directory`` itself contains a ``.git`` entry.
+
+    Treats both ``.git/`` directories and ``.git`` worktree files (used
+    for nested git worktrees) as nested-repo markers.
+    """
+    try:
+        return (directory / ".git").exists()
+    except OSError:
+        return False
+
+
+def sweep_stray_files(
+    root_dirs: Iterable[Path],
+    output_write_registry: OutputWriteRegistry,
+    image_registry: ImageRegistry | None = None,
+    *,
+    keep_patterns: Iterable[str] = DEFAULT_KEEP_PATTERNS,
+    dry_run: bool = False,
+    skip_reason: str | None = None,
+) -> SweepReport:
+    """Walk each root and delete files not in the registries' tracked sets.
+
+    Args:
+        root_dirs: Output roots to walk. Each is treated independently;
+            symlinks are not followed across roots.
+        output_write_registry: Registry whose ``entries`` keys are the
+            absolute output paths the build wrote.
+        image_registry: Optional sibling registry whose ``tracked_paths``
+            covers ``img/`` outputs (excluded from the
+            ``OutputWriteRegistry``). When ``None``, image paths under
+            any root will be treated as stray — pass the build's
+            ``ImageRegistry`` to avoid that.
+        keep_patterns: POSIX-style fnmatch patterns the sweep will not
+            touch even if absent from the registries. Defaults to
+            ``.git/**`` only.
+        dry_run: When ``True``, no deletions occur; the returned report
+            still lists what *would* be removed.
+        skip_reason: When non-``None``, the sweep is a no-op and the
+            reason is surfaced in the report. Used by callers that
+            detect stage errors or other guard conditions and want a
+            uniform "no-op" report.
+    """
+    if skip_reason is not None:
+        return SweepReport(skipped=True, skip_reason=skip_reason, dry_run=dry_run)
+
+    expected: set[Path] = set(output_write_registry.entries.keys())
+    if image_registry is not None:
+        expected.update(image_registry.tracked_paths)
+
+    state = _SweepState()
+
+    for root in root_dirs:
+        if not root.exists():
+            continue
+        if not root.is_dir():
+            logger.warning("Sweep: skipping non-directory root %s", root)
+            continue
+        _sweep_directory(
+            root,
+            root,
+            expected,
+            keep_patterns=tuple(keep_patterns),
+            dry_run=dry_run,
+            state=state,
+        )
+
+    return SweepReport(
+        deleted_files=state.deleted_files,
+        removed_dirs=state.removed_dirs,
+        skipped_subtrees=state.skipped_subtrees,
+        kept_due_to_pattern=state.kept_due_to_pattern,
+        dry_run=dry_run,
+    )
+
+
+def _sweep_directory(
+    directory: Path,
+    root: Path,
+    expected: set[Path],
+    *,
+    keep_patterns: tuple[str, ...],
+    dry_run: bool,
+    state: _SweepState,
+) -> bool:
+    """Recursively sweep ``directory``. Returns True iff it became empty.
+
+    A directory becomes empty if all entries it contains were deleted
+    by the sweep (or it was empty to begin with). The caller may then
+    remove it.
+
+    Subtrees containing a nested ``.git/`` are skipped entirely.
+    """
+    try:
+        entries = list(os.scandir(directory))
+    except OSError as exc:
+        logger.warning("Sweep: cannot scan %s: %s", directory, exc)
+        return False
+
+    became_empty = True
+
+    for entry in entries:
+        entry_path = Path(entry.path)
+        try:
+            rel = entry_path.relative_to(root)
+        except ValueError:
+            became_empty = False
+            continue
+        rel_posix = rel.as_posix()
+
+        is_dir = entry.is_dir(follow_symlinks=False)
+        is_file_or_symlink = entry.is_file(follow_symlinks=False) or entry.is_symlink()
+
+        if is_dir and entry.name == ".git":
+            # Top-level (relative to root) or nested .git directory: leave entirely alone.
+            became_empty = False
+            continue
+
+        if _matches_keep_pattern(rel_posix, keep_patterns):
+            state.kept_due_to_pattern += 1
+            became_empty = False
+            continue
+
+        if is_dir:
+            if _has_nested_git(entry_path):
+                logger.debug("Sweep: skipping nested git repo at %s", entry_path)
+                state.skipped_subtrees.append(entry_path)
+                became_empty = False
+                continue
+            child_empty = _sweep_directory(
+                entry_path,
+                root,
+                expected,
+                keep_patterns=keep_patterns,
+                dry_run=dry_run,
+                state=state,
+            )
+            if child_empty:
+                if not dry_run:
+                    try:
+                        entry_path.rmdir()
+                    except OSError as exc:
+                        logger.warning("Sweep: cannot remove empty dir %s: %s", entry_path, exc)
+                        became_empty = False
+                        continue
+                state.removed_dirs.append(entry_path)
+            else:
+                became_empty = False
+            continue
+
+        if is_file_or_symlink:
+            if entry_path in expected:
+                became_empty = False
+                continue
+            if not dry_run:
+                try:
+                    entry_path.unlink()
+                except OSError as exc:
+                    logger.warning("Sweep: cannot remove %s: %s", entry_path, exc)
+                    became_empty = False
+                    continue
+            state.deleted_files.append(entry_path)
+            continue
+
+        # Anything else (block device, fifo, …) — leave alone.
+        became_empty = False
+
+    return became_empty

--- a/src/clm/core/image_registry.py
+++ b/src/clm/core/image_registry.py
@@ -71,10 +71,16 @@ class ImageRegistry:
     Attributes:
         _images: Mapping from relative path (from img/) to source path
         _collisions: List of detected collisions
+        _output_paths: Absolute output paths the build has written image bytes to.
+            Tracked separately from ``_images`` (which is keyed by source) so the
+            stray-file sweep can include image destinations in its "expected"
+            set. ``OutputWriteRegistry`` deliberately skips ``img/`` paths, so
+            without this tracking the sweep would treat every image as stray.
     """
 
     _images: dict[str, Path] = Factory(dict)
     _collisions: list[ImageCollision] = Factory(list)
+    _output_paths: set[Path] = Factory(set)
 
     def register(self, source_path: Path) -> None:
         """Register an image file, detecting collisions with different content.
@@ -134,6 +140,22 @@ class ImageRegistry:
             # If we can't read the files, assume they're different to be safe
             return False
 
+    def record_output_write(self, output_path: Path) -> None:
+        """Record that the build wrote (or intends to write) an image to ``output_path``.
+
+        ``output_path`` must be absolute. The sweep takes the union of
+        :class:`clm.core.output_write_registry.OutputWriteRegistry` paths
+        and these image paths as the set of expected output files.
+        """
+        if not output_path.is_absolute():
+            raise ValueError(f"output_path must be absolute: {output_path}")
+        self._output_paths.add(output_path)
+
+    @property
+    def tracked_paths(self) -> frozenset[Path]:
+        """Snapshot of absolute output paths recorded via :meth:`record_output_write`."""
+        return frozenset(self._output_paths)
+
     @property
     def collisions(self) -> list[ImageCollision]:
         """Return list of detected collisions."""
@@ -149,6 +171,7 @@ class ImageRegistry:
         return len(self._collisions) > 0
 
     def clear(self) -> None:
-        """Clear all registered images and collisions."""
+        """Clear all registered images, collisions, and output paths."""
         self._images.clear()
         self._collisions.clear()
+        self._output_paths.clear()

--- a/src/clm/infrastructure/backend.py
+++ b/src/clm/infrastructure/backend.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from attrs import define, field
 
+from clm.core.image_registry import ImageRegistry
 from clm.core.output_write_registry import OutputWriteRegistry
 
 if TYPE_CHECKING:
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 @define
 class Backend(AbstractAsyncContextManager):
     output_write_registry: OutputWriteRegistry = field(factory=OutputWriteRegistry)
+    image_registry: ImageRegistry = field(factory=ImageRegistry)
 
     @abstractmethod
     async def execute_operation(self, operation: "Operation", payload: "Payload") -> None: ...

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -65,6 +65,9 @@ class LocalOpsBackend(Backend, ABC):
         # have their own collision channel via ImageRegistry. The source
         # must exist; if not, defer the FileNotFoundError to the sync
         # path so the error message stays consistent.
+        if copy_data.input_path.exists() and is_image_path(copy_data.input_path):
+            abs_output = output_path if output_path.is_absolute() else output_path.resolve()
+            self.image_registry.record_output_write(abs_output)
         if copy_data.input_path.exists() and not is_image_path(copy_data.input_path):
             abs_output = output_path if output_path.is_absolute() else output_path.resolve()
             write_result = self.output_write_registry.record_write(

--- a/tests/cli/test_output_sweep.py
+++ b/tests/cli/test_output_sweep.py
@@ -1,0 +1,390 @@
+"""Tests for the post-build stray-file sweep.
+
+The sweep removes files under each output root that the build did not
+record in either the :class:`OutputWriteRegistry` or the
+:class:`ImageRegistry`. The protected-paths surface is intentionally
+small (``.git/**`` only) so most of these tests focus on the boundary
+between "registry-tracked" and "stray".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from clm.cli.output_sweep import (
+    DEFAULT_KEEP_PATTERNS,
+    SweepReport,
+    sweep_stray_files,
+)
+from clm.core.image_registry import ImageRegistry
+from clm.core.output_write_registry import OutputWriteRegistry
+
+
+def _record(registry: OutputWriteRegistry, path: Path, content: bytes = b"x") -> None:
+    """Convenience: record ``path`` in the write registry with given bytes."""
+    registry.record_write(path, content=content, source=path)
+
+
+def _make_file(path: Path, content: bytes = b"x") -> Path:
+    """Create the file (and parents) with the given content; return path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _can_symlink_on_windows() -> bool:
+    """Probe whether the current process can create a symlink.
+
+    On Windows, ``os.symlink`` requires elevated privileges or
+    Developer Mode. The probe creates and deletes a tiny test
+    symlink; failures are silently treated as "cannot symlink".
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        target = tmp_path / "_t"
+        link = tmp_path / "_l"
+        target.write_bytes(b"")
+        try:
+            link.symlink_to(target)
+            link.unlink()
+            return True
+        except OSError:
+            return False
+
+
+@pytest.fixture
+def empty_registry() -> OutputWriteRegistry:
+    return OutputWriteRegistry()
+
+
+@pytest.fixture
+def empty_image_registry() -> ImageRegistry:
+    return ImageRegistry()
+
+
+class TestSweepDefaults:
+    """Cheapest happy paths — empty / single-file trees."""
+
+    def test_empty_registry_and_empty_tree_is_noop(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert isinstance(report, SweepReport)
+        assert report.deleted_files == []
+        assert report.removed_dirs == []
+        assert report.kept_due_to_pattern == 0
+        assert not report.skipped
+
+    def test_registry_path_present_is_kept(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        kept = _make_file(tmp_path / "section" / "lecture_01.html")
+        _record(empty_registry, kept)
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert kept.exists()
+        assert report.deleted_files == []
+        assert report.removed_dirs == []
+
+    def test_default_keep_patterns_is_only_git(self):
+        assert DEFAULT_KEEP_PATTERNS == (".git/**",)
+
+
+class TestStrayFileRemoval:
+    """The core behavior: registry-absent files get deleted."""
+
+    def test_stray_file_at_root_is_deleted(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        stray = _make_file(tmp_path / "abandoned.html")
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert not stray.exists()
+        assert stray in report.deleted_files
+
+    def test_stray_file_in_subdir_is_deleted(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        stray = _make_file(tmp_path / "old_section" / "lecture_99.html")
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert not stray.exists()
+        assert stray in report.deleted_files
+
+    def test_mixed_kept_and_stray(self, tmp_path: Path, empty_registry: OutputWriteRegistry):
+        kept = _make_file(tmp_path / "section" / "current.html")
+        stray = _make_file(tmp_path / "section" / "obsolete.html")
+        _record(empty_registry, kept)
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert kept.exists()
+        assert not stray.exists()
+        assert report.deleted_files == [stray]
+
+    def test_auxiliary_files_at_root_are_swept(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        """``.gitignore``/``README.md`` at root must be swept — the
+        principle is that the output tree is exclusively CLM's."""
+        gitignore = _make_file(tmp_path / ".gitignore", b"*.pyc\n")
+        readme = _make_file(tmp_path / "README.md", b"hand-edited")
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert not gitignore.exists()
+        assert not readme.exists()
+        assert gitignore in report.deleted_files
+        assert readme in report.deleted_files
+
+
+class TestGitDirectoryPreservation:
+    """``.git`` and its contents are never touched."""
+
+    def test_git_directory_at_root_is_preserved(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        git_dir = tmp_path / ".git"
+        git_config = _make_file(git_dir / "config", b"[core]")
+        objects = _make_file(git_dir / "objects" / "ab" / "cd1234", b"blob")
+        sweep_stray_files([tmp_path], empty_registry)
+        assert git_dir.is_dir()
+        assert git_config.exists()
+        assert objects.exists()
+
+    def test_nested_git_subtree_is_preserved(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        """A directory containing a nested ``.git/`` is treated as
+        opaque — every file inside survives, even those the sweep
+        would otherwise delete."""
+        nested_root = tmp_path / "vendored_repo"
+        _make_file(nested_root / ".git" / "HEAD", b"ref: refs/heads/main\n")
+        nested_file = _make_file(nested_root / "src" / "file.py", b"print()")
+        unrelated_stray = _make_file(tmp_path / "other_stray.txt")
+
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert nested_root.is_dir()
+        assert nested_file.exists()
+        assert not unrelated_stray.exists()
+        assert nested_root in report.skipped_subtrees
+
+    def test_git_directory_does_not_block_sibling_sweep(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        _make_file(tmp_path / ".git" / "config", b"[core]")
+        stray = _make_file(tmp_path / "section" / "stray.html")
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert not stray.exists()
+        assert (tmp_path / ".git" / "config").exists()
+        assert stray in report.deleted_files
+
+
+class TestEmptyDirectoryCleanup:
+    """Directories left empty by the sweep are removed bottom-up."""
+
+    def test_empty_dir_after_all_files_deleted_is_removed(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        section_dir = tmp_path / "old_section"
+        _make_file(section_dir / "a.html")
+        _make_file(section_dir / "b.html")
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert not section_dir.exists()
+        assert section_dir in report.removed_dirs
+
+    def test_nested_empty_dirs_removed_bottom_up(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        deep = tmp_path / "outer" / "inner" / "deepest"
+        _make_file(deep / "a.html")
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert not deep.exists()
+        assert not deep.parent.exists()
+        assert not deep.parent.parent.exists()
+        # All three intermediate directories should be reported as removed.
+        assert len(report.removed_dirs) == 3
+
+    def test_root_directory_itself_is_never_removed(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        _make_file(tmp_path / "stray.html")
+        sweep_stray_files([tmp_path], empty_registry)
+        assert tmp_path.is_dir()
+
+    def test_non_empty_dir_is_preserved(self, tmp_path: Path, empty_registry: OutputWriteRegistry):
+        keeper = _make_file(tmp_path / "section" / "current.html")
+        _record(empty_registry, keeper)
+        report = sweep_stray_files([tmp_path], empty_registry)
+        assert keeper.exists()
+        assert keeper.parent.is_dir()
+        assert report.removed_dirs == []
+
+
+class TestImageRegistryUnion:
+    """Image paths must be considered tracked via ``ImageRegistry``."""
+
+    def test_image_in_image_registry_is_kept(
+        self,
+        tmp_path: Path,
+        empty_registry: OutputWriteRegistry,
+        empty_image_registry: ImageRegistry,
+    ):
+        img = _make_file(tmp_path / "img" / "logo.png", b"\x89PNG")
+        empty_image_registry.record_output_write(img)
+        report = sweep_stray_files([tmp_path], empty_registry, image_registry=empty_image_registry)
+        assert img.exists()
+        assert report.deleted_files == []
+
+    def test_image_without_image_registry_is_swept(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        """Without an image registry the image looks stray to the sweep.
+        This is the failure mode the union prevents — the test pins it."""
+        img = _make_file(tmp_path / "img" / "logo.png", b"\x89PNG")
+        report = sweep_stray_files([tmp_path], empty_registry, image_registry=None)
+        assert not img.exists()
+        assert img in report.deleted_files
+
+    def test_stray_image_not_in_registry_is_swept(
+        self,
+        tmp_path: Path,
+        empty_registry: OutputWriteRegistry,
+        empty_image_registry: ImageRegistry,
+    ):
+        kept_img = _make_file(tmp_path / "img" / "current.png", b"\x89PNG")
+        stray_img = _make_file(tmp_path / "img" / "removed.png", b"\x89PNG")
+        empty_image_registry.record_output_write(kept_img)
+        report = sweep_stray_files([tmp_path], empty_registry, image_registry=empty_image_registry)
+        assert kept_img.exists()
+        assert not stray_img.exists()
+        assert report.deleted_files == [stray_img]
+
+
+class TestSkipReasons:
+    """When the caller passes ``skip_reason``, the sweep is a no-op."""
+
+    def test_skip_reason_short_circuits(self, tmp_path: Path, empty_registry: OutputWriteRegistry):
+        stray = _make_file(tmp_path / "stray.html")
+        report = sweep_stray_files([tmp_path], empty_registry, skip_reason="stage errored")
+        assert stray.exists()
+        assert report.skipped is True
+        assert report.skip_reason == "stage errored"
+        assert report.deleted_files == []
+
+
+class TestDryRun:
+    """Dry-run lists what would be done without touching disk."""
+
+    def test_dry_run_lists_but_does_not_delete(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        stray = _make_file(tmp_path / "stray.html")
+        empty_section = tmp_path / "old_section"
+        _make_file(empty_section / "a.html")
+
+        report = sweep_stray_files([tmp_path], empty_registry, dry_run=True)
+        assert stray.exists()
+        assert empty_section.exists()
+        assert report.dry_run is True
+        assert stray in report.deleted_files
+        assert empty_section in report.removed_dirs
+
+
+class TestSymlinks:
+    """Symlinks under the root: the link is removed, not the target."""
+
+    @pytest.mark.skipif(
+        sys.platform == "win32" and not _can_symlink_on_windows(),
+        reason="Windows requires admin or Developer Mode to create symlinks",
+    )
+    def test_stray_symlink_link_deleted_target_untouched(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        target_dir = tmp_path.parent / "sweep_symlink_target"
+        target_dir.mkdir(exist_ok=True)
+        target = target_dir / "preserved.txt"
+        target.write_bytes(b"keep me")
+        try:
+            link = tmp_path / "stray_link.txt"
+            link.symlink_to(target)
+
+            report = sweep_stray_files([tmp_path], empty_registry)
+            assert not link.exists()
+            assert not link.is_symlink()
+            assert target.exists()
+            assert target.read_bytes() == b"keep me"
+            assert link in report.deleted_files
+        finally:
+            try:
+                target.unlink()
+            except OSError:
+                pass
+            try:
+                target_dir.rmdir()
+            except OSError:
+                pass
+
+
+class TestMultipleRoots:
+    """Multiple roots are walked independently."""
+
+    def test_per_root_isolation(self, tmp_path: Path, empty_registry: OutputWriteRegistry):
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        kept_in_a = _make_file(root_a / "kept.html")
+        stray_in_a = _make_file(root_a / "stray.html")
+        stray_in_b = _make_file(root_b / "stray.html")
+        _record(empty_registry, kept_in_a)
+
+        report = sweep_stray_files([root_a, root_b], empty_registry)
+        assert kept_in_a.exists()
+        assert not stray_in_a.exists()
+        assert not stray_in_b.exists()
+        assert set(report.deleted_files) == {stray_in_a, stray_in_b}
+
+    def test_missing_root_is_silently_skipped(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        missing = tmp_path / "does_not_exist"
+        report = sweep_stray_files([missing], empty_registry)
+        assert report.deleted_files == []
+        assert report.removed_dirs == []
+
+
+class TestCustomKeepPatterns:
+    """Callers can extend ``keep_patterns`` to spare specific paths."""
+
+    def test_explicit_keep_pattern_spares_file(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        kept = _make_file(tmp_path / "manually_pinned.txt")
+        report = sweep_stray_files(
+            [tmp_path],
+            empty_registry,
+            keep_patterns=(".git/**", "manually_pinned.txt"),
+        )
+        assert kept.exists()
+        assert report.deleted_files == []
+        assert report.kept_due_to_pattern == 1
+
+    def test_keep_pattern_glob_matches_subpath(
+        self, tmp_path: Path, empty_registry: OutputWriteRegistry
+    ):
+        kept = _make_file(tmp_path / "auxiliary" / "vendor.css")
+        report = sweep_stray_files(
+            [tmp_path],
+            empty_registry,
+            keep_patterns=(".git/**", "auxiliary/**"),
+        )
+        assert kept.exists()
+        assert report.kept_due_to_pattern == 1
+
+
+def test_module_does_not_pull_in_build_command() -> None:
+    """Importing the sweep module must not transitively import
+    ``clm.cli.commands.build`` — the dependency goes build → sweep,
+    never the reverse."""
+    sweep_module = sys.modules["clm.cli.output_sweep"]
+    assert sweep_module is not None
+    assert "clm.cli.commands.build" not in (
+        getattr(attr, "__module__", "") for attr in vars(sweep_module).values()
+    )

--- a/tests/core/test_image_registry.py
+++ b/tests/core/test_image_registry.py
@@ -297,6 +297,51 @@ class TestImageRegistry:
         assert len(registry.collisions) == original_len
 
 
+class TestTrackedOutputPaths:
+    """Output paths recorded for the stray-file sweep."""
+
+    def test_initially_empty(self):
+        registry = ImageRegistry()
+        assert registry.tracked_paths == frozenset()
+
+    def test_record_output_write_adds_path(self, tmp_path):
+        registry = ImageRegistry()
+        out = (tmp_path / "img" / "diagram.png").resolve()
+        registry.record_output_write(out)
+        assert out in registry.tracked_paths
+
+    def test_record_output_write_is_idempotent(self, tmp_path):
+        registry = ImageRegistry()
+        out = (tmp_path / "img" / "diagram.png").resolve()
+        registry.record_output_write(out)
+        registry.record_output_write(out)
+        assert len(registry.tracked_paths) == 1
+
+    def test_record_output_write_rejects_relative(self):
+        registry = ImageRegistry()
+        with pytest.raises(ValueError, match="absolute"):
+            registry.record_output_write(Path("img/relative.png"))
+
+    def test_tracked_paths_is_immutable_snapshot(self, tmp_path):
+        registry = ImageRegistry()
+        out = (tmp_path / "img" / "a.png").resolve()
+        registry.record_output_write(out)
+
+        snapshot = registry.tracked_paths
+        assert isinstance(snapshot, frozenset)
+        # Recording another path must not retroactively mutate the snapshot.
+        other = (tmp_path / "img" / "b.png").resolve()
+        registry.record_output_write(other)
+        assert other not in snapshot
+        assert other in registry.tracked_paths
+
+    def test_clear_resets_tracked_paths(self, tmp_path):
+        registry = ImageRegistry()
+        registry.record_output_write((tmp_path / "img" / "a.png").resolve())
+        registry.clear()
+        assert registry.tracked_paths == frozenset()
+
+
 class TestImageCollision:
     """Tests for the ImageCollision dataclass."""
 


### PR DESCRIPTION
## Summary

PR2 of the three-PR rollout from
[`docs/claude/design/git-friendly-output-writes.md`](docs/claude/design/git-friendly-output-writes.md)
(D2 in the design). Adds the end-of-build stray-file sweep behind a
new \`BuildConfig.sweep\` field and the \`CLM_OUTPUT_SWEEP\` dogfood
env var. Default behavior is unchanged — the sweep is opt-in for
this release; PR3 flips the default.

- **New module** \`src/clm/cli/output_sweep.py\` with
  \`sweep_stray_files(root_dirs, registry, image_registry=None, *, keep_patterns=(\".git/**\",), dry_run=False, skip_reason=None) -> SweepReport\`.
  Walks each root, deletes files absent from the registry union, and
  removes empty directories bottom-up.
- **\`ImageRegistry\`** gains \`tracked_paths\` and
  \`record_output_write()\` so image destinations (deliberately not
  tracked by \`OutputWriteRegistry\`) are part of the expected set.
  \`LocalOpsBackend.copy_file_to_output\` now records image output
  paths via the new method when \`is_image_path(input)\`.
- **\`Backend\`** gains an \`image_registry\` field threaded through
  from \`course.image_registry\` in \`build.py\`.
- **CLI** gains \`--no-sweep\` (forward-compatible: the flag always
  wins when the default flips in PR3). During this release the sweep
  is gated by \`CLM_OUTPUT_SWEEP=1\` so we can A/B it.

## Design contract honored

| Edge case | Behavior |
|---|---|
| EC5 \`--only-sections\` | Skipped — that mode has its own section-scoped cleanup. |
| EC7 stage errored | Skipped — registry has no entries for writes that never happened. |
| EC8 watch mode | Skipped — event-driven rebuilds only populate changed files. |
| EC9 nested \`.git/\` | Treated as opaque subtree (skipped). |
| EC10 symlinks | Walked with \`follow_symlinks=False\`; stray link is unlinked, target untouched. |
| Auxiliary files (\`.gitignore\`, \`README.md\`, editor caches) | Swept — the principle is that the output tree is exclusively CLM's. |

\`SKIP_DIRS_FOR_OUTPUT\` / \`SKIP_DIRS_PATTERNS\` / \`SKIP_OUTPUT_FILE_GLOBS\`
from \`path_utils.py\` are **not** in the keep-patterns allow-list, per
the strict-principle resolution in the design.

## Deviation from the design doc

The design called for a hidden \`--sweep\` flag in PR2. I chose the
simpler env-var pattern (\`CLM_OUTPUT_SWEEP=1\`) instead, matching
PR1's \`CLM_HASH_AWARE_WRITES\` rollout. PR3 will replace
\`_resolve_sweep_opt_in\` with a direct \`sweep=not no_sweep\` wiring
and remove the env var.

## Test plan

- [x] \`pytest tests/cli/test_output_sweep.py\` — 23 new tests
- [x] \`pytest tests/core/test_image_registry.py\` — 6 new tests for \`tracked_paths\`
- [x] \`pytest\` (fast suite) — 4871 passed, 9 skipped, 1 xfailed (no regressions)
- [x] \`ruff check\` + \`ruff format\` clean
- [x] \`mypy\` clean on changed files
- [ ] Smoke test: build a course with \`CLM_OUTPUT_SWEEP=1\`, induce a rename, verify the old files are removed and \`.git/\` survives (deferred to manual verification ahead of PR3)

## Follow-ups

- **PR3** — flip \`BuildConfig.sweep\` and \`hash_aware_writes_enabled()\`
  defaults; replace the wipe-and-restore flow with conditional \`--clean\`;
  deprecate \`--keep-directory\`; update \`commands.md\` /
  \`migration.md\` info topics; update \`CHANGELOG.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)