### PR TITLE
fix(slides): write slide source files with LF on Windows (#132)

### DIFF
--- a/src/clm/notebooks/slide_writer.py
+++ b/src/clm/notebooks/slide_writer.py
@@ -133,7 +133,7 @@ def write_narrative(
     updated = update_narrative(text, notes_map, lang, tag=tag)
 
     dest = output_path or path
-    dest.write_text(updated, encoding="utf-8")
+    dest.write_text(updated, encoding="utf-8", newline="\n")
     logger.info("Wrote %s cells for %d slides to %s", tag, len(notes_map), dest)
     return dest
 

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -732,7 +732,7 @@ def assign_ids_in_file(path: Path, options: AssignOptions) -> AssignResult:
     text = path.read_text(encoding="utf-8")
     new_text, result = assign_ids_for_text(text, path, options)
     if not options.report_only and new_text != text:
-        path.write_text(new_text, encoding="utf-8")
+        path.write_text(new_text, encoding="utf-8", newline="\n")
     return result
 
 

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -582,7 +582,7 @@ def normalize_file(
     if all_changes and not dry_run:
         new_text = _reconstruct(preamble, cells)
         if new_text != text:
-            path.write_text(new_text, encoding="utf-8")
+            path.write_text(new_text, encoding="utf-8", newline="\n")
             modified = True
 
     return NormalizationResult(

--- a/src/clm/slides/split.py
+++ b/src/clm/slides/split.py
@@ -281,8 +281,8 @@ def split_in_file(
         )
 
     if not dry_run:
-        de_path.write_text(de_text, encoding="utf-8")
-        en_path.write_text(en_text, encoding="utf-8")
+        de_path.write_text(de_text, encoding="utf-8", newline="\n")
+        en_path.write_text(en_text, encoding="utf-8", newline="\n")
 
     return SplitResult(
         source=str(source),
@@ -560,7 +560,7 @@ def unify_in_file(
         raise UnifyError(f"refusing to overwrite existing target without --force: {target}")
 
     if not dry_run:
-        target.write_text(unified, encoding="utf-8")
+        target.write_text(unified, encoding="utf-8", newline="\n")
 
     return UnifyResult(
         de_source=str(de_source),

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -137,7 +137,7 @@ class FileState:
         if not self.dirty:
             return
         text = reconstruct(self.preamble, self.cells)
-        self.path.write_text(text, encoding="utf-8")
+        self.path.write_text(text, encoding="utf-8", newline="\n")
         self.dirty = False
 
     @staticmethod

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -229,11 +229,11 @@ def extract_voiceover(
         new_slide_text = _reconstruct(preamble, remaining_cells)
         # Clean up double blank lines left by removal
         new_slide_text = re.sub(r"\n{3,}", "\n\n", new_slide_text)
-        path.write_text(new_slide_text, encoding="utf-8")
+        path.write_text(new_slide_text, encoding="utf-8", newline="\n")
 
         # Write the companion file
         companion_text = _reconstruct("", companion_cells)
-        comp.write_text(companion_text, encoding="utf-8")
+        comp.write_text(companion_text, encoding="utf-8", newline="\n")
 
     return result
 
@@ -444,7 +444,7 @@ def inline_voiceover(
         slide_cells.extend(unmatched)
 
         new_text = _reconstruct(preamble, slide_cells)
-        path.write_text(new_text, encoding="utf-8")
+        path.write_text(new_text, encoding="utf-8", newline="\n")
 
         comp.unlink()
         result.companion_deleted = True
@@ -586,5 +586,5 @@ def update_companion_narrative(
 
     existing_text = companion.read_text(encoding="utf-8") if companion.exists() else ""
     new_text = render_companion_update(existing_text, notes_by_slide_id, lang, tag=tag)
-    companion.write_text(new_text, encoding="utf-8")
+    companion.write_text(new_text, encoding="utf-8", newline="\n")
     return companion

--- a/tests/slides/test_split.py
+++ b/tests/slides/test_split.py
@@ -309,3 +309,36 @@ class TestUnifyInFile:
         (tmp_path / "b.en.py").write_text(HEADER_PREAMBLE, encoding="utf-8")
         with pytest.raises(UnifyError, match="basename"):
             unify_in_file(tmp_path / "a.de.py", tmp_path / "b.en.py")
+
+
+# ---------------------------------------------------------------------------
+# Line-ending preservation (issue #132)
+# ---------------------------------------------------------------------------
+
+
+class TestLineEndingsAreLF:
+    """Split/unify outputs must use LF on disk on all platforms.
+
+    Course repositories pin ``* text=auto eol=lf`` in ``.gitattributes``.
+    ``Path.write_text`` without ``newline="\\n"`` translates every ``\\n``
+    to ``os.linesep`` (``\\r\\n`` on Windows), producing spurious diffs and
+    breaking byte-equivalence gates. Assert in binary mode so universal-
+    newlines normalisation cannot mask the regression.
+    """
+
+    def test_split_writes_lf_only(self, tmp_path: Path) -> None:
+        source = tmp_path / "deck.py"
+        source.write_text(HEADER_PREAMBLE + _slide_pair("a", "Eins", "One"), encoding="utf-8")
+        split_in_file(source)
+        de_bytes = (tmp_path / "deck.de.py").read_bytes()
+        en_bytes = (tmp_path / "deck.en.py").read_bytes()
+        assert b"\r\n" not in de_bytes
+        assert b"\r\n" not in en_bytes
+
+    def test_unify_writes_lf_only(self, tmp_path: Path) -> None:
+        source = tmp_path / "deck.py"
+        source.write_text(HEADER_PREAMBLE + _slide_pair("a", "Eins", "One"), encoding="utf-8")
+        split_in_file(source)
+        target = tmp_path / "unified.py"
+        unify_in_file(tmp_path / "deck.de.py", tmp_path / "deck.en.py", target=target)
+        assert b"\r\n" not in target.read_bytes()


### PR DESCRIPTION
## Summary

- Fixes #132: `clm slides split` (and parallel slide-source writers) wrote `.de.py` / `.en.py` and friends with CRLF on Windows because `Path.write_text` applies `os.linesep` by default. Course repos pin `* text=auto eol=lf` in `.gitattributes` (verified against PythonCourses), so the working-tree CRLF produced spurious "modified" rows in `git status` and broke the Phase D pilot's byte-equivalence gate.
- Adds `newline="\n"` at the primary site in `clm.slides.split` (split + unify directions) and at the 7 parallel `Path.write_text` callsites in `clm.slides` (`assign_ids`, `normalizer`, `sync_writeback`, `voiceover_tools`) and `clm.notebooks.slide_writer` — all of which write course-repo slide sources on Windows and shared the same hazard.
- Adds a `TestLineEndingsAreLF` regression test that reads in binary mode (`read_bytes`) so universal-newlines normalisation on read cannot mask the divergence. Verified the test fails on the pre-fix code (`b'\r\n' not in de_bytes` → CRLF found) and passes after.

## Test plan

- [x] `pytest tests/slides tests/notebooks tests/voiceover` — 1120 passed locally
- [x] `ruff check` clean on all modified files
- [x] Regression test confirmed to fire against the original bug (CRLF visible in failure output)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)