### PR TITLE
feat(normalize): add --canonicalize-start-completed for split round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides normalize --canonicalize-start-completed`.** New opt-in
+  flag for the interleaving operation. By default the normalizer leaves a
+  `start`/`completed` cohesion pair (`[DE_start, DE_completed, EN_start,
+  EN_completed]`) untouched when the DE and EN code differ — the
+  content-similarity gate can't confirm the pairing, so it reports a
+  `similarity_failure` review item. This is the layout that breaks the
+  byte-identical `unify(split(deck)) == deck` round-trip, because
+  `clm slides unify` always emits the canonical interleave
+  (`[DE_start, EN_start, DE_completed, EN_completed]`). With the flag,
+  such pairs are paired *structurally* (by `start`/`completed` tag and
+  position rather than content) and forced into the canonical interleave,
+  so a deck can be normalized before a split and round-trip exactly.
+  Default-off preserves the cohesion layout for decks that are not being
+  converted. Available on the CLI and the `normalize_slides` MCP tool.
+
 ### Changed
 
 ### Fixed

--- a/src/clm/cli/commands/normalize_slides.py
+++ b/src/clm/cli/commands/normalize_slides.py
@@ -38,6 +38,17 @@ from clm.slides.normalizer import (
     help="Preview changes without modifying files.",
 )
 @click.option(
+    "--canonicalize-start-completed",
+    is_flag=True,
+    help=(
+        "Force start/completed cohesion pairs into the canonical DE/EN "
+        "interleave, even when DE/EN code differs (e.g. localized "
+        "identifiers). Run before `clm slides split` so the round-trip "
+        "unify(split(deck)) == deck holds byte-for-byte. Only affects the "
+        "interleaving operation."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -52,6 +63,7 @@ def normalize_slides_cmd(
     path: Path,
     operations: str | None,
     dry_run: bool,
+    canonicalize_start_completed: bool,
     as_json: bool,
     data_dir: Path | None,
 ):
@@ -76,7 +88,7 @@ def normalize_slides_cmd(
         clm normalize-slides course-specs/python-basics.xml
     """
     op_list = _parse_operations(operations)
-    result = _dispatch(path, op_list, dry_run, data_dir)
+    result = _dispatch(path, op_list, dry_run, data_dir, canonicalize_start_completed)
 
     if as_json:
         click.echo(json.dumps(_result_to_dict(result), indent=2))
@@ -111,14 +123,31 @@ def _dispatch(
     operations: list[str] | None,
     dry_run: bool,
     data_dir: Path | None,
+    canonicalize_start_completed: bool = False,
 ) -> NormalizationResult:
     if path.is_file() and path.suffix == ".xml":
         slides_dir = _resolve_slides_dir(data_dir, path)
-        return normalize_course(path, slides_dir, operations=operations, dry_run=dry_run)
+        return normalize_course(
+            path,
+            slides_dir,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
     elif path.is_dir():
-        return normalize_directory(path, operations=operations, dry_run=dry_run)
+        return normalize_directory(
+            path,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
     elif path.is_file():
-        return normalize_file(path, operations=operations, dry_run=dry_run)
+        return normalize_file(
+            path,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
     else:
         raise click.ClickException(f"Path is not a file or directory: {path}")
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -557,6 +557,7 @@ clm normalize-slides [OPTIONS] PATH
 |--------|-------------|
 | `--operations TEXT` | Comma-separated operations: `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `all` (default: `all`) |
 | `--dry-run` | Preview changes without modifying files |
+| `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--json` | Output as JSON |
 | `--data-dir DIR` | Course data directory (contains slides/) |
 
@@ -567,6 +568,8 @@ clm normalize-slides slides/module_010/topic_100_intro/slides_intro.py
 clm normalize-slides slides/module_010/ --dry-run
 clm normalize-slides slides/module_010/ --operations tag_migration
 clm normalize-slides slides/module_010/ --operations slide_ids --json
