### PR TITLE
fix(http-replay): close leaked httpcore connection in vcrpy stub (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **HTTP-replay builds no longer deadlock on a `.batch()` cell
+  ([#143](https://github.com/hoelzl/clm/issues/143)).** vcrpy 8.1.x's httpcore
+  stub reads the response body and swaps `response.stream` for a buffered
+  `ByteStream` but never `close()`s the original httpcore `Response`, so every
+  recorded request leaked one pooled connection. A LangChain `.batch()` /
+  `RunnableParallel` burst then exhausted httpcore's connection pool and the
+  worker threads blocked forever in `wait_for_connection`, hanging the Stage-3
+  HTML build until the build-level job timeout fired (and, before
+  [#157](https://github.com/hoelzl/clm/issues/157), doing so silently). The
+  HTTP-replay bootstrap now reinstalls vcrpy's sync and async httpcore stubs
+  with an explicit `close()`/`aclose()` before the stream swap, returning the
+  connection to the pool; the recorded bytes are unchanged, so cassettes stay
+  byte-identical. As a defense-in-depth safety net, replay-engaged jobs now also
+  default a generous per-cell timeout (`CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS`,
+  default `600`s; set `0` to opt out, `CLM_CELL_TIMEOUT_SECONDS` overrides) so
+  any *future* replay-layer hang fails as a clean cell timeout instead of
+  stalling to the job timeout. The strategic follow-up — replacing in-process
+  vcrpy with an out-of-process transport — is tracked in
+  [#165](https://github.com/hoelzl/clm/issues/165).
 - **Split and bilingual builds now produce byte-equivalent output
   ([#133](https://github.com/hoelzl/clm/issues/133)).** The notebook
   processor strips jupytext's `lines_to_next_cell` cell metadata from build

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -226,7 +226,8 @@ These help diagnose builds that hang on a single notebook (see issue #143).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CLM_CELL_TIMEOUT_SECONDS` | Per-cell execution timeout (seconds) passed to nbclient. When set to a positive integer, a cell that does not return to idle within this window raises a cell timeout error (surfaced as a normal cell error) instead of blocking the worker until the build-level job timeout fires. Unset / non-positive keeps the historical no-timeout behavior. | (unset → no per-cell timeout) |
+| `CLM_CELL_TIMEOUT_SECONDS` | Per-cell execution timeout (seconds) passed to nbclient. When set to a positive integer, a cell that does not return to idle within this window raises a cell timeout error (surfaced as a normal cell error) instead of blocking the worker until the build-level job timeout fires. Always takes precedence over the replay-mode default below. Unset / non-positive keeps the historical no-timeout behavior for non-replay builds. | (unset → no per-cell timeout, except replay builds — see next row) |
+| `CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS` | Default per-cell timeout (seconds) applied **only to HTTP-replay-engaged jobs** (any `--http-replay` mode but `disabled`), so a replay-layer hang surfaces as a clean cell timeout instead of stalling to the build-level job timeout (issue #143). Real cells in replay decks finish in seconds, so only a genuine hang reaches this ceiling. `CLM_CELL_TIMEOUT_SECONDS` overrides it; set to `0` to opt out. | `600` |
 | `CLM_SLOW_CELL_LOG_THRESHOLD_SECONDS` | Cells slower than this are logged at INFO (`slow cell N/total took Xs`) so a stalling notebook is visible without enabling DEBUG. | `60` |
 
 ### MCP Server

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2114,6 +2114,7 @@ Create and manage ZIP archives of course output.
 | `CLM_MAX_WORKERS` | Cap effective worker count per build invocation (empty/zero/negative = no cap) |
 | `CLM_HTTP_REPLAY_MODE` | Default HTTP replay record mode for `clm build` (one of `replay`, `once`, `new-episodes`, `refresh`, `disabled`). Overridden by `--http-replay`. Defaults to `replay` when `CI=true`, else `new-episodes`. |
 | `CLM_HTTP_REPLAY_IGNORE_HOSTS` | Comma-separated list of request hosts that vcrpy should let pass through to the real network instead of recording into the cassette. Defaults to `api.smith.langchain.com` (LangSmith telemetry). Set to an empty string to disable the default. |
+| `CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS` | Default per-cell execution timeout (seconds) applied to HTTP-replay-engaged jobs only (any `--http-replay` mode but `disabled`), so a replay-layer hang fails as a clean cell timeout instead of stalling to the build-level job timeout (issue #143). `CLM_CELL_TIMEOUT_SECONDS` overrides it; set to `0` to opt out. Default `600`. |
 | `CLM_HTTP_REPLAY_TRACE` | Set to `1` to enable the forensic trace harness for HTTP-replay diagnostics. Off by default; writes per-invocation trace bundles under `$CLM_HTTP_REPLAY_TRACE_DIR`. See `docs/claude/design/http-replay-trace.md`. |
 | `CLM_HTTP_REPLAY_TRACE_DIR` | Root directory for trace bundles when `CLM_HTTP_REPLAY_TRACE=1`. Defaults to `./clm-http-replay-traces`. |
 | `CLM_HTTP_REPLAY_TRACE_VERBOSE` | When tracing is on, include extra per-event detail (default off). Accepts `1`/`true`/`yes`. |

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -128,6 +128,40 @@ try:
 except ValueError:
     CELL_EXECUTION_TIMEOUT = None
 
+# Defense-in-depth (issue #143): when HTTP replay is engaged, the kernel runs the
+# vcrpy bootstrap, which historically could deadlock a cell silently until the
+# build-level job timeout fired. The root-cause leak is fixed in the bootstrap,
+# but to keep any *future* replay-layer hang from stalling a whole build we default
+# a generous per-cell timeout for replay-engaged jobs only. Real cells in the
+# LLM/RAG decks that use replay finish in seconds, so only a genuine hang reaches
+# this ceiling. An explicit CLM_CELL_TIMEOUT_SECONDS always wins; set
+# CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS=0 to opt out of the default.
+try:
+    _raw_replay_cell_timeout = float(os.environ.get("CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS", "600"))
+    _HTTP_REPLAY_DEFAULT_CELL_TIMEOUT: int | None = (
+        int(_raw_replay_cell_timeout) if _raw_replay_cell_timeout > 0 else None
+    )
+except ValueError:
+    _HTTP_REPLAY_DEFAULT_CELL_TIMEOUT = 600
+
+
+def _effective_cell_timeout(payload: "NotebookPayload") -> int | None:
+    """Resolve the per-cell nbclient timeout for a single notebook job.
+
+    An explicit ``CLM_CELL_TIMEOUT_SECONDS`` always wins. Otherwise, when HTTP
+    replay is engaged for this job (any mode but ``disabled``), fall back to the
+    generous replay default so a replay-layer hang surfaces as a clean
+    ``CellTimeoutError`` instead of stalling to the build-level job timeout
+    (issue #143). Non-replay builds keep the historical no-timeout behavior.
+    """
+    if CELL_EXECUTION_TIMEOUT is not None:
+        return CELL_EXECUTION_TIMEOUT
+    mode = getattr(payload, "http_replay_mode", None)
+    if mode and mode != "disabled":
+        return _HTTP_REPLAY_DEFAULT_CELL_TIMEOUT
+    return None
+
+
 # Mapping from CLM HTTP replay modes to vcrpy record_mode values.
 # "disabled" is intentionally absent — in that mode the bootstrap cell
 # is not injected at all.
@@ -380,6 +414,51 @@ def _clm_eager_append(request, response):
 _clm_cassette.append = _clm_eager_append
 # Belt-and-suspenders: graceful kernel shutdown still flushes via ``__exit__``.
 _clm_atexit.register(_clm_ctx.__exit__, None, None, None)
+
+# --- CLM fix for issue #143: vcrpy httpcore connection-pool leak ---
+# vcrpy 8.1.x's httpcore stubs read the response body and swap ``.stream`` for a
+# buffered ByteStream but never ``close()`` the original httpcore ``Response``, so
+# the pooled connection is never returned. httpx later closes vcrpy's *replacement*
+# ByteStream (a no-op), not the original, so every recorded request leaks one
+# pooled connection. A langchain ``.batch()`` burst then exhausts the pool and the
+# worker threads block forever in ``httpcore.connection_pool.wait_for_connection``
+# (the silent Stage-3 deadlock). Reinstall the two stub functions with an explicit
+# close before the stream swap. vcrpy's installed wrappers resolve these names from
+# the ``httpcore_stubs`` module globals at call time, so reassigning them here takes
+# effect even though the cassette is already entered.
+import vcr.stubs.httpcore_stubs as _clm_hcs
+def _clm_vcr_handle_request(cassette, real_handle_request, self, real_request):
+    real_request_body = b"".join(real_request.stream)
+    real_request.stream = _clm_hcs.ByteStream(real_request_body)
+    vcr_request, vcr_response = _clm_hcs._vcr_request(cassette, real_request, real_request_body)
+    if vcr_response:
+        return vcr_response
+    real_response = real_handle_request(self, real_request)
+    real_response_content = b"".join(real_response.stream)
+    try:
+        real_response.close()
+    except Exception:
+        pass
+    real_response.stream = _clm_hcs.ByteStream(real_response_content)
+    _clm_hcs._record_responses(cassette, vcr_request, real_response, real_response_content)
+    return real_response
+_clm_hcs._vcr_handle_request = _clm_vcr_handle_request
+async def _clm_vcr_handle_async_request(cassette, real_handle_async_request, self, real_request):
+    real_request_body = b"".join([_p async for _p in real_request.stream])
+    real_request.stream = _clm_hcs.ByteStream(real_request_body)
+    vcr_request, vcr_response = _clm_hcs._vcr_request(cassette, real_request, real_request_body)
+    if vcr_response:
+        return vcr_response
+    real_response = await real_handle_async_request(self, real_request)
+    real_response_content = b"".join([_p async for _p in real_response.stream])
+    try:
+        await real_response.aclose()
+    except Exception:
+        pass
+    real_response.stream = _clm_hcs.ByteStream(real_response_content)
+    _clm_hcs._record_responses(cassette, vcr_request, real_response, real_response_content)
+    return real_response
+_clm_hcs._vcr_handle_async_request = _clm_vcr_handle_async_request
 """
 
 
@@ -1695,15 +1774,19 @@ class NotebookProcessor:
             # Expose the correlation id to the preprocessor's per-cell
             # timing logs (issue #143 instrumentation).
             self._current_cid = cid
-            if CELL_EXECUTION_TIMEOUT is not None:
+            cell_timeout = _effective_cell_timeout(payload)
+            if cell_timeout is not None:
                 logger.info(
-                    "%s: per-cell execution timeout active: %ss (CLM_CELL_TIMEOUT_SECONDS)",
+                    "%s: per-cell execution timeout active: %ss%s",
                     cid,
-                    CELL_EXECUTION_TIMEOUT,
+                    cell_timeout,
+                    ""
+                    if CELL_EXECUTION_TIMEOUT is not None
+                    else " (http-replay default; set CLM_CELL_TIMEOUT_SECONDS to override)",
                 )
             ep = TrackingExecutePreprocessor(
                 self,
-                timeout=CELL_EXECUTION_TIMEOUT,
+                timeout=cell_timeout,
                 startup_timeout=300,
                 allow_errors=payload.skip_errors,
             )

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -23,10 +23,12 @@ import pytest
 from nbformat import NotebookNode
 
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+from clm.workers.notebook import notebook_processor as notebook_processor_module
 from clm.workers.notebook.notebook_processor import (
     CellIdGenerator,
     NotebookProcessor,
     TrackingExecutePreprocessor,
+    _effective_cell_timeout,
     _normalize_jupytext_metadata_filters,
     _strip_lines_to_next_cell,
 )
@@ -4061,3 +4063,50 @@ class TestSkipEvaluation:
         MockEP.assert_not_called()
         # Notebook output is non-empty JSON.
         assert result and result.strip()
+
+
+class TestEffectiveCellTimeout:
+    """Per-cell timeout resolution (issue #143 defense-in-depth, Option F).
+
+    An explicit CLM_CELL_TIMEOUT_SECONDS always wins; otherwise replay-engaged
+    jobs get a generous default so a replay-layer hang fails as a clean
+    CellTimeoutError instead of stalling to the job timeout, while non-replay
+    builds keep the historical no-timeout behavior.
+    """
+
+    def _payload(self, mode):
+        p = make_payload("", kind="speaker", format_="html")
+        if mode is not None:
+            p = p.model_copy(update={"http_replay_mode": mode})
+        return p
+
+    def test_disabled_mode_has_no_timeout(self):
+        with patch.object(notebook_processor_module, "CELL_EXECUTION_TIMEOUT", None):
+            assert _effective_cell_timeout(self._payload("disabled")) is None
+
+    def test_no_mode_has_no_timeout(self):
+        with patch.object(notebook_processor_module, "CELL_EXECUTION_TIMEOUT", None):
+            assert _effective_cell_timeout(self._payload(None)) is None
+
+    @pytest.mark.parametrize("mode", ["once", "replay", "new-episodes", "refresh"])
+    def test_replay_modes_get_the_default(self, mode):
+        with patch.object(notebook_processor_module, "CELL_EXECUTION_TIMEOUT", None):
+            assert (
+                _effective_cell_timeout(self._payload(mode))
+                == notebook_processor_module._HTTP_REPLAY_DEFAULT_CELL_TIMEOUT
+            )
+
+    def test_explicit_env_timeout_wins_even_for_replay(self):
+        with patch.object(notebook_processor_module, "CELL_EXECUTION_TIMEOUT", 42):
+            assert _effective_cell_timeout(self._payload("once")) == 42
+
+    def test_explicit_env_timeout_applies_to_disabled_too(self):
+        with patch.object(notebook_processor_module, "CELL_EXECUTION_TIMEOUT", 42):
+            assert _effective_cell_timeout(self._payload("disabled")) == 42
+
+    def test_replay_default_can_be_opted_out(self):
+        with (
+            patch.object(notebook_processor_module, "CELL_EXECUTION_TIMEOUT", None),
+            patch.object(notebook_processor_module, "_HTTP_REPLAY_DEFAULT_CELL_TIMEOUT", None),
+        ):
+            assert _effective_cell_timeout(self._payload("once")) is None


### PR DESCRIPTION
## Summary

Fixes the cassette-mode (HTTP-replay) build hang in #143: a vcrpy connection leak that deadlocks `clm build` on a LangChain `.batch()` cell.

## Root cause

vcrpy 8.1.x's `vcr/stubs/httpcore_stubs.py` reads the response body and swaps `response.stream` for a buffered `ByteStream` but **never `close()`s the original httpcore `Response`**. httpx later closes vcrpy's *replacement* stream (a no-op), not the original, so **every recorded request leaks one pooled httpcore connection**. A `.batch()` / `RunnableParallel` burst then exhausts the pool and the worker threads block forever in `httpcore.connection_pool.wait_for_connection`, hanging the Stage-3 HTML build until the 1200 s job timeout.

`py-spy` on a frozen kernel (16-worker cassette stress repro) — every langchain `.batch()` worker thread:

```
batch                 (langchain_core/runnables/base.py:915)
send                  (httpx/_client.py:914)
_vcr_handle_request   (vcr/stubs/httpcore_stubs.py:162)
wait_for_connection   (httpcore/_sync/connection_pool.py:35)
wait                  (httpcore/_synchronization.py:290)
```

Reproduces on 1.6.0 **and** master; **only** in cassette mode (`--http-replay` ≠ `disabled`), which is why `--http-replay disabled` builds were unaffected.

## The fix

**Option A — stop the leak.** The HTTP-replay bootstrap reinstalls vcrpy's sync and async httpcore stubs with an explicit `close()` / `aclose()` before the stream swap, returning the connection to the pool. Recorded bytes are unchanged (the close runs *after* the body is buffered), so cassettes stay byte-identical.

**Option F — defense in depth.** Replay-engaged jobs now default a generous per-cell timeout via `_effective_cell_timeout()` (`CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS`, default `600`s; `0` to opt out; `CLM_CELL_TIMEOUT_SECONDS` always overrides) so any *future* replay-layer hang fails as a clean `CellTimeoutError` instead of stalling to the job timeout. Non-replay builds keep the historical no-timeout behavior.

## Validation

- Reproduced the deadlock on a 16-worker cassette stress build (all 16 jobs frozen at the same `.batch()` cell; py-spy trace above), then confirmed the patched build completes — **0 stalls, 0 errors, 344 s**.
- New unit tests for `_effective_cell_timeout` (explicit-override precedence, replay default, opt-out).
- `ruff`, `mypy`, and the fast `pytest` suite all green via pre-commit.

## Docs

`CHANGELOG.md`, `docs/user-guide/configuration.md`, and the `clm info commands` env-var table document `CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS` and the replay-mode default-timeout behavior.

## Follow-up

This connection leak is the latest in a series of vcrpy-internals workarounds in the replay bootstrap. The strategic exit — replacing in-process vcrpy with an out-of-process replay transport (mitmproxy) — is tracked separately in #165.

Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
