### PR TITLE
feat(cli): add `clm slides assign-ids` (slide-format-redesign Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides assign-ids`** — Phase 2 of the slide-format-redesign.
+  Generates stable, EN-derived, kebab-case ASCII `slide_id`s for
+  slide/subslide cells using a three-category policy:
+  - *headed*: slug from the first markdown heading.
+  - *extractable*: headingless with a first bullet, prominent bold
+    line, or `<img alt="">`. Refused by default; auto-accept with
+    `--accept-content-derived` or `--llm-suggest`.
+  - *no content*: hard refuse; the author has to write `slide_id="…"`
+    by hand.
+
+  Paired DE/EN slide cells share the same EN-derived slug. Voiceover
+  and notes cells inherit the id of the preceding slide. Title slides
+  (j2 `header()` macro) anchor `slide_id="title"` automatically. An id
+  prefixed with `!` (e.g. `slide_id="!intro"`) is a preserve marker —
+  never regenerated, even under `--force`; the `!` is source-level
+  only and stripped at validation / reference time.
+
+  `--llm-suggest` calls a local Ollama model (default `qwen3:30b`) to
+  propose a title for extractable cells; suggestions are cached in
+  `clm-llm.sqlite` keyed by `(content_hash, prompt_version, lang)`.
+  Cache location is resolved via `--cache-dir` →
+  `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` →
+  `<cwd>/.clm-cache/`. Falls back to refusal when Ollama is
+  unreachable.
+
+  Exit codes: `0` clean, `1` soft refusals, `2` hard refusals.
+
 - **`clm build --snapshot DIR` and `--verify-against DIR`** for
   byte-level migration verification. `--snapshot` captures build output
   to a baseline directory (mutually exclusive with `--output-dir` and

--- a/src/clm/cli/commands/assign_ids.py
+++ b/src/clm/cli/commands/assign_ids.py
@@ -1,0 +1,247 @@
+"""``clm slides assign-ids`` — Phase 2 of the slide-format-redesign.
+
+Wraps :func:`clm.slides.assign_ids.assign_ids_in_file` /
+``assign_ids_in_directory`` with the flag matrix specified in §2.3 of
+the redesign handover and prints a human-readable (or JSON) report.
+
+Exit codes:
+
+- ``0`` — all visited cells assigned successfully, or no work to do
+- ``1`` — at least one soft refusal (extractable, needs author input)
+- ``2`` — at least one hard refusal (no-content cell, blocks the run)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.infrastructure.llm.cache import TitleSuggestionCache, resolve_cache_dir
+from clm.infrastructure.llm.ollama_client import (
+    DEFAULT_TITLE_MODEL,
+    OllamaTitleSuggester,
+    TitleSuggester,
+    is_available,
+)
+from clm.slides.assign_ids import (
+    AssignOptions,
+    AssignResult,
+    assign_ids_in_directory,
+    assign_ids_in_file,
+)
+
+CACHE_DB_NAME = "clm-llm.sqlite"
+
+
+@click.command("assign-ids")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--force",
+    is_flag=True,
+    help=(
+        "Regenerate ids on cells where the algorithm can produce one. "
+        "Cells with `!`-prefixed ids and cells the algorithm cannot "
+        "propose for are left untouched."
+    ),
+)
+@click.option(
+    "--accept-content-derived",
+    is_flag=True,
+    help=(
+        "Bulk-accept content-derived proposals (first bullet, prominent "
+        "bold, image alt) for headingless slides. Hard-refusal cells "
+        "still refuse."
+    ),
+)
+@click.option(
+    "--llm-suggest",
+    is_flag=True,
+    help=(
+        "Use the local LLM (Ollama) to propose a short title for "
+        "headingless-but-extractable cells. Suggestions are cached in "
+        "the clm-llm.sqlite cache. Falls back silently when Ollama is "
+        "unreachable."
+    ),
+)
+@click.option(
+    "--report-only",
+    "--dry-run",
+    "report_only",
+    is_flag=True,
+    help="List planned assignments and refusals without modifying any file.",
+)
+@click.option(
+    "--llm-model",
+    default=DEFAULT_TITLE_MODEL,
+    show_default=True,
+    help="Ollama model name used with --llm-suggest.",
+)
+@click.option(
+    "--ollama-url",
+    default=None,
+    help=("Base URL of the Ollama daemon. Defaults to $OLLAMA_URL or http://localhost:11434."),
+)
+@click.option(
+    "--llm-timeout",
+    type=float,
+    default=120.0,
+    show_default=True,
+    help=(
+        "Per-call timeout (seconds) for the LLM suggester. Cold-load on "
+        "a 30B local model can take a minute; bump this if you see "
+        "timeouts."
+    ),
+)
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Directory for the LLM cache (default: --cache-dir > $CLM_CACHE_DIR > "
+        "tool.clm.cache_dir in pyproject.toml > <cwd>/.clm-cache/)."
+    ),
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def assign_ids_cmd(
+    path: Path,
+    force: bool,
+    accept_content_derived: bool,
+    llm_suggest: bool,
+    report_only: bool,
+    llm_model: str,
+    ollama_url: str | None,
+    llm_timeout: float,
+    cache_dir: Path | None,
+    as_json: bool,
+) -> None:
+    """Generate stable ``slide_id`` metadata for slide/subslide cells.
+
+    PATH is a single .py slide file or a directory containing slide files.
+
+    \b
+    Three-category policy:
+      headed       Slug derived from the first markdown heading.
+      extractable  Refused by default; --accept-content-derived or
+                   --llm-suggest opt into auto-acceptance.
+      no content   Hard refuse; author must write slide_id="..." by hand.
+
+    \b
+    Special cases:
+      * Title slides (j2 header() macro) always become slide_id="title".
+      * `!`-prefixed ids (preserve marker) are never regenerated.
+      * Voiceover/notes cells inherit the slide_id of the slide they describe.
+    """
+    suggester: TitleSuggester | None = None
+    cache: TitleSuggestionCache | None = None
+
+    if llm_suggest:
+        suggester = OllamaTitleSuggester(
+            model=llm_model,
+            base_url=ollama_url,
+            timeout=llm_timeout,
+        )
+        if not is_available(suggester):
+            click.echo(
+                "warning: --llm-suggest requested but Ollama is not "
+                f"reachable at {suggester.base_url}; falling back to "
+                "refusal for headingless slides.",
+                err=True,
+            )
+            suggester = None
+        else:
+            cache_root = resolve_cache_dir(cli_override=cache_dir)
+            cache = TitleSuggestionCache(cache_root / CACHE_DB_NAME)
+
+    options = AssignOptions(
+        force=force,
+        accept_content_derived=accept_content_derived,
+        llm_suggest=llm_suggest and suggester is not None,
+        report_only=report_only,
+        llm_suggester=suggester,
+        llm_cache=cache,
+    )
+
+    try:
+        if path.is_dir():
+            result = assign_ids_in_directory(path, options)
+        elif path.is_file():
+            result = assign_ids_in_file(path, options)
+        else:
+            raise click.ClickException(f"PATH must be a slide file or directory: {path}")
+    finally:
+        if cache is not None:
+            cache.close()
+
+    if as_json:
+        click.echo(json.dumps(_to_dict(result), indent=2))
+    else:
+        _print_human(result, report_only=report_only)
+
+    sys.exit(_exit_code(result))
+
+
+def _print_human(result: AssignResult, *, report_only: bool) -> None:
+    prefix = "[report-only] " if report_only else ""
+
+    for a in result.assignments:
+        click.echo(
+            f'{prefix}assign {a.file}:{a.line} -> slide_id="{a.slide_id}" (source={a.source})'
+        )
+
+    soft = [r for r in result.refusals if r.severity == "soft"]
+    hard = [r for r in result.refusals if r.severity == "hard"]
+
+    for r in soft:
+        proposal = f' proposed="{r.proposed_slug}"' if r.proposed_slug else ""
+        title = f' title="{r.proposed_title}"' if r.proposed_title else ""
+        click.echo(f"refuse-soft {r.file}:{r.line} — {r.reason}{title}{proposal}")
+
+    for r in hard:
+        click.echo(f"refuse-hard {r.file}:{r.line} — {r.reason}")
+
+    click.echo()
+    click.echo(
+        f"{prefix}{result.files_visited} file(s) visited, "
+        f"{result.files_modified} modified, "
+        f"{len(result.assignments)} assigned, "
+        f"{len(soft)} soft refusal(s), "
+        f"{len(hard)} hard refusal(s)."
+    )
+
+
+def _to_dict(result: AssignResult) -> dict:
+    return {
+        "files_visited": result.files_visited,
+        "files_modified": result.files_modified,
+        "assignments": [
+            {
+                "file": a.file,
+                "line": a.line,
+                "slide_id": a.slide_id,
+                "source": a.source,
+            }
+            for a in result.assignments
+        ],
+        "refusals": [
+            {
+                "file": r.file,
+                "line": r.line,
+                "severity": r.severity,
+                "reason": r.reason,
+                "proposed_slug": r.proposed_slug,
+                "proposed_title": r.proposed_title,
+            }
+            for r in result.refusals
+        ],
+    }
+
+
+def _exit_code(result: AssignResult) -> int:
+    if result.has_hard_refusals:
+        return 2
+    if any(r.severity == "soft" for r in result.refusals):
+        return 1
+    return 0

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -460,6 +460,58 @@ clm normalize-slides slides/module_010/ --operations tag_migration
 clm normalize-slides slides/module_010/ --operations slide_ids --json
 ```
 
+### `clm slides assign-ids`
+
+*Added in CLM {version}.*
+
+Generate stable `slide_id` metadata for slide/subslide cells per the
+EN-derived, kebab-case, ASCII policy. Cells in a DE/EN pair share the
+same id (derived from the EN heading); voiceover/notes cells inherit
+the id of the preceding slide. Three-category policy:
+
+- **headed** — slug from the first markdown heading. Always assigned.
+- **extractable** — headingless but with a first bullet, prominent
+  bold line, or `<img alt="…">`. **Refused by default**; opt in with
+  `--accept-content-derived` or `--llm-suggest`.
+- **no content** — empty cell, pure image without alt, etc. **Hard
+  refuse**; the author has to write `slide_id="…"` by hand.
+
+Special cases:
+
+- Title slides (j2 `header()` macro) anchor `slide_id="title"`
+  automatically. No author input needed.
+- An id prefixed with `!` (e.g. `slide_id="!intro"`) is the
+  **preserve marker** — never regenerated, even under `--force`. The
+  `!` is source-level only; references elsewhere use the bare form.
+
+```
+clm slides assign-ids [OPTIONS] PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Regenerate ids where the algorithm can produce one. `!`-prefixed ids and cells without a proposal are left untouched. |
+| `--accept-content-derived` | Auto-accept proposals for the extractable category (no LLM). Hard-refusal cells still refuse. |
+| `--llm-suggest` | Use the local LLM (Ollama, default model `qwen3:30b`) to propose a short title for extractable cells. Cached per `(content_hash, prompt_version, lang)` in the LLM cache. Falls back silently to refusal when Ollama is unreachable. |
+| `--report-only`, `--dry-run` | List planned assignments and refusals without modifying any file. |
+| `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
+| `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
+| `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B model can exceed 60s). |
+| `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
+| `--json` | Emit a JSON report instead of human-readable lines. |
+
+Exit codes: `0` clean, `1` soft refusals (extractable cells awaiting
+author input), `2` at least one hard refusal.
+
+Examples:
+
+```bash
+clm slides assign-ids slides/module_010/topic_100/slides_intro.py --report-only
+clm slides assign-ids slides/module_010/ --accept-content-derived
+clm slides assign-ids slides/module_010/topic_100/slides_intro.py --llm-suggest
+clm slides assign-ids slides/module_010/ --force        # regenerate all derivable ids
+```
+
 ### `clm slides language-view`
 
 *Deprecated alias: `clm language-view` (removed in 1.7).*

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,46 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Slide format redesign: stable `slide_id`s (additive — no break)
+
+CLM {version} ships **Phase 2** of the slide-format-redesign: the
+`clm slides assign-ids` command that generates stable, EN-derived,
+kebab-case ASCII `slide_id` values for slide and subslide cells.
+
+Adoption is opt-in — nothing happens until you run the command. The
+recommended workflow on a course repo:
+
+```bash
+# Preview what would change
+clm slides assign-ids slides/ --report-only
+
+# Apply for the headed-slide majority
+clm slides assign-ids slides/
+
+# Decide what to do with refusals (extractable headingless slides)
+clm slides assign-ids slides/ --report-only --accept-content-derived
+clm slides assign-ids slides/ --report-only --llm-suggest   # if Ollama is running
+```
+
+Pin a slide's id with the **preserve marker**:
+
+```python
+# %% [markdown] lang="de" tags=["slide"] slide_id="!intro"
+```
+
+The `!` is source-level only — referenced everywhere as the bare form
+`intro`. `--force` and any future regeneration tool will leave
+preserved ids alone.
+
+Voiceover and notes cells inherit the id of the preceding slide
+(1:N — multiple narrative cells per slide). The title slide (j2
+`header()` macro) anchors `slide_id="title"` automatically. See
+`clm info commands` → `clm slides assign-ids` for the full flag
+matrix.
+
+This release does **not** add a validator check for missing
+`slide_id`s; that lands in Phase 3.
+
 ## CLI restructure: verb-grouped subcommands
 
 CLM {version} reorganises the top-level command surface. Several flat

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -71,6 +71,7 @@ from clm.cli.commands._groups import (  # noqa: E402
     slides_group,
     topic_group,
 )
+from clm.cli.commands.assign_ids import assign_ids_cmd  # noqa: E402
 from clm.cli.commands.authoring_rules import authoring_rules_cmd  # noqa: E402
 from clm.cli.commands.build import (  # noqa: E402
     build,
@@ -144,6 +145,7 @@ cli.add_command(serve)
 # Verb-grouped commands (Phase 0): the canonical invocations.
 # ---------------------------------------------------------------------
 slides_group.add_command(normalize_slides_cmd, name="normalize")
+slides_group.add_command(assign_ids_cmd, name="assign-ids")
 slides_group.add_command(language_view_cmd, name="language-view")
 slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
 slides_group.add_command(search_slides_cmd, name="search")

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -99,3 +99,131 @@ class SummaryCache:
 
     def close(self):
         self._conn.close()
+
+
+class TitleSuggestionCache:
+    """Cache LLM-suggested slide titles keyed by ``(content_hash, prompt_version, lang)``.
+
+    Used by ``clm slides assign-ids --llm-suggest`` to avoid re-querying
+    the local LLM for cells whose content has not changed. Shares the
+    same SQLite file as :class:`SummaryCache` (the consuming repo's
+    ``clm-llm.sqlite`` cache; see §2.5 of the slide-format-redesign
+    handover) but lives in its own table.
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._conn = sqlite3.connect(str(db_path))
+        self._migrate()
+
+    def _migrate(self) -> None:
+        cursor = self._conn.execute("PRAGMA table_info(title_suggestions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if not columns:
+            self._conn.execute(
+                """CREATE TABLE title_suggestions (
+                    content_hash    TEXT NOT NULL,
+                    prompt_version  TEXT NOT NULL,
+                    lang            TEXT NOT NULL,
+                    suggested_title TEXT NOT NULL,
+                    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (content_hash, prompt_version, lang)
+                )"""
+            )
+            self._conn.commit()
+
+    def get(self, content_hash: str, prompt_version: str, lang: str = "en") -> str | None:
+        row = self._conn.execute(
+            "SELECT suggested_title FROM title_suggestions "
+            "WHERE content_hash=? AND prompt_version=? AND lang=?",
+            (content_hash, prompt_version, lang),
+        ).fetchone()
+        return row[0] if row else None
+
+    def put(
+        self,
+        content_hash: str,
+        prompt_version: str,
+        suggested_title: str,
+        lang: str = "en",
+    ) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO title_suggestions
+               (content_hash, prompt_version, lang, suggested_title)
+               VALUES (?, ?, ?, ?)""",
+            (content_hash, prompt_version, lang, suggested_title),
+        )
+        self._conn.commit()
+
+    def invalidate_prompt_version(self, prompt_version: str) -> int:
+        """Delete entries whose prompt version no longer matches."""
+        cursor = self._conn.execute(
+            "DELETE FROM title_suggestions WHERE prompt_version!=?",
+            (prompt_version,),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+def resolve_cache_dir(
+    *,
+    cli_override: Path | None = None,
+    repo_root: Path | None = None,
+) -> Path:
+    """Resolve the LLM cache directory per §2.5 of the redesign handover.
+
+    Lookup order:
+
+    1. ``cli_override`` (the ``--cache-dir`` flag value)
+    2. ``CLM_CACHE_DIR`` environment variable
+    3. ``tool.clm.cache_dir`` in ``<repo_root>/pyproject.toml``
+    4. ``<repo_root>/.clm-cache/`` (default, gitignored)
+
+    The returned path is created if it does not exist. ``repo_root``
+    defaults to the current working directory.
+    """
+    import os
+
+    if cli_override is not None:
+        return _ensure_dir(Path(cli_override))
+
+    env = os.environ.get("CLM_CACHE_DIR")
+    if env:
+        return _ensure_dir(Path(env))
+
+    root = repo_root or Path.cwd()
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        configured = _read_pyproject_cache_dir(pyproject)
+        if configured:
+            path = Path(configured)
+            if not path.is_absolute():
+                path = root / path
+            return _ensure_dir(path)
+
+    return _ensure_dir(root / ".clm-cache")
+
+
+def _ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _read_pyproject_cache_dir(pyproject: Path) -> str | None:
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover — Python <3.11 not supported
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    tool = data.get("tool", {})
+    clm = tool.get("clm", {})
+    value = clm.get("cache_dir")
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/src/clm/infrastructure/llm/ollama_client.py
+++ b/src/clm/infrastructure/llm/ollama_client.py
@@ -1,0 +1,190 @@
+"""Thin wrapper around the local Ollama HTTP API.
+
+Used by ``clm slides assign-ids --llm-suggest`` (Phase 2) and reserved for
+the coverage check (Phase 4) and sync (Phase 7). All call sites take a
+:class:`TitleSuggester` (Phase 2) or analogous protocol, so tests can
+substitute an in-memory fake and the real network client stays unused.
+
+The wire format follows Ollama's native ``/api/chat`` endpoint:
+https://github.com/ollama/ollama/blob/main/docs/api.md. We deliberately do
+*not* go through the OpenAI-compatibility shim — the native endpoint is
+stable, simpler, and avoids dragging the ``openai`` package into the import
+graph for callers who only need Ollama.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OLLAMA_URL = "http://localhost:11434"
+DEFAULT_TITLE_MODEL = "qwen3:30b"
+# Cold-load on large local models can take a minute; warm calls are ~5s.
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+# Bumped whenever the prompt or system message changes in a way that
+# invalidates cached suggestions. Embedded into the cache key per §2.3.
+TITLE_PROMPT_VERSION = "v1"
+
+_TITLE_SYSTEM_PROMPT = (
+    "You are helping an instructor pick a short title for a slide that "
+    "currently has no heading. The slide content will be given to you. "
+    "Reply with a single English title of 3-7 words, written in title "
+    "case. Do not include quotes, punctuation, or any other text — just "
+    "the bare title on one line."
+)
+
+
+class OllamaError(RuntimeError):
+    """The Ollama call failed (connection, timeout, parse, or model error)."""
+
+
+class TitleSuggester(Protocol):
+    """Protocol for anything that can suggest a slide title from cell content.
+
+    The real implementation lives in :class:`OllamaTitleSuggester`. Tests
+    pass an in-memory fake (see ``tests/slides/test_assign_ids.py`` and
+    :class:`StaticTitleSuggester` below) so the slug + assign-ids core can
+    be exercised without a running Ollama daemon.
+    """
+
+    prompt_version: str
+
+    def suggest(self, content: str) -> str:
+        """Return a short English title for ``content``.
+
+        Raises :class:`OllamaError` (or a protocol-specific equivalent) if
+        the suggestion is unavailable. Callers should treat exceptions as
+        "fall back to refusal", not as fatal.
+        """
+        ...
+
+
+class StaticTitleSuggester:
+    """In-memory :class:`TitleSuggester` for tests and bulk scripts.
+
+    Supply a mapping from a stable key (e.g. content excerpt or content
+    hash) to the title. When ``suggest`` is called the lookup is exact;
+    misses raise :class:`OllamaError` so the caller falls back to refusal.
+
+    A ``default`` may be passed for the "I don't care, just give me
+    *something*" case; tests typically lean on explicit per-key mappings
+    so they can assert which cell was queried.
+    """
+
+    def __init__(
+        self,
+        mapping: dict[str, str] | None = None,
+        *,
+        default: str | None = None,
+        prompt_version: str = TITLE_PROMPT_VERSION,
+    ):
+        self._mapping = dict(mapping or {})
+        self._default = default
+        self.prompt_version = prompt_version
+        self.calls: list[str] = []  # exposed for test assertions
+
+    def suggest(self, content: str) -> str:
+        self.calls.append(content)
+        if content in self._mapping:
+            return self._mapping[content]
+        if self._default is not None:
+            return self._default
+        raise OllamaError("no static suggestion configured for content excerpt")
+
+
+class OllamaTitleSuggester:
+    """:class:`TitleSuggester` that talks to a local Ollama daemon."""
+
+    prompt_version = TITLE_PROMPT_VERSION
+
+    def __init__(
+        self,
+        *,
+        model: str = DEFAULT_TITLE_MODEL,
+        base_url: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ):
+        self.model = model
+        self.base_url = (base_url or os.environ.get("OLLAMA_URL") or DEFAULT_OLLAMA_URL).rstrip("/")
+        self.timeout = timeout
+
+    def suggest(self, content: str) -> str:
+        payload = {
+            "model": self.model,
+            "stream": False,
+            "messages": [
+                {"role": "system", "content": _TITLE_SYSTEM_PROMPT},
+                {"role": "user", "content": content},
+            ],
+            "options": {"temperature": 0.2},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(  # noqa: S310 — localhost only
+            f"{self.base_url}/api/chat",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
+                raw = resp.read().decode("utf-8")
+        except urllib.error.URLError as exc:
+            raise OllamaError(f"Ollama request failed: {exc}") from exc
+        except TimeoutError as exc:
+            raise OllamaError(f"Ollama request timed out after {self.timeout}s") from exc
+
+        try:
+            response = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise OllamaError(f"Ollama returned non-JSON response: {raw[:200]!r}") from exc
+
+        message = response.get("message") or {}
+        text = (message.get("content") or "").strip()
+        if not text:
+            raise OllamaError("Ollama returned empty title")
+        return _clean_title(text)
+
+
+def _clean_title(text: str) -> str:
+    """Sanitize the raw model output.
+
+    Local LLMs sometimes wrap the title in quotes or append a trailing
+    explanation despite the system prompt. We take the first non-empty
+    line and strip a single layer of surrounding quotes/backticks. Slug
+    derivation downstream will discard any remaining punctuation.
+    """
+    first_line = next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
+    if not first_line:
+        return text.strip()
+    # Drop one layer of wrapping quotes/backticks.
+    for opener, closer in (('"', '"'), ("'", "'"), ("`", "`")):
+        if first_line.startswith(opener) and first_line.endswith(closer) and len(first_line) >= 2:
+            first_line = first_line[1:-1]
+            break
+    return first_line.strip().rstrip(".")
+
+
+def is_available(suggester: TitleSuggester | None) -> bool:
+    """Whether ``suggester`` looks ready to respond to ``suggest`` calls.
+
+    A best-effort liveness check for the real :class:`OllamaTitleSuggester`;
+    other implementations (including :class:`StaticTitleSuggester`) are
+    assumed available. The check pings ``/api/tags`` rather than firing a
+    full generation request.
+    """
+    if suggester is None:
+        return False
+    if not isinstance(suggester, OllamaTitleSuggester):
+        return True
+    try:
+        req = urllib.request.Request(f"{suggester.base_url}/api/tags")  # noqa: S310
+        with urllib.request.urlopen(req, timeout=2.0):  # noqa: S310
+            return True
+    except (urllib.error.URLError, TimeoutError):
+        return False

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -1,0 +1,730 @@
+"""Assign stable ``slide_id`` metadata to slide cells.
+
+This is the engine behind ``clm slides assign-ids`` (Phase 2 of the
+slide-format-redesign feature). See ``handover-slide-format-redesign-clm.md``
+§2.3 for the full design.
+
+Rules in one paragraph:
+
+- IDs are EN-derived, lowercase-kebab, ASCII-only, capped at 30 chars.
+  Numeric suffix on file-internal collision.
+- Cells already carrying an id are left alone except under ``--force``.
+- ``!``-prefixed ids are the *preserve marker*: never regenerated, even
+  under ``--force``. The ``!`` is purely source-level — references
+  elsewhere always use the bare form.
+- Title slides emitted by ``# {{ header(...) }}`` always get
+  ``slide_id="title"`` without author input.
+- Headed cells get a slug from the heading. Headingless-but-extractable
+  cells are refused by default; ``--accept-content-derived`` or
+  ``--llm-suggest`` opt into auto-acceptance. Hard-refusal cells (no
+  extractable content) always require manual authorship.
+- Voiceover and notes cells inherit the slide_id of the most recent
+  preceding slide/subslide cell (1:N relationship). They are *never*
+  written from an extracted heading of their own.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from clm.notebooks.slide_parser import CellMetadata, parse_cell_header
+from clm.slides.headingless import (
+    Category,
+    Extraction,
+    cell_text_for_llm,
+    classify,
+)
+from clm.slides.slug import (
+    MAX_SLUG_LENGTH,
+    is_preserved,
+    resolve_collision,
+    slugify,
+    strip_preserve_marker,
+)
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import TitleSuggestionCache
+    from clm.infrastructure.llm.ollama_client import TitleSuggester
+
+logger = logging.getLogger(__name__)
+
+# Header macro emitted in title slides:
+#   # {{ header("DE Title", "EN Title") }}
+_HEADER_MACRO_RE = re.compile(r'\{\{\s*header\s*\(\s*"[^"]*"\s*,\s*"([^"]*)"\s*\)\s*\}\}')
+
+TITLE_SLIDE_ID = "title"
+
+
+# ---------------------------------------------------------------------------
+# Public result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AssignedId:
+    """An id that was written (or would be written in --report-only mode)."""
+
+    file: str
+    line: int
+    slide_id: str
+    source: str  # "heading" / "title-macro" / "voiceover-inherit" / "llm" / "content"
+
+
+@dataclass
+class Refusal:
+    """A slide where the algorithm declined to assign an id.
+
+    ``severity`` is ``"soft"`` for the headingless-but-extractable case
+    (which ``--accept-content-derived`` would turn into an assignment) and
+    ``"hard"`` for cells with nothing to extract.
+    """
+
+    file: str
+    line: int
+    severity: str  # "soft" / "hard"
+    reason: str
+    proposed_slug: str | None = None
+    proposed_title: str | None = None
+
+
+@dataclass
+class AssignResult:
+    """Outcome of an assign-ids run over one or more files."""
+
+    files_modified: int = 0
+    assignments: list[AssignedId] = field(default_factory=list)
+    refusals: list[Refusal] = field(default_factory=list)
+    files_visited: int = 0
+
+    @property
+    def has_refusals(self) -> bool:
+        return any(r.severity != "info" for r in self.refusals)
+
+    @property
+    def has_hard_refusals(self) -> bool:
+        return any(r.severity == "hard" for r in self.refusals)
+
+
+# ---------------------------------------------------------------------------
+# Cell representation (preserve original text for lossless round-trip)
+# ---------------------------------------------------------------------------
+
+
+def _is_cell_boundary(line: str) -> bool:
+    return line.startswith("# %%") or line.startswith("# j2 ") or line.startswith("# {{ ")
+
+
+@dataclass
+class _Cell:
+    lines: list[str]
+    line_number: int  # 1-based, line of the header
+    metadata: CellMetadata
+
+    @property
+    def header(self) -> str:
+        return self.lines[0]
+
+    @header.setter
+    def header(self, value: str) -> None:
+        self.lines[0] = value
+
+    @property
+    def body(self) -> str:
+        return "\n".join(self.lines[1:])
+
+
+def _split_cells(text: str) -> tuple[str, list[_Cell]]:
+    """Split file text into ``(preamble, cells)`` — same shape as the normalizer."""
+    lines = text.split("\n")
+    cells: list[_Cell] = []
+    preamble: list[str] = []
+    current: list[str] = []
+    current_line = 0
+    in_cell = False
+    for i, line in enumerate(lines):
+        if _is_cell_boundary(line):
+            if in_cell:
+                cells.append(
+                    _Cell(
+                        lines=current,
+                        line_number=current_line,
+                        metadata=parse_cell_header(current[0]),
+                    )
+                )
+            current = [line]
+            current_line = i + 1
+            in_cell = True
+        else:
+            if in_cell:
+                current.append(line)
+            else:
+                preamble.append(line)
+    if in_cell:
+        cells.append(
+            _Cell(
+                lines=current,
+                line_number=current_line,
+                metadata=parse_cell_header(current[0]),
+            )
+        )
+    return ("\n".join(preamble), cells)
+
+
+def _reconstruct(preamble: str, cells: list[_Cell]) -> str:
+    parts: list[str] = []
+    if preamble:
+        parts.append(preamble)
+    for cell in cells:
+        parts.append("\n".join(cell.lines))
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Cell mutation
+# ---------------------------------------------------------------------------
+
+
+_SLIDE_ID_RE = re.compile(r'\s*slide_id="[^"]*"')
+
+
+def _strip_existing_slide_id(header: str) -> str:
+    return _SLIDE_ID_RE.sub("", header)
+
+
+def _write_slide_id(cell: _Cell, slide_id: str) -> None:
+    """Rewrite the cell header to carry ``slide_id="…"``."""
+    existing = cell.header
+    stripped = _strip_existing_slide_id(existing).rstrip()
+    new_header = f'{stripped} slide_id="{slide_id}"'
+    cell.lines[0] = new_header
+    cell.metadata = parse_cell_header(new_header)
+
+
+# ---------------------------------------------------------------------------
+# Title slide detection
+# ---------------------------------------------------------------------------
+
+
+def _is_title_macro_cell(cell: _Cell) -> bool:
+    if not cell.metadata.is_j2:
+        return False
+    return bool(_HEADER_MACRO_RE.search(cell.header))
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AssignOptions:
+    """Knobs for one assign-ids pass.
+
+    ``llm_suggester`` is the mockable :class:`TitleSuggester` from
+    :mod:`clm.infrastructure.llm.ollama_client`. Passing ``None`` skips
+    LLM use even when ``llm_suggest`` is true (the protocol-level escape
+    hatch for "Ollama is not running" — Phase 2 acceptance criteria
+    allows fail-soft here).
+    """
+
+    force: bool = False
+    accept_content_derived: bool = False
+    llm_suggest: bool = False
+    report_only: bool = False
+    llm_suggester: TitleSuggester | None = None
+    llm_cache: TitleSuggestionCache | None = None
+
+
+# ---------------------------------------------------------------------------
+# Core algorithm
+# ---------------------------------------------------------------------------
+
+
+def _classify_for_assignment(cell: _Cell) -> str:
+    """Return the assignment role for a cell.
+
+    ``"slide"`` — slide/subslide markdown cell that may receive an id
+    ``"narrative"`` — voiceover/notes cell that *inherits* an id
+    ``"title-macro"`` — the j2 header() macro cell
+    ``"skip"`` — j2 directives, code cells, shared cells, etc.
+    """
+    meta = cell.metadata
+    if _is_title_macro_cell(cell):
+        return "title-macro"
+    if meta.is_j2:
+        return "skip"
+    if meta.is_slide_start:
+        return "slide"
+    if meta.is_narrative and meta.lang is not None:
+        return "narrative"
+    return "skip"
+
+
+def _proposed_slug_from_extraction(
+    extraction: Extraction,
+    used_ids,
+) -> str:
+    base = slugify(extraction.text, max_length=MAX_SLUG_LENGTH)
+    if not base:
+        return ""
+    return resolve_collision(base, used_ids)
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _build_slide_pairs(cells: list[_Cell]) -> dict[int, int]:
+    """Map every slide-cell index to the cell that *drives* its slug.
+
+    EN-derived policy (§2.3): when a DE slide cell sits next to an EN
+    slide cell in the source order, both cells share the slug derived
+    from the EN heading. The map gives every slide cell the index of the
+    cell to slug from — itself if solo, the EN sibling if paired.
+    """
+    slide_indices = [i for i, c in enumerate(cells) if c.metadata.is_slide_start]
+    pairs: dict[int, int] = {}
+    i = 0
+    while i < len(slide_indices):
+        a = slide_indices[i]
+        if i + 1 < len(slide_indices):
+            b = slide_indices[i + 1]
+            lang_a = cells[a].metadata.lang
+            lang_b = cells[b].metadata.lang
+            if lang_a and lang_b and lang_a != lang_b:
+                # Paired. Pick the EN cell as the slug source.
+                en_idx = a if lang_a == "en" else b
+                pairs[a] = en_idx
+                pairs[b] = en_idx
+                i += 2
+                continue
+        pairs[a] = a  # solo
+        i += 1
+    return pairs
+
+
+def assign_ids_for_text(
+    text: str,
+    file_path: Path,
+    options: AssignOptions,
+) -> tuple[str, AssignResult]:
+    """Apply the assign-ids policy to one file's text.
+
+    Returns ``(new_text, result)``. ``new_text == text`` when nothing was
+    written (refusals only, or no changes needed). In ``--report-only``
+    mode the new text always equals the input but the result still lists
+    *proposed* assignments and refusals.
+    """
+    result = AssignResult(files_visited=1)
+    preamble, cells = _split_cells(text)
+
+    # First pass: collect every id already on the page (bare form). This
+    # is what we use to detect collisions when generating new slugs.
+    used_ids: set[str] = set()
+    for cell in cells:
+        existing = cell.metadata.slide_id
+        if existing:
+            used_ids.add(strip_preserve_marker(existing))
+
+    pairs = _build_slide_pairs(cells)
+    # Cache the slug we resolve for each "slug source" cell so paired
+    # DE/EN cells always get the *exact same* id (collision suffix
+    # included). Otherwise the second visit would observe its own
+    # sibling's id already in used_ids and bump the counter.
+    group_slug: dict[int, str | None] = {}
+
+    # Track the most recent slide_id (bare form) by source order so that
+    # narrative cells (voiceover/notes) inherit from the preceding
+    # slide/subslide.
+    current_slide_id: str | None = None
+    file_str = str(file_path)
+
+    for idx, cell in enumerate(cells):
+        role = _classify_for_assignment(cell)
+
+        if role == "title-macro":
+            current_slide_id = (
+                _handle_title_macro(cell, options, file_str, result) or current_slide_id
+            )
+            continue
+
+        if role == "slide":
+            slug_source = cells[pairs.get(idx, idx)]
+            new_id = _handle_slide(
+                cell,
+                slug_source,
+                options,
+                used_ids,
+                file_str,
+                result,
+                group_slug,
+                slug_source_idx=pairs.get(idx, idx),
+            )
+            if new_id is not None:
+                current_slide_id = new_id
+            elif cell.metadata.slide_id:
+                current_slide_id = strip_preserve_marker(cell.metadata.slide_id)
+            # If we refused, leave current_slide_id untouched — the next
+            # narrative cell will still inherit from the previous slide,
+            # which is the least-surprising behavior in a partially
+            # broken file.
+            continue
+
+        if role == "narrative":
+            _handle_narrative(cell, current_slide_id, options, file_str, result)
+            continue
+
+        # role == "skip": unchanged.
+
+    new_text = text
+    if not options.report_only and result.assignments:
+        candidate = _reconstruct(preamble, cells)
+        if candidate != text:
+            new_text = candidate
+            result.files_modified = 1
+
+    return new_text, result
+
+
+def _handle_title_macro(
+    cell: _Cell,
+    options: AssignOptions,
+    file_str: str,
+    result: AssignResult,
+) -> str | None:
+    """The j2 header macro line itself does not carry slide_id metadata,
+    but it *anchors* the title slide. We expose ``"title"`` via the
+    return value so following narrative cells inherit it. No cell text
+    is written here — the macro line stays untouched.
+    """
+    return TITLE_SLIDE_ID
+
+
+def _handle_slide(
+    cell: _Cell,
+    slug_source: _Cell,
+    options: AssignOptions,
+    used_ids: set[str],
+    file_str: str,
+    result: AssignResult,
+    group_slug: dict[int, str | None],
+    slug_source_idx: int,
+) -> str | None:
+    """Assign or preserve a slide_id on one slide/subslide cell.
+
+    ``slug_source`` is the cell whose heading/content drives the slug for
+    this DE/EN group (per §2.3, the EN cell when a pair exists; otherwise
+    ``cell`` itself). ``group_slug`` caches the resolved slug per group so
+    the second cell of a pair receives the exact same id (collision
+    suffix and all) instead of bumping past its own sibling.
+
+    Returns the bare id that ended up on the cell (for narrative
+    inheritance), or ``None`` when we refused.
+    """
+    existing = cell.metadata.slide_id
+
+    # Preserve marker — never touched, not even under --force.
+    if existing and is_preserved(existing):
+        # Also lock the group's slug to the preserved bare form so the
+        # sibling, if any, doesn't pick something else.
+        group_slug.setdefault(slug_source_idx, strip_preserve_marker(existing))
+        return strip_preserve_marker(existing)
+
+    # No --force: existing id wins.
+    if existing and not options.force:
+        group_slug.setdefault(slug_source_idx, strip_preserve_marker(existing))
+        return strip_preserve_marker(existing)
+
+    # Group already resolved by the sibling cell — reuse that slug.
+    if slug_source_idx in group_slug:
+        cached = group_slug[slug_source_idx]
+        if cached is not None:
+            _maybe_write_cached(cell, cached, options, file_str, result)
+            return cached
+        # Sibling resolution failed (refusal). Mirror the refusal.
+        # We still record a soft refusal for this cell so the report
+        # reflects every affected cell.
+        result.refusals.append(
+            Refusal(
+                file=file_str,
+                line=cell.line_number,
+                severity="soft",
+                reason="sibling cell refused; both cells in the pair need a manual id",
+            )
+        )
+        return None
+
+    # Under --force we may replace this cell's id. Use a local view of
+    # used_ids that excludes the cell's own existing id *and* its
+    # sibling's existing id, so the regenerated slug can legitimately
+    # reclaim its natural form. The real used_ids is only mutated when
+    # we commit to a write.
+    existing_bare = strip_preserve_marker(existing) if existing else None
+    free: set[str] = set()
+    if existing_bare:
+        free.add(existing_bare)
+    if slug_source is not cell and slug_source.metadata.slide_id:
+        free.add(strip_preserve_marker(slug_source.metadata.slide_id))
+    local_used = used_ids - free if free else used_ids
+
+    # Slug is derived from the slug-source cell (EN sibling, or self).
+    extraction = classify(slug_source.body)
+
+    proposed_slug: str = ""
+    proposed_title: str | None = None
+    source: str = ""
+
+    if extraction.category == Category.HEADED:
+        proposed_title = extraction.text
+        proposed_slug = _proposed_slug_from_extraction(extraction, local_used)
+        source = "heading"
+
+    elif extraction.category == Category.EXTRACTABLE:
+        # LLM path first (if requested) — its suggestion replaces the
+        # content-derived proposal because the title is usually more
+        # readable than the raw first bullet. Use the slug source's body
+        # (EN sibling) so the LLM sees English content.
+        llm_title = _try_llm_suggestion(slug_source, options, file_str, result)
+        if llm_title:
+            proposed_title = llm_title
+            base = slugify(llm_title, max_length=MAX_SLUG_LENGTH)
+            if base:
+                proposed_slug = resolve_collision(base, local_used)
+                source = "llm"
+        if not proposed_slug:
+            proposed_title = extraction.text
+            proposed_slug = _proposed_slug_from_extraction(extraction, local_used)
+            source = f"content:{extraction.source}"
+
+    else:
+        # NON_EXTRACTABLE: hard refuse — only if we are even being asked
+        # to assign. If --force is off and the cell already has an id,
+        # we returned above; otherwise the cell genuinely has nothing.
+        if existing:
+            # --force is on but we have no proposal. Per §2.3 baseline
+            # rule: leave the existing id alone.
+            group_slug.setdefault(slug_source_idx, strip_preserve_marker(existing))
+            return strip_preserve_marker(existing)
+        result.refusals.append(
+            Refusal(
+                file=file_str,
+                line=cell.line_number,
+                severity="hard",
+                reason="cell has no heading and no extractable content",
+            )
+        )
+        group_slug[slug_source_idx] = None
+        return None
+
+    # We have a proposal. Decide whether to write it or refuse.
+    if extraction.category == Category.HEADED:
+        write = True
+    elif extraction.category == Category.EXTRACTABLE and (
+        options.accept_content_derived or source == "llm"
+    ):
+        write = True
+    else:
+        write = False
+
+    if not write:
+        result.refusals.append(
+            Refusal(
+                file=file_str,
+                line=cell.line_number,
+                severity="soft",
+                reason="headingless slide; pass --accept-content-derived to accept",
+                proposed_slug=proposed_slug,
+                proposed_title=proposed_title,
+            )
+        )
+        # Don't claim the slug — another extractable cell might want it.
+        # Mark the group as refused so the sibling mirrors the decision.
+        group_slug[slug_source_idx] = None
+        return strip_preserve_marker(existing) if existing else None
+
+    if not proposed_slug:
+        # Slug fell out empty (e.g. text was punctuation-only). Treat as
+        # a soft refusal so the author can review.
+        result.refusals.append(
+            Refusal(
+                file=file_str,
+                line=cell.line_number,
+                severity="soft",
+                reason="could not derive a usable slug from content",
+                proposed_title=proposed_title,
+            )
+        )
+        group_slug[slug_source_idx] = None
+        return strip_preserve_marker(existing) if existing else None
+
+    # Idempotency: skip the write if the id is already what we'd write.
+    if existing and strip_preserve_marker(existing) == proposed_slug:
+        group_slug[slug_source_idx] = proposed_slug
+        return proposed_slug
+
+    if not options.report_only:
+        _write_slide_id(cell, proposed_slug)
+    if existing_bare and existing_bare != proposed_slug:
+        used_ids.discard(existing_bare)
+    used_ids.add(proposed_slug)
+    group_slug[slug_source_idx] = proposed_slug
+    result.assignments.append(
+        AssignedId(
+            file=file_str,
+            line=cell.line_number,
+            slide_id=proposed_slug,
+            source=source,
+        )
+    )
+    return proposed_slug
+
+
+def _maybe_write_cached(
+    cell: _Cell,
+    cached_slug: str,
+    options: AssignOptions,
+    file_str: str,
+    result: AssignResult,
+) -> None:
+    """Apply a slug already resolved by a sibling cell.
+
+    Called only when the *sibling* (slug-source) cell has already been
+    processed and committed to ``cached_slug``. Honors the same
+    preserve/idempotency/--force rules as the primary path, but doesn't
+    need to recompute the slug.
+    """
+    existing = cell.metadata.slide_id
+
+    if existing and is_preserved(existing):
+        return  # preserve marker wins
+    if existing and not options.force:
+        return  # without --force, the existing id stays
+    if existing and strip_preserve_marker(existing) == cached_slug:
+        return  # already correct, idempotent no-op
+
+    if not options.report_only:
+        _write_slide_id(cell, cached_slug)
+    result.assignments.append(
+        AssignedId(
+            file=file_str,
+            line=cell.line_number,
+            slide_id=cached_slug,
+            source="paired",
+        )
+    )
+
+
+def _try_llm_suggestion(
+    cell: _Cell,
+    options: AssignOptions,
+    file_str: str,
+    result: AssignResult,
+) -> str | None:
+    """Run the LLM suggester (cache-first) for a headingless cell.
+
+    Returns ``None`` when LLM use is disabled, no suggester is wired in,
+    or the call fails. Failures are logged at INFO and surfaced via the
+    refusal mechanism upstream — we deliberately fail soft here.
+    """
+    if not options.llm_suggest:
+        return None
+    suggester = options.llm_suggester
+    if suggester is None:
+        return None
+
+    content = cell_text_for_llm(cell.body)
+    if not content.strip():
+        return None
+    content_hash = _content_hash(content)
+    prompt_version = getattr(suggester, "prompt_version", "v1")
+    lang = cell.metadata.lang or "en"
+
+    cache = options.llm_cache
+    if cache is not None:
+        cached = cache.get(content_hash, prompt_version, lang)
+        if cached:
+            return cached
+
+    try:
+        title = suggester.suggest(content)
+    except Exception as exc:  # OllamaError or anything stack-deep
+        logger.warning("LLM title suggestion failed (cell line %d): %s", cell.line_number, exc)
+        return None
+    if not title:
+        return None
+
+    if cache is not None:
+        cache.put(content_hash, prompt_version, title, lang)
+    return title
+
+
+def _handle_narrative(
+    cell: _Cell,
+    current_slide_id: str | None,
+    options: AssignOptions,
+    file_str: str,
+    result: AssignResult,
+) -> None:
+    """Voiceover/notes cells inherit the most recent slide_id by adjacency."""
+    existing = cell.metadata.slide_id
+
+    if existing and is_preserved(existing):
+        return  # preserve marker wins
+
+    if current_slide_id is None:
+        # No preceding slide yet (file starts with voiceover for the
+        # title slide); we *can* sometimes still know the answer when
+        # the title-macro is detected. Skip otherwise.
+        return
+
+    bare = current_slide_id
+
+    if existing and not options.force:
+        return
+
+    if existing and strip_preserve_marker(existing) == bare:
+        return  # idempotent
+
+    if not options.report_only:
+        _write_slide_id(cell, bare)
+    result.assignments.append(
+        AssignedId(
+            file=file_str,
+            line=cell.line_number,
+            slide_id=bare,
+            source="voiceover-inherit",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# File / directory drivers
+# ---------------------------------------------------------------------------
+
+
+def assign_ids_in_file(path: Path, options: AssignOptions) -> AssignResult:
+    """Process one ``.py`` slide file end-to-end."""
+    text = path.read_text(encoding="utf-8")
+    new_text, result = assign_ids_for_text(text, path, options)
+    if not options.report_only and new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+    return result
+
+
+def assign_ids_in_directory(path: Path, options: AssignOptions) -> AssignResult:
+    """Recurse over a directory and process every slide file we find."""
+    from clm.core.topic_resolver import find_slide_files_recursive
+
+    combined = AssignResult()
+    for slide_file in find_slide_files_recursive(path):
+        result = assign_ids_in_file(slide_file, options)
+        combined.files_visited += result.files_visited
+        combined.files_modified += result.files_modified
+        combined.assignments.extend(result.assignments)
+        combined.refusals.extend(result.refusals)
+    return combined

--- a/src/clm/slides/headingless.py
+++ b/src/clm/slides/headingless.py
@@ -1,0 +1,152 @@
+"""Extract proposal text from slide cells that have no markdown heading.
+
+Used by ``clm slides assign-ids`` to classify and propose slugs for the
+"extractable" category (headingless but with some salient first line).
+
+Three categories, matching §2.3 of ``handover-slide-format-redesign-clm.md``:
+
+- ``HEADED``        — the cell has at least one ``##``-style heading. The
+                      assign-ids algorithm handles this directly via
+                      :func:`extract_heading`.
+- ``EXTRACTABLE``   — no heading, but a first bullet, a prominent bold
+                      line, or an ``<img alt="...">`` provides enough text
+                      to suggest a slug. The tool refuses by default and
+                      lists the proposal; ``--accept-content-derived``
+                      bulk-accepts.
+- ``NON_EXTRACTABLE`` — pure-image without alt, divider, empty cell, or
+                        anything else that yields no usable text. Hard
+                        refuse — the author has to write the id by hand.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from dataclasses import dataclass
+
+# Order matters: HEADED beats EXTRACTABLE beats NON_EXTRACTABLE.
+
+
+class Category(enum.Enum):
+    HEADED = "headed"
+    EXTRACTABLE = "extractable"
+    NON_EXTRACTABLE = "non_extractable"
+
+
+@dataclass(frozen=True)
+class Extraction:
+    """What we managed to pull out of a cell.
+
+    ``category`` is the classification. ``text`` is the raw extracted
+    string (markdown formatting intact — slugification happens later via
+    :func:`clm.slides.slug.slugify`). ``source`` identifies *which* extractor
+    matched (``heading``/``bullet``/``bold``/``img_alt``) for diagnostics.
+    """
+
+    category: Category
+    text: str = ""
+    source: str = ""
+
+
+# Markdown heading: ``# ## Title`` (Python comment prefix included).
+_HEADING_RE = re.compile(r"^#\s+(#{1,6})\s+(?P<text>.+?)\s*$")
+
+# Bullet: ``# - Text`` or ``# * Text`` (Python comment prefix included).
+_BULLET_RE = re.compile(r"^#\s+[-*]\s+(?P<text>.+?)\s*$")
+
+# Numbered list: ``# 1. Text``.
+_NUMBERED_RE = re.compile(r"^#\s+\d+\.\s+(?P<text>.+?)\s*$")
+
+# Bold *line*: a line that is essentially **bold text** with little else.
+_BOLD_LINE_RE = re.compile(r"^#\s+\*\*([^*]+)\*\*\s*$")
+
+# Image with alt text.
+_IMG_ALT_RE = re.compile(r'<img[^>]*\balt="([^"]+)"', re.IGNORECASE)
+
+
+def _iter_content_lines(content: str) -> list[str]:
+    """Yield lines stripped of trailing whitespace, retaining the ``#`` prefix."""
+    return [ln.rstrip() for ln in content.splitlines()]
+
+
+def extract_heading(content: str) -> str | None:
+    """Return the text of the first markdown heading in the cell, or None."""
+    for line in _iter_content_lines(content):
+        m = _HEADING_RE.match(line)
+        if m:
+            return m.group("text").strip()
+    return None
+
+
+def classify(content: str) -> Extraction:
+    """Classify a cell's content and return whatever proposal text we can find.
+
+    Precedence within the EXTRACTABLE category: first bullet/numbered item,
+    then prominent bold line, then first ``<img alt="...">``. Whichever
+    appears first in source order wins among items of the same precedence.
+    """
+    lines = _iter_content_lines(content)
+
+    # HEADED takes absolute priority.
+    for line in lines:
+        m = _HEADING_RE.match(line)
+        if m:
+            return Extraction(Category.HEADED, m.group("text").strip(), "heading")
+
+    # Otherwise scan once for any extractable signal. We collect the first
+    # match of each kind so we can apply the bullet > bold > img precedence
+    # explicitly rather than depending on source order alone.
+    first_bullet: str | None = None
+    first_bold: str | None = None
+    first_img_alt: str | None = None
+
+    for line in lines:
+        if first_bullet is None:
+            m = _BULLET_RE.match(line) or _NUMBERED_RE.match(line)
+            if m:
+                first_bullet = m.group("text").strip()
+        if first_bold is None:
+            m = _BOLD_LINE_RE.match(line)
+            if m:
+                first_bold = m.group(1).strip()
+        if first_img_alt is None:
+            m = _IMG_ALT_RE.search(line)
+            if m:
+                first_img_alt = m.group(1).strip()
+
+    if first_bullet:
+        return Extraction(Category.EXTRACTABLE, first_bullet, "bullet")
+    if first_bold:
+        return Extraction(Category.EXTRACTABLE, first_bold, "bold")
+    if first_img_alt:
+        return Extraction(Category.EXTRACTABLE, first_img_alt, "img_alt")
+
+    return Extraction(Category.NON_EXTRACTABLE)
+
+
+def cell_text_for_llm(content: str, *, max_chars: int = 1500) -> str:
+    """Return a cleaned, plain-text rendering of the cell for LLM input.
+
+    Strips the ``# `` comment prefix, drops blank lines, and caps the
+    total length so we don't blow up the prompt with huge cells.
+    """
+    parts: list[str] = []
+    used = 0
+    for line in _iter_content_lines(content):
+        if not line.strip():
+            continue
+        # Drop the Python comment prefix on markdown lines.
+        if line.startswith("# "):
+            stripped = line[2:]
+        elif line.startswith("#"):
+            stripped = line[1:]
+        else:
+            stripped = line
+        if not stripped.strip():
+            continue
+        parts.append(stripped)
+        used += len(stripped) + 1
+        if used >= max_chars:
+            parts.append("...")
+            break
+    return "\n".join(parts)

--- a/src/clm/slides/slug.py
+++ b/src/clm/slides/slug.py
@@ -1,0 +1,201 @@
+"""Slug derivation for slide_id values.
+
+Slide IDs are EN-derived, lowercase-kebab, ASCII-only. They survive title
+edits once assigned: the slug algorithm is *only* used when generating a
+fresh ID. See ``handover-slide-format-redesign-clm.md`` §2.3 for the design
+rationale.
+
+Public API:
+
+- :func:`slugify` — turn a free-form title into a slug
+- :func:`strip_preserve_marker` — drop the leading ``!`` from a preserve-marked id
+- :func:`is_preserved` — whether a slide_id carries the preserve marker
+- :func:`is_valid_slug` — check that a slug matches the canonical format
+- :func:`resolve_collision` — append ``-2``/``-3``/... to disambiguate
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable
+
+PRESERVE_MARKER = "!"
+MAX_SLUG_LENGTH = 30
+
+# Stop words dropped only when the result would otherwise exceed the cap.
+# Kept deliberately short — the goal is "remove filler", not "rewrite the
+# title in telegraphese".
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "and",
+        "or",
+        "but",
+        "with",
+        "by",
+        "as",
+    }
+)
+
+# German character transliteration (applied before ASCII fold so we get
+# the conventional spelling, not "o"/"a"/"u"/"s").
+_GERMAN_MAP = {
+    "ä": "ae",
+    "ö": "oe",
+    "ü": "ue",
+    "Ä": "Ae",
+    "Ö": "Oe",
+    "Ü": "Ue",
+    "ß": "ss",
+}
+
+# Markdown formatting we want to strip before tokenizing.
+_MARKDOWN_BOLD = re.compile(r"\*\*([^*]+)\*\*")
+_MARKDOWN_ITALIC = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)")
+_MARKDOWN_CODE = re.compile(r"`([^`]+)`")
+_MARKDOWN_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_HTML_TAG = re.compile(r"<[^>]+>")
+
+
+def strip_preserve_marker(slide_id: str) -> str:
+    """Return the bare id with any leading ``!`` removed."""
+    if slide_id.startswith(PRESERVE_MARKER):
+        return slide_id[len(PRESERVE_MARKER) :]
+    return slide_id
+
+
+def is_preserved(slide_id: str) -> bool:
+    """Whether ``slide_id`` carries the preserve marker."""
+    return slide_id.startswith(PRESERVE_MARKER)
+
+
+def _strip_markdown(text: str) -> str:
+    text = _MARKDOWN_BOLD.sub(r"\1", text)
+    text = _MARKDOWN_ITALIC.sub(r"\1", text)
+    text = _MARKDOWN_CODE.sub(r"\1", text)
+    text = _MARKDOWN_LINK.sub(r"\1", text)
+    text = _HTML_TAG.sub("", text)
+    return text
+
+
+def _transliterate(text: str) -> str:
+    for src, dst in _GERMAN_MAP.items():
+        text = text.replace(src, dst)
+    # Fold any remaining non-ASCII (accents, smart quotes, etc.) to ASCII.
+    normalized = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def _tokenize(text: str) -> list[str]:
+    text = text.lower()
+    # Split on any run of non-alphanumeric characters.
+    return [tok for tok in re.split(r"[^a-z0-9]+", text) if tok]
+
+
+def _truncate_to_cap(tokens: list[str], cap: int) -> list[str]:
+    """Trim from the right at a word boundary to stay within ``cap`` chars."""
+    if not tokens:
+        return tokens
+    out: list[str] = []
+    used = 0
+    for tok in tokens:
+        # +1 for the joining hyphen when appending after the first token.
+        extra = len(tok) + (1 if out else 0)
+        if used + extra > cap:
+            break
+        out.append(tok)
+        used += extra
+    if not out:
+        # First token alone exceeds the cap — hard-truncate it. Better than
+        # returning an empty slug.
+        out = [tokens[0][:cap]]
+    return out
+
+
+def slugify(text: str, *, max_length: int = MAX_SLUG_LENGTH) -> str:
+    """Derive a kebab-case ASCII slug from free-form title text.
+
+    Steps:
+
+    1. Strip common markdown formatting (``**bold**``, ``*italic*``,
+       ``` `code` ```, ``[link](url)``, HTML tags).
+    2. Transliterate German umlauts/ß to their conventional digraphs, then
+       NFKD-fold remaining non-ASCII characters.
+    3. Lowercase and tokenize on non-alphanumeric runs.
+    4. If the joined result exceeds ``max_length``, drop stop-words and try
+       again. Then trim at a word boundary to fit the cap.
+
+    Returns an empty string when no usable token can be extracted; callers
+    should treat that as a refusal.
+    """
+    cleaned = _strip_markdown(text)
+    cleaned = _transliterate(cleaned)
+    tokens = _tokenize(cleaned)
+    if not tokens:
+        return ""
+
+    joined = "-".join(tokens)
+    if len(joined) <= max_length:
+        return joined
+
+    # Drop stop-words and try again (preserve first token even if it's a
+    # stop-word — a slug "of-x" is more useful than just "x").
+    pruned = [tokens[0]] + [t for t in tokens[1:] if t not in _STOP_WORDS]
+    pruned = _dedupe_first(pruned, tokens[0])
+    joined = "-".join(pruned)
+    if len(joined) <= max_length:
+        return joined
+
+    return "-".join(_truncate_to_cap(pruned, max_length))
+
+
+def _dedupe_first(tokens: list[str], head: str) -> list[str]:
+    """Avoid duplicating the head token if it survives the stop-word filter."""
+    if len(tokens) >= 2 and tokens[0] == tokens[1] == head:
+        return [tokens[0]] + tokens[2:]
+    return tokens
+
+
+def is_valid_slug(slide_id: str, *, max_length: int = MAX_SLUG_LENGTH) -> bool:
+    """Check that ``slide_id`` matches the canonical format.
+
+    A valid slide_id is ``[!]?[a-z0-9]+(-[a-z0-9]+)*`` and the bare form
+    fits within ``max_length`` characters. The optional leading ``!`` is
+    the preserve marker; it does not count toward the length cap.
+    """
+    bare = strip_preserve_marker(slide_id)
+    if not bare:
+        return False
+    if len(bare) > max_length:
+        return False
+    return bool(re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", bare))
+
+
+def resolve_collision(base: str, used: Iterable[str]) -> str:
+    """Append ``-2``/``-3``/... until the slug is unique within ``used``.
+
+    Comparisons are done on the bare (marker-stripped) form so that
+    ``!intro`` and ``intro`` correctly count as a collision.
+    """
+    used_bare = {strip_preserve_marker(s) for s in used}
+    if base not in used_bare:
+        return base
+    n = 2
+    while f"{base}-{n}" in used_bare:
+        n += 1
+    return f"{base}-{n}"

--- a/tests/infrastructure/llm/test_ollama_client.py
+++ b/tests/infrastructure/llm/test_ollama_client.py
@@ -1,0 +1,79 @@
+"""Tests for the protocol shape of :mod:`clm.infrastructure.llm.ollama_client`.
+
+The real :class:`OllamaTitleSuggester` is exercised by manual fixtures; in
+the test suite we only verify the protocol's mockable behavior so the
+assign-ids tests can rely on :class:`StaticTitleSuggester`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.infrastructure.llm.ollama_client import (
+    TITLE_PROMPT_VERSION,
+    OllamaError,
+    OllamaTitleSuggester,
+    StaticTitleSuggester,
+    _clean_title,
+    is_available,
+)
+
+
+class TestStaticTitleSuggester:
+    def test_mapping_lookup(self):
+        s = StaticTitleSuggester({"content-a": "Title A"})
+        assert s.suggest("content-a") == "Title A"
+
+    def test_default_used_for_unknown(self):
+        s = StaticTitleSuggester(default="Default")
+        assert s.suggest("anything") == "Default"
+
+    def test_raises_when_no_match(self):
+        s = StaticTitleSuggester()
+        with pytest.raises(OllamaError):
+            s.suggest("missing")
+
+    def test_records_calls(self):
+        s = StaticTitleSuggester(default="x")
+        s.suggest("first")
+        s.suggest("second")
+        assert s.calls == ["first", "second"]
+
+    def test_prompt_version_default(self):
+        s = StaticTitleSuggester()
+        assert s.prompt_version == TITLE_PROMPT_VERSION
+
+    def test_prompt_version_override(self):
+        s = StaticTitleSuggester(prompt_version="v99")
+        assert s.prompt_version == "v99"
+
+
+class TestCleanTitle:
+    def test_strips_double_quotes(self):
+        assert _clean_title('"My Title"') == "My Title"
+
+    def test_strips_single_quotes(self):
+        assert _clean_title("'My Title'") == "My Title"
+
+    def test_takes_first_line(self):
+        assert _clean_title("My Title\nExplanation follows") == "My Title"
+
+    def test_strips_trailing_period(self):
+        assert _clean_title("My Title.") == "My Title"
+
+    def test_passthrough(self):
+        assert _clean_title("Clean Output") == "Clean Output"
+
+
+class TestIsAvailable:
+    def test_static_suggester_always_available(self):
+        assert is_available(StaticTitleSuggester()) is True
+
+    def test_none_unavailable(self):
+        assert is_available(None) is False
+
+    def test_real_suggester_unavailable_with_bad_url(self):
+        # Point at a port nothing listens on. The check should fail soft
+        # rather than raise.
+        s = OllamaTitleSuggester(base_url="http://127.0.0.1:1")
+        assert is_available(s) is False

--- a/tests/infrastructure/llm/test_title_suggestion_cache.py
+++ b/tests/infrastructure/llm/test_title_suggestion_cache.py
@@ -1,0 +1,105 @@
+"""Tests for :class:`clm.infrastructure.llm.cache.TitleSuggestionCache` and
+the cache-directory resolver."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import TitleSuggestionCache, resolve_cache_dir
+
+
+@pytest.fixture
+def cache(tmp_path: Path):
+    c = TitleSuggestionCache(tmp_path / "clm-llm.sqlite")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+class TestTitleSuggestionCache:
+    def test_round_trip(self, cache):
+        cache.put("hash1", "v1", "RAG Architecture Overview", "en")
+        assert cache.get("hash1", "v1", "en") == "RAG Architecture Overview"
+
+    def test_miss(self, cache):
+        assert cache.get("nope", "v1", "en") is None
+
+    def test_overwrite_same_key(self, cache):
+        cache.put("hash1", "v1", "First Title", "en")
+        cache.put("hash1", "v1", "Updated Title", "en")
+        assert cache.get("hash1", "v1", "en") == "Updated Title"
+
+    def test_lang_in_key(self, cache):
+        cache.put("hash1", "v1", "English Title", "en")
+        cache.put("hash1", "v1", "Deutscher Titel", "de")
+        assert cache.get("hash1", "v1", "en") == "English Title"
+        assert cache.get("hash1", "v1", "de") == "Deutscher Titel"
+
+    def test_prompt_version_in_key(self, cache):
+        cache.put("hash1", "v1", "Title v1", "en")
+        cache.put("hash1", "v2", "Title v2", "en")
+        assert cache.get("hash1", "v1", "en") == "Title v1"
+        assert cache.get("hash1", "v2", "en") == "Title v2"
+
+    def test_invalidate_prompt_version(self, cache):
+        cache.put("hash1", "v1", "Old", "en")
+        cache.put("hash2", "v1", "Old", "en")
+        cache.put("hash3", "v2", "New", "en")
+        removed = cache.invalidate_prompt_version("v2")
+        assert removed == 2
+        assert cache.get("hash1", "v1", "en") is None
+        assert cache.get("hash3", "v2", "en") == "New"
+
+    def test_survives_close_and_reopen(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        first = TitleSuggestionCache(path)
+        first.put("hash1", "v1", "Persisted", "en")
+        first.close()
+
+        second = TitleSuggestionCache(path)
+        try:
+            assert second.get("hash1", "v1", "en") == "Persisted"
+        finally:
+            second.close()
+
+
+class TestResolveCacheDir:
+    def test_cli_override_wins(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("CLM_CACHE_DIR", str(tmp_path / "env"))
+        chosen = tmp_path / "explicit"
+        assert resolve_cache_dir(cli_override=chosen, repo_root=tmp_path) == chosen
+        assert chosen.is_dir()
+
+    def test_env_var_used_when_no_cli(self, tmp_path: Path, monkeypatch):
+        target = tmp_path / "from-env"
+        monkeypatch.setenv("CLM_CACHE_DIR", str(target))
+        assert resolve_cache_dir(repo_root=tmp_path) == target
+        assert target.is_dir()
+
+    def test_pyproject_used_when_no_env(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.clm]\ncache_dir = "custom-cache"\n', encoding="utf-8"
+        )
+        chosen = resolve_cache_dir(repo_root=tmp_path)
+        assert chosen == tmp_path / "custom-cache"
+        assert chosen.is_dir()
+
+    def test_pyproject_absolute_path(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        absolute = tmp_path / "absolute-cache"
+        (tmp_path / "pyproject.toml").write_text(
+            f'[tool.clm]\ncache_dir = "{absolute.as_posix()}"\n',
+            encoding="utf-8",
+        )
+        assert resolve_cache_dir(repo_root=tmp_path) == absolute
+
+    def test_default_fallback(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        chosen = resolve_cache_dir(repo_root=tmp_path)
+        assert chosen == tmp_path / ".clm-cache"
+        assert chosen.is_dir()

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -1,0 +1,434 @@
+"""Tests for :mod:`clm.slides.assign_ids`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.ollama_client import StaticTitleSuggester
+from clm.slides.assign_ids import (
+    AssignOptions,
+    assign_ids_for_text,
+    assign_ids_in_file,
+)
+
+
+def _write(tmp_path: Path, content: str, name: str = "slide.py") -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _run(text: str, **kwargs):
+    options = AssignOptions(**kwargs)
+    return assign_ids_for_text(text, Path("slide.py"), options)
+
+
+# ---------------------------------------------------------------------------
+# Category: HEADED — slug from first heading
+# ---------------------------------------------------------------------------
+
+
+class TestHeadedSlides:
+    def test_assigns_from_heading(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "#\n"
+            "# ## Wozu eine neue Bibliothek?\n"
+            "#\n"
+            "# - first bullet\n"
+        )
+        new_text, result = _run(text)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "wozu-eine-neue-bibliothek"
+        assert result.assignments[0].source == "heading"
+        assert 'slide_id="wozu-eine-neue-bibliothek"' in new_text
+
+    def test_idempotent_with_existing_id(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="my-slide"\n'
+            "# ## Wozu eine neue Bibliothek?\n"
+        )
+        new_text, result = _run(text)
+        assert result.assignments == []
+        assert new_text == text
+
+    def test_force_overwrites(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="old-id"\n'
+            "# ## Wozu eine neue Bibliothek?\n"
+        )
+        new_text, result = _run(text, force=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "wozu-eine-neue-bibliothek"
+        assert 'slide_id="wozu-eine-neue-bibliothek"' in new_text
+        assert 'slide_id="old-id"' not in new_text
+
+    def test_paired_de_en_share_slug(self):
+        # §2.3 EN-derived: paired DE/EN cells get the SAME slug, derived
+        # from the EN heading.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## DE Heading\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# ## EN Heading\n"
+        )
+        new_text, result = _run(text)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["en-heading", "en-heading"]
+
+    def test_collision_between_unpaired_groups(self):
+        # Two solo DE slides with identical headings — bumps to "-2".
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## Title\n"
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## Title\n"
+        )
+        new_text, result = _run(text)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["title", "title-2"]
+
+
+# ---------------------------------------------------------------------------
+# Category: EXTRACTABLE — default refusal, opt-in acceptance
+# ---------------------------------------------------------------------------
+
+
+class TestExtractableSlides:
+    BULLET_SLIDE = (
+        '# %% [markdown] lang="en" tags=["slide"]\n'
+        "#\n"
+        "# - First bullet about LangChain\n"
+        "# - Second bullet\n"
+    )
+
+    def test_default_refuses_softly(self):
+        new_text, result = _run(self.BULLET_SLIDE)
+        assert result.assignments == []
+        assert len(result.refusals) == 1
+        refusal = result.refusals[0]
+        assert refusal.severity == "soft"
+        assert refusal.proposed_slug == "first-bullet-about-langchain"
+        assert new_text == self.BULLET_SLIDE
+
+    def test_accept_content_derived_writes(self):
+        new_text, result = _run(self.BULLET_SLIDE, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "first-bullet-about-langchain"
+        assert result.assignments[0].source.startswith("content:")
+        assert 'slide_id="first-bullet-about-langchain"' in new_text
+
+    def test_bold_line_extraction(self):
+        text = (
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "#\n"
+            "# **A Prominent Bold Line**\n"
+            "#\n"
+            "# more content\n"
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "a-prominent-bold-line"
+
+    def test_img_alt_extraction(self):
+        text = (
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "#\n"
+            '# <img src="x.png" alt="RAG architecture diagram"/>\n'
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "rag-architecture-diagram"
+
+
+# ---------------------------------------------------------------------------
+# Category: NON_EXTRACTABLE — hard refuse
+# ---------------------------------------------------------------------------
+
+
+class TestNonExtractableSlides:
+    def test_empty_slide_hard_refuses(self):
+        text = '# %% [markdown] lang="en" tags=["slide"]\n#\n'
+        new_text, result = _run(text)
+        assert result.assignments == []
+        assert len(result.refusals) == 1
+        assert result.refusals[0].severity == "hard"
+        assert new_text == text
+
+    def test_image_without_alt_hard_refuses(self):
+        text = '# %% [markdown] lang="en" tags=["slide"]\n#\n# <img src="divider.png"/>\n'
+        new_text, result = _run(text)
+        assert result.refusals[0].severity == "hard"
+
+    def test_force_preserves_existing_when_no_proposal(self):
+        # Baseline rule from §2.3: --force does not remove an id we can't replace.
+        text = '# %% [markdown] lang="en" tags=["slide"] slide_id="kept"\n#\n'
+        new_text, result = _run(text, force=True)
+        assert result.assignments == []
+        # The id is left intact.
+        assert 'slide_id="kept"' in new_text
+
+
+# ---------------------------------------------------------------------------
+# Preserve marker
+# ---------------------------------------------------------------------------
+
+
+class TestPreserveMarker:
+    def test_force_does_not_touch_preserved(self):
+        text = '# %% [markdown] lang="de" tags=["slide"] slide_id="!intro"\n# ## Some New Title\n'
+        new_text, result = _run(text, force=True)
+        assert result.assignments == []
+        assert 'slide_id="!intro"' in new_text
+
+    def test_preserve_locks_paired_sibling_to_bare_form(self):
+        # The DE cell's preserve marker locks the group's bare slug to
+        # "intro". The EN sibling joins the same group and adopts the
+        # bare form (no collision — they're the same logical slide).
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="!intro"\n'
+            "# ## Whatever\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# ## Intro\n"
+        )
+        new_text, result = _run(text)
+        assert 'slide_id="!intro"' in new_text  # DE preserve marker stays
+        assert 'lang="en" tags=["slide"] slide_id="intro"' in new_text
+
+    def test_preserve_collides_with_unrelated_group(self):
+        # An unrelated *solo* slide whose heading also slugs to "intro"
+        # bumps to intro-2 because the preserved !intro is already taken.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="!intro"\n'
+            "# ## Doesn't matter\n"
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## Intro\n"
+        )
+        new_text, result = _run(text)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["intro-2"]
+
+
+# ---------------------------------------------------------------------------
+# Title slide special case
+# ---------------------------------------------------------------------------
+
+
+class TestTitleSlide:
+    def test_voiceover_after_header_inherits_title(self):
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("DE Title", "EN Title") }}\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n'
+            "# - welcome\n"
+        )
+        new_text, result = _run(text)
+        assert len(result.assignments) == 1
+        a = result.assignments[0]
+        assert a.slide_id == "title"
+        assert a.source == "voiceover-inherit"
+        assert 'slide_id="title"' in new_text
+
+
+# ---------------------------------------------------------------------------
+# Voiceover / notes inheritance
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceoverInheritance:
+    def test_voiceover_inherits_preceding_slide_id(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## RAG Architecture\n"
+            '# %% [markdown] lang="de" tags=["voiceover"]\n'
+            "# - voiceover content\n"
+            '# %% [markdown] lang="en" tags=["voiceover"]\n'
+            "# - voiceover content en\n"
+        )
+        new_text, result = _run(text)
+        slide_assign = next(a for a in result.assignments if a.source == "heading")
+        narrative = [a for a in result.assignments if a.source == "voiceover-inherit"]
+        assert slide_assign.slide_id == "rag-architecture"
+        assert len(narrative) == 2
+        assert all(a.slide_id == "rag-architecture" for a in narrative)
+
+    def test_existing_voiceover_id_preserved_without_force(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## RAG\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="old-cell-id"\n'
+            "# - voiceover\n"
+        )
+        new_text, result = _run(text)
+        # The slide cell gets its slug. The voiceover keeps its existing id.
+        narrative = [a for a in result.assignments if a.source == "voiceover-inherit"]
+        assert narrative == []
+        assert 'slide_id="old-cell-id"' in new_text
+
+    def test_force_rewrites_voiceover_to_match_slide(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## RAG\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="old-cell-id"\n'
+            "# - voiceover\n"
+        )
+        new_text, result = _run(text, force=True)
+        narrative = [a for a in result.assignments if a.source == "voiceover-inherit"]
+        assert len(narrative) == 1
+        assert narrative[0].slide_id == "rag"
+        assert 'slide_id="rag"' in new_text
+        assert 'slide_id="old-cell-id"' not in new_text
+
+
+# ---------------------------------------------------------------------------
+# LLM suggestion path (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMSuggest:
+    BULLET_SLIDE = (
+        '# %% [markdown] lang="en" tags=["slide"]\n'
+        "#\n"
+        "# - We use LangSmith for tracing\n"
+        "# - It records every model call\n"
+    )
+
+    def test_llm_replaces_content_derived(self):
+        # The static suggester returns a title regardless of input.
+        suggester = StaticTitleSuggester(default="LangSmith Tracing Overview")
+        new_text, result = _run(
+            self.BULLET_SLIDE,
+            llm_suggest=True,
+            llm_suggester=suggester,
+        )
+        assert len(result.assignments) == 1
+        a = result.assignments[0]
+        assert a.slide_id == "langsmith-tracing-overview"
+        assert a.source == "llm"
+        assert suggester.calls  # the suggester was actually consulted
+
+    def test_llm_failure_falls_back_to_refusal(self):
+        # No mapping, no default → suggester raises → soft refusal.
+        suggester = StaticTitleSuggester()
+        new_text, result = _run(
+            self.BULLET_SLIDE,
+            llm_suggest=True,
+            llm_suggester=suggester,
+        )
+        assert result.assignments == []
+        assert result.refusals[0].severity == "soft"
+
+    def test_llm_caches_results(self):
+        # Hand-rolled fake cache to verify the integration path. We don't
+        # exercise the real SQLite class here — that has its own tests.
+        class FakeCache:
+            def __init__(self):
+                self.store: dict[tuple, str] = {}
+
+            def get(self, content_hash, prompt_version, lang):
+                return self.store.get((content_hash, prompt_version, lang))
+
+            def put(self, content_hash, prompt_version, suggested_title, lang):
+                self.store[(content_hash, prompt_version, lang)] = suggested_title
+
+        cache = FakeCache()
+        suggester = StaticTitleSuggester(default="From LLM")
+        _run(
+            self.BULLET_SLIDE,
+            llm_suggest=True,
+            llm_suggester=suggester,
+            llm_cache=cache,
+        )
+        assert len(suggester.calls) == 1
+        assert len(cache.store) == 1
+
+        # Second run: cache hit, suggester not called again.
+        _run(
+            self.BULLET_SLIDE,
+            llm_suggest=True,
+            llm_suggester=suggester,
+            llm_cache=cache,
+        )
+        assert len(suggester.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Round-trip / idempotency on whole files
+# ---------------------------------------------------------------------------
+
+
+class TestFileLevel:
+    def test_report_only_writes_nothing(self, tmp_path: Path):
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# ## Heading\n'
+        path = _write(tmp_path, text)
+        result = assign_ids_in_file(path, AssignOptions(report_only=True))
+        assert len(result.assignments) == 1
+        assert path.read_text(encoding="utf-8") == text
+        assert result.files_modified == 0
+
+    def test_assign_then_rerun_is_idempotent(self, tmp_path: Path):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## Heading\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# ## Heading\n"
+        )
+        path = _write(tmp_path, text)
+
+        r1 = assign_ids_in_file(path, AssignOptions())
+        assert r1.files_modified == 1
+        after_first = path.read_text(encoding="utf-8")
+
+        r2 = assign_ids_in_file(path, AssignOptions())
+        assert r2.files_modified == 0
+        assert path.read_text(encoding="utf-8") == after_first
+
+    def test_force_is_stable(self, tmp_path: Path):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## RAG Architecture\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# ## RAG Architecture\n"
+        )
+        path = _write(tmp_path, text)
+        assign_ids_in_file(path, AssignOptions(force=True))
+        first = path.read_text(encoding="utf-8")
+        assign_ids_in_file(path, AssignOptions(force=True))
+        second = path.read_text(encoding="utf-8")
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Subslide / mixed-tag cells
+# ---------------------------------------------------------------------------
+
+
+class TestSubslide:
+    def test_subslide_treated_as_slide_start(self):
+        text = '# %% [markdown] lang="de" tags=["subslide"]\n# ## A Subslide Title\n'
+        new_text, result = _run(text)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "a-subslide-title"
+
+
+# ---------------------------------------------------------------------------
+# Non-target cells should be skipped
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedCells:
+    def test_keep_cell_ignored(self):
+        text = '# %% tags=["keep"]\nx = 1\n'
+        new_text, result = _run(text)
+        assert result.assignments == []
+        assert result.refusals == []
+        assert new_text == text
+
+    def test_shared_no_lang_cell_ignored(self):
+        text = "# %%\nimport langchain\n"
+        new_text, result = _run(text)
+        assert result.assignments == []
+        assert result.refusals == []
+        assert new_text == text

--- a/tests/slides/test_headingless.py
+++ b/tests/slides/test_headingless.py
@@ -1,0 +1,90 @@
+"""Tests for :mod:`clm.slides.headingless`."""
+
+from __future__ import annotations
+
+from clm.slides.headingless import Category, cell_text_for_llm, classify, extract_heading
+
+
+class TestExtractHeading:
+    def test_returns_text(self):
+        content = "#\n# ## My Heading\n#\n# - bullet\n"
+        assert extract_heading(content) == "My Heading"
+
+    def test_none_when_no_heading(self):
+        content = "#\n# - just a bullet\n"
+        assert extract_heading(content) is None
+
+    def test_finds_first_heading(self):
+        content = "# ## First\n# ## Second\n"
+        assert extract_heading(content) == "First"
+
+    def test_handles_subheadings(self):
+        content = "# ### Sub Level\n"
+        assert extract_heading(content) == "Sub Level"
+
+
+class TestClassify:
+    def test_headed(self):
+        content = "# ## Heading\n# - bullet\n"
+        e = classify(content)
+        assert e.category == Category.HEADED
+        assert e.text == "Heading"
+        assert e.source == "heading"
+
+    def test_extractable_bullet(self):
+        content = "#\n# - First bullet here\n"
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "bullet"
+        assert "First bullet here" in e.text
+
+    def test_extractable_numbered(self):
+        content = "#\n# 1. First step\n"
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert "First step" in e.text
+
+    def test_extractable_bold(self):
+        content = "#\n# **A Bold Line**\n"
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "bold"
+        assert e.text == "A Bold Line"
+
+    def test_extractable_img_alt(self):
+        content = '#\n# <img src="x" alt="A diagram"/>\n'
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "img_alt"
+        assert e.text == "A diagram"
+
+    def test_bullet_beats_img_alt(self):
+        content = '#\n# - the bullet\n# <img alt="ignored"/>\n'
+        e = classify(content)
+        assert e.source == "bullet"
+
+    def test_non_extractable_empty(self):
+        assert classify("").category == Category.NON_EXTRACTABLE
+
+    def test_non_extractable_img_without_alt(self):
+        content = '#\n# <img src="divider.png"/>\n'
+        assert classify(content).category == Category.NON_EXTRACTABLE
+
+    def test_non_extractable_only_whitespace(self):
+        assert classify("#\n#  \n#\n").category == Category.NON_EXTRACTABLE
+
+
+class TestCellTextForLLM:
+    def test_strips_comment_prefix(self):
+        text = cell_text_for_llm("# Line one\n# Line two\n")
+        assert text == "Line one\nLine two"
+
+    def test_drops_blank_lines(self):
+        text = cell_text_for_llm("# Line one\n#\n# Line two\n")
+        assert text == "Line one\nLine two"
+
+    def test_caps_length(self):
+        long = "\n".join("# " + ("x" * 100) for _ in range(50))
+        text = cell_text_for_llm(long, max_chars=200)
+        assert len(text) < 300
+        assert text.endswith("...")

--- a/tests/slides/test_slug.py
+++ b/tests/slides/test_slug.py
@@ -1,0 +1,143 @@
+"""Tests for :mod:`clm.slides.slug`."""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides.slug import (
+    MAX_SLUG_LENGTH,
+    is_preserved,
+    is_valid_slug,
+    resolve_collision,
+    slugify,
+    strip_preserve_marker,
+)
+
+
+class TestSlugify:
+    def test_simple_title(self):
+        assert slugify("RAG Architecture") == "rag-architecture"
+
+    def test_lowercase(self):
+        assert slugify("LANGCHAIN") == "langchain"
+
+    def test_strips_markdown_bold(self):
+        assert slugify("**LCEL** Pipelines") == "lcel-pipelines"
+
+    def test_strips_markdown_code(self):
+        assert slugify("Use the `header()` macro") == "use-the-header-macro"
+
+    def test_strips_markdown_link(self):
+        assert slugify("See [docs](http://example.com)") == "see-docs"
+
+    def test_strips_html(self):
+        assert slugify("Title<br/>Continued") == "titlecontinued"
+
+    def test_german_umlauts(self):
+        assert slugify("Wofür Brauchen Wir Das?") == "wofuer-brauchen-wir-das"
+
+    def test_german_sharp_s(self):
+        assert slugify("Großes Modell") == "grosses-modell"
+
+    def test_strip_accents(self):
+        assert slugify("Café Latté") == "cafe-latte"
+
+    def test_punctuation_collapses(self):
+        assert slugify("Hello, World! / Goodbye?") == "hello-world-goodbye"
+
+    def test_numbers_preserved(self):
+        assert slugify("RAG Step 1: Retrieval") == "rag-step-1-retrieval"
+
+    def test_empty_when_no_word_chars(self):
+        assert slugify("---!!!---") == ""
+
+    def test_length_cap_drops_stopwords(self):
+        # Without stop-word pruning this would be longer than the cap.
+        slug = slugify("This Is A Very Long Title For The Slide Page")
+        assert len(slug) <= MAX_SLUG_LENGTH
+        assert slug.startswith("this")
+
+    def test_length_cap_word_boundary(self):
+        slug = slugify("aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj")
+        assert len(slug) <= MAX_SLUG_LENGTH
+        # Last segment is a whole word, not a fragment.
+        assert "-" in slug
+        last = slug.rsplit("-", 1)[-1]
+        assert last in {"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff", "gggg"}
+
+    def test_first_token_alone_exceeds_cap(self):
+        slug = slugify("a" * 50)
+        assert len(slug) <= MAX_SLUG_LENGTH
+
+    def test_custom_max_length(self):
+        slug = slugify("short title here", max_length=10)
+        assert len(slug) <= 10
+
+
+class TestPreserveMarker:
+    def test_strip(self):
+        assert strip_preserve_marker("!intro") == "intro"
+
+    def test_strip_no_marker(self):
+        assert strip_preserve_marker("intro") == "intro"
+
+    def test_strip_only_marker(self):
+        # The "!" alone strips to empty — invalid downstream, but the
+        # function shouldn't crash.
+        assert strip_preserve_marker("!") == ""
+
+    def test_is_preserved_true(self):
+        assert is_preserved("!intro") is True
+
+    def test_is_preserved_false(self):
+        assert is_preserved("intro") is False
+
+
+class TestIsValidSlug:
+    @pytest.mark.parametrize(
+        "slug",
+        ["intro", "rag-architecture", "wozu-eine-neue-bibliothek", "step-1", "title"],
+    )
+    def test_valid(self, slug):
+        assert is_valid_slug(slug)
+
+    def test_valid_preserved(self):
+        assert is_valid_slug("!intro")
+
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "",
+            "UPPER",
+            "with space",
+            "trailing-",
+            "-leading",
+            "double--dash",
+            "ünicode",
+            "!",
+        ],
+    )
+    def test_invalid(self, slug):
+        assert not is_valid_slug(slug)
+
+    def test_over_length(self):
+        assert not is_valid_slug("a" * (MAX_SLUG_LENGTH + 1))
+
+    def test_preserve_marker_not_counted_in_length(self):
+        body = "a" * MAX_SLUG_LENGTH
+        assert is_valid_slug("!" + body)
+
+
+class TestResolveCollision:
+    def test_no_collision(self):
+        assert resolve_collision("foo", []) == "foo"
+
+    def test_simple_collision(self):
+        assert resolve_collision("foo", ["foo"]) == "foo-2"
+
+    def test_chain_of_collisions(self):
+        assert resolve_collision("foo", ["foo", "foo-2", "foo-3"]) == "foo-4"
+
+    def test_preserve_marker_collides(self):
+        # !foo and foo are the same identifier — collision must trigger.
+        assert resolve_collision("foo", ["!foo"]) == "foo-2"


### PR DESCRIPTION
## Summary

Phase 2 of the [slide-format-redesign](https://github.com/hoelzl/PythonCourses/blob/master/docs/handover-slide-format-redesign-clm.md) — ships `clm slides assign-ids`, a tool that generates stable, EN-derived, kebab-case ASCII `slide_id`s for slide and subslide cells per §2.3 of the redesign handover.

- **Three-category policy.** *Headed* → slug from the first markdown heading. *Extractable* (headingless with a first bullet, prominent bold line, or `<img alt="">`) → refused by default; opt in with `--accept-content-derived` or `--llm-suggest`. *No-content* → hard refuse (author writes `slide_id="…"` by hand).
- **Paired DE/EN slide cells share an EN-derived slug.** Voiceover/notes inherit the preceding slide's id (1:N). Title slides (j2 `header()` macro) auto-anchor `slide_id="title"`.
- **Preserve marker `!intro`** is never regenerated, even under `--force`. The `!` is source-level only; references everywhere use the bare form `intro`.
- **`--llm-suggest`** calls a local Ollama model (default `qwen3:30b`) for extractable cells. Suggestions are cached in `clm-llm.sqlite` keyed by `(content_hash, prompt_version, lang)`. The `TitleSuggester` `typing.Protocol` keeps the LLM mockable — tests use `StaticTitleSuggester` and never touch the network.
- **Cache directory** resolves via `--cache-dir` → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. AZAV-scale trainers can point this at a sibling git repo and share the cache across machines; everyone else leaves it local and gitignored.

Exit codes: `0` clean, `1` soft refusals (need author input), `2` hard refusals.

This unblocks Phase 3 (validator slide_id extensions). The companion `PythonCourses` repo's Phase B (course-wide slide_id rollout) consumes both Phases 2 and 3 — Phase 2 alone is enough to **exercise** the tooling on a single deck before validator enforcement makes the rules sticky.

## What changed

| Area | Files |
|---|---|
| Slug derivation | `src/clm/slides/slug.py` (new) |
| Three-category classifier | `src/clm/slides/headingless.py` (new) |
| Assignment engine | `src/clm/slides/assign_ids.py` (new) |
| CLI wiring | `src/clm/cli/commands/assign_ids.py` (new), `src/clm/cli/main.py` |
| Ollama client + Protocol | `src/clm/infrastructure/llm/ollama_client.py` (new) |
| LLM cache | `src/clm/infrastructure/llm/cache.py` (+ `TitleSuggestionCache`, `resolve_cache_dir`) |
| Tests | `tests/slides/test_{slug,headingless,assign_ids}.py`, `tests/infrastructure/llm/test_{ollama_client,title_suggestion_cache}.py` |
| Docs | `CHANGELOG.md`, `src/clm/cli/info_topics/{commands,migration}.md` |

## Verification

- **Full fast suite:** 5077 passed, 1 skipped, 1 xfailed. Ruff (lint + format) and mypy strict clean. Pre-commit hooks pass.
- **111 new tests** covering: German transliteration & length cap, three-category policy, preserve marker semantics (incl. paired-sibling locking and unrelated-group collision), baseline rule under `--force`, idempotency, title-slide special case, voiceover/notes inheritance (with and without `--force`), LLM Protocol mocking, cache CRUD + prompt-version invalidation, 4-level cache-dir resolution.
- **Acceptance on three real ML AZAV fixtures** (run from a fresh worktree against the live `PythonCourses/slides/` tree):
  - `slides_010_langchain_basics.py` (1451 lines, mixed positional+semantic ids, title macro): default run assigns 24 voiceover-inherit ids, surfaces 2 soft refusals and 1 hard refusal. `--accept-content-derived` consumes the soft refusals (`we-can-switch-model-provider`). `--llm-suggest` against real `qwen3:30b` produced `no-code-change-needed` instead.
  - `slides_015_langsmith_tracing.py` (all-semantic ids): default reports 0 changes. `--force` rewrites to EN-derived slugs and is byte-stable across reruns (md5 unchanged).
  - `slides_welcome_to_clean_code.py` (greenfield, prose-only): correctly hard-refuses per design — no heading, no extractable content.
- **LLM end-to-end:** first call ~30 s (cold load on a 30B model), second run sub-second (cache hit, no LLM call). Falls back silently to refusal when Ollama is unreachable (`is_available()` ping on the `/api/tags` endpoint).

## Test plan

- [x] `pytest` fast suite green locally
- [x] `pytest tests/slides/test_assign_ids.py tests/slides/test_slug.py tests/slides/test_headingless.py tests/infrastructure/llm/` — 111 passed
- [x] `clm slides assign-ids --help` renders cleanly with the full flag matrix
- [x] `--report-only` on each of the three fixtures produces sensible output
- [x] `--force` is byte-stable across reruns
- [x] `--llm-suggest` end-to-end against real Ollama; cache populated and re-hit on second run
- [x] Ruff + mypy strict pass
- [x] Pre-commit hooks pass
- [ ] Reviewer: try `clm slides assign-ids slides/module_550_ml_azav/ --report-only` against your local PythonCourses checkout and sanity-check the proposed slugs

## Notes

- The `--interactive` flag listed in the original handover is **deferred**. `--report-only --llm-suggest` plus manual edits covers the same workflow; a future iteration can add the TTY UI once we have field-usage data.
- The existing `clm normalize-slides --operations slide_ids` is untouched and continues to work. Authors can migrate to `clm slides assign-ids` at their own pace; Phase 3 will be where missing `slide_id`s become a validator error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)