### PR TITLE
fix(tests): replace fixed-sleep with poll-until-state in flaky tests

### DIFF
--- a/docs/claude/TODO.md
+++ b/docs/claude/TODO.md
@@ -4,9 +4,9 @@ This file tracks known issues and planned improvements for the CLM project.
 
 ## Bugs / Technical Debt
 
-### Flaky Test: `test_heartbeat_round_trip_smoke`
+### ~~Flaky Test: `test_heartbeat_round_trip_smoke`~~ (FIXED)
 
-**Status**: 🟡 Open (2026-05-19) — observed once under xdist load
+**Status**: ✅ FIXED (2026-05-25)
 
 **Location**: `tests/infrastructure/database/test_worker_heartbeats.py::test_heartbeat_round_trip_smoke`
 
@@ -16,25 +16,29 @@ short end-to-end-shaped sequence of heartbeats and asserts the final
 row reflects the last write (`last_output_excerpt == "done"`,
 `current_cell_index == 1`).
 
-**Likely Root Cause**: the test uses a single `time.sleep(0.01)`
-between two `record_output` calls to nudge SQLite's timestamp
-precision forward. Under heavy xdist contention the 10 ms window may
-be too small for the disk-level write to land before the subsequent
-`begin_cell` runs, leaving the row in an intermediate state. The
-final `record_output("done\n")` after `begin_cell` is the row that
-*should* be observed, so the most likely failure mode is that the
-post-`begin_cell` writes happen out of order relative to what the
-test expects — or that one of the writes is silently coalesced.
+**Root Cause**: the test used a single `time.sleep(0.01)` between two
+`record_output` calls and then read the row immediately after the
+final write. Under 32-worker xdist load that 10 ms window is too
+short for the fresh reader connection to observe the latest committed
+state — the row can be sampled mid-sequence, leaving the assertion
+on intermediate values.
 
-**Recommended fix** (per the existing `worker test polling` feedback
-memory): replace the fixed `time.sleep(0.01)` and the immediate
-`_read_heartbeat` with a poll loop that reads the row repeatedly until
-it reflects the expected final state, with a generous timeout. Same
-pattern as the watchdog reconnect fix above.
+**Fix Applied**:
 
