### PR TITLE
fix(tests): widen make_notebook_json param to Sequence[Mapping]

### DIFF
--- a/docs/claude/TODO.md
+++ b/docs/claude/TODO.md
@@ -4,38 +4,6 @@ This file tracks known issues and planned improvements for the CLM project.
 
 ## Bugs / Technical Debt
 
-### Pre-existing mypy errors in `TestBootstrapDurability` test class
-
-**Status**: 🟡 Open (2026-05-21) — discovered during issue #115 Phase 3 work
-
-**Location**: `tests/workers/notebook/test_notebook_processor.py`, four
-`make_notebook_json(cells)` call sites inside the
-`TestBootstrapDurability` and skip-evaluation tests (line numbers
-shift as the file grows; grep for the helper).
-
-**Symptom**: `mypy` reports
-`Argument 1 to "make_notebook_json" has incompatible type "list[NotebookNode]"; expected "list[dict[Any, Any]]"  [arg-type]`
-on the four call sites. `list` is invariant, so a
-`list[NotebookNode]` is not assignable to `list[dict[Any, Any]]`
-even though `NotebookNode` is a `dict` subclass. The runtime
-behaviour is fine; the type signature on
-`make_notebook_json` is too narrow.
-
-**Recommended fix**: Either widen the parameter type to
-`Sequence[Mapping[str, Any]]` (covariant) or change the local
-variable annotations / construction sites to `list[dict[Any, Any]]`.
-The handover doc's "mypy clean on every touched file" Phase 2
-verification was correct for the merge code and Phase-2-touched
-tests — these four call sites predate Phase 2 and were not
-modified by issue #115 work.
-
-**Discovered during**: HTTP-replay cassette partial-chain fix
-(issue #115 Phase 3). Not caused by that change. Verified by
-stashing the Phase 3 additions and re-running mypy: same 4 errors,
-same root cause, line numbers shifted by the insertion size.
-
----
-
 ### Flaky Test: `test_heartbeat_round_trip_smoke`
 
 **Status**: 🟡 Open (2026-05-19) — observed once under xdist load

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -14,6 +14,8 @@ import json
 import time
 import uuid
 from base64 import b64encode
+from collections.abc import Mapping, Sequence
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import psutil
@@ -93,7 +95,7 @@ def make_notebook_node(cells: list[NotebookNode]) -> NotebookNode:
     )
 
 
-def make_notebook_json(cells: list[dict]) -> str:
+def make_notebook_json(cells: Sequence[Mapping[str, Any]]) -> str:
     """Create a notebook JSON string from cell dicts.
 
     Args:


### PR DESCRIPTION
## Summary
- Widens `make_notebook_json`'s parameter from `list[dict]` to `Sequence[Mapping[str, Any]]` in `tests/workers/notebook/test_notebook_processor.py`, eliminating four pre-existing mypy `[arg-type]` errors at call sites that pass `list[NotebookNode]` (invariant `list` blocked the assignment even though `NotebookNode` subclasses `dict`).
- Removes the now-resolved TODO entry in `docs/claude/TODO.md` ("Pre-existing mypy errors in `TestBootstrapDurability` test class").
- Helper is test-only, so widening the signature is cleaner than per-call-site annotations.

## Test plan
- [x] `uv run mypy tests/workers/notebook/test_notebook_processor.py` — four `make_notebook_json [arg-type]` errors gone (remaining `psutil` `import-untyped` is unrelated and pre-existing)
- [x] `uv run pytest tests/workers/notebook/test_notebook_processor.py` — 99 passed, 22 skipped, no behavior change
- [x] Pre-commit hook (ruff lint + format, fast pytest) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)