### PR TITLE
fix(build): unify --output-dir layout with --snapshot (per-target re-root)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **`clm build --output-dir DIR` now produces the per-target layout
+  that `--snapshot DIR` produces.** For a spec with `<output-targets>`
+  (e.g. `shared` / `trainer` / `speaker`), `--output-dir DIR` re-roots
+  each target under `<DIR>/<target.name>/` — matching what the regular
+  spec-driven build writes — instead of collapsing every target into
+  the legacy `<DIR>/public/`+`<DIR>/speaker/` shape that silently
+  dropped non-default targets like `trainer/`. The two flags are now
+  layout-equivalent; `--snapshot` still differs only in its safety
+  guards (empty/non-existing DIR required, mutex with
+  `--verify-against`, post-build confirmation line). `--verify-against`
+  picks up the new layout automatically whether the verify build uses
+  `--output-dir` or relies on the spec's target paths.
+
+  **Migration**: callers that depended on the old collapsed
+  `--output-dir DIR` layout (single `public/speaker` tree) for a
+  multi-target spec should either (a) drop `<output-targets>` from
+  the spec, (b) build without `--output-dir` (writing to the spec's
+  declared target paths), or (c) update downstream tooling to read
+  `<DIR>/<target.name>/`. The `Course.from_spec()` API change is
+  source-compatible: the `snapshot_root` parameter is removed and
+  `output_root` now performs the per-target re-root that
+  `snapshot_root` did before.
+
 - **CLI restructure: verb-grouped subcommands.** Several flat
   top-level commands moved under new groups for a smaller, more
   scannable surface. Old names still work and emit a deprecation

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -213,17 +213,6 @@ class BuildConfig:
     # event handler to filter events.
     resolved_section_selection: SectionSelection | None = None
 
-    # When set, the build re-roots the spec's ``<output-targets>`` under
-    # this directory (each target becomes
-    # ``<snapshot_dir>/<target.name>/``) instead of collapsing into the
-    # legacy ``public/speaker`` layout. Spec files without
-    # ``<output-targets>`` fall back to using ``snapshot_dir`` as a
-    # single output dir, mirroring the previous behavior. Drives the
-    # ``clm build --snapshot`` flow; see issue #95 (B). Defaults to
-    # ``None`` so existing callers that don't know about the field
-    # construct ``BuildConfig`` unchanged.
-    snapshot_dir: Path | None = None
-
 
 def create_output_formatter(config: BuildConfig) -> OutputFormatter:
     """Create appropriate output formatter based on configuration."""
@@ -377,31 +366,27 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
                 f"Course spec validation failed with {len(validation_errors)} error(s)."
             )
 
-    # Determine output_dir behavior. ``snapshot_dir`` is the
-    # ``--snapshot`` destination; when set with a spec that defines
-    # ``<output-targets>`` the build re-roots each target under it
-    # rather than collapsing into one output_dir. With no
-    # ``<output-targets>`` the snapshot dir collapses into a single
-    # output dir, matching the pre-fix behavior.
+    # Determine output_dir behavior. When ``output_dir`` is set with a
+    # spec that has ``<output-targets>``, ``Course.from_spec`` re-roots
+    # each target under ``<output_dir>/<target.name>/`` (the per-target
+    # layout the snapshot/verify flow depends on). With no
+    # ``<output-targets>`` ``output_dir`` collapses into a single output
+    # tree. When ``output_dir`` is ``None`` and the spec has no
+    # targets, fall back to the default ``<course_root>/output``.
     output_dir = config.output_dir
-    snapshot_dir = config.snapshot_dir
-    if output_dir is None and snapshot_dir is None and not spec.output_targets:
+    if output_dir is None and not spec.output_targets:
         output_dir = default_output
         output_dir.mkdir(exist_ok=True)
         logger.debug(f"Output directory set to {output_dir}")
 
-    if output_dir is not None:
-        logger.info(f"Processing course from {spec_file.name} in {data_dir} to {output_dir}")
-    elif snapshot_dir is not None and spec.output_targets:
+    if output_dir is not None and spec.output_targets:
         target_names = [t.name for t in spec.output_targets]
         logger.info(
-            f"Processing course from {spec_file.name} in {data_dir} into snapshot "
-            f"{snapshot_dir} with targets: {target_names}"
+            f"Processing course from {spec_file.name} in {data_dir} to "
+            f"{output_dir} with targets: {target_names}"
         )
