### PR TITLE
fix(http-replay,snapshot): allow_playback_repeats + spec-target snapshots (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Strict HTTP-replay broke on identical repeated requests (issue
+  #95 (A)).** The host-side cassette merger deduplicates by
+  `(method, uri, body)`, so the canonical cassette stores exactly one
+  entry per request fingerprint. The kernel-side bootstrap activated
+  vcrpy without `allow_playback_repeats=True`, and vcrpy's
+  `record_mode="none"` consumes each entry once — so a deck issuing
+  the same request N times (e.g. `get_post(1)` repeated three times
+  in a workshop cell, repeated LangChain prompt formatting) replayed
+  the first call and raised
+  `CannotOverwriteExistingCassetteException` on calls 2..N with every
+  matcher reported as having succeeded. The bootstrap now sets
+  `allow_playback_repeats=True`. Stale-cassette behavior for genuinely
+  new requests is unchanged — those still fail loudly.
+
+- **`clm build --snapshot DIR` ignored the spec's `<output-targets>`
+  (issue #95 (B)).** `--snapshot` was implemented as an alias for
+  `--output-dir`, which collapses every spec target into the single
+  default target's `public/`/`speaker/` toplevel layout. A spec
+  defining `shared`, `trainer`, and `speaker` targets dumped its
+  `shared/` content under `<DIR>/public/` and silently dropped
+  `trainer/` entirely. `--verify-against` then reported thousands of
+  bogus "missing" entries because the snapshot tree and the regular
+  build tree did not overlap. `--snapshot DIR` now re-roots each
+  spec target to `<DIR>/<target.name>/` (matching what the regular
+  build produces), and `--verify-against DIR` walks the spec targets
+  per-target. Diffs are prefixed with the target name so an operator
+  can tell which target diverged. Specs without `<output-targets>`
+  retain the previous single-tree behavior.
+
 - **HTTP-replay served wrong cassette response for chat-style APIs
   (PR #81).** vcrpy's default `match_on` is
   `[method, scheme, host, port, path, query]` — the request **body** is

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -213,6 +213,17 @@ class BuildConfig:
     # event handler to filter events.
     resolved_section_selection: SectionSelection | None = None
 
+    # When set, the build re-roots the spec's ``<output-targets>`` under
+    # this directory (each target becomes
+    # ``<snapshot_dir>/<target.name>/``) instead of collapsing into the
+    # legacy ``public/speaker`` layout. Spec files without
+    # ``<output-targets>`` fall back to using ``snapshot_dir`` as a
+    # single output dir, mirroring the previous behavior. Drives the
+    # ``clm build --snapshot`` flow; see issue #95 (B). Defaults to
+    # ``None`` so existing callers that don't know about the field
+    # construct ``BuildConfig`` unchanged.
+    snapshot_dir: Path | None = None
+
 
 def create_output_formatter(config: BuildConfig) -> OutputFormatter:
     """Create appropriate output formatter based on configuration."""
@@ -366,15 +377,31 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
                 f"Course spec validation failed with {len(validation_errors)} error(s)."
             )
 
-    # Determine output_dir behavior
+    # Determine output_dir behavior. ``snapshot_dir`` is the
+    # ``--snapshot`` destination; when set with a spec that defines
+    # ``<output-targets>`` the build re-roots each target under it
+    # rather than collapsing into one output_dir. With no
+    # ``<output-targets>`` the snapshot dir collapses into a single
+    # output dir, matching the pre-fix behavior.
     output_dir = config.output_dir
-    if output_dir is None and not spec.output_targets:
+    snapshot_dir = config.snapshot_dir
+    if output_dir is None and snapshot_dir is None and not spec.output_targets:
         output_dir = default_output
         output_dir.mkdir(exist_ok=True)
         logger.debug(f"Output directory set to {output_dir}")
 
     if output_dir is not None:
         logger.info(f"Processing course from {spec_file.name} in {data_dir} to {output_dir}")
+    elif snapshot_dir is not None and spec.output_targets:
+        target_names = [t.name for t in spec.output_targets]
+        logger.info(
+            f"Processing course from {spec_file.name} in {data_dir} into snapshot "
+            f"{snapshot_dir} with targets: {target_names}"
+        )
+    elif snapshot_dir is not None:
+        logger.info(
+            f"Processing course from {spec_file.name} in {data_dir} into snapshot {snapshot_dir}"
+        )
     elif spec.output_targets:
         target_names = [t.name for t in spec.output_targets]
         logger.info(
@@ -458,6 +485,7 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
         inline_images=effective_inline_images,
         section_selection=section_selection,
         http_replay_mode=config.http_replay_mode,
+        snapshot_root=snapshot_dir,
     )
 
     # Calculate root directories for cleanup
@@ -1095,6 +1123,7 @@ async def main_build(
     image_mode,
     image_format,
     inline_images,
+    snapshot_dir: Path | None = None,
 ) -> BuildSummary | None:
     """Main orchestration function for course building.
 
@@ -1137,6 +1166,7 @@ async def main_build(
         spec_file=spec_file,
         data_dir=data_dir,
         output_dir=output_dir,
+        snapshot_dir=snapshot_dir,
         log_level=log_level,
         cache_db_path=cache_db_path,
         jobs_db_path=jobs_db_path,
@@ -1588,8 +1618,13 @@ def build(
                 f"--snapshot target is not empty: {snapshot_dir}. "
                 "Pick a fresh path or remove the existing contents."
             )
-        # Treat the snapshot path as the build output destination.
-        output_dir = snapshot_dir
+        # ``snapshot_dir`` is plumbed through ``main_build`` as its own
+        # value (NOT aliased to ``output_dir``) so the spec's
+        # ``<output-targets>`` can be re-rooted under it instead of being
+        # collapsed into the legacy ``public/speaker`` shape. With no
+        # spec targets, ``Course.from_spec`` falls back to treating
+        # ``snapshot_root`` as a single ``output_root`` -- so a minimal
+        # spec still produces a flat tree at ``<snapshot_dir>/...``.
 
     if (include_html or strict_verify) and verify_against_dir is None:
         # Surface the no-op rather than silently ignoring it.
@@ -1688,6 +1723,7 @@ def build(
             image_mode,
             image_format,
             inline_images,
+            snapshot_dir=snapshot_dir,
         )
     )
 
@@ -1714,23 +1750,53 @@ def build(
     # to. main_build does not return it, but resolve_course_paths is
     # the single source of truth used inside the build pipeline too.
     _, default_output = resolve_course_paths(spec_file, data_dir)
-    effective_output = output_dir if output_dir is not None else default_output
+    if snapshot_dir is not None:
+        effective_output = snapshot_dir
+    elif output_dir is not None:
+        effective_output = output_dir
+    else:
+        effective_output = default_output
 
     if snapshot_dir is not None:
-        # snapshot_dir == output_dir at this point (we aliased it above).
         # The build report already covers what was written; print a short
         # confirmation so scripts can grep for the snapshot location.
         click.echo(f"\nSnapshot saved to: {effective_output.resolve()}")
 
     if verify_against_dir is not None:
-        from clm.snapshot import verify_against
+        from clm.snapshot import verify_against, verify_against_targets
 
-        report = verify_against(
-            snapshot_dir=verify_against_dir,
-            output_dir=effective_output,
-            include_html=include_html or strict_verify,
-            strict=strict_verify,
-        )
+        # When the spec defines ``<output-targets>`` and the user did
+        # NOT pass ``--output-dir`` (which collapses everything into a
+        # single tree), the regular build wrote to each target's own
+        # ``output_root``. The snapshot then must be compared per-target
+        # — ``<snap>/<target.name>/`` against the corresponding
+        # ``target.output_root`` — instead of as one monolithic pair.
+        # Otherwise the entire snapshot looks "extra" because the
+        # output tree literally has no overlap with the snapshot tree
+        # (e.g. ``shared/`` vs the legacy ``public/`` toplevel).
+        # Regression for issue #95 (B).
+        verify_spec = CourseSpec.from_file(spec_file.absolute())
+        if output_dir is None and verify_spec.output_targets:
+            verify_course_root, _ = resolve_course_paths(spec_file, data_dir)
+            target_pairs = []
+            for t in verify_spec.output_targets:
+                target_path = Path(t.path)
+                if not target_path.is_absolute():
+                    target_path = verify_course_root / target_path
+                target_pairs.append((t.name, target_path.resolve()))
+            report = verify_against_targets(
+                snapshot_dir=verify_against_dir,
+                targets=target_pairs,
+                include_html=include_html or strict_verify,
+                strict=strict_verify,
+            )
+        else:
+            report = verify_against(
+                snapshot_dir=verify_against_dir,
+                output_dir=effective_output,
+                include_html=include_html or strict_verify,
+                strict=strict_verify,
+            )
         click.echo("\nVerification report")
         click.echo(report.format_text())
         if report.has_diffs:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -207,6 +207,22 @@ clm build course.xml --output-dir out/ --verify-against baseline/ --ignore-cache
 
 `--verify-against` exits non-zero if any non-skipped file differs.
 
+**Specs with `<output-targets>`** (e.g. `shared`/`trainer`/`speaker`):
+both `--snapshot` and `--verify-against` honor the spec's targets.
+`--snapshot DIR` writes each target to `<DIR>/<target.name>/...`
+instead of collapsing into the legacy `public/`/`speaker/` toplevel
+shape — so e.g. a spec with `shared`, `trainer`, and `speaker`
+targets lays down `<DIR>/shared/...`, `<DIR>/trainer/...`,
+`<DIR>/speaker/...`. `--verify-against DIR` then compares each
+target's actual `output_root` against the matching `<DIR>/<name>/`
+subtree and surfaces diffs prefixed with the target name (e.g.
+`trainer/de/a.py`). Run the verify build **without** `--output-dir`
+in this mode — `--output-dir` collapses every target into a single
+tree and the verify falls back to a flat compare. Specs without
+`<output-targets>` (minimal specs) keep the original behavior:
+`--snapshot DIR` and `--verify-against DIR` operate on `<DIR>` as a
+single tree.
+
 **HTML is skipped by default** because rendered HTML uses live kernel
 execution, and any slide whose code path is non-deterministic
 (`random.choice(...)`, `print(some_object)` for a class without

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -126,6 +126,7 @@ class Course(NotebookMixin):
         inline_images: bool = False,
         section_selection: SectionSelection | None = None,
         http_replay_mode: str | None = None,
+        snapshot_root: Path | None = None,
     ) -> "Course":
         """Create a Course from a CourseSpec.
 
@@ -154,15 +155,62 @@ class Course(NotebookMixin):
                 whose topic has
                 ``http_replay="yes"`` honor this; other notebooks are
                 unaffected. When ``None``, HTTP replay is off.
+            snapshot_root: When set, re-root the spec's
+                ``<output-targets>`` under this directory so each target
+                writes to ``<snapshot_root>/<target.name>/``. Mutually
+                exclusive with ``output_root``. When the spec has no
+                ``<output-targets>``, this behaves like
+                ``output_root=snapshot_root`` (single collapsed tree).
+                Drives the ``clm build --snapshot`` flow so the captured
+                baseline has the same layout the regular build would
+                produce — keyed by target name rather than the legacy
+                ``public/speaker`` toplevel.
 
         Returns:
             Configured Course instance
         """
+        if output_root is not None and snapshot_root is not None:
+            raise ValueError(
+                "output_root and snapshot_root are mutually exclusive — "
+                "pick one. snapshot_root re-roots the spec's output "
+                "targets; output_root collapses everything into a single "
+                "tree."
+            )
+
         # Determine output targets
-        if output_root is not None:
-            # CLI override: use single output directory with all outputs
-            targets = [OutputTarget.default_target(output_root)]
-            effective_output_root = output_root
+        if snapshot_root is not None and spec.output_targets:
+            # Snapshot mode with spec targets: keep each target's filters
+            # and kinds, but redirect its output_root to
+            # ``<snapshot_root>/<target.name>/`` so the captured tree
+            # mirrors the regular build's per-target layout instead of
+            # collapsing into the legacy ``public/speaker`` shape.
+            targets = []
+            for t in spec.output_targets:
+                target = OutputTarget.from_spec(t, course_root, course_jupyterlite=spec.jupyterlite)
+                # `evolve`-style replace: rebuild with the snapshot-rooted
+                # output_root, keep `is_explicit=True` so paths stay flat.
+                from attrs import evolve
+
+                targets.append(evolve(target, output_root=(snapshot_root / t.name).resolve()))
+            if selected_targets:
+                targets = [t for t in targets if t.name in selected_targets]
+                if not targets:
+                    available = [t.name for t in spec.output_targets]
+                    raise ValueError(
+                        f"No matching targets found. "
+                        f"Requested: {selected_targets}, "
+                        f"Available: {available}"
+                    )
+            effective_output_root = snapshot_root
+        elif output_root is not None or snapshot_root is not None:
+            # CLI override: use single output directory with all outputs.
+            # Also reached when ``snapshot_root`` is set but the spec has
+            # no ``<output-targets>`` — there's nothing per-target to
+            # re-root, so collapse into the snapshot dir directly.
+            single_root = output_root if output_root is not None else snapshot_root
+            assert single_root is not None
+            targets = [OutputTarget.default_target(single_root)]
+            effective_output_root = single_root
         elif spec.output_targets:
             # Use targets from spec file
             targets = [

--- a/src/clm/snapshot/__init__.py
+++ b/src/clm/snapshot/__init__.py
@@ -2,9 +2,14 @@
 
 Public API:
     verify_against(snapshot_dir, output_dir, *, include_html, strict) -> VerifyReport
+    verify_against_targets(snapshot_dir, targets, *, include_html, strict) -> VerifyReport
     VerifyReport
 """
 
-from clm.snapshot.verifier import VerifyReport, verify_against
+from clm.snapshot.verifier import (
+    VerifyReport,
+    verify_against,
+    verify_against_targets,
+)
 
-__all__ = ["VerifyReport", "verify_against"]
+__all__ = ["VerifyReport", "verify_against", "verify_against_targets"]

--- a/src/clm/snapshot/verifier.py
+++ b/src/clm/snapshot/verifier.py
@@ -224,3 +224,114 @@ def verify_against(
         report.missing_in_snapshot.append(rel)
 
     return report
+
+
+def verify_against_targets(
+    snapshot_dir: Path,
+    targets: list[tuple[str, Path]],
+    *,
+    include_html: bool = False,
+    strict: bool = False,
+) -> VerifyReport:
+    """Compare a multi-target build against a per-target snapshot tree.
+
+    A spec with ``<output-targets>`` writes each target to its own
+    ``output_root`` (e.g. ``output/shared/``, ``output/trainer/``,
+    ``output/speaker/``). The matching snapshot — produced by
+    ``clm build --snapshot DIR`` — lays the same targets out as
+    ``DIR/shared/``, ``DIR/trainer/``, ``DIR/speaker/``. Comparing the
+    two as monolithic trees produces thousands of bogus "missing"
+    diffs because the toplevel prefixes don't match. This helper walks
+    each ``(target_name, output_root)`` pair, compares
+    ``snapshot_dir/target_name`` against ``output_root`` for that
+    target, and merges the per-target reports into one combined
+    :class:`VerifyReport` so the caller sees a single
+    ``Verification passed`` / ``Verification failed`` answer with
+    target-prefixed paths.
+
+    Args:
+        snapshot_dir: Root of the snapshot tree containing one subdir
+            per spec target (named ``<target.name>``).
+        targets: Iterable of ``(target_name, output_root)`` tuples.
+            ``output_root`` is where the regular build wrote that
+            target. A missing snapshot subdir or missing output root is
+            reported as such — every relative path under one side
+            shows up as missing on the other.
+        include_html: Forwarded to :func:`verify_against`.
+        strict: Forwarded to :func:`verify_against`.
+
+    Returns:
+        A combined :class:`VerifyReport`. Each relative path in the
+        report is prefixed with ``<target_name>/`` so diffs are
+        attributable to the right target. ``snapshot_dir`` and
+        ``output_dir`` on the report are set to ``snapshot_dir`` and
+        the first target's ``output_root`` (best-effort: there is no
+        single "output_dir" in the multi-target case).
+    """
+    snapshot_dir = snapshot_dir.resolve()
+    if not snapshot_dir.is_dir():
+        raise FileNotFoundError(f"Snapshot directory does not exist: {snapshot_dir}")
+
+    combined = VerifyReport(
+        snapshot_dir=snapshot_dir,
+        output_dir=(targets[0][1].resolve() if targets else snapshot_dir),
+    )
+
+    for target_name, output_root in targets:
+        prefix = Path(target_name)
+        snap_sub = snapshot_dir / target_name
+        out_sub = output_root.resolve()
+
+        snap_files = _collect_files(snap_sub) if snap_sub.is_dir() else set()
+        out_files = _collect_files(out_sub) if out_sub.is_dir() else set()
+
+        if not snap_sub.is_dir() and not out_sub.is_dir():
+            # Nothing on either side for this target — skip.
+            continue
+        if not snap_sub.is_dir():
+            # Every output file is "missing in snapshot".
+            for rel in sorted(out_files):
+                combined.missing_in_snapshot.append(prefix / rel)
+            continue
+        if not out_sub.is_dir():
+            # Every snapshot file is "missing in output".
+            for rel in sorted(snap_files):
+                full_rel = prefix / rel
+                ext = full_rel.suffix
+                combined.by_extension[ext].total += 1
+                combined.by_extension[ext].missing += 1
+                combined.missing_in_output.append(full_rel)
+            continue
+
+        common = snap_files & out_files
+        only_in_snap = snap_files - out_files
+        only_in_out = out_files - snap_files
+
+        for rel in sorted(common):
+            full_rel = prefix / rel
+            ext = full_rel.suffix
+            combined.by_extension[ext].total += 1
+            if _should_skip(rel, include_html=include_html, strict=strict):
+                combined.skipped.append(full_rel)
+                combined.by_extension[ext].skipped += 1
+                continue
+            snap_file = snap_sub / rel
+            out_file = out_sub / rel
+            if _content_matches(snap_file, out_file, rel, include_html=include_html, strict=strict):
+                combined.identical.append(full_rel)
+                combined.by_extension[ext].identical += 1
+            else:
+                combined.differing.append(full_rel)
+                combined.by_extension[ext].differing += 1
+
+        for rel in sorted(only_in_snap):
+            full_rel = prefix / rel
+            ext = full_rel.suffix
+            combined.by_extension[ext].total += 1
+            combined.by_extension[ext].missing += 1
+            combined.missing_in_output.append(full_rel)
+
+        for rel in sorted(only_in_out):
+            combined.missing_in_snapshot.append(prefix / rel)
+
+    return combined

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -145,7 +145,22 @@ _clm_vcr_instance = _clm_vcr.VCR(
 # English builds of the same notebook never write to the same path; the
 # host code merges staging into the canonical cassette under a file lock
 # after execution completes.
-_clm_ctx = _clm_vcr_instance.use_cassette({cassette_path!r})
+#
+# ``allow_playback_repeats=True`` is essential because the host-side
+# merge in
+# :func:`clm.workers.notebook.http_replay_cassette.merge_staging_into_canonical`
+# deduplicates by ``(method, uri, body)`` so the canonical cassette
+# carries exactly one entry per unique request fingerprint -- a deck
+# that issues the same request N times (e.g. ``get_post(1)`` repeated
+# in a workshop cell, the same LangChain prompt formatting used by
+# several cells) would otherwise see vcrpy serve the entry once and
+# raise ``CannotOverwriteExistingCassetteException`` on calls 2..N
+# even though every matcher succeeded. The flag does not weaken the
+# "stale cassette fails loudly" guarantee for genuinely *new* requests
+# not present in the cassette.
+_clm_ctx = _clm_vcr_instance.use_cassette(
+    {cassette_path!r}, allow_playback_repeats=True,
+)
 # ``__enter__`` returns the underlying ``Cassette`` (vcrpy's
 # CassetteContextDecorator name-mangles its private ``__cassette``
 # attribute, so this is the only stable way to reach the cassette).

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -864,3 +864,130 @@ def test_sweep_orphan_staging_files_no_orphans_present(tmp_path):
 
     swept = course._sweep_orphan_cassette_staging_files()
     assert swept == 0
+
+
+# ---------------------------------------------------------------------------
+# snapshot_root re-roots spec ``<output-targets>``
+#
+# Regression for issue #95 (B): the ``clm build --snapshot`` flow used to
+# alias to ``--output-dir``, which collapses spec output-targets into the
+# single default target's ``public/speaker`` layout — silently dropping
+# any target whose toplevel does not happen to be ``public``/``speaker``
+# (e.g. ``shared`` / ``trainer``). The fix keeps spec targets but
+# re-roots each one under the snapshot directory.
+# ---------------------------------------------------------------------------
+
+
+def _build_course_with_targets(course_root: Path, snapshot_root: Path | None):
+    """Construct a Course from a spec with three ``<output-targets>``."""
+    import io
+
+    from clm.core.course_spec import CourseSpec
+
+    _make_topic_dir(course_root, "module_100_live", "topic_010_intro")
+    spec_xml = """
+    <course>
+      <name><de>Test</de><en>Test</en></name>
+      <prog-lang>python</prog-lang>
+      <sections>
+        <section>
+          <name><de>S</de><en>S</en></name>
+          <topics><topic>intro</topic></topics>
+        </section>
+      </sections>
+      <output-targets>
+        <output-target name="shared"><path>output/shared</path></output-target>
+        <output-target name="trainer"><path>output/trainer</path></output-target>
+        <output-target name="speaker"><path>output/speaker</path></output-target>
+      </output-targets>
+    </course>
+    """
+    spec = CourseSpec.from_file(io.StringIO(spec_xml))
+    return Course.from_spec(spec, course_root, None, snapshot_root=snapshot_root)
+
+
+def test_snapshot_root_reroots_spec_targets_under_snapshot_dir(tmp_path):
+    """Each spec target's ``output_root`` lives at
+    ``<snapshot_root>/<target.name>/`` so the captured tree mirrors the
+    per-target layout instead of collapsing into ``public/speaker``."""
+    snap = tmp_path / "snap"
+    course = _build_course_with_targets(tmp_path, snap)
+
+    target_by_name = {t.name: t for t in course.output_targets}
+    assert set(target_by_name) == {"shared", "trainer", "speaker"}
+    assert target_by_name["shared"].output_root == (snap / "shared").resolve()
+    assert target_by_name["trainer"].output_root == (snap / "trainer").resolve()
+    assert target_by_name["speaker"].output_root == (snap / "speaker").resolve()
+    # is_explicit must stay True so the path layout under each target's
+    # output_root looks like a regular ``<lang>/...`` tree, not the
+    # legacy ``public/<lang>/...`` shape.
+    assert all(t.is_explicit for t in course.output_targets)
+
+
+def test_snapshot_root_does_not_drop_trainer_target(tmp_path):
+    """The bug from issue #95 (B): trainer/ silently disappears because
+    the default target only keeps the public/speaker toplevels. The
+    fix must preserve every spec target."""
+    snap = tmp_path / "snap"
+    course = _build_course_with_targets(tmp_path, snap)
+
+    names = {t.name for t in course.output_targets}
+    assert "trainer" in names, (
+        "trainer target was dropped — this is the regression from "
+        "the old --snapshot -> --output-dir alias that collapsed to "
+        "the default target (public/speaker only)."
+    )
+
+
+def test_snapshot_root_without_spec_targets_collapses_to_dir(tmp_path):
+    """When the spec has no ``<output-targets>``, ``snapshot_root``
+    behaves like ``output_root=snapshot_root`` — a single default
+    target rooted at the snapshot dir. Preserves the pre-fix behavior
+    for minimal specs."""
+    import io
+
+    from clm.core.course_spec import CourseSpec
+
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    spec = CourseSpec.from_file(
+        io.StringIO(
+            """
+            <course>
+              <name><de>Test</de><en>Test</en></name>
+              <prog-lang>python</prog-lang>
+              <sections>
+                <section>
+                  <name><de>S</de><en>S</en></name>
+                  <topics><topic>intro</topic></topics>
+                </section>
+              </sections>
+            </course>
+            """
+        )
+    )
+    snap = tmp_path / "snap"
+    course = Course.from_spec(spec, tmp_path, None, snapshot_root=snap)
+    assert len(course.output_targets) == 1
+    assert course.output_targets[0].output_root == snap.resolve()
+
+
+def test_snapshot_root_and_output_root_are_mutually_exclusive(tmp_path):
+    """Passing both is a programming error — the two have overlapping
+    intent and the precedence is non-obvious."""
+    import io
+
+    from clm.core.course_spec import CourseSpec
+
+    spec = CourseSpec.from_file(
+        io.StringIO(
+            """
+            <course>
+              <name><de>Test</de><en>Test</en></name>
+              <prog-lang>python</prog-lang>
+              <sections/>
+            </course>
+            """
+        )
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Course.from_spec(spec, tmp_path, tmp_path / "out", snapshot_root=tmp_path / "snap")

--- a/tests/snapshot/test_build_integration.py
+++ b/tests/snapshot/test_build_integration.py
@@ -31,6 +31,36 @@ def _write_minimal_spec(path: Path) -> Path:
     return path
 
 
+def _write_multi_target_spec(path: Path) -> Path:
+    """A spec with three ``<output-targets>``: shared, trainer, speaker.
+
+    Mirrors the AZAV-ML layout from issue #95 (B) — the original
+    failure case the per-target snapshot logic is meant to fix.
+    """
+    path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+    <name><de>Kurs</de><en>Course</en></name>
+    <prog-lang>python</prog-lang>
+    <sections/>
+    <output-targets>
+        <output-target name="shared">
+            <path>output/shared</path>
+        </output-target>
+        <output-target name="trainer">
+            <path>output/trainer</path>
+        </output-target>
+        <output-target name="speaker">
+            <path>output/speaker</path>
+        </output-target>
+    </output-targets>
+</course>
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
 def _seed_output(output_dir: Path, files: dict[str, bytes]) -> None:
     """Populate *output_dir* with the given relative paths and bytes."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -47,9 +77,15 @@ def fake_build(monkeypatch):
     The factory returns a function the test calls with the files it
     wants the "build" to produce; the actual stub is registered as a
     side effect.
+
+    When a single ``dict[str, bytes]`` is passed, files are seeded into
+    the effective output root (snapshot_dir / output_dir / default).
+    When a ``dict[str, dict[str, bytes]]`` is passed, the outer keys
+    are interpreted as per-target subdirectory names — used by the
+    multi-target snapshot tests.
     """
 
-    seeded: dict[str, bytes] = {}
+    seeded: dict = {}
 
     async def stub_main_build(
         ctx,
@@ -57,19 +93,31 @@ def fake_build(monkeypatch):
         data_dir,
         output_dir,
         *_args,
-        **_kwargs,
+        **kwargs,
     ):
-        # The real build resolves output_dir lazily; we mirror that and
-        # write to the resolved path used by the post-build hook.
-        if output_dir is None:
+        snapshot_dir = kwargs.get("snapshot_dir")
+        # The real build resolves the effective output dir based on
+        # ``--snapshot`` / ``--output-dir`` / default. Mirror that here.
+        if snapshot_dir is not None:
+            root = Path(snapshot_dir)
+        elif output_dir is not None:
+            root = Path(output_dir)
+        else:
             # Fall back to spec's grandparent / "output" — matches
             # resolve_course_paths' default-output behavior.
-            output_dir = spec_file.absolute().parents[1] / "output"
-        _seed_output(Path(output_dir), seeded)
+            root = spec_file.absolute().parents[1] / "output"
+
+        # Detect per-target payload: outer value is a dict-of-bytes.
+        per_target = bool(seeded) and all(isinstance(v, dict) for v in seeded.values())
+        if per_target:
+            for target_name, files in seeded.items():
+                _seed_output(root / target_name, files)
+        else:
+            _seed_output(root, seeded)
 
     monkeypatch.setattr(build_module, "main_build", stub_main_build)
 
-    def configure(files: dict[str, bytes]) -> None:
+    def configure(files: dict) -> None:
         seeded.clear()
         seeded.update(files)
 
@@ -232,3 +280,147 @@ class TestVerifyAgainst:
         )
         assert result.exit_code != 0
         assert "Verification failed" in result.output
+
+
+class TestSnapshotMultiTargetLayout:
+    """``--snapshot`` must honor the spec's ``<output-targets>``.
+
+    Regression for issue #95 (B): with a spec that defines named output
+    targets (``shared``, ``trainer``, ``speaker``), the old behavior
+    aliased ``--snapshot DIR`` to ``--output-dir DIR``, which collapsed
+    every target into the legacy ``public/`` and ``speaker/``
+    toplevel directories — silently dropping ``trainer/`` and renaming
+    ``shared/`` to ``public/``. The fix routes ``--snapshot`` through a
+    new ``snapshot_root`` path on ``Course.from_spec`` so each spec
+    target writes to ``<DIR>/<target.name>/`` and ``--verify-against``
+    compares per-target.
+    """
+
+    def _setup(self, tmp_path: Path):
+        spec_dir = tmp_path / "repo" / "course-specs"
+        spec_dir.mkdir(parents=True)
+        spec = _write_multi_target_spec(spec_dir / "course.xml")
+        return spec
+
+    def test_snapshot_uses_target_names_not_legacy_layout(self, tmp_path: Path, fake_build) -> None:
+        spec = self._setup(tmp_path)
+        # Per-target payload — each spec target writes its own files.
+        fake_build(
+            {
+                "shared": {"de/index.html": b"shared-de"},
+                "trainer": {"de/index.html": b"trainer-de"},
+                "speaker": {"de/index.html": b"speaker-de"},
+            }
+        )
+
+        snap = tmp_path / "snap"
+        result = _invoke_build([str(spec), "--snapshot", str(snap)], tmp_path)
+
+        assert result.exit_code == 0, result.output
+        # Files must land under <snap>/<target.name>/, NOT under the
+        # legacy <snap>/public/ or <snap>/speaker/ toplevels.
+        assert (snap / "shared" / "de" / "index.html").read_bytes() == b"shared-de"
+        assert (snap / "trainer" / "de" / "index.html").read_bytes() == b"trainer-de"
+        assert (snap / "speaker" / "de" / "index.html").read_bytes() == b"speaker-de"
+        assert not (snap / "public").exists()
+
+    def test_verify_per_target_matches_when_layouts_align(self, tmp_path: Path, fake_build) -> None:
+        spec = self._setup(tmp_path)
+
+        # Snapshot run — writes <snap>/<name>/...
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"BBB"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        baseline = tmp_path / "baseline"
+        result = _invoke_build([str(spec), "--snapshot", str(baseline)], tmp_path)
+        assert result.exit_code == 0, result.output
+        assert (baseline / "shared" / "de" / "a.py").read_bytes() == b"AAA"
+
+        # Verify run — regular build writes to spec output-targets
+        # (<course_root>/output/<name>/...). The verify helper must
+        # compare per-target so the trees match.
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"BBB"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        result = _invoke_build(
+            [str(spec), "--verify-against", str(baseline)],
+            tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Verification passed" in result.output
+
+    def test_verify_per_target_surfaces_target_scoped_diff(
+        self, tmp_path: Path, fake_build
+    ) -> None:
+        spec = self._setup(tmp_path)
+
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"BBB"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        baseline = tmp_path / "baseline"
+        result = _invoke_build([str(spec), "--snapshot", str(baseline)], tmp_path)
+        assert result.exit_code == 0, result.output
+
+        # The second run changes only the trainer target's content.
+        # The diff must be attributed to ``trainer/`` and not flagged
+        # as "everything is missing" on either side.
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"CHANGED"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        result = _invoke_build(
+            [str(spec), "--verify-against", str(baseline)],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "Verification failed" in result.output
+        # The differing path is prefixed with the target name.
+        assert "trainer" in result.output and "a.py" in result.output
+
+    def test_verify_per_target_catches_missing_target_dir(self, tmp_path: Path, fake_build) -> None:
+        """If a target's content was silently dropped from the snapshot
+        (the original issue #95 (B) bug), verify must report the missing
+        files rather than passing because the trees overlap on
+        ``shared/``."""
+        spec = self._setup(tmp_path)
+
+        # Snapshot only has 2 of 3 targets — simulating the legacy
+        # behavior that dropped ``trainer/``.
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        (baseline / "shared" / "de").mkdir(parents=True)
+        (baseline / "shared" / "de" / "a.py").write_bytes(b"AAA")
+        (baseline / "speaker" / "de").mkdir(parents=True)
+        (baseline / "speaker" / "de" / "a.py").write_bytes(b"CCC")
+        # No trainer/ subdir in baseline.
+
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"BBB"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        result = _invoke_build(
+            [str(spec), "--verify-against", str(baseline)],
+            tmp_path,
+        )
+        assert result.exit_code != 0
+        assert "Verification failed" in result.output
+        # The trainer target's a.py is "missing in snapshot".
+        assert "trainer" in result.output

--- a/tests/snapshot/test_verifier.py
+++ b/tests/snapshot/test_verifier.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from clm.snapshot import VerifyReport, verify_against
+from clm.snapshot import VerifyReport, verify_against, verify_against_targets
 
 
 def _write(root: Path, rel: str, content: bytes) -> None:
@@ -167,3 +167,78 @@ class TestReportProperties:
         report = verify_against(snap, out)
         # 1 identical + 1 differing + 1 skipped + 1 missing-in-output = 4
         assert report.total_files == 4
+
+
+class TestVerifyAgainstTargets:
+    """Per-target compare for specs with ``<output-targets>``.
+
+    Regression for issue #95 (B): the regular build writes each target
+    to its own ``output_root``; the snapshot lays them out under
+    ``<snap>/<target.name>/``. Walking the trees as one monolithic
+    pair produces thousands of bogus diffs because the prefixes don't
+    overlap. ``verify_against_targets`` walks per-target pairs and
+    prefixes each diff with the target name so the operator can see
+    which target produced it.
+    """
+
+    def test_passes_when_every_target_matches(self, tmp_path):
+        snap = tmp_path / "snap"
+        out_shared = tmp_path / "out" / "shared"
+        out_trainer = tmp_path / "out" / "trainer"
+        _write(snap, "shared/de/a.py", b"AAA")
+        _write(snap, "trainer/de/a.py", b"BBB")
+        _write(out_shared, "de/a.py", b"AAA")
+        _write(out_trainer, "de/a.py", b"BBB")
+
+        report = verify_against_targets(snap, [("shared", out_shared), ("trainer", out_trainer)])
+        assert not report.has_diffs
+        # Identical paths are prefixed with the target name.
+        ident = {p.as_posix() for p in report.identical}
+        assert ident == {"shared/de/a.py", "trainer/de/a.py"}
+
+    def test_differing_diff_is_attributed_to_target(self, tmp_path):
+        snap = tmp_path / "snap"
+        out_shared = tmp_path / "out" / "shared"
+        out_trainer = tmp_path / "out" / "trainer"
+        _write(snap, "shared/de/a.py", b"AAA")
+        _write(snap, "trainer/de/a.py", b"BBB")
+        _write(out_shared, "de/a.py", b"AAA")
+        # Trainer side diverges.
+        _write(out_trainer, "de/a.py", b"CHANGED")
+
+        report = verify_against_targets(snap, [("shared", out_shared), ("trainer", out_trainer)])
+        assert report.has_diffs
+        diffs = {p.as_posix() for p in report.differing}
+        assert diffs == {"trainer/de/a.py"}
+
+    def test_missing_target_subdir_in_snapshot_reports_missing_in_snapshot(self, tmp_path):
+        """The original issue #95 bug: ``trainer/`` silently absent from
+        the snapshot. The per-target compare must surface this rather
+        than reporting "thousands of extras"."""
+        snap = tmp_path / "snap"
+        out_shared = tmp_path / "out" / "shared"
+        out_trainer = tmp_path / "out" / "trainer"
+        _write(snap, "shared/de/a.py", b"AAA")
+        # No <snap>/trainer/ at all.
+        _write(out_shared, "de/a.py", b"AAA")
+        _write(out_trainer, "de/a.py", b"BBB")
+
+        report = verify_against_targets(snap, [("shared", out_shared), ("trainer", out_trainer)])
+        assert report.has_diffs
+        missing_in_snap = {p.as_posix() for p in report.missing_in_snapshot}
+        assert "trainer/de/a.py" in missing_in_snap
+
+    def test_missing_target_subdir_in_output_reports_missing_in_output(self, tmp_path):
+        snap = tmp_path / "snap"
+        out_shared = tmp_path / "out" / "shared"
+        out_trainer = tmp_path / "out" / "trainer"
+        out_trainer.mkdir(parents=True, exist_ok=True)  # exists but empty
+        _write(snap, "shared/de/a.py", b"AAA")
+        _write(snap, "trainer/de/a.py", b"BBB")
+        _write(out_shared, "de/a.py", b"AAA")
+        # out_trainer has no files.
+
+        report = verify_against_targets(snap, [("shared", out_shared), ("trainer", out_trainer)])
+        assert report.has_diffs
+        missing_in_out = {p.as_posix() for p in report.missing_in_output}
+        assert "trainer/de/a.py" in missing_in_out

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2065,6 +2065,30 @@ class TestHttpReplayBootstrap:
         assert "_clm_eager_append" in injected["source"]
         assert "_save" in injected["source"]
 
+    def test_inject_pins_allow_playback_repeats(self):
+        # The bootstrap must opt into vcrpy's ``allow_playback_repeats``
+        # so a deck that issues the same request N times still replays
+        # successfully against a canonical cassette with exactly one
+        # entry per fingerprint.  The host-side merger in
+        # :mod:`clm.workers.notebook.http_replay_cassette` dedupes by
+        # ``(method, uri, body)``; without this flag, vcrpy serves the
+        # entry on call #1 and raises ``CannotOverwriteExistingCassetteException``
+        # on calls #2..N — even though every matcher succeeded —
+        # because ``record_mode='none'`` consumes each entry once.
+        # Regression for issue #95 (A).
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = make_notebook_node([make_cell("code", "pass")])
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "replay")
+
+        src = nb["cells"][0]["source"]
+        assert "allow_playback_repeats=True" in src, (
+            "Bootstrap is missing ``allow_playback_repeats=True``; deduped "
+            "cassettes will fail strict replay on the second identical request."
+        )
+
     def test_inject_pins_body_in_match_on(self):
         # The bootstrap must include ``body`` in vcrpy's ``match_on`` tuple.
         # vcrpy's default matcher only looks at method+scheme+host+port+path+
@@ -2797,6 +2821,69 @@ os._exit(0)
         body = cassette_path.read_text(encoding="utf-8")
         assert "interactions" in body
         assert "127.0.0.1" in body
+
+    def test_bootstrap_replays_deduped_cassette_multiple_times(self, tmp_path):
+        """A deduped canonical cassette (one entry per fingerprint) must
+        still replay successfully when the deck issues the same request
+        N times.
+
+        The merge step in
+        :func:`clm.workers.notebook.http_replay_cassette.merge_staging_into_canonical`
+        deduplicates by ``(method, uri, body)``, so for a deck like
+        ``slides_010v_requests_get.py`` (which calls ``get_post(1)``
+        three times in a single workshop cell) the canonical cassette
+        ends up with exactly one stored interaction. Under strict
+        ``record_mode='none'`` playback, vcrpy normally consumes each
+        cassette entry exactly once — so the second identical request
+        would raise ``CannotOverwriteExistingCassetteException`` even
+        though every matcher (method, scheme, host, port, path, query,
+        body) succeeds.
+
+        The bootstrap must opt into ``allow_playback_repeats=True`` to
+        keep this scenario working. Regression for issue #95 (A).
+        """
+        pytest.importorskip("vcr")
+        import urllib.request
+
+        from clm.workers.notebook.notebook_processor import (
+            _HTTP_REPLAY_BOOTSTRAP_TEMPLATE,
+            _HTTP_REPLAY_MODE_TO_VCR_MODE,
+        )
+
+        # Pre-build a single-interaction cassette pinned to a fixed URL
+        # — no live server needed. The body is the canonical YAML shape
+        # vcrpy expects.
+        cassette_path = tmp_path / "replay.http-cassette.yaml"
+        cassette_path.write_text(
+            "interactions:\n"
+            "- request:\n"
+            "    method: GET\n"
+            "    uri: http://test.invalid/echo\n"
+            "    headers: {}\n"
+            "    body: null\n"
+            "  response:\n"
+            "    status: {code: 200, message: OK}\n"
+            "    headers:\n"
+            "      content-type: [text/plain]\n"
+            "    body: {string: hello}\n"
+            "version: 1\n",
+            encoding="utf-8",
+        )
+
+        source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
+            record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["replay"],
+            cassette_path=str(cassette_path),
+        )
+
+        ns: dict = {}
+        exec(compile(source, "<bootstrap>", "exec"), ns, ns)
+
+        # The same request three times. Without ``allow_playback_repeats``,
+        # the second call would raise ``CannotOverwriteExistingCassetteException``
+        # under ``record_mode='none'``.
+        for _ in range(3):
+            with urllib.request.urlopen("http://test.invalid/echo") as resp:
+                assert resp.read() == b"hello"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Two root-cause fixes for issue #95 that unblock
`clm build --http-replay=replay --snapshot DIR` against a course spec
with `<output-targets>`.

- **A. vcrpy bootstrap missed `allow_playback_repeats=True`.** The
  host-side cassette merger dedupes by `(method, uri, body)`, so the
  canonical cassette stores one entry per fingerprint. vcrpy's
  `record_mode='none'` then consumed each entry once and raised
  `CannotOverwriteExistingCassetteException` on repeated identical
  requests (e.g. `get_post(1)` called three times in a workshop cell;
  repeated LangChain prompt formatting). The "stale cassette fails
  loudly" guarantee for genuinely new requests is preserved.

- **B. `--snapshot DIR` ignored the spec's `<output-targets>`.** The
  old behavior aliased `--snapshot` to `--output-dir`, collapsing every
  spec target into the default target's legacy `public/`/`speaker/`
  layout — silently dropping `trainer/` and renaming `shared/` to
  `public/`. `--verify-against` then reported thousands of bogus
  "missing" entries. `Course.from_spec` now accepts `snapshot_root`,
  which re-roots each spec target to `<DIR>/<target.name>/`.
  `clm.snapshot.verify_against_targets` walks per-target pairs and
  prefixes diffs with the target name so an operator can identify
  which target diverged. Specs without `<output-targets>` keep the
  original single-tree behavior.

CHANGELOG and `clm info commands` updated to document the new behavior.

## Test plan

- [x] 12 new tests, every one of which fails when the corresponding
      fix is reverted:
  - `tests/workers/notebook/test_notebook_processor.py` — `test_inject_pins_allow_playback_repeats` (source pin), `test_bootstrap_replays_deduped_cassette_multiple_times` (replays the same request three times against a deduped cassette).
  - `tests/core/course_test.py` — 4 tests on `Course.from_spec(snapshot_root=...)` covering re-rooting, the trainer-target regression, the no-targets fallback, and the mutex with `output_root`.
  - `tests/snapshot/test_verifier.py` — 4 tests on `verify_against_targets` covering the pass/fail axes and missing-subdir scenarios.
  - `tests/snapshot/test_build_integration.py` — 4 CLI-wiring tests on `TestSnapshotMultiTargetLayout`.
- [x] Existing snapshot tests still pass (39/39 in `tests/snapshot/`).
- [x] Full fast suite passes: 5279 passed, 1 skipped, 1 xfailed.
- [x] `ruff check` + `ruff format` clean; `mypy` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)