### PR TITLE
fix(coverage,validator): recognize `workshop-…` slide_id as workshop opener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`clm slides coverage` / `clm validate` no longer flag workshop task
+  slides as missing voiceover** when the deck uses the announcement-by-
+  slide_id convention (a slide whose `slide_id` starts with `workshop-`)
+  rather than a literal `workshop` tag. `clm.slides.workshop_scope.find_workshop_ranges`
+  now treats a slide/subslide markdown cell with a `workshop-…` slide_id
+  as a workshop opener equivalent to the legacy `workshop` tag. Cells
+  inheriting that slide_id (e.g. the announcement's voiceover) do not
+  re-trigger a new range — only slide-start cells carry the boundary.
+  Verified against `module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates.py`:
+  12 previously-noisy workshop pairs (4 task slides × DE/EN, plus the
+  announcement and setup slides) are now correctly excluded; the 34
+  pre-workshop lecture pairs remain coverage-checked. The legacy
+  `workshop` tag continues to work unchanged.
+
 ### Changed
 
 - **CLI restructure: verb-grouped subcommands.** Several flat
@@ -79,7 +95,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   to `error`. Bullets with no voiceover at all are reported without
   consulting the LLM; non-bulleted slides (heading-only, image-only,
   code-only) are skipped silently. Workshop slides (cells inside a
-  `workshop` / `end-workshop` scope per
+  scope opened by either the `workshop` tag *or* a slide-start cell
+  whose `slide_id` starts with `workshop-`, closed by `end-workshop`
+  / the next opener / EOF, per
   `clm.slides.workshop_scope.find_workshop_ranges`) are also skipped
   silently — workshop exercise slides intentionally have no
   voiceover and flagging them drowns the report in known-OK

--- a/src/clm/notebooks/slide_parser.py
+++ b/src/clm/notebooks/slide_parser.py
@@ -76,6 +76,10 @@ class Cell:
     def tags(self) -> list[str]:
         return self.metadata.tags
 
+    @property
+    def slide_id(self) -> str | None:
+        return self.metadata.slide_id
+
     def text_content(self) -> str:
         """Extract readable text from the cell, stripping comment prefixes and formatting."""
         if self.metadata.cell_type == "markdown":

--- a/src/clm/slides/workshop_scope.py
+++ b/src/clm/slides/workshop_scope.py
@@ -1,11 +1,18 @@
 """Locate workshop boundaries within a slide cell list.
 
 A notebook may contain zero or more workshop sections. Each workshop starts
-at a markdown cell tagged ``workshop`` and ends — exclusively — at the first
-of:
+at one of:
+
+* a markdown cell tagged ``workshop``, or
+* a slide/subslide markdown cell whose ``slide_id`` starts with ``workshop-``
+  (the deck-level convention used when the announcement slide is tagged as a
+  regular slide but its identity carries the workshop scope forward — e.g.
+  ``slide_id="workshop-persona-switcher"`` followed by ``task-*`` slides).
+
+It ends — exclusively — at the first of:
 
 * the next markdown cell tagged ``end-workshop``,
-* the next markdown cell tagged ``workshop`` (a new workshop begins), or
+* the next workshop opener (a new workshop begins), or
 * end-of-notebook.
 
 The cell carrying ``end-workshop`` is therefore *outside* the workshop:
@@ -13,8 +20,11 @@ trainers add the tag to the heading that starts the next non-workshop
 section. A workshop without a closing ``end-workshop`` extends to EOF, which
 preserves the legacy single-workshop behaviour.
 
-Both ``workshop`` and ``end-workshop`` are recognized only on markdown cells;
-the same tags on a code cell are ignored for boundary detection.
+Both opener forms and ``end-workshop`` are recognized only on markdown cells;
+the same tags or slide_ids on a code cell are ignored for boundary detection.
+The slide_id-prefix opener additionally requires a ``slide`` or ``subslide``
+tag so that voiceover / notes cells that share the announcement slide's id
+do not fragment the range.
 """
 
 from __future__ import annotations
@@ -30,24 +40,45 @@ class _CellLike(Protocol):
     @property
     def tags(self) -> Sequence[str]: ...
 
+    @property
+    def slide_id(self) -> str | None: ...
+
+
+def _is_workshop_opener(cell: _CellLike) -> bool:
+    """Detect either the ``workshop`` tag or a ``workshop-…`` slide_id opener.
+
+    The slide_id form only counts on slide-start cells (``slide`` /
+    ``subslide``) so that voiceover or notes cells inheriting the same
+    slide_id from the announcement slide do not re-trigger a new range.
+    """
+    if cell.cell_type != "markdown":
+        return False
+    tags = cell.tags
+    if "workshop" in tags:
+        return True
+    slide_id = cell.slide_id
+    if slide_id is None or not slide_id.startswith("workshop-"):
+        return False
+    return "slide" in tags or "subslide" in tags
+
 
 def find_workshop_ranges(cells: Sequence[_CellLike]) -> list[tuple[int, int]]:
     """Return ``[(start_inclusive, end_exclusive), ...]`` for each workshop.
 
     Cells in the half-open interval ``[start, end)`` belong to one workshop.
-    The list is empty when the notebook contains no ``workshop`` heading.
+    The list is empty when the notebook contains no workshop opener (neither
+    a ``workshop`` tag nor a slide-start cell with a ``workshop-…`` slide_id).
     """
     ranges: list[tuple[int, int]] = []
     open_start: int | None = None
     for i, cell in enumerate(cells):
         if cell.cell_type != "markdown":
             continue
-        tags = cell.tags
-        if "workshop" in tags:
+        if _is_workshop_opener(cell):
             if open_start is not None:
                 ranges.append((open_start, i))
             open_start = i
-        elif "end-workshop" in tags and open_start is not None:
+        elif "end-workshop" in cell.tags and open_start is not None:
             ranges.append((open_start, i))
             open_start = None
     if open_start is not None:
@@ -61,11 +92,13 @@ def is_in_workshop(idx: int, ranges: Sequence[tuple[int, int]]) -> bool:
 
 
 def find_workshop_start_index(cells: Sequence[_CellLike]) -> int | None:
-    """Return the index of the first markdown cell tagged ``workshop``.
+    """Return the index of the first workshop opener.
 
-    Returns ``None`` if no workshop heading is present. Retained as a
-    convenience for callers that only care about the first workshop's start
-    line (e.g. validator diagnostics).
+    A workshop opener is either a markdown cell tagged ``workshop`` or a
+    slide-start markdown cell whose ``slide_id`` starts with ``workshop-``.
+    Returns ``None`` if no opener is present. Retained as a convenience for
+    callers that only care about the first workshop's start line (e.g.
+    validator diagnostics).
     """
     ranges = find_workshop_ranges(cells)
     return ranges[0][0] if ranges else None

--- a/tests/slides/test_workshop_scope.py
+++ b/tests/slides/test_workshop_scope.py
@@ -15,6 +15,7 @@ from clm.slides.workshop_scope import (
 class _Cell:
     cell_type: str
     tags: list[str] = field(default_factory=list)
+    slide_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +135,72 @@ class TestFindWorkshopRanges:
 
     def test_empty_input(self):
         assert find_workshop_ranges([]) == []
+
+
+class TestWorkshopSlideIdOpener:
+    """The ``workshop-…`` slide_id convention opens a workshop range when
+    used on a slide/subslide cell, equivalent to the ``workshop`` tag."""
+
+    def test_slide_id_prefix_opens_range_to_eof(self):
+        """Announcement slide carries the workshop scope to EOF when no
+        ``end-workshop`` tag follows."""
+        cells = [
+            _Cell("markdown", ["slide"], slide_id="intro"),
+            _Cell("code", []),
+            _Cell("markdown", ["slide"], slide_id="workshop-persona-switcher"),
+            _Cell("markdown", ["voiceover"], slide_id="workshop-persona-switcher"),
+            _Cell("markdown", ["slide"], slide_id="task-1-persona-template"),
+            _Cell("code", []),
+            _Cell("markdown", ["slide"], slide_id="task-2-use-partial"),
+        ]
+        assert find_workshop_ranges(cells) == [(2, 7)]
+
+    def test_slide_id_prefix_requires_slide_or_subslide_tag(self):
+        """A voiceover/notes cell sharing the announcement slide_id must
+        not open a new range — only the slide-start carries the boundary."""
+        cells = [
+            _Cell("markdown", ["voiceover"], slide_id="workshop-foo"),
+            _Cell("markdown", ["notes"], slide_id="workshop-foo"),
+            _Cell("markdown", ["slide"], slide_id="task-1"),
+        ]
+        assert find_workshop_ranges(cells) == []
+
+    def test_subslide_with_workshop_slide_id_opens_range(self):
+        cells = [
+            _Cell("markdown", ["slide"], slide_id="lecture-intro"),
+            _Cell("markdown", ["subslide"], slide_id="workshop-aufgabe-1"),
+            _Cell("code", []),
+        ]
+        assert find_workshop_ranges(cells) == [(1, 3)]
+
+    def test_end_workshop_closes_slide_id_opened_range(self):
+        cells = [
+            _Cell("markdown", ["slide"], slide_id="workshop-intro"),
+            _Cell("code", []),
+            _Cell("markdown", ["subslide", "end-workshop"]),
+            _Cell("markdown", ["slide"], slide_id="post-workshop"),
+        ]
+        assert find_workshop_ranges(cells) == [(0, 2)]
+
+    def test_legacy_tag_and_slide_id_opener_coexist(self):
+        """A tag-opened workshop is closed when the next opener uses the
+        slide_id form (and vice versa)."""
+        cells = [
+            _Cell("markdown", ["slide", "workshop"], slide_id="workshop-a"),
+            _Cell("code", []),
+            _Cell("markdown", ["slide"], slide_id="workshop-b"),
+            _Cell("code", []),
+        ]
+        assert find_workshop_ranges(cells) == [(0, 2), (2, 4)]
+
+    def test_slide_id_prefix_ignored_on_code_cell(self):
+        """Code cells never open a workshop range, even with a matching
+        slide_id (which would be unusual but should not derail detection)."""
+        cells = [
+            _Cell("code", ["keep"], slide_id="workshop-stub"),
+            _Cell("markdown", ["slide"], slide_id="normal-slide"),
+        ]
+        assert find_workshop_ranges(cells) == []
 
 
 class TestIsInWorkshop:


### PR DESCRIPTION
## Summary

- `clm.slides.workshop_scope.find_workshop_ranges` now treats a slide/subslide markdown cell whose `slide_id` starts with `workshop-` as a workshop opener, equivalent to the legacy `workshop` tag. Backward compatible.
- Fixes false positives on `clm slides coverage` / `clm validate` for ML AZAV decks that announce a workshop via `tags=["slide"] slide_id="workshop-…"` followed by `aufgabe-N-…` / `task-N-…` task slides (e.g. `module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates.py`).
- Addresses Priority 3 of [`docs/proposals/PYTHON_COURSES_REVAMP_NEXT_STEPS_2026-05-19.md`](https://github.com/hoelzl/clm/blob/master/docs/proposals/PYTHON_COURSES_REVAMP_NEXT_STEPS_2026-05-19.md).

## Details

The PythonCourses 2026-05-19 smoke test surfaced `clm slides coverage` flagging `slide_id='task-1-persona-template'` for missing voiceover even though workshop task slides intentionally have no voiceover. Commit `933da17f` ("feat(coverage): skip workshop slides in the coverage walker") handles `workshop`-tagged scopes but not decks where the convention is `slide_id="workshop-…"` on the announcement plus `task-N-…` / `aufgabe-N-…` on the tasks (no `workshop` tag anywhere).

The proposal doc preferred a deck-level marker over slug-pattern matching `task-\d+-…`. The deck-level marker the convention already provides is the announcement slide's `slide_id` prefix.

## Implementation

- `Cell.slide_id` passthrough property added in `src/clm/notebooks/slide_parser.py` (mirrors the existing `lang` / `tags` passthroughs).
- `_CellLike` protocol in `src/clm/slides/workshop_scope.py` extended with `slide_id: str | None`; new `_is_workshop_opener` helper centralizes the predicate. The slide_id form requires a `slide` / `subslide` tag so a voiceover or notes cell sharing the announcement slide_id does not re-trigger a new range.
- Closing semantics (`end-workshop` tag, next opener, EOF) are unchanged.
- The nbformat-side `find_workshop_ranges` in `src/clm/workers/notebook/output_spec.py` is intentionally **not** changed: task slides must still render fully in build output.

## Verification

- Direct repro against the real PythonCourses file: 12 workshop-internal slide-starts (announcement DE/EN, setup DE/EN, 4 tasks × DE/EN) now sit inside the workshop range; 34 pre-workshop lecture pairs remain coverage-checked.
- 6 new unit tests in `tests/slides/test_workshop_scope.py` covering: slide_id opens to EOF, voiceover-with-shared-id does not fragment, subslide-tagged opener, `end-workshop` closes a slide_id-opened range, mixed tag+slide_id conventions, code cell with misleading slide_id is ignored.
- Pre-commit hook passed: ruff lint, ruff format, mypy, fast pytest suite (5273 passed locally).

## Test plan

- [ ] CI pre-commit passes (ruff, mypy, fast suite).
- [ ] CI full suite passes.
- [ ] PythonCourses bumps the CLM pin and confirms `clm slides coverage` on `slides_010_prompt_templates.py` no longer flags the `aufgabe-N-…` task slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)