-**Discovered during**: HTTP-replay race fix work (issue #86 / Phases 1-3).
-Not caused by that change — the heartbeats module wasn't touched.
-Mentioning here so the next session can pick it up.
+- Added a module-level `_poll_until` helper mirroring the one in
+  `tests/recordings/test_obs.py`.
+- Replaced the `time.sleep(0.01)` + immediate `_read_heartbeat` with a
+  poll loop that re-reads the row until `current_cell_index == 1` and
+  `last_output_excerpt == "done"`, with a 2.0s timeout.
+- Verified: 20 consecutive `-n 32` runs of the test, all green.
+
+Cross-reference: `worker test polling` feedback memory — fixed-time
+sleeps / immediate assertions on background-thread or cross-connection
+state are the recurring root cause.
+
+**Originally discovered during**: HTTP-replay race fix work
+(issue #86 / Phases 1-3). Not caused by that change — the heartbeats
+module wasn't touched.
 
 ---
 
@@ -192,4 +196,4 @@ See `docs/developer-guide/architecture.md` for potential future enhancements.
 
 ---
 
-**Last Updated**: 2026-05-25 (Moved Worker Cleanup, Notebook Error Context Tracking Phases 2/3, and `course_authoring_rules` to Recently Shipped)
+**Last Updated**: 2026-05-25 (Fixed `test_heartbeat_round_trip_smoke` flake — converted fixed-sleep to poll-until-state pattern)

--- a/src/clm/recordings/workflow/watcher.py
+++ b/src/clm/recordings/workflow/watcher.py
@@ -75,6 +75,12 @@ class RecordingsWatcher:
             app to nudge the SSE queue.
         on_error: Callback on watcher-side failure (stability check
             timeout, submission exception). Receives ``(path, message)``.
+        on_rejected: Callback invoked when a file event is intentionally
+            *not* dispatched, with ``(path, reason)``. ``reason`` is
+            ``"not-accepted"`` (backend's ``accepts_file`` returned False)
+            or ``"already-claimed"`` (the path is already in flight or has
+            been submitted). Useful for observability — and lets tests
+            assert "this file was seen and ignored" without polling sleeps.
     """
 
     def __init__(
@@ -87,6 +93,7 @@ class RecordingsWatcher:
         stability_checks: int = 3,
         on_submitted: Callable[[ProcessingJob], None] | None = None,
         on_error: Callable[[Path, str], None] | None = None,
+        on_rejected: Callable[[Path, str], None] | None = None,
     ) -> None:
         self._root = root_dir
         self._job_manager = job_manager
@@ -95,6 +102,7 @@ class RecordingsWatcher:
         self._stability_checks = stability_checks
         self._on_submitted = on_submitted
         self._on_error = on_error
+        self._on_rejected = on_rejected
 
         self._observer: Observer | None = None  # type: ignore[valid-type]
         self._state = WatcherState()
@@ -148,9 +156,13 @@ class RecordingsWatcher:
         stability and then submits a job.
         """
         if not self._backend.accepts_file(path):
+            if self._on_rejected is not None:
+                self._on_rejected(path, "not-accepted")
             return
 
         if not self._state.try_claim(path):
+            if self._on_rejected is not None:
+                self._on_rejected(path, "already-claimed")
             return
 
         threading.Thread(

--- a/tests/infrastructure/database/test_worker_heartbeats.py
+++ b/tests/infrastructure/database/test_worker_heartbeats.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -42,6 +43,29 @@ def _relax_slow_write_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # -- helpers -----------------------------------------------------------------
+
+
+def _poll_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 2.0,
+    interval: float = 0.01,
+) -> None:
+    """Block until ``predicate`` returns truthy or raise ``TimeoutError``.
+
+    The heartbeat write path is synchronous, but under xdist 32-worker load
+    a fresh reader connection can observe the row mid-sequence before all
+    UPSERTs have landed in the WAL visible to a new connection. A poll loop
+    exits immediately on success and is deterministic where a fixed sleep
+    is not — see the "worker test polling" guidance and the matching
+    helper in ``tests/recordings/test_obs.py``.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise TimeoutError(f"Predicate did not become true within {timeout}s")
 
 
 @pytest.fixture
@@ -354,12 +378,23 @@ def test_heartbeat_round_trip_smoke(db_path: Path) -> None:
 
     store.begin_cell(job_id=7, cell_index=0, total_cells=2)
     store.record_output("import torch\n")
-    time.sleep(0.01)
     store.record_output("Epoch 1/3 - loss: 0.123\n")
     store.begin_cell(job_id=7, cell_index=1, total_cells=2)
     store.record_output("done\n")
 
-    row = _read_heartbeat(db_path, worker_id)
+    row: dict | None = None
+
+    def _matches_final_state() -> bool:
+        nonlocal row
+        row = _read_heartbeat(db_path, worker_id)
+        return (
+            row is not None
+            and row["current_cell_index"] == 1
+            and row["last_output_excerpt"] == "done"
+        )
+
+    _poll_until(_matches_final_state)
+
     assert row is not None
     assert row["current_cell_index"] == 1
     assert row["total_cells"] == 2

--- a/tests/infrastructure/workers/test_worker_base.py
+++ b/tests/infrastructure/workers/test_worker_base.py
@@ -44,6 +44,23 @@ def _read_worker_status(db_path: Path, worker_id: int) -> str | None:
         queue.close()
 
 
+def _read_worker_last_heartbeat(db_path: Path, worker_id: int) -> str | None:
+    """Return the ``last_heartbeat`` column for *worker_id*, or ``None`` if the row is gone.
+
+    SQLite stores ``CURRENT_TIMESTAMP`` as a fixed-width ``YYYY-MM-DD HH:MM:SS``
+    string, so lexicographic comparison matches chronological order — callers can
+    poll for ``> initial_value`` safely.
+    """
+    queue = JobQueue(db_path)
+    try:
+        conn = queue._get_conn()
+        cursor = conn.execute("SELECT last_heartbeat FROM workers WHERE id = ?", (worker_id,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    finally:
+        queue.close()
+
+
 class MockWorker(Worker):
     """Mock worker implementation for testing."""
 
@@ -241,42 +258,33 @@ def test_worker_handles_job_failure(worker_id, db_path):
 
 
 def test_worker_updates_heartbeat(worker_id, db_path):
-    """Test worker updates heartbeat regularly during operation."""
-    queue = JobQueue(db_path)
+    """Test worker updates heartbeat regularly during operation.
 
-    # Get initial heartbeat
-    conn = queue._get_conn()
-    cursor = conn.execute("SELECT last_heartbeat FROM workers WHERE id = ?", (worker_id,))
-    initial_heartbeat = cursor.fetchone()[0]
-    queue.close()
+    Workers deregister (delete their row) on graceful shutdown, so the
+    assertion has to land BEFORE ``worker.stop()``. The previous version
+    used a fixed ``time.sleep(0.3)`` to wait for a heartbeat, which under
+    xdist load could race with the scheduler. Poll until the row's
+    ``last_heartbeat`` advances past its initial value instead — see the
+    "worker test polling" guidance.
 
-    # Sleep briefly to ensure time passes
-    time.sleep(0.1)
+    SQLite's ``CURRENT_TIMESTAMP`` is second-resolution, so strict ``>``
+    requires waiting up to ~1s for the wall clock to tick into the next
+    second after the initial INSERT before the assertion can fire.
+    """
+    initial_heartbeat = _read_worker_last_heartbeat(db_path, worker_id)
+    assert initial_heartbeat is not None, "worker_id fixture should have inserted a row"
 
-    # Run worker briefly - but we need to check heartbeat BEFORE it stops
-    # because workers now deregister (delete themselves) on graceful shutdown
     worker = MockWorker(worker_id, db_path)
     thread = threading.Thread(target=worker.run)
     thread.start()
-
-    # Wait a bit for heartbeat to be updated during operation
-    time.sleep(0.3)
-
-    # Check heartbeat was updated while worker is still running
-    queue = JobQueue(db_path)
-    conn = queue._get_conn()
-    cursor = conn.execute("SELECT last_heartbeat FROM workers WHERE id = ?", (worker_id,))
-    row = cursor.fetchone()
-    queue.close()
-
-    # Worker should still exist at this point
-    assert row is not None, "Worker should still exist before stopping"
-    final_heartbeat = row[0]
-    assert final_heartbeat >= initial_heartbeat
-
-    # Now stop the worker
-    worker.stop()
-    thread.join(timeout=2)
+    try:
+        _wait_until(
+            lambda: (_read_worker_last_heartbeat(db_path, worker_id) or "") > initial_heartbeat,
+            timeout=5.0,
+        )
+    finally:
+        worker.stop()
+        thread.join(timeout=2)
 
 
 def test_worker_updates_status(worker_id, db_path):

--- a/tests/recordings/test_watcher.py
+++ b/tests/recordings/test_watcher.py
@@ -308,9 +308,10 @@ class TestEventDispatch:
         mp4 = root / "to-process" / "topic--RAW.mp4"
         mp4.write_bytes(b"video data")
 
+        # ``_on_file_event`` returns synchronously on the
+        # ``accepts_file == False`` early-return path (no thread is spawned),
+        # so the assertion can fire immediately.
         watcher._on_file_event(mp4)
-        # Give any stray thread a chance to run before asserting.
-        time.sleep(0.05)
         assert backend.submit_calls == []
 
     def test_dispatches_accepted_file_to_job_manager(self, tmp_path: Path):
@@ -353,9 +354,10 @@ class TestEventDispatch:
         # by firing a second _on_file_event while the first is still held.
         assert watcher._state.try_claim(wav) is True
         try:
+            # ``_on_file_event`` returns synchronously on the
+            # ``try_claim == False`` early-return path (no thread is spawned),
+            # so the assertion can fire immediately.
             watcher._on_file_event(wav)
-            time.sleep(0.05)
-            # The second event was rejected because the claim is held.
             assert backend.submit_calls == []
         finally:
             watcher._state.release(wav)
@@ -492,12 +494,18 @@ class TestWatcherLiveEvents:
 
         backend = _FakeBackend(accepted_suffix=".wav")
         manager = _make_manager(root, backend)
+        # The file is created AFTER ``watcher.start()`` so the rejection
+        # happens on the observer thread asynchronously. Use the
+        # ``on_rejected`` hook as a positive signal instead of a fixed
+        # sleep — see the "worker test polling" guidance.
+        rejected = threading.Event()
         watcher = RecordingsWatcher(
             root,
             manager,
             backend,
             stability_interval=0.05,
             stability_checks=2,
+            on_rejected=lambda _path, _reason: rejected.set(),
         )
         watcher.start()
 
@@ -506,8 +514,7 @@ class TestWatcherLiveEvents:
             irrelevant = tp / "lecture--RAW.mp4"
             irrelevant.write_bytes(b"video content")
 
-            # Give the watcher a moment to see the event and decide.
-            time.sleep(0.5)
+            assert rejected.wait(timeout=5.0), "Watcher did not observe the rejected file"
             assert backend.submit_calls == []
         finally:
             watcher.stop()
@@ -562,10 +569,13 @@ class TestScanExisting:
         watcher = RecordingsWatcher(
             root, manager, backend, stability_interval=0.05, stability_checks=2
         )
+        # The pre-existing file is routed through ``_scan_existing`` which
+        # runs synchronously at the end of ``start()``; by the time
+        # ``start()`` returns the rejection has already happened. No sleep
+        # needed.
         watcher.start()
 
         try:
-            time.sleep(0.5)
             assert backend.submit_calls == []
         finally:
             watcher.stop()
@@ -599,11 +609,15 @@ class TestScanExisting:
         finally:
             watcher.stop()
 
-        # Stop and restart — the file should NOT be re-submitted
+        # Stop and restart — the file should NOT be re-submitted. The
+        # second ``_scan_existing`` (invoked synchronously from
+        # ``start()``) hits the ``try_claim == False`` early-return path
+        # because the path is still in the watcher's ``_submitted`` set,
+        # so the rejection has already happened by the time ``start()``
+        # returns. No sleep needed.
         submitted_event.clear()
         watcher.start()
         try:
-            time.sleep(0.5)
             assert len(backend.submit_calls) == 1  # still just the one
         finally:
             watcher.stop()


### PR DESCRIPTION
## Summary

- Convert two heartbeat/worker tests from the fixed-sleep antipattern to poll-until-state — `test_heartbeat_round_trip_smoke` (called out in `docs/claude/TODO.md`, 2026-05-19) and `test_worker_updates_heartbeat` (caught during the audit; same shape, same risk). The latter's assertion is also tightened from `>=` (trivially true) to a strict `>` enforced by the poll predicate.
- Sweep five recordings-watcher tests: delete vestigial sleeps where `_on_file_event` / `_scan_existing` already runs synchronously, and convert `test_ignores_file_backend_rejects` to wait on a positive signal from the observer thread.
- Add an optional `on_rejected` callback to `RecordingsWatcher` (mirrors the existing `on_submitted` / `on_error` hooks). Fires on both early-return paths in `_on_file_event` with reason `"not-accepted"` or `"already-claimed"`. Useful for observability ("why didn't my file get picked up?") and gives live-observer tests a deterministic synchronization signal. The existing caller in `src/clm/recordings/web/app.py` uses keyword args and is unaffected.

Cross-reference: the `worker test polling` feedback memory — fixed-time sleeps on background-thread or cross-connection state are the recurring root cause.

## Test plan

- [x] `pytest tests/infrastructure/database/test_worker_heartbeats.py::test_heartbeat_round_trip_smoke -n 32` — 20 consecutive runs, all green.
- [x] `pytest tests/infrastructure/workers/test_worker_base.py::test_worker_updates_heartbeat -n 32` — 20 consecutive runs, all green.
- [x] `pytest tests/recordings/test_watcher.py::{TestWatcherLiveEvents::test_ignores_file_backend_rejects,TestScanExisting::test_scan_ignores_rejected_files,TestScanExisting::test_submitted_file_not_resubmitted} -n 32` — 20 consecutive runs, all green.
- [x] `pytest tests/infrastructure/workers/test_worker_base.py -n 32` (full file, 28 tests) — green.
- [x] `pytest tests/recordings/test_watcher.py -n 32` (full file, 30 tests) — green.
- [x] `pytest tests/recordings/ tests/web/ -n 32` (903 tests) — green.
- [x] Pre-commit hooks pass (ruff lint + format, mypy, fast pytest suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)