### PR TITLE
fix(slides): align header_de trailing whitespace with bilingual header (#128)

### DIFF
--- a/src/clm/workers/notebook/templates_python/macros.j2
+++ b/src/clm/workers/notebook/templates_python/macros.j2
@@ -50,7 +50,7 @@
 {% if organization %}
 # <div style="text-align:center;">{{ organization }}</div>
 # <br/>
-{% endif %}
+{% endif -%}
 {% endmacro -%}
 
 {% macro header_en(title_en) -%}

--- a/tests/workers/notebook/test_header_macros.py
+++ b/tests/workers/notebook/test_header_macros.py
@@ -127,3 +127,94 @@ class TestSiblingMacrosMatchBilingual:
         en_only_start = en_only.find('# %% [markdown] lang="en"')
         assert en_only_start != -1
         assert bilingual_en_part.rstrip() == en_only[en_only_start:].rstrip()
+
+
+# Source surrounds that mimic what ``clm slides split`` produces and what the
+# original bilingual file looks like: ``# {{ macro(...) }}`` on its own line,
+# one blank line, then the next slide's cell marker. The trailing whitespace
+# between the macro's last ``# <br/>`` and that next marker is what jupytext
+# uses to split cells — and it is where Issue #128 manifested.
+_BILINGUAL_SOURCE = (
+    "# j2 from 'macros.j2' import header\n"
+    "# {{ header('Titel', 'Title') }}\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["voiceover"]\n'
+)
+_SPLIT_DE_SOURCE = (
+    "# j2 from 'macros.j2' import header_de\n"
+    "# {{ header_de('Titel') }}\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["voiceover"]\n'
+)
+_SPLIT_EN_SOURCE = (
+    "# j2 from 'macros.j2' import header_en\n"
+    "# {{ header_en('Title') }}\n"
+    "\n"
+    '# %% [markdown] lang="en" tags=["voiceover"]\n'
+)
+
+
+def _de_cell_trailing_window(rendered: str, next_marker: str) -> str:
+    """Return the bytes from the last ``# <br/>`` up to ``next_marker``."""
+    next_idx = rendered.find(next_marker)
+    assert next_idx != -1, f"missing marker {next_marker!r} in rendered text"
+    last_br = rendered.rfind("# <br/>", 0, next_idx)
+    assert last_br != -1, "missing '# <br/>' in rendered text"
+    return rendered[last_br:next_idx]
+
+
+class TestSiblingMacrosCellBoundaryParity:
+    """Byte-exact whitespace parity between bilingual and split forms.
+
+    Looser tests above use ``.rstrip()`` to absorb Jinja's final-newline
+    asymmetry. That asymmetry is not harmless once jupytext sees the file:
+    extra trailing whitespace on the DE cell migrates into the cell content
+    and shifts ``lines_to_next_cell`` (Issue #128). These tests pin the
+    exact byte window from the last ``# <br/>`` to the next cell marker so
+    any future regression in either direction is caught.
+    """
+
+    @pytest.mark.parametrize("is_notebook", [True, False])
+    @pytest.mark.parametrize("is_html", [True, False])
+    @pytest.mark.parametrize("organization", ["", "Coding-Akademie München"])
+    def test_de_cell_trailing_window_matches(
+        self, is_notebook: bool, is_html: bool, organization: str
+    ) -> None:
+        globals_ = {
+            "is_notebook": is_notebook,
+            "is_html": is_html,
+            "author": "Test Author",
+            "organization": organization,
+        }
+        bilingual = _render(_BILINGUAL_SOURCE, **globals_)
+        split_de = _render(_SPLIT_DE_SOURCE, **globals_)
+        # In bilingual the DE cell's "next cell marker" is the EN-half it embeds;
+        # in split DE it is the next slide marker from the source surround.
+        bl_window = _de_cell_trailing_window(bilingual, '# %% [markdown] lang="en"')
+        de_window = _de_cell_trailing_window(
+            split_de, '# %% [markdown] lang="de" tags=["voiceover"]'
+        )
+        assert bl_window == de_window
+
+    @pytest.mark.parametrize("is_notebook", [True, False])
+    @pytest.mark.parametrize("is_html", [True, False])
+    @pytest.mark.parametrize("organization", ["", "Coding-Akademie München"])
+    def test_en_cell_trailing_window_matches(
+        self, is_notebook: bool, is_html: bool, organization: str
+    ) -> None:
+        globals_ = {
+            "is_notebook": is_notebook,
+            "is_html": is_html,
+            "author": "Test Author",
+            "organization": organization,
+        }
+        bilingual = _render(_BILINGUAL_SOURCE, **globals_)
+        split_en = _render(_SPLIT_EN_SOURCE, **globals_)
+        # In bilingual the EN cell's next marker is the post-macro source marker.
+        bl_window = _de_cell_trailing_window(
+            bilingual, '# %% [markdown] lang="de" tags=["voiceover"]'
+        )
+        en_window = _de_cell_trailing_window(
+            split_en, '# %% [markdown] lang="en" tags=["voiceover"]'
+        )
+        assert bl_window == en_window


### PR DESCRIPTION
## Summary

- Strip the trailing newline emitted by `header_de`'s outer `{% endif %}` in `templates_python/macros.j2` so the macro ends with `# <br/>\n` — matching the byte window the bilingual `header(de, en)` macro emits at the DE/EN boundary.
- Replace the existing `.rstrip()`-based parity test (which masked this bug) with a byte-exact check of the window from the last `# <br/>` to the next cell marker, parameterized over the 8 combinations of `is_notebook` / `is_html` / `organization`. EN-side gets an analogous (already-passing) regression check.

## Root cause

In `header(de, en)`, the DE half is followed *inside the macro* by `{% endif %}` + a literal blank line + the EN cell marker (2 `\n`s of intra-macro padding). In `header_de(de)`, the macro ended at `{% endif %}`, so its closing `\n` plus the post-macro source's blank line produced **one extra** `\n` between the DE cell content and the next cell marker.

jupytext absorbed that extra `\n` into the cell content (`"<br/>\n", "\n"` source entries) and shifted `lines_to_next_cell` off the title cell onto its successor — exactly the diff in #128.

EN side wasn't affected because the EN half of `header` *is* the last thing in the macro, so its trailing `\n` combines with the post-macro source exactly as `header_en` does. Only `header_de` needed adjusting; touching `header_en` symmetrically would have *broken* EN parity.

## Verification

Rendered all 8 combinations of `is_notebook` × `is_html` × `organization`:

| Form | Before | After |
|---|---|---|
| Bilingual DE half | `\n\n\n` | `\n\n\n` |
| Split DE (`header_de`) | `\n\n\n\n` (off by one) | `\n\n\n` ✓ |
| Bilingual EN half | `\n\n\n\n` | `\n\n\n\n` |
| Split EN (`header_en`) | `\n\n\n\n` ✓ | `\n\n\n\n` ✓ |

Pre-commit hooks (ruff lint, ruff format, fast pytest) all pass. `tests/workers/notebook/` (515 tests) and `tests/slides/` (combined 624 with header macros) all pass locally.

## Test plan

- [x] Existing `test_header_macros.py` parity tests still pass.
- [x] New `TestSiblingMacrosCellBoundaryParity` covers DE and EN sides across 8 globals combinations.
- [x] `tests/workers/notebook/` and `tests/slides/` pass locally.
- [ ] CI: full test matrix.
- [ ] Phase D pilot in PythonCourses: `diff -q $(build_split) $(build_bilingual)` should now need only the nbformat-`id` normalizer (the goal #128 stated).

## Out of scope

- The reporter's alternative (have `clm slides split` emit a different post-macro source surround) would also work but pushes responsibility into the split tool and complicates round-tripping. Macro-level fix is more contained.
- `clm info` topics unchanged: macros are internal templates, not a documented spec surface.

Fixes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)