### PR TITLE
docs(release): prep CHANGELOG and architecture for 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,77 +139,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
     refusal pattern in real corpora. Default behavior without
     `--llm-suggest` is unchanged.
 
-### Changed
-
-- **Deprecation removals slipped from CLM 1.6 to 1.7.** Two removals
-  that 1.5 documented for the 1.6 release have been pushed out by one
-  minor: the `--keep-directory` CLI flag (currently a no-op alias
-  emitting `DeprecationWarning`) and the `<kind>speaker</kind>` output
-  kind (currently accepted as a deprecated alias for `recording`).
-  Both continue to behave as in 1.5 — the flag remains a no-op, the
-  kind alias still normalizes to `recording` with a parse-time
-  warning — and are now scheduled for removal in CLM 1.7. The slip
-  aligns these two removals with the Phase 0 CLI-alias removal so
-  consumers see a single deprecation cliff, and gives the
-  PythonCourses slide-format-redesign migration room to land on 1.6
-  without scrambling. Doc strings, `clm info commands`,
-  `clm info migration`, the runtime `DeprecationWarning`, and the
-  matching test (`tests/cli/test_build_command.py`) are updated; the
-  historical 1.5.0 `### Deprecated` entry stays as written since it
-  documents what was planned at that release's ship date.
-
-- **`clm build --output-dir DIR` now produces the per-target layout
-  that `--snapshot DIR` produces.** For a spec with `<output-targets>`
-  (e.g. `shared` / `trainer` / `speaker`), `--output-dir DIR` re-roots
-  each target under `<DIR>/<target.name>/` — matching what the regular
-  spec-driven build writes — instead of collapsing every target into
-  the legacy `<DIR>/public/`+`<DIR>/speaker/` shape that silently
-  dropped non-default targets like `trainer/`. The two flags are now
-  layout-equivalent; `--snapshot` still differs only in its safety
-  guards (empty/non-existing DIR required, mutex with
-  `--verify-against`, post-build confirmation line). `--verify-against`
-  picks up the new layout automatically whether the verify build uses
-  `--output-dir` or relies on the spec's target paths.
-
-  **Migration**: callers that depended on the old collapsed
-  `--output-dir DIR` layout (single `public/speaker` tree) for a
-  multi-target spec should either (a) drop `<output-targets>` from
-  the spec, (b) build without `--output-dir` (writing to the spec's
-  declared target paths), or (c) update downstream tooling to read
-  `<DIR>/<target.name>/`. The `Course.from_spec()` API change is
-  source-compatible: the `snapshot_root` parameter is removed and
-  `output_root` now performs the per-target re-root that
-  `snapshot_root` did before.
-
-- **CLI restructure: verb-grouped subcommands.** Several flat
-  top-level commands moved under new groups for a smaller, more
-  scannable surface. Old names still work and emit a deprecation
-  notice naming the new invocation; aliases will be removed in CLM
-  1.7. The MCP tool names are unchanged in this release — that
-  rename will land in a coordinated commit with the PythonCourses
-  skills that consume them.
-
-  | Old (still works, deprecated)                  | New canonical                |
-  |------------------------------------------------|------------------------------|
-  | `clm normalize-slides`                         | `clm slides normalize`       |
-  | `clm language-view`                            | `clm slides language-view`   |
-  | `clm suggest-sync`                             | `clm slides suggest-sync`    |
-  | `clm search-slides`                            | `clm slides search`          |
-  | `clm resolve-topic`                            | `clm topic resolve`          |
-  | `clm authoring-rules`                          | `clm authoring rules`        |
-  | `clm extract-voiceover`                        | `clm voiceover extract`      |
-  | `clm inline-voiceover`                         | `clm voiceover inline`       |
-  | `clm validate-slides PATH`                     | `clm validate PATH`          |
-  | `clm validate-spec SPEC`                       | `clm validate SPEC`          |
-
-- **`clm validate <path>` consolidates `validate-slides` and
-  `validate-spec`** with argument-type dispatch: `.xml` files →
-  spec validation, `.py` files and directories → slide validation.
-  Pass `--kind=slides` or `--kind=spec` to force a specific
-  validator (useful for ambiguous cases like an empty directory).
-
-### Added
-
 - **`clm slides assign-ids`** — Phase 2 of the slide-format-redesign.
   Generates stable, EN-derived, kebab-case ASCII `slide_id`s for
   slide/subslide cells using a three-category policy:
