### PR TITLE
fix(tests): eliminate three xdist test flakes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -443,6 +443,7 @@ dev = [
     "pytest-mock>=3.12.0",
     "pytest-timeout>=2.2.0",
     "pytest-xdist>=3.5.0",
+    "hypothesis>=6.148.2",
     "mypy>=1.0",
     "ruff>=0.1.0",
     "respx>=0.20.0",

--- a/tests/infrastructure/database/test_worker_heartbeats.py
+++ b/tests/infrastructure/database/test_worker_heartbeats.py
@@ -20,12 +20,26 @@ from pathlib import Path
 
 import pytest
 
+from clm.infrastructure.database import worker_heartbeats as _wh
 from clm.infrastructure.database.schema import DATABASE_VERSION, init_database
 from clm.infrastructure.database.worker_heartbeats import (
     MAX_EXCERPT_LENGTH,
     WorkerHeartbeatStore,
     truncate_excerpt,
 )
+
+
+@pytest.fixture(autouse=True)
+def _relax_slow_write_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Under pytest-xdist load, a single SQLite write can legitimately spike
+    # past the production 50ms self-disable threshold (lock contention, WAL
+    # checkpoint, antivirus scan, etc.), silently turning subsequent writes
+    # into no-ops and producing AssertionError(None == "expected"). Lift the
+    # threshold for these tests; test_slow_write_disables_further_writes
+    # re-patches it back to 0.0 inside its own scope, so the disable path
+    # is still covered.
+    monkeypatch.setattr(_wh, "SLOW_WRITE_THRESHOLD_SECONDS", 30.0)
+
 
 # -- helpers -----------------------------------------------------------------
 

--- a/tests/infrastructure/workers/test_lifecycle_mock.py
+++ b/tests/infrastructure/workers/test_lifecycle_mock.py
@@ -211,9 +211,15 @@ class TestMockWorkerJobProcessing:
         try:
             # Start 3 workers with fast processing
             pool.start_workers("notebook", count=3, processing_delay=0.02)
+            # Close the race against thread startup under xdist load: gate on
+            # registration before polling for job completion (otherwise the
+            # 5s job-wait races with the OS scheduling worker threads).
+            assert pool.wait_for_workers_registered(timeout=10.0), (
+                "Workers should register before processing jobs"
+            )
 
             # Wait for all jobs to complete
-            completed = pool.wait_for_jobs(timeout=5.0)
+            completed = pool.wait_for_jobs(timeout=15.0)
             assert completed, "All jobs should complete within timeout"
 
             # Verify all jobs completed
@@ -250,9 +256,12 @@ class TestMockWorkerJobProcessing:
         try:
             # Start workers with 50% fail rate
             pool.start_workers("notebook", count=2, processing_delay=0.02, fail_rate=0.5)
+            assert pool.wait_for_workers_registered(timeout=10.0), (
+                "Workers should register before processing jobs"
+            )
 
             # Wait for all jobs to complete
-            completed = pool.wait_for_jobs(timeout=5.0)
+            completed = pool.wait_for_jobs(timeout=15.0)
             assert completed, "All jobs should be processed within timeout"
 
             # Verify stats show both successes and failures
@@ -358,7 +367,10 @@ class TestMockWorkerCleanup:
 
         try:
             pool.start_workers("notebook", count=2, processing_delay=0.02)
-            pool.wait_for_jobs(timeout=5.0)
+            assert pool.wait_for_workers_registered(timeout=10.0), (
+                "Workers should register before processing jobs"
+            )
+            assert pool.wait_for_jobs(timeout=15.0), "All jobs should be processed within timeout"
 
             stats = pool.get_stats()
             assert stats["total_workers"] == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1166,6 +1166,7 @@ web = [
 [package.dev-dependencies]
 dev = [
     { name = "coding-academy-lecture-manager", extra = ["drawio", "jupyterlite", "mcp", "notebook", "plantuml", "recordings", "slides", "summarize", "tui", "voiceover", "web"] },
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1318,6 +1319,7 @@ provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summa
 [package.metadata.requires-dev]
 dev = [
     { name = "coding-academy-lecture-manager", extras = ["notebook", "plantuml", "drawio", "recordings", "slides", "mcp", "summarize", "voiceover", "jupyterlite", "tui", "web"] },
+    { name = "hypothesis", specifier = ">=6.148.2" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pre-commit", specifier = ">=4.5.0" },
     { name = "pytest", specifier = ">=7.0" },


### PR DESCRIPTION
## Summary

Investigated and fixed three pytest-xdist flakes surfaced this session.
Each had a distinct root cause; the diff totals 4 files / +32 / -3.

* **`tests/slides/test_split.py` fails at collection with `ModuleNotFoundError: hypothesis`** — `hypothesis>=6.148.2` is in `[project.optional-dependencies] dev` but the comment-stated "full mirror" PEP-735 `[dependency-groups] dev` block was missing it, so `uv sync` left `.venv` without it. Added the one line + ran `uv lock`.

* **`test_heartbeat_round_trip_smoke` flakes with `assert None == 'done'`** — `WorkerHeartbeatStore` self-disables future writes when one SQLite UPSERT blows past `SLOW_WRITE_THRESHOLD_SECONDS=0.050`. Production-correct, but legitimately tripped under xdist + Windows WAL contention (captured at 64.3ms). The next `record_output` then becomes a silent no-op. Added an autouse fixture in `tests/infrastructure/database/test_worker_heartbeats.py` that bumps the threshold to 30s for the module. The dedicated `test_slow_write_disables_further_writes` re-patches to 0.0 in its own scope, so the disable path stays covered.

* **`test_multiple_workers_process_multiple_jobs` (and two siblings) time out** — three tests in `test_lifecycle_mock.py` called `start_workers` then immediately `wait_for_jobs(timeout=5.0)`, racing thread startup under 32-way xdist load. Added the `wait_for_workers_registered` gate that the other six tests in the file already use, and bumped the job-wait timeout to 15s. Matches the polling-helper pattern in `feedback_worker_test_polling`.

## Verification

* 15 consecutive stress runs of the heartbeat + worker suites under `-n auto` — **all green** (previously 1–2 fails per 10 runs).
* Full fast suite (`pytest`): **5354 passed, 14 skipped, 1 xfailed**. No regressions.
* `test_slow_write_disables_further_writes` still passes — confirms the autouse fixture composes correctly with the test's own monkeypatch.

## Test plan

- [x] `pytest tests/slides/test_split.py` collects and runs hypothesis property tests
- [x] `for i in {1..15}; do pytest tests/infrastructure/database/test_worker_heartbeats.py tests/infrastructure/workers/ -n auto; done` — all green
- [x] Full fast suite green
- [ ] CI green on the PR

## Notes

A fourth reported flake — `tests/workers/jupyterlite/test_lite_dir.py::test_assemble_lite_dir_with_branding` — could not be reproduced across 15+ stress runs against this and the full fast suite. The test body is pure-synchronous, single-process, deterministic (a few `shutil.copy2` + `json.dumps` writes into per-test `tmp_path`). My best guess is it was an indirect side-effect of the heartbeat-warning storm flooding pytest's stderr capture; with the heartbeat fix above, that pressure is gone. Left unchanged rather than speculatively adding retries — if it reflakes, please capture the actual traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)