### PR TITLE
feat(http-replay): forensic trace harness + two cassette-growth fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,4 @@ tools/diagnostic_output/
 # CLM LLM cache (default `tool.clm.cache_dir`, created by
 # `clm slides assign-ids --llm-suggest`, `clm slides coverage`, etc.)
 .clm-cache/
+clm-http-replay-traces*/

--- a/docs/claude/design/http-replay-trace.md
+++ b/docs/claude/design/http-replay-trace.md
@@ -75,7 +75,7 @@ internals:
   trace event there.
 - `Cassette.play_response` — wrap to log every served response (cassette
   hit).
-- `Cassette.can_play_response_now` — wrap to log decisions (especially
+- `Cassette.can_play_response_for` — wrap to log decisions (especially
   the `False` returns that lead to `CannotOverwriteExistingCassetteException`).
 - The `clm_json_body` matcher — emit an event per match attempt with
   the comparison outcome (matched / json-parse-failed / bytes-differ).

--- a/docs/claude/design/http-replay-trace.md
+++ b/docs/claude/design/http-replay-trace.md
@@ -1,0 +1,298 @@
+# HTTP-Replay Trace Harness — Phase A Design Draft
+
+**Status:** Design draft for review (2026-05-26). Not yet implemented.
+**Purpose:** Add forensic instrumentation to CLM's HTTP-replay subsystem so
+we can *measure* what's escaping cassettes, not guess from symptoms. This
+is the diagnostic foundation for the Phase B architectural decision (keep
+vcrpy / switch library / change abstraction).
+**Companion:** [`http-replay.md`](http-replay.md) (existing architecture);
+[`../issue-129-vcrpy-force-reset-investigation.md`](../issue-129-vcrpy-force-reset-investigation.md).
+
+## Goal
+
+Produce a complete, post-build forensic dataset that answers, for every
+LLM/HTTP call in a build:
+
+1. Was it intercepted by vcrpy at all? (vcr-level evidence)
+2. Did it hit the cassette, miss and record, or raise?
+3. Did it produce a real TCP connection to a non-loopback host?
+4. If both (1)/(2) succeeded but (3) also happened — was a `force_reset`
+   window open on another thread when the connection was created?
+
+The three streams are independent on purpose: ground truth at the socket
+layer, vcr's own view, and the host's cassette-lifecycle decisions. We
+cross-reference them in analysis. **A socket connect with no matching vcr
+interception event is a definitive bypass.**
+
+## Non-goals
+
+- No behavior change. The harness is off by default; when off, zero code
+  paths differ from today.
+- No alternative cassette format, no new fix for any known bug. This is
+  pure observation.
+- Not a permanent feature. Once we have the Phase B data, the trace code
+  can stay as an opt-in debugging aid or be retired entirely.
+
+## Three telemetry streams
+
+### Stream 1 — Socket (ground truth)
+
+**Where:** worker kernel process, injected by the bootstrap template.
+
+**Mechanism:** `sys.addaudithook` subscribing to `socket.connect`
+(available since Python 3.8). Fires for every `socket.socket.connect()`
+call regardless of which Python HTTP library issued it. Also subscribe
+to `ssl.wrap_socket` / `_ssl.sslsocket` events to capture TLS
+`server_hostname` (useful when the underlying TCP is to a load balancer
+and the host header reveals the actual provider).
+
+**Filter:** log all connects; analysis filters to non-loopback (`127.*`,
+`::1`, `localhost`) at read time. We log loopback too because the kernel
+talks to Jupyter over loopback and seeing those events helps confirm the
+hook is firing.
+
+**Event types:**
+- `socket.connect` — `{addr_family, host, port, fd}`
+- `ssl.handshake_start` — `{server_hostname}` (when known)
+
+**Why it works:** vcrpy patches *above* the socket layer. If vcr
+intercepts, no real `socket.connect` happens. So a connect to
+`api.openai.com:443` with no preceding vcr event is the bug we're
+hunting.
+
+### Stream 2 — vcrpy (the library's view)
+
+**Where:** worker kernel process, also via the bootstrap template (after
+vcr is imported).
+
+**Mechanism:** non-invasive function wrappers on a small set of vcr
+internals:
+
+- `vcr.patch.force_reset` — wrap as a context manager that logs
+  enter/exit with thread ID and a monotonic timestamp. Critical for
+  diagnosing issue #129-style races.
+- `Cassette.append` — already wrapped by `_clm_eager_append`; add a
+  trace event there.
+- `Cassette.play_response` — wrap to log every served response (cassette
+  hit).
+- `Cassette.can_play_response_now` — wrap to log decisions (especially
+  the `False` returns that lead to `CannotOverwriteExistingCassetteException`).
+- The `clm_json_body` matcher — emit an event per match attempt with
+  the comparison outcome (matched / json-parse-failed / bytes-differ).
+
+**Event types:**
+- `vcr.force_reset.enter` / `vcr.force_reset.exit` — `{tid, mono_ts}`
+- `vcr.cassette.hit` — `{method, uri, body_sha256}`
+- `vcr.cassette.append` — `{method, uri, body_sha256, status}`
+- `vcr.cassette.miss` — `{method, uri, body_sha256, why}` (`why ∈
+  {no-match, mode-blocks-record, ...}`)
+- `vcr.matcher.compare` — `{method, uri, outcome}` (sampled / verbose
+  flag controlled; defaults to outcome-only to keep volume sane)
+
+**Why it works:** these are the exact points where vcr's own logic
+decides what happens. Combining `force_reset.enter` timestamps with
+Stream 1's `socket.connect` timestamps on different threads is the
+clinching evidence the issue-129 investigation built by hand — but now
+captured automatically for every build.
+
+### Stream 3 — Cassette (host-side lifecycle)
+
+**Where:** host process (CLM main), inside `http_replay_cassette.py` and
+`Course._sweep_orphan_cassette_staging_files`.
+
+**Mechanism:** plain function-entry/exit logging at the points where
+cassette state changes on disk.
+
+**Event types:**
+- `cassette.seed` — `{canonical, staging, seeded_interaction_count}`
+- `cassette.completion_marker.write` — `{staging, ts}`
+- `cassette.merge.start` — `{canonical, n_staging_files}`
+- `cassette.merge.decision` — `{staging, decision, marker_present,
+  sweep_orphans}` where `decision ∈ {folded, discarded_orphan,
+  skipped_concurrent}`
+- `cassette.merge.dedup` — `{kept_fingerprint, dropped_n}` per
+  dedup outcome
+- `cassette.merge.write` — `{canonical, final_interaction_count}`
+- `cassette.sweep.orphan_removed` — `{staging, age_seconds}`
+
+**Why it works:** the cassette-lifecycle bugs (issue #115 partial chains,
+the pre-#87 race in seeding) are invisible at the HTTP layer. This
+stream catches them.
+
+## File layout
+
+```
+$CLM_HTTP_REPLAY_TRACE_DIR/                 # default: ./clm-http-replay-traces/
+  └── 2026-05-26T16-39-10_<short-uuid>/     # one dir per build invocation
+      ├── manifest.json                     # build metadata (cmd, mode, course)
+      ├── host.jsonl                        # Stream 3 events (cassette)
+      ├── worker-<pid>.jsonl                # Streams 1+2 per worker process
+      ├── worker-<pid>.jsonl
+      └── ...
+```
+
+**Per-worker files** (not one shared file) so workers never contend on
+the write path. Analysis merges them by timestamp.
+
+**Location** — explicitly outside `output-dir` because the build sweep
+treats output-dir as exclusively CLM's
+([`project_output_dir_exclusively_clm.md`](../../../memory/project_output_dir_exclusively_clm.md)).
+Default to a sibling of the working directory; configurable.
+
+## Event schema (JSONL)
+
+One JSON object per line:
+
+```json
+{
+  "ts_mono": 123.456789,
+  "ts_wall": "2026-05-26T16:39:23.123456+00:00",
+  "pid": 12345,
+  "tid": 67890,
+  "stream": "socket" | "vcr" | "cassette",
+  "event": "socket.connect",
+  "data": { ... event-type-specific ... }
+}
+```
+
+- `ts_mono` is `time.monotonic()`. Cross-process comparison requires the
+  wall-clock; `ts_mono` is for intra-process ordering. We need both
+  because `force_reset` races measure in milliseconds and wall-clock
+  resolution + NTP jitter would obscure them.
+- `tid` is `threading.get_ident()`. Critical for issue-129 diagnosis.
+- `data` is free-form per event type; documented inline in the
+  trace-writer source.
+
+Body payloads **are** logged, but in a redacted/truncated form designed
+to surface whitespace issues (CR/LF differences are a known source of
+matcher misses):
+
+- `length`: total byte length
+- `sha256`: hex-truncated `sha256(body)[:16]` for fingerprinting
+- `head`: `repr(body[:N])` (default `N=2048`), so `\r\n` shows as `\\r\\n`
+  rather than collapsing in display
+- `tail`: `repr(body[-N:])` when `len(body) > 2*N`, omitted otherwise
+- Truncation marker `"...<TRUNCATED M bytes>..."` between head and tail
+  when applicable
+
+Cap is configurable via `CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES` (default
+2048 per side). Course materials are not expected to contain secrets;
+`filter_headers` already redacts auth at the cassette layer, and prompts
+are part of the lecture content.
+
+## Wiring (env vars + host→worker propagation)
+
+**Enable:**
+- `CLM_HTTP_REPLAY_TRACE=1` enables the harness globally.
+- `CLM_HTTP_REPLAY_TRACE_DIR=<path>` overrides the default trace
+  directory.
+- `CLM_HTTP_REPLAY_TRACE_VERBOSE=1` (optional) enables per-matcher-compare
+  events for deep dives; off by default to keep volume manageable.
+
+**Host propagation:** in `build.py`, when `CLM_HTTP_REPLAY_TRACE` is set,
+the host (a) creates the per-build trace directory and writes
+`manifest.json`, (b) passes the trace directory path to workers via the
+existing `NotebookPayload` extension mechanism (new optional field
+`trace_dir`).
+
+**Worker bootstrap:** the bootstrap template gains a conditional block —
+when `trace_dir` is non-empty in the format args, an additional
+**`_HTTP_REPLAY_TRACE_TEMPLATE`** is concatenated before the existing
+bootstrap body. This template inlines a minimal JSONL writer (cannot
+import CLM modules from the kernel) and installs the audit hook and vcr
+wrappers.
+
+**Direct vs Docker workers:** for direct workers, the trace dir is a
+host path the kernel can write to. For Docker workers, the trace dir
+needs to be bind-mounted (similar to how cassette paths are handled
+today). Add to the Docker executor's mount list when tracing is
+enabled.
+
+## Analysis
+
+A new script: `scripts/analyze_http_replay_trace.py`.
+
+```
+uv run python scripts/analyze_http_replay_trace.py <trace_dir>
+```
+
+Outputs a structured report:
+
+```
+=== Build summary ===
+Workers: 3, Wall time: 47.3s
+Socket connects: 47 total
+  ├── Loopback (kernel/jupyter): 12
+  └── Remote: 35
+      ├── Matched a vcr event: 30   ✓ recorded or replayed normally
+      └── Bypassed: 5               ✗ no vcr event near connect
+
+=== Cassette health ===
+Hits: 28, Appends: 7, Misses raising CannotOverwrite: 0
+
+=== Bypass forensics ===
+  [PID 4567, TID 8901] socket.connect ('api.openai.com', 443) at ts_wall=...
+     Nearest vcr event on another thread: force_reset.enter (TID 8902),
+     opened 2.4ms before this connect, still open at connect time.
+     ⇒ Likely cause: vcrpy force_reset race (issue #129)
+  [PID 4567, ...] socket.connect ('smith.langchain.com', 443) ...
+     No nearby vcr event of any kind.
+     ⇒ Likely cause: bypass before vcr stub installed
+```
+
+`--format=json` for machine-readable output (feeds dashboards / CI
+gating later if we want).
+
+## Decisions (settled 2026-05-26)
+
+1. **Trace-dir scoping:** per `clm build` invocation. One timestamped
+   directory holds all topic builds from a single invocation.
+2. **Redaction:** body content is *kept* (head + tail + length + sha,
+   repr-escaped to surface CR/LF). Course materials are not expected to
+   contain secrets; the goal is debuggability over conservative
+   redaction. Auth headers are already stripped by `filter_headers` at
+   the cassette layer; trace events log header *presence* only.
+3. **Bootstrap install order:** trace wrappers installed *after* the
+   issue-129 `_clm_scoped_reset_patchers` swap, so they wrap the scoped
+   `force_reset` rather than the upstream one. This is forensic tooling,
+   not long-term production code — order is enforced by template
+   ordering rather than runtime checks.
+4. **Async paths:** symmetric wrappers for
+   `AsyncConnectionPool.handle_async_request` and async cassette
+   methods. Mechanical doubling.
+5. **Matcher-compare volume:** outcome-only by default; verbose mode
+   (per-compare with both bodies) behind
+   `CLM_HTTP_REPLAY_TRACE_VERBOSE=1`.
+
+## Touch list (files to modify when we implement)
+
+| Path | Change |
+|---|---|
+| `src/clm/workers/notebook/notebook_processor.py` | Add `_HTTP_REPLAY_TRACE_TEMPLATE`; conditional concat with `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`; new format-arg `trace_dir` (empty string when disabled). |
+| `src/clm/workers/notebook/http_replay_cassette.py` | Instrument `seed_staging_from_canonical`, `merge_staging_into_canonical`, `write_completion_marker` with `cassette.*` events. |
+| `src/clm/core/course.py` | Instrument `_sweep_orphan_cassette_staging_files` with `cassette.sweep.*` events. |
+| `src/clm/core/notebook_classes.py` | Add optional `trace_dir: str = ""` field on `NotebookPayload`. |
+| `src/clm/cli/build.py` (or wherever HTTP-replay mode resolves) | Read `CLM_HTTP_REPLAY_TRACE`, create trace dir + manifest, propagate to payload. |
+| `src/clm/infrastructure/worker_executor.py` | Docker path: bind-mount trace dir when set. Direct path: passes through naturally. |
+| `src/clm/workers/notebook/http_replay_trace.py` *(new)* | Host-side JSONL writer + manifest helpers. |
+| `scripts/analyze_http_replay_trace.py` *(new)* | Post-build analysis tool. |
+| `tests/workers/notebook/test_http_replay_trace.py` *(new)* | Writer thread-safety; bootstrap template includes trace block iff flag set; manifest schema. |
+
+## What we run after this lands
+
+1. `CLM_HTTP_REPLAY_TRACE=1 clm build` against the AZAV ML course
+   (the canonical reproducer), `--http-replay=replay` first, then
+   `--http-replay=new-episodes --ignore-cache`.
+2. `uv run python scripts/analyze_http_replay_trace.py <trace_dir>`.
+3. The output drives Phase B: if bypasses cluster around `force_reset`
+   races, the issue-129 mitigation is incomplete and we either fix it
+   harder or escape vcrpy. If bypasses are elsewhere, we have a new bug
+   to chase. If there are no bypasses, we burn down workarounds with
+   confidence.
+
+---
+
+**Next step before implementation:** review and iterate on this design.
+Specifically: is the per-worker trace file layout right; is the event
+schema rich enough; are there other vcr internals worth instrumenting
+that I've missed?

--- a/scripts/analyze_http_replay_trace.py
+++ b/scripts/analyze_http_replay_trace.py
@@ -1,0 +1,401 @@
+"""Forensic analysis for HTTP-replay trace bundles.
+
+Reads ``manifest.json`` plus all ``*.jsonl`` files under a trace directory
+produced by ``CLM_HTTP_REPLAY_TRACE=1 clm build`` and cross-references the
+three event streams (socket / vcr / cassette).
+
+The headline numbers:
+
+* **Bypassed** — outbound connects to a non-loopback host with no
+  near-by vcr event on the same worker. These are the bugs we are hunting.
+* **Race candidate** — a bypassed connect with ``vcr.force_reset.enter``
+  open on a *different* thread of the same worker at the moment of
+  ``socket.connect``. Classic issue-129 fingerprint.
+* **Cassette health** — hits (``cassette.play``), appends, and
+  cannot-play decisions, plus cassette-lifecycle outcomes (folded vs
+  discarded vs concurrent-skip).
+
+Run:
+
+    uv run python scripts/analyze_http_replay_trace.py <trace_dir>
+    uv run python scripts/analyze_http_replay_trace.py <trace_dir> --json
+    uv run python scripts/analyze_http_replay_trace.py <trace_dir> --no-bypass-details
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Window for "did vcr see this socket connect?" — anything within this
+# many seconds before the connect counts as related. Generous enough to
+# tolerate scheduling jitter, tight enough to avoid false positives.
+_MATCH_WINDOW_SECONDS = 0.5
+
+_LOOPBACK_HOSTS = ("127.", "::1", "localhost", "0.0.0.0")
+
+
+@dataclass
+class Event:
+    ts_mono: float
+    ts_wall: str
+    pid: int
+    tid: int
+    stream: str
+    event: str
+    data: dict[str, Any]
+    source_file: str
+
+    @classmethod
+    def from_line(cls, line: str, source_file: str) -> Event | None:
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        try:
+            return cls(
+                ts_mono=float(obj["ts_mono"]),
+                ts_wall=str(obj.get("ts_wall", "")),
+                pid=int(obj["pid"]),
+                tid=int(obj["tid"]),
+                stream=str(obj["stream"]),
+                event=str(obj["event"]),
+                data=dict(obj.get("data", {})),
+                source_file=source_file,
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+@dataclass
+class ForceResetWindow:
+    tid: int
+    enter_ts_mono: float
+    exit_ts_mono: float | None
+
+
+@dataclass
+class WorkerSummary:
+    pid: int
+    events: list[Event] = field(default_factory=list)
+    socket_connects: list[Event] = field(default_factory=list)
+    remote_connects: list[Event] = field(default_factory=list)
+    loopback_connects: list[Event] = field(default_factory=list)
+    cassette_hits: int = 0
+    cassette_appends: int = 0
+    cassette_append_errors: int = 0
+    can_play_true: int = 0
+    can_play_false: int = 0
+    force_reset_windows_per_tid: dict[int, list[ForceResetWindow]] = field(default_factory=dict)
+    bypassed: list[dict[str, Any]] = field(default_factory=list)
+    race_candidates: list[dict[str, Any]] = field(default_factory=list)
+    bootstrap_complete: dict[str, Any] | None = None
+    vcr_events_by_tid: dict[int, list[Event]] = field(default_factory=dict)
+
+
+@dataclass
+class HostSummary:
+    events: list[Event] = field(default_factory=list)
+    seeds: int = 0
+    merge_starts: int = 0
+    merges_with_folds: int = 0
+    folded_total: int = 0
+    deduped_total: int = 0
+    discarded_orphans: int = 0
+    skipped_concurrent: int = 0
+    lock_timeouts: int = 0
+    completion_markers: int = 0
+
+
+@dataclass
+class AnalysisResult:
+    manifest: dict[str, Any]
+    workers: dict[int, WorkerSummary]
+    host: HostSummary
+    trace_dir: Path
+
+
+def is_loopback(host: str) -> bool:
+    if not isinstance(host, str):
+        return False
+    return any(host.startswith(p) for p in _LOOPBACK_HOSTS)
+
+
+def load_events(jsonl_path: Path) -> Iterable[Event]:
+    if not jsonl_path.is_file():
+        return
+    with jsonl_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            event = Event.from_line(line, jsonl_path.name)
+            if event is not None:
+                yield event
+
+
+def analyze(trace_dir: Path) -> AnalysisResult:
+    manifest_path = trace_dir / "manifest.json"
+    manifest = (
+        json.loads(manifest_path.read_text(encoding="utf-8"))
+        if manifest_path.is_file()
+        else {}
+    )
+
+    host = HostSummary()
+    workers: dict[int, WorkerSummary] = {}
+
+    host_path = trace_dir / "host.jsonl"
+    for event in load_events(host_path):
+        host.events.append(event)
+        if event.stream != "cassette":
+            continue
+        if event.event == "cassette.seed":
+            host.seeds += 1
+        elif event.event == "cassette.merge.start":
+            host.merge_starts += 1
+        elif event.event == "cassette.merge.end":
+            folded = int(event.data.get("folded", 0) or 0)
+            if folded:
+                host.merges_with_folds += 1
+                host.folded_total += folded
+        elif event.event == "cassette.merge.decision":
+            decision = event.data.get("decision", "")
+            if decision == "folded":
+                host.deduped_total += int(event.data.get("interactions_deduped", 0) or 0)
+            elif decision == "discarded_orphan":
+                host.discarded_orphans += 1
+            elif decision == "skipped_concurrent":
+                host.skipped_concurrent += 1
+        elif event.event == "cassette.merge.lock_timeout":
+            host.lock_timeouts += 1
+        elif event.event == "cassette.completion_marker.write":
+            host.completion_markers += 1
+
+    for worker_path in sorted(trace_dir.glob("worker-*.jsonl")):
+        for event in load_events(worker_path):
+            ws = workers.setdefault(event.pid, WorkerSummary(pid=event.pid))
+            ws.events.append(event)
+
+            if event.stream == "socket" and event.event == "connect":
+                ws.socket_connects.append(event)
+                host_name = str(event.data.get("host", ""))
+                if is_loopback(host_name):
+                    ws.loopback_connects.append(event)
+                else:
+                    ws.remote_connects.append(event)
+            elif event.stream == "vcr":
+                ws.vcr_events_by_tid.setdefault(event.tid, []).append(event)
+                if event.event == "force_reset.enter":
+                    ws.force_reset_windows_per_tid.setdefault(event.tid, []).append(
+                        ForceResetWindow(
+                            tid=event.tid,
+                            enter_ts_mono=event.ts_mono,
+                            exit_ts_mono=None,
+                        )
+                    )
+                elif event.event == "force_reset.exit":
+                    windows = ws.force_reset_windows_per_tid.get(event.tid, [])
+                    for w in reversed(windows):
+                        if w.exit_ts_mono is None:
+                            w.exit_ts_mono = event.ts_mono
+                            break
+                elif event.event == "cassette.play":
+                    ws.cassette_hits += 1
+                elif event.event == "cassette.append":
+                    ws.cassette_appends += 1
+                elif event.event == "cassette.append.error":
+                    ws.cassette_append_errors += 1
+                elif event.event == "cassette.can_play":
+                    if event.data.get("result"):
+                        ws.can_play_true += 1
+                    else:
+                        ws.can_play_false += 1
+                elif event.event == "bootstrap.complete":
+                    ws.bootstrap_complete = dict(event.data)
+
+    for ws in workers.values():
+        _classify_bypasses(ws)
+
+    return AnalysisResult(manifest=manifest, workers=workers, host=host, trace_dir=trace_dir)
+
+
+def _classify_bypasses(ws: WorkerSummary) -> None:
+    """Decide which remote connects had no near-by vcr event."""
+    for sc in ws.remote_connects:
+        same_tid_events = ws.vcr_events_by_tid.get(sc.tid, [])
+        nearby = [
+            ev
+            for ev in same_tid_events
+            if sc.ts_mono - _MATCH_WINDOW_SECONDS <= ev.ts_mono <= sc.ts_mono + 0.05
+        ]
+        if nearby:
+            continue
+        open_windows: list[ForceResetWindow] = []
+        for tid, windows in ws.force_reset_windows_per_tid.items():
+            if tid == sc.tid:
+                continue
+            for w in windows:
+                exit_ts = w.exit_ts_mono if w.exit_ts_mono is not None else sc.ts_mono + 1.0
+                if w.enter_ts_mono <= sc.ts_mono <= exit_ts:
+                    open_windows.append(w)
+        record = {
+            "ts_mono": sc.ts_mono,
+            "ts_wall": sc.ts_wall,
+            "tid": sc.tid,
+            "host": sc.data.get("host"),
+            "port": sc.data.get("port"),
+            "open_force_reset_other_tids": [
+                {"tid": w.tid, "enter_ts_mono": w.enter_ts_mono, "exit_ts_mono": w.exit_ts_mono}
+                for w in open_windows
+            ],
+        }
+        if open_windows:
+            ws.race_candidates.append(record)
+        else:
+            ws.bypassed.append(record)
+
+
+def format_text(result: AnalysisResult, *, show_bypass_details: bool = True) -> str:
+    out: list[str] = []
+    out.append(f"Trace directory: {result.trace_dir}")
+    if result.manifest:
+        out.append(f"Started at:      {result.manifest.get('started_at', '?')}")
+        out.append(f"Replay mode:     {result.manifest.get('http_replay_mode', '?')}")
+        out.append(f"Host PID:        {result.manifest.get('host_pid', '?')}")
+        out.append(f"Verbose:         {result.manifest.get('verbose', False)}")
+        out.append(f"Max body bytes:  {result.manifest.get('max_body_bytes', '?')}")
+    out.append("")
+
+    out.append(f"Workers seen:    {len(result.workers)}")
+    total_connects = sum(len(w.socket_connects) for w in result.workers.values())
+    total_loopback = sum(len(w.loopback_connects) for w in result.workers.values())
+    total_remote = sum(len(w.remote_connects) for w in result.workers.values())
+    total_bypassed = sum(len(w.bypassed) for w in result.workers.values())
+    total_race = sum(len(w.race_candidates) for w in result.workers.values())
+    out.append(f"Socket connects: {total_connects} ({total_loopback} loopback, {total_remote} remote)")
+    matched = total_remote - total_bypassed - total_race
+    out.append(f"  Matched a vcr event: {matched}")
+    out.append(f"  Bypassed (no vcr event near connect): {total_bypassed}")
+    out.append(f"  Race candidates (bypass + force_reset open on other TID): {total_race}")
+    out.append("")
+
+    total_hits = sum(w.cassette_hits for w in result.workers.values())
+    total_appends = sum(w.cassette_appends for w in result.workers.values())
+    total_append_errs = sum(w.cassette_append_errors for w in result.workers.values())
+    total_can_play_t = sum(w.can_play_true for w in result.workers.values())
+    total_can_play_f = sum(w.can_play_false for w in result.workers.values())
+    out.append("Cassette (worker-side):")
+    out.append(f"  Hits (play_response):      {total_hits}")
+    out.append(f"  Appends:                   {total_appends}")
+    out.append(f"  Append errors:             {total_append_errs}")
+    out.append(f"  can_play True / False:     {total_can_play_t} / {total_can_play_f}")
+    out.append("")
+
+    out.append("Cassette (host-side lifecycle):")
+    out.append(f"  Seeds:                     {result.host.seeds}")
+    out.append(f"  Merge starts:              {result.host.merge_starts}")
+    out.append(f"  Merges that folded:        {result.host.merges_with_folds}")
+    out.append(f"  Interactions folded:       {result.host.folded_total}")
+    out.append(f"  Interactions deduped:      {result.host.deduped_total}")
+    out.append(f"  Orphans discarded:         {result.host.discarded_orphans}")
+    out.append(f"  Skipped concurrent:        {result.host.skipped_concurrent}")
+    out.append(f"  Lock timeouts:             {result.host.lock_timeouts}")
+    out.append(f"  Completion markers:        {result.host.completion_markers}")
+    out.append("")
+
+    if show_bypass_details and (total_bypassed > 0 or total_race > 0):
+        out.append("Bypass forensics:")
+        for pid, ws in sorted(result.workers.items()):
+            for rec in ws.race_candidates:
+                others = ", ".join(
+                    f"TID {w['tid']} enter={w['enter_ts_mono']:.6f} exit={w['exit_ts_mono']}"
+                    for w in rec["open_force_reset_other_tids"]
+                )
+                out.append(
+                    f"  [worker pid={pid} tid={rec['tid']} t={rec['ts_mono']:.6f}] "
+                    f"connect to {rec['host']}:{rec['port']}  "
+                    f"RACE — force_reset open on: {others}"
+                )
+            for rec in ws.bypassed:
+                out.append(
+                    f"  [worker pid={pid} tid={rec['tid']} t={rec['ts_mono']:.6f}] "
+                    f"connect to {rec['host']}:{rec['port']}  "
+                    f"BYPASS — no near-by vcr event"
+                )
+        out.append("")
+
+    return "\n".join(out)
+
+
+def format_json(result: AnalysisResult) -> str:
+    payload = {
+        "trace_dir": str(result.trace_dir),
+        "manifest": result.manifest,
+        "host": {
+            "seeds": result.host.seeds,
+            "merge_starts": result.host.merge_starts,
+            "merges_with_folds": result.host.merges_with_folds,
+            "folded_total": result.host.folded_total,
+            "deduped_total": result.host.deduped_total,
+            "discarded_orphans": result.host.discarded_orphans,
+            "skipped_concurrent": result.host.skipped_concurrent,
+            "lock_timeouts": result.host.lock_timeouts,
+            "completion_markers": result.host.completion_markers,
+        },
+        "workers": {
+            str(pid): {
+                "events_total": len(ws.events),
+                "socket_connects": len(ws.socket_connects),
+                "loopback_connects": len(ws.loopback_connects),
+                "remote_connects": len(ws.remote_connects),
+                "cassette_hits": ws.cassette_hits,
+                "cassette_appends": ws.cassette_appends,
+                "cassette_append_errors": ws.cassette_append_errors,
+                "can_play_true": ws.can_play_true,
+                "can_play_false": ws.can_play_false,
+                "bypassed": ws.bypassed,
+                "race_candidates": ws.race_candidates,
+                "bootstrap_complete": ws.bootstrap_complete,
+            }
+            for pid, ws in sorted(result.workers.items())
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace_dir", type=Path, help="Per-invocation trace directory")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the text report",
+    )
+    parser.add_argument(
+        "--no-bypass-details",
+        action="store_true",
+        help="Suppress the per-event bypass forensics list (text format only)",
+    )
+    args = parser.parse_args(argv)
+
+    trace_dir: Path = args.trace_dir
+    if not trace_dir.is_dir():
+        print(f"error: {trace_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    result = analyze(trace_dir)
+    if args.json:
+        print(format_json(result))
+    else:
+        print(format_text(result, show_bypass_details=not args.no_bypass_details))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_http_replay_trace.py
+++ b/scripts/analyze_http_replay_trace.py
@@ -150,32 +150,33 @@ def analyze(trace_dir: Path) -> AnalysisResult:
     host = HostSummary()
     workers: dict[int, WorkerSummary] = {}
 
-    host_path = trace_dir / "host.jsonl"
-    for event in load_events(host_path):
-        host.events.append(event)
-        if event.stream != "cassette":
-            continue
-        if event.event == "cassette.seed":
-            host.seeds += 1
-        elif event.event == "cassette.merge.start":
-            host.merge_starts += 1
-        elif event.event == "cassette.merge.end":
-            folded = int(event.data.get("folded", 0) or 0)
-            if folded:
-                host.merges_with_folds += 1
-                host.folded_total += folded
-        elif event.event == "cassette.merge.decision":
-            decision = event.data.get("decision", "")
-            if decision == "folded":
-                host.deduped_total += int(event.data.get("interactions_deduped", 0) or 0)
-            elif decision == "discarded_orphan":
-                host.discarded_orphans += 1
-            elif decision == "skipped_concurrent":
-                host.skipped_concurrent += 1
-        elif event.event == "cassette.merge.lock_timeout":
-            host.lock_timeouts += 1
-        elif event.event == "cassette.completion_marker.write":
-            host.completion_markers += 1
+    host_paths = [trace_dir / "host.jsonl", *sorted(trace_dir.glob("host-*.jsonl"))]
+    for host_path in host_paths:
+        for event in load_events(host_path):
+            host.events.append(event)
+            if not event.event.startswith("cassette."):
+                continue
+            if event.event == "cassette.seed":
+                host.seeds += 1
+            elif event.event == "cassette.merge.start":
+                host.merge_starts += 1
+            elif event.event == "cassette.merge.end":
+                folded = int(event.data.get("folded", 0) or 0)
+                if folded:
+                    host.merges_with_folds += 1
+                    host.folded_total += folded
+            elif event.event == "cassette.merge.decision":
+                decision = event.data.get("decision", "")
+                if decision == "folded":
+                    host.deduped_total += int(event.data.get("interactions_deduped", 0) or 0)
+                elif decision == "discarded_orphan":
+                    host.discarded_orphans += 1
+                elif decision == "skipped_concurrent":
+                    host.skipped_concurrent += 1
+            elif event.event == "cassette.merge.lock_timeout":
+                host.lock_timeouts += 1
+            elif event.event == "cassette.completion_marker.write":
+                host.completion_markers += 1
 
     for worker_path in sorted(trace_dir.glob("worker-*.jsonl")):
         for event in load_events(worker_path):

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -890,6 +890,25 @@ async def process_course_with_backend(
             build_reporter.cleanup()
             raise SystemExit("Build failed: split-slide routing error")
 
+        # Sweep orphan HTTP-replay staging cassettes from prior killed
+        # builds before any worker spawns. Without this, partial-chain
+        # recordings from aborted sessions stay on disk indefinitely
+        # (issue #145). The sweep is a no-op when no topic uses
+        # http-replay or when no orphans exist. ``process_all`` and
+        # ``process_file`` already call this for their own entry points;
+        # the per-stage build path used by ``clm build`` previously did
+        # not, leaving the sweep unreachable in normal use.
+        try:
+            swept = course._sweep_orphan_cassette_staging_files()
+        except Exception as exc:  # noqa: BLE001 — defensive: sweep failure must not block build
+            logger.warning(
+                f"Pre-build orphan cassette sweep raised "
+                f"{type(exc).__name__}: {exc}; continuing without sweep."
+            )
+            swept = 0
+        if swept:
+            logger.info(f"Pre-build orphan cassette sweep: merged {swept} canonical cassette(s).")
+
         summary: BuildSummary | None = None
         try:
             for stage in execution_stages():

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1199,7 +1199,7 @@ async def main_build(
             _trace_invocation_dir,
             http_replay_mode=resolved_http_replay_mode,
         )
-        _os.environ["CLM_HTTP_REPLAY_TRACE_DIR"] = str(_trace_invocation_dir)
+        _os.environ["CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR"] = str(_trace_invocation_dir)
         click.echo(f"HTTP-replay trace active: {_trace_invocation_dir}")
 
     # Sweep is on by default. ``--no-sweep`` opts out; ``--incremental``

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1171,6 +1171,37 @@ async def main_build(
 
     _os.environ["CLM_HTTP_REPLAY_MODE"] = resolved_http_replay_mode
 
+    # Forensic HTTP-replay trace harness. When CLM_HTTP_REPLAY_TRACE=1 is
+    # set on the host, create a per-invocation trace directory and pin it
+    # so subsequent get_writer("host") / get_invocation_dir() calls land
+    # in the right place. The directory path is also exported via env so
+    # Direct workers inherit it through os.environ.copy(); the Docker
+    # executor needs an explicit allowlist entry (see worker_executor.py).
+    # Off by default — when CLM_HTTP_REPLAY_TRACE is unset, this is a
+    # no-op and no trace directory is created.
+    from clm.workers.notebook.http_replay_trace import (
+        is_enabled as _trace_is_enabled,
+    )
+    from clm.workers.notebook.http_replay_trace import (
+        make_invocation_dir as _trace_make_invocation_dir,
+    )
+    from clm.workers.notebook.http_replay_trace import (
+        set_invocation_dir as _trace_set_invocation_dir,
+    )
+    from clm.workers.notebook.http_replay_trace import (
+        write_manifest as _trace_write_manifest,
+    )
+
+    if _trace_is_enabled():
+        _trace_invocation_dir = _trace_make_invocation_dir()
+        _trace_set_invocation_dir(_trace_invocation_dir)
+        _trace_write_manifest(
+            _trace_invocation_dir,
+            http_replay_mode=resolved_http_replay_mode,
+        )
+        _os.environ["CLM_HTTP_REPLAY_TRACE_DIR"] = str(_trace_invocation_dir)
+        click.echo(f"HTTP-replay trace active: {_trace_invocation_dir}")
+
     # Sweep is on by default. ``--no-sweep`` opts out; ``--incremental``
     # implies ``--no-sweep`` because incremental users explicitly trust
     # the on-disk state and a sweep would delete files the cache replay

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -414,6 +414,13 @@ class Course(NotebookMixin):
             CassettePaths,
             merge_staging_into_canonical,
         )
+        from clm.workers.notebook.http_replay_trace import get_writer
+
+        _host_writer = get_writer("host")
+        _host_writer.emit(
+            "cassette.sweep.start",
+            {"n_canonical_paths": len(canonical_paths)},
+        )
 
         swept = 0
         for canonical in sorted(canonical_paths):
@@ -443,6 +450,10 @@ class Course(NotebookMixin):
             if merged:
                 logger.info(f"Merged {merged} orphan staging cassette(s) into '{canonical}'.")
                 swept += 1
+        _host_writer.emit(
+            "cassette.sweep.end",
+            {"n_canonical_paths": len(canonical_paths), "swept": swept},
+        )
         return swept
 
     async def process_stage_for_target(

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -23,6 +23,26 @@ from clm.infrastructure.utils.path_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _resolve_trace_dir_for_payload() -> str:
+    """Return the active HTTP-replay trace directory (string) or empty.
+
+    Reads the host's pinned invocation dir set by ``clm build`` when
+    ``CLM_HTTP_REPLAY_TRACE=1``. The returned string is the absolute path
+    that the worker bootstrap template will receive via the
+    ``http_replay_trace_dir`` payload field; the worker writes
+    ``worker-<pid>.jsonl`` under it. Empty string means tracing is off.
+    """
+    from clm.workers.notebook.http_replay_trace import (
+        get_invocation_dir,
+        is_enabled,
+    )
+
+    if not is_enabled():
+        return ""
+    invocation_dir = get_invocation_dir()
+    return str(invocation_dir) if invocation_dir is not None else ""
+
+
 @frozen
 class ProcessNotebookOperation(Operation):
     input_file: "NotebookFile"
@@ -239,6 +259,7 @@ class ProcessNotebookOperation(Operation):
             skip_errors=self.skip_errors,
             http_replay_mode=self.http_replay_mode,
             http_replay_cassette_name=self._resolve_cassette_name(),
+            http_replay_trace_dir=_resolve_trace_dir_for_payload(),
             img_path_prefix=self.compute_img_path_prefix(),
             source_topic_dir=self.compute_source_topic_dir(),
             svg_available_stems=(

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -41,6 +41,12 @@ class NotebookPayload(Payload):
     # to this path inside the temp dir via ``other_files``; in Docker mode
     # it is already present at this path under the source mount.
     http_replay_cassette_name: str | None = None
+    # Absolute path of the per-invocation HTTP-replay trace directory
+    # when the forensic trace harness is active (``CLM_HTTP_REPLAY_TRACE=1``
+    # on the host). Empty string means tracing is off — the bootstrap
+    # template installs neither the socket audit hook nor the vcr
+    # wrappers. Design: ``docs/claude/design/http-replay-trace.md``.
+    http_replay_trace_dir: str = ""
     # Relative path from output file to shared img/ folder (e.g., "../../../../img/")
     img_path_prefix: str = "img/"
     # Path to topic directory relative to data_dir (for Docker mode with source mount).

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -227,6 +227,26 @@ class DockerWorkerExecutor(WorkerExecutor):
                 volumes[str(self.data_dir.absolute())] = {"bind": "/source", "mode": "rw"}
                 environment["CLM_HOST_DATA_DIR"] = str(self.data_dir.absolute())
 
+            # Forensic HTTP-replay trace harness. When the host activated
+            # tracing (CLM_HTTP_REPLAY_TRACE=1), bind-mount the trace
+            # directory at the same path inside the container so the
+            # absolute path embedded in NotebookPayload.http_replay_trace_dir
+            # is valid for the kernel, and pass through the trace env vars
+            # the bootstrap reads.
+            trace_dir_host = os.environ.get("CLM_HTTP_REPLAY_TRACE_DIR", "").strip()
+            if os.environ.get("CLM_HTTP_REPLAY_TRACE", "").strip() and trace_dir_host:
+                from pathlib import Path as _TracePath
+
+                _trace_path = _TracePath(trace_dir_host).resolve()
+                _trace_path.mkdir(parents=True, exist_ok=True)
+                volumes[str(_trace_path)] = {"bind": str(_trace_path), "mode": "rw"}
+                environment["CLM_HTTP_REPLAY_TRACE"] = os.environ["CLM_HTTP_REPLAY_TRACE"]
+                environment["CLM_HTTP_REPLAY_TRACE_DIR"] = str(_trace_path)
+                for _k in ("CLM_HTTP_REPLAY_TRACE_VERBOSE", "CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES"):
+                    _v = os.environ.get(_k, "")
+                    if _v:
+                        environment[_k] = _v
+
             log_mounts = f"  Workspace: {self.workspace_path.absolute()} -> /workspace (rw)"
             if self.data_dir:
                 log_mounts += f"\n  Source: {self.data_dir.absolute()} -> /source (rw)"

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -233,16 +233,20 @@ class DockerWorkerExecutor(WorkerExecutor):
             # absolute path embedded in NotebookPayload.http_replay_trace_dir
             # is valid for the kernel, and pass through the trace env vars
             # the bootstrap reads.
-            trace_dir_host = os.environ.get("CLM_HTTP_REPLAY_TRACE_DIR", "").strip()
-            if os.environ.get("CLM_HTTP_REPLAY_TRACE", "").strip() and trace_dir_host:
+            trace_inv_host = os.environ.get("CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR", "").strip()
+            if os.environ.get("CLM_HTTP_REPLAY_TRACE", "").strip() and trace_inv_host:
                 from pathlib import Path as _TracePath
 
-                _trace_path = _TracePath(trace_dir_host).resolve()
+                _trace_path = _TracePath(trace_inv_host).resolve()
                 _trace_path.mkdir(parents=True, exist_ok=True)
                 volumes[str(_trace_path)] = {"bind": str(_trace_path), "mode": "rw"}
                 environment["CLM_HTTP_REPLAY_TRACE"] = os.environ["CLM_HTTP_REPLAY_TRACE"]
-                environment["CLM_HTTP_REPLAY_TRACE_DIR"] = str(_trace_path)
-                for _k in ("CLM_HTTP_REPLAY_TRACE_VERBOSE", "CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES"):
+                environment["CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR"] = str(_trace_path)
+                for _k in (
+                    "CLM_HTTP_REPLAY_TRACE_DIR",
+                    "CLM_HTTP_REPLAY_TRACE_VERBOSE",
+                    "CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES",
+                ):
                     _v = os.environ.get(_k, "")
                     if _v:
                         environment[_k] = _v

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -437,19 +437,57 @@ def _dedup_key(request) -> tuple:
     replicate every nuance of vcrpy's matching semantics. Method, URI,
     and body cover the common cases (GET with query strings, POST with
     a body, REST endpoints with different paths) for teaching material.
+
+    Body extraction handles ``bytes``/``str``/``None`` plus
+    ``BytesIO``/file-like objects. Streaming bodies are a real-world
+    case: LangSmith's compressed-multipart upload (``api.smith.langchain.com``)
+    passes a ``BytesIO`` to ``requests.Session.post``, which vcrpy stores
+    as-is and YAML serializes via ``!!python/object/new:_io.BytesIO``.
+    Without reading the stream into bytes here, ``str(BytesIO_instance)``
+    would key on the object's repr (``<_io.BytesIO object at 0x...>``) —
+    different across instances even for identical payloads — and merge
+    would treat every loaded entry as a fresh interaction, growing the
+    canonical cassette by N entries on every build.
     """
     body = getattr(request, "body", None)
-    if isinstance(body, bytes):
-        body_key: object = body
-    elif body is None:
-        body_key = b""
-    else:
-        body_key = str(body).encode("utf-8", errors="replace")
+    body_key = _body_to_dedup_bytes(body)
     return (
         getattr(request, "method", ""),
         getattr(request, "uri", ""),
         body_key,
     )
+
+
+def _body_to_dedup_bytes(body) -> bytes:
+    """Coerce a request body to stable bytes for dedup fingerprinting."""
+    if body is None:
+        return b""
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, bytearray):
+        return bytes(body)
+    if isinstance(body, str):
+        return body.encode("utf-8", errors="replace")
+    # Stream-like (BytesIO, file objects): read into bytes, rewind so the
+    # body remains consumable by anything that reads it after us.
+    read = getattr(body, "read", None)
+    if callable(read):
+        try:
+            data = read()
+        except Exception:  # noqa: BLE001 — defensive: never crash dedup
+            return repr(body).encode("utf-8", errors="replace")
+        seek = getattr(body, "seek", None)
+        if callable(seek):
+            try:
+                seek(0)
+            except Exception:  # noqa: BLE001 — best-effort rewind
+                pass
+        if isinstance(data, bytes):
+            return data
+        if isinstance(data, bytearray):
+            return bytes(data)
+        return str(data).encode("utf-8", errors="replace")
+    return repr(body).encode("utf-8", errors="replace")
 
 
 def _atomic_write_text(target: Path, text: str) -> None:

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -30,6 +30,14 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+
+def _trace(event: str, data: dict | None = None) -> None:
+    """Emit a cassette-stream trace event (no-op when tracing is off)."""
+    from clm.workers.notebook.http_replay_trace import get_writer
+
+    get_writer("host").emit(event, data)
+
+
 _STAGING_SUFFIX = ".staging-"
 _LOCK_SUFFIX = ".lock"
 _COMPLETION_MARKER_SUFFIX = ".completed"
@@ -90,8 +98,22 @@ def seed_staging_from_canonical(paths: CassettePaths) -> None:
     request in replay mode (issue #86).
     """
     paths.staging.parent.mkdir(parents=True, exist_ok=True)
+    seeded_bytes = 0
     if paths.canonical.exists():
         shutil.copy2(paths.canonical, paths.staging)
+        try:
+            seeded_bytes = paths.staging.stat().st_size
+        except OSError:
+            seeded_bytes = 0
+    _trace(
+        "cassette.seed",
+        {
+            "canonical": str(paths.canonical),
+            "staging": str(paths.staging),
+            "canonical_existed": paths.canonical.exists() or seeded_bytes > 0,
+            "seeded_bytes": seeded_bytes,
+        },
+    )
 
 
 def merge_staging_into_canonical(
@@ -162,7 +184,16 @@ def merge_staging_into_canonical(
             staging_files = [
                 p for p in all_staging if not p.name.endswith(_COMPLETION_MARKER_SUFFIX)
             ]
+            _trace(
+                "cassette.merge.start",
+                {
+                    "canonical": str(canonical),
+                    "n_staging_files": len(staging_files),
+                    "sweep_orphans": sweep_orphans,
+                },
+            )
             if not staging_files:
+                _trace("cassette.merge.end", {"canonical": str(canonical), "folded": 0})
                 return 0
 
             markered: list[Path] = []
@@ -217,14 +248,37 @@ def merge_staging_into_canonical(
                         f"Could not load staging cassette '{staging_path}' "
                         f"({type(exc).__name__}: {exc}); skipping."
                     )
+                    _trace(
+                        "cassette.merge.decision",
+                        {
+                            "staging": str(staging_path),
+                            "decision": "load_failed",
+                            "exc_type": type(exc).__name__,
+                        },
+                    )
                     continue
+                folded_from_this = 0
+                duplicates_in_this = 0
                 for request, response in zip(staging_requests, staging_responses, strict=False):
                     key = _dedup_key(request)
                     if key in seen_keys:
+                        duplicates_in_this += 1
                         continue
                     merged_requests.append(request)
                     merged_responses.append(response)
                     seen_keys.add(key)
+                    folded_from_this += 1
+                _trace(
+                    "cassette.merge.decision",
+                    {
+                        "staging": str(staging_path),
+                        "decision": "folded",
+                        "marker_present": True,
+                        "interactions_loaded": len(staging_requests),
+                        "interactions_folded": folded_from_this,
+                        "interactions_deduped": duplicates_in_this,
+                    },
+                )
 
             # Only rewrite canonical if we actually folded markered
             # work in. Pre-build sweeps that find only markerless
@@ -247,14 +301,44 @@ def merge_staging_into_canonical(
                         f"Discarded orphan staging cassette '{staging_path}' "
                         f"(no completion marker — aborted previous-build session)."
                     )
+                    _trace(
+                        "cassette.merge.decision",
+                        {
+                            "staging": str(staging_path),
+                            "decision": "discarded_orphan",
+                            "marker_present": False,
+                        },
+                    )
                     _delete_quietly(staging_path)
+            else:
+                for staging_path in markerless:
+                    _trace(
+                        "cassette.merge.decision",
+                        {
+                            "staging": str(staging_path),
+                            "decision": "skipped_concurrent",
+                            "marker_present": False,
+                        },
+                    )
 
+            _trace(
+                "cassette.merge.end",
+                {
+                    "canonical": str(canonical),
+                    "folded": len(markered),
+                    "final_interaction_count": len(merged_requests),
+                },
+            )
             return len(markered)
     except Timeout:
         logger.error(
             f"Timed out after {_MERGE_LOCK_TIMEOUT_SECONDS:.0f}s waiting for cassette "
             f"merge lock at '{lock_path}'. Cassette '{canonical}' was not updated. "
             f"Staging files remain on disk and will be picked up by the next build."
+        )
+        _trace(
+            "cassette.merge.lock_timeout",
+            {"canonical": str(canonical), "lock_timeout_seconds": _MERGE_LOCK_TIMEOUT_SECONDS},
         )
         return 0
 
@@ -323,11 +407,24 @@ def write_completion_marker(paths: CassettePaths) -> None:
     }
     try:
         _atomic_write_text(target, json.dumps(payload, sort_keys=True) + "\n")
+        _trace(
+            "cassette.completion_marker.write",
+            {"staging": str(paths.staging), "marker": str(target)},
+        )
     except OSError as exc:
         logger.warning(
             f"Could not write cassette completion marker '{target}' "
             f"({type(exc).__name__}: {exc}); this worker's recordings "
             f"will be treated as aborted and discarded on the next build."
+        )
+        _trace(
+            "cassette.completion_marker.error",
+            {
+                "staging": str(paths.staging),
+                "marker": str(target),
+                "exc_type": type(exc).__name__,
+                "exc_msg": str(exc),
+            },
         )
 
 

--- a/src/clm/workers/notebook/http_replay_trace.py
+++ b/src/clm/workers/notebook/http_replay_trace.py
@@ -1,0 +1,294 @@
+"""Forensic trace harness for HTTP-replay debugging.
+
+The harness emits three independent telemetry streams to per-process
+JSONL files so the analysis script can cross-reference them:
+
+* ``socket`` events from a ``sys.addaudithook`` in the worker kernel
+  (ground truth — anything intercepted by vcrpy never reaches this hook).
+* ``vcr`` events from wrapped vcrpy internals (cassette hit/miss, append,
+  ``force_reset`` enter/exit with thread id).
+* ``cassette`` events from host-side lifecycle calls (seed, merge
+  decisions, dedup outcomes, completion-marker writes, orphan sweeps).
+
+This module owns the host side and exposes the body-redaction primitives
+used both here and (duplicated) in the worker bootstrap template. See
+:mod:`clm.workers.notebook.notebook_processor` for the worker-side
+inlined version.
+
+Activate with ``CLM_HTTP_REPLAY_TRACE=1``; trace files land under
+``$CLM_HTTP_REPLAY_TRACE_DIR`` (default ``./clm-http-replay-traces``) in a
+per-invocation subdirectory containing ``manifest.json``, ``host.jsonl``,
+and ``worker-<pid>.jsonl`` per worker. Design doc:
+``docs/claude/design/http-replay-trace.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_ENABLED_ENV = "CLM_HTTP_REPLAY_TRACE"
+_DIR_ENV = "CLM_HTTP_REPLAY_TRACE_DIR"
+_VERBOSE_ENV = "CLM_HTTP_REPLAY_TRACE_VERBOSE"
+_MAX_BODY_BYTES_ENV = "CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES"
+
+_DEFAULT_DIR_NAME = "clm-http-replay-traces"
+_DEFAULT_MAX_BODY_BYTES = 2048
+
+_MANIFEST_SCHEMA = 1
+
+
+def is_enabled() -> bool:
+    return _truthy(os.environ.get(_ENABLED_ENV, ""))
+
+
+def is_verbose() -> bool:
+    return _truthy(os.environ.get(_VERBOSE_ENV, ""))
+
+
+def max_body_bytes() -> int:
+    raw = os.environ.get(_MAX_BODY_BYTES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_BODY_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_BODY_BYTES
+    return value if value >= 0 else _DEFAULT_MAX_BODY_BYTES
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def resolve_trace_root() -> Path:
+    override = os.environ.get(_DIR_ENV, "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.cwd() / _DEFAULT_DIR_NAME
+
+
+def make_invocation_dir(
+    *,
+    root: Path | None = None,
+    timestamp: datetime | None = None,
+) -> Path:
+    """Create a fresh per-invocation trace directory under ``root``.
+
+    The directory name encodes both a UTC timestamp (sortable) and a
+    short random suffix so two builds started in the same second still
+    land in distinct directories.
+    """
+    root = root or resolve_trace_root()
+    ts = (timestamp or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H-%M-%S")
+    suffix = uuid.uuid4().hex[:8]
+    invocation_dir = root / f"{ts}_{suffix}"
+    invocation_dir.mkdir(parents=True, exist_ok=True)
+    return invocation_dir
+
+
+def write_manifest(
+    invocation_dir: Path,
+    *,
+    http_replay_mode: str | None,
+    command_argv: list[str] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> Path:
+    payload: dict[str, Any] = {
+        "schema": _MANIFEST_SCHEMA,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "host_pid": os.getpid(),
+        "http_replay_mode": http_replay_mode,
+        "verbose": is_verbose(),
+        "max_body_bytes": max_body_bytes(),
+        "argv": command_argv if command_argv is not None else list(sys.argv),
+    }
+    if extra:
+        payload.update(extra)
+    target = invocation_dir / "manifest.json"
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return target
+
+
+@dataclass
+class RedactedBody:
+    length: int
+    sha256: str
+    head: str
+    tail: str | None
+    truncated: int
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "length": self.length,
+            "sha256": self.sha256,
+            "head": self.head,
+        }
+        if self.tail is not None:
+            out["tail"] = self.tail
+            out["truncated"] = self.truncated
+        return out
+
+
+def redact_body(body: bytes | str | None, max_per_side: int | None = None) -> dict[str, Any]:
+    """Redact ``body`` into a forensic-friendly dict.
+
+    The output preserves enough detail to surface whitespace-level
+    matcher mismatches (CR/LF differences are a known cause): ``head``
+    and ``tail`` use ``repr()`` so escape sequences are visible. The
+    SHA-256 hex (first 16 chars) is the stable fingerprint that
+    matchers can cluster on; ``length`` is the total byte count.
+    """
+    if max_per_side is None:
+        max_per_side = max_body_bytes()
+    raw = _coerce_to_bytes(body)
+    length = len(raw)
+    sha = hashlib.sha256(raw).hexdigest()[:16] if length > 0 else ""
+    if length <= 2 * max_per_side:
+        head = repr(raw)
+        tail = None
+        truncated = 0
+    else:
+        head = repr(raw[:max_per_side])
+        tail = repr(raw[-max_per_side:])
+        truncated = length - 2 * max_per_side
+    return RedactedBody(
+        length=length,
+        sha256=sha,
+        head=head,
+        tail=tail,
+        truncated=truncated,
+    ).to_dict()
+
+
+def _coerce_to_bytes(body: bytes | str | None) -> bytes:
+    if body is None:
+        return b""
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, bytearray):
+        return bytes(body)
+    if isinstance(body, str):
+        return body.encode("utf-8", errors="replace")
+    read = getattr(body, "read", None)
+    if callable(read):
+        try:
+            data = read()
+        except Exception:
+            return str(body).encode("utf-8", errors="replace")
+        if isinstance(data, (bytes, bytearray)):
+            return bytes(data)
+        return str(data).encode("utf-8", errors="replace")
+    return str(body).encode("utf-8", errors="replace")
+
+
+class TraceWriter:
+    """Thread-safe JSONL appender for one trace stream.
+
+    Holds an open append-mode file handle for the lifetime of the
+    process so emit() does not pay file-open overhead per event. Writes
+    are serialized through a ``threading.Lock`` because a single host
+    process emits cassette-lifecycle events from multiple threads
+    (concurrent course-file processing).
+    """
+
+    def __init__(self, path: Path, *, stream: str) -> None:
+        self._path = path
+        self._stream = stream
+        self._lock = threading.Lock()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = path.open("a", encoding="utf-8", newline="\n")
+        self._start_mono = time.monotonic()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def emit(self, event: str, data: dict[str, Any] | None = None) -> None:
+        record = {
+            "ts_mono": time.monotonic() - self._start_mono,
+            "ts_wall": datetime.now(timezone.utc).isoformat(),
+            "pid": os.getpid(),
+            "tid": threading.get_ident(),
+            "stream": self._stream,
+            "event": event,
+            "data": data or {},
+        }
+        line = json.dumps(record, sort_keys=False) + "\n"
+        with self._lock:
+            self._fh.write(line)
+            self._fh.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._fh.closed:
+                self._fh.close()
+
+
+class _NullWriter:
+    """Stand-in writer used when tracing is disabled. All emits are no-ops."""
+
+    def emit(self, event: str, data: dict[str, Any] | None = None) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+_writers_lock = threading.Lock()
+_writers: dict[str, TraceWriter] = {}
+_invocation_dir: Path | None = None
+
+
+def set_invocation_dir(path: Path | None) -> None:
+    """Pin the current process's invocation directory.
+
+    The host process calls this once after creating the trace directory
+    via :func:`make_invocation_dir` so subsequent :func:`get_writer`
+    calls land in the right place. ``None`` disables tracing for the
+    process.
+    """
+    global _invocation_dir
+    with _writers_lock:
+        _invocation_dir = path
+
+
+def get_invocation_dir() -> Path | None:
+    return _invocation_dir
+
+
+def get_writer(stream: str) -> TraceWriter | _NullWriter:
+    """Return the writer for ``stream`` (e.g. ``"host"``), or a null writer."""
+    if _invocation_dir is None or not is_enabled():
+        return _NullWriter()
+    with _writers_lock:
+        existing = _writers.get(stream)
+        if existing is not None:
+            return existing
+        path = _invocation_dir / f"{stream}.jsonl"
+        writer = TraceWriter(path, stream=stream)
+        _writers[stream] = writer
+        return writer
+
+
+def close_all_writers() -> None:
+    with _writers_lock:
+        for writer in _writers.values():
+            try:
+                writer.close()
+            except Exception:
+                pass
+        _writers.clear()

--- a/src/clm/workers/notebook/http_replay_trace.py
+++ b/src/clm/workers/notebook/http_replay_trace.py
@@ -38,6 +38,7 @@ from typing import Any
 
 _ENABLED_ENV = "CLM_HTTP_REPLAY_TRACE"
 _DIR_ENV = "CLM_HTTP_REPLAY_TRACE_DIR"
+_INVOCATION_ENV = "CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR"
 _VERBOSE_ENV = "CLM_HTTP_REPLAY_TRACE_VERBOSE"
 _MAX_BODY_BYTES_ENV = "CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES"
 
@@ -267,18 +268,47 @@ def set_invocation_dir(path: Path | None) -> None:
 
 
 def get_invocation_dir() -> Path | None:
-    return _invocation_dir
+    """Return the pinned invocation directory, falling back to env var.
+
+    The host process pins via :func:`set_invocation_dir` after creating
+    the directory. Direct worker subprocesses inherit env from the host;
+    Docker workers receive the var through the explicit allowlist. Either
+    way, worker code that imports this module fresh discovers the
+    invocation dir via ``CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR``.
+    """
+    if _invocation_dir is not None:
+        return _invocation_dir
+    env_value = os.environ.get(_INVOCATION_ENV, "").strip()
+    if env_value:
+        path = Path(env_value)
+        if path.is_dir():
+            return path
+    return None
 
 
 def get_writer(stream: str) -> TraceWriter | _NullWriter:
-    """Return the writer for ``stream`` (e.g. ``"host"``), or a null writer."""
-    if _invocation_dir is None or not is_enabled():
+    """Return the writer for ``stream`` (e.g. ``"host"``), or a null writer.
+
+    The file name is ``<stream>.jsonl`` for host-pinned streams and
+    ``<stream>-<pid>.jsonl`` when this process is a worker subprocess
+    (i.e., the invocation dir was discovered from the env rather than
+    pinned in-process). The pid suffix prevents concurrent worker
+    processes from racing on the same file.
+    """
+    if not is_enabled():
+        return _NullWriter()
+    invocation_dir = get_invocation_dir()
+    if invocation_dir is None:
         return _NullWriter()
     with _writers_lock:
         existing = _writers.get(stream)
         if existing is not None:
             return existing
-        path = _invocation_dir / f"{stream}.jsonl"
+        if _invocation_dir is None:
+            file_name = f"{stream}-{os.getpid()}.jsonl"
+        else:
+            file_name = f"{stream}.jsonl"
+        path = invocation_dir / file_name
         writer = TraceWriter(path, stream=stream)
         _writers[stream] = writer
         return writer

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -503,7 +503,7 @@ if _clm_trace_dir:
 
     _clm_cassette.play_response = _clm_traced_play
 
-    _clm_orig_can_play = _clm_cassette.can_play_response_now
+    _clm_orig_can_play = _clm_cassette.can_play_response_for
 
     def _clm_traced_can_play(request):
         result = _clm_orig_can_play(request)
@@ -518,7 +518,7 @@ if _clm_trace_dir:
             pass
         return result
 
-    _clm_cassette.can_play_response_now = _clm_traced_can_play
+    _clm_cassette.can_play_response_for = _clm_traced_can_play
 
     _clm_trace_emit("vcr", "bootstrap.complete", {{
         "vcr_version": getattr(_clm_vcr, "__version__", "unknown"),

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -335,7 +335,221 @@ _clm_atexit.register(_clm_ctx.__exit__, None, None, None)
 """
 
 
-def _inject_http_replay_bootstrap(nb: NotebookNode, cassette_path: str, mode: str) -> None:
+# Appended to the bootstrap when ``CLM_HTTP_REPLAY_TRACE=1`` is set on the
+# host. Installs three telemetry streams (socket audit hook, vcr method
+# wrappers, atexit close) into the kernel; emits JSONL events to a
+# per-worker file in ``trace_dir``. Wraps the post-bootstrap state — so
+# ``force_reset`` events reflect the scoped (issue-129) variant and
+# ``cassette.append`` events reflect the eager-save variant. The trace
+# captures execution; it does not capture the final cassette save at
+# atexit time (registered after the bootstrap's ``__exit__``, so trace
+# close runs LIFO first). Design: ``docs/claude/design/http-replay-trace.md``.
+_HTTP_REPLAY_TRACE_TEMPLATE = """\
+# CLM HTTP REPLAY TRACE - DO NOT EDIT
+_clm_trace_dir = {trace_dir!r}
+_clm_trace_verbose = {trace_verbose!r}
+_clm_trace_max_body = {trace_max_body!r}
+
+if _clm_trace_dir:
+    import hashlib as _clm_t_hashlib
+    import os as _clm_t_os
+    import socket as _clm_t_socket  # noqa: F401
+    import sys as _clm_t_sys
+    import threading as _clm_t_threading
+    import time as _clm_t_time
+    import contextlib as _clm_t_contextlib
+    from datetime import datetime as _clm_t_datetime, timezone as _clm_t_timezone
+
+    _clm_t_os.makedirs(_clm_trace_dir, exist_ok=True)
+    _clm_trace_path = _clm_t_os.path.join(
+        _clm_trace_dir, "worker-" + str(_clm_t_os.getpid()) + ".jsonl"
+    )
+    _clm_trace_fh = open(_clm_trace_path, "a", encoding="utf-8", newline="\\n")
+    _clm_trace_lock = _clm_t_threading.Lock()
+    _clm_trace_start = _clm_t_time.monotonic()
+
+    def _clm_redact_body(body, max_per_side=_clm_trace_max_body):
+        if body is None:
+            raw = b""
+        elif isinstance(body, (bytes, bytearray)):
+            raw = bytes(body)
+        elif isinstance(body, str):
+            raw = body.encode("utf-8", errors="replace")
+        else:
+            read = getattr(body, "read", None)
+            if callable(read):
+                try:
+                    data = read()
+                except Exception:
+                    raw = str(body).encode("utf-8", errors="replace")
+                else:
+                    if isinstance(data, (bytes, bytearray)):
+                        raw = bytes(data)
+                    else:
+                        raw = str(data).encode("utf-8", errors="replace")
+            else:
+                raw = str(body).encode("utf-8", errors="replace")
+        length = len(raw)
+        sha = _clm_t_hashlib.sha256(raw).hexdigest()[:16] if length > 0 else ""
+        if length <= 2 * max_per_side:
+            return {{"length": length, "sha256": sha, "head": repr(raw)}}
+        return {{
+            "length": length,
+            "sha256": sha,
+            "head": repr(raw[:max_per_side]),
+            "tail": repr(raw[-max_per_side:]),
+            "truncated": length - 2 * max_per_side,
+        }}
+
+    def _clm_trace_emit(stream, event, data=None):
+        record = {{
+            "ts_mono": _clm_t_time.monotonic() - _clm_trace_start,
+            "ts_wall": _clm_t_datetime.now(_clm_t_timezone.utc).isoformat(),
+            "pid": _clm_t_os.getpid(),
+            "tid": _clm_t_threading.get_ident(),
+            "stream": stream,
+            "event": event,
+            "data": data or {{}},
+        }}
+        try:
+            line = _clm_json.dumps(record) + "\\n"
+        except (TypeError, ValueError):
+            line = _clm_json.dumps({{
+                "ts_mono": record["ts_mono"],
+                "ts_wall": record["ts_wall"],
+                "pid": record["pid"],
+                "tid": record["tid"],
+                "stream": stream,
+                "event": event,
+                "data": {{"_unserializable": True}},
+            }}) + "\\n"
+        with _clm_trace_lock:
+            _clm_trace_fh.write(line)
+            _clm_trace_fh.flush()
+
+    def _clm_audit_hook(event, args):
+        try:
+            if event == "socket.connect" and len(args) >= 2:
+                address = args[1]
+                if isinstance(address, tuple) and len(address) >= 2:
+                    host, port = address[0], address[1]
+                else:
+                    host, port = repr(address), None
+                _clm_trace_emit("socket", "connect", {{"host": host, "port": port}})
+        except Exception:
+            pass
+
+    _clm_t_sys.addaudithook(_clm_audit_hook)
+
+    _clm_orig_force_reset = _clm_vcr_patch.force_reset
+
+    @_clm_t_contextlib.contextmanager
+    def _clm_logged_force_reset():
+        _clm_trace_emit("vcr", "force_reset.enter")
+        try:
+            with _clm_orig_force_reset():
+                yield
+        finally:
+            _clm_trace_emit("vcr", "force_reset.exit")
+
+    _clm_vcr_patch.force_reset = _clm_logged_force_reset
+
+    _clm_orig_traced_append = _clm_cassette.append
+
+    def _clm_traced_append(request, response):
+        try:
+            result = _clm_orig_traced_append(request, response)
+        except Exception as exc:
+            _clm_trace_emit("vcr", "cassette.append.error", {{
+                "method": getattr(request, "method", ""),
+                "uri": getattr(request, "uri", ""),
+                "exc_type": type(exc).__name__,
+                "exc_msg": str(exc),
+            }})
+            raise
+        try:
+            status = None
+            if isinstance(response, dict):
+                s = response.get("status")
+                if isinstance(s, dict):
+                    status = s.get("code")
+                else:
+                    status = s
+            _clm_trace_emit("vcr", "cassette.append", {{
+                "method": getattr(request, "method", ""),
+                "uri": getattr(request, "uri", ""),
+                "body": _clm_redact_body(getattr(request, "body", None)),
+                "status": status,
+            }})
+        except Exception:
+            pass
+        return result
+
+    _clm_cassette.append = _clm_traced_append
+
+    _clm_orig_play = _clm_cassette.play_response
+
+    def _clm_traced_play(request):
+        response = _clm_orig_play(request)
+        try:
+            _clm_trace_emit("vcr", "cassette.play", {{
+                "method": getattr(request, "method", ""),
+                "uri": getattr(request, "uri", ""),
+                "body": _clm_redact_body(getattr(request, "body", None)),
+            }})
+        except Exception:
+            pass
+        return response
+
+    _clm_cassette.play_response = _clm_traced_play
+
+    _clm_orig_can_play = _clm_cassette.can_play_response_now
+
+    def _clm_traced_can_play(request):
+        result = _clm_orig_can_play(request)
+        try:
+            _clm_trace_emit("vcr", "cassette.can_play", {{
+                "method": getattr(request, "method", ""),
+                "uri": getattr(request, "uri", ""),
+                "body": _clm_redact_body(getattr(request, "body", None)),
+                "result": bool(result),
+            }})
+        except Exception:
+            pass
+        return result
+
+    _clm_cassette.can_play_response_now = _clm_traced_can_play
+
+    _clm_trace_emit("vcr", "bootstrap.complete", {{
+        "vcr_version": getattr(_clm_vcr, "__version__", "unknown"),
+        "scoped_force_reset": getattr(_clm_vcr_patch.reset_patchers, "_clm_scoped", False),
+        "verbose": _clm_trace_verbose,
+    }})
+
+    def _clm_trace_close():
+        try:
+            _clm_trace_emit("vcr", "trace.close")
+        except Exception:
+            pass
+        try:
+            _clm_trace_fh.flush()
+            _clm_trace_fh.close()
+        except Exception:
+            pass
+
+    _clm_atexit.register(_clm_trace_close)
+"""
+
+
+def _inject_http_replay_bootstrap(
+    nb: NotebookNode,
+    cassette_path: str,
+    mode: str,
+    *,
+    trace_dir: str = "",
+    trace_verbose: bool = False,
+    trace_max_body: int = 2048,
+) -> None:
     """Prepend a vcrpy-activation cell to ``nb``.
 
     ``cassette_path`` must be an absolute path to the worker's staging
@@ -344,6 +558,11 @@ def _inject_http_replay_bootstrap(nb: NotebookNode, cassette_path: str, mode: st
     file. The cell is tagged ``del`` and marked with
     ``metadata.clm_injected = "http_replay"`` so the post-execution pass
     can remove it by metadata rather than by string-matching the source.
+
+    When ``trace_dir`` is non-empty, the forensic trace template is
+    appended to the bootstrap so the kernel emits socket/vcr/cassette
+    events to ``<trace_dir>/worker-<pid>.jsonl``. Empty string (the
+    common case) leaves the bootstrap unchanged.
     """
     vcr_mode = _HTTP_REPLAY_MODE_TO_VCR_MODE[mode]
     from nbformat.v4 import new_code_cell
@@ -351,6 +570,12 @@ def _inject_http_replay_bootstrap(nb: NotebookNode, cassette_path: str, mode: st
     source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
         record_mode=vcr_mode, cassette_path=cassette_path
     )
+    if trace_dir:
+        source += "\n" + _HTTP_REPLAY_TRACE_TEMPLATE.format(
+            trace_dir=trace_dir,
+            trace_verbose=trace_verbose,
+            trace_max_body=trace_max_body,
+        )
     cell = new_code_cell(
         source=source,
         metadata={
@@ -1586,7 +1811,26 @@ class NotebookProcessor:
         mode = payload.http_replay_mode
         if not mode or mode == "disabled" or mode not in _HTTP_REPLAY_MODE_TO_VCR_MODE:
             return False
-        _inject_http_replay_bootstrap(processed_nb, str(paths.staging), mode)
+        trace_dir = getattr(payload, "http_replay_trace_dir", "") or ""
+        trace_verbose = os.environ.get("CLM_HTTP_REPLAY_TRACE_VERBOSE", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        trace_max_body_raw = os.environ.get("CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES", "").strip()
+        try:
+            trace_max_body = int(trace_max_body_raw) if trace_max_body_raw else 2048
+        except ValueError:
+            trace_max_body = 2048
+        _inject_http_replay_bootstrap(
+            processed_nb,
+            str(paths.staging),
+            mode,
+            trace_dir=trace_dir,
+            trace_verbose=trace_verbose,
+            trace_max_body=trace_max_body,
+        )
         logger.debug(
             f"{payload.correlation_id}: Injected http-replay bootstrap "
             f"(mode={mode}, staging='{paths.staging}', canonical='{paths.canonical}') "

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -111,6 +111,14 @@ _HTTP_REPLAY_MODE_TO_VCR_MODE = {
 
 _HTTP_REPLAY_BOOTSTRAP_MARKER = "http_replay"
 
+# Hosts whose traffic vcrpy should not record into the cassette. Defaults
+# cover LangSmith's telemetry upload endpoint (request bodies contain
+# per-build timestamps + UUIDs, defeating the body matcher and causing
+# stale-source builds to grow cassettes indefinitely). Add more here as
+# we encounter other telemetry endpoints with the same shape, or override
+# at build time via ``CLM_HTTP_REPLAY_IGNORE_HOSTS`` (comma-separated).
+_DEFAULT_HTTP_REPLAY_IGNORE_HOSTS = ("api.smith.langchain.com",)
+
 _HTTP_REPLAY_BOOTSTRAP_TEMPLATE = """\
 # CLM HTTP REPLAY BOOTSTRAP - DO NOT EDIT
 import atexit as _clm_atexit
@@ -268,6 +276,17 @@ _clm_vcr_instance = _clm_vcr.VCR(
     filter_post_data_parameters=["password", "token", "api_key"],
     filter_query_parameters=["api_key", "token"],
     decode_compressed_response=True,
+    # Observability/telemetry endpoints whose request bodies contain
+    # per-build non-determinism (timestamps, UUIDs, multipart boundaries)
+    # that defeat the body matcher and cause a fresh cassette entry on
+    # every build even when the slide source is unchanged. LangSmith's
+    # ``/runs/multipart`` upload is the canonical example. ``ignore_hosts``
+    # lets vcr's stubs pass these straight through to the real network,
+    # so telemetry still reaches the user's dashboard but never enters
+    # the cassette. Override or extend at build time via
+    # ``CLM_HTTP_REPLAY_IGNORE_HOSTS`` (comma-separated). Set to empty
+    # string to record everything.
+    ignore_hosts={ignore_hosts!r},
     # vcrpy's default ``match_on`` is
     # ``("method", "scheme", "host", "port", "path", "query")`` -- the
     # request body is *not* part of the match key.  All POSTs to the same
@@ -549,6 +568,7 @@ def _inject_http_replay_bootstrap(
     trace_dir: str = "",
     trace_verbose: bool = False,
     trace_max_body: int = 2048,
+    ignore_hosts: tuple[str, ...] | list[str] = _DEFAULT_HTTP_REPLAY_IGNORE_HOSTS,
 ) -> None:
     """Prepend a vcrpy-activation cell to ``nb``.
 
@@ -568,7 +588,9 @@ def _inject_http_replay_bootstrap(
     from nbformat.v4 import new_code_cell
 
     source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
-        record_mode=vcr_mode, cassette_path=cassette_path
+        record_mode=vcr_mode,
+        cassette_path=cassette_path,
+        ignore_hosts=list(ignore_hosts),
     )
     if trace_dir:
         source += "\n" + _HTTP_REPLAY_TRACE_TEMPLATE.format(
@@ -1823,6 +1845,14 @@ class NotebookProcessor:
             trace_max_body = int(trace_max_body_raw) if trace_max_body_raw else 2048
         except ValueError:
             trace_max_body = 2048
+        ignore_hosts_raw = os.environ.get("CLM_HTTP_REPLAY_IGNORE_HOSTS")
+        ignore_hosts: tuple[str, ...]
+        if ignore_hosts_raw is None:
+            ignore_hosts = _DEFAULT_HTTP_REPLAY_IGNORE_HOSTS
+        else:
+            ignore_hosts = tuple(
+                host.strip() for host in ignore_hosts_raw.split(",") if host.strip()
+            )
         _inject_http_replay_bootstrap(
             processed_nb,
             str(paths.staging),
@@ -1830,6 +1860,7 @@ class NotebookProcessor:
             trace_dir=trace_dir,
             trace_verbose=trace_verbose,
             trace_max_body=trace_max_body,
+            ignore_hosts=ignore_hosts,
         )
         logger.debug(
             f"{payload.correlation_id}: Injected http-replay bootstrap "

--- a/src/clm/workers/notebook/notebook_worker.py
+++ b/src/clm/workers/notebook/notebook_worker.py
@@ -200,6 +200,7 @@ class NotebookWorker(Worker):
                 skip_errors=payload_data.get("skip_errors", False),
                 http_replay_mode=payload_data.get("http_replay_mode"),
                 http_replay_cassette_name=payload_data.get("http_replay_cassette_name"),
+                http_replay_trace_dir=payload_data.get("http_replay_trace_dir", ""),
                 img_path_prefix=payload_data.get("img_path_prefix", "img/"),
                 source_topic_dir=payload_data.get("source_topic_dir", ""),
                 author=payload_data.get("author", "Dr. Matthias Hölzl"),

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1536,3 +1536,32 @@ class TestMaybeRunSweepSkipReasons:
         )
         assert len(calls) == 1
         assert calls[0]["skip_reason"] is None
+
+
+class TestProcessCourseInvokesCassetteSweep:
+    """Regression for issue #145.
+
+    The pre-build orphan staging-cassette sweep
+    (:meth:`Course._sweep_orphan_cassette_staging_files`) was documented
+    to run before every ``clm build`` but was actually only invoked from
+    ``Course.process_all`` / ``Course.process_file``. The ``clm build``
+    path goes through ``process_course_with_backend`` →
+    ``course.process_stage`` and never called the sweep, so orphan
+    ``*.staging-*`` files from killed previous runs accumulated forever.
+    This test pins the call so a future refactor cannot silently re-break
+    it.
+    """
+
+    def test_sweep_call_present_in_run_stages(self) -> None:
+        import inspect
+
+        from clm.cli.commands.build import process_course_with_backend
+
+        source = inspect.getsource(process_course_with_backend)
+        assert "_sweep_orphan_cassette_staging_files" in source, (
+            "process_course_with_backend must invoke "
+            "course._sweep_orphan_cassette_staging_files() before the "
+            "stage loop (issue #145). If this assertion fires, the call "
+            "was removed or moved out of the build entry path — restore "
+            "it or the orphan cleanup stops happening during normal builds."
+        )

--- a/tests/workers/notebook/test_http_replay_cassette.py
+++ b/tests/workers/notebook/test_http_replay_cassette.py
@@ -1,0 +1,90 @@
+"""Unit tests for HTTP-replay cassette helpers — especially the dedup key.
+
+The bulk of the cassette lifecycle is covered by integration tests; this
+module pins behavior of the small pure-Python helpers that have caused
+production incidents when they were silently wrong.
+"""
+
+from __future__ import annotations
+
+import io
+
+from clm.workers.notebook.http_replay_cassette import _body_to_dedup_bytes, _dedup_key
+
+
+class _StubRequest:
+    """Minimal stand-in for ``vcr.request.Request``."""
+
+    def __init__(self, method: str, uri: str, body):
+        self.method = method
+        self.uri = uri
+        self.body = body
+
+
+class TestBodyToDedupBytes:
+    def test_none_body(self):
+        assert _body_to_dedup_bytes(None) == b""
+
+    def test_bytes_passthrough(self):
+        assert _body_to_dedup_bytes(b"abc") == b"abc"
+
+    def test_bytearray_normalized_to_bytes(self):
+        out = _body_to_dedup_bytes(bytearray(b"xyz"))
+        assert isinstance(out, bytes)
+        assert out == b"xyz"
+
+    def test_str_encoded_utf8(self):
+        assert _body_to_dedup_bytes("héllo") == "héllo".encode()
+
+    def test_bytesio_read_and_rewound(self):
+        stream = io.BytesIO(b"payload")
+        out = _body_to_dedup_bytes(stream)
+        assert out == b"payload"
+        # The stream must be rewound so other consumers (e.g. requests.Session)
+        # can still read it after dedup keying.
+        assert stream.read() == b"payload"
+
+    def test_two_bytesio_with_identical_content_produce_equal_keys(self):
+        # Regression for the production growth bug: vcrpy YAML serializes
+        # a BytesIO request body via ``!!python/object/new:_io.BytesIO``;
+        # loading the cassette twice produces two distinct BytesIO
+        # instances with the same content. ``str(BytesIO_instance)``
+        # contains the object's memory address, so the previous dedup
+        # logic treated them as distinct entries and merged both into
+        # canonical on every build, growing the cassette by the same
+        # number of LangSmith uploads each rebuild.
+        a = io.BytesIO(b"identical payload")
+        b = io.BytesIO(b"identical payload")
+        assert _body_to_dedup_bytes(a) == _body_to_dedup_bytes(b)
+
+
+class TestDedupKey:
+    def test_method_uri_body_form_the_key(self):
+        r = _StubRequest("POST", "https://example.com/x", b"hello")
+        assert _dedup_key(r) == ("POST", "https://example.com/x", b"hello")
+
+    def test_bytesio_bodies_with_same_content_dedup(self):
+        # Two requests that the merge SHOULD recognize as identical even
+        # though their bodies are distinct BytesIO instances (the case
+        # that surfaced as cassette growth on every LangChain build).
+        r1 = _StubRequest(
+            "POST",
+            "https://api.smith.langchain.com/runs/multipart",
+            io.BytesIO(b"compressed multipart payload"),
+        )
+        r2 = _StubRequest(
+            "POST",
+            "https://api.smith.langchain.com/runs/multipart",
+            io.BytesIO(b"compressed multipart payload"),
+        )
+        assert _dedup_key(r1) == _dedup_key(r2)
+
+    def test_different_uri_yields_different_key(self):
+        r1 = _StubRequest("GET", "https://a.example.com/", None)
+        r2 = _StubRequest("GET", "https://b.example.com/", None)
+        assert _dedup_key(r1) != _dedup_key(r2)
+
+    def test_different_body_yields_different_key(self):
+        r1 = _StubRequest("POST", "https://api.example.com/", b"one")
+        r2 = _StubRequest("POST", "https://api.example.com/", b"two")
+        assert _dedup_key(r1) != _dedup_key(r2)

--- a/tests/workers/notebook/test_http_replay_trace.py
+++ b/tests/workers/notebook/test_http_replay_trace.py
@@ -309,7 +309,7 @@ class TestBootstrapTraceTemplate:
             def play_response(self, request):
                 return None
 
-            def can_play_response_now(self, request):
+            def can_play_response_for(self, request):
                 return True
 
         class _StubVcrPatch:

--- a/tests/workers/notebook/test_http_replay_trace.py
+++ b/tests/workers/notebook/test_http_replay_trace.py
@@ -1,0 +1,534 @@
+"""Tests for the HTTP-replay forensic trace harness.
+
+Covers:
+
+* The host-side helpers (``redact_body``, ``TraceWriter``,
+  ``make_invocation_dir``, ``write_manifest``, env-var sensing).
+* The bootstrap template's trace block (formats, parses, includes the
+  expected wrappers).
+* The analysis script's ability to digest a synthetic trace bundle.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from clm.workers.notebook import http_replay_trace as trace_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_trace_state(monkeypatch):
+    monkeypatch.delenv("CLM_HTTP_REPLAY_TRACE", raising=False)
+    monkeypatch.delenv("CLM_HTTP_REPLAY_TRACE_DIR", raising=False)
+    monkeypatch.delenv("CLM_HTTP_REPLAY_TRACE_VERBOSE", raising=False)
+    monkeypatch.delenv("CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES", raising=False)
+    trace_mod.close_all_writers()
+    trace_mod.set_invocation_dir(None)
+    yield
+    trace_mod.close_all_writers()
+    trace_mod.set_invocation_dir(None)
+
+
+class TestEnvSensing:
+    def test_is_enabled_default_off(self):
+        assert trace_mod.is_enabled() is False
+
+    def test_is_enabled_truthy_values(self, monkeypatch):
+        for v in ("1", "true", "yes", "on", "TRUE", "Yes"):
+            monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE", v)
+            assert trace_mod.is_enabled() is True, f"expected {v!r} to enable"
+
+    def test_is_enabled_falsy_values(self, monkeypatch):
+        for v in ("", "0", "false", "no", "off"):
+            monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE", v)
+            assert trace_mod.is_enabled() is False, f"expected {v!r} to leave off"
+
+    def test_max_body_bytes_default(self):
+        assert trace_mod.max_body_bytes() == 2048
+
+    def test_max_body_bytes_override(self, monkeypatch):
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES", "4096")
+        assert trace_mod.max_body_bytes() == 4096
+
+    def test_max_body_bytes_bad_value_falls_back(self, monkeypatch):
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES", "garbage")
+        assert trace_mod.max_body_bytes() == 2048
+
+    def test_max_body_bytes_negative_falls_back(self, monkeypatch):
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES", "-1")
+        assert trace_mod.max_body_bytes() == 2048
+
+
+class TestRedactBody:
+    def test_short_body_no_tail(self):
+        out = trace_mod.redact_body(b"hello")
+        assert out["length"] == 5
+        assert out["head"] == "b'hello'"
+        assert "tail" not in out
+        assert out["sha256"]  # non-empty
+
+    def test_none_body(self):
+        out = trace_mod.redact_body(None)
+        assert out["length"] == 0
+        assert out["head"] == "b''"
+        assert out["sha256"] == ""
+
+    def test_crlf_preserved_in_repr(self):
+        out = trace_mod.redact_body(b"line1\r\nline2")
+        # repr() must surface the CR/LF escape sequence so analysis can spot it
+        assert "\\r\\n" in out["head"], f"expected \\\\r\\\\n in {out['head']!r}"
+
+    def test_long_body_head_tail_split(self):
+        body = b"A" * 100 + b"B" * 100
+        out = trace_mod.redact_body(body, max_per_side=20)
+        assert out["length"] == 200
+        assert "tail" in out
+        assert out["truncated"] == 200 - 40
+        assert out["head"].count("A") == 20
+        assert out["tail"].count("B") == 20
+
+    def test_unicode_body_safe(self):
+        out = trace_mod.redact_body("hëllo wörld")
+        assert out["length"] > 0
+        assert "head" in out
+
+    def test_sha_stable_across_calls(self):
+        a = trace_mod.redact_body(b"identical")
+        b = trace_mod.redact_body(b"identical")
+        assert a["sha256"] == b["sha256"]
+
+    def test_sha_differs_for_different_bodies(self):
+        a = trace_mod.redact_body(b"one")
+        b = trace_mod.redact_body(b"two")
+        assert a["sha256"] != b["sha256"]
+
+
+class TestInvocationDir:
+    def test_make_invocation_dir_under_root(self, tmp_path):
+        ts = datetime(2026, 5, 26, 16, 39, 10, tzinfo=timezone.utc)
+        out = trace_mod.make_invocation_dir(root=tmp_path, timestamp=ts)
+        assert out.parent == tmp_path
+        assert out.name.startswith("2026-05-26T16-39-10_")
+        assert out.is_dir()
+
+    def test_make_invocation_dir_distinct_per_call(self, tmp_path):
+        ts = datetime(2026, 5, 26, 16, 39, 10, tzinfo=timezone.utc)
+        a = trace_mod.make_invocation_dir(root=tmp_path, timestamp=ts)
+        b = trace_mod.make_invocation_dir(root=tmp_path, timestamp=ts)
+        assert a != b  # uuid suffix breaks the tie
+
+    def test_resolve_trace_root_default_is_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        assert trace_mod.resolve_trace_root() == tmp_path / "clm-http-replay-traces"
+
+    def test_resolve_trace_root_override(self, monkeypatch, tmp_path):
+        target = tmp_path / "custom"
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE_DIR", str(target))
+        assert trace_mod.resolve_trace_root() == target.resolve()
+
+
+class TestManifest:
+    def test_write_manifest_round_trip(self, tmp_path):
+        invocation = trace_mod.make_invocation_dir(root=tmp_path)
+        out = trace_mod.write_manifest(
+            invocation,
+            http_replay_mode="replay",
+            command_argv=["clm", "build", "spec.xml"],
+        )
+        assert out.is_file()
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["http_replay_mode"] == "replay"
+        assert payload["argv"] == ["clm", "build", "spec.xml"]
+        assert payload["schema"] == 1
+        assert "started_at" in payload
+
+    def test_write_manifest_includes_extra(self, tmp_path):
+        invocation = trace_mod.make_invocation_dir(root=tmp_path)
+        out = trace_mod.write_manifest(
+            invocation,
+            http_replay_mode=None,
+            extra={"course": "AZAV-ML"},
+        )
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["course"] == "AZAV-ML"
+
+
+class TestTraceWriter:
+    def test_emit_writes_one_jsonl_line(self, tmp_path):
+        path = tmp_path / "out.jsonl"
+        writer = trace_mod.TraceWriter(path, stream="vcr")
+        writer.emit("test.event", {"k": "v"})
+        writer.close()
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["stream"] == "vcr"
+        assert record["event"] == "test.event"
+        assert record["data"] == {"k": "v"}
+        assert record["pid"] == os.getpid()
+        assert record["tid"] == threading.get_ident()
+
+    def test_emit_thread_safe(self, tmp_path):
+        path = tmp_path / "concurrent.jsonl"
+        writer = trace_mod.TraceWriter(path, stream="socket")
+        n_threads = 8
+        per_thread = 50
+
+        def worker(label: int) -> None:
+            for i in range(per_thread):
+                writer.emit("connect", {"i": i, "label": label})
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        writer.close()
+
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == n_threads * per_thread
+        for line in lines:
+            json.loads(line)  # every line must parse — no torn writes
+
+    def test_get_writer_no_op_when_disabled(self, tmp_path):
+        # Default fixture state: no invocation dir, env not set.
+        w = trace_mod.get_writer("host")
+        w.emit("anything", {"x": 1})  # must not raise
+        assert isinstance(w, trace_mod._NullWriter)
+
+    def test_get_writer_writes_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE", "1")
+        invocation = trace_mod.make_invocation_dir(root=tmp_path)
+        trace_mod.set_invocation_dir(invocation)
+        w = trace_mod.get_writer("host")
+        w.emit("seed", {"a": 1})
+        trace_mod.close_all_writers()
+        target = invocation / "host.jsonl"
+        record = json.loads(target.read_text(encoding="utf-8").splitlines()[0])
+        assert record["event"] == "seed"
+        assert record["data"]["a"] == 1
+
+
+class TestBootstrapTraceTemplate:
+    """The injected trace cell must format, parse, and behave as expected."""
+
+    def test_inject_without_trace_dir_omits_trace_block(self):
+        from nbformat.v4 import new_notebook
+
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = new_notebook()
+        _inject_http_replay_bootstrap(nb, "/abs/foo.yaml", "replay")
+        source = nb["cells"][0]["source"]
+        assert "CLM HTTP REPLAY TRACE" not in source
+        ast.parse(source)
+
+    def test_inject_with_trace_dir_appends_trace_block(self, tmp_path):
+        from nbformat.v4 import new_notebook
+
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = new_notebook()
+        _inject_http_replay_bootstrap(
+            nb,
+            "/abs/foo.yaml",
+            "replay",
+            trace_dir=str(tmp_path),
+            trace_verbose=False,
+            trace_max_body=1024,
+        )
+        source = nb["cells"][0]["source"]
+        assert "CLM HTTP REPLAY TRACE" in source
+        # Must still parse as valid Python
+        ast.parse(source)
+        # Trace dir must be embedded as a Python string literal
+        assert repr(str(tmp_path)) in source
+        # Audit hook + force_reset wrap + cassette wraps must be present
+        assert "sys.addaudithook" in source or "_clm_t_sys.addaudithook" in source
+        assert "_clm_logged_force_reset" in source
+        assert "_clm_traced_append" in source
+        assert "_clm_traced_play" in source
+        assert "_clm_traced_can_play" in source
+
+    def test_inject_empty_trace_dir_still_no_trace_block(self):
+        from nbformat.v4 import new_notebook
+
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = new_notebook()
+        _inject_http_replay_bootstrap(
+            nb,
+            "/abs/foo.yaml",
+            "replay",
+            trace_dir="",
+        )
+        source = nb["cells"][0]["source"]
+        assert "CLM HTTP REPLAY TRACE" not in source
+
+    def test_trace_template_inlined_redactor_matches_host(self, tmp_path):
+        """The bootstrap inlines its own ``_clm_redact_body`` because it
+        cannot import CLM modules from the kernel. This test exec's the
+        trace template (with vcr stubs) and compares the inlined
+        redactor's output to the host ``redact_body`` for a handful of
+        inputs, so the two implementations cannot silently drift apart.
+        """
+        from clm.workers.notebook.notebook_processor import (
+            _HTTP_REPLAY_TRACE_TEMPLATE,
+        )
+
+        source = _HTTP_REPLAY_TRACE_TEMPLATE.format(
+            trace_dir=str(tmp_path),
+            trace_verbose=False,
+            trace_max_body=2048,
+        )
+        # The template references _clm_vcr_patch / _clm_cassette / _clm_atexit /
+        # _clm_json / _clm_vcr from the bootstrap above. Stub minimally so the
+        # template can exec in isolation.
+        import atexit as _real_atexit
+
+        class _StubCassette:
+            def append(self, request, response):
+                return None
+
+            def play_response(self, request):
+                return None
+
+            def can_play_response_now(self, request):
+                return True
+
+        class _StubVcrPatch:
+            class reset_patchers:
+                _clm_scoped = True
+
+            @staticmethod
+            def force_reset():
+                import contextlib
+
+                return contextlib.nullcontext()
+
+        ns: dict = {
+            "_clm_vcr_patch": _StubVcrPatch(),
+            "_clm_cassette": _StubCassette(),
+            "_clm_atexit": _real_atexit,
+            "_clm_json": json,
+            "_clm_vcr": type("V", (), {"__version__": "stub"}),
+        }
+        exec(source, ns)
+        inlined = ns["_clm_redact_body"]
+
+        cases = [b"", b"x", b"hello\r\nworld", b"A" * 50 + b"B" * 50]
+        for body in cases:
+            inlined_out = inlined(body, 16)
+            host_out = trace_mod.redact_body(body, max_per_side=16)
+            assert inlined_out == host_out, f"mismatch on {body!r}: {inlined_out=} {host_out=}"
+
+
+class TestAnalysisScript:
+    """The analyze_http_replay_trace script must digest a synthetic bundle."""
+
+    def _build_synthetic_bundle(self, tmp_path: Path) -> Path:
+        invocation = tmp_path / "trace"
+        invocation.mkdir()
+        (invocation / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "started_at": "2026-05-26T16:39:10+00:00",
+                    "host_pid": 99,
+                    "http_replay_mode": "replay",
+                    "verbose": False,
+                    "max_body_bytes": 2048,
+                    "argv": ["clm", "build"],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        def _event(stream, event, *, pid, tid, ts_mono, data=None):
+            return (
+                json.dumps(
+                    {
+                        "ts_mono": ts_mono,
+                        "ts_wall": "2026-05-26T16:39:10+00:00",
+                        "pid": pid,
+                        "tid": tid,
+                        "stream": stream,
+                        "event": event,
+                        "data": data or {},
+                    }
+                )
+                + "\n"
+            )
+
+        # host: one seed, one merge that folds one entry
+        (invocation / "host.jsonl").write_text(
+            _event(
+                "cassette",
+                "cassette.seed",
+                pid=99,
+                tid=1,
+                ts_mono=0.0,
+                data={"canonical": "/c", "staging": "/s", "seeded_bytes": 0},
+            )
+            + _event(
+                "cassette",
+                "cassette.merge.start",
+                pid=99,
+                tid=1,
+                ts_mono=1.0,
+                data={"canonical": "/c", "n_staging_files": 1},
+            )
+            + _event(
+                "cassette",
+                "cassette.merge.decision",
+                pid=99,
+                tid=1,
+                ts_mono=1.1,
+                data={
+                    "staging": "/s",
+                    "decision": "folded",
+                    "interactions_loaded": 1,
+                    "interactions_folded": 1,
+                    "interactions_deduped": 0,
+                },
+            )
+            + _event(
+                "cassette",
+                "cassette.merge.end",
+                pid=99,
+                tid=1,
+                ts_mono=1.2,
+                data={"canonical": "/c", "folded": 1, "final_interaction_count": 1},
+            ),
+            encoding="utf-8",
+        )
+
+        # worker 1234: classic race — force_reset opens on TID B,
+        # remote socket.connect fires on TID A in the window.
+        lines = []
+        lines.append(_event("vcr", "force_reset.enter", pid=1234, tid=2, ts_mono=10.0))
+        lines.append(
+            _event(
+                "socket",
+                "connect",
+                pid=1234,
+                tid=1,
+                ts_mono=10.001,
+                data={"host": "api.openai.com", "port": 443},
+            )
+        )
+        lines.append(_event("vcr", "force_reset.exit", pid=1234, tid=2, ts_mono=10.01))
+        # And a clean cassette hit on TID 1 a moment later — must NOT count as bypass
+        lines.append(
+            _event(
+                "vcr",
+                "cassette.can_play",
+                pid=1234,
+                tid=1,
+                ts_mono=10.1,
+                data={"host": "api.openai.com", "result": True},
+            )
+        )
+        lines.append(
+            _event(
+                "vcr",
+                "cassette.play",
+                pid=1234,
+                tid=1,
+                ts_mono=10.11,
+                data={"host": "api.openai.com"},
+            )
+        )
+        # A loopback connect (kernel ↔ jupyter) must not be counted as remote
+        lines.append(
+            _event(
+                "socket",
+                "connect",
+                pid=1234,
+                tid=1,
+                ts_mono=10.2,
+                data={"host": "127.0.0.1", "port": 50000},
+            )
+        )
+        # A pure bypass: remote connect with NO vcr event nearby
+        lines.append(
+            _event(
+                "socket",
+                "connect",
+                pid=1234,
+                tid=1,
+                ts_mono=20.0,
+                data={"host": "smith.langchain.com", "port": 443},
+            )
+        )
+        (invocation / "worker-1234.jsonl").write_text("".join(lines), encoding="utf-8")
+        return invocation
+
+    def test_analyze_classifies_race_and_bypass(self, tmp_path):
+        sys.path.insert(0, str(Path("scripts").resolve()))
+        try:
+            import analyze_http_replay_trace as ana
+        finally:
+            sys.path.pop(0)
+
+        bundle = self._build_synthetic_bundle(tmp_path)
+        result = ana.analyze(bundle)
+
+        assert result.manifest["http_replay_mode"] == "replay"
+        assert result.host.seeds == 1
+        assert result.host.folded_total == 1
+
+        assert 1234 in result.workers
+        ws = result.workers[1234]
+        assert len(ws.loopback_connects) == 1
+        assert len(ws.remote_connects) == 2
+        # The connect at t=10.001 is a race candidate (force_reset open on TID 2)
+        assert len(ws.race_candidates) == 1
+        assert ws.race_candidates[0]["host"] == "api.openai.com"
+        # The connect at t=20.0 is a pure bypass (no vcr event near it)
+        assert len(ws.bypassed) == 1
+        assert ws.bypassed[0]["host"] == "smith.langchain.com"
+
+    def test_analyze_text_report_smoketest(self, tmp_path):
+        sys.path.insert(0, str(Path("scripts").resolve()))
+        try:
+            import analyze_http_replay_trace as ana
+        finally:
+            sys.path.pop(0)
+
+        bundle = self._build_synthetic_bundle(tmp_path)
+        result = ana.analyze(bundle)
+        report = ana.format_text(result)
+        assert "Bypassed" in report
+        assert "Race candidates" in report
+        assert "api.openai.com" in report or "smith.langchain.com" in report
+
+    def test_analyze_cli_runs(self, tmp_path):
+        bundle = self._build_synthetic_bundle(tmp_path)
+        proc = subprocess.run(
+            [sys.executable, "scripts/analyze_http_replay_trace.py", str(bundle), "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert "workers" in payload
+        assert "host" in payload

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2091,6 +2091,65 @@ class TestHttpReplayBootstrap:
             "cassettes will fail strict replay on the second identical request."
         )
 
+    def test_inject_defaults_ignore_langsmith_host(self):
+        # LangSmith trace uploads (POST api.smith.langchain.com/runs/multipart)
+        # carry per-build timestamps + UUIDs in the request body. The
+        # ``clm_json_body`` matcher then never matches a previously-recorded
+        # entry, so every build records a fresh one — making cassettes grow
+        # on every rebuild even when the slide source is unchanged. The
+        # bootstrap defaults vcrpy's ``ignore_hosts`` to skip LangSmith so
+        # those requests pass through to the real network and never enter
+        # the cassette.
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = make_notebook_node([make_cell("code", "pass")])
+        _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "replay")
+
+        src = nb["cells"][0]["source"]
+        assert "ignore_hosts=" in src, "Bootstrap is missing the ``ignore_hosts`` arg."
+        assert "api.smith.langchain.com" in src, (
+            "Bootstrap default ``ignore_hosts`` must include LangSmith's "
+            "telemetry endpoint; otherwise cassettes grow on every rebuild."
+        )
+
+    def test_inject_ignore_hosts_overridable(self):
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = make_notebook_node([make_cell("code", "pass")])
+        _inject_http_replay_bootstrap(
+            nb,
+            "/abs/c.yaml",
+            "replay",
+            ignore_hosts=("foo.example.com", "bar.example.com"),
+        )
+
+        src = nb["cells"][0]["source"]
+        assert "foo.example.com" in src
+        assert "bar.example.com" in src
+        # And the default shouldn't sneak in when caller passed an explicit list
+        assert "api.smith.langchain.com" not in src
+
+    def test_inject_ignore_hosts_can_be_empty(self):
+        from clm.workers.notebook.notebook_processor import (
+            _inject_http_replay_bootstrap,
+        )
+
+        nb = make_notebook_node([make_cell("code", "pass")])
+        _inject_http_replay_bootstrap(
+            nb,
+            "/abs/c.yaml",
+            "replay",
+            ignore_hosts=(),
+        )
+
+        src = nb["cells"][0]["source"]
+        # Empty list literal in the rendered source
+        assert "ignore_hosts=[]" in src
+
     def test_inject_pins_body_in_match_on(self):
         # The bootstrap must include a body matcher in vcrpy's ``match_on`` tuple.
         # vcrpy's default matcher only looks at method+scheme+host+port+path+
@@ -3475,6 +3534,7 @@ class TestBootstrapDurability:
         source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
             record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["refresh"],
             cassette_path=str(cassette_path),
+            ignore_hosts=[],
         )
 
         # Capture atexit registrations so we can verify the cassette was
@@ -3538,6 +3598,7 @@ from clm.workers.notebook.notebook_processor import (
 source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
     record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE['refresh'],
     cassette_path=r'''{cassette_path}''',
+            ignore_hosts=[],
 )
 ns = {{}}
 exec(compile(source, '<bootstrap>', 'exec'), ns, ns)
@@ -3614,6 +3675,7 @@ os._exit(0)
         source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
             record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["replay"],
             cassette_path=str(cassette_path),
+            ignore_hosts=[],
         )
 
         ns: dict = {}
@@ -3680,6 +3742,7 @@ os._exit(0)
             source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
                 record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["replay"],
                 cassette_path=str(tmp_path / "scope.http-cassette.yaml"),
+                ignore_hosts=[],
             )
             # Exec only the patch prefix -- no need to open a cassette
             # just to inspect the swapped reset_patchers.
@@ -3753,6 +3816,7 @@ os._exit(0)
         source = _HTTP_REPLAY_BOOTSTRAP_TEMPLATE.format(
             record_mode=_HTTP_REPLAY_MODE_TO_VCR_MODE["refresh"],
             cassette_path=str(cassette_path),
+            ignore_hosts=[],
         )
         # Suppress the bootstrap's atexit registration so the cassette
         # context exits cleanly at the end of the test rather than at


### PR DESCRIPTION
## Summary

Adds an off-by-default forensic trace harness for HTTP-replay debugging and uses it to find and fix three real cassette bugs against the AZAV ML course. Net effect: trace tooling for the future + cassettes stop changing on no-op rebuilds.

- **Phase A trace harness**: three independent telemetry streams (socket / vcr / cassette) producing structured JSONL bundles, plus an analysis script that cross-references them and surfaces bypass forensics (including the issue-129 race fingerprint).
- **Issue #145 fix**: `Course._sweep_orphan_cassette_staging_files` was documented to run pre-build but was never invoked from `clm build` (only from `process_all`/`process_file`). Orphan `.staging-*` files from killed sessions accumulated forever. Added the call to `process_course_with_backend`.
- **Two cassette-growth bugs**: LangSmith telemetry was being recorded with per-build timestamps, and the merge's dedup key used `str(BytesIO)` (object memory address) for stream bodies, so every loaded LangSmith entry looked "new" and got folded into canonical again. Both needed fixing; either alone is insufficient.

## Activate the harness

```bash
CLM_HTTP_REPLAY_TRACE=1 clm build <spec> --http-replay=replay
uv run python scripts/analyze_http_replay_trace.py clm-http-replay-traces/<timestamp_uuid>/
```

Off by default — when the env var is unset, the bootstrap is byte-identical to before and no trace dir is created. Optional knobs: `CLM_HTTP_REPLAY_TRACE_DIR`, `CLM_HTTP_REPLAY_TRACE_VERBOSE=1`, `CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES=N`.

## Commits

1. `98df223` — feat: forensic trace harness (initial sketch)
2. `57d1f6e` — fix: 5 bugs surfaced when first running the harness against AZAV ML (worker subprocesses didn't pick up the trace dir; `NotebookPayload` bridge in `notebook_worker.py` dropped the new field; wrong vcrpy method name `can_play_response_now` → `can_play_response_for`; cassette helpers in worker subprocesses now write to `host-<pid>.jsonl` to avoid races; analysis script aggregates host events by event-name prefix).
3. `ea84449` — chore: gitignore trace output directories.
4. `6f0ecbc` — fix(#145): invoke orphan staging-cassette sweep from the actual build path.
5. `b85c18c` — fix: two bugs that grew cassettes on every no-op rebuild (telemetry capture + unstable dedup key for BytesIO bodies).

## Verification

- 67+ new tests, full suite green (1500+ tests).
- AZAV ML W02 / W03b / W05 trace runs all clean: 0 bypasses, 0 issue-129 race candidates, all cassette hits accounted for. `scoped_force_reset: true` confirmed in every worker via `bootstrap.complete` events.
- After the dedup fix: `git diff` of the AZAV ML cassettes is **empty** after a `--http-replay=new-episodes --ignore-cache` rebuild, repeated twice to confirm steady-state stability.
- After the orphan-sweep fix: pre-existing orphan staging files get discarded; no leftover staging persists more than one build cycle.

## Test plan

- [ ] CI green on this branch
- [ ] Run a no-op rebuild of any LangChain-using section in your local PythonCourses and confirm `git status` shows no cassette modifications afterwards
- [ ] (Optional) Try `CLM_HTTP_REPLAY_TRACE=1 clm build ...` against a real course and run the analysis script — confirm the bundle layout and report make sense
- [ ] Review the issue-#145 fix specifically — it's a one-line behavior change in `process_course_with_backend` plus a defensive try/except; verify it lines up with your sense of where the sweep should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)