### PR TITLE
feat(cli): snapshot/verify harness + verb-grouped subcommands (PR A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI restructure: verb-grouped subcommands.** Several flat
+  top-level commands moved under new groups for a smaller, more
+  scannable surface. Old names still work and emit a deprecation
+  notice naming the new invocation; aliases will be removed in CLM
+  1.7. The MCP tool names are unchanged in this release — that
+  rename will land in a coordinated commit with the PythonCourses
+  skills that consume them.
+
+  | Old (still works, deprecated)                  | New canonical                |
+  |------------------------------------------------|------------------------------|
+  | `clm normalize-slides`                         | `clm slides normalize`       |
+  | `clm language-view`                            | `clm slides language-view`   |
+  | `clm suggest-sync`                             | `clm slides suggest-sync`    |
+  | `clm search-slides`                            | `clm slides search`          |
+  | `clm resolve-topic`                            | `clm topic resolve`          |
+  | `clm authoring-rules`                          | `clm authoring rules`        |
+  | `clm extract-voiceover`                        | `clm voiceover extract`      |
+  | `clm inline-voiceover`                         | `clm voiceover inline`       |
+  | `clm validate-slides PATH`                     | `clm validate PATH`          |
+  | `clm validate-spec SPEC`                       | `clm validate SPEC`          |
+
+- **`clm validate <path>` consolidates `validate-slides` and
+  `validate-spec`** with argument-type dispatch: `.xml` files →
+  spec validation, `.py` files and directories → slide validation.
+  Pass `--kind=slides` or `--kind=spec` to force a specific
+  validator (useful for ambiguous cases like an empty directory).
+
+### Added
+
+- **`clm build --snapshot DIR` and `--verify-against DIR`** for
+  byte-level migration verification. `--snapshot` captures build output
+  to a baseline directory (mutually exclusive with `--output-dir` and
+  `--verify-against`); `--verify-against` builds and compares the
+  output tree against a previously-captured snapshot, exiting non-zero
+  on any diff. Designed for the slide-format-redesign migration
+  protocol (snapshot → apply change → verify byte-identical).
+  - `.html` files are skipped by default because their content includes
+    live-kernel execution output. Slides that use `random.choice`,
+    `print(obj)` of a default-`__repr__` object, or have interleaved
+    stdout/exception output produce different rendered HTML each run
+    — this is a property of slide content, not of CLM.
+  - `--include-html` re-enables HTML comparison with hex memory
+    addresses normalized (`0xADDR` sentinel).
+  - `--strict-verify` byte-compares every file with no normalization
+    and no skipping; implies `--include-html`.
+
 ## [1.5.0] - 2026-05-17
 
 ### Changed

--- a/src/clm/cli/commands/_aliases.py
+++ b/src/clm/cli/commands/_aliases.py
@@ -1,0 +1,82 @@
+"""Deprecation-alias helper for the Phase 0 CLI restructure.
+
+The slide-format-redesign rollout (CLM 1.6+) moves several flat commands
+under verb-grouped subcommands — `clm normalize-slides` →
+`clm slides normalize`, `clm extract-voiceover` → `clm voiceover extract`,
+etc. Old names keep working for two minor releases so downstream
+PythonCourses skills, hook commands, and trainer muscle memory have time
+to migrate.
+
+This helper wraps an existing ``click.Command`` as a deprecated top-level
+alias that emits a one-line ``DeprecationWarning``-style notice on stderr
+naming the new invocation, then forwards to the same underlying callback
+without otherwise altering behavior. The alias inherits the original
+command's parameters by reference, so adding a new option to the
+canonical command shows up on the alias automatically.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import click
+
+
+def deprecated_alias(target: click.Command, *, new_invocation: str) -> click.Command:
+    """Return a deprecated alias of *target* that forwards to its callback.
+
+    Args:
+        target: The canonical command. Its callback is reused unchanged.
+        new_invocation: The new command path users should switch to,
+            without the leading ``clm`` (e.g. ``"slides normalize"`` or
+            ``"voiceover extract"``).
+
+    The returned command:
+
+    - Has the same name as *target* — caller is responsible for
+      registering it where the old name should live.
+    - Carries the same parameters as *target* (shared list reference),
+      so flag additions propagate automatically.
+    - Sets ``deprecated=True`` so Click renders the help text with
+      "(deprecated)" and prints its standard warning.
+    - Wraps the callback to also emit a one-line stderr notice naming
+      the new invocation, so users see the migration path even when
+      they ignore Click's bare "deprecated" tag.
+    """
+    if target.callback is None:
+        # The helper is intended for plain commands, not pass-through
+        # groups. Callers that need a deprecated group should compose
+        # the deprecation message differently.
+        raise TypeError(
+            f"deprecated_alias requires target.callback to be set; "
+            f"got command {target.name!r} with no callback."
+        )
+
+    original_callback = target.callback
+    old_name = target.name
+
+    from typing import Any
+
+    @functools.wraps(original_callback)
+    def wrapped_callback(*args: Any, **kwargs: Any) -> Any:
+        click.echo(
+            f"DeprecationWarning: `clm {old_name}` is deprecated. "
+            f"Use `clm {new_invocation}` instead. "
+            f"The alias will be removed in CLM 1.7.",
+            err=True,
+        )
+        return original_callback(*args, **kwargs)
+
+    return click.Command(
+        name=old_name,
+        callback=wrapped_callback,
+        params=list(target.params),
+        help=target.help,
+        epilog=target.epilog,
+        short_help=target.short_help,
+        options_metavar=target.options_metavar,
+        add_help_option=target.add_help_option,
+        no_args_is_help=target.no_args_is_help,
+        hidden=target.hidden,
+        deprecated=True,
+    )

--- a/src/clm/cli/commands/_groups.py
+++ b/src/clm/cli/commands/_groups.py
@@ -1,0 +1,33 @@
+"""New verb-group definitions for the Phase 0 CLI restructure.
+
+The flat top-level layout (``clm normalize-slides``, ``clm
+extract-voiceover``, ``clm resolve-topic``, ...) had grown to 11+
+commands with two duplications (``validate-slides``/``validate-spec``
+and ``extract-voiceover``/``inline-voiceover`` as siblings of the
+``voiceover`` group). This module introduces the three new groups —
+``slides``, ``topic``, ``authoring`` — under which existing commands
+are re-registered with shorter names in ``clm.cli.main``. The
+``voiceover`` group already exists in ``clm.cli.commands.voiceover``.
+
+Each group here is a thin ``@click.group()`` with no shared state;
+the registration of subcommands happens in ``main.py``.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.group("slides")
+def slides_group() -> None:
+    """Slide authoring: normalize, validate, search, language tools, etc."""
+
+
+@click.group("topic")
+def topic_group() -> None:
+    """Topic resolution and inspection."""
+
+
+@click.group("authoring")
+def authoring_group() -> None:
+    """Authoring-rules introspection."""

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1206,6 +1206,48 @@ async def main_build(
     type=click.Path(exists=False, file_okay=False, dir_okay=True, path_type=Path),
 )
 @click.option(
+    "--snapshot",
+    "snapshot_dir",
+    type=click.Path(exists=False, file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help=(
+        "Capture build output to DIR as a verification baseline. Acts as "
+        "an explicit override of --output-dir; mutually exclusive with "
+        "--output-dir and --verify-against. The target directory must "
+        "either not exist yet or be empty."
+    ),
+)
+@click.option(
+    "--verify-against",
+    "verify_against_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help=(
+        "After build, compare the output tree against the snapshot at "
+        "DIR. Exits non-zero on any diff. By default .html files are "
+        "skipped because they include live-kernel execution output; "
+        "see --include-html and --strict."
+    ),
+)
+@click.option(
+    "--include-html",
+    is_flag=True,
+    help=(
+        "With --verify-against: include .html in the comparison, with "
+        "hex memory addresses normalized to a sentinel. Has no effect "
+        "without --verify-against."
+    ),
+)
+@click.option(
+    "--strict-verify",
+    is_flag=True,
+    help=(
+        "With --verify-against: byte-compare every file with no "
+        "normalization and no skipping. Implies --include-html. Has no "
+        "effect without --verify-against."
+    ),
+)
+@click.option(
     "--watch",
     "-w",
     is_flag=True,
@@ -1421,6 +1463,10 @@ def build(
     spec_file,
     data_dir,
     output_dir,
+    snapshot_dir,
+    verify_against_dir,
+    include_html,
+    strict_verify,
     watch,
     watch_mode,
     debounce,
@@ -1455,6 +1501,37 @@ def build(
     no_env_file,
 ):
     """Build a course from a spec file."""
+    # ------------------------------------------------------------------
+    # Snapshot / verify wiring (Phase 1 of slide-format-redesign track).
+    # --snapshot DIR and --verify-against DIR can both be combined with
+    # the normal build, but --snapshot is mutually exclusive with
+    # --output-dir (it is an explicit output-dir override) and with
+    # --verify-against (different intents).
+    # ------------------------------------------------------------------
+    if snapshot_dir is not None:
+        if output_dir is not None:
+            raise click.UsageError(
+                "--snapshot and --output-dir are mutually exclusive; "
+                "--snapshot already specifies where build output goes."
+            )
+        if verify_against_dir is not None:
+            raise click.UsageError(
+                "--snapshot and --verify-against are mutually exclusive; "
+                "snapshot captures a baseline, verify compares against one."
+            )
+        if snapshot_dir.exists() and any(snapshot_dir.iterdir()):
+            raise click.UsageError(
+                f"--snapshot target is not empty: {snapshot_dir}. "
+                "Pick a fresh path or remove the existing contents."
+            )
+        # Treat the snapshot path as the build output destination.
+        output_dir = snapshot_dir
+
+    if (include_html or strict_verify) and verify_against_dir is None:
+        # Surface the no-op rather than silently ignoring it.
+        raise click.UsageError(
+            "--include-html / --strict-verify have no effect without --verify-against."
+        )
     cache_db_path = ctx.obj["CACHE_DB_PATH"]
     jobs_db_path = ctx.obj["JOBS_DB_PATH"]
 
@@ -1543,6 +1620,37 @@ def build(
             inline_images,
         )
     )
+
+    # ------------------------------------------------------------------
+    # Post-build: --snapshot and --verify-against
+    # ------------------------------------------------------------------
+    # Resolve the effective output path that main_build actually wrote
+    # to. main_build does not return it, but resolve_course_paths is
+    # the single source of truth used inside the build pipeline too.
+    _, default_output = resolve_course_paths(spec_file, data_dir)
+    effective_output = output_dir if output_dir is not None else default_output
+
+    if snapshot_dir is not None:
+        # snapshot_dir == output_dir at this point (we aliased it above).
+        # The build report already covers what was written; print a short
+        # confirmation so scripts can grep for the snapshot location.
+        click.echo(f"\nSnapshot saved to: {effective_output.resolve()}")
+
+    if verify_against_dir is not None:
+        from clm.snapshot import verify_against
+
+        report = verify_against(
+            snapshot_dir=verify_against_dir,
+            output_dir=effective_output,
+            include_html=include_html or strict_verify,
+            strict=strict_verify,
+        )
+        click.echo("\nVerification report")
+        click.echo(report.format_text())
+        if report.has_diffs:
+            click.echo("\nVerification failed: build output diverges from snapshot.")
+            sys.exit(1)
+        click.echo("\nVerification passed: build output matches snapshot.")
 
 
 @click.command(name="targets")

--- a/src/clm/cli/commands/validate.py
+++ b/src/clm/cli/commands/validate.py
@@ -1,0 +1,138 @@
+"""Unified ``clm validate <path>`` command (Phase 0 of slide-format-redesign).
+
+Inspects the given path and dispatches to either spec validation
+(``.xml`` files) or slide validation (``.py`` files or directories).
+Override with ``--kind=slides|spec`` for ambiguous cases (e.g. an empty
+directory, or an ``.xml`` file you nonetheless want to feed to the
+slide validator).
+
+The two underlying commands (``validate-slides``, ``validate-spec``)
+remain available as deprecated aliases — this command consolidates
+them so 95% of users no longer have to remember which to use.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from clm.cli.commands.validate_slides import validate_slides_cmd
+from clm.cli.commands.validate_spec import validate_spec_cmd
+
+
+def _infer_kind(path: Path) -> str | None:
+    """Return ``"spec"``, ``"slides"``, or ``None`` if ambiguous."""
+    if path.is_file():
+        suffix = path.suffix.lower()
+        if suffix == ".xml":
+            return "spec"
+        if suffix == ".py":
+            return "slides"
+        return None
+    if path.is_dir():
+        # Directories are slide directories. An "empty directory of spec
+        # files" isn't a real shape — directories aren't passed to the
+        # spec validator. If you want to validate a spec, pass the .xml.
+        return "slides"
+    return None
+
+
+@click.command("validate")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--kind",
+    type=click.Choice(["slides", "spec"], case_sensitive=False),
+    default=None,
+    help=("Force a specific validator. Default inference: .xml → spec, .py / directory → slides."),
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help=("Course data directory (contains slides/). Passed through to both validators."),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output as JSON.",
+)
+@click.option(
+    "--checks",
+    type=str,
+    default=None,
+    help=(
+        "Slides-only: comma-separated list of checks. "
+        "Deterministic: format, pairing, tags. "
+        "Review: code_quality, voiceover, completeness. "
+        "Default: all deterministic checks. Not valid with --kind=spec."
+    ),
+)
+@click.option(
+    "--quick",
+    is_flag=True,
+    help=(
+        "Slides-only: fast syntax-only check (format + tags). "
+        "For PostToolUse hooks. Not valid with --kind=spec."
+    ),
+)
+@click.option(
+    "--include-disabled",
+    is_flag=True,
+    help=('Spec-only: validate sections marked enabled="false". Not valid with --kind=slides.'),
+)
+@click.pass_context
+def validate_cmd(
+    ctx: click.Context,
+    path: Path,
+    kind: str | None,
+    data_dir: Path | None,
+    as_json: bool,
+    checks: str | None,
+    quick: bool,
+    include_disabled: bool,
+) -> None:
+    """Validate a course spec file or slide files.
+
+    \b
+    Argument dispatch:
+        clm validate course.xml             # → spec validation
+        clm validate slides/                # → slide validation
+        clm validate slides/x.py            # → slide validation
+        clm validate something --kind=spec  # → forced spec validation
+    """
+    resolved_kind = (kind or "").lower() or _infer_kind(path)
+    if resolved_kind is None:
+        raise click.UsageError(
+            f"Cannot infer validator kind from {path}. "
+            "Pass --kind=slides or --kind=spec explicitly."
+        )
+
+    if resolved_kind == "spec":
+        if checks or quick:
+            raise click.UsageError(
+                "--checks and --quick are slides-only; not valid with --kind=spec."
+            )
+        if not path.is_file() or path.suffix.lower() != ".xml":
+            # Spec validator expects a single XML file; refuse anything
+            # else explicitly so the error doesn't come from deeper code.
+            raise click.UsageError(f"--kind=spec requires an .xml file, got {path}.")
+        ctx.invoke(
+            validate_spec_cmd,
+            spec_file=path,
+            data_dir=data_dir,
+            as_json=as_json,
+            include_disabled=include_disabled,
+        )
+    else:  # slides
+        if include_disabled:
+            raise click.UsageError("--include-disabled is spec-only; not valid with --kind=slides.")
+        ctx.invoke(
+            validate_slides_cmd,
+            path=path,
+            checks=checks,
+            quick=quick,
+            as_json=as_json,
+            data_dir=data_dir,
+        )

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -14,6 +14,14 @@ clm [OPTIONS] COMMAND [ARGS]...
 
 ## Commands
 
+The CLI is organised into a small top-level surface plus verb groups
+(`slides`, `topic`, `authoring`, `voiceover`). The reference below
+uses the canonical (group-qualified) names; older flat names like
+`clm normalize-slides`, `clm validate-slides`, etc. still work as
+deprecated aliases and print a one-line migration hint on each
+invocation. The aliases will be removed in CLM 1.7; see
+`clm info migration` for the full rename table.
+
 ### `clm build`
 
 Build a course from a spec file.
@@ -28,6 +36,10 @@ Key options:
 |--------|-------------|
 | `-d, --data-dir DIR` | Source data directory |
 | `-o, --output-dir DIR` | Output directory (overrides spec targets) |
+| `--snapshot DIR` | Capture build output to DIR as a verification baseline. Mutually exclusive with `--output-dir` and `--verify-against`. Target must not exist or be empty. See "Snapshot / verify" below. |
+| `--verify-against DIR` | Build, then byte-compare the output tree against the snapshot at DIR. Exits non-zero on any diff. `.html` is skipped by default (kernel-execution noise). See "Snapshot / verify" below. |
+| `--include-html` | With `--verify-against`: include `.html` files using hex-address normalization. |
+| `--strict-verify` | With `--verify-against`: byte-compare every file, no normalization or skipping. |
 | `-w, --watch` | Watch for changes and auto-rebuild |
 | `--watch-mode [fast\|normal]` | `fast` = notebooks only; `normal` = all formats |
 | `--ignore-cache` | Reprocess all files (still updates cache) |
@@ -171,6 +183,49 @@ from a corrupted output tree, or a script that depends on a clean
 build — use `--clean`. Nested `.git/` directories are preserved
 across the wipe.
 
+#### Snapshot / verify
+
+`--snapshot` and `--verify-against` implement byte-level migration
+verification. Use them when you need to confirm that an applied
+change produced exactly the same build output as a pre-change
+baseline.
+
+Capture a baseline:
+
+```bash
+clm build course.xml --snapshot baseline/ --ignore-cache
+```
+
+Apply the migration (slide_id rollout, language-split conversion,
+mechanical normalize, etc.), then verify:
+
+```bash
+clm build course.xml --output-dir out/ --verify-against baseline/ --ignore-cache
+```
+
+`--verify-against` exits non-zero if any non-skipped file differs.
+
+**HTML is skipped by default** because rendered HTML uses live kernel
+execution, and any slide whose code path is non-deterministic
+(`random.choice(...)`, `print(some_object)` for a class without
+`__repr__`, error-and-print stream interleaving) produces different
+HTML each run. The `.ipynb`, `.py`, `.png`, and other artifacts are
+byte-deterministic post-CLM 1.5; verifying those is what most
+migrations actually need.
+
+Two opt-in modes raise the strictness:
+
+- `--include-html` re-enables HTML comparison but normalizes hex
+  memory addresses (`<__main__.Foo at 0x2733c2b8ad0>` →
+  `<__main__.Foo at 0xADDR>`). Other content diffs still surface.
+- `--strict-verify` compares every file raw, with no normalization
+  and no skipping. Implies `--include-html`. Useful for
+  reproducibility audits where any cross-run variance is suspect.
+
+`--ignore-cache` is recommended on both sides: a stale cache can mask
+the very diffs the verify is meant to detect. The cache requires
+complete HTTP-cassette coverage for sections that make LLM calls.
+
 ### `clm targets`
 
 List output targets defined in a course spec file.
@@ -205,7 +260,9 @@ clm outline course.xml --format json
 clm outline course.xml --include-disabled
 ```
 
-### `clm resolve-topic`
+### `clm topic resolve`
+
+*Deprecated alias: `clm resolve-topic` (removed in 1.7).*
 
 Resolve a topic ID to its filesystem path.
 
@@ -229,7 +286,9 @@ clm resolve-topic intro --course-spec course-specs/python.xml
 clm resolve-topic intro --module module_545_ml_azav_cohort_2026_04
 ```
 
-### `clm search-slides`
+### `clm slides search`
+
+*Deprecated alias: `clm search-slides` (removed in 1.7).*
 
 Fuzzy search across topic names and slide file titles.
 
@@ -252,7 +311,12 @@ clm search-slides "RAG introduction" --language en
 clm search-slides lists --course-spec course-specs/python.xml
 ```
 
-### `clm validate-spec`
+### `clm validate` (spec mode)
+
+`clm validate course.xml` dispatches to spec validation when the
+argument is an `.xml` file.
+
+*Deprecated alias: `clm validate-spec` (removed in 1.7).*
 
 Validate a course specification XML file for consistency.
 
@@ -338,7 +402,12 @@ clm sync-includes course-specs/ml-azav.xml --dry-run
 clm sync-includes course-specs/ml-azav.xml --data-dir /path/to/course
 ```
 
-### `clm validate-slides`
+### `clm validate` (slides mode)
+
+`clm validate slides/` (or `clm validate slides_foo.py`) dispatches
+to slide validation when the argument is a `.py` file or directory.
+
+*Deprecated alias: `clm validate-slides` (removed in 1.7).*
 
 Validate slide files for format, tag, and pairing correctness. Runs deterministic
 checks and extracts structured review material for content-quality checks.
@@ -364,7 +433,9 @@ clm validate-slides slides/module_010/ --json
 clm validate-slides slides/module_010/topic_100_intro/ --quick
 ```
 
-### `clm normalize-slides`
+### `clm slides normalize`
+
+*Deprecated alias: `clm normalize-slides` (removed in 1.7).*
 
 Normalize slide files by applying mechanical fixes: tag migration (`alt`→`completed`),
 workshop tag insertion, DE/EN interleaving, and slide ID auto-generation.
@@ -389,7 +460,9 @@ clm normalize-slides slides/module_010/ --operations tag_migration
 clm normalize-slides slides/module_010/ --operations slide_ids --json
 ```
 
-### `clm language-view`
+### `clm slides language-view`
+
+*Deprecated alias: `clm language-view` (removed in 1.7).*
 
 Extract a single-language view of a bilingual slide file. Each cell is
 preceded by an `[original line N]` annotation so edits can be mapped back.
@@ -411,7 +484,9 @@ clm language-view slides_intro.py en --include-voiceover
 clm language-view slides_intro.py en --include-notes
 ```
 
-### `clm suggest-sync`
+### `clm slides suggest-sync`
+
+*Deprecated alias: `clm suggest-sync` (removed in 1.7).*
 
 Compare a slide file against git HEAD and detect asymmetric bilingual edits.
 Suggests which cells need translation updates. Does not modify the file.
@@ -432,7 +507,9 @@ clm suggest-sync slides_intro.py
 clm suggest-sync slides_intro.py --source-language de --json
 ```
 
-### `clm extract-voiceover`
+### `clm voiceover extract`
+
+*Deprecated alias: `clm extract-voiceover` (removed in 1.7).*
 
 Extract voiceover and notes cells from a slide file to a companion
 `voiceover_*.py` file, linked via `slide_id`/`for_slide` metadata.
@@ -454,7 +531,9 @@ clm extract-voiceover slides_intro.py
 clm extract-voiceover slides_intro.py --dry-run
 ```
 
-### `clm inline-voiceover`
+### `clm voiceover inline`
+
+*Deprecated alias: `clm inline-voiceover` (removed in 1.7).*
 
 Inline voiceover cells from a companion `voiceover_*.py` file back into the
 slide file, matching via `for_slide`/`slide_id` metadata. Deletes the companion
@@ -476,7 +555,9 @@ clm inline-voiceover slides_intro.py
 clm inline-voiceover slides_intro.py --dry-run
 ```
 
-### `clm authoring-rules`
+### `clm authoring rules`
+
+*Deprecated alias: `clm authoring-rules` (removed in 1.7).*
 
 Look up merged authoring rules (common + course-specific) for a course.
 Reads per-course `.authoring.md` files from the `course-specs/` directory.

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,67 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## CLI restructure: verb-grouped subcommands
+
+CLM {version} reorganises the top-level command surface. Several flat
+commands moved under new groups for a smaller, more scannable layout:
+
+| Old (still works, deprecated)        | New canonical                |
+|--------------------------------------|------------------------------|
+| `clm normalize-slides`               | `clm slides normalize`       |
+| `clm language-view`                  | `clm slides language-view`   |
+| `clm suggest-sync`                   | `clm slides suggest-sync`    |
+| `clm search-slides`                  | `clm slides search`          |
+| `clm resolve-topic`                  | `clm topic resolve`          |
+| `clm authoring-rules`                | `clm authoring rules`        |
+| `clm extract-voiceover`              | `clm voiceover extract`      |
+| `clm inline-voiceover`               | `clm voiceover inline`       |
+| `clm validate-slides PATH`           | `clm validate PATH`          |
+| `clm validate-spec SPEC`             | `clm validate SPEC`          |
+
+### Deprecation timeline
+
+- **{version}**: Old names still work and emit a one-line
+  deprecation notice on stderr naming the new invocation. The
+  notice does not affect exit codes or stdout, so scripts that
+  pipe `--json` output through `jq` continue to work; only
+  interactive users see the migration hint.
+- **1.7 (planned)**: Old names removed.
+
+### `clm validate` consolidates the two validators
+
+`clm validate <path>` replaces both `validate-slides` and
+`validate-spec`. It inspects the argument:
+
+- `.xml` file → spec validation (formerly `validate-spec`)
+- `.py` file or directory → slide validation (formerly `validate-slides`)
+
+For ambiguous cases (an `.xml` you want fed to the slide validator,
+or vice versa), pass `--kind=slides` or `--kind=spec` explicitly.
+
+All flags from both old commands are still available; the new
+command refuses combinations that don't apply (`--quick` with
+`--kind=spec`, `--include-disabled` with `--kind=slides`).
+
+### How to migrate
+
+For scripts and CI:
+
+- **Greppable rename**: each old name maps 1:1 to a new path. A
+  global find-and-replace of `clm normalize-slides` →
+  `clm slides normalize` (and similar for the other names) is
+  safe.
+- **PostToolUse hooks** referencing the old names will print the
+  deprecation notice each edit. Update the hook command to the
+  new path to silence it.
+- **Skill files** (`.claude/commands/*.md` in consuming repos)
+  should be updated to the new paths; the deprecation will be a
+  noticeable lint signal if you forget any.
+
+For interactive use, no action is needed — the old names keep
+working until 1.7, and the deprecation notice tells you the new
+path each time you invoke an old one.
+
 ## `clm build` no longer wipes the output tree by default
 
 CLM {version} changes how `clm build` manages each output root. The

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -65,6 +65,12 @@ def help(ctx):
 # Import and register commands from submodules
 # These imports must come after cli is defined, hence noqa: E402
 # Re-export commonly used functions for backwards compatibility with tests
+from clm.cli.commands._aliases import deprecated_alias  # noqa: E402
+from clm.cli.commands._groups import (  # noqa: E402
+    authoring_group,
+    slides_group,
+    topic_group,
+)
 from clm.cli.commands.authoring_rules import authoring_rules_cmd  # noqa: E402
 from clm.cli.commands.build import (  # noqa: E402
     build,
@@ -86,6 +92,7 @@ from clm.cli.commands.status import status  # noqa: E402
 from clm.cli.commands.suggest_sync import suggest_sync_cmd  # noqa: E402
 from clm.cli.commands.summarize import summarize  # noqa: E402
 from clm.cli.commands.sync_includes import sync_includes_cmd  # noqa: E402
+from clm.cli.commands.validate import validate_cmd  # noqa: E402
 from clm.cli.commands.validate_slides import validate_slides_cmd  # noqa: E402
 from clm.cli.commands.validate_spec import validate_spec_cmd  # noqa: E402
 from clm.cli.commands.voiceover_tools import (  # noqa: E402
@@ -118,29 +125,39 @@ except ImportError:
 
 from clm.cli.commands.jupyterlite import jupyterlite_group  # noqa: E402
 
-# Register individual commands
-cli.add_command(authoring_rules_cmd)
+# ---------------------------------------------------------------------
+# Top-level commands that stay flat after the Phase 0 restructure.
+# ---------------------------------------------------------------------
 cli.add_command(build)
 cli.add_command(list_targets, name="targets")
+cli.add_command(outline)
+cli.add_command(validate_cmd)
 cli.add_command(delete_database)
 cli.add_command(status)
 cli.add_command(monitor)
 cli.add_command(info)
-cli.add_command(outline)
-cli.add_command(resolve_topic_cmd)
-cli.add_command(search_slides_cmd)
-cli.add_command(normalize_slides_cmd)
-cli.add_command(validate_slides_cmd)
-cli.add_command(language_view_cmd)
-cli.add_command(suggest_sync_cmd)
-cli.add_command(validate_spec_cmd)
 cli.add_command(sync_includes_cmd)
-cli.add_command(extract_voiceover_cmd)
-cli.add_command(inline_voiceover_cmd)
 cli.add_command(summarize)
 cli.add_command(serve)
 
-# Register command groups
+# ---------------------------------------------------------------------
+# Verb-grouped commands (Phase 0): the canonical invocations.
+# ---------------------------------------------------------------------
+slides_group.add_command(normalize_slides_cmd, name="normalize")
+slides_group.add_command(language_view_cmd, name="language-view")
+slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
+slides_group.add_command(search_slides_cmd, name="search")
+cli.add_command(slides_group)
+
+topic_group.add_command(resolve_topic_cmd, name="resolve")
+cli.add_command(topic_group)
+
+authoring_group.add_command(authoring_rules_cmd, name="rules")
+cli.add_command(authoring_group)
+
+# ---------------------------------------------------------------------
+# Existing infrastructure groups (unchanged by Phase 0).
+# ---------------------------------------------------------------------
 cli.add_command(config)
 cli.add_command(db)
 cli.add_command(docker_group)
@@ -151,7 +168,13 @@ cli.add_command(zip_group)
 
 # Optional commands (gated behind extras)
 if voiceover_group is not None:
+    # Phase 0: move extract/inline under the voiceover group as
+    # canonical subcommands. They keep working as top-level deprecated
+    # aliases below.
+    voiceover_group.add_command(extract_voiceover_cmd, name="extract")
+    voiceover_group.add_command(inline_voiceover_cmd, name="inline")
     cli.add_command(voiceover_group)
+
 if polish_cmd is not None:
     cli.add_command(polish_cmd)
 if recordings_group is not None:
@@ -159,6 +182,23 @@ if recordings_group is not None:
 if mcp_cmd is not None:
     cli.add_command(mcp_cmd)
 cli.add_command(jupyterlite_group)
+
+# ---------------------------------------------------------------------
+# Deprecated top-level aliases (Phase 0). Each old name keeps working
+# with a deprecation notice naming the new invocation. Removal slated
+# for CLM 1.7.
+# ---------------------------------------------------------------------
+cli.add_command(deprecated_alias(normalize_slides_cmd, new_invocation="slides normalize"))
+cli.add_command(deprecated_alias(language_view_cmd, new_invocation="slides language-view"))
+cli.add_command(deprecated_alias(suggest_sync_cmd, new_invocation="slides suggest-sync"))
+cli.add_command(deprecated_alias(search_slides_cmd, new_invocation="slides search"))
+cli.add_command(deprecated_alias(resolve_topic_cmd, new_invocation="topic resolve"))
+cli.add_command(deprecated_alias(authoring_rules_cmd, new_invocation="authoring rules"))
+cli.add_command(deprecated_alias(validate_slides_cmd, new_invocation="validate"))
+cli.add_command(deprecated_alias(validate_spec_cmd, new_invocation="validate"))
+if voiceover_group is not None:
+    cli.add_command(deprecated_alias(extract_voiceover_cmd, new_invocation="voiceover extract"))
+    cli.add_command(deprecated_alias(inline_voiceover_cmd, new_invocation="voiceover inline"))
 
 
 # Re-export commonly used functions for backwards compatibility with tests

--- a/src/clm/snapshot/__init__.py
+++ b/src/clm/snapshot/__init__.py
@@ -1,0 +1,10 @@
+"""Build-output snapshot and verification.
+
+Public API:
+    verify_against(snapshot_dir, output_dir, *, include_html, strict) -> VerifyReport
+    VerifyReport
+"""
+
+from clm.snapshot.verifier import VerifyReport, verify_against
+
+__all__ = ["VerifyReport", "verify_against"]

--- a/src/clm/snapshot/normalize.py
+++ b/src/clm/snapshot/normalize.py
@@ -1,0 +1,33 @@
+"""Content normalization for snapshot comparison.
+
+Only HTML normalization is implemented today. Slide code that uses live
+kernel execution (e.g. ``print(obj)`` of a default-``__repr__`` object)
+emits hex memory addresses that differ across runs due to ASLR; the
+normalizer rewrites those to a fixed sentinel so byte comparison works.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Matches hex memory addresses as they appear in default Python __repr__
+# output: ``<__main__.Foo at 0x2733c2b8ad0>``, ``0x000002733C2BA120``, etc.
+# 4+ hex digits to avoid false-matching short literals like ``0xff``.
+_HEX_ADDR = re.compile(rb"0[xX][0-9a-fA-F]{4,}")
+_HEX_ADDR_PLACEHOLDER = b"0xADDR"
+
+
+def normalize_html(content: bytes) -> bytes:
+    """Return *content* with hex memory addresses replaced by a sentinel."""
+    return _HEX_ADDR.sub(_HEX_ADDR_PLACEHOLDER, content)
+
+
+def normalize_for_compare(rel_path: str, content: bytes, *, include_html: bool) -> bytes:
+    """Apply class-aware normalization, or return content unchanged.
+
+    Used by the verifier to make a "harmless-diff-tolerant" byte
+    comparison. The ``rel_path`` ending is the only routing input.
+    """
+    if include_html and rel_path.endswith(".html"):
+        return normalize_html(content)
+    return content

--- a/src/clm/snapshot/verifier.py
+++ b/src/clm/snapshot/verifier.py
@@ -1,0 +1,226 @@
+"""Compare two CLM build-output trees byte-by-byte and produce a
+class-aware report.
+
+Migration verification (the Phase-1 use case in the slide-format-redesign
+track) needs to confirm that an applied change produced byte-identical
+build output relative to a pre-change snapshot. The fixed point of
+"byte-identical" is intentionally strict: any diff that is not an
+explicitly-tolerated normalization (today, just hex memory addresses
+in HTML when ``include_html=True``) shows up as a failure.
+
+By default ``.html`` files are skipped because their content includes
+live-kernel execution output. CLM's notebook conversion is fully
+deterministic post-PR-#76, but slides whose source code uses
+``random.choice``, ``print(obj)``-with-default-``__repr__``, or has
+intermixed stdout/exception output produce different rendered HTML each
+run — these are properties of slide content, not of CLM. Skipping HTML
+removes that noise floor; ``--include-html`` re-enables it with hex
+address normalization, and ``--strict`` turns off all skips and
+normalization.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.snapshot.normalize import normalize_for_compare
+
+# File extensions whose content can vary run-to-run because they include
+# the output of live kernel execution. Excluded from comparison unless
+# the user opts in with ``--include-html`` (which then applies
+# normalization) or ``--strict`` (which compares them raw).
+_NOISY_EXTENSIONS: frozenset[str] = frozenset({".html"})
+
+
+@dataclass
+class ExtCounts:
+    total: int = 0
+    identical: int = 0
+    differing: int = 0
+    skipped: int = 0
+    missing: int = 0  # missing in output (was in snapshot but build did not produce it)
+
+
+@dataclass
+class VerifyReport:
+    snapshot_dir: Path
+    output_dir: Path
+    identical: list[Path] = field(default_factory=list)
+    differing: list[Path] = field(default_factory=list)
+    skipped: list[Path] = field(default_factory=list)
+    missing_in_output: list[Path] = field(default_factory=list)
+    missing_in_snapshot: list[Path] = field(default_factory=list)
+    by_extension: dict[str, ExtCounts] = field(default_factory=lambda: defaultdict(ExtCounts))
+
+    @property
+    def has_diffs(self) -> bool:
+        """True if any non-skipped file diverged or is missing on either side."""
+        return bool(self.differing or self.missing_in_output or self.missing_in_snapshot)
+
+    @property
+    def total_files(self) -> int:
+        return (
+            len(self.identical)
+            + len(self.differing)
+            + len(self.skipped)
+            + len(self.missing_in_output)
+        )
+
+    def format_text(self) -> str:
+        """Human-readable single-page summary."""
+        lines: list[str] = []
+        lines.append(f"Snapshot:        {self.snapshot_dir}")
+        lines.append(f"Output:          {self.output_dir}")
+        lines.append("")
+        lines.append(f"Files compared:  {self.total_files}")
+        lines.append(f"  Identical:     {len(self.identical)}")
+        lines.append(f"  Differing:     {len(self.differing)}")
+        lines.append(f"  Skipped:       {len(self.skipped)}")
+        lines.append(f"  Missing in output:    {len(self.missing_in_output)}")
+        lines.append(f"  Missing in snapshot:  {len(self.missing_in_snapshot)}")
+
+        if self.by_extension:
+            lines.append("")
+            lines.append("By extension:")
+            lines.append(
+                f"  {'ext':<12} {'total':>6} {'ident':>6} {'diff':>6} {'skip':>6} {'miss':>6}"
+            )
+            for ext in sorted(self.by_extension):
+                c = self.by_extension[ext]
+                ext_display = ext or "<none>"
+                lines.append(
+                    f"  {ext_display:<12} {c.total:>6} {c.identical:>6} "
+                    f"{c.differing:>6} {c.skipped:>6} {c.missing:>6}"
+                )
+
+        # List concrete diffs — cap to keep the report scannable.
+        cap = 50
+        if self.differing:
+            lines.append("")
+            lines.append(f"Differing files ({len(self.differing)}):")
+            for p in self.differing[:cap]:
+                lines.append(f"  ~ {p.as_posix()}")
+            if len(self.differing) > cap:
+                lines.append(f"  ... and {len(self.differing) - cap} more")
+        if self.missing_in_output:
+            lines.append("")
+            lines.append(f"Missing in output ({len(self.missing_in_output)}):")
+            for p in self.missing_in_output[:cap]:
+                lines.append(f"  - {p.as_posix()}")
+            if len(self.missing_in_output) > cap:
+                lines.append(f"  ... and {len(self.missing_in_output) - cap} more")
+        if self.missing_in_snapshot:
+            lines.append("")
+            lines.append(f"Missing in snapshot ({len(self.missing_in_snapshot)}):")
+            for p in self.missing_in_snapshot[:cap]:
+                lines.append(f"  + {p.as_posix()}")
+            if len(self.missing_in_snapshot) > cap:
+                lines.append(f"  ... and {len(self.missing_in_snapshot) - cap} more")
+
+        return "\n".join(lines)
+
+
+def _collect_files(root: Path) -> set[Path]:
+    """Return relative paths of every regular file under *root*."""
+    return {f.relative_to(root) for f in root.rglob("*") if f.is_file()}
+
+
+def _should_skip(rel_path: Path, *, include_html: bool, strict: bool) -> bool:
+    if strict:
+        return False
+    return rel_path.suffix in _NOISY_EXTENSIONS and not include_html
+
+
+def _content_matches(
+    snap_file: Path,
+    out_file: Path,
+    rel_path: Path,
+    *,
+    include_html: bool,
+    strict: bool,
+) -> bool:
+    """Byte-compare two files, optionally normalizing both sides first.
+
+    Normalization is only applied when ``include_html`` is true; under
+    ``strict`` even include_html is moot (strict turns off normalization
+    entirely).
+    """
+    snap_bytes = snap_file.read_bytes()
+    out_bytes = out_file.read_bytes()
+    if strict:
+        return snap_bytes == out_bytes
+    rel = rel_path.as_posix()
+    return normalize_for_compare(
+        rel, snap_bytes, include_html=include_html
+    ) == normalize_for_compare(rel, out_bytes, include_html=include_html)
+
+
+def verify_against(
+    snapshot_dir: Path,
+    output_dir: Path,
+    *,
+    include_html: bool = False,
+    strict: bool = False,
+) -> VerifyReport:
+    """Compare *output_dir* against *snapshot_dir* and return a report.
+
+    Args:
+        snapshot_dir: Path to a previously-captured build output. Files
+            here are the expected baseline.
+        output_dir: Path to a freshly-built output tree to verify.
+        include_html: If True, include ``.html`` files in the comparison
+            using hex-address normalization. Default skips HTML because
+            slide content with random output or default-``__repr__``
+            objects produces irreducible per-run noise.
+        strict: If True, byte-compare every file with no normalization
+            and no skipping. Overrides ``include_html``.
+
+    Returns:
+        A :class:`VerifyReport`. Inspect ``has_diffs`` for a pass/fail
+        signal and ``format_text()`` for a human-readable summary.
+    """
+    snapshot_dir = snapshot_dir.resolve()
+    output_dir = output_dir.resolve()
+
+    if not snapshot_dir.is_dir():
+        raise FileNotFoundError(f"Snapshot directory does not exist: {snapshot_dir}")
+    if not output_dir.is_dir():
+        raise FileNotFoundError(f"Output directory does not exist: {output_dir}")
+
+    snap_files = _collect_files(snapshot_dir)
+    out_files = _collect_files(output_dir)
+
+    report = VerifyReport(snapshot_dir=snapshot_dir, output_dir=output_dir)
+
+    common = snap_files & out_files
+    only_in_snap = snap_files - out_files
+    only_in_out = out_files - snap_files
+
+    for rel in sorted(common):
+        ext = rel.suffix
+        report.by_extension[ext].total += 1
+        if _should_skip(rel, include_html=include_html, strict=strict):
+            report.skipped.append(rel)
+            report.by_extension[ext].skipped += 1
+            continue
+        snap_file = snapshot_dir / rel
+        out_file = output_dir / rel
+        if _content_matches(snap_file, out_file, rel, include_html=include_html, strict=strict):
+            report.identical.append(rel)
+            report.by_extension[ext].identical += 1
+        else:
+            report.differing.append(rel)
+            report.by_extension[ext].differing += 1
+
+    for rel in sorted(only_in_snap):
+        ext = rel.suffix
+        report.by_extension[ext].total += 1
+        report.by_extension[ext].missing += 1
+        report.missing_in_output.append(rel)
+
+    for rel in sorted(only_in_out):
+        report.missing_in_snapshot.append(rel)
+
+    return report

--- a/tests/cli/test_command_aliases.py
+++ b/tests/cli/test_command_aliases.py
@@ -1,0 +1,295 @@
+"""Tests for the Phase 0 CLI restructure: verb groups + deprecated aliases.
+
+The flat top-level commands (``normalize-slides``, ``extract-voiceover``,
+``resolve-topic``, ...) were moved under verb groups in CLM 1.6, with the
+old names kept as deprecated aliases for two minor releases. These tests
+verify three properties:
+
+1. New canonical invocations work (``clm slides normalize``, ``clm
+   voiceover extract``, ``clm topic resolve``, ``clm authoring rules``).
+2. Old top-level aliases still work and produce the same behavior.
+3. Each alias emits a deprecation notice naming the new invocation, so
+   users get an immediately actionable migration hint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands._aliases import deprecated_alias
+from clm.cli.main import cli
+
+
+def _invoke(args: list[str], tmp_path: Path | None = None) -> click.testing.Result:
+    """Invoke the top-level ``cli`` group with a CliRunner."""
+    return CliRunner().invoke(cli, args)
+
+
+# ---------------------------------------------------------------------------
+# deprecated_alias helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedAliasHelper:
+    def test_alias_runs_target_callback(self):
+        # The target command's *name* is the name users will see and the
+        # name the alias is registered under. The migration message
+        # uses target.name verbatim, so test fixtures must align names.
+        invocations: list[tuple] = []
+
+        @click.command("old-name")
+        @click.argument("name")
+        @click.option("--flag", is_flag=True)
+        def target(name: str, flag: bool) -> None:
+            invocations.append((name, flag))
+
+        alias = deprecated_alias(target, new_invocation="new-group new-name")
+
+        @click.group()
+        def root() -> None: ...
+
+        root.add_command(alias)
+        result = CliRunner().invoke(root, ["old-name", "hello", "--flag"])
+
+        assert result.exit_code == 0
+        assert invocations == [("hello", True)]
+
+    def test_alias_emits_migration_notice(self):
+        @click.command("old-name")
+        def target() -> None: ...
+
+        alias = deprecated_alias(target, new_invocation="new path")
+
+        @click.group()
+        def root() -> None: ...
+
+        root.add_command(alias)
+        result = CliRunner().invoke(root, ["old-name"])
+
+        assert result.exit_code == 0
+        assert "DeprecationWarning" in result.output
+        assert "`clm old-name` is deprecated" in result.output
+        assert "Use `clm new path` instead" in result.output
+
+    def test_alias_help_marks_deprecated(self):
+        @click.command("old-name", help="Do a thing.")
+        def target() -> None: ...
+
+        alias = deprecated_alias(target, new_invocation="new path")
+
+        @click.group()
+        def root() -> None: ...
+
+        root.add_command(alias)
+        result = CliRunner().invoke(root, ["old-name", "--help"])
+
+        assert result.exit_code == 0
+        assert "(Deprecated)" in result.output
+
+    def test_alias_inherits_params(self):
+        @click.command("old-name")
+        @click.argument("name")
+        @click.option("--count", type=int, default=1)
+        def target(name: str, count: int) -> None: ...
+
+        alias = deprecated_alias(target, new_invocation="new path")
+        # Alias should expose the same parameter list (by reference).
+        assert alias.params is not target.params  # different list object
+        assert len(alias.params) == len(target.params)
+        # Parameters themselves are the same objects.
+        for a, c in zip(alias.params, target.params):
+            assert a is c
+
+    def test_alias_raises_for_callback_less_target(self):
+        # Groups have no callback unless explicitly set; the helper is
+        # designed for plain commands.
+        @click.group("g")
+        def g() -> None: ...
+
+        # Click groups DO have a callback set (a pass-through). Force the
+        # callback-less case by constructing a Command directly.
+        no_cb = click.Command(name="no-callback")
+        with pytest.raises(TypeError, match="requires target.callback"):
+            deprecated_alias(no_cb, new_invocation="x")
+
+
+# ---------------------------------------------------------------------------
+# CLI structure: new groups expose canonical subcommands
+# ---------------------------------------------------------------------------
+
+
+class TestNewGroupStructure:
+    @pytest.mark.parametrize(
+        "group_path",
+        [
+            ["slides", "--help"],
+            ["topic", "--help"],
+            ["authoring", "--help"],
+        ],
+    )
+    def test_groups_are_reachable(self, group_path: list[str]) -> None:
+        result = _invoke(group_path)
+        assert result.exit_code == 0
+
+    @pytest.mark.parametrize(
+        "subcommand_path",
+        [
+            ["slides", "normalize", "--help"],
+            ["slides", "language-view", "--help"],
+            ["slides", "suggest-sync", "--help"],
+            ["slides", "search", "--help"],
+            ["topic", "resolve", "--help"],
+            ["authoring", "rules", "--help"],
+        ],
+    )
+    def test_canonical_subcommands_resolve(self, subcommand_path: list[str]) -> None:
+        result = _invoke(subcommand_path)
+        assert result.exit_code == 0
+        # Help output should not announce deprecation for canonical paths.
+        assert "(Deprecated)" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Deprecation aliases: old top-level names still work
+# ---------------------------------------------------------------------------
+
+
+# Mapping: (old-flat-name, new-canonical-path)
+ALIAS_RENAMES: list[tuple[str, str]] = [
+    ("normalize-slides", "slides normalize"),
+    ("language-view", "slides language-view"),
+    ("suggest-sync", "slides suggest-sync"),
+    ("search-slides", "slides search"),
+    ("resolve-topic", "topic resolve"),
+    ("authoring-rules", "authoring rules"),
+    ("validate-slides", "validate"),
+    ("validate-spec", "validate"),
+]
+
+
+class TestDeprecatedTopLevelAliases:
+    @pytest.mark.parametrize("old, new", ALIAS_RENAMES)
+    def test_alias_is_registered(self, old: str, new: str) -> None:
+        result = _invoke([old, "--help"])
+        assert result.exit_code == 0
+        # Each alias help should self-describe as deprecated.
+        assert "(Deprecated)" in result.output
+
+    @pytest.mark.parametrize("old, new", ALIAS_RENAMES)
+    def test_alias_help_does_not_emit_warning(self, old: str, new: str) -> None:
+        # --help should *not* invoke the callback, so the migration
+        # notice should not fire. Click's own "(deprecated)" tag still
+        # shows up in the help text — but the "use X instead" line is
+        # callback-only.
+        result = _invoke([old, "--help"])
+        assert "Use `clm" not in result.output
+
+
+class TestExtractInlineVoiceoverAliases:
+    # Conditional on the [voiceover] extra being installed. The CLI
+    # registration in main.py only adds these aliases when the
+    # voiceover_group import succeeded.
+    def _voiceover_available(self) -> bool:
+        from clm.cli.main import voiceover_group
+
+        return voiceover_group is not None
+
+    def test_extract_alias_registered(self) -> None:
+        if not self._voiceover_available():
+            pytest.skip("voiceover extra not installed")
+        result = _invoke(["extract-voiceover", "--help"])
+        assert result.exit_code == 0
+        assert "(Deprecated)" in result.output
+
+    def test_inline_alias_registered(self) -> None:
+        if not self._voiceover_available():
+            pytest.skip("voiceover extra not installed")
+        result = _invoke(["inline-voiceover", "--help"])
+        assert result.exit_code == 0
+        assert "(Deprecated)" in result.output
+
+    def test_canonical_voiceover_extract_resolves(self) -> None:
+        if not self._voiceover_available():
+            pytest.skip("voiceover extra not installed")
+        result = _invoke(["voiceover", "extract", "--help"])
+        assert result.exit_code == 0
+        assert "(Deprecated)" not in result.output
+
+    def test_canonical_voiceover_inline_resolves(self) -> None:
+        if not self._voiceover_available():
+            pytest.skip("voiceover extra not installed")
+        result = _invoke(["voiceover", "inline", "--help"])
+        assert result.exit_code == 0
+        assert "(Deprecated)" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unified `clm validate` dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDispatch:
+    def _write_spec(self, path: Path) -> Path:
+        path.write_text(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <sections/>
+</course>
+""",
+            encoding="utf-8",
+        )
+        return path
+
+    def _write_slide(self, path: Path) -> Path:
+        path.write_text(
+            '# %% [markdown] lang="en" tags=["slide"]\n# # Hello\n',
+            encoding="utf-8",
+        )
+        return path
+
+    def test_xml_dispatches_to_spec_validator(self, tmp_path: Path) -> None:
+        spec = self._write_spec(tmp_path / "course.xml")
+        # Provide a slides dir for the spec validator's data-dir
+        # inference. We just need _something_ that exists.
+        slides_dir = tmp_path / "slides"
+        slides_dir.mkdir()
+        result = _invoke(["validate", str(spec), "--data-dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+    def test_py_file_dispatches_to_slide_validator(self, tmp_path: Path) -> None:
+        slide = self._write_slide(tmp_path / "slides_test.py")
+        result = _invoke(["validate", str(slide)])
+        # The slide-validator's exit code depends on findings; we only
+        # care that we got past dispatch. Any non-usage exit is fine.
+        assert "Cannot infer validator kind" not in result.output
+
+    def test_directory_dispatches_to_slide_validator(self, tmp_path: Path) -> None:
+        slide_dir = tmp_path / "slides"
+        slide_dir.mkdir()
+        self._write_slide(slide_dir / "slides_test.py")
+        result = _invoke(["validate", str(slide_dir)])
+        assert "Cannot infer validator kind" not in result.output
+
+    def test_kind_spec_rejects_slides_only_flags(self, tmp_path: Path) -> None:
+        spec = self._write_spec(tmp_path / "course.xml")
+        result = _invoke(["validate", str(spec), "--kind=spec", "--quick"])
+        assert result.exit_code != 0
+        assert "slides-only" in result.output
+
+    def test_kind_slides_rejects_spec_only_flags(self, tmp_path: Path) -> None:
+        slide = self._write_slide(tmp_path / "slides_test.py")
+        result = _invoke(["validate", str(slide), "--kind=slides", "--include-disabled"])
+        assert result.exit_code != 0
+        assert "spec-only" in result.output
+
+    def test_kind_spec_rejects_non_xml(self, tmp_path: Path) -> None:
+        slide = self._write_slide(tmp_path / "slides_test.py")
+        result = _invoke(["validate", str(slide), "--kind=spec"])
+        assert result.exit_code != 0
+        assert "--kind=spec requires an .xml file" in result.output

--- a/tests/cli/test_command_aliases.py
+++ b/tests/cli/test_command_aliases.py
@@ -88,7 +88,9 @@ class TestDeprecatedAliasHelper:
         result = CliRunner().invoke(root, ["old-name", "--help"])
 
         assert result.exit_code == 0
-        assert "(Deprecated)" in result.output
+        # Click renders the deprecation tag as "(Deprecated)" in 8.1.x
+        # and "(DEPRECATED)" in 8.3.x — compare case-insensitively.
+        assert "(deprecated)" in result.output.lower()
 
     def test_alias_inherits_params(self):
         @click.command("old-name")
@@ -150,7 +152,9 @@ class TestNewGroupStructure:
         result = _invoke(subcommand_path)
         assert result.exit_code == 0
         # Help output should not announce deprecation for canonical paths.
-        assert "(Deprecated)" not in result.output
+        # Case-insensitive guard against Click version variance (8.1.x
+        # renders "(Deprecated)"; 8.3.x renders "(DEPRECATED)").
+        assert "(deprecated)" not in result.output.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +181,9 @@ class TestDeprecatedTopLevelAliases:
         result = _invoke([old, "--help"])
         assert result.exit_code == 0
         # Each alias help should self-describe as deprecated.
-        assert "(Deprecated)" in result.output
+        # Case-insensitive: Click 8.1.x renders "(Deprecated)";
+        # Click 8.3.x renders "(DEPRECATED)".
+        assert "(deprecated)" in result.output.lower()
 
     @pytest.mark.parametrize("old, new", ALIAS_RENAMES)
     def test_alias_help_does_not_emit_warning(self, old: str, new: str) -> None:
@@ -203,28 +209,29 @@ class TestExtractInlineVoiceoverAliases:
             pytest.skip("voiceover extra not installed")
         result = _invoke(["extract-voiceover", "--help"])
         assert result.exit_code == 0
-        assert "(Deprecated)" in result.output
+        # Case-insensitive — see TestDeprecatedAliasHelper above.
+        assert "(deprecated)" in result.output.lower()
 
     def test_inline_alias_registered(self) -> None:
         if not self._voiceover_available():
             pytest.skip("voiceover extra not installed")
         result = _invoke(["inline-voiceover", "--help"])
         assert result.exit_code == 0
-        assert "(Deprecated)" in result.output
+        assert "(deprecated)" in result.output.lower()
 
     def test_canonical_voiceover_extract_resolves(self) -> None:
         if not self._voiceover_available():
             pytest.skip("voiceover extra not installed")
         result = _invoke(["voiceover", "extract", "--help"])
         assert result.exit_code == 0
-        assert "(Deprecated)" not in result.output
+        assert "(deprecated)" not in result.output.lower()
 
     def test_canonical_voiceover_inline_resolves(self) -> None:
         if not self._voiceover_available():
             pytest.skip("voiceover extra not installed")
         result = _invoke(["voiceover", "inline", "--help"])
         assert result.exit_code == 0
-        assert "(Deprecated)" not in result.output
+        assert "(deprecated)" not in result.output.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_resolve_topic.py
+++ b/tests/cli/test_resolve_topic.py
@@ -48,9 +48,13 @@ class TestResolveTopicCommand:
 
     def test_json_output(self, course_tree):
         runner = CliRunner()
+        # Use new canonical `topic resolve` path — the deprecated
+        # `resolve-topic` alias emits a stderr notice that CliRunner's
+        # default mix_stderr=True would merge into the JSON parser's
+        # input.
         result = runner.invoke(
             cli,
-            ["resolve-topic", "intro", "--data-dir", str(course_tree), "--json"],
+            ["topic", "resolve", "intro", "--data-dir", str(course_tree), "--json"],
         )
         assert result.exit_code == 0
         data = json.loads(result.output)

--- a/tests/cli/test_validate_slides.py
+++ b/tests/cli/test_validate_slides.py
@@ -71,7 +71,12 @@ class TestValidateSlidesCommand:
         )
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["validate-slides", str(p), "--json"])
+        # Use the new canonical `validate` command (auto-dispatches
+        # by file type) so stdout stays clean — the deprecated
+        # `validate-slides` alias emits a stderr notice that
+        # CliRunner's default mix_stderr=True would merge into the
+        # JSON parser's input.
+        result = runner.invoke(cli, ["validate", str(p), "--json"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -89,7 +94,7 @@ class TestValidateSlidesCommand:
         )
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["validate-slides", str(p), "--json"])
+        result = runner.invoke(cli, ["validate", str(p), "--json"])
 
         assert result.exit_code == 0  # JSON mode doesn't set exit code
         data = json.loads(result.output)
@@ -228,9 +233,9 @@ class TestValidateSlidesCommand:
         )
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["validate-slides", str(p), "--checks", "code_quality", "--json"]
-        )
+        # Use the new canonical `validate` command — see test_json_output
+        # above for rationale.
+        result = runner.invoke(cli, ["validate", str(p), "--checks", "code_quality", "--json"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)

--- a/tests/cli/test_validate_spec.py
+++ b/tests/cli/test_validate_spec.py
@@ -83,9 +83,13 @@ class TestValidateSpecCommand:
         )
 
         runner = CliRunner()
+        # Use the new canonical `validate` command (dispatches by file
+        # type — .xml → spec). The deprecated `validate-spec` alias
+        # emits a stderr notice that CliRunner's default
+        # mix_stderr=True would merge into the JSON parser's input.
         result = runner.invoke(
             cli,
-            ["validate-spec", str(spec_file), "--data-dir", str(tmp_path), "--json"],
+            ["validate", str(spec_file), "--data-dir", str(tmp_path), "--json"],
         )
 
         assert result.exit_code == 0
@@ -107,7 +111,7 @@ class TestValidateSpecCommand:
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["validate-spec", str(spec_file), "--data-dir", str(tmp_path), "--json"],
+            ["validate", str(spec_file), "--data-dir", str(tmp_path), "--json"],
         )
 
         assert result.exit_code == 0  # JSON mode doesn't set exit code
@@ -220,10 +224,12 @@ class TestValidateSpecIncludeDisabled:
         )
 
         runner = CliRunner()
+        # Use new canonical `validate` command — see test_json_output
+        # in TestValidateSpecCommand for rationale.
         result = runner.invoke(
             cli,
             [
-                "validate-spec",
+                "validate",
                 str(spec_file),
                 "--data-dir",
                 str(tmp_path),

--- a/tests/snapshot/test_build_cli.py
+++ b/tests/snapshot/test_build_cli.py
@@ -1,0 +1,146 @@
+"""CLI flag-validation tests for ``clm build --snapshot`` and
+``clm build --verify-against``.
+
+These tests exercise the usage-error path: each command shape triggers
+the validation check at the top of ``build()`` *before* any build
+pipeline runs, so they are cheap and do not need any worker setup.
+
+End-to-end build determinism (the actual snapshot/verify cycle on a
+real spec) lives in ``tests/integration/`` so it can be marked slow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import build as build_module
+
+
+def _write_minimal_spec(path: Path) -> Path:
+    path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <sections/>
+</course>
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _invoke_build(args, tmp_path: Path):
+    """Invoke ``build`` with the parent-context dict the top-level
+    group normally seeds. Without it, the command bails on the missing
+    DB-path keys."""
+    obj = {
+        "CACHE_DB_PATH": tmp_path / "cache.db",
+        "JOBS_DB_PATH": tmp_path / "jobs.db",
+    }
+    return CliRunner().invoke(build_module.build, args, obj=obj)
+
+
+class TestSnapshotFlagValidation:
+    def test_snapshot_and_output_dir_mutex(self, tmp_path: Path) -> None:
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        result = _invoke_build(
+            [
+                str(spec),
+                "--snapshot",
+                str(tmp_path / "snap"),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        assert "--snapshot" in result.output and "--output-dir" in result.output
+
+    def test_snapshot_and_verify_mutex(self, tmp_path: Path) -> None:
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        result = _invoke_build(
+            [
+                str(spec),
+                "--snapshot",
+                str(tmp_path / "snap"),
+                "--verify-against",
+                str(baseline),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_snapshot_target_must_be_empty(self, tmp_path: Path) -> None:
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        snap = tmp_path / "snap"
+        snap.mkdir()
+        (snap / "stale.txt").write_text("leftover", encoding="utf-8")
+        result = _invoke_build(
+            [str(spec), "--snapshot", str(snap)],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "not empty" in result.output
+
+    def test_snapshot_into_nonexistent_dir_passes_validation(self, tmp_path: Path) -> None:
+        # The validation step should accept a non-existent target;
+        # the build itself will create it. We assert the run got past
+        # the validation by not finding the usage-error wording.
+        # (The build will likely fail later for unrelated reasons in
+        # this minimal-spec setup; we only care about the validation
+        # gate here.)
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        result = _invoke_build(
+            [str(spec), "--snapshot", str(tmp_path / "fresh-snap")],
+            tmp_path,
+        )
+        # Either succeeded entirely OR failed for a build-pipeline
+        # reason. The usage-error path must not have fired.
+        assert "mutually exclusive" not in result.output
+        assert "not empty" not in result.output
+
+
+class TestVerifyFlagValidation:
+    def test_include_html_without_verify_errors(self, tmp_path: Path) -> None:
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        result = _invoke_build(
+            [str(spec), "--include-html"],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "--include-html" in result.output
+        assert "no effect" in result.output
+
+    def test_strict_verify_without_verify_errors(self, tmp_path: Path) -> None:
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        result = _invoke_build(
+            [str(spec), "--strict-verify"],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "--strict-verify" in result.output
+        assert "no effect" in result.output
+
+    def test_verify_against_requires_existing_dir(self, tmp_path: Path) -> None:
+        # Click's exists=True on the --verify-against type catches this
+        # before our own logic runs; the error message comes from Click.
+        spec = _write_minimal_spec(tmp_path / "course.xml")
+        result = _invoke_build(
+            [
+                str(spec),
+                "--verify-against",
+                str(tmp_path / "missing-baseline"),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        # Click's standard error text for an exists=True path.
+        assert "does not exist" in result.output or "Invalid value" in result.output

--- a/tests/snapshot/test_build_integration.py
+++ b/tests/snapshot/test_build_integration.py
@@ -1,0 +1,234 @@
+"""Integration tests for the snapshot/verify CLI flow.
+
+These tests monkey-patch ``main_build`` to skip the real build pipeline
+(which is exercised elsewhere) and instead drop pre-canned output into
+the build's effective output directory. That lets us validate the full
+flag-to-verifier wiring end-to-end without paying a 30-second build per
+test case.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import build as build_module
+
+
+def _write_minimal_spec(path: Path) -> Path:
+    path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <sections/>
+</course>
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed_output(output_dir: Path, files: dict[str, bytes]) -> None:
+    """Populate *output_dir* with the given relative paths and bytes."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        path = output_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+
+@pytest.fixture
+def fake_build(monkeypatch):
+    """Replace ``main_build`` with an async no-op that pre-populates output.
+
+    The factory returns a function the test calls with the files it
+    wants the "build" to produce; the actual stub is registered as a
+    side effect.
+    """
+
+    seeded: dict[str, bytes] = {}
+
+    async def stub_main_build(
+        ctx,
+        spec_file,
+        data_dir,
+        output_dir,
+        *_args,
+        **_kwargs,
+    ):
+        # The real build resolves output_dir lazily; we mirror that and
+        # write to the resolved path used by the post-build hook.
+        if output_dir is None:
+            # Fall back to spec's grandparent / "output" — matches
+            # resolve_course_paths' default-output behavior.
+            output_dir = spec_file.absolute().parents[1] / "output"
+        _seed_output(Path(output_dir), seeded)
+
+    monkeypatch.setattr(build_module, "main_build", stub_main_build)
+
+    def configure(files: dict[str, bytes]) -> None:
+        seeded.clear()
+        seeded.update(files)
+
+    return configure
+
+
+def _invoke_build(args, tmp_path: Path):
+    obj = {
+        "CACHE_DB_PATH": tmp_path / "cache.db",
+        "JOBS_DB_PATH": tmp_path / "jobs.db",
+    }
+    return CliRunner().invoke(build_module.build, args, obj=obj)
+
+
+class TestSnapshotCapture:
+    def test_snapshot_writes_to_target_dir(self, tmp_path: Path, fake_build) -> None:
+        # Spec must live under a parent that itself has a parent
+        # (resolve_course_paths goes ``parents[1]``), so put it two
+        # levels deep.
+        spec_dir = tmp_path / "repo" / "course-specs"
+        spec_dir.mkdir(parents=True)
+        spec = _write_minimal_spec(spec_dir / "course.xml")
+        fake_build(
+            {
+                "a.py": b"hello",
+                "sub/b.ipynb": b"{}",
+            }
+        )
+
+        snap = tmp_path / "snap"
+        result = _invoke_build(
+            [str(spec), "--snapshot", str(snap)],
+            tmp_path,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (snap / "a.py").read_bytes() == b"hello"
+        assert (snap / "sub" / "b.ipynb").read_bytes() == b"{}"
+        assert "Snapshot saved to" in result.output
+
+
+class TestVerifyAgainst:
+    def _build_baseline(self, tmp_path: Path, fake_build, payload):
+        spec_dir = tmp_path / "repo" / "course-specs"
+        spec_dir.mkdir(parents=True)
+        spec = _write_minimal_spec(spec_dir / "course.xml")
+        baseline = tmp_path / "baseline"
+        fake_build(payload)
+        result = _invoke_build([str(spec), "--snapshot", str(baseline)], tmp_path)
+        assert result.exit_code == 0, result.output
+        return spec, baseline
+
+    def test_verify_passes_when_output_matches_snapshot(self, tmp_path: Path, fake_build) -> None:
+        spec, baseline = self._build_baseline(
+            tmp_path,
+            fake_build,
+            {"x.ipynb": b"identical", "y.py": b"py-source"},
+        )
+        # Second build produces the same output; verify must pass.
+        fake_build({"x.ipynb": b"identical", "y.py": b"py-source"})
+        out = tmp_path / "out2"
+        result = _invoke_build(
+            [
+                str(spec),
+                "--output-dir",
+                str(out),
+                "--verify-against",
+                str(baseline),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Verification passed" in result.output
+
+    def test_verify_fails_when_output_differs(self, tmp_path: Path, fake_build) -> None:
+        spec, baseline = self._build_baseline(
+            tmp_path,
+            fake_build,
+            {"x.ipynb": b"original"},
+        )
+        # Second build produces different content; verify must fail.
+        fake_build({"x.ipynb": b"changed"})
+        out = tmp_path / "out2"
+        result = _invoke_build(
+            [
+                str(spec),
+                "--output-dir",
+                str(out),
+                "--verify-against",
+                str(baseline),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "Verification failed" in result.output
+        assert "x.ipynb" in result.output
+
+    def test_html_default_skip_keeps_verify_passing(self, tmp_path: Path, fake_build) -> None:
+        # Two different HTMLs should not cause verify to fail by default
+        # — HTML is excluded because of live-kernel noise.
+        spec, baseline = self._build_baseline(
+            tmp_path,
+            fake_build,
+            {"page.html": b"<p>0x1111aaaa</p>", "kept.ipynb": b"x"},
+        )
+        fake_build({"page.html": b"<p>0x2222bbbb</p>", "kept.ipynb": b"x"})
+        out = tmp_path / "out2"
+        result = _invoke_build(
+            [
+                str(spec),
+                "--output-dir",
+                str(out),
+                "--verify-against",
+                str(baseline),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Verification passed" in result.output
+
+    def test_include_html_normalizes_hex_addresses(self, tmp_path: Path, fake_build) -> None:
+        spec, baseline = self._build_baseline(
+            tmp_path,
+            fake_build,
+            {"page.html": b"<p>obj at 0x1111aaaa</p>"},
+        )
+        fake_build({"page.html": b"<p>obj at 0x2222bbbb</p>"})
+        out = tmp_path / "out2"
+        result = _invoke_build(
+            [
+                str(spec),
+                "--output-dir",
+                str(out),
+                "--verify-against",
+                str(baseline),
+                "--include-html",
+            ],
+            tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_strict_verify_surfaces_html_address_diffs(self, tmp_path: Path, fake_build) -> None:
+        spec, baseline = self._build_baseline(
+            tmp_path,
+            fake_build,
+            {"page.html": b"<p>obj at 0x1111aaaa</p>"},
+        )
+        fake_build({"page.html": b"<p>obj at 0x2222bbbb</p>"})
+        out = tmp_path / "out2"
+        result = _invoke_build(
+            [
+                str(spec),
+                "--output-dir",
+                str(out),
+                "--verify-against",
+                str(baseline),
+                "--strict-verify",
+            ],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "Verification failed" in result.output

--- a/tests/snapshot/test_normalize.py
+++ b/tests/snapshot/test_normalize.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``clm.snapshot.normalize``."""
+
+from __future__ import annotations
+
+from clm.snapshot.normalize import normalize_for_compare, normalize_html
+
+
+class TestNormalizeHtml:
+    def test_default_repr_address_is_redacted(self):
+        out = normalize_html(b"<pre>&lt;__main__.Foo at 0x2733c2b8ad0&gt;</pre>")
+        assert out == b"<pre>&lt;__main__.Foo at 0xADDR&gt;</pre>"
+
+    def test_multiple_addresses_redacted(self):
+        out = normalize_html(b"<a>0x1234abcd</a><b>0xDEADBEEF</b>")
+        assert out == b"<a>0xADDR</a><b>0xADDR</b>"
+
+    def test_uppercase_hex_marker_redacted(self):
+        out = normalize_html(b"0X1234ABCD")
+        assert out == b"0xADDR"
+
+    def test_short_hex_literal_left_alone(self):
+        # 0xff and 0xAB are too short to be plausible memory addresses;
+        # they more commonly appear as actual constants in slide code.
+        assert normalize_html(b"0xff") == b"0xff"
+        assert normalize_html(b"0xAB") == b"0xAB"
+
+    def test_non_hex_content_unchanged(self):
+        original = b"<html><body><p>plain</p></body></html>"
+        assert normalize_html(original) == original
+
+
+class TestNormalizeForCompare:
+    def test_html_normalized_when_include_html(self):
+        out = normalize_for_compare(
+            "speaker/x/y.html",
+            b"<pre>0x2733c2b8ad0</pre>",
+            include_html=True,
+        )
+        assert out == b"<pre>0xADDR</pre>"
+
+    def test_html_not_normalized_by_default(self):
+        # include_html=False — caller is responsible for skipping HTML;
+        # this function only normalizes when explicitly asked.
+        original = b"<pre>0x2733c2b8ad0</pre>"
+        assert normalize_for_compare("foo.html", original, include_html=False) == original
+
+    def test_non_html_left_alone_even_when_include_html(self):
+        # ipynb has its own determinism layer (PR #76); we don't strip
+        # hex addresses from it because they might be meaningful content.
+        original = b'"output": "0x2733c2b8ad0"'
+        assert normalize_for_compare("foo.ipynb", original, include_html=True) == original

--- a/tests/snapshot/test_verifier.py
+++ b/tests/snapshot/test_verifier.py
@@ -1,0 +1,169 @@
+"""Unit tests for ``clm.snapshot.verifier``.
+
+Build-real-courses integration is in test_build_integration.py;
+these tests use synthetic directory trees so they run in <1s.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.snapshot import VerifyReport, verify_against
+
+
+def _write(root: Path, rel: str, content: bytes) -> None:
+    """Create root/rel with parent dirs and write *content*."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+@pytest.fixture
+def trees(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (snapshot_dir, output_dir) as empty siblings under tmp_path."""
+    snap = tmp_path / "snap"
+    out = tmp_path / "out"
+    snap.mkdir()
+    out.mkdir()
+    return snap, out
+
+
+class TestIdenticalTrees:
+    def test_zero_diffs_when_byte_identical(self, trees):
+        snap, out = trees
+        for rel in ("a.ipynb", "sub/b.py", "deep/nested/c.html"):
+            _write(snap, rel, b"identical")
+            _write(out, rel, b"identical")
+        report = verify_against(snap, out)
+        # HTML is skipped by default; the other two should be identical.
+        assert not report.has_diffs
+        assert len(report.identical) == 2
+        assert len(report.skipped) == 1
+        assert report.differing == []
+
+    def test_extension_summary_populated(self, trees):
+        snap, out = trees
+        _write(snap, "x.ipynb", b"x")
+        _write(out, "x.ipynb", b"x")
+        _write(snap, "y.py", b"y")
+        _write(out, "y.py", b"y")
+        report = verify_against(snap, out)
+        assert report.by_extension[".ipynb"].total == 1
+        assert report.by_extension[".ipynb"].identical == 1
+        assert report.by_extension[".py"].identical == 1
+
+
+class TestDiffDetection:
+    def test_modified_file_is_reported(self, trees):
+        snap, out = trees
+        _write(snap, "a.ipynb", b"original")
+        _write(out, "a.ipynb", b"changed")
+        report = verify_against(snap, out)
+        assert report.has_diffs
+        assert Path("a.ipynb") in report.differing
+        assert report.identical == []
+
+    def test_missing_in_output_is_reported(self, trees):
+        snap, out = trees
+        _write(snap, "ghost.ipynb", b"x")
+        _write(snap, "kept.ipynb", b"y")
+        _write(out, "kept.ipynb", b"y")
+        report = verify_against(snap, out)
+        assert report.has_diffs
+        assert Path("ghost.ipynb") in report.missing_in_output
+        assert report.differing == []
+
+    def test_missing_in_snapshot_is_reported(self, trees):
+        snap, out = trees
+        _write(snap, "kept.ipynb", b"y")
+        _write(out, "kept.ipynb", b"y")
+        _write(out, "extra.ipynb", b"new")
+        report = verify_against(snap, out)
+        assert report.has_diffs
+        assert Path("extra.ipynb") in report.missing_in_snapshot
+
+    def test_format_text_contains_summary(self, trees):
+        snap, out = trees
+        _write(snap, "a.ipynb", b"a1")
+        _write(out, "a.ipynb", b"a2")
+        report = verify_against(snap, out)
+        text = report.format_text()
+        assert "Differing:" in text
+        assert "a.ipynb" in text
+
+
+class TestHtmlHandling:
+    def test_html_skipped_by_default(self, trees):
+        snap, out = trees
+        # Two HTMLs with different content; default behavior must not
+        # surface them as diffs (this is the noise-floor mitigation).
+        _write(snap, "foo.html", b"<pre>0x1111aaaa</pre>")
+        _write(out, "foo.html", b"<pre>0x2222bbbb</pre>")
+        report = verify_against(snap, out)
+        assert not report.has_diffs
+        assert Path("foo.html") in report.skipped
+
+    def test_html_hex_addresses_normalize_with_include_html(self, trees):
+        snap, out = trees
+        # Same content modulo memory addresses → must be reported
+        # identical when --include-html is on.
+        _write(snap, "foo.html", b"<pre>obj at 0x1111aaaa</pre>")
+        _write(out, "foo.html", b"<pre>obj at 0x2222bbbb</pre>")
+        report = verify_against(snap, out, include_html=True)
+        assert not report.has_diffs
+        assert Path("foo.html") in report.identical
+
+    def test_html_real_diff_surfaces_with_include_html(self, trees):
+        snap, out = trees
+        # Content differs in a way normalization cannot mask.
+        _write(snap, "foo.html", b"<pre>blue</pre>")
+        _write(out, "foo.html", b"<pre>green</pre>")
+        report = verify_against(snap, out, include_html=True)
+        assert report.has_diffs
+        assert Path("foo.html") in report.differing
+
+    def test_strict_compares_html_raw(self, trees):
+        snap, out = trees
+        # Strict mode does not normalize — hex address diffs surface.
+        _write(snap, "foo.html", b"<pre>obj at 0x1111aaaa</pre>")
+        _write(out, "foo.html", b"<pre>obj at 0x2222bbbb</pre>")
+        report = verify_against(snap, out, strict=True)
+        assert report.has_diffs
+        assert Path("foo.html") in report.differing
+
+
+class TestErrors:
+    def test_missing_snapshot_dir_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            verify_against(tmp_path / "nonexistent", tmp_path)
+
+    def test_missing_output_dir_raises(self, tmp_path):
+        snap = tmp_path / "snap"
+        snap.mkdir()
+        with pytest.raises(FileNotFoundError):
+            verify_against(snap, tmp_path / "nonexistent")
+
+
+class TestReportProperties:
+    def test_has_diffs_only_when_truly_different(self, trees):
+        snap, out = trees
+        _write(snap, "a.ipynb", b"x")
+        _write(out, "a.ipynb", b"x")
+        report = verify_against(snap, out)
+        assert isinstance(report, VerifyReport)
+        assert not report.has_diffs
+
+    def test_total_files_counts_all_categories(self, trees):
+        snap, out = trees
+        _write(snap, "ok.ipynb", b"x")
+        _write(out, "ok.ipynb", b"x")
+        _write(snap, "diff.ipynb", b"a")
+        _write(out, "diff.ipynb", b"b")
+        _write(snap, "skipped.html", b"a")
+        _write(out, "skipped.html", b"b")
+        _write(snap, "ghost.ipynb", b"only-in-snap")
+        report = verify_against(snap, out)
+        # 1 identical + 1 differing + 1 skipped + 1 missing-in-output = 4
+        assert report.total_files == 4


### PR DESCRIPTION
## Summary

PR A of the slide-format-redesign rollout. Two phases that together unblock the course-side migration (CLM phases 0 and 1 in `docs/handover-slide-format-redesign-clm.md` in `hoelzl/PythonCourses`).

### Phase 1: build-snapshot / verify harness

New first-class migration-verification harness for byte-level "snapshot → apply migration → verify byte-identical" workflows.

- `clm build spec.xml --snapshot DIR` captures build output to DIR as a verification baseline.
- `clm build spec.xml --verify-against DIR` builds and byte-compares the output tree against a previously-captured snapshot, exiting non-zero on any diff with a class-aware report.
- `.html` skipped by default (kernel-execution noise from slides with random output, default `__repr__` memory addresses, or stream/error interleave). `--include-html` re-enables HTML with hex-address normalization. `--strict-verify` byte-compares everything raw.

Validated against AZAV W01-W03a: post-PR-#76, **1488 of 1898 output files are 100% deterministic** across builds (all `.ipynb`, `.png`, `.py`, `.json`, `.md`, `.toml`, `.http`, `.jpg`, etc.). The 47 differing `.html` files are all traceable to slide-content non-determinism — separately documented in `hoelzl/PythonCourses` `planning/AZAV_ML_NONDETERMINISTIC_SLIDES.md`.

### Phase 0: verb-grouped subcommands + deprecation aliases

Restructures the flat top-level command surface (11+ commands, two duplications) into verb groups. Each renamed command keeps working as a **deprecated top-level alias** for two minor releases (removal slated for CLM 1.7) and prints a one-line stderr migration hint.

| Old (still works, deprecated) | New canonical                  |
|-------------------------------|--------------------------------|
| `clm normalize-slides`        | `clm slides normalize`         |
| `clm language-view`           | `clm slides language-view`     |
| `clm suggest-sync`            | `clm slides suggest-sync`      |
| `clm search-slides`           | `clm slides search`            |
| `clm resolve-topic`           | `clm topic resolve`            |
| `clm authoring-rules`         | `clm authoring rules`          |
| `clm extract-voiceover`       | `clm voiceover extract`        |
| `clm inline-voiceover`        | `clm voiceover inline`         |
| `clm validate-slides PATH`    | `clm validate PATH`            |
| `clm validate-spec SPEC`      | `clm validate SPEC`            |

New `clm validate <path>` consolidates the two validators with argument-type dispatch (`.xml` → spec, `.py`/dir → slides), with `--kind=slides|spec` override for ambiguous cases.

### Docs

- `CHANGELOG.md`: `[Unreleased]` entry covering both phases.
- `src/clm/cli/info_topics/commands.md`: new "Snapshot / verify" subsection under `clm build`; section headings renamed to canonical paths with deprecated-alias notes.
- `src/clm/cli/info_topics/migration.md`: full rename table + how-to-migrate guidance.

### Deferred to a coordinated follow-up

**MCP tool renames** (also called out in the handover as Phase 0 scope) are deferred so they can ship in lockstep with the corresponding Claude Code skill updates in `hoelzl/PythonCourses`. The CLI rename in this PR has no cross-repo impact beyond deprecation notices.

## Test plan

- [x] `pytest -m "not docker and not slow"` — 5045 passed, 7 skipped, 1 xfailed (no regressions vs master)
- [x] 75 new tests in `tests/snapshot/` and `tests/cli/test_command_aliases.py`
- [x] `ruff format` clean, `ruff check` clean
- [x] `mypy --strict` clean on new modules
- [x] End-to-end smoke: `clm build tests/test-data/course-specs/test-spec-3.xml --snapshot baseline/ --ignore-cache` writes 30 files; `--verify-against baseline/` on clean re-build reports 0 diffs (exit 0); tampered baseline reports the diff and exits 1.
- [ ] CI green (will populate once Actions run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)