### PR TITLE
feat(http-replay): out-of-process mitmproxy HTTP-replay transport, opt-in (#165)

### DIFF
--- a/docs/claude/design/http-replay-trace.md
+++ b/docs/claude/design/http-replay-trace.md
@@ -296,3 +296,65 @@ gating later if we want).
 Specifically: is the per-worker trace file layout right; is the event
 schema rich enough; are there other vcr internals worth instrumenting
 that I've missed?
+
+---
+
+## P5 re-port — mitmproxy transport mode (2026-05-31)
+
+Implemented for issue #165 P5. The harness above was designed for the
+in-kernel **vcrpy** path, where Stream 2 (vcr) is the interception
+evidence. Under the **out-of-process mitmproxy transport**
+(`CLM_HTTP_REPLAY_TRANSPORT=mitmproxy`) two of the three streams change:
+
+- **Stream 1 (socket) survives, but its meaning inverts.** vcrpy patched
+  *above* the socket, so a real `socket.connect` to a provider was the bug.
+  The proxy lives *below* the kernel's HTTP client: the kernel now
+  *legitimately* opens a TCP connection — to the **proxy**. So a connect to
+  the proxy is expected; a connect to anything else is the escape.
+- **Stream 2 (vcr) goes dark.** The kernel no longer imports vcr or patches
+  httpcore (the whole point of the transport), so there are no vcr internals
+  to wrap and no `force_reset` race to detect. Its role — *was this request
+  intercepted?* — moves to a new **Stream 2′ (proxy)** emitted by the addon.
+- **Stream 3 (cassette) is unchanged** (host-side merge lifecycle).
+
+### Stream 2′ — proxy (the addon's view)
+
+**Where:** the `mitmdump` process, via
+`clm.infrastructure.http_replay_mitm.trace_log.ProxyTraceLog` (pure stdlib,
+path-importable in the isolated mitmdump interpreter, same JSONL record shape
+as `TraceWriter`). Written to `proxy-<pid>.jsonl`.
+
+**Event types:**
+- `proxy.ready` — `{listen_host, listen_port, mode, build_id, ignore_hosts}`.
+  The `listen_port` is what lets the analyzer recognize a to-proxy connect.
+- `proxy.request` — `{method, scheme, host, port, has_tag, action}` where
+  `action ∈ {served, miss, ignored, forward, passthrough}` (the addon's
+  decision: cassette hit / strict-404 / ignore_hosts-forwarded / record-mode
+  upstream / untagged-no-catch-all).
+- `proxy.response` — `{host, port, status, recorded}` (emitted when an upstream
+  reply is persisted to a staging cassette).
+
+**Wiring:** `build.py` records `transport` in `manifest.json` and forwards the
+trace dir to `MitmproxyManager(trace_dir=…)`, which passes
+`--set clm_trace_dir=…` to mitmdump. Off entirely unless
+`CLM_HTTP_REPLAY_TRACE=1` (the directory is only created then).
+
+### Analyzer changes (`analyze_http_replay_trace.py`)
+
+`analyze()` reads `manifest["transport"]` (default `"vcrpy"` for
+back-compatibility with old bundles) and branches:
+
+- **vcrpy** → the original `_classify_bypasses` (vcr-event cross-reference +
+  `force_reset` race detection). Unchanged.
+- **mitmproxy** → `_classify_bypasses_transport`: a remote (non-loopback)
+  connect whose **port is the proxy's** is a *to-proxy* connect (expected); any
+  other remote connect is a **bypass**. Direct builds reach the proxy on
+  loopback, so any remote connect is already a bypass; Docker builds reach it
+  at the bridge-gateway IP on the proxy port, which the port match recognizes.
+  No race candidates (nothing patches the kernel).
+
+The report gains a **Proxy (interception evidence)** section and a
+**connection-bound** health line: the issue #143 leak signature was ≈1 leaked
+pooled connection per request (connects ≈ flows); healthy pooling to the
+out-of-process proxy keeps connects ≪ flows. This is how the deadlock-defeat
+gate (gate 1) is re-proven for the transport.

--- a/docs/claude/issue-165-p5-readiness.md
+++ b/docs/claude/issue-165-p5-readiness.md
@@ -1,0 +1,167 @@
+# Issue #165 P5 — cutover readiness report
+
+**Status:** prep (2026-05-31). P5 step 1 (trace-harness re-port) is **done**; the
+default-flip and workaround deletion remain **deferred to a post-merge release**
+per the plan invariant.
+
+This report is the decision aid for the eventual cutover. It records (1) why the
+flip is not done in this session, (2) the parity-gate readiness — distinguishing
+gates with committed runnable tests from those proven only by uncommitted
+e2e/probe runs, (3) the exact in-kernel-workaround deletion inventory with
+per-item deletion-safety, and (4) the deletion blast radius. Two empirical
+re-proofs run this session (gate 1 via the re-ported harness; gate 6 record-mode)
+are recorded inline.
+
+## Why the flip is deferred (not done now)
+
+The transport (P1–P4) is **branch-only**: draft PR #173 on
+`claude/issue-165-mitmproxy-transport`, **not merged to master, not in any
+release** (latest tag `v1.6.2`; master tip is #177/#172/#175). The plan invariant
+(issue-165-production-plan.md:8–14) says:
+
+> "The default flips to mitmproxy only after every parity gate holds **across a
+> full release cycle**, and the 8 in-kernel workarounds are deleted only then."
+
+Since the transport has not shipped behind the flag in any release, the flip and
+the deletions are categorically future-release work. Doing them now would violate
+the staging discipline. **vcrpy stays the default and is never uninstalled** (it
+remains the YAML serializer behind `cassette doctor` / `strip_cassette_hosts` /
+the cassette bridge).
+
+## Parity-gate readiness
+
+Audited gate-by-gate (workflow `wf_0d04be79-2d0`, skeptical lens: a gate is only
+*closed* if a runnable test proves it). Headline: the gates are **mechanism-proven
+by committed unit/smoke tests**, but several **scale / real-TLS / whole-build-byte
+proofs live only in uncommitted probe scripts + manual builds**. Before the
+cutover these should be committed as tests or re-run and recorded.
+
+| # | Gate | Committed test? | Residual gap |
+|---|------|-----------------|--------------|
+| 1 | Deadlock-defeat (16-worker, 0 stalls, py-spy clean) | **No** | Re-confirmed this session via the re-ported harness — isolated 0-bypass proof + 116-flow build with no pool-exhaustion signature (below). The full-scale *completing* 16-worker build is still not a committed test (cutover-gate item). |
+| 2 | HTTPS round-trip on Windows, real endpoints | Partial | Committed smoke tests are **HTTP-only (localhost, no CA trust)**; real HTTPS + `SSL_CERT_FILE`/CA only in uncommitted probe + manual OpenRouter build. |
+| 3 | Cassette byte-identity vs vcrpy | **Yes** | Strong: 9 `cassette_format` tests (plain/gzip/multi-value headers/LF/UTF-8/round-trip/reason-phrase). Only residual: identity vs a *real committed* cassette was e2e-only. |
+| 4 | Tooling (doctor / strip / merge) loads bridge cassettes | Partial | Only **merge** has a committed test against a bridge cassette; doctor/strip rely on the gate-3 byte-identity argument, not a direct test. |
+| 5 | Secret/telemetry hygiene; no-op rebuild grows nothing | **Yes** (+ live) | Secret-strip + ignore_hosts + filter byte-identity covered by unit/smoke; the **"grows nothing"** record half **closed this session** (real OpenRouter record → secret-clean cassette, below). Bonus: the partial build matched 111 dummy-key requests to real-key cassettes (filter parity at scale). |
+| 6 | JSON-match parity (real LLM JSON POSTs replay-hit) | **Yes** (+ live) | Replay-hit semantic JSON matching unit+smoke proven; **record-mode "grows nothing" closed this session** (real OpenRouter, byte-identical no-op rebuild, below). |
+| 7 | Strict-replay miss → fast non-zero build exit | Partial | Addon-layer non-retryable 404 is tested. This session showed the addon fast-fail is real, but a **langchain agent/retry layer above the SDK can re-issue a missed request**, so a miss can stall until the per-cell **Option-F timeout** (kept) fires — the full "fast exit" chain depends on that backstop, reinforcing the keep-Option-F decision. |
+| 8 | Concurrency routing (DE/EN multi-topic, split fallback) | Partial | Demux mechanism well covered; **actual concurrent** DE/EN traffic and the `.de/.en` split base-cassette fallback are not pinned for this transport (asserted by design). |
+| 9 | Default-unchanged (transport unset ⇒ bit-identical) | Partial | Early-return / no-inject invariants tested; **whole-build byte-identity** only verified in the uncommitted e2e. |
+
+**Cutover-gate recommendation:** before flipping the default, convert the
+uncommitted e2e/probe proofs for gates 1, 2, 7, 8, 9 into committed tests (or a
+documented, repeatable cutover-gate script), and close the gate-5/6 record-mode
+half (gate 6 run below).
+
+### Gate 1 re-proof (this session) — re-ported harness, mitmproxy transport
+
+Two empirical checks, both via the re-ported harness:
+
+1. **Isolated proxy smoke** (clean process, no kernel/venv): the real `mitmdump`
+   proxy started, the addon emitted `proxy.ready`, an HTTPS `GET` through the
+   proxy returned **200** (CA trust via the certifi+proxy-CA bundle works), the
+   `proxy` stream logged the request+response, and
+   `analyze_http_replay_trace.py` (transport mode) classified every kernel
+   `socket.connect` as **to-proxy with 0 bypasses**.
+2. **Partial reproducer build** (`chains-parallel-repro`, replay, 2 DE/EN decks,
+   dummy key): the transport intercepted at production fidelity — the addon
+   **served 111 of 116 flows** as cassette hits, with **no connection-pool
+   deadlock signature** (the kernel's real httpx pooled normally through the
+   proxy; the #143 leak class is structurally gone). Notably, those 111 hits
+   were dummy-key requests matching **real-key** committed cassettes — strong
+   at-scale evidence for the gate-5 secret-filter and gate-6 JSON-matcher
+   **replay** parity.
+
+   The build did **not complete**: 5 requests replay-**missed** the committed
+   cassettes (which predate the current build → request drift) → the addon's
+   non-retryable 404 → **langchain's agent/retry layer re-invoked** rather than
+   fast-failing, so the cell stalled (the per-cell **Option-F timeout** — kept —
+   is the real backstop here). This is a stale-cassette + langchain-retry
+   finding the harness *surfaced* (111 served / 5 miss attribution), **not** a
+   transport deadlock. It also sharpens gate 7: the addon-layer fast-fail is
+   real, but a retry/agent layer *above* the SDK can re-issue a missed request,
+   so the per-cell timeout must stay.
+
+**Conclusion:** deadlock-defeat is re-confirmed for the transport (isolated
+0-bypass proof + no pool-exhaustion signature at 116 flows). The full-scale
+16-worker *completing*-build proof remains a cutover-gate item (as already
+noted), now additionally gated on refreshing the reproducer's stale cassettes.
+Whether vcrpy would also miss those 5 requests was not A/B-tested — flag for the
+cutover gate.
+
+### Gate 6 re-proof (this session) — record-mode "grows nothing", real OPENROUTER
+
+**PASS.** A minimal real OpenRouter chat completion recorded through the addon
+(`new-episodes`): recorded a real interaction (HTTP 200, 2225-byte cassette);
+the recorded cassette is **secret-clean** — no raw key value, no
+`authorization`/`bearer` header, no `x-api-key`, no LangSmith host (filter
+parity with vcrpy holds on a *real* recording, not just synthetic fixtures); and
+a second identical request in `new-episodes` **served from cache** (no second
+upstream call) leaving the cassette **byte-identical** (sha unchanged,
+2225→2225). The record-mode "no-op rebuild grows nothing" half of gates 5/6 is
+therefore closed. (One-call run, key read from `.env`, never printed or
+persisted; the scratch cassette held no secret and was discarded.)
+
+## In-kernel workaround deletion inventory
+
+The "~480-line bootstrap" = `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE`
+(notebook_processor.py:209–~524) + `_HTTP_REPLAY_TRACE_TEMPLATE` (~527–~720). It
+embeds these workarounds. **None is deletable before the default-flip AND removal
+of the in-kernel vcrpy bootstrap** — both transports coexist behind the flag and
+vcrpy is still the default, so deleting any of these reintroduces its bug for
+every default (non-mitmproxy) build.
+
+| Workaround | In-kernel site | Disposition under transport | Replacement / parity |
+|---|---|---|---|
+| `scoped_force_reset` (#129) | nbp:253–269 | **Moot** (kernel httpcore never patched) | none needed — addon never enters a vcr cassette context |
+| `httpcore_close_fork` (#143) | nbp:442–514 | **Moot** (kernel never patched) | none needed; delete with bootstrap + relax the `[replay]` vcrpy pin + remove `test_http_replay_vcr_pin_guard.py` |
+| `convert_to_unicode_deepcopy` | nbp:284–289 | **Reimplemented** | `cassette_format.py:378` (deepcopy in `serialize_interactions`); ⚠ no drift-guard ties the two deepcopy sites |
+| `clm_json_body_matcher` | nbp:292–395 | **Reimplemented** | `cassette_format.py:279` + `REPLAY_MATCHERS`; drift-guarded by `test_filter_constants_and_matchers_match_bootstrap` |
+| `ignore_hosts` | nbp:193 (shared fn) + template:376 | **Reimplemented** (shared policy) | `resolve_http_replay_ignore_hosts` is **module-scope, used by both transports** — KEEP the function; only the template usage goes |
+| `allow_playback_repeats` | template:417 | **Reimplemented by construction** | addon serve loop is non-depleting (addon.py:292–297); ⚠ **no mitmproxy-side repeat regression test yet** |
+| `eager_append` | nbp:432–438 | **Reimplemented** | addon eager `write_cassette` (addon.py:343); kill-survival differs by design (markerless staging is swept, not folded) |
+| `per_cell_timeout` (Option-F) | nbp:146–169, applied :1885 | **KEEP** | transport-agnostic loud-failure net; not an HTTP concern — do **not** delete at the flip |
+
+Parity confidence is **high** for every reimplemented item (verbatim mirrors with
+a drift-guard test on the filter/matcher constants). Two follow-ups surfaced:
+
+- **`allow_playback_repeats` has no mitmproxy-side regression test.** Add a
+  "record once, replay the same request 2× with 0 upstream hits" smoke test
+  before deleting the in-kernel flag, so the non-depletion guarantee is pinned on
+  the surviving transport.
+- **`convert_to_unicode_deepcopy` drift is not guarded.** The kernel persister and
+  the addon's `serialize_interactions` deepcopy are independent; retiring one does
+  not auto-flag the other. Acceptable (the in-kernel one is deleted at the flip),
+  but note it.
+
+## Deletion blast radius (what to update at the flip)
+
+When `_HTTP_REPLAY_BOOTSTRAP_TEMPLATE` + `_inject_http_replay_bootstrap` are
+removed (mitmproxy becomes the sole transport):
+
+- **Delete** `TestBootstrapDurability` (test_notebook_processor.py ~3620–3971) and
+  the inject-shape/inject-policy tests (~2160–2380) — they `.format()`/`exec` the
+  template.
+- **Delete** `tests/workers/notebook/test_http_replay_vcr_pin_guard.py` entirely
+  (it guards the forked vcrpy 8.1.x internals) and **relax/remove** the
+  `pyproject.toml [replay]` vcrpy `>=8.1.1,<8.2` upper bound it protects.
+- **Rewrite** `test_filter_constants_and_matchers_match_bootstrap` to assert the
+  `cassette_format` constants directly (it currently reads the template text).
+- **Re-point** the two `cassette_format.py` doc comments (lines ~65, ~283) that
+  name the bootstrap as the parity source-of-truth.
+- **Keep** `resolve_http_replay_ignore_hosts` (module-scope, used by build.py).
+- The in-kernel `_HTTP_REPLAY_TRACE_TEMPLATE` and its
+  `test_trace_template_inlined_redactor_matches_host` test are superseded by the
+  P5 proxy-stream trace path (this session).
+
+## Sequencing for the cutover (future release)
+
+1. Land the transport behind the flag in a release (merge #173). Let it bake.
+2. Convert the uncommitted e2e/probe proofs (gates 1, 2, 7, 8, 9) into committed
+   tests or a repeatable cutover-gate script; add the `allow_playback_repeats`
+   mitmproxy regression test.
+3. After the gates hold across that release cycle, flip the default to mitmproxy
+   (keep `CLM_HTTP_REPLAY_TRANSPORT=vcrpy` selectable as rollback insurance).
+4. **Only then**, in the same commit that removes the in-kernel vcrpy bootstrap,
+   delete the moot/reimplemented workarounds above, remove the pin-guard, and
+   relax the vcrpy pin. Keep the Option-F per-cell timeout and vcrpy-as-serializer.

--- a/docs/claude/issue-165-phase0-findings.md
+++ b/docs/claude/issue-165-phase0-findings.md
@@ -1,0 +1,100 @@
+# Issue #165 — Phase 0 GO-gate findings
+
+Phase 0 of the mitmproxy migration (issue #165) is the evidence gate that
+decides whether to proceed. Two load-bearing unknowns dominated the assessment;
+both have now been measured empirically. Probe scripts live (throwaway) at
+`C:\Users\tc\Tmp\clm-phase0\`.
+
+Environment: Windows 11, Python 3.13.2, httpx 0.28.1, vcrpy 8.1.1 (the version
+CLM pins and forks), mitmdump via `uv tool install mitmproxy`
+(`C:\Users\tc\AppData\Roaming\uv\tools\mitmproxy\Scripts\mitmdump.exe`).
+
+## Gate 1 — HTTPS CA trust: **GREEN** (the easy path)
+
+The assessment's #1 risk: httpx/openai build their TLS context from vendored
+`certifi` and might ignore an injected CA, forcing a fragile per-kernel
+`certifi`-splice. The adversarial critic explicitly predicted httpx would
+ignore `SSL_CERT_FILE`.
+
+`ca_trust_probe.py` starts `mitmdump` with an isolated confdir, then drives a
+real HTTPS GET through it under each CA-trust config:
+
+| Config | Result |
+|---|---|
+| httpx default, no CA env | **FAIL** `CERTIFICATE_VERIFY_FAILED` (confirms mitm *is* intercepting) |
+| httpx default + `SSL_CERT_FILE`=mitm CA | **PASS 200** ← the key test |
+| httpx default + `REQUESTS_CA_BUNDLE`=mitm CA | FAIL (httpx ignores the requests-specific var) |
+| httpx `verify=<mitm CA>` explicit | PASS 200 (control: interception works) |
+| httpx default + certifi-splice (certifi+mitm) | PASS 200 (fallback also works) |
+| `requests` + `REQUESTS_CA_BUNDLE`=mitm CA | PASS 200 (LangSmith/telemetry path) |
+| openai-SDK-style httpx client + `SSL_CERT_FILE` | PASS 200 (inherits httpx) |
+
+**Conclusion:** httpx 0.28.1 **honors `SSL_CERT_FILE`** — no certifi-splice
+required. This refutes the assessment's highest-uncertainty risk; the splice
+remains as a proven fallback. Production guidance:
+
+- Point `SSL_CERT_FILE` at a **certifi + mitm-CA concatenated bundle** (not the
+  mitm CA alone), so `ignore_hosts` pass-through traffic that goes *directly* to
+  a real endpoint still validates against the real CA.
+- Use `REQUESTS_CA_BUNDLE` too for the `requests`-based LangSmith path.
+
+**Caveat:** measured on httpx 0.28.1 (CLM's locked version). Re-confirm if a
+course repo pins an older httpx.
+
+## Gate 2 — deadlock defeat (mechanism level): **GREEN**
+
+The assessment's #2 concern (critic): the claim that an out-of-process proxy
+"eliminates the deadlock class" was asserted by design, never measured.
+
+`deadlock_mechanism_probe.py` reproduces the #143 mechanism in miniature — a
+kernel httpx pool capped at `max_connections=2`, a burst of 6 concurrent GETs —
+and compares two transports:
+
+| Arm | Transport | Result |
+|---|---|---|
+| `vcrpy` | vanilla vcrpy 8.1.1 record-mode (the **unpatched, leaking** httpcore stub — master *minus* the #143 close() fork) | **DEADLOCK** — only 2/6 return; the other 4 block forever in `wait_for_connection` (subprocess hangs to the 30s timeout) |
+| `mitmproxy` | same burst through `mitmdump`; kernel uses real httpx/httpcore | **ALL 6/6 COMPLETED** in ~4s |
+
+**Conclusion:** the exact #143 pool-exhaustion deadlock reproduces with vcrpy's
+leaking in-process stub, and the out-of-process transport eliminates it — the
+kernel's real httpx returns connections to its pool normally because nothing is
+patched in-process. The deadlock *class* is genuinely defeated, not just the
+one instance the #168 stopgap patched.
+
+## What Phase 0 did NOT yet prove (remaining gate)
+
+This mechanism proof is single-process and small. It does **not** answer the
+critic's follow-on: can a **single shared `mitmdump`** sustain a real
+**16-kernel `.batch()` burst** without becoming a *new* serialization/throughput
+bottleneck? That needs the full reproducer:
+
+- Rig: `~/Programming/Python/Tests/clm-bug-repros/issue-143-cassette-connection-pool-deadlock/`,
+  spec `course-specs/chains-parallel-stress-cassette.xml` (9 topic copies, 16
+  workers), launcher `run-clm.ps1` (repoint its `PYTHONPATH` worktree to this
+  branch).
+- Requires: real OpenRouter API credit (recording path), the minimal
+  `CLM_HTTP_REPLAY_TRANSPORT=mitmproxy` build wiring (start manager in
+  `build.py`, inject `HTTP(S)_PROXY` + the certifi+CA bundle in
+  `worker_executor.py`, bypass the vcrpy bootstrap in `notebook_processor.py`),
+  and a `py-spy` clean check vs. the patched-vcrpy reference run.
+
+## Prototype package status (this branch)
+
+`src/clm/infrastructure/http_replay_mitm/` (ported from
+`claude/mitmproxy-prototype`): `MitmproxyManager` (Windows-aware lifecycle:
+`CREATE_NEW_PROCESS_GROUP` + `CTRL_BREAK_EVENT`, port pick, readiness poll) and
+`ClmReplayAddon` (record / replay / new-episodes / refresh / once; 599-on-miss;
+eager flush; native `.mitm` format — YAML bridge is later work). The 4 smoke
+tests pass with the `uv tool` mitmdump. The smoke test's
+`importorskip("mitmproxy")` was removed (the in-process import is wrong for the
+`uv tool install` model — the test only needs mitmdump as a subprocess).
+
+## Net effect on the decision
+
+Both dominant unknowns resolved favorably. The conservative ~2–3.5 week estimate
+was driven largely by the HTTPS/certifi unknown, now de-risked. The GO case is
+materially stronger than the cautious baseline assumed. Remaining real work:
+the single-proxy throughput proof, the YAML cassette bridge, request→cassette
+routing for concurrent multi-topic builds, secret/`ignore_hosts` parity in the
+addon, and Docker-worker reachability — all per the staged plan, vcrpy remaining
+the default until parity gates pass.

--- a/docs/claude/issue-165-phase0-findings.md
+++ b/docs/claude/issue-165-phase0-findings.md
@@ -61,22 +61,68 @@ kernel's real httpx returns connections to its pool normally because nothing is
 patched in-process. The deadlock *class* is genuinely defeated, not just the
 one instance the #168 stopgap patched.
 
-## What Phase 0 did NOT yet prove (remaining gate)
+## Gate 3 — full-build single-proxy throughput: **GREEN**
 
-This mechanism proof is single-process and small. It does **not** answer the
-critic's follow-on: can a **single shared `mitmdump`** sustain a real
-**16-kernel `.batch()` burst** without becoming a *new* serialization/throughput
-bottleneck? That needs the full reproducer:
+The critic's follow-on to gate 2: a single-process micro-repro can't show
+whether **one shared `mitmdump`** sustains a real **16-kernel `.batch()` burst**
+or becomes a new serialization/throughput bottleneck. Run against the full
+reproducer (`chains-parallel-stress-cassette.xml`, 9 topic copies × DE/EN = 18
+notebooks, `--notebook-workers 16`, `--http-replay new-episodes`) through the
+minimal transport wiring (this branch), launcher `C:\Users\tc\Tmp\clm-phase0\run-mitm.ps1`
+(`PYTHONPATH`→this worktree, `CLM_HTTP_REPLAY_TRANSPORT=mitmproxy`,
+`CLM_MITMDUMP`→uv-tool mitmdump), key sourced from `PythonCourses/.env`,
+`LANGSMITH_TRACING=false`:
 
-- Rig: `~/Programming/Python/Tests/clm-bug-repros/issue-143-cassette-connection-pool-deadlock/`,
-  spec `course-specs/chains-parallel-stress-cassette.xml` (9 topic copies, 16
-  workers), launcher `run-clm.ps1` (repoint its `PYTHONPATH` worktree to this
-  branch).
-- Requires: real OpenRouter API credit (recording path), the minimal
-  `CLM_HTTP_REPLAY_TRANSPORT=mitmproxy` build wiring (start manager in
-  `build.py`, inject `HTTP(S)_PROXY` + the certifi+CA bundle in
-  `worker_executor.py`, bypass the vcrpy bootstrap in `notebook_processor.py`),
-  and a `py-spy` clean check vs. the patched-vcrpy reference run.
+```
+✓ Build completed successfully in 118.5s
+  Stage 3/4: HTML Speaker (18 jobs)
+  36 files processed · 0 errors · 0 warnings
+```
+
+Corroborating evidence:
+- `mitm/transport.mitm` = **506 KB** — the proxy recorded real OpenRouter HTTPS
+  flows (the LLM calls genuinely routed through it and the CA was trusted under
+  load).
+- `clm.log`: `mitmproxy transport active: proxy=http://127.0.0.1:NNNNN
+  mode=new-episodes …` then `Stopping mitmproxy transport…` — clean lifecycle.
+- **0** occurrences of `wait_for_connection` / `PoolTimeout` / `CellTimeoutError`
+  in the build log — the exact inverse of the vcrpy run, where `py-spy` showed
+  all 16 kernels frozen in `wait_for_connection`.
+- **0** vcrpy bootstraps injected (`grep -ci "import vcr|_vcr_handle"` == 0) —
+  the bypass holds under full concurrency.
+
+**Conclusion:** the same 16-worker reproducer that deadlocks under vcrpy
+completes cleanly in ~2 minutes through one shared mitmdump. The single-proxy
+throughput concern is empirically cleared at production-like load; per-worker
+proxies are not needed for this workload. The HTTPS/CA path also works
+end-to-end against real OpenRouter under load (gate 1 confirmed at scale).
+
+### Minimal transport wiring (this branch, opt-in, default-off)
+
+Three surgical edits gated on `CLM_HTTP_REPLAY_TRANSPORT=mitmproxy` (unset =
+today's behavior, bit-identical):
+- `build.py` `_maybe_start_mitmproxy_transport`: starts one `mitmdump` before
+  workers spawn, splices a **certifi + proxy-CA** bundle, sets
+  `HTTP(S)_PROXY`/`SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` in `os.environ` (Direct
+  workers inherit via `os.environ.copy()`); stopped in the build `finally`.
+- `notebook_processor.py` `_resolve_cassette_paths`: returns `None` under the
+  transport → no vcrpy bootstrap, no staging, no merge; kernel httpx is never
+  patched.
+- `proxy_manager.py` `_locate_mitmdump`: `CLM_MITMDUMP` override for the
+  `uv tool install` model.
+
+Note: this proof used **one shared cassette** (no per-(topic,language,kind)
+routing) and **Direct** workers only — both correctness/coverage items remain
+for later phases, but neither affects the deadlock/throughput conclusion.
+
+## What still remains for production (later phases, per the staged plan)
+
+Not blockers for the GO decision, but required before vcrpy can be retired:
+the YAML cassette bridge (vs the prototype's native `.mitm`), request→cassette
+routing for concurrent multi-topic correctness, secret-filtering + `ignore_hosts`
++ JSON-body-match parity in the addon, strict-replay-miss → non-zero build exit
+parity, and Docker-worker reachability (`host.docker.internal` + CA-in-container).
+vcrpy stays the default until those parity gates pass.
 
 ## Prototype package status (this branch)
 

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -232,19 +232,69 @@ behavior (the design doc wrongly called these "trivial").
   secrets/LangSmith; real LLM JSON POSTs replay-hit (no spurious 599); a
   deliberate miss fails the build non-zero.
 
-## P4 — Docker worker support  ·  ~3–5 d  ·  risk: high  ·  separately gated
+## P4 — Docker worker support  ·  ~3–5 d  ·  risk: high  ·  **DONE**
 
-A `127.0.0.1` mitmdump is unreachable inside a container.
+**Status (done):** Docker notebook workers now reach the proxy and the full
+record→merge→replay round-trip works inside a container.
 
-- Rewrite the container env host to `host.docker.internal` (mirror the
-  `CLM_API_URL` pattern; `extra_hosts: host-gateway` is already set); add
-  `HTTP(S)_PROXY` + `SSL_CERT_FILE` to the Docker env allowlist; mount + trust
-  the per-build CA inside the container.
-- **Gate:** a Docker-worker build completes an HTTPS LLM round-trip via
-  `host.docker.internal` with CA trust. **If infeasible:** Docker stays
-  vcrpy-only and vcrpy is retained for it — this does not block Direct-mode
-  mitmproxy, but vcrpy deletion is gated on Docker being supported or explicitly
-  scoped out.
+- **Wildcard bind, scoped:** `build._maybe_start_mitmproxy_transport` binds the
+  proxy `0.0.0.0` (so containers reach it via `host.docker.internal`) **only when
+  a Docker _notebook_ worker is configured** (`_build_has_docker_notebook_worker`);
+  Direct-only and diagram-only-Docker builds keep the `127.0.0.1` bind. The
+  `os.environ` proxy URL stays a loopback address — `MitmproxyManager._client_host`
+  returns `127.0.0.1` for a wildcard bind so Direct workers and the readiness poll
+  connect via loopback (`connect("0.0.0.0")` is invalid on Windows); the bind host
+  itself stays the wildcard.
+- **Per-container injection:** `DockerWorkerExecutor` injects into the **notebook**
+  container only (`worker_executor._mitmproxy_docker_env`): `HTTP(S)_PROXY` rewritten
+  host→`host.docker.internal` (preserving the port), `NO_PROXY=host.docker.internal`
+  so worker↔CLM-REST-API traffic (`CLM_API_URL`) **bypasses** the proxy (else worker
+  registration would replay-miss and stall the build), a **read-only CA-bundle bind
+  mount** + `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`, and
+  `CLM_HTTP_REPLAY_TRANSPORT` passthrough. `host.docker.internal` is a shared
+  `_DOCKER_HOST_ALIAS` constant used by both the API-URL build and `NO_PROXY` so they
+  cannot drift. `extra_hosts host-gateway` was already set.
+- **Host-namespace cassette tag:** `_resolve_mitmproxy_tag` resolves the
+  `X-CLM-Cassette` tag against `payload.source_topic_dir` (the **host** path) — the
+  proxy + `merge_mitmproxy_cassette_staging` run host-side, so a container `/source`
+  path would write staging to a bogus host location. The vcrpy path still uses the
+  container `source_dir` (its in-container kernel writes there).
+
+**Gate (PASSED):** a real Docker notebook-worker build completed the
+record→merge→replay round-trip via `host.docker.internal` with CA trust: the
+container's HTTPS GET was intercepted (200), worker registration succeeded through
+`NO_PROXY`, staging landed at the **host** canonical path, and an offline replay (the
+recorded body was tampered to a sentinel) served the cassette — proving the
+replay-mode proxy never forwards upstream. The lite image (no `vcr` installed) ran
+fine, confirming the transport drops the kernel's vcr dependency.
+
+**Caveats / follow-ups (confirmed by the P4 adversarial review; behind the opt-in
+flag, default-unset unaffected):**
+
+- **Open-proxy LAN exposure (MEDIUM):** the `0.0.0.0` bind makes the proxy an
+  unauthenticated listener on the LAN for the build's duration; in record-capable
+  modes (default non-CI is `new-episodes`) it can relay/record arbitrary traffic and
+  attacker-supplied responses could be merged into committed cassettes. This mirrors
+  the existing `0.0.0.0` `WorkerApiServer` and is now scoped to Docker-notebook builds.
+  **Hardening follow-up:** bind the docker-bridge gateway IP instead of all interfaces,
+  or enable `mitmdump --proxyauth` with a per-build credential injected alongside
+  `HTTP(S)_PROXY`.
+- **Image must contain mitmproxy-aware CLM (MEDIUM):** the in-container tag bootstrap /
+  vcrpy-skip live in `notebook_processor`, so the worker **image must be built from a
+  CLM version that has the mitmproxy transport** (≥ the P2 tag-bootstrap). A pre-mitmproxy
+  image silently mis-routes record-mode traffic to the catch-all (strict modes fail loud
+  via the 404-miss). The E2E gate validated against a **source-shadowed** lite image (the
+  local prebuilt image is 1.5.0); production needs a rebuilt image. There is no host↔image
+  version negotiation — a runtime guard is a possible follow-up.
+- **Firewall opacity (NIT):** the host readiness poll proves only loopback reachability,
+  not docker-bridge reachability; a firewall blocking the bridge→proxy port surfaces as
+  generic LLM connection failures bounded by `max_job_time` + the #93 fail-on-error policy,
+  not a clear "proxy unreachable". A container-side preflight is a possible follow-up.
+- **Nested-subdir notebooks (LOW):** an http-replay notebook must keep its cassette beside
+  the notebook at the topic root; a notebook nested in a sub-dir diverges the tag (topic-dir)
+  from the merge (notebook-parent) and would misplace record-mode staging (replay unaffected).
+  Pre-existing in the vcrpy direct path; converging is a separate follow-up touching both
+  transports.
 
 ## P5 — trace-harness re-port + vcrpy retirement  ·  ~3–5 d  ·  risk: medium
 
@@ -296,8 +346,10 @@ flag with its parity gate; nothing changes the default until P5.
 - **Routing mechanism (P2):** per-request worker tagging vs per-worker proxies.
   Tagging keeps the proven single-proxy model and one cassette-merge path;
   per-worker proxies re-open port management. Recommendation: tagging.
-- **Docker in v1 (P4):** support now, or ship Direct-only and keep vcrpy for
-  Docker? The recordings/CI footprint determines urgency.
+- **Docker in v1 (P4):** ~~support now, or ship Direct-only and keep vcrpy for
+  Docker?~~ **Resolved: supported now** (P4 DONE) — Docker notebook workers reach
+  the proxy via `host.docker.internal` with CA trust, gate passed. Remaining items
+  are the P4 hardening follow-ups (proxyauth/bridge-bind; production image rebuild).
 - **Upstream-first:** if the upstream vcrpy `close()` + scoped `force_reset`
   patches (`docs/claude/vcrpy-upstream-patches.md`) land, the #143/#129 forks
   retire independently — reducing the urgency delta but not the cross-process

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -296,16 +296,51 @@ flag, default-unset unaffected):**
   Pre-existing in the vcrpy direct path; converging is a separate follow-up touching both
   transports.
 
-## P5 — trace-harness re-port + vcrpy retirement  ·  ~3–5 d  ·  risk: medium
+## P5 — trace-harness re-port + vcrpy retirement  ·  ~3–5 d  ·  risk: medium  ·  **STEP 1 DONE; flip/deletion deferred**
 
-- Re-port the Phase-A diagnostic: its `socket.connect` ground-truth survives,
-  but the vcr-stream events go dark — rebuild the methodology against proxy logs.
-- Run the full parity-gate suite (below). If all pass and Docker is supported or
-  scoped out, flip the default to mitmproxy for one release with
+**Status (2026-05-31):** step 1 (the trace-harness re-port) is **shipped on the
+branch** and the one open record-mode parity gate is **closed**. The default-flip
+and workaround deletion stay **deferred to a post-merge release** — the transport
+is still branch-only (draft #173, not merged, latest tag v1.6.2), so the plan's
+own invariant ("flip only after the gates hold across a full release cycle") is
+not yet satisfiable. Full readiness analysis, the per-gate audit, the
+workaround-deletion inventory, and the deletion blast radius are in
+`docs/claude/issue-165-p5-readiness.md`.
+
+- **Trace-harness re-port (DONE).** Under the transport the kernel `socket`
+  stream survives but its meaning inverts (the kernel's intended target is the
+  proxy) and the `vcr` stream goes dark. New pieces: a pure stdlib
+  `http_replay_mitm/trace_log.py` (`ProxyTraceLog`, path-importable in the
+  mitmdump interpreter) the addon uses to emit a **`proxy` stream**
+  (`proxy.ready`/`request`/`response`); a self-contained
+  `_HTTP_REPLAY_SOCKET_TRACE_TEMPLATE` appended to the tag bootstrap so the
+  kernel still emits the `socket` ground truth; manager `trace_dir` plumbing +
+  manifest `transport` field; and `analyze_http_replay_trace.py` gains a
+  transport mode (bypass = a connect whose port is not the proxy's; proxy-flow
+  stats replace the dark vcr stream). Design addendum in
+  `docs/claude/design/http-replay-trace.md`. Proven by the isolated proxy smoke
+  (proxy.ready + HTTPS-via-proxy 200 + 0-bypass) and a 116-flow reproducer build
+  (111 served, **no pool-exhaustion deadlock signature**).
+- **Gate 6 record-mode "grows nothing" — CLOSED.** A minimal real-OpenRouter
+  record through the addon produced a **secret-clean** cassette (no key /
+  authorization / x-api-key / LangSmith) and a no-op rebuild left it
+  **byte-identical**. This was the only gate the plan did not claim closed.
+- **Finding (sharpens gate 7, validates keeping Option-F):** a strict-replay
+  miss fast-fails at the addon (404) and the SDK, but **langchain's agent/retry
+  layer above the SDK can re-issue a missed request**, so a stale-cassette miss
+  can stall a cell until the per-cell Option-F timeout fires. Keep Option-F.
+- **Still to do at the cutover (future release):** convert the uncommitted
+  scale/e2e proofs (gates 1, 2, 7, 8, 9) into committed tests or a repeatable
+  cutover-gate script; add an `allow_playback_repeats` regression test on the
+  mitmproxy side; then flip the default for one release with
   `CLM_HTTP_REPLAY_TRANSPORT=vcrpy` still selectable as rollback insurance.
-- **Only then** delete the 8 in-kernel workarounds + the ~480-line bootstrap
-  templates. Keep the Option-F per-cell timeout as a transport-agnostic
-  loud-failure net. Keep vcrpy installed as the YAML serializer.
+- **Only then** delete the moot/reimplemented in-kernel workarounds + the
+  ~480-line bootstrap templates **in the same commit that removes the in-kernel
+  vcrpy bootstrap** (deleting earlier reintroduces #129/#143 for every default
+  build — see the readiness inventory), remove `test_http_replay_vcr_pin_guard.py`
+  and relax the `[replay]` vcrpy pin. Keep the Option-F per-cell timeout as a
+  transport-agnostic loud-failure net, and keep vcrpy installed as the YAML
+  serializer.
 
 ---
 

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -136,11 +136,11 @@ matcher functions so behavior is identical by construction.
   content-type is JSON case-insensitively; byte-compare otherwise) — the exact
   `match_on` the in-kernel vcrpy uses. A real LLM JSON POST replay-hits even when
   the live body differs only by key order / separators (smoke test); a byte key
-  would 599-miss. A drift-guard test pins the `FILTER_*` constants + matcher set
+  would miss. A drift-guard test pins the `FILTER_*` constants + matcher set
   to the bootstrap literals.
 - **Strict `once`/`refresh` per target**: `addon._modes_for` resolves
   `(serve, record, overwrite)` per target — `once` is existence-dependent
-  (present → strict replay/599-on-miss; absent → record-and-serve), `refresh`
+  (present → strict replay/404-on-miss; absent → record-and-serve), `refresh`
   never serves and overwrites. `refresh`-overwrite is completed by the new
   `merge_staging_into_canonical(overwrite_existing=…)` (last-seen-staging-wins,
   in-place canonical replacement) wired on for `refresh` in **both** the
@@ -148,12 +148,19 @@ matcher functions so behavior is identical by construction.
   refresh-overwrite gap for both transports. The default (`overwrite_existing=False`)
   additive branch is kept **verbatim** so the vcrpy default path stays
   byte-identical.
-- **Strict-replay-miss → non-zero build exit**: a miss returns the diagnostic
-  HTTP 599 (never escaping to the network). The kernel's SDK surfaces it as an
-  `APIStatusError` → cell error → the #93 fail-on-error policy → non-zero build
-  exit, the same end state as vcrpy's `CannotOverwriteExistingCassetteException`
-  (the 599 is briefly retried by the SDK's 5xx retry, bounded; it never hangs or
-  passes). Gate covered by the existing strict-miss smoke test + #93 policy.
+- **Strict-replay-miss → fast non-zero build exit**: a miss returns a
+  **non-retryable HTTP 404** (`_REPLAY_MISS_STATUS`) with an SDK-shaped
+  `{"error": {message, type, code}}` body and never escapes to the network. The
+  kernel's SDK raises `NotFoundError` on the **first attempt** → cell error → the
+  #93 fail-on-error policy → non-zero build exit, the out-of-process analogue of
+  vcrpy raising `CannotOverwriteExistingCassetteException` synchronously. **The
+  e2e gate caught that the original 599 (a 5xx) was *retried* by the SDK** —
+  measured: a probe showed openai 2.32 retries 599/500/429 (3 calls) but raises
+  on the first attempt for 404/400/422; under a deck's many `.batch()` calls the
+  599 retry amplified one stale-cassette miss into a ~1200s build-timeout hang.
+  The 404 fix makes a forced miss fail the build in seconds with a clean
+  `NotFoundError: clm_replay_miss: …` (validated end-to-end against the #143
+  reproducer; isolated probe shows 1.8s single-attempt vs 3.5s retried).
 - **Kill-survival**: the addon writes the staging cassette eagerly on every
   recorded response (unchanged from P2), so a build-timeout kill of mitmdump
   loses nothing.
@@ -162,25 +169,33 @@ matcher functions so behavior is identical by construction.
   joined on stop (no leak) and `_drain_output` no longer races the thread with
   `communicate()`. Unit-tested against an 800 KiB-output subprocess.
 
-**Gates:** secret/telemetry hygiene (no auth/cookie/api-key, no LangSmith) and
-JSON-match parity (real JSON POSTs replay-hit, no spurious 599) and strict-miss →
-non-zero exit are covered by the new unit + smoke tests; full fast suite green
-(5795 passed).
+**Gates:** secret/telemetry hygiene (no auth/cookie/api-key, no LangSmith),
+JSON-match parity (real JSON POSTs replay-hit, no spurious miss) and strict-miss →
+fast non-zero exit are covered by the new unit + smoke tests; full fast suite
+green (5795 passed).
+
+**E2E gate run against the #143 reproducer (18 committed DE/EN split-deck
+cassettes, dummy key, no network egress):** gates **5 + 6 PASS at production
+scale** — all 18 notebooks re-executed (`--ignore-cache`, 177s), every real LLM
+JSON POST replay-**hit** (exit 0, 0 errors, no miss), the 18 cassettes came out
+**byte-identical**, and the dummy key's auth header was filtered before matching
+so it still matched the real-key recording. Gate **7**: a forced miss (renamed
+cassette) initially exposed a real defect — the 599 retry-amplification hang
+above — now **fixed (non-retryable 404)** and re-validated: a forced miss fails
+the build with a clean `NotFoundError` cell error in seconds, no timeout. The
+only piece still **deferred (needs OPENROUTER credentials + real spend):** the
+record-mode "no-op rebuild grows nothing" half — lower-risk (record byte-identity
+is unit-proven), best run as part of the P5 cutover gate.
 
 **Adversarial review (workflow `wf_7e8803f5-482`, 5 probe-driven lenses → verify):
-1 confirmed, 2 refuted.** Confirmed (MEDIUM, severity overstated by the verdict —
-no correctness bug): the "599 → bounded SDK retry → fail" claim was asserted but
-not documented in-code. Fixed in this branch by documenting it at
-`addon._replay_miss_response` and at `notebook_processor`'s replay cell-timeout —
-the existing 600s per-cell ceiling (`_HTTP_REPLAY_DEFAULT_CELL_TIMEOUT`, issue
-#143 Option-F) is the backstop against any future unbounded SDK retry. Refuted:
-(a) `set-cookie` in `filter_headers` "violates HTTP semantics" — intentional
-vcrpy parity, drift-guarded; (b) kernel-side 599 not explicitly detected — the
-599 is explicit/structured and SDKs fail on it; out of P3 scope. **Deferred (e2e
-gate, not a code change):** a one-off real-LLM no-op-rebuild run to confirm the
-empty cassette git-diff + a deliberate miss fails the build non-zero with the
-real SDK (the strict-miss smoke test + #93 policy cover the mechanism; the e2e
-confirmation needs OPENROUTER credentials).
+1 confirmed, 2 refuted.** Confirmed (MEDIUM): the "599 → bounded SDK retry → fail"
+claim was asserted but unvalidated — the e2e then proved it was actually a
+~1200s hang (599 is a 5xx → SDK-retried → amplified across `.batch()` calls).
+Fixed by switching the miss to a non-retryable 404 (fast first-attempt
+`NotFoundError`), validated by probe + e2e. Refuted: (a) `set-cookie` in
+`filter_headers` "violates HTTP semantics" — intentional vcrpy parity,
+drift-guarded; (b) kernel-side miss not explicitly detected — the miss is
+explicit/structured and SDKs fail on it; out of P3 scope.
 
 The prototype addon lacked parity with the vcrpy bootstrap's load-bearing
 behavior (the design doc wrongly called these "trivial").
@@ -254,13 +269,17 @@ A `127.0.0.1` mitmdump is unreachable inside a container.
    cassettes unchanged — P1.
 5. Secret/telemetry hygiene: no auth/cookie/api-key headers, no LangSmith; no-op
    rebuild grows nothing — P3 ✅ (filter byte-identity vs vcrpy + ignore_hosts;
-   secret-stripping + LangSmith-not-recorded smoke tests).
-6. JSON-match parity: real LLM JSON POSTs replay-hit, no spurious 599 — P3 ✅
+   secret-stripping + LangSmith-not-recorded smoke tests; **e2e: 18 real cassettes
+   replayed byte-identical with a dummy key**).
+6. JSON-match parity: real LLM JSON POSTs replay-hit, no spurious miss — P3 ✅
    (vcr-matcher-chain replay scan incl. `clm_json_body`; JSON-POST replay smoke
-   test). End-to-end real-LLM no-op-rebuild diff still wants a one-off manual run.
-7. Strict-replay failure parity: a miss → non-zero build exit, not swallowed —
-   P3 ✅ via the 599 → SDK `APIStatusError` → #93 policy (strict-miss smoke test
-   asserts the 599; #93 turns it into a non-zero exit).
+   test; **e2e: 18-notebook real replay, exit 0, no miss**). Record-mode no-op
+   "grows nothing" half still wants a one-off real-LLM run (OPENROUTER creds).
+7. Strict-replay failure parity: a miss → *fast* non-zero build exit, not
+   swallowed — P3 ✅ via a **non-retryable 404** → SDK `NotFoundError` → #93
+   policy. **e2e-validated:** the original 599 (a 5xx) was SDK-retried into a
+   ~1200s timeout hang; the 404 fix fails a forced miss in seconds with a clean
+   cell error (probe + reproducer build).
 8. Concurrency routing: DE/EN multi-topic routes correctly, no contamination;
    split fallback resolves — P2.
 9. Default-unchanged: transport unset ⇒ build bit-identical to vcrpy (✅ tests).

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -19,9 +19,22 @@ format), opt-in Direct-mode wiring, 4 smoke + 3 no-op regression tests.
 
 ---
 
-## P1 — vcrpy-YAML cassette bridge  ·  ~3–4 d  ·  risk: medium
+## P1 — vcrpy-YAML cassette bridge  ·  ~3–4 d  ·  risk: medium  ·  **DONE**
 
-The addon persists native `.mitm` today. Production must read/write the
+**Status (done):** the addon now persists the vcrpy v1 YAML schema via a
+pure `cassette_format.py` bridge (imports only `vcr` + stdlib; importable
+both as a CLM submodule and by bare path inside the `uv tool` mitmdump
+interpreter, which now carries vcrpy via `uv tool install mitmproxy --with
+vcrpy`). The bridge routes through vcrpy's own `serialize` / `Request` /
+`decode_response`, so output is byte-identical to a vcrpy-recorded
+cassette. Gate proven by `tests/infrastructure/test_http_replay_mitm_cassette_format.py`
+(byte-identity vs vcrpy for plain + gzip + multi-value headers, LF
+endings, no `convert_to_unicode` aliasing leak, round-trip load, and
+`merge_staging_into_canonical` folding a bridge cassette). The 4 mitmproxy
+smoke tests pass against the new format (record → replay → strict-miss
+599). Still single-shared-cassette — per-target routing is P2.
+
+The addon persisted native `.mitm` before. Production must read/write the
 **existing vcrpy v1 YAML schema** so committed course cassettes and the
 doctor/strip/merge tooling keep working unchanged.
 

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -1,0 +1,150 @@
+# Issue #165 — production plan (mitmproxy HTTP-replay transport)
+
+Phase 0 is complete and all three GO gates are GREEN (see
+`issue-165-phase0-findings.md`): CA trust, deadlock-class elimination, and
+single-proxy throughput at 16-worker load. The architectural risk is retired.
+What follows is **known production engineering**, not unknowns.
+
+**Invariant for every phase below:** vcrpy stays the **default**;
+`CLM_HTTP_REPLAY_TRANSPORT=mitmproxy` is opt-in and must remain bit-identical to
+today when unset. vcrpy is **never uninstalled** — it remains the pure YAML
+serializer behind `clm cassette doctor`, `strip_cassette_hosts.py`, and
+`merge_staging_into_canonical`. The default flips to mitmproxy only after every
+parity gate holds across a full release cycle, and the 8 in-kernel workarounds
+are deleted only then.
+
+Current state (branch `claude/issue-165-mitmproxy-transport`, draft #173, stacked
+on insurance #172): `MitmproxyManager` + `ClmReplayAddon` (native `.mitm`
+format), opt-in Direct-mode wiring, 4 smoke + 3 no-op regression tests.
+
+---
+
+## P1 — vcrpy-YAML cassette bridge  ·  ~3–4 d  ·  risk: medium
+
+The addon persists native `.mitm` today. Production must read/write the
+**existing vcrpy v1 YAML schema** so committed course cassettes and the
+doctor/strip/merge tooling keep working unchanged.
+
+- Convert `HTTPFlow` ⇄ vcrpy `(Request, response-dict)` at the addon boundary.
+- Write via `vcr.serialize.serialize` + `FilesystemPersister` — verified
+  near-pure (import `yaml` / `vcr.request.Request` / `vcr.serializers.compat`;
+  no live VCR/cassette/patching context needed). Read via `vcr.deserialize`.
+- **Must:** LF-only writes through the shared atomic-write helper (not
+  `FilesystemPersister`'s default newline) to avoid CRLF flapping under the
+  repo's `eol=lf` gitattributes; emit headers as dict-of-lists and
+  `response.body.string` as UTF-8 text so `cassette doctor` / `strip` load it;
+  `decode_compressed_response` parity (gzip/deflate/br); avoid the
+  `convert_to_unicode` bytes→str in-place mutation (the workaround-#2 footgun)
+  by not aliasing dicts between the index and the writer.
+- **Gate:** a mitmproxy-recorded cassette for a deck is byte-comparable to the
+  vcrpy-produced one; `cassette doctor` and `strip_cassette_hosts.py` operate on
+  it unchanged.
+
+## P2 — request→cassette routing (concurrent multi-topic)  ·  ~2–3 d  ·  risk: medium
+
+The Phase-0 proof used **one shared cassette**; production needs each request
+mapped to the correct per-(topic, language, kind) cassette under concurrency.
+
+- Tag each request per worker (e.g. an `X-CLM-Cassette` header injected by the
+  worker env / a tiny client hook, stripped before recording) so the single
+  addon demuxes flows into the correct per-target staging file — or run one
+  proxy per worker (rejected unless P1/throughput says otherwise; the shared
+  proxy is proven sufficient).
+- Reuse the existing `merge_staging_into_canonical` (resolve_paths, FileLock,
+  `.completed` markers, `sweep_orphans`, dedup key) — format-agnostic, hardened
+  by the #145 + BytesIO fixes.
+- Preserve the `.de`/`.en` split-deck base-cassette fallback (#159/#161).
+- **Gate:** a concurrent DE/EN multi-topic build routes each topic's flows to the
+  correct staging file and merges with no cross-contamination; split fallback
+  still resolves.
+
+## P3 — correctness/security parity in the addon  ·  ~3–5 d  ·  risk: high
+
+The prototype addon lacks parity with the vcrpy bootstrap's load-bearing
+behavior (the design doc wrongly called these "trivial").
+
+- **Secret filtering** at record time: `authorization`, `cookie`, `x-api-key`,
+  `set-cookie` headers + post-data/query params (match the bootstrap's
+  `filter_headers` / `filter_post_data_parameters` / `filter_query_parameters`).
+- **`ignore_hosts`** pass-through (default `api.smith.langchain.com`,
+  `CLM_HTTP_REPLAY_IGNORE_HOSTS` override) so LangSmith telemetry never enters
+  the cassette (re-introducing the PR #146 churn).
+- **JSON-semantic body matching** in `_request_key` (parse JSON when
+  content-type is `application/json` case-insensitively; byte-compare otherwise)
+  — matching `_clm_json_body_matcher`, or a byte-exact key 599-misses real LLM
+  JSON POSTs.
+- **Strict-replay-miss → loud build failure**: verify the 599 propagates as a
+  non-zero build exit equivalent to vcrpy's `CannotOverwriteExistingCassetteException`
+  + the #93 exit policy, and is not swallowed/retried by the langchain/openai
+  retry layers.
+- **Kill-survival:** confirm the addon flushes each flow synchronously on
+  response (eager-append equivalent) so a build-timeout kill of mitmdump loses
+  no recorded interactions.
+- **Manager robustness:** drain mitmdump stdout on a reader thread (avoid a
+  multi-hour-build PIPE-buffer deadlock); define proxy lifetime under watch-mode
+  rebuilds (one proxy across the watch session vs per-rebuild).
+- **Gates:** no-op rebuild yields an empty cassette git-diff and contains no
+  secrets/LangSmith; real LLM JSON POSTs replay-hit (no spurious 599); a
+  deliberate miss fails the build non-zero.
+
+## P4 — Docker worker support  ·  ~3–5 d  ·  risk: high  ·  separately gated
+
+A `127.0.0.1` mitmdump is unreachable inside a container.
+
+- Rewrite the container env host to `host.docker.internal` (mirror the
+  `CLM_API_URL` pattern; `extra_hosts: host-gateway` is already set); add
+  `HTTP(S)_PROXY` + `SSL_CERT_FILE` to the Docker env allowlist; mount + trust
+  the per-build CA inside the container.
+- **Gate:** a Docker-worker build completes an HTTPS LLM round-trip via
+  `host.docker.internal` with CA trust. **If infeasible:** Docker stays
+  vcrpy-only and vcrpy is retained for it — this does not block Direct-mode
+  mitmproxy, but vcrpy deletion is gated on Docker being supported or explicitly
+  scoped out.
+
+## P5 — trace-harness re-port + vcrpy retirement  ·  ~3–5 d  ·  risk: medium
+
+- Re-port the Phase-A diagnostic: its `socket.connect` ground-truth survives,
+  but the vcr-stream events go dark — rebuild the methodology against proxy logs.
+- Run the full parity-gate suite (below). If all pass and Docker is supported or
+  scoped out, flip the default to mitmproxy for one release with
+  `CLM_HTTP_REPLAY_TRANSPORT=vcrpy` still selectable as rollback insurance.
+- **Only then** delete the 8 in-kernel workarounds + the ~480-line bootstrap
+  templates. Keep the Option-F per-cell timeout as a transport-agnostic
+  loud-failure net. Keep vcrpy installed as the YAML serializer.
+
+---
+
+## Parity gates (gate vcrpy default-flip / workaround deletion)
+
+1. Deadlock-defeat: 16-worker stress repro, 0 stalls, py-spy-clean (✅ Phase 0).
+2. HTTPS round-trip on Windows against real endpoints (✅ Phase 0, at scale).
+3. Cassette byte-identity vs vcrpy (compressed bodies decoded, dict-of-lists
+   headers, UTF-8 body string, LF endings) — P1.
+4. Tooling: `cassette doctor` / `strip_cassette_hosts` / merge load mitmproxy
+   cassettes unchanged — P1.
+5. Secret/telemetry hygiene: no auth/cookie/api-key headers, no LangSmith; no-op
+   rebuild grows nothing — P3.
+6. JSON-match parity: real LLM JSON POSTs replay-hit, no spurious 599 — P3.
+7. Strict-replay failure parity: a miss → non-zero build exit, not swallowed — P3.
+8. Concurrency routing: DE/EN multi-topic routes correctly, no contamination;
+   split fallback resolves — P2.
+9. Default-unchanged: transport unset ⇒ build bit-identical to vcrpy (✅ tests).
+
+## Sequencing & estimate
+
+P1 → P2 → P3 are the core (vcrpy-parity); they can partly overlap but P3 depends
+on P1's format. P4 is independent and optional-for-v1. P5 is the cutover.
+**Core (P1–P3): ~8–12 d. With P4–P5: ~14–22 d.** Each phase ships behind the
+flag with its parity gate; nothing changes the default until P5.
+
+## Open design decisions for the owner
+
+- **Routing mechanism (P2):** per-request worker tagging vs per-worker proxies.
+  Tagging keeps the proven single-proxy model and one cassette-merge path;
+  per-worker proxies re-open port management. Recommendation: tagging.
+- **Docker in v1 (P4):** support now, or ship Direct-only and keep vcrpy for
+  Docker? The recordings/CI footprint determines urgency.
+- **Upstream-first:** if the upstream vcrpy `close()` + scoped `force_reset`
+  patches (`docs/claude/vcrpy-upstream-patches.md`) land, the #143/#129 forks
+  retire independently — reducing the urgency delta but not the cross-process
+  capability story.

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -53,7 +53,29 @@ doctor/strip/merge tooling keep working unchanged.
   vcrpy-produced one; `cassette doctor` and `strip_cassette_hosts.py` operate on
   it unchanged.
 
-## P2 — request→cassette routing (concurrent multi-topic)  ·  ~2–3 d  ·  risk: medium
+## P2 — request→cassette routing (concurrent multi-topic)  ·  ~2–3 d  ·  risk: medium  ·  **DONE**
+
+**Status (done):** each worker injects a lightweight tag bootstrap (patch
+httpx `Client`/`AsyncClient.send` to add `X-CLM-Cassette: <canonical>`)
+instead of the vcrpy bootstrap under the transport; the tag is
+`payload.http_replay_cassette_name` resolved exactly like the vcrpy path,
+so it **already carries the #159 split-deck base-cassette fallback** (replay
+→ fallback-aware name, record → strict name) and equals the host
+merge-discovery canonical by construction. The single addon demuxes flows
+by tag into one `<cassette>.staging-mitm-<build_id>` per canonical (vcrpy
+YAML), strips the tag before recording/forwarding, and routes untagged
+traffic to a catch-all so strict replay never escapes. The **host** writes
+the `.completed` marker for this build's staging in the build `finally`
+(`Course.merge_mitmproxy_cassette_staging(build_id)`) — the reliable
+build-completion signal (mitmproxy's `done` hook does not fire on a Windows
+`CTRL_BREAK`) — then folds via the existing `merge_staging_into_canonical`.
+A force-killed build never reaches the marker step, so its staging stays
+markerless and the next pre-build sweep discards it (issue #115 semantics,
+at build-end granularity). Gate proven: a routing smoke test (two tagged
++ one untagged request → correct per-cassette staging, tag stripped, no
+cross-contamination, catch-all, real host marker+merge round-trip) plus
+unit tests for tag injection/strip, tag resolution, and the host merge
+(folds markered, leaves markerless, LF endings).
 
 The Phase-0 proof used **one shared cassette**; production needs each request
 mapped to the correct per-(topic, language, kind) cassette under concurrency.

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -77,6 +77,22 @@ cross-contamination, catch-all, real host marker+merge round-trip) plus
 unit tests for tag injection/strip, tag resolution, and the host merge
 (folds markered, leaves markerless, LF endings).
 
+**Adversarial review (workflow `wf_eeeba6cb-563`, 5 probe-driven lenses)
+confirmed 4 findings; the convert_to_unicode aliasing concern was refuted by
+a control probe (the `serialize_interactions` deepcopy is load-bearing).**
+Fixed in this branch: (1) **HIGH** — `once` mode aborted the build because the
+Phase-0 catch-all existence guard in `addon.running()` checked the
+always-empty build-scratch catch-all; removed it, `once`/`refresh` now route
+per-target via the mode sets (regression test added). (2) **LOW** — a
+non-ASCII HTTP/1.1 reason phrase was recorded where vcrpy would crash and the
+result was not vcrpy-replayable; `cassette_format` now drops it to `None`
+(ASCII reasons stay byte-identical). **Deferred** (not P1/P2 regressions): the
+`refresh`-overwrite gap (the mode-blind `merge_staging_into_canonical` keeps
+the stale canonical entry — *identical behavior in the in-process vcrpy path*,
+so a cross-cutting merge change → P3) and the catch-all's O(n²) eager
+full-rewrite (latent; tagged per-notebook targets stay tiny, proven fine at
+the 18-notebook / 506 KB scale → perf follow-up).
+
 The Phase-0 proof used **one shared cassette**; production needs each request
 mapped to the correct per-(topic, language, kind) cassette under concurrency.
 
@@ -98,6 +114,14 @@ mapped to the correct per-(topic, language, kind) cassette under concurrency.
 The prototype addon lacks parity with the vcrpy bootstrap's load-bearing
 behavior (the design doc wrongly called these "trivial").
 
+- **Strict `once` / `refresh` semantics per target** (deferred from P2's review):
+  under the transport `once` currently behaves like `new-episodes` and `refresh`
+  records additively. `refresh`-overwrite needs a **mode-aware merge** —
+  `merge_staging_into_canonical` is mode-blind and keeps the stale canonical
+  entry on a re-record (the *in-process vcrpy path has the identical bug*), so
+  the fix (thread the mode through; staging-wins for `refresh`/`record`) lands
+  here and benefits **both** transports. `once`-must-exist should error/miss per
+  tagged canonical rather than via the build-scratch catch-all.
 - **Secret filtering** at record time: `authorization`, `cookie`, `x-api-key`,
   `set-cookie` headers + post-data/query params (match the bootstrap's
   `filter_headers` / `filter_post_data_parameters` / `filter_query_parameters`).

--- a/docs/claude/issue-165-production-plan.md
+++ b/docs/claude/issue-165-production-plan.md
@@ -109,9 +109,80 @@ mapped to the correct per-(topic, language, kind) cassette under concurrency.
   correct staging file and merges with no cross-contamination; split fallback
   still resolves.
 
-## P3 — correctness/security parity in the addon  ·  ~3–5 d  ·  risk: high
+## P3 — correctness/security parity in the addon  ·  ~3–5 d  ·  risk: high  ·  **DONE**
 
-The prototype addon lacks parity with the vcrpy bootstrap's load-bearing
+**Status (done):** the addon now has secret/telemetry hygiene + matching/mode
+parity with the in-kernel vcrpy bootstrap, all reusing vcrpy's *own* filter and
+matcher functions so behavior is identical by construction.
+
+- **Secret filtering + ignore_hosts** live in `cassette_format.build_request_filter`,
+  which reconstructs vcrpy's `VCR._build_before_record_request` closure from the
+  public `vcr.filters.{replace_headers,replace_query_parameters,replace_post_data_parameters}`
+  (same `(h, None)` mapping, same order, same deepcopy) and returns `None` for an
+  ignore-host (forward-but-don't-record). The addon applies it on **both** hooks:
+  `request()` (so secrets never even enter the match key) and `response()` (so the
+  *filtered* request is what gets recorded — byte-identical to vcrpy). Proven by a
+  byte-identity test vs `VCR._build_before_record_request` (incl. the
+  `application/json; charset=…` no-rewrite edge) and end-to-end smoke tests
+  (auth/x-api-key/api_key/token stripped from the recorded cassette; LangSmith
+  forwarded but not recorded). `ignore_hosts` is plumbed build.py → manager
+  (`clm_ignore_hosts` option) → addon, resolved by the shared
+  `notebook_processor.resolve_http_replay_ignore_hosts()` (default
+  `api.smith.langchain.com`, `CLM_HTTP_REPLAY_IGNORE_HOSTS` override) so both
+  transports honour the same policy.
+- **JSON-semantic matching**: replay lookup is a pairwise scan reusing
+  `vcr.matchers.{method,scheme,host,port,path,query}` + a `clm_json_body_matcher`
+  that mirrors the bootstrap's `_clm_json_body_matcher` (parse JSON when
+  content-type is JSON case-insensitively; byte-compare otherwise) — the exact
+  `match_on` the in-kernel vcrpy uses. A real LLM JSON POST replay-hits even when
+  the live body differs only by key order / separators (smoke test); a byte key
+  would 599-miss. A drift-guard test pins the `FILTER_*` constants + matcher set
+  to the bootstrap literals.
+- **Strict `once`/`refresh` per target**: `addon._modes_for` resolves
+  `(serve, record, overwrite)` per target — `once` is existence-dependent
+  (present → strict replay/599-on-miss; absent → record-and-serve), `refresh`
+  never serves and overwrites. `refresh`-overwrite is completed by the new
+  `merge_staging_into_canonical(overwrite_existing=…)` (last-seen-staging-wins,
+  in-place canonical replacement) wired on for `refresh` in **both** the
+  mitmproxy host merge and the **vcrpy per-worker merge** — fixing the
+  refresh-overwrite gap for both transports. The default (`overwrite_existing=False`)
+  additive branch is kept **verbatim** so the vcrpy default path stays
+  byte-identical.
+- **Strict-replay-miss → non-zero build exit**: a miss returns the diagnostic
+  HTTP 599 (never escaping to the network). The kernel's SDK surfaces it as an
+  `APIStatusError` → cell error → the #93 fail-on-error policy → non-zero build
+  exit, the same end state as vcrpy's `CannotOverwriteExistingCassetteException`
+  (the 599 is briefly retried by the SDK's 5xx retry, bounded; it never hangs or
+  passes). Gate covered by the existing strict-miss smoke test + #93 policy.
+- **Kill-survival**: the addon writes the staging cassette eagerly on every
+  recorded response (unchanged from P2), so a build-timeout kill of mitmdump
+  loses nothing.
+- **Manager robustness**: a daemon **reader thread** drains mitmdump stdout into a
+  bounded ring buffer so a multi-hour build can't deadlock on a full pipe; it is
+  joined on stop (no leak) and `_drain_output` no longer races the thread with
+  `communicate()`. Unit-tested against an 800 KiB-output subprocess.
+
+**Gates:** secret/telemetry hygiene (no auth/cookie/api-key, no LangSmith) and
+JSON-match parity (real JSON POSTs replay-hit, no spurious 599) and strict-miss →
+non-zero exit are covered by the new unit + smoke tests; full fast suite green
+(5795 passed).
+
+**Adversarial review (workflow `wf_7e8803f5-482`, 5 probe-driven lenses → verify):
+1 confirmed, 2 refuted.** Confirmed (MEDIUM, severity overstated by the verdict —
+no correctness bug): the "599 → bounded SDK retry → fail" claim was asserted but
+not documented in-code. Fixed in this branch by documenting it at
+`addon._replay_miss_response` and at `notebook_processor`'s replay cell-timeout —
+the existing 600s per-cell ceiling (`_HTTP_REPLAY_DEFAULT_CELL_TIMEOUT`, issue
+#143 Option-F) is the backstop against any future unbounded SDK retry. Refuted:
+(a) `set-cookie` in `filter_headers` "violates HTTP semantics" — intentional
+vcrpy parity, drift-guarded; (b) kernel-side 599 not explicitly detected — the
+599 is explicit/structured and SDKs fail on it; out of P3 scope. **Deferred (e2e
+gate, not a code change):** a one-off real-LLM no-op-rebuild run to confirm the
+empty cassette git-diff + a deliberate miss fails the build non-zero with the
+real SDK (the strict-miss smoke test + #93 policy cover the mechanism; the e2e
+confirmation needs OPENROUTER credentials).
+
+The prototype addon lacked parity with the vcrpy bootstrap's load-bearing
 behavior (the design doc wrongly called these "trivial").
 
 - **Strict `once` / `refresh` semantics per target** (deferred from P2's review):
@@ -182,9 +253,14 @@ A `127.0.0.1` mitmdump is unreachable inside a container.
 4. Tooling: `cassette doctor` / `strip_cassette_hosts` / merge load mitmproxy
    cassettes unchanged — P1.
 5. Secret/telemetry hygiene: no auth/cookie/api-key headers, no LangSmith; no-op
-   rebuild grows nothing — P3.
-6. JSON-match parity: real LLM JSON POSTs replay-hit, no spurious 599 — P3.
-7. Strict-replay failure parity: a miss → non-zero build exit, not swallowed — P3.
+   rebuild grows nothing — P3 ✅ (filter byte-identity vs vcrpy + ignore_hosts;
+   secret-stripping + LangSmith-not-recorded smoke tests).
+6. JSON-match parity: real LLM JSON POSTs replay-hit, no spurious 599 — P3 ✅
+   (vcr-matcher-chain replay scan incl. `clm_json_body`; JSON-POST replay smoke
+   test). End-to-end real-LLM no-op-rebuild diff still wants a one-off manual run.
+7. Strict-replay failure parity: a miss → non-zero build exit, not swallowed —
+   P3 ✅ via the 599 → SDK `APIStatusError` → #93 policy (strict-miss smoke test
+   asserts the 599; #93 turns it into a non-zero exit).
 8. Concurrency routing: DE/EN multi-topic routes correctly, no contamination;
    split fallback resolves — P2.
 9. Default-unchanged: transport unset ⇒ build bit-identical to vcrpy (✅ tests).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,6 +353,11 @@ module = [
     "vcr.*",
     "filelock",
     "filelock.*",
+    # mitmproxy runs out-of-process (uv tool install); the addon module is
+    # loaded by mitmdump's own interpreter, not clm's venv, so the package is
+    # intentionally absent from clm's environment.
+    "mitmproxy",
+    "mitmproxy.*",
 ]
 ignore_missing_imports = true
 

--- a/scripts/analyze_http_replay_trace.py
+++ b/scripts/analyze_http_replay_trace.py
@@ -25,6 +25,7 @@ Run:
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import sys
 from collections.abc import Iterable
@@ -36,8 +37,6 @@ from typing import Any
 # many seconds before the connect counts as related. Generous enough to
 # tolerate scheduling jitter, tight enough to avoid false positives.
 _MATCH_WINDOW_SECONDS = 0.5
-
-_LOOPBACK_HOSTS = ("127.", "::1", "localhost", "0.0.0.0")
 
 
 @dataclass
@@ -86,6 +85,11 @@ class WorkerSummary:
     socket_connects: list[Event] = field(default_factory=list)
     remote_connects: list[Event] = field(default_factory=list)
     loopback_connects: list[Event] = field(default_factory=list)
+    # mitmproxy transport only: remote connects whose port is the proxy's —
+    # the expected path (the kernel reaches the out-of-process proxy), NOT a
+    # bypass. Empty under the in-kernel vcrpy path (the proxy is loopback there
+    # or there is no proxy at all).
+    to_proxy_connects: list[Event] = field(default_factory=list)
     cassette_hits: int = 0
     cassette_appends: int = 0
     cassette_append_errors: int = 0
@@ -113,17 +117,58 @@ class HostSummary:
 
 
 @dataclass
+class ProxySummary:
+    """mitmproxy-transport interception evidence (the ``proxy`` stream).
+
+    Replaces the in-kernel ``vcr`` stream under the out-of-process transport:
+    the kernel no longer imports vcr, so the proxy's own per-flow decisions are
+    what tell us each request was intercepted rather than escaping upstream.
+    """
+
+    events: list[Event] = field(default_factory=list)
+    proxy_ports: set[int] = field(default_factory=set)
+    proxy_ready: list[dict[str, Any]] = field(default_factory=list)
+    flows_total: int = 0
+    served: int = 0
+    miss: int = 0
+    ignored: int = 0
+    forward: int = 0
+    passthrough: int = 0
+    recorded: int = 0
+
+
+@dataclass
 class AnalysisResult:
     manifest: dict[str, Any]
     workers: dict[int, WorkerSummary]
     host: HostSummary
     trace_dir: Path
+    transport: str = "vcrpy"
+    proxy: ProxySummary = field(default_factory=ProxySummary)
 
 
 def is_loopback(host: str) -> bool:
-    if not isinstance(host, str):
+    """True if ``host`` is a loopback peer (kernel↔Jupyter, or the Direct proxy).
+
+    Parsed-address matching rather than string prefixes, so it correctly covers
+    the whole ``127.0.0.0/8`` block, ``::1`` *and* its expanded
+    ``0:0:0:0:0:0:0:1`` form, and the IPv4-mapped ``::ffff:127.0.0.1`` that a
+    dual-stack kernel's ``socket.connect`` audit event may report verbatim — a
+    prefix list missed those and over-reported them as escapes (issue #165 P5).
+    """
+    if not isinstance(host, str) or not host:
         return False
-    return any(host.startswith(p) for p in _LOOPBACK_HOSTS)
+    if host == "localhost":
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        # A real upstream hostname (e.g. api.openai.com) — not loopback.
+        return False
+    if addr.is_loopback:
+        return True
+    mapped = getattr(addr, "ipv4_mapped", None)
+    return mapped is not None and mapped.is_loopback
 
 
 def load_events(jsonl_path: Path) -> Iterable[Event]:
@@ -142,13 +187,43 @@ def load_events(jsonl_path: Path) -> Iterable[Event]:
 def analyze(trace_dir: Path) -> AnalysisResult:
     manifest_path = trace_dir / "manifest.json"
     manifest = (
-        json.loads(manifest_path.read_text(encoding="utf-8"))
-        if manifest_path.is_file()
-        else {}
+        json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.is_file() else {}
     )
 
+    transport = str(manifest.get("transport", "vcrpy"))
     host = HostSummary()
+    proxy = ProxySummary()
     workers: dict[int, WorkerSummary] = {}
+
+    # Proxy stream (mitmproxy transport, issue #165 P5): per-flow interception
+    # decisions written by the addon. This is the evidence the (now-dark) vcr
+    # stream used to provide.
+    proxy_paths = [trace_dir / "proxy.jsonl", *sorted(trace_dir.glob("proxy-*.jsonl"))]
+    for proxy_path in proxy_paths:
+        for event in load_events(proxy_path):
+            if event.stream != "proxy":
+                continue
+            proxy.events.append(event)
+            if event.event == "proxy.ready":
+                proxy.proxy_ready.append(event.data)
+                port = event.data.get("listen_port")
+                if isinstance(port, int):
+                    proxy.proxy_ports.add(port)
+            elif event.event == "proxy.request":
+                proxy.flows_total += 1
+                action = str(event.data.get("action", ""))
+                if action == "served":
+                    proxy.served += 1
+                elif action == "miss":
+                    proxy.miss += 1
+                elif action == "ignored":
+                    proxy.ignored += 1
+                elif action == "forward":
+                    proxy.forward += 1
+                elif action == "passthrough":
+                    proxy.passthrough += 1
+            elif event.event == "proxy.response" and event.data.get("recorded"):
+                proxy.recorded += 1
 
     host_paths = [trace_dir / "host.jsonl", *sorted(trace_dir.glob("host-*.jsonl"))]
     for host_path in host_paths:
@@ -221,9 +296,19 @@ def analyze(trace_dir: Path) -> AnalysisResult:
                     ws.bootstrap_complete = dict(event.data)
 
     for ws in workers.values():
-        _classify_bypasses(ws)
+        if transport == "mitmproxy":
+            _classify_bypasses_transport(ws, proxy.proxy_ports)
+        else:
+            _classify_bypasses(ws)
 
-    return AnalysisResult(manifest=manifest, workers=workers, host=host, trace_dir=trace_dir)
+    return AnalysisResult(
+        manifest=manifest,
+        workers=workers,
+        host=host,
+        trace_dir=trace_dir,
+        transport=transport,
+        proxy=proxy,
+    )
 
 
 def _classify_bypasses(ws: WorkerSummary) -> None:
@@ -262,9 +347,47 @@ def _classify_bypasses(ws: WorkerSummary) -> None:
             ws.bypassed.append(record)
 
 
+def _classify_bypasses_transport(ws: WorkerSummary, proxy_ports: set[int]) -> None:
+    """Bypass model for the out-of-process mitmproxy transport (issue #165 P5).
+
+    Under the transport the kernel's *intended* target IS the proxy, so the
+    vcr-stream cross-reference is meaningless (there is no vcr stream) and the
+    bypass rule inverts. We classify every kernel connect by port:
+
+    * port == the proxy's → a connect *to the proxy* (the expected path). This
+      is loopback for a Direct build (proxy on 127.0.0.1) and the bridge-gateway
+      IP for a Docker build — the port match recognizes both.
+    * other loopback (e.g. kernel↔Jupyter) → ignored, neither to-proxy nor escape.
+    * any other remote host → a genuine **escape**: the kernel reached a real
+      upstream without going through the proxy.
+
+    ``force_reset`` races cannot occur (nothing patches the kernel), so there
+    are no race candidates.
+    """
+    for sc in ws.socket_connects:
+        port = sc.data.get("port")
+        host = str(sc.data.get("host", ""))
+        if isinstance(port, int) and port in proxy_ports:
+            ws.to_proxy_connects.append(sc)
+            continue
+        if is_loopback(host):
+            continue  # kernel↔Jupyter (or other) loopback — not the proxy, not an escape
+        ws.bypassed.append(
+            {
+                "ts_mono": sc.ts_mono,
+                "ts_wall": sc.ts_wall,
+                "tid": sc.tid,
+                "host": sc.data.get("host"),
+                "port": port,
+                "open_force_reset_other_tids": [],
+            }
+        )
+
+
 def format_text(result: AnalysisResult, *, show_bypass_details: bool = True) -> str:
     out: list[str] = []
     out.append(f"Trace directory: {result.trace_dir}")
+    out.append(f"Transport:       {result.transport}")
     if result.manifest:
         out.append(f"Started at:      {result.manifest.get('started_at', '?')}")
         out.append(f"Replay mode:     {result.manifest.get('http_replay_mode', '?')}")
@@ -279,24 +402,65 @@ def format_text(result: AnalysisResult, *, show_bypass_details: bool = True) -> 
     total_remote = sum(len(w.remote_connects) for w in result.workers.values())
     total_bypassed = sum(len(w.bypassed) for w in result.workers.values())
     total_race = sum(len(w.race_candidates) for w in result.workers.values())
-    out.append(f"Socket connects: {total_connects} ({total_loopback} loopback, {total_remote} remote)")
-    matched = total_remote - total_bypassed - total_race
-    out.append(f"  Matched a vcr event: {matched}")
-    out.append(f"  Bypassed (no vcr event near connect): {total_bypassed}")
-    out.append(f"  Race candidates (bypass + force_reset open on other TID): {total_race}")
-    out.append("")
+    total_to_proxy = sum(len(w.to_proxy_connects) for w in result.workers.values())
 
-    total_hits = sum(w.cassette_hits for w in result.workers.values())
-    total_appends = sum(w.cassette_appends for w in result.workers.values())
-    total_append_errs = sum(w.cassette_append_errors for w in result.workers.values())
-    total_can_play_t = sum(w.can_play_true for w in result.workers.values())
-    total_can_play_f = sum(w.can_play_false for w in result.workers.values())
-    out.append("Cassette (worker-side):")
-    out.append(f"  Hits (play_response):      {total_hits}")
-    out.append(f"  Appends:                   {total_appends}")
-    out.append(f"  Append errors:             {total_append_errs}")
-    out.append(f"  can_play True / False:     {total_can_play_t} / {total_can_play_f}")
-    out.append("")
+    if result.transport == "mitmproxy":
+        out.append(
+            f"Socket connects: {total_connects} ({total_loopback} loopback, {total_remote} remote)"
+        )
+        out.append(f"  To proxy (expected): {total_to_proxy}")
+        out.append(f"  Bypassed (escaped the proxy): {total_bypassed}")
+        out.append("")
+
+        out.append("Proxy (interception evidence):")
+        out.append(f"  Listen port(s):            {sorted(result.proxy.proxy_ports) or '?'}")
+        out.append(f"  Flows total:               {result.proxy.flows_total}")
+        out.append(f"  Served (cassette hit):     {result.proxy.served}")
+        out.append(f"  Strict-miss (404):         {result.proxy.miss}")
+        out.append(f"  Forwarded upstream:        {result.proxy.forward}")
+        out.append(f"  Ignored (not recorded):    {result.proxy.ignored}")
+        out.append(f"  Passthrough (untagged):    {result.proxy.passthrough}")
+        out.append(f"  Responses recorded:        {result.proxy.recorded}")
+        # Connection-bound health: the issue #143 leak signature was ~1 leaked
+        # pooled connection per request (connects ≈ flows). Healthy pooling to
+        # the out-of-process proxy keeps connects ≪ flows. Only meaningful with
+        # a reasonable sample — at a handful of flows the per-connect noise
+        # (TLS tunnel setup, DNS) swamps the ratio, so we gate on flows.
+        flows = result.proxy.flows_total
+        if flows >= 10 and total_to_proxy:
+            ratio = total_to_proxy / flows
+            verdict = "healthy (pooled)" if ratio <= 0.5 else "INVESTIGATE (≈1:1 → leak?)"
+            out.append(
+                f"  Conn-bound: {total_to_proxy} proxy connects / {flows} flows "
+                f"= {ratio:.2f} → {verdict}"
+            )
+        elif flows:
+            out.append(
+                f"  Conn-bound: {total_to_proxy} proxy connects / {flows} flows "
+                f"(too few flows for a ratio verdict)"
+            )
+        out.append("")
+    else:
+        out.append(
+            f"Socket connects: {total_connects} ({total_loopback} loopback, {total_remote} remote)"
+        )
+        matched = total_remote - total_bypassed - total_race
+        out.append(f"  Matched a vcr event: {matched}")
+        out.append(f"  Bypassed (no vcr event near connect): {total_bypassed}")
+        out.append(f"  Race candidates (bypass + force_reset open on other TID): {total_race}")
+        out.append("")
+
+        total_hits = sum(w.cassette_hits for w in result.workers.values())
+        total_appends = sum(w.cassette_appends for w in result.workers.values())
+        total_append_errs = sum(w.cassette_append_errors for w in result.workers.values())
+        total_can_play_t = sum(w.can_play_true for w in result.workers.values())
+        total_can_play_f = sum(w.can_play_false for w in result.workers.values())
+        out.append("Cassette (worker-side):")
+        out.append(f"  Hits (play_response):      {total_hits}")
+        out.append(f"  Appends:                   {total_appends}")
+        out.append(f"  Append errors:             {total_append_errs}")
+        out.append(f"  can_play True / False:     {total_can_play_t} / {total_can_play_f}")
+        out.append("")
 
     out.append("Cassette (host-side lifecycle):")
     out.append(f"  Seeds:                     {result.host.seeds}")
@@ -323,11 +487,16 @@ def format_text(result: AnalysisResult, *, show_bypass_details: bool = True) -> 
                     f"connect to {rec['host']}:{rec['port']}  "
                     f"RACE — force_reset open on: {others}"
                 )
+            bypass_reason = (
+                "escaped the proxy (port is not the proxy's)"
+                if result.transport == "mitmproxy"
+                else "no near-by vcr event"
+            )
             for rec in ws.bypassed:
                 out.append(
                     f"  [worker pid={pid} tid={rec['tid']} t={rec['ts_mono']:.6f}] "
                     f"connect to {rec['host']}:{rec['port']}  "
-                    f"BYPASS — no near-by vcr event"
+                    f"BYPASS — {bypass_reason}"
                 )
         out.append("")
 
@@ -337,7 +506,18 @@ def format_text(result: AnalysisResult, *, show_bypass_details: bool = True) -> 
 def format_json(result: AnalysisResult) -> str:
     payload = {
         "trace_dir": str(result.trace_dir),
+        "transport": result.transport,
         "manifest": result.manifest,
+        "proxy": {
+            "proxy_ports": sorted(result.proxy.proxy_ports),
+            "flows_total": result.proxy.flows_total,
+            "served": result.proxy.served,
+            "miss": result.proxy.miss,
+            "ignored": result.proxy.ignored,
+            "forward": result.proxy.forward,
+            "passthrough": result.proxy.passthrough,
+            "recorded": result.proxy.recorded,
+        },
         "host": {
             "seeds": result.host.seeds,
             "merge_starts": result.host.merge_starts,
@@ -355,6 +535,7 @@ def format_json(result: AnalysisResult) -> str:
                 "socket_connects": len(ws.socket_connects),
                 "loopback_connects": len(ws.loopback_connects),
                 "remote_connects": len(ws.remote_connects),
+                "to_proxy_connects": len(ws.to_proxy_connects),
                 "cassette_hits": ws.cassette_hits,
                 "cassette_appends": ws.cassette_appends,
                 "cassette_append_errors": ws.cassette_append_errors,

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -131,7 +131,35 @@ def _resolve_fail_on_missing_xref(cli_value: bool | None, resolved_http_replay_m
     return resolved_http_replay_mode == "replay"
 
 
-def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
+def _build_has_docker_notebook_worker(worker_config: object | None) -> bool:
+    """True when this build will start a Docker-mode **notebook** worker.
+
+    Only the notebook worker makes the LLM HTTP traffic the replay proxy
+    intercepts (plantuml/drawio/jupyterlite never touch it). A ``127.0.0.1``
+    proxy is unreachable from inside a container, so a Docker notebook worker
+    forces the mitmproxy transport to bind a wildcard address (``0.0.0.0``)
+    that the container reaches via ``host.docker.internal`` (issue #165 P4).
+
+    Scoping to the notebook worker keeps the wider ``0.0.0.0`` bind (and its
+    LAN-exposure window — see ``_maybe_start_mitmproxy_transport``) off builds
+    whose only Docker workers are diagram converters that never use the proxy.
+    ``None`` worker_config (older callers / tests) is treated as Direct-only.
+    """
+    if worker_config is None:
+        return False
+    try:
+        return any(
+            c.worker_type == "notebook" and c.execution_mode == "docker" and c.count > 0
+            for c in worker_config.get_all_worker_configs()  # type: ignore[attr-defined]
+        )
+    except Exception:  # noqa: BLE001 — detection must never break the build
+        logger.debug("Could not resolve worker execution modes; assuming Direct-only")
+        return False
+
+
+def _maybe_start_mitmproxy_transport(
+    mode: str | None, jobs_db_path: Path, worker_config: object | None = None
+):
     """Start an out-of-process mitmproxy HTTP-replay transport when opted in.
 
     Experimental (issue #165). Opt in with ``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy``;
@@ -151,7 +179,14 @@ def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
     per-(topic,language,kind) staging files folded into their canonicals
     after the proxy stops (see ``Course.merge_mitmproxy_cassette_staging``).
     The ``transport.http-cassette.yaml`` here is only the catch-all for any
-    untagged traffic. Direct-mode only; Docker support is a later phase.
+    untagged traffic.
+
+    **Docker (P4):** when ``worker_config`` reports any Docker-mode worker the
+    proxy binds ``0.0.0.0`` so containers can reach it via
+    ``host.docker.internal``; the ``os.environ`` proxy URL stays a loopback
+    address (``MitmproxyManager.proxy_url``) for Direct workers and the
+    readiness poll, while the Docker executor rewrites the host and mounts the
+    CA per container. Direct-only builds keep binding ``127.0.0.1`` unchanged.
     """
     import os as _os
 
@@ -173,12 +208,26 @@ def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
     base.mkdir(parents=True, exist_ok=True)
     cassette = base / "transport.http-cassette.yaml"
     confdir = base / "confdir"
+    # Bind a wildcard address only when a Docker notebook worker must reach us
+    # via host.docker.internal; Direct-only (and diagram-only-Docker) builds keep
+    # the loopback bind so the replay proxy is never exposed beyond the host.
+    # NOTE (issue #165 P4 hardening follow-up): a 0.0.0.0 bind makes the proxy an
+    # unauthenticated listener on the LAN for the build's duration; in
+    # record-capable modes it can relay/record arbitrary traffic. This mirrors the
+    # existing 0.0.0.0 WorkerApiServer and is gated to opt-in Docker builds, but a
+    # future hardening should bind the docker-bridge gateway IP or add
+    # mitmdump --proxyauth with a per-build credential.
+    listen_host = "0.0.0.0" if _build_has_docker_notebook_worker(worker_config) else "127.0.0.1"
     # Same telemetry-suppression policy as the in-kernel vcrpy path: LangSmith
     # by default, overridable via CLM_HTTP_REPLAY_IGNORE_HOSTS. The addon
     # forwards these hosts but never records them into a cassette.
     ignore_hosts = resolve_http_replay_ignore_hosts()
     manager = MitmproxyManager(
-        cassette_path=cassette, mode=mode, confdir=confdir, ignore_hosts=ignore_hosts
+        cassette_path=cassette,
+        mode=mode,
+        listen_host=listen_host,
+        confdir=confdir,
+        ignore_hosts=ignore_hosts,
     )
     manager.start()
 
@@ -1510,8 +1559,12 @@ async def main_build(
 
     # Experimental out-of-process HTTP-replay transport (issue #165). Must run
     # BEFORE workers spawn so they inherit HTTP(S)_PROXY + the CA bundle via
-    # os.environ.copy(). No-op unless CLM_HTTP_REPLAY_TRANSPORT=mitmproxy.
-    mitm_manager = _maybe_start_mitmproxy_transport(config.http_replay_mode, config.jobs_db_path)
+    # os.environ.copy() (Direct) or the per-container injection (Docker, P4).
+    # No-op unless CLM_HTTP_REPLAY_TRANSPORT=mitmproxy. ``worker_config`` lets
+    # it bind 0.0.0.0 when Docker workers will reach it via host.docker.internal.
+    mitm_manager = _maybe_start_mitmproxy_transport(
+        config.http_replay_mode, config.jobs_db_path, worker_config=worker_config
+    )
 
     output_formatter.show_startup_message("Starting workers...")
     started_workers = start_managed_workers(lifecycle_manager, worker_config)

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -146,9 +146,12 @@ def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
     httpx/httpcore is therefore never patched — the structural fix for the
     issue #143 connection-pool deadlock.
 
-    Minimal Direct-mode wiring for the Phase-0 proof: one shared proxy and one
-    shared cassette (no per-(topic,language,kind) routing yet) and no Docker
-    support — both are later phases per the staged plan.
+    One shared proxy serves the whole build; each worker tags its requests
+    with the destination cassette (P2), so the addon demuxes them into
+    per-(topic,language,kind) staging files folded into their canonicals
+    after the proxy stops (see ``Course.merge_mitmproxy_cassette_staging``).
+    The ``transport.http-cassette.yaml`` here is only the catch-all for any
+    untagged traffic. Direct-mode only; Docker support is a later phase.
     """
     import os as _os
 
@@ -1547,6 +1550,17 @@ async def main_build(
                 mitm_manager.stop()
             except Exception as e:
                 logger.error(f"Failed to stop mitmproxy: {e}", exc_info=True)
+            # The addon wrote per-(topic,language,kind) staging cassettes as it
+            # recorded; now that the proxy has flushed and exited, mark this
+            # build's staging files complete and fold them into their canonical
+            # cassettes (issue #165 P2). Reaching here is the build-completion
+            # signal, so partial recordings from a force-killed build (which
+            # never reaches this point) stay markerless and are discarded by the
+            # next build's pre-build sweep.
+            try:
+                course.merge_mitmproxy_cassette_staging(mitm_manager.build_id)
+            except Exception as e:
+                logger.error(f"Failed to merge mitmproxy cassettes: {e}", exc_info=True)
 
     return summary
 

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -131,6 +131,85 @@ def _resolve_fail_on_missing_xref(cli_value: bool | None, resolved_http_replay_m
     return resolved_http_replay_mode == "replay"
 
 
+def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
+    """Start an out-of-process mitmproxy HTTP-replay transport when opted in.
+
+    Experimental (issue #165). Opt in with ``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy``;
+    default unset keeps the in-process vcrpy path unchanged. Returns the running
+    :class:`MitmproxyManager` (so the caller can stop it) or ``None``.
+
+    When active it (1) starts one ``mitmdump`` for the whole build, (2) sets
+    ``HTTP(S)_PROXY`` + a ``certifi`` + proxy-CA bundle in ``os.environ`` so
+    Direct workers inherit them via ``os.environ.copy()``, and (3) leaves
+    ``CLM_HTTP_REPLAY_TRANSPORT`` set so each kernel skips the vcrpy bootstrap
+    (``_resolve_cassette_paths`` returns ``None``). The kernel's real
+    httpx/httpcore is therefore never patched — the structural fix for the
+    issue #143 connection-pool deadlock.
+
+    Minimal Direct-mode wiring for the Phase-0 proof: one shared proxy and one
+    shared cassette (no per-(topic,language,kind) routing yet) and no Docker
+    support — both are later phases per the staged plan.
+    """
+    import os as _os
+
+    if (
+        _os.environ.get("CLM_HTTP_REPLAY_TRANSPORT") != "mitmproxy"
+        or not mode
+        or mode == "disabled"
+    ):
+        return None
+
+    import time as _time
+
+    import certifi
+
+    from clm.infrastructure.http_replay_mitm import MitmproxyManager
+
+    base = Path(jobs_db_path).resolve().parent / "mitm"
+    base.mkdir(parents=True, exist_ok=True)
+    cassette = base / "transport.mitm"
+    confdir = base / "confdir"
+    manager = MitmproxyManager(cassette_path=cassette, mode=mode, confdir=confdir)
+    manager.start()
+
+    # mitmdump writes its CA during startup; the manager only polls the port,
+    # so wait briefly for the CA file too before splicing it.
+    ca = manager.ca_cert_path
+    deadline = _time.monotonic() + 5.0
+    while not ca.exists() and _time.monotonic() < deadline:
+        _time.sleep(0.05)
+    if not ca.exists():
+        manager.stop()
+        raise RuntimeError(f"mitmproxy CA cert not generated at {ca}")
+
+    # Combined bundle: real roots (certifi) + the proxy CA, so both proxy-forged
+    # certs (kernel->proxy) and ignore_hosts direct traffic validate. httpx 0.28
+    # honors SSL_CERT_FILE; requests honors REQUESTS_CA_BUNDLE (Phase-0 verified).
+    bundle = base / "ca-bundle.pem"
+    bundle.write_bytes(Path(certifi.where()).read_bytes() + b"\n" + ca.read_bytes())
+
+    proxy = manager.proxy_url
+    _os.environ.update(
+        {
+            "HTTP_PROXY": proxy,
+            "HTTPS_PROXY": proxy,
+            "http_proxy": proxy,
+            "https_proxy": proxy,
+            "SSL_CERT_FILE": str(bundle),
+            "REQUESTS_CA_BUNDLE": str(bundle),
+            "CURL_CA_BUNDLE": str(bundle),
+        }
+    )
+    logger.info(
+        "mitmproxy transport active: proxy=%s mode=%s cassette=%s ca_bundle=%s",
+        proxy,
+        mode,
+        cassette,
+        bundle,
+    )
+    return manager
+
+
 def _find_env_file(start_dir: Path) -> Path | None:
     """Walk up from start_dir looking for a .env file.
 
@@ -1419,6 +1498,11 @@ async def main_build(
         data_dir=data_dir,
     )
 
+    # Experimental out-of-process HTTP-replay transport (issue #165). Must run
+    # BEFORE workers spawn so they inherit HTTP(S)_PROXY + the CA bundle via
+    # os.environ.copy(). No-op unless CLM_HTTP_REPLAY_TRANSPORT=mitmproxy.
+    mitm_manager = _maybe_start_mitmproxy_transport(config.http_replay_mode, config.jobs_db_path)
+
     output_formatter.show_startup_message("Starting workers...")
     started_workers = start_managed_workers(lifecycle_manager, worker_config)
     if started_workers:
@@ -1457,6 +1541,12 @@ async def main_build(
                 logger.info(f"Stopped {len(started_workers)} worker(s)")
             except Exception as e:
                 logger.error(f"Failed to stop workers: {e}", exc_info=True)
+        if mitm_manager is not None:
+            logger.info("Stopping mitmproxy transport...")
+            try:
+                mitm_manager.stop()
+            except Exception as e:
+                logger.error(f"Failed to stop mitmproxy: {e}", exc_info=True)
 
     return summary
 

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -222,12 +222,18 @@ def _maybe_start_mitmproxy_transport(
     # by default, overridable via CLM_HTTP_REPLAY_IGNORE_HOSTS. The addon
     # forwards these hosts but never records them into a cassette.
     ignore_hosts = resolve_http_replay_ignore_hosts()
+    # Forward the forensic trace dir (issue #165 P5) so the addon can write the
+    # per-flow ``proxy`` stream alongside the worker ``socket`` stream. The host
+    # pins this env earlier (when CLM_HTTP_REPLAY_TRACE=1); unset → no tracing.
+    trace_inv = _os.environ.get("CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR", "").strip()
+    trace_dir = Path(trace_inv) if trace_inv else None
     manager = MitmproxyManager(
         cassette_path=cassette,
         mode=mode,
         listen_host=listen_host,
         confdir=confdir,
         ignore_hosts=ignore_hosts,
+        trace_dir=trace_dir,
     )
     manager.start()
 
@@ -1476,9 +1482,17 @@ async def main_build(
     if _trace_is_enabled():
         _trace_invocation_dir = _trace_make_invocation_dir()
         _trace_set_invocation_dir(_trace_invocation_dir)
+        # Record which transport produced this trace bundle so the analyzer
+        # picks the right bypass model: under "mitmproxy" the ``vcr`` stream is
+        # dark and the ``proxy`` stream is the interception evidence; under
+        # "vcrpy" the in-kernel ``vcr`` stream is used (issue #165 P5).
+        _trace_transport = (
+            "mitmproxy" if _os.environ.get("CLM_HTTP_REPLAY_TRANSPORT") == "mitmproxy" else "vcrpy"
+        )
         _trace_write_manifest(
             _trace_invocation_dir,
             http_replay_mode=resolved_http_replay_mode,
+            extra={"transport": _trace_transport},
         )
         _os.environ["CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR"] = str(_trace_invocation_dir)
         click.echo(f"HTTP-replay trace active: {_trace_invocation_dir}")

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -167,7 +167,7 @@ def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
 
     base = Path(jobs_db_path).resolve().parent / "mitm"
     base.mkdir(parents=True, exist_ok=True)
-    cassette = base / "transport.mitm"
+    cassette = base / "transport.http-cassette.yaml"
     confdir = base / "confdir"
     manager = MitmproxyManager(cassette_path=cassette, mode=mode, confdir=confdir)
     manager.start()

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -167,12 +167,19 @@ def _maybe_start_mitmproxy_transport(mode: str | None, jobs_db_path: Path):
     import certifi
 
     from clm.infrastructure.http_replay_mitm import MitmproxyManager
+    from clm.workers.notebook.notebook_processor import resolve_http_replay_ignore_hosts
 
     base = Path(jobs_db_path).resolve().parent / "mitm"
     base.mkdir(parents=True, exist_ok=True)
     cassette = base / "transport.http-cassette.yaml"
     confdir = base / "confdir"
-    manager = MitmproxyManager(cassette_path=cassette, mode=mode, confdir=confdir)
+    # Same telemetry-suppression policy as the in-kernel vcrpy path: LangSmith
+    # by default, overridable via CLM_HTTP_REPLAY_IGNORE_HOSTS. The addon
+    # forwards these hosts but never records them into a cassette.
+    ignore_hosts = resolve_http_replay_ignore_hosts()
+    manager = MitmproxyManager(
+        cassette_path=cassette, mode=mode, confdir=confdir, ignore_hosts=ignore_hosts
+    )
     manager.start()
 
     # mitmdump writes its CA during startup; the manager only polls the port,
@@ -1558,7 +1565,9 @@ async def main_build(
             # never reaches this point) stay markerless and are discarded by the
             # next build's pre-build sweep.
             try:
-                course.merge_mitmproxy_cassette_staging(mitm_manager.build_id)
+                course.merge_mitmproxy_cassette_staging(
+                    mitm_manager.build_id, mode=config.http_replay_mode
+                )
             except Exception as e:
                 logger.error(f"Failed to merge mitmproxy cassettes: {e}", exc_info=True)
 

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -370,6 +370,91 @@ class Course(NotebookMixin):
         await self.process_dir_group_for_targets(backend)
         await self.process_jupyterlite_for_targets(backend)
 
+    def _collect_http_replay_canonical_paths(self) -> set[Path]:
+        """Unique canonical cassette paths for every http-replay notebook.
+
+        A topic may contain several notebooks but only one canonical
+        cassette per notebook. ``cassette_path`` returns the existing
+        canonical (preferring the nested ``_cassettes/`` layout);
+        ``expected_cassette_path`` always yields a path even when no
+        cassette has been recorded yet, and its parent dir is the right
+        glob target for staging files on a first run. Shared by the
+        pre-build orphan sweep and the post-build mitmproxy merge.
+        """
+        from clm.core.course_files.notebook_file import NotebookFile
+
+        canonical_paths: set[Path] = set()
+        for file in self.files:
+            if not isinstance(file, NotebookFile):
+                continue
+            if not file.http_replay:
+                continue
+            canonical = file.cassette_path or file.expected_cassette_path
+            canonical_paths.add(canonical)
+        return canonical_paths
+
+    def merge_mitmproxy_cassette_staging(self, build_id: str | None = None) -> int:
+        """Fold per-target staging files written by the mitmproxy transport.
+
+        The out-of-process transport (issue #165) records into per-(topic,
+        language,kind) ``<cassette>.staging-mitm-<build_id>`` files beside
+        each canonical cassette. This runs **after** the proxy stops (from
+        the build's ``finally``) to fold them into their canonicals via the
+        same dedup/merge path the vcrpy workers use.
+
+        Reaching this method *is* the build-completion signal (the build's
+        ``finally`` ran), so for each canonical we write the ``.completed``
+        marker for **this build's** staging file (``build_id``), exactly as
+        the vcrpy path's host writes a completion marker on clean notebook
+        completion. mitmproxy's ``done`` hook is unreliable on a Windows
+        ``CTRL_BREAK`` shutdown, so the host owns this signal. A force-killed
+        build never reaches here, so its staging stays markerless and is
+        discarded by the next build's pre-build sweep (issue #115).
+
+        ``sweep_orphans=False``: markerless staging (older builds, or a
+        concurrent build still recording) is left untouched. A no-op for
+        builds that did not use the transport.
+
+        Returns the number of staging files folded into canonical.
+        """
+        canonical_paths = self._collect_http_replay_canonical_paths()
+        if not canonical_paths:
+            return 0
+
+        from clm.workers.notebook.http_replay_cassette import (
+            CassettePaths,
+            merge_staging_into_canonical,
+            write_completion_marker,
+        )
+
+        folded = 0
+        for canonical in sorted(canonical_paths):
+            if not canonical.parent.is_dir():
+                continue
+            # Mark this build's staging file complete so the merge folds it.
+            if build_id:
+                staging = canonical.parent / f"{canonical.name}.staging-mitm-{build_id}"
+                if staging.is_file():
+                    write_completion_marker(CassettePaths(canonical=canonical, staging=staging))
+            if not any(canonical.parent.glob(f"{canonical.name}.staging-*")):
+                continue
+            synthetic = canonical.parent / f"{canonical.name}.staging-mitm-merge"
+            try:
+                merged = merge_staging_into_canonical(
+                    CassettePaths(canonical=canonical, staging=synthetic),
+                    sweep_orphans=False,
+                )
+            except Exception as exc:  # noqa: BLE001 — never mask the build result
+                logger.warning(
+                    f"Post-build mitmproxy cassette merge failed for "
+                    f"'{canonical}' ({type(exc).__name__}: {exc})."
+                )
+                continue
+            if merged:
+                logger.info(f"Merged {merged} mitmproxy staging cassette(s) into '{canonical}'.")
+                folded += merged
+        return folded
+
     def _sweep_orphan_cassette_staging_files(self) -> int:
         """Merge any orphan HTTP-replay staging cassettes into canonical.
 
@@ -407,26 +492,7 @@ class Course(NotebookMixin):
             had at least one staging file present). Zero when nothing
             needed sweeping or when ``http-replay`` is not used.
         """
-        from clm.core.course_files.notebook_file import NotebookFile
-
-        # Collect unique canonical cassette paths to sweep. A topic may
-        # contain several notebooks but only one canonical cassette per
-        # notebook; merging twice would be harmless (the lock serializes
-        # and the second pass finds zero stagings) but wasteful.
-        canonical_paths: set[Path] = set()
-        for file in self.files:
-            if not isinstance(file, NotebookFile):
-                continue
-            if not file.http_replay:
-                continue
-            # ``cassette_path`` returns the existing canonical (preferring
-            # the nested ``_cassettes/`` layout); ``expected_cassette_path``
-            # always yields a path even when no cassette has been recorded
-            # yet. Orphans can sit next to the *expected* path on first run,
-            # so prefer that — its parent dir is the right glob target.
-            canonical = file.cassette_path or file.expected_cassette_path
-            canonical_paths.add(canonical)
-
+        canonical_paths = self._collect_http_replay_canonical_paths()
         if not canonical_paths:
             return 0
 

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -393,7 +393,9 @@ class Course(NotebookMixin):
             canonical_paths.add(canonical)
         return canonical_paths
 
-    def merge_mitmproxy_cassette_staging(self, build_id: str | None = None) -> int:
+    def merge_mitmproxy_cassette_staging(
+        self, build_id: str | None = None, *, mode: str | None = None
+    ) -> int:
         """Fold per-target staging files written by the mitmproxy transport.
 
         The out-of-process transport (issue #165) records into per-(topic,
@@ -415,6 +417,10 @@ class Course(NotebookMixin):
         concurrent build still recording) is left untouched. A no-op for
         builds that did not use the transport.
 
+        ``mode`` is the CLM http-replay mode; ``refresh`` folds with
+        ``overwrite_existing=True`` so a re-recorded interaction supersedes the
+        stale canonical entry (issue #165 P3), matching vcrpy ``all`` semantics.
+
         Returns the number of staging files folded into canonical.
         """
         canonical_paths = self._collect_http_replay_canonical_paths()
@@ -427,6 +433,7 @@ class Course(NotebookMixin):
             write_completion_marker,
         )
 
+        overwrite_existing = mode == "refresh"
         folded = 0
         for canonical in sorted(canonical_paths):
             if not canonical.parent.is_dir():
@@ -443,6 +450,7 @@ class Course(NotebookMixin):
                 merged = merge_staging_into_canonical(
                     CassettePaths(canonical=canonical, staging=synthetic),
                     sweep_orphans=False,
+                    overwrite_existing=overwrite_existing,
                 )
             except Exception as exc:  # noqa: BLE001 — never mask the build result
                 logger.warning(

--- a/src/clm/infrastructure/http_replay_mitm/__init__.py
+++ b/src/clm/infrastructure/http_replay_mitm/__init__.py
@@ -1,0 +1,9 @@
+"""mitmproxy-based HTTP replay transport (prototype).
+
+See ``docs/claude/design/http-replay-mitmproxy-prototype.md`` for the
+architecture, scope, and follow-up work needed to make this production.
+"""
+
+from clm.infrastructure.http_replay_mitm.proxy_manager import MitmproxyManager
+
+__all__ = ["MitmproxyManager"]

--- a/src/clm/infrastructure/http_replay_mitm/__init__.py
+++ b/src/clm/infrastructure/http_replay_mitm/__init__.py
@@ -1,7 +1,10 @@
-"""mitmproxy-based HTTP replay transport (prototype).
+"""mitmproxy-based HTTP replay transport.
 
-See ``docs/claude/design/http-replay-mitmproxy-prototype.md`` for the
-architecture, scope, and follow-up work needed to make this production.
+Opt-in alternative to the in-process vcrpy transport, selected with
+``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy`` (vcrpy remains the default). See
+``docs/claude/issue-165-production-plan.md`` for the phased production plan
+(P1-P4 shipped: vcrpy-YAML bridge, request routing, correctness/security
+parity, and Docker worker support).
 """
 
 from clm.infrastructure.http_replay_mitm.proxy_manager import MitmproxyManager

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -4,82 +4,105 @@ This module is loaded by ``mitmdump`` (not by the CLM workers). It is
 invoked via ``mitmdump --scripts <this-file>`` and reads its config from
 mitmproxy options the manager sets on the command line.
 
-Storage format for the prototype is mitmproxy's native ``.mitm`` binary
-flow stream — chosen so we can validate the transport architecture
-without also rebuilding the cassette-format and staging/merge layers.
-Compatibility with the existing vcrpy YAML schema is follow-up work
-(see the design doc).
+Storage is the **vcrpy v1 YAML cassette schema** (issue #165, P1) so that
+committed course cassettes, ``clm cassette doctor``,
+``strip_cassette_hosts.py`` and the host-side
+``merge_staging_into_canonical`` all keep working unchanged — a
+mitmproxy-recorded cassette is byte-identical to a vcrpy-recorded one for
+the same HTTP exchange. The format conversion lives in the pure
+:mod:`clm.infrastructure.http_replay_mitm.cassette_format` module so it
+can be unit-tested in CLM's venv and imported by bare path inside the
+isolated ``mitmdump`` interpreter.
+
+Request→cassette routing for concurrent multi-topic builds (the
+``X-CLM-Cassette`` tag + per-target staging files) is P2; this module
+still records into the single ``clm_cassette_path`` it is given.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import sys
 from pathlib import Path
-from typing import IO
 
 from mitmproxy import ctx, http
-from mitmproxy.io import FlowReader, FlowWriter
 
 logger = logging.getLogger("clm.http_replay_mitm.addon")
+
+# The cassette format bridge is pure (vcr + stdlib only). Inside CLM's own
+# venv it imports as a package submodule; inside the isolated mitmdump
+# interpreter (``uv tool install mitmproxy --with vcrpy``) the ``clm``
+# package is absent, so we fall back to a bare path import of the sibling
+# module. If vcrpy itself is missing from the mitmdump environment, both
+# imports fail and we surface a loud, actionable error at startup.
+_CF_IMPORT_ERROR: Exception | None = None
+try:  # CLM venv
+    from clm.infrastructure.http_replay_mitm import cassette_format as cf
+except ImportError:  # mitmdump interpreter — import the sibling by path
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        import cassette_format as cf  # type: ignore[import-not-found,no-redef]
+    except ImportError as exc:  # vcrpy missing from the mitmdump env
+        cf = None  # type: ignore[assignment]
+        _CF_IMPORT_ERROR = exc
 
 
 # Mode mapping mirrors vcrpy semantics one-for-one. ``disabled`` is
 # handled by the manager (it doesn't start mitmproxy at all), so the
 # addon never sees it.
 MODE_REPLAY = "replay"  # serve from cassette, error on miss
-MODE_RECORD = "record"  # always hit upstream, append new flows
+MODE_RECORD = "record"  # always hit upstream, record (overwrite)
 MODE_NEW_EPISODES = "new-episodes"  # serve cassette hits, record misses
 MODE_REFRESH = "refresh"  # always hit upstream, overwrite cassette
 MODE_ONCE = "once"  # like new-episodes but cassette must exist
 
+# Modes that serve recorded responses from the cassette.
+_REPLAY_CAPABLE = (MODE_REPLAY, MODE_NEW_EPISODES, MODE_ONCE)
+# Modes that persist newly observed interactions.
+_RECORD_CAPABLE = (MODE_RECORD, MODE_NEW_EPISODES, MODE_REFRESH, MODE_ONCE)
+# Modes that preserve (rather than overwrite) any existing cassette entries.
+_ADDITIVE = (MODE_NEW_EPISODES, MODE_ONCE)
 
-def _request_key(request: http.Request) -> tuple[str, str, bytes]:
-    """Fingerprint a request for cassette matching.
-
-    Matches CLM's existing dedup logic: method + full URI + body bytes.
-    Body is included to defend against the silent-wrong-response failure
-    mode that vcrpy's default ``match_on`` exhibits when call order shifts.
-    """
-    body = request.raw_content or b""
-    return (request.method.upper(), request.pretty_url, body)
+# Headers stripped from a served (replayed) response: we hold the full
+# decoded body in memory, so the recorded content-length / transfer
+# framing no longer applies — let mitmproxy recompute them from the body.
+_SERVE_DROP_HEADERS = frozenset({"content-length", "transfer-encoding"})
 
 
 class ClmReplayAddon:
-    """Cassette-backed request/response interception.
+    """Cassette-backed request/response interception (vcrpy-YAML storage).
 
     Lifecycle:
-      * ``load(loader)`` declares the custom options the manager passes.
+      * ``load(loader)`` declares the options the manager passes.
       * ``running()`` loads the existing cassette (if any) and indexes it
         by request fingerprint for O(1) replay lookup.
-      * ``request(flow)`` intercepts before the upstream call: on a hit
-        we set ``flow.response`` to short-circuit; on a miss in strict
-        ``replay`` mode we set an error response so the worker fails
-        cleanly instead of escaping to the network.
-      * ``response(flow)`` runs after a real upstream response; we
-        persist the flow to the cassette unless the mode forbids it.
+      * ``request(flow)`` intercepts before the upstream call: on a hit we
+        set ``flow.response`` to short-circuit; on a miss in strict
+        ``replay`` mode we set a 599 so the worker fails cleanly instead
+        of escaping to the network.
+      * ``response(flow)`` runs after a real upstream response; we persist
+        the interaction to the cassette (eagerly, so a kernel/proxy kill
+        cannot lose recordings) unless the mode forbids it.
     """
 
     def __init__(self) -> None:
         self._cassette_path: Path | None = None
         self._mode: str = MODE_REPLAY
-        # Maps request fingerprint -> recorded HTTPFlow. We keep the
-        # full flow rather than just the response so future format
-        # changes (matching on headers, etc.) only need to extend the
-        # key — the value already has everything.
-        self._index: dict[tuple[str, str, bytes], http.HTTPFlow] = {}
-        # New flows that haven't been written yet. Persisted on each
-        # response (eager append) so a worker crash mid-build cannot
-        # lose in-memory recordings — same invariant as vcrpy patch #6.
-        self._writer: FlowWriter | None = None
-        self._writer_handle: IO[bytes] | None = None
+        # Replay index: request fingerprint -> stored vcr response dict.
+        self._index: dict[tuple[str, str, bytes], dict] = {}
+        # Ordered interactions to persist. Seeded from the existing
+        # cassette in additive modes so a rewrite preserves prior entries;
+        # empty (overwrite) otherwise.
+        self._interactions: list = []
+        self._seen: set[tuple[str, str, bytes]] = set()
 
     def load(self, loader) -> None:
         loader.add_option(
             name="clm_cassette_path",
             typespec=str,
             default="",
-            help="Path to the .mitm cassette file for CLM replay/record.",
+            help="Path to the vcrpy-YAML cassette file for CLM replay/record.",
         )
         loader.add_option(
             name="clm_mode",
@@ -89,6 +112,16 @@ class ClmReplayAddon:
         )
 
     def running(self) -> None:
+        if cf is None:
+            logger.error(
+                "CLM mitmproxy addon requires vcrpy in the mitmdump environment "
+                "(install with: uv tool install mitmproxy --with vcrpy). "
+                "Import failed: %s",
+                _CF_IMPORT_ERROR,
+            )
+            ctx.master.shutdown()
+            return
+
         cassette_path_str = ctx.options.clm_cassette_path
         if not cassette_path_str:
             logger.warning("clm_cassette_path not set; addon will pass through all traffic")
@@ -96,19 +129,10 @@ class ClmReplayAddon:
         self._cassette_path = Path(cassette_path_str)
         self._mode = ctx.options.clm_mode
 
-        # Refresh mode discards the existing cassette before loading.
         if self._mode == MODE_REFRESH and self._cassette_path.exists():
             self._cassette_path.unlink()
 
-        # Load existing flows into the lookup index. ``record`` and
-        # ``refresh`` start from an empty index — they're explicitly
-        # overwriting whatever was there.
-        if (
-            self._mode in (MODE_REPLAY, MODE_NEW_EPISODES, MODE_ONCE)
-            and self._cassette_path.exists()
-        ):
-            self._load_index()
-        elif self._mode == MODE_ONCE and not self._cassette_path.exists():
+        if self._mode == MODE_ONCE and not self._cassette_path.exists():
             logger.error(
                 "Mode 'once' requires an existing cassette at %s — refusing to start",
                 self._cassette_path,
@@ -116,11 +140,8 @@ class ClmReplayAddon:
             ctx.master.shutdown()
             return
 
-        # Open the writer in append mode for record-capable modes.
-        if self._mode in (MODE_RECORD, MODE_NEW_EPISODES, MODE_REFRESH):
-            self._cassette_path.parent.mkdir(parents=True, exist_ok=True)
-            self._writer_handle = open(self._cassette_path, "ab")
-            self._writer = FlowWriter(self._writer_handle)
+        if self._mode in _REPLAY_CAPABLE and self._cassette_path.exists():
+            self._load_index()
 
         logger.info(
             "Addon ready: mode=%s cassette=%s indexed=%d",
@@ -130,30 +151,25 @@ class ClmReplayAddon:
         )
 
     def done(self) -> None:
-        if self._writer_handle is not None:
-            self._writer_handle.flush()
-            self._writer_handle.close()
-            self._writer_handle = None
-            self._writer = None
+        # The cassette is rewritten eagerly on every recorded response, so
+        # there is nothing to flush here for the single-cassette (P1)
+        # model. Kept for lifecycle symmetry / P2 marker writing.
+        return
 
     def request(self, flow: http.HTTPFlow) -> None:
-        if self._cassette_path is None:
+        if self._cassette_path is None or cf is None:
             return  # no cassette configured -> pure pass-through
 
-        key = _request_key(flow.request)
+        key = self._flow_request_key(flow.request)
         cached = self._index.get(key)
-        if cached is not None and cached.response is not None:
-            # Serve from cassette. Setting flow.response short-circuits
-            # the upstream call. Copying preserves the cached response
-            # for subsequent identical requests (allow_playback_repeats
-            # equivalent — we keep the entry in the index).
-            flow.response = cached.response.copy()
+        if cached is not None:
+            flow.response = self._build_reply(cached)
             return
 
         if self._mode == MODE_REPLAY:
-            # Strict replay: a cassette miss is a programming error.
-            # We synthesize a 599 so the worker sees a clear failure
-            # rather than the request being silently dropped.
+            # Strict replay: a cassette miss is a programming error. Emit a
+            # diagnostic 599 so the worker fails clearly rather than the
+            # request being silently dropped or escaping to the network.
             flow.response = http.Response.make(
                 599,
                 json.dumps(
@@ -168,42 +184,80 @@ class ClmReplayAddon:
             )
 
     def response(self, flow: http.HTTPFlow) -> None:
-        if self._writer is None or flow.response is None:
+        if self._cassette_path is None or cf is None:
+            return
+        if self._mode not in _RECORD_CAPABLE:
+            return
+        if flow.response is None:
             return
 
-        # Skip recording for synthetic 599s we emitted ourselves on
-        # replay miss — they never went upstream.
-        if flow.response.status_code == 599 and (
-            flow.response.headers.get("Content-Type") or ""
-        ).startswith("application/json"):
-            try:
-                body = json.loads(flow.response.content or b"{}")
-                if isinstance(body, dict) and body.get("error") == "clm_replay_miss":
-                    return
-            except (json.JSONDecodeError, ValueError):
-                pass
-
-        key = _request_key(flow.request)
-        if key in self._index:
-            # Already in cassette: don't duplicate. (Even in record
-            # mode we dedupe so repeated invocations of the same
-            # notebook don't grow the cassette unboundedly.)
+        # Skip recording the synthetic 599 we emitted on a replay miss —
+        # it never went upstream.
+        if flow.response.status_code == 599 and self._is_replay_miss_marker(flow.response):
             return
 
-        self._index[key] = flow
-        self._writer.add(flow)
-        # Force flush so a kernel kill doesn't lose this entry.
-        if self._writer_handle is not None:
-            self._writer_handle.flush()
+        request = cf.vcr_request_from_parts(
+            flow.request.method,
+            flow.request.url,
+            flow.request.headers.fields,
+            flow.request.raw_content or b"",
+        )
+        key = cf.fingerprint(request)
+        if key in self._seen:
+            # Already recorded this build: don't duplicate. The host-side
+            # merge dedups too, but keeping the in-memory cassette deduped
+            # keeps the eager rewrite cheap and the file stable.
+            return
+
+        response = cf.vcr_response_dict_from_parts(
+            flow.response.status_code,
+            flow.response.reason,
+            flow.response.headers.fields,
+            flow.response.raw_content or b"",
+            decode_compressed=True,
+        )
+        self._interactions.append((request, response))
+        self._index[key] = response
+        self._seen.add(key)
+        # Eager rewrite so a build-timeout kill of mitmdump loses nothing.
+        cf.write_cassette(self._cassette_path, self._interactions)
+
+    # -- helpers ---------------------------------------------------------
+
+    def _flow_request_key(self, request: http.Request) -> tuple[str, str, bytes]:
+        vcr_request = cf.vcr_request_from_parts(
+            request.method, request.url, request.headers.fields, request.raw_content or b""
+        )
+        return cf.fingerprint(vcr_request)
+
+    def _build_reply(self, response: dict) -> http.Response:
+        status_code, header_pairs, content = cf.response_dict_to_reply_parts(response)
+        # mitmproxy's Headers (the Iterable-of-tuples form of Response.make)
+        # requires bytes field pairs — the str/dict form would collapse
+        # duplicate header names (e.g. Set-Cookie). Encode as ASCII (header
+        # values were ASCII-decoded at record time). content-length /
+        # transfer-encoding are dropped so mitmproxy reframes from the body.
+        headers = [
+            (k.encode("ascii", "replace"), v.encode("ascii", "replace"))
+            for k, v in header_pairs
+            if k.lower() not in _SERVE_DROP_HEADERS
+        ]
+        return http.Response.make(status_code, content, headers)
+
+    @staticmethod
+    def _is_replay_miss_marker(response: http.Response) -> bool:
+        if not (response.headers.get("Content-Type") or "").startswith("application/json"):
+            return False
+        try:
+            body = json.loads(response.content or b"{}")
+        except (json.JSONDecodeError, ValueError):
+            return False
+        return isinstance(body, dict) and body.get("error") == "clm_replay_miss"
 
     def _load_index(self) -> None:
         assert self._cassette_path is not None
         try:
-            with open(self._cassette_path, "rb") as handle:
-                reader = FlowReader(handle)
-                for flow in reader.stream():
-                    if isinstance(flow, http.HTTPFlow) and flow.response is not None:
-                        self._index[_request_key(flow.request)] = flow
+            interactions = cf.load_interactions(self._cassette_path)
         except Exception as exc:  # noqa: BLE001 — defensive
             logger.warning(
                 "Failed to load cassette %s (%s: %s); starting with empty index",
@@ -211,6 +265,14 @@ class ClmReplayAddon:
                 type(exc).__name__,
                 exc,
             )
+            return
+        for request, response in interactions:
+            key = cf.fingerprint(request)
+            self._index[key] = response
+            self._seen.add(key)
+            if self._mode in _ADDITIVE:
+                # Preserve existing entries on the next rewrite.
+                self._interactions.append((request, response))
 
 
 addons = [ClmReplayAddon()]

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -182,24 +182,20 @@ class ClmReplayAddon:
         cassette_path_str = ctx.options.clm_cassette_path
         self._default_cassette = Path(cassette_path_str) if cassette_path_str else None
 
-        if (
-            self._mode == MODE_REFRESH
-            and self._default_cassette is not None
-            and self._default_cassette.exists()
-        ):
-            self._default_cassette.unlink()
-
-        if (
-            self._mode == MODE_ONCE
-            and self._default_cassette is not None
-            and not self._default_cassette.exists()
-        ):
-            logger.error(
-                "Mode 'once' requires an existing cassette at %s — refusing to start",
-                self._default_cassette,
-            )
-            ctx.master.shutdown()
-            return
+        # NOTE: vcrpy's strict ``once`` (cassette-must-exist) and ``refresh``
+        # (overwrite) semantics are not enforced per target under the
+        # out-of-process transport yet. The Phase-0 model had a single shared
+        # cassette, so this method could existence-check / unlink it; but under
+        # P2's per-(topic,language,kind) tag routing, ``clm_cassette_path`` is
+        # only the build-scratch *catch-all* (created empty on every fresh
+        # build — see build.py). A ``once`` existence check against it would
+        # wrongly abort the proxy at startup, and a ``refresh`` unlink of it
+        # would clear nothing real. So we do neither here. Until per-target
+        # strict semantics land (issue #165 P3), ``once`` behaves like
+        # ``new-episodes`` (serve cassette hits, record misses) and ``refresh``
+        # records fresh interactions additively (the host merge dedups against
+        # canonical — the same imperfect overwrite the in-process vcrpy path
+        # exhibits today). The mode sets above encode this routing.
 
         logger.info(
             "Addon ready: mode=%s default_cassette=%s build=%s",

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -1,0 +1,216 @@
+"""mitmproxy addon implementing CLM's record/replay semantics.
+
+This module is loaded by ``mitmdump`` (not by the CLM workers). It is
+invoked via ``mitmdump --scripts <this-file>`` and reads its config from
+mitmproxy options the manager sets on the command line.
+
+Storage format for the prototype is mitmproxy's native ``.mitm`` binary
+flow stream — chosen so we can validate the transport architecture
+without also rebuilding the cassette-format and staging/merge layers.
+Compatibility with the existing vcrpy YAML schema is follow-up work
+(see the design doc).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import IO
+
+from mitmproxy import ctx, http
+from mitmproxy.io import FlowReader, FlowWriter
+
+logger = logging.getLogger("clm.http_replay_mitm.addon")
+
+
+# Mode mapping mirrors vcrpy semantics one-for-one. ``disabled`` is
+# handled by the manager (it doesn't start mitmproxy at all), so the
+# addon never sees it.
+MODE_REPLAY = "replay"  # serve from cassette, error on miss
+MODE_RECORD = "record"  # always hit upstream, append new flows
+MODE_NEW_EPISODES = "new-episodes"  # serve cassette hits, record misses
+MODE_REFRESH = "refresh"  # always hit upstream, overwrite cassette
+MODE_ONCE = "once"  # like new-episodes but cassette must exist
+
+
+def _request_key(request: http.Request) -> tuple[str, str, bytes]:
+    """Fingerprint a request for cassette matching.
+
+    Matches CLM's existing dedup logic: method + full URI + body bytes.
+    Body is included to defend against the silent-wrong-response failure
+    mode that vcrpy's default ``match_on`` exhibits when call order shifts.
+    """
+    body = request.raw_content or b""
+    return (request.method.upper(), request.pretty_url, body)
+
+
+class ClmReplayAddon:
+    """Cassette-backed request/response interception.
+
+    Lifecycle:
+      * ``load(loader)`` declares the custom options the manager passes.
+      * ``running()`` loads the existing cassette (if any) and indexes it
+        by request fingerprint for O(1) replay lookup.
+      * ``request(flow)`` intercepts before the upstream call: on a hit
+        we set ``flow.response`` to short-circuit; on a miss in strict
+        ``replay`` mode we set an error response so the worker fails
+        cleanly instead of escaping to the network.
+      * ``response(flow)`` runs after a real upstream response; we
+        persist the flow to the cassette unless the mode forbids it.
+    """
+
+    def __init__(self) -> None:
+        self._cassette_path: Path | None = None
+        self._mode: str = MODE_REPLAY
+        # Maps request fingerprint -> recorded HTTPFlow. We keep the
+        # full flow rather than just the response so future format
+        # changes (matching on headers, etc.) only need to extend the
+        # key — the value already has everything.
+        self._index: dict[tuple[str, str, bytes], http.HTTPFlow] = {}
+        # New flows that haven't been written yet. Persisted on each
+        # response (eager append) so a worker crash mid-build cannot
+        # lose in-memory recordings — same invariant as vcrpy patch #6.
+        self._writer: FlowWriter | None = None
+        self._writer_handle: IO[bytes] | None = None
+
+    def load(self, loader) -> None:
+        loader.add_option(
+            name="clm_cassette_path",
+            typespec=str,
+            default="",
+            help="Path to the .mitm cassette file for CLM replay/record.",
+        )
+        loader.add_option(
+            name="clm_mode",
+            typespec=str,
+            default=MODE_REPLAY,
+            help="CLM replay mode: replay | record | new-episodes | refresh | once.",
+        )
+
+    def running(self) -> None:
+        cassette_path_str = ctx.options.clm_cassette_path
+        if not cassette_path_str:
+            logger.warning("clm_cassette_path not set; addon will pass through all traffic")
+            return
+        self._cassette_path = Path(cassette_path_str)
+        self._mode = ctx.options.clm_mode
+
+        # Refresh mode discards the existing cassette before loading.
+        if self._mode == MODE_REFRESH and self._cassette_path.exists():
+            self._cassette_path.unlink()
+
+        # Load existing flows into the lookup index. ``record`` and
+        # ``refresh`` start from an empty index — they're explicitly
+        # overwriting whatever was there.
+        if (
+            self._mode in (MODE_REPLAY, MODE_NEW_EPISODES, MODE_ONCE)
+            and self._cassette_path.exists()
+        ):
+            self._load_index()
+        elif self._mode == MODE_ONCE and not self._cassette_path.exists():
+            logger.error(
+                "Mode 'once' requires an existing cassette at %s — refusing to start",
+                self._cassette_path,
+            )
+            ctx.master.shutdown()
+            return
+
+        # Open the writer in append mode for record-capable modes.
+        if self._mode in (MODE_RECORD, MODE_NEW_EPISODES, MODE_REFRESH):
+            self._cassette_path.parent.mkdir(parents=True, exist_ok=True)
+            self._writer_handle = open(self._cassette_path, "ab")
+            self._writer = FlowWriter(self._writer_handle)
+
+        logger.info(
+            "Addon ready: mode=%s cassette=%s indexed=%d",
+            self._mode,
+            self._cassette_path,
+            len(self._index),
+        )
+
+    def done(self) -> None:
+        if self._writer_handle is not None:
+            self._writer_handle.flush()
+            self._writer_handle.close()
+            self._writer_handle = None
+            self._writer = None
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        if self._cassette_path is None:
+            return  # no cassette configured -> pure pass-through
+
+        key = _request_key(flow.request)
+        cached = self._index.get(key)
+        if cached is not None and cached.response is not None:
+            # Serve from cassette. Setting flow.response short-circuits
+            # the upstream call. Copying preserves the cached response
+            # for subsequent identical requests (allow_playback_repeats
+            # equivalent — we keep the entry in the index).
+            flow.response = cached.response.copy()
+            return
+
+        if self._mode == MODE_REPLAY:
+            # Strict replay: a cassette miss is a programming error.
+            # We synthesize a 599 so the worker sees a clear failure
+            # rather than the request being silently dropped.
+            flow.response = http.Response.make(
+                599,
+                json.dumps(
+                    {
+                        "error": "clm_replay_miss",
+                        "method": flow.request.method,
+                        "url": flow.request.pretty_url,
+                        "cassette": str(self._cassette_path),
+                    }
+                ).encode(),
+                {"Content-Type": "application/json"},
+            )
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        if self._writer is None or flow.response is None:
+            return
+
+        # Skip recording for synthetic 599s we emitted ourselves on
+        # replay miss — they never went upstream.
+        if flow.response.status_code == 599 and (
+            flow.response.headers.get("Content-Type") or ""
+        ).startswith("application/json"):
+            try:
+                body = json.loads(flow.response.content or b"{}")
+                if isinstance(body, dict) and body.get("error") == "clm_replay_miss":
+                    return
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        key = _request_key(flow.request)
+        if key in self._index:
+            # Already in cassette: don't duplicate. (Even in record
+            # mode we dedupe so repeated invocations of the same
+            # notebook don't grow the cassette unboundedly.)
+            return
+
+        self._index[key] = flow
+        self._writer.add(flow)
+        # Force flush so a kernel kill doesn't lose this entry.
+        if self._writer_handle is not None:
+            self._writer_handle.flush()
+
+    def _load_index(self) -> None:
+        assert self._cassette_path is not None
+        try:
+            with open(self._cassette_path, "rb") as handle:
+                reader = FlowReader(handle)
+                for flow in reader.stream():
+                    if isinstance(flow, http.HTTPFlow) and flow.response is not None:
+                        self._index[_request_key(flow.request)] = flow
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "Failed to load cassette %s (%s: %s); starting with empty index",
+                self._cassette_path,
+                type(exc).__name__,
+                exc,
+            )
+
+
+addons = [ClmReplayAddon()]

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -23,7 +23,7 @@ The tag header is stripped before recording or forwarding upstream.
 
 Untagged traffic (a kernel that somehow bypassed the tag bootstrap) falls
 back to the single ``clm_cassette_path`` catch-all so strict ``replay``
-mode still returns a 599 instead of escaping to the network.
+mode still returns a non-retryable 404 instead of escaping to the network.
 """
 
 from __future__ import annotations
@@ -64,7 +64,7 @@ except ImportError:  # mitmdump interpreter — import the sibling by path
 # refresh for defensiveness (CLM does not emit it). The serve/record/overwrite
 # semantics each implies are computed per-target in ``_modes_for`` because
 # ``once`` depends on whether the target cassette already exists.
-MODE_REPLAY = "replay"  # serve from cassette, 599 on miss, never record
+MODE_REPLAY = "replay"  # serve from cassette, 404 on miss, never record
 MODE_RECORD = "record"  # alias of refresh (not emitted by CLM)
 MODE_NEW_EPISODES = "new-episodes"  # serve cassette hits, record misses
 MODE_REFRESH = "refresh"  # always hit upstream, overwrite cassette
@@ -92,6 +92,18 @@ _STAGING_INFIX = ".staging-mitm-"
 # decoded body in memory, so the recorded content-length / transfer
 # framing no longer applies — let mitmproxy recompute them from the body.
 _SERVE_DROP_HEADERS = frozenset({"content-length", "transfer-encoding"})
+
+# Status synthesized for a strict-replay miss. It MUST be a status the LLM
+# SDKs do NOT retry, so a stale-cassette miss fails on the first attempt — the
+# out-of-process analogue of vcrpy raising CannotOverwriteExistingCassetteException
+# synchronously. openai/anthropic/langchain retry 408/409/429 and every 5xx
+# (incl. the old 599 we used), which under a deck's many ``.batch()`` calls
+# amplified one miss into 3x the requests + backoff and blew past the build's
+# job timeout (issue #165 P3, measured). A 4xx like 404 raises immediately
+# (NotFoundError) with no retry. The miss is still identified by its
+# ``clm_replay_miss`` body, not this status (see ``_is_replay_miss_marker``),
+# so it never collides with a legitimately recorded 404 response.
+_REPLAY_MISS_STATUS = 404
 
 
 class _Target:
@@ -148,8 +160,8 @@ class ClmReplayAddon:
         ``X-CLM-Cassette`` tag, strips it, and either serves a cassette hit
         (matched with the vcrpy matcher chain incl. JSON-semantic bodies) or —
         in a strict mode (``replay`` / ``once`` with an existing cassette) —
-        synthesizes a 599 on miss so the worker fails cleanly instead of
-        escaping to the network.
+        synthesizes a non-retryable 404 on miss so the worker fails cleanly
+        and fast instead of escaping to the network.
       * ``response(flow)`` persists a real upstream response into the flow's
         target cassette (eagerly, so a kernel/proxy kill cannot lose
         recordings), recording the *filtered* request so the on-disk cassette
@@ -266,7 +278,7 @@ class ClmReplayAddon:
         filtered = self._filter_request(flow.request)
         if filtered is None:
             # ignore_hosts (e.g. LangSmith telemetry) or an unfilterable request:
-            # forward upstream untouched, record nothing, never 599.
+            # forward upstream untouched, record nothing, never a miss response.
             flow.metadata[_FLOW_IGNORED_KEY] = True
             return
 
@@ -296,7 +308,9 @@ class ClmReplayAddon:
             return  # ignore_hosts / unfilterable: never record
         if flow.metadata.get(_FLOW_SERVED_KEY):
             return  # served from cassette this build — nothing new to record
-        if flow.response.status_code == 599 and self._is_replay_miss_marker(flow.response):
+        if flow.response.status_code == _REPLAY_MISS_STATUS and self._is_replay_miss_marker(
+            flow.response
+        ):
             return  # synthetic miss; never went upstream
 
         target = self._target_for(flow.metadata.get(_FLOW_TAG_KEY))
@@ -392,10 +406,10 @@ class ClmReplayAddon:
         absent → record-and-serve like new-episodes). This is the per-target
         resolution of vcrpy's record-mode semantics:
 
-        * ``replay``          → serve hits, 599 on miss, never record;
+        * ``replay``          → serve hits, 404 on miss, never record;
         * ``new-episodes``    → serve hits, record misses;
         * ``refresh``/``record`` → never serve, always record, overwrite;
-        * ``once`` + present  → serve hits, 599 on miss, never record;
+        * ``once`` + present  → serve hits, 404 on miss, never record;
         * ``once`` + absent   → serve hits, record misses.
         """
         mode = self._mode
@@ -438,28 +452,43 @@ class ClmReplayAddon:
             return None
 
     def _replay_miss_response(self, flow: http.HTTPFlow, target: _Target) -> http.Response:
-        # A strict-replay miss returns HTTP 599 so the request never escapes to
-        # the network. This is the out-of-process analogue of vcrpy's in-kernel
-        # CannotOverwriteExistingCassetteException: the kernel's HTTP SDK
-        # (openai/anthropic/langchain) surfaces the 599 as an APIStatusError →
-        # cell error → the #93 fail-on-error policy → non-zero build exit.
-        # SDKs treat 5xx as retryable, so a miss is briefly retried (bounded by
-        # the SDK's max_retries, typically 2-3) before it raises — it cannot
-        # hang or silently pass. Defense-in-depth against an unbounded/raised
-        # SDK retry ceiling: the replay-engaged per-cell timeout
-        # (``notebook_processor._HTTP_REPLAY_DEFAULT_CELL_TIMEOUT``, default
-        # 600s) bounds any stall regardless of SDK behavior.
+        # A strict-replay miss returns a NON-RETRYABLE 4xx (``_REPLAY_MISS_STATUS``)
+        # so the request never escapes to the network AND the kernel's SDK raises
+        # on the FIRST attempt — the out-of-process analogue of vcrpy raising
+        # CannotOverwriteExistingCassetteException synchronously. The SDK surfaces
+        # it as an APIStatusError (NotFoundError) → cell error → the #93
+        # fail-on-error policy → non-zero build exit, fast. (Using a 5xx such as
+        # the old 599 made the SDK retry the miss as a server error, amplifying
+        # one miss into 3x the requests + backoff across a deck's ``.batch()``
+        # calls and stalling the build until its job timeout — issue #165 P3.)
+        # ``Connection: close`` keeps a flood of misses from piling onto one
+        # pooled connection.
+        #
+        # The body uses the ``{"error": {message, type, code}}`` envelope the
+        # LLM SDKs expect, so the kernel surfaces a clean
+        # ``NotFoundError: clm_replay_miss: …`` instead of a confusing pydantic
+        # "invalid error body" complaint — a loud, *clear* failure (the gate-7
+        # goal). The top-level ``clm_replay_miss`` flag is the marker
+        # ``_is_replay_miss_marker`` keys on (status-independent).
+        method = flow.request.method
+        url = flow.request.pretty_url
+        message = f"clm_replay_miss: no recorded interaction for {method} {url} in cassette {target.canonical}"
         return http.Response.make(
-            599,
+            _REPLAY_MISS_STATUS,
             json.dumps(
                 {
-                    "error": "clm_replay_miss",
-                    "method": flow.request.method,
-                    "url": flow.request.pretty_url,
+                    "error": {
+                        "message": message,
+                        "type": "clm_replay_miss",
+                        "code": "clm_replay_miss",
+                    },
+                    "clm_replay_miss": True,
+                    "method": method,
+                    "url": url,
                     "cassette": str(target.canonical),
                 }
             ).encode(),
-            {"Content-Type": "application/json"},
+            {"Content-Type": "application/json", "Connection": "close"},
         )
 
     def _build_reply(self, response: dict) -> http.Response:
@@ -484,7 +513,7 @@ class ClmReplayAddon:
             body = json.loads(response.content or b"{}")
         except (json.JSONDecodeError, ValueError):
             return False
-        return isinstance(body, dict) and body.get("error") == "clm_replay_miss"
+        return isinstance(body, dict) and body.get("clm_replay_miss") is True
 
 
 addons = [ClmReplayAddon()]

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -32,6 +32,7 @@ import json
 import logging
 import sys
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 from mitmproxy import ctx, http
@@ -56,23 +57,18 @@ except ImportError:  # mitmdump interpreter — import the sibling by path
         _CF_IMPORT_ERROR = exc
 
 
-# Mode mapping mirrors vcrpy semantics one-for-one. ``disabled`` is
-# handled by the manager (it doesn't start mitmproxy at all), so the
-# addon never sees it.
-MODE_REPLAY = "replay"  # serve from cassette, error on miss
-MODE_RECORD = "record"  # always hit upstream, record (overwrite)
+# CLM HTTP-replay modes (the four CLM exposes; ``disabled`` is handled by the
+# manager — it doesn't start mitmproxy at all — so the addon never sees it).
+# These map 1:1 to vcrpy record modes: replay→none, once→once,
+# new-episodes→new_episodes, refresh→all. ``record`` is kept as an alias of
+# refresh for defensiveness (CLM does not emit it). The serve/record/overwrite
+# semantics each implies are computed per-target in ``_modes_for`` because
+# ``once`` depends on whether the target cassette already exists.
+MODE_REPLAY = "replay"  # serve from cassette, 599 on miss, never record
+MODE_RECORD = "record"  # alias of refresh (not emitted by CLM)
 MODE_NEW_EPISODES = "new-episodes"  # serve cassette hits, record misses
 MODE_REFRESH = "refresh"  # always hit upstream, overwrite cassette
-MODE_ONCE = "once"  # like new-episodes but cassette must exist
-
-# Modes that serve recorded responses from the cassette.
-_REPLAY_CAPABLE = (MODE_REPLAY, MODE_NEW_EPISODES, MODE_ONCE)
-# Modes that persist newly observed interactions.
-_RECORD_CAPABLE = (MODE_RECORD, MODE_NEW_EPISODES, MODE_REFRESH, MODE_ONCE)
-# Modes that preserve (rather than overwrite) existing cassette entries
-# when writing the *catch-all* cassette in full (tagged staging files only
-# ever hold the build's new interactions; the host merge folds them).
-_ADDITIVE = (MODE_NEW_EPISODES, MODE_ONCE)
+MODE_ONCE = "once"  # cassette present → strict replay; absent → record
 
 # Per-request worker tag identifying the destination cassette (lower-cased
 # because HTTP header lookups are case-insensitive and HTTP/2 lowercases).
@@ -81,6 +77,10 @@ _TAG_HEADER = "x-clm-cassette"
 # header (the tag must not be forwarded upstream or recorded).
 _FLOW_TAG_KEY = "clm_cassette_tag"
 _FLOW_SERVED_KEY = "clm_served_from_cache"
+# Set when request() decided this flow must NOT be recorded (an ``ignore_hosts``
+# host such as LangSmith telemetry, or an unfilterable request): it is forwarded
+# upstream untouched and response() skips persisting it.
+_FLOW_IGNORED_KEY = "clm_ignored_no_record"
 
 # Staging filename infix. Must start with ``.staging-`` so the host-side
 # ``merge_staging_into_canonical`` glob (``<name>.staging-*``) finds it. The
@@ -97,7 +97,16 @@ _SERVE_DROP_HEADERS = frozenset({"content-length", "transfer-encoding"})
 class _Target:
     """One destination cassette and its in-build recording/replay state."""
 
-    __slots__ = ("canonical", "write_path", "is_staging", "loaded", "index", "interactions", "seen")
+    __slots__ = (
+        "canonical",
+        "write_path",
+        "is_staging",
+        "loaded",
+        "cassette_existed",
+        "recorded",
+        "to_write",
+        "seen",
+    )
 
     def __init__(self, canonical: Path, write_path: Path, *, is_staging: bool) -> None:
         # Where the interactions ultimately live (replay source; merge target).
@@ -108,8 +117,21 @@ class _Target:
         self.write_path = write_path
         self.is_staging = is_staging
         self.loaded = False
-        self.index: dict[tuple[str, str, bytes], dict] = {}
-        self.interactions: list = []
+        # Whether the canonical cassette existed when first referenced this
+        # build — the discriminator for ``once`` (present → strict replay).
+        self.cassette_existed = False
+        # Replay match corpus: existing canonical entries (replay-capable
+        # modes) plus interactions recorded this build. Scanned pairwise with
+        # the vcrpy matcher chain so JSON bodies match semantically.
+        self.recorded: list[tuple] = []
+        # What gets serialized to ``write_path``. For a tagged staging file
+        # this holds only this build's new interactions (the host merge folds
+        # them into canonical); for the untagged catch-all it holds the full
+        # cassette (seeded existing entries + new) so the in-place rewrite
+        # preserves prior recordings.
+        self.to_write: list[tuple] = []
+        # Fingerprints already recorded this build (dedup; mirrors the host
+        # merge's ``_dedup_key`` so the addon and merge agree).
         self.seen: set[tuple[str, str, bytes]] = set()
 
 
@@ -118,15 +140,20 @@ class ClmReplayAddon:
 
     Lifecycle:
       * ``load(loader)`` declares the options the manager passes.
-      * ``running()`` records the mode + catch-all cassette and a per-build
-        id used to name staging files.
-      * ``request(flow)`` routes by the ``X-CLM-Cassette`` tag, strips it,
-        and either serves a cassette hit (short-circuit) or — in strict
-        ``replay`` mode — synthesizes a 599 on miss so the worker fails
-        cleanly instead of escaping to the network.
-      * ``response(flow)`` persists a real upstream response into the
-        flow's target cassette (eagerly, so a kernel/proxy kill cannot
-        lose recordings) unless the mode forbids it.
+      * ``running()`` records the mode + catch-all cassette + a per-build id
+        used to name staging files, and builds the secret/ignore-host request
+        filter (parity with the in-kernel vcrpy ``before_record_request``).
+      * ``request(flow)`` filters the request (dropping secrets; ignore_hosts
+        → pass straight through, never recorded), routes by the
+        ``X-CLM-Cassette`` tag, strips it, and either serves a cassette hit
+        (matched with the vcrpy matcher chain incl. JSON-semantic bodies) or —
+        in a strict mode (``replay`` / ``once`` with an existing cassette) —
+        synthesizes a 599 on miss so the worker fails cleanly instead of
+        escaping to the network.
+      * ``response(flow)`` persists a real upstream response into the flow's
+        target cassette (eagerly, so a kernel/proxy kill cannot lose
+        recordings), recording the *filtered* request so the on-disk cassette
+        is byte-identical to a vcrpy-recorded one, unless the mode forbids it.
 
     The ``.completed`` markers that tell the host merge a staging file is
     safe to fold are written by the **host** in the build's ``finally``
@@ -141,6 +168,10 @@ class ClmReplayAddon:
         self._mode: str = MODE_REPLAY
         self._default_cassette: Path | None = None
         self._build_id: str = ""
+        # Built in running() from clm_ignore_hosts: filters secrets out of every
+        # recorded request and returns None for ignore_hosts so telemetry passes
+        # straight through (never recorded). Mirrors the in-kernel vcrpy filters.
+        self._request_filter: Callable[..., object] | None = None
         # Keyed by canonical-path string; "" is the untagged catch-all.
         self._targets: dict[str, _Target] = {}
 
@@ -156,7 +187,7 @@ class ClmReplayAddon:
             name="clm_mode",
             typespec=str,
             default=MODE_REPLAY,
-            help="CLM replay mode: replay | record | new-episodes | refresh | once.",
+            help="CLM replay mode: replay | new-episodes | refresh | once.",
         )
         loader.add_option(
             name="clm_build_id",
@@ -164,6 +195,13 @@ class ClmReplayAddon:
             default="",
             help="Per-build id used to name staging files so the host can "
             "mark this build's recordings complete.",
+        )
+        loader.add_option(
+            name="clm_ignore_hosts",
+            typespec=str,
+            default="",
+            help="Comma-separated hosts whose traffic is forwarded but never "
+            "recorded (LangSmith telemetry by default). Mirrors vcrpy ignore_hosts.",
         )
 
     def running(self) -> None:
@@ -182,25 +220,26 @@ class ClmReplayAddon:
         cassette_path_str = ctx.options.clm_cassette_path
         self._default_cassette = Path(cassette_path_str) if cassette_path_str else None
 
-        # NOTE: vcrpy's strict ``once`` (cassette-must-exist) and ``refresh``
-        # (overwrite) semantics are not enforced per target under the
-        # out-of-process transport yet. The Phase-0 model had a single shared
-        # cassette, so this method could existence-check / unlink it; but under
-        # P2's per-(topic,language,kind) tag routing, ``clm_cassette_path`` is
-        # only the build-scratch *catch-all* (created empty on every fresh
-        # build — see build.py). A ``once`` existence check against it would
-        # wrongly abort the proxy at startup, and a ``refresh`` unlink of it
-        # would clear nothing real. So we do neither here. Until per-target
-        # strict semantics land (issue #165 P3), ``once`` behaves like
-        # ``new-episodes`` (serve cassette hits, record misses) and ``refresh``
-        # records fresh interactions additively (the host merge dedups against
-        # canonical — the same imperfect overwrite the in-process vcrpy path
-        # exhibits today). The mode sets above encode this routing.
+        ignore_hosts = tuple(
+            h.strip() for h in (ctx.options.clm_ignore_hosts or "").split(",") if h.strip()
+        )
+        # The before_record_request closure: removes secret headers
+        # (authorization/cookie/x-api-key), strips api_key/token query params and
+        # password/token/api_key body params, and returns None for ignore_hosts.
+        # filter_* default to cassette_format's constants (kept in lockstep with
+        # the in-kernel vcrpy bootstrap by a drift-guard test).
+        self._request_filter = cf.build_request_filter(ignore_hosts=ignore_hosts)
+
+        # ``once``/``refresh`` strictness is resolved per target in
+        # ``_modes_for`` (``once`` depends on whether the target cassette
+        # already exists), so there is nothing to existence-check or unlink
+        # here — ``clm_cassette_path`` is only the build-scratch catch-all.
 
         logger.info(
-            "Addon ready: mode=%s default_cassette=%s build=%s",
+            "Addon ready: mode=%s default_cassette=%s ignore_hosts=%s build=%s",
             self._mode,
             self._default_cassette,
+            ignore_hosts,
             self._build_id,
         )
 
@@ -221,37 +260,40 @@ class ClmReplayAddon:
             # recorded into the cassette.
             del flow.request.headers[_TAG_HEADER]
 
+        # Filter first: secrets are removed and an ignore_hosts host yields None.
+        # The filtered request is what we match against (and what we record), so
+        # secret removal and matching stay consistent on both sides.
+        filtered = self._filter_request(flow.request)
+        if filtered is None:
+            # ignore_hosts (e.g. LangSmith telemetry) or an unfilterable request:
+            # forward upstream untouched, record nothing, never 599.
+            flow.metadata[_FLOW_IGNORED_KEY] = True
+            return
+
         target = self._target_for(tag)
         if target is None:
             return  # untagged with no catch-all configured -> pass through
 
         self._ensure_loaded(target)
-        key = self._request_key(flow.request)
-        cached = target.index.get(key)
-        if cached is not None:
-            flow.response = self._build_reply(cached)
-            flow.metadata[_FLOW_SERVED_KEY] = True
-            return
+        serve, record, _overwrite = self._modes_for(target.cassette_existed)
 
-        if self._mode == MODE_REPLAY:
-            flow.response = http.Response.make(
-                599,
-                json.dumps(
-                    {
-                        "error": "clm_replay_miss",
-                        "method": flow.request.method,
-                        "url": flow.request.pretty_url,
-                        "cassette": str(target.canonical),
-                    }
-                ).encode(),
-                {"Content-Type": "application/json"},
-            )
+        if serve:
+            for rec_request, rec_response in target.recorded:
+                if cf.requests_match(filtered, rec_request):
+                    flow.response = self._build_reply(rec_response)
+                    flow.metadata[_FLOW_SERVED_KEY] = True
+                    return
+
+        if not record:
+            # Strict replay (``replay``, or ``once`` with an existing cassette):
+            # a miss must fail loudly, never escaping to the real network.
+            flow.response = self._replay_miss_response(flow, target)
 
     def response(self, flow: http.HTTPFlow) -> None:
         if cf is None or flow.response is None:
             return
-        if self._mode not in _RECORD_CAPABLE:
-            return
+        if flow.metadata.get(_FLOW_IGNORED_KEY):
+            return  # ignore_hosts / unfilterable: never record
         if flow.metadata.get(_FLOW_SERVED_KEY):
             return  # served from cassette this build — nothing new to record
         if flow.response.status_code == 599 and self._is_replay_miss_marker(flow.response):
@@ -260,13 +302,15 @@ class ClmReplayAddon:
         target = self._target_for(flow.metadata.get(_FLOW_TAG_KEY))
         if target is None:
             return
+        self._ensure_loaded(target)
+        _serve, record, _overwrite = self._modes_for(target.cassette_existed)
+        if not record:
+            return
 
-        request = cf.vcr_request_from_parts(
-            flow.request.method,
-            flow.request.url,
-            flow.request.headers.fields,
-            flow.request.raw_content or b"",
-        )
+        request = self._filter_request(flow.request)
+        if request is None:
+            return  # defensive: should have been flagged ignored in request()
+
         key = cf.fingerprint(request)
         if key in target.seen:
             return  # already recorded this build — keep the eager rewrite cheap
@@ -278,11 +322,11 @@ class ClmReplayAddon:
             flow.response.raw_content or b"",
             decode_compressed=True,
         )
-        target.interactions.append((request, response))
-        target.index[key] = response
+        target.recorded.append((request, response))
+        target.to_write.append((request, response))
         target.seen.add(key)
         # Eager rewrite so a build-timeout kill of mitmdump loses nothing.
-        cf.write_cassette(target.write_path, target.interactions)
+        cf.write_cassette(target.write_path, target.to_write)
 
     # -- routing ---------------------------------------------------------
 
@@ -309,7 +353,14 @@ class ClmReplayAddon:
         if target.loaded:
             return
         target.loaded = True
-        if self._mode not in _REPLAY_CAPABLE or not target.canonical.exists():
+        existed = target.canonical.exists()
+        target.cassette_existed = existed
+        _serve, _record, overwrite = self._modes_for(existed)
+        # ``refresh``/``record`` (overwrite) starts from a clean slate — never
+        # seed the match corpus (we always hit upstream) nor ``to_write`` (the
+        # cassette is rewritten from this build only). Nothing to load if the
+        # canonical doesn't exist yet either.
+        if overwrite or not existed:
             return
         try:
             interactions = cf.load_interactions(target.canonical)
@@ -322,22 +373,94 @@ class ClmReplayAddon:
             )
             return
         for request, response in interactions:
-            key = cf.fingerprint(request)
-            target.index[key] = response
-            target.seen.add(key)
-            # The catch-all rewrites the whole cassette, so it must keep
-            # existing entries; tagged staging files hold only new
-            # interactions (the host merge folds them into canonical).
-            if not target.is_staging and self._mode in _ADDITIVE:
-                target.interactions.append((request, response))
+            target.recorded.append((request, response))
+            target.seen.add(cf.fingerprint(request))
+            # The catch-all rewrites the whole cassette in place, so it must
+            # keep existing entries; tagged staging files hold only this
+            # build's new interactions (the host merge folds them into
+            # canonical). ``to_write`` is never serialized in non-recording
+            # modes, so seeding it for the catch-all is harmless there.
+            if not target.is_staging:
+                target.to_write.append((request, response))
 
     # -- helpers ---------------------------------------------------------
 
-    def _request_key(self, request: http.Request) -> tuple[str, str, bytes]:
-        vcr_request = cf.vcr_request_from_parts(
-            request.method, request.url, request.headers.fields, request.raw_content or b""
+    def _modes_for(self, cassette_existed: bool) -> tuple[bool, bool, bool]:
+        """Return ``(serve, record, overwrite)`` for the current mode.
+
+        Only ``once`` depends on ``cassette_existed`` (present → strict replay,
+        absent → record-and-serve like new-episodes). This is the per-target
+        resolution of vcrpy's record-mode semantics:
+
+        * ``replay``          → serve hits, 599 on miss, never record;
+        * ``new-episodes``    → serve hits, record misses;
+        * ``refresh``/``record`` → never serve, always record, overwrite;
+        * ``once`` + present  → serve hits, 599 on miss, never record;
+        * ``once`` + absent   → serve hits, record misses.
+        """
+        mode = self._mode
+        if mode == MODE_NEW_EPISODES:
+            return (True, True, False)
+        if mode in (MODE_REFRESH, MODE_RECORD):
+            return (False, True, True)
+        if mode == MODE_ONCE:
+            return (True, False, False) if cassette_existed else (True, True, False)
+        # MODE_REPLAY and any unknown mode: strict replay is the safe default.
+        return (True, False, False)
+
+    def _filter_request(self, request: http.Request):
+        """Build the filtered vcr Request for matching/recording, or ``None``.
+
+        ``None`` means "do not record, pass straight through" — either an
+        ignore_hosts host or (defensively) a request the vcrpy filters could not
+        process. Returning the unfiltered request is never an option: it could
+        leak a secret-bearing ``authorization`` header into the cassette.
+        """
+        request_filter = self._request_filter
+        if request_filter is None:
+            # running() always builds the filter before any flow is handled;
+            # if it somehow hasn't, fail safe (don't record) rather than leak.
+            return None
+        try:
+            vcr_request = cf.vcr_request_from_parts(
+                request.method,
+                request.url,
+                request.headers.fields,
+                request.raw_content or b"",
+            )
+            return request_filter(vcr_request)
+        except Exception as exc:  # noqa: BLE001 — never crash the proxy
+            logger.warning(
+                "Request filtering failed (%s: %s); forwarding without recording",
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    def _replay_miss_response(self, flow: http.HTTPFlow, target: _Target) -> http.Response:
+        # A strict-replay miss returns HTTP 599 so the request never escapes to
+        # the network. This is the out-of-process analogue of vcrpy's in-kernel
+        # CannotOverwriteExistingCassetteException: the kernel's HTTP SDK
+        # (openai/anthropic/langchain) surfaces the 599 as an APIStatusError →
+        # cell error → the #93 fail-on-error policy → non-zero build exit.
+        # SDKs treat 5xx as retryable, so a miss is briefly retried (bounded by
+        # the SDK's max_retries, typically 2-3) before it raises — it cannot
+        # hang or silently pass. Defense-in-depth against an unbounded/raised
+        # SDK retry ceiling: the replay-engaged per-cell timeout
+        # (``notebook_processor._HTTP_REPLAY_DEFAULT_CELL_TIMEOUT``, default
+        # 600s) bounds any stall regardless of SDK behavior.
+        return http.Response.make(
+            599,
+            json.dumps(
+                {
+                    "error": "clm_replay_miss",
+                    "method": flow.request.method,
+                    "url": flow.request.pretty_url,
+                    "cassette": str(target.canonical),
+                }
+            ).encode(),
+            {"Content-Type": "application/json"},
         )
-        return cf.fingerprint(vcr_request)
 
     def _build_reply(self, response: dict) -> http.Response:
         status_code, header_pairs, content = cf.response_dict_to_reply_parts(response)

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -34,6 +34,7 @@ import sys
 import uuid
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any, Protocol
 
 from mitmproxy import ctx, http
 
@@ -55,6 +56,18 @@ except ImportError:  # mitmdump interpreter — import the sibling by path
     except ImportError as exc:  # vcrpy missing from the mitmdump env
         cf = None  # type: ignore[assignment]
         _CF_IMPORT_ERROR = exc
+
+# The proxy-flow trace writer (issue #165 P5 forensic harness). Pure stdlib, so
+# it always imports — both as a CLM submodule and by bare path inside the
+# mitmdump interpreter. Off unless the manager passes ``clm_trace_dir``.
+try:  # CLM venv
+    from clm.infrastructure.http_replay_mitm import trace_log as _trace_log
+except ImportError:  # mitmdump interpreter — import the sibling by path
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        import trace_log as _trace_log  # type: ignore[import-not-found,no-redef]
+    except ImportError:  # pragma: no cover — pure stdlib, should never fail
+        _trace_log = None  # type: ignore[assignment]
 
 
 # CLM HTTP-replay modes (the four CLM exposes; ``disabled`` is handled by the
@@ -104,6 +117,32 @@ _SERVE_DROP_HEADERS = frozenset({"content-length", "transfer-encoding"})
 # ``clm_replay_miss`` body, not this status (see ``_is_replay_miss_marker``),
 # so it never collides with a legitimately recorded 404 response.
 _REPLAY_MISS_STATUS = 404
+
+
+class _TraceLike(Protocol):
+    """The slice of ``ProxyTraceLog`` the addon depends on (so the trace can be
+    either a real log or the no-op stand-in without confusing the type checker)."""
+
+    def emit(self, event: str, data: dict[str, Any] | None = None) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _DisabledTrace:
+    """No-op proxy-trace stand-in used when the trace module can't be imported.
+
+    ``trace_log`` is pure stdlib so this should never be needed in practice,
+    but it lets the addon call ``self._trace.emit(...)`` unconditionally.
+    """
+
+    def emit(self, event: str, data: dict[str, Any] | None = None) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+_DISABLED_TRACE = _DisabledTrace()
 
 
 class _Target:
@@ -186,6 +225,10 @@ class ClmReplayAddon:
         self._request_filter: Callable[..., object] | None = None
         # Keyed by canonical-path string; "" is the untagged catch-all.
         self._targets: dict[str, _Target] = {}
+        # Forensic per-flow trace (issue #165 P5). Disabled until running()
+        # reads ``clm_trace_dir``; off entirely unless the build sets
+        # CLM_HTTP_REPLAY_TRACE=1 and the manager forwards the directory.
+        self._trace: _TraceLike = _DISABLED_TRACE
 
     def load(self, loader) -> None:
         loader.add_option(
@@ -214,6 +257,14 @@ class ClmReplayAddon:
             default="",
             help="Comma-separated hosts whose traffic is forwarded but never "
             "recorded (LangSmith telemetry by default). Mirrors vcrpy ignore_hosts.",
+        )
+        loader.add_option(
+            name="clm_trace_dir",
+            typespec=str,
+            default="",
+            help="Forensic HTTP-replay trace directory (issue #165 P5). When set, "
+            "the addon writes per-flow proxy events to proxy-<pid>.jsonl there. "
+            "Empty disables tracing.",
         )
 
     def running(self) -> None:
@@ -247,6 +298,25 @@ class ClmReplayAddon:
         # already exists), so there is nothing to existence-check or unlink
         # here — ``clm_cassette_path`` is only the build-scratch catch-all.
 
+        # Forensic trace (issue #165 P5). The ``proxy.ready`` event records the
+        # listen port so the analyzer can tell a worker's connect-to-proxy from
+        # a genuine bypass (a connect whose port is NOT this proxy's).
+        trace_dir = getattr(ctx.options, "clm_trace_dir", "") or ""
+        if trace_dir and _trace_log is not None:
+            self._trace = _trace_log.ProxyTraceLog.from_trace_dir(trace_dir)
+        listen_port = getattr(ctx.options, "listen_port", None)
+        listen_host = getattr(ctx.options, "listen_host", "")
+        self._trace.emit(
+            "proxy.ready",
+            {
+                "listen_host": listen_host,
+                "listen_port": listen_port,
+                "mode": self._mode,
+                "build_id": self._build_id,
+                "ignore_hosts": list(ignore_hosts),
+            },
+        )
+
         logger.info(
             "Addon ready: mode=%s default_cassette=%s ignore_hosts=%s build=%s",
             self._mode,
@@ -258,8 +328,10 @@ class ClmReplayAddon:
     def done(self) -> None:
         # Staging files are written eagerly on each recorded response, and
         # the host writes the .completed markers after the proxy stops, so
-        # there is nothing to flush here. Kept for lifecycle symmetry.
-        return
+        # there is nothing to flush here. Best-effort close the trace log
+        # (every trace line is already flushed, so a missed close — e.g. a
+        # Windows CTRL_BREAK that skips this hook — loses nothing).
+        self._trace.close()
 
     def request(self, flow: http.HTTPFlow) -> None:
         if cf is None:
@@ -280,10 +352,12 @@ class ClmReplayAddon:
             # ignore_hosts (e.g. LangSmith telemetry) or an unfilterable request:
             # forward upstream untouched, record nothing, never a miss response.
             flow.metadata[_FLOW_IGNORED_KEY] = True
+            self._trace_request(flow, tag, "ignored")
             return
 
         target = self._target_for(tag)
         if target is None:
+            self._trace_request(flow, tag, "passthrough")
             return  # untagged with no catch-all configured -> pass through
 
         self._ensure_loaded(target)
@@ -294,12 +368,20 @@ class ClmReplayAddon:
                 if cf.requests_match(filtered, rec_request):
                     flow.response = self._build_reply(rec_response)
                     flow.metadata[_FLOW_SERVED_KEY] = True
+                    self._trace_request(flow, tag, "served")
                     return
 
         if not record:
             # Strict replay (``replay``, or ``once`` with an existing cassette):
             # a miss must fail loudly, never escaping to the real network.
             flow.response = self._replay_miss_response(flow, target)
+            self._trace_request(flow, tag, "miss")
+            return
+
+        # Recording modes (new-episodes / refresh / once-when-absent) on a
+        # cache miss: the request is forwarded upstream and response() persists
+        # the reply. This is the only path that produces a real upstream connect.
+        self._trace_request(flow, tag, "forward")
 
     def response(self, flow: http.HTTPFlow) -> None:
         if cf is None or flow.response is None:
@@ -341,6 +423,38 @@ class ClmReplayAddon:
         target.seen.add(key)
         # Eager rewrite so a build-timeout kill of mitmdump loses nothing.
         cf.write_cassette(target.write_path, target.to_write)
+        self._trace.emit(
+            "proxy.response",
+            {
+                "host": flow.request.host,
+                "port": flow.request.port,
+                "status": flow.response.status_code,
+                "recorded": True,
+            },
+        )
+
+    # -- tracing ---------------------------------------------------------
+
+    def _trace_request(self, flow: http.HTTPFlow, tag: str | None, action: str) -> None:
+        """Emit one ``proxy.request`` forensic event for this flow.
+
+        ``action`` is the addon's decision for the request: ``served`` (cassette
+        hit), ``miss`` (strict-replay 404), ``ignored`` (ignore_hosts, forwarded
+        not recorded), ``forward`` (recording mode, will hit upstream) or
+        ``passthrough`` (untagged, no catch-all). The analyzer uses these as the
+        interception-evidence stream that replaces the (now-dark) ``vcr`` stream.
+        """
+        self._trace.emit(
+            "proxy.request",
+            {
+                "method": flow.request.method,
+                "scheme": flow.request.scheme,
+                "host": flow.request.host,
+                "port": flow.request.port,
+                "has_tag": tag is not None,
+                "action": action,
+            },
+        )
 
     # -- routing ---------------------------------------------------------
 

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -10,13 +10,20 @@ committed course cassettes, ``clm cassette doctor``,
 ``merge_staging_into_canonical`` all keep working unchanged — a
 mitmproxy-recorded cassette is byte-identical to a vcrpy-recorded one for
 the same HTTP exchange. The format conversion lives in the pure
-:mod:`clm.infrastructure.http_replay_mitm.cassette_format` module so it
-can be unit-tested in CLM's venv and imported by bare path inside the
-isolated ``mitmdump`` interpreter.
+:mod:`clm.infrastructure.http_replay_mitm.cassette_format` module.
 
-Request→cassette routing for concurrent multi-topic builds (the
-``X-CLM-Cassette`` tag + per-target staging files) is P2; this module
-still records into the single ``clm_cassette_path`` it is given.
+**Request→cassette routing (P2):** a single shared proxy serves a whole
+build, so each worker tags its outgoing requests with an ``X-CLM-Cassette``
+header (the absolute canonical cassette path, injected by the kernel
+bootstrap). This addon demuxes flows by that tag into one
+``*.staging-mitm-<build>`` file per canonical cassette (vcrpy-YAML), writes
+a ``.completed`` marker on clean shutdown, and the host folds each staging
+file into its canonical via the existing ``merge_staging_into_canonical``.
+The tag header is stripped before recording or forwarding upstream.
+
+Untagged traffic (a kernel that somehow bypassed the tag bootstrap) falls
+back to the single ``clm_cassette_path`` catch-all so strict ``replay``
+mode still returns a 599 instead of escaping to the network.
 """
 
 from __future__ import annotations
@@ -24,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import uuid
 from pathlib import Path
 
 from mitmproxy import ctx, http
@@ -61,8 +69,24 @@ MODE_ONCE = "once"  # like new-episodes but cassette must exist
 _REPLAY_CAPABLE = (MODE_REPLAY, MODE_NEW_EPISODES, MODE_ONCE)
 # Modes that persist newly observed interactions.
 _RECORD_CAPABLE = (MODE_RECORD, MODE_NEW_EPISODES, MODE_REFRESH, MODE_ONCE)
-# Modes that preserve (rather than overwrite) any existing cassette entries.
+# Modes that preserve (rather than overwrite) existing cassette entries
+# when writing the *catch-all* cassette in full (tagged staging files only
+# ever hold the build's new interactions; the host merge folds them).
 _ADDITIVE = (MODE_NEW_EPISODES, MODE_ONCE)
+
+# Per-request worker tag identifying the destination cassette (lower-cased
+# because HTTP header lookups are case-insensitive and HTTP/2 lowercases).
+_TAG_HEADER = "x-clm-cassette"
+# Stashed on the flow so response() can route after request() strips the
+# header (the tag must not be forwarded upstream or recorded).
+_FLOW_TAG_KEY = "clm_cassette_tag"
+_FLOW_SERVED_KEY = "clm_served_from_cache"
+
+# Staging filename infix. Must start with ``.staging-`` so the host-side
+# ``merge_staging_into_canonical`` glob (``<name>.staging-*``) finds it. The
+# trailing build id (set by the manager) lets the host write the
+# ``.completed`` marker for *this* build's staging files only.
+_STAGING_INFIX = ".staging-mitm-"
 
 # Headers stripped from a served (replayed) response: we hold the full
 # decoded body in memory, so the recorded content-length / transfer
@@ -70,45 +94,76 @@ _ADDITIVE = (MODE_NEW_EPISODES, MODE_ONCE)
 _SERVE_DROP_HEADERS = frozenset({"content-length", "transfer-encoding"})
 
 
+class _Target:
+    """One destination cassette and its in-build recording/replay state."""
+
+    __slots__ = ("canonical", "write_path", "is_staging", "loaded", "index", "interactions", "seen")
+
+    def __init__(self, canonical: Path, write_path: Path, *, is_staging: bool) -> None:
+        # Where the interactions ultimately live (replay source; merge target).
+        self.canonical = canonical
+        # Where this addon writes: a per-build staging file for tagged
+        # targets (folded by the host), or the canonical itself for the
+        # untagged catch-all.
+        self.write_path = write_path
+        self.is_staging = is_staging
+        self.loaded = False
+        self.index: dict[tuple[str, str, bytes], dict] = {}
+        self.interactions: list = []
+        self.seen: set[tuple[str, str, bytes]] = set()
+
+
 class ClmReplayAddon:
     """Cassette-backed request/response interception (vcrpy-YAML storage).
 
     Lifecycle:
       * ``load(loader)`` declares the options the manager passes.
-      * ``running()`` loads the existing cassette (if any) and indexes it
-        by request fingerprint for O(1) replay lookup.
-      * ``request(flow)`` intercepts before the upstream call: on a hit we
-        set ``flow.response`` to short-circuit; on a miss in strict
-        ``replay`` mode we set a 599 so the worker fails cleanly instead
-        of escaping to the network.
-      * ``response(flow)`` runs after a real upstream response; we persist
-        the interaction to the cassette (eagerly, so a kernel/proxy kill
-        cannot lose recordings) unless the mode forbids it.
+      * ``running()`` records the mode + catch-all cassette and a per-build
+        id used to name staging files.
+      * ``request(flow)`` routes by the ``X-CLM-Cassette`` tag, strips it,
+        and either serves a cassette hit (short-circuit) or — in strict
+        ``replay`` mode — synthesizes a 599 on miss so the worker fails
+        cleanly instead of escaping to the network.
+      * ``response(flow)`` persists a real upstream response into the
+        flow's target cassette (eagerly, so a kernel/proxy kill cannot
+        lose recordings) unless the mode forbids it.
+
+    The ``.completed`` markers that tell the host merge a staging file is
+    safe to fold are written by the **host** in the build's ``finally``
+    (see ``Course.merge_mitmproxy_cassette_staging``) — that is the
+    reliable build-completion signal, and mitmproxy's ``done`` hook does
+    not fire on a Windows ``CTRL_BREAK`` shutdown. A force-killed build
+    never reaches the host marker step, so its staging stays markerless
+    and the next pre-build sweep discards it.
     """
 
     def __init__(self) -> None:
-        self._cassette_path: Path | None = None
         self._mode: str = MODE_REPLAY
-        # Replay index: request fingerprint -> stored vcr response dict.
-        self._index: dict[tuple[str, str, bytes], dict] = {}
-        # Ordered interactions to persist. Seeded from the existing
-        # cassette in additive modes so a rewrite preserves prior entries;
-        # empty (overwrite) otherwise.
-        self._interactions: list = []
-        self._seen: set[tuple[str, str, bytes]] = set()
+        self._default_cassette: Path | None = None
+        self._build_id: str = ""
+        # Keyed by canonical-path string; "" is the untagged catch-all.
+        self._targets: dict[str, _Target] = {}
 
     def load(self, loader) -> None:
         loader.add_option(
             name="clm_cassette_path",
             typespec=str,
             default="",
-            help="Path to the vcrpy-YAML cassette file for CLM replay/record.",
+            help="Catch-all vcrpy-YAML cassette for untagged traffic (tagged "
+            "requests route to per-cassette staging files).",
         )
         loader.add_option(
             name="clm_mode",
             typespec=str,
             default=MODE_REPLAY,
             help="CLM replay mode: replay | record | new-episodes | refresh | once.",
+        )
+        loader.add_option(
+            name="clm_build_id",
+            typespec=str,
+            default="",
+            help="Per-build id used to name staging files so the host can "
+            "mark this build's recordings complete.",
         )
 
     def running(self) -> None:
@@ -122,54 +177,67 @@ class ClmReplayAddon:
             ctx.master.shutdown()
             return
 
-        cassette_path_str = ctx.options.clm_cassette_path
-        if not cassette_path_str:
-            logger.warning("clm_cassette_path not set; addon will pass through all traffic")
-            return
-        self._cassette_path = Path(cassette_path_str)
         self._mode = ctx.options.clm_mode
+        self._build_id = ctx.options.clm_build_id or uuid.uuid4().hex
+        cassette_path_str = ctx.options.clm_cassette_path
+        self._default_cassette = Path(cassette_path_str) if cassette_path_str else None
 
-        if self._mode == MODE_REFRESH and self._cassette_path.exists():
-            self._cassette_path.unlink()
+        if (
+            self._mode == MODE_REFRESH
+            and self._default_cassette is not None
+            and self._default_cassette.exists()
+        ):
+            self._default_cassette.unlink()
 
-        if self._mode == MODE_ONCE and not self._cassette_path.exists():
+        if (
+            self._mode == MODE_ONCE
+            and self._default_cassette is not None
+            and not self._default_cassette.exists()
+        ):
             logger.error(
                 "Mode 'once' requires an existing cassette at %s — refusing to start",
-                self._cassette_path,
+                self._default_cassette,
             )
             ctx.master.shutdown()
             return
 
-        if self._mode in _REPLAY_CAPABLE and self._cassette_path.exists():
-            self._load_index()
-
         logger.info(
-            "Addon ready: mode=%s cassette=%s indexed=%d",
+            "Addon ready: mode=%s default_cassette=%s build=%s",
             self._mode,
-            self._cassette_path,
-            len(self._index),
+            self._default_cassette,
+            self._build_id,
         )
 
     def done(self) -> None:
-        # The cassette is rewritten eagerly on every recorded response, so
-        # there is nothing to flush here for the single-cassette (P1)
-        # model. Kept for lifecycle symmetry / P2 marker writing.
+        # Staging files are written eagerly on each recorded response, and
+        # the host writes the .completed markers after the proxy stops, so
+        # there is nothing to flush here. Kept for lifecycle symmetry.
         return
 
     def request(self, flow: http.HTTPFlow) -> None:
-        if self._cassette_path is None or cf is None:
-            return  # no cassette configured -> pure pass-through
+        if cf is None:
+            return
 
-        key = self._flow_request_key(flow.request)
-        cached = self._index.get(key)
+        tag = flow.request.headers.get(_TAG_HEADER)
+        flow.metadata[_FLOW_TAG_KEY] = tag
+        if tag is not None:
+            # Strip the routing tag so it is neither forwarded upstream nor
+            # recorded into the cassette.
+            del flow.request.headers[_TAG_HEADER]
+
+        target = self._target_for(tag)
+        if target is None:
+            return  # untagged with no catch-all configured -> pass through
+
+        self._ensure_loaded(target)
+        key = self._request_key(flow.request)
+        cached = target.index.get(key)
         if cached is not None:
             flow.response = self._build_reply(cached)
+            flow.metadata[_FLOW_SERVED_KEY] = True
             return
 
         if self._mode == MODE_REPLAY:
-            # Strict replay: a cassette miss is a programming error. Emit a
-            # diagnostic 599 so the worker fails clearly rather than the
-            # request being silently dropped or escaping to the network.
             flow.response = http.Response.make(
                 599,
                 json.dumps(
@@ -177,23 +245,24 @@ class ClmReplayAddon:
                         "error": "clm_replay_miss",
                         "method": flow.request.method,
                         "url": flow.request.pretty_url,
-                        "cassette": str(self._cassette_path),
+                        "cassette": str(target.canonical),
                     }
                 ).encode(),
                 {"Content-Type": "application/json"},
             )
 
     def response(self, flow: http.HTTPFlow) -> None:
-        if self._cassette_path is None or cf is None:
+        if cf is None or flow.response is None:
             return
         if self._mode not in _RECORD_CAPABLE:
             return
-        if flow.response is None:
-            return
-
-        # Skip recording the synthetic 599 we emitted on a replay miss —
-        # it never went upstream.
+        if flow.metadata.get(_FLOW_SERVED_KEY):
+            return  # served from cassette this build — nothing new to record
         if flow.response.status_code == 599 and self._is_replay_miss_marker(flow.response):
+            return  # synthetic miss; never went upstream
+
+        target = self._target_for(flow.metadata.get(_FLOW_TAG_KEY))
+        if target is None:
             return
 
         request = cf.vcr_request_from_parts(
@@ -203,11 +272,8 @@ class ClmReplayAddon:
             flow.request.raw_content or b"",
         )
         key = cf.fingerprint(request)
-        if key in self._seen:
-            # Already recorded this build: don't duplicate. The host-side
-            # merge dedups too, but keeping the in-memory cassette deduped
-            # keeps the eager rewrite cheap and the file stable.
-            return
+        if key in target.seen:
+            return  # already recorded this build — keep the eager rewrite cheap
 
         response = cf.vcr_response_dict_from_parts(
             flow.response.status_code,
@@ -216,15 +282,62 @@ class ClmReplayAddon:
             flow.response.raw_content or b"",
             decode_compressed=True,
         )
-        self._interactions.append((request, response))
-        self._index[key] = response
-        self._seen.add(key)
+        target.interactions.append((request, response))
+        target.index[key] = response
+        target.seen.add(key)
         # Eager rewrite so a build-timeout kill of mitmdump loses nothing.
-        cf.write_cassette(self._cassette_path, self._interactions)
+        cf.write_cassette(target.write_path, target.interactions)
+
+    # -- routing ---------------------------------------------------------
+
+    def _target_for(self, tag: str | None) -> _Target | None:
+        if tag:
+            key = str(Path(tag))
+            target = self._targets.get(key)
+            if target is None:
+                canonical = Path(tag)
+                staging = canonical.parent / f"{canonical.name}{_STAGING_INFIX}{self._build_id}"
+                target = _Target(canonical, staging, is_staging=True)
+                self._targets[key] = target
+            return target
+
+        if self._default_cassette is None:
+            return None
+        target = self._targets.get("")
+        if target is None:
+            target = _Target(self._default_cassette, self._default_cassette, is_staging=False)
+            self._targets[""] = target
+        return target
+
+    def _ensure_loaded(self, target: _Target) -> None:
+        if target.loaded:
+            return
+        target.loaded = True
+        if self._mode not in _REPLAY_CAPABLE or not target.canonical.exists():
+            return
+        try:
+            interactions = cf.load_interactions(target.canonical)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "Failed to load cassette %s (%s: %s); starting empty",
+                target.canonical,
+                type(exc).__name__,
+                exc,
+            )
+            return
+        for request, response in interactions:
+            key = cf.fingerprint(request)
+            target.index[key] = response
+            target.seen.add(key)
+            # The catch-all rewrites the whole cassette, so it must keep
+            # existing entries; tagged staging files hold only new
+            # interactions (the host merge folds them into canonical).
+            if not target.is_staging and self._mode in _ADDITIVE:
+                target.interactions.append((request, response))
 
     # -- helpers ---------------------------------------------------------
 
-    def _flow_request_key(self, request: http.Request) -> tuple[str, str, bytes]:
+    def _request_key(self, request: http.Request) -> tuple[str, str, bytes]:
         vcr_request = cf.vcr_request_from_parts(
             request.method, request.url, request.headers.fields, request.raw_content or b""
         )
@@ -253,26 +366,6 @@ class ClmReplayAddon:
         except (json.JSONDecodeError, ValueError):
             return False
         return isinstance(body, dict) and body.get("error") == "clm_replay_miss"
-
-    def _load_index(self) -> None:
-        assert self._cassette_path is not None
-        try:
-            interactions = cf.load_interactions(self._cassette_path)
-        except Exception as exc:  # noqa: BLE001 — defensive
-            logger.warning(
-                "Failed to load cassette %s (%s: %s); starting with empty index",
-                self._cassette_path,
-                type(exc).__name__,
-                exc,
-            )
-            return
-        for request, response in interactions:
-            key = cf.fingerprint(request)
-            self._index[key] = response
-            self._seen.add(key)
-            if self._mode in _ADDITIVE:
-                # Preserve existing entries on the next rewrite.
-                self._interactions.append((request, response))
 
 
 addons = [ClmReplayAddon()]

--- a/src/clm/infrastructure/http_replay_mitm/cassette_format.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_format.py
@@ -285,7 +285,7 @@ def clm_json_body_matcher(r1: Request, r2: Request) -> None:
     compare the parsed values; otherwise byte-compare. Raises
     ``AssertionError`` on mismatch (the convention vcr's matcher chain expects).
 
-    This is why a real LLM JSON ``POST`` replay-hits instead of 599-missing: a
+    This is why a real LLM JSON ``POST`` replay-hits instead of missing: a
     byte-exact body key would diverge whenever vcrpy's
     ``filter_post_data_parameters`` re-dumped the JSON with default separators
     at record time but the live body uses compact separators. **Keep this in

--- a/src/clm/infrastructure/http_replay_mitm/cassette_format.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_format.py
@@ -28,21 +28,52 @@ vcrpy would have written for the same HTTP exchange.
 from __future__ import annotations
 
 import copy
+import functools
+import json
 import os
 import uuid
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
 
-# vcr is used purely as a serializer here. Importing these names does not
-# patch httpcore/urllib3 (verified: patching only activates when a VCR
-# cassette context is entered). The isolated mitmdump environment must
-# therefore have vcrpy installed alongside mitmproxy.
-from vcr.filters import decode_response
+# vcr is used purely as a serializer + filter/matcher library here. Importing
+# these names does not patch httpcore/urllib3 (verified: patching only
+# activates when a VCR cassette context is entered). The isolated mitmdump
+# environment must therefore have vcrpy installed alongside mitmproxy.
+from vcr import matchers as _vcr_matchers
+from vcr.filters import (
+    decode_response,
+)
+from vcr.filters import (
+    replace_headers as _vcr_replace_headers,
+)
+from vcr.filters import (
+    replace_post_data_parameters as _vcr_replace_post_data_parameters,
+)
+from vcr.filters import (
+    replace_query_parameters as _vcr_replace_query_parameters,
+)
 from vcr.persisters.filesystem import FilesystemPersister
 from vcr.request import Request
 from vcr.serialize import serialize as _vcr_serialize
 from vcr.serializers import yamlserializer
+
+# ---------------------------------------------------------------------------
+# Secret/telemetry filtering + matching parity (issue #165, P3)
+# ---------------------------------------------------------------------------
+# These MUST mirror the values baked into the in-kernel vcrpy bootstrap
+# (``notebook_processor._HTTP_REPLAY_BOOTSTRAP_TEMPLATE``'s
+# ``_clm_vcr_instance``) so a mitmproxy-recorded cassette is filtered and
+# matched byte-identically to a vcrpy-recorded one. A drift-guard test
+# (``test_http_replay_mitm_cassette_format.py``) asserts they stay in lockstep.
+#
+# ``filter_headers`` removes secret-bearing *request* headers (vcrpy filters
+# request headers only; response ``set-cookie`` is left as vcrpy leaves it).
+# ``filter_query_parameters`` / ``filter_post_data_parameters`` strip secrets
+# from the URL query and JSON/form request body respectively.
+FILTER_HEADERS = ["authorization", "cookie", "x-api-key", "set-cookie"]
+FILTER_POST_DATA_PARAMETERS = ["password", "token", "api_key"]
+FILTER_QUERY_PARAMETERS = ["api_key", "token"]
 
 # A single recorded HTTP interaction: a vcr Request paired with the
 # serialized-response dict (``{"status", "headers", "body"}``) that vcrpy
@@ -187,6 +218,145 @@ def fingerprint(request: Request) -> tuple[str, str, bytes]:
         getattr(request, "uri", ""),
         body_bytes,
     )
+
+
+def build_request_filter(
+    *,
+    filter_headers: Iterable[object] = FILTER_HEADERS,
+    filter_query_parameters: Iterable[object] = FILTER_QUERY_PARAMETERS,
+    filter_post_data_parameters: Iterable[object] = FILTER_POST_DATA_PARAMETERS,
+    ignore_hosts: Iterable[str] = (),
+):
+    """Return ``before_record_request(Request) -> Request | None``.
+
+    Reconstructs vcrpy's own ``VCR._build_before_record_request`` closure from
+    the *public* ``vcr.filters`` functions so a request is filtered exactly as
+    the in-kernel vcrpy path filters it:
+
+    * each filter-list entry maps to a ``(name, None)`` removal,
+    * filters run header → query → post-data (the order vcrpy uses), each
+      after a defensive ``copy.deepcopy`` so the caller's request is untouched,
+    * an ignore-host check then returns ``None`` to signal "do not record" —
+      the addon treats that as "pass straight through to the network", the
+      out-of-process analogue of vcrpy's ``ignore_hosts``.
+
+    Because the recorded request is the *filtered* one and the replay lookup
+    filters the incoming request the same way before matching, secret removal
+    never breaks matching (both sides drop the same headers/params) and the
+    cassette never carries ``authorization``/``cookie``/``x-api-key`` request
+    headers, ``api_key``/``token`` query params, or ``password``/``token``/
+    ``api_key`` body params.
+    """
+    funcs = []
+    if filter_headers:
+        replacements = [h if isinstance(h, tuple) else (h, None) for h in filter_headers]
+        funcs.append(functools.partial(_vcr_replace_headers, replacements=replacements))
+    if filter_query_parameters:
+        replacements = [p if isinstance(p, tuple) else (p, None) for p in filter_query_parameters]
+        funcs.append(functools.partial(_vcr_replace_query_parameters, replacements=replacements))
+    if filter_post_data_parameters:
+        replacements = [
+            p if isinstance(p, tuple) else (p, None) for p in filter_post_data_parameters
+        ]
+        funcs.append(
+            functools.partial(_vcr_replace_post_data_parameters, replacements=replacements)
+        )
+    hosts_to_ignore = set(ignore_hosts)
+
+    def before_record_request(request: Request) -> Request | None:
+        request = copy.deepcopy(request)
+        for fn in funcs:
+            if request is None:
+                break
+            request = fn(request)
+        if request is not None and getattr(request, "host", None) in hosts_to_ignore:
+            return None
+        return request
+
+    return before_record_request
+
+
+def clm_json_body_matcher(r1: Request, r2: Request) -> None:
+    """JSON-semantic request-body matcher (vcr matcher protocol).
+
+    A verbatim mirror of the in-kernel ``_clm_json_body_matcher`` in
+    ``notebook_processor._HTTP_REPLAY_BOOTSTRAP_TEMPLATE``: when both requests
+    carry a JSON content-type (case-insensitive), parse both bodies as JSON and
+    compare the parsed values; otherwise byte-compare. Raises
+    ``AssertionError`` on mismatch (the convention vcr's matcher chain expects).
+
+    This is why a real LLM JSON ``POST`` replay-hits instead of 599-missing: a
+    byte-exact body key would diverge whenever vcrpy's
+    ``filter_post_data_parameters`` re-dumped the JSON with default separators
+    at record time but the live body uses compact separators. **Keep this in
+    lockstep with the bootstrap's matcher** (drift-guard test asserts it).
+    """
+
+    def _body_bytes(req: Request) -> bytes:
+        body = req.body
+        if body is None:
+            return b""
+        if isinstance(body, (bytes, bytearray)):
+            return bytes(body)
+        if isinstance(body, str):
+            return body.encode("utf-8", errors="replace")
+        read = getattr(body, "read", None)
+        if callable(read):
+            data = read()
+            seek = getattr(body, "seek", None)
+            if callable(seek):
+                try:
+                    seek(0)
+                except Exception:  # noqa: BLE001 — best-effort rewind
+                    pass
+            return data if isinstance(data, bytes) else str(data).encode("utf-8", errors="replace")
+        return str(body).encode("utf-8", errors="replace")
+
+    def _is_json(req: Request) -> bool:
+        headers = getattr(req, "headers", {}) or {}
+        for k, v in headers.items():
+            if str(k).lower() == "content-type":
+                val = v[0] if isinstance(v, (list, tuple)) and v else v
+                return "application/json" in str(val).lower()
+        return False
+
+    b1 = _body_bytes(r1)
+    b2 = _body_bytes(r2)
+    if _is_json(r1) and _is_json(r2):
+        try:
+            p1 = json.loads(b1) if b1 else None
+            p2 = json.loads(b2) if b2 else None
+            if p1 != p2:
+                raise AssertionError
+            return
+        except (ValueError, TypeError):
+            pass  # fall through to byte comparison
+    if b1 != b2:
+        raise AssertionError
+
+
+# The match key mirrors the bootstrap's
+# ``match_on=("method","scheme","host","port","path","query","clm_json_body")``
+# exactly — the request *body* (JSON-semantic) is part of the key so a stale
+# cassette fails loudly rather than serving the wrong recorded interaction.
+REPLAY_MATCHERS = (
+    _vcr_matchers.method,
+    _vcr_matchers.scheme,
+    _vcr_matchers.host,
+    _vcr_matchers.port,
+    _vcr_matchers.path,
+    _vcr_matchers.query,
+    clm_json_body_matcher,
+)
+
+
+def requests_match(incoming: Request, recorded: Request) -> bool:
+    """Return ``True`` iff ``incoming`` matches ``recorded`` under CLM's
+    match_on — the exact matcher set the in-kernel vcrpy uses. Reusing
+    ``vcr.matchers.requests_match`` keeps the replay equivalence classes
+    identical to vcrpy's (e.g. ``query`` is order-insensitive, JSON bodies
+    compare by value)."""
+    return bool(_vcr_matchers.requests_match(incoming, recorded, list(REPLAY_MATCHERS)))
 
 
 def serialize_interactions(interactions: Iterable[Interaction]) -> str:

--- a/src/clm/infrastructure/http_replay_mitm/cassette_format.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_format.py
@@ -63,6 +63,22 @@ def _decode_ascii(value: object) -> str:
     return str(value)
 
 
+def _ascii_reason(reason_phrase: str | None) -> str | None:
+    """Normalise an HTTP reason phrase to an ASCII ``str`` or ``None``.
+
+    vcrpy decodes the reason as ASCII and stores ``None`` when absent. We
+    map empty/missing to ``None`` and drop a non-ASCII reason to ``None``
+    too (it could not round-trip through vcrpy's ASCII (de)serialization).
+    """
+    if not reason_phrase:
+        return None
+    try:
+        reason_phrase.encode("ascii")
+    except UnicodeEncodeError:
+        return None
+    return reason_phrase
+
+
 def vcr_request_from_parts(
     method: str,
     url: str,
@@ -107,6 +123,16 @@ def vcr_response_dict_from_parts(
     (mitmproxy's ``flow.response.raw_content``), not the decoded content,
     so :func:`decode_response` sees the ``content-encoding`` header and
     decompresses identically to vcrpy.
+
+    The reason phrase is forced to ASCII (or dropped to ``None``): vcrpy
+    decodes it as ASCII (``extensions["reason_phrase"].decode("ascii")``)
+    and would *raise* on a non-ASCII reason — and a stored non-ASCII
+    ``status.message`` cannot be replayed by the in-kernel vcrpy transport
+    (its ``_deserialize_response`` does ``message.encode("ascii")``). So for
+    the common ASCII case this is byte-identical to vcrpy; for the rare
+    non-ASCII HTTP/1.1 reason (real LLM endpoints use ASCII reasons or
+    HTTP/2, which has none) we drop it to ``None`` rather than crash or
+    write a cassette vcrpy cannot read back.
     """
     headers: dict[str, list[str]] = defaultdict(list)
     for name, value in header_fields:
@@ -114,8 +140,9 @@ def vcr_response_dict_from_parts(
 
     response = {
         # vcrpy stores ``message: None`` when there is no reason phrase
-        # (e.g. HTTP/2). Normalise empty strings to None to match.
-        "status": {"code": status_code, "message": reason_phrase or None},
+        # (e.g. HTTP/2). Normalise empty strings to None to match, and keep
+        # the stored message ASCII-clean so the cassette stays vcrpy-replayable.
+        "status": {"code": status_code, "message": _ascii_reason(reason_phrase)},
         "headers": dict(headers),
         "body": {"string": raw_body},
     }

--- a/src/clm/infrastructure/http_replay_mitm/cassette_format.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_format.py
@@ -1,0 +1,257 @@
+"""vcrpy-YAML cassette bridge for the mitmproxy transport (issue #165, P1).
+
+The mitmproxy addon records and replays at the network layer, but the
+*on-disk* format must stay byte-compatible with the existing vcrpy v1
+YAML cassette schema so that committed course cassettes, ``clm cassette
+doctor``, ``strip_cassette_hosts.py`` and
+:func:`clm.workers.notebook.http_replay_cassette.merge_staging_into_canonical`
+keep working unchanged.
+
+This module is **pure**: it imports only :mod:`vcr` (used purely as a
+serializer — importing the serializer surface does *not* activate any
+httpcore/urllib3 patching) and the standard library. It has **no**
+``clm`` package imports, so it can be imported two ways:
+
+* as ``clm.infrastructure.http_replay_mitm.cassette_format`` inside CLM's
+  own virtualenv (unit tests, host code), and
+* by bare path import inside the isolated ``mitmdump`` interpreter
+  (``uv tool install mitmproxy --with vcrpy``), where the ``clm`` package
+  is not installed but ``vcr`` is.
+
+The conversion functions deliberately mirror vcrpy's own
+``vcr.stubs.httpcore_stubs._make_vcr_request`` /
+``_serialize_response`` and ``vcr.filters.decode_response`` so a
+mitmproxy-recorded interaction serializes to bytes identical to what
+vcrpy would have written for the same HTTP exchange.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import uuid
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+# vcr is used purely as a serializer here. Importing these names does not
+# patch httpcore/urllib3 (verified: patching only activates when a VCR
+# cassette context is entered). The isolated mitmdump environment must
+# therefore have vcrpy installed alongside mitmproxy.
+from vcr.filters import decode_response
+from vcr.persisters.filesystem import FilesystemPersister
+from vcr.request import Request
+from vcr.serialize import serialize as _vcr_serialize
+from vcr.serializers import yamlserializer
+
+# A single recorded HTTP interaction: a vcr Request paired with the
+# serialized-response dict (``{"status", "headers", "body"}``) that vcrpy
+# stores. The body string is kept as ``bytes`` in memory; it is only
+# decoded to ``str`` at serialization time (see :func:`serialize_interactions`).
+Interaction = tuple[Request, dict]
+
+# Header fields as mitmproxy exposes them: an iterable of ``(name, value)``
+# pairs that may be ``bytes`` or ``str``. vcrpy decodes header bytes as
+# ASCII, so we mirror that.
+HeaderFields = Iterable[tuple[object, object]]
+
+
+def _decode_ascii(value: object) -> str:
+    """Decode a header name/value to ``str`` the way vcrpy does (ASCII)."""
+    if isinstance(value, bytes):
+        return value.decode("ascii")
+    return str(value)
+
+
+def vcr_request_from_parts(
+    method: str,
+    url: str,
+    header_fields: HeaderFields,
+    body: bytes,
+) -> Request:
+    """Build a vcr :class:`~vcr.request.Request` matching vcrpy's httpcore stub.
+
+    Mirrors ``vcr.stubs.httpcore_stubs._make_vcr_request``: multiple
+    headers with the same name are concatenated with ``", "`` (as HTTPX
+    does), then handed to :class:`~vcr.request.Request`, whose
+    ``HeadersDict`` collapses them to a single value while preserving the
+    first-seen casing. Going through the real ``Request`` constructor
+    guarantees ``_to_dict()`` produces the exact shape vcrpy serializes.
+    """
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for name, value in header_fields:
+        grouped[_decode_ascii(name)].append(_decode_ascii(value))
+    headers = {name: ", ".join(values) for name, values in grouped.items()}
+    return Request(method, url, body, headers)
+
+
+def vcr_response_dict_from_parts(
+    status_code: int,
+    reason_phrase: str | None,
+    header_fields: HeaderFields,
+    raw_body: bytes,
+    *,
+    decode_compressed: bool = True,
+) -> dict:
+    """Build the vcr response dict matching vcrpy's httpcore stub.
+
+    Mirrors ``vcr.stubs.httpcore_stubs._serialize_response`` (status +
+    headers-as-dict-of-lists + ``body.string`` raw bytes) and then, when
+    ``decode_compressed`` is true (CLM always sets
+    ``decode_compressed_response=True``), runs vcrpy's own
+    :func:`vcr.filters.decode_response` so a gzip/deflate/br body is
+    decompressed, the ``content-encoding`` header dropped, and
+    ``content-length`` rewritten — exactly as vcrpy records it.
+
+    ``raw_body`` must be the **encoded** bytes as they came off the wire
+    (mitmproxy's ``flow.response.raw_content``), not the decoded content,
+    so :func:`decode_response` sees the ``content-encoding`` header and
+    decompresses identically to vcrpy.
+    """
+    headers: dict[str, list[str]] = defaultdict(list)
+    for name, value in header_fields:
+        headers[_decode_ascii(name)].append(_decode_ascii(value))
+
+    response = {
+        # vcrpy stores ``message: None`` when there is no reason phrase
+        # (e.g. HTTP/2). Normalise empty strings to None to match.
+        "status": {"code": status_code, "message": reason_phrase or None},
+        "headers": dict(headers),
+        "body": {"string": raw_body},
+    }
+    if decode_compressed:
+        # decode_response deep-copies its input, so this never mutates the
+        # dict we just built; it returns the decompressed equivalent.
+        response = decode_response(response)
+    return response
+
+
+def fingerprint(request: Request) -> tuple[str, str, bytes]:
+    """Dedup/replay fingerprint: ``(method, uri, body-bytes)``.
+
+    Matches :func:`clm.workers.notebook.http_replay_cassette._dedup_key`
+    so the addon's in-build dedup and the host-side merge agree on what
+    counts as "the same request". (JSON-semantic body matching is P3.)
+    """
+    body = request.body
+    if body is None:
+        body_bytes = b""
+    elif isinstance(body, bytes):
+        body_bytes = body
+    elif isinstance(body, bytearray):
+        body_bytes = bytes(body)
+    elif isinstance(body, str):
+        body_bytes = body.encode("utf-8", errors="replace")
+    else:  # BytesIO / iterator — read defensively
+        read = getattr(body, "read", None)
+        if callable(read):
+            data = read()
+            seek = getattr(body, "seek", None)
+            if callable(seek):
+                try:
+                    seek(0)
+                except Exception:  # noqa: BLE001 — best-effort rewind
+                    pass
+            body_bytes = data if isinstance(data, bytes) else str(data).encode("utf-8", "replace")
+        else:
+            body_bytes = repr(body).encode("utf-8", "replace")
+    return (
+        getattr(request, "method", ""),
+        getattr(request, "uri", ""),
+        body_bytes,
+    )
+
+
+def serialize_interactions(interactions: Iterable[Interaction]) -> str:
+    """Serialize interactions to vcrpy v1 YAML.
+
+    Routes through ``vcr.serialize.serialize`` + the YAML serializer so the
+    output is byte-identical to a vcrpy-written cassette. vcrpy's
+    ``convert_to_unicode`` mutates ``response["body"]["string"]`` from
+    ``bytes`` to ``str`` **in place** during serialization; we deep-copy
+    first (exactly as CLM's ``_ClmDeepCopyPersister`` does in the kernel
+    bootstrap) so the caller's in-memory interactions keep their ``bytes``
+    bodies and stay valid for subsequent replays/writes.
+    """
+    requests = []
+    responses = []
+    for request, response in interactions:
+        requests.append(request)
+        responses.append(response)
+    cassette_dict = copy.deepcopy({"requests": requests, "responses": responses})
+    payload: str = _vcr_serialize(cassette_dict, yamlserializer)
+    return payload
+
+
+def load_interactions(path: Path) -> list[Interaction]:
+    """Load a vcrpy YAML cassette into ``(Request, response-dict)`` pairs.
+
+    Uses vcrpy's ``FilesystemPersister`` so the in-memory shape matches
+    what the merge helper and the kernel produce. Returns an empty list
+    when the cassette does not exist.
+    """
+    path = Path(path)
+    if not path.exists():
+        return []
+    requests, responses = FilesystemPersister.load_cassette(path, serializer=yamlserializer)
+    return list(zip(requests, responses, strict=False))
+
+
+def write_cassette(path: Path, interactions: Iterable[Interaction]) -> None:
+    """Serialize and atomically write a cassette with LF line endings.
+
+    LF-only writes are required (see
+    :func:`clm.workers.notebook.http_replay_cassette._atomic_write_text`):
+    the repo's ``eol=lf`` gitattributes would otherwise flap the cassette
+    CRLF↔LF between builds and checkouts and perturb its bytes.
+    """
+    atomic_write_lf(Path(path), serialize_interactions(interactions))
+
+
+def response_dict_to_reply_parts(response: dict) -> tuple[int, list[tuple[str, str]], bytes]:
+    """Decompose a stored vcr response dict for replay reconstruction.
+
+    Returns ``(status_code, header_pairs, content_bytes)`` suitable for
+    building a mitmproxy ``Response``. The stored body may be ``str`` (as
+    loaded from YAML) or ``bytes`` (freshly recorded this build); it is
+    normalised to ``bytes``. Headers are flattened from the dict-of-lists
+    schema to repeated ``(name, value)`` pairs.
+    """
+    status_code = int(response["status"]["code"])
+    body_string = response.get("body", {}).get("string")
+    if body_string is None:
+        content = b""
+    elif isinstance(body_string, bytes):
+        content = body_string
+    else:
+        content = str(body_string).encode("utf-8")
+
+    header_pairs: list[tuple[str, str]] = []
+    for name, values in (response.get("headers") or {}).items():
+        if isinstance(values, (list, tuple)):
+            for value in values:
+                header_pairs.append((str(name), str(value)))
+        else:
+            header_pairs.append((str(name), str(values)))
+    return status_code, header_pairs, content
+
+
+def atomic_write_lf(target: Path, text: str) -> None:
+    """Write ``text`` to ``target`` atomically with LF line endings.
+
+    Self-contained reimplementation of CLM's ``_atomic_write_text`` (the
+    mitmdump interpreter cannot import the ``clm`` package): writes to a
+    sibling temp file with ``newline="\\n"`` then ``os.replace``.
+    """
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.parent / f"{target.name}.tmp-{uuid.uuid4().hex}"
+    try:
+        tmp.write_text(text, encoding="utf-8", newline="\n")
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -20,6 +20,7 @@ import socket
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 from types import TracebackType
 
@@ -71,6 +72,11 @@ class MitmproxyManager:
         # makes the prototype easier to reason about.
         self.confdir = Path(confdir) if confdir is not None else None
         self.extra_args = extra_args or []
+        # Per-build id: the addon names its staging files
+        # ``<cassette>.staging-mitm-<build_id>`` so the host can mark
+        # exactly this build's recordings complete after the proxy stops
+        # (see ``Course.merge_mitmproxy_cassette_staging``).
+        self.build_id = uuid.uuid4().hex
         self._process: subprocess.Popen | None = None
         self._log_file = None
 
@@ -148,6 +154,8 @@ class MitmproxyManager:
             f"clm_cassette_path={self.cassette_path}",
             "--set",
             f"clm_mode={self.mode}",
+            "--set",
+            f"clm_build_id={self.build_id}",
             # Quiet flow logging — the addon emits its own structured logs.
             "--set",
             "termlog_verbosity=warn",

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -5,9 +5,12 @@ a child of the ``clm build`` parent process: locating the executable,
 picking a free port, loading our addon, waiting for the proxy to accept
 TCP connections before workers spawn, and graceful shutdown.
 
-This is prototype scope — the manager is functional and used by the
-smoke test, but is not yet integrated into ``clm build``. Wiring that up
-is follow-up work; see the design doc for the integration plan.
+Integrated into ``clm build`` behind ``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy``
+(issue #165): the build starts one manager for the whole run and stops it in
+its ``finally``. The bind host is ``127.0.0.1`` for Direct-only builds and
+``0.0.0.0`` when Docker workers must reach the proxy via ``host.docker.internal``
+(P4); same-host clients and the readiness poll always connect via loopback
+(:meth:`_client_host`).
 """
 
 from __future__ import annotations
@@ -77,8 +80,8 @@ class MitmproxyManager:
         self._configured_port = listen_port
         self.listen_port: int | None = None  # set on start
         # mitmproxy stores its CA + config under ``confdir``. Per-build
-        # isolation keeps the CA out of the user's home directory and
-        # makes the prototype easier to reason about.
+        # isolation keeps the CA out of the user's home directory and gives
+        # each build its own short-lived CA.
         self.confdir = Path(confdir) if confdir is not None else None
         self.extra_args = extra_args or []
         # Hosts the addon forwards but never records (LangSmith telemetry by
@@ -95,11 +98,28 @@ class MitmproxyManager:
         self._output: collections.deque[str] = collections.deque(maxlen=_OUTPUT_RING_LINES)
         self._reader_thread: threading.Thread | None = None
 
+    def _client_host(self) -> str:
+        """Loopback-reachable host clients use to connect to the proxy.
+
+        When we bind the IPv4 wildcard (``0.0.0.0`` / empty, for Docker
+        reachability — see :meth:`start`), clients on the same machine must
+        still connect via loopback — ``connect("0.0.0.0")`` is invalid on
+        Windows and unreliable elsewhere. Direct-mode workers and our own
+        readiness poll therefore use ``127.0.0.1``. When we bind a concrete
+        host we connect to exactly that host.
+
+        Only IPv4 is supported: ``build`` only ever emits ``0.0.0.0`` or
+        ``127.0.0.1``, and :func:`_pick_free_port` binds an ``AF_INET`` socket.
+        """
+        if self.listen_host in ("0.0.0.0", ""):
+            return "127.0.0.1"
+        return self.listen_host
+
     @property
     def proxy_url(self) -> str:
         if self.listen_port is None:
             raise MitmproxyError("Proxy not started; listen_port unknown")
-        return f"http://{self.listen_host}:{self.listen_port}"
+        return f"http://{self._client_host()}:{self.listen_port}"
 
     @property
     def ca_cert_path(self) -> Path:
@@ -113,13 +133,15 @@ class MitmproxyManager:
         return confdir / "mitmproxy-ca-cert.pem"
 
     def env_vars(self, *, include_ca: bool = False) -> dict[str, str]:
-        """Environment variables to merge into worker subprocesses.
+        """Loopback proxy (and optionally CA) env vars for a worker process.
 
-        When ``include_ca`` is true, also exports cert-bundle paths so
-        Python HTTP libraries trust the proxy for HTTPS interception.
-        We default this off because the CA cert is only generated on
-        first run; the smoke test exercises HTTP-only paths and doesn't
-        need it.
+        Convenience helper; the integrated ``clm build`` path does not call it
+        — it splices a combined certifi+proxy-CA bundle into ``os.environ`` for
+        Direct workers (``build._maybe_start_mitmproxy_transport``) and mounts
+        the CA per Docker container (``worker_executor._mitmproxy_docker_env``).
+        ``include_ca`` defaults off because the CA cert is only written once
+        mitmdump has started; callers that need HTTPS interception must ensure
+        the cert exists first.
         """
         env: dict[str, str] = {
             "HTTP_PROXY": self.proxy_url,
@@ -283,7 +305,7 @@ class MitmproxyManager:
                     f"mitmdump exited during startup (rc={self._process.returncode}):\n{output}"
                 )
             try:
-                with socket.create_connection((self.listen_host, self.listen_port), timeout=0.2):
+                with socket.create_connection((self._client_host(), self.listen_port), timeout=0.2):
                     return
             except OSError:
                 time.sleep(0.05)
@@ -352,9 +374,9 @@ def _pick_free_port(host: str) -> int:
     """Bind to port 0 and let the OS pick a free port, then release.
 
     There is a small TOCTOU window between releasing the port here and
-    mitmdump binding it — acceptable for a prototype on localhost. A
-    production version could keep the socket open and hand the fd to
-    the child (Unix) or accept the small risk on Windows.
+    mitmdump binding it; on a single host this is acceptable. ``host`` is
+    always an IPv4 address (``0.0.0.0`` or ``127.0.0.1``), matching the
+    ``AF_INET`` socket below.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind((host, 0))

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -247,11 +247,21 @@ class MitmproxyManager:
 def _locate_mitmdump() -> str:
     """Find the mitmdump executable for the current Python environment.
 
-    Preference order: ``shutil.which`` (honors PATH), then the scripts
-    directory of the running interpreter. Raises ``MitmproxyError`` if
-    neither finds it — typically meaning the ``[mitmproxy]`` extra
-    isn't installed.
+    Preference order: explicit ``CLM_MITMDUMP`` env override, then
+    ``shutil.which`` (honors PATH), then the scripts directory of the
+    running interpreter. Raises ``MitmproxyError`` if none find it.
+
+    The ``CLM_MITMDUMP`` override is the recommended hook for the settled
+    ``uv tool install mitmproxy`` model (and CI provisioning), where
+    ``mitmdump`` lives in its own isolated environment rather than the
+    worker venv's scripts directory.
     """
+    override = os.environ.get("CLM_MITMDUMP")
+    if override:
+        if Path(override).exists():
+            return override
+        raise MitmproxyError(f"CLM_MITMDUMP={override!r} does not exist")
+
     found = shutil.which("mitmdump")
     if found:
         return found

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -279,7 +279,10 @@ def _locate_mitmdump() -> str:
             return str(candidate)
 
     raise MitmproxyError(
-        "Could not locate mitmdump executable. Install with: pip install -e '.[mitmproxy]'"
+        "Could not locate mitmdump executable. Install the out-of-process proxy with: "
+        "uv tool install mitmproxy --with vcrpy "
+        "(the addon needs vcrpy in the mitmdump environment to read/write cassettes), "
+        "then point CLM at it via the CLM_MITMDUMP env var if it is not on PATH."
     )
 
 

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -1,0 +1,287 @@
+"""Lifecycle manager for the mitmproxy subprocess.
+
+The manager handles the operational mechanics of running ``mitmdump`` as
+a child of the ``clm build`` parent process: locating the executable,
+picking a free port, loading our addon, waiting for the proxy to accept
+TCP connections before workers spawn, and graceful shutdown.
+
+This is prototype scope — the manager is functional and used by the
+smoke test, but is not yet integrated into ``clm build``. Wiring that up
+is follow-up work; see the design doc for the integration plan.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import TracebackType
+
+logger = logging.getLogger(__name__)
+
+# Path to the addon module so we can pass it to ``mitmdump --scripts``.
+_ADDON_PATH = Path(__file__).parent / "addon.py"
+
+# How long we wait for the proxy to accept TCP connections before
+# giving up. Local startup is typically <500ms; cap conservatively.
+_STARTUP_TIMEOUT_SECONDS = 10.0
+
+# How long we wait for graceful shutdown before sending SIGKILL/terminate.
+# mitmdump flushes flow streams on exit, so we want enough time for that.
+_SHUTDOWN_GRACE_SECONDS = 5.0
+
+
+class MitmproxyError(RuntimeError):
+    """Raised when the proxy subprocess fails to start or exits unexpectedly."""
+
+
+class MitmproxyManager:
+    """Manage a single ``mitmdump`` subprocess for an HTTP-replay session.
+
+    Used as a context manager — the proxy is started on ``__enter__``
+    and stopped (gracefully, with a force-kill fallback) on ``__exit__``.
+
+    Worker subprocesses spawned while the manager is active should have
+    :meth:`env_vars` merged into their environment so their HTTP traffic
+    is routed through the proxy.
+    """
+
+    def __init__(
+        self,
+        cassette_path: Path,
+        mode: str = "replay",
+        listen_host: str = "127.0.0.1",
+        listen_port: int | None = None,
+        confdir: Path | None = None,
+        extra_args: list[str] | None = None,
+    ) -> None:
+        self.cassette_path = Path(cassette_path)
+        self.mode = mode
+        self.listen_host = listen_host
+        self._configured_port = listen_port
+        self.listen_port: int | None = None  # set on start
+        # mitmproxy stores its CA + config under ``confdir``. Per-build
+        # isolation keeps the CA out of the user's home directory and
+        # makes the prototype easier to reason about.
+        self.confdir = Path(confdir) if confdir is not None else None
+        self.extra_args = extra_args or []
+        self._process: subprocess.Popen | None = None
+        self._log_file = None
+
+    @property
+    def proxy_url(self) -> str:
+        if self.listen_port is None:
+            raise MitmproxyError("Proxy not started; listen_port unknown")
+        return f"http://{self.listen_host}:{self.listen_port}"
+
+    @property
+    def ca_cert_path(self) -> Path:
+        """Filesystem path to mitmproxy's CA certificate.
+
+        Workers that need to validate HTTPS traffic through the proxy
+        should trust this file (typically by setting ``SSL_CERT_FILE``
+        and ``REQUESTS_CA_BUNDLE``).
+        """
+        confdir = self.confdir if self.confdir is not None else (Path.home() / ".mitmproxy")
+        return confdir / "mitmproxy-ca-cert.pem"
+
+    def env_vars(self, *, include_ca: bool = False) -> dict[str, str]:
+        """Environment variables to merge into worker subprocesses.
+
+        When ``include_ca`` is true, also exports cert-bundle paths so
+        Python HTTP libraries trust the proxy for HTTPS interception.
+        We default this off because the CA cert is only generated on
+        first run; the smoke test exercises HTTP-only paths and doesn't
+        need it.
+        """
+        env: dict[str, str] = {
+            "HTTP_PROXY": self.proxy_url,
+            "HTTPS_PROXY": self.proxy_url,
+            "http_proxy": self.proxy_url,
+            "https_proxy": self.proxy_url,
+        }
+        if include_ca:
+            cert = str(self.ca_cert_path)
+            env.update(
+                {
+                    "SSL_CERT_FILE": cert,
+                    "REQUESTS_CA_BUNDLE": cert,
+                    "CURL_CA_BUNDLE": cert,
+                }
+            )
+        return env
+
+    def __enter__(self) -> MitmproxyManager:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.stop()
+
+    def start(self) -> None:
+        if self._process is not None:
+            raise MitmproxyError("Manager already started")
+
+        mitmdump = _locate_mitmdump()
+        self.listen_port = self._configured_port or _pick_free_port(self.listen_host)
+
+        cmd: list[str] = [
+            mitmdump,
+            "--listen-host",
+            self.listen_host,
+            "--listen-port",
+            str(self.listen_port),
+            "--scripts",
+            str(_ADDON_PATH),
+            "--set",
+            f"clm_cassette_path={self.cassette_path}",
+            "--set",
+            f"clm_mode={self.mode}",
+            # Quiet flow logging — the addon emits its own structured logs.
+            "--set",
+            "termlog_verbosity=warn",
+            "--set",
+            "flow_detail=0",
+        ]
+        if self.confdir is not None:
+            cmd.extend(["--set", f"confdir={self.confdir}"])
+        cmd.extend(self.extra_args)
+
+        env = os.environ.copy()
+        # Make the addon's logger visible.
+        env.setdefault("PYTHONUNBUFFERED", "1")
+
+        # On Windows we need CREATE_NEW_PROCESS_GROUP so we can send
+        # CTRL_BREAK_EVENT for graceful shutdown without killing the
+        # parent.
+        creationflags = 0
+        if sys.platform == "win32":
+            creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+        logger.info("Starting mitmdump: %s", " ".join(cmd))
+        self._process = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            creationflags=creationflags,
+        )
+
+        try:
+            self._wait_for_ready()
+        except Exception:
+            self.stop()
+            raise
+
+    def stop(self) -> None:
+        if self._process is None:
+            return
+        proc = self._process
+        self._process = None
+
+        if proc.poll() is not None:
+            # Already exited.
+            return
+
+        try:
+            if sys.platform == "win32":
+                proc.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                proc.send_signal(signal.SIGTERM)
+        except (ProcessLookupError, OSError) as exc:
+            logger.warning("Failed to send graceful shutdown to mitmdump: %s", exc)
+
+        try:
+            proc.wait(timeout=_SHUTDOWN_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            logger.warning("mitmdump did not exit within %.1fs; forcing", _SHUTDOWN_GRACE_SECONDS)
+            proc.kill()
+            try:
+                proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                logger.error("mitmdump survived SIGKILL; leaking process")
+
+    def _wait_for_ready(self) -> None:
+        """Poll the listen port until it accepts a TCP connection or we time out."""
+        assert self._process is not None
+        assert self.listen_port is not None
+
+        deadline = time.monotonic() + _STARTUP_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self._process.poll() is not None:
+                output = self._drain_output()
+                raise MitmproxyError(
+                    f"mitmdump exited during startup (rc={self._process.returncode}):\n{output}"
+                )
+            try:
+                with socket.create_connection((self.listen_host, self.listen_port), timeout=0.2):
+                    return
+            except OSError:
+                time.sleep(0.05)
+        output = self._drain_output()
+        raise MitmproxyError(
+            f"mitmdump did not become ready within {_STARTUP_TIMEOUT_SECONDS:.1f}s:\n{output}"
+        )
+
+    def _drain_output(self) -> str:
+        if self._process is None or self._process.stdout is None:
+            return ""
+        try:
+            data, _ = self._process.communicate(timeout=1.0)
+            return (data or b"").decode("utf-8", errors="replace")
+        except subprocess.TimeoutExpired:
+            return ""
+
+
+def _locate_mitmdump() -> str:
+    """Find the mitmdump executable for the current Python environment.
+
+    Preference order: ``shutil.which`` (honors PATH), then the scripts
+    directory of the running interpreter. Raises ``MitmproxyError`` if
+    neither finds it — typically meaning the ``[mitmproxy]`` extra
+    isn't installed.
+    """
+    found = shutil.which("mitmdump")
+    if found:
+        return found
+
+    interpreter_dir = Path(sys.executable).parent
+    candidates: list[Path] = []
+    if sys.platform == "win32":
+        candidates.append(interpreter_dir / "mitmdump.exe")
+        candidates.append(interpreter_dir / "Scripts" / "mitmdump.exe")
+    else:
+        candidates.append(interpreter_dir / "mitmdump")
+        candidates.append(interpreter_dir / "bin" / "mitmdump")
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+
+    raise MitmproxyError(
+        "Could not locate mitmdump executable. Install with: pip install -e '.[mitmproxy]'"
+    )
+
+
+def _pick_free_port(host: str) -> int:
+    """Bind to port 0 and let the OS pick a free port, then release.
+
+    There is a small TOCTOU window between releasing the port here and
+    mitmdump binding it — acceptable for a prototype on localhost. A
+    production version could keep the socket open and hand the fd to
+    the child (Unix) or accept the small risk on Windows.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        port: int = sock.getsockname()[1]
+        return port

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -73,11 +73,17 @@ class MitmproxyManager:
         confdir: Path | None = None,
         extra_args: list[str] | None = None,
         ignore_hosts: tuple[str, ...] | list[str] = (),
+        trace_dir: Path | None = None,
     ) -> None:
         self.cassette_path = Path(cassette_path)
         self.mode = mode
         self.listen_host = listen_host
         self._configured_port = listen_port
+        # Forensic HTTP-replay trace directory (issue #165 P5). When set, the
+        # addon writes per-flow proxy events to ``proxy-<pid>.jsonl`` there so
+        # ``scripts/analyze_http_replay_trace.py`` can cross-reference the
+        # worker socket stream against the proxy's interception decisions.
+        self.trace_dir = Path(trace_dir) if trace_dir is not None else None
         self.listen_port: int | None = None  # set on start
         # mitmproxy stores its CA + config under ``confdir``. Per-build
         # isolation keeps the CA out of the user's home directory and gives
@@ -203,6 +209,8 @@ class MitmproxyManager:
         ]
         if self.confdir is not None:
             cmd.extend(["--set", f"confdir={self.confdir}"])
+        if self.trace_dir is not None:
+            cmd.extend(["--set", f"clm_trace_dir={self.trace_dir}"])
         cmd.extend(self.extra_args)
 
         env = os.environ.copy()

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -12,6 +12,7 @@ is follow-up work; see the design doc for the integration plan.
 
 from __future__ import annotations
 
+import collections
 import logging
 import os
 import shutil
@@ -19,6 +20,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -36,6 +38,12 @@ _STARTUP_TIMEOUT_SECONDS = 10.0
 # How long we wait for graceful shutdown before sending SIGKILL/terminate.
 # mitmdump flushes flow streams on exit, so we want enough time for that.
 _SHUTDOWN_GRACE_SECONDS = 5.0
+
+# Bounded ring buffer of mitmdump stdout lines. A reader thread drains the
+# pipe continuously so a multi-hour build can never deadlock on a full
+# OS pipe buffer (~64 KiB) while mitmdump blocks on write; we keep only the
+# tail, which is all startup-failure / shutdown diagnostics need.
+_OUTPUT_RING_LINES = 1000
 
 
 class MitmproxyError(RuntimeError):
@@ -61,6 +69,7 @@ class MitmproxyManager:
         listen_port: int | None = None,
         confdir: Path | None = None,
         extra_args: list[str] | None = None,
+        ignore_hosts: tuple[str, ...] | list[str] = (),
     ) -> None:
         self.cassette_path = Path(cassette_path)
         self.mode = mode
@@ -72,13 +81,19 @@ class MitmproxyManager:
         # makes the prototype easier to reason about.
         self.confdir = Path(confdir) if confdir is not None else None
         self.extra_args = extra_args or []
+        # Hosts the addon forwards but never records (LangSmith telemetry by
+        # default); passed through to the addon as ``clm_ignore_hosts``.
+        self.ignore_hosts = tuple(ignore_hosts)
         # Per-build id: the addon names its staging files
         # ``<cassette>.staging-mitm-<build_id>`` so the host can mark
         # exactly this build's recordings complete after the proxy stops
         # (see ``Course.merge_mitmproxy_cassette_staging``).
         self.build_id = uuid.uuid4().hex
         self._process: subprocess.Popen | None = None
-        self._log_file = None
+        # Reader thread + bounded ring buffer draining mitmdump stdout so the
+        # pipe never fills and blocks the proxy on a long build.
+        self._output: collections.deque[str] = collections.deque(maxlen=_OUTPUT_RING_LINES)
+        self._reader_thread: threading.Thread | None = None
 
     @property
     def proxy_url(self) -> str:
@@ -156,6 +171,8 @@ class MitmproxyManager:
             f"clm_mode={self.mode}",
             "--set",
             f"clm_build_id={self.build_id}",
+            "--set",
+            f"clm_ignore_hosts={','.join(self.ignore_hosts)}",
             # Quiet flow logging — the addon emits its own structured logs.
             "--set",
             "termlog_verbosity=warn",
@@ -185,6 +202,7 @@ class MitmproxyManager:
             stderr=subprocess.STDOUT,
             creationflags=creationflags,
         )
+        self._start_reader()
 
         try:
             self._wait_for_ready()
@@ -220,6 +238,38 @@ class MitmproxyManager:
             except subprocess.TimeoutExpired:
                 logger.error("mitmdump survived SIGKILL; leaking process")
 
+        # The reader thread exits when the pipe hits EOF (process gone). Join
+        # it so we don't leak a thread per build and the ring buffer is final.
+        reader = self._reader_thread
+        self._reader_thread = None
+        if reader is not None:
+            reader.join(timeout=2.0)
+
+    def _start_reader(self) -> None:
+        """Spawn a daemon thread that drains mitmdump stdout into the ring buffer.
+
+        Without a continuous drain, a long build can fill the OS pipe buffer;
+        mitmdump then blocks on its next write and the proxy stalls — a silent
+        multi-hour-build deadlock. The thread reads until EOF (process exit).
+        """
+        if self._process is None or self._process.stdout is None:
+            return
+
+        stream = self._process.stdout
+
+        def _pump() -> None:
+            try:
+                for raw in iter(stream.readline, b""):
+                    self._output.append(raw.decode("utf-8", errors="replace").rstrip("\r\n"))
+            except (ValueError, OSError):
+                # Stream closed underneath us during shutdown — expected.
+                return
+
+        self._reader_thread = threading.Thread(
+            target=_pump, name="mitmdump-stdout-reader", daemon=True
+        )
+        self._reader_thread.start()
+
     def _wait_for_ready(self) -> None:
         """Poll the listen port until it accepts a TCP connection or we time out."""
         assert self._process is not None
@@ -243,13 +293,17 @@ class MitmproxyManager:
         )
 
     def _drain_output(self) -> str:
-        if self._process is None or self._process.stdout is None:
-            return ""
-        try:
-            data, _ = self._process.communicate(timeout=1.0)
-            return (data or b"").decode("utf-8", errors="replace")
-        except subprocess.TimeoutExpired:
-            return ""
+        """Return mitmdump's recent stdout (the ring buffer's tail).
+
+        The reader thread owns the pipe, so we must not call ``communicate()``
+        here (it would race the thread on the same fd). When the process has
+        exited we give the reader a brief moment to flush the final lines, then
+        snapshot the buffer.
+        """
+        reader = self._reader_thread
+        if reader is not None and self._process is not None and self._process.poll() is not None:
+            reader.join(timeout=1.0)
+        return "\n".join(self._output)
 
 
 def _locate_mitmdump() -> str:

--- a/src/clm/infrastructure/http_replay_mitm/trace_log.py
+++ b/src/clm/infrastructure/http_replay_mitm/trace_log.py
@@ -1,0 +1,126 @@
+"""Minimal JSONL trace writer for the mitmproxy addon (issue #165 P5).
+
+The forensic HTTP-replay trace harness
+(``docs/claude/design/http-replay-trace.md``) cross-references three event
+streams: ``socket`` (worker-kernel ground truth via an audit hook),
+``cassette`` (host-side lifecycle) and — under the in-process vcrpy path —
+``vcr`` (wrapped vcrpy internals).
+
+Under the **out-of-process mitmproxy transport** the ``vcr`` stream goes dark:
+the kernel no longer imports vcr or patches httpcore, so there are no vcr
+internals to wrap. The proxy's own per-flow decisions become the
+interception-evidence stream instead. This module is that stream's writer
+(``stream="proxy"``).
+
+It is imported by :mod:`clm.infrastructure.http_replay_mitm.addon`, which runs
+inside the isolated ``mitmdump`` interpreter (``uv tool install mitmproxy``)
+where the ``clm`` package is absent. Like
+:mod:`clm.infrastructure.http_replay_mitm.cassette_format` it therefore imports
+**only the stdlib** so the addon can load it by bare path, and it emits the
+*same* JSONL record shape as
+:class:`clm.workers.notebook.http_replay_trace.TraceWriter` so
+``scripts/analyze_http_replay_trace.py`` reads every stream uniformly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Stream name for proxy-side flow events — the interception-evidence stream
+# under the mitmproxy transport (replaces the kernel ``vcr`` stream). The
+# analyzer keys on this exact string.
+PROXY_STREAM = "proxy"
+
+
+class ProxyTraceLog:
+    """Thread-safe JSONL appender for the addon's per-flow proxy events.
+
+    One instance per ``mitmdump`` process writes ``proxy-<pid>.jsonl`` into the
+    build's trace invocation directory (the pid suffix matches the
+    ``worker-<pid>.jsonl`` convention so the analyzer can glob ``proxy-*``).
+    A disabled instance (no trace directory configured) is a cheap no-op so the
+    addon can call :meth:`emit` unconditionally on every flow.
+
+    The writer is crash-proof on purpose: forensic tracing must never take down
+    the proxy, so :meth:`emit` swallows any write error rather than propagating
+    it into mitmproxy's flow handling.
+    """
+
+    __slots__ = ("_fh", "_lock", "_path", "_start_mono")
+
+    def __init__(self, path: Path | None) -> None:
+        self._lock = threading.Lock()
+        self._start_mono = time.monotonic()
+        self._path = path
+        self._fh = None
+        if path is not None:
+            # Construction must be as crash-proof as emit(): a file-open failure
+            # (Windows AV holding a stale recycled-PID file, a TOCTOU dir removal
+            # after from_trace_dir's is_dir() check, a dir already at the path)
+            # must degrade to a disabled no-op log, NOT propagate out of the
+            # addon's running() — where mitmproxy turns any exception into a hard
+            # sys.exit(1) startup abort, i.e. it would crash the very proxy the
+            # forensic trace is meant to observe.
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                self._fh = path.open("a", encoding="utf-8", newline="\n")
+            except OSError:
+                self._fh = None
+
+    @classmethod
+    def from_trace_dir(cls, trace_dir: str | os.PathLike[str] | None) -> ProxyTraceLog:
+        """Build a log writing ``proxy-<pid>.jsonl`` under ``trace_dir``.
+
+        An empty/``None`` ``trace_dir`` — or one the host has not created yet —
+        yields a disabled (no-op) log rather than crashing the proxy.
+        """
+        if not trace_dir:
+            return cls(None)
+        directory = Path(trace_dir)
+        if not directory.is_dir():
+            return cls(None)
+        return cls(directory / f"{PROXY_STREAM}-{os.getpid()}.jsonl")
+
+    @property
+    def enabled(self) -> bool:
+        return self._fh is not None
+
+    @property
+    def path(self) -> Path | None:
+        return self._path
+
+    def emit(self, event: str, data: dict[str, Any] | None = None) -> None:
+        fh = self._fh
+        if fh is None:
+            return
+        try:
+            record = {
+                "ts_mono": time.monotonic() - self._start_mono,
+                "ts_wall": datetime.now(timezone.utc).isoformat(),
+                "pid": os.getpid(),
+                "tid": threading.get_ident(),
+                "stream": PROXY_STREAM,
+                "event": event,
+                "data": data or {},
+            }
+            line = json.dumps(record, sort_keys=False) + "\n"
+            with self._lock:
+                fh.write(line)
+                fh.flush()
+        except Exception:
+            # Forensic tracing must never crash the proxy.
+            return
+
+    def close(self) -> None:
+        with self._lock:
+            if self._fh is not None and not self._fh.closed:
+                try:
+                    self._fh.close()
+                except Exception:
+                    pass

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -24,6 +24,87 @@ from clm.infrastructure.workers.windows_job_object import WorkerJobObject
 
 logger = logging.getLogger(__name__)
 
+# DNS alias every container uses to reach the host (extra_hosts host-gateway):
+# the CLM REST API (CLM_API_URL) and, under the mitmproxy transport, the proxy.
+# Shared by the API-URL construction and NO_PROXY so the two can never drift
+# (NO_PROXY must list exactly the API host or worker registration would be
+# routed through the replay proxy — see _mitmproxy_docker_env).
+_DOCKER_HOST_ALIAS = "host.docker.internal"
+
+# Dedicated in-container bind-mount target for the mitmproxy CA bundle (issue
+# #165 P4). NOT the CLM source tree (that lives at /app/clm); this is a mount-
+# only path. A single read-only file mount works on Docker Desktop (Windows/
+# WSL2) and native Linux alike.
+_MITM_CA_CONTAINER_PATH = "/clm/mitmproxy-ca-bundle.pem"
+
+
+def _mitmproxy_docker_env(
+    host_environ: dict[str, str],
+) -> tuple[dict[str, str], tuple[str, str] | None]:
+    """Container env additions + CA bind-mount for the mitmproxy transport (#165 P4).
+
+    Returns ``({}, None)`` unless the host activated the out-of-process
+    HTTP-replay transport (``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy`` with an
+    ``HTTP(S)_PROXY`` set by ``build._maybe_start_mitmproxy_transport``). A
+    ``127.0.0.1`` proxy is unreachable from inside a container, so when active
+    this:
+
+    - rewrites ``HTTP(S)_PROXY`` from the host's loopback proxy URL to
+      ``host.docker.internal`` (the container's route back to the host;
+      ``extra_hosts host-gateway`` is already set) so the kernel's LLM traffic
+      is intercepted by the shared proxy;
+    - sets ``NO_PROXY=host.docker.internal`` so the worker's REST-API traffic to
+      the CLM host (``CLM_API_URL``) **bypasses** the proxy — otherwise worker
+      registration/heartbeats would hit the replay proxy as cassette misses and
+      the build would stall before any notebook ran;
+    - points the three cert-bundle env vars at the proxy CA bundle, bind-mounted
+      read-only at :data:`_MITM_CA_CONTAINER_PATH`, so the container's TLS
+      trusts the proxy-forged certificates;
+    - passes ``CLM_HTTP_REPLAY_TRANSPORT`` through so the in-container notebook
+      processor injects the cassette-routing tag bootstrap (P2) and skips the
+      in-kernel vcrpy bootstrap.
+
+    The second return value is ``(host_ca_path, container_ca_path)`` for the
+    read-only bind mount, or ``None`` when no usable host CA bundle is found.
+    """
+    if host_environ.get("CLM_HTTP_REPLAY_TRANSPORT") != "mitmproxy":
+        return {}, None
+    proxy = host_environ.get("HTTPS_PROXY") or host_environ.get("HTTP_PROXY")
+    if not proxy:
+        return {}, None
+
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(proxy)
+    try:
+        port = parts.port
+    except ValueError:
+        port = None
+    netloc = _DOCKER_HOST_ALIAS + (f":{port}" if port else "")
+    container_proxy = urlunsplit((parts.scheme or "http", netloc, "", "", ""))
+
+    env: dict[str, str] = {
+        "HTTP_PROXY": container_proxy,
+        "HTTPS_PROXY": container_proxy,
+        "http_proxy": container_proxy,
+        "https_proxy": container_proxy,
+        # Worker <-> CLM REST API (CLM_API_URL host) must NOT be proxied, or
+        # registration/heartbeats would be replayed as cassette misses. Uses the
+        # same _DOCKER_HOST_ALIAS the API URL is built from so they can't drift.
+        "NO_PROXY": _DOCKER_HOST_ALIAS,
+        "no_proxy": _DOCKER_HOST_ALIAS,
+        "CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy",
+    }
+
+    mount: tuple[str, str] | None = None
+    ca_host = host_environ.get("SSL_CERT_FILE")
+    if ca_host and Path(ca_host).is_file():
+        mount = (str(Path(ca_host).absolute()), _MITM_CA_CONTAINER_PATH)
+        env["SSL_CERT_FILE"] = _MITM_CA_CONTAINER_PATH
+        env["REQUESTS_CA_BUNDLE"] = _MITM_CA_CONTAINER_PATH
+        env["CURL_CA_BUNDLE"] = _MITM_CA_CONTAINER_PATH
+    return env, mount
+
 
 @dataclass
 class WorkerConfig:
@@ -199,7 +280,7 @@ class DockerWorkerExecutor(WorkerExecutor):
             # This solves the SQLite WAL mode issues on Windows Docker
             from clm.infrastructure.api.server import DEFAULT_PORT
 
-            api_url = f"http://host.docker.internal:{DEFAULT_PORT}"
+            api_url = f"http://{_DOCKER_HOST_ALIAS}:{DEFAULT_PORT}"
 
             # Build volume mounts
             volumes = {
@@ -250,6 +331,29 @@ class DockerWorkerExecutor(WorkerExecutor):
                     _v = os.environ.get(_k, "")
                     if _v:
                         environment[_k] = _v
+
+            # Out-of-process mitmproxy HTTP-replay transport (issue #165 P4):
+            # route the container's LLM traffic through the host proxy via
+            # host.docker.internal and trust its CA, while keeping worker<->API
+            # traffic off the proxy. Only the notebook worker makes the LLM
+            # traffic the proxy intercepts, so we inject solely for it — diagram
+            # converters (plantuml/drawio) get no needless proxy env or CA mount.
+            # No-op unless the host activated the transport
+            # (CLM_HTTP_REPLAY_TRANSPORT=mitmproxy).
+            mitm_env, mitm_mount = (
+                _mitmproxy_docker_env(dict(os.environ)) if worker_type == "notebook" else ({}, None)
+            )
+            if mitm_env:
+                environment.update(mitm_env)
+                logger.debug(
+                    "mitmproxy transport: container proxy=%s NO_PROXY=%s CA=%s",
+                    environment.get("HTTPS_PROXY"),
+                    environment.get("NO_PROXY"),
+                    environment.get("SSL_CERT_FILE", "NOT MOUNTED"),
+                )
+            if mitm_mount is not None:
+                host_ca, container_ca = mitm_mount
+                volumes[host_ca] = {"bind": container_ca, "mode": "ro"}
 
             log_mounts = f"  Workspace: {self.workspace_path.absolute()} -> /workspace (rw)"
             if self.data_dir:

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -120,6 +120,7 @@ def merge_staging_into_canonical(
     paths: CassettePaths,
     *,
     sweep_orphans: bool = False,
+    overwrite_existing: bool = False,
 ) -> int:
     """Merge per-worker staging files into the canonical cassette.
 
@@ -155,6 +156,16 @@ def merge_staging_into_canonical(
             per-worker post-execution invocation), markerless staging
             files are left untouched — they may belong to a concurrent
             worker that hasn't completed yet.
+        overwrite_existing: Mode-aware merge for ``refresh`` (vcrpy ``all``).
+            When ``True`` a staging interaction **wins** over a canonical
+            interaction with the same fingerprint (last-seen within staging
+            wins, so a freshly recorded response replaces a stale one) while
+            preserving canonical position for minimal diff churn. When
+            ``False`` (default — ``new-episodes`` / ``once`` / ``replay`` and
+            every pre-build sweep) the long-standing first-seen-wins behavior
+            is used, byte-identical to before this parameter existed. This is
+            the producer-agnostic fix for the refresh-overwrite gap (issue
+            #165 P3) and benefits both the vcrpy and mitmproxy transports.
 
     Returns:
         Number of staging files folded into the canonical (markered
@@ -234,51 +245,121 @@ def merge_staging_into_canonical(
                         f"before merge ({type(exc).__name__}: {exc}); treating as empty."
                     )
 
-            seen_keys = {_dedup_key(req) for req in canonical_requests}
-            merged_requests = list(canonical_requests)
-            merged_responses = list(canonical_responses)
-
-            for staging_path in markered:
-                try:
-                    staging_requests, staging_responses = FilesystemPersister.load_cassette(
-                        staging_path, serializer=yamlserializer
-                    )
-                except Exception as exc:  # noqa: BLE001 — defensive
-                    logger.warning(
-                        f"Could not load staging cassette '{staging_path}' "
-                        f"({type(exc).__name__}: {exc}); skipping."
-                    )
+            # ``overwrite_existing`` lets a staging interaction replace a
+            # canonical one with the same fingerprint (refresh/``all``); the
+            # default first-seen-wins path is kept verbatim so a no-op build's
+            # cassette stays byte-identical to before this parameter existed.
+            if overwrite_existing:
+                # Last-seen within staging wins (a freshly recorded response
+                # supersedes an earlier/seeded one); canonical entries are
+                # replaced in place to keep the diff minimal, and genuinely new
+                # staging entries are appended in first-seen order.
+                staging_value: dict[tuple, tuple] = {}
+                staging_order: list[tuple] = []
+                for staging_path in markered:
+                    try:
+                        staging_requests, staging_responses = FilesystemPersister.load_cassette(
+                            staging_path, serializer=yamlserializer
+                        )
+                    except Exception as exc:  # noqa: BLE001 — defensive
+                        logger.warning(
+                            f"Could not load staging cassette '{staging_path}' "
+                            f"({type(exc).__name__}: {exc}); skipping."
+                        )
+                        _trace(
+                            "cassette.merge.decision",
+                            {
+                                "staging": str(staging_path),
+                                "decision": "load_failed",
+                                "exc_type": type(exc).__name__,
+                            },
+                        )
+                        continue
+                    folded_from_this = 0
+                    duplicates_in_this = 0
+                    for request, response in zip(staging_requests, staging_responses, strict=False):
+                        key = _dedup_key(request)
+                        if key in staging_value:
+                            duplicates_in_this += 1
+                        else:
+                            staging_order.append(key)
+                            folded_from_this += 1
+                        staging_value[key] = (request, response)  # last-seen wins
                     _trace(
                         "cassette.merge.decision",
                         {
                             "staging": str(staging_path),
-                            "decision": "load_failed",
-                            "exc_type": type(exc).__name__,
+                            "decision": "folded_overwrite",
+                            "marker_present": True,
+                            "interactions_loaded": len(staging_requests),
+                            "interactions_folded": folded_from_this,
+                            "interactions_deduped": duplicates_in_this,
                         },
                     )
-                    continue
-                folded_from_this = 0
-                duplicates_in_this = 0
-                for request, response in zip(staging_requests, staging_responses, strict=False):
+                merged_requests = []
+                merged_responses = []
+                placed: set = set()
+                for request, response in zip(canonical_requests, canonical_responses, strict=False):
                     key = _dedup_key(request)
-                    if key in seen_keys:
-                        duplicates_in_this += 1
+                    if key in staging_value:
+                        new_request, new_response = staging_value[key]
+                        merged_requests.append(new_request)
+                        merged_responses.append(new_response)
+                        placed.add(key)
+                    else:
+                        merged_requests.append(request)
+                        merged_responses.append(response)
+                for key in staging_order:
+                    if key not in placed:
+                        new_request, new_response = staging_value[key]
+                        merged_requests.append(new_request)
+                        merged_responses.append(new_response)
+            else:
+                seen_keys = {_dedup_key(req) for req in canonical_requests}
+                merged_requests = list(canonical_requests)
+                merged_responses = list(canonical_responses)
+
+                for staging_path in markered:
+                    try:
+                        staging_requests, staging_responses = FilesystemPersister.load_cassette(
+                            staging_path, serializer=yamlserializer
+                        )
+                    except Exception as exc:  # noqa: BLE001 — defensive
+                        logger.warning(
+                            f"Could not load staging cassette '{staging_path}' "
+                            f"({type(exc).__name__}: {exc}); skipping."
+                        )
+                        _trace(
+                            "cassette.merge.decision",
+                            {
+                                "staging": str(staging_path),
+                                "decision": "load_failed",
+                                "exc_type": type(exc).__name__,
+                            },
+                        )
                         continue
-                    merged_requests.append(request)
-                    merged_responses.append(response)
-                    seen_keys.add(key)
-                    folded_from_this += 1
-                _trace(
-                    "cassette.merge.decision",
-                    {
-                        "staging": str(staging_path),
-                        "decision": "folded",
-                        "marker_present": True,
-                        "interactions_loaded": len(staging_requests),
-                        "interactions_folded": folded_from_this,
-                        "interactions_deduped": duplicates_in_this,
-                    },
-                )
+                    folded_from_this = 0
+                    duplicates_in_this = 0
+                    for request, response in zip(staging_requests, staging_responses, strict=False):
+                        key = _dedup_key(request)
+                        if key in seen_keys:
+                            duplicates_in_this += 1
+                            continue
+                        merged_requests.append(request)
+                        merged_responses.append(response)
+                        seen_keys.add(key)
+                        folded_from_this += 1
+                    _trace(
+                        "cassette.merge.decision",
+                        {
+                            "staging": str(staging_path),
+                            "decision": "folded",
+                            "marker_present": True,
+                            "interactions_loaded": len(staging_requests),
+                            "interactions_folded": folded_from_this,
+                            "interactions_deduped": duplicates_in_this,
+                        },
+                    )
 
             # Only rewrite canonical if we actually folded markered
             # work in. Pre-build sweeps that find only markerless

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -2068,15 +2068,37 @@ class NotebookProcessor:
         """Resolve the ``X-CLM-Cassette`` routing tag for the mitmproxy transport.
 
         The tag is the absolute canonical cassette path this notebook's
-        traffic belongs to. It is resolved exactly like the vcrpy path's
-        :meth:`_resolve_cassette_paths` (same ``payload.http_replay_cassette_name``
-        — which already carries the split-deck base-cassette fallback for
-        ``replay`` and the strict language-specific name for record modes,
-        issue #159 — and the same ``resolve_paths`` canonical computation),
-        so the proxy's per-target staging file lands beside the very
-        cassette the host-side merge will fold it into. Returns ``None``
-        when the topic did not opt into a replay-capable mode or no
-        cassette / writable target dir resolves.
+        traffic belongs to. It uses the same ``payload.http_replay_cassette_name``
+        as the vcrpy path's :meth:`_resolve_cassette_paths` (which already
+        carries the split-deck base-cassette fallback for ``replay`` and the
+        strict language-specific name for record modes, issue #159) and the
+        same ``resolve_paths`` canonical computation.
+
+        **Host namespace (issue #165 P4):** unlike the vcrpy path — where the
+        in-container *kernel* writes the staging cassette and therefore needs
+        the container-mapped ``source_dir`` (``/source/...``) — the mitmproxy
+        proxy and the ``merge_mitmproxy_cassette_staging`` host step run on the
+        **host**. The tag must therefore name a **host** path so the proxy
+        writes ``<tag>.staging-mitm-<build_id>`` beside the real canonical
+        cassette the host-side merge folds it into. We resolve against
+        ``payload.source_topic_dir`` (the host topic dir in both Direct and
+        Docker modes — Docker workers derive their container ``source_dir``
+        *from* it) and fall back to the container ``source_dir`` only if no
+        host path is available. In Direct mode the two are identical, so this
+        is a no-op there. Returns ``None`` when the topic did not opt into a
+        replay-capable mode or no cassette / target dir resolves.
+
+        **Invariant:** an http-replay notebook must keep its cassette beside the
+        notebook at the topic root (the ``_cassettes/`` dir under
+        ``source_topic_dir``). ``cassette_name`` is resolved relative to the
+        notebook's own parent while the tag here resolves against
+        ``source_topic_dir``; for a notebook nested in a sub-directory of the
+        topic the two diverge, so the proxy would write staging to a dir the
+        host-side merge (``Course.merge_mitmproxy_cassette_staging``) does not
+        scan and a record-mode recording would be misplaced (replay is
+        unaffected — it reads the committed canonical). This mirrors the
+        existing vcrpy direct path's topic-dir-based resolution; converging
+        nested layouts is a separate follow-up touching both transports.
         """
         mode = payload.http_replay_mode
         if not mode or mode == "disabled" or mode not in _HTTP_REPLAY_MODE_TO_VCR_MODE:
@@ -2084,10 +2106,10 @@ class NotebookProcessor:
         cassette_name = payload.http_replay_cassette_name
         if not cassette_name:
             return None
-        if source_dir is not None:
-            target_dir: Path = source_dir
-        elif payload.source_topic_dir:
-            target_dir = Path(payload.source_topic_dir)
+        if payload.source_topic_dir:
+            target_dir: Path = Path(payload.source_topic_dir)
+        elif source_dir is not None:
+            target_dir = source_dir
         else:
             return None
         from .http_replay_cassette import resolve_paths

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -697,6 +697,61 @@ if _clm_trace_dir:
 """
 
 
+# Out-of-process transport (issue #165, P2). Injected into the kernel
+# *instead of* the heavy vcrpy bootstrap when
+# ``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy``. It does not patch httpcore or
+# enter any cassette context — it only tags every outgoing httpx request
+# with the destination cassette path so the single shared mitmproxy can
+# demux flows to the correct per-(topic,language,kind) cassette. The proxy
+# strips the ``X-CLM-Cassette`` header before recording or forwarding.
+# The patch is on the httpx ``Client``/``AsyncClient`` *classes*, so it
+# covers clients created before or after this cell (openai/langchain both
+# route through ``Client.send``). One tag per kernel (fresh kernel per
+# notebook), captured in the closure — the same lifetime the vcrpy
+# bootstrap relies on. No literal ``{}`` in the body so ``str.format`` only
+# substitutes ``{tag!r}``.
+_HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE = """\
+# CLM HTTP REPLAY TAG BOOTSTRAP - DO NOT EDIT
+import httpx as _clm_httpx
+_CLM_CASSETTE_TAG = {tag!r}
+if not getattr(_clm_httpx.Client.send, "_clm_tagged", False):
+    _clm_orig_send = _clm_httpx.Client.send
+    def _clm_tagged_send(self, request, *args, **kwargs):
+        request.headers["x-clm-cassette"] = _CLM_CASSETTE_TAG
+        return _clm_orig_send(self, request, *args, **kwargs)
+    _clm_tagged_send._clm_tagged = True
+    _clm_httpx.Client.send = _clm_tagged_send
+if not getattr(_clm_httpx.AsyncClient.send, "_clm_tagged", False):
+    _clm_orig_asend = _clm_httpx.AsyncClient.send
+    async def _clm_tagged_asend(self, request, *args, **kwargs):
+        request.headers["x-clm-cassette"] = _CLM_CASSETTE_TAG
+        return await _clm_orig_asend(self, request, *args, **kwargs)
+    _clm_tagged_asend._clm_tagged = True
+    _clm_httpx.AsyncClient.send = _clm_tagged_asend
+"""
+
+
+def _inject_http_replay_tag_bootstrap(nb: NotebookNode, tag: str) -> None:
+    """Prepend the mitmproxy cassette-routing tag cell to ``nb``.
+
+    ``tag`` is the absolute canonical cassette path the host-side merge
+    will fold into. The cell carries the same ``clm_injected`` marker as
+    the vcrpy bootstrap so :func:`_strip_injected_cells` removes it before
+    the notebook reaches HTML / the execution cache.
+    """
+    from nbformat.v4 import new_code_cell
+
+    source = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag=tag)
+    cell = new_code_cell(
+        source=source,
+        metadata={
+            "tags": ["del"],
+            "clm_injected": _HTTP_REPLAY_BOOTSTRAP_MARKER,
+        },
+    )
+    nb["cells"].insert(0, cell)
+
+
 def _inject_http_replay_bootstrap(
     nb: NotebookNode,
     cassette_path: str,
@@ -1983,6 +2038,38 @@ class NotebookProcessor:
         paths: CassettePaths = resolve_paths(target_dir, cassette_name)
         return paths
 
+    def _resolve_mitmproxy_tag(
+        self, payload: NotebookPayload, source_dir: Path | None
+    ) -> str | None:
+        """Resolve the ``X-CLM-Cassette`` routing tag for the mitmproxy transport.
+
+        The tag is the absolute canonical cassette path this notebook's
+        traffic belongs to. It is resolved exactly like the vcrpy path's
+        :meth:`_resolve_cassette_paths` (same ``payload.http_replay_cassette_name``
+        — which already carries the split-deck base-cassette fallback for
+        ``replay`` and the strict language-specific name for record modes,
+        issue #159 — and the same ``resolve_paths`` canonical computation),
+        so the proxy's per-target staging file lands beside the very
+        cassette the host-side merge will fold it into. Returns ``None``
+        when the topic did not opt into a replay-capable mode or no
+        cassette / writable target dir resolves.
+        """
+        mode = payload.http_replay_mode
+        if not mode or mode == "disabled" or mode not in _HTTP_REPLAY_MODE_TO_VCR_MODE:
+            return None
+        cassette_name = payload.http_replay_cassette_name
+        if not cassette_name:
+            return None
+        if source_dir is not None:
+            target_dir: Path = source_dir
+        elif payload.source_topic_dir:
+            target_dir = Path(payload.source_topic_dir)
+        else:
+            return None
+        from .http_replay_cassette import resolve_paths
+
+        return str(resolve_paths(target_dir, cassette_name).canonical)
+
     def _persist_recorded_cassette(
         self,
         cid: str,
@@ -2061,13 +2148,32 @@ class NotebookProcessor:
         processed_nb: NotebookNode,
         payload: NotebookPayload,
         paths: "CassettePaths | None",
+        source_dir: Path | None = None,
     ) -> bool:
-        """Inject the vcrpy bootstrap cell when the topic opted into replay.
+        """Inject the http-replay bootstrap cell when the topic opted in.
 
-        ``paths`` is the resolved canonical/staging pair from
-        :meth:`_resolve_cassette_paths`. Returns ``True`` when a cell was
-        injected so the caller can decide whether to run the strip pass.
+        Under the out-of-process transport (``CLM_HTTP_REPLAY_TRANSPORT=
+        mitmproxy``) this injects the lightweight cassette-routing *tag*
+        bootstrap (which patches httpx to tag each request with its
+        destination cassette so the shared proxy demuxes correctly); the
+        kernel's httpcore is never patched. Otherwise it injects the
+        in-kernel vcrpy bootstrap using ``paths`` (the resolved
+        canonical/staging pair from :meth:`_resolve_cassette_paths`).
+        Returns ``True`` when a cell was injected so the caller runs the
+        strip pass.
         """
+        if os.environ.get("CLM_HTTP_REPLAY_TRANSPORT") == "mitmproxy":
+            tag = self._resolve_mitmproxy_tag(payload, source_dir)
+            if tag is None:
+                return False
+            _inject_http_replay_tag_bootstrap(processed_nb, tag)
+            logger.debug(
+                f"{payload.correlation_id}: Injected http-replay tag bootstrap "
+                f"(mitmproxy transport, cassette='{tag}') for "
+                f"'{payload.input_file_name}'"
+            )
+            return True
+
         if paths is None:
             return False
         mode = payload.http_replay_mode
@@ -2137,7 +2243,7 @@ class NotebookProcessor:
 
                     seed_staging_from_canonical(cassette_paths)
                 replay_injected = self._maybe_inject_http_replay(
-                    processed_nb, payload, cassette_paths
+                    processed_nb, payload, cassette_paths, source_dir
                 )
                 execution_succeeded = False
                 try:

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -136,6 +136,11 @@ except ValueError:
 # LLM/RAG decks that use replay finish in seconds, so only a genuine hang reaches
 # this ceiling. An explicit CLM_CELL_TIMEOUT_SECONDS always wins; set
 # CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS=0 to opt out of the default.
+#
+# Under the out-of-process mitmproxy transport (issue #165) this same ceiling is
+# the backstop for a strict-replay miss: the addon returns HTTP 599, which the
+# SDK retries as a 5xx (bounded by its max_retries) before raising — this timeout
+# guarantees the cell fails even if a future SDK has an unbounded retry policy.
 try:
     _raw_replay_cell_timeout = float(os.environ.get("CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS", "600"))
     _HTTP_REPLAY_DEFAULT_CELL_TIMEOUT: int | None = (
@@ -181,6 +186,23 @@ _HTTP_REPLAY_BOOTSTRAP_MARKER = "http_replay"
 # we encounter other telemetry endpoints with the same shape, or override
 # at build time via ``CLM_HTTP_REPLAY_IGNORE_HOSTS`` (comma-separated).
 _DEFAULT_HTTP_REPLAY_IGNORE_HOSTS = ("api.smith.langchain.com",)
+
+
+def resolve_http_replay_ignore_hosts() -> tuple[str, ...]:
+    """Resolve the http-replay ignore-hosts list from the environment.
+
+    Unset ``CLM_HTTP_REPLAY_IGNORE_HOSTS`` → the default
+    (:data:`_DEFAULT_HTTP_REPLAY_IGNORE_HOSTS`); set (even to the empty string)
+    → the comma-separated override, where an empty string means "record every
+    host". Shared by the in-kernel vcrpy bootstrap injection and the
+    out-of-process mitmproxy transport (build.py) so both honour the same
+    telemetry-suppression policy.
+    """
+    raw = os.environ.get("CLM_HTTP_REPLAY_IGNORE_HOSTS")
+    if raw is None:
+        return _DEFAULT_HTTP_REPLAY_IGNORE_HOSTS
+    return tuple(host.strip() for host in raw.split(",") if host.strip())
+
 
 _HTTP_REPLAY_BOOTSTRAP_TEMPLATE = """\
 # CLM HTTP REPLAY BOOTSTRAP - DO NOT EDIT
@@ -2124,7 +2146,10 @@ class NotebookProcessor:
             )
 
         try:
-            merged = merge_staging_into_canonical(paths)
+            # ``refresh`` (vcrpy ``all``) re-records every interaction, so a
+            # freshly recorded response must supersede the stale canonical entry
+            # rather than being dropped by first-seen dedup (issue #165 P3).
+            merged = merge_staging_into_canonical(paths, overwrite_existing=(mode == "refresh"))
         except Exception as exc:  # noqa: BLE001 — defensive: never let merge mask
             #  the original notebook execution error.
             logger.exception(
@@ -2191,14 +2216,7 @@ class NotebookProcessor:
             trace_max_body = int(trace_max_body_raw) if trace_max_body_raw else 2048
         except ValueError:
             trace_max_body = 2048
-        ignore_hosts_raw = os.environ.get("CLM_HTTP_REPLAY_IGNORE_HOSTS")
-        ignore_hosts: tuple[str, ...]
-        if ignore_hosts_raw is None:
-            ignore_hosts = _DEFAULT_HTTP_REPLAY_IGNORE_HOSTS
-        else:
-            ignore_hosts = tuple(
-                host.strip() for host in ignore_hosts_raw.split(",") if host.strip()
-            )
+        ignore_hosts = resolve_http_replay_ignore_hosts()
         _inject_http_replay_bootstrap(
             processed_nb,
             str(paths.staging),

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -755,17 +755,103 @@ if not getattr(_clm_httpx.AsyncClient.send, "_clm_tagged", False):
 """
 
 
-def _inject_http_replay_tag_bootstrap(nb: NotebookNode, tag: str) -> None:
+# Socket-only forensic trace for the mitmproxy transport (issue #165 P5).
+# Appended to the tag bootstrap when CLM_HTTP_REPLAY_TRACE=1. Under the
+# transport the kernel never imports vcr or patches httpcore, so the heavy
+# ``_HTTP_REPLAY_TRACE_TEMPLATE`` (which wraps vcr internals and references
+# ``_clm_vcr_patch``/``_clm_cassette``/``_clm_json``/``_clm_atexit`` from the
+# vcrpy bootstrap) cannot run here. This template is fully self-contained — it
+# imports its own json/atexit and only installs the ``socket.connect`` audit
+# hook (Stream 1, the ground truth). The proxy-side ``proxy`` stream
+# (Stream 2′, written by the addon) supplies the interception evidence the
+# now-dark ``vcr`` stream used to. It writes the SAME ``worker-<pid>.jsonl``
+# file the vcr trace uses (only one of the two ever runs per kernel) so
+# ``analyze_http_replay_trace.py`` reads it identically. No literal ``{}`` in
+# the body except the doubled ``{{}}`` so ``str.format`` only fills ``{trace_dir!r}``.
+_HTTP_REPLAY_SOCKET_TRACE_TEMPLATE = """\
+# CLM HTTP REPLAY SOCKET TRACE - DO NOT EDIT
+_clm_strace_dir = {trace_dir!r}
+if _clm_strace_dir:
+    import atexit as _clm_st_atexit
+    import json as _clm_st_json
+    import os as _clm_st_os
+    import socket as _clm_st_socket  # noqa: F401
+    import sys as _clm_st_sys
+    import threading as _clm_st_threading
+    import time as _clm_st_time
+    from datetime import datetime as _clm_st_datetime, timezone as _clm_st_timezone
+
+    _clm_st_os.makedirs(_clm_strace_dir, exist_ok=True)
+    _clm_strace_path = _clm_st_os.path.join(
+        _clm_strace_dir, "worker-" + str(_clm_st_os.getpid()) + ".jsonl"
+    )
+    _clm_strace_fh = open(_clm_strace_path, "a", encoding="utf-8", newline="\\n")
+    _clm_strace_lock = _clm_st_threading.Lock()
+    _clm_strace_start = _clm_st_time.monotonic()
+
+    def _clm_strace_emit(stream, event, data=None):
+        try:
+            record = {{
+                "ts_mono": _clm_st_time.monotonic() - _clm_strace_start,
+                "ts_wall": _clm_st_datetime.now(_clm_st_timezone.utc).isoformat(),
+                "pid": _clm_st_os.getpid(),
+                "tid": _clm_st_threading.get_ident(),
+                "stream": stream,
+                "event": event,
+                "data": data or {{}},
+            }}
+            line = _clm_st_json.dumps(record) + "\\n"
+            with _clm_strace_lock:
+                _clm_strace_fh.write(line)
+                _clm_strace_fh.flush()
+        except Exception:
+            pass
+
+    def _clm_saudit_hook(event, args):
+        try:
+            if event == "socket.connect" and len(args) >= 2:
+                address = args[1]
+                if isinstance(address, tuple) and len(address) >= 2:
+                    host, port = address[0], address[1]
+                else:
+                    host, port = repr(address), None
+                _clm_strace_emit("socket", "connect", {{"host": host, "port": port}})
+        except Exception:
+            pass
+
+    _clm_st_sys.addaudithook(_clm_saudit_hook)
+    _clm_strace_emit("socket", "bootstrap.complete", {{"transport": "mitmproxy"}})
+
+    def _clm_strace_close():
+        try:
+            _clm_strace_fh.flush()
+            _clm_strace_fh.close()
+        except Exception:
+            pass
+
+    _clm_st_atexit.register(_clm_strace_close)
+"""
+
+
+def _inject_http_replay_tag_bootstrap(nb: NotebookNode, tag: str, *, trace_dir: str = "") -> None:
     """Prepend the mitmproxy cassette-routing tag cell to ``nb``.
 
     ``tag`` is the absolute canonical cassette path the host-side merge
     will fold into. The cell carries the same ``clm_injected`` marker as
     the vcrpy bootstrap so :func:`_strip_injected_cells` removes it before
     the notebook reaches HTML / the execution cache.
+
+    When ``trace_dir`` is non-empty (CLM_HTTP_REPLAY_TRACE=1), the
+    self-contained socket-only forensic trace is appended so the kernel emits
+    the ``socket`` ground-truth stream to ``<trace_dir>/worker-<pid>.jsonl``
+    (issue #165 P5). Empty string (the common case) leaves the cell as just
+    the tag bootstrap.
     """
     from nbformat.v4 import new_code_cell
 
     source = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag=tag)
+    if trace_dir:
+        source += "\n" + _HTTP_REPLAY_SOCKET_TRACE_TEMPLATE.format(trace_dir=trace_dir)
     cell = new_code_cell(
         source=source,
         metadata={
@@ -2215,7 +2301,18 @@ class NotebookProcessor:
             tag = self._resolve_mitmproxy_tag(payload, source_dir)
             if tag is None:
                 return False
-            _inject_http_replay_tag_bootstrap(processed_nb, tag)
+            # Forensic socket trace (issue #165 P5): the kernel emits its
+            # ground-truth ``socket`` stream so the analyzer can confirm every
+            # connect goes to the proxy (none escapes). Prefer the payload field
+            # (same source the vcrpy path uses); fall back to the host-pinned env
+            # the Direct worker inherits, so the socket stream is reliably written
+            # whenever CLM_HTTP_REPLAY_TRACE=1 even if the field was not threaded.
+            trace_dir = (
+                getattr(payload, "http_replay_trace_dir", "")
+                or os.environ.get("CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR", "")
+                or ""
+            )
+            _inject_http_replay_tag_bootstrap(processed_nb, tag, trace_dir=trace_dir)
             logger.debug(
                 f"{payload.correlation_id}: Injected http-replay tag bootstrap "
                 f"(mitmproxy transport, cassette='{tag}') for "

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1941,6 +1941,15 @@ class NotebookProcessor:
         this directory; the host code merges staging into canonical via
         the same view of the filesystem.
         """
+        if os.environ.get("CLM_HTTP_REPLAY_TRANSPORT") == "mitmproxy":
+            # Out-of-process transport (issue #165): the mitmproxy proxy records
+            # and replays at the network layer, so the kernel needs no vcrpy
+            # bootstrap, no per-worker staging file, and no canonical merge.
+            # Returning None makes the seed / inject / merge calls all no-op, and
+            # the kernel's real httpx/httpcore is never patched (the structural
+            # fix for the issue #143 connection-pool deadlock).
+            return None
+
         from .http_replay_cassette import CassettePaths, resolve_paths
 
         mode = payload.http_replay_mode

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -137,10 +137,12 @@ except ValueError:
 # this ceiling. An explicit CLM_CELL_TIMEOUT_SECONDS always wins; set
 # CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS=0 to opt out of the default.
 #
-# Under the out-of-process mitmproxy transport (issue #165) this same ceiling is
-# the backstop for a strict-replay miss: the addon returns HTTP 599, which the
-# SDK retries as a 5xx (bounded by its max_retries) before raising — this timeout
-# guarantees the cell fails even if a future SDK has an unbounded retry policy.
+# Under the out-of-process mitmproxy transport (issue #165) a strict-replay miss
+# is engineered to fail FAST on its own: the addon returns a non-retryable 4xx
+# (404), so the SDK raises on the first attempt rather than retrying it as a 5xx
+# (an earlier 599 was retried, amplifying a miss across a deck's ``.batch()``
+# calls until this ceiling fired — measured at ~1200s). This timeout now only
+# backstops a genuine unexpected hang, not the expected miss path.
 try:
     _raw_replay_cell_timeout = float(os.environ.get("CLM_HTTP_REPLAY_CELL_TIMEOUT_SECONDS", "600"))
     _HTTP_REPLAY_DEFAULT_CELL_TIMEOUT: int | None = (

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1675,3 +1675,123 @@ class TestMaybeStartMitmproxyTransport:
         monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
         result = build_module._maybe_start_mitmproxy_transport("disabled", tmp_path / "jobs.db")
         assert result is None
+
+
+def _fake_worker_config(specs):
+    """Stand-in for WorkersManagementConfig.get_all_worker_configs().
+
+    ``specs`` is a list of ``(worker_type, execution_mode, count)`` tuples.
+    """
+    cfgs = [SimpleNamespace(worker_type=wt, execution_mode=m, count=c) for (wt, m, c) in specs]
+    return SimpleNamespace(get_all_worker_configs=lambda: cfgs)
+
+
+class TestBuildHasDockerNotebookWorker:
+    """Detecting whether a build will start a Docker *notebook* worker (the only
+    worker using the replay proxy) — decides the wildcard bind (issue #165 P4)."""
+
+    def test_none_config_is_direct_only(self) -> None:
+        assert build_module._build_has_docker_notebook_worker(None) is False
+
+    def test_all_direct_is_false(self) -> None:
+        wc = _fake_worker_config(
+            [("notebook", "direct", 4), ("plantuml", "direct", 1), ("drawio", "direct", 1)]
+        )
+        assert build_module._build_has_docker_notebook_worker(wc) is False
+
+    def test_docker_notebook_is_true(self) -> None:
+        wc = _fake_worker_config([("notebook", "docker", 2), ("plantuml", "direct", 1)])
+        assert build_module._build_has_docker_notebook_worker(wc) is True
+
+    def test_docker_only_for_non_notebook_is_false(self) -> None:
+        # Diagram converters never use the replay proxy, so a docker plantuml/
+        # drawio worker must NOT trigger the wider 0.0.0.0 bind.
+        wc = _fake_worker_config(
+            [("notebook", "direct", 4), ("plantuml", "docker", 1), ("drawio", "docker", 1)]
+        )
+        assert build_module._build_has_docker_notebook_worker(wc) is False
+
+    def test_docker_notebook_with_zero_count_is_false(self) -> None:
+        wc = _fake_worker_config([("notebook", "docker", 0), ("plantuml", "direct", 1)])
+        assert build_module._build_has_docker_notebook_worker(wc) is False
+
+    def test_resolution_error_is_treated_as_direct_only(self) -> None:
+        def _boom():
+            raise RuntimeError("cannot resolve")
+
+        wc = SimpleNamespace(get_all_worker_configs=_boom)
+        assert build_module._build_has_docker_notebook_worker(wc) is False
+
+
+class _FakeMitmManager:
+    """Records the listen_host kwarg and emulates just enough of the real
+    manager for ``_maybe_start_mitmproxy_transport`` (no real mitmdump)."""
+
+    last_listen_host: str | None = None
+
+    def __init__(self, *, cassette_path, mode, listen_host, confdir, ignore_hosts):
+        _FakeMitmManager.last_listen_host = listen_host
+        self._confdir = Path(confdir)
+        self.build_id = "fakebuild"
+
+    def start(self):
+        self._confdir.mkdir(parents=True, exist_ok=True)
+        self.ca_cert_path.write_bytes(b"-----BEGIN CERTIFICATE-----\nfake\n")
+
+    @property
+    def ca_cert_path(self) -> Path:
+        return self._confdir / "mitmproxy-ca-cert.pem"
+
+    @property
+    def proxy_url(self) -> str:
+        return "http://127.0.0.1:9999"
+
+    def stop(self):
+        pass
+
+
+class TestMitmproxyTransportBindHost:
+    """The proxy binds 0.0.0.0 only when Docker workers must reach it via
+    host.docker.internal; Direct-only builds keep the loopback bind (#165 P4)."""
+
+    def _run(self, monkeypatch, tmp_path, worker_config):
+        import os
+
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+        monkeypatch.setattr(
+            "clm.infrastructure.http_replay_mitm.MitmproxyManager", _FakeMitmManager
+        )
+        _FakeMitmManager.last_listen_host = None
+        saved = dict(os.environ)
+        try:
+            mgr = build_module._maybe_start_mitmproxy_transport(
+                "replay", tmp_path / "jobs.db", worker_config=worker_config
+            )
+            assert mgr is not None
+            return _FakeMitmManager.last_listen_host, dict(os.environ)
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+
+    def test_binds_wildcard_for_docker_notebook(self, monkeypatch, tmp_path) -> None:
+        wc = _fake_worker_config([("notebook", "docker", 1)])
+        listen_host, env = self._run(monkeypatch, tmp_path, wc)
+        assert listen_host == "0.0.0.0"
+        # The exported proxy URL stays loopback for Direct workers / the poll.
+        assert env["HTTP_PROXY"] == "http://127.0.0.1:9999"
+
+    def test_binds_loopback_for_direct(self, monkeypatch, tmp_path) -> None:
+        wc = _fake_worker_config([("notebook", "direct", 4)])
+        listen_host, _ = self._run(monkeypatch, tmp_path, wc)
+        assert listen_host == "127.0.0.1"
+
+    def test_binds_loopback_for_diagram_only_docker(self, monkeypatch, tmp_path) -> None:
+        # Docker plantuml/drawio but Direct notebook: no proxy user in a
+        # container, so keep the loopback bind (no LAN exposure).
+        wc = _fake_worker_config([("notebook", "direct", 4), ("drawio", "docker", 1)])
+        listen_host, _ = self._run(monkeypatch, tmp_path, wc)
+        assert listen_host == "127.0.0.1"
+
+    def test_binds_loopback_when_no_worker_config(self, monkeypatch, tmp_path) -> None:
+        listen_host, _ = self._run(monkeypatch, tmp_path, None)
+        assert listen_host == "127.0.0.1"

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1653,3 +1653,25 @@ class TestProcessCourseInvokesCassetteSweep:
             "was removed or moved out of the build entry path — restore "
             "it or the orphan cleanup stops happening during normal builds."
         )
+
+
+class TestMaybeStartMitmproxyTransport:
+    """The experimental mitmproxy transport (issue #165) must be a strict no-op
+    unless explicitly opted in, so existing builds are never affected."""
+
+    def test_returns_none_when_transport_not_opted_in(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.delenv("CLM_HTTP_REPLAY_TRANSPORT", raising=False)
+        # Returns before locating mitmdump, so no external dependency needed.
+        result = build_module._maybe_start_mitmproxy_transport("replay", tmp_path / "jobs.db")
+        assert result is None
+
+    def test_returns_none_when_other_transport_value(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "vcrpy")
+        result = build_module._maybe_start_mitmproxy_transport("replay", tmp_path / "jobs.db")
+        assert result is None
+
+    def test_returns_none_when_mode_disabled(self, monkeypatch, tmp_path) -> None:
+        # Even opted in, a disabled replay mode means no proxy is needed.
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+        result = build_module._maybe_start_mitmproxy_transport("disabled", tmp_path / "jobs.db")
+        assert result is None

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1728,9 +1728,11 @@ class _FakeMitmManager:
     manager for ``_maybe_start_mitmproxy_transport`` (no real mitmdump)."""
 
     last_listen_host: str | None = None
+    last_trace_dir: object = None
 
-    def __init__(self, *, cassette_path, mode, listen_host, confdir, ignore_hosts):
+    def __init__(self, *, cassette_path, mode, listen_host, confdir, ignore_hosts, trace_dir=None):
         _FakeMitmManager.last_listen_host = listen_host
+        _FakeMitmManager.last_trace_dir = trace_dir
         self._confdir = Path(confdir)
         self.build_id = "fakebuild"
 
@@ -1795,3 +1797,16 @@ class TestMitmproxyTransportBindHost:
     def test_binds_loopback_when_no_worker_config(self, monkeypatch, tmp_path) -> None:
         listen_host, _ = self._run(monkeypatch, tmp_path, None)
         assert listen_host == "127.0.0.1"
+
+    def test_forwards_trace_dir_from_invocation_env(self, monkeypatch, tmp_path) -> None:
+        # When CLM_HTTP_REPLAY_TRACE pinned an invocation dir, the transport
+        # forwards it to the manager so the addon can write the proxy stream
+        # (issue #165 P5). Unset -> None.
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR", str(tmp_path / "trace-inv"))
+        self._run(monkeypatch, tmp_path, None)
+        assert _FakeMitmManager.last_trace_dir == Path(tmp_path / "trace-inv")
+
+    def test_no_trace_dir_when_invocation_env_unset(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.delenv("CLM_HTTP_REPLAY_TRACE_INVOCATION_DIR", raising=False)
+        self._run(monkeypatch, tmp_path, None)
+        assert _FakeMitmManager.last_trace_dir is None

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -877,6 +877,65 @@ def test_sweep_orphan_staging_files_no_orphans_present(tmp_path):
     assert swept == 0
 
 
+def test_merge_mitmproxy_cassette_staging_folds_markered_leaves_markerless(tmp_path):
+    """Post-build mitmproxy merge folds markered staging, leaves markerless.
+
+    The out-of-process transport (issue #165 P2) writes per-cassette
+    ``*.staging-mitm-*`` files beside each canonical with a ``.completed``
+    marker on clean shutdown. ``Course.merge_mitmproxy_cassette_staging``
+    folds the markered ones (build finished cleanly) and leaves markerless
+    ones (mitmdump force-killed) for the next pre-build sweep to discard —
+    the same partial-recording protection the vcrpy workers get.
+    """
+    pytest.importorskip("vcr")
+    pytest.importorskip("filelock")
+
+    topic_dir = _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    canonical = topic_dir / "slides_intro.http-cassette.yaml"
+    markered = topic_dir / "slides_intro.http-cassette.yaml.staging-mitm-buildA"
+    markerless = topic_dir / "slides_intro.http-cassette.yaml.staging-mitm-buildB"
+    _write_orphan_cassette(markered, uri="http://example/recorded", body="R1")
+    _write_orphan_cassette(markerless, uri="http://example/partial", body="P1")
+    (markered.parent / f"{markered.name}.completed").write_text("{}\n", encoding="utf-8")
+
+    sections_xml = """
+    <sections>
+      <section http-replay="yes">
+        <name><de>S</de><en>S</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+
+    folded = course.merge_mitmproxy_cassette_staging()
+
+    assert folded == 1
+    assert canonical.exists()
+    content = canonical.read_text(encoding="utf-8")
+    assert "http://example/recorded" in content  # markered folded
+    assert "http://example/partial" not in content  # markerless NOT folded
+    assert not markered.exists()  # consumed + marker deleted
+    assert markerless.exists()  # left for the next pre-build sweep
+    # Canonical cassette is written with LF endings (no CRLF flapping).
+    assert b"\r\n" not in canonical.read_bytes()
+
+
+def test_merge_mitmproxy_cassette_staging_no_replay_topics(tmp_path):
+    """No http-replay topics → merge is a no-op and never imports vcr/filelock."""
+    _make_topic_dir(tmp_path, "module_100_live", "topic_010_intro")
+    sections_xml = """
+    <sections>
+      <section>
+        <name><de>S</de><en>S</en></name>
+        <topics><topic>intro</topic></topics>
+      </section>
+    </sections>
+    """
+    course = _build_course(tmp_path, sections_xml)
+    assert course.merge_mitmproxy_cassette_staging() == 0
+
+
 # ---------------------------------------------------------------------------
 # output_root re-roots spec ``<output-targets>``
 #

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -84,7 +84,7 @@ def upstream_server() -> Iterator[str]:
 
 @pytest.fixture
 def cassette_path(tmp_path: Path) -> Path:
-    return tmp_path / "smoke.mitm"
+    return tmp_path / "smoke.http-cassette.yaml"
 
 
 def _get_via_proxy(url: str, proxy_url: str) -> requests.Response:

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -7,8 +7,8 @@ local HTTP server, validating:
   upstream (record mode);
 * responses are persisted to the cassette and served from it on a
   subsequent run (replay mode);
-* strict ``replay`` mode returns a deterministic 599 on cache miss
-  instead of escaping to the network.
+* strict ``replay`` mode returns a deterministic non-retryable 404 on cache
+  miss instead of escaping to the network.
 
 mitmproxy runs out-of-process (settled production model: ``uv tool install
 mitmproxy``), so it is NOT imported in-process here — these tests only need
@@ -201,11 +201,14 @@ def test_replay_serves_from_cassette_without_upstream_hit(
     assert _CountingHandler.upstream_hits == 1, "replay-mode request should not reach upstream"
 
 
-def test_strict_replay_miss_returns_599(
+def test_strict_replay_miss_returns_nonretryable_404(
     upstream_server: str, cassette_path: Path, tmp_path: Path
 ) -> None:
-    """A request not in the cassette returns the addon's diagnostic 599
-    rather than escaping to upstream."""
+    """A request not in the cassette returns the addon's diagnostic miss
+    response — a NON-RETRYABLE 404 (issue #165 P3) so the kernel's LLM SDK
+    raises on the first attempt instead of retrying it as a 5xx (the old 599
+    was retried, amplifying a miss across a deck's batched calls into a build
+    timeout). The upstream counter must NOT advance."""
     confdir = tmp_path / "mitm-confdir"
 
     # Seed the cassette with one URL.
@@ -215,15 +218,17 @@ def test_strict_replay_miss_returns_599(
         _get_via_proxy(f"{upstream_server}/recorded", proxy.proxy_url)
     assert _CountingHandler.upstream_hits == 1
 
-    # Now request a DIFFERENT URL in strict replay mode. The addon
-    # should synthesize a 599 and the upstream counter should NOT
-    # advance.
+    # Now request a DIFFERENT URL in strict replay mode. The addon should
+    # synthesize the diagnostic miss and the upstream counter must NOT advance.
     with MitmproxyManager(cassette_path=cassette_path, mode="replay", confdir=confdir) as proxy:
         response = _get_via_proxy(f"{upstream_server}/never-recorded", proxy.proxy_url)
 
-    assert response.status_code == 599
+    assert response.status_code == 404, "miss must be a non-retryable 4xx, not a retryable 5xx"
     payload = response.json()
-    assert payload["error"] == "clm_replay_miss"
+    assert payload["clm_replay_miss"] is True
+    # SDK-friendly error envelope so the kernel surfaces a clean NotFoundError.
+    assert payload["error"]["type"] == "clm_replay_miss"
+    assert "clm_replay_miss" in payload["error"]["message"]
     assert payload["method"] == "GET"
     assert payload["url"].endswith("/never-recorded")
     assert _CountingHandler.upstream_hits == 1, (
@@ -394,7 +399,7 @@ def test_json_post_replays_with_semantically_equal_body(
 ) -> None:
     """P3 JSON-match parity: a JSON POST replay-hits even when the live body
     differs from the recorded one only by key order / separators — a byte-exact
-    key would spuriously 599-miss every real LLM POST."""
+    key would spuriously miss every real LLM POST."""
     confdir = tmp_path / "mitm-confdir"
     cass = tmp_path / "topicJ" / "_cassettes" / "slidesJ.http-cassette.yaml"
     target = f"{upstream_server}/chat"

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -244,6 +244,31 @@ def test_routing_demuxes_tagged_requests_to_per_cassette_staging(
     assert not staging_a[0].exists()  # folded + consumed
 
 
+def test_once_mode_starts_without_existing_catchall(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """Regression (issue #165): ``once`` must not abort the proxy when the
+    catch-all cassette does not exist.
+
+    Under P2 the ``clm_cassette_path`` catch-all is created empty on every
+    fresh build, so the old Phase-0 ``once`` existence guard wrongly shut the
+    proxy down at startup (``MitmproxyError: Mode 'once' requires an existing
+    cassette``). Per-target routing means the real cassettes are the tagged
+    canonicals, not the catch-all.
+    """
+    confdir = tmp_path / "mitm-confdir"
+    cass = tmp_path / "topicO" / "_cassettes" / "slidesO.http-cassette.yaml"
+    assert not cassette_path.exists()  # fresh scratch catch-all
+
+    # Previously raised MitmproxyError during startup; must now start cleanly.
+    with MitmproxyManager(cassette_path=cassette_path, mode="once", confdir=confdir) as proxy:
+        response = _get_via_proxy(f"{upstream_server}/once", proxy.proxy_url, tag=str(cass))
+
+    assert response.status_code == 200
+    # A miss in once mode records into the tagged per-cassette staging file.
+    assert _staging_files(cass), "once should record a miss into per-cassette staging"
+
+
 def test_env_vars_exposes_proxy_url(cassette_path: Path, tmp_path: Path) -> None:
     """The env_vars dict has the four HTTP_PROXY variants workers need."""
     confdir = tmp_path / "mitm-confdir"

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -52,15 +52,39 @@ class _CountingHandler(BaseHTTPRequestHandler):
     """
 
     upstream_hits = 0
+    # Records the (method, path, headers) the upstream actually saw — used by
+    # tests that need to assert what reached the network (e.g. the routing tag
+    # was stripped before forwarding upstream).
+    last_seen: dict | None = None
 
-    def do_GET(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
-        type(self).upstream_hits += 1
-        body = json.dumps({"path": self.path, "hit": type(self).upstream_hits}).encode()
+    def _respond(self, payload: dict) -> None:
+        body = json.dumps(payload).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
+        type(self).upstream_hits += 1
+        type(self).last_seen = {"method": "GET", "path": self.path, "headers": dict(self.headers)}
+        # Echo only the path without the query string: a real API never reflects
+        # your api_key/token query params back into its response body (and
+        # responses are not secret-filtered), so reflecting them here would be
+        # an unrealistic test-only secret leak.
+        self._respond({"path": self.path.split("?", 1)[0], "hit": type(self).upstream_hits})
+
+    def do_POST(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
+        type(self).upstream_hits += 1
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        type(self).last_seen = {
+            "method": "POST",
+            "path": self.path,
+            "headers": dict(self.headers),
+            "body": raw.decode("utf-8", errors="replace"),
+        }
+        self._respond({"path": self.path.split("?", 1)[0], "hit": type(self).upstream_hits})
 
     def log_message(self, *_args, **_kwargs) -> None:  # silence stderr noise
         return
@@ -70,6 +94,7 @@ class _CountingHandler(BaseHTTPRequestHandler):
 def upstream_server() -> Iterator[str]:
     """Run a localhost HTTP server in a thread for the duration of one test."""
     _CountingHandler.upstream_hits = 0
+    _CountingHandler.last_seen = None
     server = HTTPServer(("127.0.0.1", 0), _CountingHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -87,15 +112,40 @@ def cassette_path(tmp_path: Path) -> Path:
     return tmp_path / "smoke.http-cassette.yaml"
 
 
-def _get_via_proxy(url: str, proxy_url: str, tag: str | None = None) -> requests.Response:
-    headers = {"X-CLM-Cassette": tag} if tag is not None else None
+def _get_via_proxy(
+    url: str,
+    proxy_url: str,
+    tag: str | None = None,
+    extra_headers: dict | None = None,
+) -> requests.Response:
+    headers = dict(extra_headers or {})
+    if tag is not None:
+        headers["X-CLM-Cassette"] = tag
     return requests.get(
         url,
-        headers=headers,
+        headers=headers or None,
         proxies={"http": proxy_url, "https": proxy_url},
         # mitmproxy intercepts HTTP cleanly; HTTPS would need CA trust
         # set up. The smoke test stays on HTTP for simplicity — see the
         # design doc for the HTTPS story.
+        timeout=10.0,
+    )
+
+
+def _post_json_via_proxy(
+    url: str,
+    proxy_url: str,
+    body: bytes,
+    tag: str | None = None,
+) -> requests.Response:
+    headers = {"Content-Type": "application/json"}
+    if tag is not None:
+        headers["X-CLM-Cassette"] = tag
+    return requests.post(
+        url,
+        data=body,
+        headers=headers,
+        proxies={"http": proxy_url, "https": proxy_url},
         timeout=10.0,
     )
 
@@ -267,6 +317,137 @@ def test_once_mode_starts_without_existing_catchall(
     assert response.status_code == 200
     # A miss in once mode records into the tagged per-cassette staging file.
     assert _staging_files(cass), "once should record a miss into per-cassette staging"
+
+
+def _fold_staging_to_canonical(canonical: Path, staging: Path) -> None:
+    """Drive the real host marker+merge so the recorded staging lands in the
+    canonical cassette (what a subsequent replay-mode proxy loads from)."""
+    from clm.workers.notebook.http_replay_cassette import (
+        CassettePaths,
+        merge_staging_into_canonical,
+        write_completion_marker,
+    )
+
+    paths = CassettePaths(canonical=canonical, staging=staging)
+    write_completion_marker(paths)
+    merge_staging_into_canonical(paths)
+
+
+def test_secret_request_headers_and_params_stripped_from_recording(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """P3 secret hygiene: ``authorization``/``x-api-key`` headers and
+    ``api_key``/``token`` query params never reach the recorded cassette."""
+    confdir = tmp_path / "mitm-confdir"
+    cass = tmp_path / "topicS" / "_cassettes" / "slidesS.http-cassette.yaml"
+
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        resp = _get_via_proxy(
+            f"{upstream_server}/secret?api_key=SHHH&token=TTT&keep=1",
+            proxy.proxy_url,
+            tag=str(cass),
+            extra_headers={"Authorization": "Bearer SUPERSECRET", "X-API-Key": "KKK"},
+        )
+    assert resp.status_code == 200
+
+    staging = _staging_files(cass)
+    assert len(staging) == 1, staging
+    text = staging[0].read_text(encoding="utf-8")
+    # Secret-bearing headers / params must be absent; the cassette is committed.
+    assert "SUPERSECRET" not in text
+    assert "authorization" not in text.lower()
+    assert "x-api-key" not in text.lower()
+    assert "api_key" not in text and "SHHH" not in text
+    assert "token" not in text and "TTT" not in text
+    # The non-secret query param survives (the request is still recorded).
+    assert "keep=1" in text
+
+
+def test_ignore_hosts_forwarded_but_not_recorded(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """P3 telemetry hygiene: an ignore_hosts host is forwarded upstream but
+    never recorded (the LangSmith case, exercised here against localhost)."""
+    confdir = tmp_path / "mitm-confdir"
+    cass = tmp_path / "topicI" / "_cassettes" / "slidesI.http-cassette.yaml"
+
+    with MitmproxyManager(
+        cassette_path=cassette_path,
+        mode="new-episodes",
+        confdir=confdir,
+        ignore_hosts=("127.0.0.1",),
+    ) as proxy:
+        resp = _get_via_proxy(f"{upstream_server}/telemetry", proxy.proxy_url, tag=str(cass))
+
+    assert resp.status_code == 200  # forwarded to upstream
+    assert _CountingHandler.upstream_hits == 1  # reached the network
+    assert not _staging_files(cass)  # but nothing recorded
+    # Nor did it land in the catch-all.
+    if cassette_path.exists():
+        assert "/telemetry" not in cassette_path.read_text(encoding="utf-8")
+
+
+def test_json_post_replays_with_semantically_equal_body(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """P3 JSON-match parity: a JSON POST replay-hits even when the live body
+    differs from the recorded one only by key order / separators — a byte-exact
+    key would spuriously 599-miss every real LLM POST."""
+    confdir = tmp_path / "mitm-confdir"
+    cass = tmp_path / "topicJ" / "_cassettes" / "slidesJ.http-cassette.yaml"
+    target = f"{upstream_server}/chat"
+
+    # 1. Record a JSON POST.
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        _post_json_via_proxy(target, proxy.proxy_url, b'{"model":"x","n":1}', tag=str(cass))
+    assert _CountingHandler.upstream_hits == 1
+    staging = _staging_files(cass)
+    assert len(staging) == 1
+    _fold_staging_to_canonical(cass, staging[0])
+
+    # 2. Replay with a semantically-identical but textually-different body.
+    with MitmproxyManager(cassette_path=cassette_path, mode="replay", confdir=confdir) as proxy:
+        replayed = _post_json_via_proxy(
+            target, proxy.proxy_url, b'{"n": 1, "model": "x"}', tag=str(cass)
+        )
+    assert replayed.status_code == 200, replayed.text
+    assert _CountingHandler.upstream_hits == 1, "JSON POST must replay-hit, not escape upstream"
+
+
+def test_refresh_rerecords_while_replay_serves_existing_cassette(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """P3 once/refresh semantics: ``replay`` serves an existing cassette
+    (no upstream hit) while ``refresh`` ignores it and re-hits upstream."""
+    confdir = tmp_path / "mitm-confdir"
+    cass = tmp_path / "topicR" / "_cassettes" / "slidesR.http-cassette.yaml"
+    target = f"{upstream_server}/seeded"
+
+    # Seed a canonical cassette by recording once and folding.
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        _get_via_proxy(target, proxy.proxy_url, tag=str(cass))
+    _fold_staging_to_canonical(cass, _staging_files(cass)[0])
+    assert cass.exists()
+
+    # replay: served from cassette, upstream untouched.
+    _CountingHandler.upstream_hits = 0
+    with MitmproxyManager(cassette_path=cassette_path, mode="replay", confdir=confdir) as proxy:
+        r1 = _get_via_proxy(target, proxy.proxy_url, tag=str(cass))
+    assert r1.status_code == 200
+    assert _CountingHandler.upstream_hits == 0, "replay must serve the existing cassette"
+
+    # refresh: ignores the existing cassette and re-hits upstream.
+    _CountingHandler.upstream_hits = 0
+    with MitmproxyManager(cassette_path=cassette_path, mode="refresh", confdir=confdir) as proxy:
+        r2 = _get_via_proxy(target, proxy.proxy_url, tag=str(cass))
+    assert r2.status_code == 200
+    assert _CountingHandler.upstream_hits == 1, "refresh must re-hit upstream, not serve cassette"
 
 
 def test_env_vars_exposes_proxy_url(cassette_path: Path, tmp_path: Path) -> None:

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -1,0 +1,188 @@
+"""Smoke tests for the mitmproxy-based HTTP-replay prototype.
+
+These tests exercise the proxy manager + addon round-trip against a
+local HTTP server, validating:
+
+* the proxy starts, accepts connections, and routes traffic through to
+  upstream (record mode);
+* responses are persisted to the cassette and served from it on a
+  subsequent run (replay mode);
+* strict ``replay`` mode returns a deterministic 599 on cache miss
+  instead of escaping to the network.
+
+mitmproxy runs out-of-process (settled production model: ``uv tool install
+mitmproxy``), so it is NOT imported in-process here — these tests only need
+``mitmdump`` reachable as a subprocess and ``requests`` in the test env. The
+module is skipped when ``mitmdump`` can't be located (see ``_locate_mitmdump``
+guard below) or ``requests`` isn't installed.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+requests = pytest.importorskip("requests")
+
+from clm.infrastructure.http_replay_mitm import MitmproxyManager
+from clm.infrastructure.http_replay_mitm.proxy_manager import (
+    MitmproxyError,
+    _locate_mitmdump,
+)
+
+# Skip the whole module if mitmdump isn't reachable — the [mitmproxy]
+# extra installs the Python package but the executable lookup may still
+# fail on some environments.
+try:
+    _locate_mitmdump()
+except MitmproxyError:
+    pytest.skip("mitmdump executable not available", allow_module_level=True)
+
+
+class _CountingHandler(BaseHTTPRequestHandler):
+    """Tiny HTTP handler that counts hits and echoes a fixed body.
+
+    The class-level counter lets the test distinguish "request reached
+    the upstream server" from "request was served from cassette".
+    """
+
+    upstream_hits = 0
+
+    def do_GET(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
+        type(self).upstream_hits += 1
+        body = json.dumps({"path": self.path, "hit": type(self).upstream_hits}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args, **_kwargs) -> None:  # silence stderr noise
+        return
+
+
+@pytest.fixture
+def upstream_server() -> Iterator[str]:
+    """Run a localhost HTTP server in a thread for the duration of one test."""
+    _CountingHandler.upstream_hits = 0
+    server = HTTPServer(("127.0.0.1", 0), _CountingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address[0], server.server_address[1]
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+@pytest.fixture
+def cassette_path(tmp_path: Path) -> Path:
+    return tmp_path / "smoke.mitm"
+
+
+def _get_via_proxy(url: str, proxy_url: str) -> requests.Response:
+    return requests.get(
+        url,
+        proxies={"http": proxy_url, "https": proxy_url},
+        # mitmproxy intercepts HTTP cleanly; HTTPS would need CA trust
+        # set up. The smoke test stays on HTTP for simplicity — see the
+        # design doc for the HTTPS story.
+        timeout=10.0,
+    )
+
+
+def test_proxy_starts_and_routes_traffic(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """Record-mode: traffic flows upstream and is persisted to the cassette."""
+    confdir = tmp_path / "mitm-confdir"
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        response = _get_via_proxy(f"{upstream_server}/hello", proxy.proxy_url)
+
+    assert response.status_code == 200
+    assert response.json()["path"] == "/hello"
+    assert _CountingHandler.upstream_hits == 1
+    assert cassette_path.exists()
+    assert cassette_path.stat().st_size > 0
+
+
+def test_replay_serves_from_cassette_without_upstream_hit(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """Record once, then a fresh replay-mode proxy serves the request without
+    touching the upstream server."""
+    confdir = tmp_path / "mitm-confdir"
+    target = f"{upstream_server}/cached"
+
+    # 1. Record.
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        first = _get_via_proxy(target, proxy.proxy_url)
+    assert first.status_code == 200
+    assert _CountingHandler.upstream_hits == 1
+
+    # 2. Replay against the same cassette. No upstream hits should
+    # occur; the response payload should match what we recorded.
+    with MitmproxyManager(cassette_path=cassette_path, mode="replay", confdir=confdir) as proxy:
+        replayed = _get_via_proxy(target, proxy.proxy_url)
+    assert replayed.status_code == 200
+    assert replayed.json() == first.json()
+    assert _CountingHandler.upstream_hits == 1, "replay-mode request should not reach upstream"
+
+
+def test_strict_replay_miss_returns_599(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """A request not in the cassette returns the addon's diagnostic 599
+    rather than escaping to upstream."""
+    confdir = tmp_path / "mitm-confdir"
+
+    # Seed the cassette with one URL.
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        _get_via_proxy(f"{upstream_server}/recorded", proxy.proxy_url)
+    assert _CountingHandler.upstream_hits == 1
+
+    # Now request a DIFFERENT URL in strict replay mode. The addon
+    # should synthesize a 599 and the upstream counter should NOT
+    # advance.
+    with MitmproxyManager(cassette_path=cassette_path, mode="replay", confdir=confdir) as proxy:
+        response = _get_via_proxy(f"{upstream_server}/never-recorded", proxy.proxy_url)
+
+    assert response.status_code == 599
+    payload = response.json()
+    assert payload["error"] == "clm_replay_miss"
+    assert payload["method"] == "GET"
+    assert payload["url"].endswith("/never-recorded")
+    assert _CountingHandler.upstream_hits == 1, (
+        "strict-replay miss must not fall through to upstream"
+    )
+
+
+def test_env_vars_exposes_proxy_url(cassette_path: Path, tmp_path: Path) -> None:
+    """The env_vars dict has the four HTTP_PROXY variants workers need."""
+    confdir = tmp_path / "mitm-confdir"
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        env = proxy.env_vars()
+    assert env["HTTP_PROXY"] == proxy.proxy_url
+    assert env["HTTPS_PROXY"] == proxy.proxy_url
+    assert env["http_proxy"] == proxy.proxy_url
+    assert env["https_proxy"] == proxy.proxy_url
+    assert "SSL_CERT_FILE" not in env
+
+    env_with_ca = proxy.env_vars(include_ca=True)
+    assert "SSL_CERT_FILE" in env_with_ca
+    assert "REQUESTS_CA_BUNDLE" in env_with_ca

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -87,15 +87,26 @@ def cassette_path(tmp_path: Path) -> Path:
     return tmp_path / "smoke.http-cassette.yaml"
 
 
-def _get_via_proxy(url: str, proxy_url: str) -> requests.Response:
+def _get_via_proxy(url: str, proxy_url: str, tag: str | None = None) -> requests.Response:
+    headers = {"X-CLM-Cassette": tag} if tag is not None else None
     return requests.get(
         url,
+        headers=headers,
         proxies={"http": proxy_url, "https": proxy_url},
         # mitmproxy intercepts HTTP cleanly; HTTPS would need CA trust
         # set up. The smoke test stays on HTTP for simplicity — see the
         # design doc for the HTTPS story.
         timeout=10.0,
     )
+
+
+def _staging_files(canonical: Path) -> list[Path]:
+    """Per-build staging files beside ``canonical`` (markers excluded)."""
+    return [
+        p
+        for p in canonical.parent.glob(f"{canonical.name}.staging-mitm-*")
+        if not p.name.endswith(".completed")
+    ]
 
 
 def test_proxy_starts_and_routes_traffic(
@@ -168,6 +179,69 @@ def test_strict_replay_miss_returns_599(
     assert _CountingHandler.upstream_hits == 1, (
         "strict-replay miss must not fall through to upstream"
     )
+
+
+def test_routing_demuxes_tagged_requests_to_per_cassette_staging(
+    upstream_server: str, cassette_path: Path, tmp_path: Path
+) -> None:
+    """P2: tagged requests route to per-cassette staging; untagged → catch-all.
+
+    Each request carries an ``X-CLM-Cassette`` header naming its
+    destination canonical cassette. The addon demuxes flows into one
+    ``*.staging-mitm-*`` file per canonical (with a ``.completed`` marker on
+    clean shutdown), strips the tag header before recording, and routes
+    untagged traffic to the shared catch-all — all without cross-contamination.
+    """
+    confdir = tmp_path / "mitm-confdir"
+    cass_a = tmp_path / "topicA" / "_cassettes" / "slidesA.http-cassette.yaml"
+    cass_b = tmp_path / "topicB" / "_cassettes" / "slidesB.http-cassette.yaml"
+
+    with MitmproxyManager(
+        cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+    ) as proxy:
+        ra = _get_via_proxy(f"{upstream_server}/a", proxy.proxy_url, tag=str(cass_a))
+        rb = _get_via_proxy(f"{upstream_server}/b", proxy.proxy_url, tag=str(cass_b))
+        rc = _get_via_proxy(f"{upstream_server}/c", proxy.proxy_url)  # untagged
+
+    assert ra.status_code == rb.status_code == rc.status_code == 200
+    assert _CountingHandler.upstream_hits == 3
+
+    # Each tagged cassette got exactly one staging file with its own request.
+    staging_a = _staging_files(cass_a)
+    staging_b = _staging_files(cass_b)
+    assert len(staging_a) == 1, staging_a
+    assert len(staging_b) == 1, staging_b
+
+    text_a = staging_a[0].read_text(encoding="utf-8")
+    text_b = staging_b[0].read_text(encoding="utf-8")
+    assert "/a" in text_a and "/b" not in text_a  # no cross-contamination
+    assert "/b" in text_b and "/a" not in text_b
+    # The routing tag header is stripped before recording.
+    assert "x-clm-cassette" not in text_a.lower()
+    assert "x-clm-cassette" not in text_b.lower()
+
+    # Untagged traffic landed in the catch-all, not in any tagged cassette.
+    assert cassette_path.exists()
+    assert "/c" in cassette_path.read_text(encoding="utf-8")
+    assert "/c" not in text_a and "/c" not in text_b
+
+    # The host writes the .completed marker after the proxy stops and folds
+    # the staging into its canonical (issue #165 P2). Drive that real merge
+    # path against the proxy-written staging and assert the interaction lands
+    # in the canonical cassette.
+    from clm.workers.notebook.http_replay_cassette import (
+        CassettePaths,
+        merge_staging_into_canonical,
+        write_completion_marker,
+    )
+
+    write_completion_marker(CassettePaths(canonical=cass_a, staging=staging_a[0]))
+    folded = merge_staging_into_canonical(CassettePaths(canonical=cass_a, staging=staging_a[0]))
+    assert folded == 1
+    assert cass_a.exists()
+    canonical_text = cass_a.read_text(encoding="utf-8")
+    assert "/a" in canonical_text and "/b" not in canonical_text
+    assert not staging_a[0].exists()  # folded + consumed
 
 
 def test_env_vars_exposes_proxy_url(cassette_path: Path, tmp_path: Path) -> None:

--- a/tests/infrastructure/test_http_replay_mitm_cassette_format.py
+++ b/tests/infrastructure/test_http_replay_mitm_cassette_format.py
@@ -1,0 +1,220 @@
+"""P1 gate (issue #165): byte-identity of the mitmproxy cassette bridge.
+
+These tests pin ``clm.infrastructure.http_replay_mitm.cassette_format`` to
+vcrpy's *own* serialization path. The transport may only flip the cassette
+storage from vcrpy's in-kernel patching to an out-of-process proxy if the
+bytes on disk are indistinguishable — committed course cassettes, ``clm
+cassette doctor`` and ``strip_cassette_hosts.py`` must not be able to tell
+which producer wrote a cassette.
+
+Strategy: feed the *same* HTTP parts to (a) vcrpy's real httpcore-stub
+helpers and (b) our bridge, then assert the serialized YAML is identical.
+vcr is a hard dependency of these tests (the ``[replay]`` extra).
+"""
+
+from __future__ import annotations
+
+import gzip
+
+import pytest
+
+# The whole module needs vcrpy; skip cleanly where the extra is absent.
+pytest.importorskip("vcr")
+
+import httpcore  # noqa: E402  (after importorskip)
+from vcr.filters import decode_response  # noqa: E402
+from vcr.request import Request  # noqa: E402
+from vcr.serialize import serialize as vcr_serialize  # noqa: E402
+from vcr.serializers import yamlserializer  # noqa: E402
+from vcr.stubs.httpcore_stubs import (  # noqa: E402
+    _make_vcr_request,
+    _serialize_response,
+)
+
+from clm.infrastructure.http_replay_mitm import cassette_format as cf  # noqa: E402
+
+
+def _httpcore_request(method: str, url: str, fields, body: bytes) -> httpcore.Request:
+    return httpcore.Request(method, url, headers=list(fields), content=body)
+
+
+def _httpcore_response(status: int, reason: str | None, fields, body: bytes) -> httpcore.Response:
+    extensions = {"reason_phrase": reason.encode("ascii")} if reason is not None else {}
+    return httpcore.Response(status, headers=list(fields), content=body, extensions=extensions)
+
+
+# (method, url, request fields, request body, status, reason, response fields, raw body)
+_POST_JSON = (
+    "POST",
+    "https://openrouter.ai/api/v1/chat/completions",
+    [(b"content-type", b"application/json"), (b"accept", b"application/json")],
+    b'{"model":"x","messages":[{"role":"user","content":"hi"}]}',
+    200,
+    "OK",
+    [(b"content-type", b"application/json"), (b"x-request-id", b"abc123")],
+    b'{"id":"chatcmpl-1","choices":[{"message":{"content":"hello"}}]}',
+)
+
+
+def _vcrpy_reference_yaml(case, *, decode_compressed=True) -> str:
+    method, url, req_fields, req_body, status, reason, resp_fields, raw_body = case
+    real_request = _httpcore_request(method, url, req_fields, req_body)
+    real_response = _httpcore_response(status, reason, resp_fields, raw_body)
+    vcr_request = _make_vcr_request(real_request, req_body)
+    response_dict = _serialize_response(real_response, raw_body)
+    if decode_compressed:
+        response_dict = decode_response(response_dict)
+    return vcr_serialize({"requests": [vcr_request], "responses": [response_dict]}, yamlserializer)
+
+
+def _bridge_yaml(case, *, decode_compressed=True) -> str:
+    method, url, req_fields, req_body, status, reason, resp_fields, raw_body = case
+    request = cf.vcr_request_from_parts(method, url, req_fields, req_body)
+    response = cf.vcr_response_dict_from_parts(
+        status, reason, resp_fields, raw_body, decode_compressed=decode_compressed
+    )
+    return cf.serialize_interactions([(request, response)])
+
+
+def test_request_dict_matches_vcrpy():
+    method, url, req_fields, req_body, *_ = _POST_JSON
+    real_request = _httpcore_request(method, url, req_fields, req_body)
+    expected = _make_vcr_request(real_request, req_body)._to_dict()
+    actual = cf.vcr_request_from_parts(method, url, req_fields, req_body)._to_dict()
+    assert actual == expected
+
+
+def test_response_dict_matches_vcrpy():
+    _, _, _, _, status, reason, resp_fields, raw_body = _POST_JSON
+    real_response = _httpcore_response(status, reason, resp_fields, raw_body)
+    expected = decode_response(_serialize_response(real_response, raw_body))
+    actual = cf.vcr_response_dict_from_parts(status, reason, resp_fields, raw_body)
+    assert actual == expected
+
+
+def test_serialized_yaml_byte_identical_plain():
+    assert _bridge_yaml(_POST_JSON) == _vcrpy_reference_yaml(_POST_JSON)
+
+
+def test_serialized_yaml_byte_identical_gzip():
+    """A gzip-compressed response must decode to the same bytes vcrpy stores."""
+    payload = b'{"id":"chatcmpl-2","choices":[{"message":{"content":"gzipped"}}]}'
+    compressed = gzip.compress(payload)
+    case = (
+        "POST",
+        "https://openrouter.ai/api/v1/chat/completions",
+        [(b"content-type", b"application/json")],
+        b'{"model":"x"}',
+        200,
+        "OK",
+        [
+            (b"content-type", b"application/json"),
+            (b"content-encoding", b"gzip"),
+            (b"content-length", str(len(compressed)).encode("ascii")),
+        ],
+        compressed,
+    )
+    bridge = _bridge_yaml(case)
+    reference = _vcrpy_reference_yaml(case)
+    assert bridge == reference
+    # And the decoded payload is actually present (content-encoding stripped).
+    assert "gzipped" in bridge
+    assert "content-encoding" not in bridge
+
+
+def test_multivalue_request_headers_comma_joined():
+    """Repeated request headers join with ', ' like HTTPX/vcrpy."""
+    case = (
+        "GET",
+        "https://example.com/x",
+        [(b"accept", b"text/html"), (b"accept", b"application/json")],
+        b"",
+        200,
+        "OK",
+        [(b"content-type", b"text/plain")],
+        b"ok",
+    )
+    assert _bridge_yaml(case) == _vcrpy_reference_yaml(case)
+
+
+def test_multivalue_response_headers_preserved_as_list():
+    """Repeated response headers (e.g. Set-Cookie) stay a multi-element list."""
+    _, _, _, _, status, reason, _, raw_body = _POST_JSON
+    resp_fields = [
+        (b"set-cookie", b"a=1"),
+        (b"set-cookie", b"b=2"),
+        (b"content-type", b"text/plain"),
+    ]
+    real_response = _httpcore_response(status, reason, resp_fields, raw_body)
+    expected = decode_response(_serialize_response(real_response, raw_body))
+    actual = cf.vcr_response_dict_from_parts(status, reason, resp_fields, raw_body)
+    assert actual == expected
+    assert actual["headers"]["set-cookie"] == ["a=1", "b=2"]
+
+
+def test_serialize_does_not_mutate_in_memory_body():
+    """The convert_to_unicode bytes->str mutation must not leak to the index."""
+    _, _, _, _, status, reason, resp_fields, raw_body = _POST_JSON
+    response = cf.vcr_response_dict_from_parts(status, reason, resp_fields, raw_body)
+    request = cf.vcr_request_from_parts("GET", "https://example.com/", [], b"")
+    assert isinstance(response["body"]["string"], bytes)
+    cf.serialize_interactions([(request, response)])
+    # Still bytes after serialization (deepcopy guard); a second serialize
+    # would otherwise emit a different (str-bodied) shape.
+    assert isinstance(response["body"]["string"], bytes)
+
+
+def test_write_cassette_uses_lf_endings(tmp_path):
+    request = cf.vcr_request_from_parts(*_POST_JSON[:3], _POST_JSON[3])
+    response = cf.vcr_response_dict_from_parts(
+        _POST_JSON[4], _POST_JSON[5], _POST_JSON[6], _POST_JSON[7]
+    )
+    path = tmp_path / "slides.http-cassette.yaml"
+    cf.write_cassette(path, [(request, response)])
+    raw = path.read_bytes()
+    assert b"\r\n" not in raw
+    assert raw.endswith(b"\n")
+
+
+def test_round_trip_load(tmp_path):
+    request = cf.vcr_request_from_parts(*_POST_JSON[:3], _POST_JSON[3])
+    response = cf.vcr_response_dict_from_parts(
+        _POST_JSON[4], _POST_JSON[5], _POST_JSON[6], _POST_JSON[7]
+    )
+    path = tmp_path / "slides.http-cassette.yaml"
+    cf.write_cassette(path, [(request, response)])
+
+    loaded = cf.load_interactions(path)
+    assert len(loaded) == 1
+    loaded_req, loaded_resp = loaded[0]
+    assert loaded_req.method == "POST"
+    assert loaded_req.uri == _POST_JSON[1]
+    # Loaded body is bytes again (FilesystemPersister -> convert_to_bytes).
+    assert loaded_resp["body"]["string"] == _POST_JSON[7]
+
+
+def test_merge_helper_loads_bridge_cassette(tmp_path):
+    """The host-side merge must consume a bridge-written cassette unchanged."""
+    from clm.workers.notebook.http_replay_cassette import (
+        CassettePaths,
+        merge_staging_into_canonical,
+        write_completion_marker,
+    )
+
+    canonical = tmp_path / "slides.http-cassette.yaml"
+    staging = canonical.parent / f"{canonical.name}.staging-mitm-test"
+
+    request = cf.vcr_request_from_parts(*_POST_JSON[:3], _POST_JSON[3])
+    response = cf.vcr_response_dict_from_parts(
+        _POST_JSON[4], _POST_JSON[5], _POST_JSON[6], _POST_JSON[7]
+    )
+    cf.write_cassette(staging, [(request, response)])
+    write_completion_marker(CassettePaths(canonical=canonical, staging=staging))
+
+    folded = merge_staging_into_canonical(CassettePaths(canonical=canonical, staging=staging))
+    assert folded == 1
+    assert canonical.exists()
+    # Canonical now holds the interaction and the staging file is consumed.
+    merged = cf.load_interactions(canonical)
+    assert len(merged) == 1
+    assert not staging.exists()

--- a/tests/infrastructure/test_http_replay_mitm_cassette_format.py
+++ b/tests/infrastructure/test_http_replay_mitm_cassette_format.py
@@ -220,6 +220,125 @@ def test_round_trip_load(tmp_path):
     assert loaded_resp["body"]["string"] == _POST_JSON[7]
 
 
+def test_filter_byte_identical_to_vcrpy_before_record_request():
+    """Our request filter must drop exactly what vcrpy's own
+    ``before_record_request`` drops, byte-for-byte — so a mitmproxy-recorded
+    cassette is indistinguishable from a vcrpy-recorded one after filtering."""
+    import vcr
+
+    ignore = ("api.smith.langchain.com",)
+    vcrpy_filter = vcr.VCR(
+        filter_headers=cf.FILTER_HEADERS,
+        filter_query_parameters=cf.FILTER_QUERY_PARAMETERS,
+        filter_post_data_parameters=cf.FILTER_POST_DATA_PARAMETERS,
+        ignore_hosts=ignore,
+        decode_compressed_response=True,
+    )._build_before_record_request({})
+    ours = cf.build_request_filter(ignore_hosts=ignore)
+
+    cases = [
+        (
+            "POST",
+            "https://openrouter.ai/api/v1/chat?api_key=S&model=x&token=T",
+            [
+                (b"authorization", b"Bearer S"),
+                (b"content-type", b"application/json"),
+                (b"x-api-key", b"K"),
+                (b"accept", b"application/json"),
+            ],
+            b'{"model":"x","api_key":"S","password":"p","messages":[{"role":"user","content":"hi"}]}',
+        ),
+        ("GET", "https://example.com/x?token=T&q=1", [(b"cookie", b"sid=abc")], b""),
+        (
+            "POST",
+            "https://o.ai/v1",
+            [(b"content-type", b"application/json; charset=utf-8")],
+            b'{"k":1}',
+        ),
+    ]
+    for method, url, fields, body in cases:
+        ref = vcrpy_filter(cf.vcr_request_from_parts(method, url, fields, body))
+        got = ours(cf.vcr_request_from_parts(method, url, fields, body))
+        assert ref._to_dict() == got._to_dict(), url
+
+
+def test_filter_removes_secrets():
+    """The filtered request carries no secret headers / query / body params."""
+    f = cf.build_request_filter()
+    req = cf.vcr_request_from_parts(
+        "POST",
+        "https://openrouter.ai/api/v1/chat?api_key=SECRET&model=x&token=TT",
+        [
+            (b"authorization", b"Bearer SECRET"),
+            (b"x-api-key", b"K"),
+            (b"content-type", b"application/json"),
+        ],
+        b'{"model":"x","api_key":"SECRET","password":"pw"}',
+    )
+    filtered = f(req)
+    header_names = {k.lower() for k in filtered.headers}
+    assert "authorization" not in header_names
+    assert "x-api-key" not in header_names
+    assert "api_key" not in filtered.uri and "token" not in filtered.uri
+    body = filtered.body or b""
+    assert b"SECRET" not in body and b"api_key" not in body and b"password" not in body
+
+
+def test_filter_ignore_host_returns_none():
+    f = cf.build_request_filter(ignore_hosts=("api.smith.langchain.com",))
+    ignored = cf.vcr_request_from_parts("POST", "https://api.smith.langchain.com/runs", [], b"{}")
+    kept = cf.vcr_request_from_parts("POST", "https://openrouter.ai/v1", [], b"{}")
+    assert f(ignored) is None
+    assert f(kept) is not None
+
+
+def test_json_body_matcher_semantic_and_byte_fallback():
+    json_h = [(b"content-type", b"application/json")]
+    compact = cf.vcr_request_from_parts("POST", "https://o.ai/c", json_h, b'{"a":1,"b":2}')
+    reordered = cf.vcr_request_from_parts("POST", "https://o.ai/c", json_h, b'{"b": 2, "a": 1}')
+    different = cf.vcr_request_from_parts("POST", "https://o.ai/c", json_h, b'{"a":9}')
+    assert cf.requests_match(compact, reordered)  # JSON value equality
+    assert not cf.requests_match(compact, different)
+
+    text_h = [(b"content-type", b"text/plain")]
+    t1 = cf.vcr_request_from_parts("POST", "https://o.ai/t", text_h, b"hello")
+    t2 = cf.vcr_request_from_parts("POST", "https://o.ai/t", text_h, b"hello")
+    t3 = cf.vcr_request_from_parts("POST", "https://o.ai/t", text_h, b"world")
+    assert cf.requests_match(t1, t2)  # byte equality
+    assert not cf.requests_match(t1, t3)
+
+
+def test_requests_match_query_order_insensitive_and_path_sensitive():
+    a = cf.vcr_request_from_parts("GET", "https://o.ai/x?a=1&b=2", [], b"")
+    b = cf.vcr_request_from_parts("GET", "https://o.ai/x?b=2&a=1", [], b"")
+    other_path = cf.vcr_request_from_parts("GET", "https://o.ai/y?a=1&b=2", [], b"")
+    assert cf.requests_match(a, b)  # query matcher sorts
+    assert not cf.requests_match(a, other_path)
+
+
+def test_filter_constants_and_matchers_match_bootstrap():
+    """Drift guard: cassette_format's filter constants + match_on must stay in
+    lockstep with the in-kernel vcrpy bootstrap, or a mitmproxy cassette would
+    filter/match differently from a vcrpy one."""
+    from clm.workers.notebook import notebook_processor as nbp
+
+    template = nbp._HTTP_REPLAY_BOOTSTRAP_TEMPLATE
+    assert 'filter_headers=["authorization", "cookie", "x-api-key", "set-cookie"]' in template
+    assert 'filter_post_data_parameters=["password", "token", "api_key"]' in template
+    assert 'filter_query_parameters=["api_key", "token"]' in template
+    assert (
+        'match_on=("method", "scheme", "host", "port", "path", "query", "clm_json_body")'
+        in template
+    )
+
+    assert cf.FILTER_HEADERS == ["authorization", "cookie", "x-api-key", "set-cookie"]
+    assert cf.FILTER_POST_DATA_PARAMETERS == ["password", "token", "api_key"]
+    assert cf.FILTER_QUERY_PARAMETERS == ["api_key", "token"]
+    names = [m.__name__ for m in cf.REPLAY_MATCHERS]
+    assert names[:6] == ["method", "scheme", "host", "port", "path", "query"]
+    assert "json_body" in names[6]
+
+
 def test_merge_helper_loads_bridge_cassette(tmp_path):
     """The host-side merge must consume a bridge-written cassette unchanged."""
     from clm.workers.notebook.http_replay_cassette import (

--- a/tests/infrastructure/test_http_replay_mitm_cassette_format.py
+++ b/tests/infrastructure/test_http_replay_mitm_cassette_format.py
@@ -152,6 +152,33 @@ def test_multivalue_response_headers_preserved_as_list():
     assert actual["headers"]["set-cookie"] == ["a=1", "b=2"]
 
 
+def test_no_reason_phrase_normalises_to_none():
+    """HTTP/2-style responses (no reason phrase) match vcrpy's message: None."""
+    _, _, _, _, status, _, resp_fields, raw_body = _POST_JSON
+    # httpcore with empty extensions -> _serialize_response yields message=None.
+    real_response = _httpcore_response(status, None, resp_fields, raw_body)
+    expected = decode_response(_serialize_response(real_response, raw_body))
+    actual = cf.vcr_response_dict_from_parts(status, "", resp_fields, raw_body)
+    assert actual == expected
+    assert actual["status"]["message"] is None
+
+
+def test_non_ascii_reason_phrase_dropped_to_none():
+    """A non-ASCII reason phrase is dropped (vcrpy can't (de)serialize it).
+
+    vcrpy decodes the reason as ASCII and would crash on non-ASCII bytes; a
+    stored non-ASCII message could not be replayed by the in-kernel vcrpy
+    transport. We keep the cassette vcrpy-replayable by storing None.
+    """
+    _, _, _, _, status, _, resp_fields, raw_body = _POST_JSON
+    actual = cf.vcr_response_dict_from_parts(status, "Café", resp_fields, raw_body)
+    assert actual["status"]["message"] is None
+    # The serialized cassette is therefore plain ASCII and reloads cleanly.
+    request = cf.vcr_request_from_parts("GET", "https://example.com/", [], b"")
+    yaml_text = cf.serialize_interactions([(request, actual)])
+    yaml_text.encode("ascii")  # must not raise
+
+
 def test_serialize_does_not_mutate_in_memory_body():
     """The convert_to_unicode bytes->str mutation must not leak to the index."""
     _, _, _, _, status, reason, resp_fields, raw_body = _POST_JSON

--- a/tests/infrastructure/test_http_replay_mitm_manager.py
+++ b/tests/infrastructure/test_http_replay_mitm_manager.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``MitmproxyManager`` plumbing that needs no real mitmdump.
+
+The stdout reader thread (issue #165 P3) is the important piece here: a
+multi-hour build must never deadlock because mitmdump filled the OS pipe
+buffer while the manager wasn't reading it. We exercise the reader against a
+plain Python subprocess that emits far more output than a pipe buffer holds.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+from clm.infrastructure.http_replay_mitm.proxy_manager import MitmproxyManager
+
+
+def _manager() -> MitmproxyManager:
+    # cassette_path is irrelevant for the reader-thread mechanics.
+    return MitmproxyManager(cassette_path="unused.yaml")
+
+
+def test_reader_thread_drains_large_output_without_deadlock(tmp_path) -> None:
+    """A subprocess that prints far more than a pipe buffer (~64 KiB) must run
+    to completion — proving the reader thread drains continuously instead of
+    letting the child block on a full pipe."""
+    # ~50k lines * ~16 bytes ≈ 800 KiB, an order of magnitude past the pipe buffer.
+    code = "import sys\nfor i in range(50000):\n    print('mitm-log-line', i)\n"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    mgr = _manager()
+    mgr._process = proc
+    mgr._start_reader()
+
+    # Without draining, the child would block on write and never exit. Give it
+    # a generous-but-bounded window; a hang here is the deadlock we prevent.
+    proc.wait(timeout=30.0)
+    assert proc.returncode == 0
+
+    output = mgr._drain_output()
+    # Only the tail is retained (bounded ring buffer), so assert on the end.
+    assert "mitm-log-line 49999" in output
+    # And the buffer is bounded — it must not have grown unbounded.
+    assert len(mgr._output) <= 1000
+
+
+def test_reader_thread_joined_and_output_available_after_exit(tmp_path) -> None:
+    """After the child exits, ``_drain_output`` returns its captured tail and
+    the reader thread is joinable (no per-build thread leak)."""
+    code = "print('hello from child')\n"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    mgr = _manager()
+    mgr._process = proc
+    mgr._start_reader()
+    proc.wait(timeout=10.0)
+
+    # Reader thread should finish on EOF shortly after the process exits.
+    deadline = time.monotonic() + 5.0
+    while mgr._reader_thread is not None and mgr._reader_thread.is_alive():
+        if time.monotonic() > deadline:
+            break
+        time.sleep(0.02)
+
+    assert "hello from child" in mgr._drain_output()

--- a/tests/infrastructure/test_http_replay_mitm_manager.py
+++ b/tests/infrastructure/test_http_replay_mitm_manager.py
@@ -70,3 +70,41 @@ def test_reader_thread_joined_and_output_available_after_exit(tmp_path) -> None:
         time.sleep(0.02)
 
     assert "hello from child" in mgr._drain_output()
+
+
+class TestClientHostAndProxyUrl:
+    """Bind/loopback host separation for Docker reachability (issue #165 P4).
+
+    When the proxy binds a wildcard address so containers can reach it via
+    ``host.docker.internal``, same-host clients (Direct workers, the readiness
+    poll) must still connect via loopback — ``connect("0.0.0.0")`` is invalid
+    on Windows.
+    """
+
+    def test_loopback_bind_is_unchanged(self) -> None:
+        mgr = MitmproxyManager(cassette_path="unused.yaml", listen_host="127.0.0.1")
+        mgr.listen_port = 54321
+        assert mgr._client_host() == "127.0.0.1"
+        assert mgr.proxy_url == "http://127.0.0.1:54321"
+
+    def test_wildcard_bind_connects_via_loopback(self) -> None:
+        mgr = MitmproxyManager(cassette_path="unused.yaml", listen_host="0.0.0.0")
+        mgr.listen_port = 54321
+        # Bind address stays the wildcard (what mitmdump --listen-host gets)...
+        assert mgr.listen_host == "0.0.0.0"
+        # ...but clients/poll use loopback so connect() is valid on Windows.
+        assert mgr._client_host() == "127.0.0.1"
+        assert mgr.proxy_url == "http://127.0.0.1:54321"
+
+    def test_empty_host_is_treated_as_wildcard(self) -> None:
+        # An empty listen_host binds all IPv4 interfaces (INADDR_ANY), so
+        # clients/poll must still use loopback.
+        mgr = MitmproxyManager(cassette_path="unused.yaml", listen_host="")
+        mgr.listen_port = 7
+        assert mgr._client_host() == "127.0.0.1"
+
+    def test_concrete_host_is_used_verbatim(self) -> None:
+        mgr = MitmproxyManager(cassette_path="unused.yaml", listen_host="192.168.1.5")
+        mgr.listen_port = 8080
+        assert mgr._client_host() == "192.168.1.5"
+        assert mgr.proxy_url == "http://192.168.1.5:8080"

--- a/tests/infrastructure/test_http_replay_mitm_manager.py
+++ b/tests/infrastructure/test_http_replay_mitm_manager.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 
+from clm.infrastructure.http_replay_mitm import proxy_manager
 from clm.infrastructure.http_replay_mitm.proxy_manager import MitmproxyManager
 
 
@@ -108,3 +109,37 @@ class TestClientHostAndProxyUrl:
         mgr.listen_port = 8080
         assert mgr._client_host() == "192.168.1.5"
         assert mgr.proxy_url == "http://192.168.1.5:8080"
+
+
+class TestStartCommandTraceDir:
+    """The forensic trace dir (issue #165 P5) reaches the addon via a
+    ``--set clm_trace_dir=`` option only when configured."""
+
+    class _FakeProc:
+        stdout = None
+
+        def poll(self):
+            return None
+
+    def _captured_cmd(self, monkeypatch, **kwargs) -> list[str]:
+        captured: dict[str, list[str]] = {}
+
+        def _fake_popen(cmd, **_kw):
+            captured["cmd"] = cmd
+            return self._FakeProc()
+
+        monkeypatch.setattr(proxy_manager, "_locate_mitmdump", lambda: "mitmdump")
+        monkeypatch.setattr(proxy_manager, "_pick_free_port", lambda host: 12345)
+        monkeypatch.setattr(proxy_manager.subprocess, "Popen", _fake_popen)
+        monkeypatch.setattr(MitmproxyManager, "_wait_for_ready", lambda self: None)
+        mgr = MitmproxyManager(cassette_path="unused.yaml", **kwargs)
+        mgr.start()
+        return captured["cmd"]
+
+    def test_trace_dir_adds_clm_trace_dir_set(self, monkeypatch, tmp_path) -> None:
+        cmd = self._captured_cmd(monkeypatch, trace_dir=tmp_path)
+        assert any(str(part) == f"clm_trace_dir={tmp_path}" for part in cmd)
+
+    def test_no_trace_dir_omits_clm_trace_dir_set(self, monkeypatch) -> None:
+        cmd = self._captured_cmd(monkeypatch)
+        assert not any("clm_trace_dir=" in str(part) for part in cmd)

--- a/tests/infrastructure/test_http_replay_mitm_trace_log.py
+++ b/tests/infrastructure/test_http_replay_mitm_trace_log.py
@@ -1,0 +1,101 @@
+"""Unit tests for the addon's proxy-flow trace writer (issue #165 P5).
+
+``ProxyTraceLog`` is pure stdlib so the addon can load it by bare path inside
+the isolated mitmdump interpreter. These tests pin its on-disk schema (which
+must match the host-side ``TraceWriter``), its disabled-by-default behavior,
+and its crash-proofness — a forensic logger must never take down the proxy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from clm.infrastructure.http_replay_mitm.trace_log import PROXY_STREAM, ProxyTraceLog
+
+
+def _read_lines(path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+class TestDisabled:
+    def test_none_path_is_no_op(self, tmp_path) -> None:
+        log = ProxyTraceLog(None)
+        assert log.enabled is False
+        # Emitting must not create any file or raise.
+        log.emit("proxy.ready", {"listen_port": 1})
+        log.close()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_from_trace_dir_empty_is_disabled(self) -> None:
+        assert ProxyTraceLog.from_trace_dir("").enabled is False
+        assert ProxyTraceLog.from_trace_dir(None).enabled is False
+
+    def test_from_trace_dir_missing_dir_is_disabled(self, tmp_path) -> None:
+        # The host creates the invocation dir before starting the proxy; a
+        # missing dir disables rather than crashing the proxy.
+        missing = tmp_path / "does-not-exist"
+        assert ProxyTraceLog.from_trace_dir(missing).enabled is False
+
+    def test_construction_open_failure_degrades_to_disabled(self, tmp_path) -> None:
+        # Construction must be as crash-proof as emit(): if open() fails AFTER
+        # from_trace_dir's is_dir() check passes (here a directory sits at the
+        # exact log-file path → open("a") raises), the log must degrade to a
+        # disabled no-op, never propagate — else it crashes proxy startup
+        # (mitmproxy turns an exception in running() into sys.exit(1)).
+        blocker = tmp_path / f"{PROXY_STREAM}-{os.getpid()}.jsonl"
+        blocker.mkdir()  # a directory exactly where the log file would be opened
+        log = ProxyTraceLog.from_trace_dir(tmp_path)  # must NOT raise
+        assert log.enabled is False
+        log.emit("proxy.ready", {"x": 1})  # still a safe no-op
+        log.close()
+
+
+class TestEnabled:
+    def test_from_trace_dir_writes_pid_suffixed_file(self, tmp_path) -> None:
+        log = ProxyTraceLog.from_trace_dir(tmp_path)
+        assert log.enabled is True
+        assert log.path is not None
+        assert log.path.name == f"{PROXY_STREAM}-{os.getpid()}.jsonl"
+        log.close()
+
+    def test_emit_writes_host_compatible_schema(self, tmp_path) -> None:
+        log = ProxyTraceLog.from_trace_dir(tmp_path)
+        log.emit("proxy.ready", {"listen_port": 8080, "mode": "replay"})
+        log.emit(
+            "proxy.request",
+            {"method": "POST", "host": "api.openai.com", "port": 443, "action": "served"},
+        )
+        log.close()
+
+        records = _read_lines(log.path)
+        assert len(records) == 2
+        for rec in records:
+            # Same field set as clm.workers.notebook.http_replay_trace.TraceWriter.
+            assert set(rec) == {"ts_mono", "ts_wall", "pid", "tid", "stream", "event", "data"}
+            assert rec["stream"] == PROXY_STREAM
+            assert rec["pid"] == os.getpid()
+            assert isinstance(rec["ts_mono"], (int, float))
+        assert records[0]["event"] == "proxy.ready"
+        assert records[0]["data"]["listen_port"] == 8080
+        assert records[1]["data"]["action"] == "served"
+
+    def test_emit_appends_across_instances(self, tmp_path) -> None:
+        # Two logs for the same pid append (the addon makes one per process,
+        # but appending is the safe semantics if reopened).
+        ProxyTraceLog.from_trace_dir(tmp_path).emit("proxy.request", {"action": "miss"})
+        log2 = ProxyTraceLog.from_trace_dir(tmp_path)
+        log2.emit("proxy.request", {"action": "forward"})
+        log2.close()
+        records = _read_lines(log2.path)
+        assert [r["data"]["action"] for r in records] == ["miss", "forward"]
+
+    def test_emit_is_crash_proof(self, tmp_path) -> None:
+        # A non-JSON-serializable payload must be swallowed, not raised.
+        log = ProxyTraceLog.from_trace_dir(tmp_path)
+        log.emit("proxy.request", {"bad": object()})  # must not raise
+        log.emit("proxy.request", {"action": "served"})  # later good events still write
+        log.close()
+        records = _read_lines(log.path)
+        assert len(records) == 1
+        assert records[0]["data"]["action"] == "served"

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -12,10 +12,12 @@ import pytest
 
 from clm.infrastructure.database.schema import init_database
 from clm.infrastructure.workers.worker_executor import (
+    _MITM_CA_CONTAINER_PATH,
     DirectWorkerExecutor,
     DockerWorkerExecutor,
     WorkerConfig,
     WorkerExecutor,
+    _mitmproxy_docker_env,
 )
 
 
@@ -508,3 +510,177 @@ class TestDockerWorkerExecutor:
         # Simulate container stopped
         mock_container.status = "exited"
         assert executor.is_worker_running(worker_id) is False
+
+
+class TestMitmproxyDockerEnv:
+    """The mitmproxy transport's per-container env + CA mount (issue #165 P4)."""
+
+    def test_inactive_is_noop(self) -> None:
+        assert _mitmproxy_docker_env({}) == ({}, None)
+        # A different transport value is also a no-op.
+        assert _mitmproxy_docker_env({"CLM_HTTP_REPLAY_TRANSPORT": "vcrpy"}) == ({}, None)
+
+    def test_active_without_proxy_is_noop(self) -> None:
+        # Defensive: transport flag set but build.py never exported a proxy URL.
+        assert _mitmproxy_docker_env({"CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy"}) == ({}, None)
+
+    def test_rewrites_loopback_proxy_to_host_docker_internal(self) -> None:
+        env, mount = _mitmproxy_docker_env(
+            {
+                "CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy",
+                "HTTP_PROXY": "http://127.0.0.1:63564",
+            }
+        )
+        assert env["HTTP_PROXY"] == "http://host.docker.internal:63564"
+        assert env["HTTPS_PROXY"] == "http://host.docker.internal:63564"
+        assert env["http_proxy"] == "http://host.docker.internal:63564"
+        assert env["https_proxy"] == "http://host.docker.internal:63564"
+        # The kernel must skip the vcrpy bootstrap and inject the tag bootstrap.
+        assert env["CLM_HTTP_REPLAY_TRANSPORT"] == "mitmproxy"
+        assert mount is None
+
+    def test_no_proxy_excludes_the_api_host(self) -> None:
+        """Worker<->CLM REST API traffic must bypass the replay proxy, or worker
+        registration would be replayed as a cassette miss and stall the build."""
+        env, _ = _mitmproxy_docker_env(
+            {"CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy", "HTTP_PROXY": "http://127.0.0.1:1"}
+        )
+        assert env["NO_PROXY"] == "host.docker.internal"
+        assert env["no_proxy"] == "host.docker.internal"
+
+    def test_prefers_https_proxy_over_http_proxy(self) -> None:
+        env, _ = _mitmproxy_docker_env(
+            {
+                "CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy",
+                "HTTP_PROXY": "http://127.0.0.1:1",
+                "HTTPS_PROXY": "http://127.0.0.1:63564",
+            }
+        )
+        assert env["HTTPS_PROXY"] == "http://host.docker.internal:63564"
+
+    def test_mounts_ca_bundle_and_points_cert_vars_at_it(self, tmp_path) -> None:
+        ca = tmp_path / "ca-bundle.pem"
+        ca.write_bytes(b"-----BEGIN CERTIFICATE-----\n")
+        env, mount = _mitmproxy_docker_env(
+            {
+                "CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy",
+                "HTTP_PROXY": "http://127.0.0.1:63564",
+                "SSL_CERT_FILE": str(ca),
+            }
+        )
+        assert mount == (str(ca.absolute()), _MITM_CA_CONTAINER_PATH)
+        assert env["SSL_CERT_FILE"] == _MITM_CA_CONTAINER_PATH
+        assert env["REQUESTS_CA_BUNDLE"] == _MITM_CA_CONTAINER_PATH
+        assert env["CURL_CA_BUNDLE"] == _MITM_CA_CONTAINER_PATH
+
+    def test_missing_ca_file_skips_mount(self) -> None:
+        env, mount = _mitmproxy_docker_env(
+            {
+                "CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy",
+                "HTTP_PROXY": "http://127.0.0.1:63564",
+                "SSL_CERT_FILE": "/nonexistent/ca.pem",
+            }
+        )
+        assert mount is None
+        assert "SSL_CERT_FILE" not in env  # don't point at a path we didn't mount
+
+    def test_malformed_proxy_port_is_handled(self) -> None:
+        # build.py always emits a well-formed loopback URL, but the urlsplit
+        # .port ValueError branch must degrade gracefully (no port, no raise).
+        env, _ = _mitmproxy_docker_env(
+            {"CLM_HTTP_REPLAY_TRANSPORT": "mitmproxy", "HTTP_PROXY": "http://127.0.0.1:notaport"}
+        )
+        assert env["HTTP_PROXY"] == "http://host.docker.internal"
+        assert env["HTTPS_PROXY"] == "http://host.docker.internal"
+
+
+class TestDockerWorkerExecutorMitmproxy:
+    """start_worker wires the mitmproxy transport into the container (#165 P4)."""
+
+    def _run_start_worker(self, db_path, workspace_path, worker_type="notebook"):
+        import docker.errors
+
+        mock_client = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "deadbeefcafe"
+        mock_client.containers.run.return_value = mock_container
+        mock_client.containers.get.side_effect = docker.errors.NotFound("nope")
+
+        executor = DockerWorkerExecutor(
+            docker_client=mock_client, db_path=db_path, workspace_path=workspace_path
+        )
+        config = WorkerConfig(
+            worker_type=worker_type,
+            count=1,
+            execution_mode="docker",
+            image=f"{worker_type}:latest",
+        )
+        executor.start_worker(worker_type, 0, config)
+        return mock_client.containers.run.call_args
+
+    @patch("docker.DockerClient")
+    def test_injects_proxy_ca_and_transport_when_active(
+        self, _mock_docker, db_path, workspace_path, tmp_path, monkeypatch
+    ):
+        ca = tmp_path / "ca-bundle.pem"
+        ca.write_bytes(b"-----BEGIN CERTIFICATE-----\n")
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+        monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:63564")
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:63564")
+        monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+
+        call_args = self._run_start_worker(db_path, workspace_path)
+        env = call_args.kwargs["environment"]
+        volumes = call_args.kwargs["volumes"]
+
+        # Proxy rewritten to the container's route back to the host.
+        assert env["HTTPS_PROXY"] == "http://host.docker.internal:63564"
+        # API traffic stays off the proxy.
+        assert env["NO_PROXY"] == "host.docker.internal"
+        # Kernel skips vcrpy + injects the tag bootstrap.
+        assert env["CLM_HTTP_REPLAY_TRANSPORT"] == "mitmproxy"
+        # CA bundle mounted read-only and trusted.
+        assert env["SSL_CERT_FILE"] == _MITM_CA_CONTAINER_PATH
+        assert volumes[str(ca.absolute())] == {"bind": _MITM_CA_CONTAINER_PATH, "mode": "ro"}
+        # extra_hosts host-gateway is already set by the executor (precondition for P4).
+        assert call_args.kwargs["extra_hosts"] == {"host.docker.internal": "host-gateway"}
+
+    @patch("docker.DockerClient")
+    def test_no_injection_when_transport_inactive(
+        self, _mock_docker, db_path, workspace_path, monkeypatch
+    ):
+        monkeypatch.delenv("CLM_HTTP_REPLAY_TRANSPORT", raising=False)
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+
+        call_args = self._run_start_worker(db_path, workspace_path)
+        env = call_args.kwargs["environment"]
+        volumes = call_args.kwargs["volumes"]
+
+        assert "HTTPS_PROXY" not in env
+        assert "NO_PROXY" not in env
+        assert "CLM_HTTP_REPLAY_TRANSPORT" not in env
+        assert _MITM_CA_CONTAINER_PATH not in [v.get("bind") for v in volumes.values()]
+
+    @patch("docker.DockerClient")
+    def test_no_injection_for_non_notebook_worker(
+        self, _mock_docker, db_path, workspace_path, tmp_path, monkeypatch
+    ):
+        # Only the notebook worker uses the replay proxy; a docker plantuml/
+        # drawio container must not get the proxy env or the CA mount even when
+        # the transport is active.
+        ca = tmp_path / "ca-bundle.pem"
+        ca.write_bytes(b"-----BEGIN CERTIFICATE-----\n")
+        monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+        monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:63564")
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:63564")
+        monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+
+        call_args = self._run_start_worker(db_path, workspace_path, worker_type="plantuml")
+        env = call_args.kwargs["environment"]
+        volumes = call_args.kwargs["volumes"]
+
+        assert "HTTPS_PROXY" not in env
+        assert "NO_PROXY" not in env
+        assert "CLM_HTTP_REPLAY_TRANSPORT" not in env
+        assert str(ca.absolute()) not in volumes

--- a/tests/workers/notebook/test_http_replay_cassette.py
+++ b/tests/workers/notebook/test_http_replay_cassette.py
@@ -9,7 +9,15 @@ from __future__ import annotations
 
 import io
 
-from clm.workers.notebook.http_replay_cassette import _body_to_dedup_bytes, _dedup_key
+import pytest
+
+from clm.workers.notebook.http_replay_cassette import (
+    CassettePaths,
+    _body_to_dedup_bytes,
+    _dedup_key,
+    merge_staging_into_canonical,
+    write_completion_marker,
+)
 
 
 class _StubRequest:
@@ -88,3 +96,120 @@ class TestDedupKey:
         r1 = _StubRequest("POST", "https://api.example.com/", b"one")
         r2 = _StubRequest("POST", "https://api.example.com/", b"two")
         assert _dedup_key(r1) != _dedup_key(r2)
+
+
+class TestMergeOverwriteExisting:
+    """Mode-aware merge (issue #165 P3): ``refresh`` overwrites a stale entry.
+
+    The default (``overwrite_existing=False``) keeps the canonical entry
+    (first-seen-wins) — the long-standing behavior used by ``new-episodes`` /
+    ``once`` / ``replay`` and every pre-build sweep. ``refresh`` (vcrpy ``all``)
+    must instead let a freshly recorded interaction supersede the stale one.
+    """
+
+    @staticmethod
+    def _interaction(cf, method, url, body, resp_body):
+        request = cf.vcr_request_from_parts(method, url, [(b"content-type", b"text/plain")], body)
+        response = cf.vcr_response_dict_from_parts(
+            200, "OK", [(b"content-type", b"text/plain")], resp_body
+        )
+        return request, response
+
+    def _write_canonical_and_markered_staging(self, tmp_path, canonical_pairs, staging_pairs):
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = canonical.parent / f"{canonical.name}.staging-mitm-test"
+        cf.write_cassette(canonical, canonical_pairs)
+        cf.write_cassette(staging, staging_pairs)
+        write_completion_marker(CassettePaths(canonical=canonical, staging=staging))
+        return cf, canonical, staging
+
+    def test_overwrite_false_keeps_canonical_entry(self, tmp_path):
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        url = "https://o.ai/v1/c"
+        canonical_pairs = [self._interaction(cf, "POST", url, b"req", b"OLD")]
+        staging_pairs = [self._interaction(cf, "POST", url, b"req", b"NEW")]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, canonical_pairs, staging_pairs
+        )
+
+        folded = merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging), overwrite_existing=False
+        )
+        assert folded == 1
+        merged = cf.load_interactions(canonical)
+        assert len(merged) == 1
+        # Default first-seen-wins: the stale canonical response is kept.
+        assert merged[0][1]["body"]["string"] in (b"OLD", "OLD")
+
+    def test_overwrite_true_staging_wins(self, tmp_path):
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        url = "https://o.ai/v1/c"
+        canonical_pairs = [self._interaction(cf, "POST", url, b"req", b"OLD")]
+        staging_pairs = [self._interaction(cf, "POST", url, b"req", b"NEW")]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, canonical_pairs, staging_pairs
+        )
+
+        folded = merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging), overwrite_existing=True
+        )
+        assert folded == 1
+        merged = cf.load_interactions(canonical)
+        assert len(merged) == 1
+        # refresh overwrite: the freshly recorded response replaces the stale one.
+        assert merged[0][1]["body"]["string"] in (b"NEW", "NEW")
+
+    def test_overwrite_preserves_position_and_appends_new(self, tmp_path):
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        a = "https://o.ai/a"
+        b = "https://o.ai/b"
+        c = "https://o.ai/c"
+        canonical_pairs = [
+            self._interaction(cf, "POST", a, b"ra", b"A_OLD"),
+            self._interaction(cf, "POST", b, b"rb", b"B_OLD"),
+        ]
+        # Staging re-records A (overwrite) and adds a new C; B is untouched.
+        staging_pairs = [
+            self._interaction(cf, "POST", a, b"ra", b"A_NEW"),
+            self._interaction(cf, "POST", c, b"rc", b"C_NEW"),
+        ]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, canonical_pairs, staging_pairs
+        )
+
+        folded = merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging), overwrite_existing=True
+        )
+        assert folded == 1
+        merged = cf.load_interactions(canonical)
+        uris = [req.uri for req, _ in merged]
+        # A stays in its original position (replaced in place), B kept, C appended.
+        assert uris == [a, b, c]
+        by_uri = {req.uri: resp["body"]["string"] for req, resp in merged}
+        assert by_uri[a] in (b"A_NEW", "A_NEW")  # overwritten
+        assert by_uri[b] in (b"B_OLD", "B_OLD")  # untouched
+        assert by_uri[c] in (b"C_NEW", "C_NEW")  # appended
+
+    def test_overwrite_last_seen_within_staging_wins(self, tmp_path):
+        """When one staging file holds the same request twice (vcrpy ``all``
+        seeds canonical then appends the fresh recording), the LAST occurrence
+        wins so the fresh response — not the seeded stale one — lands."""
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        url = "https://o.ai/v1/c"
+        canonical_pairs = [self._interaction(cf, "POST", url, b"req", b"OLD")]
+        # Staging contains seeded-old THEN freshly-recorded-new (same key).
+        staging_pairs = [
+            self._interaction(cf, "POST", url, b"req", b"SEEDED_OLD"),
+            self._interaction(cf, "POST", url, b"req", b"FRESH_NEW"),
+        ]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, canonical_pairs, staging_pairs
+        )
+
+        merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging), overwrite_existing=True
+        )
+        merged = cf.load_interactions(canonical)
+        assert len(merged) == 1
+        assert merged[0][1]["body"]["string"] in (b"FRESH_NEW", "FRESH_NEW")

--- a/tests/workers/notebook/test_http_replay_mitm_tag.py
+++ b/tests/workers/notebook/test_http_replay_mitm_tag.py
@@ -9,6 +9,7 @@ resolution and confirm the kernel's httpcore is never patched.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from nbformat.v4 import new_code_cell, new_notebook
@@ -72,11 +73,31 @@ def test_resolve_mitmproxy_tag_uses_payload_cassette_name(monkeypatch, tmp_path)
     assert tag == str(tmp_path / "_cassettes" / "slides.http-cassette.yaml")
 
 
-def test_resolve_mitmproxy_tag_prefers_source_dir(monkeypatch, tmp_path):
-    """Docker-style source mount (``source_dir``) wins over source_topic_dir."""
+def test_resolve_mitmproxy_tag_uses_host_topic_dir_not_container_source_dir(monkeypatch, tmp_path):
+    """The tag must name a HOST path even in Docker mode (issue #165 P4).
+
+    The proxy and the host-side merge run on the host, so a container-mapped
+    ``source_dir`` (``/source/...``) would make the proxy write staging to a
+    bogus host path and the merge would never find it. The host
+    ``source_topic_dir`` therefore wins over the container ``source_dir``.
+    """
     monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
     proc = NotebookProcessor(CompletedOutput(format="code"))
-    payload = _payload(source_topic_dir="/host/elsewhere")
+    host_dir = tmp_path / "host_topic"
+    container_dir = Path("/source/topic")  # what a Docker worker would pass
+    payload = _payload(source_topic_dir=str(host_dir))
+
+    tag = proc._resolve_mitmproxy_tag(payload, container_dir)
+
+    # Resolved against the host dir, NOT the container /source path.
+    assert tag == str(host_dir / "_cassettes" / "slides.http-cassette.yaml")
+
+
+def test_resolve_mitmproxy_tag_falls_back_to_source_dir_when_no_host_dir(monkeypatch, tmp_path):
+    """If no host ``source_topic_dir`` is available, fall back to ``source_dir``."""
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    payload = _payload(source_topic_dir=None)
 
     tag = proc._resolve_mitmproxy_tag(payload, tmp_path)
 
@@ -89,6 +110,13 @@ def test_resolve_mitmproxy_tag_none_when_disabled(monkeypatch, tmp_path):
     assert proc._resolve_mitmproxy_tag(_payload(http_replay_mode="disabled"), tmp_path) is None
     assert proc._resolve_mitmproxy_tag(_payload(http_replay_mode=None), tmp_path) is None
     assert proc._resolve_mitmproxy_tag(_payload(http_replay_cassette_name=None), tmp_path) is None
+
+
+def test_resolve_mitmproxy_tag_none_when_no_dir_available(monkeypatch):
+    """No host source_topic_dir and no container source_dir -> no tag."""
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    assert proc._resolve_mitmproxy_tag(_payload(source_topic_dir=None), None) is None
 
 
 def test_maybe_inject_chooses_tag_bootstrap_under_transport(monkeypatch, tmp_path):

--- a/tests/workers/notebook/test_http_replay_mitm_tag.py
+++ b/tests/workers/notebook/test_http_replay_mitm_tag.py
@@ -1,0 +1,118 @@
+"""P2 (issue #165): the mitmproxy cassette-routing tag bootstrap.
+
+Under ``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy`` the worker injects a tiny
+cell that tags every outgoing httpx request with its destination cassette
+(so the single shared proxy demuxes correctly) instead of the heavy
+in-kernel vcrpy bootstrap. These tests pin that injection + the tag
+resolution and confirm the kernel's httpcore is never patched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nbformat.v4 import new_code_cell, new_notebook
+
+from clm.workers.notebook.notebook_processor import (
+    _HTTP_REPLAY_BOOTSTRAP_MARKER,
+    NotebookProcessor,
+    _inject_http_replay_tag_bootstrap,
+    _strip_injected_cells,
+)
+from clm.workers.notebook.output_spec import CompletedOutput
+
+
+def _payload(**overrides):
+    base = {
+        "http_replay_mode": "new-episodes",
+        "http_replay_cassette_name": "_cassettes/slides.http-cassette.yaml",
+        "source_topic_dir": None,
+        "correlation_id": "cid-1",
+        "input_file_name": "slides.py",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_inject_tag_bootstrap_inserts_marked_cell():
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+    tag = "/src/topic/_cassettes/slides.http-cassette.yaml"
+
+    _inject_http_replay_tag_bootstrap(nb, tag)
+
+    assert len(nb["cells"]) == 2
+    cell0 = nb["cells"][0]
+    assert cell0["metadata"]["clm_injected"] == _HTTP_REPLAY_BOOTSTRAP_MARKER
+    assert "del" in cell0["metadata"]["tags"]
+    # The tag is embedded as a repr literal and the routing header is set.
+    assert repr(tag) in cell0["source"]
+    assert "x-clm-cassette" in cell0["source"]
+    # It is the lightweight tag bootstrap, NOT the heavy vcrpy one: no
+    # httpcore/vcr patching reaches the kernel.
+    assert "httpcore" not in cell0["source"]
+    assert "import vcr" not in cell0["source"]
+    assert "httpx" in cell0["source"]
+
+
+def test_strip_removes_tag_bootstrap_cell():
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+    _inject_http_replay_tag_bootstrap(nb, "/x/foo.http-cassette.yaml")
+    _strip_injected_cells(nb)
+    assert len(nb["cells"]) == 1
+    assert nb["cells"][0]["source"] == "print(1)"
+
+
+def test_resolve_mitmproxy_tag_uses_payload_cassette_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    payload = _payload(source_topic_dir=str(tmp_path))
+
+    tag = proc._resolve_mitmproxy_tag(payload, None)
+
+    assert tag == str(tmp_path / "_cassettes" / "slides.http-cassette.yaml")
+
+
+def test_resolve_mitmproxy_tag_prefers_source_dir(monkeypatch, tmp_path):
+    """Docker-style source mount (``source_dir``) wins over source_topic_dir."""
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    payload = _payload(source_topic_dir="/host/elsewhere")
+
+    tag = proc._resolve_mitmproxy_tag(payload, tmp_path)
+
+    assert tag == str(tmp_path / "_cassettes" / "slides.http-cassette.yaml")
+
+
+def test_resolve_mitmproxy_tag_none_when_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    assert proc._resolve_mitmproxy_tag(_payload(http_replay_mode="disabled"), tmp_path) is None
+    assert proc._resolve_mitmproxy_tag(_payload(http_replay_mode=None), tmp_path) is None
+    assert proc._resolve_mitmproxy_tag(_payload(http_replay_cassette_name=None), tmp_path) is None
+
+
+def test_maybe_inject_chooses_tag_bootstrap_under_transport(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+    payload = _payload(source_topic_dir=str(tmp_path))
+
+    # ``paths`` is None under the transport (vcrpy staging is skipped), but
+    # the tag bootstrap still gets injected.
+    injected = proc._maybe_inject_http_replay(nb, payload, None, tmp_path)
+
+    assert injected is True
+    assert len(nb["cells"]) == 2
+    assert "x-clm-cassette" in nb["cells"][0]["source"]
+    assert "import vcr" not in nb["cells"][0]["source"]
+
+
+def test_maybe_inject_noop_without_transport_and_no_paths(monkeypatch):
+    monkeypatch.delenv("CLM_HTTP_REPLAY_TRANSPORT", raising=False)
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+
+    injected = proc._maybe_inject_http_replay(nb, _payload(), None, None)
+
+    assert injected is False
+    assert len(nb["cells"]) == 1

--- a/tests/workers/notebook/test_http_replay_mitm_tag.py
+++ b/tests/workers/notebook/test_http_replay_mitm_tag.py
@@ -9,6 +9,9 @@ resolution and confirm the kernel's httpcore is never patched.
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -16,6 +19,7 @@ from nbformat.v4 import new_code_cell, new_notebook
 
 from clm.workers.notebook.notebook_processor import (
     _HTTP_REPLAY_BOOTSTRAP_MARKER,
+    _HTTP_REPLAY_SOCKET_TRACE_TEMPLATE,
     NotebookProcessor,
     _inject_http_replay_tag_bootstrap,
     _strip_injected_cells,
@@ -61,6 +65,69 @@ def test_strip_removes_tag_bootstrap_cell():
     _strip_injected_cells(nb)
     assert len(nb["cells"]) == 1
     assert nb["cells"][0]["source"] == "print(1)"
+
+
+def test_tag_bootstrap_without_trace_dir_omits_socket_trace():
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+    _inject_http_replay_tag_bootstrap(nb, "/x/foo.http-cassette.yaml")
+    src = nb["cells"][0]["source"]
+    assert "x-clm-cassette" in src  # still the tag bootstrap
+    assert "SOCKET TRACE" not in src
+    assert "addaudithook" not in src
+
+
+def test_tag_bootstrap_with_trace_dir_appends_socket_trace(tmp_path):
+    """Issue #165 P5: under the transport the kernel's socket ground-truth
+    stream must be installed by the tag bootstrap (the vcr trace template
+    cannot run — vcr is never imported)."""
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+    _inject_http_replay_tag_bootstrap(nb, "/x/foo.http-cassette.yaml", trace_dir=str(tmp_path))
+    src = nb["cells"][0]["source"]
+    # Tag bootstrap is still present...
+    assert "x-clm-cassette" in src
+    # ...plus the self-contained socket trace (audit hook, worker file)...
+    assert "addaudithook" in src
+    assert "socket.connect" in src
+    assert "worker-" in src
+    # ...and it must NOT pull in the heavy vcr trace machinery (vcr is never
+    # imported under the transport, so those symbols would NameError).
+    assert "import vcr" not in src
+    assert "force_reset" not in src
+    assert "_clm_vcr_patch" not in src
+    assert "play_response" not in src
+
+
+def test_socket_trace_template_execs_standalone_and_emits(tmp_path):
+    """The socket trace must run with NONE of the vcrpy-bootstrap symbols
+    defined (it is self-contained). Exec it in a clean subprocess and confirm
+    it writes a worker JSONL with the socket bootstrap.complete event."""
+    rendered = _HTTP_REPLAY_SOCKET_TRACE_TEMPLATE.format(trace_dir=str(tmp_path))
+    script = rendered + "\n_clm_strace_close()\n"
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    files = list(tmp_path.glob("worker-*.jsonl"))
+    assert len(files) == 1, files
+    records = [json.loads(line) for line in files[0].read_text().splitlines() if line]
+    streams_events = {(r["stream"], r["event"]) for r in records}
+    assert ("socket", "bootstrap.complete") in streams_events
+    assert all(r["stream"] == "socket" for r in records)
+
+
+def test_maybe_inject_under_transport_injects_socket_trace_when_traced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLM_HTTP_REPLAY_TRANSPORT", "mitmproxy")
+    proc = NotebookProcessor(CompletedOutput(format="code"))
+    nb = new_notebook(cells=[new_code_cell("print(1)")])
+    payload = _payload(source_topic_dir=str(tmp_path), http_replay_trace_dir=str(tmp_path))
+
+    injected = proc._maybe_inject_http_replay(nb, payload, None, tmp_path)
+
+    assert injected is True
+    src = nb["cells"][0]["source"]
+    assert "x-clm-cassette" in src
+    assert "addaudithook" in src  # socket trace wired through the payload field
+    assert "import vcr" not in src
 
 
 def test_resolve_mitmproxy_tag_uses_payload_cassette_name(monkeypatch, tmp_path):

--- a/tests/workers/notebook/test_http_replay_trace.py
+++ b/tests/workers/notebook/test_http_replay_trace.py
@@ -532,3 +532,229 @@ class TestAnalysisScript:
         payload = json.loads(proc.stdout)
         assert "workers" in payload
         assert "host" in payload
+
+
+class TestIsLoopback:
+    """is_loopback must recognize all loopback forms a dual-stack kernel's
+    socket.connect audit event can report verbatim (issue #165 P5), so they are
+    not over-reported as escapes."""
+
+    def _ana(self):
+        sys.path.insert(0, str(Path("scripts").resolve()))
+        try:
+            import analyze_http_replay_trace as ana
+        finally:
+            sys.path.pop(0)
+        return ana
+
+    def test_loopback_forms_recognized(self):
+        ana = self._ana()
+        for h in [
+            "127.0.0.1",
+            "127.0.0.5",  # whole 127.0.0.0/8
+            "::1",
+            "0:0:0:0:0:0:0:1",  # expanded IPv6 loopback
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "localhost",
+        ]:
+            assert ana.is_loopback(h) is True, h
+
+    def test_non_loopback_not_recognized(self):
+        ana = self._ana()
+        for h in ["10.0.0.2", "api.openai.com", "smith.langchain.com", "0.0.0.0", ""]:
+            assert ana.is_loopback(h) is False, h
+
+
+class TestTransportModeAnalysis:
+    """Under transport=mitmproxy the analyzer inverts the bypass rule and reads
+    the ``proxy`` stream as interception evidence (issue #165 P5).
+
+    The kernel's intended remote target IS the proxy, so a remote connect on the
+    proxy port is expected (to-proxy), and a remote connect to any other port is
+    a genuine escape. The dark ``vcr`` stream is not consulted.
+    """
+
+    PROXY_PORT = 12345
+
+    def _build_bundle(self, tmp_path: Path) -> Path:
+        invocation = tmp_path / "trace"
+        invocation.mkdir()
+        (invocation / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "started_at": "2026-05-31T10:00:00+00:00",
+                    "host_pid": 99,
+                    "http_replay_mode": "new-episodes",
+                    "transport": "mitmproxy",
+                    "verbose": False,
+                    "max_body_bytes": 2048,
+                    "argv": ["clm", "build"],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        def _event(stream, event, *, pid, tid, ts_mono, data=None):
+            return (
+                json.dumps(
+                    {
+                        "ts_mono": ts_mono,
+                        "ts_wall": "2026-05-31T10:00:00+00:00",
+                        "pid": pid,
+                        "tid": tid,
+                        "stream": stream,
+                        "event": event,
+                        "data": data or {},
+                    }
+                )
+                + "\n"
+            )
+
+        # Proxy stream: the addon's per-flow decisions.
+        proxy_lines = [
+            _event(
+                "proxy",
+                "proxy.ready",
+                pid=5000,
+                tid=1,
+                ts_mono=0.0,
+                data={
+                    "listen_host": "0.0.0.0",
+                    "listen_port": self.PROXY_PORT,
+                    "mode": "new-episodes",
+                },
+            ),
+            _event(
+                "proxy",
+                "proxy.request",
+                pid=5000,
+                tid=1,
+                ts_mono=1.0,
+                data={"method": "POST", "host": "api.openai.com", "port": 443, "action": "served"},
+            ),
+            _event(
+                "proxy",
+                "proxy.request",
+                pid=5000,
+                tid=1,
+                ts_mono=1.1,
+                data={"method": "POST", "host": "api.openai.com", "port": 443, "action": "forward"},
+            ),
+            _event(
+                "proxy",
+                "proxy.response",
+                pid=5000,
+                tid=1,
+                ts_mono=1.2,
+                data={"host": "api.openai.com", "port": 443, "status": 200, "recorded": True},
+            ),
+            _event(
+                "proxy",
+                "proxy.request",
+                pid=5000,
+                tid=1,
+                ts_mono=1.3,
+                data={
+                    "method": "POST",
+                    "host": "smith.langchain.com",
+                    "port": 443,
+                    "action": "ignored",
+                },
+            ),
+        ]
+        (invocation / "proxy-5000.jsonl").write_text("".join(proxy_lines), encoding="utf-8")
+
+        # Worker stream: a loopback Jupyter connect (NOT the proxy port), a
+        # Direct-style loopback connect TO the proxy port, a Docker-style
+        # gateway-IP connect to the proxy port, and a genuine escape on :443.
+        worker_lines = [
+            _event(
+                "socket",
+                "connect",
+                pid=4242,
+                tid=1,
+                ts_mono=0.4,
+                data={"host": "127.0.0.1", "port": 50000},
+            ),
+            _event(
+                "socket",
+                "connect",
+                pid=4242,
+                tid=1,
+                ts_mono=0.5,
+                data={"host": "127.0.0.1", "port": self.PROXY_PORT},
+            ),
+            _event(
+                "socket",
+                "connect",
+                pid=4242,
+                tid=1,
+                ts_mono=0.6,
+                data={"host": "10.0.0.2", "port": self.PROXY_PORT},
+            ),
+            _event(
+                "socket",
+                "connect",
+                pid=4242,
+                tid=1,
+                ts_mono=0.7,
+                data={"host": "api.openai.com", "port": 443},
+            ),
+        ]
+        (invocation / "worker-4242.jsonl").write_text("".join(worker_lines), encoding="utf-8")
+        return invocation
+
+    def _ana(self):
+        sys.path.insert(0, str(Path("scripts").resolve()))
+        try:
+            import analyze_http_replay_trace as ana
+        finally:
+            sys.path.pop(0)
+        return ana
+
+    def test_proxy_stream_and_bypass_inversion(self, tmp_path):
+        ana = self._ana()
+        result = ana.analyze(self._build_bundle(tmp_path))
+
+        assert result.transport == "mitmproxy"
+        assert result.proxy.proxy_ports == {self.PROXY_PORT}
+        assert result.proxy.flows_total == 3
+        assert result.proxy.served == 1
+        assert result.proxy.forward == 1
+        assert result.proxy.ignored == 1
+        assert result.proxy.recorded == 1
+
+        ws = result.workers[4242]
+        assert len(ws.loopback_connects) == 2  # jupyter + the Direct loopback-to-proxy
+        assert len(ws.remote_connects) == 2  # the gateway-IP one + the escape
+        # Both proxy-port connects (loopback Direct + remote Docker gateway) are
+        # to-proxy, NOT bypasses.
+        assert len(ws.to_proxy_connects) == 2
+        assert {c.data["host"] for c in ws.to_proxy_connects} == {"127.0.0.1", "10.0.0.2"}
+        # Only the :443 connect that is NOT on the proxy port is the genuine escape.
+        assert len(ws.bypassed) == 1
+        assert ws.bypassed[0]["host"] == "api.openai.com"
+        # No vcr stream → no race candidates under the transport.
+        assert ws.race_candidates == []
+
+    def test_text_report_transport_sections(self, tmp_path):
+        ana = self._ana()
+        result = ana.analyze(self._build_bundle(tmp_path))
+        report = ana.format_text(result)
+        assert "Transport:       mitmproxy" in report
+        assert "Proxy (interception evidence):" in report
+        assert "To proxy (expected): 2" in report
+        assert "Bypassed (escaped the proxy): 1" in report
+        assert "BYPASS — escaped the proxy" in report
+
+    def test_json_report_has_proxy_block(self, tmp_path):
+        ana = self._ana()
+        result = ana.analyze(self._build_bundle(tmp_path))
+        payload = json.loads(ana.format_json(result))
+        assert payload["transport"] == "mitmproxy"
+        assert payload["proxy"]["proxy_ports"] == [self.PROXY_PORT]
+        assert payload["proxy"]["flows_total"] == 3
+        assert payload["workers"]["4242"]["to_proxy_connects"] == 2
+        assert payload["workers"]["4242"]["remote_connects"] == 2


### PR DESCRIPTION
Out-of-process **mitmproxy** HTTP-replay transport for issue #165, fully behind the opt-in flag `CLM_HTTP_REPLAY_TRANSPORT=mitmproxy`. **vcrpy stays the default and is never uninstalled** (it remains the YAML serializer behind `cassette doctor` / `strip_cassette_hosts` / the cassette bridge). With the flag unset the build is a verified **bit-identical no-op**, so this is safe to land as a baking step.

The pin-guard insurance (#172) has merged; this PR's base is now `master`.

**Explicitly *not* in this PR (deferred to a post-merge release):** the default-flip to mitmproxy and the deletion of the in-kernel vcrpy workarounds. Per the plan invariant those happen only after the transport has *held across a full release cycle*. Merging this starts that bake -- it does not change the default. Readiness analysis, the per-gate audit, the workaround-deletion inventory and its blast radius are in `docs/claude/issue-165-p5-readiness.md`.

## Phases (all behind the flag; each shipped with its parity gate)

| Phase | Scope | Status |
|---|---|---|
| **0** | CA-trust, deadlock-class elimination, single-proxy throughput at 16-worker load | all GREEN (`issue-165-phase0-findings.md`) |
| **P1** | vcrpy-YAML cassette bridge (byte-identical to a vcrpy cassette; doctor/strip/merge unchanged) | done |
| **P2** | request to cassette routing -- per-worker `X-CLM-Cassette` tag, single proxy demuxes to per-target staging; split-deck fallback preserved | done |
| **P3** | addon correctness/security parity -- secret filtering, `ignore_hosts`, JSON-semantic matching, `once`/`refresh`, strict-miss to non-retryable 404 to fast non-zero exit | done |
| **P4** | Docker worker support -- `host.docker.internal` reachability + CA-in-container, `NO_PROXY` for the REST API, host-namespace cassette tag | done |
| **P5 step 1** | forensic trace harness re-ported against the proxy (`proxy` stream replaces the dark `vcr` stream; analyzer transport mode) | done |

## Verification

- **CI green** on the head (Docker integration, lint+typecheck, Python 3.11/3.12/3.13, codecov/patch); full fast suite + ruff + mypy clean locally.
- **Default-unchanged** invariant covered by regression tests (transport unset => no proxy, no bootstrap change, no trace).
- **Empirical:** the exact `chains-parallel-stress-cassette.xml` reproducer that deadlocks 16 kernels under vcrpy completes through one shared `mitmdump`; an isolated proxy smoke proves CA trust + 0-bypass; **gate 6 closed with a real OpenRouter run** (secret-clean recording + byte-identical no-op rebuild).
- Each phase has a detailed comment on this PR; the adversarial reviews (P2/P3/P4/P5) are linked there, with all confirmed findings fixed.

## Remaining before the eventual default-flip (a future release, not this PR)

Convert the uncommitted scale/e2e proofs for gates 1/2/7/8/9 into committed tests or a repeatable cutover-gate script; add an `allow_playback_repeats` regression test on the mitmproxy side. Then flip the default for one release with `CLM_HTTP_REPLAY_TRANSPORT=vcrpy` still selectable as rollback insurance; **only then** delete the in-kernel workarounds + the bootstrap (in the same commit that removes the in-kernel vcrpy path), remove `test_http_replay_vcr_pin_guard.py`, and relax the `[replay]` vcrpy pin. The Option-F per-cell timeout stays (a side finding here: a 404 replay-miss can be re-issued by langchain's retry/agent layer above the SDK, so the per-cell timeout is the real backstop).

Refs #165, #143, #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