+# Pre-conversion: canonicalize start/completed order so the split round-trips exactly
+clm slides normalize slides/module_010/topic_100_intro/ --operations interleaving --canonicalize-start-completed
 ```
 
 ### `clm slides assign-ids`

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -166,6 +166,7 @@ def create_server(data_dir: Path) -> FastMCP:
         path: str,
         operations: list[str] | None = None,
         dry_run: bool = False,
+        canonicalize_start_completed: bool = False,
     ) -> str:
         """Normalize slide files by applying mechanical fixes.
 
@@ -179,8 +180,18 @@ def create_server(data_dir: Path) -> FastMCP:
             operations: Which operations to apply: tag_migration,
                 workshop_tags, interleaving, all.  Default: all.
             dry_run: If True, preview changes without modifying files.
+            canonicalize_start_completed: Force start/completed cohesion
+                pairs into the canonical DE/EN interleave (even when DE/EN
+                code differs) so a subsequent split/unify round-trips
+                byte-for-byte. Only affects the interleaving operation.
         """
-        return await handle_normalize_slides(path, data_dir, operations=operations, dry_run=dry_run)
+        return await handle_normalize_slides(
+            path,
+            data_dir,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
 
     @mcp.tool()
     async def get_language_view(

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -438,6 +438,7 @@ async def handle_normalize_slides(
     *,
     operations: list[str] | None = None,
     dry_run: bool = False,
+    canonicalize_start_completed: bool = False,
 ) -> str:
     """Normalize slide files by applying mechanical fixes.
 
@@ -447,6 +448,9 @@ async def handle_normalize_slides(
         data_dir: Root data directory (contains ``slides/``).
         operations: Which operations to apply.  Default: all.
         dry_run: If ``True``, preview changes without modifying files.
+        canonicalize_start_completed: Force start/completed cohesion pairs
+            into the canonical DE/EN interleave so a subsequent split/unify
+            round-trips byte-for-byte. Only affects the interleaving op.
 
     Returns:
         JSON string with normalization results.
@@ -457,11 +461,27 @@ async def handle_normalize_slides(
 
     if target.is_file() and target.suffix == ".xml":
         slides_dir = data_dir / "slides"
-        result = _normalize_course(target, slides_dir, operations=operations, dry_run=dry_run)
+        result = _normalize_course(
+            target,
+            slides_dir,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
     elif target.is_dir():
-        result = _normalize_directory(target, operations=operations, dry_run=dry_run)
+        result = _normalize_directory(
+            target,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
     else:
-        result = _normalize_file(target, operations=operations, dry_run=dry_run)
+        result = _normalize_file(
+            target,
+            operations=operations,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
 
     return json.dumps(_normalization_result_to_dict(result), indent=2)
 

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -209,10 +209,41 @@ def _classify_cell(cell: _RawCell) -> str:
     return "markdown"
 
 
+def _is_start_completed_pair(de_cell: _RawCell, en_cell: _RawCell) -> bool:
+    """True if a DE/EN code pair is a ``start``/``completed`` cohesion unit.
+
+    A same-language ``start`` cell (or its paired ``completed`` cell)
+    represents the *same* logical cell shown in two output variants. Its
+    DE/EN counterpart is identified by the matching ``start``/``completed``
+    tag and document position — not by content similarity, which routinely
+    differs for localized identifiers (e.g. ``begruessung`` vs ``greeting``).
+    """
+    de_tags = set(de_cell.metadata.tags)
+    en_tags = set(en_cell.metadata.tags)
+    return ("start" in de_tags and "start" in en_tags) or (
+        "completed" in de_tags and "completed" in en_tags
+    )
+
+
 def _apply_interleaving(
-    cells: list[_RawCell], file_path: str
+    cells: list[_RawCell],
+    file_path: str,
+    *,
+    canonicalize_start_completed: bool = False,
 ) -> tuple[list[_RawCell], list[Change], list[ReviewItem]]:
     """Reorder cells for proper DE/EN interleaving.
+
+    Args:
+        cells: The cells to reorder in place (returns a new list).
+        file_path: Source path, used for change/review reporting.
+        canonicalize_start_completed: When ``True``, ``start``/``completed``
+            code pairs are paired *structurally* (by tag + position) and
+            forced into the canonical interleave
+            ``[DE_start, EN_start, DE_completed, EN_completed]``, bypassing
+            the content-similarity gate that otherwise leaves them in the
+            permitted cohesion layout ``[DE_start, DE_completed, EN_start,
+            EN_completed]``. Used to pre-normalize decks before a split, so
+            the round-trip ``unify(split(deck)) == deck`` holds byte-for-byte.
 
     Returns ``(reordered_cells, changes, review_items)``.
     """
@@ -277,6 +308,16 @@ def _apply_interleaving(
         # Tier 2: positional pairing with similarity verification
         for pair_idx, (de_i, en_i) in enumerate(zip(de_indices, en_indices, strict=True)):
             failed = _check_similarity(cells[de_i], cells[en_i])
+            if (
+                failed
+                and canonicalize_start_completed
+                and _is_start_completed_pair(cells[de_i], cells[en_i])
+            ):
+                # Structural start/completed pairing is authoritative for
+                # these cells; ignore content-similarity failures (e.g.
+                # localized function names) and force the canonical
+                # interleave.
+                failed = []
             if failed:
                 review_items.append(
                     ReviewItem(
@@ -534,6 +575,7 @@ def normalize_file(
     operations: list[str] | None = None,
     dry_run: bool = False,
     assign_options: AssignOptions | None = None,
+    canonicalize_start_completed: bool = False,
 ) -> NormalizationResult:
     """Normalize a single slide file.
 
@@ -546,6 +588,10 @@ def normalize_file(
             ``--accept-content-derived``, LLM suggester, …). ``None``
             uses defaults — refuse headingless slides, never overwrite
             existing ids, no LLM.
+        canonicalize_start_completed: Forwarded to the interleaving pass;
+            forces ``start``/``completed`` cohesion pairs into the canonical
+            interleave so a subsequent ``split``/``unify`` round-trips
+            byte-for-byte. No effect unless ``interleaving`` runs.
 
     Returns:
         A :class:`NormalizationResult` with changes and review items.
@@ -569,7 +615,11 @@ def normalize_file(
         all_changes.extend(_apply_workshop_tags(cells, file_str))
 
     if "interleaving" in op_set:
-        cells, interleave_changes, interleave_reviews = _apply_interleaving(cells, file_str)
+        cells, interleave_changes, interleave_reviews = _apply_interleaving(
+            cells,
+            file_str,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
         all_changes.extend(interleave_changes)
         all_review.extend(interleave_reviews)
 
@@ -598,6 +648,7 @@ def normalize_directory(
     operations: list[str] | None = None,
     dry_run: bool = False,
     assign_options: AssignOptions | None = None,
+    canonicalize_start_completed: bool = False,
 ) -> NormalizationResult:
     """Normalize all slide files in a directory (recursive)."""
     slide_files = find_slide_files_recursive(path)
@@ -609,6 +660,7 @@ def normalize_directory(
             operations=operations,
             dry_run=dry_run,
             assign_options=assign_options,
+            canonicalize_start_completed=canonicalize_start_completed,
         )
         combined.files_modified += result.files_modified
         combined.changes.extend(result.changes)
@@ -624,6 +676,7 @@ def normalize_course(
     operations: list[str] | None = None,
     dry_run: bool = False,
     assign_options: AssignOptions | None = None,
+    canonicalize_start_completed: bool = False,
 ) -> NormalizationResult:
     """Normalize all slides referenced by a course spec."""
     from clm.core.course_spec import CourseSpec
@@ -642,6 +695,7 @@ def normalize_course(
                     operations=operations,
                     dry_run=dry_run,
                     assign_options=assign_options,
+                    canonicalize_start_completed=canonicalize_start_completed,
                 )
                 combined.files_modified += result.files_modified
                 combined.changes.extend(result.changes)

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -370,6 +370,120 @@ class TestInterleaving:
 
 
 # ---------------------------------------------------------------------------
+# canonicalize_start_completed flag
+# ---------------------------------------------------------------------------
+
+
+# Cohesion layout [DE_start, DE_completed, EN_start, EN_completed] where the
+# DE/EN code differs only by localized identifiers (begruessung vs greeting).
+# This is the layout `clm slides normalize` leaves untouched by default
+# (the similarity gate rejects the pair) but that breaks the byte-identical
+# split→unify round-trip.
+_COHESION_DIFF_NAMES = (
+    '# %% lang="de" tags=["start"]\n'
+    "def begruessung(name, alter):\n"
+    '    return f"Hallo {name}"\n'
+    "\n"
+    '# %% lang="de" tags=["completed"]\n'
+    "def begruessung(name: str, alter: int) -> str:\n"
+    '    return f"Hallo {name}"\n'
+    "\n"
+    '# %% lang="en" tags=["start"]\n'
+    "def greeting(name, age):\n"
+    '    return f"Hello {name}"\n'
+    "\n"
+    '# %% lang="en" tags=["completed"]\n'
+    "def greeting(name: str, age: int) -> str:\n"
+    '    return f"Hello {name}"\n'
+)
+
+
+class TestCanonicalizeStartCompleted:
+    def test_default_leaves_cohesion_layout_with_review(self, tmp_path):
+        """Without the flag, a differing-code start/completed pair is left
+        in cohesion layout and reported as a similarity failure."""
+        path = _write_slide(tmp_path / "slides_test.py", _COHESION_DIFF_NAMES)
+        result = normalize_file(path, operations=["interleaving"])
+
+        assert not any(c.operation == "interleaving" for c in result.changes)
+        assert any(
+            r.issue == "similarity_failure" and "code_structure" in r.details["failed_checks"]
+            for r in result.review_items
+        )
+        # Source order is unchanged (still cohesion layout).
+        assert path.read_text(encoding="utf-8") == _COHESION_DIFF_NAMES
+
+    def test_flag_forces_canonical_interleave(self, tmp_path):
+        """With the flag, the pair is forced into the canonical interleave
+        [DE_start, EN_start, DE_completed, EN_completed] with no review."""
+        path = _write_slide(tmp_path / "slides_test.py", _COHESION_DIFF_NAMES)
+        result = normalize_file(
+            path,
+            operations=["interleaving"],
+            canonicalize_start_completed=True,
+        )
+
+        assert any(c.operation == "interleaving" for c in result.changes)
+        assert result.review_items == []
+
+        lines = path.read_text(encoding="utf-8").split("\n")
+        de_start = next(i for i, ln in enumerate(lines) if "def begruessung(name, alter)" in ln)
+        en_start = next(i for i, ln in enumerate(lines) if "def greeting(name, age)" in ln)
+        de_done = next(i for i, ln in enumerate(lines) if "def begruessung(name: str" in ln)
+        en_done = next(i for i, ln in enumerate(lines) if "def greeting(name: str" in ln)
+        assert de_start < en_start < de_done < en_done
+
+    def test_flag_does_not_affect_non_start_completed_failures(self, tmp_path):
+        """The flag is scoped to start/completed pairs; a genuine markdown
+        similarity failure still produces a review item."""
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# # Folie\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["subslide"]\n'
+            "# # Slide\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(
+            path,
+            operations=["interleaving"],
+            canonicalize_start_completed=True,
+        )
+
+        assert any(r.issue == "similarity_failure" for r in result.review_items)
+
+    def test_flag_is_idempotent_on_identical_code(self, tmp_path):
+        """A start/completed pair with identical DE/EN code already
+        interleaves; the flag does not disturb the result."""
+        text = (
+            '# %% lang="de" tags=["start"]\n'
+            "names = []\n"
+            "\n"
+            '# %% lang="de" tags=["completed"]\n'
+            "names: list[str] = []\n"
+            "\n"
+            '# %% lang="en" tags=["start"]\n'
+            "names = []\n"
+            "\n"
+            '# %% lang="en" tags=["completed"]\n'
+            "names: list[str] = []\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(
+            path,
+            operations=["interleaving"],
+            canonicalize_start_completed=True,
+        )
+        lines = path.read_text(encoding="utf-8").split("\n")
+        # completed cells carry the annotation; start cells do not
+        starts = [i for i, ln in enumerate(lines) if ln == "names = []"]
+        dones = [i for i, ln in enumerate(lines) if ln == "names: list[str] = []"]
+        # canonical interleave: DE_start, EN_start, DE_completed, EN_completed
+        assert starts[0] < starts[1] < dones[0] < dones[1]
+        assert result.review_items == []
+
+
+# ---------------------------------------------------------------------------
 # Dry run
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The language-split conversion (`clm slides split` / `unify`) uses
`unify(split(deck)) == deck` byte-for-byte as its Layer-1 verification
gate. That property silently fails for any deck using the **start/completed
cohesion layout** with localized code.

Root cause is a disagreement between two tools:

- `clm slides normalize` (interleaving) pairs DE/EN cells via a
  content-similarity gate (`_check_similarity`). A `start`/`completed`
  pair whose DE/EN code differs only by localized identifiers — e.g.
  `def begruessung(name, alter)` vs `def greeting(name, age)` — fails the
  `code_structure` check, so the pair is **left** in the permitted cohesion
  layout `[DE_start, DE_completed, EN_start, EN_completed]` and reported as
  a `similarity_failure` review item.
- `clm slides unify` **always** emits the canonical interleave
  `[DE_start, EN_start, DE_completed, EN_completed]`.

So `unify(split(x)) != x` for those decks — even though the reorder is
semantically a no-op (start/completed collapse to one logical cell in every
build variant, and `.ipynb` output is unaffected).

## Change

Add an opt-in `--canonicalize-start-completed` flag to the `interleaving`
operation (CLI `clm slides normalize` / deprecated `clm normalize-slides`,
and the `normalize_slides` MCP tool; threaded through
`normalize_file` / `normalize_directory` / `normalize_course`).

When set, `start`/`completed` pairs are paired **structurally** — by
`start`/`completed` tag and document position, which is unambiguous for
these cells — bypassing the content-similarity gate and forcing the
canonical interleave. The positional zip already aligns DE_start↔EN_start
and DE_completed↔EN_completed, so no new pairing logic is needed; the flag
only suppresses the similarity rejection for these pairs.

**Default-off**, so the cohesion layout is preserved for decks that are not
being converted. Authors pre-normalize only the decks queued for splitting,
keeping the round-trip check a strict byte comparison.

## Verification

- New unit tests (`TestCanonicalizeStartCompleted`, 4 cases): default leaves
  cohesion layout + review item; flag forces canonical interleave with no
  review; flag is scoped to start/completed (genuine markdown similarity
  failures still reported); idempotent on identical-code pairs.
- Full `tests/slides/test_normalizer.py` (56), `tests/cli/test_normalize_slides.py`,
  `tests/slides/test_split.py`, `tests/slides/test_validator.py` (119), and
  all `-k "normalize or mcp"` (154) pass. ruff lint + format clean.
- End-to-end on a real deck (`slides_010_type_annotations.py`): split→unify
  round-trip **DIFFERS** before, **BYTE-IDENTICAL** after
  `normalize --canonicalize-start-completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)