-    elif snapshot_dir is not None:
-        logger.info(
-            f"Processing course from {spec_file.name} in {data_dir} into snapshot {snapshot_dir}"
-        )
+    elif output_dir is not None:
+        logger.info(f"Processing course from {spec_file.name} in {data_dir} to {output_dir}")
     elif spec.output_targets:
         target_names = [t.name for t in spec.output_targets]
         logger.info(
@@ -485,7 +470,6 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
         inline_images=effective_inline_images,
         section_selection=section_selection,
         http_replay_mode=config.http_replay_mode,
-        snapshot_root=snapshot_dir,
     )
 
     # Calculate root directories for cleanup
@@ -1155,7 +1139,6 @@ async def main_build(
     image_mode,
     image_format,
     inline_images,
-    snapshot_dir: Path | None = None,
 ) -> BuildSummary | None:
     """Main orchestration function for course building.
 
@@ -1198,7 +1181,6 @@ async def main_build(
         spec_file=spec_file,
         data_dir=data_dir,
         output_dir=output_dir,
-        snapshot_dir=snapshot_dir,
         log_level=log_level,
         cache_db_path=cache_db_path,
         jobs_db_path=jobs_db_path,
@@ -1318,6 +1300,13 @@ async def main_build(
     "--output-dir",
     "-o",
     type=click.Path(exists=False, file_okay=False, dir_okay=True, path_type=Path),
+    help=(
+        "Override where build output is written. For specs with "
+        "<output-targets>, each target is re-rooted to "
+        "<DIR>/<target.name>/ (matching the snapshot/verify layout). "
+        "For specs without output-targets, DIR becomes a single "
+        "collapsed output tree."
+    ),
 )
 @click.option(
     "--snapshot",
@@ -1325,10 +1314,12 @@ async def main_build(
     type=click.Path(exists=False, file_okay=False, dir_okay=True, path_type=Path),
     default=None,
     help=(
-        "Capture build output to DIR as a verification baseline. Acts as "
-        "an explicit override of --output-dir; mutually exclusive with "
-        "--output-dir and --verify-against. The target directory must "
-        "either not exist yet or be empty."
+        "Capture build output to DIR as a verification baseline. "
+        "Identical layout to --output-dir DIR (each spec output-target "
+        "re-rooted to <DIR>/<target.name>/) plus three safety guards: "
+        "DIR must not exist or be empty, mutually exclusive with "
+        "--output-dir and --verify-against, and prints a confirmation "
+        "line after the build."
     ),
 )
 @click.option(
@@ -1634,7 +1625,8 @@ def build(
     # --output-dir (it is an explicit output-dir override) and with
     # --verify-against (different intents).
     # ------------------------------------------------------------------
-    if snapshot_dir is not None:
+    is_snapshot = snapshot_dir is not None
+    if is_snapshot:
         if output_dir is not None:
             raise click.UsageError(
                 "--snapshot and --output-dir are mutually exclusive; "
@@ -1650,13 +1642,13 @@ def build(
                 f"--snapshot target is not empty: {snapshot_dir}. "
                 "Pick a fresh path or remove the existing contents."
             )
-        # ``snapshot_dir`` is plumbed through ``main_build`` as its own
-        # value (NOT aliased to ``output_dir``) so the spec's
-        # ``<output-targets>`` can be re-rooted under it instead of being
-        # collapsed into the legacy ``public/speaker`` shape. With no
-        # spec targets, ``Course.from_spec`` falls back to treating
-        # ``snapshot_root`` as a single ``output_root`` -- so a minimal
-        # spec still produces a flat tree at ``<snapshot_dir>/...``.
+        # ``--snapshot`` and ``--output-dir`` now share the same
+        # downstream plumbing (both re-root the spec's
+        # ``<output-targets>`` under ``<DIR>/<target.name>/``). The only
+        # CLI-level differences are the safety guards above (empty-dir
+        # check, mutex with ``--verify-against``) and the post-build
+        # confirmation print.
+        output_dir = snapshot_dir
 
     if (include_html or strict_verify) and verify_against_dir is None:
         # Surface the no-op rather than silently ignoring it.
@@ -1755,7 +1747,6 @@ def build(
             image_mode,
             image_format,
             inline_images,
-            snapshot_dir=snapshot_dir,
         )
     )
 
@@ -1782,14 +1773,9 @@ def build(
     # to. main_build does not return it, but resolve_course_paths is
     # the single source of truth used inside the build pipeline too.
     _, default_output = resolve_course_paths(spec_file, data_dir)
-    if snapshot_dir is not None:
-        effective_output = snapshot_dir
-    elif output_dir is not None:
-        effective_output = output_dir
-    else:
-        effective_output = default_output
+    effective_output = output_dir if output_dir is not None else default_output
 
-    if snapshot_dir is not None:
+    if is_snapshot:
         # The build report already covers what was written; print a short
         # confirmation so scripts can grep for the snapshot location.
         click.echo(f"\nSnapshot saved to: {effective_output.resolve()}")
@@ -1797,25 +1783,29 @@ def build(
     if verify_against_dir is not None:
         from clm.snapshot import verify_against, verify_against_targets
 
-        # When the spec defines ``<output-targets>`` and the user did
-        # NOT pass ``--output-dir`` (which collapses everything into a
-        # single tree), the regular build wrote to each target's own
-        # ``output_root``. The snapshot then must be compared per-target
-        # — ``<snap>/<target.name>/`` against the corresponding
-        # ``target.output_root`` — instead of as one monolithic pair.
-        # Otherwise the entire snapshot looks "extra" because the
-        # output tree literally has no overlap with the snapshot tree
-        # (e.g. ``shared/`` vs the legacy ``public/`` toplevel).
-        # Regression for issue #95 (B).
+        # When the spec defines ``<output-targets>`` the regular build
+        # writes per-target — either to each target's spec-declared path
+        # (no ``--output-dir``) or to ``<output_dir>/<target.name>/``
+        # (with ``--output-dir DIR``). The snapshot must be compared
+        # per-target — ``<snap>/<target.name>/`` against the
+        # corresponding output root — instead of as one monolithic
+        # pair, otherwise the entire snapshot looks "extra" because
+        # the toplevel prefixes differ. Regression for issue #95 (B).
         verify_spec = CourseSpec.from_file(spec_file.absolute())
-        if output_dir is None and verify_spec.output_targets:
+        if verify_spec.output_targets:
             verify_course_root, _ = resolve_course_paths(spec_file, data_dir)
             target_pairs = []
             for t in verify_spec.output_targets:
-                target_path = Path(t.path)
-                if not target_path.is_absolute():
-                    target_path = verify_course_root / target_path
-                target_pairs.append((t.name, target_path.resolve()))
+                if output_dir is not None:
+                    # ``--output-dir DIR`` re-roots each target to
+                    # ``<DIR>/<target.name>/`` (matching what
+                    # ``Course.from_spec`` produces).
+                    target_pairs.append((t.name, (output_dir / t.name).resolve()))
+                else:
+                    target_path = Path(t.path)
+                    if not target_path.is_absolute():
+                        target_path = verify_course_root / target_path
+                    target_pairs.append((t.name, target_path.resolve()))
             report = verify_against_targets(
                 snapshot_dir=verify_against_dir,
                 targets=target_pairs,

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -35,8 +35,8 @@ Key options:
 | Option | Description |
 |--------|-------------|
 | `-d, --data-dir DIR` | Source data directory |
-| `-o, --output-dir DIR` | Output directory (overrides spec targets) |
-| `--snapshot DIR` | Capture build output to DIR as a verification baseline. Mutually exclusive with `--output-dir` and `--verify-against`. Target must not exist or be empty. See "Snapshot / verify" below. |
+| `-o, --output-dir DIR` | Override where build output is written. For specs with `<output-targets>`, each target is re-rooted to `<DIR>/<target.name>/` (same layout `--snapshot` produces and what the regular spec-driven build writes). For specs without output-targets, DIR becomes a single collapsed output tree. |
+| `--snapshot DIR` | Capture build output to DIR as a verification baseline. Identical layout to `--output-dir DIR` plus three safety guards: DIR must not exist or be empty, mutually exclusive with `--output-dir` and `--verify-against`, and prints a confirmation line after the build. See "Snapshot / verify" below. |
 | `--verify-against DIR` | Build, then byte-compare the output tree against the snapshot at DIR. Exits non-zero on any diff. `.html` is skipped by default (kernel-execution noise). See "Snapshot / verify" below. |
 | `--include-html` | With `--verify-against`: include `.html` files using hex-address normalization. |
 | `--strict-verify` | With `--verify-against`: byte-compare every file, no normalization or skipping. |
@@ -246,20 +246,18 @@ clm build course.xml --output-dir out/ --verify-against baseline/ --ignore-cache
 `--verify-against` exits non-zero if any non-skipped file differs.
 
 **Specs with `<output-targets>`** (e.g. `shared`/`trainer`/`speaker`):
-both `--snapshot` and `--verify-against` honor the spec's targets.
-`--snapshot DIR` writes each target to `<DIR>/<target.name>/...`
-instead of collapsing into the legacy `public/`/`speaker/` toplevel
-shape — so e.g. a spec with `shared`, `trainer`, and `speaker`
-targets lays down `<DIR>/shared/...`, `<DIR>/trainer/...`,
+both `--snapshot DIR` and `--output-dir DIR` write each target to
+`<DIR>/<target.name>/...` — a spec with `shared`, `trainer`, and
+`speaker` targets lays down `<DIR>/shared/...`, `<DIR>/trainer/...`,
 `<DIR>/speaker/...`. `--verify-against DIR` then compares each
 target's actual `output_root` against the matching `<DIR>/<name>/`
 subtree and surfaces diffs prefixed with the target name (e.g.
-`trainer/de/a.py`). Run the verify build **without** `--output-dir`
-in this mode — `--output-dir` collapses every target into a single
-tree and the verify falls back to a flat compare. Specs without
-`<output-targets>` (minimal specs) keep the original behavior:
-`--snapshot DIR` and `--verify-against DIR` operate on `<DIR>` as a
-single tree.
+`trainer/de/a.py`). The verify build picks up the layout
+automatically — whether you pass `--output-dir DIR` or rely on the
+spec's declared target paths, `--verify-against` walks per-target.
+Specs without `<output-targets>` (minimal specs) keep the
+single-tree behavior: `--snapshot DIR`, `--output-dir DIR`, and
+`--verify-against DIR` all operate on `<DIR>` as one flat tree.
 
 **HTML is skipped by default** because rendered HTML uses live kernel
 execution, and any slide whose code path is non-deterministic

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -126,14 +126,21 @@ class Course(NotebookMixin):
         inline_images: bool = False,
         section_selection: SectionSelection | None = None,
         http_replay_mode: str | None = None,
-        snapshot_root: Path | None = None,
     ) -> "Course":
         """Create a Course from a CourseSpec.
 
         Args:
             spec: The parsed course specification
             course_root: Root directory of the course source
