### PR TITLE
fix(slides): assign-ids no-op when existing id matches proposal

### DIFF
--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -532,6 +532,15 @@ def _handle_slide(
             group_slug[slug_source_idx] = None
             return None
 
+    # Idempotency short-circuit: if the cell already carries the exact id
+    # we would propose, the cell is in the desired state — no write, no
+    # refusal — regardless of --accept-content-derived. Without this the
+    # EXTRACTABLE branch would refuse a cell whose author already accepted
+    # the content-derived slug on a previous run.
+    if existing and proposed_slug and strip_preserve_marker(existing) == proposed_slug:
+        group_slug[slug_source_idx] = proposed_slug
+        return proposed_slug
+
     # We have a proposal. Decide whether to write it or refuse.
     if extraction.category == Category.HEADED:
         write = True

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -142,6 +142,39 @@ class TestExtractableSlides:
         assert len(result.assignments) == 1
         assert result.assignments[0].slide_id == "rag-architecture-diagram"
 
+    def test_force_with_matching_existing_id_is_silent_no_op(self):
+        # Regression: a cell whose existing id already equals the
+        # content-derived proposal is a no-op even without
+        # --accept-content-derived. Previously this combination produced
+        # a spurious soft refusal that misled the author into thinking
+        # the flag was being ignored.
+        text = (
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="first-bullet-about-langchain"\n'
+            "#\n"
+            "# - First bullet about LangChain\n"
+            "# - Second bullet\n"
+        )
+        new_text, result = _run(text, force=True)
+        assert result.assignments == []
+        assert result.refusals == []
+        assert new_text == text
+
+    def test_force_with_matching_existing_id_on_paired_cells(self):
+        # Same regression in the DE/EN-pair case: when both siblings
+        # carry the EN-derived slug already, the run is a clean no-op.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="first-bullet-about-langchain"\n'
+            "#\n"
+            "# - Erster Punkt zu LangChain\n"
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="first-bullet-about-langchain"\n'
+            "#\n"
+            "# - First bullet about LangChain\n"
+        )
+        new_text, result = _run(text, force=True)
+        assert result.assignments == []
+        assert result.refusals == []
+        assert new_text == text
+
 
 # ---------------------------------------------------------------------------
 # Category: NON_EXTRACTABLE — hard refuse


### PR DESCRIPTION
## Summary

- `clm slides assign-ids --force` was producing a spurious soft refusal on EXTRACTABLE cells whose author had already accepted the content-derived slug on a previous run — even though the existing id already matched what the algorithm would propose. The misleading message told the user to "pass `--accept-content-derived`," but running with that flag was then a silent no-op (idempotency caught it), making the flag look ignored.
- Root cause: `_handle_slide` in `src/clm/slides/assign_ids.py` made the write-vs-refuse decision *before* the idempotency check, so an EXTRACTABLE cell whose `existing == proposed_slug` was wrongly refused unless `--accept-content-derived` was passed.
- Fix: short-circuit when `existing == proposed_slug`, regardless of flag combination. HEADED cells already had effectively this behavior (idempotency check fired before any write); this aligns EXTRACTABLE with that.

## Test plan

- [x] `pytest tests/slides/test_assign_ids.py` — 48 passed (includes 2 new regression tests covering the solo-cell and DE/EN-pair cases)
- [x] `pytest tests/slides/` — 605 passed
- [x] End-to-end smoke test against the file that exposed the bug (`PythonCourses/.../slides_020_chains_composition.py`): now reports `0 modified, 0 assigned, 0 soft refusal(s), 0 hard refusal(s).` with `--force` alone, matching reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)