### PR TITLE
feat(slides): `clm slides sync` direction auto-detection (Phase 7 v2 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides sync` direction auto-detection (v2 follow-up, Phase 7 of the slide-format-redesign).**
+  `--source-lang` is now optional. When omitted, the direction of edit
+  is inferred from two signals in order of preference:
+
+  1. **`SyncSnapshotCache` drift** — for each snapshot row covering the
+     pair, the side whose current cell hash differs from the
+     last-known-synced hash is treated as the drifted side. Snapshot
+     evidence is content-addressed, so rebases that rewrite commit
+     metadata do not destabilise it. If snapshot rows disagree on
+     which side drifted, or any row shows BOTH sides drifted (the
+     3-way merge case), the snapshot signal is reported as ambiguous.
+
+  2. **Git commit timestamp** — when snapshots give no definite
+     answer, the half whose most-recent commit (`git log -1 %ct`) is
+     newer is the source. Requires both files tracked in a git repo.
+
+  Inference falls back to requiring `--source-lang` when neither
+  signal is conclusive (no snapshot rows, no git history, untracked
+  files, equal timestamps, or the two signals disagree). `--source-lang`
+  remains available as an explicit override; if it disagrees with the
+  inferred direction, a warning is emitted on stderr and the explicit
+  value is honored.
+
+  Implementation lives in new module `clm.slides.sync_direction`
+  (`infer_source_lang` + `DirectionInference`). The CLI command
+  computes inference inside the cache-open scope so the snapshot table
+  is consulted when available.
+
+  **What's still deferred:** LLM-assisted 3-way merge prompt for
+  "both sides drifted" cells (visible to direction inference as the
+  ambiguous case).
+
 ### Changed
 
 ### Fixed

--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -20,7 +20,7 @@ checked into the CLM repo.
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
 | 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **Shipped** (CLM phases 1–4); issue #89 closed; P5 = PC-side corpus rerun, pending CLM release | [PR #101](https://github.com/hoelzl/clm/pull/101) merged 2026-05-19, master commit `c820fb8` |
-| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 + v2 + v2 `--apply --trivial` shipped**: v1 via [PR #105](https://github.com/hoelzl/clm/pull/105) (master `4d1c645`); v2 walker via [PR #110](https://github.com/hoelzl/clm/pull/110) (master `bdca1c9`); `--apply --trivial` follow-up on branch `claude/slide-format-redesign-phase-7-v2-trivial` ([PR #114](https://github.com/hoelzl/clm/pull/114)). Direction auto-detection and 3-way merge still deferred. | PRs #105, #110 merged 2026-05-20; [PR #114](https://github.com/hoelzl/clm/pull/114) opened 2026-05-21 |
+| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 + v2 + `--apply --trivial` + direction auto-detection shipped**: v1 via [PR #105](https://github.com/hoelzl/clm/pull/105) (master `4d1c645`); v2 walker via [PR #110](https://github.com/hoelzl/clm/pull/110) (master `bdca1c9`); `--apply --trivial` via [PR #114](https://github.com/hoelzl/clm/pull/114) (master `45f1d5e`); direction auto-detection on branch `claude/slide-format-redesign-phase-7-v2-direction`. 3-way merge for both-sides-drifted cells still deferred. | PRs #105, #110, #114 merged 2026-05-20; direction PR opened 2026-05-21 |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation (CLM-side fully shipped via PRs #96 + #112) | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |
 
@@ -141,16 +141,19 @@ shipped versus what's deferred to v2.
 - [x] LLM prompt scaffolding (`sync_prompts.py`) + `--dry-run` diff producer.
 - [x] `--interactive` apply/skip/edit walker. *(v2, [PR #110](https://github.com/hoelzl/clm/pull/110) merged 2026-05-20, master `bdca1c9`)*
 - [x] Pilot accept-rate counters (`pairs_accepted` / `pairs_skipped` / `pairs_edited` / `pairs_quit`) + `SyncSnapshotCache`. *(v2, PR #110)*
-- [ ] `--apply --trivial` path. *(follow-up PR)*
-- [ ] Direction auto-detection from git history. *(follow-up PR)*
-- [ ] LLM-assisted 3-way merge for "both sides drifted" cells. *(follow-up PR)*
+- [x] `--apply --trivial` path. *(follow-up [PR #114](https://github.com/hoelzl/clm/pull/114) merged 2026-05-20, master `45f1d5e`)*
+- [x] Direction auto-detection (snapshot drift + git timestamps). *(follow-up PR on branch `claude/slide-format-redesign-phase-7-v2-direction`, 2026-05-21)*
+- [ ] LLM-assisted 3-way merge for "both sides drifted" cells. *(follow-up PR, deferred until pilot data is in)*
 - [x] Pilot instrumentation (per-session counters).
 - [x] CLI registration + `clm info commands` update.
 - [x] Tests (cache + sync logic + CLI smoke + walker + snapshot cache).
 
 ### Branch convention
 
-`claude/slide-format-redesign-phase-7` (v1, merged via PR #105). `claude/slide-format-redesign-phase-7-v2` (v2, merged via PR #110).
+`claude/slide-format-redesign-phase-7` (v1, merged via PR #105).
+`claude/slide-format-redesign-phase-7-v2` (v2 walker, merged via PR #110).
+`claude/slide-format-redesign-phase-7-v2-trivial` (`--apply --trivial`, merged via PR #114).
+`claude/slide-format-redesign-phase-7-v2-direction` (direction auto-detection, current branch).
 
 ## 4. Priority 3 — workshop-`workshop-…` slide_id opener (DONE)
 
@@ -344,6 +347,56 @@ before CLM can proceed, file it as a comment on the corresponding issue
   directly removes that round-trip and the slide_parser-stripped
   hash recomputation guesswork — the walker is now a pure consumer
   of pre-computed hashes.
+
+## 10c. Decisions Recorded — Priority 2 direction auto-detection (2026-05-21)
+
+- **Snapshot drift preferred over git timestamps.** Snapshot rows are
+  content-addressed (`(de_hash, en_hash)` keyed by file path + slide_id
+  + role); a rebase that rewrites commit metadata does not invalidate
+  them. Git timestamps, by contrast, lie under rebase / cherry-pick /
+  manual `commit --date` overrides. When snapshot evidence is
+  conclusive it is used directly; git is only consulted to cross-check
+  for disagreement.
+- **Disagreement is a hard fall-back, not a tiebreak.** When snapshot
+  and git point at different sides, the CLI requires `--source-lang`
+  explicitly rather than picking one signal as the tiebreaker. The
+  most common cause of disagreement is a stale snapshot row left by
+  a sync that was never followed by a re-sync after the corresponding
+  author edit — silently picking the snapshot side would steamroll the
+  edit that just happened. Requiring an explicit choice keeps the user
+  in the loop for the genuinely ambiguous cases.
+- **Both-sides-drifted in a snapshot row = 3-way merge case.** Direction
+  inference reports this as an "ambiguous" snapshot signal (and falls
+  back to git or requires `--source-lang`) rather than picking one
+  side. The 3-way prompt that resolves these cells is ITEM 2 of the v2
+  follow-up list and is intentionally deferred to a later PR.
+- **Explicit `--source-lang` always wins; disagreement only warns.**
+  The user gets the last word. The warning surfaces on stderr so it
+  is visible interactively but does not corrupt `--json` stdout. The
+  rationale: when an author knows they just edited DE but the
+  snapshot says EN, the inference is probably reading stale state,
+  not a bug in their head — but it is worth surfacing so they can
+  double-check.
+- **Inference module is independent of `clm.slides.sync`.** A small
+  `_ROLE_TAGS` set and `_index_first` helper duplicate sync's role
+  filter rather than importing from it. The risk of a circular
+  TYPE_CHECKING dependency outweighs the dozen lines of duplication;
+  if a third consumer ever needs the role taxonomy, the right move
+  is a `clm.slides.sync_roles` module both consume from.
+- **`git log -1 --format=%ct -- <name>` with `cwd=<parent>`.** Run
+  from the file's parent directory so git walks up to find the repo
+  root automatically; the `--` separator disambiguates the path from
+  a potential ref. Untracked files produce returncode 0 with empty
+  stdout (treated as "not tracked"); a non-git directory produces
+  returncode 128 (treated as "no git history"); missing `git` binary
+  raises FileNotFoundError (treated as "no git history"). All three
+  collapse to the same fall-back path.
+- **Test harness uses real `subprocess.run` against `git init` in
+  `tmp_path`, not mocked git.** Mocking git would test our wrapper
+  against an assumption about git's CLI shape rather than against
+  git itself. The fixture cost (one `_init_repo`, two `_commit` calls
+  + `time.sleep(1.1)` for distinct timestamps) is ~2s per test —
+  acceptable for the half-dozen cases we cover.
 
 ## 11. Decisions Recorded — Priority 3 fix (2026-05-20)
 

--- a/docs/claude/python-courses-revamp-handover.md
+++ b/docs/claude/python-courses-revamp-handover.md
@@ -20,7 +20,7 @@ checked into the CLM repo.
 |---|---|---|---|
 | 3 | Phase 4 coverage walker: recognize `workshop-…` slide_id as opener | **Shipped** | [#98](https://github.com/hoelzl/clm/pull/98), branch `claude/coverage-workshop-slide-id-opener` |
 | 1 | `assign-ids` extraction expansion (#89) — prose + AST + sibling + LLM fallback | **Shipped** (CLM phases 1–4); issue #89 closed; P5 = PC-side corpus rerun, pending CLM release | [PR #101](https://github.com/hoelzl/clm/pull/101) merged 2026-05-19, master commit `c820fb8` |
-| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 + v2 + `--apply --trivial` + direction auto-detection shipped**: v1 via [PR #105](https://github.com/hoelzl/clm/pull/105) (master `4d1c645`); v2 walker via [PR #110](https://github.com/hoelzl/clm/pull/110) (master `bdca1c9`); `--apply --trivial` via [PR #114](https://github.com/hoelzl/clm/pull/114) (master `45f1d5e`); direction auto-detection on branch `claude/slide-format-redesign-phase-7-v2-direction`. 3-way merge for both-sides-drifted cells still deferred. | PRs #105, #110, #114 merged 2026-05-20; direction PR opened 2026-05-21 |
+| 2 | Phase 7 `clm slides sync` (cross-language LLM sync, `SyncCache`) | **v1 + v2 + `--apply --trivial` + direction auto-detection shipped**: v1 via [PR #105](https://github.com/hoelzl/clm/pull/105) (master `4d1c645`); v2 walker via [PR #110](https://github.com/hoelzl/clm/pull/110) (master `bdca1c9`); `--apply --trivial` via [PR #114](https://github.com/hoelzl/clm/pull/114) (master `45f1d5e`); direction auto-detection via [PR #118](https://github.com/hoelzl/clm/pull/118). 3-way merge for both-sides-drifted cells still deferred. | PRs #105, #110, #114 merged 2026-05-20; [PR #118](https://github.com/hoelzl/clm/pull/118) opened 2026-05-21 |
 | 4 | Close hoelzl/clm#95 once PythonCourses confirms clean snapshot/verify | Awaiting PC confirmation (CLM-side fully shipped via PRs #96 + #112) | — |
 | 5 | `http-replay-skip` tag (deck-side chained-LLM-call escape hatch) | **Do not start** — gated on PythonCourses decision | — |
 
@@ -142,7 +142,7 @@ shipped versus what's deferred to v2.
 - [x] `--interactive` apply/skip/edit walker. *(v2, [PR #110](https://github.com/hoelzl/clm/pull/110) merged 2026-05-20, master `bdca1c9`)*
 - [x] Pilot accept-rate counters (`pairs_accepted` / `pairs_skipped` / `pairs_edited` / `pairs_quit`) + `SyncSnapshotCache`. *(v2, PR #110)*
 - [x] `--apply --trivial` path. *(follow-up [PR #114](https://github.com/hoelzl/clm/pull/114) merged 2026-05-20, master `45f1d5e`)*
-- [x] Direction auto-detection (snapshot drift + git timestamps). *(follow-up PR on branch `claude/slide-format-redesign-phase-7-v2-direction`, 2026-05-21)*
+- [x] Direction auto-detection (snapshot drift + git timestamps). *(follow-up [PR #118](https://github.com/hoelzl/clm/pull/118), 2026-05-21)*
 - [ ] LLM-assisted 3-way merge for "both sides drifted" cells. *(follow-up PR, deferred until pilot data is in)*
 - [x] Pilot instrumentation (per-session counters).
 - [x] CLI registration + `clm info commands` update.
@@ -153,7 +153,7 @@ shipped versus what's deferred to v2.
 `claude/slide-format-redesign-phase-7` (v1, merged via PR #105).
 `claude/slide-format-redesign-phase-7-v2` (v2 walker, merged via PR #110).
 `claude/slide-format-redesign-phase-7-v2-trivial` (`--apply --trivial`, merged via PR #114).
-`claude/slide-format-redesign-phase-7-v2-direction` (direction auto-detection, current branch).
+`claude/slide-format-redesign-phase-7-v2-direction` (direction auto-detection, [PR #118](https://github.com/hoelzl/clm/pull/118)).
 
 ## 4. Priority 3 — workshop-`workshop-…` slide_id opener (DONE)
 

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -36,6 +36,7 @@ from clm.infrastructure.llm.ollama_client import (
     is_available,
 )
 from clm.slides.sync import SyncOptions, SyncResult, sync_split_pair
+from clm.slides.sync_direction import infer_source_lang
 from clm.slides.sync_trivial import apply_trivial_proposals
 from clm.slides.sync_walker import WalkerOptions, run_interactive_walker
 
@@ -54,10 +55,13 @@ CACHE_DB_NAME = "clm-llm.sqlite"
 @click.option(
     "--source-lang",
     type=click.Choice(["de", "en"]),
-    required=True,
+    required=False,
+    default=None,
     help=(
         "Language that was edited; updates are proposed for the other "
-        "side. Required in v1 (no auto-detection yet)."
+        "side. When omitted, the direction is inferred from the "
+        "SyncSnapshotCache (preferred) or from git commit timestamps; "
+        "pass explicitly to override the inferred direction."
     ),
 )
 @click.option(
@@ -139,7 +143,7 @@ CACHE_DB_NAME = "clm-llm.sqlite"
 def slides_sync_cmd(
     de_path: Path,
     en_path: Path,
-    source_lang: str,
+    source_lang: str | None,
     dry_run: bool,
     interactive: bool,
     apply_writes: bool,
@@ -185,23 +189,6 @@ def slides_sync_cmd(
     if trivial and not apply_writes:
         raise click.UsageError("--trivial is a modifier for --apply; pass --apply --trivial")
 
-    # Direction-of-edit is required so the LLM knows which side is the
-    # source of truth. Auto-detection via git history is on the v2 list.
-    judge = OllamaSyncJudge(
-        model=llm_model,
-        base_url=ollama_url,
-        timeout=llm_timeout,
-    )
-    if not is_available(judge):
-        click.echo(
-            f"warning: Ollama is not reachable at {judge.base_url}; "
-            "every pair will be recorded as an LLM-unavailable error.",
-            err=True,
-        )
-        judge_for_options = None
-    else:
-        judge_for_options = judge
-
     cache: SyncCache | None = None
     snapshot_cache: SyncSnapshotCache | None = None
     if not no_cache:
@@ -209,15 +196,40 @@ def slides_sync_cmd(
         cache = SyncCache(cache_root / CACHE_DB_NAME)
         snapshot_cache = SyncSnapshotCache(cache_root / CACHE_DB_NAME)
 
-    options = SyncOptions(
-        source_lang=source_lang,
-        judge=judge_for_options,
-        cache=cache,
-    )
-
     apply_trivial = apply_writes and trivial
 
     try:
+        # Direction-of-edit: explicit --source-lang always wins, but we
+        # cross-check against snapshot/git inference and warn on
+        # disagreement so the user notices a suspicious explicit value.
+        resolved_source_lang = _resolve_source_lang(
+            source_lang,
+            de_path,
+            en_path,
+            snapshot_cache=snapshot_cache,
+        )
+
+        judge = OllamaSyncJudge(
+            model=llm_model,
+            base_url=ollama_url,
+            timeout=llm_timeout,
+        )
+        if not is_available(judge):
+            click.echo(
+                f"warning: Ollama is not reachable at {judge.base_url}; "
+                "every pair will be recorded as an LLM-unavailable error.",
+                err=True,
+            )
+            judge_for_options = None
+        else:
+            judge_for_options = judge
+
+        options = SyncOptions(
+            source_lang=resolved_source_lang,
+            judge=judge_for_options,
+            cache=cache,
+        )
+
         result = sync_split_pair(de_path, en_path, options)
         if apply_trivial:
             apply_trivial_proposals(result, snapshot_cache=snapshot_cache)
@@ -244,6 +256,51 @@ def slides_sync_cmd(
         )
 
     sys.exit(_exit_code(result))
+
+
+def _resolve_source_lang(
+    source_lang: str | None,
+    de_path: Path,
+    en_path: Path,
+    *,
+    snapshot_cache: SyncSnapshotCache | None,
+) -> str:
+    """Decide which side is the source for this sync pass.
+
+    When the user passes ``--source-lang`` explicitly, that value is
+    honored. We still run inference so we can warn on disagreement —
+    a mismatch usually means the user is about to overwrite the side
+    they actually edited.
+
+    When ``--source-lang`` is omitted, inference must yield a definite
+    answer. Otherwise we raise :class:`click.UsageError` so the user
+    can re-run with an explicit value.
+    """
+    inference = infer_source_lang(de_path, en_path, snapshot_cache)
+
+    if source_lang is not None:
+        if inference.source_lang is not None and inference.source_lang != source_lang:
+            click.echo(
+                f"warning: --source-lang={source_lang!r} disagrees with "
+                f"inferred direction {inference.source_lang!r} "
+                f"({inference.signal}: {inference.reason}); honoring explicit override.",
+                err=True,
+            )
+        return source_lang
+
+    if inference.source_lang is None:
+        raise click.UsageError(
+            "--source-lang was not provided and could not be inferred "
+            f"({inference.signal}: {inference.reason}). "
+            "Pass --source-lang de or --source-lang en explicitly."
+        )
+
+    click.echo(
+        f"note: --source-lang inferred as {inference.source_lang!r} "
+        f"({inference.signal}: {inference.reason})",
+        err=True,
+    )
+    return inference.source_lang
 
 
 def _print_human(

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -654,9 +654,18 @@ edit / quit prompt and writes accepted (or edited) proposals to the
 target file. `--apply --trivial` auto-applies the safe subset of
 proposals (EOL-only or whitespace-only-one-line diffs) without
 prompting; non-trivial proposals fall through to the report (or to the
-`--interactive` walker when both flags are passed). Direction-of-edit
-must be passed explicitly via `--source-lang` (auto-detection from git
-history is on the future list).
+`--interactive` walker when both flags are passed).
+
+**Direction-of-edit** is inferred when `--source-lang` is omitted.
+Inference prefers `SyncSnapshotCache` drift evidence (content-
+addressed; survives rebases) and falls back to git commit timestamps
+when no snapshot row points at a clear winner. The CLI prints a
+short note on stderr showing which signal won. Pass `--source-lang`
+explicitly to override; a warning is emitted when the explicit value
+disagrees with the inferred direction, and the explicit value is
+honored. Inference falls back to requiring `--source-lang` when both
+signals are unusable (no snapshot rows, no git history, equal
+timestamps, or the two signals contradict each other).
 
 Cells synced: markdown `slide` / `subslide` cells and narrative
 `voiceover` / `notes` cells. Shared code cells are intentionally
@@ -671,7 +680,7 @@ clm slides sync [OPTIONS] DE_PATH EN_PATH
 
 | Option | Description |
 |--------|-------------|
-| `--source-lang de\|en` | **Required.** Language that was edited; updates are proposed for the other side. |
+| `--source-lang de\|en` | Language that was edited; updates are proposed for the other side. Optional — inferred from snapshot drift or git commit timestamps when omitted. An explicit value that disagrees with the inferred direction triggers a warning and is honored. |
 | `--dry-run / --no-dry-run` | Show proposed diffs without modifying any file (default). `--interactive` and `--apply --trivial` implicitly disable dry-run. |
 | `--interactive` | Walk proposed updates one by one with `[a]pply / [s]kip / [e]dit / [q]uit` per proposal; accepted / edited proposals are written to the target file and the post-write `(de_hash, en_hash)` is recorded in `sync_snapshots`. Mutually exclusive with `--json`. |
 | `--apply` | Write proposals to disk. Currently requires `--trivial`; full unconditional `--apply` is not yet supported. |
@@ -704,13 +713,17 @@ auto-applied outcome). The PythonCourses Phase D pilot ships when
 Both `--interactive` accepts/edits and `--apply --trivial` auto-applies
 write a `sync_snapshots` row per write, capturing the post-write
 `(de_hash, en_hash)` for that `(de_path, en_path, slide_id, role)`
-slot. A future direction-auto-detection pass will compare on-disk
-hashes against these rows to infer which side drifted.
+slot. The direction-auto-detection pass that runs when
+`--source-lang` is omitted reads these rows to decide which side
+drifted since the last sync.
 
 Examples:
 
 ```bash
-# After editing the DE deck, see what should change on the EN side.
+# After committing the DE edit, infer direction from snapshot/git history.
+clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py
+
+# Same, but explicit (overrides inference; warns if inference disagrees).
 clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py --source-lang de
 
 # Walk proposals interactively, applying or editing per cell.

--- a/src/clm/slides/sync_direction.py
+++ b/src/clm/slides/sync_direction.py
@@ -1,0 +1,350 @@
+"""Direction-of-edit inference for ``clm slides sync``.
+
+Phase 7 v2 follow-up of the slide-format-redesign. When the user omits
+``--source-lang``, this module infers which half of the DE/EN split pair
+was the source of the most recent edit so the sync pass knows whose
+cells to propose updates *from*.
+
+Two signals are consulted, in order of preference:
+
+1. **Snapshot drift** (preferred). A
+   :class:`~clm.infrastructure.llm.cache.SyncSnapshotCache` row for the
+   pair captures the ``(de_hash, en_hash)`` last accepted by the user.
+   If the current on-disk hash matches on exactly one side, the *other*
+   side drifted since the last sync — that drifted side is the source.
+   Snapshots are content-addressed: a rebase that rewrites commit
+   metadata does not invalidate them.
+
+2. **Git commit timestamp** (fallback). When no snapshot evidence is
+   conclusive, the most recently committed half is treated as the
+   source. Requires both files tracked in a git repo.
+
+Both signals are computed when possible; if they disagree, the result
+is ambiguous and the caller must require an explicit ``--source-lang``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.slides.sync_writeback import cell_content_hash
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import SyncSnapshotCache
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DirectionInference",
+    "infer_source_lang",
+]
+
+
+# Roles the sync walker covers — kept in sync with ``clm.slides.sync``.
+# Duplicated here (rather than imported) to keep this module independent
+# of the engine module and avoid a circular import at type-check time.
+_ROLE_TAGS = {"slide", "subslide", "voiceover", "notes"}
+
+
+@dataclass
+class DirectionInference:
+    """Result of trying to infer which side was edited.
+
+    ``source_lang`` is ``"de"`` or ``"en"`` when one of the signals
+    yielded a definite answer, or ``None`` when no signal was usable
+    (no git history, no snapshot rows, signals disagree, or a tie).
+
+    ``signal`` names which source the answer came from:
+    ``"snapshot"``, ``"git-timestamp"``, ``"snapshot+git-timestamp"``
+    (used when the two disagree, in which case ``source_lang`` is
+    ``None``), or ``"none"`` when nothing was conclusive.
+
+    ``reason`` is a short human-readable explanation surfaced to the
+    user in the CLI's note/warning output.
+    """
+
+    source_lang: str | None
+    signal: str
+    reason: str
+
+
+def infer_source_lang(
+    de_path: Path,
+    en_path: Path,
+    snapshot_cache: SyncSnapshotCache | None,
+) -> DirectionInference:
+    """Infer which side was edited from snapshots and/or git history.
+
+    Returns a :class:`DirectionInference` describing the verdict. The
+    caller is responsible for surfacing the result to the user (echoing
+    a note when inferring, warning on disagreement with an explicit
+    ``--source-lang`` override, or raising a ``UsageError`` when no
+    signal was usable).
+    """
+    snapshot = _infer_from_snapshot(de_path, en_path, snapshot_cache)
+    git_ts = _infer_from_git_timestamp(de_path, en_path)
+
+    # Snapshot rows exist but disagree internally — bail to manual.
+    if snapshot.verdict == "ambiguous":
+        return DirectionInference(
+            source_lang=None,
+            signal="snapshot",
+            reason=snapshot.detail,
+        )
+
+    snap_side = snapshot.side
+    git_side = git_ts.side if git_ts.verdict == "ok" else None
+
+    # Both signals usable and definite — cross-check.
+    if snap_side is not None and git_side is not None and snap_side != git_side:
+        return DirectionInference(
+            source_lang=None,
+            signal="snapshot+git-timestamp",
+            reason=(
+                f"snapshot points to {snap_side!r} ({snapshot.detail}) "
+                f"but git timestamps point to {git_side!r} ({git_ts.detail})"
+            ),
+        )
+
+    if snap_side is not None:
+        return DirectionInference(
+            source_lang=snap_side,
+            signal="snapshot",
+            reason=snapshot.detail,
+        )
+
+    if git_side is not None:
+        return DirectionInference(
+            source_lang=git_side,
+            signal="git-timestamp",
+            reason=git_ts.detail,
+        )
+
+    # Neither signal yielded a definite verdict. Combine the reasons so
+    # the user knows why both paths failed.
+    parts = []
+    if snapshot.detail:
+        parts.append(f"snapshot: {snapshot.detail}")
+    if git_ts.detail:
+        parts.append(f"git: {git_ts.detail}")
+    reason = "; ".join(parts) if parts else "no snapshot evidence and no git history available"
+    return DirectionInference(source_lang=None, signal="none", reason=reason)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SignalResult:
+    """Outcome of one signal source.
+
+    ``verdict``:
+      * ``"ok"`` — ``side`` carries ``"de"`` / ``"en"``.
+      * ``"ambiguous"`` — the signal exists but is internally inconsistent
+        (e.g. snapshot rows disagree). ``side`` is ``None``.
+      * ``"none"`` — the signal produced no answer (no rows, no git,
+        equal timestamps). ``side`` is ``None``.
+    """
+
+    verdict: str
+    side: str | None
+    detail: str
+
+
+def _infer_from_snapshot(
+    de_path: Path,
+    en_path: Path,
+    snapshot_cache: SyncSnapshotCache | None,
+) -> _SignalResult:
+    if snapshot_cache is None:
+        return _SignalResult(verdict="none", side=None, detail="no snapshot cache")
+
+    rows = [
+        (slide_id, role, de_hash, en_hash)
+        for de_p, en_p, slide_id, role, de_hash, en_hash, _direction, _at in (
+            snapshot_cache.iter_entries()
+        )
+        if de_p == str(de_path) and en_p == str(en_path)
+    ]
+    if not rows:
+        return _SignalResult(verdict="none", side=None, detail="no snapshot rows for this pair")
+
+    try:
+        de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
+        en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return _SignalResult(
+            verdict="none", side=None, detail=f"could not read source files: {exc}"
+        )
+
+    de_index = _index_first(de_cells, "de")
+    en_index = _index_first(en_cells, "en")
+
+    de_drift = 0
+    en_drift = 0
+    both_drift = 0
+    matched = 0
+
+    for slide_id, role, snap_de_hash, snap_en_hash in rows:
+        de_cell = de_index.get((slide_id, role))
+        en_cell = en_index.get((slide_id, role))
+        if de_cell is None or en_cell is None:
+            continue
+        matched += 1
+        cur_de_hash = cell_content_hash(de_cell.content)
+        cur_en_hash = cell_content_hash(en_cell.content)
+        de_changed = cur_de_hash != snap_de_hash
+        en_changed = cur_en_hash != snap_en_hash
+        if de_changed and en_changed:
+            both_drift += 1
+        elif de_changed:
+            de_drift += 1
+        elif en_changed:
+            en_drift += 1
+
+    if matched == 0:
+        return _SignalResult(
+            verdict="none",
+            side=None,
+            detail="snapshot rows reference slide_ids no longer in the files",
+        )
+
+    # Both sides drifted on the same cell anywhere → 3-way territory.
+    # That's ITEM 2 of the v2 follow-up list, not direction inference.
+    if both_drift > 0:
+        return _SignalResult(
+            verdict="ambiguous",
+            side=None,
+            detail=f"{both_drift} snapshot row(s) show both sides drifted (3-way merge case)",
+        )
+
+    if de_drift > 0 and en_drift == 0:
+        return _SignalResult(
+            verdict="ok",
+            side="de",
+            detail=f"DE drifted in {de_drift} of {matched} snapshot row(s); EN unchanged",
+        )
+    if en_drift > 0 and de_drift == 0:
+        return _SignalResult(
+            verdict="ok",
+            side="en",
+            detail=f"EN drifted in {en_drift} of {matched} snapshot row(s); DE unchanged",
+        )
+    if de_drift > 0 and en_drift > 0:
+        return _SignalResult(
+            verdict="ambiguous",
+            side=None,
+            detail=f"snapshot rows disagree: DE drifted in {de_drift}, EN drifted in {en_drift}",
+        )
+
+    # de_drift == 0 and en_drift == 0 and both_drift == 0: everything
+    # matches the last snapshot — no edits since.
+    return _SignalResult(
+        verdict="none",
+        side=None,
+        detail=f"all {matched} snapshot row(s) match current file state",
+    )
+
+
+def _infer_from_git_timestamp(de_path: Path, en_path: Path) -> _SignalResult:
+    de_ct = _git_last_commit_timestamp(de_path)
+    en_ct = _git_last_commit_timestamp(en_path)
+    if de_ct is None and en_ct is None:
+        return _SignalResult(
+            verdict="none",
+            side=None,
+            detail="neither file is tracked in a git repo",
+        )
+    if de_ct is None:
+        return _SignalResult(
+            verdict="none",
+            side=None,
+            detail=f"{de_path.name} is not tracked in git",
+        )
+    if en_ct is None:
+        return _SignalResult(
+            verdict="none",
+            side=None,
+            detail=f"{en_path.name} is not tracked in git",
+        )
+
+    if de_ct > en_ct:
+        return _SignalResult(
+            verdict="ok",
+            side="de",
+            detail=f"DE last commit @{de_ct} is newer than EN @{en_ct}",
+        )
+    if en_ct > de_ct:
+        return _SignalResult(
+            verdict="ok",
+            side="en",
+            detail=f"EN last commit @{en_ct} is newer than DE @{de_ct}",
+        )
+    return _SignalResult(
+        verdict="none",
+        side=None,
+        detail=f"DE and EN last-commit timestamps are equal (@{de_ct})",
+    )
+
+
+def _git_last_commit_timestamp(path: Path) -> int | None:
+    """Return committer timestamp of the most recent commit touching ``path``.
+
+    Returns ``None`` when git is unavailable, the directory is not in a
+    git repo, or the file is untracked.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "log", "-1", "--format=%ct", "--", path.name],
+            cwd=str(path.parent),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if completed.returncode != 0:
+        return None
+    raw = completed.stdout.strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _index_first(cells: list[Cell], expected_lang: str) -> dict[tuple[str, str], Cell]:
+    """Index sync-relevant cells by ``(slide_id, role)``; first occurrence wins.
+
+    Mirrors the role/lang filter from :func:`clm.slides.sync._index_cells`
+    but keeps a single cell per key — direction inference is a coarse
+    structural signal, so the first cell in source order is enough.
+    """
+    out: dict[tuple[str, str], Cell] = {}
+    for cell in cells:
+        if cell.metadata.is_j2:
+            continue
+        if cell.metadata.cell_type != "markdown":
+            continue
+        if cell.metadata.lang != expected_lang:
+            continue
+        sid = cell.metadata.slide_id
+        if not sid:
+            continue
+        role: str | None = None
+        for tag in cell.metadata.tags:
+            if tag in _ROLE_TAGS:
+                role = tag
+                break
+        if role is None:
+            continue
+        out.setdefault((sid, role), cell)
+    return out

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from clm.cli.commands.slides_sync import slides_sync_cmd
+from clm.infrastructure.llm.cache import SyncSnapshotCache
 
 
 @pytest.fixture
