### PR TITLE
fix(slides): symmetrize workshop tags across DE/EN pairs so split builds don't leak solutions

### DIFF
--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -3,7 +3,10 @@
 Applies mechanical fixes to percent-format ``.py`` slide files:
 
 - **Tag migration**: ``alt`` → ``completed`` after ``start`` cells
-- **Workshop tag insertion**: adds ``workshop`` to workshop heading cells
+- **Workshop tag insertion**: adds ``workshop`` to workshop heading cells,
+  and symmetrizes ``workshop``/``end-workshop`` tags across DE/EN heading
+  pairs so single-language split builds detect the same workshop ranges as
+  bilingual builds
 - **Interleaving normalization**: reorders cells so paired DE/EN cells
   are adjacent
 
@@ -28,6 +31,7 @@ from clm.core.topic_resolver import (
     matches_for_binding,
 )
 from clm.notebooks.slide_parser import parse_cell_header
+from clm.slides.pairing import build_slide_groups
 from clm.slides.raw_cells import RawCell as _RawCell
 from clm.slides.raw_cells import reconstruct as _reconstruct
 from clm.slides.raw_cells import split_cells as _split_raw_cells
@@ -180,6 +184,64 @@ def _add_tag_to_header(header: str, tag: str) -> str:
             new_tags = f'"{tag}"'
         return header[: tags_match.start()] + f"tags=[{new_tags}]" + header[tags_match.end() :]
     return header.rstrip() + f' tags=["{tag}"]'
+
+
+# ---------------------------------------------------------------------------
+# Workshop tag symmetry: propagate workshop/end-workshop across DE/EN pairs
+# ---------------------------------------------------------------------------
+
+# Tags that scope a *slide* (a DE/EN pair), not a single language. They must
+# appear on both halves of a slide so that a single-language split build sees
+# the same workshop ranges a bilingual build does.
+_SLIDE_SCOPED_TAGS = ("workshop", "end-workshop")
+
+
+def _apply_workshop_symmetry(cells: list[_RawCell], file_path: str) -> list[Change]:
+    """Propagate slide-scoped ``workshop``/``end-workshop`` tags across pairs.
+
+    ``workshop`` and ``end-workshop`` mark a *slide* (a DE/EN heading pair) as a
+    workshop boundary. The notebook build derives workshop ranges from these
+    tags to decide which code cells to blank in the Code-Along/Partial kinds.
+
+    A *bilingual* build runs that range scan over the interleaved cell stream,
+    so a tag on **either** language's heading establishes a range that — by
+    cell index — also covers the other language's cells. A single-language
+    *split* build (``*.de.py`` / ``*.en.py``) only sees one language: if the
+    tag is missing on that language's heading, no range is detected and the
+    workshop's solution code leaks into the Code-Along/Partial output instead
+    of being blanked.
+
+    This pass closes that gap by copying the tag to the untagged half of every
+    DE/EN heading pair. Bilingual output is unchanged (the range was already
+    detected); split output now matches it. Headings must be adjacent in source
+    order to be paired (see :func:`clm.slides.pairing.build_slide_groups`),
+    which holds after interleaving and after ``unify``.
+    """
+    changes: list[Change] = []
+    for group in build_slide_groups(cells):
+        if len(group) != 2:
+            continue
+        i, j = group
+        for tag in _SLIDE_SCOPED_TAGS:
+            i_has = tag in cells[i].metadata.tags
+            j_has = tag in cells[j].metadata.tags
+            if i_has == j_has:
+                continue
+            target = cells[j] if i_has else cells[i]
+            new_header = _add_tag_to_header(target.header, tag)
+            target.header = new_header
+            target.metadata = parse_cell_header(new_header)
+            changes.append(
+                Change(
+                    file=file_path,
+                    operation="workshop_tags",
+                    line=target.line_number,
+                    description=(
+                        f"Propagated '{tag}' tag to paired {target.metadata.lang or '?'} heading"
+                    ),
+                )
+            )
+    return changes
 
 
 # ---------------------------------------------------------------------------
