### PR TITLE
fix(http-replay): restore across-build cache hits for HTTP-replay topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **`execution_cache_hash` no longer folds cassette bytes into the
+  cache key.** Folding cassette content into the hash was meant to
+  invalidate the executed-notebook cache after a cassette refresh, but
+  in practice it created an unfixable cache-miss loop:
+  `compute_other_files` reads the cassette at payload construction
+  (pre-execution), while record-capable modes
+  (`once`/`new-episodes`/`refresh`) rewrite the cassette
+  post-execution — so the next build's lookup hash uses the
+  post-execution cassette and never matches the prior build's stored
+  hash. The same disagreement fires the first time a cassette
+  transitions from missing to populated, and whenever `.gitattributes`
+  normalizes CRLF↔LF between builds. The cache key now uses only
+  `prog_lang:language:data`; users who want re-execution after a
+  manual cassette edit should use `--ignore-cache`. The
+  build-scoped cassette-snapshot mechanism introduced in 1.6.0
+  (`_build_cassette_snapshots` / `_snapshot_cassettes_for_build`) is
+  removed since it only existed to keep the within-build hash stable.
+
 ### Fixed
+
+- **HTTP-replay cassettes now write LF line endings on every
+  platform.** `http_replay_cassette._atomic_write_text` previously
+  called `Path.write_text` without `newline=`, defaulting to
+  `os.linesep` (i.e. `\r\n` on Windows). With a `.gitattributes`
+  setting of `* text=auto eol=lf` (the recommended layout for course
+  repositories), that produced a permanent flip-flop: each build
+  wrote CRLF, each `git checkout`/`restore` rewrote LF, and the next
+  build wrote CRLF again. Cassettes are now written LF-only.
 
 - **Cassette merge discards partial chains from aborted recording
   sessions (issue #115).** Previously, a kernel that died mid-cell —

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -101,15 +101,6 @@ class Course(NotebookMixin):
     # in `section_selection.resolved_indices` (in declared order). When
     # None, all sections in the spec are built.
     section_selection: SectionSelection | None = None
-    # Build-scoped snapshot of HTTP-replay cassette bytes, keyed by the
-    # canonical (resolved) cassette path on disk. Populated by
-    # :meth:`_snapshot_cassettes_for_build` at the start of ``process_all``/
-    # ``process_file`` so that every payload constructed during a single
-    # build invocation sees byte-identical cassette contents — even when
-    # vcrpy in ``new-episodes``/``once``/``refresh`` mode appends new
-    # interactions to the cassette mid-build (Stage 3 → Stage 4 drift).
-    # Consumed by ``ProcessNotebookOperation.compute_other_files``.
-    _build_cassette_snapshots: dict[Path, bytes] = Factory(dict)
 
     @classmethod
     def from_spec(
@@ -310,59 +301,14 @@ class Course(NotebookMixin):
             logger.warning(f"Cannot process file: not in course: {path}")
             return
 
-        # Same ordering as process_all: sweep orphan staging cassettes
-        # *before* snapshotting, so the snapshot reflects the post-sweep
-        # canonical (orphan interactions folded in, staging files removed).
+        # Sweep orphan staging cassettes (see ``process_all``).
         self._sweep_orphan_cassette_staging_files()
-
-        # Snapshot cassettes so every payload built during this invocation
-        # sees the same bytes even if the kernel mid-build appends new
-        # interactions to the cassette on disk.
-        self._snapshot_cassettes_for_build()
 
         # Process file for each output target
         for target in self.output_targets:
             op = await file.get_processing_operation(target.output_root, target=target)
             await op.execute(backend)
             logger.debug(f"Processed file {path} for target '{target.name}'")
-
-    def _snapshot_cassettes_for_build(self) -> None:
-        """Capture cassette bytes once per build, keyed by canonical path.
-
-        Stage 3 (Recording HTML) and Stage 4 (Completed/Trainer/Partial
-        HTML) construct independent payloads that both fold cassette bytes
-        into :py:meth:`NotebookPayload.execution_cache_hash`. When vcrpy
-        runs in ``new-episodes``/``once``/``refresh`` mode and actually
-        records something new, the cassette file on disk changes between
-        Stage 3 and Stage 4, so the two stages would otherwise compute
-        different cache keys and miss the executed-notebook cache.
-
-        Taking the snapshot at the start of ``process_all`` (or
-        ``process_file``) and consulting it from
-        :py:meth:`ProcessNotebookOperation.compute_other_files` keeps the
-        bytes consistent across the whole build, regardless of which stage
-        constructs the payload first.
-        """
-        from clm.core.course_files.notebook_file import NotebookFile
-
-        self._build_cassette_snapshots.clear()
-        if not self.http_replay_mode or self.http_replay_mode == "disabled":
-            return
-        for file in self.files:
-            if not isinstance(file, NotebookFile):
-                continue
-            if not file.http_replay:
-                continue
-            cassette = file.cassette_path
-            if cassette is None:
-                continue
-            key = cassette.resolve()
-            if key in self._build_cassette_snapshots:
-                continue
-            try:
-                self._build_cassette_snapshots[key] = cassette.read_bytes()
-            except OSError as exc:
-                logger.warning("Could not snapshot cassette %s for build: %s", cassette, exc)
 
     async def process_all(self, backend: Backend):
         """Process all files for all output targets."""
@@ -378,17 +324,7 @@ class Course(NotebookMixin):
         # the file. The sweep folds the orphan's recorded interactions
         # into the canonical cassette via the existing dedup helper, so
         # no recordings are lost.
-        #
-        # The sweep must run *before* the snapshot below — otherwise the
-        # snapshot would capture the pre-sweep canonical and Stage 3's
-        # workers would write executed_notebooks under that hash while
-        # Stage 4 reads under the post-sweep hash.
         self._sweep_orphan_cassette_staging_files()
-
-        # Snapshot cassette bytes once per build so Stage 3 and Stage 4
-        # see the same cassette contents even if vcrpy appends new
-        # interactions mid-build (see _snapshot_cassettes_for_build).
-        self._snapshot_cassettes_for_build()
 
         for stage in execution_stages():
             logger.debug(f"Processing stage {stage}")

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -118,28 +118,7 @@ class ProcessNotebookOperation(Operation):
             cassette = self.input_file.cassette_path
             cassette_name = self.input_file.cassette_relative_name
             if cassette is not None and cassette_name is not None:
-                # Prefer the build-scoped snapshot taken at the start of
-                # ``course.process_all()``/``process_file()``. Without
-                # this, Stage 3 (Recording HTML) and Stage 4
-                # (Completed/Trainer/Partial HTML) can hash different
-                # cassette bytes for the same notebook when vcrpy in
-                # ``new-episodes``/``once``/``refresh`` mode appends new
-                # interactions to the cassette during Stage 3, causing
-                # Stage 4 to miss the executed-notebook cache and
-                # re-execute the kernel unnecessarily. Falls back to
-                # reading the file directly so call sites that construct
-                # operations outside of ``process_all``/``process_file``
-                # (tests, ad-hoc tools) keep working.
-                snapshots = getattr(self.input_file.course, "_build_cassette_snapshots", None)
-                snapshot_bytes: bytes | None = None
-                if snapshots:
-                    try:
-                        snapshot_bytes = snapshots.get(cassette.resolve())
-                    except OSError:
-                        snapshot_bytes = None
-                if snapshot_bytes is None:
-                    snapshot_bytes = cassette.read_bytes()
-                other_files[cassette_name] = b64encode(snapshot_bytes)
+                other_files[cassette_name] = b64encode(cassette.read_bytes())
 
         return other_files
 

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -73,24 +73,22 @@ class NotebookPayload(Payload):
         Speaker and Completed HTML share the same executed notebook.
         Completed HTML is just Speaker HTML with "notes" cells filtered out.
 
-        When ``http_replay_mode`` is active, the cassette contents are
-        folded into the hash so that refreshing the cassette invalidates
-        the cached executed notebook for that topic.
+        The cassette contents are intentionally NOT folded into the hash.
+        Doing so was tried earlier but produced an unfixable cache-miss
+        loop: ``compute_other_files`` reads the cassette at payload
+        construction (before the kernel runs), while record-capable
+        modes (``once``/``new-episodes``/``refresh``) write the cassette
+        after the kernel runs. So the next build's lookup hash uses the
+        post-execution cassette and never matches the prior build's
+        stored hash. The same issue surfaces the first time a cassette
+        is created (missing → populated) and whenever ``.gitattributes``
+        normalizes CRLF↔LF between builds. Users who want to invalidate
+        cached execution after a manual cassette edit should use
+        ``--ignore-cache``.
         """
-        # Use prog_lang:language:data (without kind or format)
-        # Format is excluded because we only cache HTML execution results
+        # Use prog_lang:language:data (without kind or format).
+        # Format is excluded because we only cache HTML execution results.
         hash_data = f"{self.prog_lang}:{self.language}:{self.data}".encode()
-        if (
-            self.http_replay_mode
-            and self.http_replay_mode != "disabled"
-            and self.http_replay_cassette_name
-        ):
-            # Cassette bytes are already present in ``other_files``
-            # (base64-encoded) when the topic opted in; an empty default
-            # keeps the hash stable if the cassette is missing at build
-            # time (e.g. first ``once`` run before recording).
-            cassette_bytes = self.other_files.get(self.http_replay_cassette_name, b"")
-            hash_data += b":cassette:" + cassette_bytes
         return hashlib.sha256(hash_data).hexdigest()
 
     def output_metadata(self) -> str:

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -361,10 +361,18 @@ def _atomic_write_text(target: Path, text: str) -> None:
     Writes to a temporary file in the same directory and then calls
     :func:`os.replace`, which is atomic on POSIX and Windows. This
     prevents a concurrent reader from observing a half-written cassette.
+
+    ``newline="\\n"`` is required: without it ``Path.write_text`` applies
+    the platform default (``os.linesep``), so Windows writes ``\\r\\n``.
+    Cassettes committed via a repository with ``* text=auto eol=lf`` in
+    ``.gitattributes`` are then rewritten LF→CRLF on every build and
+    CRLF→LF on every subsequent ``git checkout``/``restore``, producing
+    spurious "modified" rows in ``git status`` and (more importantly)
+    perturbing the cassette bytes between builds.
     """
     tmp = target.parent / f"{target.name}.tmp-{uuid.uuid4().hex}"
     try:
-        tmp.write_text(text, encoding="utf-8")
+        tmp.write_text(text, encoding="utf-8", newline="\n")
         os.replace(tmp, target)
     finally:
         if tmp.exists():

--- a/tests/core/course_files/notebook_file_test.py
+++ b/tests/core/course_files/notebook_file_test.py
@@ -496,21 +496,19 @@ class TestProcessNotebookOperationHttpReplay:
         assert "slides_replay.http-cassette.yaml" in other
 
 
-class TestBuildScopedCassetteSnapshot:
-    """Stage 3 / Stage 4 must hash the same cassette bytes within a build.
+class TestExecutionCacheHashCassetteIndependence:
+    """``execution_cache_hash`` must not depend on cassette bytes.
 
-    Recording HTML (Stage 3) and Completed/Trainer/Partial HTML (Stage 4)
-    construct independent ``NotebookPayload`` instances. Both fold the
-    cassette into ``execution_cache_hash`` when ``http_replay`` is active.
-    If vcrpy in ``new-episodes``/``once``/``refresh`` mode appends new
-    interactions during Stage 3 execution, the cassette file on disk
-    changes before Stage 4 constructs its payloads — and the two stages
-    end up computing different hashes, missing the ``executed_notebooks``
-    cache and forcing redundant kernel re-execution.
+    Folding cassette content into the hash produces an unfixable
+    cache-miss loop: build 1's payload is built before the kernel writes
+    the cassette, so build 1 stores under hash(pre-execution cassette);
+    build 2's payload is built after, so build 2 looks up under
+    hash(post-execution cassette) and misses. The same disagreement
+    fires the first time a cassette transitions from missing to
+    populated, and whenever ``.gitattributes`` normalizes CRLF↔LF
+    between builds.
 
-    The fix is a build-scoped snapshot of cassette bytes, captured at the
-    start of ``course.process_all()``, and consulted by
-    :py:meth:`ProcessNotebookOperation.compute_other_files`.
+    These tests pin the across-build cache-hit invariant.
     """
 
     def _build_course_with_replay_notebook(self, tmp_path: Path, mode: str | None = "new-episodes"):
@@ -566,165 +564,83 @@ class TestBuildScopedCassetteSnapshot:
             http_replay_mode=mode,
         )
 
-    async def test_snapshot_keeps_hash_stable_across_mid_build_cassette_mutation(self, tmp_path):
-        """Stage 3 and Stage 4 must agree on the cassette hash even when the
-        cassette file on disk changes between their payload constructions.
-
-        Without the snapshot, mutating the cassette between the two
-        payload builds would change ``execution_cache_hash`` — masking
-        Stage 4's ability to reuse Stage 3's executed-notebook cache.
-        """
+    async def test_hash_survives_mid_build_cassette_mutation(self, tmp_path):
+        """Stage 3 → Stage 4: cassette bytes may change but hash must not."""
         course, nb, cassette = self._build_course_with_replay_notebook(tmp_path)
 
-        # Start the build: take the snapshot (mirrors what
-        # ``course.process_all`` does at entry).
-        course._snapshot_cassettes_for_build()
-
-        # Stage 3: build Recording HTML payload at time T1.
         stage3_op = self._make_op(nb, tmp_path, "new-episodes", "recording")
         stage3_payload = await stage3_op.payload()
         stage3_hash = stage3_payload.execution_cache_hash()
 
         # Simulate vcrpy appending new interactions during Stage 3
-        # execution, just like ``merge_staging_into_canonical`` rewrites
-        # the canonical cassette in its ``finally`` block before Stage 4.
+        # execution.
         cassette.write_bytes(b"interactions:\n- request: stage3\n- request: stage4-new\n")
 
-        # Stage 4: build Completed HTML payload at time T2.
         stage4_op = self._make_op(nb, tmp_path, "new-episodes", "completed")
         stage4_payload = await stage4_op.payload()
         stage4_hash = stage4_payload.execution_cache_hash()
 
-        # The invariant: same notebook + same build → same execution hash.
-        # On ``master`` (no snapshot), these differ because Stage 4 hashes
-        # the post-mutation cassette bytes. With the snapshot they agree.
-        assert stage3_hash == stage4_hash, (
-            "Stage 3 and Stage 4 hashed different cassette bytes within "
-            "the same build invocation; executed_notebooks cache lookups "
-            "in Stage 4 would miss and force redundant kernel execution. "
-            "The build-scoped cassette snapshot is the fix."
-        )
+        assert stage3_hash == stage4_hash
 
-        # Both payloads must carry the pre-mutation bytes (b64-encoded).
-        from base64 import b64decode
+    async def test_hash_survives_cassette_missing_to_present(self, tmp_path):
+        """Build 1 (cassette missing) vs build 2 (cassette present): same hash.
 
-        cassette_key = "slides_replay.http-cassette.yaml"
-        assert b64decode(stage3_payload.other_files[cassette_key]) == (
-            b"interactions:\n- request: stage3\n"
-        )
-        assert b64decode(stage4_payload.other_files[cassette_key]) == (
-            b"interactions:\n- request: stage3\n"
-        )
-
-    async def test_without_snapshot_hashes_diverge_when_cassette_mutates(self, tmp_path):
-        """Sanity check: when the snapshot is empty the bug reproduces.
-
-        This pins the failure mode the fix is preventing and would be the
-        baseline behavior on ``master`` (where no snapshot exists at all).
+        This is the failure mode the user hit: build 1 creates the
+        cassette from scratch, commits it, and build 2 must read it from
+        cache. Before this fix, build 1 stored under hash(empty
+        cassette) and build 2 looked up under hash(committed cassette)
+        — never matching.
         """
         course, nb, cassette = self._build_course_with_replay_notebook(tmp_path)
 
-        # Deliberately do NOT call _snapshot_cassettes_for_build: this
-        # mirrors the pre-fix behavior where ``compute_other_files`` reads
-        # cassette bytes lazily at payload-construction time.
-        assert course._build_cassette_snapshots == {}
+        # Build 1: cassette does not exist on disk yet.
+        cassette.unlink()
+        op1 = self._make_op(nb, tmp_path, "new-episodes", "recording")
+        hash_build1 = (await op1.payload()).execution_cache_hash()
 
-        stage3_op = self._make_op(nb, tmp_path, "new-episodes", "recording")
-        stage3_payload = await stage3_op.payload()
+        # Simulate build 1 finishing: cassette is now on disk.
+        cassette.write_bytes(b"interactions:\n- request: recorded\n")
 
-        cassette.write_bytes(b"interactions:\n- request: stage3\n- request: stage4-new\n")
+        # Build 2: same notebook, cassette present.
+        op2 = self._make_op(nb, tmp_path, "new-episodes", "recording")
+        hash_build2 = (await op2.payload()).execution_cache_hash()
 
-        stage4_op = self._make_op(nb, tmp_path, "new-episodes", "completed")
-        stage4_payload = await stage4_op.payload()
-
-        assert stage3_payload.execution_cache_hash() != stage4_payload.execution_cache_hash(), (
-            "Without the build snapshot, mid-build cassette mutation must "
-            "change the execution hash — this is the bug the snapshot fixes."
+        assert hash_build1 == hash_build2, (
+            "execution_cache_hash must not depend on whether the "
+            "cassette existed at payload-construction time."
         )
 
-    async def test_snapshot_no_op_when_replay_disabled(self, tmp_path):
-        """``disabled``/``None`` modes must not populate the snapshot dict."""
-        for mode in (None, "disabled"):
-            course, _nb, _cassette = self._build_course_with_replay_notebook(
-                tmp_path,
-                mode=mode,  # type: ignore[arg-type]
-            )
-            course._snapshot_cassettes_for_build()
-            assert course._build_cassette_snapshots == {}
+    async def test_hash_survives_crlf_lf_flip(self, tmp_path):
+        """LF↔CRLF rewrites of the cassette must not change the cache key.
 
-    async def test_process_all_populates_snapshot(self, tmp_path):
-        """``Course.process_all`` must take the snapshot at entry."""
-        course, _nb, cassette = self._build_course_with_replay_notebook(tmp_path)
-        assert course._build_cassette_snapshots == {}
-
-        backend = DummyBackend()
-        await course.process_all(backend)
-
-        assert cassette.resolve() in course._build_cassette_snapshots
-        assert course._build_cassette_snapshots[cassette.resolve()] == (
-            b"interactions:\n- request: stage3\n"
-        )
-
-    async def test_stage3_and_stage4_payloads_agree_within_process_all(self, tmp_path, monkeypatch):
-        """End-to-end behavior check.
-
-        Drive a real ``course.process_all`` build through a recording
-        backend that (a) captures every payload it sees and (b) mutates
-        the cassette on disk while Stage 3 is in flight. Without the
-        build-scoped snapshot, the Recording (Stage 3) and Completed
-        (Stage 4) payloads would carry different cassette bytes and
-        therefore different ``execution_cache_hash`` values — which is the
-        exact bug this fix prevents.
+        Git's ``eol=lf`` smudge filter rewrites cassettes on checkout;
+        before this fix that silently invalidated the executed-notebook
+        cache.
         """
-        from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+        course, nb, cassette = self._build_course_with_replay_notebook(tmp_path)
 
-        course, _nb, cassette = self._build_course_with_replay_notebook(tmp_path)
+        cassette.write_bytes(b"interactions:\n- request: one\n- request: two\n")
+        op_lf = self._make_op(nb, tmp_path, "new-episodes", "recording")
+        hash_lf = (await op_lf.payload()).execution_cache_hash()
 
-        # Recording backend that mutates the cassette mid-Stage-3, before
-        # Stage 4 ever runs. This simulates vcrpy appending new
-        # interactions during Recording HTML execution.
-        seen: list[NotebookPayload] = []
+        cassette.write_bytes(b"interactions:\r\n- request: one\r\n- request: two\r\n")
+        op_crlf = self._make_op(nb, tmp_path, "new-episodes", "recording")
+        hash_crlf = (await op_crlf.payload()).execution_cache_hash()
 
-        class _MutatingBackend(DummyBackend):
-            async def execute_operation(self, operation, payload):  # type: ignore[override]
-                if isinstance(payload, NotebookPayload):
-                    seen.append(payload)
-                    # Mutate the cassette only when Stage 3's Recording
-                    # HTML payload runs, matching the real-world failure
-                    # mode (vcrpy appends interactions during Recording
-                    # HTML execution; ``merge_staging_into_canonical``
-                    # rewrites the cassette in a ``finally`` block before
-                    # Stage 4 starts).
-                    if payload.kind == "recording" and payload.format == "html":
-                        cassette.write_bytes(
-                            b"interactions:\n- request: stage3\n- request: stage4-new\n"
-                        )
-                await super().execute_operation(operation, payload)
+        assert hash_lf == hash_crlf
 
-        await course.process_all(_MutatingBackend())
+    async def test_hash_survives_replay_mode_toggle(self, tmp_path):
+        """Whether replay is on or off, the cache key over source data
+        is the same."""
+        course, nb, _cassette = self._build_course_with_replay_notebook(tmp_path)
 
-        # Find the recording + completed payloads for the English HTML
-        # output — both are derived from the same notebook within the same
-        # build invocation.
-        recording = [p for p in seen if p.kind == "recording" and p.format == "html"]
-        completed = [p for p in seen if p.kind == "completed" and p.format == "html"]
-        assert recording and completed, (
-            "Expected the build to produce at least one Recording and one "
-            "Completed payload for the .py notebook."
-        )
+        op_replay = self._make_op(nb, tmp_path, "replay", "recording")
+        op_disabled = self._make_op(nb, tmp_path, "disabled", "recording")
 
-        # Pair them by language and assert the execution hash matches.
-        # Without the snapshot, the Completed payload (Stage 4, after the
-        # cassette mutation) would hash different bytes and miss the
-        # executed_notebooks cache — forcing redundant kernel runs.
-        for rec in recording:
-            for comp in completed:
-                if rec.language == comp.language:
-                    assert rec.execution_cache_hash() == comp.execution_cache_hash(), (
-                        f"Stage 3 and Stage 4 produced different execution "
-                        f"hashes for language={rec.language!r}; this would "
-                        f"miss the executed_notebooks cache."
-                    )
+        hash_replay = (await op_replay.payload()).execution_cache_hash()
+        hash_disabled = (await op_disabled.payload()).execution_cache_hash()
+
+        assert hash_replay == hash_disabled
 
 
 class TestGetOperationStage:

--- a/tests/infrastructure/messaging/test_notebook_classes.py
+++ b/tests/infrastructure/messaging/test_notebook_classes.py
@@ -109,7 +109,19 @@ class TestNotebookPayload:
 
 
 class TestExecutionCacheHash:
-    """Test execution_cache_hash folds cassette contents when replay is active."""
+    """Cassette bytes are intentionally NOT folded into the hash.
+
+    Folding them caused an unfixable cache-miss loop:
+    ``compute_other_files`` reads the cassette at payload construction
+    (pre-execution), while record-capable modes
+    (``once``/``new-episodes``/``refresh``) rewrite the cassette
+    post-execution. The next build's lookup hash uses the post-execution
+    cassette and never matches the prior build's stored hash. The same
+    issue surfaces the first time a cassette is created (missing →
+    populated) and whenever ``.gitattributes`` normalizes CRLF↔LF
+    between builds. Users who want re-execution after manual cassette
+    edits should use ``--ignore-cache``.
+    """
 
     def _payload(self, **overrides):
         defaults = {
@@ -132,39 +144,51 @@ class TestExecutionCacheHash:
         p2 = self._payload()
         assert p1.execution_cache_hash() == p2.execution_cache_hash()
 
-    def test_hash_changes_when_cassette_bytes_change(self):
-        """Refreshing the cassette must invalidate the cache key."""
+    def test_hash_invariant_under_cassette_bytes_change(self):
+        """Cassette growth must NOT change the cache key.
+
+        Pins the across-build cache-hit invariant: build 1 hashes (and
+        stores) under cassette state A; vcrpy then writes state B;
+        build 2 hashes under state B; both must yield the same hash so
+        the lookup hits.
+        """
         p_old = self._payload(
-            http_replay_mode="replay",
+            http_replay_mode="new-episodes",
             http_replay_cassette_name="slides.http-cassette.yaml",
             other_files={"slides.http-cassette.yaml": b"old-cassette-bytes"},
         )
         p_new = self._payload(
-            http_replay_mode="replay",
+            http_replay_mode="new-episodes",
             http_replay_cassette_name="slides.http-cassette.yaml",
             other_files={"slides.http-cassette.yaml": b"new-cassette-bytes"},
         )
-        assert p_old.execution_cache_hash() != p_new.execution_cache_hash()
+        assert p_old.execution_cache_hash() == p_new.execution_cache_hash()
 
-    def test_hash_ignores_cassette_when_mode_disabled(self):
-        """``disabled`` mode must not affect the hash."""
-        p_none = self._payload()
-        p_disabled = self._payload(
-            http_replay_mode="disabled",
+    def test_hash_invariant_under_missing_to_present_cassette(self):
+        """First build (cassette missing) must produce the same hash as
+        the second build (cassette present)."""
+        p_first = self._payload(
+            http_replay_mode="new-episodes",
             http_replay_cassette_name="slides.http-cassette.yaml",
-            other_files={"slides.http-cassette.yaml": b"does-not-matter"},
+            other_files={},  # cassette not on disk yet
         )
-        assert p_none.execution_cache_hash() == p_disabled.execution_cache_hash()
+        p_second = self._payload(
+            http_replay_mode="new-episodes",
+            http_replay_cassette_name="slides.http-cassette.yaml",
+            other_files={"slides.http-cassette.yaml": b"recorded-interactions"},
+        )
+        assert p_first.execution_cache_hash() == p_second.execution_cache_hash()
 
-    def test_hash_differs_between_replay_and_no_replay(self):
-        """Turning replay on must change the hash even with same source."""
+    def test_hash_invariant_across_replay_mode(self):
+        """The hash must not depend on whether replay is on, since the
+        cache key is over source data only."""
         p_plain = self._payload()
         p_replay = self._payload(
             http_replay_mode="replay",
             http_replay_cassette_name="slides.http-cassette.yaml",
             other_files={"slides.http-cassette.yaml": b"cassette"},
         )
-        assert p_plain.execution_cache_hash() != p_replay.execution_cache_hash()
+        assert p_plain.execution_cache_hash() == p_replay.execution_cache_hash()
 
 
 class TestNotebookResult:

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2562,6 +2562,37 @@ class TestCassetteMerge:
         assert "http://example/old" in content
         assert "http://example/new" in content
 
+    def test_merge_writes_lf_endings_on_every_platform(self, tmp_path):
+        """Cassette files must have LF endings even on Windows.
+
+        ``Path.write_text`` without ``newline=`` defaults to
+        ``os.linesep`` (``\\r\\n`` on Windows). With ``.gitattributes``
+        forcing ``eol=lf``, that produces a permanent LF↔CRLF
+        flip-flop: builds write CRLF, ``git checkout`` writes LF, next
+        build writes CRLF again, and so on.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("filelock")
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+        )
+
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = tmp_path / "slides.http-cassette.yaml.staging-worker"
+        _write_cassette(staging, uri="http://example/a", body="A")
+        _touch_completion_marker(staging)
+
+        paths = CassettePaths(canonical=canonical, staging=staging)
+        merge_staging_into_canonical(paths)
+
+        raw = canonical.read_bytes()
+        assert b"\r\n" not in raw, (
+            "Canonical cassette contains CRLF line endings on this platform. "
+            "_atomic_write_text must pass newline='\\n' to Path.write_text "
+            "so cassettes are LF-only regardless of os.linesep."
+        )
+
     def test_concurrent_merges_do_not_lose_interactions(self, tmp_path):
         """Two workers merging different recordings must produce a union, not a last-writer-wins."""
         pytest.importorskip("vcr")


### PR DESCRIPTION
## Summary

Fixes two compounding bugs that caused every rebuild of an HTTP-replay course to silently miss the executed-notebook cache, forcing every notebook with a cassette to re-execute even when the source hadn't changed. Reported by @hoelzl after observing all seven LangChain decks in `module_550_ml_azav` rebuilding on a no-source-change second build, with the cassettes coming back as "modified" in `git status` despite having just been committed.

## Root causes

**1. `execution_cache_hash` folded cassette bytes into the cache key.** `compute_other_files` reads the cassette at payload-construction time (pre-execution), but record-capable modes (`once` / `new-episodes` / `refresh`) rewrite the cassette afterwards. So build N's stored hash uses the pre-execution cassette state and build N+1's lookup hash uses the post-execution state — they cannot match. The same disagreement fires:

- the first time a cassette is created (missing → populated),
- whenever vcrpy records new episodes between builds (cassette grows),
- whenever `git checkout` re-smudges the file under `* text=auto eol=lf`.

Reproduced end-to-end against the user's `clm_cache.db`: build 2's stored hash matched only when computed from the committed `.py` text plus the cassette converted to CRLF — confirming build 1 had stored under `hash(empty cassette)` while build 2 looked up under `hash(populated CRLF cassette)`.

**2. `_atomic_write_text` wrote CRLF on Windows.** `Path.write_text` without a `newline=` argument defaults to `os.linesep` (`\r\n` on Windows). Combined with a course repo's `* text=auto eol=lf` `.gitattributes` setting, every build wrote CRLF, every `git checkout`/`restore` rewrote LF, and `git status` permanently flapped.

## Fix

- `execution_cache_hash` now keys on `prog_lang:language:data` only. `--ignore-cache` is the documented escape hatch for re-running after a manual cassette edit.
- `_atomic_write_text` passes `newline="\n"`. Cassettes are LF-only on every platform.
- Removed the now-dead `_build_cassette_snapshots` / `_snapshot_cassettes_for_build` plumbing (introduced in 1.6.0 to stabilise the within-build hash that no longer references cassette bytes).

Net **−81 lines** across `src/` and `tests/`.

## Test plan

- [x] `pytest` (fast suite) — 5521 passed, 1 skipped, 1 xfailed
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] New regression tests pin both invariants:
  - `execution_cache_hash` is stable under cassette growth, missing→populated transitions, CRLF↔LF flips, and replay-mode toggles.
  - `merge_staging_into_canonical` writes LF endings even on Windows.
- [ ] On a course repo affected by the bug: delete the modified cassettes, `git restore` them (to pick up the LF version from HEAD), then rebuild — expect a clean cache hit and clean `git status`.

## Notes for reviewers

The CHANGELOG entry under `Changed` explains the cache-key rationale and the `Fixed` entry covers the LF write, so the *why* survives in the repo and this doesn't get re-introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)