### PR TITLE
docs(handover): mark Priority 2 v1 as shipped after PR #105 merge

### DIFF
--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -20,7 +20,7 @@ checked into the CLM repo.
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
 | 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **Shipped** (CLM phases 1–4); issue #89 closed; P5 = PC-side corpus rerun, pending CLM release | [PR #101](https://github.com/hoelzl/clm/pull/101) merged 2026-05-19, master commit `c820fb8` |
-| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 in [PR #105](https://github.com/hoelzl/clm/pull/105)** (--dry-run only); interactive walker + --apply --trivial deferred to v2 | branch `claude/slide-format-redesign-phase-7`, commit `d09eb80` |
+| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 shipped** (--dry-run only); interactive walker + --apply --trivial deferred to v2 | [PR #105](https://github.com/hoelzl/clm/pull/105) merged 2026-05-20, master commit `4d1c645` |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |
 
@@ -88,11 +88,11 @@ language file to its companion (e.g. after editing `<deck>.de.py`,
 propose corresponding edits to `<deck>.en.py`), backed by an LLM call
 gated by a `SyncCache` table on `(de_hash, en_hash, prompt_version)`.
 
-**Status:** v1 implemented on branch
-`claude/slide-format-redesign-phase-7`. The PythonCourses-side
+**Status:** v1 **shipped** via [PR #105](https://github.com/hoelzl/clm/pull/105),
+merged to master 2026-05-20 as commit `4d1c645`. The PythonCourses-side
 `handover-slide-format-redesign-clm.md` §3 Phase 7 is still the
 canonical spec for the full feature; this section tracks what v1
-shipped versus what's deferred.
+shipped versus what's deferred to v2.
 
 ### Spec summary (from PC handover §3, repeated in the proposal)
 


### PR DESCRIPTION
## Summary

Updates the CLM-side PythonCourses-revamp handover doc to reflect
that PR #105 (`clm slides sync` v1, Phase 7 of the slide-format-redesign)
merged to master 2026-05-20 as commit \`4d1c645\`.

Marks the Priority 2 row in §0 as **v1 shipped** and updates §3
Phase 7's status header with the merge reference. Phase D pilot
follow-up (PythonCourses-side) and v2 of Phase 7 (interactive
walker + --apply --trivial + pilot accept-rate measurement) remain
on the future-work list.

Docs-only — no code changes.

## Test plan

- [x] Visual inspection of the rendered handover doc
- [x] Confirmed PR #105 state and merge SHA via `gh pr view 105`

🤖 Generated with [Claude Code](https://claude.com/claude-code)