### PR TITLE
fix(tests): heartbeat integration test must use format=html to execute cells

### DIFF
--- a/tests/workers/notebook/test_worker_heartbeat_integration.py
+++ b/tests/workers/notebook/test_worker_heartbeat_integration.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock
 import pytest
 from nbformat.v4 import new_code_cell, new_notebook
 
+from clm.infrastructure.database import worker_heartbeats as _wh
 from clm.infrastructure.database.schema import init_database
 from clm.infrastructure.database.worker_heartbeats import WorkerHeartbeatStore
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
@@ -32,6 +33,19 @@ from clm.workers.notebook.notebook_processor import (
     TrackingExecutePreprocessor,
 )
 from clm.workers.notebook.output_spec import create_output_spec
+
+
+@pytest.fixture(autouse=True)
+def _relax_slow_write_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The production 50ms self-disable threshold legitimately trips under
+    # xdist load (lock contention, WAL checkpoint, antivirus scan) and also
+    # during the slow integration test below — a single SQLite write that
+    # spikes past 50ms silently turns subsequent writes into no-ops and the
+    # `expected at least one heartbeat row` assertion then fails with
+    # `None is not None`. Lift the threshold for these tests; sibling
+    # ``test_worker_heartbeats.py`` does the same.
+    monkeypatch.setattr(_wh, "SLOW_WRITE_THRESHOLD_SECONDS", 30.0)
+
 
 # -- shared helpers ----------------------------------------------------------
 
@@ -220,9 +234,13 @@ def test_three_cell_notebook_emits_heartbeats(db_path: Path, tmp_path: Path) -> 
         "print('cell 2 final')\n"
     )
 
-    spec = create_output_spec(
-        kind="completed", prog_lang="python", language="en", format="notebook"
-    )
+    # Use ``format="html"``: only the HTML format goes through
+    # ``_create_using_nbconvert`` which actually spawns a kernel and
+    # invokes ``TrackingExecutePreprocessor`` (and therefore emits the
+    # per-cell heartbeats we're testing here). ``format="notebook"``
+    # goes through ``_create_using_jupytext`` and never executes any
+    # cells, so no heartbeats fire.
+    spec = create_output_spec(kind="completed", prog_lang="python", language="en", format="html")
     store = WorkerHeartbeatStore(db_path, worker_id=1)
     proc = NotebookProcessor(spec, heartbeat_store=store, heartbeat_job_id=4242)
 
@@ -230,11 +248,11 @@ def test_three_cell_notebook_emits_heartbeats(db_path: Path, tmp_path: Path) -> 
         data=nb_source,
         input_file=str(tmp_path / "tiny.py"),
         input_file_name="tiny.py",
-        output_file=str(tmp_path / "tiny.ipynb"),
+        output_file=str(tmp_path / "tiny.html"),
         kind="completed",
         prog_lang="python",
         language="en",
-        format="notebook",
+        format="html",
         template_dir="",
         other_files={},
         correlation_id=f"hb-test-{uuid.uuid4().hex[:8]}",


### PR DESCRIPTION
## Summary

**Blocker for the 1.6.0 release.** Found this while running Step 2 of the release procedure (`uv run pytest -m "not docker"` on master at `0c88ea9`): `test_three_cell_notebook_emits_heartbeats` fails every run with `AssertionError: expected at least one heartbeat row after execution; assert None is not None`.

### Root cause

The test constructs a 3-cell notebook, runs it through `NotebookProcessor.process_notebook`, and expects per-cell heartbeats in the `worker_heartbeats` table. But it was passing `format="notebook"` — `NotebookProcessor.create_contents` only routes through `_create_using_nbconvert` (which spawns a real ipykernel and invokes `TrackingExecutePreprocessor`) when `format == "html"`. With `format="notebook"` it goes through `_create_using_jupytext` instead, which never executes any cells. The test therefore never triggered the heartbeat code path it was supposed to verify; the `worker_heartbeats` row stayed empty.

### Why CI didn't catch this

The test is marked `slow + integration`. `.github/workflows/ci.yml` excludes the `slow` marker on every job, so this test has been silently uncovered since it was added in PR #84 (heartbeat feature, master commit `64b9585`). The failure only surfaces locally under `pytest -m "not docker"` — the project's documented pre-release gate per `docs/developer-guide/releasing.md`.

### Fixes

1. `format="notebook"` → `format="html"` (plus matching `output_file` extension). HTML output is the only format that executes cells. Added a comment explaining the gate.
2. Added the autouse `_relax_slow_write_threshold` fixture that sibling `tests/infrastructure/database/test_worker_heartbeats.py` already uses. Now that cells actually execute, a SQLite write can legitimately spike past the production 50ms self-disable threshold (especially under xdist load on Windows) and silently turn subsequent heartbeat writes into no-ops — exactly the failure mode flagged in the project memory. The `test_slow_write_disables_further_writes` sibling test patches it back to 0.0 inside its own scope, so the disable path stays covered.

## Test plan

- [x] Targeted: `pytest tests/workers/notebook/test_worker_heartbeat_integration.py -m "not docker"` — 5 passed in 12.80s
- [x] Pre-release gate: `pytest -m "not docker"` — **5561 passed, 24 skipped, 1 xfailed in 239s** (clean)
- [x] Pre-commit hooks (ruff + mypy + fast pytest) green on commit

## After this lands

Step 2 of the release is satisfied. Next: `bump-my-version bump minor` → tag → CI green → `uv publish`. I'll pause for confirmation before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)