### PR TITLE
fix(validate): skip bilingual DE/EN pairing check on split files (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm validate` no longer false-errors on split slide files
+  ([#160](https://github.com/hoelzl/clm/issues/160)).** The bilingual DE/EN
+  `pairing` sub-checks — cell-count parity, per-pair tag/type consistency, and
+  DE/EN adjacency — are now skipped on single-language split halves
+  (`*.de.py` / `*.en.py`), detected via the same `.de`/`.en` stem logic the
+  build-time split routing uses. A `.de.py` legitimately contains only German
+  cells, so the old unconditional check reported a spurious
+  `DE/EN cell count mismatch: N German, 0 English` on every converted deck,
+  burying real findings as the language-split migration proceeds. The
+  applicable checks are unchanged: `format`, `tags`, the per-language review
+  checks, and the per-file `slide_id` integrity checks still run on split
+  files, and the cross-file shared-cell parity diff between a `.de.py` /
+  `.en.py` pair is still applied. Bilingual decks (no `.de`/`.en` suffix) are
+  unaffected — the full pairing check still runs.
 - **HTTP-replay builds no longer deadlock on a `.batch()` cell
   ([#143](https://github.com/hoelzl/clm/issues/143)).** vcrpy 8.1.x's httpcore
   stub reads the response body and swaps `response.stream` for a buffered

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -531,6 +531,17 @@ adjacency, and — since CLM {version} — **`slide_id` metadata**:
 | paired DE/EN slides carry mismatched bare `slide_id`s | `warning` | Suggested fix: `clm slides assign-ids --force`. |
 | `slide_id` is not a valid kebab-case ASCII slug (≤30 chars) | `warning` | The leading `!` preserve marker is permitted and does not count toward the length cap. |
 
+Since CLM {version}, the **bilingual** `pairing` sub-checks (DE/EN cell
+count parity, per-pair tag/type consistency, and DE/EN adjacency) are
+**skipped on single-language split files** (`*.de.py` / `*.en.py`) — a
+split half legitimately carries cells of only one language, so these
+checks would otherwise report a false `DE/EN cell count mismatch` on every
+converted deck (issue #160). The per-file `slide_id` integrity checks (and
+the `format` / `tags` groups) still run on split files unchanged, and the
+cross-file shared-cell parity diff between a `.de.py` / `.en.py` pair is
+still applied when validating a directory or course spec. Bilingual decks
+(no `.de` / `.en` suffix) are unaffected — the full pairing check still runs.
+
 Since CLM {version}, the `tags` check group also verifies **workshop
 scope** (issue #78). The `partial` output kind leaves a workshop's code
 cells empty for live code-alongs; if the workshop scope is missing, the

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -20,6 +20,7 @@ from clm.core.topic_resolver import (
     find_slide_files_recursive,
     matches_for_binding,
 )
+from clm.infrastructure.utils.path_utils import split_lang_suffix
 from clm.notebooks.slide_parser import Cell, parse_cells
 from clm.slides.pairing import (
     TITLE_SLIDE_ID,
@@ -382,84 +383,101 @@ def _check_workshop_headings(cells: list[Cell], file_path: str) -> list[Finding]
     return findings
 
 
-def _check_pairing(cells: list[Cell], file_path: str) -> list[Finding]:
-    """Check DE/EN cell pairing: count, position, and tag consistency."""
+def _check_pairing(cells: list[Cell], file_path: str, *, is_split: bool = False) -> list[Finding]:
+    """Check DE/EN cell pairing: count, position, and tag consistency.
+
+    When ``is_split`` is set the file is a single-language split half
+    (``*.de.py`` / ``*.en.py``), so the genuinely *bilingual* sub-checks —
+    DE/EN count parity, positional tag/type pairing, and DE/EN adjacency —
+    are skipped: a split file legitimately carries cells of only one
+    language, and running them would fire a false count mismatch on every
+    converted deck (issue #160). Cross-file shared-cell parity between the
+    two halves is validated separately by :func:`_check_shared_cell_parity`.
+
+    The per-file ``slide_id`` integrity checks (presence, slug format,
+    uniqueness, narrative adjacency) always run — they apply equally to a
+    single-language file and never misfire on one (no DE/EN slide groups
+    form, so the pair-consistency clause is a no-op).
+    """
     findings: list[Finding] = []
 
-    # Collect language-tagged content cells (skip j2, notes, voiceover)
-    de_cells: list[Cell] = []
-    en_cells: list[Cell] = []
+    if not is_split:
+        # Collect language-tagged content cells (skip j2, notes, voiceover)
+        de_cells: list[Cell] = []
+        en_cells: list[Cell] = []
 
-    for cell in cells:
-        meta = cell.metadata
-        if meta.is_j2 or meta.is_narrative:
-            continue
-        if meta.lang == "de":
-            de_cells.append(cell)
-        elif meta.lang == "en":
-            en_cells.append(cell)
+        for cell in cells:
+            meta = cell.metadata
+            if meta.is_j2 or meta.is_narrative:
+                continue
+            if meta.lang == "de":
+                de_cells.append(cell)
+            elif meta.lang == "en":
+                en_cells.append(cell)
 
-    # Count mismatch
-    if len(de_cells) != len(en_cells):
-        findings.append(
-            Finding(
-                severity="error",
-                category="pairing",
-                file=file_path,
-                line=1,
-                message=(
-                    f"DE/EN cell count mismatch: {len(de_cells)} German, {len(en_cells)} English"
-                ),
-                suggestion="Each German cell should have a corresponding English cell",
-            )
-        )
-
-    # Positional pairing — check tags match between pairs
-    for i, (de, en) in enumerate(zip(de_cells, en_cells, strict=False)):
-        de_tags = set(de.metadata.tags)
-        en_tags = set(en.metadata.tags)
-
-        if de_tags != en_tags:
-            findings.append(
-                Finding(
-                    severity="warning",
-                    category="pairing",
-                    file=file_path,
-                    line=de.line_number,
-                    message=(
-                        f"Tag mismatch in DE/EN pair {i + 1}: "
-                        f"DE={sorted(de_tags)}, EN={sorted(en_tags)}"
-                    ),
-                    suggestion="Paired DE/EN cells should have the same tags",
-                )
-            )
-
-        # Check cell type consistency
-        if de.metadata.cell_type != en.metadata.cell_type:
+        # Count mismatch
+        if len(de_cells) != len(en_cells):
             findings.append(
                 Finding(
                     severity="error",
                     category="pairing",
                     file=file_path,
-                    line=de.line_number,
+                    line=1,
                     message=(
-                        f"Cell type mismatch in DE/EN pair {i + 1}: "
-                        f"DE={de.metadata.cell_type}, EN={en.metadata.cell_type}"
+                        f"DE/EN cell count mismatch: "
+                        f"{len(de_cells)} German, {len(en_cells)} English"
                     ),
-                    suggestion="Paired DE/EN cells should have the same cell type",
+                    suggestion="Each German cell should have a corresponding English cell",
                 )
             )
 
-    # Adjacency check — paired DE/EN cells should not have other lang-tagged
-    # or narrative cells between them. The canonical layout produced by
-    # ``normalize-slides`` is::
-    #
-    #     [de content] [en content] [de voiceover] [en voiceover]
-    #
-    # A common violation introduced by classroom/video deck merges is
-    # ``[de slide] [de voiceover] [en slide] [en voiceover]`` — voiceover
-    # wedged between the DE and EN halves of a content pair.
-    findings.extend(_check_ordering(cells, file_path))
+        # Positional pairing — check tags match between pairs
+        for i, (de, en) in enumerate(zip(de_cells, en_cells, strict=False)):
+            de_tags = set(de.metadata.tags)
+            en_tags = set(en.metadata.tags)
+
+            if de_tags != en_tags:
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="pairing",
+                        file=file_path,
+                        line=de.line_number,
+                        message=(
+                            f"Tag mismatch in DE/EN pair {i + 1}: "
+                            f"DE={sorted(de_tags)}, EN={sorted(en_tags)}"
+                        ),
+                        suggestion="Paired DE/EN cells should have the same tags",
+                    )
+                )
+
+            # Check cell type consistency
+            if de.metadata.cell_type != en.metadata.cell_type:
+                findings.append(
+                    Finding(
+                        severity="error",
+                        category="pairing",
+                        file=file_path,
+                        line=de.line_number,
+                        message=(
+                            f"Cell type mismatch in DE/EN pair {i + 1}: "
+                            f"DE={de.metadata.cell_type}, EN={en.metadata.cell_type}"
+                        ),
+                        suggestion="Paired DE/EN cells should have the same cell type",
+                    )
+                )
+
+        # Adjacency check — paired DE/EN cells should not have other lang-tagged
+        # or narrative cells between them. The canonical layout produced by
+        # ``normalize-slides`` is::
+        #
+        #     [de content] [en content] [de voiceover] [en voiceover]
+        #
+        # A common violation introduced by classroom/video deck merges is
+        # ``[de slide] [de voiceover] [en slide] [en voiceover]`` — voiceover
+        # wedged between the DE and EN halves of a content pair.
+        findings.extend(_check_ordering(cells, file_path))
+
     findings.extend(_check_slide_ids(cells, file_path))
 
     return findings
@@ -1180,7 +1198,12 @@ def validate_file(
     if "tags" in check_set:
         findings.extend(_check_tags(cells, file_str))
     if "pairing" in check_set:
-        findings.extend(_check_pairing(cells, file_str))
+        # Split halves (``*.de.py`` / ``*.en.py``) carry a single language,
+        # so the bilingual DE/EN count/adjacency checks don't apply — see
+        # _check_pairing (issue #160). Cross-file parity is validated by the
+        # directory/course entrypoints via _check_shared_cell_parity.
+        is_split = split_lang_suffix(path) is not None
+        findings.extend(_check_pairing(cells, file_str, is_split=is_split))
 
     # Review material extraction
     review_checks = check_set & ALL_REVIEW_CHECKS

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -630,6 +630,174 @@ class TestCheckPairing:
         assert result.findings == []
 
 
+class TestSplitFilePairing:
+    """Issue #160: the bilingual DE/EN pairing checks must be suppressed on
+    single-language split halves (``*.de.py`` / ``*.en.py``), which by design
+    contain cells of only one language. Per-file slide_id integrity and the
+    format/tags checks must keep running, and bilingual files are unaffected.
+    """
+
+    def test_de_split_file_no_count_mismatch(self, tmp_path):
+        # A .de.py with only German cells must NOT trip the DE/EN count check.
+        p = _write_slide(
+            tmp_path,
+            "slides_010.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% [markdown] lang="de" tags=["subslide"] slide_id="details"
+            # ## Mehr
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert result.findings == []
+
+    def test_en_split_file_no_count_mismatch(self, tmp_path):
+        # Symmetric: a .en.py with only English cells is also clean.
+        p = _write_slide(
+            tmp_path,
+            "slides_010.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% [markdown] lang="en" tags=["subslide"] slide_id="details"
+            # ## More
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert result.findings == []
+
+    def test_split_file_still_runs_format_and_tags(self, tmp_path):
+        # The applicable checks keep firing; only the bilingual pairing
+        # checks are suppressed. A malformed tag is still an error, and there
+        # is no false count-mismatch finding.
+        p = _write_slide(
+            tmp_path,
+            "slides_020.de.py",
+            """\
+            # %% [markdown] lang="de" tags=broken
+            # ## Kaputt
+            """,
+        )
+        result = validate_file(p, checks=None)
+        assert any(
+            f.category == "format" and "Malformed tags" in f.message for f in result.findings
+        )
+        assert not any("cell count mismatch" in f.message for f in result.findings)
+
+    def test_split_file_still_checks_slide_ids(self, tmp_path):
+        # slide_id integrity is a per-file property and must keep running on
+        # a split half — a duplicate id is still a (pairing-category) error.
+        p = _write_slide(
+            tmp_path,
+            "slides_030.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="dup"
+            # ## A
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="dup"
+            # ## B
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        errors = [f for f in result.findings if f.severity == "error"]
+        assert len(errors) == 1
+        assert "duplicate slide_id" in errors[0].message
+        assert not any("cell count mismatch" in f.message for f in result.findings)
+
+    def test_bilingual_file_still_flags_count_mismatch(self, tmp_path):
+        # Control: a bilingual deck (no .de/.en suffix) is unaffected — the
+        # count check still fires.
+        p = _write_slide(
+            tmp_path,
+            "slides_040.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"]
+            # ## Titel
+
+            # %% [markdown] lang="de" tags=["subslide"]
+            # ## Extra German
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert any("cell count mismatch" in f.message for f in result.findings)
+
+    def test_directory_split_pair_no_false_count_mismatch(self, tmp_path):
+        # A topic directory holding a complete split pair validates clean: no
+        # per-file count mismatch, and the byte-identical shared cell passes
+        # the cross-file parity check.
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        _write_slide(
+            topic,
+            "slides_intro.de.py",
+            """\
+            # j2 from "macros.j2" import header_de
+            # {{ header_de("Mein Titel") }}
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        _write_slide(
+            topic,
+            "slides_intro.en.py",
+            """\
+            # j2 from "macros.j2" import header_en
+            # {{ header_en("My Title") }}
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        assert not any("cell count mismatch" in f.message for f in result.findings)
+        assert result.findings == []
+
+    def test_directory_split_pair_still_catches_divergent_shared_cell(self, tmp_path):
+        # The cross-file parity check is unchanged: a shared cell that differs
+        # between the two halves is still reported as a pairing error.
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        _write_slide(
+            topic,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        _write_slide(
+            topic,
+            "slides_intro.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% tags=["keep"]
+            x = 99
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        parity_errors = [
+            f
+            for f in result.findings
+            if f.severity == "error" and "shared cell" in f.message.lower()
+        ]
+        assert len(parity_errors) == 1
+
+
 class TestCheckOrdering:
     """DE/EN adjacency checks (canonical layout)."""
 


### PR DESCRIPTION
## Summary

Fixes #160. `clm validate` applied its bilingual DE/EN `pairing` check (cell-count parity, per-pair tag/type consistency, and DE/EN adjacency) unconditionally per file, so single-language split halves (`*.de.py` / `*.en.py`) tripped a false error:

```
[ERROR] slides_010_type_annotations.de.py:1: DE/EN cell count mismatch: 20 German, 0 English
```

A `.de.py` legitimately contains only German cells, so the bilingual check does not apply. As the language-split migration proceeds, every converted deck would trip it — noise that buries real findings.

## What changed

- **`_check_pairing`** gained an `is_split` keyword. When set, the genuinely *bilingual* sub-checks (DE/EN count parity, positional tag/type pairing, and DE/EN adjacency via `_check_ordering`) are skipped, while the per-file **`slide_id` integrity checks** still run.
- **`validate_file`** detects a split half via `split_lang_suffix()` — the same `.de`/`.en` stem logic the build-time split routing (`_group_paths_into_units`) uses — and passes the flag through.
- The cross-file **`_check_shared_cell_parity`** diff between a `.de.py` / `.en.py` pair is **unchanged**, so genuine shared-cell divergence is still caught at directory/spec scope.
- Bilingual decks (no `.de`/`.en` suffix) are unaffected. `validate_quick` already self-suppressed on count mismatch (so the PostToolUse hook never misfired) and needs no change. The MCP server inherits the fix through the same public entrypoints.

## Acceptance criteria

- [x] `clm validate slides_NNN.de.py` (default deterministic checks) reports no pairing/count error; `format`/`tags` still enforced.
- [x] A directory/spec with split pairs validates without the false count-mismatch, while a genuinely malformed split pair (shared cells differing) is still caught by `_check_shared_cell_parity`.
- [x] Bilingual files are unaffected (pairing still enforced).

## Tests & docs

- New `TestSplitFilePairing` suite (7 tests): split `.de.py`/`.en.py` skip the count mismatch; `format`/`tags`/`slide_id` checks still fire on split files; bilingual control still flags the mismatch; directory split pairs validate clean; divergent shared cell in a split pair still caught.
- Full local suite green (ruff, mypy, and `tests/cli` + `tests/slides` + `tests/build/test_split_sources.py`: 1822 passed). Pre-commit hooks passed on commit.
- Documented in the `commands` info topic and `CHANGELOG.md` (per the Info Topics Maintenance Rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)