@@ -433,6 +362,75 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `since_last_output_seconds`, and `last_output_excerpt`. Note: `idle`
   only renders for cells that emit stdout/stderr — LangChain LLM cells
   return values silently and leave `idle` blank, which is correct.
+
+### Changed
+
+- **Deprecation removals slipped from CLM 1.6 to 1.7.** Two removals
+  that 1.5 documented for the 1.6 release have been pushed out by one
+  minor: the `--keep-directory` CLI flag (currently a no-op alias
+  emitting `DeprecationWarning`) and the `<kind>speaker</kind>` output
+  kind (currently accepted as a deprecated alias for `recording`).
+  Both continue to behave as in 1.5 — the flag remains a no-op, the
+  kind alias still normalizes to `recording` with a parse-time
+  warning — and are now scheduled for removal in CLM 1.7. The slip
+  aligns these two removals with the Phase 0 CLI-alias removal so
+  consumers see a single deprecation cliff, and gives the
+  PythonCourses slide-format-redesign migration room to land on 1.6
+  without scrambling. Doc strings, `clm info commands`,
+  `clm info migration`, the runtime `DeprecationWarning`, and the
+  matching test (`tests/cli/test_build_command.py`) are updated; the
+  historical 1.5.0 `### Deprecated` entry stays as written since it
+  documents what was planned at that release's ship date.
+
+- **`clm build --output-dir DIR` now produces the per-target layout
+  that `--snapshot DIR` produces.** For a spec with `<output-targets>`
+  (e.g. `shared` / `trainer` / `speaker`), `--output-dir DIR` re-roots
+  each target under `<DIR>/<target.name>/` — matching what the regular
+  spec-driven build writes — instead of collapsing every target into
+  the legacy `<DIR>/public/`+`<DIR>/speaker/` shape that silently
+  dropped non-default targets like `trainer/`. The two flags are now
+  layout-equivalent; `--snapshot` still differs only in its safety
+  guards (empty/non-existing DIR required, mutex with
+  `--verify-against`, post-build confirmation line). `--verify-against`
+  picks up the new layout automatically whether the verify build uses
+  `--output-dir` or relies on the spec's target paths.
+
+  **Migration**: callers that depended on the old collapsed
+  `--output-dir DIR` layout (single `public/speaker` tree) for a
+  multi-target spec should either (a) drop `<output-targets>` from
+  the spec, (b) build without `--output-dir` (writing to the spec's
+  declared target paths), or (c) update downstream tooling to read
+  `<DIR>/<target.name>/`. The `Course.from_spec()` API change is
+  source-compatible: the `snapshot_root` parameter is removed and
+  `output_root` now performs the per-target re-root that
+  `snapshot_root` did before.
+
+- **CLI restructure: verb-grouped subcommands.** Several flat
+  top-level commands moved under new groups for a smaller, more
+  scannable surface. Old names still work and emit a deprecation
+  notice naming the new invocation; aliases will be removed in CLM
+  1.7. The MCP tool names are unchanged in this release — that
+  rename will land in a coordinated commit with the PythonCourses
+  skills that consume them.
+
+  | Old (still works, deprecated)                  | New canonical                |
+  |------------------------------------------------|------------------------------|
+  | `clm normalize-slides`                         | `clm slides normalize`       |
+  | `clm language-view`                            | `clm slides language-view`   |
+  | `clm suggest-sync`                             | `clm slides suggest-sync`    |
+  | `clm search-slides`                            | `clm slides search`          |
+  | `clm resolve-topic`                            | `clm topic resolve`          |
+  | `clm authoring-rules`                          | `clm authoring rules`        |
+  | `clm extract-voiceover`                        | `clm voiceover extract`      |
+  | `clm inline-voiceover`                         | `clm voiceover inline`       |
+  | `clm validate-slides PATH`                     | `clm validate PATH`          |
+  | `clm validate-spec SPEC`                       | `clm validate SPEC`          |
+
+- **`clm validate <path>` consolidates `validate-slides` and
+  `validate-spec`** with argument-type dispatch: `.xml` files →
+  spec validation, `.py` files and directories → slide validation.
+  Pass `--kind=slides` or `--kind=spec` to force a specific
+  validator (useful for ambiguous cases like an empty directory).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.6.0] - 2026-05-21
+
+### Added
+
 - **`clm slides sync --apply --trivial` (v2 follow-up, Phase 7 of the slide-format-redesign).**
   Auto-apply the safe subset of LLM sync proposals without prompting.
   A proposal qualifies as "trivial" iff its diff is one of:
@@ -130,22 +138,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
     EXTRACTABLE branch, which silently no-op'd on the dominant
     refusal pattern in real corpora. Default behavior without
     `--llm-suggest` is unchanged.
-
-### Fixed
-
-- **`clm slides coverage` / `clm validate` no longer flag workshop task
-  slides as missing voiceover** when the deck uses the announcement-by-
-  slide_id convention (a slide whose `slide_id` starts with `workshop-`)
-  rather than a literal `workshop` tag. `clm.slides.workshop_scope.find_workshop_ranges`
-  now treats a slide/subslide markdown cell with a `workshop-…` slide_id
-  as a workshop opener equivalent to the legacy `workshop` tag. Cells
-  inheriting that slide_id (e.g. the announcement's voiceover) do not
-  re-trigger a new range — only slide-start cells carry the boundary.
-  Verified against `module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates.py`:
-  12 previously-noisy workshop pairs (4 task slides × DE/EN, plus the
-  announcement and setup slides) are now correctly excluded; the 34
-  pre-workshop lecture pairs remain coverage-checked. The legacy
-  `workshop` tag continues to work unchanged.
 
 ### Changed
 
@@ -443,6 +435,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   return values silently and leave `idle` blank, which is correct.
 
 ### Fixed
+
+- **`clm slides coverage` / `clm validate` no longer flag workshop task
+  slides as missing voiceover** when the deck uses the announcement-by-
+  slide_id convention (a slide whose `slide_id` starts with `workshop-`)
+  rather than a literal `workshop` tag. `clm.slides.workshop_scope.find_workshop_ranges`
+  now treats a slide/subslide markdown cell with a `workshop-…` slide_id
+  as a workshop opener equivalent to the legacy `workshop` tag. Cells
+  inheriting that slide_id (e.g. the announcement's voiceover) do not
+  re-trigger a new range — only slide-start cells carry the boundary.
+  Verified against `module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates.py`:
+  12 previously-noisy workshop pairs (4 task slides × DE/EN, plus the
+  announcement and setup slides) are now correctly excluded; the 34
+  pre-workshop lecture pairs remain coverage-checked. The legacy
+  `workshop` tag continues to work unchanged.
 
 - **Strict HTTP-replay broke on identical repeated requests (issue
   #95 (A)).** The host-side cassette merger deduplicates by

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1021,10 +1021,14 @@ the `clm.slides` CLI tools.
 
 ### `clm.slides` (authoring tools)
 
-CLI-facing tooling for AI-assisted slide authoring. Powers `clm resolve-topic`,
-`clm search-slides`, `clm validate-spec`, `clm validate-slides`,
-`clm normalize-slides`, `clm language-view`, `clm suggest-sync`,
-`clm extract-voiceover`, `clm inline-voiceover`, and `clm authoring-rules`.
+CLI-facing tooling for AI-assisted slide authoring. Powers `clm topic resolve`,
+`clm slides search`, `clm validate` (spec + slide validation),
+`clm slides normalize`, `clm slides language-view`, `clm slides suggest-sync`,
+`clm slides assign-ids`, `clm slides coverage`, `clm slides split` /
+`clm slides unify`, `clm slides sync`, `clm voiceover extract` /
+`clm voiceover inline`, and `clm authoring rules`. (Flat-form aliases —
+`clm resolve-topic`, `clm search-slides`, etc. — still work in 1.6 with
+a deprecation warning; removal in 1.7.)
 
 Key entry points: `tags` (canonical tag sets), `search.search_slides`,
 `spec_validator.validate_spec`, `validator.validate_file`,
@@ -1036,9 +1040,35 @@ Key entry points: `tags` (canonical tag sets), `search.search_slides`,
 generator with EN-derived slug + preserve marker + optional LLM
 suggester), `pairing.build_slide_groups` / `build_slide_pairs` (shared
 DE/EN adjacency + title-macro helpers used by validator + Phase 6
-split-source parity check), and `coverage.check_coverage_in_file` /
+split-source parity check), `coverage.check_coverage_in_file` /
 `check_coverage_in_directory` (LLM-driven voiceover coverage check
-backed by `CoverageCache` in the LLM cache database).
+backed by `CoverageCache` in the LLM cache database),
+`split.split_file` / `unify.unify_files` (bidirectional
+bilingual ↔ split-by-language `.py` converters with byte-identical
+round-trip), `sync.sync_pair` (cross-language LLM-driven proposal
+generator with `SyncCache` content-addressed proposal memoization
+and `SyncSnapshotCache` location-addressed last-known-synced
+anchors), and `raw_cells` (the shared lossless cell-primitive
+module — `RawCell`, `split_cells`, `reconstruct`,
+`is_cell_boundary` — that `assign-ids` / `normalize` / `split` /
+`sync` all share).
+
+### `clm.snapshot` (build-output verification harness)
+
+Byte-level compare of two CLM build trees, exposed at the CLI as
+`clm build --snapshot DIR` (capture) and `clm build --verify-against DIR`
+(compare). Library-only — there is no `clm snapshot` subcommand; the
+build command drives both flags. Entry points:
+`verify_against(snapshot_dir, output_dir, *, include_html, strict)`
+(flat single-tree compare), `verify_against_targets(snapshot_dir,
+targets, *, include_html, strict)` (per-target compare for specs with
+`<output-targets>` — diffs prefixed by target name), `VerifyReport`
+(pass/fail signal via `has_diffs`, human-readable rollup via
+`format_text()`), and `normalize_for_compare` (HTML hex-address
+normalization used under `--include-html`). `.html` is skipped by
+default because rendered HTML contains live-kernel output;
+`--include-html` opts in with hex-address normalization, and
+`--strict-verify` byte-compares everything with no skipping.
 
 ### `clm.mcp` (Model Context Protocol server)
 


