### PR TITLE
fix(http-replay): scope vcrpy force_reset to urllib3 (issue #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   wrote CRLF, each `git checkout`/`restore` rewrote LF, and the next
   build wrote CRLF again. Cassettes are now written LF-only.
 
+- **Concurrent LLM cells no longer escape the HTTP-replay cassette
+  (issue #129).** Under `--ignore-cache --http-replay=new-episodes`,
+  the HTTP-replay bootstrap injected into every notebook now replaces
+  `vcr.patch.reset_patchers` with a filtered generator that yields all
+  patchers except the httpcore ones. Vcrpy's urllib3 stub calls
+  `force_reset()` around every connection setup, which previously
+  un-patched httpcore globally; if a background thread doing
+  urllib3/requests traffic (e.g. LangSmith trace uploads) was in that
+  window when a foreground httpcore call (e.g. an OpenRouter chat
+  completion via httpx) dispatched, the foreground call resolved to
+  the unpatched httpcore handler, hit the real upstream API, and never
+  landed in the cassette. The scoped reset still un-patches urllib3
+  (the recursion guard vcrpy needs), but leaves httpcore patched.
+  Workaround for an upstream vcrpy issue; remove once vcrpy ships a
+  scoped `force_reset` (search for `_clm_scoped_reset_patchers`).
+  Investigation: `docs/claude/issue-129-vcrpy-force-reset-investigation.md`.
+
 - **Cassette merge discards partial chains from aborted recording
   sessions (issue #115).** Previously, a kernel that died mid-cell —
   after recording the first call of a chained pair but before the

--- a/docs/claude/TODO.md
+++ b/docs/claude/TODO.md
@@ -171,6 +171,20 @@ environment={
 
 ## Recently Shipped
 
+- **HTTP-replay cassette escape under concurrent LangSmith traffic
+  (issue #129)** — shipped 2026-05-25 in
+  `src/clm/workers/notebook/notebook_processor.py` as part of
+  `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`. The bootstrap now installs a scoped
+  `vcr.patch.reset_patchers` that does not un-patch httpcore inside the
+  urllib3 stub's `force_reset()` window. This eliminates the race where
+  concurrent foreground httpcore calls (e.g. LLM via httpx) escaped vcr
+  when a background thread (e.g. LangSmith trace upload via
+  `requests`) was constructing a urllib3 connection. Workaround for an
+  upstream vcrpy issue. **TODO: remove the workaround once vcrpy ships
+  a scoped `force_reset` upstream** — track `kevin1024/vcrpy`,
+  removal checklist in
+  `docs/claude/issue-129-vcrpy-force-reset-investigation.md`.
+
 - **Worker Process Leaks on Windows (Kernel Teardown + Pool Sizing)** —
   shipped 2026-04-12 via PR hoelzl/clm#32 (commits `ebf9f1e`, `80228aa`,
   `58a8fb5`, `0c21853`, `d215d6b`). All five proposed fixes landed:
@@ -196,4 +210,4 @@ See `docs/developer-guide/architecture.md` for potential future enhancements.
 
 ---
 
-**Last Updated**: 2026-05-25 (Fixed `test_heartbeat_round_trip_smoke` flake — converted fixed-sleep to poll-until-state pattern)
+**Last Updated**: 2026-05-25 (Issue #129 vcrpy force_reset workaround shipped; fixed `test_heartbeat_round_trip_smoke` flake — converted fixed-sleep to poll-until-state pattern; moved Worker Cleanup, Notebook Error Context Tracking Phases 2/3, and `course_authoring_rules` to Recently Shipped)

--- a/docs/claude/issue-129-vcrpy-force-reset-investigation.md
+++ b/docs/claude/issue-129-vcrpy-force-reset-investigation.md
@@ -1,0 +1,274 @@
+# Issue #129 Investigation: vcrpy `force_reset()` race
+
+Investigation date: **2026-05-25**
+Issue: <https://github.com/hoelzl/clm/issues/129>
+Reproducers: `C:\Users\tc\Programming\Python\Tests\clm-bug-repros\issue-129-vcrpy-force-reset-race\`
+Status: **workaround #2 shipped 2026-05-25 in
+`src/clm/workers/notebook/notebook_processor.py`
+(`_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`).** Tests:
+`tests/workers/notebook/test_notebook_processor.py::TestBootstrapDurability::test_bootstrap_scopes_vcr_force_reset_to_urllib3`
+and `…::test_bootstrap_force_reset_does_not_strip_httpcore_patch`.
+
+**Remove the workaround** when vcrpy ships a scoped `force_reset()`
+upstream (track `kevin1024/vcrpy`). Search for `_clm_scoped_reset_patchers`
+to find the block.
+
+## TL;DR
+
+Under `clm build --ignore-cache --http-replay=new-episodes`, a small
+fraction of LLM HTTP calls hit the real upstream API but never land in
+the cassette. The issue lists two hypotheses — httpcore stub install
+ordering, and connection pool reuse — and neither is correct. The actual
+root cause is:
+
+**`vcr.patch.force_reset()`** — a context manager vcrpy's urllib3 stub
+opens on every connection setup — temporarily **un-patches every vcr
+stub including `httpcore.ConnectionPool.handle_request`**. The un-patch
+is global, not scoped to urllib3, and not thread-safe. When LangSmith's
+background thread (which uses `requests`/urllib3) is in the middle of a
+connection setup, the httpcore patch is gone for a few milliseconds. If
+the foreground thread dispatches `pool.handle_request(req)` during that
+window, the call resolves to the unpatched original and bypasses vcr
+entirely.
+
+Concretely: foreground LLM calls via httpx race with background
+LangSmith trace uploads via requests. The race window is
+`vcr/stubs/__init__.py:333,357`, and the global un-patch is
+`vcr/patch.py:450-464`.
+
+## What the issue claims vs. what I found
+
+### Hypothesis 1 from the issue — refuted
+
+> `langchain_openrouter` (via the speakeasy SDK underneath) constructs an
+> httpx transport object before vcrpy's `httpcore_stubs` patches the
+> relevant function table.
+
+This is incorrect. `httpx.Client` is created **inside** the `with
+my_vcr.use_cassette(…)` block. More importantly, Python resolves
+`pool.handle_request` via class-attribute lookup at every call, so even
+a pre-constructed pool would pick up the patched method. I verified the
+class attribute `httpcore.ConnectionPool.handle_request` had vcr's
+wrapper ID at every observable snapshot inside the with-block.
+
+### Hypothesis 2 from the issue — refuted
+
+> The first call goes through the patched transport, the connection is
+> reused, and the second call bypasses the interception layer when the
+> connection is replayed.
+
+This is also incorrect. Both LLM calls in my reproducer use the same
+`httpcore.ConnectionPool` instance (`id()` matches). vcrpy patches
+`ConnectionPool.handle_request`, not the per-connection objects, so
+connection reuse cannot bypass it. (The vcr wrapper sits in front of
+`pool.handle_request`, which sits in front of `connection.handle_request`.)
+
+The issue's observation that "which call escapes varies by import
+order" is correct, but the underlying mechanism is the
+`force_reset()` race, not pool reuse.
+
+### Actual root cause
+
+`vcr/stubs/__init__.py` (the urllib3 stub) opens `force_reset()` twice
+per HTTP request:
+
+```python
+# __init__:
+with force_reset():
+    self.real_connection = self._baseclass(*args, **kwargs)
+
+# connect():
+with force_reset():
+    return self.real_connection.connect(*args, **kwargs)
+```
+
+These are protective wrappers around the construction and socket-connect
+of the real underlying urllib3 connection, to keep `super().__init__()`
+chains from re-entering vcr's patched classes.
+
+`vcr/patch.py`'s `force_reset()` is implemented as:
+
+```python
+@contextlib.contextmanager
+def force_reset():
+    with contextlib.ExitStack() as exit_stack:
+        for patcher in reset_patchers():
+            exit_stack.enter_context(patcher)
+        yield
+```
+
+where `reset_patchers()` yields `mock.patch.object` patchers that
+restore the **original** value for every library vcrpy supports —
+httplib, urllib3, botocore, httplib2, tornado, **and httpcore**:
+
+```python
+yield mock.patch.object(
+    httpcore.ConnectionPool, "handle_request",
+    _HttpcoreConnectionPool_handle_request,  # the original, un-patched
+)
+```
+
+So while a urllib3 connection is being set up — including the
+network-level socket connect, which can take 50–300 ms — every other
+vcr stub is also un-patched globally on the class. Any thread that
+dispatches through `httpcore.ConnectionPool.handle_request` during this
+window hits the real httpcore, bypasses vcr's wrapper, and never
+appears in the cassette.
+
+## Why LangSmith is involved (but is not the bug)
+
+LangSmith's main `Client` uses `requests` (urllib3) for trace uploads,
+not httpx. Its background thread pumps the trace queue continuously.
+Each upload involves at least one urllib3 connection setup, which means
+each upload opens `force_reset()` for the duration of its connection.
+With `LANGSMITH_TRACING=true`, the rate of `force_reset()` windows is
+high enough to coincide with at least one of the few openrouter calls
+per LLM cell.
+
+Disabling LangSmith (`LANGSMITH_TRACING=false`) eliminates the bug —
+not because LangSmith was the cause, but because the only other
+concurrent urllib3 traffic in the build is gone.
+
+## Evidence — reproduction summary
+
+| Scenario | urllib3 traffic? | openrouter calls captured |
+|---|---|---|
+| Minimal reproducer with LangSmith on | yes (LangSmith BG thread) | 1 of 2 (intermittent — varies which) |
+| Same reproducer with `LANGSMITH_TRACING=false` | no | 2 of 2 |
+| openrouter SDK directly, no langchain | no | 2 of 2 |
+| openrouter SDK + manual BG thread doing `requests.get(...)` | yes | 1 of 2 |
+| openrouter SDK + manual BG thread doing `httpx.get(...)` | no (httpcore only) | 2 of 2 |
+| Sequential `requests.get(...)` then 2× openrouter | yes, but no concurrency | 2 of 2 |
+| Hold `vcr.patch.force_reset()` open on BG thread, fire `httpx.get(...)` on FG | n/a — direct | call escapes cassette |
+| Replace `vcr.patch.force_reset` with `nullcontext` and re-run the BG-thread reproducer | n/a — bug removed | 2 of 2 |
+
+The last two rows are the clinching evidence: holding `force_reset()`
+open directly causes an httpx call to escape, and replacing it with a
+no-op causes the bug to disappear under concurrent load.
+
+## Why this is intermittent
+
+vcr's class-level patching is correct in the steady state — Python's
+method resolution finds vcr's wrapper, vcr's wrapper calls the original.
+The bug exists only in the brief window where `force_reset()` has
+swapped `httpcore.ConnectionPool.handle_request` back to the original.
+Whether the bug triggers for a given LLM call depends on:
+
+- whether a urllib3 connection setup is in progress on another thread
+  at the moment the LLM call resolves `pool.handle_request`,
+- which socket setups are slow (TLS handshake to a fresh host is slowest),
+- and how many LangSmith uploads are queued.
+
+This matches the issue's observation that the escape "varies depending on
+what else has been imported earlier in the session" — import order
+affects timing.
+
+## Proposed paths forward
+
+Three options in increasing order of effort. They are complementary;
+(1) is for immediate Phase D unblock and (2) is for durable safety.
+
+### 1. Recommended for immediate Phase D unblock — set `LANGSMITH_TRACING=false` for cassette rebuilds
+
+A one-line env var change. The teaching-material build does not need
+LangSmith tracing during cassette capture. Where to set it:
+
+- For ad-hoc rebuilds: prefix the build command, or `setx
+  LANGSMITH_TRACING false` for the session.
+- For automated rebuilds: `clm build` could unset `LANGSMITH_TRACING`
+  (and `LANGCHAIN_TRACING_V2`) in the worker subprocess environment
+  when `--http-replay=new-episodes` and `--ignore-cache` are both
+  active. Reasonable default — these flags are inherently a "capture
+  only" mode where tracing adds nothing.
+
+Verified to eliminate the bug in `repro_no_langsmith.py`. No code
+changes to vcr or notebook_worker required.
+
+### 2. Implemented — scope `reset_patchers` in the notebook bootstrap
+
+**Shipped 2026-05-25** in `src/clm/workers/notebook/notebook_processor.py`
+as part of `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`. The bootstrap, which is
+prepended as the first cell of every HTTP-replay notebook, now replaces
+`vcr.patch.reset_patchers` with a filtered generator that yields all the
+patchers *except* the httpcore ones:
+
+```python
+_clm_original_reset_patchers = _clm_vcr_patch.reset_patchers
+_clm_force_reset_skip = (
+    (_clm_httpcore.ConnectionPool, "handle_request"),
+    (_clm_httpcore.AsyncConnectionPool, "handle_async_request"),
+)
+def _clm_scoped_reset_patchers():
+    for _p in _clm_original_reset_patchers():
+        if (_p.getter(), _p.attribute) in _clm_force_reset_skip:
+            continue
+        yield _p
+_clm_scoped_reset_patchers._clm_scoped = True
+_clm_vcr_patch.reset_patchers = _clm_scoped_reset_patchers
+```
+
+`force_reset()` itself resolves `reset_patchers` via the module globals
+at call time, so this swap propagates to every callsite (both
+`__init__` and `connect` in `vcr/stubs/__init__.py`). The
+recursion-avoidance guard `force_reset()` exists for still works because
+all urllib3 patchers are still yielded — only httpcore (and the
+analogous AsyncConnectionPool) is dropped.
+
+A `_clm_scoped = True` marker makes the bootstrap idempotent: if the
+same kernel exec's the bootstrap twice (or tests exec the template
+repeatedly), the second pass short-circuits instead of stacking
+wrappers and losing the true upstream original.
+
+Regression tests live at
+`tests/workers/notebook/test_notebook_processor.py::TestBootstrapDurability::test_bootstrap_scopes_vcr_force_reset_to_urllib3`
+(checks the swap is in place and the yielded patcher set is correct)
+and `…::test_bootstrap_force_reset_does_not_strip_httpcore_patch` (opens
+a real cassette, enters `force_reset()`, and confirms httpcore stays
+patched). Both tests `importlib.reload(vcr.patch)` first so they
+observe the bootstrap's actual effect rather than state left over by a
+previous test in the same xdist worker.
+
+#### Removal checklist (when vcrpy fixes this upstream)
+
+1. Confirm the vcrpy release includes a scoped `force_reset()` (either
+   a new `libs=` parameter or per-stub helpers like `force_reset_urllib3()`).
+2. Bump the vcrpy minimum in `pyproject.toml`.
+3. Delete the `if not getattr(_clm_vcr_patch.reset_patchers, "_clm_scoped", …)`
+   block in `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE` and the
+   `import vcr.patch as _clm_vcr_patch` line above it.
+4. Delete the two regression tests in `TestBootstrapDurability`.
+5. Delete this section of this document (leave the investigation as
+   historical context).
+
+### 3. Upstream fix in vcrpy
+
+The right long-term fix is to scope `force_reset()` per-stub upstream.
+Open an issue/PR against `kevin1024/vcrpy` proposing a `libs=("urllib3",)`
+parameter to `force_reset()`, and have `vcr/stubs/__init__.py` pass it.
+Several months out before a tagged release the user could pin, so this
+should not block CLM work.
+
+## Files in `C:\Users\tc\Programming\Python\Tests\clm-bug-repros\issue-129-vcrpy-force-reset-race\`
+
+See the `README.md` in that directory for a per-script tour. The two
+files worth pointing at:
+
+- `verify_root_cause.py` — direct proof that holding
+  `vcr.patch.force_reset()` open causes httpx calls to escape.
+- `repro_thread.py` — minimal real-world reproducer (no langchain, no
+  langsmith) using just `openrouter` SDK + a BG thread doing
+  `requests.get(...)`.
+
+## References
+
+- Issue: <https://github.com/hoelzl/clm/issues/129>
+- PR #126 (merged): partial fix — closed the `--ignore-cache` SQLite
+  job-cache gate path that was masking workers entirely. This
+  investigation is the residual bug PR #126 mentions in its commit
+  message.
+- vcrpy source paths (pin: `vcrpy 8.1.1`, `httpcore 1.0.9`, `httpx 0.28.1`):
+  - `vcr/patch.py:99` — captures `_HttpcoreConnectionPool_handle_request` at import.
+  - `vcr/patch.py:307-322` — `_httpcore` method, applies the patch on enter.
+  - `vcr/patch.py:398-464` — `reset_patchers()`, yields the *un-patching* patchers.
+  - `vcr/patch.py:467-472` — `force_reset()` context manager.
+  - `vcr/stubs/__init__.py:333,357` — the two `with force_reset():` callsites in the urllib3 stub.

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -117,7 +117,61 @@ import atexit as _clm_atexit
 import copy as _clm_copy
 import json as _clm_json
 import vcr as _clm_vcr
+import vcr.patch as _clm_vcr_patch
 from vcr.persisters.filesystem import FilesystemPersister as _ClmFsPersister
+
+
+# CLM workaround for vcrpy issue (clm#129).
+#
+# vcrpy's urllib3 stub opens ``vcr.patch.force_reset()`` on every
+# urllib3 connection construction and socket connect (see
+# ``vcr/stubs/__init__.py`` __init__/connect). ``force_reset()`` is a
+# context manager that globally un-patches *every* vcr stub for the
+# duration of its body -- including ``httpcore.ConnectionPool.handle_request``
+# (see ``vcr/patch.py::reset_patchers``). The recursion guard
+# ``force_reset()`` exists for is only relevant to urllib3 (so that the
+# real connection's ``super().__init__()`` doesn't re-enter vcr's
+# patched ``HTTPConnection``); un-patching httpcore is collateral damage.
+#
+# The race: when a foreground thread makes an httpcore call (e.g.
+# httpx-based LLM SDK) while a background thread is constructing a
+# urllib3 connection (e.g. LangSmith trace upload via ``requests``),
+# the foreground call resolves ``pool.handle_request`` during the
+# unpatched window, bypasses vcr entirely, hits the real upstream API,
+# and never gets recorded -- silently invalidating the cassette.
+#
+# Fix: replace ``reset_patchers`` with a filtered generator that yields
+# all the patchers *except* the httpcore ones. ``force_reset()`` itself
+# looks up ``reset_patchers`` via the module globals at call time, so
+# this swap takes effect immediately and propagates to every stub that
+# uses ``force_reset()``.
+#
+# REMOVE THIS BLOCK once vcrpy ships a scoped ``force_reset`` upstream
+# (track ``kevin1024/vcrpy``). Investigation:
+# ``docs/claude/issue-129-vcrpy-force-reset-investigation.md``.
+#
+# Idempotent: the kernel normally executes the bootstrap once per
+# notebook, but tests exec the template repeatedly in the same
+# interpreter. Marking our replacement and short-circuiting on re-exec
+# keeps ``_clm_original_reset_patchers`` pointing at the *true* upstream
+# generator across repeated bootstraps.
+if not getattr(_clm_vcr_patch.reset_patchers, "_clm_scoped", False):
+    _clm_original_reset_patchers = _clm_vcr_patch.reset_patchers
+    try:
+        import httpcore as _clm_httpcore
+        _clm_force_reset_skip = (
+            (_clm_httpcore.ConnectionPool, "handle_request"),
+            (_clm_httpcore.AsyncConnectionPool, "handle_async_request"),
+        )
+    except ImportError:  # pragma: no cover -- httpcore required when vcr active
+        _clm_force_reset_skip = ()
+    def _clm_scoped_reset_patchers():
+        for _p in _clm_original_reset_patchers():
+            if (_p.getter(), _p.attribute) in _clm_force_reset_skip:
+                continue
+            yield _p
+    _clm_scoped_reset_patchers._clm_scoped = True
+    _clm_vcr_patch.reset_patchers = _clm_scoped_reset_patchers
 
 
 # vcrpy's ``vcr.serialize.serialize`` (called from

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -3626,6 +3626,157 @@ os._exit(0)
             with urllib.request.urlopen("http://test.invalid/echo") as resp:
                 assert resp.read() == b"hello"
 
+    def test_bootstrap_scopes_vcr_force_reset_to_urllib3(self, tmp_path):
+        """``vcr.patch.reset_patchers`` must skip the httpcore patchers.
+
+        vcrpy's urllib3 stub opens ``vcr.patch.force_reset()`` on every
+        urllib3 connection setup; ``force_reset()`` un-patches every
+        stub including httpcore. When a foreground thread makes an
+        httpcore call while a background thread is in that window, the
+        call resolves to the original (unpatched) httpcore handler and
+        bypasses vcr entirely -- silently losing cassette entries.
+
+        The bootstrap replaces ``vcr.patch.reset_patchers`` with a
+        filtered generator that yields all the patchers except the
+        httpcore ones (the recursion guard ``force_reset()`` exists for
+        only cares about urllib3). This test verifies the swap happened
+        and that the urllib3 recursion guard is still intact.
+
+        Regression for clm#129. Remove this test once vcrpy ships a
+        scoped ``force_reset`` upstream and the bootstrap patch is
+        retired.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("httpcore")
+        import importlib
+
+        import httpcore
+        import urllib3.connection
+        import urllib3.connectionpool
+        import vcr.patch
+
+        from clm.workers.notebook.notebook_processor import (
+            _HTTP_REPLAY_BOOTSTRAP_TEMPLATE,
+            _HTTP_REPLAY_MODE_TO_VCR_MODE,
+        )
+
+        # Other tests in the same process may have already exec'd the
+        # bootstrap and installed our scoped reset_patchers. Reload to
+        # restore the upstream original so we can observe what the
+        # bootstrap actually changes.
+        importlib.reload(vcr.patch)
+        original_reset_patchers = vcr.patch.reset_patchers
+        original_targets = {(p.getter(), p.attribute) for p in original_reset_patchers()}
+        # Sanity: upstream definition yields the httpcore patchers we're
+        # going to strip. If this fails the upstream behavior changed and
+        # our patch may no longer be needed.
+        assert (httpcore.ConnectionPool, "handle_request") in original_targets
+        assert (
+            httpcore.AsyncConnectionPool,
+            "handle_async_request",
+        ) in original_targets
+
+        try:
+            source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
+                record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["replay"],
+                cassette_path=str(tmp_path / "scope.http-cassette.yaml"),
+            )
+            # Exec only the patch prefix -- no need to open a cassette
+            # just to inspect the swapped reset_patchers.
+            prefix, _, _ = source.partition("class _ClmDeepCopyPersister")
+            ns: dict = {}
+            exec(compile(prefix, "<bootstrap-prefix>", "exec"), ns, ns)
+
+            # The bootstrap must have replaced reset_patchers.
+            assert vcr.patch.reset_patchers is not original_reset_patchers
+            assert getattr(vcr.patch.reset_patchers, "_clm_scoped", False)
+
+            patchers = list(vcr.patch.reset_patchers())
+            targets = {(p.getter(), p.attribute) for p in patchers}
+
+            # httpcore patchers must NOT be present -- that's the bug we're fixing.
+            assert (httpcore.ConnectionPool, "handle_request") not in targets
+            assert (
+                httpcore.AsyncConnectionPool,
+                "handle_async_request",
+            ) not in targets
+
+            # urllib3 patchers MUST still be present -- they're the recursion
+            # guard force_reset() actually needs.
+            assert (urllib3.connection, "HTTPConnection") in targets
+            assert (urllib3.connection, "HTTPSConnection") in targets
+            assert (
+                urllib3.connectionpool.HTTPConnectionPool,
+                "ConnectionCls",
+            ) in targets
+            assert (
+                urllib3.connectionpool.HTTPSConnectionPool,
+                "ConnectionCls",
+            ) in targets
+        finally:
+            # Re-install scoped wrapper for any subsequent tests in this
+            # worker, so they get the same environment as the kernel.
+            ns2: dict = {}
+            exec(compile(prefix, "<bootstrap-prefix>", "exec"), ns2, ns2)
+
+    def test_bootstrap_force_reset_does_not_strip_httpcore_patch(self, tmp_path):
+        """Holding ``force_reset()`` open must leave httpcore patched.
+
+        End-to-end behavior check that complements the unit test above:
+        open a real cassette, then enter ``vcr.patch.force_reset()`` and
+        confirm ``httpcore.ConnectionPool.handle_request`` is *still*
+        vcr's wrapper (not the original handler).
+
+        Regression for clm#129. The unscoped upstream ``force_reset()``
+        restores the original handler here, which is exactly what lets
+        concurrent foreground httpcore calls escape the cassette.
+        """
+        pytest.importorskip("vcr")
+        pytest.importorskip("httpcore")
+        import atexit as _atexit_module
+        import importlib
+        import unittest.mock as _mock
+
+        import httpcore
+        import vcr.patch
+
+        from clm.workers.notebook.notebook_processor import (
+            _HTTP_REPLAY_BOOTSTRAP_TEMPLATE,
+            _HTTP_REPLAY_MODE_TO_VCR_MODE,
+        )
+
+        # Drop any scoped wrapper a previous test in this worker may have
+        # installed so we observe the bootstrap's actual effect.
+        importlib.reload(vcr.patch)
+
+        cassette_path = tmp_path / "force_reset.http-cassette.yaml"
+        source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
+            record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["refresh"],
+            cassette_path=str(cassette_path),
+        )
+        # Suppress the bootstrap's atexit registration so the cassette
+        # context exits cleanly at the end of the test rather than at
+        # interpreter shutdown (which would fire after `__cassette` is
+        # already nulled and log a confusing AttributeError).
+        ns: dict = {}
+        with _mock.patch.object(_atexit_module, "register", lambda *a, **kw: None):
+            exec(compile(source, "<bootstrap>", "exec"), ns, ns)
+        try:
+            # Outside force_reset(), httpcore is patched by vcr.
+            patched_handler = httpcore.ConnectionPool.handle_request
+            import vcr.patch
+
+            with vcr.patch.force_reset():
+                # With the scoped patch, force_reset() must leave the
+                # httpcore wrapper intact. Without the patch, it would
+                # be restored to vcr.patch._HttpcoreConnectionPool_handle_request.
+                assert httpcore.ConnectionPool.handle_request is patched_handler, (
+                    "force_reset() restored the original httpcore handler; "
+                    "scoped patch is not in effect (clm#129)"
+                )
+        finally:
+            ns["_clm_ctx"].__exit__(None, None, None)
+
 
 # ============================================================================
 # skip_evaluation honors topic ``evaluate="no"``


### PR DESCRIPTION
## Summary

Closes #129.

- HTTP-replay bootstrap (`_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`) now installs a scoped `vcr.patch.reset_patchers` that filters out the httpcore patchers, so vcrpy's `force_reset()` no longer un-patches `httpcore.ConnectionPool.handle_request` during urllib3 connection setup. Foreground httpx/httpcore calls no longer escape vcr when a background thread is in the middle of a urllib3 connection (e.g. LangSmith trace upload).
- Two regression tests in `TestBootstrapDurability` that exercise the swap end-to-end and assert httpcore stays patched inside `force_reset()`.
- Investigation, reproducers, and removal checklist filed in `docs/claude/issue-129-vcrpy-force-reset-investigation.md`.

## Root cause (one line per fact)

- vcrpy's urllib3 stub wraps every connection construction and socket connect in `vcr.patch.force_reset()` (`vcr/stubs/__init__.py:333,357`).
- `force_reset()` un-patches **every** vcr stub globally — including `httpcore.ConnectionPool.handle_request` — for the duration of its body (`vcr/patch.py::reset_patchers` lines 450-464).
- The recursion guard `force_reset()` exists for is only relevant to urllib3; un-patching httpcore is collateral damage.
- When a foreground thread dispatches `pool.handle_request(req)` while a BG thread is in that window, the call resolves to the unpatched httpcore handler, bypasses vcr entirely, hits the real API, and silently disappears from the cassette.
- Confirmed by holding `vcr.patch.force_reset()` open on a BG thread and watching an `httpx.get()` escape (reproducer: `verify_root_cause.py` in the repros dir).

The issue's two listed hypotheses (httpcore stub install ordering; connection pool reuse) are both refuted by direct observation — the pool is the same instance for both calls and the class attribute is `vcr_wrapper` at every snapshot. Full evidence table in the investigation doc.

## Why this fix

The recursion guard `force_reset()` exists for needs only the urllib3 stubs un-patched (so that the real connection's `super().__init__()` doesn't re-enter vcr's patched `HTTPConnection`). Skipping the httpcore branch of `reset_patchers()` keeps the guard's intent intact while closing the race for httpcore-using foreground code. Verified to eliminate the bug under the same threading reproducer that demonstrated it (`verify_scoped_fix.py` → 2/2 openrouter calls captured).

`force_reset()` itself resolves `reset_patchers` via the `vcr.patch` module globals at call time, so swapping `vcr.patch.reset_patchers` propagates to every callsite without touching `force_reset` directly. The swap is idempotent via a `_clm_scoped = True` marker — repeated bootstrap execs (only happens in tests) short-circuit.

## Removal trigger

This is an upstream-vcrpy workaround. **Remove it when vcrpy ships a scoped `force_reset()`** (track `kevin1024/vcrpy`). Search for `_clm_scoped_reset_patchers` to find the block; full removal checklist in `docs/claude/issue-129-vcrpy-force-reset-investigation.md`.

## Test plan

- [x] `tests/workers/notebook/test_notebook_processor.py::TestBootstrapDurability` — all 5 tests pass (2 new + 3 pre-existing).
- [x] Full notebook-worker suite (518 tests) passes.
- [x] Fast suite (5530 tests) passes.
- [x] Pre-commit hooks pass: ruff (lint), ruff (format), mypy, pytest (fast).
- [x] Real-world verifier (`verify_scoped_fix.py` against PythonCourses sprightly-sprouting-steele) — 2/2 openrouter calls captured under concurrent urllib3 BG-thread load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)