### PR TITLE
fix(http-replay): include request body in vcrpy match_on

### DIFF
--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -120,6 +120,23 @@ _clm_vcr_instance = _clm_vcr.VCR(
     filter_post_data_parameters=["password", "token", "api_key"],
     filter_query_parameters=["api_key", "token"],
     decode_compressed_response=True,
+    # vcrpy's default ``match_on`` is
+    # ``("method", "scheme", "host", "port", "path", "query")`` -- the
+    # request body is *not* part of the match key.  All POSTs to the same
+    # chat-completion endpoint then look identical to vcrpy and recorded
+    # interactions are served in on-disk order.  When the call sequence
+    # at replay time differs from the recording sequence (e.g. because
+    # the source has been edited since the cassette was recorded, or
+    # because the output kind being built filters out some cells), vcrpy
+    # serves the wrong interaction -- typically a non-streaming JSON
+    # response to a ``stream=True`` request -- and downstream LangChain
+    # adapters crash with confusing errors like
+    # ``'tuple' object has no attribute 'model_dump'``.  Including the
+    # body in the match key turns silent mis-matching into a clear
+    # CannotOverwriteExistingCassetteException at the first divergent
+    # request, which is the desired CI behaviour: stale cassettes fail
+    # loudly rather than producing bogus responses.
+    match_on=("method", "scheme", "host", "port", "path", "query", "body"),
 )
 # The cassette path is the worker's per-invocation *staging* file (an
 # absolute path resolved on the host before the cell was injected). Each

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2065,6 +2065,29 @@ class TestHttpReplayBootstrap:
         assert "_clm_eager_append" in injected["source"]
         assert "_save" in injected["source"]
 
+    def test_inject_pins_body_in_match_on(self):
+        # The bootstrap must include ``body`` in vcrpy's ``match_on`` tuple.
+        # vcrpy's default matcher only looks at method+scheme+host+port+path+
+        # query, so two POSTs to the same chat-completion endpoint with
+        # different request bodies (e.g. ``stream=true`` vs ``stream=false``)
+        # are indistinguishable. Without body matching, vcrpy serves the
+        # interactions in on-disk order, which silently breaks replay when
+        # the call sequence diverges from the recording order -- producing
+        # confusing downstream errors such as
+        # ``'tuple' object has no attribute 'model_dump'`` in
+        # langchain-openrouter when it receives a JSON ChatResult instead
+        # of an EventStream.  Pin the matcher so we never regress.
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = make_notebook_node([make_cell("code", "pass")])
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "replay")
+
+        src = nb["cells"][0]["source"]
+        assert "match_on=" in src
+        assert '"body"' in src
+
     def test_inject_uses_vcr_mode_mapping(self):
         from clm.workers.notebook.notebook_processor import (
             _inject_http_replay_bootstrap,


### PR DESCRIPTION
# fix(http-replay): include request body in vcrpy match_on

**Branch:** `claude/http-replay-body-matcher` (single commit `4fb58cc`)
**Recommended merge order:** 1st of 4 in the cassette/monitor series.
**Followup:** `slides_010_langchain_basics.http-cassette.yaml` (and any other
opted-in topic whose source has changed since recording) must be regenerated
with `--http-replay=refresh` once this lands — see "Migration" below.

## Summary

vcrpy's default `match_on` is `[method, scheme, host, port, path, query]`. The
body is **not** in the default set. For chat-style APIs where every call hits
the same endpoint (e.g. `POST https://openrouter.ai/api/v1/chat/completions`)
this means vcrpy cannot tell two distinct calls apart; it serves recorded
interactions back to the client in **on-disk order**.

When the cassette's on-disk order diverges from the runtime call order — which
happens whenever the slide source has been edited but the cassette has not been
re-recorded — vcrpy serves a `stream=false` JSON response to a `stream=true`
request. The OpenRouter SDK then reads `Content-Type: application/json`, takes
the non-streaming branch, and returns a `ChatResult` pydantic model.
`langchain-openrouter` iterates it expecting `EventStream`, pydantic v2 yields
`(field, value)` tuples, and the cell crashes with:

```
AttributeError: 'tuple' object has no attribute 'model_dump'
```

This was being reported by trainers as "the streaming cells just break with a
weird pydantic error." The build proceeded silently right up until the failing
cell, so the underlying replay/source divergence was invisible.

## Fix

Add `"body"` to `match_on` in the vcrpy bootstrap injected into every replay-
enabled notebook (`src/clm/workers/notebook/notebook_processor.py`). With body
matching, vcrpy can distinguish requests that differ only by `"stream": true`
vs `"stream": false`, and serves the correct recorded interaction regardless
of on-disk ordering.

When a cassette is genuinely incomplete (the source asks for an interaction
that was never recorded), vcrpy now raises `CannotOverwriteExistingCassetteException`
at the divergent request — the loud failure mode the design doc
(`docs/claude/design/http-replay.md`) already calls for under CI's `replay`
mode. This replaces the silent corruption with an immediately diagnosable
error.

## Test plan

- [x] Added regression test pinning `match_on=["method","scheme","host","port","path","query","body"]` in the injected bootstrap.
- [x] Full `tests/workers/notebook/` suite (648 tests) passes.
- [x] End-to-end repro on `slides_010_langchain_basics.py`: with master, build silently corrupts and dies with `model_dump`; with this fix, build exits with a clear `CannotOverwriteExistingCassetteException` pointing at the divergent cell.
- [x] Standalone repro (no notebook kernel) in `repro/` confirms this is not nbclient-specific.

## Risk

- **Breaking for stale cassettes**: any topic whose cassette is no longer
  consistent with the slide source will now fail loudly under
  `--http-replay=replay`. This is the intended behavior — the alternative is
  silent-wrong output — but trainers must regenerate cassettes after merging.
  See migration below.
- **No effect when cassette matches source**: the body matcher is strictly more
  specific than the default; cassettes that previously matched will continue
  to match.

## Migration

After merging:

```
clm build <spec> --http-replay=refresh
```

…on each course that uses replay (re-records every interaction). This is a
one-time operation per course. For local iteration on a single topic, the
existing `--http-replay=new-episodes` mode (the local default) continues to
work: vcrpy appends any unmatched request to the cassette instead of erroring.

## Related context

- Discovered while investigating "completed/partial phase takes minutes for the
  langchain intro notebook" — turned out to be three independent issues; this
  is one of them. See companion PRs:
  - `claude/cassette-snapshot-fix` (cache-invariant drift)
  - `claude/fix-orphan-staging-cassette` (orphan crash on next build)
  - `claude/worker-heartbeat` (visibility into long-running cells)
- Root-cause analysis: `STREAMING-CASSETTE-BUG-REPORT.md` in the investigation worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