@@ -33,11 +34,13 @@ def pair(tmp_path: Path) -> tuple[Path, Path]:
 
 
 class TestArgumentParsing:
-    def test_missing_source_lang_errors(self, cli_runner: CliRunner, pair):
+    def test_missing_source_lang_errors_outside_git(self, cli_runner: CliRunner, pair, tmp_path):
+        """With no snapshot rows and no git history, inference fails and
+        the CLI surfaces an actionable error pointing at --source-lang."""
         de_path, en_path = pair
         result = cli_runner.invoke(
             slides_sync_cmd,
-            [str(de_path), str(en_path)],
+            [str(de_path), str(en_path), "--no-cache"],
         )
         assert result.exit_code != 0
         assert "source-lang" in (result.stderr or result.output).lower()
@@ -394,3 +397,158 @@ class TestApplyTrivial:
         # Each outcome carries the applied_trivially flag.
         applied_flags = [o.get("applied_trivially") for o in payload["outcomes"]]
         assert any(applied_flags)
+
+
+class TestDirectionAutoDetection:
+    """End-to-end smoke for the omitted-``--source-lang`` path.
+
+    These tests construct a tiny git repo + snapshot cache to drive the
+    inference module from the CLI surface. The static judge keeps the
+    test from depending on a live Ollama instance.
+    """
+
+    @staticmethod
+    def _stub_judge(monkeypatch, proposed_text: str = "# ## Introduction") -> None:
+        from clm.cli.commands import slides_sync as cmd_module
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+        proposal = SyncProposal(verdict="update", proposed_text=proposed_text)
+        monkeypatch.setattr(cmd_module, "is_available", lambda _judge: True)
+        monkeypatch.setattr(
+            cmd_module,
+            "OllamaSyncJudge",
+            lambda **_kw: StaticSyncJudge(default_proposal=proposal),
+        )
+
+    @staticmethod
+    def _seed_snapshot(
+        cache_dir: Path,
+        *,
+        de_path: Path,
+        en_path: Path,
+        slide_id: str,
+        role: str,
+        de_text: str,
+        en_text: str,
+    ) -> None:
+        from clm.cli.commands.slides_sync import CACHE_DB_NAME
+        from clm.slides.sync_writeback import cell_content_hash
+
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        snapshot_cache = SyncSnapshotCache(cache_dir / CACHE_DB_NAME)
+        try:
+            snapshot_cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id=slide_id,
+                role=role,
+                de_hash=cell_content_hash(de_text),
+                en_hash=cell_content_hash(en_text),
+                direction="de->en",
+            )
+        finally:
+            snapshot_cache.close()
+
+    def test_omitted_source_lang_infers_from_snapshot(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        self._stub_judge(monkeypatch)
+        de_body = "# ## Einleitung\n# - eins"
+        en_body = "# ## Introduction\n# - one\n# - two"  # EN has drifted
+        de = f'# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n{de_body}\n'
+        en = f'# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n{en_body}\n'
+        de_path = tmp_path / "slides_intro.de.py"
+        en_path = tmp_path / "slides_intro.en.py"
+        de_path.write_text(de, encoding="utf-8")
+        en_path.write_text(en, encoding="utf-8")
+
+        cache_dir = tmp_path / "cache"
+        # Snapshot says original EN was "# ## Introduction\n# - one"; the
+        # current EN drifted; DE is unchanged.
+        self._seed_snapshot(
+            cache_dir,
+            de_path=de_path,
+            en_path=en_path,
+            slide_id="intro",
+            role="slide",
+            de_text=de_body,
+            en_text="# ## Introduction\n# - one",
+        )
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--cache-dir",
+                str(cache_dir),
+            ],
+        )
+        # Inference picked 'en' as source → direction en->de → DE side is
+        # the target. The run completes without raising UsageError.
+        assert result.exit_code != 2, result.output
+        combined = (result.stderr or "") + (result.output or "")
+        assert "inferred as 'en'" in combined
+        assert "snapshot" in combined
+
+    def test_omitted_source_lang_in_non_git_dir_raises_usage(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de = '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n# ## A\n'
+        en = '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## A\n'
+        de_path = tmp_path / "x.de.py"
+        en_path = tmp_path / "x.en.py"
+        de_path.write_text(de, encoding="utf-8")
+        en_path.write_text(en, encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--no-cache"],
+        )
+        assert result.exit_code != 0
+        combined = (result.stderr or "") + (result.output or "")
+        assert "could not be inferred" in combined
+        assert "--source-lang" in combined
+
+    def test_explicit_source_lang_disagreeing_with_inference_warns(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        self._stub_judge(monkeypatch)
+        de_body = "# ## Einleitung\n# - eins"
+        en_body = "# ## Introduction\n# - one (changed)"  # EN drifted
+        de = f'# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n{de_body}\n'
+        en = f'# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n{en_body}\n'
+        de_path = tmp_path / "slides_intro.de.py"
+        en_path = tmp_path / "slides_intro.en.py"
+        de_path.write_text(de, encoding="utf-8")
+        en_path.write_text(en, encoding="utf-8")
+
+        cache_dir = tmp_path / "cache"
+        self._seed_snapshot(
+            cache_dir,
+            de_path=de_path,
+            en_path=en_path,
+            slide_id="intro",
+            role="slide",
+            de_text=de_body,
+            en_text="# ## Introduction\n# - one",
+        )
+
+        # User passes --source-lang=de, but snapshot says EN drifted.
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--source-lang",
+                "de",
+                "--cache-dir",
+                str(cache_dir),
+            ],
+        )
+        combined = (result.stderr or "") + (result.output or "")
+        assert "warning" in combined.lower()
+        assert "disagrees with inferred direction 'en'" in combined
+        # The explicit override is still honored — direction de->en is
+        # used, so the EN cell is treated as the target.
+        assert result.exit_code != 2, result.output

