### PR TITLE
fix(build): eliminate orphan HTTP-replay staging cassette crashes

### DIFF
--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -277,6 +277,11 @@ class Course(NotebookMixin):
             logger.warning(f"Cannot process file: not in course: {path}")
             return
 
+        # Same ordering as process_all: sweep orphan staging cassettes
+        # *before* snapshotting, so the snapshot reflects the post-sweep
+        # canonical (orphan interactions folded in, staging files removed).
+        self._sweep_orphan_cassette_staging_files()
+
         # Snapshot cassettes so every payload built during this invocation
         # sees the same bytes even if the kernel mid-build appends new
         # interactions to the cassette on disk.
@@ -331,6 +336,22 @@ class Course(NotebookMixin):
         logger.info(f"Processing all files for {self.course_root}")
         logger.info(f"Output targets: {[t.name for t in self.output_targets]}")
 
+        # Sweep orphan HTTP-replay staging files into their canonical
+        # cassettes *before* any payload is constructed. Otherwise a
+        # ``*.http-cassette.yaml.staging-*`` file left behind by a
+        # previously-killed worker can race with concurrent worker B's
+        # merge-and-delete pass, causing worker A's payload builder to
+        # crash with ``FileNotFoundError`` when it tries to b64-encode
+        # the file. The sweep folds the orphan's recorded interactions
+        # into the canonical cassette via the existing dedup helper, so
+        # no recordings are lost.
+        #
+        # The sweep must run *before* the snapshot below — otherwise the
+        # snapshot would capture the pre-sweep canonical and Stage 3's
+        # workers would write executed_notebooks under that hash while
+        # Stage 4 reads under the post-sweep hash.
+        self._sweep_orphan_cassette_staging_files()
+
         # Snapshot cassette bytes once per build so Stage 3 and Stage 4
         # see the same cassette contents even if vcrpy appends new
         # interactions mid-build (see _snapshot_cassettes_for_build).
@@ -355,6 +376,93 @@ class Course(NotebookMixin):
 
         await self.process_dir_group_for_targets(backend)
         await self.process_jupyterlite_for_targets(backend)