-            output_root: Override output directory (None = use spec targets)
+            output_root: When set with a spec that has
+                ``<output-targets>``, re-root each target under
+                ``<output_root>/<target.name>/`` (matching what the
+                regular build writes — keyed by target name, not the
+                legacy ``public/speaker`` toplevel). When set with a
+                spec that has no ``<output-targets>``, behaves as a
+                single collapsed output tree at ``output_root``. When
+                ``None``, the spec's ``<output-targets>`` paths are
+                used unchanged.
             output_languages: Filter languages (applies to all targets)
             output_kinds: Filter kinds (applies to all targets)
             fallback_execute: Whether to fall back to execution on cache miss
@@ -155,43 +162,25 @@ class Course(NotebookMixin):
                 whose topic has
                 ``http_replay="yes"`` honor this; other notebooks are
                 unaffected. When ``None``, HTTP replay is off.
-            snapshot_root: When set, re-root the spec's
-                ``<output-targets>`` under this directory so each target
-                writes to ``<snapshot_root>/<target.name>/``. Mutually
-                exclusive with ``output_root``. When the spec has no
-                ``<output-targets>``, this behaves like
-                ``output_root=snapshot_root`` (single collapsed tree).
-                Drives the ``clm build --snapshot`` flow so the captured
-                baseline has the same layout the regular build would
-                produce — keyed by target name rather than the legacy
-                ``public/speaker`` toplevel.
 
         Returns:
             Configured Course instance
         """
-        if output_root is not None and snapshot_root is not None:
-            raise ValueError(
-                "output_root and snapshot_root are mutually exclusive — "
-                "pick one. snapshot_root re-roots the spec's output "
-                "targets; output_root collapses everything into a single "
-                "tree."
-            )
-
         # Determine output targets
-        if snapshot_root is not None and spec.output_targets:
-            # Snapshot mode with spec targets: keep each target's filters
-            # and kinds, but redirect its output_root to
-            # ``<snapshot_root>/<target.name>/`` so the captured tree
-            # mirrors the regular build's per-target layout instead of
-            # collapsing into the legacy ``public/speaker`` shape.
+        if output_root is not None and spec.output_targets:
+            # Re-root each spec target under ``<output_root>/<target.name>/``
+            # so the output layout matches what the regular build writes —
+            # keyed by target name, not the legacy ``public/speaker``
+            # toplevel. This is the behavior the snapshot/verify flow
+            # depends on and what users expect for a multi-target override.
+            from attrs import evolve
+
             targets = []
             for t in spec.output_targets:
                 target = OutputTarget.from_spec(t, course_root, course_jupyterlite=spec.jupyterlite)
-                # `evolve`-style replace: rebuild with the snapshot-rooted
-                # output_root, keep `is_explicit=True` so paths stay flat.
-                from attrs import evolve
-
-                targets.append(evolve(target, output_root=(snapshot_root / t.name).resolve()))
+                # ``is_explicit`` is preserved (set by ``OutputTarget.from_spec``)
+                # so paths under each re-rooted output_root stay flat.
+                targets.append(evolve(target, output_root=(output_root / t.name).resolve()))
             if selected_targets:
                 targets = [t for t in targets if t.name in selected_targets]
                 if not targets:
@@ -201,16 +190,12 @@ class Course(NotebookMixin):
                         f"Requested: {selected_targets}, "
                         f"Available: {available}"
                     )
-            effective_output_root = snapshot_root
-        elif output_root is not None or snapshot_root is not None:
-            # CLI override: use single output directory with all outputs.
-            # Also reached when ``snapshot_root`` is set but the spec has
-            # no ``<output-targets>`` — there's nothing per-target to
-            # re-root, so collapse into the snapshot dir directly.
-            single_root = output_root if output_root is not None else snapshot_root
-            assert single_root is not None
-            targets = [OutputTarget.default_target(single_root)]
-            effective_output_root = single_root
+            effective_output_root = output_root
+        elif output_root is not None:
+            # CLI override on a spec with no ``<output-targets>``: a
+            # single default target rooted at ``output_root``.
+            targets = [OutputTarget.default_target(output_root)]
+            effective_output_root = output_root
         elif spec.output_targets:
             # Use targets from spec file
             targets = [

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -867,18 +867,19 @@ def test_sweep_orphan_staging_files_no_orphans_present(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# snapshot_root re-roots spec ``<output-targets>``
+# output_root re-roots spec ``<output-targets>``
 #
-# Regression for issue #95 (B): the ``clm build --snapshot`` flow used to
-# alias to ``--output-dir``, which collapses spec output-targets into the
-# single default target's ``public/speaker`` layout — silently dropping
-# any target whose toplevel does not happen to be ``public``/``speaker``
-# (e.g. ``shared`` / ``trainer``). The fix keeps spec targets but
-# re-roots each one under the snapshot directory.
+# Regression for issue #95 (B): ``clm build --snapshot DIR`` and
+# ``clm build --output-dir DIR`` both re-root each spec ``<output-target>``
+# under ``<DIR>/<target.name>/``. The previous behavior (--output-dir
+# collapsed everything into the default target's ``public/speaker``
+# layout — silently dropping any target whose toplevel was not
+# ``public``/``speaker``, e.g. ``trainer``) caused thousands of bogus
+# diffs in verify runs and is no longer supported.
 # ---------------------------------------------------------------------------
 
 
-def _build_course_with_targets(course_root: Path, snapshot_root: Path | None):
+def _build_course_with_targets(course_root: Path, output_root: Path | None):
     """Construct a Course from a spec with three ``<output-targets>``."""
     import io
 
@@ -903,47 +904,47 @@ def _build_course_with_targets(course_root: Path, snapshot_root: Path | None):
     </course>
     """
     spec = CourseSpec.from_file(io.StringIO(spec_xml))
