### PR TITLE
docs(deprecation): slip --keep-directory + speaker-kind removals to 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **Deprecation removals slipped from CLM 1.6 to 1.7.** Two removals
+  that 1.5 documented for the 1.6 release have been pushed out by one
+  minor: the `--keep-directory` CLI flag (currently a no-op alias
+  emitting `DeprecationWarning`) and the `<kind>speaker</kind>` output
+  kind (currently accepted as a deprecated alias for `recording`).
+  Both continue to behave as in 1.5 — the flag remains a no-op, the
+  kind alias still normalizes to `recording` with a parse-time
+  warning — and are now scheduled for removal in CLM 1.7. The slip
+  aligns these two removals with the Phase 0 CLI-alias removal so
+  consumers see a single deprecation cliff, and gives the
+  PythonCourses slide-format-redesign migration room to land on 1.6
+  without scrambling. Doc strings, `clm info commands`,
+  `clm info migration`, the runtime `DeprecationWarning`, and the
+  matching test (`tests/cli/test_build_command.py`) are updated; the
+  historical 1.5.0 `### Deprecated` entry stays as written since it
+  documents what was planned at that release's ship date.
+
 - **`clm build --output-dir DIR` now produces the per-target layout
   that `--snapshot DIR` produces.** For a spec with `<output-targets>`
   (e.g. `shared` / `trainer` / `speaker`), `--output-dir DIR` re-roots

