### PR TITLE
refactor(workers): reconstruct payloads by total deserialization (#17 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   drift, and CI now installs the `[replay]` extra so those tests run there.
   Ready-to-submit upstream patches that would let the fork be retired are in
   `docs/claude/vcrpy-upstream-patches.md`.
-
+- **Worker payloads are reconstructed by total deserialization, not a
+  hand-listed field set (issue #17 follow-up).** The notebook worker now
+  rebuilds its `NotebookPayload` via `Payload.from_job_payload`, which
+  `model_validate`s the entire serialized dict (symmetric with the host's
+  `model_dump`), so a newly added payload field can never again be silently
+  dropped at the worker boundary — the failure mode that disabled
+  cross-references. A malformed job missing a required descriptor field now
+  fails loudly instead of being coerced to defaults, and the
+  `(kind, prog_lang, language, format)` metadata extraction is centralized in
+  `notebook_metadata_tags_from_payload` (used by the worker and the
+  result/cache bookkeeping), removing previously divergent fallback defaults.
+  A structural round-trip test tied to `NotebookPayload.model_fields` guards
+  the invariant for every current and future field.
 - **`clm recordings check` is now backend-aware** (issue #33). The command
   reads `recordings.processing_backend` and only checks the dependencies the
   active backend actually needs, and the output table header shows which

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -536,6 +536,7 @@ class SqliteBackend(LocalOpsBackend):
                                     )
                                     from clm.infrastructure.messaging.notebook_classes import (
                                         NotebookResult,
+                                        notebook_metadata_tags_from_payload,
                                     )
 
                                     payload_dict = json.loads(row[0])
@@ -555,11 +556,8 @@ class SqliteBackend(LocalOpsBackend):
                                             input_file=str(job_info["input_file"]),
                                             content_hash=content_hash,
                                             result=result_text,
-                                            output_metadata_tags=(
-                                                payload_dict.get("kind", "participant"),
-                                                payload_dict.get("prog_lang", "python"),
-                                                payload_dict.get("language", "en"),
-                                                payload_dict.get("format", "notebook"),
+                                            output_metadata_tags=notebook_metadata_tags_from_payload(
+                                                payload_dict
                                             ),
                                         )
                                     elif job_type in ("plantuml", "drawio"):
@@ -1006,11 +1004,11 @@ class SqliteBackend(LocalOpsBackend):
         """
         if job_type == "notebook":
             # NotebookPayload.output_metadata() returns tuple of (kind, prog_lang, language, format)
-            kind = payload_dict.get("kind", "participant")
-            prog_lang = payload_dict.get("prog_lang", "python")
-            language = payload_dict.get("language", "en")
-            format_val = payload_dict.get("format", "notebook")
-            return str((kind, prog_lang, language, format_val))
+            from clm.infrastructure.messaging.notebook_classes import (
+                notebook_metadata_tags_from_payload,
+            )
+
+            return str(notebook_metadata_tags_from_payload(payload_dict))
         elif job_type in ("plantuml", "drawio"):
             # ImagePayload.output_metadata() returns output_format
             output_format = payload_dict.get("output_format", "png")

--- a/src/clm/infrastructure/messaging/base_classes.py
+++ b/src/clm/infrastructure/messaging/base_classes.py
@@ -1,6 +1,8 @@
 import hashlib
 from abc import ABC, abstractmethod
-from typing import Any, Literal
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel, Field
 
@@ -38,6 +40,49 @@ class Payload(TransferModel):
     input_file_name: str
     output_file: str
     data: str
+
+    @classmethod
+    def from_job_payload(
+        cls,
+        payload_data: Mapping[str, Any],
+        *,
+        content: str,
+        input_file: str,
+        output_file: str,
+        fallback_correlation_id: str,
+    ) -> Self:
+        """Reconstruct a payload from a job's serialized JSON payload dict.
+
+        The host serializes payloads with ``model_dump(mode="json")`` (see
+        ``SqliteBackend``); this deserializes the *whole* dict back via
+        ``model_validate``, so the round-trip is symmetric and total. A field
+        added to a payload subclass therefore can never be silently dropped at
+        the worker boundary — a hand-listed constructor previously dropped
+        ``cross_references`` (and ``svg_available_stems`` / ``inline_images``)
+        exactly this way (issue #17), leaving every ``clm:`` link unrewritten.
+
+        Only the file-bound fields are overridden, because at consume time they
+        do not come from the payload: the canonical input/output paths are
+        columns on the job row, and in Docker source-mount mode the ``content``
+        (notebook / diagram source) is read from the mounted filesystem rather
+        than carried inline. **Do not "simplify" these overrides away** — both
+        direct and Docker modes depend on them.
+
+        A required descriptor field missing from ``payload_data`` raises a
+        ``ValidationError`` rather than being silently defaulted: the host
+        always sets them, so a gap means a genuinely malformed job that should
+        fail loudly.
+        """
+        return cls.model_validate(
+            {
+                **dict(payload_data),
+                "data": content,
+                "input_file": input_file,
+                "input_file_name": Path(input_file).name,
+                "output_file": output_file,
+                "correlation_id": payload_data.get("correlation_id", fallback_correlation_id),
+            }
+        )
 
     def content_hash(self) -> str:
         return hashlib.sha256(self.data.encode("utf-8")).hexdigest()

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -1,5 +1,6 @@
 import hashlib
-from typing import Literal
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from clm.infrastructure.messaging.base_classes import Payload, ProcessingError, Result
 
@@ -10,6 +11,27 @@ def notebook_metadata(kind, prog_lang, language, output_format) -> str:
 
 def notebook_metadata_tags(kind, prog_lang, language, output_format) -> tuple[str, str, str, str]:
     return kind, prog_lang, language, output_format
+
+
+def notebook_metadata_tags_from_payload(
+    payload_data: Mapping[str, Any],
+) -> tuple[str, str, str, str]:
+    """Extract the ``(kind, prog_lang, language, format)`` tuple from a
+    serialized notebook payload dict, using one canonical set of fallbacks.
+
+    Several host- and worker-side call sites previously duplicated this
+    extraction with *divergent* defaults (``kind`` fell back to ``"participant"``
+    in the result/metadata path but ``"completed"`` in the worker), an
+    avoidable source of drift. The fallbacks are unreachable for real jobs —
+    the host always sets these required fields — but keep result and cache
+    bookkeeping robust against a malformed payload.
+    """
+    return notebook_metadata_tags(
+        payload_data.get("kind", "participant"),
+        payload_data.get("prog_lang", "python"),
+        payload_data.get("language", "en"),
+        payload_data.get("format", "notebook"),
+    )
 
 
 class NotebookPayload(Payload):

--- a/src/clm/workers/notebook/notebook_worker.py
+++ b/src/clm/workers/notebook/notebook_worker.py
@@ -173,55 +173,36 @@ class NotebookWorker(Worker):
                 logger.info(f"Job {job.id} was cancelled after reading input, aborting")
                 return
 
-            # Create output spec
-            output_spec = create_output_spec(
-                kind=payload_data.get("kind", "completed"),
-                prog_lang=payload_data.get("prog_lang", "python"),
-                language=payload_data.get("language", "en"),
-                format=payload_data.get("format", "notebook"),
+            # Reconstruct the full typed payload from the serialized job data.
+            # ``from_job_payload`` deserializes the whole dict so no field can
+            # be silently dropped at the worker boundary (issue #17); see its
+            # docstring for the file-bound override rationale.
+            payload = NotebookPayload.from_job_payload(
+                payload_data,
+                content=notebook_text,
+                input_file=str(input_path),
+                output_file=job.output_file,
+                fallback_correlation_id=f"job-{job.id}",
             )
 
-            # Reconstruct the full NotebookPayload from the serialized job
-            # data. Deserialize the whole dict via ``model_validate`` rather
-            # than re-listing fields by hand: the host serializes the payload
-            # with ``model_dump(mode="json")`` (see ``SqliteBackend``), so
-            # round-tripping the dict preserves *every* field automatically.
-            # The previous hand-maintained constructor silently dropped any
-            # field it did not name — e.g. ``cross_references`` (issue #17),
-            # which left every ``clm:`` link unrewritten in the output, and
-            # ``svg_available_stems`` / ``inline_images``. ``data`` and the
-            # path fields are overridden because in Docker source-mount mode
-            # the notebook text and paths come from the filesystem rather than
-            # the payload.
-            payload = NotebookPayload.model_validate(
-                {
-                    # Defaults for the required descriptor fields, preserved
-                    # from the previous hand-written reconstruction so a
-                    # partial payload still validates; ``payload_data`` below
-                    # overrides them whenever the host set them (it always
-                    # does for real jobs). Every other field — including
-                    # cross_references — flows through automatically.
-                    "kind": "completed",
-                    "prog_lang": "python",
-                    "language": "en",
-                    "format": "notebook",
-                    **payload_data,
-                    "data": notebook_text,
-                    "input_file": str(input_path),
-                    "input_file_name": input_path.name,
-                    "output_file": job.output_file,
-                    "correlation_id": payload_data.get("correlation_id", f"job-{job.id}"),
-                }
+            # Create output spec from the reconstructed (typed) payload, so the
+            # descriptor values come from a single validated source rather than
+            # re-reading the raw dict with ad-hoc defaults.
+            output_spec = create_output_spec(
+                kind=payload.kind,
+                prog_lang=payload.prog_lang,
+                language=payload.language,
+                format=payload.format,
             )
 
             # Determine source directory for supporting files (Docker mode with source mount)
             source_dir: Path | None = None
-            if host_data_dir and payload_data.get("source_topic_dir"):
+            if host_data_dir and payload.source_topic_dir:
                 # Convert host topic directory to container path
                 from clm.infrastructure.workers.worker_base import convert_input_path_to_container
 
                 source_dir = convert_input_path_to_container(
-                    payload_data["source_topic_dir"], host_data_dir
+                    payload.source_topic_dir, host_data_dir
                 )
                 logger.debug(
                     f"Docker mode: using source directory {source_dir} for supporting files"
@@ -280,10 +261,10 @@ class NotebookWorker(Worker):
                 job.output_file,
                 job.content_hash,
                 {
-                    "format": payload_data.get("format", "notebook"),
-                    "kind": payload_data.get("kind", "participant"),
-                    "prog_lang": payload_data.get("prog_lang", "python"),
-                    "language": payload_data.get("language", "en"),
+                    "format": payload.format,
+                    "kind": payload.kind,
+                    "prog_lang": payload.prog_lang,
+                    "language": payload.language,
                 },
             )
             logger.debug(f"Added result to cache for {job.output_file}")

--- a/tests/infrastructure/messaging/test_notebook_classes.py
+++ b/tests/infrastructure/messaging/test_notebook_classes.py
@@ -61,49 +61,87 @@ class TestNotebookPayload:
         assert sample_payload.other_files == {}
         assert sample_payload.fallback_execute is False
 
-    def test_json_roundtrip_preserves_worker_consumed_fields(self):
-        """Regression guard for issue #17.
+    def test_from_job_payload_round_trips_every_field(self):
+        """Structural regression guard for issue #17.
 
-        The notebook worker reconstructs the payload from the job's serialized
-        JSON. It must preserve *every* field the host sets — a hand-maintained
-        field list previously dropped ``cross_references`` (and
-        ``svg_available_stems`` / ``inline_images``), silently disabling the
-        cross-reference rewrite so every ``clm:`` link shipped unrewritten.
-        Serialize with the same call the backend uses (``model_dump(mode=
-        "json")``) and reconstruct the way ``NotebookWorker`` now does
-        (``model_validate`` of the whole dict), then assert the fields survive.
+        The worker reconstructs the payload from the job's serialized JSON via
+        ``NotebookPayload.from_job_payload`` (which deserializes the whole dict
+        through ``model_validate``). It must preserve *every* field the host
+        sets — a hand-listed reconstruction previously dropped
+        ``cross_references`` (and ``svg_available_stems`` / ``inline_images``),
+        silently disabling the cross-reference rewrite so every ``clm:`` link
+        shipped unrewritten.
+
+        Every field is given a distinctive non-default value so a *dropped*
+        field is always caught (a dropped field would fall back to its default
+        and the dump comparison would differ). The ``model_fields`` set-equality
+        check ties this test to the model: adding a field makes it fail until
+        the new field is covered here, which then proves it survives the
+        round-trip too.
         """
-        original = NotebookPayload(
-            correlation_id="cid",
-            input_file="/in.py",
-            input_file_name="in.py",
-            output_file="/out.html",
-            data="src",
-            kind="completed",
-            prog_lang="python",
-            language="en",
-            format="html",
-            cross_references={"workshop": "../W/02%20Workshop.html"},
-            svg_available_stems=["diagram"],
-            inline_images=True,
+        # A non-default value for every NotebookPayload field.
+        values = {
+            "correlation_id": "cid-x",
+            "input_file": "/in/notebook.py",
+            "input_file_name": "notebook.py",
+            "output_file": "/out/nb.html",
+            "data": "SOURCE",
+            "kind": "trainer",
+            "prog_lang": "cpp",
+            "language": "de",
+            "format": "html",
+            "template_dir": "tmpl",
+            "other_files": {"helper.py": b"x = 1"},
+            "fallback_execute": True,
+            "skip_evaluation": True,
+            "skip_errors": True,
+            "http_replay_mode": "once",
+            "http_replay_cassette_name": "cassette.yaml",
+            "http_replay_trace_dir": "/trace",
+            "img_path_prefix": "../../img/",
+            "source_topic_dir": "module_100/topic_010_intro",
+            "svg_available_stems": ["diagram"],
+            "inline_images": True,
+            "author": "Ada Lovelace",
+            "organization": "Coding Academy",
+            "cross_references": {"workshop": "../Workshops/02%20Workshop.html"},
+        }
+        assert set(values) == set(NotebookPayload.model_fields), (
+            "NotebookPayload fields changed — add the new field above with a "
+            "non-default value so the round-trip guard covers it."
         )
 
+        original = NotebookPayload(**values)
+        # Same serialization the SqliteBackend uses to enqueue the job.
         dumped = original.model_dump(mode="json")
-        # The worker overrides data + path fields (filesystem/job) and takes
-        # everything else verbatim from the serialized dict.
-        restored = NotebookPayload.model_validate(
-            {
-                **dumped,
-                "data": "src",
-                "input_file": "/in.py",
-                "input_file_name": "in.py",
-                "output_file": "/out.html",
-            }
+
+        # Reconstruct exactly as NotebookWorker does. The file-bound overrides
+        # are set to the original's values so the whole model must round-trip.
+        restored = NotebookPayload.from_job_payload(
+            dumped,
+            content=original.data,
+            input_file=original.input_file,
+            output_file=original.output_file,
+            fallback_correlation_id="unused-correlation-id-present",
         )
 
-        assert restored.cross_references == {"workshop": "../W/02%20Workshop.html"}
-        assert restored.svg_available_stems == ["diagram"]
-        assert restored.inline_images is True
+        assert restored.model_dump() == original.model_dump()
+
+    def test_from_job_payload_raises_on_missing_required_field(self):
+        """A malformed job payload (missing a required descriptor) fails loudly
+        rather than being silently defaulted — the host always sets these, so a
+        gap is a real bug worth surfacing."""
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        with _pytest.raises(ValidationError):
+            NotebookPayload.from_job_payload(
+                {"kind": "completed"},  # missing prog_lang / language / format
+                content="src",
+                input_file="/in.py",
+                output_file="/out.html",
+                fallback_correlation_id="cid",
+            )
 
     def test_notebook_text_property(self, sample_payload):
         """Should return data as notebook_text property."""

--- a/tests/workers/notebook/test_notebook_worker.py
+++ b/tests/workers/notebook/test_notebook_worker.py
@@ -242,7 +242,12 @@ class TestNotebookWorkerProcessJob:
             input_file="/nonexistent/notebook.ipynb",
             output_file="/output/notebook.html",
             content_hash="test-hash",
-            payload={"kind": "completed", "prog_lang": "python"},
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
             status="processing",
             created_at=datetime.now(),
         )
@@ -266,7 +271,12 @@ class TestNotebookWorkerProcessJob:
             input_file=str(input_file),
             output_file=str(tmp_path / "output.html"),
             content_hash="test-hash",
-            payload={"kind": "completed"},
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
             status="processing",
             created_at=datetime.now(),
         )
@@ -293,7 +303,12 @@ class TestNotebookWorkerProcessJob:
             input_file=str(input_file),
             output_file=str(tmp_path / "output.html"),
             content_hash="test-hash",
-            payload={"kind": "completed"},
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
             status="processing",
             created_at=datetime.now(),
         )
@@ -371,7 +386,12 @@ class TestNotebookWorkerProcessJob:
             input_file=str(input_file),
             output_file=str(output_file),
             content_hash="test-hash",
-            payload={"kind": "completed"},
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
             status="processing",
             created_at=datetime.now(),
         )
@@ -409,7 +429,12 @@ class TestNotebookWorkerProcessJob:
             input_file=str(input_file),
             output_file=str(output_file),
             content_hash="test-hash",
-            payload={"kind": "completed"},
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
             status="processing",
             created_at=datetime.now(),
         )
