### PR TITLE
docs+tooling: ship #133 investigation and diff_build_outputs.py

### DIFF
--- a/docs/claude/issue-133-investigation.md
+++ b/docs/claude/issue-133-investigation.md
@@ -1,0 +1,279 @@
+# Issue #133 — split vs bilingual `lines_to_next_cell` divergence
+
+**Status:** investigated 2026-05-25, producer-side fix deferred,
+consumer-side workaround shipped as `scripts/diff_build_outputs.py`.
+**Severity:** Low (cosmetic metadata; HTML rendering identical;
+Phase D byte-equivalence gate affected).
+**Related issues:** [#128](https://github.com/hoelzl/clm/issues/128) (fixed
+in #131), [#132](https://github.com/hoelzl/clm/issues/132) (CRLF on split
+output, open), [#133](https://github.com/hoelzl/clm/issues/133) (this one,
+open).
+
+## TL;DR
+
+`clm slides split` produces files whose built `.ipynb` and `.py` outputs
+diverge from the bilingual build on the `lines_to_next_cell` cell-metadata
+field. The cause is **not** trailing whitespace in the split file — both
+files have byte-identical inter-cell whitespace where they diverge.
+The cause is **jupytext's PEP 8 lookahead through neighboring cells**:
+the same physical blank-line count is interpreted differently depending
+on whether the next cell is code or markdown, and on what kind of
+instruction the *following* code cell starts with. Bilingual interleaves
+DE/EN code cells; split places a DE markdown cell next to the same DE
+code cell — different lookahead, different "expected" blank-line count,
+different metadata.
+
+A "normalize whitespace between cells" feature (whether implemented as a
+new `clm normalize` operation or by invoking `ruff format`) would
+**not** fix this. It would also be in tension with `ruff format`'s PEP 8
+blank-line rules around top-level `def`/`class`, which differ between
+bilingual and split layouts. Don't go that route.
+
+The right producer-side fix is post-filter metadata cleanup in the
+notebook worker. The right consumer-side workaround until that ships is
+the comparison script described below.
+
+## Empirical trace (the bit you'll want when picking this back up)
+
+**Reproducer setup** (CLM `f3f20be`, PythonCourses unchanged):
+
+1. `clm slides split slides/module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates.py --force`
+2. Save the bilingual file aside (CLM rejects coexistence by design).
+3. Build both forms into separate `--output-dir`s with
+   `--http-replay=replay --ignore-cache --only-sections idx:6`.
+4. Diff.
+
+**Direct minimal reproducer without a build cycle** (this is the trace I
+ran during the investigation — it isolates the jupytext step from CLM's
+filter/template steps and produces the same metadata divergence on the
+same two cells):
+
+```python
+import jupytext
+from pathlib import Path
+from clm.slides.split import split_text
+
+deck = Path("slides/module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates.py")
+text = deck.read_text(encoding="utf-8")
+de_text, en_text = split_text(text)
+
+tmp = Path("/tmp")
+(tmp / "bil.py").write_text(text, encoding="utf-8", newline="\n")
+(tmp / "de.py").write_text(de_text, encoding="utf-8", newline="\n")
+
+nb_bil = jupytext.read(tmp / "bil.py")
+nb_de = jupytext.read(tmp / "de.py")
+```
+
+In `nb_bil` (149 cells, no filter applied), only cell 142 carries
+`lines_to_next_cell` (=2, attached to the EN markdown cell of the
+"Task 4 / Aufgabe 4" slide — author-induced spacing).
+
+In `nb_de` (86 cells), the DE-side picks up **two new** entries:
+
+| Cell | `lines_to_next_cell` | Cell source starts with |
+|---|---|---|
+| 81 | 1 | `for vague in vague_questions: …` |
+| 83 | 2 | `def clarify_and_answer(vague: str) -> tuple[str, str]: …` |
+
+Those are exactly the cells the issue identifies. They are not empty;
+the issue body says "empty-source DE code cells" because CLM's
+`is_cell_contents_included` clears their source later, during the
+code-along build. The metadata is attached upstream of that, at the
+`jupytext.reads` step in `notebook_processor.process_notebook_for_spec`.
+
+## Why jupytext attaches the metadata for one form but not the other
+
+The interesting code path is in `jupytext`:
+
+- `cell_reader.py:171` — `lines_to_next_cell` is written to the cell
+  metadata only when the **actual** blank-line count differs from
+  `pep8_lines_between_cells(prev_lines, next_lines, ext)`.
+- `pep8.py:82` — the "expected" computation:
+
+  ```python
+  if cell_ends_with_function_or_class(prev_lines):
+      return 2 if cell_has_code(next_lines) else 1
+  if cell_ends_with_code(prev_lines) and next_instruction_is_function_or_class(next_lines):
+      return 2
+  return 1
+  ```
+
+- `pep8.py:6` — `next_instruction_is_function_or_class` walks past `#`
+  comment lines, blank lines, decorator `@…` lines, and continuation
+  lines — i.e. through an entire markdown cell rendered as `#`-comments
+  — into the *next* substantive line. If that line begins with `def`,
+  `async`, or `class`, the function returns `True`.
+
+Now the specific divergent positions:
+
+**Cell 81 in split DE — `for vague` followed by a DE markdown cell:**
+
+Inter-cell whitespace is one blank line (verified by `cat -An` on both
+files at the divergent positions; see the appendix). The next cell
+starts `# %% [markdown] lang="de" …` and its `#`-prefixed body runs for
+~30 lines, after which jupytext's lookahead reaches the **next** code
+cell — which starts `def clarify_and_answer(…)`. So
+`next_instruction_is_function_or_class` returns `True`, jupytext expects
+**2** blank lines, file has **1**, metadata `lines_to_next_cell=1` is
+recorded.
+
+In bilingual, the same DE `for vague` cell is followed by an EN code
+cell that *also* starts `for vague in vague_questions:`. Lookahead
+returns `False` (it's `for`, not `def`/`class`), expected is **1**,
+actual is **1**, no metadata.
+
+**Cell 83 in split DE — `def clarify_and_answer` followed by a DE markdown cell:**
+
+`cell_ends_with_function_or_class(prev_lines)` is `True` (the cell ends
+inside the function body, last non-blank, non-`)` line is indented). So
+expected = **2 if next has code, else 1**. The next cell is markdown
+(`# %% [markdown] …`), so `cell_has_code(next_lines)` walks the lines and
+finds nothing but `#`-comments and blanks → returns `False` → expected
+= **1**. But the actual count between `def clarify…` and the next cell
+marker is **2** blank lines (PEP 8 spacing after a function def). So
+metadata `lines_to_next_cell=2` is recorded.
+
+In bilingual, the `def clarify…` cell is followed by an EN code cell
+that also starts `def clarify_and_answer`. `cell_has_code(next_lines)`
+returns `True` → expected = **2**. Actual = **2**. No metadata.
+
+**This is the asymmetry — same source whitespace, different lookahead
+result.**
+
+## Why "normalize whitespace between cells" doesn't help
+
+1. The whitespace **is** already identical at the divergent positions
+   (verified). There is nothing to canonicalize that would change the
+   outcome.
+2. Even with strict canonicalization (e.g. "always exactly one blank
+   line between cells"), jupytext's lookahead still differs because the
+   *cell type sequence* differs. You'd need to canonicalize the cell
+   sequence, not the whitespace — and that defeats the point of split.
+3. `ruff format` was floated as the canonicalizer. It does reformat
+   blank lines around top-level `def`/`class` (verified — three blank
+   lines collapse to two; one blank line expands to two before a `def`).
+   But ruff treats `# %%` markers as ordinary comments, so its choices
+   depend on the *surrounding code* — which differs between bilingual
+   and split for exactly the same reason `lines_to_next_cell` differs.
+   Running ruff would change the divergence pattern without removing
+   it, while also forcing a one-time large diff on every existing deck.
+4. PythonCourses currently has no slide pre-commit hook; CLM's
+   pre-commit applies ruff only under `src/` and `tests/`. Introducing
+   one would be a significant policy change for a Low-severity cosmetic
+   issue.
+
+Conclusion: **don't add a whitespace-normalize operation to
+`clm normalize` to fix #133.** If we ever want one for other reasons
+(smaller diffs across commits, author readability), do it without
+invoking ruff and accept that it will not address #133.
+
+## The right producer-side fix (when we want to do it)
+
+`notebook_processor.py:903-927` (`_process_notebook_node`) is the
+location. The cells in `nb` still carry `lines_to_next_cell` from
+`jupytext.reads`, computed against neighbors that may have been
+*filtered out* one line later.
+
+Two viable variants:
+
+- **Option A — strip stale `lines_to_next_cell` only where the metadata
+  is provably stale.** Track which source indices survive the
+  `is_cell_included` filter; for each survivor whose original
+  next-index didn't survive, pop `lines_to_next_cell` from
+  `cell["metadata"]`. Conservative: preserves user-authored spacing
+  intent (e.g. cell 142's `lines_to_next_cell: 2`) for cells whose
+  immediate source neighbor survives.
+- **Option B — pop `lines_to_next_cell` from every cell after
+  filtering.** Simpler. Loses author spacing intent (the `: 2` on cell
+  142 becomes implicit). Probably acceptable for the output of a
+  filtered build; would not be acceptable for source files.
+
+Start with Option A. The implementation is ~10 lines and lives entirely
+in `_process_notebook_node`. Worth a unit test on a fixture with two
+adjacent same-language code cells that survive filtering (metadata
+should be preserved) plus a code-markdown-code triplet where the middle
+cell is filtered out (metadata should be stripped on the surrounding
+cells).
+
+There's no urgency. The consumer-side workaround covers the Phase D
+gate; ship the producer fix opportunistically next time we touch
+`notebook_processor.py`.
+
+## The consumer-side workaround (shipped)
+
+`scripts/diff_build_outputs.py` — takes two build directories, walks
+both trees, and reports byte-identical / identical-after-normalization /
+still-differing files. Normalizers:
+
+- **`.ipynb`** — JSON-parse, drop `cell["id"]` (nbformat's random UUIDs;
+  unavoidable noise across builds) and `cell["metadata"]["lines_to_next_cell"]`
+  (the issue at hand), then re-serialize with stable key ordering.
+- **`.py`** — collapse any run of blank lines that immediately precedes
+  a `# %%` cell marker to exactly one blank line. This catches the
+  downstream side of the same metadata — jupytext writes blank lines
+  based on `lines_to_next_cell`, so the `.py` output's blank-line counts
+  differ wherever the metadata does. Blank lines inside a cell body
+  (e.g. between two top-level `def`s in a code cell) are not touched.
+
+Usage:
+
+```
+uv run python scripts/diff_build_outputs.py <dir_a> <dir_b>
+uv run python scripts/diff_build_outputs.py <dir_a> <dir_b> --show-diffs
+uv run python scripts/diff_build_outputs.py <dir_a> <dir_b> --raw   # debug: skip normalizers
+```
+
+Exit codes: `0` if every file matches (raw or normalized), `1` if any
+file still differs, `2` on argument errors.
+
+Smoke-tested 2026-05-25 against a simulated bilingual-vs-split build of
+`slides_010_prompt_templates.py`: 2 files diverge raw (`.ipynb` +
+`.py`), both become identical after normalization.
+
+## Phase D pilot using this script
+
+Per
+[PythonCourses `docs/handover-slide-format-redesign-next-steps.md`
+§"Recommended pilot path"](../../../../Courses/Own/PythonCourses/docs/handover-slide-format-redesign-next-steps.md),
+the Phase D byte-equivalence gate is:
+
+1. Build the bilingual form → `/tmp/build-bilingual/`.
+2. `clm slides split deck.py`, swap the bilingual file aside.
+3. Build the split form → `/tmp/build-split/`.
+4. `uv run python scripts/diff_build_outputs.py /tmp/build-bilingual /tmp/build-split`.
+5. Expect **zero** files in the "differ after normalization" bucket.
+   Anything in that bucket is a real divergence worth investigating.
+
+## Appendix — raw inter-cell whitespace verification
+
+For the curious, here's the proof that whitespace at the divergent
+position is byte-identical between bilingual and split DE. The position
+of the `for vague in vague_questions:` code cell that gets
+`lines_to_next_cell=1` in split DE but no metadata in bilingual:
+
+```
+=== BILINGUAL: 1289-1297 ===
+    print(f"VAGE:    {vague}")
+    print(f"PRÄZIS: {clarified}")
+    print()
+                                    ← exactly one blank line
+# %% lang="en" slide_id="…cell-115"  ← next cell: EN code
+for vague in vague_questions:
+    …
+```
+
+```
+=== SPLIT DE: 700-708 ===
+    print(f"VAGE:    {vague}")
+    print(f"PRÄZIS: {clarified}")
+    print()
+                                    ← exactly one blank line (same)
+# %% [markdown] lang="de" tags=["slide"] slide_id="task-4-chain-by-hand"  ← next cell: DE markdown
+#
+# ## Aufgabe 4 -- Von Hand verketten
+…
+```
+
+Whitespace = identical. Lookahead target = different (EN `for` vs DE
+markdown that eventually leads to a `def`). Metadata = different.

--- a/scripts/diff_build_outputs.py
+++ b/scripts/diff_build_outputs.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Diff two CLM build outputs modulo known cosmetic noise.
+
+Used as the consumer-side workaround for the
+[Phase D byte-equivalence gate](../docs/claude/issue-133-investigation.md):
+when verifying that bilingual vs split builds of the same deck produce
+equivalent output, the raw `.ipynb` / `.py` files differ in two harmless
+ways that are not worth blocking a pilot over.
+
+1. **nbformat auto-`id` fields** on every cell are random UUIDs. They
+   never match across two independent builds even when the content is
+   identical.
+2. **jupytext's `lines_to_next_cell` metadata** records deviations from
+   PEP 8 expected blank-line counts. Because jupytext's check
+   (`pep8_lines_between_cells` in `jupytext/pep8.py`) looks ahead through
+   neighboring cells, identical inter-cell whitespace can produce
+   different metadata when the bilingual file interleaves DE/EN code
+   cells but the split file places a DE markdown cell next. See
+   `docs/claude/issue-133-investigation.md` for the full trace and the
+   producer-side fix this workaround papers over.
+
+Both of those have an `.ipynb` half (cell metadata) and a `.py` half
+(blank-line counts driven by `lines_to_next_cell` on write). This script
+normalizes both.
+
+Usage:
+    python scripts/diff_build_outputs.py <dir_a> <dir_b>
+    python scripts/diff_build_outputs.py <dir_a> <dir_b> --show-diffs
+
+Exits 0 if every file matches (byte-identical OR identical after
+normalization); exits 1 if any file still differs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Normalizers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_ipynb(text: str) -> str:
+    """Drop nbformat auto-`id` and jupytext `lines_to_next_cell` from `.ipynb`.
+
+    Re-serializes with `json.dumps(..., indent=1, sort_keys=True)` so the
+    normalized form is stable across builds even if cell metadata key
+    ordering shifts.
+    """
+    nb = json.loads(text)
+    for cell in nb.get("cells", []):
+        cell.pop("id", None)
+        meta = cell.get("metadata")
+        if isinstance(meta, dict):
+            meta.pop("lines_to_next_cell", None)
+    return json.dumps(nb, indent=1, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+_CELL_MARKER_RE = re.compile(r"^#\s*%%")
+
+
+def _normalize_py(text: str) -> str:
+    """Collapse blank-line runs immediately before `# %%` markers to one.
+
+    Jupytext writes blank-line counts based on each cell's
+    `lines_to_next_cell` metadata (or PEP 8 default when absent). When
+    one build records the metadata and the other does not, the same
+    cells end up with different inter-cell spacing. We canonicalize
+    on "exactly one blank line before each cell marker" so the spacing
+    differences fall out.
+
+    Blank lines inside a cell's body (e.g. between two top-level `def`s
+    of a code cell) are untouched — only the run that *immediately
+    precedes* a cell marker is collapsed.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    pending_blanks = 0
+    for line in lines:
+        if line == "":
+            pending_blanks += 1
+            continue
+        if pending_blanks and _CELL_MARKER_RE.match(line):
+            out.append("")  # exactly one blank line before each cell marker
+        else:
+            out.extend([""] * pending_blanks)
+        pending_blanks = 0
+        out.append(line)
+    out.extend([""] * pending_blanks)
+    return "\n".join(out)
+
+
+_NORMALIZERS: dict[str, Callable[[str], str]] = {
+    ".ipynb": _normalize_ipynb,
+    ".py": _normalize_py,
+}
+
+
+def _normalize_path(p: Path) -> str | None:
+    """Return the normalized text of `p`, or None if it has no normalizer."""
+    norm = _NORMALIZERS.get(p.suffix)
+    if norm is None:
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+    return norm(text)
+
+
+# ---------------------------------------------------------------------------
+# Tree walk + diff
+# ---------------------------------------------------------------------------
+
+
+def _walk_tree(root: Path) -> dict[Path, Path]:
+    """Map relative path -> absolute path for every file in `root`."""
+    return {p.relative_to(root): p for p in root.rglob("*") if p.is_file()}
+
+
+def _unified_diff(a: str, b: str, label_a: str, label_b: str, *, n: int = 3) -> str:
+    return "".join(
+        difflib.unified_diff(
+            a.splitlines(keepends=True),
+            b.splitlines(keepends=True),
+            fromfile=label_a,
+            tofile=label_b,
+            n=n,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("dir_a", type=Path, help="First build directory.")
+    parser.add_argument("dir_b", type=Path, help="Second build directory.")
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Compare raw bytes without applying normalizers (debug aid).",
+    )
+    parser.add_argument(
+        "--show-diffs",
+        action="store_true",
+        help="Print a unified diff for each mismatching file.",
+    )
+    parser.add_argument(
+        "--diff-context",
+        type=int,
+        default=3,
+        help="Lines of context in --show-diffs output (default: 3).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.dir_a.is_dir():
+        print(f"error: {args.dir_a} is not a directory", file=sys.stderr)
+        return 2
+    if not args.dir_b.is_dir():
+        print(f"error: {args.dir_b} is not a directory", file=sys.stderr)
+        return 2
+
+    tree_a = _walk_tree(args.dir_a)
+    tree_b = _walk_tree(args.dir_b)
+
+    paths = sorted(set(tree_a) | set(tree_b))
+
+    n_identical = 0
+    n_normalized_match = 0
+    n_diff_after_norm = 0
+    n_raw_diff = 0
+    n_only_a = 0
+    n_only_b = 0
+    n_skipped = 0
+
+    diffs: list[tuple[Path, str]] = []
+    only_in_a: list[Path] = []
+    only_in_b: list[Path] = []
+
+    for rel in paths:
+        if rel not in tree_a:
+            n_only_b += 1
+            only_in_b.append(rel)
+            continue
+        if rel not in tree_b:
+            n_only_a += 1
+            only_in_a.append(rel)
+            continue
+        pa, pb = tree_a[rel], tree_b[rel]
+        raw_a = pa.read_bytes()
+        raw_b = pb.read_bytes()
+        if raw_a == raw_b:
+            n_identical += 1
+            continue
+
+        if args.raw:
+            n_raw_diff += 1
+            diffs.append((rel, ""))
+            continue
+
+        norm_a = _normalize_path(pa)
+        norm_b = _normalize_path(pb)
+        if norm_a is None or norm_b is None:
+            n_skipped += 1
+            diffs.append((rel, "(no normalizer for this extension)"))
+            continue
+        if norm_a == norm_b:
+            n_normalized_match += 1
+            continue
+        n_diff_after_norm += 1
+        body = (
+            _unified_diff(
+                norm_a,
+                norm_b,
+                f"A/{rel.as_posix()}",
+                f"B/{rel.as_posix()}",
+                n=args.diff_context,
+            )
+            if args.show_diffs
+            else ""
+        )
+        diffs.append((rel, body))
+
+    print()
+    print(f"Summary ({args.dir_a} vs {args.dir_b}):")
+    print(f"  identical (byte-for-byte):     {n_identical}")
+    if not args.raw:
+        print(f"  identical after normalization: {n_normalized_match}")
+        print(f"  differ after normalization:    {n_diff_after_norm}")
+    else:
+        print(f"  differ (raw):                  {n_raw_diff}")
+    print(f"  only in A:                     {n_only_a}")
+    print(f"  only in B:                     {n_only_b}")
+    if n_skipped:
+        print(f"  no normalizer (counted as diff): {n_skipped}")
+
+    if only_in_a:
+        print()
+        print("Only in A:")
+        for rel in only_in_a:
+            print(f"  {rel}")
+    if only_in_b:
+        print()
+        print("Only in B:")
+        for rel in only_in_b:
+            print(f"  {rel}")
+    if diffs:
+        print()
+        print("Files that still differ:")
+        for rel, body in diffs:
+            print(f"  - {rel}")
+            if body:
+                print(body)
+
+    return 1 if (diffs or only_in_a or only_in_b) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Investigate clm#133 (split vs bilingual builds disagree on `lines_to_next_cell` cell metadata). Root cause is jupytext's PEP 8 lookahead through neighboring cells in `pep8_lines_between_cells`, not inter-cell whitespace — the whitespace is byte-identical at the divergent positions. Whitespace-normalize or `ruff format` based fixes would not help (and would conflict with ruff's own blank-line rules around top-level `def`/`class`).
- Ship `scripts/diff_build_outputs.py` as the consumer-side workaround for the Phase D byte-equivalence gate. Walks two build trees, normalizes nbformat auto-`id` and `lines_to_next_cell` from `.ipynb` files, collapses pre-marker blank-line runs in `.py` files, then compares. Exit 0 if every file matches, 1 if any file still differs.
- Capture the full root-cause trace, recommended producer-side fix, and appendix of raw whitespace verification at `docs/claude/issue-133-investigation.md`. Producer-side fix (post-filter metadata cleanup in `notebook_processor.py:_process_notebook_node`) is deferred — severity is Low and the consumer-side workaround covers the Phase D gate.

PythonCourses' `docs/handover-slide-format-redesign-next-steps.md` was updated separately (PythonCourses commit `280e691f` on master) to reference this script in the Phase D verification recipe.

## Test plan

- [x] `ruff check` + `ruff format --check` on the new script — passes.
- [x] Smoke test: simulated bilingual-vs-split build of `slides_010_prompt_templates.py` exhibits the divergence on `.ipynb` + `.py`; the script reports 2 raw diffs and 0 diffs after normalization. Exit 0 on match, 1 on forced divergence.
- [ ] CI on the branch (will land here on push).
- [ ] Phase D pilot: invoke against the next real bilingual-vs-split build pair when one is run. Expect every file in "byte-identical" or "identical after normalization" buckets.

## Out of scope

- The producer-side fix (post-filter `lines_to_next_cell` cleanup). Documented in `docs/claude/issue-133-investigation.md` so it can be picked up next time someone is in `notebook_processor.py`.
- clm#132 (CRLF in split `.de.py`/`.en.py` on Windows). Independent issue, has its own one-line fix outlined in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)