### PR TITLE
feat(scripts): one-shot cassette cleanup by request host

### DIFF
--- a/scripts/strip_cassette_hosts.py
+++ b/scripts/strip_cassette_hosts.py
@@ -1,0 +1,177 @@
+"""Strip entries from on-disk HTTP-replay cassettes by request host.
+
+CLM's HTTP-replay bootstrap now sets ``ignore_hosts`` so telemetry
+endpoints (LangSmith etc.) don't enter new cassettes going forward.
+Existing cassettes recorded before that fix still carry those entries
+and will continue to bloat git diffs until purged. This script reads
+each cassette in place, drops any interaction whose request URI's host
+is in the configured list, and rewrites the cassette via vcrpy's
+persister so the on-disk format stays consistent with what CLM
+produces.
+
+Defaults to LangSmith. Override with --host (repeatable) for other
+telemetry/observability endpoints whose request bodies are too volatile
+to dedupe cleanly.
+
+Usage:
+
+    uv run python scripts/strip_cassette_hosts.py <root_dir>
+    uv run python scripts/strip_cassette_hosts.py <root_dir> --host api.smith.langchain.com --host api.langfuse.com
+    uv run python scripts/strip_cassette_hosts.py <root_dir> --dry-run
+
+Exit code 0 if all cassettes processed successfully (whether or not
+anything was stripped); 1 if any cassette failed to load/save; 2 on
+argument errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_HOSTS = ("api.smith.langchain.com",)
+_CASSETTE_GLOB = "*.http-cassette.yaml"
+
+
+def _request_host(request: Any) -> str:
+    """Best-effort hostname extraction from a vcr Request."""
+    try:
+        host = getattr(request, "host", None)
+        if host:
+            return str(host)
+    except Exception:  # noqa: BLE001 — defensive
+        pass
+    uri = str(getattr(request, "uri", "") or "")
+    if "://" in uri:
+        return uri.split("://", 1)[1].split("/", 1)[0].split(":", 1)[0]
+    return ""
+
+
+def _iter_cassette_paths(root: Path) -> Iterable[Path]:
+    for path in root.rglob(_CASSETTE_GLOB):
+        if path.is_file():
+            yield path
+
+
+def strip_cassette(
+    path: Path,
+    hosts_to_drop: set[str],
+    *,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Return (entries_before, entries_after). Writes only if non-dry-run.
+
+    Skips cassettes that vcrpy can't load (logged + returned as (0, 0))
+    so a corrupt file doesn't abort a course-wide cleanup.
+    """
+    from vcr.persisters.filesystem import FilesystemPersister
+    from vcr.serialize import serialize as vcr_serialize
+    from vcr.serializers import yamlserializer
+
+    try:
+        requests, responses = FilesystemPersister.load_cassette(path, serializer=yamlserializer)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        print(f"  ! skipping {path.name}: load failed ({type(exc).__name__}: {exc})", file=sys.stderr)
+        return (0, 0)
+
+    before = len(requests)
+    keep_requests = []
+    keep_responses = []
+    for req, resp in zip(requests, responses, strict=False):
+        host = _request_host(req)
+        if host in hosts_to_drop:
+            continue
+        keep_requests.append(req)
+        keep_responses.append(resp)
+    after = len(keep_requests)
+
+    if after == before:
+        return (before, after)
+
+    if dry_run:
+        return (before, after)
+
+    payload = vcr_serialize(
+        {"requests": keep_requests, "responses": keep_responses},
+        yamlserializer,
+    )
+    tmp = path.parent / f"{path.name}.tmp-strip"
+    try:
+        tmp.write_text(payload, encoding="utf-8", newline="\n")
+        tmp.replace(path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+    return (before, after)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "root",
+        type=Path,
+        help="Directory to walk for *.http-cassette.yaml files (recursive)",
+    )
+    parser.add_argument(
+        "--host",
+        action="append",
+        default=None,
+        metavar="HOST",
+        help=(
+            f"Hostname whose entries should be removed (repeatable). "
+            f"Defaults to {list(_DEFAULT_HOSTS)} when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing any cassette.",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    hosts_to_drop = set(args.host) if args.host else set(_DEFAULT_HOSTS)
+    print(f"Stripping hosts: {sorted(hosts_to_drop)}")
+    if args.dry_run:
+        print("(dry-run: no files will be modified)")
+
+    total_files = 0
+    total_changed = 0
+    total_dropped = 0
+    failures = 0
+    for path in sorted(_iter_cassette_paths(root)):
+        total_files += 1
+        try:
+            before, after = strip_cassette(path, hosts_to_drop, dry_run=args.dry_run)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            print(f"  ! {path}: failed ({type(exc).__name__}: {exc})", file=sys.stderr)
+            failures += 1
+            continue
+        if before != after:
+            total_changed += 1
+            total_dropped += before - after
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            print(f"  - {rel}: {before} -> {after}  (dropped {before - after})")
+
+    print()
+    print(f"Cassettes scanned:  {total_files}")
+    print(f"Cassettes modified: {total_changed}")
+    print(f"Entries dropped:    {total_dropped}")
+    if failures:
+        print(f"Cassettes failed:   {failures}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/strip_cassette_hosts.py`, a one-shot tool to remove all HTTP-replay cassette entries whose request host is in a configurable list (default: `api.smith.langchain.com`).

Companion to the bootstrap-side `ignore_hosts` default added in #146. That default stops *new* telemetry traffic from entering freshly-recorded cassettes; this script removes pre-existing entries that pre-date the fix and would otherwise sit in cassettes forever, bloating every git diff.

Uses vcrpy's own persister to load and re-serialize each cassette, so the on-disk format stays byte-for-byte consistent with what CLM produces.

## How it works

* Walks a root directory for `*.http-cassette.yaml` files.
* For each cassette: drops any interaction whose request hostname matches the configured list, re-serializes via `vcr.serialize.serialize` + `yamlserializer`, writes atomically.
* Skips cassettes that vcrpy can't load (corrupt YAML, format drift), so a single bad file doesn't abort a course-wide cleanup.
* `--host` is repeatable for extending the default; `--dry-run` reports without writing.

Exit code 0 on success (whether or not anything was stripped), 1 if any cassette load/save failed, 2 on argument errors.

## Verification

Run against PythonCourses' AZAV ML cassettes:

```
Stripping hosts: ['api.smith.langchain.com']
  - module_550_ml_azav/topic_050_langchain_simple_chatbot/slides_010_langchain_basics:        25 -> 16  (dropped 9)
  - module_550_ml_azav/topic_050_langchain_simple_chatbot/slides_015_langsmith_tracing:       4 -> 2   (dropped 2)
  - module_550_ml_azav/topic_050_langchain_simple_chatbot/slides_020_langchain_chatbot_port: 11 -> 6   (dropped 5)
  - module_550_ml_azav/topic_055_prompt_templates/slides_010_prompt_templates:               44 -> 35  (dropped 9)
  - module_550_ml_azav/topic_060_chains_and_lcel/slides_010_chains_intro:                    47 -> 38  (dropped 9)
  - module_550_ml_azav/topic_060_chains_and_lcel/slides_020_chains_composition:              37 -> 28  (dropped 9)
Cassettes scanned:  25
Cassettes modified: 6
Entries dropped:    43
```

5907 lines deleted on the PythonCourses side ([branch `claude/strip-stale-langsmith-cassettes`](https://github.com/hoelzl/PythonCourses/tree/claude/strip-stale-langsmith-cassettes)). Each stripped cassette verified to still load cleanly via vcrpy after the strip.

## Test plan

- [ ] PR #146 must be merged first (the `ignore_hosts` default it adds is what makes the stripped cassettes safe for replay — without it, replay would fail looking for the removed entries)
- [ ] Run the script with `--dry-run` against your local cassettes and inspect the reported deltas before applying
- [ ] After applying, run a no-op `clm build --http-replay=replay --ignore-cache` on a stripped section and confirm 0 errors

## Notes

* History-rewrite companion: a related branch `claude/history-rewrite-parked` carries `scripts/rewrite_strip_cassette_history.sh` and is documented at `~/tmp/clm-history-rewrite-experiment/REPORT.md`. That work is *parked* — it removes the cassette files from `.git` history entirely (~400 MiB saved). Adoption requires force-pushing the rewritten course-repo master, which is destructive and out of scope here. The branch is preserved so the procedure stays reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)