### PR TITLE
fix(cross-references): deliver href map to worker + URL-encode hrefs (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Cross-references (`clm:`) now actually render as working links
+  ([#17](https://github.com/hoelzl/clm/issues/17)).** Two defects made the
+  feature a no-op end-to-end as first merged: (1) the notebook worker
+  reconstructed its payload from a hand-listed set of fields and silently
+  dropped `cross_references` (and `svg_available_stems` / `inline_images`), so
+  the resolved href map never reached the rewrite step and every `clm:` link
+  shipped verbatim; the worker now deserializes the whole payload via
+  `model_validate`, so no field can be dropped again. (2) Resolved hrefs were
+  not URL-encoded, but CLM output filenames are `"{NN} {title}{ext}"` and the
+  embedded space is not a valid Markdown link destination — renderers
+  (nbconvert, JupyterLab/VS Code) left `[text](02 Foo.html)` as literal text
+  rather than an anchor; hrefs are now percent-encoded
+  (`02%20Foo.html`). Added a Markdown→HTML rendering regression test and a
+  payload round-trip test.
 - **`clm validate` no longer false-errors on split slide files
   ([#160](https://github.com/hoelzl/clm/issues/160)).** The bilingual DE/EN
   `pairing` sub-checks — cell-count parity, per-pair tag/type consistency, and

--- a/src/clm/core/cross_references.py
+++ b/src/clm/core/cross_references.py
@@ -41,6 +41,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 from clm.core.utils.text_utils import sanitize_file_name
 from clm.infrastructure.utils.path_utils import (
@@ -272,7 +273,7 @@ class CrossReferenceResolver:
         # the relative path is purely a function of the two section dirs.
         from_path = PurePosixPath(from_section_dir)
         target_path = PurePosixPath(target_section_dir) / target_file_name
-        href = _relative_posix(target_path, from_path)
+        href = _encode_href(_relative_posix(target_path, from_path))
         return ResolvedReference(reference=reference, href=href, ambiguous=ambiguous)
 
     def build_href_map(
@@ -506,3 +507,19 @@ def _relative_posix(target: PurePosixPath, start: PurePosixPath) -> str:
     if not rel_parts:
         return "."
     return "/".join(rel_parts)
+
+
+def _encode_href(path: str) -> str:
+    """Percent-encode a relative href so it is a usable Markdown link target.
+
+    CLM output filenames follow ``"{number_in_section:02} {title}{ext}"`` and
+    therefore almost always contain spaces (and may contain other characters
+    such as parentheses). A bare space is not valid inside a CommonMark inline
+    link destination, so renderers — nbconvert's ``HTMLExporter``,
+    JupyterLab/VS Code — leave ``[text](02 Foo.html)`` as *literal text*
+    rather than emitting a working ``<a>`` anchor. Percent-encoding the path
+    while preserving the ``/`` separators (e.g. ``../Workshops/03%20Foo.html``)
+    is treated as a link by every renderer and resolves back to the real file
+    in the browser (issue #17).
+    """
+    return quote(path, safe="/")

--- a/src/clm/workers/notebook/notebook_worker.py
+++ b/src/clm/workers/notebook/notebook_worker.py
@@ -181,30 +181,37 @@ class NotebookWorker(Worker):
                 format=payload_data.get("format", "notebook"),
             )
 
-            # Create NotebookPayload for processing
-            # Note: This is a simplified version that works with the new architecture
-            payload = NotebookPayload(
-                data=notebook_text,
-                input_file=str(input_path),
-                input_file_name=input_path.name,
-                output_file=job.output_file,
-                kind=payload_data.get("kind", "completed"),
-                prog_lang=payload_data.get("prog_lang", "python"),
-                language=payload_data.get("language", "en"),
-                format=payload_data.get("format", "notebook"),
-                template_dir=payload_data.get("template_dir", ""),
-                other_files=payload_data.get("other_files", {}),
-                correlation_id=payload_data.get("correlation_id", f"job-{job.id}"),
-                fallback_execute=payload_data.get("fallback_execute", False),
-                skip_evaluation=payload_data.get("skip_evaluation", False),
-                skip_errors=payload_data.get("skip_errors", False),
-                http_replay_mode=payload_data.get("http_replay_mode"),
-                http_replay_cassette_name=payload_data.get("http_replay_cassette_name"),
-                http_replay_trace_dir=payload_data.get("http_replay_trace_dir", ""),
-                img_path_prefix=payload_data.get("img_path_prefix", "img/"),
-                source_topic_dir=payload_data.get("source_topic_dir", ""),
-                author=payload_data.get("author", "Dr. Matthias Hölzl"),
-                organization=payload_data.get("organization", ""),
+            # Reconstruct the full NotebookPayload from the serialized job
+            # data. Deserialize the whole dict via ``model_validate`` rather
+            # than re-listing fields by hand: the host serializes the payload
+            # with ``model_dump(mode="json")`` (see ``SqliteBackend``), so
+            # round-tripping the dict preserves *every* field automatically.
+            # The previous hand-maintained constructor silently dropped any
+            # field it did not name — e.g. ``cross_references`` (issue #17),
+            # which left every ``clm:`` link unrewritten in the output, and
+            # ``svg_available_stems`` / ``inline_images``. ``data`` and the
+            # path fields are overridden because in Docker source-mount mode
+            # the notebook text and paths come from the filesystem rather than
+            # the payload.
+            payload = NotebookPayload.model_validate(
+                {
+                    # Defaults for the required descriptor fields, preserved
+                    # from the previous hand-written reconstruction so a
+                    # partial payload still validates; ``payload_data`` below
+                    # overrides them whenever the host set them (it always
+                    # does for real jobs). Every other field — including
+                    # cross_references — flows through automatically.
+                    "kind": "completed",
+                    "prog_lang": "python",
+                    "language": "en",
+                    "format": "notebook",
+                    **payload_data,
+                    "data": notebook_text,
+                    "input_file": str(input_path),
+                    "input_file_name": input_path.name,
+                    "output_file": job.output_file,
+                    "correlation_id": payload_data.get("correlation_id", f"job-{job.id}"),
+                }
             )
 
             # Determine source directory for supporting files (Docker mode with source mount)

--- a/tests/core/test_cross_references.py
+++ b/tests/core/test_cross_references.py
@@ -108,9 +108,11 @@ def test_split_reference(reference: str, expected: tuple[str, str | None]) -> No
 # rewrite_cross_references
 # --------------------------------------------------------------------------- #
 def test_rewrite_replaces_href() -> None:
+    # The resolver always hands ``rewrite_cross_references`` an already
+    # percent-encoded href (issue #17), so the substitution is verbatim.
     text = "See [the workshop](clm:functions_workshop)."
-    out = rewrite_cross_references(text, {"functions_workshop": "../Workshops/03 Functions.html"})
-    assert out == "See [the workshop](../Workshops/03 Functions.html)."
+    out = rewrite_cross_references(text, {"functions_workshop": "../Workshops/03%20Functions.html"})
+    assert out == "See [the workshop](../Workshops/03%20Functions.html)."
 
 
 def test_rewrite_drops_link_on_empty_href() -> None:
@@ -238,7 +240,9 @@ def test_resolver_maps_topic_id_to_html_href() -> None:
     )
     assert resolved is not None
     # From section "Basics" up one and into "Workshops" with the renamed file.
-    assert resolved.href == "../Workshops/03 Functions.html"
+    # The space in the filename is percent-encoded so the link renders as a
+    # working anchor (issue #17).
+    assert resolved.href == "../Workshops/03%20Functions.html"
     assert resolved.ambiguous is False
 
 
@@ -255,7 +259,7 @@ def test_resolver_href_is_per_variant() -> None:
         format="notebook",
     )
     assert de_nb is not None
-    assert de_nb.href == "../Workshops/03 Funktionen.ipynb"
+    assert de_nb.href == "../Workshops/03%20Funktionen.ipynb"
 
     en_code = resolver.resolve(
         "functions_workshop",
@@ -266,7 +270,7 @@ def test_resolver_href_is_per_variant() -> None:
     )
     assert en_code is not None
     # code format extension follows the prog lang (.py for python).
-    assert en_code.href == "../Workshops/03 Functions.py"
+    assert en_code.href == "../Workshops/03%20Functions.py"
 
 
 def test_resolver_returns_none_for_missing_topic() -> None:
@@ -332,7 +336,7 @@ def test_resolver_ambiguous_multi_notebook_topic() -> None:
     assert resolved is not None
     assert resolved.ambiguous is True
     # Deterministic fallback: lowest number_in_section -> Part A (slot 1).
-    assert resolved.href == "../Advanced/01 Part A.html"
+    assert resolved.href == "../Advanced/01%20Part%20A.html"
 
 
 def test_resolver_disambiguator_selects_specific_deck() -> None:
@@ -348,7 +352,7 @@ def test_resolver_disambiguator_selects_specific_deck() -> None:
     )
     assert resolved is not None
     assert resolved.ambiguous is False
-    assert resolved.href == "../Advanced/02 Part B.html"
+    assert resolved.href == "../Advanced/02%20Part%20B.html"
 
 
 # --------------------------------------------------------------------------- #
@@ -430,7 +434,7 @@ def test_href_map_ambiguous_emits_warning_but_resolves() -> None:
         format="html",
         fail_on_missing=True,
     )
-    assert hrefs == {"advanced": "../Advanced/01 Part A.html"}
+    assert hrefs == {"advanced": "../Advanced/01%20Part%20A.html"}
     assert len(issues) == 1
     assert issues[0].severity == "warning"
 
@@ -506,7 +510,7 @@ def test_payload_compute_cross_references_resolves_for_variant() -> None:
     )
     data = "See [the workshop](clm:functions_workshop)."
     hrefs = op.compute_cross_references(data)
-    assert hrefs == {"functions_workshop": "../Workshops/03 Functions.html"}
+    assert hrefs == {"functions_workshop": "../Workshops/03%20Functions.html"}
 
 
 def test_payload_compute_cross_references_empty_without_refs() -> None:

--- a/tests/infrastructure/messaging/test_notebook_classes.py
+++ b/tests/infrastructure/messaging/test_notebook_classes.py
@@ -61,6 +61,50 @@ class TestNotebookPayload:
         assert sample_payload.other_files == {}
         assert sample_payload.fallback_execute is False
 
+    def test_json_roundtrip_preserves_worker_consumed_fields(self):
+        """Regression guard for issue #17.
+
+        The notebook worker reconstructs the payload from the job's serialized
+        JSON. It must preserve *every* field the host sets — a hand-maintained
+        field list previously dropped ``cross_references`` (and
+        ``svg_available_stems`` / ``inline_images``), silently disabling the
+        cross-reference rewrite so every ``clm:`` link shipped unrewritten.
+        Serialize with the same call the backend uses (``model_dump(mode=
+        "json")``) and reconstruct the way ``NotebookWorker`` now does
+        (``model_validate`` of the whole dict), then assert the fields survive.
+        """
+        original = NotebookPayload(
+            correlation_id="cid",
+            input_file="/in.py",
+            input_file_name="in.py",
+            output_file="/out.html",
+            data="src",
+            kind="completed",
+            prog_lang="python",
+            language="en",
+            format="html",
+            cross_references={"workshop": "../W/02%20Workshop.html"},
+            svg_available_stems=["diagram"],
+            inline_images=True,
+        )
+
+        dumped = original.model_dump(mode="json")
+        # The worker overrides data + path fields (filesystem/job) and takes
+        # everything else verbatim from the serialized dict.
+        restored = NotebookPayload.model_validate(
+            {
+                **dumped,
+                "data": "src",
+                "input_file": "/in.py",
+                "input_file_name": "in.py",
+                "output_file": "/out.html",
+            }
+        )
+
+        assert restored.cross_references == {"workshop": "../W/02%20Workshop.html"}
+        assert restored.svg_available_stems == ["diagram"]
+        assert restored.inline_images is True
+
     def test_notebook_text_property(self, sample_payload):
         """Should return data as notebook_text property."""
         assert sample_payload.notebook_text == "notebook content here"

--- a/tests/workers/notebook/test_cross_reference_rewrite.py
+++ b/tests/workers/notebook/test_cross_reference_rewrite.py
@@ -45,7 +45,9 @@ def _payload(cross_references: dict[str, str], format_: str = "html") -> Noteboo
 def test_rewrite_produces_working_relative_link(format_: str) -> None:
     processor = NotebookProcessor(CompletedOutput(format=format_))
     ext = "html" if format_ == "html" else "ipynb"
-    href = f"../Workshops/03 Functions.{ext}"
+    # The resolver percent-encodes the href (issue #17); the worker rewrite is
+    # a verbatim substitution of that encoded value.
+    href = f"../Workshops/03%20Functions.{ext}"
     cell = _markdown_cell("See [the workshop](clm:functions_workshop).")
 
     processor._process_markdown_cell_contents(
@@ -55,6 +57,35 @@ def test_rewrite_produces_working_relative_link(format_: str) -> None:
     )
 
     assert cell["source"] == f"See [the workshop]({href})."
+
+
+def test_rewritten_link_renders_as_html_anchor() -> None:
+    """End-to-end guard for issue #17: a rewritten href must survive
+    Markdown -> HTML rendering as a real ``<a>`` anchor.
+
+    CLM output filenames are ``"{NN} {title}{ext}"`` and therefore contain
+    spaces. A bare space is not a valid CommonMark inline-link destination, so
+    nbconvert renders ``[text](02 Foo.html)`` as *literal text* rather than a
+    link. The resolver percent-encodes the href to prevent exactly this; here
+    we render the rewritten cell through the same exporter CLM uses and assert
+    an anchor is produced (not literal markdown).
+    """
+    import nbformat
+    from nbconvert import HTMLExporter
+
+    processor = NotebookProcessor(CompletedOutput(format="html"))
+    href = "../Workshops/03%20Functions.html"
+    cell = _markdown_cell("See [the workshop](clm:functions_workshop).")
+    processor._process_markdown_cell_contents(
+        cell, "img/", _payload({"functions_workshop": href}, format_="html")
+    )
+
+    nb = nbformat.v4.new_notebook()
+    nb.cells = [nbformat.v4.new_markdown_cell(cell["source"])]
+    body, _ = HTMLExporter(template_name="classic").from_notebook_node(nb)
+
+    assert f'href="{href}"' in body, "rewritten cross-reference must render as a working anchor"
+    assert "[the workshop]" not in body, "the Markdown link syntax must not survive as literal text"
 
 
 def test_rewrite_drops_link_when_href_empty() -> None:


### PR DESCRIPTION
## Summary

Fixes #17. The cross-references feature (`[text](clm:topic-id)`) was merged via #153 but was **non-functional end-to-end**. Verifying it in an isolated 2-topic build (`intro` → `[the Functions workshop](clm:workshop)`) surfaced two independent bugs; both are fixed here with regression tests.

## Bug 1 — the resolved href map never reached the worker

`clm validate-spec` resolved the target fine, and the host-side `compute_cross_references` produced the correct map (`html → 02 slides_workshop.html`, `notebook → .ipynb`, `code → ''`). But the build left every `clm:` link verbatim (`<a href="clm:workshop">`) in **all** formats.

Root cause: `notebook_worker.py` reconstructed `NotebookPayload` from a **hand-listed** set of fields and silently dropped `cross_references` (and `svg_available_stems` / `inline_images`), so `payload.cross_references` was always `{}` at the worker and the rewrite was skipped. The host serializes the payload with `model_dump(mode="json")`, so the data was present in the job — only the reconstruction discarded it.

Fix: reconstruct via `NotebookPayload.model_validate(...)` of the whole serialized dict, so **no field can be silently dropped again**. Required descriptor fields keep their previous defaults so partial payloads still validate.

## Bug 2 — hrefs weren't URL-encoded, so links rendered as literal text

With Bug 1 fixed, the `.ipynb` link worked but the **HTML still wasn't a link**: it rendered as `<p>See [the Functions workshop](02 slides_workshop.html)`. CLM filenames are `"{NN} {title}{ext}"`, so every href contains a space — not a valid CommonMark inline-link destination, so nbconvert/JupyterLab/VS Code render it as literal text. (Confirmed directly against nbconvert: bare space → literal text; `%20` → `<a href="02%20slides_workshop.html">`.)

Fix: `CrossReferenceResolver.resolve` now percent-encodes the href (`02%20slides_workshop.html`). The existing tests asserted the unencoded form and never rendered, so this shipped uncaught.

## Tests

- **New Markdown→HTML rendering regression test** — renders the rewritten cell through CLM's exporter and asserts a real `<a>` anchor (the gap that let Bug 2 ship).
- **New payload round-trip test** — `model_dump(mode="json")` → `model_validate` preserves `cross_references`/`svg_available_stems`/`inline_images` (guards Bug 1).
- Updated resolver assertions to the percent-encoded form.

## Verification

Built a throwaway course (outside PythonCourses). After both fixes:
- **HTML** (producer *and* cache-reuse paths): `<a href="02%20slides_workshop.html">the Functions workshop</a>` ✓
- **Notebook**: `](02%20slides_workshop.ipynb)` ✓
- **Code**: link correctly dropped to plain text ✓
- Zero raw `clm:` or unencoded broken links remain.

`ruff` + `mypy` clean; the fast suite and the worker/messaging/build-command/cross-ref suites (787 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