--- a/tests/slides/test_sync_direction.py
+++ b/tests/slides/test_sync_direction.py
@@ -1,0 +1,455 @@
+"""Tests for :mod:`clm.slides.sync_direction` (direction auto-detection)."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncSnapshotCache
+from clm.slides.sync_direction import infer_source_lang
+from clm.slides.sync_writeback import cell_content_hash
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slide_cell(*, lang: str, slide_id: str, body: str, tag: str = "slide") -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["{tag}"] slide_id="{slide_id}"\n{body.strip()}\n'
+
+
+def _write_pair(
+    tmp_path: Path,
+    *,
+    de_body: str,
+    en_body: str,
+    slide_id: str = "intro",
+    stem: str = "slides_intro",
+) -> tuple[Path, Path]:
+    de = _slide_cell(lang="de", slide_id=slide_id, body=de_body)
+    en = _slide_cell(lang="en", slide_id=slide_id, body=en_body)
+    de_path = tmp_path / f"{stem}.de.py"
+    en_path = tmp_path / f"{stem}.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command inside ``repo`` and return stdout (or raise)."""
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def _init_repo(repo: Path) -> None:
+    """Create a fresh git repo with deterministic author config."""
+    _git(repo, "init", "-q")
+    # Avoid relying on the developer's global config (some environments
+    # have neither user.name nor user.email).
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _commit(repo: Path, message: str, *paths: Path) -> None:
+    rels = [str(p.relative_to(repo)) for p in paths]
+    _git(repo, "add", "--", *rels)
+    _git(repo, "commit", "-q", "-m", message)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-based inference
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotInference:
+    def test_en_side_drifted_returns_en_as_source(self, tmp_path: Path):
+        """Snapshot hash matches current DE but not current EN → EN drifted → source=en."""
+        de_path, en_path = _write_pair(
+            tmp_path,
+            de_body="# ## Einleitung",
+            en_body="# ## Introduction (updated)",
+        )
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            # Snapshot row: DE hash matches current; EN hash captured a
+            # PRIOR EN body (so current EN differs).
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role="slide",
+                de_hash=cell_content_hash("# ## Einleitung"),
+                en_hash=cell_content_hash("# ## Introduction"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang == "en"
+            assert inference.signal == "snapshot"
+            assert "EN drifted" in inference.reason
+        finally:
+            cache.close()
+
+    def test_de_side_drifted_returns_de_as_source(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            de_body="# ## Einleitung (geändert)",
+            en_body="# ## Introduction",
+        )
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role="slide",
+                de_hash=cell_content_hash("# ## Einleitung"),
+                en_hash=cell_content_hash("# ## Introduction"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang == "de"
+            assert inference.signal == "snapshot"
+        finally:
+            cache.close()
+
+    def test_both_sides_in_sync_returns_no_signal(self, tmp_path: Path):
+        """Snapshot rows that all match current state give no direction signal."""
+        de_path, en_path = _write_pair(
+            tmp_path,
+            de_body="# ## Einleitung",
+            en_body="# ## Introduction",
+        )
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role="slide",
+                de_hash=cell_content_hash("# ## Einleitung"),
+                en_hash=cell_content_hash("# ## Introduction"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            # Snapshot fell through to "none" — caller may still fall to git.
+            assert inference.source_lang is None
+            # The reason mentions the snapshot path was tried.
+            assert "snapshot" in inference.reason
+        finally:
+            cache.close()
+
+    def test_both_sides_drifted_is_ambiguous(self, tmp_path: Path):
+        """A 3-way merge case (both sides drifted) bails to manual."""
+        de_path, en_path = _write_pair(
+            tmp_path,
+            de_body="# ## Einleitung (geändert)",
+            en_body="# ## Introduction (changed)",
+        )
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role="slide",
+                de_hash=cell_content_hash("# ## Einleitung"),
+                en_hash=cell_content_hash("# ## Introduction"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang is None
+            assert inference.signal == "snapshot"
+            assert "both sides drifted" in inference.reason
+        finally:
+            cache.close()
+
+    def test_no_snapshot_cache_falls_through(self, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A", en_body="# ## A")
+        inference = infer_source_lang(de_path, en_path, snapshot_cache=None)
+        # No snapshot AND no git → "none".
+        assert inference.source_lang is None
+        assert inference.signal == "none"
+
+    def test_disagreeing_rows_are_ambiguous(self, tmp_path: Path):
+        """Two snapshot rows pointing at different sides → ambiguous."""
+        de = _slide_cell(lang="de", slide_id="a", body="# ## A geändert") + _slide_cell(
+            lang="de", slide_id="b", body="# ## B"
+        )
+        en = _slide_cell(lang="en", slide_id="a", body="# ## A") + _slide_cell(
+            lang="en", slide_id="b", body="# ## B changed"
+        )
+        de_path = tmp_path / "x.de.py"
+        en_path = tmp_path / "x.en.py"
+        de_path.write_text(de, encoding="utf-8")
+        en_path.write_text(en, encoding="utf-8")
+
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            # Row for 'a': original was "# ## A" on both sides → DE drifted.
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="a",
+                role="slide",
+                de_hash=cell_content_hash("# ## A"),
+                en_hash=cell_content_hash("# ## A"),
+                direction="de->en",
+            )
+            # Row for 'b': original was "# ## B" on both sides → EN drifted.
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="b",
+                role="slide",
+                de_hash=cell_content_hash("# ## B"),
+                en_hash=cell_content_hash("# ## B"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang is None
+            assert inference.signal == "snapshot"
+            assert "disagree" in inference.reason
+        finally:
+            cache.close()
+
+    def test_rows_for_a_different_file_pair_are_ignored(self, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A", en_body="# ## A changed")
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            # Put a row for a completely different file pair.
+            cache.put(
+                de_path=str(tmp_path / "other.de.py"),
+                en_path=str(tmp_path / "other.en.py"),
+                slide_id="intro",
+                role="slide",
+                de_hash="aaaa",
+                en_hash="bbbb",
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            # No matching rows for THIS pair → no snapshot evidence.
+            assert inference.source_lang is None
+            assert "no snapshot rows for this pair" in inference.reason
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Git-timestamp inference
+# ---------------------------------------------------------------------------
+
+
+class TestGitTimestampInference:
+    def test_more_recent_commit_wins(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A old", en_body="# ## A old")
+        _commit(tmp_path, "initial pair", de_path, en_path)
+
+        # Wait so the next commit's timestamp is strictly greater.
+        time.sleep(1.1)
+
+        # Touch EN only and commit — EN becomes the newer side.
+        en_path.write_text(
+            _slide_cell(lang="en", slide_id="intro", body="# ## A new"),
+            encoding="utf-8",
+        )
+        _commit(tmp_path, "edit en", en_path)
+
+        inference = infer_source_lang(de_path, en_path, snapshot_cache=None)
+        assert inference.source_lang == "en"
+        assert inference.signal == "git-timestamp"
+
+    def test_equal_timestamps_falls_back(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A", en_body="# ## A")
+        # Single commit touches both files → identical %ct on both.
+        _commit(tmp_path, "initial pair", de_path, en_path)
+
+        inference = infer_source_lang(de_path, en_path, snapshot_cache=None)
+        assert inference.source_lang is None
+        assert inference.signal == "none"
+        assert "equal" in inference.reason
+
+    def test_untracked_file_falls_back(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A", en_body="# ## A")
+        # Track only DE; EN remains untracked.
+        _commit(tmp_path, "de only", de_path)
+
+        inference = infer_source_lang(de_path, en_path, snapshot_cache=None)
+        assert inference.source_lang is None
+        # Reason mentions which file is untracked.
+        assert en_path.name in inference.reason
+
+    def test_no_git_repo_falls_back(self, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A", en_body="# ## A")
+        # tmp_path is NOT a git repo.
+        inference = infer_source_lang(de_path, en_path, snapshot_cache=None)
+        assert inference.source_lang is None
+        assert inference.signal == "none"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot/git interaction
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotGitInteraction:
+    def test_snapshot_wins_over_agreeing_git(self, tmp_path: Path):
+        """When both signals point at the same side, snapshot is named in the result."""
+        _init_repo(tmp_path)
+        de_path, en_path = _write_pair(
+            tmp_path, de_body="# ## Einleitung", en_body="# ## Introduction"
+        )
+        _commit(tmp_path, "initial pair", de_path, en_path)
+
+        # Mutate EN on disk + a snapshot that captured the old state.
+        time.sleep(1.1)
+        new_en = _slide_cell(lang="en", slide_id="intro", body="# ## Introduction (updated)")
+        en_path.write_text(new_en, encoding="utf-8")
+        _commit(tmp_path, "edit en", en_path)
+
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role="slide",
+                de_hash=cell_content_hash("# ## Einleitung"),
+                en_hash=cell_content_hash("# ## Introduction"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang == "en"
+            # Snapshot's verdict takes precedence in the signal label even
+            # though git agrees.
+            assert inference.signal == "snapshot"
+        finally:
+            cache.close()
+
+    def test_snapshot_and_git_disagree_is_ambiguous(self, tmp_path: Path):
+        """Snapshot says one side, git says the other — fall back."""
+        _init_repo(tmp_path)
+        de_path, en_path = _write_pair(
+            tmp_path, de_body="# ## Einleitung", en_body="# ## Introduction"
+        )
+        _commit(tmp_path, "initial pair", de_path, en_path)
+
+        # Mutate DE on disk and commit; git timestamp now points at DE.
+        time.sleep(1.1)
+        de_path.write_text(
+            _slide_cell(lang="de", slide_id="intro", body="# ## Einleitung (geändert)"),
+            encoding="utf-8",
+        )
+        _commit(tmp_path, "edit de", de_path)
+
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            # But the snapshot row says EN drifted (current DE matches
+            # snapshot.de_hash AFTER our edit — fake by setting the
+            # snapshot.de_hash to the CURRENT DE content, and
+            # snapshot.en_hash to a fake "old" value so EN looks drifted).
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role="slide",
+                de_hash=cell_content_hash("# ## Einleitung (geändert)"),  # matches current DE
+                en_hash=cell_content_hash("# ## SOMETHING ELSE"),  # mismatches current EN
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            # Snapshot says EN, git says DE → ambiguous.
+            assert inference.source_lang is None
+            assert inference.signal == "snapshot+git-timestamp"
+            assert "disagree" in inference.reason or "but git timestamps" in inference.reason
+        finally:
+            cache.close()
+
+    def test_git_used_when_snapshot_has_no_rows(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A old", en_body="# ## A old")
+        _commit(tmp_path, "initial pair", de_path, en_path)
+
+        time.sleep(1.1)
+        de_path.write_text(
+            _slide_cell(lang="de", slide_id="intro", body="# ## A new"),
+            encoding="utf-8",
+        )
+        _commit(tmp_path, "edit de", de_path)
+
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang == "de"
+            assert inference.signal == "git-timestamp"
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_snapshot_row_for_missing_slide_id_is_skipped(self, tmp_path: Path):
+        """A snapshot row whose slide_id has been removed from the file should not crash."""
+        de_path, en_path = _write_pair(tmp_path, de_body="# ## A", en_body="# ## A")
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="vanished",
+                role="slide",
+                de_hash="aaa",
+                en_hash="bbb",
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            # No matched rows → "none" — caller falls to git or asks.
+            assert inference.source_lang is None
+            assert "no longer in the files" in inference.reason
+        finally:
+            cache.close()
+
+    @pytest.mark.parametrize(
+        "role_tag",
+        ["slide", "subslide", "voiceover", "notes"],
+    )
+    def test_all_sync_roles_index_correctly(self, tmp_path: Path, role_tag: str):
+        """Direction inference must walk the same roles the sync engine does."""
+        de = _slide_cell(lang="de", slide_id="intro", body="# narrative DE", tag=role_tag)
+        en = _slide_cell(lang="en", slide_id="intro", body="# narrative EN changed", tag=role_tag)
+        de_path = tmp_path / "x.de.py"
+        en_path = tmp_path / "x.en.py"
+        de_path.write_text(de, encoding="utf-8")
+        en_path.write_text(en, encoding="utf-8")
+
+        cache = SyncSnapshotCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                slide_id="intro",
+                role=role_tag,
+                de_hash=cell_content_hash("# narrative DE"),
+                en_hash=cell_content_hash("# narrative EN"),
+                direction="de->en",
+            )
+            inference = infer_source_lang(de_path, en_path, cache)
+            assert inference.source_lang == "en"
+        finally:
+            cache.close()


### PR DESCRIPTION
## Summary

Direction auto-detection for `clm slides sync` — the first of the two
deferred Phase 7 v2 follow-ups. `--source-lang` is now optional; when
omitted, the direction of edit is inferred from `SyncSnapshotCache`
drift (preferred, content-addressed) or `git log -1 %ct` (fallback),
with disagreement falling back to requiring an explicit value.

- New module `clm.slides.sync_direction` (`infer_source_lang` +
  `DirectionInference`).
- Snapshot-first preference: rebases / commit-date rewrites don't lie.
- Both-sides-drifted snapshot rows are flagged as the 3-way merge case
  (ambiguous direction) — the actual prompt for those is the second
  v2 follow-up, deferred until pilot data is in.
- Explicit `--source-lang` always wins; a stderr warning surfaces a
  disagreement with the inferred direction so the user double-checks.

## What's still deferred

LLM-assisted 3-way merge prompt for "both sides drifted" cells. The
inference module now surfaces this case as the `signal="snapshot"` /
`source_lang=None` /  `"both sides drifted"` reason; a future PR adds
the `[d]e wins / [e]n wins / [s]kip / [q]uit` walker on top.

## Test plan

- [x] `pytest tests/slides/test_sync_direction.py` — 19 new unit tests
      (real `subprocess.run` against `git init` in `tmp_path`; no
      mocked git internals).
- [x] `pytest tests/slides/test_sync*.py tests/cli/test_slides_sync.py`
      — 80 sync-related tests passing locally.
- [x] `pytest -m "not docker"` — full non-docker suite (1 pre-existing
      heartbeat flake unrelated to this change; 15 transient e2e xdist
      worker setup errors that pass individually).
- [x] Pre-commit (ruff lint + ruff format + mypy strict + fast
      pytest) passes.
- [x] `CHANGELOG.md` `[Unreleased]` and `src/clm/cli/info_topics/commands.md`
      (`clm slides sync` section) updated to describe the new optional
      `--source-lang` behavior.
- [x] CLM-side handover (`docs/claude/python-courses-revamp-handover.md`)
      updated: Priority 2 phase tracker box ticked, decisions recorded
      in new §10c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)