### PR TITLE
fix(build): exit non-zero on job timeout + resilient log rotation; instrument notebook hang (refs #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `## Workshop (Continued)` inside an already-open scope are not flagged.
   Runs in `--quick` mode as well.
 
+- **Per-cell timing instrumentation in the notebook worker (issue #143).**
+  `TrackingExecutePreprocessor` now logs a `cell N/total begin` line before
+  and a `cell N/total done in Xs` line after every cell at DEBUG, plus an
+  INFO `slow cell` line for cells slower than
+  `CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS` (default 60s). When a build later
+  times out, the last `begin` line with no matching `done` line pinpoints
+  the stuck cell. New opt-in `CLM_CELL_TIMEOUT_SECONDS` env var sets
+  nbclient's per-cell `timeout` so a hung cell raises a normal cell error
+  instead of blocking the whole build until the job timeout fires (the
+  build worker previously always ran cells with `timeout=None`, unlike a
+  direct `jupyter execute --timeout=120`).
+
 ### Changed
 
 - **`clm recordings check` is now backend-aware** (issue #33). The command
@@ -110,6 +122,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   byte-equivalence gate (and an extra trailing newline in the `.py`/`.html`).
   The field carries no semantic meaning for executed `.ipynb`/HTML output and
   source files are untouched — only build output is normalized.
+- **`clm build` now exits non-zero when worker jobs time out (issue #143,
+  sub-bug A).** A build where one or more jobs do not complete within
+  `max_wait_for_completion_duration` (default 1,200s) previously could
+  print "Build completed successfully" and exit 0 even though jobs were
+  still pending and the output tree was incomplete. `wait_for_completion`
+  now records one infrastructure error per stuck job in the build summary,
+  flags the summary as timed-out, and the build exits 1 unconditionally —
+  independent of `--fail-on-error`, because a timeout means the output is
+  incomplete.
+- **Resilient log rotation on Windows (issue #143, sub-bug B).** The main
+  build log now uses `ResilientRotatingFileHandler`, which tolerates the
+  Windows "file in use by another process" (`WinError 32`) error that the
+  stock `RotatingFileHandler.doRollover()` raised when worker subprocesses
+  shared the log file. A locked rollover is now skipped (and logged once at
+  DEBUG) instead of flooding the console with a traceback per log record.
 - **`clm db vacuum` / `clm db clean` now actually reclaim disk space on the
   jobs database (issue #144).** The jobs DB runs in WAL mode, where a plain
   `VACUUM` rewrites the database into write-ahead-log pages rather than the

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -220,6 +220,15 @@ and `CLM_LLM__API_KEY` (or `OPENAI_API_KEY`) to authenticate.
 | `CLM_MAX_WORKER_STARTUP_CONCURRENCY` | Max concurrent worker starts | `10` |
 | `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` | Skip output-write deduplication for files larger than this many megabytes. Repeat writes to a large-file output are reported as a single summary collision counter rather than per-event warnings. Set to `0` to force every write through the large-file fast path (useful for tests). | `50` |
 
+### Notebook Execution Diagnostics
+
+These help diagnose builds that hang on a single notebook (see issue #143).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CLM_CELL_TIMEOUT_SECONDS` | Per-cell execution timeout (seconds) passed to nbclient. When set to a positive integer, a cell that does not return to idle within this window raises a cell timeout error (surfaced as a normal cell error) instead of blocking the worker until the build-level job timeout fires. Unset / non-positive keeps the historical no-timeout behavior. | (unset → no per-cell timeout) |
+| `CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS` | Cells slower than this are logged at INFO (`slow cell N/total took Xs`) so a stalling notebook is visible without enabling DEBUG. | `60` |
+
 ### MCP Server
 
 | Variable | Description | Default |

--- a/src/clm/cli/build_data_classes.py
+++ b/src/clm/cli/build_data_classes.py
@@ -145,6 +145,12 @@ class BuildSummary:
     output_dedup_count: int = 0
     output_conflicts: list[OutputConflictInfo] = field(default_factory=list)
     output_large_file_collision_count: int = 0
+    timed_out: bool = False
+    """True when the build aborted because one or more worker jobs did not
+    complete within ``max_wait_for_completion_duration`` (issue #143). A
+    timed-out build must always exit non-zero, independent of the
+    ``--fail-on-error`` policy, because pending jobs mean the output tree is
+    incomplete."""
 
     @property
     def successful_files(self) -> int:

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -55,6 +55,11 @@ class BuildReporter:
         # This prevents spurious errors from being displayed during worker shutdown
         self._build_finished: bool = False
 
+        # Set when a worker-job timeout aborts the build (issue #143). Carried
+        # into BuildSummary.timed_out so the entry point can force a non-zero
+        # exit independent of the --fail-on-error policy.
+        self._timed_out: bool = False
+
         # Output-write registry summary, populated by
         # :meth:`report_output_writes` shortly before ``finish_build``.
         self._output_dedup_count: int = 0
@@ -220,6 +225,15 @@ class BuildReporter:
         if self.formatter.should_show_error(error):
             self.formatter.show_error(error)
 
+    def mark_timed_out(self) -> None:
+        """Flag the build as aborted by a worker-job timeout (issue #143).
+
+        Recorded on the :class:`BuildSummary` so the entry point exits
+        non-zero even when ``--fail-on-error`` is off — a build with stuck
+        jobs produced an incomplete output tree and must not look successful.
+        """
+        self._timed_out = True
+
     def report_warning(self, warning: BuildWarning) -> None:
         """Report a warning (display if appropriate, always collect).
 
@@ -340,6 +354,7 @@ class BuildReporter:
             output_dedup_count=self._output_dedup_count,
             output_conflicts=list(self._output_conflicts),
             output_large_file_collision_count=self._output_large_file_collision_count,
+            timed_out=self._timed_out,
         )
 
         # Display summary

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -38,6 +38,7 @@ from clm.core.course_spec import (
     CourseSpecError,
     SectionSelection,
 )
+from clm.infrastructure.backend import JobsPendingTimeoutError
 from clm.infrastructure.backends.sqlite_backend import SqliteBackend
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.messaging.correlation_ids import all_correlation_ids
@@ -910,6 +911,28 @@ def _maybe_run_sweep(
         logger.debug("Stray-file sweep found no orphans")
 
 
+def _contains_jobs_pending_timeout(exc: BaseException) -> bool:
+    """Return True if ``exc`` is (or wraps) a :class:`JobsPendingTimeoutError`.
+
+    Job submission and completion polling run inside ``asyncio.TaskGroup``
+    (see :meth:`Course.process_stage_for_target`), so a timeout raised by
+    ``wait_for_completion`` reaches the build orchestration wrapped in a
+    ``BaseExceptionGroup``. This unwraps one level of grouping (recursively)
+    so the timeout is recognised regardless of nesting.
+    """
+    if isinstance(exc, JobsPendingTimeoutError):
+        return True
+    # ``BaseExceptionGroup`` is a builtin on the supported runtimes
+    # (requires-python >= 3.11) but ruff's py310 target flags the bare
+    # name, so reference it via ``builtins`` to stay lint-clean.
+    import builtins
+
+    group_type = getattr(builtins, "BaseExceptionGroup", None)
+    if group_type is not None and isinstance(exc, group_type):
+        return any(_contains_jobs_pending_timeout(sub) for sub in exc.exceptions)
+    return False
+
+
 async def process_course_with_backend(
     course: Course,
     root_dirs: list[Path],
@@ -990,29 +1013,50 @@ async def process_course_with_backend(
 
         summary: BuildSummary | None = None
         try:
-            for stage in execution_stages():
-                num_jobs = await course.count_stage_operations(stage)
-                stage_name = get_stage_name(stage)
+            try:
+                for stage in execution_stages():
+                    num_jobs = await course.count_stage_operations(stage)
+                    stage_name = get_stage_name(stage)
 
-                # Always show stage header, even if there are 0 worker jobs
-                # (there may still be cached operations or the stage may
-                # complete instantly).
-                build_reporter.start_stage(stage_name, num_jobs)
+                    # Always show stage header, even if there are 0 worker
+                    # jobs (there may still be cached operations or the
+                    # stage may complete instantly).
+                    build_reporter.start_stage(stage_name, num_jobs)
 
-                await course.process_stage(stage, backend)
+                    await course.process_stage(stage, backend)
 
-            # Dir-groups produce the final shipping state of a course.
-            # `--only-sections` is a dev-time iteration tool, so we skip
-            # dir-group processing entirely in that mode — users who need
-            # dir-groups run a full build.
-            if not only_sections_mode:
-                await course.process_dir_group(backend)
-                if has_jupyterlite_phase:
-                    build_reporter.start_stage(
-                        get_stage_name(JUPYTERLITE_STAGE),
-                        jupyterlite_job_count,
+                # Dir-groups produce the final shipping state of a course.
+                # `--only-sections` is a dev-time iteration tool, so we skip
+                # dir-group processing entirely in that mode — users who
+                # need dir-groups run a full build.
+                if not only_sections_mode:
+                    await course.process_dir_group(backend)
+                    if has_jupyterlite_phase:
+                        build_reporter.start_stage(
+                            get_stage_name(JUPYTERLITE_STAGE),
+                            jupyterlite_job_count,
+                        )
+                    await course.process_jupyterlite_for_targets(backend)
+            except BaseException as exc:  # noqa: BLE001
+                # Issue #143 (sub-bug A): a worker-job timeout means the
+                # build did not finish — jobs are still pending and the
+                # output tree is incomplete. Previously this raised a bare
+                # TimeoutError that escaped after the summary was generated,
+                # so the build could report "completed successfully" and
+                # exit 0. Mark the summary as timed-out (forces a non-zero
+                # exit independent of --fail-on-error) and swallow the
+                # timeout so the finally block can still produce a summary
+                # that lists the stuck jobs. Any other exception re-raises
+                # unchanged.
+                if _contains_jobs_pending_timeout(exc):
+                    build_reporter.mark_timed_out()
+                    logger.error(
+                        "Build aborted: one or more worker jobs did not "
+                        "complete within the per-build timeout. The output "
+                        "tree is incomplete; see the error summary."
                     )
-                await course.process_jupyterlite_for_targets(backend)
+                else:
+                    raise
 
         finally:
             # Drain the backend's OutputWriteRegistry into the summary
@@ -1905,6 +1949,19 @@ def build(
     # ``summary is None`` covers watch mode (which never drives exit
     # policy) and any early-exit path that did not reach finish_build.
     # ------------------------------------------------------------------
+    # Issue #143 (sub-bug A): a worker-job timeout always exits non-zero,
+    # independent of --fail-on-error. Pending jobs mean the output tree is
+    # incomplete, so the build must never look successful. This is checked
+    # before the --fail-on-error gate because it is unconditional.
+    if summary is not None and summary.timed_out:
+        click.echo(
+            "\nBuild failed: one or more worker jobs timed out and did "
+            "not complete. The output tree is incomplete. See the error "
+            "summary above.",
+            err=True,
+        )
+        sys.exit(1)
+
     resolved_fail_on_error = _resolve_fail_on_error(fail_on_error, resolved_http_replay_mode)
     if resolved_fail_on_error and summary is not None and len(summary.errors) > 0:
         click.echo(

--- a/src/clm/cli/commands/shared.py
+++ b/src/clm/cli/commands/shared.py
@@ -6,12 +6,12 @@ This module contains utilities used by multiple CLI command modules.
 import locale
 import logging
 import sys
-from logging.handlers import RotatingFileHandler
 
 from rich.console import Console
 from rich.logging import RichHandler
 
 from clm.infrastructure.logging.log_paths import get_main_log_path as get_log_file_path
+from clm.infrastructure.logging.resilient_handler import ResilientRotatingFileHandler
 
 # Shared console for CLI output - uses stderr to avoid mixing with JSON output
 cli_console = Console(file=sys.stderr)
@@ -47,8 +47,11 @@ def setup_logging(log_level_name: str, console_logging: bool = False):
         handler.close()
         root_logger.removeHandler(handler)
 
-    # File handler with rotation (10 MB max, keep 3 backups)
-    file_handler = RotatingFileHandler(
+    # File handler with rotation (10 MB max, keep 3 backups).
+    # ResilientRotatingFileHandler tolerates the Windows "file in use"
+    # rollover race that otherwise floods the console with WinError 32
+    # tracebacks when worker subprocesses share the log file (issue #143).
+    file_handler = ResilientRotatingFileHandler(
         log_file,
         maxBytes=10 * 1024 * 1024,  # 10 MB
         backupCount=3,

--- a/src/clm/infrastructure/backend.py
+++ b/src/clm/infrastructure/backend.py
@@ -21,6 +21,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class JobsPendingTimeoutError(TimeoutError):
+    """Raised when ``wait_for_completion`` times out with jobs still pending.
+
+    Subclasses :class:`TimeoutError` so existing callers/tests that catch
+    ``TimeoutError`` (or match on the message) keep working, while giving
+    the build orchestration a typed signal that the build did *not*
+    complete and must exit non-zero (issue #143, sub-bug A). The pending
+    job descriptors are attached so the orchestration can record one
+    infrastructure :class:`~clm.cli.build_data_classes.BuildError` per
+    stuck job in the build summary.
+    """
+
+    def __init__(self, message: str, pending_jobs: list[dict] | None = None):
+        super().__init__(message)
+        self.pending_jobs: list[dict] = pending_jobs or []
+
+
 @define
 class Backend(AbstractAsyncContextManager):
     output_write_registry: OutputWriteRegistry = field(factory=OutputWriteRegistry)

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -17,6 +17,7 @@ from clm.core.output_write_registry import (
     WriteOutcome,
     is_image_path,
 )
+from clm.infrastructure.backend import JobsPendingTimeoutError
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.database.job_queue import JobQueue
@@ -690,9 +691,12 @@ class SqliteBackend(LocalOpsBackend):
             # Check timeout
             elapsed = asyncio.get_event_loop().time() - start_time
             if elapsed > self.max_wait_for_completion_duration:
-                raise TimeoutError(
-                    f"Jobs did not complete within {self.max_wait_for_completion_duration} seconds. "
-                    f"{len(self.active_jobs)} job(s) still pending."
+                self._report_pending_jobs_timeout(elapsed)
+                raise JobsPendingTimeoutError(
+                    f"Jobs did not complete within "
+                    f"{self.max_wait_for_completion_duration} seconds. "
+                    f"{len(self.active_jobs)} job(s) still pending.",
+                    pending_jobs=list(self.active_jobs.values()),
                 )
 
             # Wait before polling again
@@ -719,6 +723,46 @@ class SqliteBackend(LocalOpsBackend):
 
         logger.info("All jobs completed successfully")
         return True
+
+    def _report_pending_jobs_timeout(self, elapsed: float) -> None:
+        """Record one infrastructure error per still-pending job on timeout.
+
+        Without this, a ``wait_for_completion`` timeout raised only a bare
+        ``TimeoutError`` and never reached the build summary, so the build
+        could report "completed successfully" and exit 0 despite stuck jobs
+        (issue #143, sub-bug A). Recording the errors here means the timeout
+        is visible in the summary and drives the non-zero exit policy.
+        """
+        if not self.build_reporter:
+            return
+
+        from clm.cli.build_data_classes import BuildError
+
+        for job_info in self.active_jobs.values():
+            input_file = str(job_info.get("input_file", "unknown"))
+            job_type = job_info.get("job_type", "unknown")
+            self.build_reporter.report_error(
+                BuildError(
+                    error_type="infrastructure",
+                    category="job_timeout",
+                    severity="error",
+                    file_path=input_file,
+                    message=(
+                        f"{job_type} job did not complete within "
+                        f"{self.max_wait_for_completion_duration:.0f}s "
+                        f"(waited {elapsed:.0f}s); the worker appears to be "
+                        f"stuck processing this file."
+                    ),
+                    actionable_guidance=(
+                        "The worker hung on this file rather than failing. "
+                        "Try running the notebook directly (e.g. via "
+                        "'jupyter execute') to confirm it completes outside "
+                        "CLM, then re-run the build. See issue #143."
+                    ),
+                    job_id=job_info.get("job_id"),
+                    correlation_id=job_info.get("correlation_id"),
+                )
+            )
 
     async def shutdown(self):
         """Shutdown the backend and perform build-end cleanup if configured."""

--- a/src/clm/infrastructure/logging/resilient_handler.py
+++ b/src/clm/infrastructure/logging/resilient_handler.py
@@ -1,0 +1,66 @@
+"""Windows-resilient rotating file log handler.
+
+On Windows a file cannot be renamed while another process holds it open.
+CLM runs the build CLI and one or more worker subprocesses, and they all
+attach a :class:`logging.handlers.RotatingFileHandler` to the *same* log
+file. When the file crosses the rollover threshold, whichever process trips
+the rollover first calls ``doRollover()``, which tries to rename
+``clm.log`` -> ``clm.log.1`` while a sibling process still has ``clm.log``
+open. On Windows that rename raises ``PermissionError: [WinError 32] The
+process cannot access the file because it is being used by another
+process``.
+
+The stock handler funnels that exception through ``logging.Handler.handleError``,
+which prints a full traceback to ``stderr`` for *every* log record emitted
+during the contended window. On a long build this floods the console and
+buries the real build output (issue #143, sub-bug B).
+
+:class:`ResilientRotatingFileHandler` swallows the rollover failure: if the
+rename cannot happen because the file is locked, it simply keeps writing to
+the current file (which may grow slightly past ``maxBytes`` until a later,
+uncontended rollover succeeds). Losing a rollover is harmless; flooding the
+console is not.
+"""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+logger = logging.getLogger(__name__)
+
+
+class ResilientRotatingFileHandler(RotatingFileHandler):
+    """A :class:`RotatingFileHandler` that tolerates locked-file rollovers.
+
+    Behaves identically to the base handler except that an ``OSError``
+    (which includes Windows ``PermissionError``/``WinError 32``) raised
+    while rotating is caught and logged once at debug level rather than
+    propagated to ``handleError``. The handler reopens its stream if the
+    failed rollover closed it, so logging continues uninterrupted.
+    """
+
+    def doRollover(self) -> None:  # noqa: N802 - matches stdlib name
+        try:
+            super().doRollover()
+        except OSError as exc:
+            # The rollover could not rename the file (typically because a
+            # sibling process on Windows still holds it open). Keep using
+            # the current file rather than spamming a traceback per record.
+            #
+            # ``RotatingFileHandler.doRollover`` closes ``self.stream``
+            # before attempting the rename, so if the rename failed we may
+            # be left without an open stream. Reopen it so subsequent
+            # ``emit`` calls do not fail.
+            if self.stream is None and not self.delay:
+                try:
+                    self.stream = self._open()
+                except OSError:
+                    # If we cannot even reopen, leave the stream as None;
+                    # the next emit() will attempt to open again. Do not
+                    # raise — this path must never crash logging.
+                    self.stream = None
+            logger.debug(
+                "Log rollover skipped (file locked by another process): %s",
+                exc,
+            )

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import os
 import re
+import time
 import warnings
 from base64 import b64decode
 from collections.abc import Iterable
@@ -99,6 +100,33 @@ JINJA_TEMPLATES_PREFIX = os.environ.get("JINJA_TEMPLATES_PATH", "templates")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
 LOG_CELL_PROCESSING = os.environ.get("LOG_CELL_PROCESSING", "False") == "True"
 NUM_RETRIES_FOR_HTML = 6
+
+# Cells slower than this are logged at INFO so a stalling notebook is
+# visible without enabling DEBUG (issue #143). Configurable via
+# CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS for diagnosing builds with an
+# unusual I/O profile. Default 60s is well above the ~20s slowest cell
+# observed in the issue's direct jupyter-execute baseline.
+try:
+    _SLOW_CELL_LOG_THRESHOLD_SECONDS = float(
+        os.environ.get("CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS", "60")
+    )
+except ValueError:
+    _SLOW_CELL_LOG_THRESHOLD_SECONDS = 60.0
+
+# Optional per-cell execution timeout for the build worker, in seconds.
+# CLM normally runs cells with timeout=None (no per-cell limit), which
+# means a cell whose kernel never returns to idle blocks the worker
+# forever until the build-level job timeout fires (issue #143). Setting
+# CLM_CELL_TIMEOUT_SECONDS to a positive value passes that value as
+# nbclient's per-cell ``timeout`` so a stuck cell raises a
+# CellTimeoutError (surfaced as a normal cell error) instead of hanging
+# the whole build. Unset / non-positive keeps the historical no-timeout
+# behavior so existing builds are unaffected.
+try:
+    _raw_cell_timeout = float(os.environ.get("CLM_CELL_TIMEOUT_SECONDS", "0"))
+    CELL_EXECUTION_TIMEOUT: int | None = int(_raw_cell_timeout) if _raw_cell_timeout > 0 else None
+except ValueError:
+    CELL_EXECUTION_TIMEOUT = None
 
 # Mapping from CLM HTTP replay modes to vcrpy record_mode values.
 # "disabled" is intentionally absent — in that mode the bootstrap cell
@@ -862,8 +890,50 @@ class TrackingExecutePreprocessor(ExecutePreprocessor):
                 cell_index=cell_index,
                 total_cells=self._total_cells,
             )
-        # Execute the cell - on success, clear context; on error, preserve it
-        result = super().preprocess_cell(cell, resources, cell_index)
+        # Per-cell timing instrumentation (issue #143). The build worker
+        # runs cells with timeout=None, so a cell whose kernel never returns
+        # to idle (e.g. a burst of concurrent HTTP requests or a stalled
+        # iopub drain) blocks here forever until the build-level job timeout
+        # fires. Logging the start before and the elapsed time after every
+        # cell means the build log pinpoints exactly which cell stalled —
+        # the last "begin" line with no matching "done" line is the culprit.
+        cid = getattr(self.processor, "_current_cid", None) or "?"
+        total = self._total_cells if self._total_cells is not None else "?"
+        cell_started = time.monotonic()
+        logger.debug(
+            "%s: cell %s/%s begin (%s)",
+            cid,
+            cell_index,
+            total,
+            cell.get("cell_type", "code"),
+        )
+        try:
+            # Execute the cell - on success, clear context; on error, preserve it
+            result = super().preprocess_cell(cell, resources, cell_index)
+        finally:
+            elapsed = time.monotonic() - cell_started
+            logger.debug(
+                "%s: cell %s/%s done in %.2fs",
+                cid,
+                cell_index,
+                total,
+                elapsed,
+            )
+            # Surface slow cells at INFO so they show up without DEBUG. A
+            # cell that runs much longer than the direct-jupyter-execute
+            # baseline (~20s for the slowest cell in issue #143) is a strong
+            # signal for where a stall begins.
+            if elapsed >= _SLOW_CELL_LOG_THRESHOLD_SECONDS:
+                logger.info(
+                    "%s: slow cell %s/%s took %.1fs (threshold %.0fs) — "
+                    "if the build later times out, inspect this cell's I/O "
+                    "profile (issue #143)",
+                    cid,
+                    cell_index,
+                    total,
+                    elapsed,
+                    _SLOW_CELL_LOG_THRESHOLD_SECONDS,
+                )
         # Only clear on success - preserve context for error reporting
         self.processor._current_cell = None
         return result
@@ -929,6 +999,9 @@ class NotebookProcessor:
         self._warnings: list[ProcessingWarning] = []
         # Track the currently executing cell for accurate error reporting
         self._current_cell: CellContext | None = None
+        # Correlation id of the notebook currently being executed, used by
+        # the TrackingExecutePreprocessor's per-cell timing logs (issue #143).
+        self._current_cid: str | None = None
         # Author/organization for Jinja templates (set from payload in process_notebook)
         self._author: str = "Dr. Matthias Hölzl"
         self._organization: str = ""
@@ -1619,9 +1692,18 @@ class NotebookProcessor:
             # Create FRESH TrackingExecutePreprocessor for each attempt
             # This ensures no stale ZMQ state from previous failures
             # TrackingExecutePreprocessor updates _current_cell for error reporting
+            # Expose the correlation id to the preprocessor's per-cell
+            # timing logs (issue #143 instrumentation).
+            self._current_cid = cid
+            if CELL_EXECUTION_TIMEOUT is not None:
+                logger.info(
+                    "%s: per-cell execution timeout active: %ss (CLM_CELL_TIMEOUT_SECONDS)",
+                    cid,
+                    CELL_EXECUTION_TIMEOUT,
+                )
             ep = TrackingExecutePreprocessor(
                 self,
-                timeout=None,
+                timeout=CELL_EXECUTION_TIMEOUT,
                 startup_timeout=300,
                 allow_errors=payload.skip_errors,
             )

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -996,8 +996,15 @@ class TestBuildCliWrapper:
 
         monkeypatch.setattr(build_module, "git_dir_mover", fake_mover)
 
-        # BuildReporter: trivial stub.
-        monkeypatch.setattr(build_module, "BuildReporter", lambda formatter: MagicMock())
+        # BuildReporter: trivial stub. finish_build must return a real
+        # BuildSummary (not a MagicMock) so the entry-point exit policy —
+        # which now reads summary.timed_out (issue #143) — sees concrete
+        # falsey values rather than a truthy mock attribute.
+        _stub_reporter = MagicMock()
+        _stub_reporter.finish_build.return_value = BuildSummary(
+            duration=0.0, total_files=0, errors=[], warnings=[]
+        )
+        monkeypatch.setattr(build_module, "BuildReporter", lambda formatter: _stub_reporter)
 
         # Avoid real execution stages (already mocked on fake_course).
         monkeypatch.setattr(
@@ -1044,6 +1051,7 @@ def _setup_mocked_build_pipeline(
     monkeypatch: pytest.MonkeyPatch,
     *,
     summary_errors: list[BuildError] | None = None,
+    summary_timed_out: bool = False,
 ) -> tuple[Path, MagicMock]:
     """Stub every heavy dep so ``main_build`` runs end-to-end with no
     real workers, kernels, or IO. The fake ``BuildReporter`` returns a
@@ -1145,6 +1153,7 @@ def _setup_mocked_build_pipeline(
         total_files=0,
         errors=list(summary_errors or []),
         warnings=[],
+        timed_out=summary_timed_out,
     )
     fake_reporter = MagicMock()
     fake_reporter.errors = list(summary_errors or [])
@@ -1334,6 +1343,59 @@ class TestBuildExitCodeOnCellErrors:
         assert result.exit_code == 1, (
             "Expected exit 1 when --fail-on-error overrides "
             f"CLM_FAIL_ON_ERROR=0; got {result.exit_code}. "
+            f"exception={result.exception!r}\noutput:\n{result.output}"
+        )
+
+
+class TestBuildExitCodeOnJobTimeout:
+    """Issue #143 (sub-bug A): a worker-job timeout must exit non-zero.
+
+    Distinct from issue #90 (cell errors): a timeout with pending jobs is
+    an infrastructure failure and must fail the build *unconditionally* —
+    independent of the ``--fail-on-error`` policy — because the output tree
+    is incomplete.
+    """
+
+    def test_build_exits_nonzero_when_summary_timed_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec, _ = _setup_mocked_build_pipeline(tmp_path, monkeypatch, summary_timed_out=True)
+
+        result = _invoke_build(["--http-replay=new-episodes", str(spec)], tmp_path=tmp_path)
+
+        assert result.exit_code == 1, (
+            "Expected exit 1 when the build summary is flagged timed_out; "
+            f"got {result.exit_code}. exception={result.exception!r}\n"
+            f"output:\n{result.output}"
+        )
+
+    def test_timeout_overrides_no_fail_on_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--no-fail-on-error`` does NOT suppress a job-timeout failure."""
+        spec, _ = _setup_mocked_build_pipeline(tmp_path, monkeypatch, summary_timed_out=True)
+
+        result = _invoke_build(
+            ["--http-replay=new-episodes", "--no-fail-on-error", str(spec)],
+            tmp_path=tmp_path,
+        )
+
+        assert result.exit_code == 1, (
+            "A job timeout must fail the build even with --no-fail-on-error; "
+            f"got {result.exit_code}. exception={result.exception!r}\n"
+            f"output:\n{result.output}"
+        )
+
+    def test_no_timeout_no_errors_still_exits_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sanity: a clean, non-timed-out build still exits 0."""
+        spec, _ = _setup_mocked_build_pipeline(tmp_path, monkeypatch, summary_timed_out=False)
+
+        result = _invoke_build(["--http-replay=new-episodes", str(spec)], tmp_path=tmp_path)
+
+        assert result.exit_code == 0, (
+            f"Expected exit 0 on a clean build; got {result.exit_code}. "
             f"exception={result.exception!r}\noutput:\n{result.output}"
         )
 

--- a/tests/infrastructure/backends/test_sqlite_backend.py
+++ b/tests/infrastructure/backends/test_sqlite_backend.py
@@ -340,11 +340,56 @@ async def test_wait_for_completion_timeout(temp_db, temp_workspace):
         payload = MockPayload()
         await backend.execute_operation(operation, payload)
 
-        # Should timeout
-        with pytest.raises(TimeoutError, match="did not complete within"):
+        # Should timeout. The typed JobsPendingTimeoutError subclasses
+        # TimeoutError, so this assertion keeps matching while the build
+        # orchestration can detect the typed variant (issue #143).
+        from clm.infrastructure.backend import JobsPendingTimeoutError
+
+        with pytest.raises(JobsPendingTimeoutError, match="did not complete within") as excinfo:
             await backend.wait_for_completion()
+        # Pending jobs are attached so the orchestration can record one
+        # infrastructure error per stuck job.
+        assert len(excinfo.value.pending_jobs) == 1
     finally:
         backend.active_jobs.clear()  # Avoid 5s shutdown timeout waiting for unprocessed jobs
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_timeout_reports_build_errors(temp_db, temp_workspace):
+    """Issue #143 (sub-bug A): a pending-job timeout records one
+    infrastructure BuildError per stuck job on the build reporter, so the
+    timeout reaches the build summary instead of silently exiting 0."""
+    from unittest.mock import MagicMock
+
+    from clm.infrastructure.backend import JobsPendingTimeoutError
+
+    reporter = MagicMock()
+    backend = SqliteBackend(
+        db_path=temp_db,
+        workspace_path=temp_workspace,
+        max_wait_for_completion_duration=0.5,
+        skip_worker_check=True,
+        build_reporter=reporter,
+        enable_progress_tracking=False,
+    )
+
+    try:
+        operation = MockOperation(service_name_value="notebook-processor")
+        payload = MockPayload()
+        await backend.execute_operation(operation, payload)
+
+        with pytest.raises(JobsPendingTimeoutError):
+            await backend.wait_for_completion()
+
+        # Exactly one error reported, with the job-timeout signature.
+        assert reporter.report_error.call_count == 1
+        reported = reporter.report_error.call_args[0][0]
+        assert reported.category == "job_timeout"
+        assert reported.error_type == "infrastructure"
+        assert reported.severity == "error"
+    finally:
+        backend.active_jobs.clear()
         await backend.shutdown()
 
 

--- a/tests/infrastructure/logging/test_resilient_handler.py
+++ b/tests/infrastructure/logging/test_resilient_handler.py
@@ -1,0 +1,103 @@
+"""Tests for the Windows-resilient rotating file handler (issue #143, sub-bug B)."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from clm.infrastructure.logging.resilient_handler import ResilientRotatingFileHandler
+
+
+@pytest.fixture
+def log_file(tmp_path):
+    return tmp_path / "clm.log"
+
+
+def test_rollover_permission_error_is_swallowed(log_file):
+    """A locked-file rollover (Windows WinError 32) must not raise.
+
+    The stock RotatingFileHandler funnels the PermissionError through
+    handleError, which prints a traceback per record. The resilient handler
+    swallows it and keeps writing to the current file.
+    """
+    handler = ResilientRotatingFileHandler(log_file, maxBytes=1, backupCount=1, encoding="utf-8")
+    try:
+        # Force the parent's doRollover to raise the Windows lock error.
+        with patch(
+            "logging.handlers.RotatingFileHandler.doRollover",
+            side_effect=PermissionError(32, "in use by another process"),
+        ):
+            # Must not raise.
+            handler.doRollover()
+
+        # The stream is reopened so subsequent writes still work.
+        record = logging.LogRecord(
+            name="t",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="after-failed-rollover",
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+        handler.flush()
+    finally:
+        handler.close()
+
+    assert "after-failed-rollover" in log_file.read_text(encoding="utf-8")
+
+
+def test_emit_does_not_raise_when_rollover_locked(log_file):
+    """End-to-end: emitting records that trigger a locked rollover never
+    propagates an error out of the logging machinery."""
+    handler = ResilientRotatingFileHandler(log_file, maxBytes=1, backupCount=1, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    raised: list[BaseException] = []
+    handler.handleError = lambda record: raised.append(  # type: ignore[method-assign]
+        record  # pragma: no cover - should not be called
+    )
+    try:
+        with patch(
+            "logging.handlers.RotatingFileHandler.doRollover",
+            side_effect=PermissionError(32, "in use by another process"),
+        ):
+            for i in range(5):
+                record = logging.LogRecord(
+                    name="t",
+                    level=logging.INFO,
+                    pathname=__file__,
+                    lineno=1,
+                    msg=f"line-{i}",
+                    args=(),
+                    exc_info=None,
+                )
+                handler.emit(record)
+    finally:
+        handler.close()
+
+    assert raised == [], "handleError should never fire on a locked rollover"
+
+
+def test_successful_rollover_still_rotates(log_file):
+    """When the file is not locked, rollover behaves like the stock handler."""
+    handler = ResilientRotatingFileHandler(log_file, maxBytes=1, backupCount=1, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    try:
+        for i in range(3):
+            record = logging.LogRecord(
+                name="t",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg=f"x{i}",
+                args=(),
+                exc_info=None,
+            )
+            handler.emit(record)
+    finally:
+        handler.close()
+
+    # A backup file should have been created by the real rollover.
+    backup = log_file.with_name(log_file.name + ".1")
+    assert backup.exists()

--- a/tests/workers/notebook/test_worker_heartbeat_integration.py
+++ b/tests/workers/notebook/test_worker_heartbeat_integration.py
@@ -16,6 +16,7 @@ Two layers of tests live here:
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import uuid
 from pathlib import Path
@@ -205,6 +206,75 @@ class TestTrackingPreprocessorHeartbeatWiring:
             TrackingExecutePreprocessor.__mro__[1].preprocess = original
 
         assert prep._total_cells == 4
+
+
+class TestPerCellTimingInstrumentation:
+    """Issue #143: per-cell timing logs around ``preprocess_cell`` so a
+    stalling notebook is pinpointable in the build log."""
+
+    def _run_cell(self, processor, *, cell_index=0, total=3):
+        prep = TrackingExecutePreprocessor(processor, timeout=None)
+        prep._total_cells = total
+        processor._current_cid = "cid-143"
+        cell = {"cell_type": "code", "source": "1", "metadata": {}}
+        original = TrackingExecutePreprocessor.__mro__[1].preprocess_cell
+        try:
+            TrackingExecutePreprocessor.__mro__[1].preprocess_cell = (
+                lambda self, cell, resources, cell_index: (cell, resources)
+            )
+            prep.preprocess_cell(cell, {}, cell_index=cell_index)
+        finally:
+            TrackingExecutePreprocessor.__mro__[1].preprocess_cell = original
+
+    def test_emits_begin_and_done_debug_logs(
+        self, db_path: Path, processor: NotebookProcessor, caplog
+    ) -> None:
+        with caplog.at_level(logging.DEBUG, logger="clm.workers.notebook.notebook_processor"):
+            self._run_cell(processor, cell_index=7, total=12)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("cell 7/12 begin" in m for m in messages), messages
+        assert any("cell 7/12 done in" in m for m in messages), messages
+        # Correlation id is threaded through.
+        assert any("cid-143" in m for m in messages), messages
+
+    def test_slow_cell_logged_at_info(
+        self, db_path: Path, processor: NotebookProcessor, monkeypatch, caplog
+    ) -> None:
+        import clm.workers.notebook.notebook_processor as npmod
+
+        # Threshold of 0 forces the slow-cell INFO line for any cell.
+        monkeypatch.setattr(npmod, "_SLOW_CELL_LOG_THRESHOLD_SECONDS", 0.0)
+        with caplog.at_level(logging.INFO, logger="clm.workers.notebook.notebook_processor"):
+            self._run_cell(processor)
+
+        assert any("slow cell" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+
+def test_cell_execution_timeout_env_parsing(monkeypatch) -> None:
+    """``CLM_CELL_TIMEOUT_SECONDS`` controls the opt-in per-cell timeout.
+
+    Re-imports the module so the module-level constant is re-evaluated with
+    the env var set, confirming the wiring (default None, positive int when
+    set, None when invalid)."""
+    import importlib
+
+    import clm.workers.notebook.notebook_processor as npmod
+
+    monkeypatch.setenv("CLM_CELL_TIMEOUT_SECONDS", "120")
+    reloaded = importlib.reload(npmod)
+    try:
+        assert reloaded.CELL_EXECUTION_TIMEOUT == 120
+
+        monkeypatch.delenv("CLM_CELL_TIMEOUT_SECONDS", raising=False)
+        reloaded = importlib.reload(npmod)
+        assert reloaded.CELL_EXECUTION_TIMEOUT is None
+    finally:
+        # Restore a clean module state for sibling tests.
+        monkeypatch.delenv("CLM_CELL_TIMEOUT_SECONDS", raising=False)
+        importlib.reload(npmod)
 
 
 # -- integration: full notebook through real worker pipeline -----------------


### PR DESCRIPTION
## Summary

Investigation of issue #143 (`clm build` hangs indefinitely on `slides_030_chains_parallel` at Stage 3 HTML Speaker). This PR **fixes the two clearly-fixable sub-bugs with tests** and **adds diagnostic instrumentation** for the main hang. It does **not** claim to fix the root-cause hang itself, so this is **`Refs #143`**, not `Closes #143` — see "Main hang: findings" below.

## What this PR does

### Sub-bug A — build exited 0 despite stuck jobs (fixed)
A build where one or more jobs do not complete within `max_wait_for_completion_duration` (default 1,200s) could report "Build completed successfully" and exit 0 while jobs were still pending and the output tree was incomplete.

- `SqliteBackend.wait_for_completion` now raises a typed `JobsPendingTimeoutError` (subclass of `TimeoutError`, so existing catchers/`match=` still work), carrying the pending job descriptors.
- On timeout it records **one infrastructure `BuildError` per stuck job** (`category="job_timeout"`) on the build reporter, so the timeout reaches `BuildSummary.errors`.
- `_run_stages` catches the timeout (unwrapping the `TaskGroup` `BaseExceptionGroup`), flags `BuildSummary.timed_out`, and lets `finish_build()` still produce a summary.
- The Click entry point exits `1` **unconditionally** when `summary.timed_out` — independent of `--fail-on-error` — because a timeout means the output is incomplete. (This is a different path from issue #90 / PR #93, which only handled *cell errors*.)

### Sub-bug B — `PermissionError [WinError 32]` rollover spam (fixed)
New `ResilientRotatingFileHandler` (`src/clm/infrastructure/logging/resilient_handler.py`) wraps `doRollover()`: a locked-file rollover (Windows, file held open by a sibling process) is skipped and logged once at DEBUG, with the stream reopened if needed — instead of funneling a traceback through `handleError` per log record. Wired into `setup_logging`.

### Main hang — diagnostic instrumentation (not a fix)
- `TrackingExecutePreprocessor.preprocess_cell` now logs `cell N/total begin` and `cell N/total done in Xs` at DEBUG, plus an INFO `slow cell` line above `CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS` (default 60s). On a future hang, the last `begin` line with no matching `done` line pinpoints the stuck cell.
- New opt-in `CLM_CELL_TIMEOUT_SECONDS` sets nbclient's per-cell `timeout`. **The build worker has always run cells with `timeout=None`** (`notebook_processor.py`), unlike the issue's working `jupyter execute --timeout=120` — so a cell that never returns to idle blocks the worker forever until the job timeout fires. Setting this env var converts a hang into a normal cell error.

## Main hang: findings + what the maintainer needs

**Most probable block site (file:line evidence):**
- `src/clm/workers/notebook/notebook_processor.py` `_execute_notebook_with_path` constructed `TrackingExecutePreprocessor(..., timeout=None, ...)`. Execution runs synchronously via `loop.run_in_executor(None, ep.preprocess)`. With `timeout=None`, nbclient blocks indefinitely waiting for the kernel to return to idle. If the kernel never publishes the completion/idle message for a cell (e.g. a `RunnableParallel`/`pipeline.batch` burst that stalls the worker's iopub/HTTP transport in a way `jupyter execute` does not), `preprocess` never returns. The worker's own per-job timeout in `worker_base.py` is checked **after** `process_job()` returns (line ~678), so a synchronous hang inside `process_job` is never enforced — only the backend's 1,200s `wait_for_completion` eventually trips.

**Key diff vs. direct `jupyter execute`:** the worker used `timeout=None`; the issue's clean repro used `--timeout=120`. This is the single most important behavioral difference and is now both instrumented (per-cell timing) and configurable (`CLM_CELL_TIMEOUT_SECONDS`).

**What I could not do:** reproduce the full hang. It requires the consuming PythonCourses ML-AZAV repo + its live model environment + the specific `RunnableParallel`/`batch` slide; the stall does not reproduce from a synthetic burst in CLM's own test env. 

**To close #143, the maintainer should:** run the failing course build with `--log-level DEBUG` (and optionally `CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS=10`) and capture which cell logs `begin` without `done`; then re-run with `CLM_CELL_TIMEOUT_SECONDS=120` to confirm the hang converts to a cell-timeout error on that cell. That pinpoints whether the block is in cell execution (iopub drain / HTTP transport under concurrency) vs. elsewhere, and tells us whether a permanent default per-cell timeout in the worker is the right fix.

## Tests
- `tests/infrastructure/backends/test_sqlite_backend.py`: typed `JobsPendingTimeoutError` + pending-jobs payload; per-job `BuildError` reporting on timeout.
- `tests/cli/test_build_command.py::TestBuildExitCodeOnJobTimeout`: timed-out summary → exit 1, overrides `--no-fail-on-error`, clean build still exits 0.
- `tests/infrastructure/logging/test_resilient_handler.py`: locked rollover swallowed, no `handleError`, normal rollover still rotates.
- `tests/workers/notebook/test_worker_heartbeat_integration.py`: per-cell begin/done + slow-cell logs; `CLM_CELL_TIMEOUT_SECONDS` parsing.

Full fast suite green (5591 passed, 1 skipped, 1 xfailed). `ruff` + `mypy` clean.

## Left undone
- The root-cause hang itself (needs the consuming repo + live environment, per above).
- No permanent default per-cell timeout is set — kept opt-in to avoid changing execution semantics for all builds until the maintainer confirms the block site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