--- a/docs/claude/design/git-friendly-output-writes.md
+++ b/docs/claude/design/git-friendly-output-writes.md
@@ -277,7 +277,8 @@ else:
 **CLI surface:**
 - Add `--clean` flag (replaces today's implicit default).
 - Keep `--keep-directory` as a no-op alias that warns it's now the default
-  (one release of deprecation, remove in 1.6).
+  (one release of deprecation, originally planned for removal in 1.6 —
+  slipped to 1.7 to align with the Phase 0 CLI-alias cliff).
 - `--incremental` remains as-is but now buys less — it implies `--no-sweep`
   on top of the new default, since `--incremental` users explicitly
   trust the on-disk state.
@@ -326,8 +327,9 @@ The end-of-build walk is O(files-on-disk), comparable to one
 small performance win.
 
 **Resolved D3.** `--keep-directory` emits a deprecation warning for
-one release ("now default, will be removed in 1.6") and is removed
-in the following minor release. The flag is documented and ecosystem
+one release ("now default, will be removed in 1.7" — originally
+planned for 1.6, slipped to align with the Phase 0 CLI-alias removal)
+and is removed in that release. The flag is documented and ecosystem
 scripts may reference it, so silent no-op is unacceptable.
 
 ## Test plan

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1407,7 +1407,7 @@ async def main_build(
     is_flag=True,
     help=(
         "Deprecated: keeping the output tree is now the default; this "
-        "flag is a no-op alias. Will be removed in 1.6."
+        "flag is a no-op alias. Will be removed in 1.7."
     ),
 )
 @click.option(
@@ -1662,7 +1662,7 @@ def build(
         import warnings
 
         warnings.warn(
-            "--keep-directory is deprecated and will be removed in CLM 1.6. "
+            "--keep-directory is deprecated and will be removed in CLM 1.7. "
             "Keeping the output tree is now the default; this flag is a no-op. "
             "Use --clean to opt into the legacy wipe-and-restore flow.",
             DeprecationWarning,

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -47,7 +47,7 @@ Key options:
 | `--clean` | Wipe each output root and regenerate from scratch (legacy flow; preserves nested `.git/`). Use for emergency recovery from a corrupted output tree. The default no longer wipes — see "Git-friendly output writes" below. |
 | `--no-sweep` | Disable the post-build stray-file sweep. Useful when iterating on a single section and you don't want orphans from other sections deleted. |
 | `--incremental` | Keep directories, only write newly processed files (skip cached ones). Implies `--no-sweep`. |
-| `--keep-directory` | **Deprecated** (CLM {version}, will be removed in 1.6). Keeping the output tree is now the default; this flag is a no-op alias. |
+| `--keep-directory` | **Deprecated** (CLM {version}, will be removed in 1.7). Keeping the output tree is now the default; this flag is a no-op alias. |
 | `--only-sections TEXT` | Comma-separated selector tokens; rebuild only those sections and leave unselected section output untouched. Dir-group processing is skipped in this mode. See "Iterating on a single section" below. |
 | `--workers [direct\|docker]` | Worker execution mode |
 | `--notebook-workers N` | Number of notebook workers |

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -234,7 +234,7 @@ The new default does the opposite:
 | Flag | Before | After |
 |------|--------|-------|
 | (default) | wipe + restore `.git/` + rebuild | no wipe; hash-aware writes + sweep |
-| `--keep-directory` | opt out of the wipe | **deprecated** no-op alias; will be removed in 1.6 |
+| `--keep-directory` | opt out of the wipe | **deprecated** no-op alias; will be removed in 1.7 |
 | `--incremental` | implies `--keep-directory`; skip cached writes | skip cached writes; implies `--no-sweep` |
 | `--clean` | n/a (new) | opt into the legacy wipe-and-restore flow |
 | `--no-sweep` | n/a (new) | opt out of the post-build sweep |
@@ -249,8 +249,9 @@ output for unchanged content. A few scripts may need an explicit flag:
   `shutil.rmtree` each root, regenerate). Nested `.git/` directories
   are preserved across the wipe, same as before.
 - **You scripted `--keep-directory`.** The flag is now a no-op alias
-  with a `DeprecationWarning`; remove it. The deprecation runs through
-  CLM 1.5; the flag is removed entirely in 1.6.
+  with a `DeprecationWarning`; remove it. The flag is removed entirely
+  in CLM 1.7 (originally planned for 1.6 — slipped to align with the
+  Phase 0 CLI-alias removal so users have a single deprecation cliff).
 - **You scripted `--incremental` to avoid the wipe.** Drop `--incremental`
   unless you also want the disk-write skipping it adds on top of the new
   default. `--incremental` now implies `--no-sweep` as well.

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -544,8 +544,10 @@ class DirGroupSpec:
 
 
 # Valid values for output target configuration. ``speaker`` is the deprecated
-# input alias for ``recording`` — accepted for one release with a
+# input alias for ``recording`` — accepted through CLM 1.6 with a
 # DeprecationWarning logged at parse time (see :func:`_normalize_output_kind`).
+# Removal target: CLM 1.7 (originally planned for 1.6 — slipped to align with
+# the Phase 0 CLI-alias removal so users see a single deprecation cliff).
 VALID_KINDS: frozenset[str] = frozenset(
     {"code-along", "completed", "trainer", "recording", "speaker", "partial"}
 )
@@ -558,7 +560,8 @@ def _normalize_output_kind(kind: str) -> str:
     speaker notes and voiceover cells. It is preserved as an input alias for
     backwards compatibility but is logged as deprecated and remapped to
     ``recording``. New consumers should never see ``speaker`` once a spec has
-    been normalized through this function.
+    been normalized through this function. Scheduled for removal in CLM 1.7
+    (originally planned for 1.6).
     """
     if kind == "speaker":
         logger.warning(

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -280,7 +280,7 @@ class Kind(StrEnum):
     COMPLETED = "completed"
     TRAINER = "trainer"
     RECORDING = "recording"
-    SPEAKER = "speaker"  # Deprecated alias for RECORDING; kept for one release.
+    SPEAKER = "speaker"  # Deprecated alias for RECORDING; removed in CLM 1.7.
     PARTIAL = "partial"
 
 

--- a/src/clm/workers/notebook/output_spec.py
+++ b/src/clm/workers/notebook/output_spec.py
@@ -9,7 +9,7 @@ output that should be generated.
 - `CodeAlongOutput`: The output type for artefacts meant for live coding or workshops.
 - `TrainerOutput`: Private output for trainers — keeps speaker notes, strips voiceover.
 - `RecordingOutput`: Private output for video recording — keeps both notes and voiceover.
-- `SpeakerOutput`: Deprecated alias for ``RecordingOutput`` (kept for one release).
+- `SpeakerOutput`: Deprecated alias for ``RecordingOutput`` (removed in CLM 1.7).
 - `EditScriptOutput`: Output type that generates an edit script to update from codealong to completed notebook.
 """
 
@@ -523,7 +523,7 @@ def create_output_spec(kind: str, *args, **kwargs) -> OutputSpec:
             warnings.warn(
                 "Output kind 'speaker' is deprecated; use 'recording' (notes + "
                 "voiceover) or 'trainer' (notes only) instead. 'speaker' currently "
-                "maps to 'recording' and will be removed in a future release.",
+                "maps to 'recording' and will be removed in CLM 1.7.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1380,7 +1380,7 @@ class TestKeepDirectoryDeprecation:
         deprecation = [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
         assert deprecation, "expected a DeprecationWarning when --keep-directory is used"
         assert "--keep-directory" in str(deprecation[0].message)
-        assert "1.6" in str(deprecation[0].message)
+        assert "1.7" in str(deprecation[0].message)
 
     def test_no_warning_without_flag(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder


### PR DESCRIPTION
## Summary

1.5 documented two deprecations for removal in 1.6:
- `--keep-directory` (no-op alias since 1.5; emits `DeprecationWarning`)
- `<kind>speaker</kind>` output kind (deprecated input alias normalized to `recording`)

The PythonCourses slide-format-redesign migration is still in flight and pinned at CLM 1.5; cutting 1.6 with those removals would land an in-flight migration on a release that breaks the deprecation contract. Slip both to CLM 1.7 so:

- The next CLM release behaves like 1.5 for those flags/kinds — no surprise breakage during the AZAV ML / `clm slides assign-ids` migration.
- 1.7 aligns the removals with the Phase 0 CLI-alias cliff that's already scheduled for that release. Users see a single deprecation cliff instead of two.

## What changed

Doc-only, plus one test assertion bump:

- Runtime `DeprecationWarning` in `clm build` (`build.py:1665`) — "CLM 1.6" → "CLM 1.7"
- Click `--help` text for `--keep-directory` (`build.py:1410`) — "1.6" → "1.7"
- `clm info commands` table row — "1.6" → "1.7"
- `clm info migration` table row + paragraph — "1.6" → "1.7" (paragraph adds a one-line rationale)
- `course_spec.py`, `output_spec.py`, `path_utils.py` doc comments on the `speaker` kind — "kept for one release" / "future release" → "CLM 1.7"
- `tests/cli/test_build_command.py` — assertion `"1.6" in str(deprecation[0].message)` → `"1.7"`
- New `[Unreleased] ### Changed` entry in CHANGELOG explaining the slip
- `docs/claude/design/git-friendly-output-writes.md` historical mentions get a brief slip note

The historical `## [1.5.0] ### Deprecated` CHANGELOG entry is left unchanged — it documents what was planned at ship time. The slip is recorded as a new entry under `[Unreleased]`.

## Test plan

- [x] `pytest tests/cli/test_build_command.py` — 78 passed (incl. the bumped assertion)
- [x] `pytest -k "deprecat or speaker"` on speaker-kind paths — 6 passed
- [x] `ruff check src/ tests/` — clean
- [x] `mypy` on the touched source files — clean
- [x] Pre-commit hook (ruff + mypy + fast pytest) passed on commit

## Follow-up

After PythonCourses confirms a clean snapshot/verify cycle on the 1.6 release (Priority 4 in `docs/claude/python-courses-revamp-handover.md`), schedule the actual removal PRs for 1.7: delete `--keep-directory` from `clm build`, remove `Kind.SPEAKER` and the `_normalize_output_kind` "speaker" branch, remove `SpeakerOutput` and the `case "speaker":` branch in `output_spec.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)