### PR TITLE
refactor(slides): normalize slide_ids via shared assign-ids engine

### DIFF
--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -69,6 +69,7 @@ __all__ = [
     "AssignResult",
     "AssignedId",
     "Refusal",
+    "assign_ids_for_cells",
     "assign_ids_for_text",
     "assign_ids_in_directory",
     "assign_ids_in_file",
@@ -237,20 +238,23 @@ def _content_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def assign_ids_for_text(
-    text: str,
+def assign_ids_for_cells(
+    cells: list[_Cell],
     file_path: Path,
     options: AssignOptions,
-) -> tuple[str, AssignResult]:
-    """Apply the assign-ids policy to one file's text.
+) -> AssignResult:
+    """Apply the assign-ids policy to an existing cell list.
 
-    Returns ``(new_text, result)``. ``new_text == text`` when nothing was
-    written (refusals only, or no changes needed). In ``--report-only``
-    mode the new text always equals the input but the result still lists
-    *proposed* assignments and refusals.
+    Mutates ``cells`` in place (unless ``options.report_only``) and
+    returns an :class:`AssignResult` carrying the assignments and
+    refusals. The result's ``files_visited`` / ``files_modified``
+    counters are left at zero — the caller is responsible for the
+    file-level accounting and for writing the reconstructed text back to
+    disk. This is the seam :mod:`clm.slides.normalizer` uses to fold
+    assign-ids into a larger multi-operation pass without re-parsing the
+    file.
     """
-    result = AssignResult(files_visited=1)
-    preamble, cells = _split_cells(text)
+    result = AssignResult()
 
     # First pass: collect every id already on the page (bare form). This
     # is what we use to detect collisions when generating new slugs.
@@ -324,6 +328,25 @@ def assign_ids_for_text(
             continue
 
         # role == "skip": unchanged.
+
+    return result
+
+
+def assign_ids_for_text(
+    text: str,
+    file_path: Path,
+    options: AssignOptions,
+) -> tuple[str, AssignResult]:
+    """Apply the assign-ids policy to one file's text.
+
+    Returns ``(new_text, result)``. ``new_text == text`` when nothing was
+    written (refusals only, or no changes needed). In ``--report-only``
+    mode the new text always equals the input but the result still lists
+    *proposed* assignments and refusals.
+    """
+    preamble, cells = _split_cells(text)
+    result = assign_ids_for_cells(cells, file_path, options)
+    result.files_visited = 1
 
     new_text = text
     if not options.report_only and result.assignments:

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from clm.core.topic_resolver import (
     build_topic_map,
@@ -30,6 +31,9 @@ from clm.notebooks.slide_parser import parse_cell_header
 from clm.slides.raw_cells import RawCell as _RawCell
 from clm.slides.raw_cells import reconstruct as _reconstruct
 from clm.slides.raw_cells import split_cells as _split_raw_cells
+
+if TYPE_CHECKING:
+    from clm.slides.assign_ids import AssignOptions
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -460,206 +464,63 @@ def _similarity_suggestion(de_cell: _RawCell, en_cell: _RawCell, failed: list[st
 
 
 # ---------------------------------------------------------------------------
-# Slide ID auto-generation
+# Slide ID auto-generation — delegates to clm.slides.assign_ids
 # ---------------------------------------------------------------------------
 
-_HEADING_RE = re.compile(r"^#\s+(?P<hashes>#+)\s+(?P<text>.+)")
-_DEF_NAME_RE = re.compile(r"^(?:def|class)\s+(\w+)")
 
+def _apply_slide_ids(
+    cells: list[_RawCell],
+    path: Path,
+    options: AssignOptions | None = None,
+) -> tuple[list[Change], list[ReviewItem]]:
+    """Assign ``slide_id`` metadata using the shared assign-ids engine.
 
-def _slugify(text: str) -> str:
-    """Convert text to a slug suitable for slide_id."""
-    # Remove markdown formatting: **bold**, *italic*, `code`, [links](url)
-    text = re.sub(r"\*+([^*]+)\*+", r"\1", text)
-    text = re.sub(r"`([^`]+)`", r"\1", text)
-    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
-    # Lowercase
-    text = text.lower()
-    # Replace non-alphanumeric sequences with hyphens
-    text = re.sub(r"[^a-z0-9]+", "-", text)
-    # Strip leading/trailing hyphens
-    return text.strip("-")
+    This is a thin adapter over :func:`clm.slides.assign_ids.assign_ids_for_cells`
+    so ``clm slides normalize`` produces ids by the same rules as the
+    dedicated ``clm slides assign-ids`` command — EN-derived kebab slugs,
+    German transliteration, narrative inheritance, ``!``-preserve marker
+    — instead of the older naive slug-and-fallback scheme.
 
-
-def _extract_heading_text(cell: _RawCell) -> str | None:
-    """Extract the first markdown heading text from a cell."""
-    for line in cell.lines[1:]:
-        m = _HEADING_RE.match(line)
-        if m:
-            return m.group("text").strip()
-    return None
-
-
-def _extract_def_name(cell: _RawCell) -> str | None:
-    """Extract the first function/class name from a code cell."""
-    for line in cell.lines[1:]:
-        m = _DEF_NAME_RE.match(line.strip())
-        if m:
-            return m.group(1)
-    return None
-
-
-def _generate_slide_id(cell: _RawCell, file_stem: str, cell_index: int) -> str:
-    """Generate a slide_id for a cell.
-
-    Rules:
-    - Markdown with heading → heading text, lowercased, hyphenated
-    - Code with definitions → function/class name
-    - Fallback → file-stem-cell-N
+    The engine mutates ``cells`` in place (assignments are written into
+    the cell headers). We translate its ``AssignedId`` records into the
+    normalizer's :class:`Change` records and its ``Refusal`` records
+    into :class:`ReviewItem` records.
     """
-    if cell.metadata.cell_type == "markdown":
-        heading = _extract_heading_text(cell)
-        if heading:
-            slug = _slugify(heading)
-            if slug:
-                return slug
-    elif cell.metadata.cell_type == "code":
-        name = _extract_def_name(cell)
-        if name:
-            return name
+    from clm.slides.assign_ids import AssignOptions as _AO
+    from clm.slides.assign_ids import assign_ids_for_cells
 
-    return f"{file_stem}-cell-{cell_index}"
+    if options is None:
+        options = _AO()
 
+    result = assign_ids_for_cells(cells, path, options)
 
-def _add_slide_id_to_header(header: str, slide_id: str) -> str:
-    """Add slide_id="..." to a cell header line."""
-    return header.rstrip() + f' slide_id="{slide_id}"'
-
-
-def _apply_slide_ids(cells: list[_RawCell], file_path: str, file_stem: str) -> list[Change]:
-    """Auto-generate slide_id metadata for cells that lack it.
-
-    Paired DE/EN cells get the same ID (German cell as source).
-    Collision resolution with -2, -3 suffixes.
-    """
-    changes: list[Change] = []
-
-    # Step 1: Identify DE/EN pairs using the existing interleaving logic.
-    # We pair by category and position (same approach as interleaving).
-    de_by_cat: dict[str, list[int]] = {cat: [] for cat in _PAIRING_CATEGORIES}
-    en_by_cat: dict[str, list[int]] = {cat: [] for cat in _PAIRING_CATEGORIES}
-
-    for idx, cell in enumerate(cells):
-        cat = _classify_cell(cell)
-        if cat in _PAIRING_CATEGORIES:
-            if cell.metadata.lang == "de":
-                de_by_cat[cat].append(idx)
-            elif cell.metadata.lang == "en":
-                en_by_cat[cat].append(idx)
-
-    # Build de_idx → en_idx mapping for equal-count categories
-    de_to_en: dict[int, int] = {}
-    for cat in _PAIRING_CATEGORIES:
-        de_indices = de_by_cat[cat]
-        en_indices = en_by_cat[cat]
-        if len(de_indices) == len(en_indices):
-            for de_i, en_i in zip(de_indices, en_indices, strict=True):
-                de_to_en[de_i] = en_i
-
-    en_to_de: dict[int, int] = {v: k for k, v in de_to_en.items()}
-
-    # Step 2: Generate IDs for all content cells (skip j2, shared, narrative
-    # without lang).  Track used IDs for collision resolution.
-    used_ids: dict[str, int] = {}  # base_id → count of uses
-    # Map cell index → assigned ID
-    assigned: dict[int, str] = {}
-
-    # First pass: cells that already have slide_id — record them
-    for idx, cell in enumerate(cells):
-        if cell.metadata.slide_id:
-            assigned[idx] = cell.metadata.slide_id
-            base = cell.metadata.slide_id
-            used_ids[base] = used_ids.get(base, 0) + 1
-
-    # Content cell index for fallback naming
-    content_cell_counter = 0
-
-    # Second pass: assign IDs to cells that need them
-    for idx, cell in enumerate(cells):
-        meta = cell.metadata
-        if meta.is_j2:
-            continue
-        if meta.lang is None and not meta.is_narrative:
-            # Shared cell — no slide_id needed
-            continue
-        if meta.is_narrative and meta.lang is None:
-            continue
-
-        content_cell_counter += 1
-
-        if idx in assigned:
-            continue
-
-        # If this is an EN cell paired with a DE cell that already has an ID,
-        # use the same ID
-        if meta.lang == "en" and idx in en_to_de:
-            de_idx = en_to_de[idx]
-            if de_idx in assigned:
-                slide_id = assigned[de_idx]
-                assigned[idx] = slide_id
-                _apply_id_to_cell(cell, slide_id, file_path, changes)
-                continue
-
-        # Generate a new ID
-        base_id = _generate_slide_id(cell, file_stem, content_cell_counter)
-
-        # If this is a DE cell, also check if the paired EN cell already
-        # has an ID (shouldn't normally happen, but handle gracefully)
-        if meta.lang == "de" and idx in de_to_en:
-            en_idx = de_to_en[idx]
-            if en_idx in assigned:
-                slide_id = assigned[en_idx]
-                assigned[idx] = slide_id
-                _apply_id_to_cell(cell, slide_id, file_path, changes)
-                continue
-
-        # Resolve collisions
-        slide_id = _resolve_collision(base_id, used_ids)
-        used_ids[base_id] = used_ids.get(base_id, 0) + 1
-        assigned[idx] = slide_id
-
-        _apply_id_to_cell(cell, slide_id, file_path, changes)
-
-        # Also assign the same ID to the paired cell
-        if meta.lang == "de" and idx in de_to_en:
-            en_idx = de_to_en[idx]
-            if en_idx not in assigned:
-                en_cell = cells[en_idx]
-                if not en_cell.metadata.slide_id:
-                    assigned[en_idx] = slide_id
-                    _apply_id_to_cell(en_cell, slide_id, file_path, changes)
-        elif meta.lang == "en" and idx in en_to_de:
-            de_idx = en_to_de[idx]
-            if de_idx not in assigned:
-                de_cell = cells[de_idx]
-                if not de_cell.metadata.slide_id:
-                    assigned[de_idx] = slide_id
-                    _apply_id_to_cell(de_cell, slide_id, file_path, changes)
-
-    return changes
-
-
-def _resolve_collision(base_id: str, used_ids: dict[str, int]) -> str:
-    """Resolve ID collisions with -2, -3 suffixes."""
-    if base_id not in used_ids:
-        return base_id
-    count = used_ids[base_id] + 1
-    return f"{base_id}-{count}"
-
-
-def _apply_id_to_cell(cell: _RawCell, slide_id: str, file_path: str, changes: list[Change]) -> None:
-    """Apply slide_id to a cell's header and record the change."""
-    new_header = _add_slide_id_to_header(cell.header, slide_id)
-    cell.header = new_header
-    cell.metadata = parse_cell_header(new_header)
-    changes.append(
+    changes = [
         Change(
-            file=file_path,
+            file=a.file,
             operation="slide_ids",
-            line=cell.line_number,
-            description=f'Added slide_id="{slide_id}"',
+            line=a.line,
+            description=f'Added slide_id="{a.slide_id}" (source={a.source})',
         )
-    )
+        for a in result.assignments
+    ]
+
+    review_items: list[ReviewItem] = []
+    for r in result.refusals:
+        details: dict = {"severity": r.severity, "line": r.line}
+        if r.proposed_slug:
+            details["proposed_slug"] = r.proposed_slug
+        if r.proposed_title:
+            details["proposed_title"] = r.proposed_title
+        review_items.append(
+            ReviewItem(
+                file=r.file,
+                issue=f"slide_id_{r.severity}_refusal",
+                suggestion=r.reason,
+                details=details,
+            )
+        )
+
+    return changes, review_items
 
 
 # ---------------------------------------------------------------------------
@@ -672,6 +533,7 @@ def normalize_file(
     *,
     operations: list[str] | None = None,
     dry_run: bool = False,
+    assign_options: AssignOptions | None = None,
 ) -> NormalizationResult:
     """Normalize a single slide file.
 
@@ -679,6 +541,11 @@ def normalize_file(
         path: Path to the ``.py`` slide file.
         operations: Which operations to apply.  ``None`` means all.
         dry_run: If ``True``, preview changes without modifying files.
+        assign_options: Options forwarded to the shared assign-ids engine
+            for the ``slide_ids`` operation (``--force``,
+            ``--accept-content-derived``, LLM suggester, …). ``None``
+            uses defaults — refuse headingless slides, never overwrite
+            existing ids, no LLM.
 
     Returns:
         A :class:`NormalizationResult` with changes and review items.
@@ -707,8 +574,9 @@ def normalize_file(
         all_review.extend(interleave_reviews)
 
     if "slide_ids" in op_set:
-        file_stem = path.stem
-        all_changes.extend(_apply_slide_ids(cells, file_str, file_stem))
+        slide_id_changes, slide_id_reviews = _apply_slide_ids(cells, path, assign_options)
+        all_changes.extend(slide_id_changes)
+        all_review.extend(slide_id_reviews)
 
     modified = False
     if all_changes and not dry_run:
@@ -729,19 +597,19 @@ def normalize_directory(
     *,
     operations: list[str] | None = None,
     dry_run: bool = False,
+    assign_options: AssignOptions | None = None,
 ) -> NormalizationResult:
-    """Normalize all slide files in a directory (recursive).
-
-    Args:
-        path: Path to a topic directory, module directory, or ``slides/`` root.
-        operations: Which operations to apply.  ``None`` means all.
-        dry_run: If ``True``, preview changes without modifying files.
-    """
+    """Normalize all slide files in a directory (recursive)."""
     slide_files = find_slide_files_recursive(path)
     combined = NormalizationResult()
 
     for sf in slide_files:
-        result = normalize_file(sf, operations=operations, dry_run=dry_run)
+        result = normalize_file(
+            sf,
+            operations=operations,
+            dry_run=dry_run,
+            assign_options=assign_options,
+        )
         combined.files_modified += result.files_modified
         combined.changes.extend(result.changes)
         combined.review_items.extend(result.review_items)
@@ -755,15 +623,9 @@ def normalize_course(
     *,
     operations: list[str] | None = None,
     dry_run: bool = False,
+    assign_options: AssignOptions | None = None,
 ) -> NormalizationResult:
-    """Normalize all slides referenced by a course spec.
-
-    Args:
-        course_spec_path: Path to the course spec XML file.
-        slides_dir: Path to the ``slides/`` directory.
-        operations: Which operations to apply.  ``None`` means all.
-        dry_run: If ``True``, preview changes without modifying files.
-    """
+    """Normalize all slides referenced by a course spec."""
     from clm.core.course_spec import CourseSpec
 
     spec = CourseSpec.from_file(course_spec_path)
@@ -775,7 +637,12 @@ def normalize_course(
         for match in matches:
             slide_files = find_slide_files(match.path)
             for sf in slide_files:
-                result = normalize_file(sf, operations=operations, dry_run=dry_run)
+                result = normalize_file(
+                    sf,
+                    operations=operations,
+                    dry_run=dry_run,
+                    assign_options=assign_options,
+                )
                 combined.files_modified += result.files_modified
                 combined.changes.extend(result.changes)
                 combined.review_items.extend(result.review_items)

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -122,12 +122,13 @@ def _is_voiceover_cell(cell: _RawCell) -> bool:
     return cell.metadata.is_narrative
 
 
-def _ensure_slide_ids(cells: list[_RawCell], file_path: str, file_stem: str) -> int:
+def _ensure_slide_ids(cells: list[_RawCell], path: Path) -> int:
     """Auto-generate slide_ids for content cells that lack them.
 
-    Returns the number of IDs generated.
+    Delegates to the shared assign-ids engine (via the normalizer
+    adapter). Returns the number of ids assigned.
     """
-    changes = _apply_slide_ids(cells, file_path, file_stem)
+    changes, _refusals = _apply_slide_ids(cells, path)
     return len(changes)
 
 
@@ -204,7 +205,7 @@ def extract_voiceover(
         return result
 
     # Auto-generate slide_ids for cells that need them
-    result.ids_generated = _ensure_slide_ids(cells, str(path), path.stem)
+    result.ids_generated = _ensure_slide_ids(cells, path)
 
     # Build companion cells with for_slide metadata
     companion_cells: list[_RawCell] = []

--- a/tests/cli/test_normalize_slides.py
+++ b/tests/cli/test_normalize_slides.py
@@ -18,9 +18,12 @@ def _write_slide(path: Path, content: str) -> Path:
 
 class TestNormalizeSlidesCmd:
     def test_no_changes_exit_0(self, tmp_path):
+        # Shared code cell: no operation has anything to do — it's not a
+        # slide-start, has no alt/start tags, no workshop heading, and no
+        # DE/EN pair to interleave.
         path = _write_slide(
             tmp_path / "slides_test.py",
-            '# %% [markdown] tags=["slide"]\n# Title\n',
+            "# %%\nx = 1\n",
         )
         runner = CliRunner()
         result = runner.invoke(normalize_slides_cmd, [str(path)])
@@ -72,11 +75,13 @@ class TestNormalizeSlidesCmd:
         assert result.exit_code == 2
 
     def test_review_items_with_changes_exit_1(self, tmp_path):
-        # Count mismatch + other changes (slide_ids) → exit 1 (partial)
+        # Count mismatch (2 DE markdown vs 1 EN) → 1 review item; the
+        # cells carry real markdown headings, so slide_ids still assigns
+        # ids → exit 1 (partial: changes + review items).
         text = (
-            '# %% [markdown] lang="de" tags=["slide"]\n# Folie 1\n\n'
-            '# %% [markdown] lang="de" tags=["subslide"]\n# Extra\n\n'
-            '# %% [markdown] lang="en" tags=["slide"]\n# Slide 1\n'
+            '# %% [markdown] lang="de" tags=["slide"]\n# # Folie 1\n\n'
+            '# %% [markdown] lang="de" tags=["subslide"]\n# # Extra\n\n'
+            '# %% [markdown] lang="en" tags=["slide"]\n# # Slide 1\n'
         )
         path = _write_slide(tmp_path / "slides_test.py", text)
         runner = CliRunner()

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -523,48 +523,48 @@ class TestCombinedOperations:
 
 
 class TestSlideIds:
+    """Covers the slide_ids operation, which delegates to the shared
+    ``clm.slides.assign_ids`` engine: EN-derived kebab slugs, German
+    transliteration, narrative inheritance, ``!``-preserve marker. Only
+    slide-start cells (markdown with ``slide``/``subslide`` tags) get
+    fresh ids; everything else is skipped or inherits.
+    """
+
     def test_markdown_heading_becomes_slug(self, tmp_path):
-        """Markdown cell with heading → slugified heading text."""
+        """Slide-start markdown cell with heading → transliterated slug."""
         text = '# %% [markdown] lang="de" tags=["slide"]\n# # Einführung in Python\n'
         path = _write_slide(tmp_path / "slides_intro.py", text)
         result = normalize_file(path, operations=["slide_ids"])
 
         assert len(result.changes) == 1
         new_text = path.read_text(encoding="utf-8")
-        assert 'slide_id="einf-hrung-in-python"' in new_text
+        # 'ü' → 'ue' via the assign-ids transliterator.
+        assert 'slide_id="einfuehrung-in-python"' in new_text
 
-    def test_code_with_function_def(self, tmp_path):
-        """Code cell with def → function name."""
+    def test_non_slide_code_cell_skipped(self, tmp_path):
+        """Code cells without a slide/subslide tag don't get an id."""
         text = '# %% lang="de"\ndef greet(name):\n    print(f"Hello, {name}")\n'
         path = _write_slide(tmp_path / "slides_funcs.py", text)
         result = normalize_file(path, operations=["slide_ids"])
 
-        assert len(result.changes) == 1
-        new_text = path.read_text(encoding="utf-8")
-        assert 'slide_id="greet"' in new_text
+        assert len(result.changes) == 0
+        assert path.read_text(encoding="utf-8") == text
 
-    def test_code_with_class_def(self, tmp_path):
-        """Code cell with class → class name."""
-        text = '# %% lang="de"\nclass MyHandler:\n    pass\n'
-        path = _write_slide(tmp_path / "slides_classes.py", text)
-        result = normalize_file(path, operations=["slide_ids"])
-
-        assert len(result.changes) == 1
-        new_text = path.read_text(encoding="utf-8")
-        assert 'slide_id="MyHandler"' in new_text
-
-    def test_fallback_file_stem_cell_n(self, tmp_path):
-        """Cell without heading or def → file-stem-cell-N."""
-        text = '# %% [markdown] lang="de"\n# Just some text without a heading\n'
+    def test_headingless_slide_soft_refused(self, tmp_path):
+        """Slide-start cell without a heading → soft refusal (review item)."""
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# Just some text without a heading\n'
         path = _write_slide(tmp_path / "slides_misc.py", text)
         result = normalize_file(path, operations=["slide_ids"])
 
-        assert len(result.changes) == 1
-        new_text = path.read_text(encoding="utf-8")
-        assert 'slide_id="slides_misc-cell-1"' in new_text
+        assert len(result.changes) == 0
+        assert len(result.review_items) == 1
+        item = result.review_items[0]
+        assert item.issue == "slide_id_soft_refusal"
+        # File is untouched when nothing else writes.
+        assert path.read_text(encoding="utf-8") == text
 
-    def test_paired_de_en_get_same_id(self, tmp_path):
-        """Paired DE/EN cells get the same slide_id (German heading as source)."""
+    def test_paired_de_en_use_en_heading(self, tmp_path):
+        """Paired DE/EN slide cells share the EN-derived slug."""
         text = (
             '# %% [markdown] lang="de" tags=["slide"]\n'
             "# # Methoden\n"
@@ -577,11 +577,12 @@ class TestSlideIds:
 
         assert len(result.changes) == 2
         new_text = path.read_text(encoding="utf-8")
-        # Both should have the same ID derived from the DE heading
-        assert new_text.count('slide_id="methoden"') == 2
+        assert new_text.count('slide_id="methods"') == 2
+        # The DE-side slug must not leak in.
+        assert "methoden" not in new_text
 
     def test_existing_slide_id_unchanged(self, tmp_path):
-        """Cells that already have slide_id are not modified."""
+        """Existing ids are preserved without --force."""
         text = '# %% [markdown] lang="de" tags=["slide"] slide_id="custom-id"\n# # Einführung\n'
         path = _write_slide(tmp_path / "slides_test.py", text)
         result = normalize_file(path, operations=["slide_ids"])
@@ -589,8 +590,23 @@ class TestSlideIds:
         assert len(result.changes) == 0
         assert path.read_text(encoding="utf-8") == text
 
+    def test_preserve_marker_never_regenerated(self, tmp_path):
+        """``!``-prefixed ids are kept even when --force would rewrite."""
+        from clm.slides.assign_ids import AssignOptions
+
+        text = '# %% [markdown] lang="de" tags=["slide"] slide_id="!keep-me"\n# # Methoden\n'
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(
+            path,
+            operations=["slide_ids"],
+            assign_options=AssignOptions(force=True),
+        )
+
+        assert len(result.changes) == 0
+        assert "!keep-me" in path.read_text(encoding="utf-8")
+
     def test_collision_resolution(self, tmp_path):
-        """Duplicate IDs get -2, -3 suffixes."""
+        """Duplicate slugs get -2 suffix."""
         text = (
             '# %% [markdown] lang="de" tags=["slide"]\n'
             "# # Einführung\n"
@@ -603,11 +619,12 @@ class TestSlideIds:
 
         assert len(result.changes) == 2
         new_text = path.read_text(encoding="utf-8")
-        assert 'slide_id="einf-hrung"' in new_text
-        assert 'slide_id="einf-hrung-2"' in new_text
+        assert 'slide_id="einfuehrung"' in new_text
+        assert 'slide_id="einfuehrung-2"' in new_text
 
-    def test_j2_cells_skipped(self, tmp_path):
-        """j2 template cells don't get slide_ids."""
+    def test_j2_title_macro_only_slide_assigned(self, tmp_path):
+        """j2 import + j2 ``header()`` macro are untouched; the following
+        slide gets its own id (the title anchor itself never writes)."""
         text = (
             "# j2 from 'macros.j2' import header\n"
             '# {{ header("Titel", "Title") }}\n'
@@ -618,62 +635,24 @@ class TestSlideIds:
         path = _write_slide(tmp_path / "slides_test.py", text)
         result = normalize_file(path, operations=["slide_ids"])
 
-        # Only the markdown cell should get an ID, not the j2 cells
         assert len(result.changes) == 1
         new_text = path.read_text(encoding="utf-8")
-        assert "# j2 " in new_text.split("\n")[0]  # j2 unchanged
+        assert new_text.startswith("# j2 ")
         assert 'slide_id="titel"' in new_text
 
     def test_shared_cells_skipped(self, tmp_path):
-        """Shared (no-lang) cells don't get slide_ids."""
+        """Shared (no-lang) cells without a slide tag don't get ids."""
         text = '# %%\nx = 1\n\n# %% [markdown] lang="de" tags=["slide"]\n# # Titel\n'
         path = _write_slide(tmp_path / "slides_test.py", text)
         result = normalize_file(path, operations=["slide_ids"])
 
-        # Only the DE markdown cell gets an ID
         assert len(result.changes) == 1
         new_text = path.read_text(encoding="utf-8")
-        # The shared code cell should not have slide_id
         lines = new_text.split("\n")
-        assert "slide_id" not in lines[0]  # "# %%"
-
-    def test_paired_en_uses_de_heading(self, tmp_path):
-        """For DE/EN pairs, the ID comes from the German cell even if EN is different."""
-        text = (
-            '# %% [markdown] lang="de" tags=["slide"]\n'
-            "# # Variablen und Typen\n"
-            "\n"
-            '# %% [markdown] lang="en" tags=["slide"]\n'
-            "# # Variables and Types\n"
-        )
-        path = _write_slide(tmp_path / "slides_vars.py", text)
-        result = normalize_file(path, operations=["slide_ids"])
-
-        new_text = path.read_text(encoding="utf-8")
-        # Both cells should use the DE-derived ID
-        assert new_text.count('slide_id="variablen-und-typen"') == 2
-
-    def test_code_pairs_share_id(self, tmp_path):
-        """Paired DE/EN code cells share the same ID."""
-        text = (
-            '# %% lang="de"\n'
-            "def begruessung():\n"
-            '    print("Hallo")\n'
-            "\n"
-            '# %% lang="en"\n'
-            "def greeting():\n"
-            '    print("Hello")\n'
-        )
-        path = _write_slide(tmp_path / "slides_funcs.py", text)
-        result = normalize_file(path, operations=["slide_ids"])
-
-        assert len(result.changes) == 2
-        new_text = path.read_text(encoding="utf-8")
-        # Both should have the DE function name
-        assert new_text.count('slide_id="begruessung"') == 2
+        assert "slide_id" not in lines[0]  # "# %%" shared cell
 
     def test_mixed_existing_and_new_ids(self, tmp_path):
-        """Cells with existing IDs are preserved; new cells get generated IDs."""
+        """Existing ids are preserved; new slide cells get fresh slugs."""
         text = (
             '# %% [markdown] lang="de" tags=["slide"] slide_id="existing"\n'
             "# # Folie 1\n"
@@ -690,7 +669,7 @@ class TestSlideIds:
         assert 'slide_id="folie-2"' in new_text
 
     def test_existing_id_on_de_shared_with_en(self, tmp_path):
-        """EN cell paired with a DE cell that already has an ID inherits it."""
+        """EN cell paired with a pre-assigned DE cell reuses the id."""
         text = (
             '# %% [markdown] lang="de" tags=["slide"] slide_id="my-id"\n'
             "# # Folie\n"
@@ -705,19 +684,31 @@ class TestSlideIds:
         new_text = path.read_text(encoding="utf-8")
         assert new_text.count('slide_id="my-id"') == 2
 
-    def test_voiceover_cells_get_ids(self, tmp_path):
-        """Voiceover cells also get slide_ids."""
+    def test_voiceover_inherits_from_preceding_slide(self, tmp_path):
+        """Voiceover cells inherit the most recent slide's id."""
         text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# # Folie\n"
+            "\n"
             '# %% [markdown] lang="de" tags=["voiceover"]\n'
             "# DE voiceover text\n"
-            "\n"
-            '# %% [markdown] lang="en" tags=["voiceover"]\n'
-            "# EN voiceover text\n"
         )
         path = _write_slide(tmp_path / "slides_test.py", text)
         result = normalize_file(path, operations=["slide_ids"])
 
+        # One slide-start assignment + one narrative inheritance.
         assert len(result.changes) == 2
+        new_text = path.read_text(encoding="utf-8")
+        assert new_text.count('slide_id="folie"') == 2
+
+    def test_voiceover_without_preceding_slide_skipped(self, tmp_path):
+        """Voiceover with nothing before it has no anchor to inherit from."""
+        text = '# %% [markdown] lang="de" tags=["voiceover"]\n# DE voiceover text\n'
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["slide_ids"])
+
+        assert len(result.changes) == 0
+        assert "slide_id" not in path.read_text(encoding="utf-8")
 
     def test_dry_run_does_not_modify(self, tmp_path):
         """Dry run reports changes but doesn't write."""
@@ -730,7 +721,7 @@ class TestSlideIds:
         assert path.read_text(encoding="utf-8") == text
 
     def test_collision_with_existing_id(self, tmp_path):
-        """New cell colliding with an existing slide_id gets a suffix."""
+        """New slug colliding with an existing slide_id gets a suffix."""
         text = (
             '# %% [markdown] lang="de" tags=["slide"] slide_id="methoden"\n'
             "# # Methoden\n"
@@ -743,11 +734,10 @@ class TestSlideIds:
 
         assert len(result.changes) == 1
         new_text = path.read_text(encoding="utf-8")
-        # First cell keeps "methoden", second gets "methoden-2"
         assert 'slide_id="methoden-2"' in new_text
 
     def test_multiple_collisions(self, tmp_path):
-        """Three cells with the same heading get -2 and -3 suffixes."""
+        """Three slides with the same heading get -2 and -3 suffixes."""
         text = (
             '# %% [markdown] lang="de" tags=["slide"]\n'
             "# # Beispiel\n"


### PR DESCRIPTION
## Summary

- Replace the bespoke slug logic inside `clm slides normalize`'s
  `slide_ids` operation with a delegating call to the shared engine
  behind `clm slides assign-ids`. Same rules everywhere now: EN-derived
  kebab slugs, German transliteration (`ü` → `ue`), narrative
  inheritance from the preceding slide, `!`-preserve marker, soft
  refusals for headingless slides.
- Factor `assign_ids_for_cells(cells, file_path, options)` out of
  `assign_ids_for_text` so the normalizer can fold assign-ids into its
  multi-operation pass without re-parsing the file.
- `normalize_file` / `normalize_directory` / `normalize_course` gain an
  optional `assign_options: AssignOptions | None` kwarg so callers can
  pass `--force`, `--accept-content-derived`, an LLM suggester, etc.
- `voiceover_tools._ensure_slide_ids` updated to the new signature.

## Behavior changes the user should know about

- Slugs now transliterate German characters instead of dropping them:
  `einfuehrung-in-python`, not `einf-hrung-in-python`.
- DE/EN pairs derive the slug from the **EN** cell (matches
  `assign-ids`); previously DE was the source.
- Only slide-start cells (markdown with `slide`/`subslide` tags)
  receive ids. Code cells without a slide tag and the old
  `file-stem-cell-N` fallback are gone.
- Voiceover/notes cells inherit the preceding slide's id instead of
  getting their own slug.
- Headingless slide cells produce a soft refusal (review item) under
  default options. Use `clm slides assign-ids --accept-content-derived`
  or pass `assign_options=AssignOptions(accept_content_derived=True)`
  to opt in.

## Test plan

- [x] `tests/slides/test_normalizer.py::TestSlideIds` rewritten to
  cover the new behavior — transliteration, EN-derived pairs,
  narrative inheritance, preserve marker, soft refusals.
- [x] `tests/cli/test_normalize_slides.py` — two input fixtures
  refreshed (one now uses a code cell that no operation touches, the
  other adds proper `# # Heading` syntax so `slide_ids` still produces
  changes alongside the interleaving review item).
- [x] Full sweep clean: `pytest tests/slides/ tests/cli/ tests/voiceover/` —
  2156 passed, 1 skipped, 1 xfailed (both pre-existing).
- [x] `ruff check` clean, `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)