### PR TITLE
feat(cassette): add `clm cassette doctor` (issue #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   so PowerShell gets the same context-aware command, option, and value
   completions as the POSIX shells. Pass `--install-hint` to print per-shell
   instructions for making completion permanent. (Closes #22.)
+- **`clm cassette doctor` command.** New offline tool to detect (and with
+  `--fix`, repair) *chain-orphan* interactions in canonical HTTP-replay
+  cassettes (issue #125). A chain-orphan is a chat-completion response whose
+  extracted text (`choices[].message.content`, or accumulated streaming
+  `delta.content`) is at least `--min-text-len` characters (default `50`) yet
+  appears in no other interaction's request body — almost always a
+  chain-opener whose closer was never recorded. This covers the two residual
+  cases the issue-#115 completion-marker fix cannot: cassettes poisoned
+  *before* that fix landed, and the `try/except`-swallowed chain-closer case
+  the marker logic structurally cannot catch. The command walks every
+  `*.http-cassette.yaml` under the spec's source tree (or the current
+  directory when the `SPEC-FILE` argument is omitted), reports per cassette
+  (URI, request-body fingerprint, response excerpt), and supports `--json`
+  for machine-readable output. `--fix` rewrites cassettes via the existing
+  atomic-write helper so the next build re-records the broken chain; it is
+  diagnostic-only by default. Detection is deliberately a substring match —
+  fuzzy/LLM matching and auto-repair correctness guarantees are out of scope.
 - **Cross-references between notebooks (issue #17).** Link from one notebook
   to another with the `[text](clm:topic-id)` Markdown scheme. CLM resolves
   the `clm:` href at build time to the correct relative path to the

--- a/src/clm/cli/commands/cassette.py
+++ b/src/clm/cli/commands/cassette.py
@@ -1,0 +1,173 @@
+"""``clm cassette`` command group: offline cassette diagnostics and repair.
+
+Currently hosts the ``doctor`` subcommand (issue #125), which detects and
+optionally repairs chain-orphan interactions in canonical HTTP-replay
+cassettes. See :mod:`clm.workers.notebook.cassette_doctor` for the detection
+and repair logic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from clm.cli.commands.shared import cli_console, get_logger
+from clm.core.course_paths import resolve_course_paths
+from clm.workers.notebook.cassette_doctor import (
+    DEFAULT_MIN_TEXT_LEN,
+    CassetteReport,
+    diagnose_cassettes,
+    iter_cassette_paths,
+)
+
+logger = get_logger(__name__)
+
+
+@click.group("cassette")
+def cassette_group() -> None:
+    """Inspect and repair HTTP-replay cassettes."""
+
+
+def _resolve_walk_root(spec_file: Path | None) -> Path:
+    """Resolve the directory tree to walk for cassettes.
+
+    When a spec file is given, cassettes live alongside the source ``.py``
+    files under the course root (resolved the same way ``clm build`` does).
+    Without a spec, the current working directory is walked — convenient for
+    repairing a single topic directory in place.
+    """
+    if spec_file is None:
+        return Path.cwd()
+    course_root, _ = resolve_course_paths(spec_file)
+    return course_root
+
+
+def _render_text_report(reports: list[CassetteReport], *, fix: bool) -> None:
+    """Print a human-readable per-cassette report to the console."""
+    console = cli_console
+    total_orphans = 0
+    total_fixed = 0
+    inspected = 0
+    skipped = 0
+
+    for report in reports:
+        if report.error is not None:
+            skipped += 1
+            console.print(f"[yellow]! {report.path}[/yellow]: skipped ({report.error})")
+            continue
+        inspected += 1
+        if not report.has_orphans:
+            continue
+        total_orphans += len(report.orphans)
+        if report.fixed:
+            total_fixed += 1
+        status = " [green](repaired)[/green]" if report.fixed else ""
+        console.print(
+            f"[bold]{report.path}[/bold]: "
+            f"{len(report.orphans)} chain-orphan(s) "
+            f"of {report.interaction_count} interaction(s){status}"
+        )
+        for orphan in report.orphans:
+            console.print(
+                f"    [{orphan.index}] {orphan.method} {orphan.uri}\n"
+                f"        request-body: {orphan.request_fingerprint}\n"
+                f"        response ({orphan.text_len} chars): "
+                f"{orphan.text_excerpt!r}"
+            )
+
+    console.print()
+    console.print(
+        f"Cassettes inspected: {inspected}" + (f"  (skipped {skipped})" if skipped else "")
+    )
+    console.print(f"Chain-orphans found: {total_orphans}")
+    if fix:
+        console.print(f"Cassettes repaired:  {total_fixed}")
+    elif total_orphans:
+        console.print(
+            "Re-run with [bold]--fix[/bold] to remove orphan interactions "
+            "so the next build re-records them."
+        )
+
+
+@cassette_group.command("doctor")
+@click.argument(
+    "spec-file",
+    required=False,
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--fix",
+    is_flag=True,
+    default=False,
+    help=(
+        "Rewrite cassettes to drop chain-orphan interactions so the next "
+        "build re-records them. Default off (diagnostic only)."
+    ),
+)
+@click.option(
+    "--min-text-len",
+    type=click.IntRange(min=1),
+    default=DEFAULT_MIN_TEXT_LEN,
+    show_default=True,
+    help=(
+        "Minimum extracted response-content length (chars) for an "
+        "interaction to be treated as a chain-edge candidate. Shorter "
+        "responses are too likely to appear incidentally in unrelated "
+        "request bodies to flag reliably."
+    ),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON report on stdout instead of text.",
+)
+def doctor(spec_file: Path | None, fix: bool, min_text_len: int, as_json: bool) -> None:
+    """Detect (and optionally repair) orphan chain-pointing cassette interactions.
+
+    Walks every ``*.http-cassette.yaml`` under the spec's source tree (or the
+    current directory when SPEC-FILE is omitted). For each interaction, the
+    chat-completion text content is extracted and treated as a chain-edge
+    candidate when at least ``--min-text-len`` characters long. If no other
+    interaction's request body embeds that text, the interaction is flagged
+    as a chain-orphan — almost always a chain-opener whose closer was never
+    recorded (the canonical-poisoning case from issue #115 that the
+    completion-marker fix cannot retroactively repair).
+
+    \b
+    Examples:
+        clm cassette doctor course.xml                 # report orphans
+        clm cassette doctor course.xml --fix           # remove them
+        clm cassette doctor course.xml --json          # machine-readable
+        clm cassette doctor course.xml --min-text-len 80
+        clm cassette doctor                            # walk current dir
+    """
+    root = _resolve_walk_root(spec_file)
+    paths = list(iter_cassette_paths(root))
+
+    reports = diagnose_cassettes(paths, min_text_len=min_text_len, fix=fix)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "root": str(root),
+                    "min_text_len": min_text_len,
+                    "fix": fix,
+                    "cassette_count": len(reports),
+                    "orphan_count": sum(len(r.orphans) for r in reports),
+                    "cassettes": [r.to_dict() for r in reports],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not paths:
+        cli_console.print(f"No cassettes found under {root}.")
+        return
+
+    _render_text_report(reports, fix=fix)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1120,6 +1120,55 @@ clm completion powershell >> $PROFILE
 clm completion powershell --install-hint
 ```
 
+### `clm cassette`
+
+Inspect and repair HTTP-replay cassettes.
+
+| Subcommand | Description |
+|------------|-------------|
+| `cassette doctor` | Detect (and optionally repair) orphan chain-pointing interactions |
+
+#### `clm cassette doctor [SPEC-FILE]`
+
+Detects *chain-orphan* interactions in canonical `*.http-cassette.yaml`
+files — a chat-completion response whose text is substantial enough to be a
+"chain edge" yet appears in no other interaction's request body. These are
+almost always a chain-opener whose chain-closer was never recorded: the
+canonical-poisoning failure mode that the completion-marker fix (issue #115)
+prevents going *forward* but cannot retroactively repair, plus the
+`try/except`-swallowed-closer case the marker logic structurally cannot catch.
+
+Walks every `*.http-cassette.yaml` under the spec's source tree (the course
+root, resolved as `clm build` does). When `SPEC-FILE` is omitted, the current
+working directory is walked instead — convenient for repairing a single topic
+directory in place.
+
+Detection is intentionally simple (substring match — no fuzzy or LLM-based
+matching): for each interaction the chat-completion content is extracted
+(`choices[].message.content` for non-streaming JSON; accumulated
+`delta.content` for streaming SSE), and any content at least `--min-text-len`
+characters long is treated as a chain-edge candidate. If no other
+interaction's request body embeds that text as a substring, the interaction is
+flagged.
+
+| Option | Description |
+|--------|-------------|
+| `--fix` | Rewrite cassettes to drop chain-orphan interactions (via the atomic-write path), so the next build re-records them. Default off — diagnostic only. |
+| `--min-text-len N` | Minimum extracted-content length (chars) to treat as a chain-edge candidate. Default: `50`. |
+| `--json` | Emit a machine-readable JSON report on stdout instead of the text report. |
+
+`--fix` only guarantees the orphan entry is gone; it does **not** guarantee
+the next recording produces a correct chain — the author still has to
+re-record (e.g. with `--http-replay=refresh` or `new-episodes`). Cassettes
+that fail to load are reported as skipped and never rewritten.
+
+```bash
+clm cassette doctor course-specs/python-course.xml          # report only
+clm cassette doctor course-specs/python-course.xml --fix    # repair
+clm cassette doctor course-specs/python-course.xml --json   # CI gate
+clm cassette doctor                                          # walk cwd
+```
+
 ### `clm config`
 
 Manage CLM configuration files.

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -77,6 +77,7 @@ from clm.cli.commands.build import (  # noqa: E402
     build,
     list_targets,
 )
+from clm.cli.commands.cassette import cassette_group  # noqa: E402
 from clm.cli.commands.completion import completion_cmd  # noqa: E402
 from clm.cli.commands.config import config  # noqa: E402
 from clm.cli.commands.coverage import coverage_cmd  # noqa: E402
@@ -177,6 +178,7 @@ cli.add_command(authoring_group)
 # ---------------------------------------------------------------------
 # Existing infrastructure groups (unchanged by Phase 0).
 # ---------------------------------------------------------------------
+cli.add_command(cassette_group)
 cli.add_command(config)
 cli.add_command(db)
 cli.add_command(docker_group)

--- a/src/clm/workers/notebook/cassette_doctor.py
+++ b/src/clm/workers/notebook/cassette_doctor.py
@@ -1,0 +1,393 @@
+"""Offline diagnostics and repair for HTTP-replay cassettes.
+
+This module backs the ``clm cassette doctor`` command (issue #125). It
+detects *chain-orphan* interactions in canonical cassettes: chat-completion
+responses whose extracted text is substantial enough that a downstream
+request would plausibly embed it, yet no other interaction's request body
+actually does. Such an interaction is almost always a chain-opener whose
+chain-closer was never recorded — the canonical-poisoning failure mode that
+PR #123 (issue #115) fixed going *forward* but cannot retroactively repair,
+and which the completion-marker logic structurally cannot catch when a cell's
+``try/except`` swallowed the closing call.
+
+The detection heuristic is deliberately simple (substring match, no fuzzy or
+LLM-based matching — see issue #125 "out of scope"):
+
+1. For each interaction, parse the response body and extract chat-completion
+   text content (``choices[].message.content`` for non-streaming JSON;
+   accumulated ``delta.content`` for streaming SSE bodies).
+2. Treat each extracted content of length ``>= min_text_len`` as a
+   *chain-edge candidate*.
+3. If no *other* interaction's request body contains that text as a
+   substring, flag the interaction as a chain-orphan.
+
+``--fix`` rewrites the cassette without the flagged interactions using the
+same atomic-write helper the merge path uses, so the next build re-records
+the broken chain. The repair is best-effort by design (issue #125): it only
+guarantees the orphan is gone, not that the next recording is correct.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Iterator, Sequence
+from pathlib import Path
+
+from attrs import define, field
+
+logger = logging.getLogger(__name__)
+
+#: Cassettes are named ``*.http-cassette.yaml`` and live alongside the source
+#: ``.py`` files in the course tree (see ``scripts/strip_cassette_hosts.py``,
+#: which uses the same glob).
+CASSETTE_GLOB = "*.http-cassette.yaml"
+
+#: Default minimum extracted-content length for an interaction to be treated
+#: as a chain-edge candidate. Shorter responses (e.g. a one-word answer) are
+#: too likely to appear incidentally in unrelated request bodies to flag
+#: reliably.
+DEFAULT_MIN_TEXT_LEN = 50
+
+#: How much of the orphan response text to show in the human-readable report.
+_EXCERPT_LEN = 120
+
+
+@define
+class OrphanInteraction:
+    """A single chain-orphan interaction flagged in a cassette.
+
+    Attributes:
+        index: Zero-based position of the interaction within the cassette.
+        uri: Request URI of the interaction.
+        method: Request HTTP method.
+        request_fingerprint: Short stable fingerprint of the request body,
+            for correlating the report back to a specific recorded call.
+        text_excerpt: Leading slice of the extracted response content that
+            no downstream request embedded.
+        text_len: Full length of the extracted response content.
+    """
+
+    index: int
+    uri: str
+    method: str
+    request_fingerprint: str
+    text_excerpt: str
+    text_len: int
+
+    def to_dict(self) -> dict:
+        return {
+            "index": self.index,
+            "uri": self.uri,
+            "method": self.method,
+            "request_fingerprint": self.request_fingerprint,
+            "text_excerpt": self.text_excerpt,
+            "text_len": self.text_len,
+        }
+
+
+@define
+class CassetteReport:
+    """Per-cassette diagnostic result.
+
+    Attributes:
+        path: Cassette path.
+        interaction_count: Total interactions loaded from the cassette.
+        orphans: Chain-orphan interactions found.
+        fixed: ``True`` when ``--fix`` rewrote the cassette to drop orphans.
+        error: Human-readable load/parse error, when the cassette could not
+            be inspected (it is then skipped, not counted as clean).
+    """
+
+    path: Path
+    interaction_count: int = 0
+    orphans: list[OrphanInteraction] = field(factory=list)
+    fixed: bool = False
+    error: str | None = None
+
+    @property
+    def has_orphans(self) -> bool:
+        return bool(self.orphans)
+
+    def to_dict(self) -> dict:
+        return {
+            "path": str(self.path),
+            "interaction_count": self.interaction_count,
+            "orphan_count": len(self.orphans),
+            "orphans": [o.to_dict() for o in self.orphans],
+            "fixed": self.fixed,
+            "error": self.error,
+        }
+
+
+def iter_cassette_paths(root: Path) -> Iterator[Path]:
+    """Yield every ``*.http-cassette.yaml`` file under ``root`` (recursive).
+
+    Staging (``.staging-*``) and partial (``.partial-*``) sibling files do
+    not match the glob (they carry a suffix after ``.yaml``), so only
+    canonical cassettes are walked.
+    """
+    for path in sorted(root.rglob(CASSETTE_GLOB)):
+        if path.is_file():
+            yield path
+
+
+def _body_string(response: object) -> str | None:
+    """Extract the response body text from a deserialized vcr response dict.
+
+    vcr stores the body under ``response["body"]["string"]`` (str) — see the
+    cassette format in ``tests``. ``convert_to_bytes`` may have left it as
+    ``bytes``; decode defensively.
+    """
+    if not isinstance(response, dict):
+        return None
+    body = response.get("body")
+    if not isinstance(body, dict):
+        return None
+    raw = body.get("string")
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
+
+
+def _extract_nonstreaming_contents(payload: object) -> list[str]:
+    """Extract ``choices[].message.content`` from a parsed JSON response."""
+    contents: list[str] = []
+    if not isinstance(payload, dict):
+        return contents
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        return contents
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str) and content:
+                contents.append(content)
+    return contents
+
+
+def _extract_streaming_contents(body_text: str) -> list[str]:
+    """Accumulate ``delta.content`` across SSE ``data:`` lines per choice.
+
+    Streaming chat-completion bodies are ``text/event-stream`` payloads: one
+    ``data: {json}`` line per chunk, each chunk carrying
+    ``choices[].delta.content`` fragments, terminated by ``data: [DONE]``.
+    Fragments are concatenated per choice index and the per-choice strings
+    returned.
+    """
+    per_choice: dict[int, list[str]] = {}
+    saw_delta = False
+    for line in body_text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[len("data:") :].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            chunk = json.loads(data)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(chunk, dict):
+            continue
+        choices = chunk.get("choices")
+        if not isinstance(choices, list):
+            continue
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            idx = choice.get("index", 0)
+            if not isinstance(idx, int):
+                idx = 0
+            delta = choice.get("delta")
+            if isinstance(delta, dict):
+                fragment = delta.get("content")
+                if isinstance(fragment, str) and fragment:
+                    per_choice.setdefault(idx, []).append(fragment)
+                    saw_delta = True
+    if not saw_delta:
+        return []
+    return ["".join(parts) for parts in per_choice.values() if parts]
+
+
+def extract_response_contents(response: object) -> list[str]:
+    """Extract all chat-completion text contents from a vcr response.
+
+    Handles both non-streaming JSON bodies (``choices[].message.content``)
+    and streaming SSE bodies (accumulated ``delta.content``). Returns an
+    empty list for non-chat-completion responses (e.g. telemetry, embeddings)
+    or bodies that don't parse — those simply never become chain-edge
+    candidates.
+    """
+    body_text = _body_string(response)
+    if not body_text:
+        return []
+    stripped = body_text.lstrip()
+    # Non-streaming: a single JSON object.
+    if stripped.startswith("{"):
+        try:
+            payload = json.loads(body_text)
+        except (ValueError, TypeError):
+            payload = None
+        contents = _extract_nonstreaming_contents(payload)
+        if contents:
+            return contents
+    # Streaming SSE (or a body that also carries data: lines).
+    if "data:" in body_text:
+        return _extract_streaming_contents(body_text)
+    return []
+
+
+def _request_body_text(request: object) -> str:
+    """Coerce a vcr request body to text for substring search."""
+    body = getattr(request, "body", None)
+    if body is None:
+        return ""
+    if isinstance(body, bytes):
+        return body.decode("utf-8", errors="replace")
+    if isinstance(body, bytearray):
+        return bytes(body).decode("utf-8", errors="replace")
+    if isinstance(body, str):
+        return body
+    read = getattr(body, "read", None)
+    if callable(read):
+        try:
+            data = read()
+        except Exception:  # noqa: BLE001 — defensive: never crash diagnostics
+            return ""
+        seek = getattr(body, "seek", None)
+        if callable(seek):
+            try:
+                seek(0)
+            except Exception:  # noqa: BLE001 — best-effort rewind
+                pass
+        if isinstance(data, (bytes, bytearray)):
+            return bytes(data).decode("utf-8", errors="replace")
+        return str(data)
+    return str(body)
+
+
+def _request_fingerprint(request: object) -> str:
+    """Short, stable fingerprint of a request body for the report."""
+    import hashlib
+
+    body_text = _request_body_text(request)
+    if not body_text:
+        return "<empty-body>"
+    digest = hashlib.sha256(body_text.encode("utf-8", errors="replace")).hexdigest()
+    return digest[:12]
+
+
+def find_orphans(
+    requests: Sequence[object],
+    responses: Sequence[object],
+    *,
+    min_text_len: int = DEFAULT_MIN_TEXT_LEN,
+) -> list[OrphanInteraction]:
+    """Find chain-orphan interactions among parallel request/response lists.
+
+    An interaction is a chain-orphan when it has at least one extracted
+    response content of length ``>= min_text_len`` and *none* of that
+    content appears as a substring of any *other* interaction's request
+    body. The first qualifying content per interaction is reported.
+    """
+    request_bodies = [_request_body_text(req) for req in requests]
+    orphans: list[OrphanInteraction] = []
+
+    for index, (request, response) in enumerate(zip(requests, responses, strict=False)):
+        contents = extract_response_contents(response)
+        candidates = [c for c in contents if len(c) >= min_text_len]
+        if not candidates:
+            continue
+
+        orphan_text: str | None = None
+        for content in candidates:
+            embedded = any(
+                content in request_bodies[other]
+                for other in range(len(request_bodies))
+                if other != index
+            )
+            if not embedded:
+                orphan_text = content
+                break
+
+        if orphan_text is None:
+            continue
+
+        orphans.append(
+            OrphanInteraction(
+                index=index,
+                uri=str(getattr(request, "uri", "") or ""),
+                method=str(getattr(request, "method", "") or ""),
+                request_fingerprint=_request_fingerprint(request),
+                text_excerpt=orphan_text[:_EXCERPT_LEN],
+                text_len=len(orphan_text),
+            )
+        )
+
+    return orphans
+
+
+def diagnose_cassette(
+    path: Path,
+    *,
+    min_text_len: int = DEFAULT_MIN_TEXT_LEN,
+    fix: bool = False,
+) -> CassetteReport:
+    """Diagnose (and optionally repair) a single cassette.
+
+    Loads the cassette via vcr's persister, finds chain-orphans, and — when
+    ``fix`` is set and orphans exist — rewrites the cassette without the
+    orphan interactions via the shared atomic-write helper. A cassette that
+    fails to load is reported with ``error`` set and skipped (never rewritten).
+    """
+    from vcr.persisters.filesystem import FilesystemPersister
+    from vcr.serialize import serialize as vcr_serialize
+    from vcr.serializers import yamlserializer
+
+    try:
+        requests, responses = FilesystemPersister.load_cassette(path, serializer=yamlserializer)
+    except Exception as exc:  # noqa: BLE001 — defensive: one bad file must not abort the walk
+        logger.warning(f"Could not load cassette '{path}' ({type(exc).__name__}: {exc}); skipping.")
+        return CassetteReport(path=path, error=f"{type(exc).__name__}: {exc}")
+
+    orphans = find_orphans(requests, responses, min_text_len=min_text_len)
+    report = CassetteReport(
+        path=path,
+        interaction_count=len(requests),
+        orphans=orphans,
+    )
+
+    if fix and orphans:
+        from clm.workers.notebook.http_replay_cassette import _atomic_write_text
+
+        orphan_indexes = {o.index for o in orphans}
+        keep_requests = [r for i, r in enumerate(requests) if i not in orphan_indexes]
+        keep_responses = [r for i, r in enumerate(responses) if i not in orphan_indexes]
+        payload = vcr_serialize(
+            {"requests": keep_requests, "responses": keep_responses},
+            yamlserializer,
+        )
+        _atomic_write_text(path, payload)
+        report.fixed = True
+        logger.info(
+            f"Repaired cassette '{path}': removed {len(orphans)} chain-orphan "
+            f"interaction(s); the next build will re-record."
+        )
+
+    return report
+
+
+def diagnose_cassettes(
+    paths: Iterable[Path],
+    *,
+    min_text_len: int = DEFAULT_MIN_TEXT_LEN,
+    fix: bool = False,
+) -> list[CassetteReport]:
+    """Diagnose (and optionally repair) every cassette in ``paths``."""
+    return [diagnose_cassette(path, min_text_len=min_text_len, fix=fix) for path in paths]

--- a/tests/workers/notebook/test_cassette_doctor.py
+++ b/tests/workers/notebook/test_cassette_doctor.py
@@ -1,0 +1,308 @@
+"""Tests for the cassette-doctor diagnostics + repair (issue #125).
+
+The doctor flags *chain-orphan* interactions: chat-completion responses whose
+extracted text is long enough to be a chain edge yet appears in no other
+interaction's request body (a chain-opener whose closer was never recorded).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clm.workers.notebook.cassette_doctor import (
+    DEFAULT_MIN_TEXT_LEN,
+    diagnose_cassette,
+    extract_response_contents,
+    find_orphans,
+    iter_cassette_paths,
+)
+
+# vcr is an optional extra; skip the whole module when it isn't installed.
+pytest.importorskip("vcr")
+
+
+def _chat_completion_body(content: str) -> str:
+    """A minimal non-streaming OpenAI chat-completion JSON response body."""
+    return json.dumps(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
+
+
+def _streaming_body(content: str) -> str:
+    """An SSE chat-completion stream that emits ``content`` in two deltas."""
+    half = len(content) // 2
+    chunks = [content[:half], content[half:]]
+    lines = []
+    for fragment in chunks:
+        lines.append(
+            "data: " + json.dumps({"choices": [{"index": 0, "delta": {"content": fragment}}]})
+        )
+    lines.append("data: [DONE]")
+    return "\n".join(lines) + "\n"
+
+
+def _chat_request_body(prompt: str) -> str:
+    """A chat-completions request body embedding ``prompt`` in a user message."""
+    return json.dumps(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    )
+
+
+def _write_cassette(path: Path, interactions: list[tuple[str, str]]) -> None:
+    """Write a cassette from (request_body, response_body) pairs via vcr.
+
+    Each interaction is a POST to the chat-completions endpoint with the given
+    request and response bodies, serialized with the same persister CLM uses.
+    """
+    from vcr.request import Request
+    from vcr.serialize import serialize as vcr_serialize
+    from vcr.serializers import yamlserializer
+
+    requests = []
+    responses = []
+    for req_body, resp_body in interactions:
+        requests.append(
+            Request(
+                method="POST",
+                uri="https://api.openai.com/v1/chat/completions",
+                body=req_body,
+                headers={"content-type": "application/json"},
+            )
+        )
+        responses.append(
+            {
+                "status": {"code": 200, "message": "OK"},
+                "headers": {"content-type": ["application/json"]},
+                "body": {"string": resp_body},
+            }
+        )
+    payload = vcr_serialize({"requests": requests, "responses": responses}, yamlserializer)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload, encoding="utf-8", newline="\n")
+
+
+# --- content extraction ------------------------------------------------------
+
+
+class TestExtractResponseContents:
+    def test_extracts_nonstreaming_message_content(self):
+        resp = {"body": {"string": _chat_completion_body("hello world")}}
+        assert extract_response_contents(resp) == ["hello world"]
+
+    def test_extracts_streaming_delta_content(self):
+        text = "the quick brown fox jumps"
+        resp = {"body": {"string": _streaming_body(text)}}
+        assert extract_response_contents(resp) == [text]
+
+    def test_non_chat_completion_body_yields_nothing(self):
+        resp = {"body": {"string": json.dumps({"data": [{"embedding": [0.1]}]})}}
+        assert extract_response_contents(resp) == []
+
+    def test_unparseable_body_yields_nothing(self):
+        resp = {"body": {"string": "<html>not json</html>"}}
+        assert extract_response_contents(resp) == []
+
+    def test_missing_body_yields_nothing(self):
+        assert extract_response_contents({}) == []
+        assert extract_response_contents("not a dict") == []
+
+
+# --- orphan detection (pure) -------------------------------------------------
+
+_LONG_A = "Clarified question A: " + "x" * 60
+_LONG_B = "Clarified question B: " + "y" * 60
+
+
+class TestFindOrphans:
+    def test_complete_chain_has_no_orphan(self):
+        # Opener's response text is embedded in the closer's request body.
+        requests_responses = [
+            (_chat_request_body("vague A"), _chat_completion_body(_LONG_A)),
+            (_chat_request_body(f"answer this: {_LONG_A}"), _chat_completion_body("done")),
+        ]
+        from vcr.request import Request
+
+        reqs = [
+            Request(method="POST", uri="u", body=rb, headers={}) for rb, _ in requests_responses
+        ]
+        resps = [{"body": {"string": resp}} for _, resp in requests_responses]
+        assert find_orphans(reqs, resps) == []
+
+    def test_orphan_opener_is_flagged(self):
+        # Opener's response text appears in NO other request body.
+        from vcr.request import Request
+
+        reqs = [
+            Request(method="POST", uri="open", body=_chat_request_body("vague A"), headers={}),
+            Request(method="POST", uri="other", body=_chat_request_body("unrelated"), headers={}),
+        ]
+        resps = [
+            {"body": {"string": _chat_completion_body(_LONG_A)}},
+            {"body": {"string": _chat_completion_body("short")}},
+        ]
+        orphans = find_orphans(reqs, resps)
+        assert len(orphans) == 1
+        assert orphans[0].index == 0
+        assert orphans[0].uri == "open"
+        assert orphans[0].text_len == len(_LONG_A)
+
+    def test_min_text_len_boundary(self):
+        from vcr.request import Request
+
+        content = "z" * DEFAULT_MIN_TEXT_LEN  # exactly the default threshold
+        reqs = [Request(method="POST", uri="u", body="{}", headers={})]
+        resps = [{"body": {"string": _chat_completion_body(content)}}]
+
+        # At default len: candidate -> flagged (no other request embeds it).
+        assert len(find_orphans(reqs, resps)) == 1
+        # One char shorter: below threshold -> not a candidate.
+        short = "z" * (DEFAULT_MIN_TEXT_LEN - 1)
+        resps_short = [{"body": {"string": _chat_completion_body(short)}}]
+        assert find_orphans(reqs, resps_short) == []
+        # Raising the threshold above the content length also clears it.
+        assert find_orphans(reqs, resps, min_text_len=DEFAULT_MIN_TEXT_LEN + 1) == []
+
+
+# --- end-to-end on real cassette files ---------------------------------------
+
+
+class TestDiagnoseCassette:
+    def test_complete_chain_reports_no_orphans(self, tmp_path):
+        path = tmp_path / "slides.http-cassette.yaml"
+        _write_cassette(
+            path,
+            [
+                (_chat_request_body("vague A"), _chat_completion_body(_LONG_A)),
+                (_chat_request_body(f"refine: {_LONG_A}"), _chat_completion_body("answer")),
+            ],
+        )
+        report = diagnose_cassette(path)
+        assert report.interaction_count == 2
+        assert report.orphans == []
+        assert report.fixed is False
+
+    def test_orphan_opener_reported_not_fixed_by_default(self, tmp_path):
+        path = tmp_path / "slides.http-cassette.yaml"
+        _write_cassette(
+            path,
+            [
+                (_chat_request_body("vague A"), _chat_completion_body(_LONG_A)),
+                (_chat_request_body("unrelated"), _chat_completion_body("short")),
+            ],
+        )
+        report = diagnose_cassette(path)
+        assert len(report.orphans) == 1
+        assert report.orphans[0].index == 0
+        assert report.fixed is False
+        # Default (no --fix) must not rewrite the file.
+        before = path.read_text(encoding="utf-8")
+        diagnose_cassette(path)
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_fix_removes_only_the_orphan(self, tmp_path):
+        from vcr.persisters.filesystem import FilesystemPersister
+        from vcr.serializers import yamlserializer
+
+        path = tmp_path / "slides.http-cassette.yaml"
+        _write_cassette(
+            path,
+            [
+                (_chat_request_body("vague A"), _chat_completion_body(_LONG_A)),  # orphan
+                (_chat_request_body("vague B"), _chat_completion_body(_LONG_B)),  # opener (paired)
+                (_chat_request_body(f"refine: {_LONG_B}"), _chat_completion_body("ok")),  # closer
+            ],
+        )
+        report = diagnose_cassette(path, fix=True)
+        assert report.fixed is True
+        assert len(report.orphans) == 1
+        assert report.orphans[0].index == 0
+
+        # The complete B-chain survives; only the orphan A interaction is gone.
+        reqs, _ = FilesystemPersister.load_cassette(path, serializer=yamlserializer)
+        bodies = [r.body.decode("utf-8") if isinstance(r.body, bytes) else r.body for r in reqs]
+        assert len(reqs) == 2
+        assert _chat_request_body("vague A") not in bodies
+        assert _chat_request_body("vague B") in bodies
+        assert _chat_request_body(f"refine: {_LONG_B}") in bodies
+
+    def test_unreadable_cassette_is_skipped(self, tmp_path):
+        path = tmp_path / "broken.http-cassette.yaml"
+        path.write_text("this: is: not: valid: cassette\n", encoding="utf-8")
+        report = diagnose_cassette(path)
+        assert report.error is not None
+        assert report.orphans == []
+        assert report.fixed is False
+
+
+# --- cassette walking + JSON shape -------------------------------------------
+
+
+class TestIterCassettePaths:
+    def test_finds_only_canonical_cassettes(self, tmp_path):
+        canonical = tmp_path / "sub" / "slides.http-cassette.yaml"
+        canonical.parent.mkdir(parents=True)
+        canonical.write_text("version: 1\n", encoding="utf-8")
+        # Staging/partial siblings must NOT be walked.
+        (tmp_path / "sub" / "slides.http-cassette.yaml.staging-x").write_text("x", encoding="utf-8")
+        (tmp_path / "sub" / "slides.http-cassette.yaml.partial-y").write_text("y", encoding="utf-8")
+        (tmp_path / "unrelated.txt").write_text("z", encoding="utf-8")
+
+        found = list(iter_cassette_paths(tmp_path))
+        assert found == [canonical]
+
+
+class TestJsonReportShape:
+    def test_doctor_json_report_isolated(self, tmp_path, monkeypatch):
+        from click.testing import CliRunner
+
+        from clm.cli.main import cli
+
+        path = tmp_path / "slides.http-cassette.yaml"
+        _write_cassette(
+            path,
+            [
+                (_chat_request_body("vague A"), _chat_completion_body(_LONG_A)),
+                (_chat_request_body("unrelated"), _chat_completion_body("short")),
+            ],
+        )
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cassette", "doctor", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+
+        # JSON is emitted on stdout; locate the object by braces in case any
+        # stray logging merges into the captured output.
+        out = result.output
+        start = out.index("{")
+        end = out.rindex("}") + 1
+        data = json.loads(out[start:end])
+
+        assert data["min_text_len"] == DEFAULT_MIN_TEXT_LEN
+        assert data["fix"] is False
+        assert data["cassette_count"] == 1
+        assert data["orphan_count"] == 1
+        cassette = data["cassettes"][0]
+        assert cassette["interaction_count"] == 2
+        assert cassette["orphan_count"] == 1
+        orphan = cassette["orphans"][0]
+        assert orphan["index"] == 0
+        assert orphan["method"] == "POST"
+        assert "request_fingerprint" in orphan
+        assert orphan["text_len"] == len(_LONG_A)


### PR DESCRIPTION
@
## Summary

Implements `clm cassette doctor` (issue #125): an offline tool to detect and optionally repair **chain-orphan** interactions in canonical HTTP-replay cassettes.

A chain-orphan is a chat-completion response whose extracted text is substantial enough to be a "chain edge" yet appears in *no other* interactions request body — almost always a chain-opener whose chain-closer was never recorded. This covers the two residual cases the issue #115 completion-marker fix cannot:

1. Cassettes poisoned **before** the marker fix landed (already in canonical).
2. The `try/except`-swallowed chain-closer case — the cell ran cleanly, a marker was written, and the merge admitted the partial chain. The marker logic structurally cannot catch this.

## Command

```
clm cassette doctor [SPEC-FILE] [--fix] [--min-text-len N] [--json]
```

- Walks every `*.http-cassette.yaml` under the specs source tree (course root, resolved as `clm build` does), or the current directory when `SPEC-FILE` is omitted.
- Extracts chat-completion content: `choices[].message.content` (non-streaming JSON) and accumulated `delta.content` (streaming SSE).
- Content `>= --min-text-len` (default `50`) is a chain-edge candidate; if no other request body embeds it as a substring, it is flagged.
- Reports per cassette (URI, request-body fingerprint, response excerpt); `--json` for machine-readable output.
- `--fix` rewrites cassettes without the orphan entries via the existing `_atomic_write_text` helper so the next build re-records. Diagnostic-only by default.

## Design notes / scope

- Detection is a deliberate **substring match** — fuzzy/LLM matching and `--fix` correctness guarantees are explicitly out of scope per the issue.
- Cassettes that fail to load are reported as skipped and never rewritten.
- Pure logic lives in `src/clm/workers/notebook/cassette_doctor.py` (attrs dataclasses, no Click); the thin CLI shell is `src/clm/cli/commands/cassette.py`, registered as a new `cassette` group in `main.py`.
- Reused: vcr `FilesystemPersister.load_cassette` + `vcr_serialize`, the existing atomic-write helper, and the `*.http-cassette.yaml` glob convention from `scripts/strip_cassette_hosts.py`.

## Tests

`tests/workers/notebook/test_cassette_doctor.py` (14 tests): non-streaming + streaming extraction, complete-chain → no orphan, orphan-opener flagged, `--min-text-len` boundary, `--fix` removes only the orphan (preserving a complete sibling chain), default does not rewrite, unreadable cassette skipped, glob excludes `.staging-*`/`.partial-*` siblings, and the `--json` report shape via `CliRunner`.

Full `tests/cli` + `tests/workers/notebook/test_http_replay_cassette.py` suites green (1195 passed); pre-commit (ruff/mypy/fast pytest) green.

## Docs

- `src/clm/cli/info_topics/commands.md`: new `clm cassette` section.
- `CHANGELOG.md`: Unreleased → Added.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@