### PR TITLE
fix(build): make build output deterministic across processes

### DIFF
--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -383,13 +383,14 @@ class BuildReporter:
             self.report_warning(
                 BuildWarning(
                     category="output_path_conflict",
-                    severity="medium",
+                    severity="high",
                     file_path=conflict.output_path,
                     message=(
                         f"Multiple writers produced different content for "
                         f"{conflict.output_path}: first writer "
                         f"{conflict.first_writer}, last writer "
-                        f"{conflict.last_writer} (last writer won)"
+                        f"{conflict.last_writer} (last writer won — the "
+                        f"file on disk is race-dependent across runs)"
                     ),
                 )
             )

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -58,17 +58,19 @@ class LocalOpsBackend(Backend, ABC):
         output_path = copy_data.output_path
         logger.info(f"Copying {input_path} to {output_path}")
 
-        # Register with OutputWriteRegistry before the copy so dedup can
-        # short-circuit byte-identical re-writes and so conflicts are
-        # recorded for the build summary. Images are excluded — they
-        # have their own collision channel via ImageRegistry. The source
-        # must exist; if not, defer the FileNotFoundError to the sync
-        # path so the error message stays consistent.
-        if copy_data.input_path.exists() and is_image_path(copy_data.input_path):
+        # Register every write — including image-path sources — with
+        # OutputWriteRegistry. ImageRegistry still records the output
+        # path for the stray-file sweep and continues to catch source
+        # rel-path collisions across topics in shared mode, but only
+        # OutputWriteRegistry compares content hashes at the output
+        # destination. Without that, two sources writing different bytes
+        # to the same output (e.g. a static ``img/diagram.png`` and a
+        # ``pu/diagram.pu`` rendering to ``img/diagram.png``) were
+        # silently last-writer-wins.
+        if copy_data.input_path.exists():
             abs_output = output_path if output_path.is_absolute() else output_path.resolve()