+
+    def _sweep_orphan_cassette_staging_files(self) -> int:
+        """Merge any orphan HTTP-replay staging cassettes into canonical.
+
+        Walks every notebook file whose topic opted into ``http_replay``
+        and, for each *unique* canonical cassette location with at least
+        one ``*.http-cassette.yaml.staging-*`` sibling, invokes
+        :func:`merge_staging_into_canonical`. That helper takes the
+        cross-process file lock, folds in every staging file under the
+        canonical's directory (this worker's plus orphans), deduplicates
+        by request fingerprint, atomically writes the merged canonical,
+        and ``unlink``s the staging files.
+
+        Running this *before* payload construction prevents a stale
+        staging file from being enumerated by
+        :meth:`ProcessNotebookOperation.compute_other_files` and then
+        deleted by a concurrent worker's post-execution merge, which
+        used to surface as a ``FileNotFoundError`` during base64
+        encoding. Defense-in-depth: ``compute_other_files`` also filters
+        ``*.staging-*`` via ``is_ignored_file_for_output`` so a *new*
+        orphan appearing mid-build can't sneak into the payload either.
+
+        Returns:
+            Number of canonical cassettes for which a merge ran (i.e.,
+            had at least one staging file present). Zero when nothing
+            needed sweeping or when ``http-replay`` is not used.
+        """
+        from clm.core.course_files.notebook_file import NotebookFile
+
+        # Collect unique canonical cassette paths to sweep. A topic may
+        # contain several notebooks but only one canonical cassette per
+        # notebook; merging twice would be harmless (the lock serializes
+        # and the second pass finds zero stagings) but wasteful.
+        canonical_paths: set[Path] = set()
+        for file in self.files:
+            if not isinstance(file, NotebookFile):
+                continue
+            if not file.http_replay:
+                continue
+            # ``cassette_path`` returns the existing canonical (preferring
+            # the nested ``_cassettes/`` layout); ``expected_cassette_path``
+            # always yields a path even when no cassette has been recorded
+            # yet. Orphans can sit next to the *expected* path on first run,
+            # so prefer that — its parent dir is the right glob target.
+            canonical = file.cassette_path or file.expected_cassette_path
+            canonical_paths.add(canonical)
+
+        if not canonical_paths:
+            return 0
+
+        # Import here so the dependency on vcrpy / filelock (the
+        # ``[replay]`` extra) only kicks in for courses that actually use
+        # http-replay. Otherwise the module-level import would force the
+        # extra on every install.
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        swept = 0
+        for canonical in sorted(canonical_paths):
+            staging_glob = f"{canonical.name}.staging-*"
+            if not canonical.parent.is_dir():
+                continue
+            if not any(canonical.parent.glob(staging_glob)):
+                continue
+            # The ``staging`` field is irrelevant for the sweep call —
+            # ``merge_staging_into_canonical`` globs for every staging
+            # file in the canonical's parent dir, including orphans this
+            # worker did not produce. Pass a synthetic name to satisfy
+            # the dataclass.
+            synthetic = canonical.parent / f"{canonical.name}.staging-sweep"
+            try:
+                merged = merge_staging_into_canonical(
+                    CassettePaths(canonical=canonical, staging=synthetic)
+                )
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.warning(
+                    f"Pre-build orphan staging sweep failed for "
+                    f"'{canonical}' ({type(exc).__name__}: {exc}); "
+                    f"continuing — the worker-side sweep will retry."
+                )
+                continue
+            if merged:
+                logger.info(f"Merged {merged} orphan staging cassette(s) into '{canonical}'.")
+                swept += 1
+        return swept
 
     async def process_stage_for_target(
         self,

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -13,7 +13,7 @@ from clm.infrastructure.messaging.correlation_ids import (
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
 from clm.infrastructure.operation import Operation
 from clm.infrastructure.utils.path_utils import (
-    is_ignored_file_for_course,
+    is_ignored_file_for_output,
     is_image_file,
     is_image_source_file,
     output_path_for,
@@ -88,13 +88,23 @@ class ProcessNotebookOperation(Operation):
         def relative_path(file):
             return str(file.relative_path).replace("\\", "/")
 
+        # ``is_ignored_file_for_output`` is a superset of
+        # ``is_ignored_file_for_course`` plus the patterns in
+        # ``SKIP_OUTPUT_FILE_PATTERNS`` (canonical cassettes, per-worker
+        # ``.staging-*`` cassettes). The staging filter matters even though
+        # this is a payload-side enumeration: a concurrent worker may
+        # ``merge_staging_into_canonical`` and delete the staging file
+        # between glob and read, producing a ``FileNotFoundError`` on the
+        # ``read_bytes()`` below. Filtering them out here makes the
+        # payload builder robust to that race. The canonical cassette is
+        # re-added explicitly below when the topic opted in.
         other_files = {
             relative_path(file): b64encode(file.source_path.read_bytes())
             for file in self.input_file.topic.files
             if file != self.input_file
             and not is_image_file(file.path)
             and not is_image_source_file(file.path)
-            and not is_ignored_file_for_course(file.path)
+            and not is_ignored_file_for_output(file.path)
             and (companion is None or file.path != companion)
         }
 

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -73,14 +73,25 @@ SKIP_FILE_NAMES = frozenset({".clm-include"})
 # travel into worker payloads and source mounts) but must NOT be copied to
 # public or speaker output. HTTP-replay cassettes are the first case: the
 # kernel consumes them at execution time but students never see them.
+#
+# The ``.staging-`` variant is a per-worker partial cassette: it is a
+# build-internal artifact and must be invisible to *every* downstream
+# consumer (worker payloads, source mounts, AND public/speaker output).
+# Concurrent workers may delete these mid-build during merge, so they
+# must never be enumerated by the payload builder either — see
+# :func:`compute_other_files` in ``process_notebook.py``.
 SKIP_OUTPUT_FILE_PATTERNS = [
     re.compile(r".*\.http-cassette\.yaml$"),
+    re.compile(r".*\.http-cassette\.yaml\.staging-.*$"),
 ]
 
 # Parallel glob form of ``SKIP_OUTPUT_FILE_PATTERNS`` for consumers that
 # take shell-style patterns (e.g. ``shutil.ignore_patterns``). Keep in
 # sync with the regex list above.
-SKIP_OUTPUT_FILE_GLOBS = ["*.http-cassette.yaml"]
+SKIP_OUTPUT_FILE_GLOBS = [
+    "*.http-cassette.yaml",
+    "*.http-cassette.yaml.staging-*",
+]
 
 PLANTUML_EXTENSIONS = frozenset({".pu", ".puml", ".plantuml"})
 

--- a/tests/core/course_files/notebook_file_test.py
+++ b/tests/core/course_files/notebook_file_test.py
@@ -416,6 +416,85 @@ class TestProcessNotebookOperationHttpReplay:
             op, _ = self._make_operation(course_1, tmp_path, mode=mode, with_cassette=True)
             assert op._resolve_cassette_name() is None
 
+    def test_other_files_excludes_orphan_staging_cassette(self, course_1, tmp_path):
+        """Per-worker ``.staging-*`` cassettes must never enter ``other_files``.
+
+        Regression for the "orphan staging cassette crashes the next build"
+        failure mode: a concurrent worker may run
+        :func:`merge_staging_into_canonical` and ``unlink`` the staging
+        file between glob enumeration and ``read_bytes()`` inside
+        ``compute_other_files``, surfacing as ``FileNotFoundError`` during
+        b64 encoding. Defense-in-depth: even with the eager pre-build
+        sweep, a *new* orphan can appear mid-build (race with a
+        concurrent worker), so payload construction must filter
+        ``*.http-cassette.yaml.staging-*`` itself.
+        """
+        from clm.core.course import Course
+        from clm.core.course_spec import CourseSpec
+
+        spec = CourseSpec(
+            name=Text(de="Test", en="Test"),
+            prog_lang="python",
+            description=Text(de="", en=""),
+            certificate=Text(de="", en=""),
+            sections=[],
+        )
+        course = Course(spec=spec, course_root=tmp_path, output_root=tmp_path)
+        course.http_replay_mode = "replay"
+        section = Section(name=Text(de="S", en="S"), course=course)
+        topic_spec = TopicSpec(id="t", http_replay=True)
+
+        # Build a DirectoryTopic so ``add_files_in_dir`` enumerates the
+        # whole topic directory — this is the path that picks up the
+        # canonical cassette *and* the orphan staging file as ordinary
+        # course files. A FileTopic-only topic would miss both.
+        topic_dir = tmp_path / "topic_dir"
+        topic_dir.mkdir()
+        py_file = topic_dir / "slides_replay.py"
+        py_file.write_text("# %% [markdown]\n# Title\n", encoding="utf-8")
+        canonical = topic_dir / "slides_replay.http-cassette.yaml"
+        canonical.write_bytes(b"interactions: []\n")
+        orphan = topic_dir / "slides_replay.http-cassette.yaml.staging-99-abc"
+        orphan.write_bytes(b"interactions: []\n")
+
+        topic = Topic.from_spec(topic_spec, section=section, path=topic_dir)
+        topic.build_file_map()
+
+        # Sanity: the staging file landed in topic.files via add_files_in_dir.
+        topic_file_names = {f.path.name for f in topic.files}
+        assert orphan.name in topic_file_names, (
+            "test setup precondition: orphan staging file should be in topic.files"
+        )
+
+        nb = next(
+            f
+            for f in topic.files
+            if isinstance(f, NotebookFile) and f.path.name == "slides_replay.py"
+        )
+        nb.http_replay = True
+
+        op = ProcessNotebookOperation(
+            input_file=nb,
+            output_file=tmp_path / "out.html",
+            language="en",
+            format="html",
+            kind="speaker",
+            prog_lang="python",
+            http_replay_mode="replay",
+        )
+        other = op.compute_other_files()
+
+        # The orphan staging file must NOT be in other_files (any key
+        # form: relative path, basename, or with a leading ``./``).
+        for key in other:
+            assert "staging-" not in key, (
+                f"orphan staging file leaked into other_files under key {key!r}"
+            )
+
+        # Canonical cassette is still present under its kernel-cwd-relative key
+        # because the explicit assignment in compute_other_files re-adds it.
+        assert "slides_replay.http-cassette.yaml" in other
+
 
 class TestBuildScopedCassetteSnapshot:
     """Stage 3 / Stage 4 must hash the same cassette bytes within a build.

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -2,6 +2,8 @@ import logging
 from asyncio import TaskGroup
 from pathlib import Path
 
+import pytest
+
 from clm.core.course import Course
 from clm.core.course_files.notebook_file import NotebookFile
 from clm.core.utils.execution_utils import (
@@ -726,3 +728,139 @@ def test_required_include_with_missing_source_records_loading_error(tmp_path):
     errs = [e for e in course.loading_errors if e.get("category") == "include_source_missing"]
     assert len(errs) == 1
     assert "examples" in errs[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Orphan HTTP-replay staging cassette sweep
+# ---------------------------------------------------------------------------
+
+
+_ORPHAN_CASSETTE_YAML = """\
+interactions:
+- request:
+    method: GET
+    uri: {uri}
+    body: '{body}'
+    headers:
+      accept: ['*/*']
+  response:
+    status: {{code: 200, message: OK}}
+    headers:
+      content-type: [text/plain]
+    body: {{string: '{body}'}}
+version: 1
+"""
+
+
+def _write_orphan_cassette(path: Path, *, uri: str, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_ORPHAN_CASSETTE_YAML.format(uri=uri, body=body), encoding="utf-8")
+
+
+def test_sweep_orphan_staging_files_merges_and_deletes(tmp_path):
+    """Pre-build sweep folds orphan ``.staging-*`` cassettes into canonical.
+
+    Regression: a notebook killed mid-build leaves a
+    ``slides_x.http-cassette.yaml.staging-<pid>-<uuid>`` file behind. If
+    the next build's ``compute_other_files`` reaches it before
+    ``merge_staging_into_canonical`` does, payload b64 encoding crashes
+    with ``FileNotFoundError`` because a concurrent worker may delete the
+    staging file mid-glob. The sweep runs eagerly at ``process_all``
+    start so this race is closed before any payload is built.
+    """
+    import asyncio
+
+    pytest.importorskip("vcr")
+    pytest.importorskip("filelock")
+
+    topic_dir = _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    # The fixture writes slides_intro.py; rename to a stem that matches
+    # how cassettes are keyed (``<stem>.http-cassette.yaml``).
+    canonical = topic_dir / "slides_intro.http-cassette.yaml"
+    orphan_one = topic_dir / "slides_intro.http-cassette.yaml.staging-1234-abc"
+    orphan_two = topic_dir / "slides_intro.http-cassette.yaml.staging-5678-def"
+    _write_orphan_cassette(orphan_one, uri="http://example/orphan1", body="O1")
+    _write_orphan_cassette(orphan_two, uri="http://example/orphan2", body="O2")
+
+    sections_xml = """
+    <sections>
+      <section http-replay="yes">
+        <name><de>S</de><en>S</en></name>
+        <topics>
+          <topic>intro</topic>
+        </topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+
+    # Sanity: the topic opted into http-replay and our orphans are still
+    # on disk before the sweep runs.
+    nb_files = [f for f in course.files if isinstance(f, NotebookFile)]
+    assert any(f.http_replay for f in nb_files), "topic must inherit http-replay='yes'"
+    assert orphan_one.exists()
+    assert orphan_two.exists()
+
+    backend = PytestLocalOpsBackend()
+    asyncio.run(course.process_all(backend))
+
+    # Both orphan staging files are gone after process_all completes.
+    assert not orphan_one.exists()
+    assert not orphan_two.exists()
+
+    # Their recorded interactions live on in the canonical cassette.
+    assert canonical.exists()
+    content = canonical.read_text(encoding="utf-8")
+    assert "http://example/orphan1" in content
+    assert "http://example/orphan2" in content
+
+
+def test_sweep_orphan_staging_files_no_replay_topics(tmp_path):
+    """A course without ``http-replay`` topics doesn't touch any cassettes.
+
+    Defensive — the sweep runs unconditionally inside ``process_all`` so
+    we make sure it short-circuits cleanly (and never imports
+    ``vcrpy``/``filelock``) when no topic opted in. This also exercises
+    that the sweep does not crash on a course with no notebooks at all.
+    """
+    import asyncio
+
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    sections_xml = """
+    <sections>
+      <section>
+        <name><de>S</de><en>S</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+
+    # Sweep is a method so we can call it directly without spinning up
+    # the full process_all pipeline.
+    swept = course._sweep_orphan_cassette_staging_files()
+    assert swept == 0
+
+    # Full process_all also runs without raising.
+    backend = PytestLocalOpsBackend()
+    asyncio.run(course.process_all(backend))
+
+
+def test_sweep_orphan_staging_files_no_orphans_present(tmp_path):
+    """http-replay opt-in but no orphans → sweep is a no-op merge."""
+    pytest.importorskip("vcr")
+    pytest.importorskip("filelock")
+
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    sections_xml = """
+    <sections>
+      <section http-replay="yes">
+        <name><de>S</de><en>S</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+
+    swept = course._sweep_orphan_cassette_staging_files()
+    assert swept == 0

--- a/tests/infrastructure/utils/path_utils_test.py
+++ b/tests/infrastructure/utils/path_utils_test.py
@@ -383,6 +383,27 @@ class TestOutputFilePatterns:
         # Keep the glob form in sync with the regex form (same files filtered).
         assert "*.http-cassette.yaml" in SKIP_OUTPUT_FILE_GLOBS
 
+    def test_staging_cassette_regex_matches_pid_uuid_form(self):
+        # Per-worker staging files use the form
+        # ``<stem>.http-cassette.yaml.staging-<pid>-<uuid-hex>``. The
+        # regex must accept the full set so payload enumeration and the
+        # output sweep both filter them.
+        names = [
+            "slides_010.http-cassette.yaml.staging-1234-abc",
+            "notebook.http-cassette.yaml.staging-99-70e64c6cfd334794bb9bc3e8b05c3110",
+            "x.http-cassette.yaml.staging-",
+        ]
+        for name in names:
+            assert any(p.match(name) for p in SKIP_OUTPUT_FILE_PATTERNS), name
+
+    def test_staging_glob_present_alongside_canonical(self):
+        assert "*.http-cassette.yaml.staging-*" in SKIP_OUTPUT_FILE_GLOBS
+
+    def test_is_ignored_file_for_output_staging_cassette(self, tmp_path):
+        staging = tmp_path / "slides_010v.http-cassette.yaml.staging-1234-abc"
+        staging.write_text("interactions: []")
+        assert is_ignored_file_for_output(staging)
+
     def test_is_ignored_file_for_output_sibling_cassette(self, tmp_path):
         cassette = tmp_path / "slides_010v.http-cassette.yaml"
         cassette.write_text("interactions: []")


### PR DESCRIPTION
# fix(build): eliminate orphan HTTP-replay staging cassette crashes

**Branch:** `claude/fix-orphan-staging-cassette` (single commit `6e61c2d`)
**Recommended merge order:** 3rd of 4 in the cassette/monitor series.

## Summary

vcrpy writes recorded HTTP interactions to a per-worker **staging** file at
`{topic_dir}/{stem}.http-cassette.yaml.staging-{pid}-{uuid}` during notebook
execution. On clean shutdown, `merge_staging_into_canonical` folds staging
into canonical and `unlink`s the staging file. On a crash, kill, or build-
level timeout, the staging file is left behind containing partial recordings.

The next build crashes during payload construction:

```
File "src/clm/core/operations/process_notebook.py", line 92, in compute_other_files
    relative_path(file): b64encode(file.source_path.read_bytes())
FileNotFoundError: ...slides_010_langchain_basics.http-cassette.yaml.staging-11632-70e64c6cfd33...
```

Why: `compute_other_files` globs every file in the topic dir as a "supporting
file" to ship to the worker. The orphan staging file ends up in this glob.
The existing lazy sweep in `seed_staging_from_canonical` runs *later* during
worker execution, after another worker may already have merged-and-deleted
the orphan; the read then races and fails.

## Fix

Two complementary changes — both ship in this single PR:

### Part 1 — Eager orphan sweep at build start

`Course.process_all` (and the file-watcher path `Course.process_file`) now
calls a new `_sweep_orphan_cassette_staging_files()` at the top, **before any
payload is constructed**. The sweep walks every `NotebookFile` whose topic
opted into `http_replay`, collects unique canonical cassette locations, and
for each location with at least one `*.staging-*` sibling invokes the existing
`merge_staging_into_canonical` helper. Recordings are preserved (folded into
canonical via the existing `(method, uri, body)` dedup); the staging files
are atomically removed under the existing `<canonical>.lock`. vcrpy/filelock
imports are deferred so courses without `http-replay` pay no cost.

### Part 2 — Defense-in-depth filter

`*.http-cassette.yaml.staging-*` added to `SKIP_OUTPUT_FILE_PATTERNS` and
`SKIP_OUTPUT_FILE_GLOBS` in `src/clm/infrastructure/utils/path_utils.py`.
`compute_other_files` switched from `is_ignored_file_for_course` to the wider
`is_ignored_file_for_output` so the new pattern is honored. The canonical
cassette is still re-added explicitly under the kernel-cwd-relative key when
`http_replay` is active, so this filter does not accidentally drop it.

Even if a new orphan appears between sweep and enumeration (concurrent worker
race), this filter prevents the crash.

## Test plan

- [x] `tests/core/course_test.py::test_sweep_orphan_staging_files_merges_and_deletes`
      creates 2 orphan staging files, runs `process_all`, asserts orphans are
      deleted and their URIs appear in canonical.
- [x] `test_sweep_orphan_staging_files_no_replay_topics` and
      `_no_orphans_present` — sweep is a no-op when nothing to do.
- [x] `tests/core/course_files/notebook_file_test.py::TestProcessNotebookOperationHttpReplay::test_other_files_excludes_orphan_staging_cassette`
      proves the enumeration filter.
- [x] `tests/infrastructure/utils/path_utils_test.py` — regex/glob/helper
      coverage for the new skip pattern.
- [x] `pytest -m "not docker" tests/workers/notebook tests/core` → 989 passed.
- [x] Pre-commit clean.
- [x] End-to-end repro: planted a `staging-99999-…` orphan in the test
      course, ran a fresh build — orphan was swept, no `FileNotFoundError`.

## Risk

- Sweep runs once per build invocation. Walks `course.files`, filters to
  notebook files with `http_replay=True`, globs each unique cassette
  directory. For a normal course this is single-digit globs; negligible.
- Recordings are never lost — merge dedups by request fingerprint, identical
  to what the existing post-execution merge does.
- `_cassettes/` directories continue to be excluded from student output as
  before (this PR adds to that pattern set, doesn't change its semantics).

## Related context

- Companion PRs: `claude/http-replay-body-matcher`, `claude/cassette-snapshot-fix`, `claude/worker-heartbeat`.
- The lazy sweep at worker start (`seed_staging_from_canonical`) is retained as a defense-in-depth third layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