@@ -451,7 +476,12 @@ class TestNotebookWorkerProcessJob:
             input_file=str(input_file),
             output_file=str(output_file),
             content_hash="test-hash",
-            payload={"kind": "completed", "format": "html"},
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
             status="processing",
             created_at=datetime.now(),
         )
@@ -721,7 +751,12 @@ class TestNotebookWorkerIntegration:
                 input_file=str(input_file),
                 output_file=str(output_file),
                 content_hash="test-hash",
-                payload={"kind": "completed", "prog_lang": "python"},
+                payload={
+                    "kind": "completed",
+                    "prog_lang": "python",
+                    "language": "en",
+                    "format": "html",
+                },
             )
 
         # Create worker
@@ -771,7 +806,12 @@ class TestNotebookWorkerIntegration:
                 input_file=str(input_file),
                 output_file=str(output_file),
                 content_hash="test-hash",
-                payload={"kind": "completed"},
+                payload={
+                    "kind": "completed",
+                    "prog_lang": "python",
+                    "language": "en",
+                    "format": "html",
+                },
             )
 
         # Create worker


### PR DESCRIPTION
## Summary

Follow-up to #175 (issue #17). That PR fixed the cross-reference bug; this one removes its **structural root cause** so the class of bug can't recur.

The root cause was an asymmetric round-trip: the host serializes typed payloads with `model_dump(mode="json")` (total), but the worker reconstructed them with a **hand-listed constructor** (partial). Any field the worker didn't name was silently dropped — that's how `cross_references` (and `svg_available_stems` / `inline_images`) vanished. The same hand-listed shape recurs at the host-side `Result` assembly.