-    return Course.from_spec(spec, course_root, None, snapshot_root=snapshot_root)
+    return Course.from_spec(spec, course_root, output_root)
 
 
-def test_snapshot_root_reroots_spec_targets_under_snapshot_dir(tmp_path):
+def test_output_root_reroots_spec_targets_under_output_dir(tmp_path):
     """Each spec target's ``output_root`` lives at
-    ``<snapshot_root>/<target.name>/`` so the captured tree mirrors the
+    ``<output_root>/<target.name>/`` so the build tree mirrors the
     per-target layout instead of collapsing into ``public/speaker``."""
-    snap = tmp_path / "snap"
-    course = _build_course_with_targets(tmp_path, snap)
+    out = tmp_path / "out"
+    course = _build_course_with_targets(tmp_path, out)
 
     target_by_name = {t.name: t for t in course.output_targets}
     assert set(target_by_name) == {"shared", "trainer", "speaker"}
-    assert target_by_name["shared"].output_root == (snap / "shared").resolve()
-    assert target_by_name["trainer"].output_root == (snap / "trainer").resolve()
-    assert target_by_name["speaker"].output_root == (snap / "speaker").resolve()
+    assert target_by_name["shared"].output_root == (out / "shared").resolve()
+    assert target_by_name["trainer"].output_root == (out / "trainer").resolve()
+    assert target_by_name["speaker"].output_root == (out / "speaker").resolve()
     # is_explicit must stay True so the path layout under each target's
     # output_root looks like a regular ``<lang>/...`` tree, not the
     # legacy ``public/<lang>/...`` shape.
     assert all(t.is_explicit for t in course.output_targets)
 
 
