### PR TITLE
chore(gitignore): ignore the default `.clm-cache/` LLM cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,7 @@ tools/diagnostic_output/
 
 # CLM local data (voiceover trace logs, etc.)
 .clm/
+
+# CLM LLM cache (default `tool.clm.cache_dir`, created by
+# `clm slides assign-ids --llm-suggest`, `clm slides coverage`, etc.)
+.clm-cache/


### PR DESCRIPTION
## Summary

- Adds `.clm-cache/` to `.gitignore` alongside the existing `.clm/` (voiceover-trace-log) entry.
- The default `tool.clm.cache_dir` (per `resolve_cache_dir` in `src/clm/infrastructure/llm/cache.py`) resolves to `<cwd>/.clm-cache/`, so any local run of `clm slides assign-ids --llm-suggest`, `clm slides coverage`, or any other LLM-backed slides command drops a `clm-llm.sqlite` under that path. Worktrees were treating it as untracked.
- Aligns with the §8 "don't commit it" statement in `docs/claude/python-courses-revamp-handover.md` (shipped in #99).

## Test plan

- [ ] None — single-line `.gitignore` change; the pre-commit hook skipped all checks (no Python files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)