### PR TITLE
feat(assign-ids): expand extractors to clear ~95% of hard refusals (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`clm slides assign-ids` extraction expansion ([#89](https://github.com/hoelzl/clm/issues/89)).**
+  Four additive changes that clear the bulk of `assign-ids` hard refusals
+  on slide corpora dominated by prose subslides and code-cell slide
+  starts:
+  - **First-prose-line extractor** — markdown cells with no heading,
+    bullet, bold, or `<img alt>` now propose a slug from their first
+    non-empty prose line (HTML tags and inline formatting stripped,
+    trailing terminal punctuation dropped). Reported as
+    `content:prose`. Only matches jupytext markdown lines (`# something`);
+    leading comments inside code cells qualify too.
+  - **Code-cell AST extractor** (`clm.slides.code_cell_extract`) —
+    code cells tagged `slide`/`subslide` walk the top-level AST when
+    the markdown path returns NON_EXTRACTABLE. Precedence:
+    `class Foo` → `def foo` → `target = …` → `import x[, y, …]` /
+    `from m import …` → `obj.method()`. Returns `None` on `SyntaxError`
+    so unparsable cells (shell escapes, magics, half-finished stubs)
+    fall through cleanly to the hard-refusal / LLM-fallback path
+    instead of aborting the run. Reported as `content:code:<kind>`.
+  - **Sibling-pair asymmetry fix** — when the EN slug source has
+    nothing extractable but the DE sibling does, slug from the DE
+    sibling (transliteration keeps the result ASCII; collision suffix
+    enforces uniqueness). Reported as `content:sibling-<kind>` or
+    `sibling-heading`. The LLM is intentionally NOT consulted on the
+    sibling fallback — its prompts target English content and would
+    propose German-derived titles otherwise.
+  - **`--llm-suggest` fallback on hard refusals** — when classification
+    returns NON_EXTRACTABLE on the slug source and the sibling fallback
+    didn't help, `--llm-suggest` now gets a turn before the hard refusal
+    is recorded. Previously the LLM was only consulted from the
+    EXTRACTABLE branch, which silently no-op'd on the dominant
+    refusal pattern in real corpora. Default behavior without
+    `--llm-suggest` is unchanged.
+
 ### Fixed
 
 - **`clm slides coverage` / `clm validate` no longer flag workshop task

--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -19,7 +19,7 @@ checked into the CLM repo.
 | Priority | Scope | Status | PR / Branch |
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
-| 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **CLM phases 1–4 implemented** (P5 = PC-side corpus rerun) | branch `claude/assign-ids-extraction-expansion` (PR pending) |
+| 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **CLM phases 1–4 in [PR #101](https://github.com/hoelzl/clm/pull/101)** (P5 = PC-side corpus rerun) | branch `claude/assign-ids-extraction-expansion`, commit `ad911e6` |
 | 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | Not started | — |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |

--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -19,7 +19,7 @@ checked into the CLM repo.
 | Priority | Scope | Status | PR / Branch |
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
-| 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | Not started | — |
+| 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **CLM phases 1–4 implemented** (P5 = PC-side corpus rerun) | branch `claude/assign-ids-extraction-expansion` (PR pending) |
 | 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | Not started | — |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |
@@ -45,17 +45,20 @@ Read these before touching any file. This handover deliberately does
 complete and the slide-format-redesign downstream phases (split-source
 parity, coverage walker promotion to error) can run cleanly.
 
-**Status:** Design ready, no PR yet. Two PR baselines settled (#79
-Phase 2 + #80 Phase 3), so the architectural ground is stable. Work is
-purely additive to existing extractors.
+**Status:** Phases 1–4 implemented on branch
+`claude/assign-ids-extraction-expansion`. PR not yet filed; the
+recommended split is Phases 1+2 as PR #1, Phase 3 as PR #2, Phase 4 as
+PR #3 (the only one with semantic changes to `--llm-suggest` behavior).
+Currently bundled on a single branch — split before push if the PR
+review prefers the staged sequence.
 
 ### Phase tracker
 
-- [ ] **Phase 1** — first-prose-line extractor in `clm.slides.headingless` (~218 warnings cleared)
-- [ ] **Phase 2** — code-cell AST extractor in new `clm.slides.code_cell_extract` (~165 warnings)
-- [ ] **Phase 3** — sibling-pair asymmetry fix in `_handle_slide` (~10 warnings)
-- [ ] **Phase 4** — `--llm-suggest` fallback on NON_EXTRACTABLE (residual ~14)
-- [ ] **Phase 5** — corpus rerun + documentation updates; bump CLM pin in PythonCourses
+- [x] **Phase 1** — first-prose-line extractor in `clm.slides.headingless` (`content:prose`)
+- [x] **Phase 2** — code-cell AST extractor in new `clm.slides.code_cell_extract` (`content:code:class|def|assign|import|call`)
+- [x] **Phase 3** — sibling-pair asymmetry fix in `_handle_slide` (`content:sibling-…` / `sibling-heading`)
+- [x] **Phase 4** — `--llm-suggest` fallback on NON_EXTRACTABLE (`source = "llm"`)
+- [ ] **Phase 5** — corpus rerun + documentation updates; bump CLM pin in PythonCourses *(PC-side; pending CLM release that includes #89)*
 
 P1+P2 alone clear ~95%; P3+P4 close the long tail. The proposal doc
 recommends doing all four together since "they're naturally one design
@@ -205,7 +208,43 @@ before CLM can proceed, file it as a comment on the corresponding issue
 - The `.clm-cache/` directory may appear in the worktree after running
   `clm slides coverage` locally. It's gitignored — don't commit it.
 
-## 9. Decisions Recorded This Session (2026-05-20)
+## 9. Decisions Recorded — Priority 1 implementation (2026-05-20)
+
+- **Prose extractor only matches `# ` (jupytext) markdown lines.** A
+  raw `import requests` line in a code cell does NOT qualify as prose,
+  so Phase 2's AST extractor still picks up such cells. A leading
+  comment in a code cell (`# Initialize the client`) does qualify —
+  human-written comments describe intent better than the first AST
+  node typically would, so we let prose fire before the AST walker.
+- **Code-cell AST extraction labels stay verbose** (`code:class`,
+  `code:def`, `code:assign`, `code:import`, `code:call`). Wrapped by
+  the existing `_handle_slide` source-naming step they surface as
+  `content:code:<kind>` in the CLI report, which matches the proposal
+  doc's recommended format.
+- **Sibling fallback skips the LLM call.** When the EN slug source has
+  nothing extractable and we fall back to the DE sibling, we do NOT
+  consult the LLM. Its prompts target English content; firing it on
+  DE-only content would produce German-derived titles and break the
+  EN-derived contract. The DE content goes through `slugify`'s
+  transliteration instead.
+- **`extraction.source` is now plumbed through the HEADED branch.**
+  Previously the HEADED path hard-coded `source = "heading"`. Phase 3
+  needed to distinguish `heading` (direct) from `sibling-heading`
+  (fallback), so the assignment now uses `extraction.source`
+  verbatim. Direct headings still report as `"heading"` (extractor
+  sets that label); sibling-headings report as `"sibling-heading"`.
+- **Phase 4 promotes NON_EXTRACTABLE to EXTRACTABLE-equivalent when
+  LLM fires.** Rather than duplicating the write path, the LLM branch
+  rewrites `extraction` to a synthetic EXTRACTABLE with `source = "llm"`
+  so the existing write-decision logic (which already treats
+  `source == "llm"` as auto-write) handles it without a new code path.
+- **`--force` + existing-id + NON_EXTRACTABLE + LLM-title behavior is
+  unchanged** when `--llm-suggest` is off (baseline rule: don't
+  destroy an id we can't replace). With `--llm-suggest`, if LLM
+  produces a title, `--force` regenerates as expected — consistent
+  with the EXTRACTABLE-with-force path.
+
+## 10. Decisions Recorded — Priority 3 fix (2026-05-20)
 
 - **Priority 3 fix kept narrow.** Only extended the slide-parser-side
   `workshop_scope.find_workshop_ranges`, not the nbformat-side

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -579,11 +579,23 @@ same id (derived from the EN heading); voiceover/notes cells inherit
 the id of the preceding slide. Three-category policy:
 
 - **headed** — slug from the first markdown heading. Always assigned.
-- **extractable** — headingless but with a first bullet, prominent
-  bold line, or `<img alt="…">`. **Refused by default**; opt in with
-  `--accept-content-derived` or `--llm-suggest`.
-- **no content** — empty cell, pure image without alt, etc. **Hard
-  refuse**; the author has to write `slide_id="…"` by hand.
+- **extractable** — headingless but with one of:
+  - a first bullet, prominent bold line, or `<img alt="…">`,
+  - a first non-empty prose line (HTML tags and inline markdown
+    stripped, trailing terminal punctuation dropped),
+  - in a code cell: top-level `class`, `def`, assignment, `import`/
+    `from-import`, or method call (AST-based; precedence in that
+    order),
+  - in a DE/EN pair: when the EN slug source has none of the above
+    but the DE sibling does, the slug derives from the DE sibling
+    (transliterated to ASCII).
+  **Refused by default**; opt in with `--accept-content-derived` or
+  `--llm-suggest`.
+- **no content** — cell where no extractor produces anything (empty
+  cell, pure `<img>` without alt, unparsable code, magic-only cells).
+  **Hard refuse**; the author has to write `slide_id="…"` by hand,
+  or pass `--llm-suggest` to let the LLM propose a title as a last
+  resort.
 
 Special cases:
 
@@ -601,7 +613,7 @@ clm slides assign-ids [OPTIONS] PATH
 |--------|-------------|
 | `--force` | Regenerate ids where the algorithm can produce one. `!`-prefixed ids and cells without a proposal are left untouched. |
 | `--accept-content-derived` | Auto-accept proposals for the extractable category (no LLM). Hard-refusal cells still refuse. |
-| `--llm-suggest` | Use the local LLM (Ollama, default model `qwen3:30b`) to propose a short title for extractable cells. Cached per `(content_hash, prompt_version, lang)` in the LLM cache. Falls back silently to refusal when Ollama is unreachable. |
+| `--llm-suggest` | Use the local LLM (Ollama, default model `qwen3:30b`) to propose a short title. Fires on both extractable cells (replacing the content-derived title when the LLM returns one) and on hard-refusal cells (last-resort fallback before refusing). Cached per `(content_hash, prompt_version, lang)` in the LLM cache. Falls back silently to refusal when Ollama is unreachable. |
 | `--report-only`, `--dry-run` | List planned assignments and refusals without modifying any file. |
 | `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.notebooks.slide_parser import parse_cell_header
+from clm.slides.code_cell_extract import extract_from_code
 from clm.slides.headingless import (
     Category,
     Extraction,
@@ -41,6 +42,7 @@ from clm.slides.headingless import (
 )
 from clm.slides.pairing import (
     TITLE_SLIDE_ID,
+    build_slide_groups,
     build_slide_pairs,
     is_title_macro_cell,
 )
@@ -215,6 +217,22 @@ def _proposed_slug_from_extraction(
     return resolve_collision(base, used_ids)
 
 
+def _extract_from_cell(cell: _Cell) -> Extraction:
+    """Run the full extractor pipeline on a single cell.
+
+    Markdown signals win first via :func:`classify`. When the cell is a
+    code cell and markdown found nothing, the AST extractor in
+    :mod:`clm.slides.code_cell_extract` gets a turn. Falls back to
+    ``NON_EXTRACTABLE`` if neither path produces a proposal.
+    """
+    extraction = classify(cell.body)
+    if extraction.category == Category.NON_EXTRACTABLE and cell.metadata.cell_type == "code":
+        code_extraction = extract_from_code(cell.body)
+        if code_extraction is not None:
+            return code_extraction
+    return extraction
+
+
 def _content_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
@@ -243,6 +261,17 @@ def assign_ids_for_text(
             used_ids.add(strip_preserve_marker(existing))
 
     pairs = build_slide_pairs(cells)
+    # Map slug-source idx -> the OTHER member of the same DE/EN group
+    # (or None for solo slides). Used to fall back to the sibling when
+    # the primary slug source has no extractable content (Phase 3).
+    alternate_of: dict[int, int | None] = {}
+    for group in build_slide_groups(cells):
+        if len(group) == 1:
+            alternate_of[group[0]] = None
+        else:
+            a, b = group
+            en_idx = a if cells[a].metadata.lang == "en" else b
+            alternate_of[en_idx] = b if a == en_idx else a
     # Cache the slug we resolve for each "slug source" cell so paired
     # DE/EN cells always get the *exact same* id (collision suffix
     # included). Otherwise the second visit would observe its own
@@ -265,7 +294,10 @@ def assign_ids_for_text(
             continue
 
         if role == "slide":
-            slug_source = cells[pairs.get(idx, idx)]
+            slug_source_idx = pairs.get(idx, idx)
+            slug_source = cells[slug_source_idx]
+            alt_idx = alternate_of.get(slug_source_idx)
+            alternate_cell = cells[alt_idx] if alt_idx is not None else None
             new_id = _handle_slide(
                 cell,
                 slug_source,
@@ -274,7 +306,8 @@ def assign_ids_for_text(
                 file_str,
                 result,
                 group_slug,
-                slug_source_idx=pairs.get(idx, idx),
+                slug_source_idx=slug_source_idx,
+                alternate_cell=alternate_cell,
             )
             if new_id is not None:
                 current_slide_id = new_id
@@ -325,6 +358,7 @@ def _handle_slide(
     result: AssignResult,
     group_slug: dict[int, str | None],
     slug_source_idx: int,
+    alternate_cell: _Cell | None = None,
 ) -> str | None:
     """Assign or preserve a slide_id on one slide/subslide cell.
 
@@ -384,7 +418,26 @@ def _handle_slide(
     local_used = used_ids - free if free else used_ids
 
     # Slug is derived from the slug-source cell (EN sibling, or self).
-    extraction = classify(slug_source.body)
+    # ``_extract_from_cell`` combines the markdown classifier and the
+    # code-cell AST fallback into a single proposal.
+    extraction = _extract_from_cell(slug_source)
+
+    # Phase 3 fallback: if the EN slug source has nothing to slug from
+    # but the DE sibling does, slug from the DE sibling. Transliteration
+    # in :mod:`clm.slides.slug` keeps the result ASCII and uniqueness is
+    # still enforced by the existing collision suffix machinery. We do
+    # NOT consult the LLM in this branch — the LLM should propose
+    # English titles, and the sibling content is German-side.
+    sibling_fallback = False
+    if extraction.category == Category.NON_EXTRACTABLE and alternate_cell is not None:
+        alt_extraction = _extract_from_cell(alternate_cell)
+        if alt_extraction.category != Category.NON_EXTRACTABLE:
+            extraction = Extraction(
+                alt_extraction.category,
+                alt_extraction.text,
+                f"sibling-{alt_extraction.source}",
+            )
+            sibling_fallback = True
 
     proposed_slug: str = ""
     proposed_title: str | None = None
@@ -393,44 +446,68 @@ def _handle_slide(
     if extraction.category == Category.HEADED:
         proposed_title = extraction.text
         proposed_slug = _proposed_slug_from_extraction(extraction, local_used)
-        source = "heading"
+        # ``extraction.source`` is "heading" for a direct heading and
+        # "sibling-heading" when Phase 3 fell back to the DE sibling.
+        source = extraction.source
 
     elif extraction.category == Category.EXTRACTABLE:
         # LLM path first (if requested) — its suggestion replaces the
         # content-derived proposal because the title is usually more
         # readable than the raw first bullet. Use the slug source's body
-        # (EN sibling) so the LLM sees English content.
-        llm_title = _try_llm_suggestion(slug_source, options, file_str, result)
-        if llm_title:
-            proposed_title = llm_title
-            base = slugify(llm_title, max_length=MAX_SLUG_LENGTH)
-            if base:
-                proposed_slug = resolve_collision(base, local_used)
-                source = "llm"
+        # (EN sibling) so the LLM sees English content. Skip the LLM
+        # when we fell back to the DE sibling: the prompt would target
+        # German content and produce a title in the wrong language.
+        if not sibling_fallback:
+            llm_title = _try_llm_suggestion(slug_source, options, file_str, result)
+            if llm_title:
+                proposed_title = llm_title
+                base = slugify(llm_title, max_length=MAX_SLUG_LENGTH)
+                if base:
+                    proposed_slug = resolve_collision(base, local_used)
+                    source = "llm"
         if not proposed_slug:
             proposed_title = extraction.text
             proposed_slug = _proposed_slug_from_extraction(extraction, local_used)
             source = f"content:{extraction.source}"
 
     else:
-        # NON_EXTRACTABLE: hard refuse — only if we are even being asked
-        # to assign. If --force is off and the cell already has an id,
-        # we returned above; otherwise the cell genuinely has nothing.
-        if existing:
-            # --force is on but we have no proposal. Per §2.3 baseline
-            # rule: leave the existing id alone.
-            group_slug.setdefault(slug_source_idx, strip_preserve_marker(existing))
-            return strip_preserve_marker(existing)
-        result.refusals.append(
-            Refusal(
-                file=file_str,
-                line=cell.line_number,
-                severity="hard",
-                reason="cell has no heading and no extractable content",
+        # NON_EXTRACTABLE: Phase 4 last-resort LLM. Without this fallback
+        # ``--llm-suggest`` would silently no-op on the entire hard-refusal
+        # set — those cells never reached the LLM via the EXTRACTABLE
+        # branch. ``_try_llm_suggestion`` self-guards on
+        # ``options.llm_suggest`` and on suggester availability, so the
+        # call is safe regardless of CLI flags.
+        llm_title = _try_llm_suggestion(slug_source, options, file_str, result)
+        if llm_title:
+            base = slugify(llm_title, max_length=MAX_SLUG_LENGTH)
+            if base:
+                proposed_slug = resolve_collision(base, local_used)
+                proposed_title = llm_title
+                source = "llm"
+                # Promote the category so the shared write-decision
+                # below treats this exactly like an LLM-on-EXTRACTABLE
+                # outcome (write under ``source == "llm"``).
+                extraction = Extraction(Category.EXTRACTABLE, llm_title, "llm")
+
+        if extraction.category == Category.NON_EXTRACTABLE:
+            # No LLM suggestion either — hard refuse. If --force is off
+            # and the cell already has an id, we returned above;
+            # otherwise the cell genuinely has nothing.
+            if existing:
+                # --force is on but we have no proposal. Per §2.3
+                # baseline rule: leave the existing id alone.
+                group_slug.setdefault(slug_source_idx, strip_preserve_marker(existing))
+                return strip_preserve_marker(existing)
+            result.refusals.append(
+                Refusal(
+                    file=file_str,
+                    line=cell.line_number,
+                    severity="hard",
+                    reason="cell has no heading and no extractable content",
+                )
             )
-        )
-        group_slug[slug_source_idx] = None
-        return None
+            group_slug[slug_source_idx] = None
+            return None
 
     # We have a proposal. Decide whether to write it or refuse.
     if extraction.category == Category.HEADED:

--- a/src/clm/slides/code_cell_extract.py
+++ b/src/clm/slides/code_cell_extract.py
@@ -1,0 +1,152 @@
+"""AST-based slug extraction for code-typed slide cells.
+
+Used by ``clm slides assign-ids`` as a Phase-2 fallback when
+:func:`clm.slides.headingless.classify` returns ``NON_EXTRACTABLE`` on a
+cell whose ``cell_type == "code"``. Walks the top-level statements with
+:mod:`ast` and picks the most slug-worthy node by precedence:
+
+    1. class definition       -> ``class <Name>``
+    2. function / async def   -> ``function <name>``
+    3. top-level assignment   -> ``<target>``
+    4. import / from-import   -> ``import <name> [<name>...]``
+    5. expression-stmt call   -> ``<obj> <method>`` (or ``<func>``)
+
+Returns ``None`` when the source can't be parsed (shell escapes, magic
+commands, half-finished stubs) or no slug-worthy node is found. The
+caller treats ``None`` as ``NON_EXTRACTABLE`` and falls through to the
+existing refusal / LLM-fallback path.
+
+Extractor labels (``Extraction.source``) match the precedence order:
+``code:class``, ``code:def``, ``code:assign``, ``code:import``,
+``code:call``. They surface in the ``assign-ids`` report as
+``content:code:<kind>`` so authors can tell which strategy produced a
+given slug.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from clm.slides.headingless import Category, Extraction
+
+# Cap the number of import names baked into the composite title so a
+# 30-line `from foo import (a, b, c, ...)` block doesn't produce an
+# absurdly long proposed title. ``slug.py`` enforces a character cap
+# afterwards too; this is purely for readability of the report.
+_MAX_IMPORT_NAMES = 4
+
+
+def extract_from_code(source: str) -> Extraction | None:
+    """Return an ``EXTRACTABLE`` proposal derived from code, or ``None``.
+
+    ``source`` should be the raw Python body of a percent-format code
+    cell (no ``# `` prefix). A :class:`SyntaxError` produces ``None`` so
+    one unparsable cell does not abort the larger ``assign-ids`` run.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    for extractor in (
+        _from_class_def,
+        _from_function_def,
+        _from_assignment,
+        _from_import,
+        _from_call,
+    ):
+        result = extractor(tree)
+        if result is not None:
+            return result
+    return None
+
+
+def _from_class_def(tree: ast.Module) -> Extraction | None:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.ClassDef):
+            return Extraction(Category.EXTRACTABLE, f"class {stmt.name}", "code:class")
+    return None
+
+
+def _from_function_def(tree: ast.Module) -> Extraction | None:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef):
+            return Extraction(Category.EXTRACTABLE, f"function {stmt.name}", "code:def")
+    return None
+
+
+def _from_assignment(tree: ast.Module) -> Extraction | None:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                name = _assignment_target_name(target)
+                if name:
+                    return Extraction(Category.EXTRACTABLE, name, "code:assign")
+        elif isinstance(stmt, ast.AnnAssign):
+            name = _assignment_target_name(stmt.target)
+            if name:
+                return Extraction(Category.EXTRACTABLE, name, "code:assign")
+    return None
+
+
+def _assignment_target_name(node: ast.AST) -> str | None:
+    """Return a readable name for an assignment target, or None.
+
+    Handles ``x = ...`` and ``x, y = ...``. Attribute / subscript /
+    starred targets fall through to None — they're rare in slide demo
+    code and don't produce clean slugs.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Tuple | ast.List):
+        names: list[str] = [n for n in (_assignment_target_name(elt) for elt in node.elts) if n]
+        if names:
+            return " ".join(names[:_MAX_IMPORT_NAMES])
+    return None
+
+
+def _from_import(tree: ast.Module) -> Extraction | None:
+    names: list[str] = []
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Import):
+            for alias in stmt.names:
+                names.append(alias.asname or alias.name.split(".")[0])
+        elif isinstance(stmt, ast.ImportFrom):
+            for alias in stmt.names:
+                names.append(alias.asname or alias.name)
+    if not names:
+        return None
+    title = "import " + " ".join(names[:_MAX_IMPORT_NAMES])
+    return Extraction(Category.EXTRACTABLE, title, "code:import")
+
+
+def _from_call(tree: ast.Module) -> Extraction | None:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            name = _call_name(stmt.value.func)
+            if name:
+                return Extraction(Category.EXTRACTABLE, name, "code:call")
+    return None
+
+
+def _call_name(node: ast.AST) -> str | None:
+    """Render the callee of a Call expression as readable text.
+
+    ``foo()``               -> ``"foo"``
+    ``obj.method()``        -> ``"obj method"``
+    ``a.b.c()``             -> ``"a b c"``
+    ``factory()()``         -> ``"factory"``
+    ``items[0].method()``   -> ``"items method"``
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        if prefix:
+            return f"{prefix} {node.attr}"
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
+    if isinstance(node, ast.Subscript):
+        return _call_name(node.value)
+    return None

--- a/src/clm/slides/headingless.py
+++ b/src/clm/slides/headingless.py
@@ -40,7 +40,8 @@ class Extraction:
     ``category`` is the classification. ``text`` is the raw extracted
     string (markdown formatting intact — slugification happens later via
     :func:`clm.slides.slug.slugify`). ``source`` identifies *which* extractor
-    matched (``heading``/``bullet``/``bold``/``img_alt``) for diagnostics.
+    matched (``heading``/``bullet``/``bold``/``img_alt``/``prose``) for
+    diagnostics.
     """
 
     category: Category
@@ -63,6 +64,21 @@ _BOLD_LINE_RE = re.compile(r"^#\s+\*\*([^*]+)\*\*\s*$")
 # Image with alt text.
 _IMG_ALT_RE = re.compile(r'<img[^>]*\balt="([^"]+)"', re.IGNORECASE)
 
+# HTML tag (used to drop naked <img> noise before prose extraction).
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+# Inline markdown formatting to unwrap before treating a line as prose.
+_BOLD_INLINE_RE = re.compile(r"\*\*([^*]+)\*\*")
+_ITALIC_INLINE_RE = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)")
+_CODE_INLINE_RE = re.compile(r"`([^`]+)`")
+_LINK_INLINE_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+
+# Terminal punctuation stripped from the end of a prose line.
+_TRAILING_PUNCT_RE = re.compile(r"[:.?!]+\s*$")
+
+# Used to reject lines that contain no word characters after cleanup.
+_WORD_RE = re.compile(r"\w")
+
 
 def _iter_content_lines(content: str) -> list[str]:
     """Yield lines stripped of trailing whitespace, retaining the ``#`` prefix."""
@@ -78,12 +94,44 @@ def extract_heading(content: str) -> str | None:
     return None
 
 
+def _extract_first_prose_line(lines: list[str]) -> str | None:
+    """Return the first non-empty jupytext-markdown prose line, or None.
+
+    Only lines that look like jupytext markdown content (``# something``)
+    are considered — bare code lines never qualify as prose, which keeps
+    code cells routed to the AST extractor instead of accidentally
+    matching here on `import`/`def` lines. Lines that reduce to empty
+    text after stripping HTML, inline markdown formatting, and trailing
+    terminal punctuation are skipped; lines with no word characters at
+    all are rejected.
+    """
+    for line in lines:
+        # Skip blank markdown lines and any non-markdown line (e.g. raw
+        # Python statements in a code cell).
+        if not line.startswith("# "):
+            continue
+        content = line[2:]
+        content = _HTML_TAG_RE.sub("", content)
+        content = _BOLD_INLINE_RE.sub(r"\1", content)
+        content = _ITALIC_INLINE_RE.sub(r"\1", content)
+        content = _CODE_INLINE_RE.sub(r"\1", content)
+        content = _LINK_INLINE_RE.sub(r"\1", content)
+        content = _TRAILING_PUNCT_RE.sub("", content).strip()
+        if not content:
+            continue
+        if not _WORD_RE.search(content):
+            continue
+        return content
+    return None
+
+
 def classify(content: str) -> Extraction:
     """Classify a cell's content and return whatever proposal text we can find.
 
     Precedence within the EXTRACTABLE category: first bullet/numbered item,
-    then prominent bold line, then first ``<img alt="...">``. Whichever
-    appears first in source order wins among items of the same precedence.
+    then prominent bold line, then first ``<img alt="...">``, then the
+    first non-empty prose line. Whichever appears first in source order
+    wins among items of the same precedence.
     """
     lines = _iter_content_lines(content)
 
@@ -120,6 +168,10 @@ def classify(content: str) -> Extraction:
         return Extraction(Category.EXTRACTABLE, first_bold, "bold")
     if first_img_alt:
         return Extraction(Category.EXTRACTABLE, first_img_alt, "img_alt")
+
+    prose = _extract_first_prose_line(lines)
+    if prose:
+        return Extraction(Category.EXTRACTABLE, prose, "prose")
 
     return Extraction(Category.NON_EXTRACTABLE)
 

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -418,6 +418,242 @@ class TestSubslide:
 # ---------------------------------------------------------------------------
 
 
+class TestCodeCellSlideStart:
+    """Code cells tagged ``slide``/``subslide`` route through the AST
+    extractor when no markdown signal is present (Phase 2).
+    """
+
+    def test_import_block_produces_slug(self):
+        text = (
+            '# %% lang="en" tags=["subslide"]\nimport requests\nimport trafilatura\nimport ftfy\n'
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        a = result.assignments[0]
+        # slugify caps at 30 chars, dropping the trailing "ftfy" token
+        # (`import-requests-trafilatura-ftfy` is 32 chars).
+        assert a.slide_id == "import-requests-trafilatura"
+        assert a.source == "content:code:import"
+
+    def test_class_def_produces_slug(self):
+        text = '# %% lang="en" tags=["slide"]\nclass HistoryChatbot(BaseChatbot):\n    pass\n'
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "class-historychatbot"
+        assert result.assignments[0].source == "content:code:class"
+
+    def test_assignment_produces_slug(self):
+        text = '# %% lang="en" tags=["subslide"]\nresponse = client.chat.completions.create()\n'
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "response"
+        assert result.assignments[0].source == "content:code:assign"
+
+    def test_keep_tag_does_not_block_extraction(self):
+        # ``keep`` only affects build output, not assign-ids; a
+        # ``keep + subslide`` code cell still classifies as slide_start.
+        text = '# %% lang="en" tags=["keep", "subslide"]\nimport requests\nimport trafilatura\n'
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "import-requests-trafilatura"
+
+    def test_paired_de_en_code_cells_share_slug(self):
+        text = (
+            '# %% lang="de" tags=["subslide"]\n'
+            "import requests\n"
+            '# %% lang="en" tags=["subslide"]\n'
+            "import requests\n"
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["import-requests", "import-requests"]
+
+    def test_unparsable_code_still_hard_refuses(self):
+        text = '# %% lang="en" tags=["subslide"]\n!pip install requests\n'
+        new_text, result = _run(text)
+        assert result.refusals[0].severity == "hard"
+
+    def test_default_still_soft_refuses_without_accept_flag(self):
+        # Code extraction produces a soft refusal under EXTRACTABLE
+        # semantics — author needs --accept-content-derived to write.
+        text = '# %% lang="en" tags=["subslide"]\nimport requests\n'
+        new_text, result = _run(text)
+        assert result.assignments == []
+        refusal = result.refusals[0]
+        assert refusal.severity == "soft"
+        assert refusal.proposed_slug == "import-requests"
+
+    def test_comment_in_code_cell_extracted_as_prose(self):
+        # A leading ``# Comment`` in a code cell qualifies as prose via
+        # the Phase-1 extractor before the AST walker fires — that's
+        # the desired ordering since human-written comments usually
+        # describe intent better than the first AST node would.
+        text = '# %% lang="en" tags=["subslide"]\n# Initialize the client\nclient = OpenAI()\n'
+        new_text, result = _run(text, accept_content_derived=True)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "initialize-the-client"
+        assert result.assignments[0].source == "content:prose"
+
+
+class TestLLMSuggestOnHardRefusal:
+    """Phase 4: ``--llm-suggest`` fires on NON_EXTRACTABLE cells as a
+    last resort. Without this, the LLM would silently no-op on the
+    entire hard-refusal set (the dominant pattern in real corpora).
+    """
+
+    HARD_REFUSAL_TEXT = '# %% [markdown] lang="en" tags=["slide"]\n#\n# <img src="x.png"/>\n'
+
+    def test_llm_fires_on_hard_refusal(self):
+        suggester = StaticTitleSuggester(default="RAG Architecture Diagram")
+        new_text, result = _run(
+            self.HARD_REFUSAL_TEXT,
+            llm_suggest=True,
+            llm_suggester=suggester,
+        )
+        assert len(result.assignments) == 1
+        a = result.assignments[0]
+        assert a.slide_id == "rag-architecture-diagram"
+        assert a.source == "llm"
+        assert suggester.calls
+
+    def test_llm_silent_on_hard_refusal_when_flag_off(self):
+        # Without --llm-suggest, behavior on hard refusals is unchanged.
+        suggester = StaticTitleSuggester(default="Would Be Used If Asked")
+        new_text, result = _run(
+            self.HARD_REFUSAL_TEXT,
+            llm_suggester=suggester,
+        )
+        assert result.assignments == []
+        assert result.refusals[0].severity == "hard"
+        assert not suggester.calls
+
+    def test_llm_unavailable_falls_through_to_hard_refusal(self):
+        # Suggester wired but no static default → raises → fail-soft to
+        # the original hard refusal. Same shape as Ollama-down case.
+        suggester = StaticTitleSuggester()
+        new_text, result = _run(
+            self.HARD_REFUSAL_TEXT,
+            llm_suggest=True,
+            llm_suggester=suggester,
+        )
+        assert result.assignments == []
+        assert result.refusals[0].severity == "hard"
+
+    def test_llm_caches_hard_refusal_results(self):
+        class FakeCache:
+            def __init__(self):
+                self.store: dict[tuple, str] = {}
+
+            def get(self, content_hash, prompt_version, lang):
+                return self.store.get((content_hash, prompt_version, lang))
+
+            def put(self, content_hash, prompt_version, suggested_title, lang):
+                self.store[(content_hash, prompt_version, lang)] = suggested_title
+
+        cache = FakeCache()
+        suggester = StaticTitleSuggester(default="Cached Title")
+        _run(
+            self.HARD_REFUSAL_TEXT,
+            llm_suggest=True,
+            llm_suggester=suggester,
+            llm_cache=cache,
+        )
+        assert len(suggester.calls) == 1
+        assert len(cache.store) == 1
+
+        _run(
+            self.HARD_REFUSAL_TEXT,
+            llm_suggest=True,
+            llm_suggester=suggester,
+            llm_cache=cache,
+        )
+        assert len(suggester.calls) == 1
+
+    def test_llm_fires_on_empty_code_cell_with_only_magic(self):
+        # Bash-magic-only code cells are NON_EXTRACTABLE (the AST walker
+        # can't parse them) — Phase 4 still gets a shot.
+        text = '# %% lang="en" tags=["subslide"]\n!pip install transformers\n'
+        suggester = StaticTitleSuggester(default="Install Transformers")
+        new_text, result = _run(text, llm_suggest=True, llm_suggester=suggester)
+        assert len(result.assignments) == 1
+        assert result.assignments[0].slide_id == "install-transformers"
+        assert result.assignments[0].source == "llm"
+
+
+class TestSiblingAsymmetry:
+    """When the EN slug source has nothing to slug from but the DE
+    sibling does, Phase 3 falls back to the DE-derived slug rather
+    than hard-refusing the pair.
+    """
+
+    def test_de_heading_with_empty_en_sibling(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## Hallo Welt\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "#\n"
+        )
+        new_text, result = _run(text)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["hallo-welt", "hallo-welt"]
+        # The label tracks that we fell back to the sibling.
+        sources = {a.source for a in result.assignments}
+        assert sources == {"sibling-heading", "paired"}
+
+    def test_de_prose_with_empty_en_sibling(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["subslide"]\n'
+            "#\n"
+            "# Erste Anfrage\n"
+            '# %% [markdown] lang="en" tags=["subslide"]\n'
+            "#\n"
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["erste-anfrage", "erste-anfrage"]
+        de_assignment = next(a for a in result.assignments if "sibling" in a.source)
+        assert de_assignment.source == "content:sibling-prose"
+
+    def test_de_code_with_empty_en_sibling(self):
+        text = (
+            '# %% lang="de" tags=["subslide"]\n'
+            "import requests\n"
+            '# %% lang="en" tags=["subslide"]\n'
+            "#\n"
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["import-requests", "import-requests"]
+
+    def test_both_empty_still_hard_refuses(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "#\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "#\n"
+        )
+        new_text, result = _run(text)
+        assert result.assignments == []
+        # Both pair members refuse — DE hard (root cause), EN soft (mirrored).
+        severities = sorted(r.severity for r in result.refusals)
+        assert severities == ["hard", "soft"]
+
+    def test_en_heading_unchanged_when_de_empty(self):
+        # When the EN heading exists, no fallback is needed and the
+        # source label stays "heading" (not "sibling-heading").
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "#\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# ## Hello World\n"
+        )
+        new_text, result = _run(text)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["hello-world", "hello-world"]
+        sources = sorted({a.source for a in result.assignments})
+        assert sources == ["heading", "paired"]
+
+
 class TestSkippedCells:
     def test_keep_cell_ignored(self):
         text = '# %% tags=["keep"]\nx = 1\n'

--- a/tests/slides/test_code_cell_extract.py
+++ b/tests/slides/test_code_cell_extract.py
@@ -1,0 +1,174 @@
+"""Tests for :mod:`clm.slides.code_cell_extract`."""
+
+from __future__ import annotations
+
+from clm.slides.code_cell_extract import extract_from_code
+from clm.slides.headingless import Category
+
+
+class TestPrecedence:
+    def test_class_def_wins(self):
+        source = (
+            "import requests\n"
+            "x = 5\n"
+            "class HistoryChatbot(BaseChatbot):\n"
+            "    pass\n"
+            "def helper():\n"
+            "    pass\n"
+        )
+        e = extract_from_code(source)
+        assert e is not None
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "code:class"
+        assert e.text == "class HistoryChatbot"
+
+    def test_function_def_beats_assignment_and_import(self):
+        source = "import requests\nx = 5\n\ndef process_text(s):\n    return s\n"
+        e = extract_from_code(source)
+        assert e is not None
+        assert e.source == "code:def"
+        assert e.text == "function process_text"
+
+    def test_async_function_def(self):
+        source = "async def fetch(url):\n    return None\n"
+        e = extract_from_code(source)
+        assert e is not None
+        assert e.source == "code:def"
+        assert e.text == "function fetch"
+
+    def test_assignment_beats_import(self):
+        source = "import requests\n\nresponse = client.chat.completions.create()\n"
+        e = extract_from_code(source)
+        assert e is not None
+        assert e.source == "code:assign"
+        assert e.text == "response"
+
+    def test_import_beats_call(self):
+        source = "import requests\n\nclient.method()\n"
+        e = extract_from_code(source)
+        assert e is not None
+        assert e.source == "code:import"
+        assert "requests" in e.text
+
+    def test_call_when_nothing_else(self):
+        source = "response.choices[0].message.content\n"
+        # Bare attribute access — not a Call expression — falls through.
+        # That's an ast.Expr wrapping ast.Attribute, not ast.Call.
+        e = extract_from_code(source)
+        assert e is None
+
+
+class TestImportExtractor:
+    def test_single_import(self):
+        e = extract_from_code("import requests\n")
+        assert e is not None
+        assert e.source == "code:import"
+        assert e.text == "import requests"
+
+    def test_multiple_imports(self):
+        e = extract_from_code("import requests\nimport trafilatura\nimport ftfy\n")
+        assert e is not None
+        assert e.text == "import requests trafilatura ftfy"
+
+    def test_comma_separated_import(self):
+        e = extract_from_code("import requests, trafilatura, ftfy\n")
+        assert e is not None
+        assert e.text == "import requests trafilatura ftfy"
+
+    def test_from_import(self):
+        e = extract_from_code("from cleantext import clean\n")
+        assert e is not None
+        assert e.text == "import clean"
+
+    def test_mixed_import_styles(self):
+        e = extract_from_code(
+            "import requests\nimport trafilatura\nimport ftfy\nfrom cleantext import clean\n"
+        )
+        assert e is not None
+        assert e.text == "import requests trafilatura ftfy clean"
+
+    def test_import_with_asname(self):
+        e = extract_from_code("import numpy as np\n")
+        assert e is not None
+        assert e.text == "import np"
+
+    def test_dotted_import_uses_root(self):
+        e = extract_from_code("import openai.types\n")
+        assert e is not None
+        assert e.text == "import openai"
+
+    def test_import_name_cap(self):
+        # The composite title caps at 4 names to keep the report readable;
+        # the underlying slugify still enforces a character cap on top of
+        # that.
+        e = extract_from_code("import a\nimport b\nimport c\nimport d\nimport e\nimport f\n")
+        assert e is not None
+        assert e.text == "import a b c d"
+
+
+class TestAssignmentExtractor:
+    def test_simple_assignment(self):
+        e = extract_from_code("response = client.chat.completions.create()\n")
+        assert e is not None
+        assert e.source == "code:assign"
+        assert e.text == "response"
+
+    def test_annotated_assignment(self):
+        e = extract_from_code("count: int = 5\n")
+        assert e is not None
+        assert e.source == "code:assign"
+        assert e.text == "count"
+
+    def test_tuple_unpacking(self):
+        e = extract_from_code("a, b = (1, 2)\n")
+        assert e is not None
+        assert e.source == "code:assign"
+        assert "a" in e.text
+        assert "b" in e.text
+
+    def test_attribute_target_falls_through(self):
+        # `obj.attr = ...` doesn't produce a clean slug; we expect the
+        # extractor to fall through to the next strategy (import here).
+        e = extract_from_code("import os\nobj.attr = 5\n")
+        assert e is not None
+        assert e.source == "code:import"
+
+
+class TestCallExtractor:
+    def test_bare_function_call(self):
+        e = extract_from_code("setup_environment()\n")
+        assert e is not None
+        assert e.source == "code:call"
+        assert e.text == "setup_environment"
+
+    def test_method_call(self):
+        e = extract_from_code("client.chat()\n")
+        assert e is not None
+        assert e.source == "code:call"
+        assert e.text == "client chat"
+
+    def test_chained_attribute_call(self):
+        e = extract_from_code("client.chat.completions.create()\n")
+        assert e is not None
+        assert e.source == "code:call"
+        assert e.text == "client chat completions create"
+
+
+class TestUnparsable:
+    def test_syntax_error_returns_none(self):
+        e = extract_from_code("!pip install foo\n")
+        assert e is None
+
+    def test_empty_returns_none(self):
+        assert extract_from_code("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert extract_from_code("   \n   \n") is None
+
+    def test_comments_only_returns_none(self):
+        # `ast.parse` accepts comments-only input — produces a module
+        # with no statements, so no extractor fires.
+        assert extract_from_code("# A comment\n# Another comment\n") is None
+
+    def test_magic_in_comment_returns_none(self):
+        assert extract_from_code("# !pip install foo\n") is None

--- a/tests/slides/test_headingless.py
+++ b/tests/slides/test_headingless.py
@@ -74,6 +74,116 @@ class TestClassify:
         assert classify("#\n#  \n#\n").category == Category.NON_EXTRACTABLE
 
 
+class TestProseLineExtraction:
+    def test_simple_prose_line(self):
+        content = "#\n# Test with two turns -- does the bot remember?\n"
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "prose"
+        assert e.text == "Test with two turns -- does the bot remember"
+
+    def test_trailing_colon_stripped(self):
+        content = "#\n# Loading the model:\n"
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "prose"
+        assert e.text == "Loading the model"
+
+    def test_trailing_period_stripped(self):
+        content = "#\n# Here is some prose.\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Here is some prose"
+
+    def test_german_prose_passes_through(self):
+        content = "#\n# Test mit zwei Runden -- erinnert sich der Bot?\n"
+        e = classify(content)
+        assert e.source == "prose"
+        # Slugification handles the umlaut transliteration downstream;
+        # the extractor preserves the original text for the report.
+        assert e.text == "Test mit zwei Runden -- erinnert sich der Bot"
+
+    def test_long_prose_returned_intact(self):
+        long_line = "A " + ("very " * 30).strip() + " long prose line"
+        content = f"#\n# {long_line}\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert "very very very" in e.text
+
+    def test_pure_punctuation_refuses(self):
+        content = "#\n# !!!\n"
+        assert classify(content).category == Category.NON_EXTRACTABLE
+
+    def test_skips_blank_lines_before_prose(self):
+        content = "#\n#\n#\n# The actual prose\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "The actual prose"
+
+    def test_skips_naked_img_then_prose(self):
+        content = '#\n# <img src="divider.png"/>\n# Real prose here\n'
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Real prose here"
+
+    def test_naked_img_alone_refuses(self):
+        content = '#\n# <img src="divider.png"/>\n'
+        assert classify(content).category == Category.NON_EXTRACTABLE
+
+    def test_strips_inline_italic(self):
+        content = "#\n# *Some italic prose*\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Some italic prose"
+
+    def test_strips_inline_code(self):
+        content = "#\n# Calling `client.chat()` first\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Calling client.chat() first"
+
+    def test_strips_link_keeping_label(self):
+        content = "#\n# See [the docs](https://example.com) for details\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "See the docs for details"
+
+    def test_prose_runs_after_other_extractors(self):
+        # Bullet still wins even when prose precedes it on the page.
+        content = "#\n# Some intro prose.\n# - first bullet\n"
+        e = classify(content)
+        assert e.source == "bullet"
+        assert "first bullet" in e.text
+
+    def test_bold_still_wins_over_prose(self):
+        content = "#\n# Plain prose first.\n# **Bold heading-style line**\n"
+        e = classify(content)
+        assert e.source == "bold"
+        assert e.text == "Bold heading-style line"
+
+    def test_img_alt_still_wins_over_prose(self):
+        content = '#\n# Plain prose first.\n# <img alt="The diagram"/>\n'
+        e = classify(content)
+        assert e.source == "img_alt"
+        assert e.text == "The diagram"
+
+    def test_code_lines_do_not_qualify_as_prose(self):
+        # Bare Python statements in a code-cell body must not match —
+        # they should fall through to NON_EXTRACTABLE so the Phase-2
+        # code-cell extractor can pick them up.
+        content = "import requests\nimport trafilatura\n"
+        assert classify(content).category == Category.NON_EXTRACTABLE
+
+    def test_code_cell_comment_qualifies_as_prose(self):
+        # A '# Initialize the client' leading comment in a code cell is
+        # still useful slug material — let the prose extractor pick it
+        # up since the Phase-2 AST walk skips comments by design.
+        content = "# Initialize the client\nclient = OpenAI()\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Initialize the client"
+
+
 class TestCellTextForLLM:
     def test_strips_comment_prefix(self):
         text = cell_text_for_llm("# Line one\n# Line two\n")


### PR DESCRIPTION
Closes #89.

Implements all four CLM-side phases of the `assign-ids` extraction
expansion proposal. On the AZAV ML corpus this clears the dominant
292-cell hard-refusal pattern (which fans out to 407 visible warnings
via DE/EN paired-soft mirroring).

## Summary

- **Phase 1** — first-prose-line extractor in `clm.slides.headingless`.
  Markdown cells with no heading / bullet / bold / `<img alt>` now
  propose a slug from their first non-empty prose line. Strips HTML,
  inline markdown formatting, and trailing terminal punctuation.
  Reported as `content:prose`. Only matches jupytext markdown lines
  (`# something`); leading comments inside code cells qualify too.
- **Phase 2** — new `clm.slides.code_cell_extract` module. Code cells
  tagged `slide` / `subslide` walk the top-level AST when the markdown
  path returns NON_EXTRACTABLE. Precedence: `class` > `def` >
  assignment > `import` / `from-import` > expression-stmt call.
  Returns `None` on `SyntaxError` so shell escapes, magic commands,
  and half-finished stubs fall through cleanly. Reported as
  `content:code:<kind>`.
- **Phase 3** — sibling-pair asymmetry fix in `_handle_slide`. When
  the EN slug source has nothing extractable but the DE sibling does,
  slug from the DE sibling. Transliteration keeps the result ASCII;
  collision suffix enforces uniqueness. Reported as
  `content:sibling-<kind>` or `sibling-heading`. **LLM is intentionally
  skipped** on this path — its prompts target English content and
  would propose German-derived titles otherwise.
- **Phase 4** — `--llm-suggest` now fires on NON_EXTRACTABLE as a
  last resort before the hard refusal is recorded. Previously the
  LLM was only consulted from the EXTRACTABLE branch and silently
  no-op'd on the dominant refusal pattern in real corpora. Default
  behavior **without** `--llm-suggest` is byte-identical to before.

Source labels surface in the CLI / JSON report: `content:prose`,
`content:code:<kind>`, `content:sibling-<kind>`, `sibling-heading`,
`llm`.

The proposal at
[`docs/proposals/ASSIGN_IDS_EXTRACTION_EXPANSION.md`](docs/proposals/ASSIGN_IDS_EXTRACTION_EXPANSION.md)
has the full design rationale (including §2.5 which corrects a stale
claim in the issue body about `--llm-suggest` being short-circuited).

## Backward compatibility

- Cells that previously produced a slug continue to produce the
  **same** slug — extractor precedence is heading > bullet > numbered
  > bold > img_alt > prose; code-cell extractor only fires when
  `cell_type == "code"`.
- `--force` semantics are unchanged: regenerates only when the
  algorithm can produce a proposal; otherwise the existing id is left
  intact (the baseline rule from `handover-slide-format-redesign-clm.md`
  §2.3).
- Preserve marker (`!`) is unchanged.
- `--llm-suggest` fallback on hard refusals only fires when the flag
  is explicitly passed; default refusal behavior is preserved.

## Phase 5 (PythonCourses-side, after release)

After this PR merges and CLM cuts a release, PythonCourses bumps the
CLM pin and re-runs `clm slides assign-ids --accept-content-derived
slides/module_550_ml_azav/` to clear the 407 missing-ID warnings.
Tracked at `docs/claude/python-courses-revamp-handover.md` §2.

## PR-split alternative

The proposal recommended splitting into 3 PRs (1+2 / 3 / 4) since
Phase 4 has semantic changes to `--llm-suggest`. Bundled here for
review; happy to split before merge if the size is unwieldy.

## Test plan

- [x] `pytest tests/slides -q` → 540 passed (was 496; +44 new tests
      across prose, code-cell, sibling-asymmetry, and LLM-on-hard-refusal)
- [x] Full fast suite green (`pytest -q --ignore=tests/recordings`,
      exit 0; recordings flakes pre-existing, unrelated)
- [x] Pre-commit hooks (ruff lint + format, mypy, fast pytest) all pass
- [ ] Manual smoke against AZAV ML corpus once PC bumps the pin
      (Phase 5, post-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)