@@ -613,6 +675,7 @@ def normalize_file(
 
     if "workshop_tags" in op_set:
         all_changes.extend(_apply_workshop_tags(cells, file_str))
+        all_changes.extend(_apply_workshop_symmetry(cells, file_str))
 
     if "interleaving" in op_set:
         cells, interleave_changes, interleave_reviews = _apply_interleaving(

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -383,6 +383,57 @@ def _check_workshop_headings(cells: list[Cell], file_path: str) -> list[Finding]
     return findings
 
 
+def _check_workshop_tag_symmetry(cells: list[Cell], file_path: str) -> list[Finding]:
+    """Flag DE/EN slide-heading pairs that disagree on a slide-scoped tag.
+
+    ``workshop`` and ``end-workshop`` mark a *slide* (a DE/EN pair) as a
+    workshop boundary; they belong to the slide, not a single language. The
+    notebook build derives workshop ranges from these tags to decide which
+    code cells to blank in Code-Along/Partial output.
+
+    A *bilingual* build tolerates the tag on only one language's heading: its
+    range scan runs over the interleaved stream, so a tag on either half
+    establishes a range that — by index — also covers the other language. A
+    single-language *split* build does not: the untagged language loses the
+    workshop range and leaks solution code into Code-Along/Partial. This check
+    flags the asymmetry on the bilingual source so it is fixed before
+    splitting. On a single-language file there are no DE/EN pairs, so it is a
+    no-op. Run ``clm slides normalize`` to symmetrize the tags automatically.
+    """
+    findings: list[Finding] = []
+    for group in build_slide_groups(cells):
+        if len(group) != 2:
+            continue
+        i, j = group
+        for tag in ("workshop", "end-workshop"):
+            i_has = tag in cells[i].metadata.tags
+            j_has = tag in cells[j].metadata.tags
+            if i_has == j_has:
+                continue
+            tagged, untagged = (cells[i], cells[j]) if i_has else (cells[j], cells[i])
+            findings.append(
+                Finding(
+                    severity="warning",
+                    category="pairing",
+                    file=file_path,
+                    line=untagged.line_number,
+                    message=(
+                        f"slide-heading pair disagrees on the '{tag}' tag: the "
+                        f"{tagged.metadata.lang or '?'} heading has it but the "
+                        f"{untagged.metadata.lang or '?'} heading does not — a "
+                        f"split build of the untagged language will miss the "
+                        f"workshop range and may leak solution code"
+                    ),
+                    suggestion=(
+                        f"Add the '{tag}' tag to the "
+                        f"{untagged.metadata.lang or '?'} heading, or run "
+                        f"`clm slides normalize` to symmetrize it."
+                    ),
+                )
+            )
+    return findings
+
+
 def _check_pairing(cells: list[Cell], file_path: str, *, is_split: bool = False) -> list[Finding]:
     """Check DE/EN cell pairing: count, position, and tag consistency.
 
@@ -1204,6 +1255,11 @@ def validate_file(
         # directory/course entrypoints via _check_shared_cell_parity.
         is_split = split_lang_suffix(path) is not None
         findings.extend(_check_pairing(cells, file_str, is_split=is_split))
+        # workshop/end-workshop tags must match across a DE/EN heading pair;
+        # the asymmetry only manifests on the bilingual source (a split half
+        # has no DE/EN pairs to compare).
+        if not is_split:
+            findings.extend(_check_workshop_tag_symmetry(cells, file_str))
 
     # Review material extraction
     review_checks = check_set & ALL_REVIEW_CHECKS

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -178,6 +178,87 @@ class TestWorkshopTags:
 
         assert len(result.changes) == 0
 
+
+# ---------------------------------------------------------------------------
+# Workshop tag symmetry (DE/EN propagation)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkshopSymmetry:
+    """``workshop``/``end-workshop`` are slide-scoped — symmetrize across pairs.
+
+    Headings are deliberately worded so the heading-text pass
+    (``_apply_workshop_tags``) does *not* fire; only the pair-symmetry pass
+    can add the missing tag.
+    """
+
+    def test_propagates_de_to_en(self, tmp_path):
+        text = (
+            '# %% [markdown] lang="de" tags=["subslide", "workshop"]\n'
+            "# ## Aufgabe\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["subslide"]\n'
+            "# ## Exercise\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["workshop_tags"])
+
+        assert len(result.changes) == 1
+        new_text = path.read_text(encoding="utf-8")
+        # Both headings now carry the tag.
+        assert new_text.count('"workshop"') == 2
+
+    def test_propagates_en_to_de(self, tmp_path):
+        text = (
+            '# %% [markdown] lang="de" tags=["subslide"]\n'
+            "# ## Aufgabe\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["subslide", "workshop"]\n'
+            "# ## Exercise\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["workshop_tags"])
+
+        assert len(result.changes) == 1
+        new_text = path.read_text(encoding="utf-8")
+        assert new_text.count('"workshop"') == 2
+
+    def test_end_workshop_propagates(self, tmp_path):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide", "end-workshop"]\n'
+            "# ## Ende\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# ## End\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["workshop_tags"])
+
+        assert len(result.changes) == 1
+        new_text = path.read_text(encoding="utf-8")
+        assert new_text.count('"end-workshop"') == 2
+
+    def test_symmetric_pair_unchanged(self, tmp_path):
+        text = (
+            '# %% [markdown] lang="de" tags=["subslide", "workshop"]\n'
+            "# ## Aufgabe\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["subslide", "workshop"]\n'
+            "# ## Exercise\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["workshop_tags"])
+
+        assert len(result.changes) == 0
+
+    def test_solo_heading_not_propagated(self, tmp_path):
+        # A lone DE workshop heading (no EN partner) must not gain a phantom pair.
+        text = '# %% [markdown] lang="de" tags=["subslide", "workshop"]\n# ## Aufgabe\n'
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["workshop_tags"])
+
+        assert len(result.changes) == 0
+
     def test_workshop_heading_no_existing_tags(self, tmp_path):
         text = '# %% [markdown] lang="de"\n# ## Workshop: Begrüßung\n'
         path = _write_slide(tmp_path / "slides_test.py", text)

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -527,6 +527,86 @@ class TestCheckWorkshopHeadings:
 
 
 # ---------------------------------------------------------------------------
+# Workshop tag symmetry (DE/EN)
+# ---------------------------------------------------------------------------
+
+
+def _workshop_symmetry_warnings(result):
+    return [
+        f for f in result.findings if f.category == "pairing" and "disagrees on the" in f.message
+    ]
+
+
+class TestCheckWorkshopTagSymmetry:
+    """A workshop tag on only one language's heading leaks solutions in the
+    other language's split build — flag the asymmetry on the bilingual source.
+    """
+
+    def test_asymmetric_workshop_tag_warns(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "asym.py",
+            """\
+            # %% [markdown] lang="de" tags=["subslide", "workshop"]
+            # ## Mini-Workshop: Übung
+
+            # %% [markdown] lang="en" tags=["subslide"]
+            # ## Mini Workshop: Exercise
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        warnings = _workshop_symmetry_warnings(result)
+        assert len(warnings) == 1
+        assert "workshop" in warnings[0].message
+
+    def test_symmetric_workshop_tag_ok(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "sym.py",
+            """\
+            # %% [markdown] lang="de" tags=["subslide", "workshop"]
+            # ## Mini-Workshop: Übung
+
+            # %% [markdown] lang="en" tags=["subslide", "workshop"]
+            # ## Mini Workshop: Exercise
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert _workshop_symmetry_warnings(result) == []
+
+    def test_asymmetric_end_workshop_warns(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "asym_end.py",
+            """\
+            # %% [markdown] lang="de" tags=["subslide", "end-workshop"]
+            # ## Ende
+
+            # %% [markdown] lang="en" tags=["subslide"]
+            # ## End
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        warnings = _workshop_symmetry_warnings(result)
+        assert len(warnings) == 1
+        assert "end-workshop" in warnings[0].message
+
+    def test_single_language_file_no_warning(self, tmp_path):
+        # A split single-language file has no DE/EN pairs, so the check is a
+        # no-op even when a workshop heading is present.
+        p = _write_slide(
+            tmp_path,
+            "split.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["subslide", "workshop"]
+            # ## Mini Workshop: Exercise
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert _workshop_symmetry_warnings(result) == []
+
+
+# ---------------------------------------------------------------------------
 # Pairing checks
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

A `workshop` / `end-workshop` tag scopes a **slide** (a DE/EN heading pair), but the notebook build derives workshop ranges *per cell*.

- A **bilingual** build runs the range scan over the interleaved cell stream, so a tag on *either* language's heading opens a range that — by cell index — also covers the other language's cells. This **masks** decks where only one heading carries the tag.
- A single-language **split** build (`*.de.py` / `*.en.py`) sees only one language. If that heading lacks the tag, no workshop range is detected, so the workshop's solution code is **rendered in the Code-Along/Partial output** instead of being blanked for the student to fill in — a silent solution leak.

Concretely, `find_workshop_ranges` (in `workers/notebook/output_spec.py`) keys only on the `workshop` tag; `PartialOutput.annotate_cells` runs it on the pre-language-filter stream in bilingual mode, so a DE-only `workshop` tag still blanks the EN cells. After a split, the EN file has no opener and the cells leak.

## Fix

- **`clm slides normalize`** (`workshop_tags` operation) now propagates `workshop` and `end-workshop` tags to the untagged half of every adjacent DE/EN slide-heading pair (via `build_slide_groups`). Bilingual output is unchanged (the range was already detected); split output now matches it. The propagated tag survives `unify`, so `unify(split(deck))` stays consistent for a *normalized* deck.
- **`clm validate`** (`pairing` checks) flags slide-heading pairs that disagree on a `workshop`/`end-workshop` tag, so the asymmetry is caught on the bilingual source *before* splitting. It is a no-op on single-language files (no DE/EN pairs to compare).

Both changes are additive and category-scoped (`workshop_tags` / `pairing`).

## Tests

- `tests/slides/test_normalizer.py::TestWorkshopSymmetry` — DE→EN, EN→DE, `end-workshop`, symmetric-noop, solo-heading-noop.
- `tests/slides/test_validator.py::TestCheckWorkshopTagSymmetry` — asymmetric warns, symmetric ok, `end-workshop` asymmetric warns, single-language no-op.
- Full `test_normalizer`, `test_validator`, `test_pairing`, `test_workshop_scope`, `test_split_sources`, `test_normalize_slides` suites pass (223 tests).

## Context

Found while converting the AZAV ML course to DE/EN split format. Four decks had the asymmetry; two leaked workshop solutions in their EN `Partial` build. Existing `_check_workshop_headings` (issue #78) did not catch them because its heading-text regex (`^#+\s*Workshop\b`) does not match e.g. `## Mini Workshop:` — the new pairing-based check is heading-text-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)