-            self.image_registry.record_output_write(abs_output)
-        if copy_data.input_path.exists() and not is_image_path(copy_data.input_path):
-            abs_output = output_path if output_path.is_absolute() else output_path.resolve()
+            if is_image_path(copy_data.input_path):
+                self.image_registry.record_output_write(abs_output)
             write_result = self.output_write_registry.record_write(
                 abs_output,
                 content_source=copy_data.input_path,
@@ -190,9 +192,9 @@ class LocalOpsBackend(Backend, ABC):
                         self._record_dir_group_write(source=item, dest=dest)
 
     def _record_dir_group_write(self, *, source: Path, dest: Path) -> None:
-        if is_image_path(source):
-            return
         abs_dest = dest if dest.is_absolute() else dest.resolve()
+        if is_image_path(source):
+            self.image_registry.record_output_write(abs_dest)
         try:
             self.output_write_registry.record_write(
                 abs_dest,

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -136,38 +136,40 @@ class SqliteBackend(LocalOpsBackend):
                     # Register the planned write so identical-content
                     # re-emissions (common when many output variants share
                     # an include-sourced file) collapse to one write, and
-                    # path conflicts surface in the build summary. Source
-                    # paths under img/ are owned by ImageRegistry and
-                    # skipped here so the existing image_collision channel
-                    # remains the sole reporter.
+                    # path conflicts surface in the build summary. Image
+                    # sources are still tracked here so a static
+                    # ``img/X.png`` cached replay vs a ``pu/X.pu`` render
+                    # to the same output path surfaces as a real content
+                    # conflict instead of silent last-writer-wins.
                     content_bytes = result.result_bytes()
                     source_path = Path(payload.input_file)
                     skip_write = False
-                    if not is_image_path(source_path):
-                        write_result = self.output_write_registry.record_write(
-                            output_file,
-                            content=content_bytes,
-                            source=source_path,
+                    if is_image_path(source_path):
+                        self.image_registry.record_output_write(output_file)
+                    write_result = self.output_write_registry.record_write(
+                        output_file,
+                        content=content_bytes,
+                        source=source_path,
+                    )
+                    if write_result.outcome == WriteOutcome.DEDUP:
+                        logger.debug(
+                            f"Output dedup: skipping cache-hit replay to "
+                            f"{output_file} (identical content already written "
+                            f"from {write_result.entry.first_writer_source})"
                         )
-                        if write_result.outcome == WriteOutcome.DEDUP:
-                            logger.debug(
-                                f"Output dedup: skipping cache-hit replay to "
-                                f"{output_file} (identical content already written "
-                                f"from {write_result.entry.first_writer_source})"
-                            )
-                            skip_write = True
-                        elif write_result.outcome == WriteOutcome.CONFLICT:
-                            logger.warning(
-                                f"Output path conflict at {output_file}: prior "
-                                f"writer {write_result.entry.first_writer_source}, "
-                                f"new writer {source_path} (last writer wins)"
-                            )
-                        elif write_result.outcome == WriteOutcome.LARGE_FILE_COLLISION:
-                            logger.debug(
-                                f"Large-file collision at {output_file} from "
-                                f"{source_path} (over hash limit; counted as "
-                                f"collision)"
-                            )
+                        skip_write = True
+                    elif write_result.outcome == WriteOutcome.CONFLICT:
+                        logger.warning(
+                            f"Output path conflict at {output_file}: prior "
+                            f"writer {write_result.entry.first_writer_source}, "
+                            f"new writer {source_path} (last writer wins)"
+                        )
+                    elif write_result.outcome == WriteOutcome.LARGE_FILE_COLLISION:
+                        logger.debug(
+                            f"Large-file collision at {output_file} from "
+                            f"{source_path} (over hash limit; counted as "
+                            f"collision)"
+                        )
                     if not skip_write:
                         # Hash-aware skip: when the destination already
                         # holds byte-identical content from a prior build,
@@ -495,20 +497,24 @@ class SqliteBackend(LocalOpsBackend):
                             # worker subprocess wrote it), so dedup-skip
                             # is not meaningful here — but conflict
                             # detection across worker outputs in the same
-                            # build still works. Image-path sources are
-                            # owned by ImageRegistry and skipped.
+                            # build still works. Image sources are kept
+                            # in OutputWriteRegistry too, so that a
+                            # generated PNG (PlantUML/DrawIO) and a
+                            # static ``img/X.png`` writing to the same
+                            # output path surface as a content conflict.
                             source_for_registry = Path(job_info["input_file"])
-                            if not is_image_path(source_for_registry):
-                                try:
-                                    self.output_write_registry.record_write(
-                                        output_path,
-                                        content_source=output_path,
-                                        source=source_for_registry,
-                                    )
-                                except Exception as reg_exc:
-                                    logger.debug(
-                                        f"Could not register worker output {output_path}: {reg_exc}"
-                                    )
+                            if is_image_path(source_for_registry):
+                                self.image_registry.record_output_write(output_path)
+                            try:
+                                self.output_write_registry.record_write(
+                                    output_path,
+                                    content_source=output_path,
+                                    source=source_for_registry,
+                                )
+                            except Exception as reg_exc:
+                                logger.debug(
+                                    f"Could not register worker output {output_path}: {reg_exc}"
+                                )
 
                             # Read output file and reconstruct Result object to store in database
                             try:

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -189,6 +189,29 @@ def _strip_injected_cells(nb: NotebookNode) -> None:
     ]
 
 
+# Jupytext builds metadata.jupytext.cell_metadata_filter (and
+# notebook_metadata_filter) by joining a Python ``set`` of metadata keys.
+# Set iteration order varies across processes because PYTHONHASHSEED is
+# randomized by default, so the same .py source produces .ipynb files that
+# differ on this one line (e.g. ``"tags,lang,-all"`` vs ``"lang,tags,-all"``).
+# Sorting the CSV entries makes the field byte-stable across processes
+# without affecting jupytext semantics (the filter is order-independent).
+_JUPYTEXT_FILTER_FIELDS = ("cell_metadata_filter", "notebook_metadata_filter")
+
+
+def _normalize_jupytext_metadata_filters(nb: NotebookNode) -> None:
+    """Sort the CSV entries in jupytext's metadata-filter fields in-place."""
+    jupytext_meta = nb.get("metadata", {}).get("jupytext")
+    if not isinstance(jupytext_meta, dict):
+        return
+    for field in _JUPYTEXT_FILTER_FIELDS:
+        value = jupytext_meta.get(field)
+        if not isinstance(value, str) or "," not in value:
+            continue
+        entries = [e.strip() for e in value.split(",") if e.strip()]
+        jupytext_meta[field] = ",".join(sorted(entries))
+
+
 # Regex pattern to match img and video tags with src="img/..." paths
 # Captures: prefix (before img/), filename (after img/), suffix (rest of tag)
 MEDIA_SRC_PATTERN = re.compile(r'(<(?:img|video)\s+[^>]*src=["\'])img/([^"\']+)(["\'][^>]*>)')
@@ -670,6 +693,7 @@ class NotebookProcessor:
         )
         loop = asyncio.get_running_loop()
         nb = await loop.run_in_executor(None, jupytext.reads, expanded_nb, jupytext_format)
+        _normalize_jupytext_metadata_filters(nb)
         processed_nb = await self._process_notebook_node(nb, payload)
         return processed_nb
 

--- a/tests/infrastructure/backends/test_output_dedup_integration.py
+++ b/tests/infrastructure/backends/test_output_dedup_integration.py
@@ -107,19 +107,30 @@ class TestCopyFileDedup:
             assert entries[0].first_writer_source == src_a
             assert entries[0].last_writer_source == src_b
 
-    async def test_image_path_skipped(self, tmp_path):
-        img_dir = tmp_path / "topic" / "img"
-        img_dir.mkdir(parents=True)
-        src = img_dir / "diagram.png"
+    async def test_image_path_tracked_for_content_conflicts(self, tmp_path):
+        # Image-path sources now flow through OutputWriteRegistry too so
+        # content conflicts at the output path are detected (e.g. a
+        # static ``img/X.png`` and a ``pu/X.pu``-rendered ``img/X.png``
+        # writing to the same destination). ImageRegistry still records
+        # the output path for the stray-file sweep.
+        img_dir_a = tmp_path / "topic_a" / "img"
+        img_dir_b = tmp_path / "topic_b" / "img"
+        img_dir_a.mkdir(parents=True)
+        img_dir_b.mkdir(parents=True)
+        src_a = img_dir_a / "diagram.png"
+        src_b = img_dir_b / "diagram.png"
         out = tmp_path / "out.png"
-        src.write_bytes(b"PNG bytes")
+        src_a.write_bytes(b"PNG A")
+        src_b.write_bytes(b"PNG B")
 
         async with PytestLocalOpsBackend() as backend:
-            await backend.copy_file_to_output(_copy_data(src, out, tmp_path))
-            await backend.copy_file_to_output(_copy_data(src, out, tmp_path))
+            await backend.copy_file_to_output(_copy_data(src_a, out, tmp_path))
+            await backend.copy_file_to_output(_copy_data(src_b, out, tmp_path))
 
-            assert backend.output_write_registry.entries == {}
-            assert out.read_bytes() == b"PNG bytes"
+            assert backend.output_write_registry.total_conflicts == 1
+            assert out.resolve() in backend.image_registry.tracked_paths
+            # Last-writer wins on disk.
+            assert out.read_bytes() == b"PNG B"
 
     async def test_missing_source_not_registered(self, tmp_path):
         src = tmp_path / "missing.txt"
@@ -205,7 +216,10 @@ class TestCopyDirGroupRegistry:
             assert (output_dir / "grp" / "a.txt").resolve() in keys
             assert (output_dir / "grp" / "sub" / "c.txt").resolve() not in keys
 
-    async def test_recursive_copy_image_paths_skipped(self, tmp_path):
+    async def test_recursive_copy_tracks_image_paths_in_output_registry(self, tmp_path):
+        # Image-path writes now go through both registries: ImageRegistry
+        # for sweep tracking, OutputWriteRegistry for content-conflict
+        # detection at the output destination.
         from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
 
         src_root = tmp_path / "src"
@@ -227,8 +241,10 @@ class TestCopyDirGroupRegistry:
             await backend.copy_dir_group_to_output(copy_data)
 
             keys = set(backend.output_write_registry.entries)
+            img_out = (output_dir / "grp" / "img" / "diagram.png").resolve()
             assert (output_dir / "grp" / "a.txt").resolve() in keys
-            assert (output_dir / "grp" / "img" / "diagram.png").resolve() not in keys
+            assert img_out in keys
+            assert img_out in backend.image_registry.tracked_paths
 
     async def test_two_overlapping_dir_groups_detect_conflict(self, tmp_path):
         from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData

--- a/tests/integration/test_output_dedup_pipeline.py
+++ b/tests/integration/test_output_dedup_pipeline.py
@@ -119,12 +119,15 @@ class TestNUnitTestRunnerPattern:
             assert any(w.category == "output_path_conflict" for w in summary.warnings)
 
 
-class TestImageRegistryDoesNotDoubleWarn:
-    """Image-path collisions continue to fire image_collision via
-    ImageRegistry, and the new output_path_conflict channel does NOT
-    fire for the same paths."""
+class TestImageContentConflictsSurface:
+    """Image-path collisions now surface in BOTH channels: ImageRegistry
+    keeps catching source-rel-path collisions across topics in shared
+    mode, and OutputWriteRegistry catches byte-level content conflicts
+    at the output destination. The latter was previously a silent
+    last-writer-wins bug (e.g. static ``img/X.png`` vs ``pu/X.pu``
+    rendering to the same output)."""
 
-    async def test_image_collision_only_in_image_registry(self, tmp_path):
+    async def test_image_collision_fires_output_path_conflict(self, tmp_path):
         # Two topics, both with img/diagram.png but DIFFERENT content
         # (an ImageRegistry collision).
         topic_a = tmp_path / "topic_a"
@@ -141,23 +144,26 @@ class TestImageRegistryDoesNotDoubleWarn:
         image_registry.register(img_b)
         assert image_registry.has_collisions()
 
-        # Now hypothetically copy both into the same output path. The
-        # output registry SHOULD NOT register them at all.
+        # Copying both to the same output path now registers in
+        # OutputWriteRegistry and surfaces the content conflict.
         out = tmp_path / "out" / "img" / "diagram.png"
         async with PytestLocalOpsBackend() as backend:
             await backend.copy_file_to_output(_make_copy_data(img_a, out, tmp_path))
             await backend.copy_file_to_output(_make_copy_data(img_b, out, tmp_path))
 
             out_registry = backend.output_write_registry
-            assert out_registry.entries == {}
-            assert out_registry.total_conflicts == 0
+            assert out_registry.total_conflicts == 1
 
             reporter = BuildReporter(QuietOutputFormatter())
             reporter.start_build(course_name="course", total_files=2)
             reporter.report_output_writes(out_registry)
             summary = reporter.finish_build()
 
-            assert all(w.category != "output_path_conflict" for w in summary.warnings)
+            conflict_warnings = [
+                w for w in summary.warnings if w.category == "output_path_conflict"
+            ]
+            assert len(conflict_warnings) == 1
+            assert conflict_warnings[0].severity == "high"
 
 
 class TestJsonEndToEnd:

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -25,6 +25,7 @@ from clm.workers.notebook.notebook_processor import (
     CellIdGenerator,
     NotebookProcessor,
     TrackingExecutePreprocessor,
+    _normalize_jupytext_metadata_filters,
 )
 from clm.workers.notebook.output_spec import (
     CodeAlongOutput,
@@ -1886,6 +1887,55 @@ class TestMetadataStripping:
         for cell in result["cells"]:
             assert "slide_id" not in cell["metadata"]
             assert "for_slide" not in cell["metadata"]
+
+
+class TestJupytextMetadataFilterNormalization:
+    """``_normalize_jupytext_metadata_filters`` deterministically sorts
+    the CSV that jupytext writes into ``metadata.jupytext.*_filter``.
+
+    Jupytext builds these fields by joining a Python ``set``; under
+    randomized ``PYTHONHASHSEED`` the same .py input therefore yields
+    .ipynb files that differ only in CSV-entry order. The post-read
+    normalization removes that noise from the build's output.
+    """
+
+    def test_sorts_cell_metadata_filter_csv(self):
+        nb = NotebookNode({"metadata": {"jupytext": {"cell_metadata_filter": "tags,lang,-all"}}})
+        _normalize_jupytext_metadata_filters(nb)
+        assert nb["metadata"]["jupytext"]["cell_metadata_filter"] == "-all,lang,tags"
+
+    def test_different_permutations_normalize_identically(self):
+        nb_a = NotebookNode({"metadata": {"jupytext": {"cell_metadata_filter": "tags,lang,-all"}}})
+        nb_b = NotebookNode({"metadata": {"jupytext": {"cell_metadata_filter": "lang,-all,tags"}}})
+        _normalize_jupytext_metadata_filters(nb_a)
+        _normalize_jupytext_metadata_filters(nb_b)
+        assert (
+            nb_a["metadata"]["jupytext"]["cell_metadata_filter"]
+            == nb_b["metadata"]["jupytext"]["cell_metadata_filter"]
+        )
+
+    def test_normalizes_notebook_metadata_filter_too(self):
+        nb = NotebookNode(
+            {
+                "metadata": {
+                    "jupytext": {
+                        "notebook_metadata_filter": "kernelspec,jupytext,-all",
+                    }
+                }
+            }
+        )
+        _normalize_jupytext_metadata_filters(nb)
+        assert nb["metadata"]["jupytext"]["notebook_metadata_filter"] == "-all,jupytext,kernelspec"
+
+    def test_single_entry_unchanged(self):
+        nb = NotebookNode({"metadata": {"jupytext": {"cell_metadata_filter": "-all"}}})
+        _normalize_jupytext_metadata_filters(nb)
+        assert nb["metadata"]["jupytext"]["cell_metadata_filter"] == "-all"
+
+    def test_missing_jupytext_metadata_is_noop(self):
+        nb = NotebookNode({"metadata": {}})
+        _normalize_jupytext_metadata_filters(nb)
+        assert nb["metadata"] == {}
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Two run-to-run nondeterminism sources surfaced by the snapshot/verify harness investigation, both fixed here:

- **`.ipynb` `cell_metadata_filter` set-ordering.** Jupytext joins a Python `set` into the CSV stored in `metadata.jupytext.cell_metadata_filter`; under randomized `PYTHONHASHSEED` the same `.py` input produces `.ipynb` files that differ only in CSV entry order (e.g. `"tags,lang,-all"` vs `"lang,tags,-all"`). Fixed by sorting the CSV in `_normalize_jupytext_metadata_filters` right after `jupytext.reads()` in `process_notebook_for_spec`. Semantics unchanged; output is byte-stable across processes.
- **PNG same-path content conflict (silent last-writer-wins).** A static `img/X.png` and a `pu/X.pu` rendering to the same output `img/X.png` raced. `OutputWriteRegistry` already content-hashes writes, but image-path sources were short-circuited out of it via `is_image_path()` and routed only through `ImageRegistry`, which tracks source rel-paths — not output bytes. So the conflict was invisible to both registries. Fixed by routing **all** writes through `OutputWriteRegistry` while keeping `ImageRegistry` for its cross-topic source-rel-path job. `output_path_conflict` severity bumped `medium → high` and the warning message clarified ("file on disk is race-dependent across runs").

### Behavioral change to flag

After this PR, courses with overlapping static-image + diagram-source naming (e.g. both `img/X.png` and `pu/X.pu` in the same topic) will emit `output_path_conflict` warnings at **high** severity. That's the intended signal — existing builds were silently last-writer-wins. Resolve by renaming one source or removing the redundant file.

## Test plan

- [x] `pytest tests/workers/notebook/test_notebook_processor.py::TestJupytextMetadataFilterNormalization` (new, 5 tests)
- [x] `pytest tests/integration/test_output_dedup_pipeline.py tests/infrastructure/backends/test_output_dedup_integration.py` (22 tests, includes renamed/updated cases)
- [x] `pytest tests/cli/test_build_reporter_output_writes.py tests/core/test_output_write_registry.py tests/core/test_image_registry.py tests/cli/test_build_command.py` (149 tests)
- [x] Full fast suite: 4882 passed (1 flaky in `test_worker_base.py`, unrelated, passes on retry)
- [x] Manually verified Fix #1 stable across 10 `PYTHONHASHSEED` values (1..10)
- [x] `ruff check`, `ruff format --check`, `mypy` — all clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)