### PR TITLE
feat(slides): add `clm slides sync` v1 — cross-language LLM sync for split decks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides sync` (v1, Phase 7 of the slide-format-redesign).**
+  New CLI for cross-language sync of split-format decks
+  (`<deck>.de.py` / `<deck>.en.py`). Walks the pair by `slide_id`,
+  asks the local Ollama LLM to propose any needed updates to the
+  target side, and emits a unified diff per cell. Memoizes the LLM
+  call via a new `SyncCache` SQLite table keyed by
+  `(de_hash, en_hash, prompt_version)` — re-runs against an unchanged
+  pair hit the cache and avoid LLM spend.
+
+  **Flags:** `--source-lang de|en` (required; tells the judge which
+  side was edited), `--dry-run` (default and only mode in v1 — no
+  files are written), `--llm-model`, `--ollama-url`, `--llm-timeout`,
+  `--cache-dir`, `--no-cache`, `--json`. Exit codes: `0` clean,
+  `1` proposed updates pending review, `2` structural error
+  (mismatch or LLM unavailable).
+
+  **Roles synced:** markdown `slide` / `subslide` and narrative
+  `voiceover` / `notes` cells. Shared code cells are intentionally
+  excluded — split companions must keep them byte-identical, and
+  that consistency is checked by the Phase-6 validator.
+
+  **What's deferred to v2:** `--interactive` apply/skip/edit walker,
+  `--apply --trivial` write-without-prompting path, direction
+  auto-detection via cache/git, 3-way merge UX for "both sides
+  drifted" cells. The pilot instrumentation (per-session counters
+  `pairs_visited` / `pairs_in_sync` / `pairs_proposed` /
+  `pairs_error` / `cache_hits`) is wired in v1 so the eventual
+  PythonCourses Phase D pilot can measure the >80% accept-rate
+  ship/cancel criterion as soon as `--interactive` lands.
+
 - **`clm slides assign-ids` extraction expansion ([#89](https://github.com/hoelzl/clm/issues/89)).**
   Four additive changes that clear the bulk of `assign-ids` hard refusals
   on slide corpora dominated by prose subslides and code-cell slide

--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -20,7 +20,7 @@ checked into the CLM repo.
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
 | 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **Shipped** (CLM phases 1–4); issue #89 closed; P5 = PC-side corpus rerun, pending CLM release | [PR #101](https://github.com/hoelzl/clm/pull/101) merged 2026-05-19, master commit `c820fb8` |
-| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | Not started | — |
+| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 implemented** (--dry-run only); interactive walker + --apply --trivial deferred to v2 | branch `claude/slide-format-redesign-phase-7` (PR pending) |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |
 
@@ -88,9 +88,11 @@ language file to its companion (e.g. after editing `<deck>.de.py`,
 propose corresponding edits to `<deck>.en.py`), backed by an LLM call
 gated by a `SyncCache` table on `(de_hash, en_hash, prompt_version)`.
 
-**Status:** Designed in the PythonCourses-side
-`handover-slide-format-redesign-clm.md` §3 Phase 7. No CLM-side design
-doc yet; the PC handover is currently the canonical spec.
+**Status:** v1 implemented on branch
+`claude/slide-format-redesign-phase-7`. The PythonCourses-side
+`handover-slide-format-redesign-clm.md` §3 Phase 7 is still the
+canonical spec for the full feature; this section tracks what v1
+shipped versus what's deferred.
 
 ### Spec summary (from PC handover §3, repeated in the proposal)
 
@@ -103,23 +105,45 @@ doc yet; the PC handover is currently the canonical spec.
 - New `src/clm/slides/sync.py`.
 - New `src/clm/infrastructure/llm/sync_prompts.py`.
 - Extend `src/clm/infrastructure/llm/cache.py` with a `SyncCache` class reusing the same SQLite file as `CoverageCache` (separate table).
-- Register `sync` subcommand in `src/clm/cli/slides_cmd.py`.
-- Tests: `tests/infrastructure/llm/test_sync_cache.py`, `tests/slides/test_sync.py`.
+- Register `sync` subcommand under `slides_group` in `src/clm/cli/main.py` via a new `src/clm/cli/commands/slides_sync.py`.
+- Tests: `tests/infrastructure/llm/test_sync_cache.py`, `tests/slides/test_sync.py`, `tests/cli/test_slides_sync.py`.
 
-### Decisions to make at kickoff
+### Decisions made at kickoff
 
-- **3-way merge handling** (both DE and EN changed since last sync). PC handover's open UX question. **Recommendation from the PC proposal:** flag-and-defer-to-manual is acceptable for v1; LLM-suggested merge can follow as v2 once pilot data shows the rate.
-- **Pilot instrumentation.** PC proposal requests per-session accept / skip / edit counts logged to the cache (or stderr) so the pilot's "human accepts proposed diff as-is in >80% of cases" decision criterion can be measured. Build this into v1 — without it the Phase E ship/cancel decision has no data.
+- **`--source-lang` is REQUIRED in v1.** No auto-detection from git
+  history yet; the user explicitly tells us which side was edited.
+  Auto-detection is on the v2 list.
+- **3-way merge handling — flag-and-defer-to-manual.** When both DE
+  and EN halves drift from the cached snapshot, v1 surfaces a
+  structural-issue error rather than asking the LLM to merge. v2
+  may add LLM-suggested merge once pilot data shows how often this
+  case fires.
+- **Pilot instrumentation present in v1.** `SyncResult` exposes
+  per-session counters (`pairs_visited`, `pairs_in_sync`,
+  `pairs_proposed`, `pairs_error`, `cache_hits`). Accept/skip/edit
+  counters will be added in v2 alongside the `--interactive` walker.
+- **Roles synced: markdown slide/subslide + voiceover/notes.** Code
+  cells are intentionally excluded — they're shared by design across
+  split companions, and the Phase-6 validator enforces byte-equality.
+- **SyncCache row stores `(direction, proposal_json)`.** The
+  direction is stored *in the value* so a single (de_hash, en_hash)
+  pair can produce different proposals depending on which side was
+  edited. When `--source-lang` flips, the cached entry is bypassed
+  (cache only honors entries matching the requested direction).
+- **Cell-pairing strategy: `(slide_id, role)`-keyed source-order
+  zip.** Multiple cells per slide_id+role pair up positionally. Count
+  mismatches surface as structural-issue errors; one-sided slide_ids
+  surface as warnings.
 
 ### Phase tracker
 
-- [ ] Scaffold `clm.slides.sync` module + `SyncCache` table (schema v9).
-- [ ] LLM prompt scaffolding (`sync_prompts.py`) + `--dry-run` diff producer.
-- [ ] `--interactive` apply/skip/edit walker.
-- [ ] `--apply --trivial` path.
-- [ ] Pilot instrumentation (per-session counters).
-- [ ] CLI registration + `clm info commands` update.
-- [ ] Tests (cache + sync logic + CLI smoke).
+- [x] Scaffold `clm.slides.sync` module + `SyncCache` table.
+- [x] LLM prompt scaffolding (`sync_prompts.py`) + `--dry-run` diff producer.
+- [ ] `--interactive` apply/skip/edit walker. *(v2)*
+- [ ] `--apply --trivial` path. *(v2)*
+- [x] Pilot instrumentation (per-session counters).
+- [x] CLI registration + `clm info commands` update.
+- [x] Tests (cache + sync logic + CLI smoke).
 
 ### Branch convention
 
@@ -244,7 +268,43 @@ before CLM can proceed, file it as a comment on the corresponding issue
   produces a title, `--force` regenerates as expected — consistent
   with the EXTRACTABLE-with-force path.
 
-## 10. Decisions Recorded — Priority 3 fix (2026-05-20)
+## 10. Decisions Recorded — Priority 2 v1 implementation (2026-05-20)
+
+- **SyncProposal has an explicit `verdict` field**
+  (`"in_sync"` / `"update"`). Earlier draft used "empty proposed_text
+  means in_sync"; that was fragile against whitespace and LLM
+  formatting quirks. The prompt is explicit and the parser tolerates
+  legacy responses by inferring the verdict from text emptiness.
+- **`SyncCache` value stores direction.** Including direction in the
+  *value* (not the key) means a single (de_hash, en_hash) pair has
+  one cached proposal at a time, but the cache transparently
+  bypasses a stale entry when `--source-lang` flips mid-session
+  (cache returns the proposal only when the cached direction
+  matches the requested one).
+- **No "in_sync" shortcut without LLM.** Hash equality alone can't
+  tell us if DE and EN content are semantically aligned (they have
+  different surface forms by design). Every first-time pair fires
+  the LLM. The cache makes steady-state re-runs free.
+- **Code cells excluded from sync entirely.** Split format keeps
+  code cells byte-identical across DE/EN companions (Phase-6
+  validator enforces this). Re-running sync on them would be wasted
+  LLM spend.
+- **Roles walked: slide / subslide / voiceover / notes.** Other
+  markdown roles (e.g. raw j2 cells, title macros) are excluded.
+- **Pairing is `(slide_id, role)`-keyed source-order zip.** Multiple
+  cells per role within one slide_id (e.g. two voiceover cells for a
+  long slide) pair up positionally. Count mismatches surface as
+  errors — no fuzzy/best-effort matching in v1.
+- **CLI command file is named `slides_sync.py`** (not `sync.py`) to
+  disambiguate from `clm.cli.commands.sync_includes` and from
+  `clm.slides.sync` (the engine module).
+- **Lazy import of `sync_prompts` inside `OllamaSyncJudge.propose`**
+  to avoid a top-level circular reference (the prompt module
+  imports nothing from `ollama_client` directly, but the
+  `prompt_version` constant is referenced symbolically in both
+  places via the protocol's `prompt_version` attribute).
+
+## 11. Decisions Recorded — Priority 3 fix (2026-05-20)
 
 - **Priority 3 fix kept narrow.** Only extended the slide-parser-side
   `workshop_scope.find_workshop_ranges`, not the nbformat-side

--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -20,7 +20,7 @@ checked into the CLM repo.
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
 | 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **Shipped** (CLM phases 1–4); issue #89 closed; P5 = PC-side corpus rerun, pending CLM release | [PR #101](https://github.com/hoelzl/clm/pull/101) merged 2026-05-19, master commit `c820fb8` |
-| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 implemented** (--dry-run only); interactive walker + --apply --trivial deferred to v2 | branch `claude/slide-format-redesign-phase-7` (PR pending) |
+| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 in [PR #105](https://github.com/hoelzl/clm/pull/105)** (--dry-run only); interactive walker + --apply --trivial deferred to v2 | branch `claude/slide-format-redesign-phase-7`, commit `d09eb80` |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |
 

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -1,0 +1,259 @@
+"""``clm slides sync`` — Phase 7 of the slide-format-redesign.
+
+Cross-language sync helper for split-format decks (``<deck>.de.py`` /
+``<deck>.en.py``). After an author edits one side, this command walks
+the pair by ``slide_id``, asks the local LLM to propose updates to the
+other side, and prints a unified diff per cell.
+
+For v1 only ``--dry-run`` is supported (the default and only mode):
+the command is read-only and writes nothing. Interactive
+apply/skip/edit and ``--apply --trivial`` modes are planned follow-ups.
+
+Exit codes:
+
+- ``0`` — no proposed updates and no errors
+- ``1`` — at least one proposed update (author should review)
+- ``2`` — at least one structural error (mismatch / LLM unavailable)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.infrastructure.llm.cache import SyncCache, resolve_cache_dir
+from clm.infrastructure.llm.ollama_client import (
+    DEFAULT_SYNC_MODEL,
+    OllamaSyncJudge,
+    is_available,
+)
+from clm.slides.sync import SyncOptions, SyncResult, sync_split_pair
+
+CACHE_DB_NAME = "clm-llm.sqlite"
+
+
+@click.command("sync")
+@click.argument(
+    "de_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.argument(
+    "en_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--source-lang",
+    type=click.Choice(["de", "en"]),
+    required=True,
+    help=(
+        "Language that was edited; updates are proposed for the other "
+        "side. Required in v1 (no auto-detection yet)."
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=True,
+    help=(
+        "Show proposed diffs without modifying any file. The default "
+        "and only supported mode in v1 — --interactive and "
+        "--apply --trivial are planned follow-ups."
+    ),
+)
+@click.option(
+    "--llm-model",
+    default=DEFAULT_SYNC_MODEL,
+    show_default=True,
+    help="Ollama model used for the sync judge.",
+)
+@click.option(
+    "--ollama-url",
+    default=None,
+    help="Base URL of the Ollama daemon. Defaults to $OLLAMA_URL or http://localhost:11434.",
+)
+@click.option(
+    "--llm-timeout",
+    type=float,
+    default=120.0,
+    show_default=True,
+    help="Per-call timeout (seconds) for the sync judge.",
+)
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Directory for the LLM cache (default: --cache-dir > $CLM_CACHE_DIR > "
+        "tool.clm.cache_dir in pyproject.toml > <cwd>/.clm-cache/)."
+    ),
+)
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    help=(
+        "Skip cache reads and writes. Useful when iterating on the "
+        "prompt or model — every run fires fresh LLM calls."
+    ),
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def slides_sync_cmd(
+    de_path: Path,
+    en_path: Path,
+    source_lang: str,
+    dry_run: bool,
+    llm_model: str,
+    ollama_url: str | None,
+    llm_timeout: float,
+    cache_dir: Path | None,
+    no_cache: bool,
+    as_json: bool,
+) -> None:
+    """Propose cross-language sync edits for a split DE/EN deck pair.
+
+    DE_PATH and EN_PATH must be the two halves of a split-format deck
+    (``<deck>.de.py`` and ``<deck>.en.py``).
+
+    \b
+    Behavior in v1:
+      * Walks the pair by slide_id (assign-ids must have run first).
+      * For each paired cell, asks the local LLM to propose any needed
+        update to the target side.
+      * Emits a unified diff per proposed update.
+      * Memoizes LLM calls via the SyncCache; unchanged pairs cache-hit.
+      * Reports structural mismatches (cells present on one side only,
+        or unequal counts within a slide_id) as warnings/errors.
+    """
+    # Direction-of-edit is required so the LLM knows which side is the
+    # source of truth. Auto-detection via git history is on the v2 list.
+    judge = OllamaSyncJudge(
+        model=llm_model,
+        base_url=ollama_url,
+        timeout=llm_timeout,
+    )
+    if not is_available(judge):
+        click.echo(
+            f"warning: Ollama is not reachable at {judge.base_url}; "
+            "every pair will be recorded as an LLM-unavailable error.",
+            err=True,
+        )
+        judge_for_options = None
+    else:
+        judge_for_options = judge
+
+    cache: SyncCache | None = None
+    if not no_cache:
+        cache_root = resolve_cache_dir(cli_override=cache_dir)
+        cache = SyncCache(cache_root / CACHE_DB_NAME)
+
+    options = SyncOptions(
+        source_lang=source_lang,
+        judge=judge_for_options,
+        cache=cache,
+    )
+
+    try:
+        result = sync_split_pair(de_path, en_path, options)
+    finally:
+        if cache is not None:
+            cache.close()
+
+    if as_json:
+        click.echo(json.dumps(_to_dict(result), indent=2))
+    else:
+        _print_human(result, dry_run=dry_run)
+
+    sys.exit(_exit_code(result))
+
+
+def _print_human(result: SyncResult, *, dry_run: bool) -> None:
+    prefix = "[dry-run] " if dry_run else ""
+
+    for issue in result.issues:
+        click.echo(
+            f"issue-{issue.severity} {issue.slide_id} "
+            f"(de={issue.de_count}, en={issue.en_count}): {issue.reason}"
+        )
+
+    for outcome in result.outcomes:
+        if outcome.verdict == "in_sync":
+            cached_tag = " (cached)" if outcome.cached else ""
+            click.echo(
+                f"{prefix}in-sync {outcome.slide_id}/{outcome.role} "
+                f"de:{outcome.de_line} en:{outcome.en_line}{cached_tag}"
+                + (f" — {outcome.reason}" if outcome.reason else "")
+            )
+        elif outcome.verdict == "update":
+            cached_tag = " (cached)" if outcome.cached else ""
+            click.echo(
+                f"{prefix}propose {outcome.slide_id}/{outcome.role} "
+                f"({outcome.direction}) de:{outcome.de_line} "
+                f"en:{outcome.en_line}{cached_tag}"
+                + (f" — {outcome.reason}" if outcome.reason else "")
+            )
+            if outcome.diff:
+                click.echo(outcome.diff)
+                click.echo()
+        elif outcome.verdict == "error":
+            click.echo(
+                f"error {outcome.slide_id}/{outcome.role} "
+                f"de:{outcome.de_line} en:{outcome.en_line}: {outcome.error}"
+            )
+
+    click.echo()
+    click.echo(
+        f"{prefix}{result.pairs_visited} pair(s) visited, "
+        f"{result.pairs_in_sync} in sync, "
+        f"{result.pairs_proposed} proposed update(s), "
+        f"{result.pairs_error} error(s), "
+        f"{result.cache_hits} cache hit(s), "
+        f"{len(result.issues)} structural issue(s)."
+    )
+
+
+def _to_dict(result: SyncResult) -> dict:
+    return {
+        "de_path": str(result.de_path),
+        "en_path": str(result.en_path),
+        "pairs_visited": result.pairs_visited,
+        "pairs_in_sync": result.pairs_in_sync,
+        "pairs_proposed": result.pairs_proposed,
+        "pairs_error": result.pairs_error,
+        "cache_hits": result.cache_hits,
+        "outcomes": [
+            {
+                "slide_id": o.slide_id,
+                "role": o.role,
+                "de_line": o.de_line,
+                "en_line": o.en_line,
+                "direction": o.direction,
+                "verdict": o.verdict,
+                "reason": o.reason,
+                "cached": o.cached,
+                "diff": o.diff,
+                "error": o.error,
+                "proposed_text": (o.proposal.proposed_text if o.proposal is not None else ""),
+            }
+            for o in result.outcomes
+        ],
+        "issues": [
+            {
+                "slide_id": i.slide_id,
+                "severity": i.severity,
+                "reason": i.reason,
+                "de_count": i.de_count,
+                "en_count": i.en_count,
+            }
+            for i in result.issues
+        ],
+    }
+
+
+def _exit_code(result: SyncResult) -> int:
+    if result.has_errors or any(i.severity == "error" for i in result.issues):
+        return 2
+    if result.has_proposals:
+        return 1
+    return 0

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -633,6 +633,80 @@ clm slides assign-ids slides/module_010/topic_100/slides_intro.py --llm-suggest
 clm slides assign-ids slides/module_010/ --force        # regenerate all derivable ids
 ```
 