### PR DESCRIPTION
## Summary

Release-prep doc-only PR for 1.6.0. Two files touched:

### CHANGELOG.md

- Roll `[Unreleased]` into `## [1.6.0] - 2026-05-21` and add a fresh empty `[Unreleased]` block at the top.
- Relocate the workshop slide_id coverage `Fixed` entry from between the top Added block and the Changed block down to join the larger Fixed section near the bottom (so all Fixed entries are co-located).

**Known cosmetic wart**: the 1.6.0 section has two `### Added` sub-headings — top block (slides sync v2/v1, assign-ids extraction) and bottom block (assign-ids Phase 2, coverage, split routing, split/unify, validate slide_id, snapshot/verify, heartbeat) — separated by `### Changed`. Content is correctly categorized in both, but the duplicate sub-heading is technically against Keep a Changelog convention. The physical reorder to consolidate everything under one Added section would be a ~215-line block move. **If you want me to do that consolidation, say so and I'll push a follow-up commit.**

### docs/developer-guide/architecture.md

- Refresh `clm.slides` section to use verb-grouped canonical command names (`clm slides sync`, `clm slides coverage`, `clm slides split`/`unify`, etc.) and list the new entry points shipped in 1.6.0: `split.split_file`, `unify.unify_files`, `sync.sync_pair`, `raw_cells.RawCell`, `SyncCache`, `SyncSnapshotCache`.
- Add new `clm.snapshot` section covering `verify_against`, `verify_against_targets`, `VerifyReport`, and `normalize_for_compare` — the library-only verification harness driven by `clm build --snapshot` / `--verify-against`.
- Old flat command names noted as still-working-but-deprecated through 1.7.

## Deferred to Step 3 (`bump-my-version`)

Version bumps (1.5.0 → 1.6.0) across 7 files (`pyproject.toml`, `README.md`, `CLAUDE.md`, `__version__.py`, `docker/BUILDING.md`, `tests/workers/notebook/test_notebook_error_context.py`, `uv.lock`) and `docs/developer-guide/architecture.md` itself — `bump-my-version` handles those in one shot.

## Test plan

- [x] Doc-only changes; no code touched
- [x] `git diff --stat`: 2 files, +58/-22
- [x] `ruff check src/ tests/` — clean
- [x] Pre-commit hooks skipped (no source files matched)
- [x] Visually verified the 1.6.0 section in CHANGELOG renders correctly (workshop fix appears under `### Fixed`, not orphaned)

## Next steps after merge

1. `uv run pytest -m "not docker"` on master
2. `uv run bump-my-version bump minor` (creates commit + tag `v1.6.0`)
3. `uv build` and `git push && git push --tags`
4. Wait for CI green
5. `uv publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)