### PR TITLE
Design: cross-references between notebooks (Refs #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Cross-references between notebooks (issue #17).** Link from one notebook
+  to another with the `[text](clm:topic-id)` Markdown scheme. CLM resolves
+  the `clm:` href at build time to the correct relative path to the
+  same-variant (language, kind, format) target notebook, surviving renames
+  and reordering. An optional `/notebook-stem` disambiguator selects one
+  deck inside a directory topic that contains several slide notebooks;
+  without it CLM resolves deterministically and emits a
+  `cross_reference_ambiguous` warning. Per-format behavior: `html`/`notebook`
+  get working links, `code` drops the link (text only), `jupyterlite` is
+  deferred (link text left verbatim). A reference to a topic not included in
+  the build is reported as `cross_reference_target_missing` — a hard error
+  under `--http-replay=replay` (CI-strict) and a warning + dropped link
+  otherwise, controlled by `--fail-on-missing-xref / --no-fail-on-missing-xref`
+  and `CLM_FAIL_ON_MISSING_XREF` (mirrors `--fail-on-error`). `clm validate-spec`
+  also reports missing and ambiguous cross-references. v1 limitations:
+  no `#anchor`/sub-section targets, no cross-course references. See
+  `clm info spec-files` → "Cross-references".
 - **`clm slides normalize --canonicalize-start-completed`.** New opt-in
   flag for the interleaving operation. By default the normalizer leaves a
   `start`/`completed` cohesion pair (`[DE_start, DE_completed, EN_start,

--- a/docs/claude/design/cross-references.md
+++ b/docs/claude/design/cross-references.md
@@ -1,0 +1,351 @@
+# Cross-References Between Notebooks (Issue #17)
+
+**Status**: Design proposal — awaiting maintainer decisions
+**Issue**: [hoelzl/clm#17](https://github.com/hoelzl/clm/issues/17)
+**Target version**: TBD (1.7.x candidate)
+**Author**: Claude (design-first investigation)
+
+## Problem statement
+
+Authors want to link from one notebook to another (e.g. a slide deck linking
+to its workshop). Today this is impossible to do reliably because:
+
+1. CLM **renames** notebooks at generation time. The output filename is
+   `"{number_in_section:02} {sanitized_title}{ext}"`
+   (`NotebookFile.file_name`, `src/clm/core/course_files/notebook_file.py`),
+   placed under a section directory named from the *section* title
+   (`CourseFile.output_dir`). Neither the slot number nor the title is known to
+   the author at authoring time — both are derived from spec ordering and the
+   notebook's H1.
+2. The same source notebook fans out to **many output artifacts**: per
+   language (`de`/`en`), per kind (`code-along`, `completed`, `trainer`,
+   `recording`, `partial`), and per format (`html`, `notebook`, `code`,
+   `jupyterlite`). A correct link must resolve to *the sibling artifact of the
+   same language/kind/format* as the file it appears in.
+3. A hand-written relative link (`../02 Foo/...`) breaks the moment a topic is
+   reordered, retitled, added, or removed.
+
+The issue also notes the second requirement: **validate that every linked
+notebook is actually included in the course** so a link never dangles.
+
+## How CLM identifies notebooks today (investigation findings)
+
+### Stable identity: the topic ID
+
+The only stable, author-facing identifier that already exists is the
+**topic ID** — the directory/file name with its `topic_NNN_` (or
+`slides_NNN_`, `project_NNN_`) numeric prefix stripped, computed by
+`simplify_ordered_name` in `topic_resolver.build_topic_map`. For
+`slides/module_001/topic_100_introduction/`, the topic ID is `introduction`.
+
+This is exactly what `<topic>introduction</topic>` references in a spec, and
+it is stable under reordering and renumbering (the numeric prefix is *not*
+part of the ID). It is the natural anchor for a cross-reference scheme.
+
+**Caveat — topic ≠ notebook.** A directory topic may contain *several* slide
+files (`find_slide_files` returns all `slides_*.py` in the directory), each
+becoming its own `NotebookFile` with its own `number_in_section`. So a topic
+ID alone does not always uniquely name one output notebook. Options:
+
+- **Topic-granular references** (link to "the topic"): unambiguous only when a
+  topic has exactly one slide notebook. For multi-notebook topics we'd need a
+  disambiguator (the slide file stem) or a documented "links to the first
+  notebook" rule.
+- **Notebook-granular references** (link to one specific deck): requires a
+  per-notebook identifier. The slide file stem (`slides_foo` →
+  `simplify_ordered_name` → `foo`) is a candidate, or an explicit author-set ID
+  (see Decision 2).
+
+### Output naming and fan-out
+
+- Output filename: `NotebookFile.file_name(lang, ext)` →
+  `"{number_in_section:02} {sanitized_title}{ext}"`.
+- `number_in_section` is assigned by `Section.add_notebook_numbers()` *after*
+  the topic map is built — split `.de.py`/`.en.py` companions share one slot.
+- Section directory: `CourseFile.output_dir` → `target_dir /
+  sanitize_file_name(section.name[lang])`.
+- The full per-artifact path is assembled in
+  `ProcessNotebookOperation` from `output_specs(...)` (language × format ×
+  kind × target). The same operation already computes a course-relative
+  prefix for images (`compute_img_path_prefix`) — proof that
+  "compute a relative path from this output file to another output location"
+  is an established pattern.
+
+### Where a link rewrite would hook in
+
+`NotebookProcessor._process_markdown_cell_contents`
+(`src/clm/workers/notebook/notebook_processor.py`) already rewrites markdown
+cell content per output variant: `notes`/`voiceover` styling, `.png`→`.svg`,
+image-path prefixing, and data-URL inlining. A cross-reference rewrite is the
+same shape of transform and belongs here.
+
+**Crucial architectural constraint.** The notebook worker processes **one
+notebook in isolation** and has no knowledge of the other notebooks' output
+filenames. Therefore the *resolution* (topic-id → renamed relative path for
+this specific language/kind/format) must happen **at payload-construction
+time** in `ProcessNotebookOperation.payload()`, where the full `Course`
+(all sections, topics, assigned numbers, titles) is in scope — exactly like
+`img_path_prefix`. The resolved map is then passed across the worker boundary
+in `NotebookPayload`, and the worker performs only a mechanical string
+substitution. This keeps the worker stateless and the resolution testable
+without a kernel.
+
+### Validation hook
+
+`clm validate-spec` (`src/clm/slides/spec_validator.py`) already produces
+structured `SpecFinding`s for unresolved/ambiguous topics. A "cross-reference
+target not in course" check is a natural new finding type there. But note:
+spec validation does **not** parse notebook *contents* today — it only reads
+the XML and the filesystem topic map. Detecting cross-references requires
+scanning slide-file markdown for the reference syntax, which is new work for
+the validator (the build path already reads every notebook, so the build-time
+check is cheaper to add there).
+
+## Proposed design
+
+### 1. Authoring syntax
+
+Use a **custom URI scheme inside a normal Markdown link** so it is invisible
+to ordinary Markdown tooling until CLM rewrites it, and trivially
+regex-detectable:
+
+```markdown
+See the [Functions workshop](clm:functions_workshop) for exercises.
+```
+
+Where `clm:<reference>` is the CLM cross-reference. The link **text** is
+authored normally and left untouched. Only the **href** is rewritten.
+
+Reference grammar (options enumerated under Decisions):
+
+```
+clm:<topic-id>                      # link to a topic (single-notebook topics)
+clm:<topic-id>/<notebook-stem>      # disambiguate a multi-notebook topic  (optional)
+clm:<topic-id>#<anchor>             # link to a heading anchor              (optional, Decision 3)
+```
+
+Rationale for `clm:` over alternatives:
+
+- `[text](clm:id)` survives jupytext round-trips and `nbconvert` unchanged
+  (it is a syntactically valid URI), so an *unbuilt* notebook opened directly
+  in VS Code/JupyterLab simply shows a dead `clm:` link rather than corrupt
+  Markdown.
+- It is unambiguous to detect (`\]\(clm:...\)`) and cannot collide with real
+  relative links.
+- It mirrors the existing `<topic>id</topic>` vocabulary, so authors reuse a
+  concept they already know.
+
+(Alternative schemes — `[[wikilink]]`, a `{ref}` MyST role, an HTML
+`<a data-clmref>` — are compared in Decision 1.)
+
+### 2. Resolution (build-time, per artifact)
+
+A new `CrossReferenceResolver` (proposed home:
+`src/clm/core/cross_references.py`) is built once per `Course` after sections
+and notebook numbers are assigned. It exposes:
+
+```python
+def resolve(
+    self,
+    reference: str,          # the part after "clm:"
+    *,
+    from_output_file: Path,  # the artifact currently being written
+    language: str,
+    kind: str,
+    format: str,
+) -> ResolvedReference | None
+```
+
+and returns either a **relative href** from `from_output_file` to the target
+artifact of the *same* `(language, kind, format)`, or `None` if the target is
+not in the course / not produced for that variant.
+
+Per-format target rules:
+
+| Format | Link target | Notes |
+|--------|-------------|-------|
+| `html` | the target notebook's `.html` file | natural, fully working |
+| `notebook` (`.ipynb`) | the target `.ipynb` | works in Jupyter/VS Code |
+| `code` | the extracted `.py`/source file, **or** drop the link | code export is not a hyperlinked medium — see Decision 5 |
+| `jupyterlite` | the in-site notebook URL | deferred until the JupyterLite builder ships |
+
+The relative path is computed exactly like `compute_img_path_prefix` does for
+images: walk from `from_output_file` to the target artifact's known output
+path. Because both files live under the same target root with deterministic
+section-dir + `"{NN} {title}{ext}"` names, the resolver can reconstruct the
+target path without touching the filesystem.
+
+The resolved map is attached to `NotebookPayload` as a new field, e.g.:
+
+```python
+# Mapping of "clm:" reference -> already-resolved relative href for THIS
+# (language, kind, format) artifact. Empty when the notebook has no
+# cross-references. Computed in ProcessNotebookOperation.payload().
+cross_references: dict[str, str] = {}
+```
+
+The worker's `_process_markdown_cell_contents` gains a final step:
+
+```python
+if payload and payload.cross_references:
+    cell["source"] = rewrite_cross_references(cell["source"], payload.cross_references)
+```
+
+`rewrite_cross_references` finds every `](clm:<ref>)` and replaces the href
+with the resolved relative path (or applies the missing-target policy from
+Decision 4 when a ref is absent from the map).
+
+### 3. Validation: "all linked notebooks are included"
+
+Add a build-time pass (and optionally a `validate-spec` finding):
+
+- During the build, the `Course` already reads every slide file to build the
+  file map. Add a light markdown scan that extracts every `clm:` reference per
+  notebook.
+- For each reference, ask the `CrossReferenceResolver` whether the target
+  topic/notebook is part of the **resolved course** (i.e. it appears in some
+  built section, honoring the active `--section` selection and `enabled=false`
+  filtering).
+- Emit a structured finding when a reference points at a topic that is not
+  included:
+  - category `cross_reference_target_missing` (severity per Decision 4).
+- Also surface `cross_reference_ambiguous` when a topic-granular ref hits a
+  multi-notebook topic and no disambiguator was given.
+
+Because the resolver is course-aware, this also naturally handles
+section-filtered builds (`clm build --section w03`): a link to a topic that is
+real but *not in the selected sections* is reported, since the rename target
+does not exist in this output.
+
+### 4. Behavior when a target is missing/excluded
+
+Three policies, selectable (Decision 4 picks the default):
+
+- **error** — build fails with a clear finding (consistent with
+  `topic_not_found`).
+- **warning + drop link** — emit a warning and render the link text as plain
+  text (strip the href). Safest for partial/roadmap builds.
+- **warning + leave `clm:` href** — visible breakage; not recommended.
+
+### Out of scope for v1
+
+- Anchors / sub-section links (Decision 3) — gated behind a stable
+  heading-anchor scheme that CLM does not emit today.
+- `jupyterlite` link targets — deferred until the JupyterLite site builder
+  exists.
+- Cross-*course* references (linking into a different course repo).
+
+## Open product decisions (for the maintainer)
+
+> These are genuine product calls. I have **not** picked any of them — each
+> lists options and my recommendation, but the maintainer decides.
+
+### Decision 1 — Reference syntax / scheme
+
+Options:
+- **(A)** `[text](clm:topic-id)` — custom URI in a normal Markdown link.
+- **(B)** `[[topic-id|text]]` wiki-link style.
+- **(C)** MyST `{ref}` / `{doc}` role (`` {doc}`topic-id` ``).
+- **(D)** Explicit HTML `<a data-clmref="topic-id">text</a>`.
+
+**Recommendation: (A).** Lowest blast radius: valid Markdown, survives
+jupytext/nbconvert untouched, regex-detectable, reuses the existing topic-id
+vocabulary, and degrades to an obviously-dead link if a notebook is opened
+unbuilt. (C) is attractive for MyST-heavy authors but couples us to MyST
+parsing; (B) needs a new inline parser; (D) is verbose for authors.
+
+### Decision 2 — Stable identifier scheme
+
+Options:
+- **(A)** Reuse the existing **topic ID** (path-derived, already the spec
+  vocabulary). Add an optional `/notebook-stem` disambiguator for
+  multi-notebook topics.
+- **(B)** Require an explicit author-assigned ID in slide front-matter
+  (e.g. a `clm-id:` key), independent of path/title.
+- **(C)** Hybrid: default to topic ID, allow an explicit front-matter ID to
+  override for notebooks that need a rename-proof handle.
+
+**Recommendation: (A) for v1, with (C) as a documented growth path.** Topic
+IDs already exist, are validated, and authors know them. An explicit-ID
+mechanism is more work (new front-matter field, new validation for
+uniqueness/collision) and can be layered on later without breaking (A).
+The key question for the maintainer is **granularity**: are references
+topic-level (simple, but ambiguous for multi-notebook topics) or
+notebook-level (precise, needs the stem or an explicit ID)?
+
+### Decision 3 — Anchors / sub-section links in scope?
+
+Options:
+- **(A)** No — references resolve to a whole notebook only (v1).
+- **(B)** Yes — `clm:topic#heading` resolves to a heading anchor.
+
+**Recommendation: (A) for v1.** CLM does not currently emit stable,
+predictable heading anchors across HTML/`.ipynb`, and the anchor slugging
+differs per renderer. Shipping anchors means first defining and emitting a
+stable anchor scheme — a separate, larger piece of work.
+
+### Decision 4 — Behavior when a target is not included
+
+Options:
+- **(A)** Hard error, blocks the build (like `topic_not_found`).
+- **(B)** Warning + drop the link (render text only).
+- **(C)** Configurable, with a chosen default.
+
+**Recommendation: (C) with default = error in strict/CI builds, warning+drop
+in local/section-filtered builds.** A dangling cross-reference is a genuine
+authoring bug and should fail CI (consistent with the existing
+`--fail-on-error` philosophy, Issue #90). But a developer building a single
+section locally legitimately excludes link targets, so warn-and-drop avoids
+blocking iteration. A `--fail-on-missing-xref / --no-fail-on-missing-xref`
+flag (env `CLM_FAIL_ON_MISSING_XREF`) mirrors the existing exit-code controls.
+
+### Decision 5 — References in formats with no natural link target
+
+Options for `code` (extracted source) and similar:
+- **(A)** Drop the cross-reference entirely (link text only / comment text).
+- **(B)** Emit a relative path comment to the sibling source file.
+- **(C)** Leave the `clm:` reference verbatim as documentation.
+
+**Recommendation: (A).** Extracted code is not a hyperlinked medium; turning a
+`clm:` href into a bare text label (or, for code cells, leaving the surrounding
+comment) is the least surprising. `jupyterlite` should be explicitly deferred
+(builder not shipped).
+
+## Implementation plan (once decisions land)
+
+1. **Resolver + identifier** (`src/clm/core/cross_references.py`): build the
+   topic-id (and optional notebook-stem) → output-path index from a resolved
+   `Course`; implement per-`(language, kind, format)` relative-href resolution.
+   Pure, fully unit-testable without a kernel.
+2. **Reference extraction** (`src/clm/core/utils/`): a regex/markdown scanner
+   that pulls `clm:` references out of slide-file text. Shared by build and
+   validator.
+3. **Payload wiring**: add `cross_references: dict[str, str]` to
+   `NotebookPayload`; populate it in `ProcessNotebookOperation.payload()`.
+4. **Worker rewrite**: `rewrite_cross_references` + a call in
+   `_process_markdown_cell_contents`.
+5. **Validation**: new `SpecFinding` types
+   (`cross_reference_target_missing`, `cross_reference_ambiguous`) and a
+   build-time check honoring section selection.
+6. **Exit-code control** (if Decision 4 = C): flag + env var.
+7. **Docs (mandatory before release)**: update
+   `src/clm/cli/info_topics/spec-files.md` (syntax) and
+   `commands.md` (any new flags), plus `CHANGELOG.md`.
+
+## Groundwork scaffolded in this PR
+
+To de-risk the resolver shape *without* committing to any open decision, this
+PR includes a small, decision-agnostic scaffold:
+
+- `src/clm/core/cross_references.py` — a `CrossReferenceResolver` interface
+  stub plus a pure `extract_cross_references(text) -> list[str]` helper for the
+  `clm:` syntax (Decision 1 default). The extractor is correct regardless of
+  the identifier-granularity decision because it returns the raw reference
+  strings; *interpreting* them is the resolver's job and is left unimplemented
+  pending Decision 2.
+- `tests/core/test_cross_references.py` — tests for the extractor only
+  (detection, multiple refs per cell, leaving ordinary links and image links
+  untouched).
+
+No production code path calls the resolver yet, so nothing changes in build
+output until the decisions are made and the resolver is implemented.

--- a/docs/claude/design/cross-references.md
+++ b/docs/claude/design/cross-references.md
@@ -1,9 +1,54 @@
 # Cross-References Between Notebooks (Issue #17)
 
-**Status**: Design proposal — awaiting maintainer decisions
+**Status**: Implemented (v1) — decisions locked, shipping
 **Issue**: [hoelzl/clm#17](https://github.com/hoelzl/clm/issues/17)
-**Target version**: TBD (1.7.x candidate)
+**Target version**: 1.7.x
 **Author**: Claude (design-first investigation)
+
+## Implementation summary (locked decisions)
+
+The maintainer locked the open decisions and the feature is implemented:
+
+* **Syntax (Decision 1 = A):** `[text](clm:topic-id)`.
+* **Identifier (Decision 2 = A, v1):** the path-derived topic id, with an
+  optional `/notebook-stem` disambiguator. An `#anchor` is parsed but
+  **stripped** (anchors are out of scope for v1). Multi-notebook directory
+  topics resolve deterministically (lowest `number_in_section`, then name)
+  and emit a build-time **warning** (`cross_reference_ambiguous`); they do
+  **not** hard-fail.
+* **Missing target (Decision 4 = C):** configurable. Default = error under
+  `--http-replay=replay` (CI-strict), warn-and-drop otherwise. Controlled by
+  `--fail-on-missing-xref / --no-fail-on-missing-xref` and
+  `CLM_FAIL_ON_MISSING_XREF`, mirroring issue #90's `--fail-on-error`.
+* **Per-format (Decisions 4/5):** `html`/`notebook` get working relative
+  links; `code` **drops** the link (renders link text only); `jupyterlite`
+  is **deferred** (link text left verbatim).
+
+Code map:
+
+* `src/clm/core/cross_references.py` — `extract_cross_references`,
+  `split_reference`, `rewrite_cross_references`, `CrossReferenceResolver`
+  (filesystem-free per-`(language, kind, format)` href computation),
+  `validate_cross_references` (host-side build validation).
+* `src/clm/core/operations/process_notebook.py` —
+  `ProcessNotebookOperation.compute_cross_references()` resolves the href map
+  at payload-construction time; carried in `NotebookPayload.cross_references`.
+* `src/clm/workers/notebook/notebook_processor.py` —
+  `_process_markdown_cell_contents` does the mechanical rewrite only.
+* `src/clm/cli/commands/build.py` — `--fail-on-missing-xref` flag,
+  `_resolve_fail_on_missing_xref`, `_report_cross_reference_issues`.
+* `src/clm/slides/spec_validator.py` — `cross_reference_target_missing` /
+  `cross_reference_ambiguous` `SpecFinding`s for `clm validate-spec`.
+
+### v1 limitations (documented)
+
+* No `#anchor` / sub-section targets (Decision 3 = A).
+* Multi-notebook directory topics resolve to a deterministic deck with a
+  warning rather than a hard error; use a `/notebook-stem` disambiguator
+  (`clm:topic_id/slides_<stem>`) for precision.
+* `jupyterlite` link targets are deferred until the JupyterLite site builder
+  ships; link text is left verbatim.
+* Cross-*course* references are out of scope.
 
 ## Problem statement
 

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -102,6 +102,34 @@ def _resolve_fail_on_error(cli_value: bool | None, resolved_http_replay_mode: st
     return resolved_http_replay_mode == "replay"
 
 
+def _resolve_fail_on_missing_xref(cli_value: bool | None, resolved_http_replay_mode: str) -> bool:
+    """Resolve whether an unresolved ``clm:`` cross-reference target fails the
+    build (issue #17).
+
+    Precedence mirrors ``_resolve_fail_on_error`` exactly: explicit CLI flag >
+    ``CLM_FAIL_ON_MISSING_XREF`` env var > replay-mode default. The default is
+    **on** under ``--http-replay=replay`` (the CI-strict mode) and **off**
+    otherwise, so a developer building a single section locally legitimately
+    excludes link targets without the build erroring (the link is dropped with
+    a warning instead).
+    """
+    import os
+
+    if cli_value is not None:
+        return cli_value
+    env_value = os.environ.get("CLM_FAIL_ON_MISSING_XREF")
+    if env_value is not None:
+        normalized = env_value.strip().lower()
+        if normalized in ("1", "true", "yes"):
+            return True
+        if normalized in ("0", "false", "no"):
+            return False
+        raise click.UsageError(
+            f"Invalid CLM_FAIL_ON_MISSING_XREF={env_value!r}. Valid values: 1/true/yes/0/false/no."
+        )
+    return resolved_http_replay_mode == "replay"
+
+
 def _find_env_file(start_dir: Path) -> Path | None:
     """Walk up from start_dir looking for a .env file.
 
@@ -212,6 +240,13 @@ class BuildConfig:
     # to decide which section directories to clean up and by the watch-mode
     # event handler to filter events.
     resolved_section_selection: SectionSelection | None = None
+
+    # Cross-reference policy (Issue #17). When True, an unresolved ``clm:``
+    # cross-reference target fails the build; when False it is a warning and
+    # the link is dropped. Resolved from ``--fail-on-missing-xref`` /
+    # ``CLM_FAIL_ON_MISSING_XREF`` / the replay-mode default, mirroring
+    # ``fail_on_error`` (issue #90).
+    fail_on_missing_xref: bool = False
 
 
 def create_output_formatter(config: BuildConfig) -> OutputFormatter:
@@ -471,6 +506,9 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
         section_selection=section_selection,
         http_replay_mode=config.http_replay_mode,
     )
+    # Cross-reference policy (Issue #17): propagate the resolved fail-on-missing
+    # decision so payload-time rewrite and build-time validation agree.
+    course.fail_on_missing_xref = config.fail_on_missing_xref
 
     # Calculate root directories for cleanup
     root_dirs = []
@@ -732,6 +770,46 @@ def _report_loading_issues(course: Course, build_reporter: BuildReporter) -> Non
         )
 
 
+def _report_cross_reference_issues(course: Course, build_reporter: BuildReporter) -> None:
+    """Validate notebook cross-references and report findings (Issue #17).
+
+    Missing targets are errors when ``course.fail_on_missing_xref`` is set
+    (CI-strict), otherwise warnings (the link is dropped at rewrite time).
+    Ambiguous multi-notebook targets are always warnings. Honors the active
+    ``--section`` selection because the resolver is built from the already
+    filtered ``course.sections``.
+    """
+    from clm.cli.build_data_classes import BuildError, BuildWarning
+    from clm.core.cross_references import validate_cross_references
+
+    findings = validate_cross_references(course, fail_on_missing=course.fail_on_missing_xref)
+    for finding in findings:
+        if finding.severity == "error":
+            build_reporter.report_error(
+                BuildError(
+                    error_type="user",
+                    category=finding.type,
+                    severity="error",
+                    message=finding.message,
+                    file_path=finding.source_file,
+                    actionable_guidance=(
+                        "Add the referenced topic to the course spec (or the "
+                        "selected sections), fix the topic id, or pass "
+                        "--no-fail-on-missing-xref to downgrade this to a warning."
+                    ),
+                )
+            )
+        else:
+            build_reporter.report_warning(
+                BuildWarning(
+                    category=finding.type,
+                    message=finding.message,
+                    severity="high",
+                    file_path=finding.source_file,
+                )
+            )
+
+
 def _compute_section_dirs_for_cleanup(course: Course) -> list[Path]:
     """Return the full set of per-section output directories for the
     current (already filtered) ``course.sections``.
@@ -867,6 +945,7 @@ async def process_course_with_backend(
     async def _run_stages() -> BuildSummary | None:
         _report_duplicate_file_warnings(course, build_reporter)
         _report_loading_issues(course, build_reporter)
+        _report_cross_reference_issues(course, build_reporter)
 
         if _report_image_collisions(course, build_reporter):
             build_reporter.finish_build()
@@ -1158,6 +1237,7 @@ async def main_build(
     image_mode,
     image_format,
     inline_images,
+    fail_on_missing_xref=False,
 ) -> BuildSummary | None:
     """Main orchestration function for course building.
 
@@ -1262,6 +1342,7 @@ async def main_build(
         clean=clean,
         sweep=effective_sweep,
         selected_sections=selected_sections,
+        fail_on_missing_xref=fail_on_missing_xref,
     )
 
     # Create output formatter early to show startup messages
@@ -1596,6 +1677,18 @@ async def main_build(
     ),
 )
 @click.option(
+    "--fail-on-missing-xref/--no-fail-on-missing-xref",
+    default=None,
+    help=(
+        "Exit with non-zero status if a 'clm:' cross-reference points at a "
+        "topic not included in the build (issue #17). Defaults to on under "
+        "--http-replay=replay (the CI-strict default) and off under all other "
+        "replay modes — locally, a missing target is a warning and the link is "
+        "dropped (text kept). Override via "
+        "CLM_FAIL_ON_MISSING_XREF={1,true,yes,0,false,no}."
+    ),
+)
+@click.option(
     "--image-mode",
     type=click.Choice(["duplicated", "shared"], case_sensitive=False),
     default="duplicated",
@@ -1661,6 +1754,7 @@ def build(
     force_execute,
     http_replay,
     fail_on_error,
+    fail_on_missing_xref,
     image_mode,
     image_format,
     inline_images,
@@ -1759,6 +1853,9 @@ def build(
     # the precedence logic. ``main_build`` re-resolves harmlessly (the
     # resolver returns its CLI argument unchanged when not ``None``).
     resolved_http_replay_mode = _resolve_http_replay_mode(http_replay)
+    resolved_fail_on_missing_xref = _resolve_fail_on_missing_xref(
+        fail_on_missing_xref, resolved_http_replay_mode
+    )
 
     summary = asyncio.run(
         main_build(
@@ -1797,6 +1894,7 @@ def build(
             image_mode,
             image_format,
             inline_images,
+            resolved_fail_on_missing_xref,
         )
     )
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -64,6 +64,7 @@ Key options:
 | `--inline-images` | Embed images as base64 in notebooks |
 | `--http-replay [replay\|once\|new-episodes\|refresh\|disabled]` | HTTP replay record mode for topics with `http-replay="yes"` in the spec. `replay` requires a cassette (strict, CI default); `once` records on first run, replays thereafter (strict on new requests); `new-episodes` replays recorded requests and records any new ones (local default); `refresh` re-records every run; `disabled` bypasses replay. Defaults to `replay` when `CI=true`, else `new-episodes`. Also settable via `CLM_HTTP_REPLAY_MODE`. |
 | `--fail-on-error / --no-fail-on-error` | Exit with non-zero status when the build summary reports any cell or notebook error. Defaults to **on** under `--http-replay=replay` (incl. CI) and **off** under all other replay modes. Override via `CLM_FAIL_ON_ERROR={1,true,yes,0,false,no}`. See "Exit codes" below. |
+| `--fail-on-missing-xref / --no-fail-on-missing-xref` | Exit with non-zero status when a `clm:` cross-reference points at a topic not included in the build (issue #17). Defaults to **on** under `--http-replay=replay` (incl. CI) and **off** under all other replay modes (a missing target is then a warning and the link is dropped). Override via `CLM_FAIL_ON_MISSING_XREF={1,true,yes,0,false,no}`. See `clm info spec-files` → "Cross-references". |
 
 Examples:
 
@@ -1997,6 +1998,7 @@ Create and manage ZIP archives of course output.
 | `CLM_HTTP_REPLAY_TRACE_VERBOSE` | When tracing is on, include extra per-event detail (default off). Accepts `1`/`true`/`yes`. |
 | `CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES` | Cap on bytes recorded for the head/tail body excerpts in trace events (default: implementation-defined). |
 | `CLM_FAIL_ON_ERROR` | Override the default exit-on-cell-error policy for `clm build`. Accepts `1`/`true`/`yes` or `0`/`false`/`no`. Overridden by `--fail-on-error` / `--no-fail-on-error`. See `clm build` → "Exit codes". |
+| `CLM_FAIL_ON_MISSING_XREF` | Override the default exit-on-missing-cross-reference policy for `clm build` (issue #17). Accepts `1`/`true`/`yes` or `0`/`false`/`no`. Overridden by `--fail-on-missing-xref` / `--no-fail-on-missing-xref`. See `clm info spec-files` → "Cross-references". |
 | `LANGFUSE_HOST` | Langfuse server URL (or `LANGFUSE_BASE_URL`); enables LLM call tracing when set with keys below |
 | `LANGFUSE_PUBLIC_KEY` | Langfuse public key for LLM tracing |
 | `LANGFUSE_SECRET_KEY` | Langfuse secret key for LLM tracing |

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -593,9 +593,71 @@ with a pointer to this topic.
 </course>
 ```
 
+## Cross-references between notebooks (CLM {version}+)
+
+Link from one notebook to another using a custom Markdown link scheme.
+Because CLM renames notebooks at build time, you cannot hand-write a stable
+relative link — instead reference the **topic id** (the same identifier you
+use in `<topic>id</topic>`, i.e. the directory/file name with its
+`topic_NNN_` / `slides_NNN_` / `project_NNN_` numeric prefix stripped):
+
+```markdown
+See the [Functions workshop](clm:functions_workshop) for exercises.
+```
+
+At build time CLM rewrites the `clm:` href to the correct relative path to
+the **same variant** (language, kind, format) of the target notebook. The
+link **text** is never touched. An unbuilt notebook opened directly in
+VS Code / JupyterLab simply shows a dead `clm:` link rather than corrupt
+Markdown.
+
+### Reference grammar
+
+```
+clm:<topic-id>                  link to a topic (single-notebook topics)
+clm:<topic-id>/<notebook-stem>  disambiguate a directory topic with several decks
+```
+
+- `<topic-id>` is the path-derived topic id.
+- `<notebook-stem>` is a slide file's stem (e.g. `slides_part_b`), used only
+  when a directory topic contains more than one slide notebook.
+
+### Per-format behavior
+
+| Format        | Behavior                                                    |
+|---------------|-------------------------------------------------------------|
+| `html`        | rewritten to the target `.html` (working hyperlink)         |
+| `notebook`    | rewritten to the target `.ipynb` (works in Jupyter/VS Code) |
+| `code`        | link **dropped** — only the link text is rendered           |
+| `jupyterlite` | **deferred** — link text left verbatim (no rewrite yet)     |
+
+### v1 limitations
+
+- **No anchors / sub-section targets.** `clm:topic#heading` is accepted but
+  the `#heading` part is ignored (resolves to the whole notebook).
+- **Multi-notebook topics resolve deterministically.** If a directory topic
+  contains several slide notebooks and you do not add a `/notebook-stem`
+  disambiguator, CLM resolves to the first deck (lowest slot number) and
+  emits a `cross_reference_ambiguous` warning. Add a disambiguator to be
+  explicit.
+- **No cross-course references.**
+
+### Missing-target policy
+
+A `clm:` reference whose target topic is not included in the build (wrong id,
+or excluded by `--only-sections` / `enabled="false"`) is reported as
+`cross_reference_target_missing`. By default this is a **hard error** under
+`--http-replay=replay` (the CI-strict default) and a **warning + dropped
+link** otherwise. Override with `clm build --fail-on-missing-xref /
+--no-fail-on-missing-xref` or the `CLM_FAIL_ON_MISSING_XREF` environment
+variable (mirrors `--fail-on-error`). `clm validate-spec` also reports
+missing and ambiguous cross-references without a full build.
+
 ## Validation
 
 CLM validates spec files before building and reports:
 - Missing required elements
 - Duplicate target names or paths
 - Invalid kind/format/language values
+- Cross-reference targets that are missing (`cross_reference_target_missing`)
+  or ambiguous (`cross_reference_ambiguous`)

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -33,7 +33,7 @@ else:
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define
+from attrs import Factory, define, field
 
 from clm.core.course_file import CourseFile
 from clm.core.course_spec import CourseSpec, SectionSelection
@@ -58,7 +58,7 @@ from clm.infrastructure.utils.path_utils import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from clm.core.cross_references import CrossReferenceResolver
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +101,16 @@ class Course(NotebookMixin):
     # in `section_selection.resolved_indices` (in declared order). When
     # None, all sections in the spec are built.
     section_selection: SectionSelection | None = None
+    # Cross-reference policy (Issue #17): when True, an unresolved ``clm:``
+    # cross-reference target is a hard build error; when False it is a
+    # warning and the link is dropped (text kept). Wired from the build CLI
+    # ``--fail-on-missing-xref`` flag / ``CLM_FAIL_ON_MISSING_XREF`` env var.
+    fail_on_missing_xref: bool = False
+    # Lazily-built, course-scoped cross-reference resolver. Built once after
+    # sections and notebook numbers are assigned (see ``cross_reference_resolver``).
+    _cross_reference_resolver: "CrossReferenceResolver | None" = field(
+        default=None, init=False, repr=False
+    )
 
     @classmethod
     def from_spec(
@@ -263,6 +273,20 @@ class Course(NotebookMixin):
     @property
     def files(self) -> list[CourseFile]:
         return [file for section in self.sections for file in section.files]
+
+    @property
+    def cross_reference_resolver(self) -> "CrossReferenceResolver":
+        """Return the course-scoped cross-reference resolver (Issue #17).
+
+        Built lazily on first access and cached. Must only be accessed after
+        sections are built and notebook numbers are assigned (the build
+        pipeline guarantees this by the time payloads are constructed).
+        """
+        if self._cross_reference_resolver is None:
+            from clm.core.cross_references import CrossReferenceResolver
+
+            self._cross_reference_resolver = CrossReferenceResolver(self)
+        return self._cross_reference_resolver
 
     def find_file(self, path: Path) -> File | None:
         """Return a File, if path exists in the course, None otherwise."""

--- a/src/clm/core/cross_references.py
+++ b/src/clm/core/cross_references.py
@@ -1,0 +1,97 @@
+"""Cross-references between notebooks (Issue #17).
+
+Design-first scaffold. The only piece implemented here is the
+decision-agnostic *extractor*: it pulls ``clm:`` references out of slide
+markdown text. Interpreting a reference (topic-id vs notebook-stem vs an
+explicit author-assigned id) and resolving it to a renamed, per-artifact
+relative href is intentionally left unimplemented — those depend on the
+open product decisions recorded in
+``docs/claude/design/cross-references.md`` (Decisions 1, 2, 4, 5).
+
+Nothing in the build pipeline calls this module yet; importing it has no
+effect on build output.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+# The cross-reference URI scheme (Decision 1, default option A). A reference
+# is authored as a normal Markdown link whose href uses this scheme, e.g.
+# ``[Functions workshop](clm:functions_workshop)``. Only the href is
+# rewritten at build time; the link text is left untouched.
+SCHEME = "clm:"
+
+# Matches the href of a Markdown link whose target uses the ``clm:`` scheme.
+# Captures the reference (everything after ``clm:`` up to the closing paren).
+# Deliberately conservative: it only fires inside the ``](...)`` href slot,
+# so ordinary links and image links (``![alt](path)`` — note the leading
+# ``!`` is *not* excluded here because the reference still wouldn't use the
+# ``clm:`` scheme for an image) are left alone.
+_CROSS_REF_RE = re.compile(r"\]\(\s*clm:\s*(?P<ref>[^)\s]+)\s*\)")
+
+
+@dataclass(frozen=True)
+class ResolvedReference:
+    """A cross-reference resolved to a concrete, per-artifact link target.
+
+    ``href`` is the relative path from the *referring* output file to the
+    *target* output artifact of the same ``(language, kind, format)``.
+    """
+
+    reference: str
+    href: str
+
+
+def extract_cross_references(text: str) -> list[str]:
+    """Return every ``clm:`` reference found in *text*, in document order.
+
+    Decision-agnostic: returns the raw reference strings (the part after
+    ``clm:``) exactly as authored. Interpreting them — splitting an
+    optional ``/notebook-stem`` disambiguator or ``#anchor`` — is the
+    resolver's job and is deferred until the identifier scheme is chosen
+    (Decision 2/3). Duplicates are preserved so callers can report every
+    occurrence.
+
+    Args:
+        text: Markdown (or percent-format slide) source.
+
+    Returns:
+        List of reference strings, e.g. ``["functions_workshop", "intro"]``.
+    """
+    return [m.group("ref") for m in _CROSS_REF_RE.finditer(text)]
+
+
+def has_cross_references(text: str) -> bool:
+    """Return True if *text* contains at least one ``clm:`` reference."""
+    return _CROSS_REF_RE.search(text) is not None
+
+
+class CrossReferenceResolver(Protocol):
+    """Resolves a ``clm:`` reference to a per-artifact relative href.
+
+    A concrete implementation is built once per :class:`~clm.core.course.Course`
+    after sections and notebook numbers are assigned, so it knows every
+    output notebook's renamed filename. ``resolve`` returns ``None`` when
+    the target is not part of the (possibly section-filtered) course or is
+    not produced for the requested ``(language, kind, format)`` variant —
+    the caller then applies the missing-target policy (Decision 4).
+
+    Not implemented yet: the concrete resolver lands once Decisions 1, 2,
+    4 and 5 are settled (see ``docs/claude/design/cross-references.md``).
+    """
+
+    def resolve(
+        self,
+        reference: str,
+        *,
+        from_output_file: Path,
+        language: str,
+        kind: str,
+        format: str,
+    ) -> ResolvedReference | None:
+        """Resolve *reference* for one output artifact, or return ``None``."""
+        ...

--- a/src/clm/core/cross_references.py
+++ b/src/clm/core/cross_references.py
@@ -1,60 +1,97 @@
 """Cross-references between notebooks (Issue #17).
 
-Design-first scaffold. The only piece implemented here is the
-decision-agnostic *extractor*: it pulls ``clm:`` references out of slide
-markdown text. Interpreting a reference (topic-id vs notebook-stem vs an
-explicit author-assigned id) and resolving it to a renamed, per-artifact
-relative href is intentionally left unimplemented — those depend on the
-open product decisions recorded in
-``docs/claude/design/cross-references.md`` (Decisions 1, 2, 4, 5).
+Authors link from one notebook to another with a custom Markdown link
+scheme::
 
-Nothing in the build pipeline calls this module yet; importing it has no
-effect on build output.
+    See the [Functions workshop](clm:functions_workshop) for exercises.
+
+``clm:<reference>`` survives jupytext / nbconvert untouched (it is a valid
+URI) and is regex-detectable. Only the **href** is rewritten at build time;
+the link text is left as authored.
+
+This module provides three layers:
+
+* :func:`extract_cross_references` / :func:`has_cross_references` — a pure,
+  decision-agnostic scanner that pulls the raw reference strings out of
+  slide markdown.
+* :class:`CrossReferenceResolver` — built once per
+  :class:`~clm.core.course.Course` after sections and notebook numbers are
+  assigned. It maps a *topic id* to the renamed, same-variant relative href
+  for a given ``(language, kind, format)`` output artifact. Resolution is
+  filesystem-free: both the referring and target artifacts live under the
+  same ``slides/<format>/<kind>/`` root, so only the section-directory names
+  and renamed filenames are needed.
+* :func:`rewrite_cross_references` — the mechanical worker-side string
+  rewrite. It needs no knowledge of other notebooks' output names; the
+  resolved href map is computed at payload-construction time and carried
+  across the worker boundary.
+
+Identifier scheme (v1, locked): the path-derived **topic id** — the same
+identifier ``<topic>id</topic>`` references in a spec, produced by
+:func:`clm.infrastructure.utils.path_utils.simplify_ordered_name`. An
+optional ``/notebook-stem`` disambiguator selects one deck inside a
+multi-notebook directory topic; ``#anchor`` sub-section targets are out of
+scope for v1 and are stripped.
 """
 
 from __future__ import annotations
 
+import logging
 import re
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Protocol
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
 
-# The cross-reference URI scheme (Decision 1, default option A). A reference
+from clm.core.utils.text_utils import sanitize_file_name
+from clm.infrastructure.utils.path_utils import (
+    ext_for,
+    simplify_ordered_name,
+)
+
+if TYPE_CHECKING:
+    from clm.core.course import Course
+    from clm.core.course_files.notebook_file import NotebookFile
+
+logger = logging.getLogger(__name__)
+
+# The cross-reference URI scheme (locked Decision 1, option A). A reference
 # is authored as a normal Markdown link whose href uses this scheme, e.g.
 # ``[Functions workshop](clm:functions_workshop)``. Only the href is
 # rewritten at build time; the link text is left untouched.
 SCHEME = "clm:"
 
 # Matches the href of a Markdown link whose target uses the ``clm:`` scheme.
-# Captures the reference (everything after ``clm:`` up to the closing paren).
-# Deliberately conservative: it only fires inside the ``](...)`` href slot,
-# so ordinary links and image links (``![alt](path)`` — note the leading
-# ``!`` is *not* excluded here because the reference still wouldn't use the
-# ``clm:`` scheme for an image) are left alone.
-_CROSS_REF_RE = re.compile(r"\]\(\s*clm:\s*(?P<ref>[^)\s]+)\s*\)")
+# Captures the link text and the reference (everything after ``clm:`` up to
+# the closing paren). Deliberately conservative: it only fires inside the
+# ``[text](...)`` link slot, so ordinary links and image links are left
+# alone (an image link never uses the ``clm:`` scheme).
+_CROSS_REF_RE = re.compile(r"\[(?P<text>[^\]]*)\]\(\s*clm:\s*(?P<ref>[^)\s]+)\s*\)")
 
 
 @dataclass(frozen=True)
 class ResolvedReference:
     """A cross-reference resolved to a concrete, per-artifact link target.
 
-    ``href`` is the relative path from the *referring* output file to the
-    *target* output artifact of the same ``(language, kind, format)``.
+    ``href`` is the relative path (POSIX style) from the *referring* output
+    file to the *target* output artifact of the same
+    ``(language, kind, format)``. ``ambiguous`` is True when the reference
+    pointed at a directory topic containing several slide notebooks and no
+    ``/notebook-stem`` disambiguator was given — resolution then falls back
+    to a deterministic target and the build emits a warning.
     """
 
     reference: str
     href: str
+    ambiguous: bool = False
 
 
 def extract_cross_references(text: str) -> list[str]:
     """Return every ``clm:`` reference found in *text*, in document order.
 
-    Decision-agnostic: returns the raw reference strings (the part after
-    ``clm:``) exactly as authored. Interpreting them — splitting an
-    optional ``/notebook-stem`` disambiguator or ``#anchor`` — is the
-    resolver's job and is deferred until the identifier scheme is chosen
-    (Decision 2/3). Duplicates are preserved so callers can report every
-    occurrence.
+    Returns the raw reference strings (the part after ``clm:``) exactly as
+    authored, including any ``/notebook-stem`` disambiguator or ``#anchor``
+    — splitting those is the resolver's job. Duplicates are preserved so
+    callers can report every occurrence.
 
     Args:
         text: Markdown (or percent-format slide) source.
@@ -70,28 +107,402 @@ def has_cross_references(text: str) -> bool:
     return _CROSS_REF_RE.search(text) is not None
 
 
-class CrossReferenceResolver(Protocol):
-    """Resolves a ``clm:`` reference to a per-artifact relative href.
+def split_reference(reference: str) -> tuple[str, str | None]:
+    """Split a raw reference into ``(topic_id, notebook_stem)``.
 
-    A concrete implementation is built once per :class:`~clm.core.course.Course`
-    after sections and notebook numbers are assigned, so it knows every
-    output notebook's renamed filename. ``resolve`` returns ``None`` when
-    the target is not part of the (possibly section-filtered) course or is
-    not produced for the requested ``(language, kind, format)`` variant —
-    the caller then applies the missing-target policy (Decision 4).
+    ``#anchor`` sub-section targets are out of scope for v1 and are
+    stripped here (the anchor part is discarded). A ``/notebook-stem``
+    disambiguator, when present, selects one deck inside a multi-notebook
+    directory topic.
 
-    Not implemented yet: the concrete resolver lands once Decisions 1, 2,
-    4 and 5 are settled (see ``docs/claude/design/cross-references.md``).
+    Examples::
+
+        "intro"               -> ("intro", None)
+        "intro/slides_basics" -> ("intro", "slides_basics")
+        "intro#heading"       -> ("intro", None)
+        "intro/deck#heading"  -> ("intro", "deck")
     """
+    # Drop a v1-out-of-scope anchor first.
+    ref = reference.split("#", 1)[0]
+    if "/" in ref:
+        topic_id, stem = ref.split("/", 1)
+        return topic_id, (stem or None)
+    return ref, None
+
+
+@dataclass
+class _NotebookEntry:
+    """One resolvable target notebook, indexed by topic id."""
+
+    notebook: NotebookFile
+    # ``simplify_ordered_name`` of the slide-file stem, used as the
+    # optional ``/notebook-stem`` disambiguator for multi-notebook topics.
+    stem_id: str
+
+
+def rewrite_cross_references(text: str, hrefs: dict[str, str]) -> str:
+    """Rewrite every ``[text](clm:<ref>)`` link in *text* using *hrefs*.
+
+    *hrefs* maps a raw reference string (exactly as authored, the part after
+    ``clm:``) to its resolved relative href for the current output artifact.
+
+    * A reference present in *hrefs* with a non-empty href becomes a normal
+      Markdown link ``[text](<href>)``.
+    * A reference mapped to the empty string is *dropped*: the link text is
+      kept but the link itself is removed (rendered as plain text). This is
+      the ``code`` output rule (locked Decision 4) and the warn-and-drop
+      missing-target policy.
+    * A reference absent from *hrefs* is left verbatim (deferred formats such
+      as ``jupyterlite`` populate no href and rely on this; see Decision 4).
+
+    The rewrite is purely mechanical and needs no knowledge of other
+    notebooks — the href map is computed at payload-construction time.
+    """
+    if not hrefs:
+        return text
+
+    def _replace(match: re.Match[str]) -> str:
+        ref = match.group("ref")
+        link_text = match.group("text")
+        if ref not in hrefs:
+            return match.group(0)
+        href = hrefs[ref]
+        if not href:
+            # Drop the link, keep the text.
+            return link_text
+        return f"[{link_text}]({href})"
+
+    return _CROSS_REF_RE.sub(_replace, text)
+
+
+class CrossReferenceResolver:
+    """Resolve a ``clm:`` reference to a per-artifact relative href.
+
+    Built once per :class:`~clm.core.course.Course` after sections and
+    notebook numbers are assigned, so it knows every output notebook's
+    renamed filename. Resolution is filesystem-free and per
+    ``(language, kind, format)``.
+    """
+
+    def __init__(self, course: Course) -> None:
+        from clm.core.course_files.notebook_file import NotebookFile
+
+        self._course = course
+        # topic id -> list of target notebooks (one per slide file).
+        self._index: dict[str, list[_NotebookEntry]] = {}
+        for section in course.sections:
+            for topic in section.topics:
+                for file in topic.files:
+                    if not isinstance(file, NotebookFile):
+                        continue
+                    stem_id = simplify_ordered_name(file.path.stem) or file.path.stem
+                    self._index.setdefault(topic.id, []).append(
+                        _NotebookEntry(notebook=file, stem_id=stem_id)
+                    )
+
+    @property
+    def topic_ids(self) -> set[str]:
+        """Topic ids that have at least one slide notebook in the course."""
+        return set(self._index)
+
+    def _select(
+        self, topic_id: str, notebook_stem: str | None
+    ) -> tuple[NotebookFile | None, bool, int]:
+        """Pick the target notebook for *topic_id*.
+
+        Returns ``(notebook, ambiguous, candidate_count)``. ``notebook`` is
+        None when the topic id is unknown. ``ambiguous`` is True when the
+        topic has several notebooks and no disambiguator selected one (we
+        then fall back to the deterministic first entry).
+        """
+        entries = self._index.get(topic_id)
+        if not entries:
+            return None, False, 0
+
+        if notebook_stem is not None:
+            for entry in entries:
+                if entry.stem_id == notebook_stem or entry.notebook.path.stem == notebook_stem:
+                    return entry.notebook, False, len(entries)
+            # Disambiguator given but no match — treat as unresolved.
+            return None, False, len(entries)
+
+        if len(entries) == 1:
+            return entries[0].notebook, False, 1
+
+        # Multiple notebooks, no disambiguator: deterministic fallback to
+        # the lowest section slot then path name.
+        ordered = sorted(
+            entries,
+            key=lambda e: (e.notebook.number_in_section, e.notebook.path.name),
+        )
+        return ordered[0].notebook, True, len(entries)
 
     def resolve(
         self,
         reference: str,
         *,
-        from_output_file: Path,
+        from_notebook: NotebookFile,
         language: str,
         kind: str,
         format: str,
     ) -> ResolvedReference | None:
-        """Resolve *reference* for one output artifact, or return ``None``."""
-        ...
+        """Resolve *reference* for one output artifact, or return ``None``.
+
+        Returns ``None`` when the target topic is not part of the (possibly
+        section-filtered) course or when the reference carried a
+        disambiguator that matched no notebook — the caller then applies the
+        missing-target policy (locked Decision 4).
+
+        The relative href is computed from the section-directory names and
+        renamed filenames alone: the referring and target artifacts always
+        share the same ``slides/<format>/<kind>/`` parent for a given
+        ``(language, kind, format)``, so no filesystem access is needed.
+        """
+        topic_id, notebook_stem = split_reference(reference)
+        target, ambiguous, _count = self._select(topic_id, notebook_stem)
+        if target is None:
+            return None
+
+        ext = ext_for(format, target.prog_lang)
+        target_section_dir = sanitize_file_name(target.section.name[language])
+        target_file_name = target.file_name(language, ext)
+        from_section_dir = sanitize_file_name(from_notebook.section.name[language])
+
+        # Both files live under the same ``slides/<format>/<kind>/`` root, so
+        # the relative path is purely a function of the two section dirs.
+        from_path = PurePosixPath(from_section_dir)
+        target_path = PurePosixPath(target_section_dir) / target_file_name
+        href = _relative_posix(target_path, from_path)
+        return ResolvedReference(reference=reference, href=href, ambiguous=ambiguous)
+
+    def build_href_map(
+        self,
+        references: list[str],
+        *,
+        from_notebook: NotebookFile,
+        language: str,
+        kind: str,
+        format: str,
+        fail_on_missing: bool,
+    ) -> tuple[dict[str, str], list[_XRefIssue]]:
+        """Resolve every reference for one artifact into a href map.
+
+        Returns ``(hrefs, issues)``. ``hrefs`` is consumed by
+        :func:`rewrite_cross_references`:
+
+        * present reference -> resolved relative href (normal link).
+        * present reference -> ``""`` when the target is missing and
+          ``fail_on_missing`` is False (warn-and-drop) **or** when the
+          output ``format`` is ``code`` (links are always dropped there).
+        * a missing reference under ``fail_on_missing`` is **omitted** from
+          the map (left verbatim) and reported as an error issue, so the
+          build can fail without rewriting the link to something misleading.
+
+        ``jupyterlite`` is deferred: references are omitted (left verbatim)
+        and a single info issue is recorded.
+        """
+        hrefs: dict[str, str] = {}
+        issues: list[_XRefIssue] = []
+
+        drop_all = format == "code"
+        defer_all = format == "jupyterlite"
+
+        if defer_all and references:
+            issues.append(
+                _XRefIssue(
+                    severity="info",
+                    reference=references[0],
+                    message=(
+                        "jupyterlite cross-reference targets are deferred until "
+                        "the JupyterLite site builder ships; link text is left "
+                        "verbatim."
+                    ),
+                )
+            )
+            return hrefs, issues
+
+        for reference in references:
+            resolved = self.resolve(
+                reference,
+                from_notebook=from_notebook,
+                language=language,
+                kind=kind,
+                format=format,
+            )
+            if resolved is None:
+                if fail_on_missing:
+                    issues.append(
+                        _XRefIssue(
+                            severity="error",
+                            reference=reference,
+                            message=(
+                                f"Cross-reference target '{reference}' is not "
+                                f"included in the course (language={language}, "
+                                f"kind={kind}, format={format})."
+                            ),
+                        )
+                    )
+                    # Leave verbatim so the failing build does not silently
+                    # rewrite the link.
+                    continue
+                issues.append(
+                    _XRefIssue(
+                        severity="warning",
+                        reference=reference,
+                        message=(
+                            f"Cross-reference target '{reference}' is not "
+                            f"included in this build; dropping the link."
+                        ),
+                    )
+                )
+                hrefs[reference] = ""
+                continue
+
+            if resolved.ambiguous:
+                issues.append(
+                    _XRefIssue(
+                        severity="warning",
+                        reference=reference,
+                        message=(
+                            f"Cross-reference '{reference}' points at a topic "
+                            f"with multiple slide notebooks; resolved to "
+                            f"'{resolved.href}'. Add a '/notebook-stem' "
+                            f"disambiguator to be explicit."
+                        ),
+                    )
+                )
+
+            hrefs[reference] = "" if drop_all else resolved.href
+
+        return hrefs, issues
+
+
+@dataclass
+class _XRefIssue:
+    """A cross-reference issue raised while building a href map."""
+
+    severity: str  # "error", "warning", "info"
+    reference: str
+    message: str
+    detail: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CrossReferenceFinding:
+    """A build-time cross-reference validation finding (Issue #17).
+
+    Variant-agnostic: it reports whether a referenced topic is *included*
+    in the (possibly section-filtered) course and whether it is ambiguous,
+    independent of language / kind / format. ``severity`` for a missing
+    target depends on the ``fail_on_missing`` policy chosen by the caller.
+    """
+
+    severity: str  # "error", "warning"
+    type: str  # "cross_reference_target_missing" | "cross_reference_ambiguous"
+    reference: str
+    message: str
+    source_file: str
+
+
+def validate_cross_references(
+    course: Course, *, fail_on_missing: bool
+) -> list[CrossReferenceFinding]:
+    """Scan every notebook in *course* for ``clm:`` references and validate them.
+
+    A reference whose topic id is not part of the (section-filtered) course is
+    reported as ``cross_reference_target_missing`` — an error when
+    *fail_on_missing* is True, else a warning (the link will be dropped at
+    rewrite time). A reference that points at a directory topic with several
+    slide notebooks and carries no ``/notebook-stem`` disambiguator is reported
+    as a ``cross_reference_ambiguous`` warning.
+
+    Because the resolver is built from ``course.sections`` (already filtered by
+    any active ``--section`` selection), a reference to a real topic that is
+    excluded only by section filtering is correctly reported here.
+    """
+    from clm.core.course_files.notebook_file import NotebookFile
+
+    resolver = course.cross_reference_resolver
+    findings: list[CrossReferenceFinding] = []
+    seen: set[tuple[str, str]] = set()
+
+    for section in course.sections:
+        for topic in section.topics:
+            for file in topic.files:
+                if not isinstance(file, NotebookFile):
+                    continue
+                try:
+                    text = file.source_path.read_text(encoding="utf-8")
+                except OSError as exc:  # pragma: no cover - defensive
+                    logger.debug("Could not read %s for xref scan: %s", file.path, exc)
+                    continue
+                if not has_cross_references(text):
+                    continue
+                source = str(file.path)
+                for reference in extract_cross_references(text):
+                    topic_id, notebook_stem = split_reference(reference)
+                    target, ambiguous, _count = resolver._select(topic_id, notebook_stem)
+                    key = (source, reference)
+                    if target is None:
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        findings.append(
+                            CrossReferenceFinding(
+                                severity="error" if fail_on_missing else "warning",
+                                type="cross_reference_target_missing",
+                                reference=reference,
+                                message=(
+                                    f"Cross-reference target '{reference}' in "
+                                    f"'{file.path.name}' is not included in the "
+                                    f"course."
+                                ),
+                                source_file=source,
+                            )
+                        )
+                    elif ambiguous:
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        findings.append(
+                            CrossReferenceFinding(
+                                severity="warning",
+                                type="cross_reference_ambiguous",
+                                reference=reference,
+                                message=(
+                                    f"Cross-reference '{reference}' in "
+                                    f"'{file.path.name}' points at a topic with "
+                                    f"multiple slide notebooks; resolved "
+                                    f"deterministically to the first. Add a "
+                                    f"'/notebook-stem' disambiguator to be explicit."
+                                ),
+                                source_file=source,
+                            )
+                        )
+
+    return findings
+
+
+def _relative_posix(target: PurePosixPath, start: PurePosixPath) -> str:
+    """Return the POSIX relative path from directory *start* to file *target*.
+
+    Both are expressed relative to a common ``slides/<format>/<kind>/`` root.
+    *start* is a directory (the referring file's section dir); *target* is a
+    file path (section dir + filename).
+    """
+    start_parts = list(start.parts)
+    target_parts = list(target.parts)
+
+    # Find common prefix length.
+    common = 0
+    for a, b in zip(start_parts, target_parts, strict=False):
+        if a != b:
+            break
+        common += 1
+
+    up = [".."] * (len(start_parts) - common)
+    down = target_parts[common:]
+    rel_parts = up + down
+    if not rel_parts:
+        return "."
+    return "/".join(rel_parts)

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -184,6 +184,44 @@ class ProcessNotebookOperation(Operation):
         # Calculate relative path from output file to course's img/ folder
         return relative_path_to_course_img(self.output_file, course_dir)
 
+    def compute_cross_references(self, data: str) -> dict[str, str]:
+        """Resolve every ``clm:`` cross-reference in *data* for this artifact.
+
+        Returns a mapping consumed by ``rewrite_cross_references`` in the
+        worker: raw reference -> resolved relative href (empty string means
+        "drop the link, keep the text"; an omitted reference is left
+        verbatim). Resolution happens here, at payload-construction time,
+        because the full ``Course`` (all sections, assigned numbers, renamed
+        filenames) is in scope — the worker processes one notebook in
+        isolation and must not need other notebooks' output names.
+
+        Build-time *reporting* of missing/ambiguous targets is handled
+        separately by ``validate_cross_references`` (host-side, feeds the
+        build summary); here we only produce the rewrite map, applying the
+        same fail-on-missing policy so a failing build leaves dangling links
+        verbatim rather than silently dropping them.
+        """
+        from clm.core.cross_references import (
+            extract_cross_references,
+            has_cross_references,
+        )
+
+        if not has_cross_references(data):
+            return {}
+
+        course = self.input_file.course
+        resolver = course.cross_reference_resolver
+        references = extract_cross_references(data)
+        hrefs, _issues = resolver.build_href_map(
+            references,
+            from_notebook=self.input_file,
+            language=self.language,
+            kind=self.kind,
+            format=self.format,
+            fail_on_missing=course.fail_on_missing_xref,
+        )
+        return hrefs
+
     def compute_source_topic_dir(self) -> str:
         """Compute the absolute path to the topic directory.
 
@@ -268,6 +306,7 @@ class ProcessNotebookOperation(Operation):
             inline_images=course.inline_images,
             author=author,
             organization=organization,
+            cross_references=self.compute_cross_references(data),
         )
         await note_correlation_id_dependency(correlation_id, payload)
         return payload

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -62,6 +62,17 @@ class NotebookPayload(Payload):
     author: str = "Dr. Matthias Hölzl"
     # Organization name (already resolved for target language)
     organization: str = ""
+    # Cross-references (Issue #17): maps a raw ``clm:`` reference string
+    # (the part after ``clm:``, exactly as authored) to its already-resolved
+    # relative href for THIS (language, kind, format) artifact. An empty
+    # string value means "drop the link, keep the text" (the ``code`` format
+    # rule and the warn-and-drop missing-target policy). A reference absent
+    # from this map is left verbatim. Empty when the notebook has no
+    # cross-references. Computed in ProcessNotebookOperation.payload() where
+    # the full Course is in scope; the worker only does a mechanical string
+    # rewrite via ``rewrite_cross_references`` and needs no knowledge of
+    # other notebooks' output names.
+    cross_references: dict[str, str] = {}
 
     # The backend relies on having a data property
     @property

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -265,6 +265,15 @@ def validate_spec(
         suffix=_suffix,
     )
 
+    # Cross-reference checks (Issue #17): scan included slide files for
+    # ``clm:`` references and verify each target topic is included.
+    _validate_cross_references(
+        spec=spec,
+        topic_map=topic_map,
+        findings=findings,
+        suffix=_suffix,
+    )
+
     return SpecValidationResult(
         course_spec=str(course_spec_path),
         topics_total=topics_total,
@@ -434,6 +443,128 @@ def _validate_includes(
                                     ),
                                 )
                             )
+
+
+def _validate_cross_references(
+    *,
+    spec: CourseSpec,
+    topic_map: dict[str, list[TopicMatch]],
+    findings: list[SpecFinding],
+    suffix: Callable[[bool, str], str],
+) -> None:
+    """Emit findings for ``clm:`` cross-references in included slide files.
+
+    Scans every slide file of every resolved topic in *spec* for the
+    ``clm:`` link scheme and checks that each referenced topic id is itself
+    included in the spec. Two categories are produced:
+
+    * ``cross_reference_target_missing`` — error when a referenced topic id
+      is not part of the course (not in any included section). Because the
+      scan runs over ``spec.sections`` (which already reflect any
+      ``--section`` selection / disabled-section filtering applied at parse
+      time), a target that exists on disk but is not included is correctly
+      reported.
+    * ``cross_reference_ambiguous`` — warning when a topic-granular
+      reference resolves to a directory topic containing several slide
+      notebooks and no ``/notebook-stem`` disambiguator was given.
+
+    The build path performs the same check with full course context
+    (``clm.core.cross_references.validate_cross_references``); this mirror
+    lets authors catch dangling links via ``clm validate-spec`` without a
+    full build.
+    """
+    from clm.core.cross_references import (
+        extract_cross_references,
+        has_cross_references,
+        split_reference,
+    )
+    from clm.core.topic_resolver import find_slide_files, matches_for_binding
+
+    # The set of topic ids that are actually included by the spec.
+    included_topic_ids: set[str] = set()
+    for section in spec.sections:
+        for topic_spec in section.topics:
+            included_topic_ids.add(topic_spec.id)
+
+    seen: set[tuple[str, str]] = set()
+
+    for section in spec.sections:
+        section_name = section.name.en or section.name.de
+        section_disabled = not section.enabled
+        for topic_spec in section.topics:
+            effective_module = section.module_for(topic_spec)
+            matches = matches_for_binding(topic_map, topic_spec.id, effective_module)
+            if len(matches) != 1:
+                # Unresolved / ambiguous topics are already flagged; do not
+                # double-report by scanning a path we cannot pin down.
+                continue
+            for slide_file in find_slide_files(matches[0].path):
+                try:
+                    text = slide_file.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+                if not has_cross_references(text):
+                    continue
+                for reference in extract_cross_references(text):
+                    target_id, notebook_stem = split_reference(reference)
+                    key = (str(slide_file), reference)
+                    if target_id not in included_topic_ids:
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        findings.append(
+                            SpecFinding(
+                                severity="error",
+                                type="cross_reference_target_missing",
+                                topic_id=topic_spec.id,
+                                section=section_name,
+                                message=suffix(
+                                    section_disabled,
+                                    f"Topic '{topic_spec.id}' "
+                                    f"({slide_file.name}) links to "
+                                    f"'{reference}', which is not included in "
+                                    f"the course.",
+                                ),
+                                suggestion=(
+                                    "Add the target topic to the spec, fix the "
+                                    "'clm:' reference, or remove the link."
+                                ),
+                            )
+                        )
+                        continue
+                    # Ambiguity: directory topic with several slide notebooks
+                    # and no disambiguator.
+                    if notebook_stem is None:
+                        target_matches = matches_for_binding(topic_map, target_id, None)
+                        if len(target_matches) == 1:
+                            slide_count = len(find_slide_files(target_matches[0].path))
+                            if slide_count > 1:
+                                if key in seen:
+                                    continue
+                                seen.add(key)
+                                findings.append(
+                                    SpecFinding(
+                                        severity="warning",
+                                        type="cross_reference_ambiguous",
+                                        topic_id=topic_spec.id,
+                                        section=section_name,
+                                        message=suffix(
+                                            section_disabled,
+                                            f"Topic '{topic_spec.id}' "
+                                            f"({slide_file.name}) links to "
+                                            f"'{reference}', a topic with "
+                                            f"{slide_count} slide notebooks; the "
+                                            f"build resolves this "
+                                            f"deterministically to the first.",
+                                        ),
+                                        suggestion=(
+                                            "Add a '/notebook-stem' "
+                                            "disambiguator (e.g. "
+                                            f"'clm:{target_id}/slides_<stem>') "
+                                            "to select a specific deck."
+                                        ),
+                                    )
+                                )
 
 
 def _emit_section_inheritance(

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1343,6 +1343,14 @@ class NotebookProcessor:
         # Rewrite image paths from img/filename to the shared img/ folder location
         cell["source"] = self._rewrite_image_paths(cell["source"], img_path_prefix)
 
+        # Rewrite cross-references (Issue #17). The href map was resolved at
+        # payload-construction time; here the worker only does a mechanical
+        # string substitution and needs no knowledge of other notebooks.
+        if payload and payload.cross_references:
+            from clm.core.cross_references import rewrite_cross_references
+
+            cell["source"] = rewrite_cross_references(cell["source"], payload.cross_references)
+
         # Inject data URLs for images (if enabled and cell doesn't opt out)
         if payload and payload.inline_images and "nodataurl" not in tags:
             cell["source"] = self._inject_data_urls(cell["source"], payload)

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -29,6 +29,7 @@ from clm.cli.commands.build import (
     _report_duplicate_file_warnings,
     _report_image_collisions,
     _report_loading_issues,
+    _resolve_fail_on_missing_xref,
     _resolve_http_replay_mode,
     configure_workers,
     create_output_formatter,
@@ -1335,6 +1336,31 @@ class TestBuildExitCodeOnCellErrors:
             f"CLM_FAIL_ON_ERROR=0; got {result.exit_code}. "
             f"exception={result.exception!r}\noutput:\n{result.output}"
         )
+
+
+class TestResolveFailOnMissingXref:
+    """Precedence for the --fail-on-missing-xref / CLM_FAIL_ON_MISSING_XREF policy (Issue #17)."""
+
+    def test_cli_flag_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLM_FAIL_ON_MISSING_XREF", "0")
+        assert _resolve_fail_on_missing_xref(True, "new-episodes") is True
+        assert _resolve_fail_on_missing_xref(False, "replay") is False
+
+    def test_env_var_wins_over_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLM_FAIL_ON_MISSING_XREF", "1")
+        assert _resolve_fail_on_missing_xref(None, "new-episodes") is True
+        monkeypatch.setenv("CLM_FAIL_ON_MISSING_XREF", "no")
+        assert _resolve_fail_on_missing_xref(None, "replay") is False
+
+    def test_replay_mode_default_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CLM_FAIL_ON_MISSING_XREF", raising=False)
+        assert _resolve_fail_on_missing_xref(None, "replay") is True
+        assert _resolve_fail_on_missing_xref(None, "new-episodes") is False
+
+    def test_invalid_env_value_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLM_FAIL_ON_MISSING_XREF", "maybe")
+        with pytest.raises(click.UsageError):
+            _resolve_fail_on_missing_xref(None, "replay")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_cross_references.py
+++ b/tests/core/test_cross_references.py
@@ -1,0 +1,69 @@
+"""Tests for the cross-reference extractor (Issue #17 scaffold).
+
+Only the decision-agnostic extractor is implemented and therefore tested.
+The resolver is a Protocol stub pending the open product decisions in
+``docs/claude/design/cross-references.md``.
+"""
+
+from __future__ import annotations
+
+from clm.core.cross_references import (
+    SCHEME,
+    extract_cross_references,
+    has_cross_references,
+)
+
+
+def test_scheme_constant() -> None:
+    assert SCHEME == "clm:"
+
+
+def test_extracts_single_reference() -> None:
+    text = "See the [Functions workshop](clm:functions_workshop) for exercises."
+    assert extract_cross_references(text) == ["functions_workshop"]
+
+
+def test_extracts_multiple_references_in_order() -> None:
+    text = "First [intro](clm:introduction), then [the workshop](clm:functions_workshop)."
+    assert extract_cross_references(text) == [
+        "introduction",
+        "functions_workshop",
+    ]
+
+
+def test_preserves_duplicate_references() -> None:
+    text = "[a](clm:intro) and again [b](clm:intro)"
+    assert extract_cross_references(text) == ["intro", "intro"]
+
+
+def test_ignores_ordinary_links() -> None:
+    text = "A [normal link](https://example.com) and a [relative](../foo/bar.html)."
+    assert extract_cross_references(text) == []
+
+
+def test_ignores_image_links() -> None:
+    # Image links never use the clm: scheme; they must be left untouched.
+    text = "![diagram](img/diagram.png)"
+    assert extract_cross_references(text) == []
+
+
+def test_captures_disambiguator_and_anchor_verbatim() -> None:
+    # The extractor returns the raw reference; splitting "/stem" or
+    # "#anchor" is the resolver's job (Decision 2/3), so it must be
+    # preserved verbatim here.
+    text = "[deck](clm:topic_id/slides_foo) and [section](clm:topic_id#heading)"
+    assert extract_cross_references(text) == [
+        "topic_id/slides_foo",
+        "topic_id#heading",
+    ]
+
+
+def test_tolerates_internal_whitespace_in_href() -> None:
+    text = "[x](clm: introduction )"
+    assert extract_cross_references(text) == ["introduction"]
+
+
+def test_has_cross_references() -> None:
+    assert has_cross_references("[x](clm:intro)") is True
+    assert has_cross_references("[x](https://example.com)") is False
+    assert has_cross_references("plain text, no links") is False

--- a/tests/core/test_cross_references.py
+++ b/tests/core/test_cross_references.py
@@ -1,19 +1,42 @@
-"""Tests for the cross-reference extractor (Issue #17 scaffold).
+"""Tests for cross-references between notebooks (Issue #17).
 
-Only the decision-agnostic extractor is implemented and therefore tested.
-The resolver is a Protocol stub pending the open product decisions in
-``docs/claude/design/cross-references.md``.
+Covers three layers:
+
+* the decision-agnostic extractor (``extract_cross_references`` /
+  ``has_cross_references``);
+* the ``CrossReferenceResolver`` (topic-id -> per-variant relative href,
+  multi-notebook disambiguation/ambiguity, missing targets, per-format
+  rules); and
+* the mechanical worker-side rewrite (``rewrite_cross_references``).
+
+The resolver is exercised against a hand-built ``Course`` (no filesystem,
+no kernel) so the path/rename logic is unit-testable in isolation.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
+from clm.core.course_files.notebook_file import NotebookFile
 from clm.core.cross_references import (
     SCHEME,
+    CrossReferenceResolver,
     extract_cross_references,
     has_cross_references,
+    rewrite_cross_references,
+    split_reference,
+    validate_cross_references,
 )
+from clm.core.section import Section
+from clm.core.topic import Topic
+from clm.core.utils.text_utils import Text
 
 
+# --------------------------------------------------------------------------- #
+# Extractor
+# --------------------------------------------------------------------------- #
 def test_scheme_constant() -> None:
     assert SCHEME == "clm:"
 
@@ -42,15 +65,11 @@ def test_ignores_ordinary_links() -> None:
 
 
 def test_ignores_image_links() -> None:
-    # Image links never use the clm: scheme; they must be left untouched.
     text = "![diagram](img/diagram.png)"
     assert extract_cross_references(text) == []
 
 
 def test_captures_disambiguator_and_anchor_verbatim() -> None:
-    # The extractor returns the raw reference; splitting "/stem" or
-    # "#anchor" is the resolver's job (Decision 2/3), so it must be
-    # preserved verbatim here.
     text = "[deck](clm:topic_id/slides_foo) and [section](clm:topic_id#heading)"
     assert extract_cross_references(text) == [
         "topic_id/slides_foo",
@@ -67,3 +86,439 @@ def test_has_cross_references() -> None:
     assert has_cross_references("[x](clm:intro)") is True
     assert has_cross_references("[x](https://example.com)") is False
     assert has_cross_references("plain text, no links") is False
+
+
+# --------------------------------------------------------------------------- #
+# split_reference
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("reference", "expected"),
+    [
+        ("intro", ("intro", None)),
+        ("intro/slides_basics", ("intro", "slides_basics")),
+        ("intro#heading", ("intro", None)),
+        ("intro/deck#heading", ("intro", "deck")),
+    ],
+)
+def test_split_reference(reference: str, expected: tuple[str, str | None]) -> None:
+    assert split_reference(reference) == expected
+
+
+# --------------------------------------------------------------------------- #
+# rewrite_cross_references
+# --------------------------------------------------------------------------- #
+def test_rewrite_replaces_href() -> None:
+    text = "See [the workshop](clm:functions_workshop)."
+    out = rewrite_cross_references(text, {"functions_workshop": "../Workshops/03 Functions.html"})
+    assert out == "See [the workshop](../Workshops/03 Functions.html)."
+
+
+def test_rewrite_drops_link_on_empty_href() -> None:
+    text = "See [the workshop](clm:functions_workshop)."
+    out = rewrite_cross_references(text, {"functions_workshop": ""})
+    assert out == "See the workshop."
+
+
+def test_rewrite_leaves_unmapped_reference_verbatim() -> None:
+    text = "See [the workshop](clm:functions_workshop)."
+    out = rewrite_cross_references(text, {"other": "x.html"})
+    assert out == text
+
+
+def test_rewrite_noop_on_empty_map() -> None:
+    text = "See [the workshop](clm:functions_workshop)."
+    assert rewrite_cross_references(text, {}) == text
+
+
+# --------------------------------------------------------------------------- #
+# Resolver — hand-built course
+# --------------------------------------------------------------------------- #
+class _FakeSpec:
+    """Minimal stand-in for the bits of CourseSpec the resolver touches."""
+
+    prog_lang = "python"
+
+
+class _FakeCourse:
+    """A course-shaped object exposing only ``sections``/``spec``.
+
+    The resolver reads ``course.sections`` and each notebook's
+    ``section.name``, ``topic.id``, ``number_in_section``, ``title``,
+    ``path`` and ``prog_lang`` — all settable without a filesystem.
+    """
+
+    def __init__(self) -> None:
+        self.sections: list[Section] = []
+        self.spec = _FakeSpec()
+        self.image_mode = "duplicated"
+        self.fail_on_missing_xref = False
+
+    @property
+    def cross_reference_resolver(self) -> CrossReferenceResolver:
+        return CrossReferenceResolver(self)  # type: ignore[arg-type]
+
+
+def _make_notebook(
+    course: _FakeCourse,
+    topic: Topic,
+    *,
+    stem: str,
+    title_en: str,
+    title_de: str,
+    number: int,
+) -> NotebookFile:
+    nb = NotebookFile(
+        course=course,  # type: ignore[arg-type]
+        path=topic.path / f"{stem}.py",
+        topic=topic,
+        title=Text(en=title_en, de=title_de),
+        number_in_section=number,
+    )
+    topic._file_map[nb.path] = nb
+    return nb
+
+
+def _build_course() -> tuple[_FakeCourse, NotebookFile, NotebookFile]:
+    """Two sections, two single-notebook topics.
+
+    Section "Basics" contains topic ``intro`` (one deck); section
+    "Workshops" contains topic ``functions_workshop`` (one deck).
+    """
+    course = _FakeCourse()
+
+    sec_basics = Section(name=Text(en="Basics", de="Grundlagen"), course=course)  # type: ignore[arg-type]
+    sec_workshops = Section(name=Text(en="Workshops", de="Workshops"), course=course)  # type: ignore[arg-type]
+    course.sections = [sec_basics, sec_workshops]
+
+    topic_intro = Topic.from_spec(
+        __import__("clm.core.course_spec", fromlist=["TopicSpec"]).TopicSpec(id="intro"),
+        section=sec_basics,
+        path=Path("slides/module_000/topic_100_intro"),
+    )
+    sec_basics.topics.append(topic_intro)
+
+    topic_workshop = Topic.from_spec(
+        __import__("clm.core.course_spec", fromlist=["TopicSpec"]).TopicSpec(
+            id="functions_workshop"
+        ),
+        section=sec_workshops,
+        path=Path("slides/module_010/topic_200_functions_workshop"),
+    )
+    sec_workshops.topics.append(topic_workshop)
+
+    nb_intro = _make_notebook(
+        course,
+        topic_intro,
+        stem="slides_intro",
+        title_en="Introduction",
+        title_de="Einführung",
+        number=1,
+    )
+    nb_workshop = _make_notebook(
+        course,
+        topic_workshop,
+        stem="slides_functions",
+        title_en="Functions",
+        title_de="Funktionen",
+        number=3,
+    )
+    return course, nb_intro, nb_workshop
+
+
+def test_resolver_maps_topic_id_to_html_href() -> None:
+    course, nb_intro, _nb_workshop = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+
+    resolved = resolver.resolve(
+        "functions_workshop",
+        from_notebook=nb_intro,
+        language="en",
+        kind="completed",
+        format="html",
+    )
+    assert resolved is not None
+    # From section "Basics" up one and into "Workshops" with the renamed file.
+    assert resolved.href == "../Workshops/03 Functions.html"
+    assert resolved.ambiguous is False
+
+
+def test_resolver_href_is_per_variant() -> None:
+    """German titles and notebook format yield a different href."""
+    course, nb_intro, _nb = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+
+    de_nb = resolver.resolve(
+        "functions_workshop",
+        from_notebook=nb_intro,
+        language="de",
+        kind="completed",
+        format="notebook",
+    )
+    assert de_nb is not None
+    assert de_nb.href == "../Workshops/03 Funktionen.ipynb"
+
+    en_code = resolver.resolve(
+        "functions_workshop",
+        from_notebook=nb_intro,
+        language="en",
+        kind="completed",
+        format="code",
+    )
+    assert en_code is not None
+    # code format extension follows the prog lang (.py for python).
+    assert en_code.href == "../Workshops/03 Functions.py"
+
+
+def test_resolver_returns_none_for_missing_topic() -> None:
+    course, nb_intro, _nb = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+    assert (
+        resolver.resolve(
+            "does_not_exist",
+            from_notebook=nb_intro,
+            language="en",
+            kind="completed",
+            format="html",
+        )
+        is None
+    )
+
+
+def _build_multi_notebook_course() -> tuple[_FakeCourse, NotebookFile]:
+    """One topic ``advanced`` containing two slide decks."""
+    course = _FakeCourse()
+    sec = Section(name=Text(en="Basics", de="Grundlagen"), course=course)  # type: ignore[arg-type]
+    sec_adv = Section(name=Text(en="Advanced", de="Fortgeschritten"), course=course)  # type: ignore[arg-type]
+    course.sections = [sec, sec_adv]
+
+    from clm.core.course_spec import TopicSpec
+
+    topic_from = Topic.from_spec(
+        TopicSpec(id="intro"),
+        section=sec,
+        path=Path("slides/module_000/topic_100_intro"),
+    )
+    sec.topics.append(topic_from)
+    nb_from = _make_notebook(
+        course, topic_from, stem="slides_intro", title_en="Intro", title_de="Intro", number=1
+    )
+
+    topic_adv = Topic.from_spec(
+        TopicSpec(id="advanced"),
+        section=sec_adv,
+        path=Path("slides/module_010/topic_200_advanced"),
+    )
+    sec_adv.topics.append(topic_adv)
+    _make_notebook(
+        course, topic_adv, stem="slides_part_a", title_en="Part A", title_de="Teil A", number=1
+    )
+    _make_notebook(
+        course, topic_adv, stem="slides_part_b", title_en="Part B", title_de="Teil B", number=2
+    )
+    return course, nb_from
+
+
+def test_resolver_ambiguous_multi_notebook_topic() -> None:
+    course, nb_from = _build_multi_notebook_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+
+    resolved = resolver.resolve(
+        "advanced",
+        from_notebook=nb_from,
+        language="en",
+        kind="completed",
+        format="html",
+    )
+    assert resolved is not None
+    assert resolved.ambiguous is True
+    # Deterministic fallback: lowest number_in_section -> Part A (slot 1).
+    assert resolved.href == "../Advanced/01 Part A.html"
+
+
+def test_resolver_disambiguator_selects_specific_deck() -> None:
+    course, nb_from = _build_multi_notebook_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+
+    resolved = resolver.resolve(
+        "advanced/slides_part_b",
+        from_notebook=nb_from,
+        language="en",
+        kind="completed",
+        format="html",
+    )
+    assert resolved is not None
+    assert resolved.ambiguous is False
+    assert resolved.href == "../Advanced/02 Part B.html"
+
+
+# --------------------------------------------------------------------------- #
+# build_href_map — per-format and missing-target policy
+# --------------------------------------------------------------------------- #
+def test_href_map_code_format_drops_links() -> None:
+    course, nb_intro, _nb = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+    hrefs, issues = resolver.build_href_map(
+        ["functions_workshop"],
+        from_notebook=nb_intro,
+        language="en",
+        kind="completed",
+        format="code",
+        fail_on_missing=False,
+    )
+    assert hrefs == {"functions_workshop": ""}
+    assert issues == []
+
+
+def test_href_map_jupyterlite_is_deferred() -> None:
+    course, nb_intro, _nb = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+    hrefs, issues = resolver.build_href_map(
+        ["functions_workshop"],
+        from_notebook=nb_intro,
+        language="en",
+        kind="completed",
+        format="jupyterlite",
+        fail_on_missing=False,
+    )
+    # Deferred: no href produced (left verbatim), one info issue.
+    assert hrefs == {}
+    assert len(issues) == 1
+    assert issues[0].severity == "info"
+
+
+def test_href_map_missing_warns_and_drops_when_not_failing() -> None:
+    course, nb_intro, _nb = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+    hrefs, issues = resolver.build_href_map(
+        ["nope"],
+        from_notebook=nb_intro,
+        language="en",
+        kind="completed",
+        format="html",
+        fail_on_missing=False,
+    )
+    assert hrefs == {"nope": ""}
+    assert len(issues) == 1
+    assert issues[0].severity == "warning"
+
+
+def test_href_map_missing_errors_and_leaves_verbatim_when_failing() -> None:
+    course, nb_intro, _nb = _build_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+    hrefs, issues = resolver.build_href_map(
+        ["nope"],
+        from_notebook=nb_intro,
+        language="en",
+        kind="completed",
+        format="html",
+        fail_on_missing=True,
+    )
+    # Left verbatim (omitted) so the failing build does not silently rewrite.
+    assert hrefs == {}
+    assert len(issues) == 1
+    assert issues[0].severity == "error"
+
+
+def test_href_map_ambiguous_emits_warning_but_resolves() -> None:
+    course, nb_from = _build_multi_notebook_course()
+    resolver = CrossReferenceResolver(course)  # type: ignore[arg-type]
+    hrefs, issues = resolver.build_href_map(
+        ["advanced"],
+        from_notebook=nb_from,
+        language="en",
+        kind="completed",
+        format="html",
+        fail_on_missing=True,
+    )
+    assert hrefs == {"advanced": "../Advanced/01 Part A.html"}
+    assert len(issues) == 1
+    assert issues[0].severity == "warning"
+
+
+# --------------------------------------------------------------------------- #
+# validate_cross_references — host-side build validation (mocked file read)
+# --------------------------------------------------------------------------- #
+def test_validate_reports_missing_target(monkeypatch) -> None:
+    course, nb_intro, _nb = _build_course()
+
+    def fake_read(self, encoding="utf-8"):
+        if self.name == nb_intro.path.name:
+            return "See [the deck](clm:does_not_exist)."
+        return "no refs here"
+
+    monkeypatch.setattr(Path, "read_text", fake_read, raising=False)
+
+    findings = validate_cross_references(course, fail_on_missing=True)  # type: ignore[arg-type]
+    missing = [f for f in findings if f.type == "cross_reference_target_missing"]
+    assert len(missing) == 1
+    assert missing[0].severity == "error"
+
+    findings_warn = validate_cross_references(course, fail_on_missing=False)  # type: ignore[arg-type]
+    missing_warn = [f for f in findings_warn if f.type == "cross_reference_target_missing"]
+    assert len(missing_warn) == 1
+    assert missing_warn[0].severity == "warning"
+
+
+def test_validate_reports_ambiguous_target(monkeypatch) -> None:
+    course, nb_from = _build_multi_notebook_course()
+
+    def fake_read(self, encoding="utf-8"):
+        if self.name == nb_from.path.name:
+            return "See [advanced material](clm:advanced)."
+        return "no refs"
+
+    monkeypatch.setattr(Path, "read_text", fake_read, raising=False)
+
+    findings = validate_cross_references(course, fail_on_missing=True)  # type: ignore[arg-type]
+    ambiguous = [f for f in findings if f.type == "cross_reference_ambiguous"]
+    assert len(ambiguous) == 1
+    assert ambiguous[0].severity == "warning"
+
+
+def test_validate_passes_when_all_targets_present(monkeypatch) -> None:
+    course, nb_intro, _nb = _build_course()
+
+    def fake_read(self, encoding="utf-8"):
+        if self.name == nb_intro.path.name:
+            return "See [the workshop](clm:functions_workshop)."
+        return "no refs"
+
+    monkeypatch.setattr(Path, "read_text", fake_read, raising=False)
+
+    findings = validate_cross_references(course, fail_on_missing=True)  # type: ignore[arg-type]
+    assert findings == []
+
+
+# --------------------------------------------------------------------------- #
+# Payload wiring — ProcessNotebookOperation.compute_cross_references
+# --------------------------------------------------------------------------- #
+def test_payload_compute_cross_references_resolves_for_variant() -> None:
+    from clm.core.operations.process_notebook import ProcessNotebookOperation
+
+    course, nb_intro, _nb = _build_course()
+    op = ProcessNotebookOperation(
+        input_file=nb_intro,
+        output_file=Path("out/Basics/01 Introduction.html"),
+        language="en",
+        format="html",
+        kind="completed",
+        prog_lang="python",
+    )
+    data = "See [the workshop](clm:functions_workshop)."
+    hrefs = op.compute_cross_references(data)
+    assert hrefs == {"functions_workshop": "../Workshops/03 Functions.html"}
+
+
+def test_payload_compute_cross_references_empty_without_refs() -> None:
+    from clm.core.operations.process_notebook import ProcessNotebookOperation
+
+    course, nb_intro, _nb = _build_course()
+    op = ProcessNotebookOperation(
+        input_file=nb_intro,
+        output_file=Path("out/Basics/01 Introduction.html"),
+        language="en",
+        format="html",
+        kind="completed",
+        prog_lang="python",
+    )
+    assert op.compute_cross_references("no references here") == {}

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -1030,3 +1030,145 @@ class TestIncludeSectionInheritance:
         result = validate_spec(spec_file, tmp_path / "slides")
 
         assert [f for f in result.findings if f.type == "include_section_inheritance"] == []
+
+
+def _make_topic_with_content(tmp_path: Path, module: str, topic: str, content: str) -> Path:
+    """Create a topic dir whose single slide file holds *content*."""
+    topic_dir = tmp_path / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    (topic_dir / "slides_main.py").write_text(content, encoding="utf-8")
+    return topic_dir
+
+
+class TestCrossReferences:
+    """Cross-reference (clm:) validation findings (Issue #17)."""
+
+    def test_missing_target_is_error(self, tmp_path):
+        _make_topic_with_content(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_intro",
+            "# %% [markdown]\n# Intro\nSee [the deck](clm:nonexistent).\n",
+        )
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+        missing = [f for f in result.findings if f.type == "cross_reference_target_missing"]
+        assert len(missing) == 1
+        assert missing[0].severity == "error"
+        assert "nonexistent" in missing[0].message
+
+    def test_present_target_passes(self, tmp_path):
+        _make_topic_with_content(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_intro",
+            "# %% [markdown]\n# Intro\nSee [workshop](clm:workshop).\n",
+        )
+        _make_topic(tmp_path, "module_100_basics", "topic_020_workshop")
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <topic>intro</topic>
+                <topic>workshop</topic>
+              </topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+        assert [f for f in result.findings if f.type.startswith("cross_reference")] == []
+
+    def test_target_excluded_by_section_selection_is_missing(self, tmp_path):
+        """A real topic that is not referenced by the spec is reported.
+
+        ``validate_spec`` only sees the topics the spec includes, so a link
+        to a topic that exists on disk but is omitted from the spec
+        (the analogue of section filtering) is correctly flagged.
+        """
+        _make_topic_with_content(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_intro",
+            "# %% [markdown]\n# Intro\nSee [workshop](clm:workshop).\n",
+        )
+        # The 'workshop' topic exists on disk but is NOT in the spec below.
+        _make_topic(tmp_path, "module_100_basics", "topic_020_workshop")
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+        missing = [f for f in result.findings if f.type == "cross_reference_target_missing"]
+        assert len(missing) == 1
+        assert "workshop" in missing[0].message
+
+    def test_ambiguous_multi_notebook_target_warns(self, tmp_path):
+        _make_topic_with_content(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_intro",
+            "# %% [markdown]\n# Intro\nSee [advanced](clm:advanced).\n",
+        )
+        adv_dir = tmp_path / "slides" / "module_100_basics" / "topic_020_advanced"
+        adv_dir.mkdir(parents=True, exist_ok=True)
+        (adv_dir / "slides_part_a.py").write_text("# %% [markdown]\n# A\n", encoding="utf-8")
+        (adv_dir / "slides_part_b.py").write_text("# %% [markdown]\n# B\n", encoding="utf-8")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <topic>intro</topic>
+                <topic>advanced</topic>
+              </topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+        ambiguous = [f for f in result.findings if f.type == "cross_reference_ambiguous"]
+        assert len(ambiguous) == 1
+        assert ambiguous[0].severity == "warning"
+
+    def test_disambiguated_multi_notebook_target_passes(self, tmp_path):
+        _make_topic_with_content(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_intro",
+            "# %% [markdown]\n# Intro\nSee [b](clm:advanced/slides_part_b).\n",
+        )
+        adv_dir = tmp_path / "slides" / "module_100_basics" / "topic_020_advanced"
+        adv_dir.mkdir(parents=True, exist_ok=True)
+        (adv_dir / "slides_part_a.py").write_text("# %% [markdown]\n# A\n", encoding="utf-8")
+        (adv_dir / "slides_part_b.py").write_text("# %% [markdown]\n# B\n", encoding="utf-8")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <topic>intro</topic>
+                <topic>advanced</topic>
+              </topics>
+            </section></sections>""",
+        )
+
+        result = validate_spec(spec_file, tmp_path / "slides")
+        assert [f for f in result.findings if f.type.startswith("cross_reference")] == []

--- a/tests/workers/notebook/test_cross_reference_rewrite.py
+++ b/tests/workers/notebook/test_cross_reference_rewrite.py
@@ -1,0 +1,80 @@
+"""Worker-side cross-reference rewrite tests (Issue #17).
+
+The worker performs only a mechanical string substitution in
+``_process_markdown_cell_contents`` using the href map resolved at
+payload-construction time. These tests confirm the rewrite fires for
+markdown cells and honours the empty-href "drop the link" rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nbformat import NotebookNode
+
+from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+from clm.workers.notebook.notebook_processor import NotebookProcessor
+from clm.workers.notebook.output_spec import CompletedOutput
+
+
+def _markdown_cell(source: str) -> NotebookNode:
+    return NotebookNode(
+        {
+            "cell_type": "markdown",
+            "source": source,
+            "metadata": {"tags": []},
+        }
+    )
+
+
+def _payload(cross_references: dict[str, str], format_: str = "html") -> NotebookPayload:
+    return NotebookPayload(
+        input_file="/test/notebook.py",
+        input_file_name="notebook.py",
+        output_file="/test/output/notebook",
+        data="",
+        format=format_,
+        kind="completed",
+        language="en",
+        prog_lang="python",
+        correlation_id="cid",
+        cross_references=cross_references,
+    )
+
+
+@pytest.mark.parametrize("format_", ["html", "notebook"])
+def test_rewrite_produces_working_relative_link(format_: str) -> None:
+    processor = NotebookProcessor(CompletedOutput(format=format_))
+    ext = "html" if format_ == "html" else "ipynb"
+    href = f"../Workshops/03 Functions.{ext}"
+    cell = _markdown_cell("See [the workshop](clm:functions_workshop).")
+
+    processor._process_markdown_cell_contents(
+        cell,
+        "img/",
+        _payload({"functions_workshop": href}, format_=format_),
+    )
+
+    assert cell["source"] == f"See [the workshop]({href})."
+
+
+def test_rewrite_drops_link_when_href_empty() -> None:
+    processor = NotebookProcessor(CompletedOutput(format="code"))
+    cell = _markdown_cell("See [the workshop](clm:functions_workshop).")
+
+    processor._process_markdown_cell_contents(
+        cell,
+        "img/",
+        _payload({"functions_workshop": ""}, format_="code"),
+    )
+
+    assert cell["source"] == "See the workshop."
+
+
+def test_rewrite_noop_without_cross_references() -> None:
+    processor = NotebookProcessor(CompletedOutput(format="html"))
+    cell = _markdown_cell("See [the workshop](clm:functions_workshop).")
+
+    processor._process_markdown_cell_contents(cell, "img/", _payload({}))
+
+    # No href map -> left verbatim.
+    assert cell["source"] == "See [the workshop](clm:functions_workshop)."


### PR DESCRIPTION
## Design-first proposal for Issue #17

This is a **DRAFT / design-first** PR. It ships a concrete design proposal and a
decision-agnostic scaffold — **not** a full feature. The genuine product
decisions are forwarded to the maintainer below and must be settled before the
resolver is implemented.

Refs #17

### What's here
- `docs/claude/design/cross-references.md` — full design proposal grounded in
  how CLM actually renames/numbers notebooks and fans them out per
  language/kind/format.
- `src/clm/core/cross_references.py` — decision-agnostic `clm:` reference
  *extractor* + a `CrossReferenceResolver` Protocol stub. No build path calls
  it yet, so build output is unchanged.
- `tests/core/test_cross_references.py` — 9 extractor tests.

### Key investigation findings
- **Stable identity** = the **topic ID** (`simplify_ordered_name`, the same
  vocabulary as `<topic>id</topic>`). Stable under reorder/renumber. Caveat: a
  directory topic can hold several slide notebooks, so topic-id alone isn't
  always notebook-unique.
- Output filename is `"{number_in_section:02} {sanitized_title}{ext}"` under a
  section-title directory — neither known to the author.
- **Resolution must happen at payload-construction time** (in
  `ProcessNotebookOperation.payload()`, where the whole `Course` is in scope),
  mirroring the existing `img_path_prefix`. The worker only does a mechanical
  string rewrite in `_process_markdown_cell_contents`.
- Validation (`clm validate-spec`) already emits structured findings for
  unresolved topics — a `cross_reference_target_missing` finding slots in
  there, plus a build-time check honoring `--section` selection.

### Open product decisions (maintainer)
1. **Syntax**: `[text](clm:topic-id)` (rec.) vs wiki-link vs MyST `{ref}` vs HTML.
2. **Identifier**: reuse topic ID (rec. for v1) vs explicit front-matter id vs hybrid; plus **granularity** (topic-level vs notebook-level).
3. **Anchors/sub-sections in scope?** Rec.: no for v1 (no stable anchor scheme today).
4. **Missing target**: hard error vs warn+drop vs configurable. Rec.: configurable, default error in CI / warn+drop in local section-filtered builds.
5. **Formats with no link target** (`code`, `jupyterlite`): rec. drop the link for `code`, defer `jupyterlite`.

### Left undone (until decisions land)
Concrete resolver, payload field + wiring, worker rewrite, validation findings,
exit-code flag, and the mandatory `info_topics/spec-files.md` + `commands.md` +
`CHANGELOG.md` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)