-def test_snapshot_root_does_not_drop_trainer_target(tmp_path):
-    """The bug from issue #95 (B): trainer/ silently disappears because
-    the default target only keeps the public/speaker toplevels. The
+def test_output_root_does_not_drop_trainer_target(tmp_path):
+    """The bug from issue #95 (B): trainer/ silently disappeared because
+    the default target only kept the public/speaker toplevels. The
     fix must preserve every spec target."""
-    snap = tmp_path / "snap"
-    course = _build_course_with_targets(tmp_path, snap)
+    out = tmp_path / "out"
+    course = _build_course_with_targets(tmp_path, out)
 
     names = {t.name for t in course.output_targets}
     assert "trainer" in names, (
-        "trainer target was dropped — this is the regression from "
-        "the old --snapshot -> --output-dir alias that collapsed to "
-        "the default target (public/speaker only)."
+        "trainer target was dropped — regression from the old "
+        "--output-dir behavior that collapsed to the default target "
+        "(public/speaker only)."
     )
 
 
-def test_snapshot_root_without_spec_targets_collapses_to_dir(tmp_path):
-    """When the spec has no ``<output-targets>``, ``snapshot_root``
-    behaves like ``output_root=snapshot_root`` — a single default
-    target rooted at the snapshot dir. Preserves the pre-fix behavior
-    for minimal specs."""
+def test_output_root_without_spec_targets_collapses_to_dir(tmp_path):
+    """When the spec has no ``<output-targets>``, ``output_root``
+    produces a single default target rooted at the output dir. There's
+    nothing per-target to re-root, so the behavior is the same as
+    passing ``--output-dir`` to a minimal spec."""
     import io
 
     from clm.core.course_spec import CourseSpec
@@ -965,29 +966,7 @@ def test_snapshot_root_without_spec_targets_collapses_to_dir(tmp_path):
             """
         )
     )
