### PR TITLE
fix(validate): make voiceover coverage check opt-in (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **The `voiceover` slide-coverage check is now opt-in (issue #176).**
+  Course-authoring policy changed: voiceover is optional per deck, so the
+  coverage check — which reports a gap for every slide / nontrivial code cell
+  lacking a voiceover cell — is no longer part of any default, "all", or
+  "review" bundle. It runs **only** when named explicitly (`--checks voiceover`
+  on the CLI, or `checks=["voiceover"]` via the MCP `validate_slides` tool /
+  the `validate_file`/`validate_directory`/`validate_course` library
+  functions). The library/MCP `checks=None` default now resolves to a new
+  `DEFAULT_CHECKS` bundle (`format`, `pairing`, `tags`, `code_quality`,
+  `completeness`) instead of `ALL_CHECKS`; `voiceover` stays a valid name so it
+  can still be requested on demand. This removes the false-positive flood the
+  MCP review path produced on voiceover-less decks. The CLI default (already
+  deterministic-only) and the `--quick` hook path are unchanged.
 - **Hardened the HTTP-replay vcrpy fork against silent breakage (issue #143,
   toward #165).** The `[replay]` extra now pins `vcrpy>=8.1.1,<8.2` (was an
   unbounded `>=6.0.0`). The notebook HTTP-replay bootstrap forks vcrpy 8.1.x

--- a/src/clm/cli/commands/validate_slides.py
+++ b/src/clm/cli/commands/validate_slides.py
@@ -31,7 +31,9 @@ from clm.slides.validator import (
         "Comma-separated list of checks to run. "
         "Deterministic: format, pairing, tags. "
         "Review: code_quality, voiceover, completeness. "
-        "Default: all deterministic checks."
+        "Default: all deterministic checks. "
+        "voiceover coverage is opt-in (voiceover is optional per deck) — "
+        "it runs only when you name it explicitly, e.g. --checks voiceover."
     ),
 )
 @click.option(

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -513,12 +513,22 @@ clm validate-slides [OPTIONS] PATH
 
 | Option | Description |
 |--------|-------------|
-| `--checks TEXT` | Comma-separated checks: `format`, `pairing`, `tags`, `code_quality`, `voiceover`, `completeness` (default: all deterministic) |
+| `--checks TEXT` | Comma-separated checks: `format`, `pairing`, `tags`, `code_quality`, `voiceover`, `completeness` (CLI default: all deterministic) |
 | `--quick` | Fast syntax-only check (format + tags + slide_ids). Useful for PostToolUse hooks |
 | `--json` | Output as JSON |
 | `--data-dir DIR` | Course data directory (contains slides/) |
 
 `PATH` can be a single slide file, a topic directory, or a course spec XML file.
+
+Since CLM {version}, the **`voiceover` coverage check is opt-in** (issue #176).
+Voiceover is now optional per deck, so the check — which reports a gap for every
+slide / nontrivial code cell that lacks a voiceover cell — is **never** part of a
+default, "all", or "review" bundle. It runs **only** when you name it explicitly:
+`--checks voiceover` (or include it in a longer list). This applies everywhere:
+the CLI default was already deterministic-only, and the MCP `validate_slides`
+tool / the `validate_file`/`validate_directory`/`validate_course` library
+functions now exclude `voiceover` from their `checks=None` default too. The other
+review checks (`code_quality`, `completeness`) still run by default.
 
 The `pairing` check group covers DE/EN cell count, tag consistency,
 adjacency, and — since CLM {version} — **`slide_id` metadata**:

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -150,6 +150,43 @@ The PostToolUse hook on PythonCourses surfaces findings as
 warnings only and never blocks writes. Use pre-commit or
 `clm slides coverage slides/` as the gating sweep.
 
+## `voiceover` coverage check is now opt-in (issue #176)
+
+Course-authoring policy changed (2026-05-31): **voiceover is optional**
+for every deck. Decks may intentionally ship without voiceover, and
+narration is added only on explicit request.
+
+Accordingly, the `voiceover` review check (which reports a gap for every
+slide / nontrivial code cell that lacks a voiceover cell) is no longer
+part of any default, "all", or "review" bundle. It runs **only** when you
+name it explicitly.
+
+What changed:
+
+- The library functions `validate_file` / `validate_directory` /
+  `validate_course` no longer include `voiceover` in their `checks=None`
+  default. The default bundle is now `format`, `pairing`, `tags`,
+  `code_quality`, `completeness`.
+- The **MCP `validate_slides`** tool — which calls those functions with
+  `checks=None` — therefore no longer emits `voiceover_gaps` by default.
+  This was the main source of the false-positive flood on voiceover-less
+  decks.
+
+What did **not** change:
+
+- The CLI `clm validate <slides>` default was already deterministic-only
+  (`format`, `pairing`, `tags`) and never ran `voiceover`.
+- The PostToolUse quick path (`clm validate --quick`) never ran it.
+
+To run voiceover coverage on a deck that *is* meant to be fully narrated,
+ask for it explicitly:
+
+```bash
+clm validate slides/topic/slides_intro.py --checks voiceover
+```
+
+…or via MCP: `validate_slides(path, checks=["voiceover"])`.
+
 ## CLI restructure: verb-grouped subcommands
 
 CLM {version} reorganises the top-level command surface. Several flat

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -157,7 +157,9 @@ def create_server(data_dir: Path) -> FastMCP:
                 XML (absolute, or relative to the data directory).
             checks: Which checks to run.  Deterministic: format, pairing,
                 tags.  Review: code_quality, voiceover, completeness.
-                Default: all.
+                Default: all checks except ``voiceover``.  Voiceover
+                coverage is opt-in (voiceover is optional per deck, issue
+                #176) — pass ``checks=["voiceover"]`` to run it.
         """
         return await handle_validate_slides(path, data_dir, checks=checks)
 

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -374,7 +374,9 @@ async def handle_validate_slides(
         path: Path to a slide file, topic directory, or course spec XML
             (absolute or relative to data_dir).
         data_dir: Root data directory (contains ``slides/``).
-        checks: Which checks to run.  Default: all.
+        checks: Which checks to run.  Default (``None``): all checks except
+            the opt-in ``voiceover`` coverage check (issue #176) — pass
+            ``checks=["voiceover"]`` to run it.
 
     Returns:
         JSON string with validation results.

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -104,7 +104,22 @@ class ValidationResult:
 
 ALL_DETERMINISTIC_CHECKS = frozenset({"format", "pairing", "tags"})
 ALL_REVIEW_CHECKS = frozenset({"code_quality", "voiceover", "completeness"})
+# Universe of valid check names — used to validate an explicit ``--checks`` /
+# ``checks=`` request. A name in here is always *runnable* when asked for by
+# name, even if it is excluded from the default bundle below.
 ALL_CHECKS = ALL_DETERMINISTIC_CHECKS | ALL_REVIEW_CHECKS
+
+# Checks that are valid to request explicitly but are never part of a default /
+# "all" bundle. Voiceover coverage is opt-in because voiceover is optional per
+# deck (issue #176) — running it by default floods voiceover-less decks with
+# false-positive gap findings. Run it only by naming it: ``--checks voiceover``
+# / ``checks=["voiceover"]``.
+OPT_IN_CHECKS = frozenset({"voiceover"})
+
+# The bundle used when the caller does not name specific checks: everything
+# except the opt-in checks (i.e. format, pairing, tags, code_quality,
+# completeness).
+DEFAULT_CHECKS = ALL_CHECKS - OPT_IN_CHECKS
 
 
 def _check_format(cells: list[Cell], file_path: str) -> list[Finding]:
@@ -1229,14 +1244,19 @@ def validate_file(
 
     Args:
         path: Path to the ``.py`` slide file.
-        checks: Which checks to run. Default: all.
+        checks: Which checks to run. Default (``None``): every check except
+            the opt-in ones — ``format``, ``pairing``, ``tags``,
+            ``code_quality``, ``completeness``.
             Deterministic: ``"format"``, ``"pairing"``, ``"tags"``.
             Review: ``"code_quality"``, ``"voiceover"``, ``"completeness"``.
+            ``"voiceover"`` is **opt-in** (issue #176): voiceover is optional
+            per deck, so coverage runs only when you name it explicitly in
+            ``checks`` — never as part of the default bundle.
 
     Returns:
         A :class:`ValidationResult` with findings and optional review material.
     """
-    check_set = set(checks) if checks else set(ALL_CHECKS)
+    check_set = set(checks) if checks else set(DEFAULT_CHECKS)
     file_str = str(path)
 
     text = path.read_text(encoding="utf-8")
@@ -1332,6 +1352,8 @@ def validate_directory(
     Args:
         path: Path to a directory containing slide files (at any depth).
         checks: Which checks to run (passed to :func:`validate_file`).
+            ``None`` runs the default bundle, which excludes the opt-in
+            ``voiceover`` coverage check (issue #176).
     """
     slide_files = find_slide_files_recursive(path)
     all_findings: list[Finding] = []
@@ -1346,7 +1368,7 @@ def validate_directory(
     # Phase 6: surface divergent shared cells between split pairs as
     # ``pairing`` errors. This runs even when only ``pairing`` checks are
     # requested via ``checks=`` because the parity is a pairing property.
-    check_set = set(checks) if checks else set(ALL_CHECKS)
+    check_set = set(checks) if checks else set(DEFAULT_CHECKS)
     if "pairing" in check_set:
         for de_path, en_path in _slide_files_to_split_pairs(slide_files):
             all_findings.extend(_check_shared_cell_parity(de_path, en_path))
@@ -1371,6 +1393,8 @@ def validate_course(
         course_spec_path: Path to the course spec XML file.
         slides_dir: Path to the ``slides/`` directory.
         checks: Which checks to run (passed to :func:`validate_file`).
+            ``None`` runs the default bundle, which excludes the opt-in
+            ``voiceover`` coverage check (issue #176).
     """
     from clm.core.course_spec import CourseSpec
 
@@ -1381,7 +1405,7 @@ def validate_course(
     files_checked = 0
     combined_review = ReviewMaterial() if (not checks or set(checks) & ALL_REVIEW_CHECKS) else None
 
-    check_set = set(checks) if checks else set(ALL_CHECKS)
+    check_set = set(checks) if checks else set(DEFAULT_CHECKS)
 
     for binding in spec.iter_topic_bindings():
         matches = matches_for_binding(topic_map, binding.topic_id, binding.effective_module)

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -476,6 +476,35 @@ class TestHandleValidateSlides:
         # No deterministic findings expected
         assert data["findings"] == []
 
+    async def test_voiceover_opt_in_default_excludes_gaps(self, course_tree):
+        # Issue #176: voiceover coverage is opt-in, so the default MCP path
+        # (checks=None) must not surface voiceover gaps even for a deck that
+        # has obvious ones.
+        topic = course_tree / "slides" / "module_100_basics" / "topic_010_intro"
+        gappy = topic / "slides_no_vo.py"
+        gappy.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## Title\n',
+            encoding="utf-8",
+        )
+        result = await handle_validate_slides(str(gappy), course_tree)
+        data = json.loads(result)
+        review = data.get("review_material", {})
+        assert "voiceover_gaps" not in review
+
+    async def test_voiceover_opt_in_explicit_runs(self, course_tree):
+        topic = course_tree / "slides" / "module_100_basics" / "topic_010_intro"
+        gappy = topic / "slides_no_vo.py"
+        gappy.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## Title\n',
+            encoding="utf-8",
+        )
+        result = await handle_validate_slides(str(gappy), course_tree, checks=["voiceover"])
+        data = json.loads(result)
+        gaps = data["review_material"]["voiceover_gaps"]
+        assert len(gaps) > 0
+
 
 # ---------------------------------------------------------------------------
 # normalize_slides

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -8,6 +8,8 @@ from textwrap import dedent
 import pytest
 
 from clm.slides.validator import (
+    ALL_CHECKS,
+    DEFAULT_CHECKS,
     Finding,
     ReviewMaterial,
     ValidationResult,
@@ -2018,6 +2020,65 @@ class TestVoiceoverGapsInsideWorkshop:
         assert result.review_material is not None
         gaps = result.review_material.voiceover_gaps or []
         assert gaps == []
+
+
+class TestVoiceoverOptIn:
+    """Issue #176: voiceover coverage is opt-in.
+
+    Voiceover is optional per deck, so the coverage check must never run as
+    part of a default / "all" / review bundle — only when the caller names it
+    explicitly. The other review checks (code_quality, completeness) still run
+    by default.
+    """
+
+    # A deck with obvious gaps: slides and a code cell, no voiceover anywhere.
+    _GAPPY_DECK = """\
+        # %% [markdown] lang="de" tags=["slide"]
+        # ## Titel
+
+        # %% [markdown] lang="en" tags=["slide"]
+        # ## Title
+
+        # %% tags=["keep"]
+        x = 1
+        """
+
+    def test_voiceover_excluded_from_default_bundle_constant(self):
+        # The name stays valid (so it can be requested), but is not a default.
+        assert "voiceover" in ALL_CHECKS
+        assert "voiceover" not in DEFAULT_CHECKS
+        # The other review checks remain in the default bundle.
+        assert {"code_quality", "completeness", "format", "pairing", "tags"} <= DEFAULT_CHECKS
+
+    def test_default_checks_does_not_run_voiceover(self, tmp_path):
+        p = _write_slide(tmp_path, "slides_no_vo.py", self._GAPPY_DECK)
+        result = validate_file(p, checks=None)
+        # Review material is still produced (code_quality / completeness ran)...
+        assert result.review_material is not None
+        # ...but voiceover coverage was not run, so no gaps are surfaced.
+        assert result.review_material.voiceover_gaps is None
+
+    def test_explicit_voiceover_still_runs(self, tmp_path):
+        p = _write_slide(tmp_path, "slides_no_vo.py", self._GAPPY_DECK)
+        result = validate_file(p, checks=["voiceover"])
+        assert result.review_material is not None
+        assert result.review_material.voiceover_gaps is not None
+        assert len(result.review_material.voiceover_gaps) > 0
+
+    def test_directory_default_does_not_run_voiceover(self, tmp_path):
+        _write_slide(tmp_path, "slides_no_vo.py", self._GAPPY_DECK)
+        result = validate_directory(tmp_path, checks=None)
+        # combined review material exists (completeness/code_quality), but no
+        # voiceover gaps are merged in under the default bundle.
+        if result.review_material is not None:
+            assert result.review_material.voiceover_gaps is None
+
+    def test_directory_explicit_voiceover_runs(self, tmp_path):
+        _write_slide(tmp_path, "slides_no_vo.py", self._GAPPY_DECK)
+        result = validate_directory(tmp_path, checks=["voiceover"])
+        assert result.review_material is not None
+        assert result.review_material.voiceover_gaps
+        assert len(result.review_material.voiceover_gaps) > 0
 
 
 class TestCompletenessExtraction:


### PR DESCRIPTION
## Summary

Closes #176.

Course-authoring policy changed (2026-05-31): **voiceover is optional per deck.** The validator's `voiceover` coverage check reports a gap for every slide / nontrivial code cell lacking a voiceover cell, so it now floods voiceover-less decks with false positives.

This makes the `voiceover` check **opt-in**: it is no longer part of any default / "all" / "review" bundle and runs **only** when named explicitly.

### Where the flood came from
- **MCP `validate_slides`** (and any library/deep-review caller passing `checks=None`) ran the full `ALL_CHECKS` bundle — which included `voiceover` — via `validate_file` / `validate_directory` / `validate_course`.
- The **CLI** was already safe (its default is deterministic-only); `--quick` never ran it.

## Change

In `src/clm/slides/validator.py`:
- New `OPT_IN_CHECKS = frozenset({"voiceover"})` and `DEFAULT_CHECKS = ALL_CHECKS - OPT_IN_CHECKS` (= `format`, `pairing`, `tags`, `code_quality`, `completeness`).
- The three `checks=None` default branches now resolve to `DEFAULT_CHECKS` instead of `ALL_CHECKS`.
- `ALL_CHECKS` stays the **validity universe**, so `--checks voiceover` / `checks=["voiceover"]` is still accepted and runs the check on demand.

`code_quality` and `completeness` still run by default; the CLI default and `--quick` hook path are unchanged.

## Behavior (verified end-to-end)

| Invocation | `voiceover_gaps` |
|---|---|
| `validate_file(p, checks=None)` / MCP `validate_slides(p)` | not run (`None`) |
| `validate_file(p, checks=["voiceover"])` / MCP `checks=["voiceover"]` | runs |
| `clm validate <deck>` | not run |
| `clm validate <deck> --checks voiceover` | runs |

## Files

- **Core**: `validator.py` (constants + 3 default branches + docstrings)
- **Docstrings/help**: `cli/commands/validate_slides.py`, `mcp/server.py`, `mcp/tools.py`
- **Docs** (per the Info Topics Maintenance Rule): `info_topics/commands.md`, `info_topics/migration.md`, `CHANGELOG.md`
- **Tests**: `tests/slides/test_validator.py` (`TestVoiceoverOptIn`), `tests/mcp/test_tools.py` (MCP default vs explicit)

## Testing

- `ruff check` / `ruff format --check` / `mypy` clean (pre-commit hooks passed).
- Full fast suite: **5768 passed, 3 skipped, 1 xfailed**.
- Existing `TestVoiceoverGapsExtraction` suite (all `checks=["voiceover"]`) unchanged and green.

## Deferred

The issue's optional **per-deck opt-in marker** (so fully-narrated decks still get coverage-checked while voiceover-less ones stay silent) is filed as follow-up #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)