### PR TITLE
test(recordings): fix flaky armed_after_take test (transient state vs poll ceiling)

### DIFF
--- a/tests/recordings/test_session.py
+++ b/tests/recordings/test_session.py
@@ -1240,8 +1240,17 @@ class TestRetakeWindow:
     ):
         """After a normal take, the session lands in ARMED_AFTER_TAKE
         with the same deck preserved for a potential retake."""
+        # ARMED_AFTER_TAKE is a *time-limited* state: the retake timer
+        # auto-expires it to IDLE after retake_window_seconds. The window
+        # MUST exceed _wait_for_state's poll ceiling (15s), otherwise under
+        # xdist CPU starvation the poll thread can be descheduled past the
+        # window, the timer fires ARMED_AFTER_TAKE -> IDLE first, and the
+        # poll never observes the transient state ("stuck at idle within
+        # 15.0s"). Raising the timeout can't fix that — the target state is
+        # already gone. Window expiry itself is covered by
+        # test_retake_window_expires_to_idle.
         sess = _phase2_session(
-            mock_obs, recording_root, short_take_seconds=0.0, retake_window_seconds=5.0
+            mock_obs, recording_root, short_take_seconds=0.0, retake_window_seconds=60.0
         )
         sess.arm("c", "s", "01 Deck")
 


### PR DESCRIPTION
## Problem

`tests/recordings/test_session.py::TestRetakeWindow::test_rename_transitions_to_armed_after_take` flakes under xdist load on Windows with:

```
TimeoutError: Session did not reach armed_after_take within 15.0s (stuck at idle)
```

## Root cause

`ARMED_AFTER_TAKE` is a **time-limited** state: when the background rename thread enters it, `_start_retake_timer_locked` arms a timer that auto-expires the state to `IDLE` after `retake_window_seconds` (`session.py:1601`, `_on_retake_window_expired` at `session.py:1948`).

The test built its session with `retake_window_seconds=5.0` but polls for that state with `_wait_for_state`'s default **15.0s** ceiling. Because the window (5s) is **shorter than the poll ceiling (15s)**, under CPU starvation the poll thread can be descheduled past the window — the retake timer fires `ARMED_AFTER_TAKE → IDLE` first, and the poll never observes the transient state, spinning out the full 15s.

Raising the timeout cannot fix this (it was already bumped 5s→15s twice in `9ed97a0` and `c468080`): the transition isn't slow, the **target state is ephemeral** — once the 5s window closes it is permanently gone.

This was proven deterministically: a prompt observer (0.2s into a 5s window) sees `armed_after_take`; a starved observer (1.5s into a 0.5s window) sees `idle` — the exact symptom.

## Fix

Bump `retake_window_seconds` to `60.0` so the state persists well beyond the 15s poll ceiling, matching the three sibling `ARMED_AFTER_TAKE` tests (lines 1315/1346/1376). The poll now catches the state as soon as it runs even once. Window-expiry behavior remains covered by `test_retake_window_expires_to_idle` (which deliberately uses `0.1s` and waits for `IDLE`). A comment documents why the window must exceed the poll ceiling so it isn't reduced again.

## Test

`TestRetakeWindow` — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)