-    snap = tmp_path / "snap"
-    course = Course.from_spec(spec, tmp_path, None, snapshot_root=snap)
+    out = tmp_path / "out"
+    course = Course.from_spec(spec, tmp_path, out)
     assert len(course.output_targets) == 1
-    assert course.output_targets[0].output_root == snap.resolve()
-
-
-def test_snapshot_root_and_output_root_are_mutually_exclusive(tmp_path):
-    """Passing both is a programming error — the two have overlapping
-    intent and the precedence is non-obvious."""
-    import io
-
-    from clm.core.course_spec import CourseSpec
-
-    spec = CourseSpec.from_file(
-        io.StringIO(
-            """
-            <course>
-              <name><de>Test</de><en>Test</en></name>
-              <prog-lang>python</prog-lang>
-              <sections/>
-            </course>
-            """
-        )
-    )
-    with pytest.raises(ValueError, match="mutually exclusive"):
-        Course.from_spec(spec, tmp_path, tmp_path / "out", snapshot_root=tmp_path / "snap")
+    assert course.output_targets[0].output_root == out.resolve()

--- a/tests/core/test_multi_target_course.py
+++ b/tests/core/test_multi_target_course.py
@@ -110,24 +110,56 @@ class TestCourseFromSpecWithTargets:
         assert instructor.name == "instructor"
         assert instructor.languages == frozenset({"en"})
 
