### PR TITLE
fix(http-replay): discard partial-chain recordings from aborted sessions (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Cassette merge discards partial chains from aborted recording
+  sessions (issue #115).** Previously, a kernel that died mid-cell —
+  after recording the first call of a chained pair but before the
+  chain-closing call landed on disk — could permanently poison the
+  canonical cassette: the additive `first-seen-wins` dedup rule would
+  promote the orphan chain-opener to canonical, and subsequent replay
+  builds would fail on the missing chain-closer with
+  `CannotOverwriteExistingCassetteException`. Refresh could not repair
+  the poisoning either. The fix introduces a per-staging-file
+  completion marker (`<staging>.completed`): the host writes it only
+  on the success path of notebook execution. The merge now treats
+  markered staging as "safe to fold" and markerless staging either as
+  "concurrent worker, leave alone" (per-worker merge) or as "confirmed
+  orphan from aborted previous build, discard" (pre-build sweep).
+  Authors who hit issue #115 should delete the poisoned canonical
+  cassette and rebuild; the partial chain will no longer re-poison.
+
 ## [1.6.0] - 2026-05-21
 
 ### Added

--- a/docs/claude/TODO.md
+++ b/docs/claude/TODO.md
@@ -28,6 +28,38 @@ proposal doc for evidence, root-cause analysis, and an implementation plan.
 
 ---
 
+### Pre-existing mypy errors in `TestBootstrapDurability` test class
+
+**Status**: 🟡 Open (2026-05-21) — discovered during issue #115 Phase 3 work
+
+**Location**: `tests/workers/notebook/test_notebook_processor.py`, four
+`make_notebook_json(cells)` call sites inside the
+`TestBootstrapDurability` and skip-evaluation tests (line numbers
+shift as the file grows; grep for the helper).
+
+**Symptom**: `mypy` reports
+`Argument 1 to "make_notebook_json" has incompatible type "list[NotebookNode]"; expected "list[dict[Any, Any]]"  [arg-type]`
+on the four call sites. `list` is invariant, so a
+`list[NotebookNode]` is not assignable to `list[dict[Any, Any]]`
+even though `NotebookNode` is a `dict` subclass. The runtime
+behaviour is fine; the type signature on
+`make_notebook_json` is too narrow.
+
+**Recommended fix**: Either widen the parameter type to
+`Sequence[Mapping[str, Any]]` (covariant) or change the local
+variable annotations / construction sites to `list[dict[Any, Any]]`.
+The handover doc's "mypy clean on every touched file" Phase 2
+verification was correct for the merge code and Phase-2-touched
+tests — these four call sites predate Phase 2 and were not
+modified by issue #115 work.
+
+**Discovered during**: HTTP-replay cassette partial-chain fix
+(issue #115 Phase 3). Not caused by that change. Verified by
+stashing the Phase 3 additions and re-running mypy: same 4 errors,
+same root cause, line numbers shifted by the insertion size.
+
+---
+
 ### Flaky Test: `test_heartbeat_round_trip_smoke`
 
 **Status**: 🟡 Open (2026-05-19) — observed once under xdist load

--- a/docs/claude/cassette-partial-chain-fix-handover.md
+++ b/docs/claude/cassette-partial-chain-fix-handover.md
@@ -1,0 +1,662 @@
+# Handover: HTTP-Replay Cassette Partial-Chain Fix (Issue #115)
+
+## 1. Feature Overview
+
+Fix the structural bug in
+`merge_staging_into_canonical` that lets an **aborted** recording session
+permanently poison a canonical cassette by admitting a partial chain
+(chain-opener recorded, chain-closer missing). The fix introduces a
+**per-staging-file completion marker** so the merger can distinguish
+"recording session ran to completion" from "kernel died / build aborted
+/ cell raised mid-chain" and discards the latter's entries.
+
+- **Issue**: [hoelzl/clm#115](https://github.com/hoelzl/clm/issues/115)
+- **Filed as follow-up to**: #95 (closed) — §A `allow_playback_repeats`
+  + §B spec-target snapshot fixes shipped clean; this is the remaining
+  §C item from the PythonCourses redesign handover.
+- **Branch**: not yet pushed; working tree on `master` in this worktree.
+- **Worktree**: this one (`functional-forging-marble`).
+- **Status**: Phases 1 (marker plumbing), 2 (discriminating merge),
+  and 3 (end-to-end §C regression test) shipped to the worktree. PR
+  not yet opened — the intent is to bundle all three phases into one
+  PR.
+- **Investigation environment**: CLM master at commit `45f1d5e`
+  (PR #114 + Phase 7 v2 follow-up), Python 3.13 on Windows 11.
+
+### What's broken today (concrete repro from the issue)
+
+`slides_010_prompt_templates.py` in PythonCourses has a workshop cell
+that defines `clarify_and_answer(vague)` — a function chaining two LLM
+calls per loop iteration, where call-2's input depends on call-1's
+response text. The cassette `slides_010_prompt_templates.http-cassette.yaml`
+ends up with:
+
+- Q1: clarify + tutor pair (intact chain).
+- Q2: clarify + tutor pair (intact chain).
+- Q3: **clarify only** — Q3's tutor request body (which embeds Q3's
+  *currently stored* clarified text) is absent.
+
+`--http-replay=replay` fails on Q3's tutor call:
+`CannotOverwriteExistingCassetteException`. The cassette is internally
+inconsistent — call-1's response cannot be reached without orphaning
+call-2.
+
+### Why the diagnosis in #115 is correct
+
+Verified against the actual code:
+
+1. `src/clm/workers/notebook/http_replay_cassette.py:141-162` —
+   `merge_staging_into_canonical` is purely additive-by-`_dedup_key`
+   (`(method, uri, body)`), with no awareness of inter-entry
+   dependencies and no awareness of whether the staging file came
+   from a completed session.
+
+2. `src/clm/workers/notebook/notebook_processor.py:200-208` — the
+   bootstrap's eager-save patch (`_clm_eager_append`) flushes the
+   staging file on **every** successful `cassette.append`. By the
+   time a kernel dies, partial recordings (chain-opener but no
+   chain-closer) are already on disk.
+
+3. `src/clm/workers/notebook/notebook_processor.py:1516-1528` —
+   `_persist_recorded_cassette` runs in the `finally` block of
+   `_create_using_nbconvert`, so the merge happens **regardless** of
+   whether execution succeeded. The current behaviour is intentional
+   — the comment on lines 1522-1527 explicitly says "skipping the
+   merge would lose every interaction the kernel successfully
+   recorded before the failure." The fix must keep that "don't lose
+   recordings" goal in tension with "don't admit half-chains" — the
+   marker approach threads that needle.
+
+4. `src/clm/core/course.py:386` — the pre-build orphan sweep
+   (`_sweep_orphan_cassette_staging_files`) inherits the same
+   additive-only behaviour and folds in any orphan staging from a
+   previously-killed worker without distinguishing complete from
+   partial.
+
+The poisoning mechanism described in #115 — "first-seen wins, partial
+chain-opener becomes permanent, no subsequent completed run can
+repair" — is exactly what the merge code does today.
+
+### Scope caveats the issue itself flags
+
+- **`--http-replay=refresh` is separately broken** for chain-poisoned
+  cassettes by the same `_dedup_key` additive rule (canonical entry
+  for the chain-opener body is never overwritten). Fixing refresh
+  semantics is **out of scope** for this issue. The marker fix does
+  not make refresh worse.
+- **Conditional / try-except skipped cells in a successful run** can
+  still produce partial chains (cell ran to completion, but a
+  try/except internally swallowed the chain-closer). Out of scope;
+  documented as a known limitation. Handled by the optional
+  cassette-doctor follow-up.
+
+## 2. Design Decisions
+
+### Recommended approach: per-staging-file completion marker
+
+Each worker writes a sentinel file
+`<staging_path>.completed` **host-side**, after the kernel has
+returned cleanly from `_execute_notebook_with_path`, **before** the
+finally-block invokes `merge_staging_into_canonical`. The merge logic
+becomes:
+
+| Staging file | Marker present | Action |
+|---|---|---|
+| Own staging, this build | yes (host wrote on success path) | Fold entries into canonical |
+| Own staging, this build | no (execution raised) | Leave on disk; pre-build sweep next time |
+| Other worker's staging, mid-execution | no (worker still running) | **Leave alone** — don't merge, don't delete |
+| Other worker's staging, completed | yes | Fold in, delete staging + marker (its merge crashed) |
+| Orphan from previous build, completed | yes | Pre-build sweep folds in, deletes |
+| Orphan from previous build, aborted | no | Pre-build sweep **discards entries**, deletes staging |
+
+The discriminator between "leave markerless alone" (per-worker merge)
+and "discard markerless" (pre-build sweep) is a new `sweep_orphans`
+flag passed to `merge_staging_into_canonical`.
+
+### Why host-side marker, not kernel-side `atexit`
+
+The issue text suggests "register a final hook that writes the marker
+after the last cell finishes." Inside the kernel, the natural
+mechanism is `atexit`. **This is wrong** because:
+
+- `atexit` fires on **graceful kernel shutdown**, including the
+  graceful shutdown that follows a `CellExecutionError`. The cell
+  that closes the chain didn't run, but `atexit` runs anyway → marker
+  written → partial chain admitted. That's exactly the bug we're
+  trying to fix.
+- Only `TerminateProcess` / SIGKILL skips `atexit`. Most aborts in
+  practice are graceful (cell raise, Ctrl+C).
+
+Host-side marker writing is cleaner: the host writes the marker
+**only on the success path** of `_execute_notebook_with_path`, and
+that path is reached iff every cell executed without raising (or
+under `skip_errors=True`, iff nbclient returned cleanly). The
+finally block — which already handles partial-staging merge today —
+gets a new precondition for folding-in: marker must be present.
+
+### Marker location and format
+
+- Path: `<paths.staging>.completed` (sibling of the staging file,
+  same directory).
+- Content: small JSON payload with `{"completed_at": "<ISO-8601>",
+  "host_pid": <int>, "schema": 1}` for forensic debugging. **The
+  content is not load-bearing** — the file's *existence* is the
+  signal. A zero-byte file would work equally well.
+- Atomic write via the same `_atomic_write_text` helper already in
+  `http_replay_cassette.py`. Idempotent: re-writing the marker on a
+  retry path is fine.
+
+### Marker also added to ignore lists
+
+`SKIP_OUTPUT_FILE_PATTERNS` and `SKIP_OUTPUT_FILE_GLOBS` in
+`src/clm/infrastructure/utils/path_utils.py:83-94` must learn the new
+`.completed` suffix so it never travels into worker payloads or
+public/speaker output. The marker is a build-internal artifact, same
+class as `.staging-*`.
+
+### Concurrency: why "leave alone if no marker" is safe
+
+The current per-worker merge globs **all** `*.staging-*` files in
+the canonical's directory and folds+deletes them. Under today's code
+this is a latent hazard: if Worker A's post-execution merge runs
+while Worker B is still recording, A's merge folds B's partial
+recording into canonical and `unlink`s B's staging — silently
+corrupting B's run. The chain-poisoning in #115 is the visible
+symptom of this hazard meeting the dedup-first-seen-wins rule.
+
+The marker fix structurally eliminates this race:
+
+1. **Marker write must precede merge lock acquisition.** A worker
+   that successfully completes execution writes the marker first,
+   then takes the canonical lock for the merge. Other workers'
+   merges only see markers from workers that have already crossed
+   that boundary.
+2. **Markerless staging is treated as "not yet completed"** by the
+   per-worker merge — could be a still-running concurrent worker, or
+   could be a session that aborted. Either way, the right action
+   from inside a merge is "leave alone." The other worker (if alive)
+   will write its own marker and run its own merge; if it's dead,
+   the next build's pre-build sweep will discard the entries.
+3. **Pre-build sweep runs single-threaded before any worker starts**
+   (this is the invariant from the issue-#86 fix —
+   `Course._sweep_orphan_cassette_staging_files` is called from
+   `process_all`/`process_file` *before* the worker pool kicks
+   off). At that moment, every staging file present is from a
+   previous build → no concurrency, so markerless = confirmed
+   orphan = safe to discard.
+
+The split between per-worker (conservative: leave alone) and
+pre-build (decisive: discard markerless) is the load-bearing design
+choice.
+
+### Edge cases (worked through)
+
+| # | Scenario | Behaviour |
+|---|---|---|
+| 1 | Brand-new deck, first recording session aborts before chain-closer | No marker → next build discards staging entirely → no poisoning. Slightly worse than today's "some entries persist" but today's persistence is exactly the bug. Re-recording is cheap. |
+| 2 | New cell added to existing deck; first run aborts mid-new-chain | Same as #1, scoped to the new cell. New cell stays unrecorded; existing cells unaffected. |
+| 3 | Cell ran but try/except swallowed the chain-closer LLM call | Marker is written (`_execute_notebook_with_path` returned cleanly). Partial chain still admitted. **Not addressed** by this fix; needs cassette-doctor. |
+| 4 | Two workers, German and English, mixed outcomes — A succeeds, B's kernel dies | A writes marker, A's merge picks up its own entries. B's staging is markerless, A's merge leaves it alone. Next build's pre-build sweep discards B's staging. **Correct.** |
+| 5 | Marker write fails (disk full, race with antivirus on Windows) | Marker absent → session treated as aborted → recordings discarded next build. Degradation, not corruption. Logged warning. |
+| 6 | Worker process killed via `TerminateProcess` by build-level timeout | Worker process dies, no finally runs, no marker. Next build's pre-build sweep discards. **Correct.** |
+| 7 | Marker present but staging is missing (file was deleted) | Marker is orphaned. Merge ignores it (no staging to fold). Pre-build sweep deletes the orphan marker. |
+| 8 | `skip_errors=True` + cells raised mid-chain | nbclient returns cleanly → marker written → partial chain admitted. The user opted into "errors are OK" so this matches `skip_errors` semantics. **Documented as a known limitation**, same caveat as today. |
+| 9 | `--http-replay=refresh` + chain poisoning already in canonical | Refresh records new entries on top, additive merge skips entries already in canonical → poisoning persists. **Pre-existing bug, out of scope.** Workaround: delete canonical, then `new-episodes`. |
+| 10 | Two concurrent `clm build` invocations against the same source tree | Build 2's pre-build sweep would see Build 1's markerless staging and discard. **Not supported scenario**, but documented. |
+
+### Alternative considered and rejected: rename staging on success
+
+Instead of a companion marker, the host could rename
+`<canonical>.staging-<id>` → `<canonical>.complete-<id>` on
+success. The merge function only looks at `*.complete-*` files.
+
+Trade-off:
+- **Pro**: single file per session, no companion to keep in sync.
+- **Con**: rename of a file the kernel still has an open vcrpy fd on
+  is Windows-fragile (the kernel is dead by the time we rename, but
+  ZMQ/fs ordering on Windows has burned us before — see the
+  `_ReapingKernelManager` workaround).
+- **Con**: rename races against a concurrent worker's directory scan
+  more subtly than a marker write (atomicity of rename vs atomicity
+  of touch).
+
+The companion-marker approach is more explicit about
+the "is it completed?" question and matches existing patterns
+(`.lock` companions for the merge lock, `.tmp-<uuid>` companions for
+`_atomic_write_text`). Going with the marker.
+
+### Alternative considered and rejected: PID-based liveness
+
+Each staging file embeds the worker PID
+(`f"{os.getpid()}-{uuid.uuid4().hex}"`). The pre-build sweep could
+parse the PID and discard staging from dead PIDs without needing a
+marker.
+
+Rejected because:
+- PID recycling on Windows is fast — a dead worker's PID may be a
+  live unrelated process by the time the sweep runs.
+- Docker workers' PIDs are container-internal, not visible to the host.
+- The marker subsumes liveness *and* completion-status, and is more
+  explicit.
+
+## 3. Phase Breakdown
+
+Four phases, total estimated effort ~1–1.5 days for phases 1–3.
+Phase 4 is optional and probably warrants its own issue.
+
+### Phase 1 — Marker plumbing helpers [DONE]
+
+Shipped to the worktree (no PR yet — bundled with later phases).
+
+**Files modified**:
+
+- `src/clm/workers/notebook/http_replay_cassette.py` — added
+  `_COMPLETION_MARKER_SUFFIX = ".completed"`,
+  `_COMPLETION_MARKER_SCHEMA = 1`, `marker_path(staging) -> Path`,
+  `has_completion_marker(staging) -> bool`, and
+  `write_completion_marker(paths) -> None`. The writer uses the
+  existing `_atomic_write_text`, is idempotent, and downgrades on
+  `OSError` (logs warning, does not raise — partial-marker semantics
+  fail safely to "session aborted").
+- `src/clm/infrastructure/utils/path_utils.py` —
+  `SKIP_OUTPUT_FILE_PATTERNS` and `SKIP_OUTPUT_FILE_GLOBS` got an
+  explicit `.completed` rule. (The existing `.staging-.*` rule
+  already matches by accident; the explicit pattern documents intent
+  and survives a future narrowing of the staging regex.)
+- `tests/workers/notebook/test_notebook_processor.py` — new
+  `class TestCompletionMarker` with 7 tests (split the original
+  `creates_file` + `timestamp` test for clearer failure messages):
+  - `test_marker_path_sits_beside_staging`
+  - `test_has_completion_marker_false_when_absent`
+  - `test_has_completion_marker_true_when_present`
+  - `test_write_completion_marker_creates_file`
+  - `test_write_completion_marker_payload_is_valid_json_with_iso_timestamp`
+  - `test_write_completion_marker_is_idempotent`
+  - `test_marker_filename_is_ignored_for_output`
+
+**Verification**: 18 cassette-related tests pass (7 new + 11 existing
+in `TestCassetteMerge` / `TestBootstrapDurability`); 58 path-utils
+tests pass; `ruff check`, `ruff format`, and `mypy` all clean.
+
+**Phase 2 prerequisite discovered**: the worktree venv needs
+`uv sync --extra all` to get `vcrpy` and `filelock`. Without that,
+`pytest.importorskip("vcr")` at the top of the existing cassette
+tests silently skips them — make sure CI and any reviewer's local
+env have `[all]` extras installed before claiming "all tests pass."
+
+### Phase 2 — Discriminating merge [DONE]
+
+Shipped to the worktree (no PR yet — bundled with Phase 3).
+
+**Files modified**:
+
+- `src/clm/workers/notebook/http_replay_cassette.py` —
+  `merge_staging_into_canonical(paths, *, sweep_orphans=False)` rewrite
+  with per-staging-file branching (marker → fold + delete; markerless
+  + `sweep_orphans=True` → discard + delete; markerless +
+  `sweep_orphans=False` → leave alone with DEBUG log). Marker-file
+  paths matching the staging glob are filtered out of the staging set
+  before discrimination, so `has_completion_marker` is the only
+  signal. Canonical bytes are *not* rewritten when a sweep discards
+  only markerless orphans (no atomic-write churn for "nothing to
+  fold"). New `_delete_quietly` helper centralises the
+  FileNotFoundError-ok / OSError-log delete pattern, used for both
+  staging files and their markers. Return value is now the count of
+  *markered* folds only — discards are not counted (callers can tell
+  from disk state).
+- `src/clm/workers/notebook/notebook_processor.py` —
+  `_persist_recorded_cassette` gains `execution_succeeded` kw-only
+  arg. On the success path it calls `write_completion_marker(paths)`
+  before invoking the merge; on the failure path it logs and skips
+  the marker write so the partial chain stays markerless and the
+  next pre-build sweep discards it. `_create_using_nbconvert`
+  tracks `execution_succeeded = False` before the try, flips to
+  `True` after `_execute_notebook_with_path` returned cleanly, and
+  passes the flag through in the finally block.
+- `src/clm/core/course.py` — `_sweep_orphan_cassette_staging_files`
+  calls `merge_staging_into_canonical(..., sweep_orphans=True)`.
+  Docstring updated to explain the discriminator (single-threaded
+  pre-build sweep → no concurrency → markerless = confirmed orphan).
+- `docs/claude/design/http-replay.md` — appended "Completion-marker
+  semantics (issue #115)" section: contract table, success/failure
+  paths, the `skip_errors` / `try-except` / refresh limitations.
+- `CHANGELOG.md` — Unreleased / Fixed entry describing the
+  partial-chain poisoning fix and the marker mechanism.
+- `tests/workers/notebook/test_notebook_processor.py` — new
+  `TestDiscriminatingMerge` class with the 7 tests below; existing
+  `TestCassetteMerge` tests updated to drop `.completed` markers
+  beside the staging files they expect to be folded (via a new
+  `_touch_completion_marker(staging)` helper).
+- `tests/core/course_test.py` —
+  `test_sweep_orphan_staging_files_merges_and_deletes` now writes
+  `.completed` markers beside its orphans (with an updated docstring
+  clarifying that markerless orphans are *discarded* by the sweep
+  per issue #115; the "merges and deletes" branch keeps testing the
+  completed-orphan path).
+
+**New tests (all 7 pass)**:
+
+- `test_merge_folds_entries_when_marker_present` — default per-worker
+  merge with marker present folds + cleans up both files.
+- `test_merge_skips_markerless_in_per_worker_mode` — markerless
+  staging is left strictly alone (file still on disk, canonical
+  unchanged).
+- `test_merge_discards_markerless_in_sweep_mode` — `sweep_orphans=True`
+  deletes the staging file and never folds its entries; pre-existing
+  canonical entries survive.
+- `test_merge_deletes_marker_after_successful_fold` — both the
+  staging file and its `.completed` sibling are removed after a
+  successful merge.
+- `test_persist_recorded_cassette_writes_marker_on_success` — host
+  integration: `execution_succeeded=True` produces a merged canonical
+  with the recording present (marker was written → fold happened →
+  staging + marker cleaned up).
+- `test_persist_recorded_cassette_omits_marker_on_failure` —
+  `execution_succeeded=False` leaves staging on disk markerless;
+  canonical never touched.
+- `test_concurrent_workers_dont_consume_each_others_active_staging` —
+  Worker A finishes (marker present) and runs its merge; Worker B
+  is still recording (markerless). A's merge folds A but leaves B
+  intact; B's recordings are not leaked into canonical.
+
+**Verification**: 25 cassette-related tests pass (7 new
+`TestDiscriminatingMerge` + 8 existing `TestCassetteMerge` updated to
+write markers + 7 `TestCompletionMarker` + 3 `TestBootstrapDurability`);
+3 `test_sweep_orphan_staging_files_*` tests pass; full
+`test_notebook_processor.py` (117 tests) green; non-docker test suite
+green (5587 pass, 1 known pre-existing heartbeat flake unrelated to
+cassettes, 11 skipped); `ruff check`, `ruff format --check`, and
+`mypy` all clean on every touched file.
+
+---
+
+#### Original Phase 2 plan (historical, for the PR reviewer)
+
+Rewrite `merge_staging_into_canonical` to require a marker for
+folding, with a new `sweep_orphans: bool` flag:
+
+```python
+def merge_staging_into_canonical(
+    paths: CassettePaths,
+    *,
+    sweep_orphans: bool = False,
+) -> int:
+    """...
+
+    Args:
+        sweep_orphans: When True (pre-build invocation), markerless
+            staging files are treated as confirmed orphans from
+            aborted previous builds: their entries are discarded and
+            the staging files are deleted. When False (default,
+            per-worker post-execution invocation), markerless
+            staging files are left untouched — they may belong to a
+            concurrent worker that hasn't completed yet.
+    """
+```
+
+Inside the lock-held block:
+
+1. Load canonical (unchanged).
+2. For each `staging_path` in the glob:
+   - If `has_completion_marker(staging_path)`:
+     - Fold entries via existing dedup logic.
+     - Delete staging + marker on success.
+   - Elif `sweep_orphans`:
+     - Discard entries (do not fold).
+     - Delete staging (no marker to delete).
+     - Log INFO: "discarded orphan staging '<path>' (no completion marker)".
+   - Else (markerless, not in sweep mode):
+     - Skip. Log DEBUG: "skipped markerless staging '<path>'
+       (concurrent worker?)".
+3. Atomic write canonical.
+
+Update `_persist_recorded_cassette` in
+`src/clm/workers/notebook/notebook_processor.py` to accept and act
+on an `execution_succeeded` flag:
+
+```python
+def _persist_recorded_cassette(
+    self,
+    cid: str,
+    payload: NotebookPayload,
+    paths: "CassettePaths | None",
+    *,
+    execution_succeeded: bool,
+) -> None:
+    if paths is None:
+        return
+    mode = payload.http_replay_mode
+    if not mode or mode in ("disabled", "replay"):
+        return
+
+    if execution_succeeded:
+        write_completion_marker(paths)
+    # else: leave staging on disk for the next build's pre-build sweep
+    #       to discard, so a partial chain never lands in canonical.
+
+    try:
+        merged = merge_staging_into_canonical(paths)  # default sweep_orphans=False
+    ...
+```
+
+And `_create_using_nbconvert` records success/failure:
+
+```python
+execution_succeeded = False
+try:
+    await self._execute_notebook_with_path(...)
+    execution_succeeded = True
+except ...:
+    raise
+finally:
+    if replay_injected:
+        _strip_injected_cells(processed_nb)
+    self._persist_recorded_cassette(
+        cid, payload, cassette_paths,
+        execution_succeeded=execution_succeeded,
+    )
+```
+
+Update `Course._sweep_orphan_cassette_staging_files` in
+`src/clm/core/course.py:484-487` to pass `sweep_orphans=True`:
+
+```python
+merged = merge_staging_into_canonical(
+    CassettePaths(canonical=canonical, staging=synthetic),
+    sweep_orphans=True,
+)
+```
+
+Tests:
+
+- `test_merge_folds_entries_when_marker_present`
+- `test_merge_skips_markerless_in_per_worker_mode`
+- `test_merge_discards_markerless_in_sweep_mode`
+- `test_merge_deletes_marker_after_successful_fold`
+- `test_persist_recorded_cassette_writes_marker_on_success`
+- `test_persist_recorded_cassette_omits_marker_on_failure`
+  (call with `execution_succeeded=False` and verify no marker
+  is written even though merge is attempted).
+- `test_concurrent_workers_dont_consume_each_others_active_staging`
+  — Worker A completes (marker written, merge runs); inject a
+  fake "Worker B" staging file midway with no marker; assert A's
+  merge does not delete or fold B's staging.
+
+### Phase 3 — End-to-end §C regression test [DONE]
+
+Shipped to the worktree (no PR yet — bundled with Phases 1 and 2).
+
+**File modified**:
+
+- `tests/workers/notebook/test_notebook_processor.py` — new
+  `TestIssue115PartialChainRegression` class with 2 end-to-end
+  scenarios driven through the real
+  `merge_staging_into_canonical` (no kernel). Both use shared
+  class-level constants for the chain (opener URI shared between
+  the aborted and the completed staging, distinct response strings
+  so canonical's stored response unambiguously identifies the
+  winning session). Reuses the existing `_write_cassette`,
+  `_write_two_interactions`, and `_touch_completion_marker`
+  helpers from the file rather than adding parallel infrastructure.
+
+**New tests (both pass)**:
+
+- `test_pre_build_sweep_then_completed_session_lands_consistent_chain`
+  — chronological walk of the §C scenario across two builds:
+  Build 1 leaves Session A's markerless chain-opener on disk
+  (kernel died). Build 2's pre-build sweep discards A (asserts
+  canonical not even created, since no markered work was folded).
+  Build 2's worker then records Session B's full chain
+  (chain-opener with same dedup key but different response, plus
+  chain-closer whose URI embeds B's opener response) and B's
+  per-worker merge folds it. Asserts canonical holds B's response
+  (not A's stale one), the chain-closer is present, no debris on
+  disk.
+- `test_aborted_and_completed_stagings_present_concurrently_keep_completed_response`
+  — negative regression: A (markerless) and B (markered) on disk
+  at the same instant. `staging-a-aborted` sorts alphabetically
+  before `staging-b-completed`, which is the slot the pre-fix
+  "first-seen wins" merger would have used to seed canonical with
+  A's stale response. The new per-worker merge leaves A strictly
+  alone and folds only B; canonical holds B's response. A's
+  staging stays on disk for the next pre-build sweep.
+
+**Verification**: all 24 cassette-related tests pass (7
+`TestCompletionMarker` + 8 `TestCassetteMerge` + 7
+`TestDiscriminatingMerge` + 2 new
+`TestIssue115PartialChainRegression`); full
+`test_notebook_processor.py` (119 tests) green;
+`tests/core/course_test.py` (31 tests) green; combined
+150 tests pass in 13.6s under `-n0`. `ruff check`, `ruff format
+--check`, and `mypy` clean on the touched file — the 4 pre-existing
+`make_notebook_json` arg-type mypy errors in `TestBootstrapDurability`
+were verified to predate Phase 3 (same count and root cause before
+and after the insertion, line numbers shifted by the new class size).
+
+### Phase 4 — `clm cassette doctor` (OPTIONAL, separate issue) [TODO]
+
+Defer to a follow-up issue. Sketch:
+
+- New `clm cassette doctor [SPEC] [--fix] [--min-text-len N]` command.
+- Walks each canonical cassette referenced by the spec.
+- For each interaction:
+  - Parse the response body; extract chat-completion content
+    fields (`choices[].message.content` or `delta.content` in
+    streaming responses).
+  - Treat each extracted content of length ≥ `--min-text-len`
+    (default 50) as a "chain edge candidate".
+  - Check whether any other interaction's request body contains
+    that text as a substring.
+  - If not, flag as orphan.
+- Output: per-cassette report of orphan-pointing interactions.
+- `--fix` mode: rewrite the cassette without the orphan-pointing
+  entries (so the next build re-records that chain). Atomic write.
+- Useful for cleaning up cassettes that were poisoned BEFORE the
+  marker fix shipped (issue-#115 scenarios already merged into
+  canonical) and for the conditional-skip case (edge #3 above)
+  which the marker doesn't catch.
+
+Could be wired into CI as a check on every cassette change. Not
+required for the primary fix to land.
+
+## 4. Files Affected
+
+Status legend: ✅ = touched in Phase 1, 2, or 3.
+
+| File | Change | Status |
+|---|---|---|
+| `src/clm/workers/notebook/http_replay_cassette.py` | Phase 1: marker helpers. Phase 2: rewrite `merge_staging_into_canonical` with `sweep_orphans` flag + `_delete_quietly` helper. | ✅ Phase 1 / ✅ Phase 2 |
+| `src/clm/infrastructure/utils/path_utils.py` | Add `*.completed` to `SKIP_OUTPUT_FILE_PATTERNS` + `SKIP_OUTPUT_FILE_GLOBS`. | ✅ |
+| `tests/workers/notebook/test_notebook_processor.py` | `TestCompletionMarker` class (Phase 1) + `TestDiscriminatingMerge` class (Phase 2) + existing `TestCassetteMerge` updated with `_touch_completion_marker` calls + `TestIssue115PartialChainRegression` (Phase 3 end-to-end + negative regression). | ✅ Phase 1 / ✅ Phase 2 / ✅ Phase 3 |
+| `src/clm/workers/notebook/notebook_processor.py` | Thread `execution_succeeded` through `_persist_recorded_cassette`; call marker writer on success path; flip `execution_succeeded` in `_create_using_nbconvert`. | ✅ Phase 2 |
+| `src/clm/core/course.py` | Pre-build sweep passes `sweep_orphans=True`; docstring updated. | ✅ Phase 2 |
+| `tests/core/course_test.py` | `test_sweep_orphan_staging_files_merges_and_deletes` now writes `.completed` markers on its orphans (with updated docstring). | ✅ Phase 2 |
+| `docs/claude/design/http-replay.md` | Appended "Completion-marker semantics" section describing the contract. | ✅ Phase 2 |
+| `CHANGELOG.md` | Unreleased / Fixed entry: cassette merge discards partial chains from aborted sessions (#115). | ✅ Phase 2 |
+
+No info-topic update required (this is internal mechanics; no
+user-visible CLI surface change for the primary fix). If Phase 4 is
+implemented, `src/clm/cli/info_topics/commands.md` needs the new
+`clm cassette doctor` entry.
+
+## 5. Open Questions
+
+1. **Should the per-worker merge ever discard markerless staging?**
+   Current design: never. The pre-build sweep is the only place
+   that discards. This is the safest concurrency story but means a
+   long-running build with many crashed workers accumulates
+   markerless staging until the *next* build runs. Probably fine —
+   the staging files are small and inside `_cassettes/`. If
+   accumulation turns out to be a problem, add a "discard staging
+   older than 24h" rule to the per-worker merge later.
+
+2. **Should marker payload include the cassette name or build ID?**
+   Currently just `completed_at` + `host_pid` + `schema`. Tying the
+   marker to a specific build run would let the cassette-doctor
+   detect "marker present but from a stale build" — but the
+   completion semantics don't actually need that. Punting.
+
+3. **Should `skip_errors=True` skip the marker?** (Edge case #8.)
+   Tempting — "errors happened, so don't mark complete" — but it
+   requires the host to know whether *any* cell raised, which
+   nbclient doesn't surface cleanly when `allow_errors=True`.
+   `_clear_error_outputs` walks the notebook post-hoc looking for
+   error outputs, so we *could* check there. Probably not worth
+   the complexity in v1; `skip_errors` users have already accepted
+   degraded determinism. Punt.
+
+4. **Should the marker fix ship with an opt-out env var?** E.g.,
+   `CLM_CASSETTE_PARTIAL_CHAIN_FILTER=0` to revert to today's
+   behaviour. Generally CLM removes flags after rollouts (the
+   git-friendly-output-writes PR series removed all rollout env
+   vars on the second milestone). Probably no: ship without a
+   flag, document the change in CHANGELOG, deal with regressions
+   via revert if needed.
+
+## 6. Definition of Done
+
+- [ ] Phases 1, 2, 3 merged to master via a single PR (the marker
+  + merge + sweep changes are tightly coupled; splitting them buys
+  no review value).
+- [x] All existing http-replay tests still pass — particularly
+  `test_two_concurrent_workers_full_seed_record_merge_cycle`
+  (issue-#86 regression guard) and
+  `test_concurrent_merges_do_not_lose_interactions`. Verified in
+  the Phase 3 verification run (`tests/workers/notebook/test_notebook_processor.py`,
+  119 tests green under `-n0`).
+- [x] New concurrency test (Phase 2) demonstrates that a marker
+  fix does not regress issue #86
+  (`test_concurrent_workers_dont_consume_each_others_active_staging`).
+- [x] §C end-to-end test (Phase 3) passes — partial-chain merge is
+  discarded
+  (`TestIssue115PartialChainRegression::test_pre_build_sweep_then_completed_session_lands_consistent_chain`
+  plus the negative-regression sibling).
+- [ ] PythonCourses team runs an `--http-replay=replay` build of
+  `slides_010_prompt_templates.py` with a freshly bootstrapped
+  cassette and confirms no `CannotOverwriteExistingCassetteException`
+  on Q3. Signal-back: comment on issue #115 with the build log.
+- [x] CHANGELOG entry added (Phase 2; under `[Unreleased] / Fixed`,
+  see CHANGELOG.md lines 134–151).
+- [ ] Phase 4 (`cassette doctor`) filed as a separate follow-up
+  issue if not implemented in the same PR.
+
+## 7. References
+
+| Topic | Path / link |
+|---|---|
+| Issue text | [hoelzl/clm#115](https://github.com/hoelzl/clm/issues/115) |
+| Predecessor (closed) | [hoelzl/clm#95](https://github.com/hoelzl/clm/issues/95) |
+| Related closed (concurrency race) | [hoelzl/clm#86](https://github.com/hoelzl/clm/issues/86), archive `docs/claude/http-replay-race-fix-handover-archive.md` |
+| Merge code | `src/clm/workers/notebook/http_replay_cassette.py:93-187` (merge), `:190-211` (`_dedup_key`) |
+| Bootstrap (eager-save + atexit) | `src/clm/workers/notebook/notebook_processor.py:114-211` |
+| Host orchestration | `src/clm/workers/notebook/notebook_processor.py:1375-1418` (`_persist_recorded_cassette`), `:1445-1541` (`_create_using_nbconvert` finally block) |
+| Pre-build sweep | `src/clm/core/course.py:413-498` |
+| Ignore patterns | `src/clm/infrastructure/utils/path_utils.py:83-94` |
+| Existing merge tests | `tests/workers/notebook/test_notebook_processor.py:2340-2654` |
+| Design doc to update | `docs/claude/design/http-replay.md` |
+| PythonCourses §C source | PythonCourses repo: `docs/handover-slide-format-redesign-course.md` §C (read-only from CLM side) |
+
+---
+
+**Last updated**: 2026-05-21 — Phases 1, 2, and 3 shipped to worktree.
+Ready for a bundled PR covering all three phases.

--- a/docs/claude/design/http-replay.md
+++ b/docs/claude/design/http-replay.md
@@ -392,3 +392,60 @@ flakiness.
 - A new integration test locks in the replay behavior end-to-end.
 - `clm info spec-files` documents both `skip_errors` and `http_replay`.
 - A new user-guide page documents the author workflow.
+
+## Completion-marker semantics (issue #115)
+
+Cassette recording sessions are not always clean. A kernel can die
+partway through a cell that issues two chained HTTP calls (call-2's body
+depends on call-1's stored response), and vcrpy's eager-save patch in
+the bootstrap means call-1 is already on disk in the staging file by
+the time call-2 raises. Without further distinction, the post-execution
+merge folds that lone call-1 into canonical; the next build's replay
+then fails on call-2 with `CannotOverwriteExistingCassetteException`,
+and the dedup `first-seen-wins` rule means refresh cannot repair it
+either. This is the bug filed as issue #115.
+
+The fix is a **per-staging-file completion marker**: the host process
+writes `<staging>.completed` *after* `_execute_notebook_with_path`
+returned cleanly and *before* the finally block runs the merge. The
+marker's existence — not its content — is the signal that the staging
+file holds a complete recording session whose entries are safe to fold
+into canonical.
+
+| Marker present? | `sweep_orphans` | Action                                  |
+|-----------------|------------------|----------------------------------------|
+| yes             | any              | Fold entries; delete staging + marker. |
+| no              | `True`           | Discard entries; delete staging.       |
+| no              | `False`          | Leave alone (concurrent worker?).      |
+
+`sweep_orphans` is `True` only for the pre-build sweep in
+`Course._sweep_orphan_cassette_staging_files`, which is invariantly
+single-threaded and runs before any worker starts: at that moment,
+every staging file present is from a previous build. Markerless staging
+under per-worker (`sweep_orphans=False`) is ambiguous between
+"concurrent worker still recording" and "this worker's session aborted"
+— in both cases, "do nothing" is the safe action; the next pre-build
+sweep will discard if appropriate.
+
+The host writes the marker *only* on the success path
+(`execution_succeeded=True`); on the failure path the marker is omitted
+and the staging file is left on disk for the next pre-build sweep to
+discard, which structurally prevents a partial chain from poisoning
+canonical.
+
+### Edge cases and limitations
+
+- `skip_errors="yes"` lets nbclient return cleanly even when cells
+  raised. The marker is therefore written and any partial chains in
+  the recording are folded into canonical. Authors opting into
+  `skip_errors` have already accepted degraded determinism; documented
+  as a known limitation.
+- `try/except` swallowing an HTTP call inside an otherwise-successful
+  cell is not detectable from the host. The marker is written and the
+  partial chain is folded. A future `clm cassette doctor` tool (Phase
+  4) can detect and repair these via response-text → request-body
+  substring matching.
+- `--http-replay=refresh` on a previously poisoned canonical does not
+  un-poison it — the additive dedup rule keeps the chain-opener's
+  body fixed. Workaround: delete canonical and re-record. Out of
+  scope for the marker fix.

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -416,11 +416,15 @@ class Course(NotebookMixin):
         Walks every notebook file whose topic opted into ``http_replay``
         and, for each *unique* canonical cassette location with at least
         one ``*.http-cassette.yaml.staging-*`` sibling, invokes
-        :func:`merge_staging_into_canonical`. That helper takes the
-        cross-process file lock, folds in every staging file under the
-        canonical's directory (this worker's plus orphans), deduplicates
-        by request fingerprint, atomically writes the merged canonical,
-        and ``unlink``s the staging files.
+        :func:`merge_staging_into_canonical` with ``sweep_orphans=True``.
+        That helper takes the cross-process file lock, folds completed
+        sibling stagings (those with a ``.completed`` marker) into
+        canonical and **discards** markerless stagings — partial chains
+        from previously-aborted recording sessions whose chain-closing
+        request never landed on disk (issue #115). Without the discard,
+        a markerless chain-opener with a body that depends on the
+        chain-closer's stored response would poison the canonical
+        cassette permanently (dedup is first-seen-wins).
 
         Running this *before* payload construction prevents a stale
         staging file from being enumerated by
@@ -430,6 +434,13 @@ class Course(NotebookMixin):
         encoding. Defense-in-depth: ``compute_other_files`` also filters
         ``*.staging-*`` via ``is_ignored_file_for_output`` so a *new*
         orphan appearing mid-build can't sneak into the payload either.
+
+        The discriminator between "decisive discard" here and
+        "conservative leave-alone" in the post-execution worker sweep
+        is the ``sweep_orphans`` flag: by contract this method runs
+        single-threaded before any worker starts, so every staging file
+        present must be from a previous build — no concurrency, no risk
+        of clobbering a still-recording worker.
 
         Returns:
             Number of canonical cassettes for which a merge ran (i.e.,
@@ -483,7 +494,8 @@ class Course(NotebookMixin):
             synthetic = canonical.parent / f"{canonical.name}.staging-sweep"
             try:
                 merged = merge_staging_into_canonical(
-                    CassettePaths(canonical=canonical, staging=synthetic)
+                    CassettePaths(canonical=canonical, staging=synthetic),
+                    sweep_orphans=True,
                 )
             except Exception as exc:  # noqa: BLE001 — defensive
                 logger.warning(

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -80,9 +80,14 @@ SKIP_FILE_NAMES = frozenset({".clm-include"})
 # Concurrent workers may delete these mid-build during merge, so they
 # must never be enumerated by the payload builder either — see
 # :func:`compute_other_files` in ``process_notebook.py``.
+#
+# The ``.staging-<id>.completed`` variant is the per-staging completion
+# marker introduced for issue #115: same lifetime and visibility rules
+# as the staging file it accompanies — strictly build-internal.
 SKIP_OUTPUT_FILE_PATTERNS = [
     re.compile(r".*\.http-cassette\.yaml$"),
     re.compile(r".*\.http-cassette\.yaml\.staging-.*$"),
+    re.compile(r".*\.http-cassette\.yaml\.staging-.*\.completed$"),
 ]
 
 # Parallel glob form of ``SKIP_OUTPUT_FILE_PATTERNS`` for consumers that
@@ -91,6 +96,7 @@ SKIP_OUTPUT_FILE_PATTERNS = [
 SKIP_OUTPUT_FILE_GLOBS = [
     "*.http-cassette.yaml",
     "*.http-cassette.yaml.staging-*",
+    "*.http-cassette.yaml.staging-*.completed",
 ]
 
 PLANTUML_EXTENSIONS = frozenset({".pu", ".puml", ".plantuml"})

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -19,17 +19,21 @@ recordings are already on disk by the time the failure propagates.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _STAGING_SUFFIX = ".staging-"
 _LOCK_SUFFIX = ".lock"
+_COMPLETION_MARKER_SUFFIX = ".completed"
+_COMPLETION_MARKER_SCHEMA = 1
 _MERGE_LOCK_TIMEOUT_SECONDS = 300.0
 
 
@@ -90,21 +94,51 @@ def seed_staging_from_canonical(paths: CassettePaths) -> None:
         shutil.copy2(paths.canonical, paths.staging)
 
 
-def merge_staging_into_canonical(paths: CassettePaths) -> int:
-    """Merge this worker's staging file and any orphan staging files into canonical.
+def merge_staging_into_canonical(
+    paths: CassettePaths,
+    *,
+    sweep_orphans: bool = False,
+) -> int:
+    """Merge per-worker staging files into the canonical cassette.
 
     Acquires a cross-process file lock at ``<canonical>.lock`` for the
     duration of the merge so two workers cannot corrupt the canonical
-    cassette by writing concurrently. Loads the existing canonical
-    cassette (if any), folds in interactions from every staging file in
-    the canonical's directory (this worker's plus orphans from
-    previously-killed workers), deduplicates by request fingerprint, and
-    writes the merged cassette atomically via :func:`os.replace`. The
-    staging files are deleted after a successful merge.
+    cassette by writing concurrently. The per-file action depends on
+    whether the staging file carries a completion marker (see
+    :func:`write_completion_marker`) and on the ``sweep_orphans`` flag:
+
+    +-----------------+-----------------+----------------------------------+
+    | Marker present? | ``sweep_orphans``| Action                          |
+    +=================+=================+==================================+
+    | yes             | any             | Fold entries; delete staging + marker. |
+    +-----------------+-----------------+----------------------------------+
+    | no              | ``True``        | Discard entries; delete staging. |
+    +-----------------+-----------------+----------------------------------+
+    | no              | ``False``       | Leave alone (concurrent worker?).|
+    +-----------------+-----------------+----------------------------------+
+
+    Folded entries are deduplicated against canonical and against each
+    other by request fingerprint (:func:`_dedup_key`). The merged
+    cassette is written atomically via :func:`os.replace`.
+
+    Args:
+        paths: Canonical + this worker's staging location. The ``staging``
+            field is only relevant for naming; the merge globs every
+            ``*.staging-*`` sibling of the canonical regardless.
+        sweep_orphans: When ``True`` (pre-build invocation from
+            :meth:`clm.core.course.Course._sweep_orphan_cassette_staging_files`),
+            markerless staging files are treated as confirmed orphans from
+            aborted previous builds: their entries are discarded and the
+            staging files are deleted. When ``False`` (default,
+            per-worker post-execution invocation), markerless staging
+            files are left untouched — they may belong to a concurrent
+            worker that hasn't completed yet.
 
     Returns:
-        Number of staging files merged. Zero is returned for replay-only
-        topics where no recording happened.
+        Number of staging files folded into the canonical (markered
+        files only). Discarded markerless files are not counted; the
+        caller can detect "had work to do but it was all orphan" by
+        observing remaining files on disk.
     """
     # vcrpy is an optional extra; importing here keeps the module
     # importable for tests that exercise pure path resolution without
@@ -121,8 +155,39 @@ def merge_staging_into_canonical(paths: CassettePaths) -> int:
     try:
         with FileLock(str(lock_path), timeout=_MERGE_LOCK_TIMEOUT_SECONDS):
             staging_glob = f"{canonical.name}{_STAGING_SUFFIX}*"
-            staging_files = sorted(canonical.parent.glob(staging_glob))
+            all_staging = sorted(canonical.parent.glob(staging_glob))
+            # Marker files match the staging glob too (they end in
+            # ``.completed``); strip them from the staging set so the
+            # marker presence check is the *only* discriminator.
+            staging_files = [
+                p for p in all_staging if not p.name.endswith(_COMPLETION_MARKER_SUFFIX)
+            ]
             if not staging_files:
+                return 0
+
+            markered: list[Path] = []
+            markerless: list[Path] = []
+            for staging_path in staging_files:
+                if has_completion_marker(staging_path):
+                    markered.append(staging_path)
+                else:
+                    markerless.append(staging_path)
+
+            # Per-worker invocation: markerless staging files belong to
+            # concurrent workers or aborted sessions. Either way we
+            # don't touch them — the next build's pre-build sweep
+            # decides their fate when there's no concurrency to worry
+            # about. Logged at DEBUG to keep ordinary builds quiet but
+            # diagnosable when concurrency-test triage needs it.
+            if not sweep_orphans:
+                for staging_path in markerless:
+                    logger.debug(
+                        f"Skipping markerless staging cassette '{staging_path}' "
+                        f"(concurrent worker still recording, or session aborted; "
+                        f"next pre-build sweep will decide)."
+                    )
+
+            if not markered and (not sweep_orphans or not markerless):
                 return 0
 
             canonical_requests: list = []
@@ -142,7 +207,7 @@ def merge_staging_into_canonical(paths: CassettePaths) -> int:
             merged_requests = list(canonical_requests)
             merged_responses = list(canonical_responses)
 
-            for staging_path in staging_files:
+            for staging_path in markered:
                 try:
                     staging_requests, staging_responses = FilesystemPersister.load_cassette(
                         staging_path, serializer=yamlserializer
@@ -161,23 +226,30 @@ def merge_staging_into_canonical(paths: CassettePaths) -> int:
                     merged_responses.append(response)
                     seen_keys.add(key)
 
-            payload = vcr_serialize(
-                {"requests": merged_requests, "responses": merged_responses},
-                yamlserializer,
-            )
-            _atomic_write_text(canonical, payload)
+            # Only rewrite canonical if we actually folded markered
+            # work in. Pre-build sweeps that find only markerless
+            # orphans must not touch canonical — discarding does not
+            # change its content.
+            if markered:
+                payload = vcr_serialize(
+                    {"requests": merged_requests, "responses": merged_responses},
+                    yamlserializer,
+                )
+                _atomic_write_text(canonical, payload)
 
-            for staging_path in staging_files:
-                try:
-                    staging_path.unlink()
-                except FileNotFoundError:
-                    pass
-                except OSError as exc:
-                    logger.warning(
-                        f"Could not delete merged staging cassette '{staging_path}': {exc}"
+            for staging_path in markered:
+                _delete_quietly(staging_path)
+                _delete_quietly(marker_path(staging_path))
+
+            if sweep_orphans:
+                for staging_path in markerless:
+                    logger.info(
+                        f"Discarded orphan staging cassette '{staging_path}' "
+                        f"(no completion marker — aborted previous-build session)."
                     )
+                    _delete_quietly(staging_path)
 
-            return len(staging_files)
+            return len(markered)
     except Timeout:
         logger.error(
             f"Timed out after {_MERGE_LOCK_TIMEOUT_SECONDS:.0f}s waiting for cassette "
@@ -185,6 +257,78 @@ def merge_staging_into_canonical(paths: CassettePaths) -> int:
             f"Staging files remain on disk and will be picked up by the next build."
         )
         return 0
+
+
+def _delete_quietly(path: Path) -> None:
+    """Best-effort delete: ignore ``FileNotFoundError``, log other ``OSError``s.
+
+    Used during merge cleanup where we don't want one stuck file (e.g.,
+    Windows antivirus holding a handle for a beat) to surface as a
+    user-visible error — the worst that happens is the file gets
+    cleaned up by the next sweep instead of this one.
+    """
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning(f"Could not delete '{path}': {exc}")
+
+
+def marker_path(staging: Path) -> Path:
+    """Return the completion-marker path that sits beside ``staging``.
+
+    The marker is a small JSON file written by the host process *after*
+    a worker's notebook execution returned cleanly and *before* the
+    post-execution merge runs (see issue #115). Its existence — not its
+    content — is the signal that the staging file holds a complete
+    recording session whose entries are safe to fold into the canonical
+    cassette. Markerless staging files belong to aborted sessions or
+    still-running concurrent workers and are handled differently by
+    :func:`merge_staging_into_canonical`.
+    """
+    return staging.parent / f"{staging.name}{_COMPLETION_MARKER_SUFFIX}"
+
+
+def has_completion_marker(staging: Path) -> bool:
+    """Return ``True`` when the completion marker sibling of ``staging`` exists."""
+    return marker_path(staging).is_file()
+
+
+def write_completion_marker(paths: CassettePaths) -> None:
+    """Atomically write the completion marker for this worker's staging file.
+
+    Called by the host process from the success path of
+    :meth:`NotebookProcessor._create_using_nbconvert` — after the
+    kernel returned cleanly, before the finally-block triggers the
+    merge. The marker tells the merge that this staging file is safe
+    to fold into the canonical cassette; without it, the staging file
+    is treated as a partial recording (kernel killed, build aborted,
+    chain-closer cell never ran) and its entries are discarded by
+    the pre-build sweep on the next build.
+
+    Idempotent: re-writing the marker on a retry path is safe. Atomic:
+    written via :func:`_atomic_write_text` so a partially-written
+    marker is never observable. Best-effort: an :class:`OSError` while
+    writing degrades the session to "aborted" semantics (recordings
+    lost on next build), which is correctness-preserving — we log a
+    warning and do not raise.
+    """
+    target = marker_path(paths.staging)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": _COMPLETION_MARKER_SCHEMA,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "host_pid": os.getpid(),
+    }
+    try:
+        _atomic_write_text(target, json.dumps(payload, sort_keys=True) + "\n")
+    except OSError as exc:
+        logger.warning(
+            f"Could not write cassette completion marker '{target}' "
+            f"({type(exc).__name__}: {exc}); this worker's recordings "
+            f"will be treated as aborted and discarded on the next build."
+        )
 
 
 def _dedup_key(request) -> tuple:

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1373,29 +1373,57 @@ class NotebookProcessor:
         return paths
 
     def _persist_recorded_cassette(
-        self, cid: str, payload: NotebookPayload, paths: "CassettePaths | None"
+        self,
+        cid: str,
+        payload: NotebookPayload,
+        paths: "CassettePaths | None",
+        *,
+        execution_succeeded: bool,
     ) -> None:
         """Merge this worker's staging cassette into the canonical cassette.
 
         For ``replay``/``disabled`` modes (or when no paths were resolved)
-        this is a no-op. Otherwise the staging file plus any orphan
-        staging files left behind by previously-killed workers in the
-        same directory are merged into the canonical cassette under a
-        cross-process file lock, deduplicated by request fingerprint,
-        and the resulting file is written atomically. Staging files are
-        deleted after a successful merge.
+        this is a no-op. Otherwise the merge runs under a cross-process
+        file lock, folds entries from the staging file (and any
+        previously-completed sibling stagings whose marker is on disk)
+        into the canonical cassette, deduplicates by request
+        fingerprint, atomically writes the result, and deletes the
+        merged staging files plus their markers.
 
         Called from a ``finally`` block so it executes even when the
-        notebook raised — vcrpy's eager-save patch in the bootstrap
-        means partial recordings are already on disk in the staging
-        file before this method runs.
+        notebook raised. The behaviour split for issue #115:
+
+        - **Success path** (``execution_succeeded=True``): write the
+          completion marker first, then merge. The marker tells the
+          merge (and any later pre-build sweep) that this staging file
+          holds a complete recording session whose entries are safe to
+          fold into canonical.
+        - **Failure path** (``execution_succeeded=False``): skip the
+          marker write and run the merge anyway. Markerless staging is
+          treated as a partial chain (kernel died / cell raised
+          mid-chain) and is *not* folded into canonical — the next
+          build's pre-build sweep will discard it. Merged in this
+          state only completes sibling stagings (other workers) that
+          already have their markers in place.
         """
         if paths is None:
             return
         mode = payload.http_replay_mode
         if not mode or mode in ("disabled", "replay"):
             return
-        from .http_replay_cassette import merge_staging_into_canonical
+        from .http_replay_cassette import (
+            merge_staging_into_canonical,
+            write_completion_marker,
+        )
+
+        if execution_succeeded:
+            write_completion_marker(paths)
+        else:
+            logger.info(
+                f"{cid}: notebook execution failed for '{payload.input_file_name}'; "
+                f"leaving staging '{paths.staging}' without a completion marker so "
+                f"the next pre-build sweep can discard any partial-chain recordings."
+            )
 
         try:
             merged = merge_staging_into_canonical(paths)
@@ -1472,6 +1500,7 @@ class NotebookProcessor:
                 replay_injected = self._maybe_inject_http_replay(
                     processed_nb, payload, cassette_paths
                 )
+                execution_succeeded = False
                 try:
                     # To silence warnings about frozen modules...
                     os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
@@ -1504,7 +1533,7 @@ class NotebookProcessor:
                                 await self._execute_notebook_with_path(
                                     cid, path, processed_nb, payload, loop, None
                                 )
-
+                    execution_succeeded = True
                 except Exception as e:
                     file_name = payload.input_file_name
                     logger.error(
@@ -1519,13 +1548,20 @@ class NotebookProcessor:
                     # when execution raised above.
                     if replay_injected:
                         _strip_injected_cells(processed_nb)
-                    # Always merge the staging cassette into the canonical
-                    # cassette, even when execution failed. The eager-save
-                    # patch in the bootstrap means partial recordings are
-                    # already on disk in the staging file; skipping the
-                    # merge would lose every interaction the kernel
-                    # successfully recorded before the failure.
-                    self._persist_recorded_cassette(cid, payload, cassette_paths)
+                    # Persist the cassette. On the success path the host
+                    # writes the per-staging completion marker (issue
+                    # #115) so the merge folds this worker's recordings
+                    # into canonical. On the failure path the marker is
+                    # *not* written — the staging file is left on disk
+                    # for the next build's pre-build sweep to discard,
+                    # which keeps a partial chain (chain-opener recorded
+                    # but chain-closer missing) from poisoning canonical.
+                    self._persist_recorded_cassette(
+                        cid,
+                        payload,
+                        cassette_paths,
+                        execution_succeeded=execution_succeeded,
+                    )
 
                 # Cache the executed notebook for later reuse by Completed HTML
                 if self.output_spec.should_cache_execution and self.cache is not None:

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -758,15 +758,21 @@ def _write_orphan_cassette(path: Path, *, uri: str, body: str) -> None:
 
 
 def test_sweep_orphan_staging_files_merges_and_deletes(tmp_path):
-    """Pre-build sweep folds orphan ``.staging-*`` cassettes into canonical.
+    """Pre-build sweep folds completed orphan ``.staging-*`` cassettes into canonical.
 
-    Regression: a notebook killed mid-build leaves a
-    ``slides_x.http-cassette.yaml.staging-<pid>-<uuid>`` file behind. If
-    the next build's ``compute_other_files`` reaches it before
+    Regression: a notebook whose host process completed cleanly but
+    whose post-execution merge crashed (e.g., file lock timed out)
+    leaves a ``slides_x.http-cassette.yaml.staging-<pid>-<uuid>`` file
+    behind with its ``.completed`` marker still present. If the next
+    build's ``compute_other_files`` reaches that orphan before
     ``merge_staging_into_canonical`` does, payload b64 encoding crashes
-    with ``FileNotFoundError`` because a concurrent worker may delete the
-    staging file mid-glob. The sweep runs eagerly at ``process_all``
+    with ``FileNotFoundError`` because a concurrent worker may delete
+    the staging file mid-glob. The sweep runs eagerly at ``process_all``
     start so this race is closed before any payload is built.
+
+    Markerless orphans (aborted sessions, partial chains) are
+    *discarded* by the pre-build sweep (issue #115). That contract is
+    covered separately by tests in ``tests/workers/notebook``.
     """
     import asyncio
 
@@ -781,6 +787,11 @@ def test_sweep_orphan_staging_files_merges_and_deletes(tmp_path):
     orphan_two = topic_dir / "slides_intro.http-cassette.yaml.staging-5678-def"
     _write_orphan_cassette(orphan_one, uri="http://example/orphan1", body="O1")
     _write_orphan_cassette(orphan_two, uri="http://example/orphan2", body="O2")
+    # Both orphans represent completed recording sessions whose merge
+    # step never finished — marker present, staging present. The sweep
+    # must fold them into canonical and clean up.
+    (orphan_one.parent / f"{orphan_one.name}.completed").write_text("{}\n", encoding="utf-8")
+    (orphan_two.parent / f"{orphan_two.name}.completed").write_text("{}\n", encoding="utf-8")
 
     sections_xml = """
     <sections>

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2336,6 +2336,20 @@ def _write_cassette(path, *, uri: str, body: str) -> None:
     path.write_text(_SAMPLE_CASSETTE_TEMPLATE.format(uri=uri, body=body), encoding="utf-8")
 
 
+def _touch_completion_marker(staging) -> None:
+    """Drop a sentinel ``.completed`` marker beside ``staging``.
+
+    The marker's *existence* is the signal — the merge does not inspect
+    its contents. Tests that exercise the "fold into canonical" path
+    need this beside every staging file they expect to be folded; tests
+    that exercise the "discard / leave alone" branches deliberately
+    omit it.
+    """
+    marker = staging.parent / f"{staging.name}.completed"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{}\n", encoding="utf-8")
+
+
 class TestCassetteMerge:
     """Locked merge of per-worker staging files into the canonical cassette."""
 
@@ -2350,6 +2364,7 @@ class TestCassetteMerge:
         canonical = tmp_path / "slides.http-cassette.yaml"
         staging = tmp_path / "slides.http-cassette.yaml.staging-worker-a"
         _write_cassette(staging, uri="http://example/a", body="A")
+        _touch_completion_marker(staging)
 
         paths = CassettePaths(canonical=canonical, staging=staging)
         merged = merge_staging_into_canonical(paths)
@@ -2392,8 +2407,11 @@ class TestCassetteMerge:
         orphan_two = tmp_path / "slides.http-cassette.yaml.staging-orphan-2"
         own = tmp_path / "slides.http-cassette.yaml.staging-own"
         _write_cassette(orphan_one, uri="http://example/orphan1", body="O1")
+        _touch_completion_marker(orphan_one)
         _write_cassette(orphan_two, uri="http://example/orphan2", body="O2")
+        _touch_completion_marker(orphan_two)
         _write_cassette(own, uri="http://example/own", body="OWN")
+        _touch_completion_marker(own)
 
         paths = CassettePaths(canonical=canonical, staging=own)
         merged = merge_staging_into_canonical(paths)
@@ -2421,6 +2439,7 @@ class TestCassetteMerge:
         staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
         _write_cassette(canonical, uri="http://example/same", body="SAME")
         _write_cassette(staging, uri="http://example/same", body="SAME")
+        _touch_completion_marker(staging)
 
         paths = CassettePaths(canonical=canonical, staging=staging)
         merged = merge_staging_into_canonical(paths)
@@ -2442,6 +2461,7 @@ class TestCassetteMerge:
         staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
         _write_cassette(canonical, uri="http://example/old", body="OLD")
         _write_cassette(staging, uri="http://example/new", body="NEW")
+        _touch_completion_marker(staging)
 
         paths = CassettePaths(canonical=canonical, staging=staging)
         merge_staging_into_canonical(paths)
@@ -2465,7 +2485,9 @@ class TestCassetteMerge:
         staging_a = tmp_path / "slides.http-cassette.yaml.staging-worker-a"
         staging_b = tmp_path / "slides.http-cassette.yaml.staging-worker-b"
         _write_cassette(staging_a, uri="http://example/a", body="A-PAYLOAD")
+        _touch_completion_marker(staging_a)
         _write_cassette(staging_b, uri="http://example/b", body="B-PAYLOAD")
+        _touch_completion_marker(staging_b)
 
         paths_a = CassettePaths(canonical=canonical, staging=staging_a)
         paths_b = CassettePaths(canonical=canonical, staging=staging_b)
@@ -2621,6 +2643,12 @@ class TestCassetteMerge:
             ("http://example/b", "B"),
         )
 
+        # Each "host" writes its completion marker after the kernel
+        # returned cleanly — the merge below treats this as the
+        # signal that both staging files hold complete recordings.
+        _touch_completion_marker(paths_a.staging)
+        _touch_completion_marker(paths_b.staging)
+
         # Step 5: concurrent merges — both workers finish their
         # post-execution merge at the same time.
         errors: list[Exception] = []
@@ -2652,6 +2680,403 @@ class TestCassetteMerge:
         assert content.count("http://example/seed") == 1
         assert not paths_a.staging.exists()
         assert not paths_b.staging.exists()
+
+
+class TestCompletionMarker:
+    """Per-staging completion marker plumbing (issue #115 Phase 1).
+
+    The marker file ``<staging>.completed`` is the host's signal that
+    a worker's notebook execution returned cleanly and the staging
+    file's recordings are safe to fold into the canonical cassette.
+    These tests cover the low-level helpers only; the merge logic
+    that *consumes* the marker is wired up in Phase 2.
+    """
+
+    def test_marker_path_sits_beside_staging(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import marker_path
+
+        staging = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc"
+        expected = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc.completed"
+
+        assert marker_path(staging) == expected
+
+    def test_has_completion_marker_false_when_absent(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import has_completion_marker
+
+        staging = tmp_path / "slides.http-cassette.yaml.staging-xyz"
+        # Staging file doesn't even exist — marker still reports False.
+        assert has_completion_marker(staging) is False
+
+        # Staging file exists, marker does not.
+        staging.write_text("interactions: []\nversion: 1\n", encoding="utf-8")
+        assert has_completion_marker(staging) is False
+
+    def test_has_completion_marker_true_when_present(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import (
+            has_completion_marker,
+            marker_path,
+        )
+
+        staging = tmp_path / "slides.http-cassette.yaml.staging-xyz"
+        staging.write_text("interactions: []\nversion: 1\n", encoding="utf-8")
+        marker_path(staging).write_text("{}\n", encoding="utf-8")
+
+        assert has_completion_marker(staging) is True
+
+    def test_write_completion_marker_creates_file(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            has_completion_marker,
+            marker_path,
+            write_completion_marker,
+        )
+
+        canonical = tmp_path / "_cassettes" / "slides.http-cassette.yaml"
+        staging = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc"
+        paths = CassettePaths(canonical=canonical, staging=staging)
+
+        # Parent dir might not exist yet — writer must create it.
+        write_completion_marker(paths)
+
+        assert marker_path(staging).is_file()
+        assert has_completion_marker(staging) is True
+
+    def test_write_completion_marker_payload_is_valid_json_with_iso_timestamp(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            write_completion_marker,
+        )
+
+        canonical = tmp_path / "_cassettes" / "slides.http-cassette.yaml"
+        staging = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc"
+        paths = CassettePaths(canonical=canonical, staging=staging)
+
+        write_completion_marker(paths)
+
+        data = json.loads(marker_path(staging).read_text(encoding="utf-8"))
+        assert data["schema"] == 1
+        assert isinstance(data["host_pid"], int)
+        assert data["host_pid"] == psutil.Process().pid
+        # ISO-8601 UTC timestamp — parseable and not ridiculously old.
+        import datetime as _dt
+
+        parsed = _dt.datetime.fromisoformat(data["completed_at"])
+        assert parsed.tzinfo is not None
+        delta = _dt.datetime.now(_dt.timezone.utc) - parsed
+        assert abs(delta.total_seconds()) < 60
+
+    def test_write_completion_marker_is_idempotent(self, tmp_path):
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            write_completion_marker,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-abc"
+        paths = CassettePaths(canonical=canonical, staging=staging)
+
+        write_completion_marker(paths)
+        first = marker_path(staging).read_text(encoding="utf-8")
+        # Sleep a hair so the timestamp can differ on a fast clock.
+        time.sleep(0.01)
+        write_completion_marker(paths)
+        second = marker_path(staging).read_text(encoding="utf-8")
+
+        # Both writes succeeded; file still exists and parses as JSON.
+        # We don't assert the contents are byte-identical — the
+        # timestamp may legitimately advance — only that the marker
+        # is stable through re-writes (no exception, file remains).
+        assert marker_path(staging).is_file()
+        assert json.loads(first)["schema"] == 1
+        assert json.loads(second)["schema"] == 1
+
+    def test_marker_filename_is_ignored_for_output(self, tmp_path):
+        """Markers must never travel into worker payloads or public output.
+
+        Same class as ``.staging-*`` files — build-internal artifacts.
+        Tests the ``is_ignored_file_for_output`` predicate that the
+        payload builder and output copier both consult.
+        """
+        from clm.infrastructure.utils.path_utils import is_ignored_file_for_output
+
+        marker = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc.completed"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("{}\n", encoding="utf-8")
+
+        assert is_ignored_file_for_output(marker) is True
+
+
+class TestDiscriminatingMerge:
+    """Marker-aware merge: only completed sessions fold into canonical (issue #115).
+
+    These tests cover the per-file branches inside
+    :func:`merge_staging_into_canonical`. The marker file's *existence*
+    discriminates "this staging file holds a complete recording session,
+    safe to fold" from "this staging file is a partial chain whose
+    completion is unknown — either a concurrent worker still recording
+    or a previously-aborted session whose recordings would poison the
+    canonical cassette." The ``sweep_orphans`` flag tells the merge
+    which environment it is running in (single-threaded pre-build
+    sweep vs. concurrent post-execution worker).
+    """
+
+    def test_merge_folds_entries_when_marker_present(self, tmp_path):
+        """Default per-worker merge folds markered staging into canonical."""
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(staging, uri="http://example/marked", body="MARKED")
+        _touch_completion_marker(staging)
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merged = merge_staging_into_canonical(paths)  # default sweep_orphans=False
+
+        assert merged == 1
+        assert canonical.exists()
+        assert not staging.exists()
+        assert not marker_path(staging).exists()  # marker cleaned up after fold
+        assert "http://example/marked" in canonical.read_text(encoding="utf-8")
+
+    def test_merge_skips_markerless_in_per_worker_mode(self, tmp_path):
+        """A markerless staging file must be left strictly alone by per-worker merge.
+
+        The marker may be missing because (a) the producing worker is
+        still recording — taking the cross-process lock for its own
+        merge later — or (b) the producing worker's kernel died. In
+        the per-worker context we can't distinguish (a) from (b)
+        safely, so the contract is "don't touch, don't fold, don't
+        delete." The next build's pre-build sweep (single-threaded)
+        decides their fate.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(staging, uri="http://example/partial", body="PARTIAL")
+        # No marker.
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merged = merge_staging_into_canonical(paths)
+
+        # Markerless staging is not folded; canonical is unchanged.
+        assert merged == 0
+        assert not canonical.exists()
+        # Critically: staging file must still be on disk for a later
+        # sweep to discard or for the producing worker to complete.
+        assert staging.exists()
+        assert "http://example/partial" in staging.read_text(encoding="utf-8")
+
+    def test_merge_discards_markerless_in_sweep_mode(self, tmp_path):
+        """A markerless staging file is treated as a confirmed orphan under sweep_orphans=True.
+
+        The pre-build sweep runs before any worker starts, so any
+        markerless staging file present is from a previous build and
+        is therefore an aborted-session partial recording. Folding it
+        would poison canonical (this is the issue #115 mechanism);
+        discarding restores the invariant.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-prev-build"
+        _write_cassette(staging, uri="http://example/partial", body="PARTIAL")
+        # Pre-existing canonical with an unrelated entry must survive
+        # the sweep — discarding is per-staging, not "wipe canonical."
+        _write_cassette(canonical, uri="http://example/keep", body="KEEP")
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merged = merge_staging_into_canonical(paths, sweep_orphans=True)
+
+        assert merged == 0  # no markered files were folded
+        assert not staging.exists()  # orphan discarded
+        # Canonical must still contain its prior entry; the sweep
+        # discards orphan-staging entries, not canonical entries.
+        content = canonical.read_text(encoding="utf-8")
+        assert "http://example/keep" in content
+        assert "http://example/partial" not in content
+
+    def test_merge_deletes_marker_after_successful_fold(self, tmp_path):
+        """Folded markered staging cleans up both the staging file and the marker."""
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(staging, uri="http://example/x", body="X")
+        _touch_completion_marker(staging)
+        assert marker_path(staging).exists()
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merge_staging_into_canonical(paths)
+
+        # Both staging and its marker must be gone — leaving a
+        # marker behind would mark a no-longer-existing staging file
+        # as completed and confuse future sweeps.
+        assert not staging.exists()
+        assert not marker_path(staging).exists()
+
+    def test_persist_recorded_cassette_writes_marker_on_success(self, tmp_path):
+        """On the success path the host writes the marker before merging.
+
+        Goes through the real :meth:`_persist_recorded_cassette` host
+        method rather than calling :func:`write_completion_marker`
+        directly, to lock in the integration contract: a successful
+        execution path always produces a marker, regardless of how
+        the merge subsequently behaves.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            has_completion_marker,
+        )
+        from clm.workers.notebook.notebook_processor import NotebookProcessor
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(staging, uri="http://example/x", body="X")
+        paths = CassettePaths(canonical=canonical, staging=staging)
+
+        spec = CompletedOutput(format="html", language="en")
+        processor = NotebookProcessor(spec)
+        notebook_json = make_notebook_json([make_cell("code", "x = 1")])
+        payload = make_payload(notebook_json, format_="html", kind="completed").model_copy(
+            update={"http_replay_mode": "once"}
+        )
+
+        processor._persist_recorded_cassette(
+            "cid-success",
+            payload,
+            paths,
+            execution_succeeded=True,
+        )
+
+        # Marker was written → staging + marker were merged → both
+        # cleaned up by the merge. The success-path contract is
+        # observable through the canonical containing the entry.
+        assert canonical.exists()
+        assert "http://example/x" in canonical.read_text(encoding="utf-8")
+        # Staging gone, marker gone — they were folded.
+        assert not staging.exists()
+        assert not has_completion_marker(staging)
+
+    def test_persist_recorded_cassette_omits_marker_on_failure(self, tmp_path):
+        """On the failure path the host must NOT write the marker.
+
+        Without a marker the staging file is treated as a partial
+        chain and is left on disk for the next build's pre-build
+        sweep to discard. The merge is still invoked (so sibling
+        completed workers can finish their folds) but this worker's
+        staging is untouched.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            has_completion_marker,
+        )
+        from clm.workers.notebook.notebook_processor import NotebookProcessor
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-failed"
+        _write_cassette(staging, uri="http://example/partial", body="PARTIAL")
+        paths = CassettePaths(canonical=canonical, staging=staging)
+
+        spec = CompletedOutput(format="html", language="en")
+        processor = NotebookProcessor(spec)
+        notebook_json = make_notebook_json([make_cell("code", "x = 1")])
+        payload = make_payload(notebook_json, format_="html", kind="completed").model_copy(
+            update={"http_replay_mode": "once"}
+        )
+
+        processor._persist_recorded_cassette(
+            "cid-failure",
+            payload,
+            paths,
+            execution_succeeded=False,
+        )
+
+        # No marker → merge left the staging file alone → canonical
+        # was not touched.
+        assert not has_completion_marker(staging)
+        assert staging.exists(), (
+            "Failure path must leave staging on disk so the next "
+            "pre-build sweep can discard any partial chain."
+        )
+        assert not canonical.exists()
+
+    def test_concurrent_workers_dont_consume_each_others_active_staging(self, tmp_path):
+        """Worker A's merge must not delete or fold Worker B's still-recording staging file.
+
+        Worker A finishes execution and starts its post-execution
+        merge (default ``sweep_orphans=False``). Worker B is still
+        recording — its staging is on disk but markerless. The
+        contract: A's merge sees B's markerless staging, leaves it
+        alone, and folds only its own markered staging. B can then
+        complete and run its own merge unaffected.
+
+        This is the structural fix that eliminates the latent
+        seed/merge race the marker design addresses (the visible
+        symptom in issue #115 is the chain-poisoning).
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging_a = tmp_path / "slides.http-cassette.yaml.staging-worker-a"
+        staging_b = tmp_path / "slides.http-cassette.yaml.staging-worker-b"
+        _write_cassette(staging_a, uri="http://example/a", body="A")
+        _touch_completion_marker(staging_a)  # A finished cleanly.
+        _write_cassette(staging_b, uri="http://example/b-partial", body="B")
+        # B has no marker — still recording.
+
+        paths_a = CassettePaths(canonical=canonical, staging=staging_a)
+        merge_staging_into_canonical(paths_a)
+
+        # A's entries are in canonical; A's staging + marker are gone.
+        assert canonical.exists()
+        assert "http://example/a" in canonical.read_text(encoding="utf-8")
+        assert not staging_a.exists()
+        assert not marker_path(staging_a).exists()
+
+        # B's still-active staging must be untouched.
+        assert staging_b.exists(), (
+            "Worker A's merge deleted Worker B's still-active staging — "
+            "the marker-discriminator contract was violated."
+        )
+        assert "http://example/b-partial" in staging_b.read_text(encoding="utf-8")
+        # And B's entries must NOT have leaked into canonical (until
+        # B writes its own marker and runs its own merge).
+        assert "http://example/b-partial" not in canonical.read_text(encoding="utf-8")
 
 
 def _write_two_interactions(
@@ -2686,6 +3111,197 @@ def _write_two_interactions(
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
+
+
+class TestIssue115PartialChainRegression:
+    """End-to-end §C regression: aborted partial chains must not poison canonical.
+
+    The bug filed as issue #115 is structural. An aborted recording
+    session can leave a chain-opener entry on disk (request body B1,
+    response text T1) without its chain-closer (whose request body
+    would embed T1). On the next build, the pre-fix additive merger
+    folded the orphan into canonical first-seen-wins, so a later
+    completed session whose chain-opener had the same dedup key but a
+    *different* response T2 was silently skipped — the chain in
+    canonical then paired the chain-opener with T1 while the
+    chain-closer (also folded, distinct dedup key) expected the
+    response to have been T2. Replay broke on the chain-closer with
+    ``CannotOverwriteExistingCassetteException``.
+
+    These tests drive the merge layer end-to-end (no kernel needed)
+    against realistic two-staging scenarios and lock in the
+    marker-based fix: aborted sessions are markerless and either
+    discarded by the next pre-build sweep or left strictly alone by
+    the per-worker post-execution merge.
+    """
+
+    # Shared chain fixture used by both regression scenarios. The
+    # chain-opener URI is identical across A's aborted recording and
+    # B's completed recording, so the dedup key collides in exactly
+    # the way that the pre-fix "first-seen wins" merger relied on.
+    _OPENER_URI = "http://llm.example/v1/chat?prompt=clarify-Q3"
+    _OPENER_RESPONSE_ABORTED = "CLARIFIED-T1-STALE"
+    _OPENER_RESPONSE_GOOD = "CLARIFIED-T2-GOOD"
+    _CLOSER_URI = "http://llm.example/v1/chat?prompt=tutor-CLARIFIED-T2-GOOD"
+    _CLOSER_RESPONSE = "FINAL-ANSWER"
+
+    def test_pre_build_sweep_then_completed_session_lands_consistent_chain(self, tmp_path):
+        """Walk the §C scenario chronologically across two builds.
+
+        Build 1: Session A's kernel dies after the chain-opener
+        recorded but before the chain-closer ran. No marker is written
+        (the host's success path is never reached).
+
+        Build 2 start: the pre-build sweep discards A's markerless
+        staging without touching canonical.
+
+        Build 2 worker: Session B runs cleanly — both the chain-opener
+        (same request, *different* response) and the chain-closer
+        (request embedding B's opener response) are recorded, marker
+        written. B's per-worker merge folds the chain into canonical.
+
+        Post-fix outcome: canonical's chain-opener response is B's,
+        the chain-closer is present, and the closer's URI references
+        the response paired with the opener — the chain is internally
+        consistent and a future replay can walk it.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides_010_prompt_templates.http-cassette.yaml"
+
+        # Build 1: A aborts mid-chain. Staging on disk, no marker.
+        # The ``a-aborted`` suffix sorts before ``b-completed`` so the
+        # pre-fix alphabetical merge would have folded A first — the
+        # exact slot that admitted the stale response.
+        staging_a = canonical.parent / f"{canonical.name}.staging-a-aborted"
+        _write_cassette(staging_a, uri=self._OPENER_URI, body=self._OPENER_RESPONSE_ABORTED)
+        assert not marker_path(staging_a).exists()
+
+        # Build 2 start: pre-build sweep runs single-threaded before
+        # any worker. The staging field is irrelevant for the sweep;
+        # it globs every ``*.staging-*`` sibling of canonical.
+        sweep_paths = CassettePaths(
+            canonical=canonical,
+            staging=canonical.parent / f"{canonical.name}.staging-sweep",
+        )
+        merged = merge_staging_into_canonical(sweep_paths, sweep_orphans=True)
+
+        assert merged == 0, "Sweep must not fold the markerless orphan."
+        assert not staging_a.exists(), "Sweep must discard the markerless orphan."
+        # Sweep saw no markered work, so it does not write canonical.
+        assert not canonical.exists(), (
+            "Sweep must not create or touch canonical when only "
+            "markerless orphans were present — atomic-write churn for "
+            "no semantic change would be a regression."
+        )
+
+        # Build 2 worker: B records the full chain and completes.
+        staging_b = canonical.parent / f"{canonical.name}.staging-b-completed"
+        _write_two_interactions(
+            staging_b,
+            (self._OPENER_URI, self._OPENER_RESPONSE_GOOD),
+            (self._CLOSER_URI, self._CLOSER_RESPONSE),
+        )
+        _touch_completion_marker(staging_b)
+
+        merged = merge_staging_into_canonical(CassettePaths(canonical=canonical, staging=staging_b))
+        assert merged == 1
+
+        content = canonical.read_text(encoding="utf-8")
+
+        # Canonical's chain-opener stores B's response, not A's stale
+        # one — the §C symptom would have flipped these assertions.
+        assert self._OPENER_RESPONSE_GOOD in content
+        assert self._OPENER_RESPONSE_ABORTED not in content, (
+            "A's aborted-session response leaked into canonical — issue #115 regression."
+        )
+        # Chain-closer present, references B's opener response: the
+        # chain in canonical is internally consistent.
+        assert self._CLOSER_URI in content
+        assert self._CLOSER_RESPONSE in content
+
+        # No debris on disk after the two-step rollout completes.
+        assert not staging_b.exists()
+        assert not marker_path(staging_b).exists()
+        assert not staging_a.exists()
+        assert not marker_path(staging_a).exists()
+
+    def test_aborted_and_completed_stagings_present_concurrently_keep_completed_response(
+        self, tmp_path
+    ):
+        """Negative regression: with both A (aborted) and B (completed) on
+        disk at merge time, canonical must hold B's response — not A's.
+
+        Pre-fix, :func:`merge_staging_into_canonical` globbed every
+        staging file, sorted alphabetically, and folded each in order
+        with the first occurrence of a dedup key winning.
+        ``staging-a-aborted`` sorts before ``staging-b-completed``, so
+        canonical would have been seeded with A's chain-opener
+        response (``T1-stale``); B's chain-opener — same dedup key —
+        would have been skipped, and B's chain-closer would point at
+        a response that no longer appears anywhere in canonical. That
+        is the exact §C poisoning mechanism.
+
+        Post-fix the per-worker merge leaves A (markerless) strictly
+        alone — its entries never reach canonical, regardless of glob
+        order. B (markered) folds cleanly and canonical holds B's
+        consistent chain. A's staging stays on disk for the next
+        single-threaded pre-build sweep to discard.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            marker_path,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides_010_prompt_templates.http-cassette.yaml"
+
+        # Both stagings present at the same instant. ``a-aborted`` sorts
+        # alphabetically first — the exact slot the pre-fix merger
+        # would have used to seed canonical with the stale T1.
+        staging_a = canonical.parent / f"{canonical.name}.staging-a-aborted"
+        staging_b = canonical.parent / f"{canonical.name}.staging-b-completed"
+        _write_cassette(staging_a, uri=self._OPENER_URI, body=self._OPENER_RESPONSE_ABORTED)
+        _write_two_interactions(
+            staging_b,
+            (self._OPENER_URI, self._OPENER_RESPONSE_GOOD),
+            (self._CLOSER_URI, self._CLOSER_RESPONSE),
+        )
+        _touch_completion_marker(staging_b)
+
+        # Per-worker merge: the context Worker B's post-execution
+        # finally block uses to land its recording.
+        merged = merge_staging_into_canonical(CassettePaths(canonical=canonical, staging=staging_b))
+
+        # Only B was folded; A was left strictly alone.
+        assert merged == 1
+        content = canonical.read_text(encoding="utf-8")
+        assert self._OPENER_RESPONSE_GOOD in content
+        assert self._OPENER_RESPONSE_ABORTED not in content, (
+            "Markerless A's response leaked into canonical — the "
+            "pre-#115 'first-seen wins' behaviour has regressed."
+        )
+        assert self._CLOSER_URI in content
+        assert self._CLOSER_RESPONSE in content
+
+        # B's staging + marker cleaned up by the fold.
+        assert not staging_b.exists()
+        assert not marker_path(staging_b).exists()
+        # A's staging stays on disk for the next pre-build sweep to
+        # decide on. The per-worker merge must not touch it.
+        assert staging_a.exists(), (
+            "Worker B's merge deleted markerless A's staging — the "
+            "'leave alone in per-worker mode' contract was violated."
+        )
+        assert not marker_path(staging_a).exists()
 
 
 class TestBootstrapDurability:


### PR DESCRIPTION
## Summary

Fixes [#115](https://github.com/hoelzl/clm/issues/115) — a kernel that died mid-cell after recording a chained LLM call's opener but before its closer landed on disk could permanently poison the canonical cassette. The additive `first-seen-wins` dedup rule in `merge_staging_into_canonical` would promote the orphan chain-opener; subsequent replay builds then failed on the chain-closer with `CannotOverwriteExistingCassetteException`, and `--http-replay=refresh` could not repair it. PythonCourses' `slides_010_prompt_templates.py` Q3 chain was the visible repro.

The fix is a **per-staging-file completion marker** (`<staging>.completed`) written by the host *only* on the success path of notebook execution, before the finally-block triggers the merge. `merge_staging_into_canonical` gains a `sweep_orphans` flag that discriminates:

| Marker | sweep_orphans | Action |
|--------|--------------|--------|
| yes    | any          | Fold entries; delete staging + marker. |
| no     | True         | Discard entries; delete staging.       |
| no     | False        | Leave alone (concurrent worker?).      |

- **Pre-build sweep** (`Course._sweep_orphan_cassette_staging_files`) passes `sweep_orphans=True` — runs single-threaded before any worker, so markerless staging is a confirmed previous-build orphan and is safely discarded.
- **Per-worker post-execution merge** passes `sweep_orphans=False` — cannot distinguish a still-recording concurrent worker from an aborted session, so leaves markerless staging strictly alone for the next build's sweep to decide.

This split also structurally eliminates the latent seed/merge race where Worker A's post-execution merge could delete Worker B's still-active staging (the underlying mechanism that let the chain-poisoning surface).

Three phases bundled into one PR (tightly coupled; splitting buys no review value, per the handover §6):

- **Phase 1** — marker plumbing helpers (`marker_path`, `has_completion_marker`, `write_completion_marker`) + `.completed` added to `SKIP_OUTPUT_FILE_PATTERNS` / `SKIP_OUTPUT_FILE_GLOBS`. 7 `TestCompletionMarker` tests.
- **Phase 2** — discriminating merge with `sweep_orphans` flag; `_persist_recorded_cassette` threads `execution_succeeded`; `_create_using_nbconvert` flips the flag after a clean execute return; pre-build sweep passes `sweep_orphans=True`. 7 `TestDiscriminatingMerge` tests + existing `TestCassetteMerge` updated to drop `.completed` markers beside its folded stagings + the course-level sweep test updated.
- **Phase 3** — `TestIssue115PartialChainRegression`: chronological §C scenario across two builds, plus a same-instant negative regression demonstrating that the new merger picks the completed session's response over the alphabetically-first aborted session's stale response.

## Test plan

- [x] All existing http-replay tests still pass — particularly `test_two_concurrent_workers_full_seed_record_merge_cycle` (issue-#86 regression guard) and `test_concurrent_merges_do_not_lose_interactions`.
- [x] `test_concurrent_workers_dont_consume_each_others_active_staging` demonstrates the marker fix does not regress issue #86.
- [x] `TestIssue115PartialChainRegression::test_pre_build_sweep_then_completed_session_lands_consistent_chain` passes — partial-chain merge is discarded by sweep, B's completed chain lands cleanly.
- [x] `TestIssue115PartialChainRegression::test_aborted_and_completed_stagings_present_concurrently_keep_completed_response` passes — proves the new merger holds B's response (not A's stale one) even when both are on disk at the same instant.
- [x] `ruff check`, `ruff format --check`, and `mypy` clean on every touched file. (4 pre-existing mypy errors in `TestBootstrapDurability::make_notebook_json` arg-type are pre-existing and unrelated — filed in `docs/claude/TODO.md`.)
- [x] Pre-commit hook (ruff + mypy + fast pytest) passes.
- [x] Cassette + course-level test suite green post-rebase on origin/master (58 tests).
- [ ] **PythonCourses team signal-back**: run `--http-replay=replay` build of `slides_010_prompt_templates.py` with a freshly bootstrapped cassette and confirm no `CannotOverwriteExistingCassetteException` on Q3. Comment on issue #115 with the build log.

## Out of scope (documented in design doc)

- `--http-replay=refresh` on already-poisoned canonical cassettes — still pre-existing-broken by the same dedup-first-seen-wins rule. Workaround: delete canonical, then `new-episodes`.
- Conditional / try-except skipped cells in a *successful* run can still produce partial chains the marker doesn't catch (kernel returned cleanly, try/except swallowed the chain-closer). Tracked as a candidate for a future `clm cassette doctor` follow-up (Phase 4, intentionally deferred to its own issue).
- `skip_errors=True` mid-chain raises — nbclient returns cleanly so marker is written; partial chain admitted. Documented limitation, matches existing `skip_errors` opt-in semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)