### PR TITLE
fix(http-replay): pin-guard the forked vcrpy internals (#143, toward #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        # Install all dependencies except ML (PyTorch, FastAI, etc.) which aren't needed for tests
-        uv pip install --system -e ".[all-workers,summarize,recordings,slides,mcp,dev,tui,web]"
+        # Install all dependencies except ML (PyTorch, FastAI, etc.) which aren't needed for tests.
+        # ``replay`` (vcrpy + filelock) is included so the HTTP-replay tests -- including the
+        # issue #143 pin-guard / upstream-drift detector -- actually run in CI instead of being
+        # skipped by ``pytest.importorskip("vcr")``.
+        uv pip install --system -e ".[all-workers,summarize,recordings,slides,mcp,replay,dev,tui,web]"
 
     - name: Start Xvfb
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **Hardened the HTTP-replay vcrpy fork against silent breakage (issue #143,
+  toward #165).** The `[replay]` extra now pins `vcrpy>=8.1.1,<8.2` (was an
+  unbounded `>=6.0.0`). The notebook HTTP-replay bootstrap forks vcrpy 8.1.x
+  *internals* — notably the issue #143 connection-leak fix, which reinstalls
+  vcrpy's `_vcr_handle_request`/`_vcr_handle_async_request` verbatim plus an
+  explicit `close()`. An unvalidated vcrpy bump could silently change those
+  functions and resurrect the connection-pool deadlock; the tight pin makes
+  such a bump fail loudly at resolution time, and a new in-kernel guard fails
+  the build early if a kernel resolves vcrpy outside the validated 8.1.x line
+  or is missing the forked-internals symbols. A new pin-guard test
+  (`tests/workers/notebook/test_http_replay_vcr_pin_guard.py`) detects upstream
+  drift, and CI now installs the `[replay]` extra so those tests run there.
+  Ready-to-submit upstream patches that would let the fork be retired are in
+  `docs/claude/vcrpy-upstream-patches.md`.
+
 - **`clm recordings check` is now backend-aware** (issue #33). The command
   reads `recordings.processing_backend` and only checks the dependencies the
   active backend actually needs, and the output table header shows which

--- a/docs/claude/vcrpy-upstream-patches.md
+++ b/docs/claude/vcrpy-upstream-patches.md
@@ -1,0 +1,172 @@
+# Upstream vcrpy patches (retire the CLM forks)
+
+CLM's HTTP-replay bootstrap (`src/clm/workers/notebook/notebook_processor.py`)
+carries two forks of vcrpy *internals*. Both are tactical workarounds for
+genuine upstream bugs. Landing them upstream lets us delete the forks and the
+tight `vcrpy>=8.1.1,<8.2` pin in `pyproject.toml [replay]`, removing the
+"silent rot on a vcrpy bump" risk entirely.
+
+This document is the ready-to-submit material. **A human submits these PRs** —
+Claude cannot push to `kevin1024/vcrpy`. Target the latest `vcrpy` `main`
+(validated against the released **8.1.1**, Jan 2026).
+
+---
+
+## Patch 1 (PRIORITY): close the leaked httpcore connection — fixes the deadlock
+
+### The bug
+
+`vcr/stubs/httpcore_stubs.py` reads the real response body, then **replaces**
+`real_response.stream` with a buffered `ByteStream` and returns the response —
+but never `close()`s the original `httpcore.Response`. In httpcore, the pooled
+connection is returned to the `ConnectionPool` when the response is closed.
+Because vcrpy swaps the stream and hands the response to httpx, httpx later
+closes vcrpy's *replacement* `ByteStream` (a no-op for connection lifecycle),
+not the original — so **every recorded request leaks one pooled connection**.
+
+Under a burst of concurrent requests (e.g. LangChain `RunnableParallel` /
+`.batch()` against an OpenAI-compatible endpoint through httpx), the pool's
+`max_connections` is exhausted and all callers block **forever** in
+`httpcore._sync/_async.connection_pool.wait_for_connection`. There is no error
+and no timeout by default — the process simply hangs.
+
+This affects only **recording** paths (`record`, `new_episodes`, `once` on a
+miss, `all`); pure replay returns `vcr_response` before touching the network.
+
+### The fix (≈2 lines each)
+
+Read the body first (as today), then `close()`/`aclose()` the original
+response before swapping its stream.
+
+```diff
+ def _vcr_handle_request(cassette, real_handle_request, self, real_request):
+     # Reading the request stream consumes the iterator, so we need to restore it afterwards
+     real_request_body = b"".join(real_request.stream)
+     real_request.stream = ByteStream(real_request_body)
+
+     vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body)
+
+     if vcr_response:
+         return vcr_response
+
+     real_response = real_handle_request(self, real_request)
+
+     # Reading the response stream consumes the iterator, so we need to restore it afterwards
+     real_response_content = b"".join(real_response.stream)
++    # Close the original response so its pooled connection is returned to the
++    # httpcore ConnectionPool. We replace .stream with a buffered ByteStream
++    # just below; without closing here, the caller (e.g. httpx) later closes
++    # the *replacement* stream — a no-op for connection lifecycle — and the
++    # real connection leaks. Under concurrent requests the pool is exhausted
++    # and callers block forever in wait_for_connection.
++    real_response.close()
+     real_response.stream = ByteStream(real_response_content)
+
+     _record_responses(cassette, vcr_request, real_response, real_response_content)
+
+     return real_response
+
+
+ async def _vcr_handle_async_request(cassette, real_handle_async_request, self, real_request):
+     # Reading the request stream consumes the iterator, so we need to restore it afterwards
+     real_request_body = b"".join([part async for part in real_request.stream])
+     real_request.stream = ByteStream(real_request_body)
+
+     vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body)
+
+     if vcr_response:
+         return vcr_response
+
+     real_response = await real_handle_async_request(self, real_request)
+
+     # Reading the response stream consumes the iterator, so we need to restore it afterwards
+     real_response_content = b"".join([part async for part in real_response.stream])
++    # See sync variant above: return the pooled connection to httpcore.
++    await real_response.aclose()
+     real_response.stream = ByteStream(real_response_content)
+
+     _record_responses(cassette, vcr_request, real_response, real_response_content)
+
+     return real_response
+```
+
+`httpcore.Response.close()` / `aclose()` close the (already fully consumed)
+underlying stream, which releases the connection back to the pool. Reading the
+body **before** closing is required and preserved.
+
+### Suggested PR
+
+- **Title:** `Fix httpcore connection-pool leak: close real response before swapping stream`
+- **Body:** the bug section above + the diff. Note it manifests as a hang under
+  concurrent recording, not an error.
+- **Test** (vcrpy's `tests/integration/test_httpx.py` style): record N > pool
+  `max_connections` sequential-then-concurrent requests against a local server
+  with a small `httpcore` pool and assert the recording completes without
+  hanging (wrap in a timeout). A regression test that hangs without the fix and
+  passes with it.
+
+### Minimal standalone reproducer
+
+A full CLM-side reproducer (16 workers, py-spy proof) lives at
+`~/Programming/Python/Tests/clm-bug-repros/issue-143-cassette-connection-pool-deadlock/`.
+For the upstream PR, a tiny version: a threaded httpx client doing
+`max_connections + 2` POSTs through a recording cassette against a localhost
+echo server — hangs on the stock build, completes with the patch.
+
+---
+
+## Patch 2 (SECONDARY, needs design discussion): scope `force_reset()` to urllib3
+
+### The bug (CLM issue #129)
+
+`vcr.patch.force_reset()` is a context manager that **globally un-patches every
+vcr stub** for the duration of its body (it yields from `reset_patchers()`).
+vcrpy's urllib3 stub opens `force_reset()` on every connection construction and
+`connect()` so the real connection's `super().__init__()` doesn't re-enter
+vcr's patched `HTTPConnection`. But un-patching is **global**: it also
+un-patches `httpcore.ConnectionPool.handle_request` for that window.
+
+The race: a foreground thread making an httpcore call (httpx-based LLM SDK)
+while a background thread constructs a urllib3 connection (e.g. a telemetry
+upload via `requests`) can resolve `pool.handle_request` during the unpatched
+window, **bypass vcr entirely, hit the real upstream, and never record it** —
+silently invalidating the cassette.
+
+### The shape of an upstream fix
+
+`force_reset()` only needs to un-patch the **urllib3** patchers (the ones whose
+recursion it is guarding against), not httpcore/boto/etc. Options:
+
+1. Parameterize `reset_patchers()` / `force_reset()` to filter to a given
+   library, and have the urllib3 stub call `force_reset(only="urllib3")`.
+2. Or make `force_reset()` only reset patchers whose target module is in the
+   `urllib3`/`http.client` family.
+
+CLM currently swaps `reset_patchers` for a filtered generator that yields all
+patchers **except** the httpcore ones (`reset_patchers` is looked up via module
+globals at call time, so the swap propagates). That's the behavioral spec for
+an upstream fix, but the upstream version should scope *positively* to urllib3
+rather than *negatively* excluding httpcore.
+
+Full investigation: CLM `docs/claude/issue-129-vcrpy-force-reset-investigation.md`.
+
+### Note
+
+This is a more invasive change than Patch 1 and touches `force_reset`'s
+contract, so it warrants a design discussion in an issue first. Patch 1 is the
+high-value, low-risk one to land first — it removes the **deadlock** class.
+
+---
+
+## After either lands upstream
+
+1. Bump the `[replay]` pin to include the fixed vcrpy release
+   (`>=<fixed>,<next-minor>`), re-run the pin-guard test
+   (`tests/workers/notebook/test_http_replay_vcr_pin_guard.py`).
+2. `test_upstream_still_leaks_so_the_fork_is_still_needed` will start **failing**
+   once Patch 1 lands (upstream now closes the response) — that failure is the
+   signal to delete the corresponding fork block from
+   `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE` and update the test.
+3. Removing a fork reduces the in-kernel workaround count (currently 8) and
+   shrinks the surface a future vcrpy bump can break — independent of the
+   larger issue #165 mitmproxy migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,19 @@ slides = [
 # (e.g. ``requests``, ``httpx``). Enables offline, deterministic HTML
 # builds when a topic opts in via ``http-replay="yes"`` in the spec.
 replay = [
-    "vcrpy>=6.0.0",
+    # Upper bound is deliberately tight. The HTTP-replay bootstrap in
+    # ``clm/workers/notebook/notebook_processor.py`` forks vcrpy *internals*
+    # to compensate for upstream bugs: notably the issue #143 connection-leak
+    # fix reinstalls vcrpy 8.1.x's ``_vcr_handle_request`` /
+    # ``_vcr_handle_async_request`` verbatim (plus an explicit ``close()``),
+    # and the issue #129 fix swaps ``vcr.patch.reset_patchers``. Those forks
+    # are validated against vcrpy 8.1.x only; a minor/major bump can silently
+    # change the forked functions and resurrect the #143 deadlock. Capping at
+    # ``<8.2`` makes any such bump fail *loudly* at resolution time instead,
+    # forcing a human to re-validate the forks and the pin-guard test
+    # (``tests/workers/notebook/test_http_replay_vcr_pin_guard.py``) before
+    # widening the bound.
+    "vcrpy>=8.1.1,<8.2",
     # Used to serialize cassette merges across concurrent workers that
     # process the same notebook in different languages.
     "filelock>=3.12.0",

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -427,6 +427,35 @@ _clm_atexit.register(_clm_ctx.__exit__, None, None, None)
 # the ``httpcore_stubs`` module globals at call time, so reassigning them here takes
 # effect even though the cassette is already entered.
 import vcr.stubs.httpcore_stubs as _clm_hcs
+# Pin-guard (issue #143): the two functions reinstalled below are a verbatim
+# fork of vcrpy 8.1.x's stubs (plus an explicit close()), and they call upstream
+# internals -- ``_vcr_request``, ``_record_responses``, ``ByteStream`` -- by name.
+# If a future vcrpy renames or refactors these, the fork would silently stop
+# closing the leaked httpcore connection and the Stage-3 pool-exhaustion deadlock
+# would return with no error. The ``pyproject.toml`` ``[replay]`` pin
+# (``vcrpy>=8.1.1,<8.2``) is the primary defense; this guard is defense-in-depth
+# for kernels that resolve vcrpy outside that pin. It turns silent rot into a
+# loud, early bootstrap failure. Re-validate the fork + the pin-guard test
+# (``tests/workers/notebook/test_http_replay_vcr_pin_guard.py``) before widening
+# the pin.
+_clm_vcr_version = getattr(_clm_vcr, "__version__", "0")
+_clm_vcr_major_minor = ".".join(str(_clm_vcr_version).split(".")[:2])
+_clm_missing_hcs = [
+    _n for _n in (
+        "_vcr_handle_request", "_vcr_handle_async_request",
+        "_vcr_request", "_record_responses", "ByteStream",
+    ) if not hasattr(_clm_hcs, _n)
+]
+if _clm_vcr_major_minor != "8.1" or _clm_missing_hcs:
+    raise RuntimeError(
+        "CLM HTTP-replay bootstrap (issue #143): the forked vcrpy httpcore stubs "
+        "are validated only against vcrpy 8.1.x, but this kernel has vcrpy "
+        + str(_clm_vcr_version)
+        + (("; missing httpcore_stubs symbols: " + ", ".join(_clm_missing_hcs)) if _clm_missing_hcs else "")
+        + ". The connection-leak fix would silently no-op. Re-validate the forked "
+        "_vcr_handle_request/_vcr_handle_async_request and the pin-guard test, then "
+        "update the pyproject.toml [replay] pin (currently >=8.1.1,<8.2)."
+    )
 def _clm_vcr_handle_request(cassette, real_handle_request, self, real_request):
     real_request_body = b"".join(real_request.stream)
     real_request.stream = _clm_hcs.ByteStream(real_request_body)

--- a/tests/workers/notebook/test_http_replay_vcr_pin_guard.py
+++ b/tests/workers/notebook/test_http_replay_vcr_pin_guard.py
@@ -1,0 +1,259 @@
+"""Pin-guard regression tests for the forked vcrpy internals (issue #143).
+
+The HTTP-replay bootstrap in ``clm/workers/notebook/notebook_processor.py``
+does not just *use* vcrpy -- it **forks vcrpy internals** to compensate for
+upstream bugs:
+
+* The issue #143 connection-leak fix reinstalls vcrpy 8.1.x's
+  ``vcr.stubs.httpcore_stubs._vcr_handle_request`` /
+  ``_vcr_handle_async_request`` verbatim, with one change: an explicit
+  ``real_response.close()`` / ``aclose()`` before the ``.stream`` swap, so the
+  pooled httpcore connection is actually returned. Without that the pool is
+  exhausted by a ``.batch()`` burst and every worker deadlocks in
+  ``httpcore.connection_pool.wait_for_connection``.
+* The forked functions call upstream internals (``_vcr_request``,
+  ``_record_responses``, ``ByteStream``) **by name**.
+
+The danger is *silent rot*: if a future vcrpy renames/refactors those
+functions, our fork would silently stop closing the leaked connection and the
+deadlock would return with no error and no test failure. These tests are the
+loud tripwire. The primary defense is the tight ``pyproject.toml`` ``[replay]``
+pin (``vcrpy>=8.1.1,<8.2``); this file backs it up by:
+
+1. asserting the pin keeps an upper bound (runs even without vcrpy installed);
+2. asserting the *installed* vcrpy is the validated 8.1.x line;
+3. asserting the upstream stub functions still match the baseline we forked
+   from (the real drift detector);
+4. asserting the in-kernel guard actually raises on a drifted vcrpy.
+
+If a deliberate vcrpy upgrade is being made: re-read upstream
+``_vcr_handle_request`` / ``_vcr_handle_async_request``, re-confirm they still
+never ``close()`` the response (or that the leak is fixed upstream and the fork
+can be dropped), update the baselines + the bootstrap fork + the pin together.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from clm.workers.notebook.notebook_processor import _inject_http_replay_bootstrap
+
+# Repo root: tests/workers/notebook/<this file> -> parents[3].
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# The validated vcrpy line. Keep in sync with the ``[replay]`` pin and the
+# in-kernel guard in ``notebook_processor.py``.
+_VALIDATED_MAJOR_MINOR = "8.1"
+
+# Normalized (comment- and blank-line-stripped) baseline of the upstream
+# vcrpy 8.1.1 stub functions that the bootstrap forks. Captured from
+# ``inspect.getsource`` on vcrpy 8.1.1. A change here means upstream refactored
+# the functions we copied -- re-validate the fork before bumping the pin.
+_UPSTREAM_SYNC_BASELINE = [
+    "def _vcr_handle_request(cassette, real_handle_request, self, real_request):",
+    'real_request_body = b"".join(real_request.stream)',
+    "real_request.stream = ByteStream(real_request_body)",
+    "vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body)",
+    "if vcr_response:",
+    "return vcr_response",
+    "real_response = real_handle_request(self, real_request)",
+    'real_response_content = b"".join(real_response.stream)',
+    "real_response.stream = ByteStream(real_response_content)",
+    "_record_responses(cassette, vcr_request, real_response, real_response_content)",
+    "return real_response",
+]
+_UPSTREAM_ASYNC_BASELINE = [
+    "async def _vcr_handle_async_request(cassette, real_handle_async_request, self, real_request):",
+    'real_request_body = b"".join([part async for part in real_request.stream])',
+    "real_request.stream = ByteStream(real_request_body)",
+    "vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body)",
+    "if vcr_response:",
+    "return vcr_response",
+    "real_response = await real_handle_async_request(self, real_request)",
+    'real_response_content = b"".join([part async for part in real_response.stream])',
+    "real_response.stream = ByteStream(real_response_content)",
+    "_record_responses(cassette, vcr_request, real_response, real_response_content)",
+    "return real_response",
+]
+
+
+def _normalize(source: str) -> list[str]:
+    """Strip comments, blank lines, and indentation for a semantic comparison.
+
+    Comment/whitespace churn upstream should not trip the drift detector, but
+    any change to the actual statements (which is what would break our fork)
+    will.
+    """
+    out: list[str] = []
+    for raw in source.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def test_replay_pin_keeps_upper_bound() -> None:
+    """The ``[replay]`` vcrpy pin must keep an upper bound.
+
+    Runs without vcrpy installed (parses pyproject only), so it guards in CI
+    even though CI does not install the ``[replay]`` extra. An unbounded
+    ``vcrpy>=...`` would let an unvalidated release silently break the forked
+    stubs (issue #143).
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    replay = data["project"]["optional-dependencies"]["replay"]
+    vcr_specs = [s for s in replay if s.replace("_", "-").lower().startswith("vcrpy")]
+    assert vcr_specs, f"no vcrpy requirement found in [replay]: {replay}"
+    spec = vcr_specs[0]
+    assert "<" in spec, (
+        f"vcrpy pin {spec!r} has no upper bound. The bootstrap forks vcrpy "
+        "internals (issue #143); an unbounded pin lets an unvalidated release "
+        "silently resurrect the connection-pool deadlock. Keep a '<' ceiling."
+    )
+    assert _VALIDATED_MAJOR_MINOR in spec, (
+        f"vcrpy pin {spec!r} no longer references the validated {_VALIDATED_MAJOR_MINOR}.x "
+        "line; re-validate the forked stubs before changing it."
+    )
+
+
+def test_installed_vcrpy_is_validated_line() -> None:
+    """The installed vcrpy (where present) must be the validated 8.1.x line."""
+    vcr = pytest.importorskip("vcr")
+    version = getattr(vcr, "__version__", "0")
+    major_minor = ".".join(str(version).split(".")[:2])
+    assert major_minor == _VALIDATED_MAJOR_MINOR, (
+        f"installed vcrpy {version} is outside the validated {_VALIDATED_MAJOR_MINOR}.x line "
+        "the issue #143 fork was forked from. Re-validate the fork + pin."
+    )
+
+
+def test_upstream_httpcore_stubs_match_forked_baseline() -> None:
+    """The upstream stub functions must still match what the bootstrap forked.
+
+    This is the real drift detector. If vcrpy changes ``_vcr_handle_request`` /
+    ``_vcr_handle_async_request``, our verbatim fork in the bootstrap is stale:
+    it may no longer close the leaked connection, or may call internals that
+    moved. Fail loudly so a human re-validates before the deadlock returns.
+    """
+    pytest.importorskip("vcr")
+    import inspect
+
+    import vcr.stubs.httpcore_stubs as hcs
+
+    for name in ("_vcr_request", "_record_responses", "ByteStream"):
+        assert hasattr(hcs, name), (
+            f"vcrpy httpcore_stubs lost {name!r}; the issue #143 fork calls it by "
+            "name and would break. Re-validate the fork."
+        )
+
+    sync_actual = _normalize(inspect.getsource(hcs._vcr_handle_request))
+    async_actual = _normalize(inspect.getsource(hcs._vcr_handle_async_request))
+    assert sync_actual == _UPSTREAM_SYNC_BASELINE, (
+        "upstream vcrpy _vcr_handle_request changed vs the 8.1.1 baseline the "
+        "bootstrap forked. Re-read it, re-confirm the response is still not "
+        "closed upstream, and update the fork + baseline + pin together (#143)."
+    )
+    assert async_actual == _UPSTREAM_ASYNC_BASELINE, (
+        "upstream vcrpy _vcr_handle_async_request changed vs the 8.1.1 baseline "
+        "the bootstrap forked. Re-read it and update the fork + baseline + pin (#143)."
+    )
+
+
+def test_upstream_still_leaks_so_the_fork_is_still_needed() -> None:
+    """Sanity check that upstream still does NOT close the response.
+
+    If a future vcrpy adds the ``close()``/``aclose()`` itself, the fork is
+    redundant and should be retired (and the upstream PR landed). This test
+    documents that assumption: it passes while the leak exists and starts
+    failing -- prompting cleanup -- once upstream fixes it.
+    """
+    pytest.importorskip("vcr")
+    import inspect
+
+    import vcr.stubs.httpcore_stubs as hcs
+
+    sync_src = inspect.getsource(hcs._vcr_handle_request)
+    async_src = inspect.getsource(hcs._vcr_handle_async_request)
+    assert ".close()" not in sync_src, (
+        "upstream vcrpy _vcr_handle_request now closes the response -- the "
+        "issue #143 fork may be redundant. Verify and retire it."
+    )
+    assert ".aclose()" not in async_src, (
+        "upstream vcrpy _vcr_handle_async_request now closes the response -- the "
+        "issue #143 fork may be redundant. Verify and retire it."
+    )
+
+
+def _extract_guard_snippet(bootstrap_src: str) -> str:
+    """Slice the in-kernel pin-guard block out of the rendered bootstrap."""
+    start_marker = '_clm_vcr_version = getattr(_clm_vcr, "__version__", "0")'
+    end_marker = "def _clm_vcr_handle_request("
+    start = bootstrap_src.index(start_marker)
+    end = bootstrap_src.index(end_marker, start)
+    return bootstrap_src[start:end]
+
+
+_FORKED_SYMBOLS = (
+    "_vcr_handle_request",
+    "_vcr_handle_async_request",
+    "_vcr_request",
+    "_record_responses",
+    "ByteStream",
+)
+
+
+def _fake_hcs(missing: tuple[str, ...] = ()) -> object:
+    """A stand-in for ``vcr.stubs.httpcore_stubs`` with selected symbols absent.
+
+    Built as a fresh namespace per call so ``del``/omission actually makes
+    ``hasattr`` return False (a subclass can't shadow-delete an inherited attr).
+    """
+    from types import SimpleNamespace
+
+    attrs = {
+        name: (object if name == "ByteStream" else (lambda *a, **k: None))
+        for name in _FORKED_SYMBOLS
+        if name not in missing
+    }
+    return SimpleNamespace(**attrs)
+
+
+def _run_guard(version: str, hcs: object) -> None:
+    """Exec the shipped guard snippet against a fake vcr/hcs namespace.
+
+    Renders the real bootstrap cell, slices out the in-kernel guard, and execs
+    only that slice -- so we test the exact code that ships in the kernel,
+    without opening a cassette or hitting the network.
+    """
+    from nbformat.v4 import new_notebook
+
+    nb = new_notebook()
+    _inject_http_replay_bootstrap(nb, "/abs/c.yaml", "replay")
+    snippet = _extract_guard_snippet(nb["cells"][0]["source"])
+    ns: dict = {"_clm_vcr": type("V", (), {"__version__": version}), "_clm_hcs": hcs}
+    exec(snippet, ns)
+
+
+def test_bootstrap_guard_passes_on_validated_vcrpy() -> None:
+    """The guard must not raise on the validated 8.1.x line with all symbols."""
+    pytest.importorskip("vcr")
+    _run_guard("8.1.1", _fake_hcs())
+
+
+def test_bootstrap_guard_raises_on_version_drift() -> None:
+    """A vcrpy outside the validated line must trip the in-kernel guard."""
+    pytest.importorskip("vcr")
+    with pytest.raises(RuntimeError, match="issue #143"):
+        _run_guard("8.2.0", _fake_hcs())
+
+
+def test_bootstrap_guard_raises_on_missing_symbol() -> None:
+    """A missing forked-internals symbol must trip the in-kernel guard."""
+    pytest.importorskip("vcr")
+    with pytest.raises(RuntimeError, match="_vcr_request"):
+        _run_guard("8.1.1", _fake_hcs(missing=("_vcr_request",)))

--- a/uv.lock
+++ b/uv.lock
@@ -1309,7 +1309,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'voiceover-cohere'", specifier = ">=4.52.0" },
     { name = "transformers", marker = "extra == 'voiceover-granite'", specifier = ">=4.52.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "vcrpy", marker = "extra == 'replay'", specifier = ">=6.0.0" },
+    { name = "vcrpy", marker = "extra == 'replay'", specifier = ">=8.1.1,<8.2" },
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "watchfiles", marker = "extra == 'web'", specifier = ">=0.18.0" },
     { name = "wsproto", marker = "extra == 'web'", specifier = ">=1.2.0" },


### PR DESCRIPTION
## Summary

Hardens the notebook HTTP-replay machinery against **silent breakage of the
forked vcrpy internals**, and is the cheap-insurance first step toward the
issue #165 migration (replace in-process vcrpy with an out-of-process
transport). Independent of #165: this is worth landing on its own.

### The problem

The HTTP-replay bootstrap forks vcrpy **8.1.x internals**. Most visibly, the
issue #143 connection-leak fix (PR #168) reinstalls vcrpy's
`_vcr_handle_request` / `_vcr_handle_async_request` *verbatim* with one change —
an explicit `real_response.close()`/`aclose()` so the pooled httpcore
connection is returned (otherwise a langchain `.batch()` burst exhausts the
pool and every worker deadlocks). The `[replay]` pin was an **unbounded
`vcrpy>=6.0.0`**, so a future vcrpy release could be resolved into the kernel,
silently change those functions, and **resurrect the deadlock with no error**.

### Changes

- **Pin `vcrpy>=8.1.1,<8.2`** in `[replay]`. An unvalidated bump now fails
  *loudly at resolution time* instead of silently no-op'ing the fork. (8.1.1 is
  the latest release, so this strands no one.)
- **In-kernel guard** in `notebook_processor.py`: before reinstalling the
  forked stubs, assert vcrpy is 8.1.x and the forked-internals symbols
  (`_vcr_request`, `_record_responses`, `ByteStream`, …) exist; otherwise raise
  a clear `issue #143` error at bootstrap time. Defense-in-depth for kernels
  that resolve vcrpy outside the pin.
- **`tests/workers/notebook/test_http_replay_vcr_pin_guard.py`** (7 tests): a
  pin-bound check that runs even without vcrpy installed; an installed-version
  check; an **upstream-source drift detector** (fails if vcrpy changes the
  forked functions); a check that flips to failing once upstream fixes the leak
  (the signal to retire the fork); and in-kernel guard behavior tests.
- **CI now installs `[replay]`** in the `test` job so the pin-guard / drift
  tests actually run in CI instead of being skipped by `importorskip("vcr")`.
  (Verified: 202 vcr-dependent tests pass with `[replay]` installed on
  Python 3.13.)
- **`docs/claude/vcrpy-upstream-patches.md`**: ready-to-submit upstream vcrpy
  patches (the `close()` fix + the scoped `force_reset` for #129) that would
  let the forks — and this whole guard — be retired once they land.

### Why now

The #143 stopgap forks vcrpy's internal control flow pinned to 8.1.x. The
bootstrap now carries **8** such workarounds, **5 of them added in the last
fortnight**. This PR caps the scariest failure mode (silent rot on a vcrpy
bump) for ~an hour of work, regardless of whether the larger #165 migration
proceeds.

Refs #143, toward #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