-    def test_from_spec_cli_output_dir_overrides_targets(
+    def test_from_spec_cli_output_dir_reroots_spec_targets(
         self, course_spec_with_targets, course_root
     ):
-        """Test that CLI --output-dir overrides spec targets."""
+        """``--output-dir DIR`` on a spec with ``<output-targets>``
+        re-roots each target to ``<DIR>/<target.name>/`` (matching
+        the per-target layout used by ``--snapshot`` and the regular
+        spec-driven build). It does NOT collapse all targets into a
+        single ``public/speaker`` tree — the old collapsed behavior
+        silently dropped non-default targets like ``trainer``."""
         output_dir = course_root / "cli_output"
 
         course = Course.from_spec(
             spec=course_spec_with_targets,
             course_root=course_root,
-            output_root=output_dir,  # CLI override
+            output_root=output_dir,  # CLI override, per-target re-root
         )
 
-        # Should have single default target
+        # All three spec targets must be preserved with their filters.
+        assert len(course.output_targets) == 3
+        names = {t.name for t in course.output_targets}
+        assert names == {"students", "solutions", "instructor"}
+
+        by_name = {t.name: t for t in course.output_targets}
+        assert by_name["students"].output_root == (output_dir / "students").resolve()
+        assert by_name["solutions"].output_root == (output_dir / "solutions").resolve()
+        assert by_name["instructor"].output_root == (output_dir / "instructor").resolve()
+
+        # Per-target filters from the spec are preserved (not flattened
+        # to the default-target ALL_KINDS / DEFAULT_FORMATS).
+        assert by_name["students"].kinds == frozenset({"code-along"})
+        assert by_name["solutions"].kinds == frozenset({"completed"})
+        assert by_name["instructor"].languages == frozenset({"en"})
+
+    def test_from_spec_cli_output_dir_no_spec_targets_uses_default(
+        self, course_spec_no_targets, course_root
+    ):
+        """``--output-dir DIR`` on a spec without ``<output-targets>``
+        collapses into a single default target at ``DIR`` (there's
+        nothing per-target to re-root)."""
+        output_dir = course_root / "cli_output"
+
+        course = Course.from_spec(
+            spec=course_spec_no_targets,
+            course_root=course_root,
+            output_root=output_dir,
+        )
+
         assert len(course.output_targets) == 1
         assert course.output_targets[0].name == "default"
         assert course.output_targets[0].output_root == output_dir.resolve()
-
-        # Default target should have all kinds/formats/languages
         assert course.output_targets[0].kinds == ALL_KINDS
         assert course.output_targets[0].formats == DEFAULT_FORMATS
         assert course.output_targets[0].languages == ALL_LANGUAGES

--- a/tests/snapshot/test_build_integration.py
+++ b/tests/snapshot/test_build_integration.py
@@ -95,12 +95,11 @@ def fake_build(monkeypatch):
         *_args,
         **kwargs,
     ):
-        snapshot_dir = kwargs.get("snapshot_dir")
-        # The real build resolves the effective output dir based on
-        # ``--snapshot`` / ``--output-dir`` / default. Mirror that here.
-        if snapshot_dir is not None:
-            root = Path(snapshot_dir)
-        elif output_dir is not None:
+        # The CLI now folds ``--snapshot DIR`` into ``output_dir`` before
+        # calling main_build (both map to the same per-target re-rooting
+        # in ``Course.from_spec``), so the stub only needs to look at
+        # ``output_dir``.
+        if output_dir is not None:
             root = Path(output_dir)
         else:
             # Fall back to spec's grandparent / "output" — matches
@@ -323,6 +322,75 @@ class TestSnapshotMultiTargetLayout:
         assert (snap / "trainer" / "de" / "index.html").read_bytes() == b"trainer-de"
         assert (snap / "speaker" / "de" / "index.html").read_bytes() == b"speaker-de"
         assert not (snap / "public").exists()
