### PR TITLE
chore(gitattributes): force LF via eol=lf, silence CRLF warnings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,12 @@
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.db filter=lfs diff=lfs merge=lfs -text
 *.sqlite filter=lfs diff=lfs merge=lfs -text
-* text=auto
+* text=auto eol=lf
 *.sh text eol=lf
 *.py text eol=lf
 .claude/sessionStart text eol=lf
+
+# Windows scripts that REQUIRE CRLF to execute
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf


### PR DESCRIPTION
## Summary

- Add `eol=lf` to the catch-all `* text=auto` rule so the worktree matches the index byte-for-byte on every platform.
- Pin `.bat` / `.cmd` / `.ps1` to CRLF defensively (no such files committed today, but Windows execution semantics require it).

## Why

`* text=auto` plus the system default `core.autocrlf=true` on Windows checks out **246 text files** (`.md`, `.yml`, `.json`, `.xml`, etc.) as CRLF while the index stores them as LF. Every `git status` / `git commit` on Windows emits `LF will be replaced by CRLF` warnings, and tools that rewrite files as LF (ruff, pre-commit hooks) cause unnecessary churn. Any future byte-hashed content (cassettes are the obvious case — cf. PR #134 producer-side fix) is also platform-dependent under the current setup.

## Effect on the index

**Zero changes to index bytes.** All existing files were already stored as LF (`git ls-files --eol` showed `i/lf` across the board). The only effect is on the next checkout, where the previously-CRLF files re-smudge to LF in the working tree.

## Effect on in-flight branches

No EOL conflicts on rebase — both sides commit LF to the index, so the rebase sees no byte differences attributable to EOL. Other agents `git pull --rebase` and their next checkout naturally re-smudges any files master changed.

Existing worktrees with already-checked-out CRLF files keep them until: (a) a checkout touches the file, (b) the worktree is re-cloned, or (c) the user runs `git checkout HEAD -- .`. Warnings stop appearing as soon as a given file is re-smudged.

## Test plan

- [ ] Verify `git ls-files --eol .gitattributes` reports `attr/text=auto eol=lf` after merge.
- [ ] After re-checkout, confirm `git status` is clean with no `LF will be replaced by CRLF` warnings.
- [ ] Confirm `*.py` / `*.sh` files (already pinned `eol=lf`) are unchanged in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)