### PR TITLE
docs(handover): retire http-replay race fix handover (#86, #90)

### DIFF
--- a/docs/claude/http-replay-race-fix-handover-archive.md
+++ b/docs/claude/http-replay-race-fix-handover-archive.md
@@ -1,3 +1,24 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-05-19 -->
+
+# Handover Archive: HTTP-Replay Race Fix (Issue #86)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete. The fix
+> shipped as PR #87 (merged to master as commits `fe0ecf5` + `63d8cfc`,
+> 2026-05-19), closing issue #86. The deferred sub-bug (Phase 4) was filed
+> as its own issue [#90](https://github.com/hoelzl/clm/issues/90).
+>
+> **There is no active handover document.** This file must **not** be used
+> with `/resume-feature`, `/implement-next-phase`, or similar commands that
+> expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
+
+## Fully retired on 2026-05-19
+
 # Handover: Fix HTTP-Replay Race in `seed_staging_from_canonical` (Issue #86)
 
 ## 1. Feature Overview
@@ -222,7 +243,7 @@ show the right level of integration.
 - Final canonical contains all interactions from both workers
   (deduplicated where appropriate).
 
-### Phase 4 (optional, separate sub-bug): Fail the build on cell errors [TODO]
+### Phase 4 (separate sub-bug, moved out): Fail the build on cell errors [ABANDONED — tracked in #90]
 
 **File**: `src/clm/cli/commands/build.py` (around `main_build` at line 1018
 and the surrounding `asyncio.run(main_build(...))` at line 1584).
@@ -262,8 +283,9 @@ be filed independently from #86**; mentioning here so it isn't forgotten.
   Verified to fail under the reverted-buggy code; passes under the fix.
   Added module-level helper `_write_two_interactions` next to
   `_write_cassette`.
-- **Phase 4**: TODO. Separate sub-bug (exit-code-0 on cell failures);
-  track independently if pursued — not bundled with this fix.
+- **Phase 4**: ABANDONED (2026-05-19) — filed as its own GitHub issue
+  ([#90](https://github.com/hoelzl/clm/issues/90)). Not bundled with
+  this fix; intentionally moved out so the #86 PR could land focused.
 
 ### Investigation artifacts
 


### PR DESCRIPTION
## Summary

Retires the active handover document for the HTTP-replay concurrent-worker race fix (#86) now that PR #87 has merged and the deferred sub-bug has been filed as #90.

- **Phase 1**: regression test (`test_seed_does_not_delete_concurrent_workers_staging`) — shipped in PR #87.
- **Phase 2**: removed the seed-time orphan sweep — shipped in PR #87.
- **Phase 3**: end-to-end concurrent-workers test (`test_two_concurrent_workers_full_seed_record_merge_cycle`) — shipped in PR #87.
- **Phase 4**: cell-failure exit code — moved out to #90.

## What this PR does

- **Rename** `docs/claude/http-replay-race-fix-handover.md` →
  `docs/claude/http-replay-race-fix-handover-archive.md` (git detects this as a 95%-similarity rename).
- **Add** a prominent full-retirement notice at the top of the archive file:
  > ⚠️ FULLY RETIRED HANDOVER — NOT ACTIVE
  >
  > This document archives a handover whose work is fully complete. The fix
  > shipped as PR #87 (...), closing issue #86. The deferred sub-bug (Phase 4)
  > was filed as its own issue #90. There is no active handover document.
- The notice explicitly tells future \`/resume-feature\` and \`/implement-next-phase\`
  commands to skip this file.
- **Update** Phase 4's status in the archive from \`[TODO]\` to
  \`[ABANDONED — tracked in #90]\` with a brief rationale.

## Style consistency

Matches the existing archive convention used by:
- \`docs/claude/mcp-slide-tooling-handover-archive.md\`
- \`docs/claude/recordings-pipeline-handover-archive.md\`
- \`docs/claude/recordings-backends-handover-archive.md\`
- ... and four other completed-feature handovers.

## Test plan

- [x] \`git status\` shows only the rename (no source touched).
- [x] Pre-commit hook (no Python files in this PR) skipped cleanly.
- [x] Reviewer: glance at the archive notice; confirm it's prominent enough
      that a future fresh session reading it can't mistake it for active work.

## Risk

None. Pure documentation lifecycle. No source code, no tests, no public API
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)