### PR TITLE
feat(outline): show H1 titles for disabled sections, add --sections-only

### DIFF
--- a/src/clm/cli/commands/outline.py
+++ b/src/clm/cli/commands/outline.py
@@ -13,8 +13,45 @@ import click
 from clm.core.course import Course
 from clm.core.course_files.notebook_file import NotebookFile
 from clm.core.course_paths import resolve_course_paths
-from clm.core.course_spec import CourseSpec, CourseSpecError, SectionSpec
+from clm.core.course_spec import CourseSpec, CourseSpecError, SectionSpec, TopicSpec
+from clm.core.utils.notebook_utils import find_notebook_titles
 from clm.core.utils.text_utils import sanitize_file_name
+from clm.infrastructure.utils.path_utils import is_slides_file
+
+
+def _disabled_topic_slides(
+    course: Course, topic_spec: TopicSpec, language: str
+) -> list[tuple[str, str]] | None:
+    """Return ``(file_name, title)`` pairs for slide files in a disabled topic.
+
+    Resolves ``topic_spec.id`` against the course's filesystem-wide topic map
+    and reads the H1 header from each slide file the same way
+    :class:`NotebookFile` does. Returns ``None`` when the topic id cannot be
+    resolved (so callers can fall back to the legacy ``<topic_id>`` display).
+    Returns an empty list when the topic resolves but contains no slide files.
+    """
+    topic_path = course._topic_path_map.get(topic_spec.id)
+    if topic_path is None:
+        return None
+
+    slide_paths: list[Path] = []
+    if topic_path.is_file():
+        if is_slides_file(topic_path):
+            slide_paths.append(topic_path)
+    elif topic_path.is_dir():
+        for child in sorted(topic_path.iterdir()):
+            if child.is_file() and is_slides_file(child):
+                slide_paths.append(child)
+
+    results: list[tuple[str, str]] = []
+    for path in slide_paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+            title = find_notebook_titles(text, default=path.stem)
+            results.append((path.name, title[language]))
+        except (OSError, ValueError):
+            results.append((path.name, path.stem))
+    return results
 
 
 def generate_outline(
@@ -22,6 +59,7 @@ def generate_outline(
     language: str,
     *,
     disabled_sections: list[SectionSpec] | None = None,
+    sections_only: bool = False,
 ) -> str:
     """Generate a Markdown outline for a course.
 
@@ -32,6 +70,8 @@ def generate_outline(
             ``(disabled)`` marker. Interleaved into the output by declared
             order using ``id`` or name matching when possible, otherwise
             appended at the end.
+        sections_only: When True, emit only section headings (no topic
+            bullet points).
 
     Returns:
         Markdown string with the course outline
@@ -45,20 +85,33 @@ def generate_outline(
     for section in course.sections:
         lines.append(f"## {section.name[language]}")
         lines.append("")
-        for notebook in section.notebooks:
-            if isinstance(notebook, NotebookFile):
-                title = notebook.title[language]
-                lines.append(f"- {title}")
-        lines.append("")
+        if not sections_only:
+            for notebook in section.notebooks:
+                if isinstance(notebook, NotebookFile):
+                    title = notebook.title[language]
+                    lines.append(f"- {title}")
+            lines.append("")
 
     for section_spec in disabled_sections or []:
         lines.append(f"## {section_spec.name[language]} (disabled)")
         lines.append("")
-        # List declared topic IDs for visibility (they may not exist).
-        for topic_spec in section_spec.topics:
-            lines.append(f"- {topic_spec.id} (disabled)")
+        if sections_only:
+            continue
         if not section_spec.topics:
             lines.append("- (no topics declared)")
+            lines.append("")
+            continue
+        for topic_spec in section_spec.topics:
+            slides = _disabled_topic_slides(course, topic_spec, language)
+            if slides is None:
+                # Topic does not exist on disk — fall back to topic id.
+                lines.append(f"- {topic_spec.id} (disabled)")
+            elif not slides:
+                # Topic resolved but has no slide files.
+                lines.append(f"- {topic_spec.id} (disabled)")
+            else:
+                for _file_name, title in slides:
+                    lines.append(f"- {title} (disabled)")
         lines.append("")
 
     return "\n".join(lines)
@@ -69,6 +122,7 @@ def generate_outline_json(
     language: str,
     *,
     disabled_sections: list[SectionSpec] | None = None,
+    sections_only: bool = False,
 ) -> dict:
     """Generate a structured JSON outline for a course.
 
@@ -78,38 +132,41 @@ def generate_outline_json(
         disabled_sections: Disabled ``SectionSpec`` objects to include in the
             output with ``"disabled": true`` markers. Disabled sections are
             appended after the enabled sections.
+        sections_only: When True, omit the ``topics`` list from each section
+            entry.
 
     Returns:
         Dict with the course outline in structured form.
     """
     sections: list[dict] = []
     for section in course.sections:
-        topics: list[dict] = []
-        for topic in section.topics:
-            slides: list[dict] = []
-            for f in topic.files:
-                if isinstance(f, NotebookFile):
-                    slides.append(
-                        {
-                            "file": f.path.name,
-                            "title": f.title[language],
-                        }
-                    )
-            topics.append(
-                {
-                    "topic_id": topic.id,
-                    "directory": str(topic.path),
-                    "slides": slides,
-                }
-            )
         entry: dict = {
             "number": len(sections) + 1,
             "name": section.name[language],
             "disabled": False,
-            "topics": topics,
         }
         if section.id is not None:
             entry["id"] = section.id
+        if not sections_only:
+            topics: list[dict] = []
+            for topic in section.topics:
+                slides: list[dict] = []
+                for f in topic.files:
+                    if isinstance(f, NotebookFile):
+                        slides.append(
+                            {
+                                "file": f.path.name,
+                                "title": f.title[language],
+                            }
+                        )
+                topics.append(
+                    {
+                        "topic_id": topic.id,
+                        "directory": str(topic.path),
+                        "slides": slides,
+                    }
+                )
+            entry["topics"] = topics
         sections.append(entry)
 
     for section_spec in disabled_sections or []:
@@ -117,17 +174,24 @@ def generate_outline_json(
             "number": len(sections) + 1,
             "name": section_spec.name[language],
             "disabled": True,
-            "topics": [
-                {
-                    "topic_id": t.id,
-                    "directory": None,
-                    "slides": [],
-                }
-                for t in section_spec.topics
-            ],
         }
         if section_spec.id is not None:
             entry["id"] = section_spec.id
+        if not sections_only:
+            topics = []
+            for t in section_spec.topics:
+                slides_data = _disabled_topic_slides(course, t, language)
+                topic_path = course._topic_path_map.get(t.id)
+                topics.append(
+                    {
+                        "topic_id": t.id,
+                        "directory": str(topic_path) if topic_path is not None else None,
+                        "slides": [
+                            {"file": fname, "title": title} for fname, title in (slides_data or [])
+                        ],
+                    }
+                )
+            entry["topics"] = topics
         sections.append(entry)
 
     return {
@@ -198,6 +262,12 @@ def titles_are_identical(course: Course) -> bool:
     help="Include sections marked 'enabled=\"false\"' in the output, "
     "tagged with a (disabled) marker. Default: disabled sections are omitted.",
 )
+@click.option(
+    "--sections-only",
+    is_flag=True,
+    default=False,
+    help="Emit only section headings, omitting the topic/slide entries within each section.",
+)
 def outline(
     spec_file: Path,
     output_file: Path | None,
@@ -205,6 +275,7 @@ def outline(
     language: str | None,
     output_format: str,
     include_disabled: bool,
+    sections_only: bool,
 ):
     """Generate an outline of a course in Markdown or JSON format.
 
@@ -218,6 +289,7 @@ def outline(
         clm outline course.xml -L de            # German outline
         clm outline course.xml -o out.md        # Write to file
         clm outline course.xml -d ./docs        # Both languages to directory
+        clm outline course.xml --sections-only  # Section headings only
     """
     # Validate mutually exclusive options
     if output_file and output_dir:
@@ -264,10 +336,20 @@ def outline(
     def _generate(lang: str) -> str:
         if is_json:
             return json.dumps(
-                generate_outline_json(course, lang, disabled_sections=disabled_sections),
+                generate_outline_json(
+                    course,
+                    lang,
+                    disabled_sections=disabled_sections,
+                    sections_only=sections_only,
+                ),
                 indent=2,
             )
-        return generate_outline(course, lang, disabled_sections=disabled_sections)
+        return generate_outline(
+            course,
+            lang,
+            disabled_sections=disabled_sections,
+            sections_only=sections_only,
+        )
 
     # Determine languages to generate
     if output_dir:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -340,7 +340,8 @@ clm outline [OPTIONS] SPEC_FILE
 | `-d, --output-dir DIR` | Write both languages to directory |
 | `-L, --language [de\|en]` | Language selection |
 | `--format [markdown\|json]` | Output format (default: markdown) |
-| `--include-disabled` | Include sections marked `enabled="false"` with a `(disabled)` marker (default: omitted) |
+| `--include-disabled` | Include sections marked `enabled="false"` with a `(disabled)` marker (default: omitted). Topics that resolve to slide files on disk show the H1 header (each slide rendered as its own bullet); unresolvable topics fall back to the topic id |
+| `--sections-only` | Emit only section headings, omitting per-topic/slide entries within each section |
 
 Examples:
 
@@ -350,6 +351,7 @@ clm outline course.xml -L de
 clm outline course.xml -d ./docs
 clm outline course.xml --format json
 clm outline course.xml --include-disabled
+clm outline course.xml --sections-only
 ```
 
 ### `clm topic resolve`

--- a/tests/cli/test_outline.py
+++ b/tests/cli/test_outline.py
@@ -318,12 +318,16 @@ class TestOutlineIncludeDisabled:
     """
 
     @pytest.fixture
-    def spec_with_disabled_section(self, tmp_path):
+    def spec_with_disabled_section(self, request):
         """Create a spec with one enabled and one disabled section under the
-        shared test-data root so topic resolution finds the enabled topic."""
+        shared test-data root so topic resolution finds the enabled topic.
+
+        File name is per-test (request.node.name) so concurrent xdist workers
+        do not race the same shared path.
+        """
         data_dir = Path("tests/test-data")
         specs_dir = data_dir / "course-specs"
-        spec_file = specs_dir / "test-spec-with-disabled.xml"
+        spec_file = specs_dir / f"test-spec-with-disabled-{request.node.name}.xml"
         # Keep spec file inside tests/test-data/course-specs so
         # resolve_course_paths can locate the shared slides/ sibling.
         spec_file.write_text(
@@ -417,3 +421,257 @@ class TestOutlineIncludeDisabled:
         data = json.loads(result.output)
         names = [s["name"] for s in data["sections"]]
         assert names == ["Week 1 active"]
+
+
+class TestOutlineDisabledShowsRealTitles:
+    """Tests that --include-disabled emits notebook H1 titles for resolvable topics.
+
+    Earlier the disabled-section branch hard-coded the topic id as the bullet
+    label, so even when the referenced topic existed on disk the outline showed
+    the directory stem (e.g. ``some_topic_from_test_1``) instead of the H1
+    title (``Some Topic from Test 1``).
+    """
+
+    @pytest.fixture
+    def spec_with_resolvable_disabled_section(self, request):
+        """Spec whose disabled section references a topic that exists on disk."""
+        data_dir = Path("tests/test-data")
+        specs_dir = data_dir / "course-specs"
+        spec_file = specs_dir / f"test-spec-disabled-resolvable-{request.node.name}.xml"
+        spec_file.write_text(
+            dedent("""\
+                <course>
+                  <name><de>Mini-Kurs</de><en>Mini Course</en></name>
+                  <prog-lang>python</prog-lang>
+                  <description><de>Demo</de><en>Demo</en></description>
+                  <certificate><de>.</de><en>.</en></certificate>
+                  <sections>
+                    <section>
+                      <name>
+                        <de>Woche 1 aktiv</de>
+                        <en>Week 1 active</en>
+                      </name>
+                      <topics>
+                        <topic>a_topic_from_test_2</topic>
+                      </topics>
+                    </section>
+                    <section enabled="false">
+                      <name>
+                        <de>Woche 2 abgelegt</de>
+                        <en>Week 2 archived</en>
+                      </name>
+                      <topics>
+                        <topic>some_topic_from_test_1</topic>
+                        <topic>punctuation_test</topic>
+                      </topics>
+                    </section>
+                  </sections>
+                </course>
+                """),
+            encoding="utf-8",
+        )
+        yield spec_file
+        spec_file.unlink(missing_ok=True)
+
+    def test_disabled_section_emits_real_titles_markdown(
+        self, spec_with_resolvable_disabled_section
+    ):
+        """Disabled-section bullets should show the H1 header, not the topic id."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["outline", str(spec_with_resolvable_disabled_section), "--include-disabled"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "## Week 2 archived (disabled)" in result.output
+        # H1 title is rendered, not the topic id.
+        assert "- Some Topic from Test 1 (disabled)" in result.output
+        assert "- Was this really ML? (disabled)" in result.output
+        # Make sure the legacy "topic id" rendering does not also appear.
+        assert "- some_topic_from_test_1 (disabled)" not in result.output
+        assert "- punctuation_test (disabled)" not in result.output
+
+    def test_disabled_section_emits_real_titles_german(self, spec_with_resolvable_disabled_section):
+        """German rendering pulls the de side of the header() macro."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "outline",
+                str(spec_with_resolvable_disabled_section),
+                "--include-disabled",
+                "-L",
+                "de",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "- Folien von Test 1 (disabled)" in result.output
+        assert "- War das wirklich ML? (disabled)" in result.output
+
+    def test_disabled_section_emits_real_titles_json(self, spec_with_resolvable_disabled_section):
+        """JSON disabled-section topics include populated slide titles."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "outline",
+                str(spec_with_resolvable_disabled_section),
+                "--include-disabled",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        disabled_entry = next(s for s in data["sections"] if s["disabled"])
+        topic_ids = [t["topic_id"] for t in disabled_entry["topics"]]
+        assert topic_ids == ["some_topic_from_test_1", "punctuation_test"]
+        first_topic = disabled_entry["topics"][0]
+        assert first_topic["directory"] is not None
+        titles = [s["title"] for s in first_topic["slides"]]
+        assert "Some Topic from Test 1" in titles
+        second_topic = disabled_entry["topics"][1]
+        assert any(s["title"] == "Was this really ML?" for s in second_topic["slides"])
+
+
+class TestOutlineSectionsOnly:
+    """Tests for the --sections-only flag.
+
+    With --sections-only the outline must only emit section headings and skip
+    the per-topic bullet list (markdown) or omit the topics array (JSON).
+    """
+
+    @pytest.fixture
+    def test_spec_path(self):
+        return Path("tests/test-data/course-specs/test-spec-1.xml")
+
+    def test_sections_only_markdown_omits_topic_bullets(self, test_spec_path):
+        """Markdown sections-only output has no '- ' bullet lines."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["outline", str(test_spec_path), "--sections-only"])
+        assert result.exit_code == 0, result.output
+        assert "# My Course" in result.output
+        assert "## Week 1" in result.output
+        assert "## Week 2" in result.output
+        # No topic bullets present anywhere in the output.
+        for line in result.output.splitlines():
+            assert not line.startswith("- "), f"Unexpected bullet line: {line!r}"
+        # And in particular, no notebook titles leak in.
+        assert "Some Topic from Test 1" not in result.output
+
+    def test_sections_only_json_omits_topics_array(self, test_spec_path):
+        """JSON sections-only entries do not carry a 'topics' key."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["outline", str(test_spec_path), "--sections-only", "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert [s["name"] for s in data["sections"]] == ["Week 1", "Week 2"]
+        for section in data["sections"]:
+            assert "topics" not in section
+            assert section["disabled"] is False
+
+    def test_sections_only_with_include_disabled_markdown(self, request):
+        """--sections-only also suppresses topic bullets for disabled sections."""
+        data_dir = Path("tests/test-data")
+        specs_dir = data_dir / "course-specs"
+        spec_file = specs_dir / f"test-spec-sections-only-disabled-{request.node.name}.xml"
+        spec_file.write_text(
+            dedent("""\
+                <course>
+                  <name><de>Mini-Kurs</de><en>Mini Course</en></name>
+                  <prog-lang>python</prog-lang>
+                  <description><de>Demo</de><en>Demo</en></description>
+                  <certificate><de>.</de><en>.</en></certificate>
+                  <sections>
+                    <section>
+                      <name><de>Woche 1</de><en>Week 1</en></name>
+                      <topics>
+                        <topic>a_topic_from_test_2</topic>
+                      </topics>
+                    </section>
+                    <section enabled="false">
+                      <name><de>Woche 2</de><en>Week 2 archived</en></name>
+                      <topics>
+                        <topic>some_topic_from_test_1</topic>
+                      </topics>
+                    </section>
+                  </sections>
+                </course>
+                """),
+            encoding="utf-8",
+        )
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "outline",
+                    str(spec_file),
+                    "--sections-only",
+                    "--include-disabled",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert "## Week 1" in result.output
+            assert "## Week 2 archived (disabled)" in result.output
+            for line in result.output.splitlines():
+                assert not line.startswith("- "), f"Unexpected bullet line: {line!r}"
+        finally:
+            spec_file.unlink(missing_ok=True)
+
+    def test_sections_only_with_include_disabled_json(self, request):
+        """JSON sections-only output keeps disabled flag but drops topics."""
+        data_dir = Path("tests/test-data")
+        specs_dir = data_dir / "course-specs"
+        spec_file = specs_dir / f"test-spec-sections-only-disabled-json-{request.node.name}.xml"
+        spec_file.write_text(
+            dedent("""\
+                <course>
+                  <name><de>Mini-Kurs</de><en>Mini Course</en></name>
+                  <prog-lang>python</prog-lang>
+                  <description><de>Demo</de><en>Demo</en></description>
+                  <certificate><de>.</de><en>.</en></certificate>
+                  <sections>
+                    <section>
+                      <name><de>Woche 1</de><en>Week 1</en></name>
+                      <topics>
+                        <topic>a_topic_from_test_2</topic>
+                      </topics>
+                    </section>
+                    <section enabled="false">
+                      <name><de>Woche 2</de><en>Week 2 archived</en></name>
+                      <topics>
+                        <topic>some_topic_from_test_1</topic>
+                      </topics>
+                    </section>
+                  </sections>
+                </course>
+                """),
+            encoding="utf-8",
+        )
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "outline",
+                    str(spec_file),
+                    "--sections-only",
+                    "--include-disabled",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            data = json.loads(result.output)
+            disabled = [s for s in data["sections"] if s["disabled"]]
+            enabled = [s for s in data["sections"] if not s["disabled"]]
+            assert len(disabled) == 1
+            assert len(enabled) == 1
+            for section in data["sections"]:
+                assert "topics" not in section
+        finally:
+            spec_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Two improvements to `clm outline`:

- **Fix: disabled sections now show real H1 titles.** Previously `--include-disabled` rendered each topic as `- <topic_id> (disabled)` (the directory/file stem), even when the topic existed on disk and had a real `header(...)` macro. Enabled sections always showed the H1. The fix resolves each disabled topic id via the course's filesystem-wide topic map and reads the title with `find_notebook_titles`, mirroring `NotebookFile`. Topics that cannot be resolved (truly missing on disk, e.g. roadmap placeholders) keep the legacy `- <topic_id> (disabled)` fallback so existing behavior for unresolvable topics is preserved.
- **New: `--sections-only` flag.** Emit only section headings, omitting the topic/slide bullet list (markdown) or the `topics` key (JSON). Works alongside `--include-disabled`.

Example before vs. after for `--include-disabled` on a section referencing existing topics:

```
Before                                       After
## Archived (disabled)                       ## Archived (disabled)
- some_topic_from_test_1 (disabled)          - Some Topic from Test 1 (disabled)
- punctuation_test (disabled)                - Was this really ML? (disabled)
```

Also bundled: `tests/cli/test_outline.py` had a latent xdist race in the existing `spec_with_disabled_section` fixture (all 3 tests in that class wrote to the same shared spec path under `tests/test-data/course-specs/`). Adding more tests in the same dir made it flake; the fixture now uses `request.node.name` to get a unique path per test.

Per CLAUDE.md's CRITICAL info-topics rule, `src/clm/cli/info_topics/commands.md` is updated alongside the CLI changes.

## Test plan

- [x] `uv run pytest tests/cli/test_outline.py` — 36/36 pass under xdist (was 29; +7 new tests)
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run mypy src/clm/cli/commands/outline.py` clean
- [x] Pre-commit hook (fast test suite) green
- [x] Manual smoke: `clm outline … --include-disabled` shows real headers for resolvable disabled topics and falls back to id for missing ones; `clm outline … --sections-only` emits headings only; both flags compose correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)