### PR TITLE
fix(tests): poll committed DB for mock-worker registration to kill xdist flake (#163)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1156,7 +1156,5 @@ def mock_notebook_workers(mock_worker_pool):
     to process jobs.
     """
     workers = mock_worker_pool.start_workers("notebook", count=2)
-    assert mock_worker_pool.wait_for_workers_registered(timeout=5.0), (
-        "Mock notebook workers did not register within 5s"
-    )
+    assert mock_worker_pool.wait_for_workers_registered(), "Mock notebook workers did not register"
     return workers

--- a/tests/fixtures/mock_workers.py
+++ b/tests/fixtures/mock_workers.py
@@ -23,6 +23,16 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Generous ceiling for registration waits. The waits below return as soon as
+# the condition is observed, so a large ceiling costs nothing on the happy
+# path; it only bounds the pathological "never registers" case. The previous
+# 5s ceiling starved under pytest-xdist load — worker threads competing with
+# dozens of other test processes for CPU could not all run their registration
+# INSERT within 5s, even though they registered fine moments later (issue
+# #163). This mirrors the polling deadline already used by the direct-worker
+# integration tests (``_wait_for_registered_workers``).
+DEFAULT_REGISTRATION_TIMEOUT = 30.0
+
 
 @dataclass
 class MockWorkerConfig:
@@ -114,8 +124,12 @@ class MockWorker:
         self._thread = threading.Thread(target=self._run, daemon=True, name=self.container_id)
         self._thread.start()
 
-    def wait_for_registration(self, timeout: float = 5.0) -> bool:
+    def wait_for_registration(self, timeout: float = DEFAULT_REGISTRATION_TIMEOUT) -> bool:
         """Wait until this worker has registered in the database.
+
+        The registration row is committed before ``_registered_event`` is set
+        (see ``_run``), so a set event guarantees the row is visible to a fresh
+        connection.
 
         Args:
             timeout: Maximum time to wait in seconds
@@ -456,8 +470,61 @@ class MockWorkerPool:
         self._workers.extend(workers)
         return workers
 
-    def wait_for_workers_registered(self, timeout: float = 5.0) -> bool:
-        """Wait until all workers have registered in the database.
+    def wait_for_worker_count(
+        self,
+        expected: int,
+        worker_type: str | None = None,
+        timeout: float = DEFAULT_REGISTRATION_TIMEOUT,
+        poll_interval: float = 0.05,
+    ) -> bool:
+        """Poll the committed ``workers`` table until at least ``expected``
+        live (non-dead) workers — optionally of a single ``worker_type`` — are
+        visible.
+
+        This polls the same committed database state that
+        :class:`~clm.infrastructure.workers.discovery.WorkerDiscovery` reads
+        through its own connection, so it is robust to both slow thread
+        scheduling and cross-connection write-visibility under heavy
+        pytest-xdist load. A fixed in-process event ceiling, by contrast,
+        could expire while the worker threads were merely starved of CPU
+        (issue #163).
+
+        Args:
+            expected: Minimum number of live workers to wait for
+            worker_type: Restrict the count to a single worker type (None = any)
+            timeout: Maximum time to wait in seconds
+            poll_interval: Time between polls in seconds
+
+        Returns:
+            True if the count was reached within the timeout, False otherwise
+        """
+        query = "SELECT COUNT(*) FROM workers WHERE status != 'dead'"
+        params: tuple = ()
+        if worker_type is not None:
+            query += " AND worker_type = ?"
+            params = (worker_type,)
+
+        deadline = time.monotonic() + timeout
+        conn = sqlite3.connect(str(self.db_path), timeout=30.0)
+        try:
+            while True:
+                count = conn.execute(query, params).fetchone()[0]
+                if count >= expected:
+                    return True
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(poll_interval)
+        finally:
+            conn.close()
+
+    def wait_for_workers_registered(self, timeout: float = DEFAULT_REGISTRATION_TIMEOUT) -> bool:
+        """Wait until all started workers are registered and visible in the DB.
+
+        Polls committed database state (via :meth:`wait_for_worker_count`)
+        rather than per-worker in-process events: under pytest-xdist load the
+        worker threads can be starved long enough that a fixed in-process event
+        ceiling expires before they run, even though they register fine moments
+        later (issue #163).
 
         Args:
             timeout: Maximum time to wait in seconds
@@ -465,7 +532,7 @@ class MockWorkerPool:
         Returns:
             True if all workers registered within timeout, False otherwise
         """
-        return all(w.wait_for_registration(timeout=timeout) for w in self._workers)
+        return self.wait_for_worker_count(len(self._workers), timeout=timeout)
 
     def stop_all(self, timeout: float = 5.0) -> None:
         """Stop all mock workers.

--- a/tests/infrastructure/workers/test_lifecycle_mock.py
+++ b/tests/infrastructure/workers/test_lifecycle_mock.py
@@ -30,7 +30,7 @@ class TestMockWorkerBasics:
 
         try:
             worker.start()
-            assert worker.wait_for_registration(timeout=5.0), "Worker should register within 5s"
+            assert worker.wait_for_registration(), "Worker should register"
 
             # Verify worker is registered in database
             conn = sqlite3.connect(str(mock_db_path))
@@ -54,7 +54,7 @@ class TestMockWorkerBasics:
         worker = MockWorker(config, mock_db_path, worker_id=0)
 
         worker.start()
-        assert worker.wait_for_registration(timeout=5.0), "Worker should register within 5s"
+        assert worker.wait_for_registration(), "Worker should register"
         worker.stop()  # join waits for thread to finish and mark dead
 
         # Verify worker is marked as dead
@@ -125,7 +125,7 @@ class TestMockWorkerPool:
 
         try:
             workers = pool.start_workers("notebook", count=3)
-            assert pool.wait_for_workers_registered(timeout=5.0)
+            assert pool.wait_for_worker_count(3, worker_type="notebook")
 
             assert len(workers) == 3
             assert len(pool.running_workers) == 3
@@ -145,7 +145,7 @@ class TestMockWorkerPool:
         pool = MockWorkerPool(mock_db_path)
 
         workers = pool.start_workers("notebook", count=3)
-        assert pool.wait_for_workers_registered(timeout=5.0)
+        assert pool.wait_for_workers_registered()
         pool.stop_all()  # join waits for threads to finish and mark dead
 
         assert len(pool.running_workers) == 0
@@ -166,7 +166,7 @@ class TestMockWorkerPool:
             notebook_workers = pool.start_workers("notebook", count=2)
             plantuml_workers = pool.start_workers("plantuml", count=1)
             drawio_workers = pool.start_workers("drawio", count=1)
-            assert pool.wait_for_workers_registered(timeout=5.0)
+            assert pool.wait_for_workers_registered()
 
             assert len(notebook_workers) == 2
             assert len(plantuml_workers) == 1
@@ -214,7 +214,7 @@ class TestMockWorkerJobProcessing:
             # Close the race against thread startup under xdist load: gate on
             # registration before polling for job completion (otherwise the
             # 5s job-wait races with the OS scheduling worker threads).
-            assert pool.wait_for_workers_registered(timeout=10.0), (
+            assert pool.wait_for_workers_registered(), (
                 "Workers should register before processing jobs"
             )
 
@@ -256,7 +256,7 @@ class TestMockWorkerJobProcessing:
         try:
             # Start workers with 50% fail rate
             pool.start_workers("notebook", count=2, processing_delay=0.02, fail_rate=0.5)
-            assert pool.wait_for_workers_registered(timeout=10.0), (
+            assert pool.wait_for_workers_registered(), (
                 "Workers should register before processing jobs"
             )
 
@@ -286,7 +286,7 @@ class TestMockWorkerDiscovery:
         try:
             pool.start_workers("notebook", count=2)
             pool.start_workers("plantuml", count=1)
-            assert pool.wait_for_workers_registered(timeout=5.0)
+            assert pool.wait_for_workers_registered()
 
             discovery = WorkerDiscovery(mock_db_path)
             workers = discovery.discover_workers()
@@ -314,7 +314,12 @@ class TestMockWorkerDiscovery:
         try:
             pool.start_workers("notebook", count=3)
             pool.start_workers("plantuml", count=2)
-            assert pool.wait_for_workers_registered(timeout=5.0)
+            # Poll the committed DB — the same view WorkerDiscovery reads —
+            # until both worker types are registered, rather than relying on a
+            # tight in-process event ceiling that starves under xdist load
+            # (issue #163).
+            assert pool.wait_for_worker_count(3, worker_type="notebook")
+            assert pool.wait_for_worker_count(2, worker_type="plantuml")
 
             discovery = WorkerDiscovery(mock_db_path)
 
@@ -338,7 +343,7 @@ class TestMockWorkerCleanup:
 
         # Start and stop workers
         pool.start_workers("notebook", count=3)
-        assert pool.wait_for_workers_registered(timeout=5.0)
+        assert pool.wait_for_workers_registered()
         pool.stop_all()  # join waits for threads to finish and mark dead
 
         # Verify workers are marked as dead
@@ -367,7 +372,7 @@ class TestMockWorkerCleanup:
 
         try:
             pool.start_workers("notebook", count=2, processing_delay=0.02)
-            assert pool.wait_for_workers_registered(timeout=10.0), (
+            assert pool.wait_for_workers_registered(), (
                 "Workers should register before processing jobs"
             )
             assert pool.wait_for_jobs(timeout=15.0), "All jobs should be processed within timeout"

--- a/tests/infrastructure/workers/test_worker_base.py
+++ b/tests/infrastructure/workers/test_worker_base.py
@@ -17,10 +17,17 @@ from clm.infrastructure.workers.worker_base import Worker
 
 def _wait_until(
     predicate: Callable[[], bool],
-    timeout: float = 5.0,
+    timeout: float = 15.0,
     interval: float = 0.05,
 ) -> None:
-    """Poll until *predicate* returns True, or raise after *timeout* seconds."""
+    """Poll until *predicate* returns True, or raise after *timeout* seconds.
+
+    The wait returns as soon as the predicate holds, so a generous ceiling
+    costs nothing on the happy path; it only bounds the pathological case.
+    The default matches the polling deadline used by the worker integration
+    tests and guards against the fixed-ceiling starvation flake that bit the
+    mock-pool tests under pytest-xdist load (issue #163).
+    """
     deadline = time.monotonic() + timeout
     while not predicate():
         if time.monotonic() > deadline:
@@ -280,7 +287,6 @@ def test_worker_updates_heartbeat(worker_id, db_path):
     try:
         _wait_until(
             lambda: (_read_worker_last_heartbeat(db_path, worker_id) or "") > initial_heartbeat,
-            timeout=5.0,
         )
     finally:
         worker.stop()
@@ -314,15 +320,9 @@ def test_worker_updates_status(worker_id, db_path):
     thread.start()
     try:
         # Wait for the worker to pick up the job and transition to "busy".
-        _wait_until(
-            lambda: _read_worker_status(db_path, worker_id) == "busy",
-            timeout=5.0,
-        )
+        _wait_until(lambda: _read_worker_status(db_path, worker_id) == "busy")
         # Then wait for it to finish and return to "idle".
-        _wait_until(
-            lambda: _read_worker_status(db_path, worker_id) == "idle",
-            timeout=5.0,
-        )
+        _wait_until(lambda: _read_worker_status(db_path, worker_id) == "idle")
     finally:
         worker.stop()
         thread.join(timeout=5)


### PR DESCRIPTION
## Summary

Fixes #163 — `test_discover_workers_by_type` flaked under `pytest-xdist -n auto` (passed in isolation).

## Root cause

The test gated on `pool.wait_for_workers_registered(timeout=5.0)` and then asserted exact discovery counts. `wait_for_workers_registered` waited on each worker's **in-process `threading.Event` with a fixed 5s ceiling**, so under 32-way xdist load the 5 worker threads could not all run their registration `INSERT` within 5s, the wait returned `False`, and the bare `assert` failed.

This was **not** a write-visibility race: in `MockWorker._run` the registration row is committed (and the connection closed) *before* `_registered_event` is set, and `WorkerDiscovery` reads via a fresh autocommit connection opened *after* the wait. The failure was purely a **tight wall-clock ceiling starving under load** — the same flake family as the earlier `time.sleep` waits, which the worker *integration* tests already solved by polling the DB/discovery with a generous deadline (`_wait_for_registered_workers`, `_wait_for_healthy_workers`). The mock-worker pool never adopted that idiom.

## Fix

`tests/fixtures/mock_workers.py`:
- Add `DEFAULT_REGISTRATION_TIMEOUT = 30.0`. An event/poll wait returns the instant its condition holds, so a large ceiling is free on the happy path and only bounds the pathological "never registers" case.
- Add `MockWorkerPool.wait_for_worker_count(expected, worker_type=…)` that **polls the committed `workers` table** — the same view `WorkerDiscovery` reads — robust to both slow thread scheduling and any cross-connection visibility timing.
- Reimplement `wait_for_workers_registered()` on top of it (polls the DB instead of in-process events).

`tests/infrastructure/workers/test_lifecycle_mock.py` + `tests/conftest.py`:
- Drop the tight `5.0`/`10.0` overrides; the two discovery/count tests now gate on the per-type `wait_for_worker_count` they assert against.

## Other similar patterns audited (per the issue's "check for similar patterns")

- `test_direct_integration.py`, `test_lifecycle_integration.py` — already use generous (15s) DB/discovery poll helpers. ✅ unchanged.
- `test_discovery.py` — inserts rows synchronously, no threads. ✅ not susceptible.
- `test_worker_base.py` — uses a `_wait_until(predicate)` poll helper (correct idiom) but defaulted to a **5s ceiling** (same family, milder: single thread). Hardened the default to **15s** and removed three redundant explicit `timeout=5.0` overrides.

## Verification

- `test_lifecycle_mock.py`: **15/15** consecutive runs clean, and **5/5 clean under 16 background CPU-burn jobs** (simulating the contention that triggered the original flake).
- `test_worker_base.py`: 28/28. Full `tests/infrastructure/workers/` (non-docker): **339 passed, 9 skipped**.
- Pre-commit hooks (ruff lint + format, fast suite) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
