### PR TITLE
docs(claude): document resetting a worktree to master without bare-flipping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,13 @@ Full procedure lives in `docs/developer-guide/releasing.md`. The hard rules:
   `uv run ruff format src/ tests/`.
 - Commits that fail a hook did **not** happen — fix the issue, re-stage, and
   create a **new** commit. Never `--amend` a commit the hook rejected.
+- **Reset a worktree to master** without breaking the main checkout: from inside
+  the worktree run `git fetch origin && git switch -C <worktree-branch>
+  origin/master`. Git won't let the *same* branch be checked out in two worktrees
+  (no config changes this), so do **not** check out the literal `master` in a
+  worktree, and **never** set `core.bare=true` on the main repo to work around it
+  — that strips the main checkout's working tree and is a recurring source of
+  breakage.
 
 ## Documentation Map
 


### PR DESCRIPTION
Adds a `## Git Workflow` bullet documenting the correct, non-destructive way to put a worktree on the latest `master`.

## Why

Agents (various tools) repeatedly set `core.bare=true` on the main repo to "free up" the `master` branch so a worktree can check it out — which strips the main checkout's working tree and is a recurring source of breakage that has to be manually reverted.

## What

The correct move is a per-worktree branch at master's tip. Git deliberately forbids the *same* branch in two worktrees (no config changes this), so the literal `master` should never be checked out in a second worktree, and `core.bare` should never be flipped:

```
git fetch origin && git switch -C <worktree-branch> origin/master
```

Docs-only change (no code/tests touched; pre-commit hooks skipped accordingly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
