### PR TITLE
fix(notebook): strip lines_to_next_cell to converge split/bilingual builds (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Split and bilingual builds now produce byte-equivalent output
+  ([#133](https://github.com/hoelzl/clm/issues/133)).** The notebook
+  processor strips jupytext's `lines_to_next_cell` cell metadata from build
+  output. That field is a layout artifact jupytext records when the physical
+  blank-line count between two cells differs from its PEP 8 lookahead
+  heuristic. Because the heuristic depends on the *identity* of the next
+  physical cell, a `clm slides split` single-language deck and the original
+  bilingual deck recorded the field differently for cells whose neighbouring
+  cell was a same-language markdown cell (split) versus an other-language
+  code clone later filtered out (bilingual). The two forms have the same
+  surviving cells, so the divergent metadata caused spurious failures in the
+  byte-equivalence gate (and an extra trailing newline in the `.py`/`.html`).
+  The field carries no semantic meaning for executed `.ipynb`/HTML output and
+  source files are untouched — only build output is normalized.
 - **`clm db vacuum` / `clm db clean` now actually reclaim disk space on the
   jobs database (issue #144).** The jobs DB runs in WAL mode, where a plain
   `VACUUM` rewrites the database into write-ahead-log pages rather than the

--- a/docs/claude/issue-133-investigation.md
+++ b/docs/claude/issue-133-investigation.md
@@ -1,7 +1,25 @@
 # Issue #133 — split vs bilingual `lines_to_next_cell` divergence
 
-**Status:** investigated 2026-05-25, producer-side fix deferred,
-consumer-side workaround shipped as `scripts/diff_build_outputs.py`.
+**Status:** investigated 2026-05-25; **producer-side fix shipped 2026-05-30**
+(`_strip_lines_to_next_cell` in `notebook_processor.py`); consumer-side
+workaround `scripts/diff_build_outputs.py` retained as a build-equivalence
+gate.
+
+> **Producer fix as shipped.** The fix is *not* Option A below (strip only
+> where the source-successor was filtered out). Re-running the trace against
+> the actual data showed Option A does not converge: in the bilingual DE
+> build the divergent cells already carry *no* `lines_to_next_cell` (their
+> immediate source neighbour is an other-language code clone with identical
+> source, so jupytext records nothing), while the `clm slides split` DE deck
+> records `1`/`2` because the same cells sit next to a DE markdown cell — and
+> nothing is filtered in the split form for an Option-A hook to fire on.
+> Both forms yield the *same* surviving cell sequence, so the only
+> normalization that converges them is to drop the field unconditionally
+> from build output. `_process_notebook_node` now calls
+> `_strip_lines_to_next_cell(new_cells)` after filtering. Source files are
+> never touched; the field is a jupytext layout artifact with no meaning for
+> executed `.ipynb`/HTML. This matches what `diff_build_outputs.py` already
+> normalized away — the normalization simply moved producer-side.
 **Severity:** Low (cosmetic metadata; HTML rendering identical;
 Phase D byte-equivalence gate affected).
 **Related issues:** [#128](https://github.com/hoelzl/clm/issues/128) (fixed

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -5,6 +5,7 @@ import os
 import re
 import warnings
 from base64 import b64decode
+from collections.abc import Iterable
 from dataclasses import dataclass
 from hashlib import sha3_224
 from pathlib import Path
@@ -641,6 +642,31 @@ def _normalize_jupytext_metadata_filters(nb: NotebookNode) -> None:
         jupytext_meta[field] = ",".join(sorted(entries))
 
 
+def _strip_lines_to_next_cell(cells: Iterable[Cell]) -> None:
+    """Drop jupytext's ``lines_to_next_cell`` hint from every cell in-place.
+
+    ``lines_to_next_cell`` is a layout artifact that jupytext records when the
+    actual blank-line count between two cells differs from what its PEP 8
+    heuristic expects. That heuristic looks *ahead* into the next cell, so the
+    same logical cell receives a different value depending on the identity of
+    its physical neighbour in the source ``.py`` file.
+
+    A bilingual deck interleaves DE/EN cells; ``clm slides split`` emits a
+    single-language deck. After CLM filters cells by language the two forms
+    yield the *same* surviving cell sequence, but their ``lines_to_next_cell``
+    metadata diverges because jupytext computed it against different physical
+    neighbours upstream (see GitHub issue #133). The value carries no semantic
+    meaning for the executed ``.ipynb``/HTML output — it only influences the
+    blank-line count jupytext writes back out — so we strip it from the build
+    output to make split and bilingual builds byte-equivalent. Author spacing
+    intent in *source* files is untouched; this only normalizes build output.
+    """
+    for cell in cells:
+        metadata = cell.get("metadata")
+        if isinstance(metadata, dict):
+            metadata.pop("lines_to_next_cell", None)
+
+
 # Regex pattern to match img and video tags with src="img/..." paths
 # Captures: prefix (before img/), filename (after img/), suffix (rest of tag)
 MEDIA_SRC_PATTERN = re.compile(r'(<(?:img|video)\s+[^>]*src=["\'])img/([^"\']+)(["\'][^>]*>)')
@@ -1221,6 +1247,9 @@ class NotebookProcessor:
             tags = cell["metadata"].get("tags")
             if tags and POST_WORKSHOP_TAG in tags:
                 cell["metadata"]["tags"] = [t for t in tags if t != POST_WORKSHOP_TAG]
+        # Drop jupytext's ``lines_to_next_cell`` layout artifact so that split
+        # and bilingual builds produce byte-equivalent output (issue #133).
+        _strip_lines_to_next_cell(new_cells)
         nb.cells = new_cells
         nb.metadata["language_info"] = language_info(payload.prog_lang)
         nb.metadata["kernelspec"] = kernelspec_for(payload.prog_lang)

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -28,6 +28,7 @@ from clm.workers.notebook.notebook_processor import (
     NotebookProcessor,
     TrackingExecutePreprocessor,
     _normalize_jupytext_metadata_filters,
+    _strip_lines_to_next_cell,
 )
 from clm.workers.notebook.output_spec import (
     CodeAlongOutput,
@@ -1938,6 +1939,132 @@ class TestJupytextMetadataFilterNormalization:
         nb = NotebookNode({"metadata": {}})
         _normalize_jupytext_metadata_filters(nb)
         assert nb["metadata"] == {}
+
+
+class TestLinesToNextCellStripping:
+    """``_strip_lines_to_next_cell`` removes jupytext's layout artifact so that
+    split and bilingual builds produce byte-equivalent output (issue #133).
+
+    ``lines_to_next_cell`` is recorded by jupytext when the actual blank-line
+    count between two cells differs from its PEP 8 lookahead heuristic. Because
+    that heuristic depends on the *identity* of the physical next cell, the
+    same logical cell receives the value in a split deck (next cell is a DE
+    markdown) but not in a bilingual deck (next cell is an EN code clone that
+    is later filtered out). Stripping the field unconditionally converges both.
+    """
+
+    def test_strips_field_from_all_cells(self):
+        cells = [
+            make_cell("code", "for x in xs:\n    pass"),
+            make_cell("markdown", "# heading"),
+            make_cell("code", "def f():\n    pass"),
+        ]
+        cells[0]["metadata"]["lines_to_next_cell"] = 1
+        cells[2]["metadata"]["lines_to_next_cell"] = 2
+        _strip_lines_to_next_cell(cells)
+        for cell in cells:
+            assert "lines_to_next_cell" not in cell["metadata"]
+
+    def test_no_op_when_field_absent(self):
+        cells = [make_cell("code", "print('hi')"), make_cell("markdown", "# x")]
+        _strip_lines_to_next_cell(cells)
+        for cell in cells:
+            assert "lines_to_next_cell" not in cell["metadata"]
+
+    def test_preserves_other_metadata(self):
+        cell = make_cell("code", "x = 1", tags=["keep"], lang="de")
+        cell["metadata"]["lines_to_next_cell"] = 3
+        _strip_lines_to_next_cell([cell])
+        assert "lines_to_next_cell" not in cell["metadata"]
+        assert cell["metadata"]["tags"] == ["keep"]
+        assert cell["metadata"]["lang"] == "de"
+
+    @pytest.mark.asyncio
+    async def test_process_notebook_node_strips_field(self):
+        """The processing pipeline removes ``lines_to_next_cell`` from output."""
+        notebook = make_notebook_node(
+            [
+                make_cell("code", "for x in xs:\n    pass"),
+                make_cell("markdown", "# heading"),
+                make_cell("code", "def f():\n    pass"),
+            ]
+        )
+        notebook["cells"][0]["metadata"]["lines_to_next_cell"] = 1
+        notebook["cells"][2]["metadata"]["lines_to_next_cell"] = 2
+
+        spec = CompletedOutput(format="notebook")
+        processor = NotebookProcessor(spec)
+        payload = make_payload("", kind="completed", format_="notebook")
+
+        result = await processor._process_notebook_node(notebook, payload)
+
+        for cell in result["cells"]:
+            assert "lines_to_next_cell" not in cell["metadata"]
+
+    def test_split_and_bilingual_converge(self):
+        """Parsing a deck both as a bilingual file and as a jupytext-split
+        single-language file yields the same surviving cell metadata once
+        ``lines_to_next_cell`` is stripped — the exact scenario from #133.
+
+        This unit-isolates the jupytext-read + language-filter + strip steps
+        without a full build cycle. The fixture is a minimal reproduction of
+        the divergent layout: a DE code cell whose source-successor is a DE
+        markdown cell in the split form but an EN code clone in the bilingual
+        form, followed by a ``def`` cell that triggers jupytext's PEP 8
+        lookahead asymmetry.
+        """
+        import jupytext
+
+        from clm.workers.notebook.utils.jupyter_utils import (
+            is_cell_included_for_language,
+        )
+
+        bilingual = (
+            '# %% lang="de"\n'
+            "for vague in questions:\n"
+            "    print(vague)\n"
+            "\n"
+            '# %% lang="en"\n'
+            "for vague in questions:\n"
+            "    print(vague)\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# ## Aufgabe\n"
+            "\n"
+            '# %% lang="de"\n'
+            "def solve(x):\n"
+            "    return x\n"
+            "\n"
+            "\n"
+            '# %% lang="en"\n'
+            "def solve(x):\n"
+            "    return x\n"
+        )
+        split_de = (
+            '# %% lang="de"\n'
+            "for vague in questions:\n"
+            "    print(vague)\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# ## Aufgabe\n"
+            "\n"
+            '# %% lang="de"\n'
+            "def solve(x):\n"
+            "    return x\n"
+        )
+
+        def filtered_de_metadata(text: str) -> list[int | None]:
+            nb = jupytext.reads(text, fmt="py:percent")
+            cells = [c for c in nb.cells if is_cell_included_for_language(c, "de")]
+            _strip_lines_to_next_cell(cells)
+            return [c["metadata"].get("lines_to_next_cell") for c in cells]
+
+        bil_meta = filtered_de_metadata(bilingual)
+        split_meta = filtered_de_metadata(split_de)
+
+        # Same number of surviving DE cells and no residual layout artifact.
+        assert bil_meta == split_meta
+        assert all(v is None for v in bil_meta)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes the producer-side root cause of issue #133: `clm slides split` and the original bilingual deck produced build output that diverged on jupytext's `lines_to_next_cell` cell metadata, failing the Phase D byte-equivalence gate (and adding a spurious trailing newline to the `.py`/`.html`).

## Root cause

jupytext records `lines_to_next_cell` on a cell only when the physical blank-line count to the next cell differs from its PEP 8 *lookahead* heuristic. That heuristic walks into the next physical cell, so the value depends on the **identity** of the neighbour:

- **Split DE deck:** the `for vague …` cell is followed by a DE markdown cell whose body eventually leads to a `def`, so jupytext expects 2 blank lines, finds 1, and records `lines_to_next_cell=1`.
- **Bilingual deck:** the same DE cell is followed by an *EN code clone* with identical source, so jupytext expects 1, finds 1, and records nothing. The EN clone is then filtered out by the language filter.

Both forms yield the **same surviving cell sequence**, but the metadata diverges. This is a layout artifact, not whitespace — the inter-cell whitespace is byte-identical at the divergent positions (see `docs/claude/issue-133-investigation.md`).

Note this is *not* the conservative "Option A" from the original investigation (strip only where the source-successor was filtered out): re-running the trace showed Option A does not converge, because the metadata-bearing form (split) has nothing filtered. The only normalization that converges is to drop the field from build output unconditionally.

## Change

`_process_notebook_node` now calls a new `_strip_lines_to_next_cell` helper on the surviving cells after filtering. The field carries no semantic meaning for executed `.ipynb`/HTML output, and **source files are never touched** — only build output is normalized, matching what `scripts/diff_build_outputs.py` already did consumer-side.

## Tests

`TestLinesToNextCellStripping` (5 tests): helper unit tests, a `_process_notebook_node` integration test, and a jupytext-level reproduction asserting that a minimal bilingual deck and its split DE form (which diverge `[1, None, None]` vs `[None, None, None]` raw) converge after the strip. All 131 tests in `test_notebook_processor.py` pass; ruff + mypy clean.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)