+### `clm slides sync`
+
+*Added in CLM {version}.*
+
+Cross-language sync helper for split-format decks
+(`<deck>.de.py` / `<deck>.en.py`, the layout produced by
+`clm slides split`). After an author edits one half of a pair, this
+command walks the two files by `slide_id`, asks the local LLM
+(Ollama) to propose any needed update to the other side, and prints
+a unified diff per cell.
+
+The LLM call is memoized in a `SyncCache` table keyed by
+`(de_hash, en_hash, prompt_version)` — re-runs against an unchanged
+pair short-circuit to the cached proposal and avoid LLM spend. The
+cache lives in the same SQLite file as the `assign-ids` and
+`coverage` caches.
+
+**v1 scope:** the only mode is `--dry-run` (the default — no files
+are modified). `--interactive` (apply/skip/edit walker) and
+`--apply --trivial` (mechanical changes only) are planned follow-ups.
+Direction-of-edit must be passed explicitly via `--source-lang` in
+v1 (auto-detection from git history is on the v2 list).
+
+Cells synced: markdown `slide` / `subslide` cells and narrative
+`voiceover` / `notes` cells. Shared code cells are intentionally
+excluded — split companions must keep them byte-identical, and that
+consistency is enforced by the Phase-6 split-source validator
+instead. Cells without a `slide_id` are skipped silently (run
+`clm slides assign-ids` first).
+
+```
+clm slides sync [OPTIONS] DE_PATH EN_PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source-lang de\|en` | **Required.** Language that was edited; updates are proposed for the other side. |
+| `--dry-run` | Show proposed diffs without modifying any file. Default and only mode in v1. |
+| `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
+| `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
+| `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B local model can exceed 60s). |
+| `--cache-dir PATH` | Directory for the SyncCache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
+| `--no-cache` | Skip cache reads and writes (useful when iterating on the prompt or model). |
+| `--json` | Emit a JSON report instead of human-readable lines. |
+
+Exit codes: `0` clean (no proposed updates and no errors), `1` at
+least one proposed update for author review, `2` at least one
+structural error (slide_id count mismatch or LLM unavailable).
+
+A run also surfaces structural issues for slide_ids that cannot be
+paired cleanly: cells present on one side but not the other
+(severity `warning`) and slide_ids with unequal cell counts on the
+two sides (severity `error` — manual pairing needed).
+
+Pilot instrumentation: every run records per-session counters
+(`pairs_visited`, `pairs_in_sync`, `pairs_proposed`, `pairs_error`,
+`cache_hits`) so the PythonCourses Phase D pilot can quote a real
+proposal rate. Once `--interactive` lands, accept / skip / edit
+counters will be added to drive the >80%-accept ship/cancel
+criterion.
+
+Examples:
+
+```bash
+# After editing the DE deck, see what should change on the EN side.
+clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py --source-lang de
+
+# Same, JSON output for tooling.
+clm slides sync intro.de.py intro.en.py --source-lang de --json
+
+# Iterating on the prompt — skip the cache to fire fresh LLM calls every time.
+clm slides sync intro.de.py intro.en.py --source-lang de --no-cache
+```
+
 ### `clm slides coverage`
 
 *Added in CLM {version}.*

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -90,6 +90,7 @@ from clm.cli.commands.normalize_slides import normalize_slides_cmd  # noqa: E402
 from clm.cli.commands.outline import outline  # noqa: E402
 from clm.cli.commands.resolve_topic import resolve_topic_cmd  # noqa: E402
 from clm.cli.commands.search_slides import search_slides_cmd  # noqa: E402
+from clm.cli.commands.slides_sync import slides_sync_cmd  # noqa: E402
 from clm.cli.commands.split import split_cmd  # noqa: E402
 from clm.cli.commands.status import status  # noqa: E402
 from clm.cli.commands.suggest_sync import suggest_sync_cmd  # noqa: E402
@@ -154,6 +155,7 @@ slides_group.add_command(split_cmd, name="split")
 slides_group.add_command(unify_cmd, name="unify")
 slides_group.add_command(language_view_cmd, name="language-view")
 slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
+slides_group.add_command(slides_sync_cmd, name="sync")
 slides_group.add_command(search_slides_cmd, name="search")
 cli.add_command(slides_group)
 

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -265,6 +265,114 @@ class CoverageCache:
         self._conn.close()
 
 
+class SyncCache:
+    """Cache LLM-proposed cross-language sync edits.
+
+    Keyed by ``(de_hash, en_hash, prompt_version)`` per Phase 7 of the
+    slide-format-redesign. A row represents *"the LLM was asked to
+    propose an edit for this specific pair of DE/EN cell content, and
+    here is what it said"*. Re-runs against the same pair short-circuit
+    to the cached proposal so re-invocations of ``clm slides sync`` do
+    not respend on the LLM.
+
+    ``direction`` is ``"de->en"`` when the proposal updates the EN cell
+    from the DE cell's content, or ``"en->de"`` for the mirror. Stored
+    in the value (not the key) because the algorithm decides direction
+    once per pair before firing the LLM.
+
+    ``proposal`` is the LLM's verbatim suggestion (typically the full
+    replacement body of the target cell). For the *in-sync* case
+    (algorithm determined no edit needed without firing the LLM), the
+    cache is not consulted — there is nothing to memoize.
+
+    Shares the same SQLite file as :class:`SummaryCache`,
+    :class:`TitleSuggestionCache`, and :class:`CoverageCache` (the
+    consuming repo's ``clm-llm.sqlite``) but lives in its own table.
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._conn = sqlite3.connect(str(db_path))
+        self._migrate()
+
+    def _migrate(self) -> None:
+        cursor = self._conn.execute("PRAGMA table_info(sync_proposals)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if not columns:
+            self._conn.execute(
+                """CREATE TABLE sync_proposals (
+                    de_hash         TEXT NOT NULL,
+                    en_hash         TEXT NOT NULL,
+                    prompt_version  TEXT NOT NULL,
+                    direction       TEXT NOT NULL,
+                    proposal        TEXT NOT NULL,
+                    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (de_hash, en_hash, prompt_version)
+                )"""
+            )
+            self._conn.commit()
+
+    def get(
+        self,
+        de_hash: str,
+        en_hash: str,
+        prompt_version: str,
+    ) -> tuple[str, str] | None:
+        """Return ``(direction, proposal)`` or ``None`` on a miss."""
+        row = self._conn.execute(
+            "SELECT direction, proposal FROM sync_proposals "
+            "WHERE de_hash=? AND en_hash=? AND prompt_version=?",
+            (de_hash, en_hash, prompt_version),
+        ).fetchone()
+        if row is None:
+            return None
+        return (row[0], row[1])
+
+    def put(
+        self,
+        de_hash: str,
+        en_hash: str,
+        prompt_version: str,
+        direction: str,
+        proposal: str,
+    ) -> None:
+        if direction not in ("de->en", "en->de"):
+            raise ValueError(f"direction must be 'de->en' or 'en->de', got {direction!r}")
+        self._conn.execute(
+            """INSERT OR REPLACE INTO sync_proposals
+               (de_hash, en_hash, prompt_version, direction, proposal)
+               VALUES (?, ?, ?, ?, ?)""",
+            (de_hash, en_hash, prompt_version, direction, proposal),
+        )
+        self._conn.commit()
+
+    def invalidate_prompt_version(self, prompt_version: str) -> int:
+        """Delete entries whose prompt version no longer matches."""
+        cursor = self._conn.execute(
+            "DELETE FROM sync_proposals WHERE prompt_version!=?",
+            (prompt_version,),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def iter_entries(self) -> list[tuple[str, str, str, str, str, str]]:
+        """Return every cached entry for a future ``sync --dump``.
+
+        Tuples are ``(de_hash, en_hash, prompt_version, direction,
+        proposal, created_at)`` ordered by creation time so the most
+        recent proposals surface first.
+        """
+        rows = self._conn.execute(
+            "SELECT de_hash, en_hash, prompt_version, direction, "
+            "proposal, created_at "
+            "FROM sync_proposals ORDER BY created_at DESC, de_hash"
+        ).fetchall()
+        return [(r[0], r[1], r[2], r[3], r[4], r[5]) for r in rows]
+
+    def close(self) -> None:
+        self._conn.close()
+
+
 def resolve_cache_dir(
     *,
     cli_override: Path | None = None,

--- a/src/clm/infrastructure/llm/ollama_client.py
+++ b/src/clm/infrastructure/llm/ollama_client.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_OLLAMA_URL = "http://localhost:11434"
 DEFAULT_TITLE_MODEL = "qwen3:30b"
 DEFAULT_COVERAGE_MODEL = "qwen3:30b"
+DEFAULT_SYNC_MODEL = "qwen3:30b"
 # Cold-load on large local models can take a minute; warm calls are ~5s.
 DEFAULT_TIMEOUT_SECONDS = 120.0
 
@@ -180,13 +181,17 @@ def is_available(client: object | None) -> bool:
     """Whether ``client`` looks ready to respond to LLM calls.
 
     A best-effort liveness check for the real Ollama clients
-    (:class:`OllamaTitleSuggester`, :class:`OllamaCoverageJudge`); fakes
-    and any other implementation are assumed available. The check pings
-    ``/api/tags`` rather than firing a full generation request.
+    (:class:`OllamaTitleSuggester`, :class:`OllamaCoverageJudge`,
+    :class:`OllamaSyncJudge`); fakes and any other implementation are
+    assumed available. The check pings ``/api/tags`` rather than firing
+    a full generation request.
     """
     if client is None:
         return False
-    if not isinstance(client, OllamaTitleSuggester | OllamaCoverageJudge):
+    if not isinstance(
+        client,
+        OllamaTitleSuggester | OllamaCoverageJudge | OllamaSyncJudge,
+    ):
         return True
     try:
         req = urllib.request.Request(f"{client.base_url}/api/tags")  # noqa: S310
@@ -446,3 +451,261 @@ def parse_coverage_response(text: str, bullets: list[str]) -> CoverageVerdict:
         verdict = "covered" if all(b.covered for b in parsed) else "gaps"
 
     return CoverageVerdict(verdict=verdict, bullets=tuple(parsed), raw=text)
+
+
+# ---------------------------------------------------------------------------
+# Sync judge (Phase 7 of the slide-format-redesign)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SyncProposal:
+    """The LLM's verdict + (when an update is needed) the proposed text.
+
+    ``verdict`` is ``"in_sync"`` when the target cell already adequately
+    reflects the source cell (no edit needed) or ``"update"`` when the
+    target should be replaced by ``proposed_text``. For the
+    ``"in_sync"`` case, ``proposed_text`` echoes the current target —
+    callers compare it against the live cell to confirm no diff.
+
+    ``reason`` is a one-line LLM explanation for diagnostics / report
+    output. ``raw`` is the verbatim model response retained for
+    debugging.
+    """
+
+    verdict: str
+    proposed_text: str
+    reason: str = ""
+    raw: str = ""
+
+    @property
+    def needs_update(self) -> bool:
+        return self.verdict == "update"
+
+    def to_json(self) -> str:
+        """Serialize for storage in the cache."""
+        return json.dumps(
+            {
+                "verdict": self.verdict,
+                "proposed_text": self.proposed_text,
+                "reason": self.reason,
+            },
+            ensure_ascii=False,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> SyncProposal:
+        data = json.loads(payload)
+        verdict = data.get("verdict")
+        if verdict not in ("in_sync", "update"):
+            verdict = "update" if data.get("proposed_text") else "in_sync"
+        return cls(
+            verdict=str(verdict),
+            proposed_text=str(data.get("proposed_text", "")),
+            reason=str(data.get("reason", "")),
+        )
+
+
+class SyncJudge(Protocol):
+    """Protocol for anything that can propose a cross-language sync edit.
+
+    Real implementation: :class:`OllamaSyncJudge`. Tests pass a
+    :class:`StaticSyncJudge` so the pair-walker and diff producer can be
+    exercised without a running Ollama daemon.
+    """
+
+    prompt_version: str
+
+    def propose(
+        self,
+        source_text: str,
+        target_text: str,
+        *,
+        source_lang: str,
+        target_lang: str,
+    ) -> SyncProposal:
+        """Propose a target-cell body that reflects edits made on the source side.
+
+        Raises :class:`OllamaError` (or a protocol-specific equivalent)
+        on failure. Callers treat exceptions as "skip this pair with a
+        warning", not as fatal.
+        """
+        ...
+
+
+class StaticSyncJudge:
+    """In-memory :class:`SyncJudge` for tests and bulk scripts.
+
+    Supply a ``mapping`` keyed by a stable string (typically the
+    :func:`sync_key` of the request) to a :class:`SyncProposal`. Misses
+    raise :class:`OllamaError` so the caller falls back to "could not
+    propose". A ``default_proposal`` may be supplied for the "I don't
+    care, just give me *something*" case used by bulk scripts.
+    """
+
+    def __init__(
+        self,
+        mapping: dict[str, SyncProposal] | None = None,
+        *,
+        default_proposal: SyncProposal | None = None,
+        prompt_version: str | None = None,
+    ):
+        # Imported here to avoid a top-level circular import (sync_prompts
+        # eventually imports from this module for the user-prompt builder
+        # signature). The constant has no runtime cost beyond a lookup.
+        from clm.infrastructure.llm.sync_prompts import SYNC_PROMPT_VERSION
+
+        self._mapping = dict(mapping or {})
+        self._default_proposal = default_proposal
+        self.prompt_version = prompt_version or SYNC_PROMPT_VERSION
+        self.calls: list[tuple[str, str, str, str]] = []
+
+    def propose(
+        self,
+        source_text: str,
+        target_text: str,
+        *,
+        source_lang: str,
+        target_lang: str,
+    ) -> SyncProposal:
+        key = sync_key(
+            source_text,
+            target_text,
+            source_lang=source_lang,
+            target_lang=target_lang,
+        )
+        self.calls.append((source_text, target_text, source_lang, target_lang))
+        if key in self._mapping:
+            return self._mapping[key]
+        if self._default_proposal is not None:
+            return self._default_proposal
+        raise OllamaError("no static sync proposal configured for this pair")
+
+
+def sync_key(
+    source_text: str,
+    target_text: str,
+    *,
+    source_lang: str,
+    target_lang: str,
+) -> str:
+    """Stable key used by :class:`StaticSyncJudge` lookups and test asserts."""
+    return f"{source_lang}->{target_lang}\n---\n{source_text}\n---\n{target_text}"
+
+
+class OllamaSyncJudge:
+    """:class:`SyncJudge` that talks to a local Ollama daemon."""
+
+    def __init__(
+        self,
+        *,
+        model: str = DEFAULT_SYNC_MODEL,
+        base_url: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ):
+        # Lazy import keeps the prompt module decoupled from this file's
+        # other clients and lets prompt-only consumers import without
+        # paying for urllib.
+        from clm.infrastructure.llm.sync_prompts import SYNC_PROMPT_VERSION
+
+        self.prompt_version = SYNC_PROMPT_VERSION
+        self.model = model
+        self.base_url = (base_url or os.environ.get("OLLAMA_URL") or DEFAULT_OLLAMA_URL).rstrip("/")
+        self.timeout = timeout
+
+    def propose(
+        self,
+        source_text: str,
+        target_text: str,
+        *,
+        source_lang: str,
+        target_lang: str,
+    ) -> SyncProposal:
+        from clm.infrastructure.llm.sync_prompts import (
+            SYNC_SYSTEM_PROMPT,
+            build_sync_user_prompt,
+        )
+
+        user_prompt = build_sync_user_prompt(
+            source_text=source_text,
+            target_text=target_text,
+            source_lang=source_lang,
+            target_lang=target_lang,
+        )
+        payload = {
+            "model": self.model,
+            "stream": False,
+            "format": "json",
+            "messages": [
+                {"role": "system", "content": SYNC_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            "options": {"temperature": 0.2},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(  # noqa: S310 — localhost only
+            f"{self.base_url}/api/chat",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
+                raw = resp.read().decode("utf-8")
+        except urllib.error.URLError as exc:
+            raise OllamaError(f"Ollama request failed: {exc}") from exc
+        except TimeoutError as exc:
+            raise OllamaError(f"Ollama request timed out after {self.timeout}s") from exc
+
+        try:
+            response = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise OllamaError(f"Ollama returned non-JSON response: {raw[:200]!r}") from exc
+
+        message = response.get("message") or {}
+        text = (message.get("content") or "").strip()
+        if not text:
+            raise OllamaError("Ollama returned empty sync proposal")
+        return parse_sync_response(text)
+
+
+def parse_sync_response(text: str) -> SyncProposal:
+    """Parse the judge's raw response into a :class:`SyncProposal`.
+
+    Tolerates leading/trailing prose around the JSON body (some local
+    models tack on a one-line preamble despite the system prompt) by
+    locating the first ``{`` and the last ``}``.
+    """
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:]
+        cleaned = cleaned.strip()
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise OllamaError(f"could not locate JSON object in sync response: {text[:200]!r}")
+    body = cleaned[start : end + 1]
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise OllamaError(f"sync response is not valid JSON: {exc}") from exc
+
+    proposed_text = data.get("proposed_text")
+    if not isinstance(proposed_text, str):
+        raise OllamaError("sync response missing 'proposed_text' string")
+
+    verdict = data.get("verdict")
+    if verdict not in ("in_sync", "update"):
+        # Tolerate models that omit the verdict but supply a clear
+        # proposed_text — default to "update" when text is non-empty,
+        # "in_sync" otherwise.
+        verdict = "update" if proposed_text.strip() else "in_sync"
+
+    reason = data.get("reason")
+    return SyncProposal(
+        verdict=verdict,
+        proposed_text=proposed_text,
+        reason=str(reason) if isinstance(reason, str) else "",
+        raw=text,
+    )

--- a/src/clm/infrastructure/llm/sync_prompts.py
+++ b/src/clm/infrastructure/llm/sync_prompts.py
@@ -1,0 +1,80 @@
+"""Prompt templates for the cross-language sync judge.
+
+Used by :class:`clm.infrastructure.llm.ollama_client.OllamaSyncJudge`
+(Phase 7 of the slide-format-redesign). The judge is asked to propose
+an updated version of one half of a DE/EN pair when its sibling has
+drifted. The system + user prompts here are deliberately kept in a
+separate module so the version constant can be bumped without
+touching the client.
+
+Bump :data:`SYNC_PROMPT_VERSION` whenever the system message or the
+user-prompt format changes in a way that invalidates cached
+proposals — the cache key embeds this version (see ``SyncCache`` in
+``cache.py``).
+"""
+
+from __future__ import annotations
+
+# Embedded in the SyncCache key. Bump on prompt-shape changes.
+SYNC_PROMPT_VERSION = "v1"
+
+SYNC_SYSTEM_PROMPT = (
+    "You help instructors keep bilingual course slides in sync. The DE "
+    "(German) and EN (English) versions of one slide cell have "
+    "potentially drifted apart. You will be given the *source* cell "
+    "(the side that was edited) and the *target* cell (the side that "
+    "needs to catch up). Decide whether the target cell already "
+    "adequately reflects the source cell, or whether it needs to be "
+    "updated.\n\n"
+    "If an update is needed, propose a revised target-cell body that:\n"
+    "  - reflects the meaning of the source cell,\n"
+    "  - reads idiomatically in the target language (idiomatic English "
+    "when the target is EN; idiomatic German when the target is DE),\n"
+    "  - preserves the markdown / cell structure of the original target "
+    "(headings, bullets, code blocks, image tags, line breaks),\n"
+    "  - leaves identifiers, code snippets, URLs, file paths, "
+    "slide_id values, and other technical strings unchanged,\n"
+    "  - does NOT add explanations, framing, or commentary that wasn't "
+    "in the source cell.\n\n"
+    "Reply with a single JSON object and no other text. The object has "
+    "three keys:\n"
+    '  "verdict": either "in_sync" (target already adequately reflects '
+    'source, no edit needed) or "update" (target should be replaced '
+    "by proposed_text).\n"
+    '  "proposed_text": when verdict is "update", the full replacement '
+    "body of the target cell, verbatim, with the same line-breaks as a "
+    'normal jupytext markdown cell (each non-blank line prefixed with "# "). '
+    'When verdict is "in_sync", the existing target cell body verbatim. '
+    "No surrounding code fences either way.\n"
+    '  "reason": one short sentence describing the verdict.'
+)
+
+
+def build_sync_user_prompt(
+    *,
+    source_text: str,
+    target_text: str,
+    source_lang: str,
+    target_lang: str,
+) -> str:
+    """Format the user-side message for one sync request.
+
+    ``source_lang`` and ``target_lang`` are short codes (``"de"`` /
+    ``"en"``). ``source_text`` and ``target_text`` are the full cell
+    bodies including their jupytext ``# `` prefixes (we pass them
+    verbatim so the LLM matches the on-disk shape).
+    """
+    return "\n".join(
+        [
+            f"Source language: {source_lang}",
+            f"Target language: {target_lang}",
+            "",
+            f"Source cell ({source_lang}):",
+            source_text.strip("\n") or "(empty)",
+            "",
+            f"Current target cell ({target_lang}):",
+            target_text.strip("\n") or "(empty)",
+            "",
+            "Propose the updated target cell.",
+        ]
+    )

--- a/src/clm/slides/sync.py
+++ b/src/clm/slides/sync.py
@@ -1,0 +1,476 @@
+"""Cross-language sync for split-format slide pairs.
+
+Phase 7 of the slide-format-redesign. After an author edits one half of
+a split deck (``<deck>.de.py`` or ``<deck>.en.py``), this module walks
+the DE/EN pair by ``slide_id``, asks the
+:class:`clm.infrastructure.llm.ollama_client.SyncJudge` to propose any
+needed update to the target side, and emits a unified diff.
+
+For v1 the only supported mode is ``--dry-run`` — the module surfaces
+proposals as diffs in the report; no writes happen. Interactive
+apply/skip/edit and ``--apply --trivial`` modes are planned follow-ups
+and not implemented here.
+
+Design notes (see ``handover-slide-format-redesign-clm.md`` §3 Phase 7
+in the PythonCourses repo and the proposal at
+``docs/proposals/PYTHON_COURSES_REVAMP_NEXT_STEPS_2026-05-19.md`` §2):
+
+- The :class:`~clm.infrastructure.llm.cache.SyncCache` memoizes
+  ``(de_hash, en_hash, prompt_version) -> proposal``. Re-runs against an
+  unchanged pair hit the cache and avoid LLM spend.
+- The pair walker only syncs markdown ``slide`` / ``subslide`` and
+  narrative ``voiceover`` / ``notes`` cells. Code cells are shared
+  across split companions by design; their consistency is checked by
+  the Phase-6 validator, not by sync.
+- Direction is explicit via :attr:`SyncOptions.source_lang`. The user
+  tells us which side was edited; we ask the judge to propose updates
+  for the other side. A future version may auto-detect direction via
+  the cache's last-known-synced state.
+- Cells without a ``slide_id`` are skipped with an info-level warning —
+  the assign-ids step must run first.
+- A slide_id with mismatched cell counts on the two sides surfaces as a
+  structural-mismatch issue and the slide_id is skipped (LLM cannot
+  pair cells unambiguously).
+
+Pilot instrumentation: :class:`SyncResult` exposes per-session counters
+(``pairs_visited``, ``pairs_in_sync``, ``pairs_proposed``,
+``pairs_error``, ``cache_hits``) so the PythonCourses pilot can quote a
+real accept rate when the interactive walker lands.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from clm.infrastructure.llm.ollama_client import OllamaError, SyncProposal
+from clm.notebooks.slide_parser import Cell, parse_cells
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import SyncCache
+    from clm.infrastructure.llm.ollama_client import SyncJudge
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PairOutcome",
+    "SyncIssue",
+    "SyncOptions",
+    "SyncResult",
+    "sync_split_pair",
+]
+
+# Roles that participate in cross-language sync. Slide cells carry the
+# heading/bullet content; narrative cells carry voiceover/notes prose.
+# Code cells are intentionally excluded — they're shared by design.
+_ROLE_TAGS = {
+    "slide": "slide",
+    "subslide": "subslide",
+    "voiceover": "voiceover",
+    "notes": "notes",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SyncOptions:
+    """Knobs for one sync pass.
+
+    ``source_lang`` is the language the author just edited; ``target_lang``
+    is implied to be the other. The judge is asked to propose updates for
+    the target side based on the source side's content.
+
+    ``judge`` is the mockable :class:`SyncJudge`. Passing ``None`` skips
+    every LLM call — the pass still runs, every pair becomes an "LLM
+    unavailable" error, and the report is still useful as a structural
+    audit.
+
+    ``cache`` is the optional :class:`SyncCache` for memoization.
+    """
+
+    source_lang: str  # "de" or "en"
+    judge: SyncJudge | None = None
+    cache: SyncCache | None = None
+
+    @property
+    def target_lang(self) -> str:
+        return "en" if self.source_lang == "de" else "de"
+
+
+@dataclass
+class SyncIssue:
+    """A structural problem that prevents syncing a slide_id."""
+
+    slide_id: str
+    severity: str  # "warning" / "error"
+    reason: str
+    de_count: int = 0
+    en_count: int = 0
+
+
+@dataclass
+class PairOutcome:
+    """The result of asking the judge about one paired cell."""
+
+    slide_id: str
+    role: str
+    de_line: int  # 1-based line number of the DE cell header
+    en_line: int  # 1-based line number of the EN cell header
+    direction: str  # "de->en" or "en->de"
+    verdict: str  # "in_sync" / "update" / "error"
+    reason: str = ""
+    proposal: SyncProposal | None = None
+    diff: str = ""  # unified diff (target_body -> proposed_text), empty for in_sync/error
+    error: str = ""  # non-empty when verdict == "error"
+    cached: bool = False  # True when this came from SyncCache instead of fresh LLM
+
+
+@dataclass
+class SyncResult:
+    """Outcome of one ``clm slides sync`` run.
+
+    Counters are pilot instrumentation per the proposal §2 — the
+    PythonCourses Phase D pilot's ship/cancel criterion is
+    ``pairs_proposed / pairs_visited > 80% accept rate``. v1 cannot
+    measure accept rate yet (no interactive walker), but the
+    denominator is recorded so v2 can plug in.
+    """
+
+    de_path: Path
+    en_path: Path
+    outcomes: list[PairOutcome] = field(default_factory=list)
+    issues: list[SyncIssue] = field(default_factory=list)
+    pairs_visited: int = 0
+    pairs_in_sync: int = 0
+    pairs_proposed: int = 0
+    pairs_error: int = 0
+    cache_hits: int = 0
+
+    @property
+    def has_proposals(self) -> bool:
+        return self.pairs_proposed > 0
+
+    @property
+    def has_errors(self) -> bool:
+        return self.pairs_error > 0
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def sync_split_pair(
+    de_path: Path,
+    en_path: Path,
+    options: SyncOptions,
+) -> SyncResult:
+    """Run a cross-language sync pass over a split DE/EN pair.
+
+    Returns a :class:`SyncResult`. No files are modified — v1 is
+    read-only. Cached proposals are written through to the LLM cache
+    if ``options.cache`` is set (memoization side effect; not a
+    content edit).
+    """
+    if options.source_lang not in ("de", "en"):
+        raise ValueError(f"source_lang must be 'de' or 'en', got {options.source_lang!r}")
+
+    de_text = de_path.read_text(encoding="utf-8")
+    en_text = en_path.read_text(encoding="utf-8")
+
+    de_cells = parse_cells(de_text)
+    en_cells = parse_cells(en_text)
+
+    de_index = _index_cells(de_cells, "de")
+    en_index = _index_cells(en_cells, "en")
+
+    result = SyncResult(de_path=de_path, en_path=en_path)
+    seen_keys: set[tuple[str, str]] = set()
+
+    for key in sorted(set(de_index) | set(en_index)):
+        slide_id, role = key
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+
+        de_cells_for_key = de_index.get(key, [])
+        en_cells_for_key = en_index.get(key, [])
+
+        if not de_cells_for_key and en_cells_for_key:
+            result.issues.append(
+                SyncIssue(
+                    slide_id=slide_id,
+                    severity="warning",
+                    reason=f"role={role!r} exists only on the EN side; "
+                    "no DE counterpart to sync against",
+                    de_count=0,
+                    en_count=len(en_cells_for_key),
+                )
+            )
+            continue
+
+        if de_cells_for_key and not en_cells_for_key:
+            result.issues.append(
+                SyncIssue(
+                    slide_id=slide_id,
+                    severity="warning",
+                    reason=f"role={role!r} exists only on the DE side; "
+                    "no EN counterpart to sync against",
+                    de_count=len(de_cells_for_key),
+                    en_count=0,
+                )
+            )
+            continue
+
+        if len(de_cells_for_key) != len(en_cells_for_key):
+            result.issues.append(
+                SyncIssue(
+                    slide_id=slide_id,
+                    severity="error",
+                    reason=f"role={role!r} has {len(de_cells_for_key)} cells on the "
+                    f"DE side but {len(en_cells_for_key)} on the EN side; "
+                    "structural mismatch — pair this manually",
+                    de_count=len(de_cells_for_key),
+                    en_count=len(en_cells_for_key),
+                )
+            )
+            continue
+
+        for de_cell, en_cell in zip(de_cells_for_key, en_cells_for_key, strict=True):
+            outcome = _sync_pair(
+                slide_id=slide_id,
+                role=role,
+                de_cell=de_cell,
+                en_cell=en_cell,
+                options=options,
+            )
+            result.outcomes.append(outcome)
+            result.pairs_visited += 1
+            if outcome.cached:
+                result.cache_hits += 1
+            if outcome.verdict == "in_sync":
+                result.pairs_in_sync += 1
+            elif outcome.verdict == "update":
+                result.pairs_proposed += 1
+            elif outcome.verdict == "error":
+                result.pairs_error += 1
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _index_cells(cells: list[Cell], expected_lang: str) -> dict[tuple[str, str], list[Cell]]:
+    """Group cells by ``(slide_id, role)`` for ``expected_lang`` only.
+
+    Cells without a slide_id, without an explicit lang, or whose lang
+    doesn't match ``expected_lang`` are silently skipped. Code, j2,
+    and title-macro cells are also skipped (they aren't sync targets).
+    """
+    index: dict[tuple[str, str], list[Cell]] = {}
+    for cell in cells:
+        role = _role_for_cell(cell)
+        if role is None:
+            continue
+        sid = cell.metadata.slide_id
+        if not sid:
+            continue
+        if cell.metadata.lang != expected_lang:
+            continue
+        index.setdefault((sid, role), []).append(cell)
+    return index
+
+
+def _role_for_cell(cell: Cell) -> str | None:
+    """Return the sync role for ``cell``, or ``None`` to skip.
+
+    Roles: ``"slide"``, ``"subslide"``, ``"voiceover"``, ``"notes"``.
+    """
+    if cell.metadata.is_j2:
+        return None
+    if cell.metadata.cell_type != "markdown":
+        return None
+    for tag in cell.metadata.tags:
+        role = _ROLE_TAGS.get(tag)
+        if role is not None:
+            return role
+    return None
+
+
+def _sync_pair(
+    *,
+    slide_id: str,
+    role: str,
+    de_cell: Cell,
+    en_cell: Cell,
+    options: SyncOptions,
+) -> PairOutcome:
+    de_body = de_cell.content
+    en_body = en_cell.content
+    de_hash = _hash(de_body)
+    en_hash = _hash(en_body)
+
+    if options.source_lang == "de":
+        source_body, target_body = de_body, en_body
+        direction = "de->en"
+    else:
+        source_body, target_body = en_body, de_body
+        direction = "en->de"
+
+    # Cache lookup — memoizes the LLM call for the same (de_hash, en_hash)
+    # pair. The cache stores (direction, proposal_json); we re-honor the
+    # cached direction so swapping ``--source-lang`` mid-session doesn't
+    # silently mask a cached "en->de" proposal.
+    if options.cache is not None and options.judge is not None:
+        cached = options.cache.get(de_hash, en_hash, options.judge.prompt_version)
+        if cached is not None:
+            cached_direction, cached_payload = cached
+            if cached_direction == direction:
+                proposal = SyncProposal.from_json(cached_payload)
+                return _outcome_from_proposal(
+                    slide_id=slide_id,
+                    role=role,
+                    de_cell=de_cell,
+                    en_cell=en_cell,
+                    direction=direction,
+                    proposal=proposal,
+                    target_body=target_body,
+                    cached=True,
+                )
+
+    if options.judge is None:
+        return PairOutcome(
+            slide_id=slide_id,
+            role=role,
+            de_line=de_cell.line_number,
+            en_line=en_cell.line_number,
+            direction=direction,
+            verdict="error",
+            error="no judge configured (LLM unavailable)",
+        )
+
+    try:
+        proposal = options.judge.propose(
+            source_body,
+            target_body,
+            source_lang=options.source_lang,
+            target_lang=options.target_lang,
+        )
+    except OllamaError as exc:
+        logger.info("sync judge failed on %s/%s: %s", slide_id, role, exc)
+        return PairOutcome(
+            slide_id=slide_id,
+            role=role,
+            de_line=de_cell.line_number,
+            en_line=en_cell.line_number,
+            direction=direction,
+            verdict="error",
+            error=str(exc),
+        )
+
+    if options.cache is not None:
+        options.cache.put(
+            de_hash,
+            en_hash,
+            options.judge.prompt_version,
+            direction,
+            proposal.to_json(),
+        )
+
+    return _outcome_from_proposal(
+        slide_id=slide_id,
+        role=role,
+        de_cell=de_cell,
+        en_cell=en_cell,
+        direction=direction,
+        proposal=proposal,
+        target_body=target_body,
+        cached=False,
+    )
+
+
+def _outcome_from_proposal(
+    *,
+    slide_id: str,
+    role: str,
+    de_cell: Cell,
+    en_cell: Cell,
+    direction: str,
+    proposal: SyncProposal,
+    target_body: str,
+    cached: bool,
+) -> PairOutcome:
+    if proposal.verdict == "in_sync":
+        return PairOutcome(
+            slide_id=slide_id,
+            role=role,
+            de_line=de_cell.line_number,
+            en_line=en_cell.line_number,
+            direction=direction,
+            verdict="in_sync",
+            reason=proposal.reason,
+            proposal=proposal,
+            cached=cached,
+        )
+
+    # verdict == "update"
+    target_label, proposed_label = _diff_labels(direction)
+    diff = _build_diff(
+        target_body=target_body,
+        proposed_text=proposal.proposed_text,
+        target_label=target_label,
+        proposed_label=proposed_label,
+    )
+    return PairOutcome(
+        slide_id=slide_id,
+        role=role,
+        de_line=de_cell.line_number,
+        en_line=en_cell.line_number,
+        direction=direction,
+        verdict="update",
+        reason=proposal.reason,
+        proposal=proposal,
+        diff=diff,
+        cached=cached,
+    )
+
+
+def _diff_labels(direction: str) -> tuple[str, str]:
+    if direction == "de->en":
+        return ("current EN", "proposed EN")
+    return ("current DE", "proposed DE")
+
+
+def _build_diff(
+    *,
+    target_body: str,
+    proposed_text: str,
+    target_label: str,
+    proposed_label: str,
+) -> str:
+    """Unified diff from current target to proposed replacement."""
+    target_lines = target_body.splitlines(keepends=True)
+    proposed_lines = proposed_text.splitlines(keepends=True)
+    diff_lines = difflib.unified_diff(
+        target_lines,
+        proposed_lines,
+        fromfile=target_label,
+        tofile=proposed_label,
+        lineterm="",
+    )
+    return "\n".join(diff_lines)
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -117,7 +117,14 @@ class TestOllamaUnavailable:
             ],
         )
         assert result.exit_code == 2
-        payload = json.loads(result.output)
+        # On Click 8.2+ stderr is mixed into result.output when CliRunner
+        # is constructed without the (removed) ``mix_stderr=False`` flag,
+        # so the "Ollama is not reachable" warning may precede the JSON
+        # body. Locate the JSON object by its opening brace.
+        output = result.output
+        brace = output.find("{")
+        assert brace >= 0, f"no JSON object in CLI output:\n{output}"
+        payload = json.loads(output[brace:])
         assert payload["pairs_visited"] == 1
         assert payload["pairs_error"] == 1
         assert len(payload["outcomes"]) == 1

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -12,7 +12,12 @@ from clm.cli.commands.slides_sync import slides_sync_cmd
 
 @pytest.fixture
 def cli_runner():
-    return CliRunner(mix_stderr=False)
+    # Click 8.1 needs ``mix_stderr=False`` to separate stderr; Click 8.2+
+    # removed the parameter and always separates stderr. Support both.
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
 
 
 @pytest.fixture

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -1,0 +1,119 @@
+"""CLI smoke tests for ``clm slides sync``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides_sync import slides_sync_cmd
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.fixture
+def pair(tmp_path: Path) -> tuple[Path, Path]:
+    """Write a minimal split DE/EN pair to disk and return both paths."""
+    de = '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n# ## Einleitung\n'
+    en = '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## Introduction\n'
+    de_path = tmp_path / "slides_intro.de.py"
+    en_path = tmp_path / "slides_intro.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+class TestArgumentParsing:
+    def test_missing_source_lang_errors(self, cli_runner: CliRunner, pair):
+        de_path, en_path = pair
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path)],
+        )
+        assert result.exit_code != 0
+        assert "source-lang" in (result.stderr or result.output).lower()
+
+    def test_invalid_source_lang_errors(self, cli_runner: CliRunner, pair):
+        de_path, en_path = pair
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--source-lang", "fr"],
+        )
+        assert result.exit_code != 0
+        combined = (result.stderr or "") + (result.output or "")
+        assert "fr" in combined.lower() or "invalid" in combined.lower()
+
+    def test_missing_paths_errors(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(slides_sync_cmd, ["--source-lang", "de"])
+        assert result.exit_code != 0
+
+    def test_nonexistent_path_errors(self, cli_runner: CliRunner, tmp_path: Path):
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(tmp_path / "missing.de.py"),
+                str(tmp_path / "missing.en.py"),
+                "--source-lang",
+                "de",
+            ],
+        )
+        assert result.exit_code != 0
+
+
+class TestOllamaUnavailable:
+    """When Ollama is not reachable, every pair becomes an error
+    outcome. Exit code is 2 (structural error)."""
+
+    def test_unreachable_ollama_records_errors(self, cli_runner: CliRunner, pair, tmp_path: Path):
+        de_path, en_path = pair
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--source-lang",
+                "de",
+                "--ollama-url",
+                "http://127.0.0.1:1",  # nothing listens here
+                "--llm-timeout",
+                "1.0",
+                "--no-cache",
+            ],
+        )
+        # Exit 2 = at least one error.
+        assert result.exit_code == 2
+        # Warning was emitted about Ollama being unreachable.
+        assert "Ollama is not reachable" in (result.stderr or "")
+        # The lone pair was counted as an error.
+        assert "1 pair(s) visited" in result.output
+        assert "1 error(s)" in result.output
+
+    def test_json_output_shape(self, cli_runner: CliRunner, pair, tmp_path: Path):
+        import json
+
+        de_path, en_path = pair
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--source-lang",
+                "de",
+                "--ollama-url",
+                "http://127.0.0.1:1",
+                "--llm-timeout",
+                "1.0",
+                "--no-cache",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 2
+        payload = json.loads(result.output)
+        assert payload["pairs_visited"] == 1
+        assert payload["pairs_error"] == 1
+        assert len(payload["outcomes"]) == 1
+        assert payload["outcomes"][0]["verdict"] == "error"

--- a/tests/infrastructure/llm/test_ollama_client.py
+++ b/tests/infrastructure/llm/test_ollama_client.py
@@ -190,3 +190,150 @@ class TestParseCoverageResponse:
     def test_missing_bullets_list_raises(self):
         with pytest.raises(OllamaError):
             parse_coverage_response('{"verdict":"covered"}', ["a"])
+
+
+class TestStaticSyncJudge:
+    def test_mapping_lookup(self):
+        from clm.infrastructure.llm.ollama_client import (
+            StaticSyncJudge,
+            SyncProposal,
+            sync_key,
+        )
+
+        proposal = SyncProposal(verdict="update", proposed_text="# Hi")
+        key = sync_key("# Hallo", "# Hello", source_lang="de", target_lang="en")
+        s = StaticSyncJudge({key: proposal})
+        result = s.propose("# Hallo", "# Hello", source_lang="de", target_lang="en")
+        assert result == proposal
+
+    def test_default_used_for_unknown(self):
+        from clm.infrastructure.llm.ollama_client import (
+            StaticSyncJudge,
+            SyncProposal,
+        )
+
+        default = SyncProposal(verdict="in_sync", proposed_text="# anything")
+        s = StaticSyncJudge(default_proposal=default)
+        result = s.propose("a", "b", source_lang="de", target_lang="en")
+        assert result == default
+
+    def test_raises_when_no_match(self):
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge
+
+        s = StaticSyncJudge()
+        with pytest.raises(OllamaError):
+            s.propose("a", "b", source_lang="de", target_lang="en")
+
+    def test_records_calls(self):
+        from clm.infrastructure.llm.ollama_client import (
+            StaticSyncJudge,
+            SyncProposal,
+        )
+
+        s = StaticSyncJudge(default_proposal=SyncProposal("in_sync", ""))
+        s.propose("src1", "tgt1", source_lang="de", target_lang="en")
+        s.propose("src2", "tgt2", source_lang="en", target_lang="de")
+        assert s.calls == [
+            ("src1", "tgt1", "de", "en"),
+            ("src2", "tgt2", "en", "de"),
+        ]
+
+    def test_prompt_version_default(self):
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge
+        from clm.infrastructure.llm.sync_prompts import SYNC_PROMPT_VERSION
+
+        assert StaticSyncJudge().prompt_version == SYNC_PROMPT_VERSION
+
+    def test_prompt_version_override(self):
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge
+
+        assert StaticSyncJudge(prompt_version="v99").prompt_version == "v99"
+
+
+class TestSyncProposal:
+    def test_needs_update_true(self):
+        from clm.infrastructure.llm.ollama_client import SyncProposal
+
+        assert SyncProposal(verdict="update", proposed_text="# hi").needs_update
+
+    def test_needs_update_false_for_in_sync(self):
+        from clm.infrastructure.llm.ollama_client import SyncProposal
+
+        assert not SyncProposal(verdict="in_sync", proposed_text="# hi").needs_update
+
+    def test_json_round_trip(self):
+        from clm.infrastructure.llm.ollama_client import SyncProposal
+
+        original = SyncProposal(verdict="update", proposed_text="# Hi", reason="DE got new bullet")
+        restored = SyncProposal.from_json(original.to_json())
+        assert restored.verdict == "update"
+        assert restored.proposed_text == "# Hi"
+        assert restored.reason == "DE got new bullet"
+
+    def test_from_json_infers_verdict_when_missing(self):
+        from clm.infrastructure.llm.ollama_client import SyncProposal
+
+        # Older cache entry with no verdict field — accept gracefully.
+        legacy = SyncProposal.from_json('{"proposed_text": "# Hi", "reason": "x"}')
+        assert legacy.verdict == "update"
+        empty = SyncProposal.from_json('{"proposed_text": "", "reason": "x"}')
+        assert empty.verdict == "in_sync"
+
+
+class TestParseSyncResponse:
+    def test_plain_json(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = '{"verdict":"update","proposed_text":"# Hello","reason":"new bullet"}'
+        p = parse_sync_response(text)
+        assert p.verdict == "update"
+        assert p.proposed_text == "# Hello"
+        assert p.reason == "new bullet"
+
+    def test_in_sync_verdict(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = '{"verdict":"in_sync","proposed_text":"# unchanged","reason":"ok"}'
+        p = parse_sync_response(text)
+        assert p.verdict == "in_sync"
+        assert not p.needs_update
+
+    def test_prose_around_json(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = 'Sure! Here is my analysis:\n{"verdict":"update","proposed_text":"# Hi"}'
+        p = parse_sync_response(text)
+        assert p.verdict == "update"
+
+    def test_fenced_code_block(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = '```json\n{"verdict":"update","proposed_text":"# Hi"}\n```'
+        p = parse_sync_response(text)
+        assert p.verdict == "update"
+
+    def test_verdict_inferred_when_missing_and_text_present(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = '{"proposed_text":"# Hi"}'
+        p = parse_sync_response(text)
+        assert p.verdict == "update"
+
+    def test_verdict_inferred_when_missing_and_text_empty(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = '{"proposed_text":""}'
+        p = parse_sync_response(text)
+        assert p.verdict == "in_sync"
+
+    def test_invalid_json_raises(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        with pytest.raises(OllamaError):
+            parse_sync_response("no braces here at all")
+
+    def test_missing_proposed_text_raises(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        with pytest.raises(OllamaError):
+            parse_sync_response('{"verdict":"update"}')

--- a/tests/infrastructure/llm/test_sync_cache.py
+++ b/tests/infrastructure/llm/test_sync_cache.py
@@ -1,0 +1,109 @@
+"""Tests for :class:`clm.infrastructure.llm.cache.SyncCache`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncCache
+
+
+@pytest.fixture
+def cache(tmp_path: Path):
+    c = SyncCache(tmp_path / "clm-llm.sqlite")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+class TestSyncCache:
+    def test_miss(self, cache):
+        assert cache.get("de-hash", "en-hash", "v1") is None
+
+    def test_round_trip(self, cache):
+        cache.put("dh", "eh", "v1", "de->en", "EN proposal text")
+        assert cache.get("dh", "eh", "v1") == ("de->en", "EN proposal text")
+
+    def test_overwrite_same_key(self, cache):
+        cache.put("dh", "eh", "v1", "de->en", "first proposal")
+        cache.put("dh", "eh", "v1", "en->de", "second proposal")
+        assert cache.get("dh", "eh", "v1") == ("en->de", "second proposal")
+
+    def test_de_hash_in_key(self, cache):
+        cache.put("dh1", "eh", "v1", "de->en", "proposal-1")
+        cache.put("dh2", "eh", "v1", "de->en", "proposal-2")
+        assert cache.get("dh1", "eh", "v1") == ("de->en", "proposal-1")
+        assert cache.get("dh2", "eh", "v1") == ("de->en", "proposal-2")
+
+    def test_en_hash_in_key(self, cache):
+        cache.put("dh", "eh1", "v1", "de->en", "proposal-1")
+        cache.put("dh", "eh2", "v1", "de->en", "proposal-2")
+        assert cache.get("dh", "eh1", "v1") == ("de->en", "proposal-1")
+        assert cache.get("dh", "eh2", "v1") == ("de->en", "proposal-2")
+
+    def test_prompt_version_in_key(self, cache):
+        cache.put("dh", "eh", "v1", "de->en", "v1-proposal")
+        cache.put("dh", "eh", "v2", "de->en", "v2-proposal")
+        assert cache.get("dh", "eh", "v1") == ("de->en", "v1-proposal")
+        assert cache.get("dh", "eh", "v2") == ("de->en", "v2-proposal")
+
+    def test_invalid_direction_raises(self, cache):
+        with pytest.raises(ValueError, match="direction must be"):
+            cache.put("dh", "eh", "v1", "sideways", "proposal")
+
+    def test_invalidate_prompt_version(self, cache):
+        cache.put("dh1", "eh", "v1", "de->en", "p1")
+        cache.put("dh2", "eh", "v1", "de->en", "p2")
+        cache.put("dh3", "eh", "v2", "de->en", "p3")
+        removed = cache.invalidate_prompt_version("v2")
+        assert removed == 2
+        assert cache.get("dh1", "eh", "v1") is None
+        assert cache.get("dh3", "eh", "v2") == ("de->en", "p3")
+
+    def test_iter_entries_empty(self, cache):
+        assert cache.iter_entries() == []
+
+    def test_iter_entries_returns_all_rows(self, cache):
+        cache.put("dh1", "eh1", "v1", "de->en", "p1")
+        cache.put("dh2", "eh2", "v1", "en->de", "p2")
+
+        rows = cache.iter_entries()
+        assert len(rows) == 2
+        # Tuple shape: (de_hash, en_hash, prompt_version, direction,
+        # proposal, created_at)
+        keys = {(row[0], row[3]) for row in rows}
+        assert keys == {("dh1", "de->en"), ("dh2", "en->de")}
+
+    def test_survives_close_and_reopen(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        first = SyncCache(path)
+        first.put("dh", "eh", "v1", "de->en", "kept across reopen")
+        first.close()
+
+        second = SyncCache(path)
+        try:
+            assert second.get("dh", "eh", "v1") == ("de->en", "kept across reopen")
+        finally:
+            second.close()
+
+    def test_coexists_with_other_caches(self, tmp_path: Path):
+        from clm.infrastructure.llm.cache import CoverageCache, TitleSuggestionCache
+
+        path = tmp_path / "clm-llm.sqlite"
+        sync = SyncCache(path)
+        cov = CoverageCache(path)
+        tit = TitleSuggestionCache(path)
+        try:
+            sync.put("dh", "eh", "v1", "de->en", "sync-proposal")
+            cov.put("sh", "vh", "v1", "en", "covered", None)
+            tit.put("ch", "v1", "Some Title", "en")
+
+            assert sync.get("dh", "eh", "v1") == ("de->en", "sync-proposal")
+            assert cov.get("sh", "vh", "v1", "en") == ("covered", None)
+            assert tit.get("ch", "v1", "en") == "Some Title"
+        finally:
+            tit.close()
+            cov.close()
+            sync.close()

--- a/tests/slides/test_sync.py
+++ b/tests/slides/test_sync.py
@@ -1,0 +1,368 @@
+"""Tests for :mod:`clm.slides.sync`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncCache
+from clm.infrastructure.llm.ollama_client import (
+    StaticSyncJudge,
+    SyncProposal,
+    sync_key,
+)
+from clm.slides.sync import SyncOptions, sync_split_pair
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_pair(
+    tmp_path: Path,
+    *,
+    de: str,
+    en: str,
+    stem: str = "slides_intro",
+) -> tuple[Path, Path]:
+    de_path = tmp_path / f"{stem}.de.py"
+    en_path = tmp_path / f"{stem}.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _slide_cell(*, lang: str, slide_id: str, body: str, tag: str = "slide") -> str:
+    """Build a percent-format slide cell as a single string ending in newline."""
+    return f'# %% [markdown] lang="{lang}" tags=["{tag}"] slide_id="{slide_id}"\n{body.strip()}\n'
+
+
+# ---------------------------------------------------------------------------
+# Pair walking
+# ---------------------------------------------------------------------------
+
+
+class TestPairWalking:
+    def test_in_sync_pair_records_in_sync_outcome(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung\n#\n# - Punkt eins")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction\n#\n# - Point one")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="in_sync", proposed_text="# placeholder")
+        )
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        assert result.pairs_visited == 1
+        assert result.pairs_in_sync == 1
+        assert result.pairs_proposed == 0
+        assert result.outcomes[0].verdict == "in_sync"
+        assert result.outcomes[0].slide_id == "intro"
+        assert result.outcomes[0].role == "slide"
+
+    def test_update_pair_produces_diff(self, tmp_path: Path):
+        de = _slide_cell(
+            lang="de",
+            slide_id="intro",
+            body="# ## Einleitung\n#\n# - Punkt eins\n# - Punkt zwei",
+        )
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction\n#\n# - Point one")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        proposed_en = "# ## Introduction\n#\n# - Point one\n# - Point two"
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(
+                verdict="update",
+                proposed_text=proposed_en,
+                reason="DE added a new bullet",
+            )
+        )
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        assert result.pairs_proposed == 1
+        outcome = result.outcomes[0]
+        assert outcome.verdict == "update"
+        assert outcome.proposal is not None
+        assert outcome.proposal.proposed_text == proposed_en
+        assert outcome.diff  # non-empty unified diff
+        assert "Point two" in outcome.diff
+        assert outcome.reason == "DE added a new bullet"
+        assert outcome.direction == "de->en"
+
+    def test_source_lang_en_reverses_direction(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung\n#\n# - alt")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction\n#\n# - new")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(
+                verdict="update", proposed_text="# ## Einleitung\n#\n# - neu"
+            )
+        )
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="en", judge=judge))
+
+        outcome = result.outcomes[0]
+        assert outcome.direction == "en->de"
+        assert outcome.proposal is not None
+        assert "neu" in outcome.proposal.proposed_text
+
+    def test_error_when_no_judge(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=None))
+
+        assert result.pairs_visited == 1
+        assert result.pairs_error == 1
+        assert result.outcomes[0].verdict == "error"
+        assert "no judge" in result.outcomes[0].error
+
+    def test_judge_failure_fails_soft(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        # Static judge with no mapping and no default → raises OllamaError.
+        judge = StaticSyncJudge()
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        assert result.pairs_error == 1
+        assert result.outcomes[0].verdict == "error"
+        assert "no static sync proposal" in result.outcomes[0].error
+
+    def test_multiple_pairs_in_one_file(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="a", body="# ## A") + _slide_cell(
+            lang="de", slide_id="b", body="# ## B"
+        )
+        en = _slide_cell(lang="en", slide_id="a", body="# ## A en") + _slide_cell(
+            lang="en", slide_id="b", body="# ## B en"
+        )
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text="x"))
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        assert result.pairs_visited == 2
+        slide_ids = {o.slide_id for o in result.outcomes}
+        assert slide_ids == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Structural issues
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralIssues:
+    def test_slide_id_only_on_de_side(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="shared", body="# ## A") + _slide_cell(
+            lang="de", slide_id="de-only", body="# ## DE only"
+        )
+        en = _slide_cell(lang="en", slide_id="shared", body="# ## A")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text="x"))
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        assert result.pairs_visited == 1  # only the shared slide_id paired
+        assert len(result.issues) == 1
+        issue = result.issues[0]
+        assert issue.slide_id == "de-only"
+        assert issue.severity == "warning"
+        assert issue.de_count == 1
+        assert issue.en_count == 0
+
+    def test_count_mismatch_within_slide_id(self, tmp_path: Path):
+        # Two voiceover cells on DE side, one on EN — structural mismatch.
+        de = (
+            _slide_cell(lang="de", slide_id="x", body="# ## X")
+            + _slide_cell(lang="de", slide_id="x", body="# - DE narration A", tag="voiceover")
+            + _slide_cell(lang="de", slide_id="x", body="# - DE narration B", tag="voiceover")
+        )
+        en = _slide_cell(lang="en", slide_id="x", body="# ## X") + _slide_cell(
+            lang="en", slide_id="x", body="# - EN narration", tag="voiceover"
+        )
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text="x"))
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        # The "slide" role paired cleanly; the "voiceover" role didn't.
+        assert any(o.role == "slide" for o in result.outcomes)
+        assert not any(o.role == "voiceover" for o in result.outcomes)
+        assert len(result.issues) == 1
+        assert result.issues[0].slide_id == "x"
+        assert result.issues[0].severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# Cache integration
+# ---------------------------------------------------------------------------
+
+
+class TestCacheIntegration:
+    def test_cache_hit_avoids_second_judge_call(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        cache = SyncCache(tmp_path / "clm-llm.sqlite")
+        proposal = SyncProposal(verdict="update", proposed_text="# ## Introduction\n# - new")
+        judge = StaticSyncJudge(default_proposal=proposal)
+
+        try:
+            result1 = sync_split_pair(
+                de_path,
+                en_path,
+                SyncOptions(source_lang="de", judge=judge, cache=cache),
+            )
+            assert len(judge.calls) == 1
+            assert result1.cache_hits == 0
+            assert result1.pairs_proposed == 1
+
+            result2 = sync_split_pair(
+                de_path,
+                en_path,
+                SyncOptions(source_lang="de", judge=judge, cache=cache),
+            )
+            assert len(judge.calls) == 1  # not called again
+            assert result2.cache_hits == 1
+            assert result2.pairs_proposed == 1
+            assert result2.outcomes[0].cached is True
+        finally:
+            cache.close()
+
+    def test_cache_ignores_mismatched_direction(self, tmp_path: Path):
+        # If the cache has a 'en->de' entry but the current options use
+        # source_lang='de' (direction 'de->en'), the cache should be
+        # bypassed and the judge re-fired.
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        cache = SyncCache(tmp_path / "clm-llm.sqlite")
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# updated")
+        )
+        try:
+            # First run: source_lang=en, populates cache as 'en->de'.
+            sync_split_pair(
+                de_path,
+                en_path,
+                SyncOptions(source_lang="en", judge=judge, cache=cache),
+            )
+            assert len(judge.calls) == 1
+
+            # Second run: source_lang=de, direction 'de->en' — cache entry
+            # doesn't match, judge fires again.
+            sync_split_pair(
+                de_path,
+                en_path,
+                SyncOptions(source_lang="de", judge=judge, cache=cache),
+            )
+            assert len(judge.calls) == 2
+        finally:
+            cache.close()
+
+    def test_cache_writes_proposal_on_fresh_call(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        cache = SyncCache(tmp_path / "clm-llm.sqlite")
+        proposal = SyncProposal(verdict="in_sync", proposed_text="# ## Introduction")
+        judge = StaticSyncJudge(default_proposal=proposal)
+        try:
+            sync_split_pair(
+                de_path,
+                en_path,
+                SyncOptions(source_lang="de", judge=judge, cache=cache),
+            )
+            entries = cache.iter_entries()
+            assert len(entries) == 1
+            de_hash, en_hash, prompt_version, direction, payload, _ = entries[0]
+            assert direction == "de->en"
+            restored = SyncProposal.from_json(payload)
+            assert restored.verdict == "in_sync"
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Role filtering
+# ---------------------------------------------------------------------------
+
+
+class TestRoleFiltering:
+    def test_code_cells_are_skipped(self, tmp_path: Path):
+        # Shared code cells should not be synced.
+        de = (
+            _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+            + '# %% tags=["keep"]\nx = 1\n'
+        )
+        en = (
+            _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+            + '# %% tags=["keep"]\nx = 1\n'
+        )
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text="x"))
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        # Only the markdown slide pair shows up.
+        assert result.pairs_visited == 1
+        assert result.outcomes[0].role == "slide"
+
+    def test_cells_without_slide_id_are_skipped(self, tmp_path: Path):
+        # A cell with no slide_id cannot be paired — it shouldn't appear.
+        de = (
+            _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung")
+            + '# %% [markdown] lang="de" tags=["subslide"]\n# - lonely DE bullet\n'
+        )
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text="x"))
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        # Only the intro pair visited. The lonely DE bullet has no
+        # slide_id, so it doesn't even surface as an issue.
+        assert result.pairs_visited == 1
+        assert result.issues == []
+
+    def test_voiceover_cells_are_synced(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung") + _slide_cell(
+            lang="de",
+            slide_id="intro",
+            body="# Wir beginnen mit der Einleitung.",
+            tag="voiceover",
+        )
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction") + _slide_cell(
+            lang="en",
+            slide_id="intro",
+            body="# Let's start with the introduction.",
+            tag="voiceover",
+        )
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        judge = StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text="x"))
+        result = sync_split_pair(de_path, en_path, SyncOptions(source_lang="de", judge=judge))
+
+        roles = {o.role for o in result.outcomes}
+        assert roles == {"slide", "voiceover"}
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_invalid_source_lang_raises(self, tmp_path: Path):
+        de = _slide_cell(lang="de", slide_id="intro", body="# ## A")
+        en = _slide_cell(lang="en", slide_id="intro", body="# ## A")
+        de_path, en_path = _write_pair(tmp_path, de=de, en=en)
+
+        with pytest.raises(ValueError, match="source_lang"):
+            sync_split_pair(de_path, en_path, SyncOptions(source_lang="fr"))


### PR DESCRIPTION
Implements **Phase 7** of the slide-format-redesign as a v1 ship.
After an author edits one half of a split deck (`<deck>.de.py` /
`<deck>.en.py`), `clm slides sync` walks the pair by `slide_id`, asks
the local Ollama LLM to propose any needed update to the target side,
and emits a unified diff per cell.

Tracking: §3 Phase 7 of `handover-slide-format-redesign-clm.md` (in
the PythonCourses repo) and §2 of
[`docs/proposals/PYTHON_COURSES_REVAMP_NEXT_STEPS_2026-05-19.md`](docs/proposals/PYTHON_COURSES_REVAMP_NEXT_STEPS_2026-05-19.md).

## Summary

- **`SyncCache`** in `clm.infrastructure.llm.cache` — keyed by
  `(de_hash, en_hash, prompt_version)`, stores
  `(direction, proposal_json)`. Re-runs against an unchanged pair
  cache-hit and avoid LLM spend; flipping `--source-lang` mid-session
  transparently bypasses stale entries.
- **`SyncJudge` protocol** in `clm.infrastructure.llm.ollama_client`
  with `OllamaSyncJudge` (real) + `StaticSyncJudge` (test fake) +
  `SyncProposal` dataclass with explicit `verdict` field
  (`"in_sync"` / `"update"`) and `parse_sync_response` tolerant of
  prose-wrapped / code-fenced JSON.
- **`clm.infrastructure.llm.sync_prompts`** — system + user-prompt
  builders and `SYNC_PROMPT_VERSION` constant for cache invalidation.
- **`clm.slides.sync`** — pair walker, drift detection, diff producer.
  Roles synced: markdown `slide`/`subslide` and narrative
  `voiceover`/`notes` cells. Shared code cells are excluded — split
  companions must keep them byte-identical and the Phase-6 validator
  enforces that.
- **`clm slides sync` CLI** — flags `--source-lang de|en` (required;
  tells the judge which side was edited), `--dry-run` (default and
  only mode in v1), `--llm-model`, `--ollama-url`, `--llm-timeout`,
  `--cache-dir`, `--no-cache`, `--json`. Exit codes: `0` clean, `1`
  proposed updates, `2` structural error or LLM unavailable.

## Pilot instrumentation

`SyncResult` exposes per-session counters (`pairs_visited`,
`pairs_in_sync`, `pairs_proposed`, `pairs_error`, `cache_hits`) so the
PythonCourses Phase D pilot can quote a real proposal rate. The
accept/skip/edit counters needed for the >80%-accept ship/cancel
criterion land alongside the v2 `--interactive` walker.

## What's deferred to v2

- `--interactive` apply/skip/edit walker.
- `--apply --trivial` write-without-prompting path for mechanical changes.
- Direction auto-detection via cache snapshot or git history.
- 3-way merge UX when both halves of a pair drift from snapshot.

These were the v1/v2 split called out in the proposal §2 — v1 ships
the LLM scaffold + memoization + read-only diff producer so the
PythonCourses Phase D pilot can begin evaluating proposal quality
before we invest in the interactive UX.

## Design decisions recorded

Full list lives in §10 of
[`docs/claude/python-courses-revamp-handover.md`](docs/claude/python-courses-revamp-handover.md).
Highlights:

- **Explicit `verdict` on `SyncProposal`.** Earlier draft inferred
  "in sync" from empty proposed_text; that was fragile against
  whitespace and model formatting quirks.
- **Direction stored in the cache value, not the key.** A single
  (de_hash, en_hash) pair has one cached proposal at a time; cache
  transparently bypasses on direction mismatch.
- **Every first-time pair fires the LLM.** Hash equality alone can't
  tell us whether DE and EN are semantically aligned (they have
  different surface forms by design).
- **Pairing is `(slide_id, role)`-keyed source-order zip.** Multiple
  cells per role within one slide_id pair up positionally; count
  mismatches surface as `error`-severity issues.

## Test plan

- [x] `pytest tests/slides tests/infrastructure/llm tests/cli/test_slides_sync.py -q` → 648 passed (+49 new across SyncCache, SyncJudge, SyncProposal, sync module, and CLI smoke).
- [x] Pre-commit hooks (ruff lint + format, mypy, fast pytest) green. Three runs were retried for unrelated worker-heartbeat / worker-base xdist flakes (the recurring "worker test polling" flakes noted in our project memory; each failing test passes in isolation).
- [x] CLI help text renders cleanly (`clm slides sync --help`).
- [x] CLI smoke tests cover required-flag error, invalid `--source-lang`, missing paths, and the Ollama-unavailable graceful-error path with JSON output shape verification.
- [ ] Manual smoke against a real PythonCourses split deck with Ollama up (post-merge by the PythonCourses agent when bumping the CLM pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)