### PR TITLE
fix(db): truncate WAL after VACUUM so jobs DB actually shrinks (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm db vacuum` / `clm db clean` now actually reclaim disk space on the
+  jobs database (issue #144).** The jobs DB runs in WAL mode, where a plain
+  `VACUUM` rewrites the database into write-ahead-log pages rather than the
+  main `.db` file; without a truncating checkpoint the on-disk file size was
+  unchanged, so the command reported `Reclaimed: 0 MB` even when gigabytes of
+  freed space were available (a raw `sqlite3 VACUUM` on the same file shrank
+  it from 2.9 GB to 541 MB). `JobQueue.vacuum()` now issues
+  `PRAGMA wal_checkpoint(TRUNCATE)` after `VACUUM` so the freed pages are
+  folded back into the main file immediately. The CLI also re-stats the file
+  only after the connection is closed and warns when the database had free
+  pages before vacuum but the file size did not change. The cache database
+  was unaffected (it does not use WAL).
+
 ## [1.6.2] - 2026-05-26
 
 ### Added

--- a/src/clm/cli/commands/database.py
+++ b/src/clm/cli/commands/database.py
@@ -281,7 +281,10 @@ def db_vacuum(ctx, which):
 
             size_before = os.path.getsize(jobs_db_path)
             with JobQueue(jobs_db_path) as jq:
+                freelist_before = jq.freelist_count()
                 jq.vacuum()
+            # Re-stat only after the connection is fully closed so the
+            # measurement reflects the truncated/checkpointed file on disk.
             size_after = os.path.getsize(jobs_db_path)
             saved = size_before - size_after
             click.echo(
@@ -289,6 +292,17 @@ def db_vacuum(ctx, which):
             )
             if saved > 0:
                 click.echo(f"  Reclaimed: {saved / 1024 / 1024:.2f} MB")
+            elif freelist_before > 0:
+                # VACUUM had free pages to reclaim but the file did not
+                # shrink. This is the symptom from issue #144 (a WAL that
+                # was not checkpointed/truncated). Surface it instead of
+                # silently reporting a no-op.
+                click.echo(
+                    "  Warning: database had "
+                    f"{freelist_before} free pages before vacuum but the file "
+                    "size did not change. The space may not have been "
+                    "reclaimed (is another process holding the database open?)."
+                )
         else:
             click.echo(f"Jobs database not found: {jobs_db_path}")
 

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -980,11 +980,33 @@ class JobQueue:
 
         return stats
 
+    def freelist_count(self) -> int:
+        """Return the number of free (reclaimable) pages in the database.
+
+        A non-zero value before a vacuum means VACUUM has space to reclaim;
+        useful for detecting when a vacuum that reports no size change has
+        in fact silently failed to compact the file (see issue #144).
+        """
+        conn = self._get_conn()
+        row = conn.execute("PRAGMA freelist_count").fetchone()
+        return int(row[0]) if row is not None else 0
+
     def vacuum(self) -> None:
         """Compact the database to reclaim disk space.
 
         This should be called after large deletions to reclaim disk space.
         Note: VACUUM requires exclusive access and can be slow for large databases.
+
+        The jobs database runs in WAL mode (see ``init_database``). In WAL
+        mode a plain ``VACUUM`` rewrites the database into freshly allocated
+        pages, but those writes land in the write-ahead log rather than the
+        main ``.db`` file. The main file therefore does *not* shrink on disk
+        until a checkpoint folds the WAL back into it. A passive/auto
+        checkpoint won't truncate the file either, so we issue an explicit
+        ``PRAGMA wal_checkpoint(TRUNCATE)`` after VACUUM to force the freed
+        pages back into the main file and truncate the WAL. Without this the
+        on-disk size is unchanged even though VACUUM did real work, which is
+        exactly the no-op reported in issue #144.
         """
         conn = self._get_conn()
         # VACUUM cannot run inside a transaction. Python 3.12+ raises
@@ -994,6 +1016,10 @@ class JobQueue:
         if conn.in_transaction:
             conn.execute("COMMIT")
         conn.execute("VACUUM")
+        # Fold the WAL back into the main database file and truncate it so the
+        # reclaimed space is reflected in the on-disk file size immediately.
+        # This is a no-op (returns busy=0) for non-WAL databases.
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         logger.info(f"Vacuumed database: {self.db_path}")
 
     def close(self):

--- a/tests/cli/test_db_commands.py
+++ b/tests/cli/test_db_commands.py
@@ -82,6 +82,32 @@ def _seed_job(db_path: Path, *, status: str = "completed", input_file: str = "a.
     return job_id
 
 
+def _grow_jobs_db_freelist(db_path: Path, *, rows: int = 200, payload_kb: int = 64) -> None:
+    """Bloat the jobs DB then delete the rows to create reclaimable free pages.
+
+    Inserting many large ``payload`` blobs grows the file; deleting them frees
+    the pages onto the freelist without shrinking the file, which is exactly
+    the state VACUUM is meant to reclaim.
+    """
+    blob = "x" * (payload_kb * 1024)
+    with JobQueue(db_path) as jq:
+        ids = [
+            jq.add_job(
+                job_type="notebook",
+                input_file=f"f{i}.py",
+                output_file=f"f{i}.ipynb",
+                content_hash=f"hash-{i}",
+                payload={"blob": blob},
+            )
+            for i in range(rows)
+        ]
+        conn = jq._get_conn()
+        conn.executemany("DELETE FROM jobs WHERE id = ?", [(i,) for i in ids])
+        # Force WAL contents back into the main file so the deletions register
+        # as freelist pages there (mirrors a real post-build DB state).
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+
 # ---------------------------------------------------------------------------
 # db stats
 # ---------------------------------------------------------------------------
@@ -178,6 +204,39 @@ class TestDbVacuum:
         result = _invoke(db_paths, "db", "vacuum")
         assert result.exit_code == 0, result.output
         assert "not found" in result.output
+
+    def test_vacuum_jobs_db_actually_shrinks_file(self, initialized_dbs):
+        """Regression for issue #144.
+
+        The jobs DB runs in WAL mode. A plain VACUUM rewrites pages into the
+        WAL rather than the main file, so without a TRUNCATE checkpoint the
+        on-disk ``.db`` file never shrinks and the command reports a no-op.
+        Grow the freelist with insert+delete, then assert the CLI vacuum
+        reclaims real bytes and the reported "after" size matches disk.
+        """
+        import os
+
+        jobs_db = initialized_dbs["jobs"]
+        _grow_jobs_db_freelist(jobs_db)
+
+        # Sanity: there is reclaimable space and the file is sizeable.
+        with JobQueue(jobs_db) as jq:
+            assert jq.freelist_count() > 0
+        size_before = os.path.getsize(jobs_db)
+
+        result = _invoke(initialized_dbs, "db", "vacuum", "--which=jobs")
+        assert result.exit_code == 0, result.output
+
+        size_after = os.path.getsize(jobs_db)
+        # The file must actually shrink on disk.
+        assert size_after < size_before, (
+            f"jobs DB did not shrink: {size_before} -> {size_after}\n{result.output}"
+        )
+        # And the command must report a non-zero reclamation (not a no-op).
+        assert "Reclaimed:" in result.output
+        # After vacuum + truncate checkpoint there should be no free pages.
+        with JobQueue(jobs_db) as jq:
+            assert jq.freelist_count() == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`clm db vacuum` / `clm db clean` reported `Reclaimed: 0 MB` for the jobs database even when gigabytes were reclaimable (raw `sqlite3 VACUUM` on the same closed file shrank it 2.9 GB to 541 MB). The cache DB vacuumed correctly in the same run.

## Root cause

The jobs database runs in **WAL mode** (set in `init_database`); the cache DB does not. In WAL mode a plain `VACUUM` rewrites the database into write-ahead-log pages rather than the main `.db` file. The main file does not shrink on disk until a checkpoint folds the WAL back in, and a passive/auto checkpoint will not *truncate* the file. So VACUUM did real work (freelist went to 0) but the on-disk size was unchanged.

Reproduced locally: immediately after `VACUUM` with the connection open, the main file was actually *larger* (26 MB) while the WAL held the rewritten DB; the freed space only materializes after a truncating checkpoint.

## Fix

- `JobQueue.vacuum()` now issues `PRAGMA wal_checkpoint(TRUNCATE)` after `VACUUM`, folding freed pages back into the main file and truncating the WAL immediately. This is a no-op for non-WAL databases.
- Added `JobQueue.freelist_count()`.
- CLI re-stats the file only after the connection is closed, and warns when the DB had free pages before vacuum but the size did not change (issue suggestion #4).
- The cache-DB path was already correct (no WAL) and is unchanged.

## Tests

Added `test_vacuum_jobs_db_actually_shrinks_file`: grows the jobs-DB freelist via insert+delete of large payload blobs, runs the CLI `db vacuum --which=jobs` path, and asserts the file actually shrinks on disk and `Reclaimed:` is reported. `tests/cli/test_db_commands.py` (18) and vacuum/job-queue subset (59) pass; ruff + mypy clean; pre-commit hook (incl. fast suite) passed.

Manual verification: 13.3 MB jobs DB with 3227 free pages -> 86 KB after fix.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)