## Changes (the four design points discussed)

1. **Centralize the round-trip.** New `Payload.from_job_payload` deserializes the *whole* serialized dict via `model_validate` (symmetric and total with the host's `model_dump`), overriding only the file-bound fields. The notebook worker uses it for both direct and Docker paths; a newly added payload field is now carried automatically and can never be silently dropped.

2. **Drop the default shim; fail loudly; structural test.** Removed the `kind/prog_lang/language/format` default fallbacks — a malformed job missing a required descriptor now raises `ValidationError` instead of being coerced to `"completed"/"python"/...`. The 3-field round-trip test is replaced by a **structural** one tied to `NotebookPayload.model_fields`: it sets a non-default value for *every* field, and a set-equality guard forces any newly added field into coverage (so it's proven to round-trip). Added a fail-loud test, and completed the partial payloads in the worker fixtures.

3. **Document the overrides.** `from_job_payload`'s docstring explains *why* `data` and the path fields are overridden (job-row columns + Docker source mount), with a "do not simplify these away" note — both modes depend on them.

4. **Same treatment for `Result`/metadata reconstruction.** The `(kind, prog_lang, language, format)` extraction is centralized in `notebook_metadata_tags_from_payload`, now used by the worker, the host-side `NotebookResult` assembly, and `_get_output_metadata` — which previously duplicated it with **divergent** defaults (`kind` fell back to `"participant"` in one place, `"completed"` in another). As a bonus, the worker now derives `output_spec`, the source dir, and cache metadata from the single validated payload instead of re-reading the raw dict.

The drawio/plantuml workers operate on the raw dict + content and never reconstruct a typed `ImagePayload`, so there was nothing to change there.

## Tests / checks

`ruff` + `mypy` clean; the fast suite passes via pre-commit; the backends, build-command, worker, messaging, and cross-reference suites (976+ tests) pass locally. No user-facing behavior change except that a malformed job payload now fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
