### PR TITLE
fix(recordings): make `clm recordings check` backend-aware (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **`clm recordings check` is now backend-aware** (issue #33). The command
+  reads `recordings.processing_backend` and only checks the dependencies the
+  active backend actually needs, and the output table header shows which
+  backend was checked:
+  - `onnx` (default): unchanged — `ffmpeg`, `ffprobe`, `onnxruntime`.
+  - `external`: `ffmpeg` + `ffprobe` only; `onnxruntime` is no longer
+    required (the externally produced `.wav` is just muxed via ffmpeg).
+  - `auphonic`: no longer requires `ffmpeg`/`onnxruntime` (cloud
+    video-in/video-out, no local mux). Instead verifies that the API key is
+    non-empty and performs a read-only `AuphonicClient.list_presets()`
+    round-trip to confirm credentials and connectivity. A new `--offline`
+    flag skips the network call and validates config shape only.
+
+  Previously `check` always reported "All dependencies found" based solely
+  on `ffmpeg` + `onnxruntime`, giving a false green for the `auphonic`
+  backend (e.g. with an unset or rejected API key) and a false red for
+  `external` (missing `onnxruntime` it never uses).
+
 ### Fixed
 
 ## [1.6.2] - 2026-05-26

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -31,18 +31,38 @@ def recordings_group():
 
 
 @recordings_group.command()
-def check():
-    """Check that recording dependencies (ffmpeg, onnxruntime) are installed."""
-    from clm.recordings.processing.utils import check_dependencies
+@click.option(
+    "--offline",
+    is_flag=True,
+    help=(
+        "Skip the Auphonic API connectivity round-trip; only validate that "
+        "an API key is configured. No effect for the onnx/external backends."
+    ),
+)
+def check(offline: bool):
+    """Check that the active processing backend's dependencies are available.
 
-    deps = check_dependencies()
-    all_ok = True
+    The set of dependencies checked depends on
+    ``recordings.processing_backend``:
 
-    table = Table(title="Recording Dependencies")
-    table.add_column("Tool", style="cyan")
+    \b
+    - onnx     : ffmpeg, ffprobe, onnxruntime (local DeepFilterNet3 pipeline).
+    - external : ffmpeg, ffprobe (CLM muxes the externally-produced .wav).
+    - auphonic : a non-empty API key, plus a read-only API round-trip
+                 (clm recordings auphonic preset list) unless --offline.
+    """
+    from clm.recordings.processing.utils import check_dependencies_for_backend
+
+    backend = _build_recordings_config().processing_backend
+
+    table = Table(title=f"Recording Dependencies ({backend} backend)")
+    table.add_column("Check", style="cyan")
     table.add_column("Status")
     table.add_column("Info")
 
+    all_ok = True
+
+    deps = check_dependencies_for_backend(backend)
     for name, value in deps.items():
         if value:
             table.add_row(name, "[green]found[/green]", str(value))
@@ -50,13 +70,55 @@ def check():
             table.add_row(name, "[red]NOT FOUND[/red]", "")
             all_ok = False
 
+    if backend == "auphonic":
+        ok, status_cell, info = _check_auphonic_backend(offline=offline)
+        table.add_row("auphonic api", status_cell, info)
+        all_ok = all_ok and ok
+
     console.print(table)
 
     if all_ok:
-        console.print("\n[green]All dependencies found.[/green]")
+        console.print(
+            f"\n[green]All dependencies for the '{backend}' backend are available.[/green]"
+        )
     else:
-        console.print("\n[red]Some dependencies are missing. See above for details.[/red]")
+        console.print(
+            f"\n[red]Some dependencies for the '{backend}' backend are missing. "
+            "See above for details.[/red]"
+        )
         raise SystemExit(1)
+
+
+def _check_auphonic_backend(*, offline: bool) -> tuple[bool, str, str]:
+    """Verify Auphonic credentials (and optionally connectivity).
+
+    Returns ``(ok, status_cell, info)`` where ``status_cell`` and ``info``
+    are pre-rendered rich markup strings for the dependencies table.
+    """
+    api_key, _preset = _get_auphonic_config()
+    if not api_key:
+        return (
+            False,
+            "[red]NOT CONFIGURED[/red]",
+            "recordings.auphonic.api_key is empty",
+        )
+
+    if offline:
+        return (True, "[green]key set[/green]", "connectivity not checked (--offline)")
+
+    from clm.recordings.workflow.backends.auphonic_client import AuphonicError
+
+    try:
+        client = _build_auphonic_client()
+        presets = client.list_presets()
+    except AuphonicError as exc:
+        logger.warning("Auphonic connectivity check failed: %s", exc)
+        return (False, "[red]UNREACHABLE[/red]", str(exc))
+    except Exception as exc:  # network errors, missing key, etc.
+        logger.warning("Auphonic connectivity check failed: %s", exc)
+        return (False, "[red]UNREACHABLE[/red]", str(exc))
+
+    return (True, "[green]reachable[/green]", f"key valid, {len(presets)} preset(s)")
 
 
 @recordings_group.command()

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1738,11 +1738,32 @@ recording-to-lecture assignment, and status tracking.
 
 #### `clm recordings check`
 
-Check that recording dependencies (ffmpeg, onnxruntime) are installed.
+Check that the dependencies required by the **active processing backend**
+(`recordings.processing_backend`) are available. The set of checks is
+backend-aware:
+
+- `onnx` (default): `ffmpeg`, `ffprobe`, and `onnxruntime` — the local
+  DeepFilterNet3 pipeline.
+- `external`: `ffmpeg` and `ffprobe` only. CLM muxes the externally produced
+  `.wav` (e.g. from iZotope RX 11), so `onnxruntime` is **not** required.
+- `auphonic`: neither `ffmpeg` nor `onnxruntime` is required (the cloud
+  backend is video-in/video-out with no local mux). Instead, `check`
+  verifies that `recordings.auphonic.api_key` is non-empty and performs a
+  read-only API round-trip (`AuphonicClient.list_presets()`) to confirm the
+  credentials and connectivity.
+
+The output table header shows which backend was checked. The command exits
+non-zero if any required dependency is missing or the Auphonic check fails.
 
 ```
-clm recordings check
+clm recordings check [--offline]
 ```
+
+Options:
+
+- `--offline`: For the `auphonic` backend, skip the API connectivity
+  round-trip and only validate that an API key is configured. No effect for
+  the `onnx`/`external` backends.
 
 #### `clm recordings process`
 

--- a/src/clm/recordings/processing/utils.py
+++ b/src/clm/recordings/processing/utils.py
@@ -183,13 +183,9 @@ def run_onnx_denoise(input_file: Path, output_file: Path, *, atten_lim_db: float
     sf.write(str(output_file), output, sr, subtype="FLOAT")
 
 
-def check_dependencies() -> dict[str, str | Path | None]:
-    """Check all required dependencies and return their status.
-
-    Returns a dict mapping tool name to path/version (or None if not found).
-    """
+def _check_ffmpeg_binaries() -> dict[str, str | Path | None]:
+    """Check ffmpeg + ffprobe, returning a name → path/None mapping."""
     deps: dict[str, str | Path | None] = {}
-
     for name, finder in [
         ("ffmpeg", find_ffmpeg),
         ("ffprobe", find_ffprobe),
@@ -199,9 +195,56 @@ def check_dependencies() -> dict[str, str | Path | None]:
         except BinaryNotFoundError as e:
             logger.warning(str(e))
             deps[name] = None
+    return deps
 
+
+def check_dependencies() -> dict[str, str | Path | None]:
+    """Check all required dependencies for the local ONNX pipeline.
+
+    Returns a dict mapping tool name to path/version (or None if not found).
+
+    This is the backend-agnostic check covering the local DeepFilterNet3
+    pipeline (``ffmpeg`` + ``ffprobe`` + ``onnxruntime``). For a
+    backend-aware check that respects ``RecordingsConfig.processing_backend``
+    use :func:`check_dependencies_for_backend`.
+    """
+    deps = _check_ffmpeg_binaries()
     deps["onnxruntime"] = check_onnxruntime()
+    return deps
 
+
+def check_dependencies_for_backend(
+    backend: str,
+) -> dict[str, str | Path | None]:
+    """Check the dependencies required by *backend* only.
+
+    Args:
+        backend: Active processing backend name — one of ``"onnx"``,
+            ``"external"``, or ``"auphonic"``.
+
+    Returns:
+        Mapping of dependency name to its resolved path/version, or
+        ``None`` when the dependency is missing. The set of keys differs
+        per backend:
+
+        * ``onnx``: ``ffmpeg``, ``ffprobe``, ``onnxruntime`` — the local
+          DeepFilterNet3 pipeline.
+        * ``external``: ``ffmpeg``, ``ffprobe`` — the external tool
+          (e.g. iZotope RX 11) is run by the user and only delivers a
+          ``.wav``; CLM still muxes via ffmpeg. ``onnxruntime`` is **not**
+          required.
+        * ``auphonic``: empty mapping — the cloud backend is
+          video-in/video-out and does no local mux, so neither ffmpeg nor
+          onnxruntime is needed. Credential/connectivity checks are
+          handled separately by the caller (see the CLI ``check`` command).
+    """
+    if backend == "auphonic":
+        return {}
+    if backend == "external":
+        return _check_ffmpeg_binaries()
+    # Default to the onnx (local pipeline) requirements.
+    deps = _check_ffmpeg_binaries()
+    deps["onnxruntime"] = check_onnxruntime()
     return deps
 
 

--- a/tests/recordings/test_processing_utils.py
+++ b/tests/recordings/test_processing_utils.py
@@ -19,6 +19,7 @@ from clm.recordings.processing import utils
 from clm.recordings.processing.utils import (
     BinaryNotFoundError,
     check_dependencies,
+    check_dependencies_for_backend,
     check_onnxruntime,
     download_onnx_model,
     find_binary,
@@ -244,6 +245,62 @@ class TestCheckDependencies:
             deps = check_dependencies()
 
         assert deps == {"ffmpeg": None, "ffprobe": None, "onnxruntime": None}
+
+
+class TestCheckDependenciesForBackend:
+    def test_onnx_checks_ffmpeg_and_onnxruntime(self):
+        with (
+            patch(
+                "clm.recordings.processing.utils.find_ffmpeg",
+                return_value=Path("/usr/bin/ffmpeg"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.find_ffprobe",
+                return_value=Path("/usr/bin/ffprobe"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.check_onnxruntime",
+                return_value="1.17.0",
+            ),
+        ):
+            deps = check_dependencies_for_backend("onnx")
+
+        assert set(deps) == {"ffmpeg", "ffprobe", "onnxruntime"}
+        assert deps["onnxruntime"] == "1.17.0"
+
+    def test_external_checks_ffmpeg_only(self):
+        with (
+            patch(
+                "clm.recordings.processing.utils.find_ffmpeg",
+                return_value=Path("/usr/bin/ffmpeg"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.find_ffprobe",
+                return_value=Path("/usr/bin/ffprobe"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.check_onnxruntime",
+                side_effect=AssertionError("external backend must not check onnxruntime"),
+            ),
+        ):
+            deps = check_dependencies_for_backend("external")
+
+        assert set(deps) == {"ffmpeg", "ffprobe"}
+
+    def test_auphonic_checks_nothing_local(self):
+        with (
+            patch(
+                "clm.recordings.processing.utils.find_ffmpeg",
+                side_effect=AssertionError("auphonic backend must not check ffmpeg"),
+            ),
+            patch(
+                "clm.recordings.processing.utils.check_onnxruntime",
+                side_effect=AssertionError("auphonic backend must not check onnxruntime"),
+            ),
+        ):
+            deps = check_dependencies_for_backend("auphonic")
+
+        assert deps == {}
 
 
 class TestRunSubprocess:

--- a/tests/recordings/test_recordings_command.py
+++ b/tests/recordings/test_recordings_command.py
@@ -234,32 +234,133 @@ class TestBuildRecordingsConfig:
 # ---------------------------------------------------------------------------
 
 
+def _install_fake_check_deps(monkeypatch, mapping: dict):
+    """Install a fake check_dependencies_for_backend returning *mapping*."""
+    fake_utils = MagicMock()
+    fake_utils.check_dependencies_for_backend = MagicMock(return_value=mapping)
+    monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
+    return fake_utils
+
+
+def _set_backend(monkeypatch, backend: str, api_key: str = ""):
+    """Make ``_build_recordings_config`` return a config with *backend*."""
+    from clm.infrastructure.config import AuphonicConfig, RecordingsConfig
+
+    cfg = RecordingsConfig.model_construct(
+        processing_backend=backend,
+        auphonic=AuphonicConfig(api_key=api_key),
+    )
+    monkeypatch.setattr(recordings_module, "_build_recordings_config", lambda: cfg)
+    # _check_auphonic_backend reads the key via _get_auphonic_config.
+    monkeypatch.setattr(recordings_module, "_get_auphonic_config", lambda: (api_key, ""))
+
+
 class TestCheckCommand:
-    def test_all_dependencies_found(self, monkeypatch: pytest.MonkeyPatch):
-        fake_utils = MagicMock()
-        fake_utils.check_dependencies = MagicMock(
-            return_value={"ffmpeg": "/usr/bin/ffmpeg", "onnxruntime": "1.17"}
+    def test_onnx_all_dependencies_found(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "onnx")
+        fake = _install_fake_check_deps(
+            monkeypatch,
+            {"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": "/usr/bin/ffprobe", "onnxruntime": "1.17"},
         )
-        monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
 
         runner = CliRunner()
         result = runner.invoke(recordings_group, ["check"])
 
         assert result.exit_code == 0, result.output
-        assert "All dependencies found" in result.output
+        assert "All dependencies for the 'onnx' backend" in result.output
+        fake.check_dependencies_for_backend.assert_called_once_with("onnx")
 
-    def test_missing_dependencies_exit_1(self, monkeypatch: pytest.MonkeyPatch):
-        fake_utils = MagicMock()
-        fake_utils.check_dependencies = MagicMock(
-            return_value={"ffmpeg": "/usr/bin/ffmpeg", "onnxruntime": None}
+    def test_onnx_missing_dependencies_exit_1(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "onnx")
+        _install_fake_check_deps(
+            monkeypatch,
+            {"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": "/usr/bin/ffprobe", "onnxruntime": None},
         )
-        monkeypatch.setitem(sys.modules, "clm.recordings.processing.utils", fake_utils)
 
         runner = CliRunner()
         result = runner.invoke(recordings_group, ["check"])
 
         assert result.exit_code == 1
-        assert "Some dependencies are missing" in result.output
+        assert "are missing" in result.output
+
+    def test_external_skips_onnxruntime(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "external")
+        fake = _install_fake_check_deps(
+            monkeypatch, {"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": "/usr/bin/ffprobe"}
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check"])
+
+        assert result.exit_code == 0, result.output
+        assert "All dependencies for the 'external' backend" in result.output
+        assert "onnxruntime" not in result.output
+        fake.check_dependencies_for_backend.assert_called_once_with("external")
+
+    def test_auphonic_missing_api_key_exit_1(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "auphonic", api_key="")
+        _install_fake_check_deps(monkeypatch, {})
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check"])
+
+        assert result.exit_code == 1
+        assert "for the 'auphonic' backend are missing" in result.output
+        assert "NOT CONFIGURED" in result.output
+        # Auphonic does not require ffmpeg/onnxruntime.
+        assert "ffmpeg" not in result.output
+
+    def test_auphonic_offline_only_checks_key(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "auphonic", api_key="secret")
+        _install_fake_check_deps(monkeypatch, {})
+        # If the client were built, this would explode — assert it isn't.
+        monkeypatch.setattr(
+            recordings_module,
+            "_build_auphonic_client",
+            MagicMock(side_effect=AssertionError("must not contact API when --offline")),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check", "--offline"])
+
+        assert result.exit_code == 0, result.output
+        # The side_effect on _build_auphonic_client guarantees no API call
+        # happened; reaching exit 0 confirms the offline path was taken.
+        assert "All dependencies for the 'auphonic' backend" in result.output
+
+    def test_auphonic_online_reachable(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "auphonic", api_key="secret")
+        _install_fake_check_deps(monkeypatch, {})
+
+        fake_client = MagicMock()
+        fake_client.list_presets = MagicMock(return_value=[MagicMock(), MagicMock()])
+        monkeypatch.setattr(recordings_module, "_build_auphonic_client", lambda: fake_client)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check"])
+
+        assert result.exit_code == 0, result.output
+        assert "reachable" in result.output
+        assert "2 preset(s)" in result.output
+        fake_client.list_presets.assert_called_once()
+
+    def test_auphonic_online_unreachable_exit_1(self, monkeypatch: pytest.MonkeyPatch):
+        _set_backend(monkeypatch, "auphonic", api_key="bad-key")
+        _install_fake_check_deps(monkeypatch, {})
+
+        from clm.recordings.workflow.backends.auphonic_client import AuphonicHTTPError
+
+        fake_client = MagicMock()
+        fake_client.list_presets = MagicMock(
+            side_effect=AuphonicHTTPError("GET", "https://auphonic.com", 401, "bad key")
+        )
+        monkeypatch.setattr(recordings_module, "_build_auphonic_client", lambda: fake_client)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["check"])
+
+        assert result.exit_code == 1
+        assert "UNREACHABLE" in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`clm recordings check` only verified `ffmpeg` + `onnxruntime`, ignoring the active processing backend (`recordings.processing_backend`). It reported "All dependencies found" even when the configured backend could not run — a false green for `auphonic` (unset/rejected API key) and a false red for `external` (missing `onnxruntime` it never uses).

`check` is now backend-aware:

- **onnx** (default): `ffmpeg` + `ffprobe` + `onnxruntime` (unchanged).
- **external**: `ffmpeg` + `ffprobe` only; `onnxruntime` is skipped (the externally produced `.wav` is just muxed via ffmpeg).
- **auphonic**: no `ffmpeg`/`onnxruntime` (cloud video-in/video-out, no local mux). Verifies a non-empty API key and does a read-only `AuphonicClient.list_presets()` round-trip to confirm credentials + connectivity. New `--offline` flag skips the network call and validates config shape only.

The output table header now shows which backend was checked.

## Implementation

- `src/clm/recordings/processing/utils.py`: new `check_dependencies_for_backend(backend)` helper (existing `check_dependencies()` retained for the onnx pipeline). Extracted `_check_ffmpeg_binaries()`.
- `src/clm/cli/commands/recordings.py`: `check` reads the active backend, adds `--offline`, and a `_check_auphonic_backend()` helper that renders the credential/connectivity result into the table.
- Info topic `commands.md` + `CHANGELOG.md` updated.

## Tests

- `TestCheckCommand`: onnx found/missing, external skips onnxruntime, auphonic missing-key (exit 1), `--offline` (no API call — enforced via `side_effect`), online reachable, online unreachable (exit 1). AuphonicClient is mocked — no real network.
- `TestCheckDependenciesForBackend`: per-backend dependency sets (onnx/external/auphonic).

`pytest -m "not docker"` fast suite green via pre-commit hooks; focused tests pass (88 in the two recordings test files).

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)