### PR TITLE
fix(dir-group): skip phantom source paths in recursive write registration (#103)

### DIFF
--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -182,6 +182,15 @@ class LocalOpsBackend(Backend, ABC):
                         continue
                     rel = out_file.relative_to(target_dir)
                     source_file = source_dir / rel
+                    # Without this guard, a recursive dir-group whose
+                    # target_dir overlaps the output root sweeps up files
+                    # written by other pipelines (notebooks, HTML, code)
+                    # and registers them under phantom source paths the
+                    # dir-group never produced — surfacing as "Multiple
+                    # writers" warnings that point at files that don't
+                    # exist on disk. See issue #103.
+                    if not source_file.exists():
+                        continue
                     self._record_dir_group_write(source=source_file, dest=out_file)
             else:
                 for item in source_dir.iterdir():

--- a/tests/infrastructure/backends/test_output_dedup_integration.py
+++ b/tests/infrastructure/backends/test_output_dedup_integration.py
@@ -284,6 +284,57 @@ class TestCopyDirGroupRegistry:
             assert conflicts[0].first_writer_source == src_a / "shared.txt"
             assert conflicts[0].last_writer_source == src_b / "shared.txt"
 
+    async def test_recursive_copy_ignores_pre_existing_output_files(self, tmp_path):
+        # Regression test for issue #103: a recursive dir-group whose
+        # output dir is shared with other pipelines (e.g. a top-level
+        # `div/toplevel/<course>` include whose target_dir overlaps the
+        # output root) must not register every pre-existing output file
+        # as if the dir-group had written it. The misattribution showed
+        # up as "Multiple writers" warnings naming a phantom source path
+        # under the dir-group that did not exist on disk.
+        from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
+
+        src_root = tmp_path / "src"
+        src_root.mkdir()
+        # Source dir contains only top-level static files — no Folien/
+        # or other subtree the slide pipeline writes to.
+        (src_root / "README.md").write_text("readme", encoding="utf-8")
+        (src_root / "setup.sh").write_text("#!/bin/sh", encoding="utf-8")
+
+        output_dir = tmp_path / "out"
+        target_dir = output_dir / "grp"
+        # Simulate output files written by another pipeline (e.g. the
+        # slide processor) before the dir-group copy runs.
+        (target_dir / "Folien" / "Notebooks" / "Recording").mkdir(parents=True)
+        phantom_output = target_dir / "Folien" / "Notebooks" / "Recording" / "lesson.ipynb"
+        phantom_output.write_text("from-slide-pipeline", encoding="utf-8")
+
+        copy_data = CopyDirGroupData(
+            name="grp",
+            source_dirs=(src_root,),
+            relative_paths=(Path("grp"),),
+            lang="en",
+            output_dir=output_dir,
+            recursive=True,
+        )
+
+        async with PytestLocalOpsBackend() as backend:
+            await backend.copy_dir_group_to_output(copy_data)
+
+            entries = backend.output_write_registry.entries
+            # The dir-group's own static files should be registered…
+            assert (target_dir / "README.md").resolve() in entries
+            assert (target_dir / "setup.sh").resolve() in entries
+            # …but the slide-pipeline output must NOT be re-registered
+            # under the dir-group with a phantom source path.
+            phantom_entry = backend.output_write_registry.get(phantom_output.resolve())
+            phantom_source = src_root / "Folien" / "Notebooks" / "Recording" / "lesson.ipynb"
+            if phantom_entry is not None:
+                # If the phantom output was registered at all, it must
+                # not be attributed to the nonexistent dir-group source.
+                assert phantom_entry.first_writer_source != phantom_source
+                assert phantom_entry.last_writer_source != phantom_source
+
     async def test_base_path_files_registered(self, tmp_path):
         from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
 


### PR DESCRIPTION
## Summary
- Fixes #103: `_register_dir_group_writes` no longer attributes pre-existing output files to a `<dir-group>` that did not produce them.
- Root cause: the recursive branch walked the *output* tree (`target_dir.rglob("*")`) and registered a synthetic `source_dir / rel` for every file it found, without verifying that the source actually existed. When `target_dir` overlapped the output root (e.g. a top-level `div/toplevel/<course>` recursive include), files written by other pipelines (notebooks/HTML/code) got misattributed to the dir-group at phantom source paths — producing "Multiple writers produced different content" warnings that pointed at files nobody had written.
- Fix: add `if not source_file.exists(): continue` in the recursive branch, mirroring the non-recursive branch's existing pattern. Walking the output tree is preserved so `shutil.copytree`'s `ignore_patterns` handling stays implicit.

## Test plan
- [x] New regression test `TestCopyDirGroupRegistry::test_recursive_copy_ignores_pre_existing_output_files` exercises the issue's repro: source dir contains only static files (`README.md`, `setup.sh`), a slide-pipeline output is pre-placed under `target_dir/Folien/Notebooks/Recording/lesson.ipynb`. After `copy_dir_group_to_output`, the static files are registered, but the phantom path under the dir-group must not carry the nonexistent dir-group source.
- [x] Test verified to fail without the fix and pass with it.
- [x] All 102 backend tests pass (`tests/infrastructure/backends/`).
- [x] All 60 registry/operations tests pass (`tests/core/test_output_write_registry.py` + `tests/core/operations/`).
- [x] Pre-commit fast suite (5367 tests) clean on the committed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)