### PR TITLE
fix(cache): snapshot cassette bytes once per build for stable execution hash

### DIFF
--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -101,6 +101,15 @@ class Course(NotebookMixin):
     # in `section_selection.resolved_indices` (in declared order). When
     # None, all sections in the spec are built.
     section_selection: SectionSelection | None = None
+    # Build-scoped snapshot of HTTP-replay cassette bytes, keyed by the
+    # canonical (resolved) cassette path on disk. Populated by
+    # :meth:`_snapshot_cassettes_for_build` at the start of ``process_all``/
+    # ``process_file`` so that every payload constructed during a single
+    # build invocation sees byte-identical cassette contents — even when
+    # vcrpy in ``new-episodes``/``once``/``refresh`` mode appends new
+    # interactions to the cassette mid-build (Stage 3 → Stage 4 drift).
+    # Consumed by ``ProcessNotebookOperation.compute_other_files``.
+    _build_cassette_snapshots: dict[Path, bytes] = Factory(dict)
 
     @classmethod
     def from_spec(
@@ -268,16 +277,64 @@ class Course(NotebookMixin):
             logger.warning(f"Cannot process file: not in course: {path}")
             return
 
+        # Snapshot cassettes so every payload built during this invocation
+        # sees the same bytes even if the kernel mid-build appends new
+        # interactions to the cassette on disk.
+        self._snapshot_cassettes_for_build()
+
         # Process file for each output target
         for target in self.output_targets:
             op = await file.get_processing_operation(target.output_root, target=target)
             await op.execute(backend)
             logger.debug(f"Processed file {path} for target '{target.name}'")
 
+    def _snapshot_cassettes_for_build(self) -> None:
+        """Capture cassette bytes once per build, keyed by canonical path.
+
+        Stage 3 (Recording HTML) and Stage 4 (Completed/Trainer/Partial
+        HTML) construct independent payloads that both fold cassette bytes
+        into :py:meth:`NotebookPayload.execution_cache_hash`. When vcrpy
+        runs in ``new-episodes``/``once``/``refresh`` mode and actually
+        records something new, the cassette file on disk changes between
+        Stage 3 and Stage 4, so the two stages would otherwise compute
+        different cache keys and miss the executed-notebook cache.
+
+        Taking the snapshot at the start of ``process_all`` (or
+        ``process_file``) and consulting it from
+        :py:meth:`ProcessNotebookOperation.compute_other_files` keeps the
+        bytes consistent across the whole build, regardless of which stage
+        constructs the payload first.
+        """
+        from clm.core.course_files.notebook_file import NotebookFile
+
+        self._build_cassette_snapshots.clear()
+        if not self.http_replay_mode or self.http_replay_mode == "disabled":
+            return
+        for file in self.files:
+            if not isinstance(file, NotebookFile):
+                continue
+            if not file.http_replay:
+                continue
+            cassette = file.cassette_path
+            if cassette is None:
+                continue
+            key = cassette.resolve()
+            if key in self._build_cassette_snapshots:
+                continue
+            try:
+                self._build_cassette_snapshots[key] = cassette.read_bytes()
+            except OSError as exc:
+                logger.warning("Could not snapshot cassette %s for build: %s", cassette, exc)
+
     async def process_all(self, backend: Backend):
         """Process all files for all output targets."""
         logger.info(f"Processing all files for {self.course_root}")
         logger.info(f"Output targets: {[t.name for t in self.output_targets]}")
+
+        # Snapshot cassette bytes once per build so Stage 3 and Stage 4
+        # see the same cassette contents even if vcrpy appends new
+        # interactions mid-build (see _snapshot_cassettes_for_build).
+        self._snapshot_cassettes_for_build()
 
         for stage in execution_stages():
             logger.debug(f"Processing stage {stage}")

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -108,7 +108,28 @@ class ProcessNotebookOperation(Operation):
             cassette = self.input_file.cassette_path
             cassette_name = self.input_file.cassette_relative_name
             if cassette is not None and cassette_name is not None:
-                other_files[cassette_name] = b64encode(cassette.read_bytes())
+                # Prefer the build-scoped snapshot taken at the start of
+                # ``course.process_all()``/``process_file()``. Without
+                # this, Stage 3 (Recording HTML) and Stage 4
+                # (Completed/Trainer/Partial HTML) can hash different
+                # cassette bytes for the same notebook when vcrpy in
+                # ``new-episodes``/``once``/``refresh`` mode appends new
+                # interactions to the cassette during Stage 3, causing
+                # Stage 4 to miss the executed-notebook cache and
+                # re-execute the kernel unnecessarily. Falls back to
+                # reading the file directly so call sites that construct
+                # operations outside of ``process_all``/``process_file``
+                # (tests, ad-hoc tools) keep working.
+                snapshots = getattr(self.input_file.course, "_build_cassette_snapshots", None)
+                snapshot_bytes: bytes | None = None
+                if snapshots:
+                    try:
+                        snapshot_bytes = snapshots.get(cassette.resolve())
+                    except OSError:
+                        snapshot_bytes = None
+                if snapshot_bytes is None:
+                    snapshot_bytes = cassette.read_bytes()
+                other_files[cassette_name] = b64encode(snapshot_bytes)
 
         return other_files
 

--- a/tests/core/course_files/notebook_file_test.py
+++ b/tests/core/course_files/notebook_file_test.py
@@ -417,6 +417,237 @@ class TestProcessNotebookOperationHttpReplay:
             assert op._resolve_cassette_name() is None
 
 
+class TestBuildScopedCassetteSnapshot:
+    """Stage 3 / Stage 4 must hash the same cassette bytes within a build.
+
+    Recording HTML (Stage 3) and Completed/Trainer/Partial HTML (Stage 4)
+    construct independent ``NotebookPayload`` instances. Both fold the
+    cassette into ``execution_cache_hash`` when ``http_replay`` is active.
+    If vcrpy in ``new-episodes``/``once``/``refresh`` mode appends new
+    interactions during Stage 3 execution, the cassette file on disk
+    changes before Stage 4 constructs its payloads — and the two stages
+    end up computing different hashes, missing the ``executed_notebooks``
+    cache and forcing redundant kernel re-execution.
+
+    The fix is a build-scoped snapshot of cassette bytes, captured at the
+    start of ``course.process_all()``, and consulted by
+    :py:meth:`ProcessNotebookOperation.compute_other_files`.
+    """
+
+    def _build_course_with_replay_notebook(self, tmp_path: Path, mode: str | None = "new-episodes"):
+        """Return ``(course, notebook_file, cassette_path)`` ready to test."""
+        from clm.core.course import Course
+        from clm.core.course_spec import CourseSpec
+        from clm.core.output_target import OutputTarget
+
+        spec = CourseSpec(
+            name=Text(de="Test", en="Test"),
+            prog_lang="python",
+            description=Text(de="", en=""),
+            certificate=Text(de="", en=""),
+            sections=[],
+        )
+        course = Course(
+            spec=spec,
+            course_root=tmp_path,
+            output_root=tmp_path,
+            output_targets=[OutputTarget.default_target(tmp_path)],
+        )
+        course.http_replay_mode = mode
+
+        section = Section(name=Text(de="S", en="S"), course=course)
+        topic_spec = TopicSpec(id="t", http_replay=True)
+        py_file = tmp_path / "slides_replay.py"
+        py_file.write_text("# %% [markdown]\n# Title\n", encoding="utf-8")
+        cassette = tmp_path / "slides_replay.http-cassette.yaml"
+        cassette.write_bytes(b"interactions:\n- request: stage3\n")
+
+        topic = Topic.from_spec(topic_spec, section=section, path=tmp_path)
+        topic.build_file_map()
+        section.topics.append(topic)
+        course.sections.append(section)
+
+        # Find the NotebookFile inside the topic.
+        nb = next(f for f in topic.files if isinstance(f, NotebookFile))
+        # ``http_replay`` on the file mirrors what ``_from_path`` does in
+        # production when the topic opts in. Without the topic-opt-in,
+        # this is a defensive belt-and-braces in tests.
+        nb.http_replay = True
+
+        return course, nb, cassette
+
+    def _make_op(self, nb: NotebookFile, tmp_path: Path, mode: str, kind: str):
+        return ProcessNotebookOperation(
+            input_file=nb,
+            output_file=tmp_path / f"out_{kind}.html",
+            language="en",
+            format="html",
+            kind=kind,
+            prog_lang="python",
+            http_replay_mode=mode,
+        )
+
+    async def test_snapshot_keeps_hash_stable_across_mid_build_cassette_mutation(self, tmp_path):
+        """Stage 3 and Stage 4 must agree on the cassette hash even when the
+        cassette file on disk changes between their payload constructions.
+
+        Without the snapshot, mutating the cassette between the two
+        payload builds would change ``execution_cache_hash`` — masking
+        Stage 4's ability to reuse Stage 3's executed-notebook cache.
+        """
+        course, nb, cassette = self._build_course_with_replay_notebook(tmp_path)
+
+        # Start the build: take the snapshot (mirrors what
+        # ``course.process_all`` does at entry).
+        course._snapshot_cassettes_for_build()
+
+        # Stage 3: build Recording HTML payload at time T1.
+        stage3_op = self._make_op(nb, tmp_path, "new-episodes", "recording")
+        stage3_payload = await stage3_op.payload()
+        stage3_hash = stage3_payload.execution_cache_hash()
+
+        # Simulate vcrpy appending new interactions during Stage 3
+        # execution, just like ``merge_staging_into_canonical`` rewrites
+        # the canonical cassette in its ``finally`` block before Stage 4.
+        cassette.write_bytes(b"interactions:\n- request: stage3\n- request: stage4-new\n")
+
+        # Stage 4: build Completed HTML payload at time T2.
+        stage4_op = self._make_op(nb, tmp_path, "new-episodes", "completed")
+        stage4_payload = await stage4_op.payload()
+        stage4_hash = stage4_payload.execution_cache_hash()
+
+        # The invariant: same notebook + same build → same execution hash.
+        # On ``master`` (no snapshot), these differ because Stage 4 hashes
+        # the post-mutation cassette bytes. With the snapshot they agree.
+        assert stage3_hash == stage4_hash, (
+            "Stage 3 and Stage 4 hashed different cassette bytes within "
+            "the same build invocation; executed_notebooks cache lookups "
+            "in Stage 4 would miss and force redundant kernel execution. "
+            "The build-scoped cassette snapshot is the fix."
+        )
+
+        # Both payloads must carry the pre-mutation bytes (b64-encoded).
+        from base64 import b64decode
+
+        cassette_key = "slides_replay.http-cassette.yaml"
+        assert b64decode(stage3_payload.other_files[cassette_key]) == (
+            b"interactions:\n- request: stage3\n"
+        )
+        assert b64decode(stage4_payload.other_files[cassette_key]) == (
+            b"interactions:\n- request: stage3\n"
+        )
+
+    async def test_without_snapshot_hashes_diverge_when_cassette_mutates(self, tmp_path):
+        """Sanity check: when the snapshot is empty the bug reproduces.
+
+        This pins the failure mode the fix is preventing and would be the
+        baseline behavior on ``master`` (where no snapshot exists at all).
+        """
+        course, nb, cassette = self._build_course_with_replay_notebook(tmp_path)
+
+        # Deliberately do NOT call _snapshot_cassettes_for_build: this
+        # mirrors the pre-fix behavior where ``compute_other_files`` reads
+        # cassette bytes lazily at payload-construction time.
+        assert course._build_cassette_snapshots == {}
+
+        stage3_op = self._make_op(nb, tmp_path, "new-episodes", "recording")
+        stage3_payload = await stage3_op.payload()
+
+        cassette.write_bytes(b"interactions:\n- request: stage3\n- request: stage4-new\n")
+
+        stage4_op = self._make_op(nb, tmp_path, "new-episodes", "completed")
+        stage4_payload = await stage4_op.payload()
+
+        assert stage3_payload.execution_cache_hash() != stage4_payload.execution_cache_hash(), (
+            "Without the build snapshot, mid-build cassette mutation must "
+            "change the execution hash — this is the bug the snapshot fixes."
+        )
+
+    async def test_snapshot_no_op_when_replay_disabled(self, tmp_path):
+        """``disabled``/``None`` modes must not populate the snapshot dict."""
+        for mode in (None, "disabled"):
+            course, _nb, _cassette = self._build_course_with_replay_notebook(
+                tmp_path,
+                mode=mode,  # type: ignore[arg-type]
+            )
+            course._snapshot_cassettes_for_build()
+            assert course._build_cassette_snapshots == {}
+
+    async def test_process_all_populates_snapshot(self, tmp_path):
+        """``Course.process_all`` must take the snapshot at entry."""
+        course, _nb, cassette = self._build_course_with_replay_notebook(tmp_path)
+        assert course._build_cassette_snapshots == {}
+
+        backend = DummyBackend()
+        await course.process_all(backend)
+
+        assert cassette.resolve() in course._build_cassette_snapshots
+        assert course._build_cassette_snapshots[cassette.resolve()] == (
+            b"interactions:\n- request: stage3\n"
+        )
+
+    async def test_stage3_and_stage4_payloads_agree_within_process_all(self, tmp_path, monkeypatch):
+        """End-to-end behavior check.
+
+        Drive a real ``course.process_all`` build through a recording
+        backend that (a) captures every payload it sees and (b) mutates
+        the cassette on disk while Stage 3 is in flight. Without the
+        build-scoped snapshot, the Recording (Stage 3) and Completed
+        (Stage 4) payloads would carry different cassette bytes and
+        therefore different ``execution_cache_hash`` values — which is the
+        exact bug this fix prevents.
+        """
+        from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+
+        course, _nb, cassette = self._build_course_with_replay_notebook(tmp_path)
+
+        # Recording backend that mutates the cassette mid-Stage-3, before
+        # Stage 4 ever runs. This simulates vcrpy appending new
+        # interactions during Recording HTML execution.
+        seen: list[NotebookPayload] = []
+
+        class _MutatingBackend(DummyBackend):
+            async def execute_operation(self, operation, payload):  # type: ignore[override]
+                if isinstance(payload, NotebookPayload):
+                    seen.append(payload)
+                    # Mutate the cassette only when Stage 3's Recording
+                    # HTML payload runs, matching the real-world failure
+                    # mode (vcrpy appends interactions during Recording
+                    # HTML execution; ``merge_staging_into_canonical``
+                    # rewrites the cassette in a ``finally`` block before
+                    # Stage 4 starts).
+                    if payload.kind == "recording" and payload.format == "html":
+                        cassette.write_bytes(
+                            b"interactions:\n- request: stage3\n- request: stage4-new\n"
+                        )
+                await super().execute_operation(operation, payload)
+
+        await course.process_all(_MutatingBackend())
+
+        # Find the recording + completed payloads for the English HTML
+        # output — both are derived from the same notebook within the same
+        # build invocation.
+        recording = [p for p in seen if p.kind == "recording" and p.format == "html"]
+        completed = [p for p in seen if p.kind == "completed" and p.format == "html"]
+        assert recording and completed, (
+            "Expected the build to produce at least one Recording and one "
+            "Completed payload for the .py notebook."
+        )
+
+        # Pair them by language and assert the execution hash matches.
+        # Without the snapshot, the Completed payload (Stage 4, after the
+        # cassette mutation) would hash different bytes and miss the
+        # executed_notebooks cache — forcing redundant kernel runs.
+        for rec in recording:
+            for comp in completed:
+                if rec.language == comp.language:
+                    assert rec.execution_cache_hash() == comp.execution_cache_hash(), (
+                        f"Stage 3 and Stage 4 produced different execution "
+                        f"hashes for language={rec.language!r}; this would "
+                        f"miss the executed_notebooks cache."
+                    )
+
+
 class TestGetOperationStage:
     """Stage assignment controls per-file dispatch order during a build.
 


### PR DESCRIPTION
# fix(cache): snapshot cassette bytes once per build for stable execution hash

**Branch:** `claude/cassette-snapshot-fix` (single commit `0b7d3ee`)
**Recommended merge order:** 2nd of 4 in the cassette/monitor series.

## Summary

`executed_notebooks` cache hashes `{prog_lang, language, data, cassette_bytes}`
via `NotebookPayload.execution_cache_hash()`. The cassette bytes are read into
each payload's `other_files` at payload-construction time
(`ProcessNotebookOperation.compute_other_files`).

When the build runs in `--http-replay=new-episodes` mode (the local default)
and vcrpy records a new interaction during Stage 3 (Recording HTML), the
canonical cassette is rewritten in the worker's `finally` block via
`merge_staging_into_canonical` before Stage 4 (Completed/Trainer/Partial HTML)
starts.

The two payloads then see different cassette bytes:

- Stage 3 payload was constructed at T₁ → cassette V₁ → wrote `executed_notebooks` under `hash(…, V₁)`.
- Stage 4 payload was constructed at T₂ → cassette V₂ → looks up `executed_notebooks` under `hash(…, V₂)` → **miss** → full re-execution of a 60–90 s notebook for no reason.

PR #71 (Stage 4 cache invariant) caught this asymmetry on the Recording-side
write path but not on the Stage 4 read path.

## Fix

Snapshot cassette bytes **once per build** on the `Course` object before any
payload is constructed, then have `compute_other_files` consult that snapshot
instead of reading from disk. Both `process_all` (full builds) and
`process_file` (file-watcher path) take the snapshot. The snapshot is keyed by
`cassette.resolve()` so symlinks and aliasing collapse to one entry shared
across language variants and output targets.

Lazy-read fallback is preserved: when no snapshot is present (tests, ad-hoc
tools constructing operations outside `process_all`/`process_file`), the call
site falls back to `cassette.read_bytes()`. Behavior in the common case (no
cassette mutation) is byte-identical.

## Alternative considered

Drop the cassette from `execution_cache_hash()` entirely and invalidate via a
separate cassette-content marker. That would supersede this fix but changes
the invariant "cassette change → re-execute" to "cassette change → optional
divergence check," which has its own design questions (when does a `refresh`
need to invalidate? do we mark stale, opt-in re-execute, …?). This PR keeps
the existing invariant and just enforces it consistently within a build; the
deeper redesign can come later if desired.

## Test plan

- [x] 5 new tests in `tests/core/course_files/notebook_file_test.py`
      (`TestBuildScopedCassetteSnapshot`). The e2e test
      `test_stage3_and_stage4_payloads_agree_within_process_all` mutates the
      cassette mid-build via a custom `DummyBackend` to mirror vcrpy's
      `merge_staging_into_canonical` finally-block; **fails on master**,
      passes with this fix.
- [x] Narrower unit tests on `Course._snapshot_cassettes_for_build()` and the
      snapshot-empty bug-repro case.
- [x] `pytest -m "not docker"` on `tests/core/`, `tests/workers/notebook/`,
      `tests/infrastructure/backends/` → 1083 passed.
- [x] Pre-commit (ruff, mypy, fast suite) clean.

## Risk

- Adds one read per replay-enabled notebook per build invocation, before stage
  iteration. The cost is one `Path.read_bytes()` per canonical cassette per
  build; for the AZAV ML course that's <20 files <500 KB each. Negligible.
- `process_file` (file-watcher) also takes the snapshot. A single file change
  is unlikely to span Stage 3 and Stage 4, but consistency is safer than
  conditionalizing.

## Related context

- Companion PRs: `claude/http-replay-body-matcher`, `claude/fix-orphan-staging-cassette`, `claude/worker-heartbeat`.
- Underlying invariant is documented in
  `src/clm/infrastructure/messaging/notebook_classes.py:69-94` (the two hash
  formulas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
