### PR TITLE
fix: --ignore-cache + JSON-aware body matcher (replay determinism)

### DIFF
--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -203,7 +203,10 @@ class SqliteBackend(LocalOpsBackend):
                 return
 
         # Check SQLite job cache
-        if self.job_queue:
+        # Same gate as the database cache above — --ignore-cache (ignore_db)
+        # must bypass *both* caches, otherwise workers get silently skipped
+        # for output paths whose content_hash matches a prior run.
+        if not self.ignore_db and self.job_queue:
             cached = self.job_queue.check_cache(str(payload.output_file), payload.content_hash())
             if cached:
                 logger.debug(f"SQLite cache hit for {payload.output_file}")

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -115,6 +115,7 @@ _HTTP_REPLAY_BOOTSTRAP_TEMPLATE = """\
 # CLM HTTP REPLAY BOOTSTRAP - DO NOT EDIT
 import atexit as _clm_atexit
 import copy as _clm_copy
+import json as _clm_json
 import vcr as _clm_vcr
 from vcr.persisters.filesystem import FilesystemPersister as _ClmFsPersister
 
@@ -139,6 +140,74 @@ class _ClmDeepCopyPersister(_ClmFsPersister):
         )
 
 
+def _clm_json_body_matcher(r1, r2):
+    \"\"\"Match request bodies with JSON semantics when both are JSON.
+
+    vcrpy ships two issues that make its default ``body`` matcher
+    unreliable for the LangChain/OpenAI stack:
+
+    * ``filter_post_data_parameters`` rewrites JSON request bodies
+      via ``json.dumps()`` whenever it is configured, even when no
+      replacement key actually matches. ``json.dumps()`` defaults to
+      ``(", ", ": ")`` separators, so the cassette ends up with
+      pretty-printed JSON. The live ``httpx`` request body uses the
+      compact ``(",", ":")`` separators, so a byte comparison fails.
+    * The matcher's automatic JSON transform is gated on
+      ``headers.get("Content-Type")`` (case-sensitive). Real-world
+      clients send the header as lowercase ``content-type``, so the
+      transform never kicks in and the byte comparison runs anyway.
+
+    Together those issues mean every JSON POST fails to match on
+    replay even when nothing changed between recording and replay.
+    This matcher parses both bodies as JSON when their content-type
+    is JSON (case-insensitive) and compares parsed dicts; anything
+    non-JSON falls back to byte comparison so non-JSON requests
+    (multipart, form-encoded, etc.) still get strict matching.
+    \"\"\"
+    def _body_bytes(req):
+        body = req.body
+        if body is None:
+            return b\"\"
+        if isinstance(body, (bytes, bytearray)):
+            return bytes(body)
+        if isinstance(body, str):
+            return body.encode(\"utf-8\", errors=\"replace\")
+        # vcrpy hands BytesIO/stream objects in some code paths
+        read = getattr(body, \"read\", None)
+        if callable(read):
+            data = read()
+            seek = getattr(body, \"seek\", None)
+            if callable(seek):
+                try:
+                    seek(0)
+                except Exception:  # noqa: BLE001 — best-effort rewind
+                    pass
+            return data if isinstance(data, bytes) else str(data).encode(\"utf-8\", errors=\"replace\")
+        return str(body).encode(\"utf-8\", errors=\"replace\")
+
+    def _is_json(req):
+        headers = getattr(req, \"headers\", {{}}) or {{}}
+        for k, v in headers.items():
+            if str(k).lower() == \"content-type\":
+                val = v[0] if isinstance(v, (list, tuple)) and v else v
+                return \"application/json\" in str(val).lower()
+        return False
+
+    b1 = _body_bytes(r1)
+    b2 = _body_bytes(r2)
+    if _is_json(r1) and _is_json(r2):
+        try:
+            p1 = _clm_json.loads(b1) if b1 else None
+            p2 = _clm_json.loads(b2) if b2 else None
+            if p1 != p2:
+                raise AssertionError
+            return
+        except (ValueError, TypeError):
+            pass  # fall through to byte comparison
+    if b1 != b2:
+        raise AssertionError
+
+
 _clm_vcr_instance = _clm_vcr.VCR(
     record_mode={record_mode!r},
     filter_headers=["authorization", "cookie", "x-api-key", "set-cookie"],
@@ -161,8 +230,9 @@ _clm_vcr_instance = _clm_vcr.VCR(
     # CannotOverwriteExistingCassetteException at the first divergent
     # request, which is the desired CI behaviour: stale cassettes fail
     # loudly rather than producing bogus responses.
-    match_on=("method", "scheme", "host", "port", "path", "query", "body"),
+    match_on=("method", "scheme", "host", "port", "path", "query", "clm_json_body"),
 )
+_clm_vcr_instance.register_matcher("clm_json_body", _clm_json_body_matcher)
 _clm_vcr_instance.register_persister(_ClmDeepCopyPersister)
 # The cassette path is the worker's per-invocation *staging* file (an
 # absolute path resolved on the host before the cell was injected). Each

--- a/tests/infrastructure/backends/test_sqlite_backend.py
+++ b/tests/infrastructure/backends/test_sqlite_backend.py
@@ -393,6 +393,52 @@ async def test_sqlite_cache_hit(temp_db, temp_workspace):
 
 
 @pytest.mark.asyncio
+async def test_sqlite_cache_bypassed_when_ignore_db_true(temp_db, temp_workspace):
+    """`--ignore-cache` (ignore_db=True) must bypass the SQLite job cache, not just the database cache.
+
+    Regression test: previously the job-cache lookup at sqlite_backend.process()
+    was not gated on ``ignore_db``, so under ``--ignore-cache`` workers were
+    silently skipped whenever the job queue's results_cache held an entry for
+    the (output_file, content_hash) pair — even though the user explicitly
+    asked to reprocess. That hid stale state during cassette re-records and
+    snapshot recaptures (PythonCourses §1 / §5 baseline work, 2026-05-21).
+    """
+    backend = SqliteBackend(
+        db_path=temp_db,
+        workspace_path=temp_workspace,
+        ignore_db=True,  # request "reprocess all files"
+        skip_worker_check=True,  # Unit test - no workers needed
+    )
+
+    try:
+        operation = MockOperation(service_name_value="notebook-processor")
+        payload = MockPayload()
+
+        # Seed the job-queue cache with an entry matching this payload, and
+        # create the output file so the existence check would pass too.
+        job_queue = JobQueue(temp_db)
+        try:
+            job_queue.add_to_cache(
+                payload.output_file, payload.content_hash(), {"format": "notebook"}
+            )
+        finally:
+            job_queue.close()
+        output_path = temp_workspace / payload.output_file
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("stale cached content")
+
+        # Execute the operation under ignore_db=True — should NOT see the
+        # cache hit, should submit a fresh job instead.
+        await backend.execute_operation(operation, payload)
+
+        assert len(backend.active_jobs) == 1, (
+            "ignore_db=True should bypass the job-queue cache and submit a fresh job"
+        )
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_database_cache_hit(temp_db, temp_workspace):
     """Test that database manager cache prevents job submission."""
     from clm.infrastructure.messaging.base_classes import Result

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2140,6 +2140,13 @@ class TestHttpReplayBootstrap:
         # strict replay doesn't fail on every chat-completion call.
         from types import SimpleNamespace
 
+        # ``vcrpy`` is an optional ``[replay]`` extra. The bootstrap
+        # template ``import vcr`` line below blows up in CI test envs
+        # that don't install replay deps; the matcher we exercise lives
+        # *inside* that bootstrap and only matters when replay is in
+        # use, so skipping cleanly here is correct.
+        pytest.importorskip("vcr")
+
         from clm.workers.notebook.notebook_processor import (
             _inject_http_replay_bootstrap,
         )

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2090,7 +2090,7 @@ class TestHttpReplayBootstrap:
         )
 
     def test_inject_pins_body_in_match_on(self):
-        # The bootstrap must include ``body`` in vcrpy's ``match_on`` tuple.
+        # The bootstrap must include a body matcher in vcrpy's ``match_on`` tuple.
         # vcrpy's default matcher only looks at method+scheme+host+port+path+
         # query, so two POSTs to the same chat-completion endpoint with
         # different request bodies (e.g. ``stream=true`` vs ``stream=false``)
@@ -2101,6 +2101,24 @@ class TestHttpReplayBootstrap:
         # ``'tuple' object has no attribute 'model_dump'`` in
         # langchain-openrouter when it receives a JSON ChatResult instead
         # of an EventStream.  Pin the matcher so we never regress.
+        #
+        # We use a custom ``clm_json_body`` matcher rather than vcrpy's
+        # built-in ``body`` because of two latent vcrpy bugs that break
+        # byte-level matching for JSON POSTs:
+        #
+        # 1. ``filter_post_data_parameters`` re-serializes every JSON body
+        #    via ``json.dumps()`` (pretty-printed with spaces) during the
+        #    record-time filter pass, even when no replacement key
+        #    actually matches. The live ``httpx`` request body is compact
+        #    JSON (no spaces), so byte comparison fails.
+        # 2. The built-in ``body`` matcher's JSON transform is gated on
+        #    ``headers.get("Content-Type")`` (case-sensitive lookup),
+        #    while real clients (and vcrpy's own header storage) use
+        #    lowercase ``content-type``. The transform never runs.
+        #
+        # Our ``clm_json_body`` matcher does case-insensitive content-type
+        # detection and parses JSON bodies before comparison, so the
+        # formatting difference no longer matters.
         from clm.workers.notebook.notebook_processor import (
             _inject_http_replay_bootstrap,
         )
@@ -2110,7 +2128,74 @@ class TestHttpReplayBootstrap:
 
         src = nb["cells"][0]["source"]
         assert "match_on=" in src
-        assert '"body"' in src
+        assert '"clm_json_body"' in src
+        assert "register_matcher" in src
+        assert "_clm_json_body_matcher" in src
+
+    def test_clm_json_body_matcher_handles_whitespace_differences(self):
+        # Live ``httpx`` requests send compact JSON (no spaces) while
+        # vcrpy's ``filter_post_data_parameters`` rewrites JSON bodies via
+        # ``json.dumps()`` (pretty, with spaces) into the cassette. The
+        # custom ``clm_json_body`` matcher must treat the two as equal so
+        # strict replay doesn't fail on every chat-completion call.
+        from types import SimpleNamespace
+
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = make_notebook_node([make_cell("code", "pass")])
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "replay")
+        src = nb["cells"][0]["source"]
+
+        # Execute the bootstrap template in an isolated namespace and grab
+        # the matcher function. The template imports ``vcr`` and registers
+        # cassette context as side effects; suppress those by skipping
+        # ``use_cassette``/atexit by exec'ing only up to the matcher def.
+        # Easiest robust approach: just grab the function via the registered
+        # matcher dict on the global vcr instance.
+        ns: dict = {}
+        # Replace the use_cassette call so it doesn't actually open one
+        stub_src = src.split("_clm_vcr_instance.register_persister")[0]
+        stub_src += "_clm_vcr_instance.register_persister(_ClmDeepCopyPersister)\n"
+        exec(stub_src, ns)
+        matcher = ns["_clm_json_body_matcher"]
+
+        # Pretty JSON (with spaces, as the filter would produce) vs compact JSON
+        pretty = b'{"messages": [{"role": "user", "content": "hi"}], "stream": false}'
+        compact = b'{"messages":[{"role":"user","content":"hi"}],"stream":false}'
+
+        def mk(body: bytes, content_type: str | None = "application/json"):
+            headers = {}
+            if content_type is not None:
+                # Use lowercase header name to match what vcrpy stores after
+                # filtering and what httpx sends at runtime.
+                headers["content-type"] = [content_type]
+            return SimpleNamespace(body=body, headers=headers)
+
+        # JSON bodies that differ only in whitespace must match.
+        matcher(mk(pretty), mk(compact))  # no AssertionError
+
+        # JSON bodies that differ semantically must NOT match.
+        with pytest.raises(AssertionError):
+            matcher(
+                mk(pretty), mk(b'{"messages":[{"role":"user","content":"bye"}],"stream":false}')
+            )
+
+        # Non-JSON bodies fall back to byte comparison.
+        matcher(
+            mk(b"raw bytes", content_type="text/plain"), mk(b"raw bytes", content_type="text/plain")
+        )
+        with pytest.raises(AssertionError):
+            matcher(
+                mk(b"raw bytes", content_type="text/plain"),
+                mk(b"other bytes", content_type="text/plain"),
+            )
+
+        # Case-insensitive content-type detection: uppercase header name still
+        # triggers the JSON path.
+        upper = SimpleNamespace(body=pretty, headers={"Content-Type": ["application/json"]})
+        matcher(upper, mk(compact))
 
     def test_inject_uses_vcr_mode_mapping(self):
         from clm.workers.notebook.notebook_processor import (


### PR DESCRIPTION
Two latent issues in the HTTP-replay path that surfaced together during
the PythonCourses ML AZAV baseline recapture on 2026-05-21.

## 1. `--ignore-cache` was bypassing only one of two caches

`SqliteBackend.process()` consults two caches before submitting work:

- The `DatabaseManager.processed_files` cache (gated on `ignore_db`).
- The `JobQueue.results_cache` (NOT gated on `ignore_db` — the bug).

Under `--ignore-cache`, workers were silently skipped whenever the
job queue had an entry for the `(output_file, content_hash)` pair
from a prior build — even when the user explicitly asked to
reprocess. The failure mode is invisible during the build itself
(cached notebooks just don't make HTTP calls), but it causes
downstream work to fail mysteriously: cassette re-records under
`--http-replay=new-episodes` ship variant-incomplete because skipped
workers never go through the recorder.

Fix: gate the job-queue check on `not self.ignore_db` too. Adds a
regression test that seeds the job-queue cache + output file and
asserts the backend submits a fresh job under `ignore_db=True`.

## 2. JSON request bodies fail to match on strict replay

vcrpy's `filter_post_data_parameters` rewrites JSON request bodies
via `json.dumps()` whenever the filter is configured — even when no
replacement key actually matches. `json.dumps()` defaults to
`(', ', ': ')` separators, so the cassette ends up with
pretty-printed JSON. The live `httpx` request body uses the compact
`(',', ':')` separators, so a byte comparison fails on strict
replay. vcrpy's built-in `body` matcher *does* have a JSON
transform path, but it's gated on `headers.get("Content-Type")`
(case-sensitive), while real clients and vcrpy's own header storage
use lowercase `content-type` — so the transform never kicks in and
the matcher falls back to byte comparison anyway. Together those
mean every JSON POST fails to match on replay even when nothing
changed between recording and replay.

Fix: register a custom `clm_json_body` matcher that does
case-insensitive content-type detection and parses both sides as
JSON before comparing; non-JSON bodies fall back to byte
comparison so multipart/form-encoded requests keep strict matching.
Tests cover the failure-mode explicitly (pretty vs compact JSON),
semantic-difference, non-JSON fallback, and case-insensitive header
detection.

## Test plan

- `tests/infrastructure/backends/test_sqlite_backend.py` — new
  `test_sqlite_cache_bypassed_when_ignore_db_true` plus the existing
  sqlite-cache-hit / db-cache-hit tests still pass.
- `tests/workers/notebook/test_notebook_processor.py` — new
  `test_clm_json_body_matcher_handles_whitespace_differences`;
  `test_inject_pins_body_in_match_on` updated to look for
  `clm_json_body` instead of vcrpy's `body`.
- All 29 tests in `test_sqlite_backend.py` and all 20 tests in
  `TestHttpReplayBootstrap` pass on the fix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)