+
+    def test_output_dir_uses_target_names_not_legacy_layout(
+        self, tmp_path: Path, fake_build
+    ) -> None:
+        """``--output-dir DIR`` now produces the same per-target layout
+        as ``--snapshot DIR``. The old behavior — collapsing everything
+        into ``<DIR>/public/`` and silently dropping ``trainer/`` — has
+        been removed: it caused thousands of bogus verify diffs (issue
+        #95 (B)) and didn't match what the regular spec-driven build
+        wrote."""
+        spec = self._setup(tmp_path)
+        fake_build(
+            {
+                "shared": {"de/index.html": b"shared-de"},
+                "trainer": {"de/index.html": b"trainer-de"},
+                "speaker": {"de/index.html": b"speaker-de"},
+            }
+        )
+
+        out = tmp_path / "out"
+        result = _invoke_build([str(spec), "--output-dir", str(out)], tmp_path)
+
+        assert result.exit_code == 0, result.output
+        assert (out / "shared" / "de" / "index.html").read_bytes() == b"shared-de"
+        assert (out / "trainer" / "de" / "index.html").read_bytes() == b"trainer-de"
+        assert (out / "speaker" / "de" / "index.html").read_bytes() == b"speaker-de"
+        assert not (out / "public").exists()
+
+    def test_verify_per_target_works_with_output_dir(self, tmp_path: Path, fake_build) -> None:
+        """``--output-dir DIR`` + ``--verify-against BASELINE`` for a
+        multi-target spec compares ``<BASELINE>/<target.name>/`` against
+        ``<DIR>/<target.name>/`` per target — not as one monolithic
+        tree (which would surface a "missing on both sides" storm)."""
+        spec = self._setup(tmp_path)
+
+        # Capture a baseline snapshot.
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"BBB"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        baseline = tmp_path / "baseline"
+        result = _invoke_build([str(spec), "--snapshot", str(baseline)], tmp_path)
+        assert result.exit_code == 0, result.output
+
+        # Verify with --output-dir so the second build writes per-target
+        # under <out>/<target.name>/ — must match the baseline.
+        fake_build(
+            {
+                "shared": {"de/a.py": b"AAA"},
+                "trainer": {"de/a.py": b"BBB"},
+                "speaker": {"de/a.py": b"CCC"},
+            }
+        )
+        out = tmp_path / "out"
+        result = _invoke_build(
+            [
+                str(spec),
+                "--output-dir",
+                str(out),
+                "--verify-against",
+                str(baseline),
+            ],
+            tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Verification passed" in result.output
 
     def test_verify_per_target_matches_when_layouts_align(self, tmp_path: Path, fake_build) -> None:
         spec = self._setup(tmp_path)


### PR DESCRIPTION
## Summary

- `clm build --output-dir DIR` now produces the same per-target layout as `--snapshot DIR`. For a spec with `<output-targets>` (e.g. `shared`/`trainer`/`speaker`), each target is re-rooted under `<DIR>/<target.name>/` — matching what the regular spec-driven build writes.
- The previous `--output-dir DIR` behavior collapsed every target into the default target's `public/`/`speaker/` layout, silently dropping non-default targets like `trainer/`. Issue #95 (B) fixed this for `--snapshot` only via PR #96; this PR removes the same footgun from `--output-dir`.
- `--snapshot` keeps its CLI-level safety guards (empty/non-existing DIR required, mutex with `--verify-against`, confirmation print). The two flags differ only in those guards now.
- `Course.from_spec(snapshot_root=...)` parameter removed; `output_root` alone performs the per-target re-root. `--verify-against` walks per-target whenever the spec has `<output-targets>`, regardless of whether `--output-dir` was passed — no more "must build without --output-dir to verify" footgun.

## Migration

Callers that depended on the old collapsed `--output-dir DIR` layout for a multi-target spec must either (a) drop `<output-targets>` from the spec, (b) build without `--output-dir` and write to the spec's declared target paths, or (c) update downstream tooling to read `<DIR>/<target.name>/`.

## Test plan

- [x] Full fast suite passes (5408 passed, 14 skipped, 1 xfailed) — `pytest`
- [x] Targeted regression: 98 passed across `tests/core/course_test.py`, `tests/core/test_multi_target_course.py`, `tests/snapshot/`
- [x] Ruff lint + format clean on touched files
- [x] mypy clean on `src/clm/core/course.py` and `src/clm/cli/commands/build.py`
- [x] Pre-commit hook (ruff + mypy + fast pytest) passed on commit

Key new/updated tests:
- `tests/core/course_test.py::test_output_root_reroots_spec_targets_under_output_dir` (renamed from `snapshot_root` variant) — asserts each spec target re-roots under `<output_root>/<target.name>/`
- `tests/core/test_multi_target_course.py::test_from_spec_cli_output_dir_reroots_spec_targets` — replaces the old `test_from_spec_cli_output_dir_overrides_targets` (which documented the collapsed behavior) with the new per-target assertion
- `tests/snapshot/test_build_integration.py::TestSnapshotMultiTargetLayout::test_output_dir_uses_target_names_not_legacy_layout` — CLI-level test that `--output-dir DIR` on a multi-target spec writes to `<DIR>/<target.name>/`
- `tests/snapshot/test_build_integration.py::TestSnapshotMultiTargetLayout::test_verify_per_target_works_with_output_dir` — end-to-end snapshot → verify with `--output-dir` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)