### PR TITLE
feat(slides): single-language authoring sync — auto-propagate adds/edits/removes + slide_id minting (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   result/cache bookkeeping), removing previously divergent fallback defaults.
   A structural round-trip test tied to `NotebookPayload.model_fields` guards
   the invariant for every current and future field.
+- **`clm slides sync` is now the single-language authoring command and writes
+  by default** (issue #166). Edit **one** half of a split deck
+  (`<deck>.de.py` / `<deck>.en.py`) and one pass brings the other half into
+  sync: edits are propagated, brand-new slides are translated (OpenRouter
+  Claude Sonnet, `--translation-model`) and inserted, removed slides are
+  dropped, reorders are mirrored, and a shared `slide_id` is minted onto both
+  decks. **Breaking:** the default flipped from dry-run to writing the working
+  tree — a bare `clm slides sync de en` now applies changes (nothing is
+  committed; review with `git diff`). Pass `--dry-run` for the old preview.
+  Direction is now decided **per cell** by diffing each deck against a new
+  ordered, per-language structural watermark (`sync_watermarks`, recorded only
+  on a successful apply), so the global `--source-lang` flag and the
+  `sync_snapshots`-based direction inference are **removed**; a cell edited on
+  both decks is isolated as a `conflict` rather than guessed. The legacy
+  `--apply` / `--trivial` flags are **removed** (the default already applies;
+  use `--interactive` to gate proposals). Edits are still reconciled by the
+  local Ollama judge; when Ollama is unreachable, edits are recorded as errors
+  (exit 2). See `clm info migration` for the full before/after.
 - **`clm recordings check` is now backend-aware** (issue #33). The command
   reads `recordings.processing_backend` and only checks the dependencies the
   active backend actually needs, and the output table header shows which

--- a/docs/claude/TODO.md
+++ b/docs/claude/TODO.md
@@ -2,6 +2,47 @@
 
 This file tracks known issues and planned improvements for the CLM project.
 
+## Planned Improvements
+
+### Uniform, per-purpose model configurability across CLM
+
+**Status**: 📋 Investigation — tracked in #167 (raised 2026-05-31 during #166 design). Outcome may be "no change".
+
+**Context**: CLM selects LLMs ad hoc per feature, across two backends:
+
+- The OpenAI-compatible async client
+  (`infrastructure/llm/client.py` `_build_client`) — used by `summarize` and
+  voiceover `merge`/`propagate`. Model is passed per call; OpenRouter via
+  `api_base`; key from `OPENAI_API_KEY` / `CLM_LLM__API_KEY`.
+- The local Ollama client (`infrastructure/llm/ollama_client.py`) — used by the
+  slide-`sync` judge and the assign-ids `TitleSuggester`.
+
+Default models live as scattered `DEFAULT_*` module constants
+(`DEFAULT_MERGE_MODEL = anthropic/claude-sonnet-4-6`, `DEFAULT_SYNC_MODEL`, …).
+
+**Goal**: one uniform way to choose the model used for each *purpose*
+(summarize, voiceover-merge, voiceover-propagate, slide-sync-judge,
+slide-translation, assign-ids-title, polish, …), configurable via
+pyproject `[tool.clm]` / `CLM_LLM__*` env / per-command CLI override, with a
+sane per-purpose default and provider-agnostic resolution.
+
+**Approaches to evaluate** (not pre-decided):
+
+- **Internal registry over the existing OpenAI-compatible client** — lightest.
+  OpenRouter already exposes many providers through the OpenAI API shape, and
+  Ollama speaks an OpenAI-compatible endpoint too, so a per-purpose model map +
+  the existing `_build_client` may suffice without a new framework.
+- **LiteLLM** — a thin unified multi-provider proxy; less churn than LangChain.
+- **LangChain** — broadest abstraction but heavy and fast-moving; weigh the
+  dependency cost.
+- See also `docs/claude/design/dspy-authoring-research.md` (DSPy prior art).
+
+**Trigger**: #166 fixes slide-translation to Claude Sonnet via the OpenRouter
+path for now (`docs/claude/design/single-language-authoring-sync.md`); this task
+generalizes that choice rather than hardcoding more `DEFAULT_*` constants.
+
+---
+
 ## Bugs / Technical Debt
 
 ### ~~Flaky Test: `test_heartbeat_round_trip_smoke`~~ (FIXED)

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -402,6 +402,19 @@ The spine. Everything else consumes its plan.
 
 ### Phase 2 — Writeback primitives + atomic apply for the deterministic kinds
 
+**Status: ✅ core implemented 2026-05-31** — `FileState.find_cell /
+replace_cell_body / delete_cell` (keyed by `(slide_id, role)`) +
+`clm/slides/sync_apply.py` (`apply_plan`: **remove** + **edit**, atomic,
+watermark advances only on a clean complete apply *and* a real baseline). 14
+tests; mypy + ruff clean. A 15-agent adversarial review ran; all 6 confirmed
+findings folded in (cold-start `has_baseline` watermark guard;
+terminal-newline preservation on last-cell delete; language-filtered
+content index; `role_of` de-duplicated to one public helper; shared
+`_cell_matches`; docstring). **MOVE-apply deferred to Phase 2b** (reordering
+slide *groups* with their narrative companions while preserving the
+round-trip). Live `clm slides sync` still unchanged — the apply engine is not
+yet wired into the CLI.
+
 - `FileState.insert / delete / move` (`sync_writeback.py`), preserving the
   header + trailing-blank round-trip the split/unify invariant depends on.
 - Apply path for **MOVE** (reorder target by id-join), **REMOVE** (delete the

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -331,6 +331,22 @@ used and why it found 0 changes (in sync vs no baseline).
 
 - **Full 3-way LLM merge** for true conflicts (watermark is the ancestor).
 - **`--detect-moves`** content-similarity matching for delete-and-rewrite moves.
+- **Partial-apply watermark staleness** — the watermark advances all-or-nothing
+  (`_pass_is_clean`). When a pass reconciles some cells (edit/remove/move) but
+  defers others (a conflict, or — pre-Phase-3 — an add), the watermark does not
+  advance, so the reconciled edits re-surface as drift on the next run (the
+  judge then no-ops, so no data loss, but the UX is noisy). The clean fix is a
+  **per-cell** watermark advance that records reconciled cells while preserving
+  conflict cells' pre-conflict baseline — lands naturally with Phase 4 conflict
+  handling.
+- **Non-uniform inter-group blank padding** (cosmetic) — group-level move-apply
+  carries each group's own trailing blank padding verbatim, so reordering a deck
+  whose slides have *different* numbers of trailing blank lines redistributes
+  that spacing. The terminal-newline artifact is healed; genuine author
+  whitespace is preserved (not normalized), so a reorder can produce a
+  whitespace-only diff. Normalizing inter-slide spacing would violate the
+  byte-preserving split/unify contract, so it's left as-is unless real-deck
+  diffs prove noisy.
 - **Prompt tuning & batching** — the *model* is settled (Claude Sonnet via
   OpenRouter, §3.3/§8); what remains open is prompt iteration, batching of
   multiple new-slide translations per call (à la voiceover `merge_batch`), and
@@ -402,18 +418,27 @@ The spine. Everything else consumes its plan.
 
 ### Phase 2 — Writeback primitives + atomic apply for the deterministic kinds
 
-**Status: ✅ core implemented 2026-05-31** — `FileState.find_cell /
-replace_cell_body / delete_cell` (keyed by `(slide_id, role)`) +
-`clm/slides/sync_apply.py` (`apply_plan`: **remove** + **edit**, atomic,
-watermark advances only on a clean complete apply *and* a real baseline). 14
-tests; mypy + ruff clean. A 15-agent adversarial review ran; all 6 confirmed
-findings folded in (cold-start `has_baseline` watermark guard;
-terminal-newline preservation on last-cell delete; language-filtered
-content index; `role_of` de-duplicated to one public helper; shared
-`_cell_matches`; docstring). **MOVE-apply deferred to Phase 2b** (reordering
-slide *groups* with their narrative companions while preserving the
-round-trip). Live `clm slides sync` still unchanged — the apply engine is not
-yet wired into the CLI.
+**Status: ✅ implemented 2026-05-31 (incl. 2b move-apply)** — `FileState.find_cell
+/ replace_cell_body / delete_cell` (keyed by `(slide_id, role)`) +
+`clm/slides/sync_apply.py` (`apply_plan`: **remove** + **edit** + **move**,
+atomic, watermark advances only on a clean complete apply *and* a real
+baseline, via the shared `_pass_is_clean` predicate). 18 tests; mypy + ruff
+clean. Live `clm slides sync` still unchanged — the apply engine is not yet
+wired into the CLI.
+
+MOVE-apply reorders the target deck's slide *groups* (slide/subslide + its
+narrative companions + code) to match the source order by id-join. It commits
+only when the reorder reconciles the **full `(slide_id, role)` order** with the
+source (`_sync_key_order`); a narrative companion reassigned to a different
+slide that a group-level reorder cannot express is deferred and surfaced, never
+silently baselined.
+
+Two adversarial-review rounds (15 agents then 8) found **11 confirmed issues,
+all folded in**: cold-start `has_baseline` watermark guard; terminal-newline
+preservation on last-cell delete *and* on move (the dragged `""` artifact);
+language-filtered content index; `role_of`/`_cell_matches` de-duplication;
+the narrative-reassignment silent-divergence (now deferred); the move-gate
+`plan.has_errors` gap (now the shared `_pass_is_clean`).
 
 - `FileState.insert / delete / move` (`sync_writeback.py`), preserving the
   header + trailing-blank round-trip the split/unify invariant depends on.

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -497,6 +497,27 @@ id-carrying "missing counterpart" adds. Live `clm slides sync` still unchanged.
 
 ### Phase 4 — Interactive walker + conflict UX + summary / exit-codes
 
+**Part 1 — copy-paste duplicate-id resolution ✅ implemented 2026-05-31.** A
+new `rename` proposal kind. The classifier (`_resolve_duplicates`) resolves
+duplicate ids at the **slide-group** level: it identifies the original group
+(its slide matches the baseline) and emits one `rename` per copy slide;
+companions follow. It only resolves against a real both-deck baseline and
+**errors** (never guesses) when it can't identify the original or a duplicate
+isn't explained by a copied slide group. The apply (`_identify_copy_slides` +
+`_add_one_direction`) re-mints the copy slide **by position** (so byte-identical
+copies don't bind to the wrong cell) and its trailing same-id companions by
+group-adjacency. Two **fail-safe guards** — `_flag_residual_duplicates`
+(in-deck) and `_flag_cross_deck_orphans` (clean-pass parity) — error so the
+watermark can never advance over a corrupt/divergent state.
+
+Two adversarial-review rounds (the first found the feature corrupted copied
+slide *groups* with companions; the rewrite + a second review fixed the
+phantom-`remove` regression, the identical-slide/edited-companion desync, and
+the malformed-companion divergence). Known limitation (pre-existing, broader
+than this feature): a structural change is flushed to the working tree even on
+an erroring pass — it is surfaced + `git diff`-visible + revertible, and the
+watermark never advances over it, but the working tree is mutated.
+
 - Extend `sync_walker` to render ADD / REMOVE / MOVE / CONFLICT (today
   UPDATE-only).
 - Conflict three-up (watermark base / current DE / current EN) with

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -618,6 +618,32 @@ Original Phase 4 spec (for reference):
 
 ### Phase 5 — Default-flip + docs + deprecate old inference + pilot / CHANGELOG
 
+**Status: ✅ implemented 2026-05-31.** `clm slides sync`
+(`cli/commands/slides_sync.py`) is rewritten onto the new engine:
+`build_sync_plan` → `apply_plan` (batch) / `run_plan_walker` (interactive) over
+the `SyncWatermarkCache`. The **default now writes to the working tree**;
+`--dry-run` is the explicit preview; `--interactive` prompts per proposal before
+a single atomic apply. Direction is per-cell from the watermark — the **global
+`--source-lang` flag and the `sync_snapshots`-based inference are gone** — and a
+both-decks edit is isolated as a `conflict`. The legacy `--apply` / `--trivial`
+flags are **removed** (the default already applies; `--interactive` gates). New
+`--translation-model` (OpenRouter Sonnet) drives the add path. The JSON report
+carries `mode` / `exit_code` / `plan` / `apply` / `walker` blocks (the pilot
+accept-rate counters). Info topics (`commands.md` `clm slides sync` section +
+a `migration.md` breaking-change entry) and the CHANGELOG are updated per the
+**Info Topics Maintenance Rule**.
+
+The legacy engine modules (`sync.py`, `sync_walker.py`, `sync_trivial.py`,
+`sync_direction.py`) are left **dormant** (still unit-tested) rather than deleted
+— nothing in `src` imports them now that the CLI is rewired; pruning them is a
+follow-up so this phase's diff stays focused on the CLI + docs.
+
+Decision (user, 2026-05-31): both `--source-lang` and `--apply`/`--trivial` are
+**hard-removed**, not deprecated-and-ignored — a clean pre-1.0 surface for a
+feature with no external users yet (the migration topic documents the break).
+
+Original Phase 5 spec (for reference):
+
 - **Flip the default** to write-to-working-tree (never commit); `--dry-run`
   becomes the explicit preview. Update CLI help text.
 - Migrate direction inference fully onto the watermark; deprecate the

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -457,6 +457,24 @@ the narrative-reassignment silent-divergence (now deferred); the move-gate
 
 ### Phase 3 — New-slide translation + EN-authority ID minting (the ADD path)
 
+**Status: ✅ implemented 2026-05-31** — `clm/slides/sync_translate.py`
+(`SlideTranslator` protocol + `StaticSlideTranslator` + `OpenRouterSlideTranslator`,
+model fixed to Sonnet) + the add path in `sync_apply.py` (`_apply_adds` /
+`_add_one_direction`: translate → mint EN-authority id from the EN heading →
+stamp both siblings → insert the counterpart at the anchor; narrative
+companions inherit the slide's id). Adds run **before** moves and are sticky
+via the stamp (so they apply even when the rest of the pass isn't clean).
+`FileState` gained `insert_after` / `insert_before_first_sync_cell` plus
+**separator-aware** placement (`separator_blanks` / `normalize_displaced_last`),
+which keeps both blank-separated (real) and tight decks byte-clean and also
+closed a *latent* Phase 2b move issue the tight test fixtures had masked.
+29 apply tests (incl. blank-separated byte-equality). A 12-agent adversarial
+review found 6 issues, all folded in: inter-cell separator on inserts; heading
+extraction discarding bold/dash lead-ins; the slide-less-target append heal +
+ordering; parallel id-less adds on both decks (now deferred, not duplicated);
+translator leading-newline strip + `max_tokens`. Deferred follow-up:
+id-carrying "missing counterpart" adds. Live `clm slides sync` still unchanged.
+
 - Translate a new source cell → target counterpart. New prompt suite (distinct
   from the edit judge); routed through `_build_client` like the voiceover
   `propagate_*` path (structured JSON). **Model fixed: Claude Sonnet

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -331,14 +331,21 @@ used and why it found 0 changes (in sync vs no baseline).
 
 - **Full 3-way LLM merge** for true conflicts (watermark is the ancestor).
 - **`--detect-moves`** content-similarity matching for delete-and-rewrite moves.
-- **Partial-apply watermark staleness** — the watermark advances all-or-nothing
-  (`_pass_is_clean`). When a pass reconciles some cells (edit/remove/move) but
-  defers others (a conflict, or — pre-Phase-3 — an add), the watermark does not
-  advance, so the reconciled edits re-surface as drift on the next run (the
-  judge then no-ops, so no data loss, but the UX is noisy). The clean fix is a
-  **per-cell** watermark advance that records reconciled cells while preserving
-  conflict cells' pre-conflict baseline — lands naturally with Phase 4 conflict
-  handling.
+- **Partial-apply watermark staleness — *addressed for content-only passes in
+  Phase 4 Part 2b*.** The watermark used to advance all-or-nothing
+  (`_pass_is_clean`): a pass that reconciled some cells but deferred a conflict
+  advanced nothing, so the reconciled edits re-surfaced as drift next run (judge
+  no-ops them — safe but noisy). Phase 4 Part 2b adds a **per-cell** advance for
+  a *content-only, issue-free* partial pass (only edit/conflict proposals): it
+  banks every reconciled cell (applied edit, `in_sync`, unchanged) and preserves
+  only the **true deferrals** (unresolved conflicts, user-skipped edits) at their
+  pre-conflict baseline so they re-surface. Structural partial passes (any
+  add/remove/move/rename), any pass carrying a *warning* issue (both-decks
+  reorder, ambiguous de/en), and any deferral whose cell was removed on one deck
+  still hold the whole watermark — the conservative, provably-safe fallback.
+  Remaining noise on those held passes is the documented residual (a follow-up
+  could extend the per-cell advance to structural passes, but that needs
+  positional reasoning the content-only restriction sidesteps).
 - **Non-uniform inter-group blank padding** (cosmetic) — group-level move-apply
   carries each group's own trailing blank padding verbatim, so reordering a deck
   whose slides have *different* numbers of trailing blank lines redistributes
@@ -549,12 +556,49 @@ dimensions × adversarial verify) confirmed the safety invariant intact and foun
 mixed-accept+skip watermark-held test (added). 25 walker tests; 711 slides tests
 green; mypy/ruff clean. Live `clm slides sync` STILL UNCHANGED.
 
-**Part 2b — Per-cell watermark advance (the §10 partial-apply staleness fix)** is
-the remaining Phase 4 work, split out as its own commit because its failure mode
-is silent data loss (it deserves an isolated adversarial review). Today a
-skip/defer holds the *whole* watermark (safe but noisy on the next run); 2b will
-advance reconciled cells while preserving conflict/skip cells' pre-conflict
-baseline.
+**Part 2b — Per-cell watermark advance ✅ implemented 2026-05-31.** A
+content-only, issue-free partial pass now advances per-cell: it banks every
+*reconciled* cell and preserves only the *true deferrals* at their pre-conflict
+baseline so those re-surface. The watermark block is gated top-level by
+`not plan.issues` (both the full and partial paths), with a partial path behind
+`_eligible_for_partial_advance` (content-only: zero add/remove/move/rename
+proposals, real baseline, no errors, ≥1 deferral, ≥1 applied edit) + a
+completeness invariant (`len(deferred_keys) == result.deferred`) +
+`_record_watermark_partial`, which preserves `deferred_keys` (unresolved
+conflicts + user-skipped edits) and banks the rest.
+
+**The load-bearing semantic decision: `in_sync` is a *reconciliation*, not a
+deferral.** Per `SyncProposal`, an `in_sync` verdict means "the target already
+adequately reflects the source" — the judge examined both sides and decided no
+write is needed. So an `in_sync` edit **banks** (advances), exactly like an
+applied edit and exactly like the long-standing full-advance path. Preserving it
+instead would re-propose every judge-declined cell *every run forever* (the judge
+re-declines), and in real syncs most edits are `in_sync` — so banking is required
+for the tool to be usable. Only **unresolved conflicts** and **user-skipped
+edits** (an explicit "not now") re-surface.
+
+This part was the **deepest rabbit hole of the issue** — four adversarial-review
+rounds. The first two reviews (run under a too-strict "any un-written cell must
+re-surface" invariant I had seeded) flagged `in_sync`-banking as data loss; I
+over-corrected to a preserve-`in_sync` design, then recognized that re-surfacing
+`in_sync` infinite-loops and reverted to the correct bank-`in_sync` semantics.
+The reviews surfaced **three genuine bugs, all fixed**: (1) the full-advance path
+ignored `plan.issues`, so a both-decks-reorder *warning* could be silently
+baselined → fixed by gating both paths on `not plan.issues`; (2) the earlier
+preserve-by-`applied_keys` variant lost data via the full path — dissolved by the
+correct `in_sync`-banks semantics; (3) a **"removed on one deck / edited on the
+other" collision is classified as a `conflict`, not a `remove`**, so it slipped
+the structural gate, and since the cell is gone from the removing deck the
+partial advance dropped the preserve-key and next run mutated it into a *phantom
+add re-creating the deleted slide* → fixed by also requiring every preserve-key
+to be present in **both decks' current cells** (else hold). The final fix is
+monotonically safe (it only adds holds, never advances). 12
+`TestPartialWatermarkAdvance` tests; 723 slides tests green; mypy/ruff clean.
+Lesson logged: never seed an adversarial review with an unproven invariant — it
+manufactures false positives.
+
+Live `clm slides sync` STILL UNCHANGED (Phase 5 wires the engine + flips the
+default).
 
 Original Phase 4 spec (for reference):
 

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -1,0 +1,478 @@
+# Single-Language Authoring Sync — Design Note
+
+**Status**: Design agreed (pre-implementation)
+**Author**: Claude (Opus 4.8)
+**Date**: 2026-05-31
+**Scope**: `src/clm/slides/sync.py`, `sync_direction.py`, `sync_writeback.py`,
+`assign_ids.py`, the `clm slides sync` CLI, and the LLM sync/translation path
+**Issues**: [#166](https://github.com/hoelzl/clm/issues/166) (this workflow) ·
+[#162](https://github.com/hoelzl/clm/issues/162) (the cross-language
+`slide_id` invariant it serves)
+
+This note records the design decisions reached for #166 so a fresh session can
+implement against them. It resolves the four "Open questions" from the issue.
+The companion invariant work (#162's validator + guard-rail) remains
+independently valuable for hand-edited / legacy split files the sync-driven
+path never touches and is **not** in scope here.
+
+---
+
+## 1. The workflow we want
+
+Most future authoring happens on **split single-language decks**
+(`<deck>.de.py` / `<deck>.en.py`). The editing loop:
+
+1. A trainer edits **one** language deck — adds / edits / removes / reorders
+   slides. Which language depends on the course (DE or EN).
+2. They run **one command**. The other deck is brought into sync via an LLM:
+   edits propagate, new slides are translated and inserted, removed slides are
+   dropped, reorders are mirrored.
+3. The author **never manages `slide_id`s** — not even on the deck they edited.
+   IDs are minted onto **both** decks as a byproduct of the sync, kept
+   consistent across languages.
+
+Guiding principle: an author authors in one language with full IDE support
+(incl. Copilot autocompletion on the deck they're editing); the tooling handles
+the cross-language mirror and identity bookkeeping.
+
+## 2. What exists today (and the gap)
+
+See #166 for the full inventory. In one paragraph: `clm slides sync`
+(`sync.py`) walks the pair strictly by `(slide_id, role)`, asks the Ollama
+`SyncJudge` for **update**-only proposals on already-paired cells, and emits
+diffs (dry-run / `--interactive` / `--apply --trivial`). It **skips id-less
+cells** (`sync.py` `_index_cells`), **warns and skips** cells present on only
+one side (`sync.py:244-268`), and treats a `slide_id` whose cell count differs
+across sides as a **hard error** (`sync.py:270-282`). `assign-ids`
+(`assign_ids.py`) is a separate manual step that, run per-language on split
+files, produces **divergent** ids (the #162 problem). Direction is a single
+global `SyncOptions.source_lang`; `sync_direction.py` infers it from snapshot
+drift (preferred) or git timestamp (fallback) and **bails to "ambiguous" when
+both sides drifted**.
+
+The gap: sync reconciles *only* already-paired UPDATEs. There is no
+cross-language **insertion**, **deletion**, **move**, or **id minting**, and no
+defined behavior when both decks were touched.
+
+---
+
+## 3. Design decisions
+
+### 3.1 Change-detection baseline — id-less-as-new + structural watermark (Q1)
+
+**Decision.** Do **not** anchor change detection to a git pointer (HEAD /
+merge-base) the author can move. Two complementary, git-immune signals instead:
+
+- **Adds are detected by the absence of a `slide_id`.** After a successful
+  sync, *every* sync-relevant cell carries an id (sync mints them). An author
+  authoring in one language never writes ids. Therefore an **id-less cell is,
+  by construction, a cell added since the last sync** — and `git commit` does
+  not change that (committing does not run assign-ids). This defeats the
+  "author commits before syncing → `git diff HEAD` is empty → silent no-op"
+  failure mode that sinks any HEAD-based baseline.
+  - Generalized rule: **new = id-less OR id'd-but-unknown-to-the-watermark**
+    (covers the author who hand-runs `assign-ids` or copy-pastes a slide; a
+    paste that duplicates an id is a *collision* #162's validator flags, not a
+    silent mis-pair).
+- **Edits / removes / moves are detected against a self-managed structural
+  watermark** (§4) — *not* against git HEAD.
+
+**Git is a fallback/corroborator only** (cold start / fresh clone with no local
+cache), never the source of truth. See §7 for cold-start handling.
+
+**Guardrail (non-negotiable):** sync **never silently no-ops.** It always
+reports the baseline it used and distinguishes *"0 changes — decks already
+consistent"* from *"could not establish a baseline."*
+
+Rejected: git HEAD as sole baseline (fragile to commit-before-sync);
+merge-base (wrong frame — the author edits a working tree, not a divergent
+branch; merge-base re-surfaces every already-synced commit).
+
+### 3.2 Reorder vs add/remove — stable-id-on-move, no similarity matching (Q2)
+
+**Decision.** The `slide_id` *is* the cross-move identity. With the **ordered**
+watermark (§4):
+
+| Watermark vs working tree | Classification |
+|---|---|
+| same id, same `content_hash`, different position | **pure move** (reposition only; skip the translation LLM) |
+| same id, different `content_hash` | **edit** (± move) |
+| id in watermark, absent on disk | **remove** |
+| id-less on disk (or id unknown to watermark) | **add** |
+
+Stable-id-on-move is therefore *free and deterministic* — no content-similarity
+matching. The only genuine ambiguity (delete slide A + write a new id-less
+slide B in its place) is resolved by **honoring the author's edit gesture**:
+*keep-and-edit the cell* → stable id; *delete-and-rewrite* → new id. We
+**bias toward "add"** for id-less cells because wrongly fusing B into A's id
+silently corrupts the cross-language join and every downstream `for_slide` /
+`unify` link, whereas a missed move is never worse than a genuine delete.
+
+**Reorder propagation is in v1** and is LLM-free: mirror the source deck's
+order onto the target by id-join; narrative companions (`voiceover`/`notes`,
+keyed by the same `slide_id`) travel with their slide. New cells are positioned
+via the anchor precedent (§6).
+
+Deferred: opt-in `--detect-moves` (content-similarity) if pilot data shows
+authors frequently delete-and-rewrite genuine moves. Default off.
+
+### 3.3 Atomicity & review — per-proposal atomic, write-to-tree, `git diff` (Q3)
+
+**Decision.** The **uncommitted working tree is the staging/review surface.**
+
+- **Default `clm slides sync`** → compute the plan, **write both decks
+  atomically to the working tree, never commit**, and print the no-silent
+  summary. One command — matches the workflow. `git diff` is the review;
+  `git checkout` discards.
+- **`--dry-run`** → preview the plan, write nothing (the guardrail's "here's
+  what I'd do"; CI; fast check).
+- **`--interactive`** → per-proposal `[a]pply / [s]kip / [e]dit / [q]uit`
+  gating (extends the existing walker) for authors who want inline control.
+
+This **flips today's default** (currently `--dry-run` is default and bare
+`--apply` is rejected). #166 earns a real write-by-default.
+
+**Atomicity is per-proposal-unit across both decks.** One add = one unit =
+{stamp the minted id onto the previously-id-less source cell **and** insert the
+translated counterpart on the target side}. A unit writes both halves or
+neither. The run applies the accepted subset; writes batch into a single
+`FileState.flush` per deck. Skip/quit leaves a unit's source cell id-less →
+still pending → re-detected next run (idempotent).
+
+Two constraints that keep this sound:
+
+1. **Anchor insert/move positions off *stable shared ids*, not off other
+   in-flight proposals** — so accept/skip stays independent and a skipped
+   neighbor cannot strand another proposal's position.
+2. **Ids are sticky the moment they're persisted** (assign-ids rule). An
+   in-review `[e]dit` to a translation does **not** re-slug the id. The id is
+   computed once.
+
+Because the write *is* the review artifact, the issue's "mint ids before review
+so diffs are stable" concern is automatically satisfied in default mode.
+
+### 3.4 Conflict handling — per-cell direction + isolate-and-refuse (Q4)
+
+**Decision.** The watermark gives a per-cell base for **both** decks, so
+"both decks were edited" splits into two cases:
+
+- **Mixed-direction, non-overlapping — *not a conflict*.** Author added two
+  slides in DE and fixed an EN typo: different cells, so handle **each cell in
+  the direction it drifted** from the watermark. This replaces today's global
+  `SyncOptions.source_lang` with **per-cell direction** and retires the "both
+  drifted → bail" behavior. (Happy path — author edits one deck — still
+  resolves to a single unambiguous direction since only one side drifts.)
+- **True conflict — *same id drifted on both sides since the watermark*.**
+  **Isolate and refuse, per cell:** apply every non-conflicting change, leave
+  the conflicting cell **untouched on both decks**, and list it in the summary.
+  In `--interactive`, render three-up (watermark base / current DE / current
+  EN) with `[d]e-wins / [e]n-wins / [s]kip`. A conflict is a proposal `kind`
+  that **defaults to skip** — it never blocks the rest of the sync.
+
+**No in-file conflict markers** (`<<<<<<<`) — they would corrupt the
+percent-format and break `parse_cells`. Leave-untouched + summary only.
+
+**Order conflicts** (both decks independently reordered) → refuse to propagate
+order, keep each deck's order, report; per-cell content still syncs. If only
+one deck's order drifted, mirror it (§3.2).
+
+Deferred: **full 3-way LLM merge.** The watermark *is* the common ancestor it
+will need, so we build toward it — when justified, the conflict kind grows a
+`[m]erge` action.
+
+Accepted limitation: if both decks *independently add a new slide* meant to be
+"the same" slide (both id-less, no shared signal), we produce two independent
+adds → visible duplication in `git diff`, deduped by hand. Per §3.2 we do not
+similarity-guess cross-language identity. Rare; the review surface catches it.
+
+---
+
+## 4. Data model: the structural watermark
+
+A new table in the existing LLM cache DB (`clm-llm.sqlite`), superseding the
+per-cell `sync_snapshots` table for #166 and reused by direction inference:
+
+```
+sync_watermarks(
+  de_path     TEXT,     -- pair key (canonical absolute paths)
+  en_path     TEXT,
+  lang        TEXT,     -- "de" | "en": each deck has its own ordered rows
+  position    INTEGER,  -- 0-based order within the deck (sync-relevant cells)
+  slide_id    TEXT,     -- NULL only for hard-refusal/id-less cells (rare post-sync)
+  role        TEXT,     -- "slide"|"subslide"|"voiceover"|"notes"
+  content_hash TEXT,    -- cell_content_hash(): strip()+sha256 (sync_writeback)
+  synced_at   TEXT      -- UTC ISO-8601
+)
+```
+
+Properties:
+
+- **Ordered** (`position`) → enables move detection and order-conflict
+  detection (§3.2, §3.4).
+- **Per-lang rows** → enables per-cell direction (§3.4): diff DE-working vs DE
+  rows and EN-working vs EN rows independently.
+- **`content_hash` reuses `sync_writeback.cell_content_hash`** (strip + sha256)
+  so hashes match the existing apply-path snapshots.
+- Written **only on successful apply** of accepted proposals (the watermark
+  advances with the agreed state, immune to git commit cadence). This is what
+  makes the baseline survive commit-before-sync and fresh clones.
+
+Migration: keep `sync_snapshots` until direction inference is moved onto
+`sync_watermarks`; then deprecate it. The watermark lives in its **own**
+`SyncWatermarkCache` class (`clm.infrastructure.llm.cache`), alongside
+`SyncSnapshotCache`, to honor that module's one-class-per-table convention —
+same SQLite file, distinct table.
+
+---
+
+## 5. The sync algorithm (end to end)
+
+```
+1. Load DE/EN working trees → parse_cells.
+2. Load sync_watermarks for the pair (per lang). If absent → cold start (§7).
+3. Classify every sync-relevant cell per deck against its watermark:
+     id-less / unknown id        → ADD       (direction = the deck it's on)
+     id present, content drifted  → EDIT      (direction = the drifted side)
+     id present, position moved   → MOVE      (deterministic, no LLM)
+     id in watermark, gone        → REMOVE    (propagate deletion to sibling)
+     same id drifted on BOTH      → CONFLICT  (isolate, default-skip)
+4. Per-cell direction: each non-conflict cell carries its own de→en / en→de.
+5. Build the plan (typed proposals): ADD / REMOVE / MOVE / UPDATE / CONFLICT.
+     - For ADD: translate source → target (LLM), mint id from EN heading (§6),
+       attach exact target-cell bytes + the id to stamp on the source cell.
+     - For MOVE: target reorder ops by id-join (no LLM).
+     - For UPDATE: existing SyncJudge proposal path.
+6. Apply:
+     - default        → write accepted units atomically to both working trees.
+     - --dry-run      → print plan, write nothing.
+     - --interactive  → walk proposals, write accepted/edited units.
+7. On successful apply → record the new sync_watermarks rows for both decks.
+8. Print the no-silent summary (counts + conflicts + baseline used).
+```
+
+LLM use is confined to **translating new-slide content** and the existing
+**edit-propagation judge**. All structure (id-less detection, move/reorder,
+remove, id minting mechanics) is deterministic → works with the LLM down
+(adds are reported as blocked-not-dropped; see §7).
+
+---
+
+## 6. ID minting & EN-authority
+
+- For a new slide, **generate the EN counterpart first**, slug the id from the
+  **EN heading** (`assign_ids` slug rules: lowercase-kebab, ASCII, ≤30 chars,
+  collision suffix), then **write that id to both siblings**. This preserves the
+  EN-derived-id invariant even when the author only touched German.
+- Reuse `assign_ids._write_slide_id` to stamp the header; reuse
+  `clm.slides.pairing` slug/collision machinery and the `group_slug` caching
+  idea so both siblings receive the *identical* id.
+- **Stickiness/determinism:** once persisted, an id is never regenerated
+  without `--force`. The `SyncCache` memoizes `(source_hash, target_hash,
+  prompt_version) → translation`, so a re-run reproduces the same translation →
+  same slug → same id. Minting is one-time.
+- **Insertion positioning:** anchor a new target cell off the nearest
+  *neighboring shared `slide_id`* — the same anchoring `_find_insertion_point`
+  uses for voiceover companions (`voiceover_tools.py`). Runs of consecutive new
+  slides anchor off the nearest stable id and order among themselves by source
+  order.
+
+---
+
+## 7. Guardrails & error handling
+
+| Situation | Handling |
+|---|---|
+| Commit before sync | Defeated — id-less survives the commit (§3.1) |
+| Hand-assigned id on a new cell | Caught as "id unknown to watermark" → treated as ADD |
+| Copy-paste duplicate id | Caught as id collision, surfaced (not mis-paired) — #162's check |
+| Fresh clone, no watermark (cold start) | Pair by the decks' existing **shared ids** (committed with matching ids); an already-synced pair shows nothing to do; local un-synced edits fall back to **git-HEAD-per-deck** as the per-cell base |
+| No watermark **and** no git, both sides differ | Bail to explicit `--source-lang` (today's behavior) — loud, never silent |
+| First sync of a from-scratch one-language deck | All id-less → full translate + mint |
+| LLM/translator unavailable | Structural ops still apply; un-translatable ADDs reported as blocked, never silently dropped |
+| Both decks independently reordered | Order propagation refused + reported; per-cell content still syncs |
+| Same id drifted both sides | CONFLICT: isolate, default-skip, list in summary |
+
+**No-silent-no-op** is the universal backstop: every run states the baseline it
+used and why it found 0 changes (in sync vs no baseline).
+
+---
+
+## 8. Component changes
+
+| Module | Change |
+|---|---|
+| `clm.infrastructure.llm.cache` | New `SyncWatermarkCache` class + `sync_watermarks` table (ordered, per-lang, nullable `slide_id`); `get_deck` / `put_deck` (atomic whole-deck replace) / `has_pair` / `clear_pair`. |
+| `slides/sync.py` | Replace pair-by-`(slide_id, role)` UPDATE-only walk with the §5 classifier; per-cell direction; emit typed proposals (ADD/REMOVE/MOVE/UPDATE/CONFLICT). Retire the `244-268` warnings and the `270-282` structural-mismatch error as the *normal* add/remove/move signal. |
+| `slides/sync_direction.py` | Source per-cell direction from the watermark; keep global inference as the cold-start fallback. |
+| `slides/sync_writeback.py` | `FileState` grows `insert` / `delete` / `move` alongside `replace_body`; watermark recording replaces/augments `record_snapshot`. |
+| `slides/assign_ids.py` | Expose the EN-slug-from-translation minting path for reuse by sync (stamp both siblings, sticky). |
+| New: translation path | Whole-new-slide translation prompts (distinct from the edit judge), routed through the OpenAI-compatible `_build_client` (`infrastructure/llm/client.py`) exactly like the voiceover `propagate_*` path. **Model fixed to Claude Sonnet (`anthropic/claude-sonnet-4-6`) via OpenRouter** (decided 2026-05-31), exposed as a `--translation-model` + `CLM_LLM__*` / `[tool.clm]` override so it is never hardcoded-only. Generalizing per-purpose model selection across CLM is a separate investigation (#167; `docs/claude/TODO.md` → *Uniform, per-purpose model configurability*). |
+| `cli/commands/slides_sync.py` | Flip default to write-to-tree; `--dry-run` preview; extend `--interactive` walker to render ADD/REMOVE/MOVE/CONFLICT; new summary lines; exit codes account for conflicts. |
+| `cli/info_topics/commands.md` | Update `clm slides sync` docs (default-flip, new behaviors) per the Info Topics Maintenance Rule. |
+
+---
+
+## 9. Work items (re-scoped from the issue)
+
+| # (issue) | Item | v1 scope |
+|---|---|---|
+| 1 | Add / remove / move handling, not just update | **v1** — §3.2, §5 |
+| 2 | Detect changes without relying on IDs | **v1** — id-less-as-new + structural watermark (§3.1, §4) |
+| 3 | ID minting + EN-authority, written to both decks | **v1** — §6 |
+| 4 | Insertion positioning (anchor off shared ids) | **v1** — §6 |
+| 5 | ID stickiness / determinism | **v1** — §6 (SyncCache memoization → one-time mint) |
+| 6 | Reframe "structural mismatch" error as normal signal | **v1** — §8 (`sync.py:270-282`) |
+| 7 | Full-translation prompt suite | **v1** (with iteration room) — §8, §10 |
+| — | Per-cell direction + conflict isolation | **v1** — §3.4 |
+| — | Reorder propagation | **v1** — §3.2 |
+| — | No-silent-no-op guardrail | **v1** — §7 |
+
+## 10. Deferred / open (post-v1)
+
+- **Full 3-way LLM merge** for true conflicts (watermark is the ancestor).
+- **`--detect-moves`** content-similarity matching for delete-and-rewrite moves.
+- **Prompt tuning & batching** — the *model* is settled (Claude Sonnet via
+  OpenRouter, §3.3/§8); what remains open is prompt iteration, batching of
+  multiple new-slide translations per call (à la voiceover `merge_batch`), and
+  prompt-version cache keys. Quality is explicitly a tuning problem, not a
+  blocker (#166 Decisions).
+- **Uniform, per-purpose model configurability across CLM** — a separate
+  investigation (#167, `docs/claude/TODO.md`): whether to unify model selection
+  for every LLM purpose over
+  the existing OpenAI-compatible + Ollama backends, configurable via
+  `[tool.clm]` / `CLM_LLM__*` / CLI. #166 fixes Sonnet for translation now;
+  that task generalizes it rather than adding more `DEFAULT_*` constants.
+- **Self-contained vs git-corroborated removes** — whether to also consult
+  `git diff HEAD` to corroborate removes when the watermark is stale.
+
+## 11. Relationship to #162
+
+- #162 = the cross-language `slide_id` **consistency invariant** and its
+  detective (validator) + defensive (guard-rail) backstops.
+- This issue = the **workflow** that needs it, with the assignment
+  **mechanism** living inside sync (the generative directions #1/#3 of #162 are
+  realized here: sibling-aware assignment / EN-authority, minted at sync time).
+- #162's validator + guard-rail still matter independently, for hand-edited /
+  non-sync / legacy split files the generative path never touches.
+
+---
+
+## 12. Phased implementation plan
+
+Principles applied to every phase:
+
+- **Independently testable in the fast suite** — the existing sync tests mock
+  the `SyncJudge` (`judge=None` or injected); the translator is mocked the same
+  way. No phase needs a live LLM to test.
+- **Ships behind existing flags.** `--dry-run` stays the default until Phase 5
+  flips it, so partial work never changes the command's default behavior.
+- **Per-proposal atomicity and no-silent-no-op are honored from Phase 2 on.**
+- Conventions: type hints on public APIs; `attrs @define` for internal
+  structures / Pydantic at the worker boundary; `logging` not `print`; no
+  fixed `sleep` in async tests. Gate releases on `pytest -m "not docker"`.
+
+### Phase 1 — Structural watermark + classifier + per-cell direction (no writes, no LLM)
+
+**Status: ✅ implemented 2026-05-31** — `SyncWatermarkCache`
+(`infrastructure/llm/cache.py`) + `clm/slides/sync_plan.py` (classifier, plan
+types, baseline resolution, `render_plan`). 50 tests
+(`tests/slides/test_sync_plan.py` + `SyncWatermarkCache` cases in
+`tests/infrastructure/llm/test_sync_cache.py`); mypy + ruff clean; the live
+`clm slides sync` command is unchanged (not yet wired in).
+
+The spine. Everything else consumes its plan.
+
+- Add a `sync_watermarks` table + accessors to `SyncSnapshotCache`
+  (`infrastructure/llm/cache.py`): ordered, per-lang, nullable `slide_id`,
+  `content_hash` via the existing `cell_content_hash`.
+- New classifier (new `sync_plan.py`, or within `sync.py`): parse both decks,
+  diff each against its watermark + the id-less heuristic → a typed **plan** of
+  proposals `{kind: add|edit|move|remove|conflict, direction, slide_id?,
+  positions, hashes}`. **Per-cell direction is derived here.** ADD entries are
+  marked "translation pending" (filled in Phase 3).
+- Cold-start fallback: no watermark → pair by existing shared ids;
+  git-HEAD-per-deck as the per-cell base; if neither is available and the sides
+  differ, bail to explicit `--source-lang`.
+- `--dry-run` report renders the plan; the no-silent summary distinguishes
+  *in-sync* from *no-baseline*.
+- **Tests:** fixtures of (deck pair + synthetic watermark rows) → assert the
+  plan for each kind, per-cell direction, cold start, and no-baseline messaging.
+- **Exit:** correct typed plans incl. conflicts + cold start; zero writes; zero
+  LLM.
+
+### Phase 2 — Writeback primitives + atomic apply for the deterministic kinds
+
+- `FileState.insert / delete / move` (`sync_writeback.py`), preserving the
+  header + trailing-blank round-trip the split/unify invariant depends on.
+- Apply path for **MOVE** (reorder target by id-join), **REMOVE** (delete the
+  sibling cell), and **EDIT** via the *existing* `SyncJudge` update proposal
+  (now flowing in per-cell direction). The id-stamp mechanic reuses
+  `assign_ids._write_slide_id`.
+- **Per-proposal atomicity:** accepted units mutate both `FileState`s; one
+  `flush` per deck; watermark rows recorded only on success. Skip/quit writes
+  nothing.
+- Still behind `--apply` / `--interactive`; `--dry-run` remains default.
+- **Tests:** move/remove/edit-only pairs → atomic both-deck writes, watermark
+  advances, re-run is an idempotent no-op, skip leaves the unit pending.
+- **Exit:** deterministic + existing-edit sync round-trips atomically and
+  idempotently.
+
+### Phase 3 — New-slide translation + EN-authority ID minting (the ADD path)
+
+- Translate a new source cell → target counterpart. New prompt suite (distinct
+  from the edit judge); routed through `_build_client` like the voiceover
+  `propagate_*` path (structured JSON). **Model fixed: Claude Sonnet
+  (`anthropic/claude-sonnet-4-6`) via OpenRouter**, with a `--translation-model`
+  / `CLM_LLM__*` override. Memoize via `SyncCache`
+  (`(source_hash, prompt_version) → translation`) for **stickiness**.
+- Mint the id: if the source is DE, **translate EN first**, slug from the EN
+  heading (`slug` / `pairing` machinery), and stamp **both** siblings the same
+  id.
+- **Anchored insertion** via the `_find_insertion_point` precedent; runs of
+  consecutive adds order among themselves by source order off the nearest stable
+  shared id.
+- Wire ADD into the atomic apply (stamp source id + insert target counterpart =
+  one unit).
+- **Tests (translator mocked):** add an id-less slide → counterpart inserted at
+  the anchor with an identical minted id on both decks; re-run idempotent (no
+  longer "new"); `--force` regenerates; EN-authority holds when only DE was
+  edited.
+- **Exit:** full add propagation with consistent, sticky ids on both decks.
+
+### Phase 4 — Interactive walker + conflict UX + summary / exit-codes
+
+- Extend `sync_walker` to render ADD / REMOVE / MOVE / CONFLICT (today
+  UPDATE-only).
+- Conflict three-up (watermark base / current DE / current EN) with
+  `[d]e-wins / [e]n-wins / [s]kip`; non-interactive leaves conflicts untouched
+  and lists them in the summary.
+- New summary lines + exit codes: conflicts and unresolved proposals → exit 1
+  ("needs review"); structural/LLM errors → exit 2 (keep today's buckets).
+- **Tests:** walker over all kinds; conflict-resolution paths; the exit-code
+  matrix.
+- **Exit:** every proposal kind is reviewable; conflicts resolve or defer
+  cleanly.
+
+### Phase 5 — Default-flip + docs + deprecate old inference + pilot / CHANGELOG
+
+- **Flip the default** to write-to-working-tree (never commit); `--dry-run`
+  becomes the explicit preview. Update CLI help text.
+- Migrate direction inference fully onto the watermark; deprecate the
+  `sync_snapshots` global-direction path.
+- Update `clm info commands` (`cli/info_topics/commands.md`) and the migration
+  topic per the **Info Topics Maintenance Rule**; add a CHANGELOG entry.
+- Pilot counters (reuse the `SyncResult` counters) for the accept-rate metric;
+  document the prompt-iteration hooks.
+- **Exit:** the one-command workflow is live end-to-end, docs are
+  version-accurate, and `pytest -m "not docker"` is green.
+
+### Dependency graph
+
+```
+Phase 1 (watermark + classifier)
+   ├── Phase 2 (deterministic apply)
+   │      └── Phase 3 (translation + minting)  ← also needs the translator/prompt suite
+   │             └── Phase 4 (walker + conflict UX)
+   │                    └── Phase 5 (default-flip + docs)
+   └── (per-cell direction lands in Phase 1; old-inference deprecation in Phase 5)
+```

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -518,17 +518,59 @@ than this feature): a structural change is flushed to the working tree even on
 an erroring pass — it is surfaced + `git diff`-visible + revertible, and the
 watermark never advances over it, but the working tree is mutated.
 
-- Extend `sync_walker` to render ADD / REMOVE / MOVE / CONFLICT (today
-  UPDATE-only).
+**Part 2a — Interactive review walker + conflict UX + exit codes ✅ implemented
+2026-05-31.** New `clm/slides/sync_plan_walker.py` (`run_plan_walker` →
+`PlanWalkResult`) renders every proposal kind and prompts per proposal, then
+calls `apply_plan` **once** (atomic; the walker writes nothing itself).
+`apply_plan` gained an optional `decisions` map (keyed by `id(proposal)`):
+`apply`/`skip` gate edit/remove/move, `de-wins`/`en-wins` resolve a conflict by
+re-casting it as an edit flowing the winning direction; `decisions=None` is the
+**batch default and stays byte-identical** to the pre-change engine (63 batch
+tests unchanged). Conflicts render two-up (current DE vs current EN) — *not* the
+designed three-up, because the watermark stores only content hashes, not base
+*content*; a true base column needs the watermark to also store bodies (or a
+git-HEAD lookup in the git-fallback case), deferred as a refinement. Add/rename
+are intentionally **always-applied** (non-destructive; reviewed in the resulting
+`git diff`) rather than per-proposal skippable — this avoids a risky refactor of
+the Part-1-reviewed add path; the interactive gate covers the judgment-heavy
+kinds (edit/remove/move/conflict). Exit codes: 2 (plan/apply error) / 1
+(anything deferred) / 0 (clean). The new walker lives alongside the legacy
+`sync_walker.py` (which still serves the legacy `sync.py` engine wired to the
+live CLI); Phase 5 swaps the CLI onto this engine. The summary is split into an
+honest **decisions** line (what the author chose) and an **outcomes** line (what
+the engine wrote / deferred / errored) so an accepted-but-errored edit or a
+deferred id-carrying add is never reported as "applied". **Watermark stays
+all-or-nothing here** (the documented-safe behavior): any skip/defer/quit
+increments `deferred`, and `_pass_is_clean` holds the watermark — nothing
+un-applied is ever baselined. A 9-agent adversarial-review Workflow (5 review
+dimensions × adversarial verify) confirmed the safety invariant intact and found
+**2 medium issues, both fixed**: the walker mislabeled id-carrying adds as
+"auto-applied" (now rendered/counted as deferred), and the suite lacked a
+mixed-accept+skip watermark-held test (added). 25 walker tests; 711 slides tests
+green; mypy/ruff clean. Live `clm slides sync` STILL UNCHANGED.
+
+**Part 2b — Per-cell watermark advance (the §10 partial-apply staleness fix)** is
+the remaining Phase 4 work, split out as its own commit because its failure mode
+is silent data loss (it deserves an isolated adversarial review). Today a
+skip/defer holds the *whole* watermark (safe but noisy on the next run); 2b will
+advance reconciled cells while preserving conflict/skip cells' pre-conflict
+baseline.
+
+Original Phase 4 spec (for reference):
+
+- Extend the walker to render ADD / REMOVE / MOVE / CONFLICT (today
+  UPDATE-only). *(done in 2a — a new `sync_plan_walker` over the new engine.)*
 - Conflict three-up (watermark base / current DE / current EN) with
   `[d]e-wins / [e]n-wins / [s]kip`; non-interactive leaves conflicts untouched
-  and lists them in the summary.
+  and lists them in the summary. *(2a ships a two-up; base-content column
+  deferred — see above.)*
 - New summary lines + exit codes: conflicts and unresolved proposals → exit 1
   ("needs review"); structural/LLM errors → exit 2 (keep today's buckets).
+  *(done in 2a.)*
 - **Tests:** walker over all kinds; conflict-resolution paths; the exit-code
-  matrix.
+  matrix. *(done in 2a.)*
 - **Exit:** every proposal kind is reviewable; conflicts resolve or defer
-  cleanly.
+  cleanly. *(met in 2a.)*
 
 ### Phase 5 — Default-flip + docs + deprecate old inference + pilot / CHANGELOG
 

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -1,24 +1,40 @@
-"""``clm slides sync`` — Phase 7 of the slide-format-redesign.
+"""``clm slides sync`` — single-language authoring sync for split decks.
 
-Cross-language sync helper for split-format decks (``<deck>.de.py`` /
-``<deck>.en.py``). After an author edits one side, this command walks
-the pair by ``slide_id``, asks the local LLM to propose updates to the
-other side, and prints a unified diff per cell.
+Issue #166. After an author edits **one** half of a split-format deck pair
+(``<deck>.de.py`` / ``<deck>.en.py``, the layout produced by
+``clm slides split``), this command brings the *other* half into sync in a
+single pass: edits are propagated, brand-new slides are translated and inserted,
+removed slides are dropped, reorders are mirrored, and a shared ``slide_id`` is
+minted onto both decks as it goes.
+
+Direction is decided **per cell** by diffing each deck against a structural
+**watermark** — the last-synced state, recorded only on a successful apply, so it
+is immune to the author's git-commit cadence. There is no global
+``--source-lang``: different cells can flow in different directions in the same
+pass, and a cell edited on *both* sides since the last sync is isolated as a
+*conflict* rather than guessed. When no watermark exists yet, the baseline falls
+back to each deck's git ``HEAD`` (and finally to the id-less-as-new heuristic).
 
 Modes:
 
-- default ``--dry-run`` — read-only; emit diffs, write nothing.
-- ``--interactive`` — walk proposals with [a]pply/[s]kip/[e]dit/[q]uit.
-- ``--apply --trivial`` — auto-apply diffs that only change line endings
-  or move whitespace within a single line; non-trivial proposals fall
-  back to the report (or, combined with ``--interactive``, to the
-  walker).
+- **default** — write the agreed changes to the working tree in one pass. The
+  watermark advances; nothing is committed. Review with ``git diff`` (the
+  design's primary review surface).
+- ``--dry-run`` — classify only; print the plan and write nothing.
+- ``--interactive`` — walk each proposal and choose
+  ``[a]pply`` / ``[s]kip`` / ``[q]uit`` (``[d]e-wins`` / ``[e]n-wins`` for a
+  conflict) before a single atomic apply.
+
+Edits are reconciled by the local Ollama :class:`SyncJudge`; brand-new slides are
+translated by an OpenRouter :class:`SlideTranslator` (Claude Sonnet). When the
+judge is unreachable, edits are recorded as errors; when no translator key is
+configured, adds defer.
 
 Exit codes:
 
-- ``0`` — no proposed updates and no errors
-- ``1`` — at least one proposed update left for the user to review
-- ``2`` — at least one structural error (mismatch / LLM unavailable)
+- ``0`` — clean: every change applied (or nothing to do), no errors
+- ``1`` — something is left for review (a skipped proposal / unresolved conflict)
+- ``2`` — a structural error (classifier issue, missing target cell, LLM down)
 """
 
 from __future__ import annotations
@@ -26,19 +42,23 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
-from clm.infrastructure.llm.cache import SyncCache, SyncSnapshotCache, resolve_cache_dir
+from clm.infrastructure.llm.cache import SyncWatermarkCache, resolve_cache_dir
 from clm.infrastructure.llm.ollama_client import (
     DEFAULT_SYNC_MODEL,
     OllamaSyncJudge,
     is_available,
 )
-from clm.slides.sync import SyncOptions, SyncResult, sync_split_pair
-from clm.slides.sync_direction import infer_source_lang
-from clm.slides.sync_trivial import apply_trivial_proposals
-from clm.slides.sync_walker import WalkerOptions, run_interactive_walker
+from clm.slides.sync_apply import ApplyResult, apply_plan
+from clm.slides.sync_plan import PlanIssue, SyncPlan, build_sync_plan, render_plan
+from clm.slides.sync_plan_walker import PlanWalkResult, WalkerOptions, run_plan_walker
+from clm.slides.sync_translate import DEFAULT_TRANSLATION_MODEL, OpenRouterSlideTranslator
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.ollama_client import SyncJudge
 
 CACHE_DB_NAME = "clm-llm.sqlite"
 
@@ -53,23 +73,12 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
 )
 @click.option(
-    "--source-lang",
-    type=click.Choice(["de", "en"]),
-    required=False,
-    default=None,
+    "--dry-run",
+    is_flag=True,
+    default=False,
     help=(
-        "Language that was edited; updates are proposed for the other "
-        "side. When omitted, the direction is inferred from the "
-        "SyncSnapshotCache (preferred) or from git commit timestamps; "
-        "pass explicitly to override the inferred direction."
-    ),
-)
-@click.option(
-    "--dry-run/--no-dry-run",
-    default=True,
-    help=(
-        "Show proposed diffs without modifying any file (default). "
-        "``--interactive`` automatically disables dry-run."
+        "Classify only: print the plan and write nothing. The default "
+        "(without this flag) writes the agreed changes to the working tree."
     ),
 )
 @click.option(
@@ -77,38 +86,16 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     is_flag=True,
     default=False,
     help=(
-        "Walk proposed updates one by one and prompt "
-        "[a]pply / [s]kip / [e]dit / [q]uit per proposal. On accept "
-        "and on edit the target file is written in place and the new "
-        "(de_hash, en_hash) is recorded in the sync_snapshots table."
-    ),
-)
-@click.option(
-    "--apply",
-    "apply_writes",
-    is_flag=True,
-    default=False,
-    help=(
-        "Write proposals to disk. Requires --trivial; without it the "
-        "flag is rejected because unconditional auto-apply is unsafe."
-    ),
-)
-@click.option(
-    "--trivial",
-    is_flag=True,
-    default=False,
-    help=(
-        "Modifier for --apply. Auto-apply only diffs that are EOL-only "
-        "(CRLF / trailing newline) or that change whitespace within a "
-        "single line. Non-trivial proposals fall back to the report or "
-        "to the --interactive walker."
+        "Walk each proposal and choose [a]pply / [s]kip / [q]uit "
+        "([d]e-wins / [e]n-wins for a conflict) before a single atomic apply. "
+        "Mutually exclusive with --dry-run and --json."
     ),
 )
 @click.option(
     "--llm-model",
     default=DEFAULT_SYNC_MODEL,
     show_default=True,
-    help="Ollama model used for the sync judge.",
+    help="Ollama model used for the edit-reconciliation judge.",
 )
 @click.option(
     "--ollama-url",
@@ -120,313 +107,292 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     type=float,
     default=120.0,
     show_default=True,
-    help="Per-call timeout (seconds) for the sync judge.",
+    help="Per-call timeout (seconds) for the edit judge.",
+)
+@click.option(
+    "--translation-model",
+    default=DEFAULT_TRANSLATION_MODEL,
+    show_default=True,
+    help=(
+        "OpenRouter model used to translate brand-new slides for the add path. "
+        "Needs $OPENROUTER_API_KEY (or $OPENAI_API_KEY); adds defer when absent."
+    ),
 )
 @click.option(
     "--cache-dir",
     type=click.Path(path_type=Path),
     default=None,
     help=(
-        "Directory for the LLM cache (default: --cache-dir > $CLM_CACHE_DIR > "
-        "tool.clm.cache_dir in pyproject.toml > <cwd>/.clm-cache/)."
+        "Directory holding the structural watermark (default: --cache-dir > "
+        "$CLM_CACHE_DIR > tool.clm.cache_dir in pyproject.toml > <cwd>/.clm-cache/)."
     ),
 )
 @click.option(
     "--no-cache",
     is_flag=True,
     help=(
-        "Skip cache reads and writes. Useful when iterating on the "
-        "prompt or model — every run fires fresh LLM calls."
+        "Do not read or write the watermark. Every run then re-derives its "
+        "baseline from git HEAD and no synced state is persisted."
     ),
 )
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def slides_sync_cmd(
     de_path: Path,
     en_path: Path,
-    source_lang: str | None,
     dry_run: bool,
     interactive: bool,
-    apply_writes: bool,
-    trivial: bool,
     llm_model: str,
     ollama_url: str | None,
     llm_timeout: float,
+    translation_model: str,
     cache_dir: Path | None,
     no_cache: bool,
     as_json: bool,
 ) -> None:
-    """Propose cross-language sync edits for a split DE/EN deck pair.
+    """Bring a split DE/EN deck pair into sync after editing one side.
 
-    DE_PATH and EN_PATH must be the two halves of a split-format deck
+    DE_PATH and EN_PATH are the two halves of a split-format deck
     (``<deck>.de.py`` and ``<deck>.en.py``).
 
     \b
     Behavior:
-      * Walks the pair by slide_id (assign-ids must have run first).
-      * For each paired cell, asks the local LLM to propose any needed
-        update to the target side.
-      * Default mode (dry-run): emits a unified diff per proposed
-        update; no files are modified.
-      * --interactive: walks proposals one by one with
-        [a]pply / [s]kip / [e]dit / [q]uit, writes accepted/edited
-        proposals to the target file, and records the post-write
-        (de_hash, en_hash) in the sync_snapshots table.
-      * --apply --trivial: auto-applies every proposal whose diff is
-        EOL-only or whitespace-only-one-line; non-trivial proposals
-        stay in the report (or surface in the --interactive walker
-        when both flags are passed).
-      * Memoizes LLM calls via the SyncCache; unchanged pairs cache-hit.
-      * Reports structural mismatches (cells present on one side only,
-        or unequal counts within a slide_id) as warnings/errors.
+      * Diffs both decks against the structural watermark (last synced
+        state) to classify per-cell add / edit / move / remove / conflict
+        changes — direction is decided per cell, not globally.
+      * Default: writes the agreed changes to the working tree in one pass
+        (edits reconciled by the local LLM, new slides translated + inserted,
+        a shared slide_id minted onto both decks) and advances the watermark.
+        Nothing is committed — review with ``git diff``.
+      * --dry-run: prints the plan and writes nothing.
+      * --interactive: prompts per proposal before a single atomic apply.
+      * A cell edited on both sides since the last sync is isolated as a
+        conflict (left untouched, listed in the summary) rather than guessed.
     """
     if interactive and as_json:
         raise click.UsageError("--interactive and --json are mutually exclusive")
-    if apply_writes and not trivial:
+    if interactive and dry_run:
         raise click.UsageError(
-            "--apply currently requires --trivial; full --apply is not yet "
-            "supported. Use --interactive for full apply with prompts."
+            "--interactive and --dry-run are mutually exclusive "
+            "(--dry-run writes nothing; --interactive applies after prompting)"
         )
-    if trivial and not apply_writes:
-        raise click.UsageError("--trivial is a modifier for --apply; pass --apply --trivial")
 
-    cache: SyncCache | None = None
-    snapshot_cache: SyncSnapshotCache | None = None
+    watermark_cache: SyncWatermarkCache | None = None
     if not no_cache:
         cache_root = resolve_cache_dir(cli_override=cache_dir)
-        cache = SyncCache(cache_root / CACHE_DB_NAME)
-        snapshot_cache = SyncSnapshotCache(cache_root / CACHE_DB_NAME)
+        watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
 
-    apply_trivial = apply_writes and trivial
-
+    plan: SyncPlan
+    apply_result: ApplyResult | None = None
+    walk: PlanWalkResult | None = None
     try:
-        # Direction-of-edit: explicit --source-lang always wins, but we
-        # cross-check against snapshot/git inference and warn on
-        # disagreement so the user notices a suspicious explicit value.
-        resolved_source_lang = _resolve_source_lang(
-            source_lang,
-            de_path,
-            en_path,
-            snapshot_cache=snapshot_cache,
-        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=watermark_cache)
 
-        judge = OllamaSyncJudge(
-            model=llm_model,
-            base_url=ollama_url,
-            timeout=llm_timeout,
-        )
-        if not is_available(judge):
-            click.echo(
-                f"warning: Ollama is not reachable at {judge.base_url}; "
-                "every pair will be recorded as an LLM-unavailable error.",
-                err=True,
+        if dry_run:
+            mode = "dry-run"
+        elif interactive:
+            mode = "interactive"
+            judge = _resolve_judge(llm_model, ollama_url, llm_timeout)
+            translator = OpenRouterSlideTranslator(model=translation_model)
+            for issue in plan.issues:
+                click.echo(_issue_line(issue))
+            walk = run_plan_walker(
+                plan,
+                judge=judge,
+                translator=translator,
+                watermark_cache=watermark_cache,
+                options=WalkerOptions(),
             )
-            judge_for_options = None
+            apply_result = walk.apply_result
         else:
-            judge_for_options = judge
-
-        options = SyncOptions(
-            source_lang=resolved_source_lang,
-            judge=judge_for_options,
-            cache=cache,
-        )
-
-        result = sync_split_pair(de_path, en_path, options)
-        if apply_trivial:
-            apply_trivial_proposals(result, snapshot_cache=snapshot_cache)
-        if interactive:
-            run_interactive_walker(
-                result,
-                WalkerOptions(snapshot_cache=snapshot_cache),
+            mode = "apply"
+            judge = _resolve_judge(llm_model, ollama_url, llm_timeout)
+            translator = OpenRouterSlideTranslator(model=translation_model)
+            apply_result = apply_plan(
+                plan,
+                judge=judge,
+                translator=translator,
+                watermark_cache=watermark_cache,
             )
     finally:
-        if cache is not None:
-            cache.close()
-        if snapshot_cache is not None:
-            snapshot_cache.close()
+        if watermark_cache is not None:
+            watermark_cache.close()
 
-    effective_dry_run = dry_run and not interactive and not apply_trivial
+    exit_code = (
+        _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
+    )
+
     if as_json:
-        click.echo(json.dumps(_to_dict(result), indent=2))
+        click.echo(json.dumps(_to_dict(plan, apply_result, walk, mode, exit_code), indent=2))
     else:
-        _print_human(
-            result,
-            dry_run=effective_dry_run,
-            interactive=interactive,
-            apply_trivial=apply_trivial,
-        )
+        _print_human(plan, apply_result, walk, mode=mode)
 
-    sys.exit(_exit_code(result))
+    sys.exit(exit_code)
 
 
-def _resolve_source_lang(
-    source_lang: str | None,
-    de_path: Path,
-    en_path: Path,
-    *,
-    snapshot_cache: SyncSnapshotCache | None,
-) -> str:
-    """Decide which side is the source for this sync pass.
+def _resolve_judge(llm_model: str, ollama_url: str | None, llm_timeout: float) -> SyncJudge | None:
+    """Construct the edit judge, or ``None`` (with a warning) when unreachable.
 
-    When the user passes ``--source-lang`` explicitly, that value is
-    honored. We still run inference so we can warn on disagreement —
-    a mismatch usually means the user is about to overwrite the side
-    they actually edited.
-
-    When ``--source-lang`` is omitted, inference must yield a definite
-    answer. Otherwise we raise :class:`click.UsageError` so the user
-    can re-run with an explicit value.
+    A ``None`` judge records each edit proposal as an LLM-unavailable error, so
+    the run still completes and surfaces exactly what could not be reconciled.
     """
-    inference = infer_source_lang(de_path, en_path, snapshot_cache)
-
-    if source_lang is not None:
-        if inference.source_lang is not None and inference.source_lang != source_lang:
-            click.echo(
-                f"warning: --source-lang={source_lang!r} disagrees with "
-                f"inferred direction {inference.source_lang!r} "
-                f"({inference.signal}: {inference.reason}); honoring explicit override.",
-                err=True,
-            )
-        return source_lang
-
-    if inference.source_lang is None:
-        raise click.UsageError(
-            "--source-lang was not provided and could not be inferred "
-            f"({inference.signal}: {inference.reason}). "
-            "Pass --source-lang de or --source-lang en explicitly."
-        )
-
+    judge = OllamaSyncJudge(model=llm_model, base_url=ollama_url, timeout=llm_timeout)
+    if is_available(judge):
+        return judge
     click.echo(
-        f"note: --source-lang inferred as {inference.source_lang!r} "
-        f"({inference.signal}: {inference.reason})",
+        f"warning: Ollama is not reachable at {judge.base_url}; "
+        "every edit will be recorded as an LLM-unavailable error.",
         err=True,
     )
-    return inference.source_lang
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+def _plan_exit_code(plan: SyncPlan) -> int:
+    """Dry-run exit: 2 on a classifier error, 1 if anything would change, else 0."""
+    if plan.has_errors:
+        return 2
+    if plan.proposals:
+        return 1
+    return 0
+
+
+def _apply_exit_code(plan: SyncPlan, result: ApplyResult) -> int:
+    """Apply exit: 2 on any error, 1 if anything was deferred, else 0.
+
+    Mirrors :attr:`PlanWalkResult.exit_code` so batch and interactive runs share
+    one definition of clean / needs-review / error.
+    """
+    if plan.has_errors or result.has_errors:
+        return 2
+    if result.deferred > 0:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Human output
+# ---------------------------------------------------------------------------
+
+
+def _issue_line(issue: PlanIssue) -> str:
+    sid = f" {issue.slide_id}" if issue.slide_id else ""
+    return f"issue-{issue.severity}{sid}: {issue.reason}"
+
+
+def _outcome_line(result: ApplyResult) -> str:
+    return (
+        f"applied: {result.applied_edit} edit, {result.applied_remove} remove, "
+        f"{result.applied_move} move, {result.applied_add} add, "
+        f"{result.applied_rename} rename; {result.in_sync} already in sync; "
+        f"{result.deferred} deferred; {len(result.errors)} error(s); "
+        f"watermark {'advanced' if result.watermark_recorded else 'held'}."
+    )
 
 
 def _print_human(
-    result: SyncResult,
+    plan: SyncPlan,
+    apply_result: ApplyResult | None,
+    walk: PlanWalkResult | None,
     *,
-    dry_run: bool,
-    interactive: bool,
-    apply_trivial: bool,
+    mode: str,
 ) -> None:
-    prefix = "[dry-run] " if dry_run else ""
+    if mode == "dry-run":
+        click.echo(render_plan(plan))
+        return
 
-    for issue in result.issues:
-        click.echo(
-            f"issue-{issue.severity} {issue.slide_id} "
-            f"(de={issue.de_count}, en={issue.en_count}): {issue.reason}"
-        )
+    assert apply_result is not None  # apply / interactive always produce a result
+    if mode == "interactive":
+        # The walker echoed each proposal block + decision during the walk; its
+        # two-line summary reports decisions and outcomes without conflating them.
+        click.echo("")
+        for line in walk.summary() if walk is not None else []:
+            click.echo(line)
+    else:  # batch apply — show the full classified plan, then what was written
+        click.echo(render_plan(plan))
+        click.echo("")
+        click.echo(_outcome_line(apply_result))
 
-    # In interactive mode the walker has already printed per-proposal
-    # output (diff + prompt + action). The end-of-run summary still
-    # surfaces in_sync / error outcomes and the headline counters so
-    # the trainer sees everything in one place.
-    for outcome in result.outcomes:
-        if outcome.verdict == "in_sync":
-            cached_tag = " (cached)" if outcome.cached else ""
-            click.echo(
-                f"{prefix}in-sync {outcome.slide_id}/{outcome.role} "
-                f"de:{outcome.de_line} en:{outcome.en_line}{cached_tag}"
-                + (f" — {outcome.reason}" if outcome.reason else "")
-            )
-        elif outcome.verdict == "update" and outcome.applied_trivially:
-            click.echo(
-                f"applied (trivial) {outcome.slide_id}/{outcome.role} "
-                f"({outcome.direction}) de:{outcome.de_line} "
-                f"en:{outcome.en_line}" + (f" — {outcome.reason}" if outcome.reason else "")
-            )
-        elif outcome.verdict == "update" and not interactive:
-            cached_tag = " (cached)" if outcome.cached else ""
-            click.echo(
-                f"{prefix}propose {outcome.slide_id}/{outcome.role} "
-                f"({outcome.direction}) de:{outcome.de_line} "
-                f"en:{outcome.en_line}{cached_tag}"
-                + (f" — {outcome.reason}" if outcome.reason else "")
-            )
-            if outcome.diff:
-                click.echo(outcome.diff)
-                click.echo()
-        elif outcome.verdict == "error":
-            click.echo(
-                f"error {outcome.slide_id}/{outcome.role} "
-                f"de:{outcome.de_line} en:{outcome.en_line}: {outcome.error}"
-            )
-
-    click.echo()
-    click.echo(
-        f"{prefix}{result.pairs_visited} pair(s) visited, "
-        f"{result.pairs_in_sync} in sync, "
-        f"{result.pairs_proposed} proposed update(s), "
-        f"{result.pairs_error} error(s), "
-        f"{result.cache_hits} cache hit(s), "
-        f"{len(result.issues)} structural issue(s)."
-    )
-    if apply_trivial:
-        non_trivial = result.pairs_proposed - result.pairs_auto_applied
-        click.echo(
-            f"auto-apply: {result.pairs_auto_applied} trivial update(s) applied, "
-            f"{non_trivial} remaining for human review."
-        )
-    if interactive:
-        click.echo(
-            f"walker: {result.pairs_accepted} accepted, "
-            f"{result.pairs_edited} edited, "
-            f"{result.pairs_skipped} skipped, "
-            f"{result.pairs_quit} unvisited (quit)."
-        )
+    for err in apply_result.errors:
+        click.echo(f"  error: {err}")
+    if apply_result.applied > 0:
+        click.echo("Review the propagated changes with `git diff` before committing.")
 
 
-def _to_dict(result: SyncResult) -> dict:
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def _to_dict(
+    plan: SyncPlan,
+    apply_result: ApplyResult | None,
+    walk: PlanWalkResult | None,
+    mode: str,
+    exit_code: int,
+) -> dict:
     return {
-        "de_path": str(result.de_path),
-        "en_path": str(result.en_path),
-        "pairs_visited": result.pairs_visited,
-        "pairs_in_sync": result.pairs_in_sync,
-        "pairs_proposed": result.pairs_proposed,
-        "pairs_error": result.pairs_error,
-        "cache_hits": result.cache_hits,
-        "pairs_accepted": result.pairs_accepted,
-        "pairs_skipped": result.pairs_skipped,
-        "pairs_edited": result.pairs_edited,
-        "pairs_quit": result.pairs_quit,
-        "pairs_auto_applied": result.pairs_auto_applied,
-        "outcomes": [
+        "de_path": str(plan.de_path),
+        "en_path": str(plan.en_path),
+        "mode": mode,
+        "exit_code": exit_code,
+        "plan": _plan_dict(plan),
+        "apply": _apply_dict(apply_result) if apply_result is not None else None,
+        "walker": _walker_dict(walk) if walk is not None else None,
+    }
+
+
+def _plan_dict(plan: SyncPlan) -> dict:
+    return {
+        "baseline_source": plan.baseline_source,
+        "in_sync": plan.in_sync_count,
+        "counts": {
+            kind: plan.count(kind)
+            for kind in ("add", "edit", "move", "remove", "conflict", "rename")
+        },
+        "proposals": [
             {
-                "slide_id": o.slide_id,
-                "role": o.role,
-                "de_line": o.de_line,
-                "en_line": o.en_line,
-                "direction": o.direction,
-                "verdict": o.verdict,
-                "reason": o.reason,
-                "cached": o.cached,
-                "diff": o.diff,
-                "error": o.error,
-                "applied_trivially": o.applied_trivially,
-                "proposed_text": (o.proposal.proposed_text if o.proposal is not None else ""),
+                "kind": p.kind,
+                "role": p.role,
+                "direction": p.direction,
+                "slide_id": p.slide_id,
+                "reason": p.reason,
+                "translation_pending": p.translation_pending,
             }
-            for o in result.outcomes
+            for p in plan.proposals
         ],
         "issues": [
-            {
-                "slide_id": i.slide_id,
-                "severity": i.severity,
-                "reason": i.reason,
-                "de_count": i.de_count,
-                "en_count": i.en_count,
-            }
-            for i in result.issues
+            {"severity": i.severity, "slide_id": i.slide_id, "reason": i.reason}
+            for i in plan.issues
         ],
     }
 
 
-def _exit_code(result: SyncResult) -> int:
-    if result.has_errors or any(i.severity == "error" for i in result.issues):
-        return 2
-    # Trivial-auto-applied proposals are resolved without user
-    # interaction; subtract them so an all-trivial run exits 0.
-    unresolved = result.pairs_proposed - result.pairs_auto_applied
-    if unresolved > 0:
-        return 1
-    return 0
+def _apply_dict(result: ApplyResult) -> dict:
+    return {
+        "applied": {
+            "edit": result.applied_edit,
+            "remove": result.applied_remove,
+            "move": result.applied_move,
+            "add": result.applied_add,
+            "rename": result.applied_rename,
+            "total": result.applied,
+        },
+        "in_sync": result.in_sync,
+        "deferred": result.deferred,
+        "watermark_recorded": result.watermark_recorded,
+        "errors": list(result.errors),
+    }
+
+
+def _walker_dict(walk: PlanWalkResult) -> dict:
+    return {
+        "accepted": walk.accepted,
+        "conflicts_resolved": walk.conflicts_resolved,
+        "skipped": walk.skipped,
+        "auto_applied": walk.auto_applied,
+        "unvisited": walk.unvisited,
+    }

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -674,44 +674,50 @@ clm slides assign-ids slides/module_010/ --force        # regenerate all derivab
 
 *Added in CLM {version}.*
 
-Cross-language sync helper for split-format decks
+Single-language authoring sync for split-format decks
 (`<deck>.de.py` / `<deck>.en.py`, the layout produced by
-`clm slides split`). After an author edits one half of a pair, this
-command walks the two files by `slide_id`, asks the local LLM
-(Ollama) to propose any needed update to the other side, and prints
-a unified diff per cell.
+`clm slides split`). After an author edits **one** half of a pair, this
+command brings the *other* half into sync in a single pass: edits are
+propagated, brand-new slides are translated and inserted, removed
+slides are dropped, reorders are mirrored, and a shared `slide_id` is
+minted onto both decks as it goes.
 
-The LLM call is memoized in a `SyncCache` table keyed by
-`(de_hash, en_hash, prompt_version)` — re-runs against an unchanged
-pair short-circuit to the cached proposal and avoid LLM spend. The
-cache lives in the same SQLite file as the `assign-ids` and
-`coverage` caches.
+**Default behavior changed in CLM {version}: the command now writes to
+the working tree.** A bare `clm slides sync de en` applies the agreed
+changes (it no longer just prints a diff). Nothing is committed —
+review the result with `git diff`, the design's primary review surface.
+Use `--dry-run` to preview without writing. See the migration guide
+(`clm info migration`) for the full before/after.
 
-**Scope:** the default mode is dry-run (no files modified).
-`--interactive` walks proposed updates one by one with an apply / skip /
-edit / quit prompt and writes accepted (or edited) proposals to the
-target file. `--apply --trivial` auto-applies the safe subset of
-proposals (EOL-only or whitespace-only-one-line diffs) without
-prompting; non-trivial proposals fall through to the report (or to the
-`--interactive` walker when both flags are passed).
+**Per-cell direction (no `--source-lang`).** Direction is decided per
+cell by diffing each deck against a structural **watermark** — the
+last-synced deck state, recorded only on a successful apply, so it is
+immune to the author's git-commit cadence. Different cells can flow in
+different directions in the same pass. A cell with **no** `slide_id` is,
+by construction, *added since the last sync* (a commit never runs
+assign-ids), so new slides are detected even after the editing deck is
+committed. When no watermark exists yet, the baseline falls back to each
+deck's git `HEAD`, then to the id-less-as-new heuristic alone; the
+no-silent-no-op summary states which baseline was used.
 
-**Direction-of-edit** is inferred when `--source-lang` is omitted.
-Inference prefers `SyncSnapshotCache` drift evidence (content-
-addressed; survives rebases) and falls back to git commit timestamps
-when no snapshot row points at a clear winner. The CLI prints a
-short note on stderr showing which signal won. Pass `--source-lang`
-explicitly to override; a warning is emitted when the explicit value
-disagrees with the inferred direction, and the explicit value is
-honored. Inference falls back to requiring `--source-lang` when both
-signals are unusable (no snapshot rows, no git history, equal
-timestamps, or the two signals contradict each other).
+**Conflicts are isolated, never guessed.** A cell edited on *both* decks
+since the last sync (or removed on one and edited on the other) is
+surfaced as a `conflict`: both decks are left untouched and it is listed
+in the summary. Resolve it with `--interactive` (`[d]e-wins` /
+`[e]n-wins`) or by editing one side and re-running.
+
+**Two LLMs.** Edits are reconciled by the local Ollama judge
+(`--llm-model`, default `qwen3:30b`). Brand-new slides are translated by
+an OpenRouter model (`--translation-model`, default
+`anthropic/claude-sonnet-4-6`), which needs `$OPENROUTER_API_KEY` (or
+`$OPENAI_API_KEY`); without a key, add proposals defer. When Ollama is
+unreachable, edit proposals are recorded as errors (exit 2) rather than
+guessed.
 
 Cells synced: markdown `slide` / `subslide` cells and narrative
 `voiceover` / `notes` cells. Shared code cells are intentionally
-excluded — split companions must keep them byte-identical, and that
-consistency is enforced by the Phase-6 split-source validator
-instead. Cells without a `slide_id` are skipped silently (run
-`clm slides assign-ids` first).
+excluded — split companions must keep them byte-identical, enforced by
+the split-source validator instead.
 
 ```
 clm slides sync [OPTIONS] DE_PATH EN_PATH
@@ -719,66 +725,52 @@ clm slides sync [OPTIONS] DE_PATH EN_PATH
 
 | Option | Description |
 |--------|-------------|
-| `--source-lang de\|en` | Language that was edited; updates are proposed for the other side. Optional — inferred from snapshot drift or git commit timestamps when omitted. An explicit value that disagrees with the inferred direction triggers a warning and is honored. |
-| `--dry-run / --no-dry-run` | Show proposed diffs without modifying any file (default). `--interactive` and `--apply --trivial` implicitly disable dry-run. |
-| `--interactive` | Walk proposed updates one by one with `[a]pply / [s]kip / [e]dit / [q]uit` per proposal; accepted / edited proposals are written to the target file and the post-write `(de_hash, en_hash)` is recorded in `sync_snapshots`. Mutually exclusive with `--json`. |
-| `--apply` | Write proposals to disk. Currently requires `--trivial`; full unconditional `--apply` is not yet supported. |
-| `--trivial` | Modifier for `--apply`. Auto-apply diffs that are EOL-only (CR/CRLF / trailing newline) or whitespace-only-one-line. Non-trivial proposals are left for human review. |
-| `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
+| `--dry-run` | Classify only: print the plan and write nothing. (The default, without this flag, writes the agreed changes to the working tree.) |
+| `--interactive` | Walk each proposal and choose `[a]pply / [s]kip / [q]uit` (`[d]e-wins / [e]n-wins` for a conflict) before a single atomic apply. Mutually exclusive with `--dry-run` and `--json`. |
+| `--llm-model TEXT` | Ollama model for the edit-reconciliation judge (default: `qwen3:30b`). |
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
-| `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B local model can exceed 60s). |
-| `--cache-dir PATH` | Directory for the SyncCache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
-| `--no-cache` | Skip cache reads and writes (useful when iterating on the prompt or model). |
+| `--llm-timeout SECONDS` | Per-call timeout for the edit judge (default: 120s — cold-load on a 30B local model can exceed 60s). |
+| `--translation-model TEXT` | OpenRouter model used to translate brand-new slides for the add path (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`; adds defer when absent. |
+| `--cache-dir PATH` | Directory holding the structural watermark. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
+| `--no-cache` | Do not read or write the watermark. Every run then re-derives its baseline from git `HEAD` and no synced state is persisted. |
 | `--json` | Emit a JSON report instead of human-readable lines. |
 
-Exit codes: `0` clean (no proposed updates and no errors, or every
-proposal was auto-applied via `--apply --trivial`), `1` at least one
-proposed update for author review, `2` at least one structural error
-(slide_id count mismatch or LLM unavailable).
+Exit codes: `0` clean (every change applied, or nothing to do, with no
+errors), `1` something is left for review (a skipped proposal or an
+unresolved conflict), `2` a structural error (classifier error, missing
+target cell, or the edit LLM is unavailable).
 
-A run also surfaces structural issues for slide_ids that cannot be
-paired cleanly: cells present on one side but not the other
-(severity `warning`) and slide_ids with unequal cell counts on the
-two sides (severity `error` — manual pairing needed).
+A run also surfaces structural issues the classifier will not turn into
+a proposal — for example a duplicate `slide_id` whose original cannot be
+identified (`error`), or cell order that drifted on both decks
+(`warning`, order not propagated). Any issue holds the whole watermark
+so the signal is never silently baselined.
 
-Pilot instrumentation: every run records per-session counters
-(`pairs_visited`, `pairs_in_sync`, `pairs_proposed`, `pairs_error`,
-`cache_hits`). `--interactive` adds `pairs_accepted`, `pairs_edited`,
-`pairs_skipped`, and `pairs_quit`. `--apply --trivial` adds
-`pairs_auto_applied` (and sets `applied_trivially` on each
-auto-applied outcome). The PythonCourses Phase D pilot ships when
-`(pairs_accepted + pairs_edited) / pairs_resolved > 0.8`.
-
-Both `--interactive` accepts/edits and `--apply --trivial` auto-applies
-write a `sync_snapshots` row per write, capturing the post-write
-`(de_hash, en_hash)` for that `(de_path, en_path, slide_id, role)`
-slot. The direction-auto-detection pass that runs when
-`--source-lang` is omitted reads these rows to decide which side
-drifted since the last sync.
+The JSON report carries `mode` (`dry-run` / `apply` / `interactive`),
+`exit_code`, a `plan` block (`baseline_source`, per-kind `counts`,
+`in_sync`, the `proposals`, and `issues`), an `apply` block (per-kind
+`applied` counts, `in_sync`, `deferred`, `watermark_recorded`, and
+`errors`) — `null` under `--dry-run` — and a `walker` block of
+accept/skip/defer counters under `--interactive`. These counters are the
+pilot accept-rate instrumentation.
 
 Examples:
 
 ```bash
-# After committing the DE edit, infer direction from snapshot/git history.
+# Edit intro.de.py, then bring intro.en.py into sync (writes to the tree).
 clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py
 
-# Same, but explicit (overrides inference; warns if inference disagrees).
-clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py --source-lang de
+# Preview the plan first — write nothing.
+clm slides sync intro.de.py intro.en.py --dry-run
 
-# Walk proposals interactively, applying or editing per cell.
-clm slides sync intro.de.py intro.en.py --source-lang de --interactive
+# Walk each proposal, resolving conflicts as you go.
+clm slides sync intro.de.py intro.en.py --interactive
 
-# Auto-apply trivial diffs (EOL / whitespace-only); leave the rest in the report.
-clm slides sync intro.de.py intro.en.py --source-lang de --apply --trivial
+# Machine-readable plan for tooling.
+clm slides sync intro.de.py intro.en.py --dry-run --json
 
-# Auto-apply trivial diffs, then walk the rest interactively.
-clm slides sync intro.de.py intro.en.py --source-lang de --apply --trivial --interactive
-
-# Same, JSON output for tooling.
-clm slides sync intro.de.py intro.en.py --source-lang de --json
-
-# Iterating on the prompt — skip the cache to fire fresh LLM calls every time.
-clm slides sync intro.de.py intro.en.py --source-lang de --no-cache
+# Stateless run: ignore/leave the watermark, baseline off git HEAD.
+clm slides sync intro.de.py intro.en.py --no-cache
 ```
 
 ### `clm slides coverage`

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -187,6 +187,65 @@ clm validate slides/topic/slides_intro.py --checks voiceover
 
 …or via MCP: `validate_slides(path, checks=["voiceover"])`.
 
+## `clm slides sync` is now a single-language authoring command (writes by default)
+
+CLM {version} reworks `clm slides sync` into the single-language
+authoring workflow (issue #166): edit **one** half of a split deck, run
+the command, and it brings the other half into sync in a single pass —
+propagating edits, translating and inserting brand-new slides, dropping
+removed slides, mirroring reorders, and minting a shared `slide_id` onto
+both decks.
+
+### Breaking changes
+
+| Before | After |
+|--------|-------|
+| **Default was dry-run** (printed diffs, wrote nothing). | **Default writes to the working tree.** A bare `clm slides sync de en` applies the agreed changes. Nothing is committed — review with `git diff`. Pass `--dry-run` for the old preview-only behavior. |
+| `--source-lang de\|en` selected the edited side (or was inferred from `sync_snapshots` drift / git timestamps). | **Removed.** Direction is decided **per cell** by diffing each deck against the structural watermark, so a single pass can carry edits in both directions. A cell edited on both decks is isolated as a `conflict` instead of being guessed. Passing `--source-lang` is now a usage error. |
+| `--apply --trivial` auto-applied EOL-/whitespace-only diffs. | **Removed.** The new default already applies; there is no trivial-only mode. Use `--interactive` to gate proposals one by one. Passing `--apply` or `--trivial` is now a usage error. |
+| Per-cell `sync_snapshots` rows recorded the last accepted `(de_hash, en_hash)` for direction inference. | The engine now records an ordered, per-language **`sync_watermarks`** baseline (the whole deck, with cell order and id-less cells), written only on a successful apply. `sync_snapshots` is no longer written or read by `sync`. |
+
+### What stays the same
+
+- The pair arguments (`DE_PATH EN_PATH`), `--interactive`, `--json`,
+  `--llm-model`, `--ollama-url`, `--llm-timeout`, `--cache-dir`, and
+  `--no-cache` are unchanged in spelling. `--interactive` still prompts
+  per proposal (now `[a]pply / [s]kip / [q]uit`, plus
+  `[d]e-wins / [e]n-wins` on a conflict) before a single atomic apply.
+- Exit codes keep their buckets: `0` clean, `1` something left for
+  review (a skipped proposal / unresolved conflict), `2` a structural
+  error (classifier error, missing target cell, or the edit LLM down).
+
+### What's new
+
+- `--translation-model TEXT` (default `anthropic/claude-sonnet-4-6`)
+  picks the OpenRouter model that translates brand-new slides on the add
+  path. It needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`); without a
+  key, add proposals defer (everything else still applies).
+
+### How to migrate
+
+```bash
+# Before: bare invocation was a safe dry-run.
+clm slides sync intro.de.py intro.en.py            # now WRITES — review with git diff
+
+# Keep the old preview behavior explicitly.
+clm slides sync intro.de.py intro.en.py --dry-run
+
+# Drop --source-lang entirely — direction is per-cell now.
+clm slides sync intro.de.py intro.en.py            # (was: --source-lang de)
+
+# Replace --apply --trivial with the default apply, or gate with --interactive.
+clm slides sync intro.de.py intro.en.py            # (was: --apply --trivial)
+clm slides sync intro.de.py intro.en.py --interactive
+```
+
+Because the default now mutates files, wire `clm slides sync` into a
+clean working tree (commit or stash first) so `git diff` shows exactly
+what the sync proposed. The watermark advances only on a successful,
+non-deferred apply, so a conflict or a skipped proposal re-surfaces on
+the next run rather than being silently baselined.
+
 ## CLI restructure: verb-grouped subcommands
 
 CLM {version} reorganises the top-level command surface. Several flat

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -473,6 +473,135 @@ class SyncSnapshotCache:
         self._conn.close()
 
 
+class SyncWatermarkCache:
+    """Ordered, per-language structural watermark of the last synced deck state.
+
+    This is the baseline against which the Issue #166 change classifier
+    (:mod:`clm.slides.sync_plan`) detects adds / edits / moves / removes when
+    one half of a split deck is edited. Where :class:`SyncSnapshotCache` stores
+    a *per-cell* ``(de_hash, en_hash)`` pair keyed by ``slide_id`` (for
+    direction inference), the watermark stores the **whole deck** as an ordered
+    list of cells *per language*, so it can:
+
+    - represent **id-less** cells (``slide_id`` is nullable), and
+    - capture cell **order** (for move / reorder detection).
+
+    A pair's two decks are written together, only on a successful sync apply, so
+    the watermark advances with the agreed state and is immune to the author's
+    git-commit cadence. Cold-start (no watermark) falls back to git HEAD.
+
+    Shares the same SQLite file as the other LLM caches; lives in its own table.
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._conn = sqlite3.connect(str(db_path))
+        self._migrate()
+
+    def _migrate(self) -> None:
+        cursor = self._conn.execute("PRAGMA table_info(sync_watermarks)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if not columns:
+            self._conn.execute(
+                """CREATE TABLE sync_watermarks (
+                    de_path      TEXT NOT NULL,
+                    en_path      TEXT NOT NULL,
+                    lang         TEXT NOT NULL,
+                    position     INTEGER NOT NULL,
+                    slide_id     TEXT,
+                    role         TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    synced_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (de_path, en_path, lang, position)
+                )"""
+            )
+            self._conn.commit()
+
+    def get_deck(
+        self,
+        de_path: str,
+        en_path: str,
+        lang: str,
+    ) -> list[tuple[int, str | None, str, str]]:
+        """Return the watermark for one deck, ordered by position.
+
+        Tuples are ``(position, slide_id, role, content_hash)``;
+        ``slide_id`` is ``None`` for id-less rows. An empty list means the
+        deck has no watermark (cold start for this pair).
+        """
+        rows = self._conn.execute(
+            "SELECT position, slide_id, role, content_hash FROM sync_watermarks "
+            "WHERE de_path=? AND en_path=? AND lang=? ORDER BY position",
+            (de_path, en_path, lang),
+        ).fetchall()
+        return [(r[0], r[1], r[2], r[3]) for r in rows]
+
+    def put_deck(
+        self,
+        *,
+        de_path: str,
+        en_path: str,
+        lang: str,
+        cells: list[tuple[int, str | None, str, str]],
+    ) -> None:
+        """Replace the watermark for one deck atomically.
+
+        ``cells`` is an ordered list of ``(position, slide_id, role,
+        content_hash)``. The whole ``(de_path, en_path, lang)`` slice is
+        deleted and rewritten in a single transaction so a deck's watermark
+        is never observed half-updated.
+        """
+        if lang not in ("de", "en"):
+            raise ValueError(f"lang must be 'de' or 'en', got {lang!r}")
+        with self._conn:  # single transaction (BEGIN/COMMIT or ROLLBACK)
+            self._conn.execute(
+                "DELETE FROM sync_watermarks WHERE de_path=? AND en_path=? AND lang=?",
+                (de_path, en_path, lang),
+            )
+            self._conn.executemany(
+                "INSERT INTO sync_watermarks "
+                "(de_path, en_path, lang, position, slide_id, role, content_hash) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (de_path, en_path, lang, position, slide_id, role, content_hash)
+                    for (position, slide_id, role, content_hash) in cells
+                ],
+            )
+
+    def has_pair(self, de_path: str, en_path: str) -> bool:
+        """Return True when any watermark row exists for the pair."""
+        row = self._conn.execute(
+            "SELECT 1 FROM sync_watermarks WHERE de_path=? AND en_path=? LIMIT 1",
+            (de_path, en_path),
+        ).fetchone()
+        return row is not None
+
+    def clear_pair(self, de_path: str, en_path: str) -> int:
+        """Delete all watermark rows for the pair; return rows removed."""
+        cursor = self._conn.execute(
+            "DELETE FROM sync_watermarks WHERE de_path=? AND en_path=?",
+            (de_path, en_path),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def iter_entries(self) -> list[tuple[str, str, str, int, str | None, str, str, str]]:
+        """Return every watermark row for a future ``sync --dump``.
+
+        Tuples are ``(de_path, en_path, lang, position, slide_id, role,
+        content_hash, synced_at)`` ordered by pair, language, and position.
+        """
+        rows = self._conn.execute(
+            "SELECT de_path, en_path, lang, position, slide_id, role, "
+            "content_hash, synced_at "
+            "FROM sync_watermarks ORDER BY de_path, en_path, lang, position"
+        ).fetchall()
+        return [(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]) for r in rows]
+
+    def close(self) -> None:
+        self._conn.close()
+
+
 def resolve_cache_dir(
     *,
     cli_override: Path | None = None,

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -10,13 +10,17 @@ Scope of this engine:
   author removed (deterministic, no LLM).
 - **edit** — ask the existing :class:`SyncJudge` to propose the target-side
   rewrite for a cell that drifted on the source side, then write it.
-- **move** / **add** / **conflict** — *not applied here*. Moves need slide-group
-  reordering (Phase 2b); adds need translation + id minting (Phase 3); conflicts
-  are isolated by design. They are counted as ``deferred`` so nothing is silent.
+- **move** — reorder the target deck's slide groups to match the source deck's
+  order (deterministic, no LLM). Applied only when the rest of the pass is
+  clean (real baseline, no errors, no deferred add/conflict), because a reorder
+  is idempotent only once the watermark advances to record the new order.
+- **add** / **conflict** — *not applied here*. Adds need translation + id minting
+  (Phase 3); conflicts are isolated by design. Counted as ``deferred`` so
+  nothing is silent.
 
 Atomicity: each proposal is all-or-nothing for its target cell; the two decks
 are flushed once at the end. The **watermark advances only on a complete,
-clean apply** (no deferred proposals, no errors) — so an un-applied move can
+clean apply** (no deferred proposals, no errors) — so un-applied work can
 never be silently baked into the baseline and lost.
 """
 
@@ -28,6 +32,7 @@ from typing import TYPE_CHECKING
 
 from clm.infrastructure.llm.ollama_client import OllamaError
 from clm.notebooks.slide_parser import parse_cells
+from clm.slides.raw_cells import RawCell
 from clm.slides.sync_plan import Proposal, SyncPlan, ordered_sync_cells
 from clm.slides.sync_writeback import FileState, role_of
 
@@ -48,14 +53,15 @@ class ApplyResult:
 
     applied_edit: int = 0
     applied_remove: int = 0
+    applied_move: int = 0
     in_sync: int = 0  # an edit the judge decided needed no change
-    deferred: int = 0  # move / add / conflict — not handled by this engine
+    deferred: int = 0  # add / conflict (or moves declined this pass)
     watermark_recorded: bool = False
     errors: list[str] = field(default_factory=list)
 
     @property
     def applied(self) -> int:
-        return self.applied_edit + self.applied_remove
+        return self.applied_edit + self.applied_remove + self.applied_move
 
     @property
     def has_errors(self) -> bool:
@@ -71,9 +77,10 @@ def apply_plan(
     """Apply the remove/edit proposals in ``plan`` and advance the watermark.
 
     ``judge`` provides the target-side rewrite for ``edit`` proposals; pass
-    ``None`` to skip edits (each is recorded as an error). Writes nothing for
-    move/add/conflict proposals. The two decks are flushed once; the watermark
-    is recorded only when the plan applied cleanly and completely.
+    ``None`` to skip edits (each is recorded as an error). Applies remove / edit
+    / move; add and conflict are counted as ``deferred``. The two decks are
+    flushed once; the watermark is recorded only when the plan applied cleanly
+    and completely.
     """
     result = ApplyResult()
 
@@ -85,15 +92,23 @@ def apply_plan(
     de_state = FileState.load(plan.de_path)
     en_state = FileState.load(plan.en_path)
 
+    moves: list[Proposal] = []
     for proposal in plan.proposals:
         kind = proposal.kind
         if kind == "remove":
             _apply_remove(proposal, de_state, en_state, result)
         elif kind == "edit":
             _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
+        elif kind == "move":
+            moves.append(proposal)
         else:
-            # move / add / conflict — out of scope for this engine.
+            # add / conflict — out of scope for this engine.
             result.deferred += 1
+
+    # Moves are applied last, and only if the rest of the pass is clean (so the
+    # watermark will advance and the reorder stays idempotent).
+    if moves:
+        _apply_moves(moves, de_state, en_state, result, plan)
 
     de_state.flush()
     en_state.flush()
@@ -101,17 +116,21 @@ def apply_plan(
     # Advance the watermark only when everything we were asked to do was done.
     # Deferred moves/adds mean the decks are not yet fully in sync, so baking
     # the current state into the baseline would silently lose that work.
-    if (
-        watermark_cache is not None
-        and plan.has_baseline
-        and result.deferred == 0
-        and not result.errors
-        and not plan.has_errors
-    ):
+    if watermark_cache is not None and _pass_is_clean(plan, result):
         _record_watermark(watermark_cache, plan.de_path, plan.en_path)
         result.watermark_recorded = True
 
     return result
+
+
+def _pass_is_clean(plan: SyncPlan, result: ApplyResult) -> bool:
+    """Whether the pass fully reconciled both decks against a real baseline.
+
+    The single predicate shared by the move gate and the watermark-advance
+    decision so the two can never drift apart: a real baseline, no
+    classifier errors, no apply-time errors, and nothing deferred.
+    """
+    return plan.has_baseline and not plan.has_errors and not result.errors and result.deferred == 0
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +203,138 @@ def _apply_edit(
         result.applied_edit += 1
     else:
         result.errors.append(f"edit {proposal.slide_id}/{proposal.role}: target cell not found")
+
+
+def _apply_moves(
+    moves: list[Proposal],
+    de_state: FileState,
+    en_state: FileState,
+    result: ApplyResult,
+    plan: SyncPlan,
+) -> None:
+    """Reorder the target deck's slide groups to match the source deck.
+
+    Gated on the rest of the pass being clean (real baseline, no errors, no
+    deferred add/conflict) so the watermark will advance — a reorder is
+    idempotent only once the new order is recorded. Mixed-direction moves
+    (each deck reordered different cells) are ambiguous and deferred.
+
+    A group-level reorder cannot express every move the per-cell classifier
+    can detect (e.g. a narrative companion reassigned to a *different* slide).
+    So we only commit when the reorder actually reconciles the full
+    ``(slide_id, role)`` order with the source; otherwise the moves are
+    deferred and surfaced rather than silently counted as applied (which would
+    advance the watermark over a divergence).
+    """
+    if not _pass_is_clean(plan, result):
+        result.deferred += len(moves)
+        return
+
+    directions = {m.direction for m in moves}
+    if len(directions) > 1:
+        result.deferred += len(moves)
+        result.errors.append("moves in both directions; order ambiguous — deferred")
+        return
+
+    if "de->en" in directions:
+        source_state, target_state = de_state, en_state
+    else:
+        source_state, target_state = en_state, de_state
+
+    reordered = _group_reorder(target_state.cells, _group_order(source_state.cells))
+    candidate = reordered if reordered is not None else target_state.cells
+    if _sync_key_order(candidate) == _sync_key_order(source_state.cells):
+        if reordered is not None:
+            _heal_terminal_newline(reordered, target_state)
+            target_state.cells = reordered
+            target_state.dirty = True
+        result.applied_move += len(moves)
+    else:
+        result.deferred += len(moves)
+        result.errors.append(
+            "some moves are not expressible by a slide-group reorder "
+            "(narrative companion reassigned to a different slide) — deferred"
+        )
+
+
+def _group_order(cells: list[RawCell]) -> list[str]:
+    """Ordered ``slide_id``s of the slide/subslide cells (one per slide group)."""
+    return [c.metadata.slide_id for c in cells if c.metadata.is_slide_start and c.metadata.slide_id]
+
+
+def _sync_key_order(cells: list[RawCell]) -> list[tuple[str, str]]:
+    """Ordered ``(slide_id, role)`` of every id-carrying sync cell.
+
+    The full-granularity order the classifier reasons about — used to confirm
+    a group-level reorder actually reconciled both decks before committing it.
+    """
+    out: list[tuple[str, str]] = []
+    for cell in cells:
+        role = role_of(cell.metadata)
+        if role is not None and cell.metadata.slide_id:
+            out.append((cell.metadata.slide_id, role))
+    return out
+
+
+def _split_groups(cells: list[RawCell]) -> tuple[list[RawCell], list[list[RawCell]]]:
+    """Split ``cells`` into a head and a list of slide groups.
+
+    A group is a slide/subslide cell plus every following cell (narrative
+    companions, code) until the next slide/subslide. Cells before the first
+    slide (j2 header, intro) are the head and never move.
+    """
+    head: list[RawCell] = []
+    groups: list[list[RawCell]] = []
+    current: list[RawCell] | None = None
+    for cell in cells:
+        if cell.metadata.is_slide_start:
+            current = [cell]
+            groups.append(current)
+        elif current is None:
+            head.append(cell)
+        else:
+            current.append(cell)
+    return head, groups
+
+
+def _group_reorder(cells: list[RawCell], source_order: list[str]) -> list[RawCell] | None:
+    """Return ``cells`` with slide groups reordered to follow ``source_order``.
+
+    Pure: returns a new cell list, or ``None`` if the group order is already
+    correct. Groups whose id is absent from ``source_order`` keep their
+    relative position (stable sort); each group's cells move as a verbatim
+    unit, so the round-trip is preserved.
+    """
+    head, groups = _split_groups(cells)
+    if not groups:
+        return None
+    index = {sid: i for i, sid in enumerate(source_order)}
+    fallback = len(source_order) + 1
+
+    def _key(group: list[RawCell]) -> int:
+        sid = group[0].metadata.slide_id
+        return index.get(sid, fallback) if sid is not None else fallback
+
+    reordered = sorted(groups, key=_key)
+    if [g[0].metadata.slide_id for g in groups] == [g[0].metadata.slide_id for g in reordered]:
+        return None
+    return head + [cell for group in reordered for cell in group]
+
+
+def _heal_terminal_newline(new_cells: list[RawCell], target: FileState) -> None:
+    """Drop the terminal-newline artifact off a reordered ex-last cell.
+
+    ``split_cells`` parks the file's final newline as a trailing ``""`` on the
+    last cell. After a reorder that cell may no longer be last, where the
+    ``""`` would render as a spurious mid-file blank line. Strip that one
+    ``""`` (genuine trailing blanks are preserved); :meth:`FileState.flush`
+    restores the terminal newline.
+    """
+    if not target.ends_with_newline or not new_cells or not target.cells:
+        return
+    original_last = target.cells[-1]
+    if new_cells[-1] is not original_last and original_last.lines and original_last.lines[-1] == "":
+        original_last.lines.pop()
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -1,0 +1,229 @@
+"""Apply engine for the single-language authoring workflow.
+
+Phase 2 of Issue #166. Consumes the typed :class:`~clm.slides.sync_plan.SyncPlan`
+produced by the Phase 1 classifier and writes the agreed changes to the target
+deck(s), then advances the structural watermark so the next run is a no-op.
+
+Scope of this engine:
+
+- **remove** — delete the target-side cell whose source-side counterpart the
+  author removed (deterministic, no LLM).
+- **edit** — ask the existing :class:`SyncJudge` to propose the target-side
+  rewrite for a cell that drifted on the source side, then write it.
+- **move** / **add** / **conflict** — *not applied here*. Moves need slide-group
+  reordering (Phase 2b); adds need translation + id minting (Phase 3); conflicts
+  are isolated by design. They are counted as ``deferred`` so nothing is silent.
+
+Atomicity: each proposal is all-or-nothing for its target cell; the two decks
+are flushed once at the end. The **watermark advances only on a complete,
+clean apply** (no deferred proposals, no errors) — so an un-applied move can
+never be silently baked into the baseline and lost.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from clm.infrastructure.llm.ollama_client import OllamaError
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import Proposal, SyncPlan, ordered_sync_cells
+from clm.slides.sync_writeback import FileState, role_of
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from clm.infrastructure.llm.cache import SyncWatermarkCache
+    from clm.infrastructure.llm.ollama_client import SyncJudge
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ApplyResult", "apply_plan"]
+
+
+@dataclass
+class ApplyResult:
+    """Outcome of applying a :class:`SyncPlan`."""
+
+    applied_edit: int = 0
+    applied_remove: int = 0
+    in_sync: int = 0  # an edit the judge decided needed no change
+    deferred: int = 0  # move / add / conflict — not handled by this engine
+    watermark_recorded: bool = False
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def applied(self) -> int:
+        return self.applied_edit + self.applied_remove
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(self.errors)
+
+
+def apply_plan(
+    plan: SyncPlan,
+    *,
+    judge: SyncJudge | None,
+    watermark_cache: SyncWatermarkCache | None = None,
+) -> ApplyResult:
+    """Apply the remove/edit proposals in ``plan`` and advance the watermark.
+
+    ``judge`` provides the target-side rewrite for ``edit`` proposals; pass
+    ``None`` to skip edits (each is recorded as an error). Writes nothing for
+    move/add/conflict proposals. The two decks are flushed once; the watermark
+    is recorded only when the plan applied cleanly and completely.
+    """
+    result = ApplyResult()
+
+    # Pre-apply content (parser-stripped) for the judge, keyed by (slide_id,
+    # role). Read before FileState mutates anything.
+    de_content = _content_index(plan.de_path, "de")
+    en_content = _content_index(plan.en_path, "en")
+
+    de_state = FileState.load(plan.de_path)
+    en_state = FileState.load(plan.en_path)
+
+    for proposal in plan.proposals:
+        kind = proposal.kind
+        if kind == "remove":
+            _apply_remove(proposal, de_state, en_state, result)
+        elif kind == "edit":
+            _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
+        else:
+            # move / add / conflict — out of scope for this engine.
+            result.deferred += 1
+
+    de_state.flush()
+    en_state.flush()
+
+    # Advance the watermark only when everything we were asked to do was done.
+    # Deferred moves/adds mean the decks are not yet fully in sync, so baking
+    # the current state into the baseline would silently lose that work.
+    if (
+        watermark_cache is not None
+        and plan.has_baseline
+        and result.deferred == 0
+        and not result.errors
+        and not plan.has_errors
+    ):
+        _record_watermark(watermark_cache, plan.de_path, plan.en_path)
+        result.watermark_recorded = True
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Per-kind appliers
+# ---------------------------------------------------------------------------
+
+
+def _apply_remove(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    result: ApplyResult,
+) -> None:
+    if proposal.slide_id is None:
+        result.errors.append(f"remove {proposal.role}: proposal has no slide_id")
+        return
+    target_state = en_state if proposal.direction == "de->en" else de_state
+    if target_state.delete_cell(proposal.slide_id, proposal.role):
+        result.applied_remove += 1
+    else:
+        result.errors.append(f"remove {proposal.slide_id}/{proposal.role}: target cell not found")
+
+
+def _apply_edit(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    de_content: dict[tuple[str, str], str],
+    en_content: dict[tuple[str, str], str],
+    judge: SyncJudge | None,
+    result: ApplyResult,
+) -> None:
+    if proposal.slide_id is None:
+        result.errors.append(f"edit {proposal.role}: proposal has no slide_id")
+        return
+    key = (proposal.slide_id, proposal.role)
+    if proposal.direction == "de->en":
+        source_lang, target_lang = "de", "en"
+        source_body = de_content.get(key, "")
+        target_body = en_content.get(key, "")
+        target_state = en_state
+    else:
+        source_lang, target_lang = "en", "de"
+        source_body = en_content.get(key, "")
+        target_body = de_content.get(key, "")
+        target_state = de_state
+
+    if judge is None:
+        result.errors.append(
+            f"edit {proposal.slide_id}/{proposal.role}: no judge (LLM unavailable)"
+        )
+        return
+
+    try:
+        sync_proposal = judge.propose(
+            source_body, target_body, source_lang=source_lang, target_lang=target_lang
+        )
+    except OllamaError as exc:
+        logger.info("edit judge failed on %s/%s: %s", proposal.slide_id, proposal.role, exc)
+        result.errors.append(f"edit {proposal.slide_id}/{proposal.role}: {exc}")
+        return
+
+    if sync_proposal.verdict != "update":
+        result.in_sync += 1
+        return
+
+    if target_state.replace_cell_body(
+        proposal.slide_id, proposal.role, sync_proposal.proposed_text
+    ):
+        result.applied_edit += 1
+    else:
+        result.errors.append(f"edit {proposal.slide_id}/{proposal.role}: target cell not found")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
+    """Map ``(slide_id, role) -> parser-stripped content`` for one deck.
+
+    Filtered to ``lang`` so the apply-side lookup matches exactly what the
+    Phase 1 classifier (``ordered_sync_cells``) extracted — the same
+    role+language predicate, so the judge can never be fed an
+    other-language cell that happens to share a key.
+    """
+    index: dict[tuple[str, str], str] = {}
+    for cell in parse_cells(path.read_text(encoding="utf-8")):
+        role = role_of(cell.metadata)
+        if role is None:
+            continue
+        if cell.metadata.lang != lang:
+            continue
+        sid = cell.metadata.slide_id
+        if not sid:
+            continue
+        index.setdefault((sid, role), cell.content)
+    return index
+
+
+def _record_watermark(
+    cache: SyncWatermarkCache,
+    de_path: Path,
+    en_path: Path,
+) -> None:
+    """Record both decks' post-apply state as the new baseline."""
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -54,7 +54,25 @@ _SLIDE_ROLES = {"slide", "subslide"}
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ApplyResult", "apply_plan"]
+# Per-proposal decisions an interactive walker can hand to :func:`apply_plan`.
+# ``apply`` / ``skip`` gate the deterministic kinds (edit / remove / move);
+# ``de-wins`` / ``en-wins`` resolve a conflict by propagating the winning side.
+# A conflict with no decision (or ``skip``) is deferred. The decisions map is
+# keyed by ``id(proposal)`` of the proposals in the same :class:`SyncPlan`.
+DECISION_APPLY = "apply"
+DECISION_SKIP = "skip"
+DECISION_DE_WINS = "de-wins"
+DECISION_EN_WINS = "en-wins"
+
+__all__ = [
+    "DECISION_APPLY",
+    "DECISION_DE_WINS",
+    "DECISION_EN_WINS",
+    "DECISION_SKIP",
+    "ApplyResult",
+    "apply_plan",
+    "content_index",
+]
 
 
 @dataclass
@@ -92,6 +110,7 @@ def apply_plan(
     judge: SyncJudge | None,
     translator: SlideTranslator | None = None,
     watermark_cache: SyncWatermarkCache | None = None,
+    decisions: dict[int, str] | None = None,
 ) -> ApplyResult:
     """Apply ``plan``'s proposals to the decks and advance the watermark.
 
@@ -101,13 +120,22 @@ def apply_plan(
     move / id-less add; conflicts and id-carrying adds are ``deferred``. The two
     decks are flushed once; the watermark advances only on a clean, complete
     apply.
+
+    ``decisions`` drives interactive review (``None`` = the batch default, which
+    applies every deterministic kind and defers conflicts). When provided, it
+    maps ``id(proposal)`` to a decision (:data:`DECISION_APPLY` /
+    :data:`DECISION_SKIP` for edit / remove / move; :data:`DECISION_DE_WINS` /
+    :data:`DECISION_EN_WINS` / :data:`DECISION_SKIP` for a conflict). A skipped
+    proposal is counted as ``deferred`` so the watermark cannot advance over it.
+    Add / rename proposals are always applied (they are non-destructive and the
+    counterpart is reviewed in the resulting ``git diff``).
     """
     result = ApplyResult()
 
     # Pre-apply content (parser-stripped) for the judge, keyed by (slide_id,
     # role). Read before FileState mutates anything.
-    de_content = _content_index(plan.de_path, "de")
-    en_content = _content_index(plan.en_path, "en")
+    de_content = content_index(plan.de_path, "de")
+    en_content = content_index(plan.en_path, "en")
 
     de_state = FileState.load(plan.de_path)
     en_state = FileState.load(plan.en_path)
@@ -116,14 +144,25 @@ def apply_plan(
     for proposal in plan.proposals:
         kind = proposal.kind
         if kind == "remove":
-            _apply_remove(proposal, de_state, en_state, result)
+            if _accepted(decisions, proposal):
+                _apply_remove(proposal, de_state, en_state, result)
+            else:
+                result.deferred += 1
         elif kind == "edit":
-            _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
+            if _accepted(decisions, proposal):
+                _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
+            else:
+                result.deferred += 1
         elif kind == "move":
-            moves.append(proposal)
+            if _accepted(decisions, proposal):
+                moves.append(proposal)
+            else:
+                result.deferred += 1
         elif kind == "conflict":
-            result.deferred += 1
-        # "add" is handled by _apply_adds below (it walks the decks directly).
+            _apply_conflict(
+                proposal, decisions, de_state, en_state, de_content, en_content, judge, result
+            )
+        # "add" / "rename" are handled by _apply_adds below (always applied).
 
     # Adds run before moves so a freshly-inserted slide takes part in any
     # reorder. Adds are sticky via the stamped id (a re-run no longer sees an
@@ -156,6 +195,74 @@ def apply_plan(
         result.watermark_recorded = True
 
     return result
+
+
+def _accepted(decisions: dict[int, str] | None, proposal: Proposal) -> bool:
+    """Whether a deterministic proposal (edit / remove / move) should apply.
+
+    ``None`` is batch mode — every deterministic kind applies. Otherwise the
+    proposal applies only on an explicit :data:`DECISION_APPLY`.
+    """
+    if decisions is None:
+        return True
+    return decisions.get(id(proposal)) == DECISION_APPLY
+
+
+def _conflict_decision(decisions: dict[int, str] | None, proposal: Proposal) -> str:
+    """The resolution for a conflict proposal (defaults to skip/defer)."""
+    if decisions is None:
+        return DECISION_SKIP
+    return decisions.get(id(proposal), DECISION_SKIP)
+
+
+def _conflict_as_edit(proposal: Proposal, direction: str) -> Proposal:
+    """Recast a resolved conflict as an ``edit`` flowing the winning direction."""
+    return Proposal(
+        kind="edit",
+        role=proposal.role,
+        direction=direction,
+        slide_id=proposal.slide_id,
+    )
+
+
+def _apply_conflict(
+    proposal: Proposal,
+    decisions: dict[int, str] | None,
+    de_state: FileState,
+    en_state: FileState,
+    de_content: dict[tuple[str, str], str],
+    en_content: dict[tuple[str, str], str],
+    judge: SyncJudge | None,
+    result: ApplyResult,
+) -> None:
+    """Resolve a conflict per its decision, or defer it.
+
+    ``de-wins`` / ``en-wins`` propagate the winning side as an ordinary edit
+    (the judge rewrites the losing side to match); any other decision defers.
+    """
+    decision = _conflict_decision(decisions, proposal)
+    if decision == DECISION_DE_WINS:
+        _apply_edit(
+            _conflict_as_edit(proposal, "de->en"),
+            de_state,
+            en_state,
+            de_content,
+            en_content,
+            judge,
+            result,
+        )
+    elif decision == DECISION_EN_WINS:
+        _apply_edit(
+            _conflict_as_edit(proposal, "en->de"),
+            de_state,
+            en_state,
+            de_content,
+            en_content,
+            judge,
+            result,
+        )
+    else:
+        result.deferred += 1
 
 
 def _pass_is_clean(plan: SyncPlan, result: ApplyResult) -> bool:
@@ -699,13 +806,14 @@ def _group_reorder(cells: list[RawCell], source_order: list[str]) -> list[RawCel
 # ---------------------------------------------------------------------------
 
 
-def _content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
+def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
     """Map ``(slide_id, role) -> parser-stripped content`` for one deck.
 
     Filtered to ``lang`` so the apply-side lookup matches exactly what the
     Phase 1 classifier (``ordered_sync_cells``) extracted — the same
     role+language predicate, so the judge can never be fed an
-    other-language cell that happens to share a key.
+    other-language cell that happens to share a key. Public so the interactive
+    walker can render each proposal's current source/target bodies.
     """
     index: dict[tuple[str, str], str] = {}
     for cell in parse_cells(path.read_text(encoding="utf-8")):

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -14,9 +14,12 @@ Scope of this engine:
   order (deterministic, no LLM). Applied only when the rest of the pass is
   clean (real baseline, no errors, no deferred add/conflict), because a reorder
   is idempotent only once the watermark advances to record the new order.
-- **add** / **conflict** — *not applied here*. Adds need translation + id minting
-  (Phase 3); conflicts are isolated by design. Counted as ``deferred`` so
-  nothing is silent.
+- **add** — translate a brand-new id-less slide, mint its EN-authority id onto
+  *both* decks, and insert the counterpart at the anchor (needs a
+  ``translator``; without one, deferred). A narrative companion inherits the
+  slide's id. id-carrying "missing counterpart" adds are a follow-up.
+- **conflict** — isolated by design; counted as ``deferred`` so nothing is
+  silent.
 
 Atomicity: each proposal is all-or-nothing for its target cell; the two decks
 are flushed once at the end. The **watermark advances only on a complete,
@@ -27,13 +30,16 @@ never be silently baked into the baseline and lost.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.llm.ollama_client import OllamaError
-from clm.notebooks.slide_parser import parse_cells
+from clm.notebooks.slide_parser import parse_cell_header, parse_cells
 from clm.slides.raw_cells import RawCell
+from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_plan import Proposal, SyncPlan, ordered_sync_cells
+from clm.slides.sync_translate import TranslationError
 from clm.slides.sync_writeback import FileState, role_of
 
 if TYPE_CHECKING:
@@ -41,6 +47,10 @@ if TYPE_CHECKING:
 
     from clm.infrastructure.llm.cache import SyncWatermarkCache
     from clm.infrastructure.llm.ollama_client import SyncJudge
+    from clm.slides.sync_translate import SlideTranslator
+
+_SLIDE_ID_RE = re.compile(r'\s*slide_id="[^"]*"')
+_SLIDE_ROLES = {"slide", "subslide"}
 
 logger = logging.getLogger(__name__)
 
@@ -54,14 +64,15 @@ class ApplyResult:
     applied_edit: int = 0
     applied_remove: int = 0
     applied_move: int = 0
+    applied_add: int = 0
     in_sync: int = 0  # an edit the judge decided needed no change
-    deferred: int = 0  # add / conflict (or moves declined this pass)
+    deferred: int = 0  # conflict (or moves/adds declined this pass)
     watermark_recorded: bool = False
     errors: list[str] = field(default_factory=list)
 
     @property
     def applied(self) -> int:
-        return self.applied_edit + self.applied_remove + self.applied_move
+        return self.applied_edit + self.applied_remove + self.applied_move + self.applied_add
 
     @property
     def has_errors(self) -> bool:
@@ -72,15 +83,17 @@ def apply_plan(
     plan: SyncPlan,
     *,
     judge: SyncJudge | None,
+    translator: SlideTranslator | None = None,
     watermark_cache: SyncWatermarkCache | None = None,
 ) -> ApplyResult:
-    """Apply the remove/edit proposals in ``plan`` and advance the watermark.
+    """Apply ``plan``'s proposals to the decks and advance the watermark.
 
-    ``judge`` provides the target-side rewrite for ``edit`` proposals; pass
-    ``None`` to skip edits (each is recorded as an error). Applies remove / edit
-    / move; add and conflict are counted as ``deferred``. The two decks are
-    flushed once; the watermark is recorded only when the plan applied cleanly
-    and completely.
+    ``judge`` provides the target-side rewrite for ``edit`` proposals (``None``
+    records each edit as an error). ``translator`` produces the counterpart for
+    a brand-new id-less slide (``None`` defers adds). Applies remove / edit /
+    move / id-less add; conflicts and id-carrying adds are ``deferred``. The two
+    decks are flushed once; the watermark advances only on a clean, complete
+    apply.
     """
     result = ApplyResult()
 
@@ -101,9 +114,14 @@ def apply_plan(
             _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
         elif kind == "move":
             moves.append(proposal)
-        else:
-            # add / conflict — out of scope for this engine.
+        elif kind == "conflict":
             result.deferred += 1
+        # "add" is handled by _apply_adds below (it walks the decks directly).
+
+    # Adds run before moves so a freshly-inserted slide takes part in any
+    # reorder. Adds are sticky via the stamped id (a re-run no longer sees an
+    # id-less cell), so unlike moves they do not require a clean pass.
+    _apply_adds(de_state, en_state, result, plan, translator)
 
     # Moves are applied last, and only if the rest of the pass is clean (so the
     # watermark will advance and the reorder stays idempotent).
@@ -205,6 +223,187 @@ def _apply_edit(
         result.errors.append(f"edit {proposal.slide_id}/{proposal.role}: target cell not found")
 
 
+# ---------------------------------------------------------------------------
+# Add (translate + mint + insert)
+# ---------------------------------------------------------------------------
+
+
+def _apply_adds(
+    de_state: FileState,
+    en_state: FileState,
+    result: ApplyResult,
+    plan: SyncPlan,
+    translator: SlideTranslator | None,
+) -> None:
+    """Translate, mint, and insert the counterpart for each id-less new slide.
+
+    Walks each deck's id-less sync cells (which are exactly the plan's id-less
+    ``add`` proposals): a slide mints a fresh EN-derived id stamped onto *both*
+    siblings; a narrative companion inherits the preceding slide's id. The
+    translated counterpart is inserted on the other deck at the matching
+    anchor. id-carrying "missing counterpart" adds are out of scope here and
+    deferred. Adds are sticky via the stamp, so they apply regardless of
+    whether the rest of the pass is clean.
+    """
+    add_props = [p for p in plan.proposals if p.kind == "add"]
+    if not add_props:
+        return
+
+    idd = [p for p in add_props if p.slide_id is not None]
+    if idd:
+        result.deferred += len(idd)  # missing-counterpart adds: a follow-up
+
+    idless = [p for p in add_props if p.slide_id is None]
+    if not idless:
+        return
+    if translator is None:
+        result.deferred += len(idless)
+        result.errors.append("id-less add(s) present but no translator available")
+        return
+    if len({p.direction for p in idless}) > 1:
+        # id-less new slides on BOTH decks: the author edited both sides, which
+        # is off the single-language path. Pairing them is out of scope; defer
+        # rather than translate each independently and duplicate the slide.
+        result.deferred += len(idless)
+        result.errors.append(
+            "id-less new slides on both decks — edit one deck at a time (deferred)"
+        )
+        return
+
+    used_ids = {
+        cell.metadata.slide_id
+        for state in (de_state, en_state)
+        for cell in state.cells
+        if cell.metadata.slide_id
+    }
+    _add_one_direction(de_state, en_state, "de", "en", translator, used_ids, result)
+    _add_one_direction(en_state, de_state, "en", "de", translator, used_ids, result)
+
+
+def _add_one_direction(
+    source_state: FileState,
+    target_state: FileState,
+    source_lang: str,
+    target_lang: str,
+    translator: SlideTranslator,
+    used_ids: set[str],
+    result: ApplyResult,
+) -> None:
+    current_slide_id: str | None = None
+    anchor: tuple[str, str] | None = None
+    for cell in list(source_state.cells):
+        role = role_of(cell.metadata)
+        if role is None:
+            continue
+        sid = cell.metadata.slide_id
+        if sid is not None:
+            # An existing paired cell — not an add. It anchors what follows.
+            if role in _SLIDE_ROLES:
+                current_slide_id = sid
+            anchor = (sid, role)
+            continue
+
+        # id-less => an add: translate first (the body is unchanged by stamping).
+        # Normalise away the terminal-newline artifact split_cells parks on the
+        # last cell, so the body the translator sees doesn't depend on position.
+        source_body = cell.body.rstrip("\n")
+        try:
+            target_body = translator.translate(
+                source_body=source_body,
+                source_lang=source_lang,
+                target_lang=target_lang,
+                role=role,
+            )
+        except TranslationError as exc:
+            result.deferred += 1
+            result.errors.append(f"add {role}: translation failed: {exc}")
+            continue
+
+        if role in _SLIDE_ROLES:
+            # EN-authority: slug the id from the EN text (the translation when
+            # the author edited DE, the source itself when they edited EN).
+            en_body = target_body if target_lang == "en" else source_body
+            new_id = resolve_collision(_slug_or_default(en_body), used_ids)
+            used_ids.add(new_id)
+            current_slide_id = new_id
+        elif current_slide_id is None:
+            result.deferred += 1
+            result.errors.append(
+                f"add {role}: id-less narrative with no preceding slide — deferred"
+            )
+            continue
+        else:
+            new_id = current_slide_id
+
+        _stamp_slide_id(cell, new_id)  # stamp the previously-id-less source cell
+        source_state.dirty = True
+        new_cell = _build_cell(target_lang, cell.metadata.tags, new_id, target_body)
+        _insert_at_anchor(target_state, anchor, new_cell)
+        anchor = (new_id, role)
+        result.applied_add += 1
+
+
+def _slug_or_default(en_body: str) -> str:
+    return slugify(_extract_heading(en_body)) or "slide"
+
+
+def _extract_heading(body: str) -> str:
+    """Best-effort slide heading text from a percent-format cell body.
+
+    Drops the ``# `` comment prefix as a fixed prefix (not a char set, so a
+    ``**bold**`` lead-in survives), returns a Markdown heading's text, and
+    treats a line as a bullet only when it starts with an actual ``-``/``*``/
+    ``+`` *list marker* (followed by whitespace). ``slugify`` then strips any
+    residual Markdown.
+    """
+    for raw in body.split("\n"):
+        if raw.startswith("# "):
+            md = raw[2:].strip()
+        elif raw.startswith("#"):
+            md = raw[1:].strip()
+        else:
+            md = raw.strip()
+        if not md:
+            continue
+        heading = re.match(r"#{1,6}\s+(.*)", md)
+        if heading:
+            return heading.group(1).strip()
+        if not re.match(r"[-*+]\s", md):
+            return md
+    return ""
+
+
+def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
+    """Write ``slide_id="…"`` onto a cell header (mirrors assign-ids)."""
+    stripped = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
+    header = f'{stripped} slide_id="{slide_id}"'
+    cell.lines[0] = header
+    cell.metadata = parse_cell_header(header)
+
+
+def _build_cell(lang: str, tags: list[str], slide_id: str, body: str) -> RawCell:
+    """Build a fresh markdown RawCell carrying the translated counterpart.
+
+    The body is built bare (no leading/trailing blank lines); the insert
+    primitive grants the deck's inter-cell separator based on final position.
+    """
+    tag_repr = ", ".join(f'"{t}"' for t in tags) if tags else '"slide"'
+    header = f'# %% [markdown] lang="{lang}" tags=[{tag_repr}] slide_id="{slide_id}"'
+    body_lines = body.split("\n")
+    while body_lines and body_lines[0] == "":  # drop a stray leading blank
+        body_lines.pop(0)
+    while body_lines and body_lines[-1] == "":
+        body_lines.pop()
+    return RawCell(lines=[header, *body_lines], line_number=0, metadata=parse_cell_header(header))
+
+
+def _insert_at_anchor(
+    target_state: FileState, anchor: tuple[str, str] | None, new_cell: RawCell
+) -> None:
+    if anchor is None or not target_state.insert_after(anchor[0], anchor[1], new_cell):
+        target_state.insert_before_first_sync_cell(new_cell)
+
+
 def _apply_moves(
     moves: list[Proposal],
     de_state: FileState,
@@ -245,9 +444,12 @@ def _apply_moves(
     candidate = reordered if reordered is not None else target_state.cells
     if _sync_key_order(candidate) == _sync_key_order(source_state.cells):
         if reordered is not None:
-            _heal_terminal_newline(reordered, target_state)
+            sep = target_state.separator_blanks()
+            original_last = target_state.cells[-1] if target_state.cells else None
             target_state.cells = reordered
             target_state.dirty = True
+            if original_last is not None:
+                target_state.normalize_displaced_last(original_last, sep)
         result.applied_move += len(moves)
     else:
         result.deferred += len(moves)
@@ -319,22 +521,6 @@ def _group_reorder(cells: list[RawCell], source_order: list[str]) -> list[RawCel
     if [g[0].metadata.slide_id for g in groups] == [g[0].metadata.slide_id for g in reordered]:
         return None
     return head + [cell for group in reordered for cell in group]
-
-
-def _heal_terminal_newline(new_cells: list[RawCell], target: FileState) -> None:
-    """Drop the terminal-newline artifact off a reordered ex-last cell.
-
-    ``split_cells`` parks the file's final newline as a trailing ``""`` on the
-    last cell. After a reorder that cell may no longer be last, where the
-    ``""`` would render as a spurious mid-file blank line. Strip that one
-    ``""`` (genuine trailing blanks are preserved); :meth:`FileState.flush`
-    restores the terminal newline.
-    """
-    if not target.ends_with_newline or not new_cells or not target.cells:
-        return
-    original_last = target.cells[-1]
-    if new_cells[-1] is not original_last and original_last.lines and original_last.lines[-1] == "":
-        original_last.lines.pop()
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -141,6 +141,15 @@ def apply_plan(
     en_state = FileState.load(plan.en_path)
 
     moves: list[Proposal] = []
+    # (slide_id, role) of every TRUE deferral this pass: an unresolved conflict
+    # or a user-skipped edit/remove/move. The per-cell partial watermark advance
+    # preserves exactly these cells at their old baseline so they re-surface next
+    # run; everything else (an applied edit, an unchanged cell, and an edit the
+    # judge reconciled with an in_sync verdict) banks its current state. in_sync
+    # is a reconciliation decision — "the target already reflects the source",
+    # per SyncProposal — so it advances, the same as on a fully clean pass; were
+    # it preserved it would re-surface every run forever (the judge re-declines).
+    deferred_keys: set[tuple[str, str]] = set()
     for proposal in plan.proposals:
         kind = proposal.kind
         if kind == "remove":
@@ -148,19 +157,30 @@ def apply_plan(
                 _apply_remove(proposal, de_state, en_state, result)
             else:
                 result.deferred += 1
+                _note_deferred(deferred_keys, proposal)
         elif kind == "edit":
             if _accepted(decisions, proposal):
                 _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
             else:
                 result.deferred += 1
+                _note_deferred(deferred_keys, proposal)
         elif kind == "move":
             if _accepted(decisions, proposal):
                 moves.append(proposal)
             else:
                 result.deferred += 1
+                _note_deferred(deferred_keys, proposal)
         elif kind == "conflict":
             _apply_conflict(
-                proposal, decisions, de_state, en_state, de_content, en_content, judge, result
+                proposal,
+                decisions,
+                de_state,
+                en_state,
+                de_content,
+                en_content,
+                judge,
+                result,
+                deferred_keys,
             )
         # "add" / "rename" are handled by _apply_adds below (always applied).
 
@@ -187,14 +207,42 @@ def apply_plan(
     de_state.flush()
     en_state.flush()
 
-    # Advance the watermark only when everything we were asked to do was done.
-    # Deferred moves/adds mean the decks are not yet fully in sync, so baking
-    # the current state into the baseline would silently lose that work.
-    if watermark_cache is not None and _pass_is_clean(plan, result):
-        _record_watermark(watermark_cache, plan.de_path, plan.en_path)
-        result.watermark_recorded = True
+    # Watermark advance. A fully clean pass advances the whole deck. A
+    # *content-only* partial pass (edits/conflicts only, so structure is
+    # unchanged) advances the reconciled cells per-cell while preserving the
+    # deferred cells' pre-conflict baseline — so a deferred conflict no longer
+    # forces every reconciled edit to re-surface next run. Any other partial
+    # pass holds the whole watermark (nothing un-applied is ever baselined).
+    #
+    # ``not plan.issues`` gates BOTH paths: a both-decks reorder or an ambiguous
+    # de/en state is emitted as a *warning* (no proposal, no error) whose order/
+    # ambiguity is deliberately not reconciled. Advancing over it — on either the
+    # full or the partial path — would bake the new positions and silently lose
+    # the "resolve manually" signal, so any issue holds the whole watermark.
+    if watermark_cache is not None and not plan.issues:
+        if _pass_is_clean(plan, result):
+            _record_watermark(watermark_cache, plan.de_path, plan.en_path)
+            result.watermark_recorded = True
+        elif (
+            _eligible_for_partial_advance(plan, result)
+            # Completeness invariant: in a content-only pass every deferral is one
+            # distinct (slide_id, role), so the recorded keys must account for
+            # *every* deferral. If they don't (an unforeseen deferral with no
+            # key), hold the whole watermark rather than risk advancing over it.
+            and len(deferred_keys) == result.deferred
+            and _record_watermark_partial(
+                watermark_cache, plan.de_path, plan.en_path, deferred_keys
+            )
+        ):
+            result.watermark_recorded = True
 
     return result
+
+
+def _note_deferred(deferred_keys: set[tuple[str, str]], proposal: Proposal) -> None:
+    """Record a deferred proposal's ``(slide_id, role)`` for the partial advance."""
+    if proposal.slide_id is not None:
+        deferred_keys.add((proposal.slide_id, proposal.role))
 
 
 def _accepted(decisions: dict[int, str] | None, proposal: Proposal) -> bool:
@@ -234,11 +282,14 @@ def _apply_conflict(
     en_content: dict[tuple[str, str], str],
     judge: SyncJudge | None,
     result: ApplyResult,
+    deferred_keys: set[tuple[str, str]],
 ) -> None:
     """Resolve a conflict per its decision, or defer it.
 
     ``de-wins`` / ``en-wins`` propagate the winning side as an ordinary edit
-    (the judge rewrites the losing side to match); any other decision defers.
+    (the judge rewrites the losing side to match); any other decision defers,
+    recording the key so the per-cell advance keeps its pre-conflict baseline
+    and the conflict re-surfaces next run.
     """
     decision = _conflict_decision(decisions, proposal)
     if decision == DECISION_DE_WINS:
@@ -263,6 +314,7 @@ def _apply_conflict(
         )
     else:
         result.deferred += 1
+        _note_deferred(deferred_keys, proposal)
 
 
 def _pass_is_clean(plan: SyncPlan, result: ApplyResult) -> bool:
@@ -843,3 +895,91 @@ def _record_watermark(
             lang=lang,
             cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
         )
+
+
+def _eligible_for_partial_advance(plan: SyncPlan, result: ApplyResult) -> bool:
+    """Whether a per-cell partial watermark advance is safe for this pass.
+
+    Restricted to a **content-only** partial pass: every proposal is an
+    ``edit`` or ``conflict`` (no add / remove / move / rename) AND the plan
+    carries **no issues**. The no-issues guard matters: a both-decks reorder or
+    an ambiguous de/en state is emitted as a *warning* (not a proposal and not
+    an error), and its order/ambiguity is deliberately not reconciled — so a
+    pass carrying any issue must hold the whole watermark, else that
+    un-propagated signal would be silently baselined. With neither structural
+    proposals nor issues, both decks' ordered ``(slide_id, role)`` structure is
+    unchanged, so current positions equal baseline positions.
+
+    Requires a real baseline, no errors, no issues, at least one deferral (a
+    clean pass already did a full advance), and at least one *reconciled write*
+    (``applied_edit > 0``) — there is nothing to bank in a pass that only
+    deferred, so it just holds. Any other partial pass falls back to holding the
+    whole watermark — safe, just noisier on the next run.
+    """
+    if not plan.has_baseline or plan.issues or result.errors:
+        return False
+    if result.deferred <= 0 or result.applied_edit <= 0:
+        return False
+    structural = (
+        plan.count("add") + plan.count("remove") + plan.count("move") + plan.count("rename")
+    )
+    return structural == 0
+
+
+def _record_watermark_partial(
+    cache: SyncWatermarkCache,
+    de_path: Path,
+    en_path: Path,
+    preserve_keys: set[tuple[str, str]],
+) -> bool:
+    """Advance the watermark per-cell, holding the true deferrals at baseline.
+
+    Records the **current** state for every cell — the reconciliation default,
+    matching the full advance — EXCEPT for any ``(slide_id, role)`` in
+    ``preserve_keys`` (an unresolved conflict or a user-skipped edit), which
+    keeps its **old** baseline hash so it re-surfaces next run instead of being
+    silently baselined. An ``in_sync`` edit is *not* a deferral — the judge
+    reconciled it — so it banks like an applied edit.
+
+    Valid only on a content-only, issue-free pass (see
+    :func:`_eligible_for_partial_advance`): structure is unchanged, so current
+    positions equal baseline positions. Returns ``False`` without writing if any
+    preserved key is absent from *either* deck's old baseline **or** current
+    cells. The current-cell check matters: a "removed on one deck / edited on the
+    other" collision is classified as a ``conflict`` (not a ``remove``), so it
+    slips the structural gate, yet the cell is gone from the removing deck — we
+    cannot faithfully preserve it there, so we hold the whole watermark and let
+    the conflict re-surface instead of dropping it.
+    """
+    old: dict[str, dict[tuple[str, str], str]] = {}
+    cells_by_lang = {
+        "de": ordered_sync_cells(parse_cells(de_path.read_text(encoding="utf-8")), "de"),
+        "en": ordered_sync_cells(parse_cells(en_path.read_text(encoding="utf-8")), "en"),
+    }
+    current: dict[str, set[tuple[str, str]]] = {}
+    for lang in ("de", "en"):
+        old[lang] = {
+            (sid, role): chash
+            for (_pos, sid, role, chash) in cache.get_deck(str(de_path), str(en_path), lang)
+            if sid is not None
+        }
+        current[lang] = {
+            (c.slide_id, c.role) for c in cells_by_lang[lang] if c.slide_id is not None
+        }
+    for key in preserve_keys:
+        if key not in old["de"] or key not in old["en"]:
+            return False
+        if key not in current["de"] or key not in current["en"]:
+            return False
+
+    for lang in ("de", "en"):
+        rows: list[tuple[int, str | None, str, str]] = []
+        for c in cells_by_lang[lang]:
+            if c.slide_id is not None and (c.slide_id, c.role) in preserve_keys:
+                # Hold the deferral at its pre-conflict baseline so it re-surfaces.
+                chash = old[lang][(c.slide_id, c.role)]
+            else:
+                chash = c.content_hash  # bank: applied / in_sync / unchanged
+            rows.append((c.position, c.slide_id, c.role, chash))
+        cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang=lang, cells=rows)
+    return True

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -40,7 +40,7 @@ from clm.slides.raw_cells import RawCell
 from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_plan import Proposal, SyncPlan, ordered_sync_cells
 from clm.slides.sync_translate import TranslationError
-from clm.slides.sync_writeback import FileState, role_of
+from clm.slides.sync_writeback import FileState, cell_content_hash, role_of
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -65,6 +65,7 @@ class ApplyResult:
     applied_remove: int = 0
     applied_move: int = 0
     applied_add: int = 0
+    applied_rename: int = 0
     in_sync: int = 0  # an edit the judge decided needed no change
     deferred: int = 0  # conflict (or moves/adds declined this pass)
     watermark_recorded: bool = False
@@ -72,7 +73,13 @@ class ApplyResult:
 
     @property
     def applied(self) -> int:
-        return self.applied_edit + self.applied_remove + self.applied_move + self.applied_add
+        return (
+            self.applied_edit
+            + self.applied_remove
+            + self.applied_move
+            + self.applied_add
+            + self.applied_rename
+        )
 
     @property
     def has_errors(self) -> bool:
@@ -128,6 +135,16 @@ def apply_plan(
     if moves:
         _apply_moves(moves, de_state, en_state, result, plan)
 
+    # Fail-safe: a complete resolution leaves no duplicate id behind. If one
+    # survives (a should-not-happen bug), error so the watermark cannot advance
+    # over a corrupt state and the situation is surfaced rather than baselined.
+    _flag_residual_duplicates(de_state, "de", result)
+    _flag_residual_duplicates(en_state, "en", result)
+    # On an otherwise-clean pass both decks must carry the same (slide_id, role)
+    # set; a one-sided orphan is a silent cross-deck divergence.
+    if not result.errors and result.deferred == 0 and not plan.has_errors:
+        _flag_cross_deck_orphans(de_state, en_state, result)
+
     de_state.flush()
     en_state.flush()
 
@@ -149,6 +166,41 @@ def _pass_is_clean(plan: SyncPlan, result: ApplyResult) -> bool:
     classifier errors, no apply-time errors, and nothing deferred.
     """
     return plan.has_baseline and not plan.has_errors and not result.errors and result.deferred == 0
+
+
+def _flag_residual_duplicates(state: FileState, label: str, result: ApplyResult) -> None:
+    """Error on any ``(slide_id, role)`` left duplicated after the apply walk."""
+    seen: set[tuple[str, str]] = set()
+    for cell in state.cells:
+        role = role_of(cell.metadata)
+        sid = cell.metadata.slide_id
+        if role is None or sid is None:
+            continue
+        key = (sid, role)
+        if key in seen:
+            result.errors.append(f"unresolved duplicate slide_id {sid!r}/{role} on {label}")
+        else:
+            seen.add(key)
+
+
+def _sync_keys(state: FileState) -> set[tuple[str, str]]:
+    """The set of ``(slide_id, role)`` sync keys in a deck."""
+    keys: set[tuple[str, str]] = set()
+    for cell in state.cells:
+        role = role_of(cell.metadata)
+        sid = cell.metadata.slide_id
+        if role is not None and sid is not None:
+            keys.add((sid, role))
+    return keys
+
+
+def _flag_cross_deck_orphans(de_state: FileState, en_state: FileState, result: ApplyResult) -> None:
+    """Error on any sync key present on one deck but not the other."""
+    de_keys, en_keys = _sync_keys(de_state), _sync_keys(en_state)
+    for sid, role in sorted(de_keys - en_keys):
+        result.errors.append(f"slide_id {sid!r}/{role} present on de but missing on en")
+    for sid, role in sorted(en_keys - de_keys):
+        result.errors.append(f"slide_id {sid!r}/{role} present on en but missing on de")
 
 
 # ---------------------------------------------------------------------------
@@ -235,18 +287,25 @@ def _apply_adds(
     plan: SyncPlan,
     translator: SlideTranslator | None,
 ) -> None:
-    """Translate, mint, and insert the counterpart for each id-less new slide.
+    """Translate, mint, and insert counterparts for new and copy-pasted slides.
 
-    Walks each deck's id-less sync cells (which are exactly the plan's id-less
-    ``add`` proposals): a slide mints a fresh EN-derived id stamped onto *both*
-    siblings; a narrative companion inherits the preceding slide's id. The
-    translated counterpart is inserted on the other deck at the matching
-    anchor. id-carrying "missing counterpart" adds are out of scope here and
-    deferred. Adds are sticky via the stamp, so they apply regardless of
-    whether the rest of the pass is clean.
+    One deck walk per direction handles two cases:
+
+    - **add** (id-less cell): a new slide mints a fresh EN-authority id stamped
+      onto *both* siblings; a narrative companion inherits the preceding slide's
+      id; the translated counterpart is inserted on the other deck.
+    - **rename** (copy-pasted duplicate id): the copy *slide* cell chosen by
+      :func:`_identify_copy_slides` (by position, so identical copies don't
+      defeat it) is re-minted to a fresh id — its companions follow by
+      group-adjacency — leaving the original alone, then handled like an add.
+
+    id-carrying "missing counterpart" adds are out of scope and deferred. Both
+    cases are sticky via the stamp, so they apply regardless of whether the rest
+    of the pass is clean.
     """
     add_props = [p for p in plan.proposals if p.kind == "add"]
-    if not add_props:
+    rename_props = [p for p in plan.proposals if p.kind == "rename"]
+    if not add_props and not rename_props:
         return
 
     idd = [p for p in add_props if p.slide_id is not None]
@@ -254,21 +313,29 @@ def _apply_adds(
         result.deferred += len(idd)  # missing-counterpart adds: a follow-up
 
     idless = [p for p in add_props if p.slide_id is None]
-    if not idless:
+    if len(idless) + len(rename_props) == 0:
         return
     if translator is None:
-        result.deferred += len(idless)
-        result.errors.append("id-less add(s) present but no translator available")
+        result.deferred += len(idless) + len(rename_props)
+        result.errors.append("add/rename present but no translator available")
         return
-    if len({p.direction for p in idless}) > 1:
-        # id-less new slides on BOTH decks: the author edited both sides, which
-        # is off the single-language path. Pairing them is out of scope; defer
-        # rather than translate each independently and duplicate the slide.
+
+    process_idless = True
+    if idless and len({p.direction for p in idless}) > 1:
+        # id-less new slides on BOTH decks: off the single-language path. Defer
+        # the adds (renames are independent and still apply).
         result.deferred += len(idless)
         result.errors.append(
             "id-less new slides on both decks — edit one deck at a time (deferred)"
         )
-        return
+        process_idless = False
+
+    de_copy_ids = _identify_copy_slides(
+        de_state, "de", [p for p in rename_props if p.direction == "de->en"]
+    )
+    en_copy_ids = _identify_copy_slides(
+        en_state, "en", [p for p in rename_props if p.direction == "en->de"]
+    )
 
     used_ids = {
         cell.metadata.slide_id
@@ -276,8 +343,49 @@ def _apply_adds(
         for cell in state.cells
         if cell.metadata.slide_id
     }
-    _add_one_direction(de_state, en_state, "de", "en", translator, used_ids, result)
-    _add_one_direction(en_state, de_state, "en", "de", translator, used_ids, result)
+    _add_one_direction(
+        de_state, en_state, "de", "en", translator, used_ids, result, de_copy_ids, process_idless
+    )
+    _add_one_direction(
+        en_state, de_state, "en", "de", translator, used_ids, result, en_copy_ids, process_idless
+    )
+
+
+def _identify_copy_slides(
+    source_state: FileState, source_lang: str, rename_props: list[Proposal]
+) -> set[int]:
+    """Pick the physical copy *slide* cell for each rename, by position.
+
+    For an edited copy the hash is already unique; for a byte-identical copy
+    several slide cells share the hash, so each rename is bound to the matching
+    cell whose sync-cell index is closest to its ``source_position`` — the copy
+    the classifier designated, never the in-place original. Returns the set of
+    ``id()`` of the cells to re-mint.
+    """
+    by_sig: dict[tuple[str, str, str], list[tuple[int, RawCell]]] = {}
+    pos = -1
+    for cell in source_state.cells:
+        role = role_of(cell.metadata)
+        if role is None or cell.metadata.lang != source_lang:
+            continue
+        pos += 1
+        sid = cell.metadata.slide_id
+        if role in _SLIDE_ROLES and sid is not None:
+            by_sig.setdefault((sid, role, cell_content_hash(cell.body)), []).append((pos, cell))
+
+    copy_ids: set[int] = set()
+    for prop in rename_props:
+        if prop.slide_id is None or prop.content_hash is None:
+            continue
+        want = prop.source_position if prop.source_position is not None else 0
+        candidates = [
+            (p, c)
+            for (p, c) in by_sig.get((prop.slide_id, prop.role, prop.content_hash), [])
+            if id(c) not in copy_ids
+        ]
+        if candidates:
+            copy_ids.add(id(min(candidates, key=lambda pc: abs(pc[0] - want))[1]))
+    return copy_ids
 
 
 def _add_one_direction(
@@ -288,59 +396,122 @@ def _add_one_direction(
     translator: SlideTranslator,
     used_ids: set[str],
     result: ApplyResult,
+    copy_slide_ids: set[int],
+    process_idless: bool,
 ) -> None:
+    """Walk the source deck, minting ids for new and copy-pasted slides.
+
+    ``copy_slide_ids`` is the set of ``id()`` of copy-paste *slide* cells to
+    re-mint (chosen by :func:`_identify_copy_slides`). A copied slide's narrative
+    companions are re-minted by group-adjacency — ``renaming_from`` holds the
+    copy slide's old id so each following same-id companion inherits the freshly
+    minted id — rather than by a per-companion hash match (which identical
+    companions defeat).
+    """
     current_slide_id: str | None = None
+    renaming_from: str | None = None  # old id of a copy slide whose companions follow
     anchor: tuple[str, str] | None = None
     for cell in list(source_state.cells):
         role = role_of(cell.metadata)
-        if role is None:
+        if role is None or cell.metadata.lang != source_lang:
             continue
         sid = cell.metadata.slide_id
-        if sid is not None:
-            # An existing paired cell — not an add. It anchors what follows.
-            if role in _SLIDE_ROLES:
-                current_slide_id = sid
-            anchor = (sid, role)
-            continue
-
-        # id-less => an add: translate first (the body is unchanged by stamping).
-        # Normalise away the terminal-newline artifact split_cells parks on the
-        # last cell, so the body the translator sees doesn't depend on position.
-        source_body = cell.body.rstrip("\n")
-        try:
-            target_body = translator.translate(
-                source_body=source_body,
-                source_lang=source_lang,
-                target_lang=target_lang,
-                role=role,
-            )
-        except TranslationError as exc:
-            result.deferred += 1
-            result.errors.append(f"add {role}: translation failed: {exc}")
-            continue
 
         if role in _SLIDE_ROLES:
-            # EN-authority: slug the id from the EN text (the translation when
-            # the author edited DE, the source itself when they edited EN).
-            en_body = target_body if target_lang == "en" else source_body
+            is_copy = id(cell) in copy_slide_ids
+            if sid is not None and not is_copy:
+                current_slide_id = sid  # existing slide; anchors what follows
+                renaming_from = None
+                anchor = (sid, role)
+                continue
+            if sid is None and not process_idless:
+                renaming_from = None
+                continue  # deferred parallel id-less add
+            # id-less add OR copy slide: translate, mint EN-authority id, place.
+            target_body = _translate(cell, source_lang, target_lang, translator, role, result)
+            if target_body is None:
+                renaming_from = None
+                continue
+            en_body = target_body if target_lang == "en" else cell.body.rstrip("\n")
             new_id = resolve_collision(_slug_or_default(en_body), used_ids)
             used_ids.add(new_id)
-            current_slide_id = new_id
-        elif current_slide_id is None:
-            result.deferred += 1
-            result.errors.append(
-                f"add {role}: id-less narrative with no preceding slide — deferred"
+            _place_new_cell(
+                cell, new_id, target_lang, target_body, source_state, target_state, anchor
             )
+            anchor = (new_id, role)
+            current_slide_id = new_id
+            renaming_from = sid if is_copy else None  # for a copy, sid is the old dup id
+            if is_copy:
+                result.applied_rename += 1
+            else:
+                result.applied_add += 1
             continue
-        else:
-            new_id = current_slide_id
 
-        _stamp_slide_id(cell, new_id)  # stamp the previously-id-less source cell
-        source_state.dirty = True
-        new_cell = _build_cell(target_lang, cell.metadata.tags, new_id, target_body)
-        _insert_at_anchor(target_state, anchor, new_cell)
-        anchor = (new_id, role)
-        result.applied_add += 1
+        # narrative role
+        is_copy_companion = renaming_from is not None and sid is not None and sid == renaming_from
+        if sid is not None and not is_copy_companion:
+            anchor = (sid, role)  # existing companion (of a non-copied slide)
+            continue
+        if sid is None and not process_idless:
+            continue
+        if current_slide_id is None:
+            result.deferred += 1
+            result.errors.append(f"add {role}: narrative with no preceding slide — deferred")
+            continue
+        target_body = _translate(cell, source_lang, target_lang, translator, role, result)
+        if target_body is None:
+            continue
+        # Companions inherit the slide's id (the freshly minted one for a copy).
+        _place_new_cell(
+            cell, current_slide_id, target_lang, target_body, source_state, target_state, anchor
+        )
+        anchor = (current_slide_id, role)
+        if is_copy_companion:
+            result.applied_rename += 1
+        else:
+            result.applied_add += 1
+
+
+def _translate(
+    cell: RawCell,
+    source_lang: str,
+    target_lang: str,
+    translator: SlideTranslator,
+    role: str,
+    result: ApplyResult,
+) -> str | None:
+    """Translate a cell body, recording a deferral + error on failure.
+
+    rstrip drops the terminal-newline artifact so the translator input does not
+    depend on cell position.
+    """
+    try:
+        return translator.translate(
+            source_body=cell.body.rstrip("\n"),
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=role,
+        )
+    except TranslationError as exc:
+        result.deferred += 1
+        result.errors.append(f"{role}: translation failed: {exc}")
+        return None
+
+
+def _place_new_cell(
+    cell: RawCell,
+    new_id: str,
+    target_lang: str,
+    target_body: str,
+    source_state: FileState,
+    target_state: FileState,
+    anchor: tuple[str, str] | None,
+) -> None:
+    """Stamp the source cell's id and insert the translated counterpart."""
+    _stamp_slide_id(cell, new_id)
+    source_state.dirty = True
+    new_cell = _build_cell(target_lang, cell.metadata.tags, new_id, target_body)
+    _insert_at_anchor(target_state, anchor, new_cell)
 
 
 def _slug_or_default(en_body: str) -> str:

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -1,0 +1,771 @@
+"""Structural change classifier for the single-language authoring workflow.
+
+Phase 1 of Issue #166. After an author edits one half of a split deck
+(``<deck>.de.py`` / ``<deck>.en.py``), this module diffs both decks against a
+**structural watermark** (the last synced state) and produces a typed *plan*
+of cross-language proposals: ``add`` / ``edit`` / ``move`` / ``remove`` /
+``conflict``. It assigns a **per-cell direction** (which side drifted) and
+isolates true conflicts (the same ``slide_id`` drifted on both sides).
+
+This is pure analysis — **no files are written and no LLM is called**. The
+``add`` proposals are emitted as *translation-pending*; later phases fill in
+the translated counterpart and mint the ``slide_id``. See
+``docs/claude/design/single-language-authoring-sync.md`` for the full design.
+
+Baseline resolution (``build_sync_plan``):
+
+1. the **watermark** (:class:`clm.infrastructure.llm.cache.SyncWatermarkCache`)
+   when present — written only on a successful sync apply, so immune to the
+   author's git-commit cadence;
+2. else **git HEAD** of each deck (covers a fresh clone with no local cache);
+3. else **no baseline** — only id-less adds and shared-id pairing can be
+   inferred; a shared id that differs across decks needs an explicit
+   ``--source-lang`` and is surfaced as an issue rather than guessed.
+
+Key invariant from the design: after a sync, every sync-relevant cell carries a
+``slide_id``. So a cell with **no** ``slide_id`` is, by construction, *added
+since the last sync* — a git-immune signal that survives committing the deck.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.slides.sync_writeback import cell_content_hash
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import SyncWatermarkCache
+
+__all__ = [
+    "BaselineCell",
+    "CurrentCell",
+    "PlanIssue",
+    "Proposal",
+    "SyncPlan",
+    "build_sync_plan",
+    "classify_changes",
+    "ordered_sync_cells",
+    "render_plan",
+]
+
+# Roles that participate in cross-language sync. Mirrors
+# ``clm.slides.sync._ROLE_TAGS`` (duplicated to keep this module independent of
+# the engine module and avoid a circular import).
+_ROLE_TAGS = {
+    "slide": "slide",
+    "subslide": "subslide",
+    "voiceover": "voiceover",
+    "notes": "notes",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BaselineCell:
+    """One cell as recorded in the watermark (or derived from git HEAD)."""
+
+    position: int
+    slide_id: str | None
+    role: str
+    content_hash: str
+
+
+@dataclass(frozen=True)
+class CurrentCell:
+    """One sync-relevant cell as it exists in the working tree right now."""
+
+    position: int  # index among sync-relevant cells of this deck's language
+    slide_id: str | None
+    role: str
+    content_hash: str
+    line_number: int  # 1-based header line, for anchoring / messaging
+
+
+@dataclass
+class Proposal:
+    """One cross-language change the sync would make.
+
+    ``kind`` is ``add`` / ``edit`` / ``move`` / ``remove`` / ``conflict``.
+    ``direction`` is ``"de->en"`` / ``"en->de"`` (the side that drifted is the
+    source), or ``None`` for a conflict. ``slide_id`` is ``None`` for an
+    id-less add. Positions are 0-based indices among sync-relevant cells and
+    are best-effort context for later phases (anchoring, walker rendering).
+    """
+
+    kind: str
+    role: str
+    direction: str | None
+    slide_id: str | None
+    reason: str = ""
+    translation_pending: bool = False  # True for ``add`` (content not yet made)
+    source_position: int | None = None
+    target_position: int | None = None
+    old_position: int | None = None
+    new_position: int | None = None
+
+
+@dataclass
+class PlanIssue:
+    """A structural situation the classifier will not turn into a proposal."""
+
+    severity: str  # "warning" | "error"
+    slide_id: str | None
+    reason: str
+
+
+@dataclass
+class SyncPlan:
+    """The full result of classifying one split pair against its baseline."""
+
+    de_path: Path
+    en_path: Path
+    baseline_source: str  # "watermark" | "git-head" | "none"
+    proposals: list[Proposal] = field(default_factory=list)
+    issues: list[PlanIssue] = field(default_factory=list)
+    in_sync_count: int = 0
+
+    @property
+    def has_baseline(self) -> bool:
+        return self.baseline_source != "none"
+
+    @property
+    def has_errors(self) -> bool:
+        return any(i.severity == "error" for i in self.issues)
+
+    @property
+    def is_noop(self) -> bool:
+        """True when there is nothing to apply (and nothing went wrong)."""
+        return not self.proposals and not self.has_errors
+
+    def count(self, kind: str) -> int:
+        return sum(1 for p in self.proposals if p.kind == kind)
+
+    def summary(self) -> str:
+        """One-line, no-silent-no-op headline.
+
+        Distinguishes *"0 changes — already consistent"* from *"could not
+        establish a baseline"* so a quiet run is never ambiguous.
+        """
+        if self.proposals or self.has_errors:
+            parts = [
+                f"{self.count('add')} add",
+                f"{self.count('edit')} edit",
+                f"{self.count('move')} move",
+                f"{self.count('remove')} remove",
+                f"{self.count('conflict')} conflict",
+            ]
+            tail = f"; {len(self.issues)} issue(s)" if self.issues else ""
+            return (
+                f"baseline={self.baseline_source}: "
+                + ", ".join(parts)
+                + f"; {self.in_sync_count} in sync"
+                + tail
+            )
+        if not self.has_baseline:
+            return (
+                "baseline=none: no watermark and no git HEAD to diff against — "
+                "cannot detect edits/removes. Pass --source-lang or commit a "
+                "baseline. (id-less adds are still detected.)"
+            )
+        return (
+            f"baseline={self.baseline_source}: 0 changes — decks already "
+            f"consistent ({self.in_sync_count} cell(s) in sync)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cell extraction
+# ---------------------------------------------------------------------------
+
+
+def _role_for_cell(cell: Cell) -> str | None:
+    if cell.metadata.is_j2:
+        return None
+    if cell.metadata.cell_type != "markdown":
+        return None
+    for tag in cell.metadata.tags:
+        role = _ROLE_TAGS.get(tag)
+        if role is not None:
+            return role
+    return None
+
+
+def ordered_sync_cells(cells: list[Cell], expected_lang: str) -> list[CurrentCell]:
+    """Return sync-relevant cells of ``expected_lang`` in source order.
+
+    ``position`` is the 0-based index among the returned cells, so it is
+    stable for a fixed file and shifts predictably when cells are added or
+    removed (move detection uses relative order, not absolute position).
+    """
+    out: list[CurrentCell] = []
+    position = 0
+    for cell in cells:
+        role = _role_for_cell(cell)
+        if role is None:
+            continue
+        if cell.metadata.lang != expected_lang:
+            continue
+        out.append(
+            CurrentCell(
+                position=position,
+                slide_id=cell.metadata.slide_id or None,
+                role=role,
+                content_hash=cell_content_hash(cell.content),
+                line_number=cell.line_number,
+            )
+        )
+        position += 1
+    return out
+
+
+def _baseline_from_watermark(
+    rows: list[tuple[int, str | None, str, str]],
+) -> list[BaselineCell]:
+    return [
+        BaselineCell(position=pos, slide_id=sid, role=role, content_hash=chash)
+        for (pos, sid, role, chash) in rows
+    ]
+
+
+def _lang_for_path(path: Path) -> str | None:
+    name = path.name
+    if name.endswith(".de.py"):
+        return "de"
+    if name.endswith(".en.py"):
+        return "en"
+    return None
+
+
+def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
+    """Derive a baseline from the committed (HEAD) version of ``path``.
+
+    Returns ``None`` when git is unavailable, the file is untracked, or the
+    deck's language cannot be inferred from its name. An empty list means the
+    file existed at HEAD but had no sync-relevant cells.
+    """
+    lang = _lang_for_path(path)
+    if lang is None:
+        return None
+    try:
+        completed = subprocess.run(
+            ["git", "show", f"HEAD:./{path.name}"],
+            cwd=str(path.parent),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if completed.returncode != 0:
+        return None
+    cells = parse_cells(completed.stdout)
+    return [
+        BaselineCell(
+            position=c.position,
+            slide_id=c.slide_id,
+            role=c.role,
+            content_hash=c.content_hash,
+        )
+        for c in ordered_sync_cells(cells, lang)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _index_by_key(
+    cells: list[CurrentCell],
+) -> tuple[dict[tuple[str, str], CurrentCell], list[CurrentCell], set[tuple[str, str]]]:
+    """Index id-carrying cells by ``(slide_id, role)``.
+
+    Returns ``(by_key, idless, collisions)``. ``collisions`` holds keys that
+    appear more than once (duplicate id in one deck) — those keys are excluded
+    from normal pairing and surfaced as an error issue by the caller.
+    """
+    by_key: dict[tuple[str, str], CurrentCell] = {}
+    collisions: set[tuple[str, str]] = set()
+    idless: list[CurrentCell] = []
+    for cell in cells:
+        if cell.slide_id is None:
+            idless.append(cell)
+            continue
+        key = (cell.slide_id, cell.role)
+        if key in by_key:
+            collisions.add(key)
+            continue
+        by_key[key] = cell
+    return by_key, idless, collisions
+
+
+def _baseline_index(
+    baseline: list[BaselineCell] | None,
+) -> dict[tuple[str, str], BaselineCell]:
+    if baseline is None:
+        return {}
+    out: dict[tuple[str, str], BaselineCell] = {}
+    for cell in baseline:
+        if cell.slide_id is None:
+            continue
+        out.setdefault((cell.slide_id, cell.role), cell)
+    return out
+
+
+def _state(now: CurrentCell | None, base: BaselineCell | None) -> str:
+    """One side's status for a key: same / edited / added / removed / absent."""
+    if now is not None and base is not None:
+        return "same" if now.content_hash == base.content_hash else "edited"
+    if now is not None:
+        return "added"
+    if base is not None:
+        return "removed"
+    return "absent"
+
+
+def _lcs_complement(base_order: list, now_order: list) -> set:
+    """Items NOT in the longest common subsequence of two orderings.
+
+    Both arguments are orderings of the *same set* of items, so the LCS is the
+    largest subset already in agreeing relative order; the complement is the
+    minimal set of items that must have moved.
+    """
+    a, b = base_order, now_order
+    n, m = len(a), len(b)
+    if n == 0:
+        return set()
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(n - 1, -1, -1):
+        for j in range(m - 1, -1, -1):
+            if a[i] == b[j]:
+                dp[i][j] = 1 + dp[i + 1][j + 1]
+            else:
+                dp[i][j] = max(dp[i + 1][j], dp[i][j + 1])
+    keep: set = set()
+    i = j = 0
+    while i < n and j < m:
+        if a[i] == b[j]:
+            keep.add(a[i])
+            i += 1
+            j += 1
+        elif dp[i + 1][j] >= dp[i][j + 1]:
+            i += 1
+        else:
+            j += 1
+    return set(a) - keep
+
+
+def _moved_keys(
+    by_key: dict[tuple[str, str], CurrentCell],
+    base_index: dict[tuple[str, str], BaselineCell],
+    states: dict[tuple[str, str], str],
+) -> set[tuple[str, str]]:
+    """Keys that are unchanged in content but repositioned for one deck."""
+    stable = [k for k, st in states.items() if st == "same" and k in by_key and k in base_index]
+    base_order = sorted(stable, key=lambda k: base_index[k].position)
+    now_order = sorted(stable, key=lambda k: by_key[k].position)
+    return _lcs_complement(base_order, now_order)
+
+
+def classify_changes(
+    de_current: list[CurrentCell],
+    en_current: list[CurrentCell],
+    de_baseline: list[BaselineCell] | None,
+    en_baseline: list[BaselineCell] | None,
+    *,
+    de_path: Path,
+    en_path: Path,
+    baseline_source: str,
+) -> SyncPlan:
+    """Diff both decks against their baselines into a typed :class:`SyncPlan`.
+
+    Pure: no IO, no LLM. ``de_baseline`` / ``en_baseline`` are ``None`` when no
+    baseline exists for that deck; if either is ``None`` the pair runs in the
+    limited cold-start path (id-less adds + shared-id pairing only).
+    """
+    plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source=baseline_source)
+
+    de_by_key, de_idless, de_collisions = _index_by_key(de_current)
+    en_by_key, en_idless, en_collisions = _index_by_key(en_current)
+
+    for key in sorted(de_collisions | en_collisions):
+        sid, role = key
+        side = "DE" if key in de_collisions else "EN"
+        if key in de_collisions and key in en_collisions:
+            side = "both decks"
+        plan.issues.append(
+            PlanIssue(
+                severity="error",
+                slide_id=sid,
+                reason=f"role={role!r} slide_id appears more than once on {side}; "
+                "ids must be unique within a deck — resolve the collision",
+            )
+        )
+
+    has_baseline = de_baseline is not None and en_baseline is not None
+    if not has_baseline:
+        _classify_cold(
+            plan, de_by_key, en_by_key, de_idless, en_idless, de_collisions | en_collisions
+        )
+        _append_idless_adds(plan, de_idless, en_idless)
+        plan.proposals.sort(key=_proposal_sort_key)
+        return plan
+
+    de_base = _baseline_index(de_baseline)
+    en_base = _baseline_index(en_baseline)
+
+    excluded = de_collisions | en_collisions
+    keys = (set(de_by_key) | set(en_by_key) | set(de_base) | set(en_base)) - excluded
+
+    states_de: dict[tuple[str, str], str] = {}
+    states_en: dict[tuple[str, str], str] = {}
+    for key in keys:
+        states_de[key] = _state(de_by_key.get(key), de_base.get(key))
+        states_en[key] = _state(en_by_key.get(key), en_base.get(key))
+
+    moved_de = _moved_keys(de_by_key, de_base, states_de)
+    moved_en = _moved_keys(en_by_key, en_base, states_en)
+    order_conflict_reported = False
+
+    for key in sorted(keys):
+        sid, role = key
+        de_st = states_de[key]
+        en_st = states_en[key]
+        de_now = de_by_key.get(key)
+        en_now = en_by_key.get(key)
+
+        # --- both present now -------------------------------------------------
+        if de_now is not None and en_now is not None:
+            if de_st == "edited" and en_st == "edited":
+                plan.proposals.append(
+                    Proposal(
+                        kind="conflict",
+                        role=role,
+                        direction=None,
+                        slide_id=sid,
+                        reason="edited on both sides since last sync",
+                    )
+                )
+            elif de_st == "edited" and en_st == "same":
+                plan.proposals.append(_edit(sid, role, "de->en", de_now, en_now))
+            elif en_st == "edited" and de_st == "same":
+                plan.proposals.append(_edit(sid, role, "en->de", en_now, de_now))
+            elif de_st == "same" and en_st == "same":
+                _emit_same(
+                    plan,
+                    key,
+                    role,
+                    de_now,
+                    en_now,
+                    moved_de,
+                    moved_en,
+                    order_conflict_reported,
+                )
+                if key in moved_de and key in moved_en:
+                    order_conflict_reported = True
+            else:
+                # added/edited mixes that aren't a clean edit (e.g. one side
+                # freshly minted the id while the other changed). Safe default:
+                # treat newly-paired-but-unverifiable as in sync; flag the genuinely
+                # ambiguous edit-vs-add combos.
+                if "edited" in (de_st, en_st):
+                    plan.issues.append(
+                        PlanIssue(
+                            severity="warning",
+                            slide_id=sid,
+                            reason=f"role={role!r} ambiguous state (de={de_st}, en={en_st}); "
+                            "resolve manually",
+                        )
+                    )
+                else:
+                    plan.in_sync_count += 1
+            continue
+
+        # --- removed on one side ---------------------------------------------
+        if de_st == "removed" and en_now is not None:
+            if en_st == "edited":
+                plan.proposals.append(
+                    Proposal(
+                        kind="conflict",
+                        role=role,
+                        direction=None,
+                        slide_id=sid,
+                        reason="removed on DE but edited on EN since last sync",
+                    )
+                )
+            else:
+                plan.proposals.append(
+                    Proposal(
+                        kind="remove",
+                        role=role,
+                        direction="de->en",
+                        slide_id=sid,
+                        reason="removed on DE",
+                        target_position=en_now.position,
+                    )
+                )
+            continue
+        if en_st == "removed" and de_now is not None:
+            if de_st == "edited":
+                plan.proposals.append(
+                    Proposal(
+                        kind="conflict",
+                        role=role,
+                        direction=None,
+                        slide_id=sid,
+                        reason="removed on EN but edited on DE since last sync",
+                    )
+                )
+            else:
+                plan.proposals.append(
+                    Proposal(
+                        kind="remove",
+                        role=role,
+                        direction="en->de",
+                        slide_id=sid,
+                        reason="removed on EN",
+                        target_position=de_now.position,
+                    )
+                )
+            continue
+
+        # --- present on one side, no counterpart -> add ----------------------
+        if de_now is not None and en_st == "absent":
+            plan.proposals.append(_add(sid, role, "de->en", de_now))
+            continue
+        if en_now is not None and de_st == "absent":
+            plan.proposals.append(_add(sid, role, "en->de", en_now))
+            continue
+
+        # --- removed on both / removed+absent -> nothing to propagate --------
+        # (de removed & en absent/removed, or mirror) falls through to no-op.
+
+    _append_idless_adds(plan, de_idless, en_idless)
+    plan.proposals.sort(key=_proposal_sort_key)
+    return plan
+
+
+def _emit_same(
+    plan: SyncPlan,
+    key: tuple[str, str],
+    role: str,
+    de_now: CurrentCell,
+    en_now: CurrentCell,
+    moved_de: set,
+    moved_en: set,
+    order_conflict_reported: bool,
+) -> None:
+    sid = key[0]
+    in_de = key in moved_de
+    in_en = key in moved_en
+    if in_de and not in_en:
+        plan.proposals.append(
+            Proposal(
+                kind="move",
+                role=role,
+                direction="de->en",
+                slide_id=sid,
+                reason="reordered on DE",
+                old_position=en_now.position,
+                new_position=de_now.position,
+            )
+        )
+    elif in_en and not in_de:
+        plan.proposals.append(
+            Proposal(
+                kind="move",
+                role=role,
+                direction="en->de",
+                slide_id=sid,
+                reason="reordered on EN",
+                old_position=de_now.position,
+                new_position=en_now.position,
+            )
+        )
+    elif in_de and in_en:
+        if not order_conflict_reported:
+            plan.issues.append(
+                PlanIssue(
+                    severity="warning",
+                    slide_id=None,
+                    reason="cell order drifted on both decks; order not propagated "
+                    "(resolve ordering manually)",
+                )
+            )
+        plan.in_sync_count += 1
+    else:
+        plan.in_sync_count += 1
+
+
+def _classify_cold(
+    plan: SyncPlan,
+    de_by_key: dict[tuple[str, str], CurrentCell],
+    en_by_key: dict[tuple[str, str], CurrentCell],
+    de_idless: list[CurrentCell],
+    en_idless: list[CurrentCell],
+    excluded: set[tuple[str, str]],
+) -> None:
+    """No-baseline path: pair by shared id, add id-less, flag ambiguities.
+
+    Without a baseline we cannot tell an edit from a removal or assign a
+    direction, so a shared id whose content differs across decks is surfaced
+    as an issue (needs explicit ``--source-lang``) rather than guessed.
+    """
+    keys = (set(de_by_key) | set(en_by_key)) - excluded
+    for key in sorted(keys):
+        sid, role = key
+        de_now = de_by_key.get(key)
+        en_now = en_by_key.get(key)
+        if de_now is not None and en_now is not None:
+            # Cross-language hashes never match (different prose), so we cannot
+            # assert "in sync" from content; treat a shared id as a confirmed
+            # pair and leave content reconciliation to a baseline-backed run.
+            plan.in_sync_count += 1
+        elif de_now is not None:
+            plan.proposals.append(_add(sid, role, "de->en", de_now, cold=True))
+        elif en_now is not None:
+            plan.proposals.append(_add(sid, role, "en->de", en_now, cold=True))
+
+
+def _append_idless_adds(
+    plan: SyncPlan,
+    de_idless: list[CurrentCell],
+    en_idless: list[CurrentCell],
+) -> None:
+    for cell in de_idless:
+        plan.proposals.append(_add(None, cell.role, "de->en", cell))
+    for cell in en_idless:
+        plan.proposals.append(_add(None, cell.role, "en->de", cell))
+
+
+def _add(
+    slide_id: str | None,
+    role: str,
+    direction: str,
+    source: CurrentCell,
+    *,
+    cold: bool = False,
+) -> Proposal:
+    if slide_id is None:
+        reason = "new id-less slide"
+    elif cold:
+        reason = "slide_id present on one side only (no baseline)"
+    else:
+        reason = "new slide (id unknown to baseline)"
+    return Proposal(
+        kind="add",
+        role=role,
+        direction=direction,
+        slide_id=slide_id,
+        reason=reason,
+        translation_pending=True,
+        source_position=source.position,
+    )
+
+
+def _edit(
+    slide_id: str,
+    role: str,
+    direction: str,
+    source: CurrentCell | None,
+    target: CurrentCell | None,
+) -> Proposal:
+    return Proposal(
+        kind="edit",
+        role=role,
+        direction=direction,
+        slide_id=slide_id,
+        reason=f"edited on {direction.split('->')[0].upper()}",
+        source_position=source.position if source else None,
+        target_position=target.position if target else None,
+    )
+
+
+_KIND_ORDER = {"conflict": 0, "remove": 1, "edit": 2, "move": 3, "add": 4}
+
+
+def _proposal_sort_key(p: Proposal) -> tuple:
+    return (
+        _KIND_ORDER.get(p.kind, 9),
+        p.source_position if p.source_position is not None else 1_000_000,
+        p.slide_id or "",
+        p.role,
+    )
+
+
+# ---------------------------------------------------------------------------
+# IO wrapper + report
+# ---------------------------------------------------------------------------
+
+
+def build_sync_plan(
+    de_path: Path,
+    en_path: Path,
+    *,
+    watermark_cache: SyncWatermarkCache | None = None,
+    allow_git_fallback: bool = True,
+) -> SyncPlan:
+    """Resolve the baseline and classify the pair into a :class:`SyncPlan`.
+
+    Baseline priority: watermark → git HEAD → none (see module docstring).
+    Reads the two files; writes nothing.
+    """
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_current = ordered_sync_cells(de_cells, "de")
+    en_current = ordered_sync_cells(en_cells, "en")
+
+    de_baseline: list[BaselineCell] | None = None
+    en_baseline: list[BaselineCell] | None = None
+    source = "none"
+
+    if watermark_cache is not None and watermark_cache.has_pair(str(de_path), str(en_path)):
+        de_baseline = _baseline_from_watermark(
+            watermark_cache.get_deck(str(de_path), str(en_path), "de")
+        )
+        en_baseline = _baseline_from_watermark(
+            watermark_cache.get_deck(str(de_path), str(en_path), "en")
+        )
+        source = "watermark"
+    elif allow_git_fallback:
+        gb_de = _baseline_from_git_head(de_path)
+        gb_en = _baseline_from_git_head(en_path)
+        if gb_de is not None and gb_en is not None:
+            de_baseline, en_baseline = gb_de, gb_en
+            source = "git-head"
+
+    return classify_changes(
+        de_current,
+        en_current,
+        de_baseline,
+        en_baseline,
+        de_path=de_path,
+        en_path=en_path,
+        baseline_source=source,
+    )
+
+
+def render_plan(plan: SyncPlan) -> str:
+    """Render a human-readable, no-silent-no-op report of the plan."""
+    lines: list[str] = []
+    for issue in plan.issues:
+        sid = f" {issue.slide_id}" if issue.slide_id else ""
+        lines.append(f"issue-{issue.severity}{sid}: {issue.reason}")
+    for p in plan.proposals:
+        sid = p.slide_id if p.slide_id is not None else "(id-less)"
+        direction = f" {p.direction}" if p.direction else ""
+        suffix = " [translation pending]" if p.translation_pending else ""
+        detail = f" — {p.reason}" if p.reason else ""
+        lines.append(f"{p.kind}{direction} {sid}/{p.role}{suffix}{detail}")
+    lines.append("")
+    lines.append(plan.summary())
+    return "\n".join(lines)

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -62,6 +62,10 @@ _ROLE_TAGS = {
     "notes": "notes",
 }
 
+# Roles that lead a slide group; narrative roles (voiceover/notes) belong to the
+# most recent slide group rather than starting their own.
+_SLIDE_ROLES = {"slide", "subslide"}
+
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -93,11 +97,16 @@ class CurrentCell:
 class Proposal:
     """One cross-language change the sync would make.
 
-    ``kind`` is ``add`` / ``edit`` / ``move`` / ``remove`` / ``conflict``.
-    ``direction`` is ``"de->en"`` / ``"en->de"`` (the side that drifted is the
-    source), or ``None`` for a conflict. ``slide_id`` is ``None`` for an
-    id-less add. Positions are 0-based indices among sync-relevant cells and
-    are best-effort context for later phases (anchoring, walker rendering).
+    ``kind`` is ``add`` / ``edit`` / ``move`` / ``remove`` / ``conflict`` /
+    ``rename``. ``direction`` is ``"de->en"`` / ``"en->de"`` (the side that
+    drifted is the source), or ``None`` for a conflict. ``slide_id`` is ``None``
+    for an id-less add, and the *duplicated* id for a ``rename``. Positions are
+    0-based indices among sync-relevant cells and are best-effort context for
+    later phases (anchoring, walker rendering).
+
+    ``content_hash`` is set on a ``rename`` proposal: it identifies which of the
+    duplicate-id cells is the copy (the apply re-mints the cell matching this
+    hash, leaving the original alone).
     """
 
     kind: str
@@ -105,11 +114,12 @@ class Proposal:
     direction: str | None
     slide_id: str | None
     reason: str = ""
-    translation_pending: bool = False  # True for ``add`` (content not yet made)
+    translation_pending: bool = False  # True for ``add`` / ``rename`` (content not yet made)
     source_position: int | None = None
     target_position: int | None = None
     old_position: int | None = None
     new_position: int | None = None
+    content_hash: str | None = None  # the copy's hash, for ``rename``
 
 
 @dataclass
@@ -286,26 +296,139 @@ def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
 
 def _index_by_key(
     cells: list[CurrentCell],
-) -> tuple[dict[tuple[str, str], CurrentCell], list[CurrentCell], set[tuple[str, str]]]:
-    """Index id-carrying cells by ``(slide_id, role)``.
+) -> tuple[dict[tuple[str, str], list[CurrentCell]], list[CurrentCell]]:
+    """Index id-carrying cells by ``(slide_id, role)``, keeping duplicates.
 
-    Returns ``(by_key, idless, collisions)``. ``collisions`` holds keys that
-    appear more than once (duplicate id in one deck) — those keys are excluded
-    from normal pairing and surfaced as an error issue by the caller.
+    Returns ``(by_key, idless)`` where ``by_key`` maps each key to *all* cells
+    carrying it (a list of length > 1 is a duplicate-id collision, resolved by
+    :func:`_resolve_duplicates`).
     """
-    by_key: dict[tuple[str, str], CurrentCell] = {}
-    collisions: set[tuple[str, str]] = set()
+    by_key: dict[tuple[str, str], list[CurrentCell]] = {}
     idless: list[CurrentCell] = []
     for cell in cells:
         if cell.slide_id is None:
             idless.append(cell)
             continue
-        key = (cell.slide_id, cell.role)
-        if key in by_key:
-            collisions.add(key)
+        by_key.setdefault((cell.slide_id, cell.role), []).append(cell)
+    return by_key, idless
+
+
+def _slide_groups(cells: list[CurrentCell]) -> list[list[CurrentCell]]:
+    """Split ordered cells into slide groups (slide + trailing companions).
+
+    Each group's first cell is a slide/subslide; the rest are its narrative
+    companions. A companion that precedes any slide forms its own one-cell
+    group (an orphan, never a copied-group member).
+    """
+    groups: list[list[CurrentCell]] = []
+    current: list[CurrentCell] | None = None
+    for cell in cells:
+        if cell.role in _SLIDE_ROLES:
+            current = [cell]
+            groups.append(current)
+        elif current is not None:
+            current.append(cell)
+        else:
+            groups.append([cell])  # orphan companion before the first slide
+            current = None
+    return groups
+
+
+def _resolve_duplicates(
+    current: list[CurrentCell],
+    by_key: dict[tuple[str, str], list[CurrentCell]],
+    base_index: dict[tuple[str, str], BaselineCell],
+    direction: str,
+    plan: SyncPlan,
+) -> tuple[dict[tuple[str, str], CurrentCell], set[tuple[str, str]]]:
+    """Collapse duplicate-id cells to one original each, renaming the copies.
+
+    Copy-pasting a slide produces two slide *groups* sharing an id (the slide
+    cell and its narrative companions). Resolution is done at the **group**
+    level: when the watermark identifies the original group (its slide matches
+    the baseline), the other groups are copies — a single ``rename`` for the
+    copy's slide cell re-mints the whole group (the apply re-binds the
+    companions). When the original cannot be identified, or a duplicate is *not*
+    explained by a copied slide group (e.g. a lone duplicated companion), it is
+    surfaced as an error and left for manual resolution — never guessed.
+    """
+    excluded: set[int] = set()  # id() of copy-group cells sharing the slide's id
+    errored_ids: set[str] = set()
+
+    groups_by_slide_id: dict[str, list[list[CurrentCell]]] = {}
+    for group in _slide_groups(current):
+        head = group[0]
+        if head.role in _SLIDE_ROLES and head.slide_id is not None:
+            groups_by_slide_id.setdefault(head.slide_id, []).append(group)
+
+    for sid, group_list in groups_by_slide_id.items():
+        if len(group_list) < 2:
             continue
-        by_key[key] = cell
-    return by_key, idless, collisions
+        slide_role = group_list[0][0].role
+        base = base_index.get((sid, slide_role))
+        candidates = [
+            g for g in group_list if base is not None and g[0].content_hash == base.content_hash
+        ]
+        if base is None or not candidates:
+            plan.issues.append(
+                PlanIssue(
+                    severity="error",
+                    slide_id=sid,
+                    reason=f"slide_id appears {len(group_list)}x and the original cannot be "
+                    "identified (no baseline match) — resolve the duplicate manually",
+                )
+            )
+            errored_ids.add(sid)
+            for group in group_list:
+                # Only the slide cells carry the duplicated id here; drop them
+                # from pairing (surfaced as an error). Companions with a
+                # different id stay and are paired/added normally.
+                excluded.update(id(c) for c in group if c.slide_id == sid)
+            continue
+        original = min(candidates, key=lambda g: abs(g[0].position - base.position))
+        for group in group_list:
+            if group is original:
+                continue
+            slide_cell = group[0]
+            plan.proposals.append(
+                Proposal(
+                    kind="rename",
+                    role=slide_cell.role,
+                    direction=direction,
+                    slide_id=sid,
+                    content_hash=slide_cell.content_hash,
+                    translation_pending=True,
+                    source_position=slide_cell.position,
+                    reason="copy-pasted duplicate slide group — re-minted as a new slide",
+                )
+            )
+            # Exclude only the cells that actually carry the duplicated id (the
+            # slide and its same-id companions). A companion whose id differs is
+            # not part of this group's identity — leave it to normal pairing so
+            # it can't become a silent cross-deck orphan.
+            excluded.update(id(c) for c in group if c.slide_id == sid)
+
+    singular: dict[tuple[str, str], CurrentCell] = {}
+    for key, cells in by_key.items():
+        survivors = [c for c in cells if id(c) not in excluded]
+        if not survivors:
+            continue
+        if len(survivors) == 1:
+            singular[key] = survivors[0]
+        elif key[0] not in errored_ids:
+            sid, role = key
+            plan.issues.append(
+                PlanIssue(
+                    severity="error",
+                    slide_id=sid,
+                    reason=f"role={role!r} slide_id appears {len(survivors)}x without a copied "
+                    "slide group to explain it (a lone duplicated companion?) — resolve manually",
+                )
+            )
+    # Keys that had cells but produced no original (errored) must be dropped
+    # from the diff universe, else they re-enter as phantom `remove`s.
+    error_keys = set(by_key) - set(singular)
+    return singular, error_keys
 
 
 def _baseline_index(
@@ -394,37 +517,37 @@ def classify_changes(
     """
     plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source=baseline_source)
 
-    de_by_key, de_idless, de_collisions = _index_by_key(de_current)
-    en_by_key, en_idless, en_collisions = _index_by_key(en_current)
-
-    for key in sorted(de_collisions | en_collisions):
-        sid, role = key
-        side = "DE" if key in de_collisions else "EN"
-        if key in de_collisions and key in en_collisions:
-            side = "both decks"
-        plan.issues.append(
-            PlanIssue(
-                severity="error",
-                slide_id=sid,
-                reason=f"role={role!r} slide_id appears more than once on {side}; "
-                "ids must be unique within a deck — resolve the collision",
-            )
-        )
+    de_lists, de_idless = _index_by_key(de_current)
+    en_lists, en_idless = _index_by_key(en_current)
 
     has_baseline = de_baseline is not None and en_baseline is not None
+    de_base = _baseline_index(de_baseline)
+    en_base = _baseline_index(en_baseline)
+
+    # Collapse duplicate-id cells to one original each, emitting a `rename` for
+    # every copy (or an error when the original can't be identified). Duplicate
+    # resolution only renames against a real both-deck baseline; with a missing
+    # or asymmetric baseline it gets no baseline (every duplicate then errors).
+    dup_de_base = de_base if has_baseline else {}
+    dup_en_base = en_base if has_baseline else {}
+    de_by_key, de_error_keys = _resolve_duplicates(
+        de_current, de_lists, dup_de_base, "de->en", plan
+    )
+    en_by_key, en_error_keys = _resolve_duplicates(
+        en_current, en_lists, dup_en_base, "en->de", plan
+    )
+
     if not has_baseline:
-        _classify_cold(
-            plan, de_by_key, en_by_key, de_idless, en_idless, de_collisions | en_collisions
-        )
+        _classify_cold(plan, de_by_key, en_by_key, de_idless, en_idless, set())
         _append_idless_adds(plan, de_idless, en_idless)
         plan.proposals.sort(key=_proposal_sort_key)
         return plan
 
-    de_base = _baseline_index(de_baseline)
-    en_base = _baseline_index(en_baseline)
-
-    excluded = de_collisions | en_collisions
-    keys = (set(de_by_key) | set(en_by_key) | set(de_base) | set(en_base)) - excluded
+    # Drop keys an errored duplicate left unresolved, so a still-in-baseline key
+    # whose original was dropped does not re-enter the diff as a phantom remove.
+    keys = (set(de_by_key) | set(en_by_key) | set(de_base) | set(en_base)) - (
+        de_error_keys | en_error_keys
+    )
 
     states_de: dict[tuple[str, str], str] = {}
     states_en: dict[tuple[str, str], str] = {}
@@ -690,7 +813,7 @@ def _edit(
     )
 
 
-_KIND_ORDER = {"conflict": 0, "remove": 1, "edit": 2, "move": 3, "add": 4}
+_KIND_ORDER = {"conflict": 0, "remove": 1, "edit": 2, "move": 3, "add": 4, "rename": 5}
 
 
 def _proposal_sort_key(p: Proposal) -> tuple:

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -1,0 +1,370 @@
+"""Interactive review walker over a :class:`~clm.slides.sync_plan.SyncPlan`.
+
+Phase 4 (part 2) of Issue #166. The Phase 1 classifier emits a typed plan of
+``add`` / ``edit`` / ``move`` / ``remove`` / ``rename`` / ``conflict``
+proposals; this module renders each one and lets the author decide what to do
+before the apply engine writes anything:
+
+- **edit / remove / move** — ``[a]pply`` / ``[s]kip`` / ``[q]uit``. Skipping
+  defers the proposal (the watermark will not advance over it, so it re-surfaces
+  next run rather than being silently baselined).
+- **conflict** (the same ``slide_id`` drifted on both decks since the last sync)
+  — a two-up of the current DE and EN bodies plus
+  ``[d]e-wins`` / ``[e]n-wins`` / ``[s]kip``. A winner is propagated as an
+  ordinary edit; skip leaves both decks untouched and lists the conflict.
+- **add / rename** — non-destructive, so they are auto-applied (translate +
+  insert + mint id). They are still rendered so the author sees them; the
+  generated counterpart is reviewed in the resulting ``git diff`` (the design's
+  primary review surface).
+
+The walker collects per-proposal decisions during the walk and then calls
+:func:`~clm.slides.sync_apply.apply_plan` **once** (the apply is atomic and
+flushes each deck a single time). It performs no writes itself.
+
+``prompt_fn`` and ``echo`` are injected so the test suite can drive the walker
+with a scripted list of answers and capture output without a real terminal.
+The live ``clm slides sync`` wiring is Phase 5; this module is tested in
+isolation against a mocked judge / translator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import click
+
+from clm.slides.sync_apply import (
+    DECISION_APPLY,
+    DECISION_DE_WINS,
+    DECISION_EN_WINS,
+    DECISION_SKIP,
+    ApplyResult,
+    apply_plan,
+    content_index,
+)
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import SyncWatermarkCache
+    from clm.infrastructure.llm.ollama_client import SyncJudge
+    from clm.slides.sync_plan import Proposal, SyncPlan
+    from clm.slides.sync_translate import SlideTranslator
+
+
+__all__ = [
+    "APPLY",
+    "AUTO",
+    "DE_WINS",
+    "DEFERRED",
+    "EN_WINS",
+    "QUIT",
+    "SKIP",
+    "PlanWalkResult",
+    "WalkerAction",
+    "WalkerOptions",
+    "render_proposal",
+    "run_plan_walker",
+]
+
+
+# Walker action keys — bare strings so a test can scrub the action log trivially.
+APPLY = "apply"
+SKIP = "skip"
+QUIT = "quit"
+DE_WINS = "de-wins"
+EN_WINS = "en-wins"
+AUTO = "auto"  # id-less add / rename, applied without prompting
+DEFERRED = "deferred"  # id-carrying add — apply_plan defers it (follow-up scope)
+
+_GATED_KINDS = {"edit", "remove", "move"}
+_AUTO_KINDS = {"add", "rename"}
+
+
+@dataclass
+class WalkerAction:
+    """One decision the walker recorded for a proposal (telemetry / tests)."""
+
+    kind: str
+    slide_id: str | None
+    role: str
+    direction: str | None
+    action: str  # APPLY / SKIP / QUIT / DE_WINS / EN_WINS / AUTO
+
+
+@dataclass
+class WalkerOptions:
+    """Knobs for one walker pass.
+
+    ``prompt_fn`` returns the raw answer for one prompt (the walker reads its
+    first character); ``echo`` receives each line of output. Defaults dispatch
+    to :func:`click.prompt` / :func:`click.echo`.
+    """
+
+    prompt_fn: Callable[[str], str] | None = None
+    echo: Callable[[str], None] | None = None
+
+
+@dataclass
+class PlanWalkResult:
+    """Outcome of an interactive walk: the apply result plus the decision log."""
+
+    plan: SyncPlan
+    apply_result: ApplyResult
+    actions: list[WalkerAction] = field(default_factory=list)
+
+    def _count(self, *, kinds: set[str] | None = None, action: str | None = None) -> int:
+        return sum(
+            1
+            for a in self.actions
+            if (kinds is None or a.kind in kinds) and (action is None or a.action == action)
+        )
+
+    @property
+    def accepted(self) -> int:
+        """Gated proposals the author accepted (edit / remove / move).
+
+        A *decision* count, not an outcome — an accepted edit can still error
+        (e.g. its target cell is missing). Actual writes are in
+        ``apply_result.applied_*``; the two summary lines keep the distinction.
+        """
+        return self._count(action=APPLY)
+
+    @property
+    def conflicts_resolved(self) -> int:
+        return self._count(action=DE_WINS) + self._count(action=EN_WINS)
+
+    @property
+    def skipped(self) -> int:
+        """Gated proposals + conflicts the author skipped."""
+        return self._count(action=SKIP)
+
+    @property
+    def auto_applied(self) -> int:
+        """id-less add / rename proposals routed for auto-apply.
+
+        Excludes id-carrying adds, which the engine defers (they carry the
+        :data:`DEFERRED` action). Reflects what was *routed*; what was actually
+        written is ``apply_result.applied_add + apply_result.applied_rename``.
+        """
+        return self._count(action=AUTO)
+
+    @property
+    def unvisited(self) -> int:
+        """Proposals not reached because the author quit the walk."""
+        return self._count(action=QUIT)
+
+    @property
+    def exit_code(self) -> int:
+        """0 = clean, 1 = needs review (deferred), 2 = structural / LLM error.
+
+        Mirrors the legacy ``clm slides sync`` buckets: a structural plan issue
+        or an apply-time error (LLM unavailable, residual duplicate, cross-deck
+        orphan) is exit 2; anything merely deferred (a skipped proposal or an
+        unresolved conflict) is exit 1.
+        """
+        if self.plan.has_errors or self.apply_result.has_errors:
+            return 2
+        if self.apply_result.deferred > 0:
+            return 1
+        return 0
+
+    def summary(self) -> list[str]:
+        """Headline lines for the end-of-run report (Phase 5 prints these).
+
+        Two lines that never conflate intent with outcome: the first reports the
+        author's *decisions* on the gated kinds, the second reports what the
+        engine actually *did* (including auto-applied adds/renames, deferrals,
+        and errors).
+        """
+        r = self.apply_result
+        return [
+            f"walker decisions: {self.accepted} accepted, "
+            f"{self.conflicts_resolved} conflict(s) resolved, "
+            f"{self.skipped} skipped, "
+            f"{self.unvisited} unvisited (quit).",
+            f"applied: {r.applied_edit} edit, {r.applied_remove} remove, "
+            f"{r.applied_move} move, {r.applied_add} add, {r.applied_rename} rename; "
+            f"{r.in_sync} already in sync; {r.deferred} deferred; "
+            f"{len(r.errors)} error(s); "
+            f"watermark {'advanced' if r.watermark_recorded else 'held'}.",
+        ]
+
+
+def run_plan_walker(
+    plan: SyncPlan,
+    *,
+    judge: SyncJudge | None,
+    translator: SlideTranslator | None = None,
+    watermark_cache: SyncWatermarkCache | None = None,
+    options: WalkerOptions | None = None,
+) -> PlanWalkResult:
+    """Walk ``plan``'s proposals, prompt per proposal, then apply once.
+
+    Returns a :class:`PlanWalkResult` carrying the apply outcome and the
+    per-proposal decision log. The apply (and therefore every file write) runs
+    once, after the whole walk, so quitting mid-walk simply defers the
+    not-yet-decided gated proposals.
+    """
+    options = options or WalkerOptions()
+    prompt_fn = options.prompt_fn or _default_prompt
+    echo = options.echo or click.echo
+
+    de_bodies = content_index(plan.de_path, "de")
+    en_bodies = content_index(plan.en_path, "en")
+
+    decisions: dict[int, str] = {}
+    actions: list[WalkerAction] = []
+    quitting = False
+
+    for proposal in plan.proposals:
+        kind = proposal.kind
+
+        if kind in _AUTO_KINDS:
+            echo(render_proposal(proposal, de_bodies, en_bodies))
+            # An id-carrying "add" is a missing-counterpart case that apply_plan
+            # defers unconditionally (out of v1 scope) — never claim it was
+            # applied. id-less adds and renames are auto-applied (and reviewed in
+            # the resulting git diff).
+            if kind == "add" and proposal.slide_id is not None:
+                echo("  → deferred (id-carrying add; missing-counterpart follow-up)")
+                actions.append(_action(proposal, DEFERRED))
+            else:
+                echo("  → will auto-apply (add/rename; counterpart reviewed in git diff)")
+                actions.append(_action(proposal, AUTO))
+            continue
+
+        if quitting:
+            decisions[id(proposal)] = DECISION_SKIP
+            actions.append(_action(proposal, QUIT))
+            continue
+
+        echo(render_proposal(proposal, de_bodies, en_bodies))
+
+        if kind == "conflict":
+            choice = _prompt_conflict(prompt_fn, echo)
+        else:  # edit / remove / move
+            choice = _prompt_gated(prompt_fn, echo)
+
+        if choice == QUIT:
+            quitting = True
+            decisions[id(proposal)] = DECISION_SKIP
+            actions.append(_action(proposal, QUIT))
+            continue
+
+        decisions[id(proposal)] = _DECISION_FOR_CHOICE[choice]
+        actions.append(_action(proposal, choice))
+        echo(f"  {choice} {_label(proposal)}")
+
+    apply_result = apply_plan(
+        plan,
+        judge=judge,
+        translator=translator,
+        watermark_cache=watermark_cache,
+        decisions=decisions,
+    )
+    return PlanWalkResult(plan=plan, apply_result=apply_result, actions=actions)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_proposal(
+    proposal: Proposal,
+    de_bodies: dict[tuple[str, str], str],
+    en_bodies: dict[tuple[str, str], str],
+) -> str:
+    """Render one proposal as a human-readable review block.
+
+    ``edit`` and ``conflict`` get a two-up of the current DE and EN bodies so
+    the author can judge the change / pick a winner; the deterministic single
+    structural kinds get a one-line description (their effect is reviewed in the
+    resulting ``git diff``).
+    """
+    lines = [_header(proposal)]
+    if proposal.reason:
+        lines.append(f"  reason: {proposal.reason}")
+
+    if proposal.kind in ("edit", "conflict") and proposal.slide_id is not None:
+        key = (proposal.slide_id, proposal.role)
+        lines.extend(_two_up(de_bodies.get(key, ""), en_bodies.get(key, "")))
+    return "\n".join(lines)
+
+
+def _header(proposal: Proposal) -> str:
+    sid = proposal.slide_id if proposal.slide_id is not None else "(id-less)"
+    direction = f" {proposal.direction}" if proposal.direction else ""
+    pending = " [translation pending]" if proposal.translation_pending else ""
+    label = "CONFLICT" if proposal.kind == "conflict" else proposal.kind
+    return f"{label}{direction} {sid}/{proposal.role}{pending}"
+
+
+def _two_up(de_body: str, en_body: str) -> list[str]:
+    out = ["  --- DE (current) ---"]
+    out.extend(f"  {line}" for line in de_body.splitlines() or [""])
+    out.append("  --- EN (current) ---")
+    out.extend(f"  {line}" for line in en_body.splitlines() or [""])
+    return out
+
+
+def _label(proposal: Proposal) -> str:
+    sid = proposal.slide_id if proposal.slide_id is not None else "(id-less)"
+    return f"{sid}/{proposal.role}"
+
+
+def _action(proposal: Proposal, action: str) -> WalkerAction:
+    return WalkerAction(
+        kind=proposal.kind,
+        slide_id=proposal.slide_id,
+        role=proposal.role,
+        direction=proposal.direction,
+        action=action,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompting
+# ---------------------------------------------------------------------------
+
+# Map a (non-quit) walk choice to the apply-engine decision it produces.
+_DECISION_FOR_CHOICE = {
+    APPLY: DECISION_APPLY,
+    SKIP: DECISION_SKIP,
+    DE_WINS: DECISION_DE_WINS,
+    EN_WINS: DECISION_EN_WINS,
+}
+
+
+def _default_prompt(message: str) -> str:
+    answer: str = click.prompt(message, default="s", show_default=True)
+    return answer
+
+
+def _prompt_gated(prompt_fn: Callable[[str], str], echo: Callable[[str], None]) -> str:
+    """Prompt until the author picks apply / skip / quit (empty = skip)."""
+    while True:
+        first = (prompt_fn("[a]pply / [s]kip / [q]uit") or "").strip().lower()[:1]
+        if first == "a":
+            return APPLY
+        if first in ("s", ""):
+            return SKIP
+        if first == "q":
+            return QUIT
+        echo("unknown choice; type a / s / q")
+
+
+def _prompt_conflict(prompt_fn: Callable[[str], str], echo: Callable[[str], None]) -> str:
+    """Prompt until the author picks de-wins / en-wins / skip / quit."""
+    while True:
+        first = (prompt_fn("[d]e-wins / [e]n-wins / [s]kip / [q]uit") or "").strip().lower()[:1]
+        if first == "d":
+            return DE_WINS
+        if first == "e":
+            return EN_WINS
+        if first in ("s", ""):
+            return SKIP
+        if first == "q":
+            return QUIT
+        echo("unknown choice; type d / e / s / q")

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -1,0 +1,163 @@
+"""Slide-content translation for the single-language authoring workflow.
+
+Phase 3 of Issue #166. When the author adds a brand-new slide in one language,
+the sync engine translates it into the other language so the decks stay at
+parity (the issue's "full translation, not a stub" decision). This is distinct
+from the edit ``SyncJudge`` (which reconciles an *existing* pair): here there is
+no counterpart yet, so a stronger model is warranted.
+
+The model is fixed to **Claude Sonnet via OpenRouter** for now
+(:data:`DEFAULT_TRANSLATION_MODEL`), routed through a synchronous OpenAI client
+so the apply engine stays synchronous. Per-purpose model configurability is a
+separate investigation (#167). Prompt iteration is expected (#166 Decisions).
+
+The engine depends only on the :class:`SlideTranslator` protocol, so tests drive
+it with :class:`StaticSlideTranslator` and never touch the network.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_TRANSLATION_MODEL",
+    "OpenRouterSlideTranslator",
+    "SlideTranslator",
+    "StaticSlideTranslator",
+    "TranslationError",
+]
+
+# Claude Sonnet via OpenRouter — the voiceover propagate path's precedent.
+DEFAULT_TRANSLATION_MODEL = "anthropic/claude-sonnet-4-6"
+
+
+class TranslationError(Exception):
+    """A new-slide translation could not be produced."""
+
+
+@runtime_checkable
+class SlideTranslator(Protocol):
+    """Produces a target-language body for a brand-new source-language cell."""
+
+    prompt_version: str
+
+    def translate(
+        self,
+        *,
+        source_body: str,
+        source_lang: str,
+        target_lang: str,
+        role: str,
+    ) -> str:
+        """Return the translated cell body (percent-format, comment-prefixed).
+
+        ``source_body`` is the cell body as the parser produces it (markdown
+        lines prefixed with ``# ``). The return value must keep that shape so
+        it slots straight into a percent-format cell. Raises
+        :class:`TranslationError` on failure.
+        """
+        ...
+
+
+@dataclass
+class StaticSlideTranslator:
+    """A deterministic translator for tests and offline runs.
+
+    ``mapping`` keys on the exact ``source_body``; ``default`` is the fallback.
+    With neither, :meth:`translate` raises — mirroring ``StaticSyncJudge``.
+    """
+
+    default: str | None = None
+    mapping: dict[str, str] = field(default_factory=dict)
+    prompt_version: str = "static"
+
+    def translate(
+        self,
+        *,
+        source_body: str,
+        source_lang: str,
+        target_lang: str,
+        role: str,
+    ) -> str:
+        if source_body in self.mapping:
+            return self.mapping[source_body]
+        if self.default is not None:
+            return self.default
+        raise TranslationError(f"no static translation for {source_body!r}")
+
+
+@dataclass
+class OpenRouterSlideTranslator:
+    """LLM-backed translator (synchronous OpenAI client, default Sonnet).
+
+    A v1 implementation: the prompt is intentionally simple and expected to be
+    tuned (#166 Decisions / design note §10). ``api_base`` defaults to
+    OpenRouter; ``api_key`` falls back to the usual env vars in
+    :meth:`_client`.
+    """
+
+    model: str = DEFAULT_TRANSLATION_MODEL
+    api_base: str | None = "https://openrouter.ai/api/v1"
+    api_key: str | None = None
+    temperature: float = 0.2
+    max_tokens: int = 4096
+    prompt_version: str = "translate-v1"
+
+    def _client(self):  # pragma: no cover - thin network adapter
+        import os
+
+        import openai
+
+        key = (
+            self.api_key or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        )
+        return openai.OpenAI(base_url=self.api_base, api_key=key)
+
+    def translate(
+        self,
+        *,
+        source_body: str,
+        source_lang: str,
+        target_lang: str,
+        role: str,
+    ) -> str:  # pragma: no cover - exercised via mocked client / integration
+        system = _SYSTEM_PROMPT.format(
+            source_lang=_LANG_NAMES.get(source_lang, source_lang),
+            target_lang=_LANG_NAMES.get(target_lang, target_lang),
+            role=role,
+        )
+        try:
+            response = self._client().chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": source_body},
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+        except Exception as exc:
+            raise TranslationError(f"translation LLM call failed: {exc}") from exc
+        content = response.choices[0].message.content
+        if not content or not content.strip():
+            raise TranslationError("translation LLM returned empty content")
+        # Strip BOTH ends: a leading newline would inject a blank first line
+        # into the built cell; a trailing one would add a stray blank.
+        return str(content).strip("\n")
+
+
+_LANG_NAMES = {"de": "German", "en": "English"}
+
+_SYSTEM_PROMPT = (
+    "You translate a single slide cell from {source_lang} to {target_lang} for a "
+    "programming course. The cell is a {role} cell in Jupyter percent-format: every "
+    "line is prefixed with '# ' and may contain Markdown (headings like '# ## Title', "
+    "bullet lists, inline code). Translate ONLY the natural-language prose. Preserve "
+    "verbatim: the '# ' line prefixes, Markdown structure and heading levels, code "
+    "spans and identifiers, URLs, and slide directives. Do not add, drop, or reorder "
+    "lines. Return only the translated cell body, no commentary, no code fences."
+)

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -66,6 +66,26 @@ def _cell_matches(cell: RawCell, slide_id: str, role: str) -> bool:
     return cell.metadata.slide_id == slide_id and role_of(cell.metadata) == role
 
 
+def _trailing_blanks(cell: RawCell) -> int:
+    """Count the blank body lines at the end of ``cell``."""
+    n = 0
+    for line in reversed(cell.lines[1:]):
+        if line == "":
+            n += 1
+        else:
+            break
+    return n
+
+
+def _set_trailing_blanks(cell: RawCell, n: int) -> None:
+    """Force ``cell`` to end with exactly ``n`` blank body lines."""
+    body = cell.lines[1:]
+    while body and body[-1] == "":
+        body.pop()
+    body.extend([""] * n)
+    cell.lines = [cell.lines[0], *body]
+
+
 def target_path_for_outcome(outcome: PairOutcome, result: SyncResult) -> Path:
     """Return the file path the outcome would write to."""
     if outcome.direction == "de->en":
@@ -209,6 +229,86 @@ class FileState:
                 self.dirty = True
                 return True
         return False
+
+    def separator_blanks(self) -> int:
+        """The deck's inter-cell blank-line gap (0 = tight, 1 = blank-separated).
+
+        Read from the first cell, which is always non-last when there are two
+        or more cells, so its trailing-blank count reflects the *separator*
+        convention rather than the terminal-newline artifact the last cell
+        carries. Compute it **before** a structural mutation. Non-uniform
+        decks fall back to the first gap (documented limitation).
+        """
+        if len(self.cells) < 2:
+            return 0
+        return _trailing_blanks(self.cells[0])
+
+    def insert_after(self, slide_id: str, role: str, new_cell: RawCell) -> bool:
+        """Insert ``new_cell`` immediately after the ``(slide_id, role)`` cell.
+
+        Returns ``False`` when the anchor cell is absent. Used by the Issue
+        #166 add path to place a translated counterpart next to its neighbour.
+        """
+        sep = self.separator_blanks()
+        original_last = self.cells[-1] if self.cells else None
+        for i, cell in enumerate(self.cells):
+            if _cell_matches(cell, slide_id, role):
+                self.cells.insert(i + 1, new_cell)
+                self.dirty = True
+                self._place_inserted(new_cell, original_last, sep)
+                return True
+        return False
+
+    def insert_before_first_sync_cell(self, new_cell: RawCell) -> None:
+        """Insert ``new_cell`` ahead of the first sync cell (after the head).
+
+        The anchor for an add with no preceding shared cell — it becomes the
+        deck's first slide, sitting after any j2 header / intro cells but
+        before the existing slides/narrative. Appends only when the deck has no
+        sync cell at all.
+        """
+        sep = self.separator_blanks()
+        original_last = self.cells[-1] if self.cells else None
+        for i, cell in enumerate(self.cells):
+            if role_of(cell.metadata) is not None:
+                self.cells.insert(i, new_cell)
+                self.dirty = True
+                self._place_inserted(new_cell, original_last, sep)
+                return
+        self.cells.append(new_cell)
+        self.dirty = True
+        self._place_inserted(new_cell, original_last, sep)
+
+    def _place_inserted(self, new_cell: RawCell, original_last: RawCell | None, sep: int) -> None:
+        """Give ``new_cell`` the deck's separator (or none, if it is now last).
+
+        When ``new_cell`` lands last, it carries no explicit trailing blank —
+        :meth:`flush` restores the terminal newline — and the cell it displaced
+        from the end is normalised to the separator (its terminal artifact is
+        not a real gap).
+        """
+        if self.cells and self.cells[-1] is new_cell:
+            _set_trailing_blanks(new_cell, 0)
+            if original_last is not None:
+                self.normalize_displaced_last(original_last, sep)
+        else:
+            _set_trailing_blanks(new_cell, sep)
+
+    def normalize_displaced_last(self, original_last: RawCell, sep: int) -> None:
+        """Normalise the trailing blanks of a cell pushed off the end.
+
+        ``split_cells`` parks the file's final newline as a trailing ``""`` on
+        the last cell. When a move/insert pushes that cell off the end, that
+        ``""`` is the terminal artifact, not a real separator — reset its
+        trailing blanks to the deck ``sep`` (so a tight deck loses it and a
+        blank-separated deck keeps one). :meth:`flush` restores the terminal
+        newline on whatever ends up last. No-op when still last.
+        """
+        if not self.ends_with_newline or not self.cells:
+            return
+        if self.cells[-1] is original_last:
+            return
+        _set_trailing_blanks(original_last, sep)
 
     def flush(self) -> None:
         if not self.dirty:

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -4,8 +4,11 @@ Used by:
 
 - :mod:`clm.slides.sync_walker` — interactive ``--interactive`` walker
 - :mod:`clm.slides.sync_trivial` — ``--apply --trivial`` auto-applier
+- :mod:`clm.slides.sync_apply` — Issue #166 authoring apply engine
+  (drives ``find_cell`` / ``replace_cell_body`` / ``delete_cell``, keyed by
+  ``(slide_id, role)`` rather than line number)
 
-Both paths must keep cell headers and trailing-blank padding verbatim so
+These paths must keep cell headers and trailing-blank padding verbatim so
 the surrounding bytes never shift; the v1 / Phase 5 round-trip
 invariant is what makes `clm slides split` / `unify` work, and the
 sync write paths inherit that contract. All three primitives here are
@@ -20,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from clm.notebooks.slide_parser import CellMetadata
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
 
 if TYPE_CHECKING:
@@ -31,8 +35,35 @@ __all__ = [
     "FileState",
     "cell_content_hash",
     "record_snapshot",
+    "role_of",
     "target_path_for_outcome",
 ]
+
+# Tags that identify a sync-relevant cell's role. Duplicated from
+# ``clm.slides.sync`` / ``clm.slides.sync_plan`` to keep this low-level
+# write module free of an import cycle (sync_plan imports this module).
+_SYNC_ROLE_TAGS = {"slide", "subslide", "voiceover", "notes"}
+
+
+def role_of(metadata: CellMetadata) -> str | None:
+    """Return the sync role of a cell from its metadata, or ``None``.
+
+    Public so :mod:`clm.slides.sync_apply` reuses the exact same predicate
+    instead of keeping its own copy.
+    """
+    if metadata.is_j2:
+        return None
+    if metadata.cell_type != "markdown":
+        return None
+    for tag in metadata.tags:
+        if tag in _SYNC_ROLE_TAGS:
+            return tag
+    return None
+
+
+def _cell_matches(cell: RawCell, slide_id: str, role: str) -> bool:
+    """Whether ``cell`` carries ``slide_id`` in sync ``role``."""
+    return cell.metadata.slide_id == slide_id and role_of(cell.metadata) == role
 
 
 def target_path_for_outcome(outcome: PairOutcome, result: SyncResult) -> Path:
@@ -107,12 +138,18 @@ class FileState:
     preamble: str
     cells: list[RawCell]
     dirty: bool = False
+    ends_with_newline: bool = True
 
     @classmethod
     def load(cls, path: Path) -> FileState:
         text = path.read_text(encoding="utf-8")
         preamble, cells = split_cells(text)
-        return cls(path=path, preamble=preamble, cells=cells)
+        return cls(
+            path=path,
+            preamble=preamble,
+            cells=cells,
+            ends_with_newline=text.endswith("\n"),
+        )
 
     def replace_body(self, outcome: PairOutcome, new_text: str) -> None:
         """Replace the body of the target cell named by ``outcome``.
@@ -133,10 +170,55 @@ class FileState:
             "file changed since the sync pass parsed it?"
         )
 
+    def find_cell(self, slide_id: str, role: str) -> RawCell | None:
+        """Return the cell carrying ``slide_id`` in ``role``, or ``None``.
+
+        Used by the Issue #166 apply engine, whose proposals are keyed by
+        ``(slide_id, role)`` rather than by line number — so deletes and
+        edits stay correct even as earlier operations shift line numbers.
+        """
+        for cell in self.cells:
+            if _cell_matches(cell, slide_id, role):
+                return cell
+        return None
+
+    def replace_cell_body(self, slide_id: str, role: str, new_text: str) -> bool:
+        """Rewrite the body of the ``(slide_id, role)`` cell in place.
+
+        Returns ``False`` when no such cell exists. Header and trailing
+        blank-line padding stay verbatim (same contract as
+        :meth:`replace_body`).
+        """
+        cell = self.find_cell(slide_id, role)
+        if cell is None:
+            return False
+        self._rewrite_cell_body(cell, new_text)
+        self.dirty = True
+        return True
+
+    def delete_cell(self, slide_id: str, role: str) -> bool:
+        """Remove the ``(slide_id, role)`` cell, lines and all.
+
+        Returns ``False`` when no such cell exists. The cell owns its
+        boundary line, body, and trailing blanks, so dropping it from the
+        list leaves the surrounding cells' bytes untouched.
+        """
+        for i, cell in enumerate(self.cells):
+            if _cell_matches(cell, slide_id, role):
+                del self.cells[i]
+                self.dirty = True
+                return True
+        return False
+
     def flush(self) -> None:
         if not self.dirty:
             return
         text = reconstruct(self.preamble, self.cells)
+        # Deleting the file's last cell drops the trailing-newline element
+        # that ``split_cells`` parked on it; restore the original terminal
+        # newline so a remove never emits a "No newline at end of file" diff.
+        if self.ends_with_newline and not text.endswith("\n"):
+            text += "\n"
         self.path.write_text(text, encoding="utf-8", newline="\n")
         self.dirty = False
 

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -1,14 +1,28 @@
-"""CLI smoke tests for ``clm slides sync``."""
+"""CLI tests for ``clm slides sync`` (Issue #166 engine, Phase 5).
+
+The live command now runs the single-language authoring engine: it diffs both
+decks against the structural watermark, decides direction per cell, and — by
+default — writes the agreed changes to the working tree. ``--dry-run`` previews,
+``--interactive`` prompts. There is no global ``--source-lang`` and no
+``--apply`` / ``--trivial`` (those were removed in Phase 5).
+
+These tests drive the CLI surface with a watermark seeded directly into the
+cache and a :class:`StaticSyncJudge` patched in, so they exercise flag parsing,
+engine wiring, file writes, and watermark advance without a live LLM.
+"""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
-from clm.cli.commands.slides_sync import slides_sync_cmd
-from clm.infrastructure.llm.cache import SyncSnapshotCache
+from clm.cli.commands.slides_sync import CACHE_DB_NAME, slides_sync_cmd
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import ordered_sync_cells
 
 
 @pytest.fixture
@@ -21,534 +35,343 @@ def cli_runner():
         return CliRunner()
 
 
-@pytest.fixture
-def pair(tmp_path: Path) -> tuple[Path, Path]:
-    """Write a minimal split DE/EN pair to disk and return both paths."""
-    de = '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n# ## Einleitung\n'
-    en = '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## Introduction\n'
-    de_path = tmp_path / "slides_intro.de.py"
-    en_path = tmp_path / "slides_intro.en.py"
-    de_path.write_text(de, encoding="utf-8")
-    en_path.write_text(en, encoding="utf-8")
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cell(lang: str, sid: str, body: str, *, role: str = "slide") -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["{role}"] slide_id="{sid}"\n{body}\n'
+
+
+def _write_pair(
+    tmp_path: Path, de_text: str, en_text: str, *, stem: str = "slides_intro"
+) -> tuple[Path, Path]:
+    de_path = tmp_path / f"{stem}.de.py"
+    en_path = tmp_path / f"{stem}.en.py"
+    de_path.write_text(de_text, encoding="utf-8")
+    en_path.write_text(en_text, encoding="utf-8")
     return de_path, en_path
 
 
-class TestArgumentParsing:
-    def test_missing_source_lang_errors_outside_git(self, cli_runner: CliRunner, pair, tmp_path):
-        """With no snapshot rows and no git history, inference fails and
-        the CLI surfaces an actionable error pointing at --source-lang."""
-        de_path, en_path = pair
+def _seed_watermark(
+    cache_dir: Path,
+    de_path: Path,
+    en_path: Path,
+    *,
+    de_text: str,
+    en_text: str,
+) -> None:
+    """Record ``(de_text, en_text)`` as the last-synced baseline for the pair.
+
+    Mirrors ``sync_apply._record_watermark`` exactly (same ``ordered_sync_cells``
+    + ``content_hash``), so the classifier sees a deck whose current on-disk
+    content differs from this baseline as *edited*.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    wm = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
+    try:
+        for lang, text in (("de", de_text), ("en", en_text)):
+            cells = ordered_sync_cells(parse_cells(text), lang)
+            wm.put_deck(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                lang=lang,
+                cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            )
+    finally:
+        wm.close()
+
+
+def _stub_judge(
+    monkeypatch, proposed_text: str, *, verdict: str = "update", reason: str = ""
+) -> None:
+    """Patch the CLI to skip the Ollama liveness check and use a static judge."""
+    from clm.cli.commands import slides_sync as cmd
+    from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+    proposal = SyncProposal(verdict=verdict, proposed_text=proposed_text, reason=reason)
+    monkeypatch.setattr(cmd, "is_available", lambda _judge: True)
+    monkeypatch.setattr(
+        cmd,
+        "OllamaSyncJudge",
+        lambda **_kw: StaticSyncJudge(default_proposal=proposal),
+    )
+
+
+def _combined(result) -> str:
+    return (result.stderr or "") + (result.output or "")
+
+
+def _json_payload(result) -> dict:
+    # On Click 8.2+ a stderr warning can precede the JSON body when the runner
+    # falls back to a merged stream; locate the object by its opening brace.
+    brace = result.output.find("{")
+    assert brace >= 0, f"no JSON object in CLI output:\n{result.output}"
+    return json.loads(result.output[brace:])
+
+
+# A reusable edit scenario: DE drifted from the watermark, EN unchanged.
+_DE_BASE = _cell("de", "intro", "# ## Einleitung")
+_EN_BASE = _cell("en", "intro", "# ## Introduction")
+_DE_EDITED = _cell("de", "intro", "# ## Einleitung\n# - Punkt eins")
+_EN_PROPOSAL = "# ## Introduction\n# - Point one"
+
+
+def _edit_scenario(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Seed a watermark, then leave DE edited and EN at baseline on disk."""
+    cache_dir = tmp_path / "cache"
+    de_path, en_path = _write_pair(tmp_path, _DE_EDITED, _EN_BASE)
+    _seed_watermark(cache_dir, de_path, en_path, de_text=_DE_BASE, en_text=_EN_BASE)
+    return de_path, en_path, cache_dir
+
+
+# ---------------------------------------------------------------------------
+# Removed flags (Phase 5 hard break)
+# ---------------------------------------------------------------------------
+
+
+class TestRemovedFlags:
+    @pytest.mark.parametrize("flag", ["--source-lang", "--apply", "--trivial"])
+    def test_legacy_flag_is_rejected(self, cli_runner: CliRunner, tmp_path: Path, flag: str):
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        extra = ["de"] if flag == "--source-lang" else []
         result = cli_runner.invoke(
             slides_sync_cmd,
-            [str(de_path), str(en_path), "--no-cache"],
+            [str(de_path), str(en_path), flag, *extra, "--no-cache"],
         )
-        assert result.exit_code != 0
-        assert "source-lang" in (result.stderr or result.output).lower()
+        assert result.exit_code == 2
+        combined = _combined(result).lower()
+        assert "no such option" in combined or flag in combined
 
-    def test_invalid_source_lang_errors(self, cli_runner: CliRunner, pair):
-        de_path, en_path = pair
+
+# ---------------------------------------------------------------------------
+# Dry-run preview
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_previews_edit_without_writing(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        before = en_path.read_text(encoding="utf-8")
+
         result = cli_runner.invoke(
             slides_sync_cmd,
-            [str(de_path), str(en_path), "--source-lang", "fr"],
+            [str(de_path), str(en_path), "--dry-run", "--cache-dir", str(cache_dir)],
         )
-        assert result.exit_code != 0
-        combined = (result.stderr or "") + (result.output or "")
-        assert "fr" in combined.lower() or "invalid" in combined.lower()
 
-    def test_missing_paths_errors(self, cli_runner: CliRunner):
-        result = cli_runner.invoke(slides_sync_cmd, ["--source-lang", "de"])
-        assert result.exit_code != 0
+        # An edit is proposed → exit 1; nothing on disk changed.
+        assert result.exit_code == 1, result.output
+        assert "edit" in result.output
+        assert "de->en" in result.output
+        assert en_path.read_text(encoding="utf-8") == before
 
-    def test_nonexistent_path_errors(self, cli_runner: CliRunner, tmp_path: Path):
+    def test_dry_run_json_shape(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
         result = cli_runner.invoke(
             slides_sync_cmd,
-            [
-                str(tmp_path / "missing.de.py"),
-                str(tmp_path / "missing.en.py"),
-                "--source-lang",
-                "de",
-            ],
+            [str(de_path), str(en_path), "--dry-run", "--json", "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 1
+        payload = _json_payload(result)
+        assert payload["mode"] == "dry-run"
+        assert payload["exit_code"] == 1
+        assert payload["apply"] is None
+        assert payload["walker"] is None
+        assert payload["plan"]["baseline_source"] == "watermark"
+        assert payload["plan"]["counts"]["edit"] == 1
+        assert payload["plan"]["proposals"][0]["direction"] == "de->en"
+
+
+# ---------------------------------------------------------------------------
+# Default write-to-tree apply
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def test_default_apply_writes_target(self, cli_runner: CliRunner, tmp_path: Path, monkeypatch):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Point one" in en_path.read_text(encoding="utf-8")
+        assert "applied: 1 edit" in result.output
+        assert "watermark advanced" in result.output
+
+    def test_apply_json_shape(self, cli_runner: CliRunner, tmp_path: Path, monkeypatch):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--json", "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0
+        payload = _json_payload(result)
+        assert payload["mode"] == "apply"
+        assert payload["apply"]["applied"]["edit"] == 1
+        assert payload["apply"]["applied"]["total"] == 1
+        assert payload["apply"]["watermark_recorded"] is True
+        assert payload["apply"]["errors"] == []
+
+    def test_apply_then_rerun_is_idempotent_noop(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        first = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+        assert first.exit_code == 0, first.output
+
+        # The watermark advanced to the now-synced state, so a second run sees
+        # zero changes.
+        second = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--json", "--cache-dir", str(cache_dir)],
+        )
+        assert second.exit_code == 0
+        payload = _json_payload(second)
+        assert payload["plan"]["counts"]["edit"] == 0
+        assert payload["apply"]["applied"]["total"] == 0
+
+    def test_both_sides_edited_is_deferred_conflict(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        cache_dir = tmp_path / "cache"
+        de_edited = _cell("de", "intro", "# ## Einleitung\n# - DE neu")
+        en_edited = _cell("en", "intro", "# ## Introduction\n# - EN new")
+        de_path, en_path = _write_pair(tmp_path, de_edited, en_edited)
+        _seed_watermark(cache_dir, de_path, en_path, de_text=_DE_BASE, en_text=_EN_BASE)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+
+        # A both-sides edit is isolated as a conflict: deferred, both decks
+        # untouched, watermark held.
+        assert result.exit_code == 1, result.output
+        assert "conflict" in result.output
+        assert "watermark held" in result.output
+        assert de_path.read_text(encoding="utf-8") == de_edited
+        assert en_path.read_text(encoding="utf-8") == en_edited
+
+
+# ---------------------------------------------------------------------------
+# Interactive
+# ---------------------------------------------------------------------------
+
+
+class TestInteractive:
+    def test_interactive_apply_writes_and_reports(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--interactive", "--cache-dir", str(cache_dir)],
+            input="a\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Point one" in en_path.read_text(encoding="utf-8")
+        assert "1 accepted" in result.output
+        assert "applied: 1 edit" in result.output
+
+    def test_interactive_skip_defers(self, cli_runner: CliRunner, tmp_path: Path, monkeypatch):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        before = en_path.read_text(encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--interactive", "--cache-dir", str(cache_dir)],
+            input="s\n",
+        )
+
+        # Skipped → deferred → exit 1; EN untouched; watermark held.
+        assert result.exit_code == 1, result.output
+        assert en_path.read_text(encoding="utf-8") == before
+        assert "1 skipped" in result.output
+        assert "watermark held" in result.output
+
+    def test_interactive_and_json_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--interactive", "--json", "--no-cache"],
         )
         assert result.exit_code != 0
+        assert "mutually exclusive" in _combined(result)
+
+    def test_interactive_and_dry_run_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--interactive", "--dry-run", "--no-cache"],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in _combined(result)
+
+
+# ---------------------------------------------------------------------------
+# LLM unavailable
+# ---------------------------------------------------------------------------
 
 
 class TestOllamaUnavailable:
-    """When Ollama is not reachable, every pair becomes an error
-    outcome. Exit code is 2 (structural error)."""
+    def test_unreachable_ollama_records_edit_errors(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
 
-    def test_unreachable_ollama_records_errors(self, cli_runner: CliRunner, pair, tmp_path: Path):
-        de_path, en_path = pair
         result = cli_runner.invoke(
             slides_sync_cmd,
             [
                 str(de_path),
                 str(en_path),
-                "--source-lang",
-                "de",
                 "--ollama-url",
                 "http://127.0.0.1:1",  # nothing listens here
                 "--llm-timeout",
                 "1.0",
-                "--no-cache",
+                "--cache-dir",
+                str(cache_dir),
             ],
         )
-        # Exit 2 = at least one error.
-        assert result.exit_code == 2
-        # Warning was emitted about Ollama being unreachable.
+
+        # The lone edit can't be reconciled → error → exit 2; watermark held.
+        assert result.exit_code == 2, result.output
         assert "Ollama is not reachable" in (result.stderr or "")
-        # The lone pair was counted as an error.
-        assert "1 pair(s) visited" in result.output
         assert "1 error(s)" in result.output
+        assert "watermark held" in result.output
 
-    def test_json_output_shape(self, cli_runner: CliRunner, pair, tmp_path: Path):
-        import json
 
-        de_path, en_path = pair
+# ---------------------------------------------------------------------------
+# No baseline (cold, no watermark, no git)
+# ---------------------------------------------------------------------------
+
+
+class TestNoBaseline:
+    def test_no_watermark_no_git_reports_baseline_none(self, cli_runner: CliRunner, tmp_path: Path):
+        # Identical ids on both sides, no watermark, tmp dir is not a git repo:
+        # the classifier can pair by id but cannot detect edits → no proposals,
+        # and the no-silent-no-op summary explains why.
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
         result = cli_runner.invoke(
             slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--ollama-url",
-                "http://127.0.0.1:1",
-                "--llm-timeout",
-                "1.0",
-                "--no-cache",
-                "--json",
-            ],
+            [str(de_path), str(en_path), "--dry-run", "--no-cache"],
         )
-        assert result.exit_code == 2
-        # On Click 8.2+ stderr is mixed into result.output when CliRunner
-        # is constructed without the (removed) ``mix_stderr=False`` flag,
-        # so the "Ollama is not reachable" warning may precede the JSON
-        # body. Locate the JSON object by its opening brace.
-        output = result.output
-        brace = output.find("{")
-        assert brace >= 0, f"no JSON object in CLI output:\n{output}"
-        payload = json.loads(output[brace:])
-        assert payload["pairs_visited"] == 1
-        assert payload["pairs_error"] == 1
-        assert len(payload["outcomes"]) == 1
-        assert payload["outcomes"][0]["verdict"] == "error"
-        # New v2 keys ride along with zero values when no walker ran.
-        assert payload["pairs_accepted"] == 0
-        assert payload["pairs_skipped"] == 0
-        assert payload["pairs_edited"] == 0
-        assert payload["pairs_quit"] == 0
-
-
-class TestInteractiveCli:
-    """End-to-end smoke for ``--interactive`` driven by a stub judge.
-
-    These tests can't reach a real Ollama daemon and instead patch the
-    judge selection inside ``slides_sync_cmd`` to return a
-    :class:`StaticSyncJudge`. That keeps the CLI surface (flag parsing,
-    walker wiring, file writes, snapshot recording) under test without
-    requiring the local LLM.
-    """
-
-    def test_interactive_apply_writes_target_and_reports_counters(
-        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
-    ):
-        from clm.cli.commands import slides_sync as cmd_module
-        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
-
-        # Force the CLI to skip the Ollama liveness check and supply a
-        # judge that always proposes an update.
-        proposal = SyncProposal(
-            verdict="update",
-            proposed_text="# ## Introduction\n# - Point one\n# - Point two",
-            reason="DE added a bullet",
-        )
-        monkeypatch.setattr(cmd_module, "is_available", lambda _judge: True)
-        monkeypatch.setattr(
-            cmd_module,
-            "OllamaSyncJudge",
-            lambda **_kw: StaticSyncJudge(default_proposal=proposal),
-        )
-
-        de = (
-            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
-            "# ## Einleitung\n# - Punkt eins\n# - Punkt zwei\n"
-        )
-        en = (
-            '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n'
-            "# ## Introduction\n# - Point one\n"
-        )
-        de_path = tmp_path / "slides_intro.de.py"
-        en_path = tmp_path / "slides_intro.en.py"
-        de_path.write_text(de, encoding="utf-8")
-        en_path.write_text(en, encoding="utf-8")
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--interactive",
-                "--cache-dir",
-                str(tmp_path / "cache"),
-            ],
-            input="a\n",
-        )
-
-        # Exit 1 = at least one proposed update (now accepted).
-        assert result.exit_code == 1
-        assert "Point two" in en_path.read_text(encoding="utf-8")
-        assert "walker:" in result.output
-        assert "1 accepted" in result.output
-
-    def test_interactive_json_is_rejected(self, cli_runner: CliRunner, tmp_path: Path):
-        de = '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n# ## A\n'
-        en = '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## A\n'
-        de_path = tmp_path / "x.de.py"
-        en_path = tmp_path / "x.en.py"
-        de_path.write_text(de, encoding="utf-8")
-        en_path.write_text(en, encoding="utf-8")
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--interactive",
-                "--json",
-            ],
-        )
-        combined = (result.stderr or "") + (result.output or "")
-        assert result.exit_code != 0
-        assert "mutually exclusive" in combined
-
-
-class TestApplyTrivial:
-    """``--apply --trivial`` CLI smoke tests.
-
-    These tests follow the same monkeypatch pattern as
-    :class:`TestInteractiveCli` — the local LLM is never reached and
-    the judge is replaced with a :class:`StaticSyncJudge` whose proposed
-    text drives the trivial-vs-non-trivial decision.
-    """
-
-    @staticmethod
-    def _stub_judge(
-        monkeypatch,
-        proposed_text: str,
-        reason: str = "",
-    ) -> None:
-        from clm.cli.commands import slides_sync as cmd_module
-        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
-
-        proposal = SyncProposal(verdict="update", proposed_text=proposed_text, reason=reason)
-        monkeypatch.setattr(cmd_module, "is_available", lambda _judge: True)
-        monkeypatch.setattr(
-            cmd_module,
-            "OllamaSyncJudge",
-            lambda **_kw: StaticSyncJudge(default_proposal=proposal),
-        )
-
-    @staticmethod
-    def _pair(tmp_path: Path, *, de_body: str, en_body: str) -> tuple[Path, Path]:
-        de = f'# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n{de_body}\n'
-        en = f'# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n{en_body}\n'
-        de_path = tmp_path / "slides_intro.de.py"
-        en_path = tmp_path / "slides_intro.en.py"
-        de_path.write_text(de, encoding="utf-8")
-        en_path.write_text(en, encoding="utf-8")
-        return de_path, en_path
-
-    def test_apply_without_trivial_is_rejected(self, cli_runner: CliRunner, tmp_path: Path):
-        de_path, en_path = self._pair(tmp_path, de_body="# ## A", en_body="# ## A")
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--apply",
-            ],
-        )
-        combined = (result.stderr or "") + (result.output or "")
-        assert result.exit_code != 0
-        assert "--trivial" in combined
-
-    def test_trivial_without_apply_is_rejected(self, cli_runner: CliRunner, tmp_path: Path):
-        de_path, en_path = self._pair(tmp_path, de_body="# ## A", en_body="# ## A")
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--trivial",
-            ],
-        )
-        combined = (result.stderr or "") + (result.output or "")
-        assert result.exit_code != 0
-        assert "--apply" in combined
-
-    def test_trivial_diff_is_auto_applied(self, cli_runner: CliRunner, tmp_path: Path, monkeypatch):
-        # EN has a double-space inside one bullet; proposal collapses it.
-        self._stub_judge(monkeypatch, "# ## Introduction\n# - one")
-        de_path, en_path = self._pair(
-            tmp_path,
-            de_body="# ## Einleitung\n# - eins",
-            en_body="# ## Introduction\n# -  one",
-        )
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--apply",
-                "--trivial",
-                "--cache-dir",
-                str(tmp_path / "cache"),
-            ],
-        )
-
-        # Exit 0 = all proposals resolved (the only one was trivial).
-        assert result.exit_code == 0
-        # File rewritten.
-        en_text = en_path.read_text(encoding="utf-8")
-        assert "# - one" in en_text
-        assert "# -  one" not in en_text
-        # Report mentions the auto-apply.
-        assert "auto-apply:" in result.output
-        assert "1 trivial update(s) applied" in result.output
-        assert "applied (trivial)" in result.output
-
-    def test_non_trivial_diff_falls_through_to_report(
-        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
-    ):
-        # Proposal adds a bullet — not a whitespace-only-one-line change.
-        self._stub_judge(monkeypatch, "# ## Introduction\n# - one\n# - two")
-        de_path, en_path = self._pair(
-            tmp_path,
-            de_body="# ## Einleitung\n# - eins\n# - zwei",
-            en_body="# ## Introduction\n# - one",
-        )
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--apply",
-                "--trivial",
-                "--cache-dir",
-                str(tmp_path / "cache"),
-            ],
-        )
-
-        # Exit 1 = proposal remains for human review.
-        assert result.exit_code == 1
-        # File unchanged (non-trivial was NOT auto-applied).
-        assert "# - two" not in en_path.read_text(encoding="utf-8")
-        # Report carries both the auto-apply line (0 applied) and the
-        # propose entry.
-        assert "auto-apply: 0 trivial update(s) applied" in result.output
-        assert "propose intro/slide" in result.output
-
-    def test_json_shape_includes_pairs_auto_applied(
-        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
-    ):
-        import json as _json
-
-        self._stub_judge(monkeypatch, "# ## Introduction\n# - one")
-        de_path, en_path = self._pair(
-            tmp_path,
-            de_body="# ## Einleitung",
-            en_body="# ## Introduction\n# -  one",
-        )
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--apply",
-                "--trivial",
-                "--json",
-                "--cache-dir",
-                str(tmp_path / "cache"),
-            ],
-        )
-
-        assert result.exit_code == 0
-        brace = result.output.find("{")
-        assert brace >= 0
-        payload = _json.loads(result.output[brace:])
-        assert payload["pairs_auto_applied"] == 1
-        # Each outcome carries the applied_trivially flag.
-        applied_flags = [o.get("applied_trivially") for o in payload["outcomes"]]
-        assert any(applied_flags)
-
-
-class TestDirectionAutoDetection:
-    """End-to-end smoke for the omitted-``--source-lang`` path.
-
-    These tests construct a tiny git repo + snapshot cache to drive the
-    inference module from the CLI surface. The static judge keeps the
-    test from depending on a live Ollama instance.
-    """
-
-    @staticmethod
-    def _stub_judge(monkeypatch, proposed_text: str = "# ## Introduction") -> None:
-        from clm.cli.commands import slides_sync as cmd_module
-        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
-
-        proposal = SyncProposal(verdict="update", proposed_text=proposed_text)
-        monkeypatch.setattr(cmd_module, "is_available", lambda _judge: True)
-        monkeypatch.setattr(
-            cmd_module,
-            "OllamaSyncJudge",
-            lambda **_kw: StaticSyncJudge(default_proposal=proposal),
-        )
-
-    @staticmethod
-    def _seed_snapshot(
-        cache_dir: Path,
-        *,
-        de_path: Path,
-        en_path: Path,
-        slide_id: str,
-        role: str,
-        de_text: str,
-        en_text: str,
-    ) -> None:
-        from clm.cli.commands.slides_sync import CACHE_DB_NAME
-        from clm.slides.sync_writeback import cell_content_hash
-
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        snapshot_cache = SyncSnapshotCache(cache_dir / CACHE_DB_NAME)
-        try:
-            snapshot_cache.put(
-                de_path=str(de_path),
-                en_path=str(en_path),
-                slide_id=slide_id,
-                role=role,
-                de_hash=cell_content_hash(de_text),
-                en_hash=cell_content_hash(en_text),
-                direction="de->en",
-            )
-        finally:
-            snapshot_cache.close()
-
-    def test_omitted_source_lang_infers_from_snapshot(
-        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
-    ):
-        self._stub_judge(monkeypatch)
-        de_body = "# ## Einleitung\n# - eins"
-        en_body = "# ## Introduction\n# - one\n# - two"  # EN has drifted
-        de = f'# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n{de_body}\n'
-        en = f'# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n{en_body}\n'
-        de_path = tmp_path / "slides_intro.de.py"
-        en_path = tmp_path / "slides_intro.en.py"
-        de_path.write_text(de, encoding="utf-8")
-        en_path.write_text(en, encoding="utf-8")
-
-        cache_dir = tmp_path / "cache"
-        # Snapshot says original EN was "# ## Introduction\n# - one"; the
-        # current EN drifted; DE is unchanged.
-        self._seed_snapshot(
-            cache_dir,
-            de_path=de_path,
-            en_path=en_path,
-            slide_id="intro",
-            role="slide",
-            de_text=de_body,
-            en_text="# ## Introduction\n# - one",
-        )
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--cache-dir",
-                str(cache_dir),
-            ],
-        )
-        # Inference picked 'en' as source → direction en->de → DE side is
-        # the target. The run completes without raising UsageError.
-        assert result.exit_code != 2, result.output
-        combined = (result.stderr or "") + (result.output or "")
-        assert "inferred as 'en'" in combined
-        assert "snapshot" in combined
-
-    def test_omitted_source_lang_in_non_git_dir_raises_usage(
-        self, cli_runner: CliRunner, tmp_path: Path
-    ):
-        de = '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n# ## A\n'
-        en = '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## A\n'
-        de_path = tmp_path / "x.de.py"
-        en_path = tmp_path / "x.en.py"
-        de_path.write_text(de, encoding="utf-8")
-        en_path.write_text(en, encoding="utf-8")
-
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [str(de_path), str(en_path), "--no-cache"],
-        )
-        assert result.exit_code != 0
-        combined = (result.stderr or "") + (result.output or "")
-        assert "could not be inferred" in combined
-        assert "--source-lang" in combined
-
-    def test_explicit_source_lang_disagreeing_with_inference_warns(
-        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
-    ):
-        self._stub_judge(monkeypatch)
-        de_body = "# ## Einleitung\n# - eins"
-        en_body = "# ## Introduction\n# - one (changed)"  # EN drifted
-        de = f'# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n{de_body}\n'
-        en = f'# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n{en_body}\n'
-        de_path = tmp_path / "slides_intro.de.py"
-        en_path = tmp_path / "slides_intro.en.py"
-        de_path.write_text(de, encoding="utf-8")
-        en_path.write_text(en, encoding="utf-8")
-
-        cache_dir = tmp_path / "cache"
-        self._seed_snapshot(
-            cache_dir,
-            de_path=de_path,
-            en_path=en_path,
-            slide_id="intro",
-            role="slide",
-            de_text=de_body,
-            en_text="# ## Introduction\n# - one",
-        )
-
-        # User passes --source-lang=de, but snapshot says EN drifted.
-        result = cli_runner.invoke(
-            slides_sync_cmd,
-            [
-                str(de_path),
-                str(en_path),
-                "--source-lang",
-                "de",
-                "--cache-dir",
-                str(cache_dir),
-            ],
-        )
-        combined = (result.stderr or "") + (result.output or "")
-        assert "warning" in combined.lower()
-        assert "disagrees with inferred direction 'en'" in combined
-        # The explicit override is still honored — direction de->en is
-        # used, so the EN cell is treated as the target.
-        assert result.exit_code != 2, result.output
+        assert result.exit_code == 0, result.output
+        assert "baseline=none" in result.output

--- a/tests/infrastructure/llm/test_sync_cache.py
+++ b/tests/infrastructure/llm/test_sync_cache.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from clm.infrastructure.llm.cache import SyncCache, SyncSnapshotCache
+from clm.infrastructure.llm.cache import SyncCache, SyncSnapshotCache, SyncWatermarkCache
 
 
 @pytest.fixture
@@ -215,3 +215,135 @@ class TestSyncSnapshotCache:
         rows = snapshots.iter_entries()
         assert len(rows) == 1
         assert rows[0][:4] == ("a.de.py", "a.en.py", "intro", "slide")
+
+
+# ---------------------------------------------------------------------------
+# SyncWatermarkCache (Issue #166, Phase 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def watermarks(tmp_path: Path):
+    c = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+class TestSyncWatermarkCache:
+    def test_empty_deck_is_cold(self, watermarks):
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == []
+        assert watermarks.has_pair("a.de.py", "a.en.py") is False
+
+    def test_put_and_get_deck_ordered(self, watermarks):
+        cells = [
+            (0, "intro", "slide", "h0"),
+            (1, "intro", "voiceover", "h1"),
+            (2, "topic", "slide", "h2"),
+        ]
+        watermarks.put_deck(de_path="a.de.py", en_path="a.en.py", lang="de", cells=cells)
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == cells
+        assert watermarks.has_pair("a.de.py", "a.en.py") is True
+
+    def test_nullable_slide_id(self, watermarks):
+        cells = [(0, None, "slide", "h0"), (1, "topic", "slide", "h1")]
+        watermarks.put_deck(de_path="a.de.py", en_path="a.en.py", lang="en", cells=cells)
+        got = watermarks.get_deck("a.de.py", "a.en.py", "en")
+        assert got[0][1] is None
+        assert got == cells
+
+    def test_languages_are_isolated(self, watermarks):
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "dh")]
+        )
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="en", cells=[(0, "x", "slide", "eh")]
+        )
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "dh")]
+        assert watermarks.get_deck("a.de.py", "a.en.py", "en") == [(0, "x", "slide", "eh")]
+
+    def test_put_deck_replaces_atomically(self, watermarks):
+        watermarks.put_deck(
+            de_path="a.de.py",
+            en_path="a.en.py",
+            lang="de",
+            cells=[(0, "a", "slide", "h0"), (1, "b", "slide", "h1")],
+        )
+        # Rewrite with a shorter, different deck — old rows must be gone.
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "c", "slide", "h2")]
+        )
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "c", "slide", "h2")]
+
+    def test_invalid_lang_raises(self, watermarks):
+        with pytest.raises(ValueError, match="lang must be"):
+            watermarks.put_deck(
+                de_path="a.de.py", en_path="a.en.py", lang="fr", cells=[(0, "x", "slide", "h")]
+            )
+
+    def test_pairs_are_isolated(self, watermarks):
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "ah")]
+        )
+        watermarks.put_deck(
+            de_path="b.de.py", en_path="b.en.py", lang="de", cells=[(0, "y", "slide", "bh")]
+        )
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "ah")]
+        assert watermarks.get_deck("b.de.py", "b.en.py", "de") == [(0, "y", "slide", "bh")]
+
+    def test_clear_pair(self, watermarks):
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+        )
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="en", cells=[(0, "x", "slide", "h")]
+        )
+        removed = watermarks.clear_pair("a.de.py", "a.en.py")
+        assert removed == 2
+        assert watermarks.has_pair("a.de.py", "a.en.py") is False
+
+    def test_survives_close_and_reopen(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        first = SyncWatermarkCache(path)
+        first.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+        )
+        first.close()
+        second = SyncWatermarkCache(path)
+        try:
+            assert second.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h")]
+        finally:
+            second.close()
+
+    def test_coexists_with_other_caches(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        wm = SyncWatermarkCache(path)
+        snap = SyncSnapshotCache(path)
+        try:
+            wm.put_deck(
+                de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+            )
+            snap.put(
+                de_path="a.de.py",
+                en_path="a.en.py",
+                slide_id="x",
+                role="slide",
+                de_hash="dh",
+                en_hash="eh",
+                direction="de->en",
+            )
+            assert wm.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h")]
+            assert snap.get("a.de.py", "a.en.py", "x", "slide") == ("dh", "eh", "de->en")
+        finally:
+            snap.close()
+            wm.close()
+
+    def test_iter_entries(self, watermarks):
+        watermarks.put_deck(
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+        )
+        rows = watermarks.iter_entries()
+        assert len(rows) == 1
+        # (de_path, en_path, lang, position, slide_id, role, content_hash, synced_at)
+        assert rows[0][:7] == ("a.de.py", "a.en.py", "de", 0, "x", "slide", "h")

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -1,0 +1,318 @@
+"""Tests for :mod:`clm.slides.sync_apply` (Issue #166, Phase 2 apply engine)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_plan import Proposal, SyncPlan, build_sync_plan, ordered_sync_cells
+from clm.slides.sync_writeback import FileState
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n'
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )
+
+
+def _update_judge(text: str) -> StaticSyncJudge:
+    return StaticSyncJudge(default_proposal=SyncProposal(verdict="update", proposed_text=text))
+
+
+# ---------------------------------------------------------------------------
+# FileState primitives
+# ---------------------------------------------------------------------------
+
+
+class TestFileStatePrimitives:
+    def test_find_and_replace_cell_body(self, tmp_path: Path):
+        path = tmp_path / "deck.en.py"
+        path.write_text(
+            _slide("en", "a", "# ## A\n# - one") + _slide("en", "b", "# ## B"),
+            encoding="utf-8",
+        )
+        state = FileState.load(path)
+        assert state.find_cell("a", "slide") is not None
+        assert state.find_cell("missing", "slide") is None
+        assert state.replace_cell_body("a", "slide", "# ## A\n# - one\n# - two") is True
+        state.flush()
+        text = path.read_text(encoding="utf-8")
+        assert "- two" in text
+        assert "# ## B" in text  # untouched
+
+    def test_delete_cell(self, tmp_path: Path):
+        path = tmp_path / "deck.en.py"
+        path.write_text(
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+            encoding="utf-8",
+        )
+        state = FileState.load(path)
+        assert state.delete_cell("a", "slide") is True
+        state.flush()
+        cells = parse_cells(path.read_text(encoding="utf-8"))
+        ids = [c.metadata.slide_id for c in cells if c.metadata.slide_id]
+        assert ids == ["b"]
+
+    def test_delete_missing_returns_false(self, tmp_path: Path):
+        path = tmp_path / "deck.en.py"
+        path.write_text(_slide("en", "a", "# ## A"), encoding="utf-8")
+        state = FileState.load(path)
+        assert state.delete_cell("nope", "slide") is False
+        assert state.dirty is False
+
+    def test_delete_last_cell_preserves_terminal_newline(self, tmp_path: Path):
+        # Removing the file's last cell must not strip its trailing newline
+        # (which split_cells parks on that cell) — else a "No newline at end
+        # of file" diff and a pre-commit end-of-file-fixer trip.
+        path = tmp_path / "deck.en.py"
+        path.write_text(
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+            encoding="utf-8",
+        )
+        assert path.read_text(encoding="utf-8").endswith("\n")
+        state = FileState.load(path)
+        assert state.delete_cell("b", "slide") is True
+        state.flush()
+        assert path.read_text(encoding="utf-8").endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — edit
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEdit:
+    def test_edit_writes_target_body(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung\n# - eins\n# - zwei")
+        en = _slide("en", "intro", "# ## Introduction\n# - one")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(de, encoding="utf-8")  # (unchanged here; edit comes below)
+            # Author edits DE: add a bullet.
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung\n# - eins\n# - zwei\n# - drei"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1
+
+            judge = _update_judge("# ## Introduction\n# - one\n# - two\n# - three")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 1
+        assert "- three" in en_path.read_text(encoding="utf-8")
+
+    def test_edit_idempotent_after_watermark_advance(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung\n# - eins")
+        en = _slide("en", "intro", "# ## Introduction\n# - one")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung\n# - eins\n# - zwei"), encoding="utf-8"
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            judge = _update_judge("# ## Introduction\n# - one\n# - two")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+            assert result.watermark_recorded is True
+
+            # Re-planning against the advanced watermark is a no-op.
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert plan2.is_noop
+
+    def test_edit_in_sync_verdict_writes_nothing(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(_slide("de", "intro", "# ## Einleitung (neu)"), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            before = en_path.read_text(encoding="utf-8")
+            judge = StaticSyncJudge(
+                default_proposal=SyncProposal(verdict="in_sync", proposed_text="x")
+            )
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 0
+        assert result.in_sync == 1
+        assert en_path.read_text(encoding="utf-8") == before
+
+    def test_edit_without_judge_is_error(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(_slide("de", "intro", "# ## Einleitung (neu)"), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 0
+        assert result.has_errors
+        assert result.watermark_recorded is False  # errors block watermark advance
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — remove
+# ---------------------------------------------------------------------------
+
+
+class TestApplyRemove:
+    def test_remove_deletes_target_cell(self, tmp_path: Path):
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author removes slide b from DE.
+            de_path.write_text(_slide("de", "a", "# ## A"), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("remove") == 1
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+
+            # Re-plan is a no-op after the propagated removal.
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_remove == 1
+        en_ids = [
+            c.metadata.slide_id
+            for c in parse_cells(en_path.read_text("utf-8"))
+            if c.metadata.slide_id
+        ]
+        assert en_ids == ["a"]
+        assert plan2.is_noop
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — deferred kinds & watermark discipline
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredAndWatermark:
+    def test_cold_start_does_not_advance_watermark(self, tmp_path: Path):
+        # baseline=none: shared-id pairs are counted in_sync but never
+        # content-verified, so the watermark must NOT be recorded — else
+        # unverified cross-language drift gets silently baselined.
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## Apfel"),
+            _slide("en", "a", "# ## Totally different content"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = build_sync_plan(de_path, en_path, allow_git_fallback=False)
+            assert plan.baseline_source == "none"
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            recorded = cache.has_pair(str(de_path), str(en_path))
+        finally:
+            cache.close()
+
+        assert result.watermark_recorded is False
+        assert recorded is False
+
+    def test_move_is_deferred_and_watermark_not_advanced(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A"),
+            _slide("en", "a", "# ## A"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+            plan.proposals.append(
+                Proposal(kind="move", role="slide", direction="de->en", slide_id="a")
+            )
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            recorded = cache.has_pair(str(de_path), str(en_path))
+        finally:
+            cache.close()
+
+        assert result.deferred == 1
+        assert result.applied == 0
+        assert result.watermark_recorded is False
+        assert recorded is False  # un-applied move must not be baselined
+
+    def test_remove_missing_target_is_error(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A"),
+            _slide("en", "a", "# ## A"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+            plan.proposals.append(
+                Proposal(kind="remove", role="slide", direction="de->en", slide_id="ghost")
+            )
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_remove == 0
+        assert result.has_errors
+
+    def test_one_edit_error_does_not_block_a_remove(self, tmp_path: Path):
+        # A plan with a remove (deterministic) and an edit that errors (no
+        # judge): the remove still applies; the error is recorded.
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B"),
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+        )
+        plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+        plan.proposals.append(
+            Proposal(kind="remove", role="slide", direction="de->en", slide_id="b")
+        )
+        plan.proposals.append(Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"))
+        result = apply_plan(plan, judge=None, watermark_cache=None)
+
+        assert result.applied_remove == 1
+        assert result.has_errors  # the edit had no judge
+        en_ids = [
+            c.metadata.slide_id
+            for c in parse_cells(en_path.read_text("utf-8"))
+            if c.metadata.slide_id
+        ]
+        assert en_ids == ["a"]

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
-from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_apply import DECISION_APPLY, DECISION_SKIP, apply_plan
 from clm.slides.sync_plan import PlanIssue, Proposal, SyncPlan, build_sync_plan, ordered_sync_cells
 from clm.slides.sync_translate import StaticSlideTranslator
 from clm.slides.sync_writeback import FileState
@@ -1051,3 +1051,428 @@ class TestApplyRename:
         # Not silently baselined: the mismatched companion forces a deferral.
         assert result.deferred >= 1
         assert result.watermark_recorded is False
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — per-cell partial watermark advance (Phase 4 part 2b)
+# ---------------------------------------------------------------------------
+
+
+def _keys_of(path: Path, lang: str) -> list[tuple[str | None, str]]:
+    cells = ordered_sync_cells(parse_cells(path.read_text("utf-8")), lang)
+    return [(c.slide_id, c.role) for c in cells]
+
+
+class _MarkerJudge:
+    """A judge that returns ``update`` only when the source body contains a
+    marker, else the ``in_sync`` (verdict != "update") verdict the real judge
+    emits when it decides the target already reflects the source edit."""
+
+    prompt_version = "test"
+
+    def __init__(self, update_markers: set[str], proposed: str) -> None:
+        self._markers = update_markers
+        self._proposed = proposed
+
+    def propose(self, source_text, target_text, *, source_lang, target_lang):  # noqa: ANN001
+        if any(m in source_text for m in self._markers):
+            return SyncProposal(verdict="update", proposed_text=self._proposed)
+        return SyncProposal(verdict="in_sync", proposed_text="")
+
+
+class TestPartialWatermarkAdvance:
+    def test_reconciled_edit_advances_while_deferred_conflict_resurfaces(self, tmp_path: Path):
+        # The headline 2b win: an edit on 'a' applied alongside a deferred
+        # conflict on 'b'. The watermark advances PER-CELL — 'a' is banked (no
+        # longer re-surfaces) while 'b' (preserved at its pre-conflict baseline)
+        # is still detected as a conflict on the next run. No data loss.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # DE 'a' edited (a plain edit); BOTH sides of 'b' edited (a conflict).
+            de_path.write_text(
+                _slide("de", "a", "# ## A-de2") + _slide("de", "b", "# ## B-de2"),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1 and plan.count("conflict") == 1
+
+            judge = _update_judge("# ## A-en2")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 1
+        assert result.deferred == 1
+        assert result.watermark_recorded is True  # partial advance fired
+        # Edit 'a' was banked; only the conflict 'b' is left for the next run.
+        assert plan2.count("edit") == 0
+        assert plan2.count("conflict") == 1
+        assert plan2.proposals[0].slide_id == "b"
+        # The conflict's cells were never written (isolated); the edit was.
+        assert "# ## A-en2" in en_path.read_text("utf-8")
+        assert "# ## B-de2" in de_path.read_text("utf-8")
+        assert "# ## B-en2" in en_path.read_text("utf-8")
+
+    def test_skipped_edit_advances_sibling_and_resurfaces(self, tmp_path: Path):
+        # Interactive: accept the edit on 'a', skip the edit on 'b'. 'a' banks,
+        # 'b' re-surfaces next run (its source-side baseline is preserved).
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A-de2") + _slide("de", "b", "# ## B-de2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 2
+            decisions = {
+                id(p): (DECISION_APPLY if p.slide_id == "a" else DECISION_SKIP)
+                for p in plan.proposals
+            }
+            judge = _update_judge("# ## A-en2")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache, decisions=decisions)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 1
+        assert result.deferred == 1
+        assert result.watermark_recorded is True
+        # Only the skipped 'b' edit remains; 'a' was banked.
+        assert plan2.count("edit") == 1
+        assert plan2.proposals[0].slide_id == "b"
+
+    def test_conflict_only_pass_holds_watermark(self, tmp_path: Path):
+        # No reconciled write to bank -> not eligible for a partial advance, so
+        # the watermark holds (matches all-or-nothing). Proven with a SEEDED
+        # cache so the hold is the applied_edit>0 gate, not the missing-baseline
+        # guard.
+        de = _slide("de", "a", "# ## A")
+        en = _slide("en", "a", "# ## A")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(_slide("de", "a", "# ## A-de2"), encoding="utf-8")
+            en_path.write_text(_slide("en", "a", "# ## A-en2"), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("conflict") == 1 and plan.count("edit") == 0
+            before = {
+                lang: cache.get_deck(str(de_path), str(en_path), lang) for lang in ("de", "en")
+            }
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            after = {
+                lang: cache.get_deck(str(de_path), str(en_path), lang) for lang in ("de", "en")
+            }
+        finally:
+            cache.close()
+
+        assert result.deferred == 1
+        assert result.applied_edit == 0
+        assert result.watermark_recorded is False
+        assert after == before  # baseline untouched
+
+    def test_structural_partial_pass_holds_watermark(self, tmp_path: Path):
+        # An edit reconciled + a conflict deferred, but the pass also has an
+        # id-less ADD (structural). Structure changed, so the partial advance is
+        # NOT eligible; the watermark holds whole.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A-de2")
+                + _slide("de", "b", "# ## B-de2")
+                + '# %% [markdown] lang="de" tags=["slide"]\n# ## Neu\n',
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1
+            assert plan.count("conflict") == 1
+            assert plan.count("add") == 1  # structural
+            judge = _update_judge("# ## A-en2")
+            translator = StaticSlideTranslator(mapping={"# ## Neu": "# ## New"})
+            result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.deferred >= 1  # the conflict
+        assert result.watermark_recorded is False  # structural -> held
+
+    def test_partial_advance_preserves_positions_and_keys(self, tmp_path: Path):
+        # After a partial advance the watermark keeps the same (slide_id, role)
+        # structure as the decks (content-only invariant) — no rows dropped or
+        # re-ordered.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A-de2") + _slide("de", "b", "# ## B-de2"),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            apply_plan(plan, judge=_update_judge("# ## A-en2"), watermark_cache=cache)
+            wm_de = [
+                (p, s, r) for (p, s, r, _h) in cache.get_deck(str(de_path), str(en_path), "de")
+            ]
+        finally:
+            cache.close()
+
+        assert wm_de == [(0, "a", "slide"), (1, "b", "slide")]
+        assert _keys_of(de_path, "de") == [("a", "slide"), ("b", "slide")]
+
+    def test_in_sync_edit_is_reconciled_partial_path(self, tmp_path: Path):
+        # An in_sync verdict is a reconciliation ("the target already reflects the
+        # source", per SyncProposal) — NOT a deferral. On a partial pass it banks
+        # like an applied edit: it must NOT re-surface (else the judge re-declines
+        # it every run forever). Only the true deferral (the conflict) re-surfaces.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B") + _slide("de", "c", "# ## C")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B") + _slide("en", "c", "# ## C")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # DE a,b edited (de->en edits); c edited on BOTH (a conflict).
+            de_path.write_text(
+                _slide("de", "a", "# ## A-de2")
+                + _slide("de", "b", "# ## B-de2")
+                + _slide("de", "c", "# ## C-de2"),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _slide("en", "a", "# ## A")
+                + _slide("en", "b", "# ## B")
+                + _slide("en", "c", "# ## C-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 2 and plan.count("conflict") == 1
+            # 'a' -> update (applied); 'b' -> in_sync (judge reconciles, no write).
+            judge = _MarkerJudge({"A-de2"}, "# ## A-en2")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 1  # 'a'
+        assert result.in_sync == 1  # 'b' reconciled (no write)
+        assert result.deferred == 1  # conflict 'c'
+        assert result.watermark_recorded is True  # partial advance fired
+        # Both 'a' (applied) and 'b' (in_sync) are banked; only 'c' re-surfaces.
+        assert plan2.count("edit") == 0
+        assert plan2.count("conflict") == 1
+        assert plan2.proposals[0].slide_id == "c"
+
+    def test_in_sync_only_edit_is_reconciled_full_path(self, tmp_path: Path):
+        # A pass whose only non-applied work is an in_sync edit (deferred==0) goes
+        # the full-advance path — and an in_sync verdict banks there too (it is a
+        # reconciliation). The next run is a no-op; the edit does not re-surface.
+        de = _slide("de", "a", "# ## A")
+        en = _slide("en", "a", "# ## A")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(_slide("de", "a", "# ## A-de2"), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1
+            judge = _MarkerJudge(set(), "x")  # never matches -> always in_sync
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 0
+        assert result.in_sync == 1
+        assert result.deferred == 0
+        assert result.watermark_recorded is True  # full advance (deferred == 0)
+        assert plan2.is_noop  # reconciled -> banked -> does not re-surface
+
+    def test_both_decks_reorder_warning_holds_watermark(self, tmp_path: Path):
+        # Regression for the high-sev 2b finding: a both-decks reorder is emitted
+        # as a *warning* (no move proposal, not an error). The partial advance
+        # must NOT fire (it would bake the new order and lose the "resolve
+        # ordering manually" signal); plan.issues forces a hold.
+        def deck(lang: str, order: list[str]) -> str:
+            return "".join(_slide(lang, s, f"# ## {s.upper()}") for s in order)
+
+        de_path, en_path = _write_pair(
+            tmp_path, deck("de", ["a", "b", "d", "e"]), deck("en", ["a", "b", "d", "e"])
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Swap a<->b on BOTH decks (both-decks reorder -> warning, no move);
+            # edit 'd' on DE only (applied); 'e' edited on both (conflict).
+            de_path.write_text(
+                _slide("de", "b", "# ## B")
+                + _slide("de", "a", "# ## A")
+                + _slide("de", "d", "# ## D-de2")
+                + _slide("de", "e", "# ## E-de2"),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _slide("en", "b", "# ## B")
+                + _slide("en", "a", "# ## A")
+                + _slide("en", "d", "# ## D")
+                + _slide("en", "e", "# ## E-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("move") == 0
+            assert plan.issues  # the order-drift warning
+            result = apply_plan(plan, judge=_update_judge("# ## D-en2"), watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.watermark_recorded is False  # held, not silently baselined
+        assert plan2.issues  # the order warning still surfaces next run
+
+    def test_reorder_warning_holds_full_advance_path(self, tmp_path: Path):
+        # Same warning hazard but with NO proposals at all (deferred==0), so the
+        # pass would otherwise be `_pass_is_clean` and take the FULL advance. The
+        # top-level `not plan.issues` gate must hold it there too — else the new
+        # order is silently baselined and the "resolve manually" signal vanishes.
+        def deck(lang: str, order: list[str]) -> str:
+            return "".join(_slide(lang, s, f"# ## {s.upper()}") for s in order)
+
+        de_path, en_path = _write_pair(
+            tmp_path, deck("de", ["a", "b", "c"]), deck("en", ["a", "b", "c"])
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Swap a<->b on BOTH decks, no content change anywhere (both-decks
+            # reorder -> warning, no proposals, deferred == 0).
+            for path, lang in ((de_path, "de"), (en_path, "en")):
+                path.write_text(deck(lang, ["b", "a", "c"]), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert not plan.proposals  # nothing to apply
+            assert plan.issues  # order-drift warning
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.deferred == 0  # would be _pass_is_clean but for the issue
+        assert result.watermark_recorded is False  # held by the not-plan.issues gate
+        assert plan2.issues  # warning re-surfaces
+
+    def test_en_side_skipped_edit_advances_sibling_and_resurfaces(self, tmp_path: Path):
+        # Mirror of the DE-side skipped-edit test (review symmetry gap): an
+        # en->de skipped edit must also re-surface (both decks' baselines are
+        # preserved for un-written cells).
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(
+                _slide("en", "a", "# ## A-en2") + _slide("en", "b", "# ## B-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 2
+            decisions = {
+                id(p): (DECISION_APPLY if p.slide_id == "a" else DECISION_SKIP)
+                for p in plan.proposals
+            }
+            result = apply_plan(
+                plan, judge=_update_judge("# ## A-de2"), watermark_cache=cache, decisions=decisions
+            )
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 1
+        assert result.deferred == 1
+        assert result.watermark_recorded is True
+        assert plan2.count("edit") == 1
+        assert plan2.proposals[0].slide_id == "b"
+
+    def test_removed_de_edited_en_conflict_holds_watermark(self, tmp_path: Path):
+        # A "removed on DE / edited on EN" collision is classified as a CONFLICT
+        # (not a remove), so it slips the structural gate. But 'b' is gone from
+        # DE's current cells, so the partial advance cannot faithfully preserve
+        # it — it must hold the whole watermark, else the conflict is dropped and
+        # next run mutates into a phantom add re-creating the removed slide.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # DE: edit 'a' (the reconciled write) + REMOVE 'b'. EN: edit 'b'.
+            de_path.write_text(_slide("de", "a", "# ## A-de2"), encoding="utf-8")
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B-en2"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1 and plan.count("conflict") == 1
+            assert plan.count("remove") == 0  # the removal is a conflict, not a remove
+            result = apply_plan(plan, judge=_update_judge("# ## A-en2"), watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.deferred == 1
+        assert result.watermark_recorded is False  # held, not dropped
+        conflicts = [p.slide_id for p in plan2.proposals if p.kind == "conflict"]
+        assert "b" in conflicts  # 'b' re-surfaces as a conflict
+        assert plan2.count("add") == 0  # NOT a phantom re-add of the removed slide
+
+    def test_edited_de_removed_en_conflict_holds_watermark(self, tmp_path: Path):
+        # Mirror of the above: removed on EN, edited on DE.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # DE: edit 'a' (reconciled write) + edit 'b'. EN: REMOVE 'b'.
+            de_path.write_text(
+                _slide("de", "a", "# ## A-de2") + _slide("de", "b", "# ## B-de2"),
+                encoding="utf-8",
+            )
+            en_path.write_text(_slide("en", "a", "# ## A"), encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1 and plan.count("conflict") == 1
+            assert plan.count("remove") == 0
+            result = apply_plan(plan, judge=_update_judge("# ## A-en2"), watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.deferred == 1
+        assert result.watermark_recorded is False
+        conflicts = [p.slide_id for p in plan2.proposals if p.kind == "conflict"]
+        assert "b" in conflicts
+        assert plan2.count("add") == 0

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -8,7 +8,7 @@ from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_apply import apply_plan
-from clm.slides.sync_plan import Proposal, SyncPlan, build_sync_plan, ordered_sync_cells
+from clm.slides.sync_plan import PlanIssue, Proposal, SyncPlan, build_sync_plan, ordered_sync_cells
 from clm.slides.sync_writeback import FileState
 
 # ---------------------------------------------------------------------------
@@ -252,7 +252,9 @@ class TestDeferredAndWatermark:
         assert result.watermark_recorded is False
         assert recorded is False
 
-    def test_move_is_deferred_and_watermark_not_advanced(self, tmp_path: Path):
+    def test_conflict_is_deferred_and_watermark_not_advanced(self, tmp_path: Path):
+        # A conflict is isolated (never applied), so the watermark must not
+        # advance — un-reconciled state must not be baselined.
         de_path, en_path = _write_pair(
             tmp_path,
             _slide("de", "a", "# ## A"),
@@ -262,7 +264,7 @@ class TestDeferredAndWatermark:
         try:
             plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
             plan.proposals.append(
-                Proposal(kind="move", role="slide", direction="de->en", slide_id="a")
+                Proposal(kind="conflict", role="slide", direction=None, slide_id="a")
             )
             result = apply_plan(plan, judge=None, watermark_cache=cache)
             recorded = cache.has_pair(str(de_path), str(en_path))
@@ -272,7 +274,7 @@ class TestDeferredAndWatermark:
         assert result.deferred == 1
         assert result.applied == 0
         assert result.watermark_recorded is False
-        assert recorded is False  # un-applied move must not be baselined
+        assert recorded is False  # un-reconciled conflict must not be baselined
 
     def test_remove_missing_target_is_error(self, tmp_path: Path):
         de_path, en_path = _write_pair(
@@ -316,3 +318,181 @@ class TestDeferredAndWatermark:
             if c.metadata.slide_id
         ]
         assert en_ids == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — move (Phase 2b)
+# ---------------------------------------------------------------------------
+
+
+def _vo(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n{body}\n'
+
+
+def _slide_order(path: Path) -> list[str]:
+    return [
+        c.metadata.slide_id
+        for c in parse_cells(path.read_text(encoding="utf-8"))
+        if c.metadata.is_slide_start
+    ]
+
+
+class TestApplyMove:
+    def test_reorder_propagates_to_target(self, tmp_path: Path):
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B") + _slide("de", "c", "# ## C")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B") + _slide("en", "c", "# ## C")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author moves c to the front on DE.
+            de_path.write_text(
+                _slide("de", "c", "# ## C")
+                + _slide("de", "a", "# ## A")
+                + _slide("de", "b", "# ## B"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("move") >= 1
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_move >= 1
+        assert _slide_order(en_path) == ["c", "a", "b"]
+        # Byte-clean: identical to building the deck in target order — no
+        # spurious blank line from the dragged terminal-newline artifact.
+        expected = (
+            _slide("en", "c", "# ## C") + _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        )
+        assert en_path.read_text(encoding="utf-8") == expected
+        assert plan2.is_noop  # idempotent after watermark advance
+
+    def test_move_carries_narrative_companion(self, tmp_path: Path):
+        de = (
+            _slide("de", "a", "# ## A")
+            + _vo("de", "a", "# voiceover a")
+            + _slide("de", "b", "# ## B")
+            + _vo("de", "b", "# voiceover b")
+        )
+        en = (
+            _slide("en", "a", "# ## A")
+            + _vo("en", "a", "# voiceover a")
+            + _slide("en", "b", "# ## B")
+            + _vo("en", "b", "# voiceover b")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Move the whole b-group ahead of a on DE.
+            de_path.write_text(
+                _slide("de", "b", "# ## B")
+                + _vo("de", "b", "# voiceover b")
+                + _slide("de", "a", "# ## A")
+                + _vo("de", "a", "# voiceover a"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        # EN slide order mirrors DE, and each voiceover stays under its slide.
+        en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+        sync_ids = [(c.metadata.slide_id, c.tags[0]) for c in en_cells if c.metadata.slide_id]
+        assert sync_ids == [
+            ("b", "slide"),
+            ("b", "voiceover"),
+            ("a", "slide"),
+            ("a", "voiceover"),
+        ]
+
+    def test_move_deferred_when_plan_has_an_add(self, tmp_path: Path):
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Reorder AND add an id-less slide on DE.
+            de_path.write_text(
+                _slide("de", "b", "# ## B")
+                + _slide("de", "a", "# ## A")
+                + '# %% [markdown] lang="de" tags=["slide"]\n# ## Neu\n',
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("add") == 1
+            assert plan.count("move") >= 1
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        # The add can't be applied (Phase 3), so the move is held back too and
+        # the watermark does not advance — EN keeps its original order.
+        assert result.applied_move == 0
+        assert result.watermark_recorded is False
+        assert _slide_order(en_path) == ["a", "b"]
+
+    def test_narrative_reassignment_is_deferred_not_baselined(self, tmp_path: Path):
+        # The author swaps the two voiceovers across slides (slide order stays
+        # a,b, but notes change which slide they sit under). A slide-group
+        # reorder cannot express that, so it must be deferred and surfaced —
+        # never silently counted as applied and baselined.
+        de = (
+            _slide("de", "a", "# ## A")
+            + _vo("de", "a", "# vo a")
+            + _slide("de", "b", "# ## B")
+            + _vo("de", "b", "# vo b")
+        )
+        en = de.replace('lang="de"', 'lang="en"')
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Swap the voiceovers: vo-b now under slide a, vo-a under slide b.
+            swapped = (
+                _slide("de", "a", "# ## A")
+                + _vo("de", "b", "# vo b")
+                + _slide("de", "b", "# ## B")
+                + _vo("de", "a", "# vo a")
+            )
+            de_path.write_text(swapped, encoding="utf-8")
+            before_en = en_path.read_text(encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("move") >= 1
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_move == 0
+        assert result.deferred >= 1
+        assert result.watermark_recorded is False  # divergence not baselined
+        assert en_path.read_text(encoding="utf-8") == before_en  # EN untouched
+
+    def test_classifier_error_defers_move(self, tmp_path: Path):
+        # A classifier error (e.g. an id collision elsewhere) makes the pass
+        # un-clean: a move must not write to disk while the watermark refuses
+        # to advance (the gate and the watermark check share one predicate).
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B"),
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+            plan.issues.append(PlanIssue(severity="error", slide_id="x", reason="collision"))
+            plan.proposals.append(
+                Proposal(kind="move", role="slide", direction="de->en", slide_id="b")
+            )
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_move == 0
+        assert result.deferred >= 1
+        assert result.watermark_recorded is False
+        assert _slide_order(en_path) == ["a", "b"]  # EN untouched

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -823,3 +823,231 @@ class TestBlankSeparatedDecks:
             _bcell("en", "# ## B", "b"),
         )
         assert en_path.read_text(encoding="utf-8") == expected
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — rename (copy-pasted duplicate id)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyRename:
+    def test_copy_paste_is_renamed_with_counterpart(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "intro", "# ## Einleitung"),
+            _slide("en", "intro", "# ## Introduction"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author copy-pastes the intro slide (keeping its id) and edits the
+            # copy — two cells now carry slide_id="intro".
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung")
+                + _slide("de", "intro", "# ## Neues Kapitel"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("rename") == 1
+            assert not plan.has_errors
+            translator = StaticSlideTranslator(mapping={"# ## Neues Kapitel": "# ## New Chapter"})
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_rename == 1
+        # Original intro untouched; the copy re-minted on both decks.
+        de_intro = _cell_for(de_path, "intro")
+        assert de_intro is not None and "Einleitung" in de_intro.content
+        de_copy = _cell_for(de_path, "new-chapter")
+        en_copy = _cell_for(en_path, "new-chapter")
+        assert de_copy is not None and "Neues Kapitel" in de_copy.content
+        assert en_copy is not None and "New Chapter" in en_copy.content
+        assert _slide_order(en_path) == ["intro", "new-chapter"]
+        assert plan2.is_noop  # the duplicate is resolved, baselined, idempotent
+
+    def test_copy_without_translator_is_deferred(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "intro", "# ## Einleitung"),
+            _slide("en", "intro", "# ## Introduction"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung")
+                + _slide("de", "intro", "# ## Neues Kapitel"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result = apply_plan(plan, judge=None, translator=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_rename == 0
+        assert result.deferred >= 1
+        assert result.watermark_recorded is False
+
+    def test_copied_group_with_identical_companion_is_resolved(self, tmp_path: Path):
+        # Copy a slide GROUP (slide + voiceover), edit the copied slide but leave
+        # the copied voiceover identical to the original. The whole group must be
+        # re-minted — companion included — leaving no duplicate.
+        de = _slide("de", "intro", "# ## Einleitung") + _vo("de", "intro", "# Sprechertext")
+        en = _slide("en", "intro", "# ## Introduction") + _vo("en", "intro", "# Narration")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung")
+                + _vo("de", "intro", "# Sprechertext")
+                + _slide("de", "intro", "# ## Neues Kapitel")
+                + _vo("de", "intro", "# Sprechertext"),  # copy companion = identical
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert not plan.has_errors
+            translator = StaticSlideTranslator(
+                mapping={
+                    "# ## Neues Kapitel": "# ## New Chapter",
+                    "# Sprechertext": "# Narration",
+                }
+            )
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert not result.has_errors
+        for path in (de_path, en_path):
+            ids = [
+                (c.metadata.slide_id, c.tags[0])
+                for c in parse_cells(path.read_text(encoding="utf-8"))
+                if c.metadata.slide_id
+            ]
+            # No duplicate "intro"; the copy group is its own slide+companion.
+            assert ids == [
+                ("intro", "slide"),
+                ("intro", "voiceover"),
+                ("new-chapter", "slide"),
+                ("new-chapter", "voiceover"),
+            ]
+        assert plan2.is_noop  # idempotent — the duplicate is gone, not re-detected
+
+    def test_standalone_companion_duplicate_is_an_error(self, tmp_path: Path):
+        # Only the voiceover is copy-pasted (the slide is NOT duplicated). There
+        # is no copied slide to anchor a new id, so it must error, not corrupt.
+        de = _slide("de", "intro", "# ## Einleitung") + _vo("de", "intro", "# Sprechertext")
+        en = _slide("en", "intro", "# ## Introduction") + _vo("en", "intro", "# Narration")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung")
+                + _vo("de", "intro", "# Sprechertext")
+                + _vo("de", "intro", "# Sprechertext zwei"),  # second voiceover, same id
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(default="# whatever")
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert plan.has_errors
+        assert plan.count("rename") == 0
+        assert result.applied_rename == 0
+        assert result.watermark_recorded is False
+
+    def test_identical_slide_edited_companion_remints_the_copy_not_original(self, tmp_path: Path):
+        # Slide headings byte-identical, but the copied companion is edited. The
+        # COPY (by position) must be re-minted, leaving the ORIGINAL's id and its
+        # cross-language pairing intact.
+        de = _slide("de", "s", "# ## Titel") + _vo("de", "s", "# VO eins")
+        en = _slide("en", "s", "# ## Title") + _vo("en", "s", "# VO one")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "s", "# ## Titel")
+                + _vo("de", "s", "# VO eins")
+                + _slide("de", "s", "# ## Titel")  # identical heading
+                + _vo("de", "s", "# VO zwei"),  # edited companion
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(
+                mapping={"# ## Titel": "# ## Title", "# VO zwei": "# VO two"}
+            )
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert not result.has_errors
+        # The ORIGINAL 's' keeps its companion on BOTH decks (EN pairing intact).
+        assert _cell_for(de_path, "s", "voiceover").content.strip() == "# VO eins"
+        assert _cell_for(en_path, "s", "voiceover").content.strip() == "# VO one"
+        # The copy got a fresh id and carries the edited companion.
+        assert "VO zwei" in _cell_for(de_path, "title", "voiceover").content
+        assert "VO two" in _cell_for(en_path, "title", "voiceover").content
+
+    def test_unidentifiable_duplicate_errors_without_destructive_remove(self, tmp_path: Path):
+        # Two 'a' slides, BOTH edited away from the baseline → original cannot be
+        # identified → error. Crucially, the errored key must NOT re-enter the
+        # diff as a phantom `remove` that deletes the EN cell.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A one")
+                + _slide("de", "a", "# ## A two")
+                + _slide("de", "b", "# ## B"),
+                encoding="utf-8",
+            )
+            before_en = en_path.read_text(encoding="utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(default="# ## X")
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert plan.has_errors
+        assert plan.count("remove") == 0  # no phantom remove for the errored 'a'
+        assert result.applied_remove == 0
+        assert result.watermark_recorded is False
+        assert en_path.read_text(encoding="utf-8") == before_en  # EN untouched
+
+    def test_malformed_copy_companion_is_safe(self, tmp_path: Path):
+        # A copied group whose companion carries a DIFFERENT id than its slide.
+        # The slide renames, but the mismatched companion is left to normal
+        # pairing (an id-carrying add -> deferred), so the watermark cannot
+        # advance over the divergence.
+        de = _slide("de", "intro", "# ## Einleitung") + _vo("de", "intro", "# Sprechertext")
+        en = _slide("en", "intro", "# ## Introduction") + _vo("en", "intro", "# Narration")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung")
+                + _vo("de", "intro", "# Sprechertext")
+                + _slide("de", "intro", "# ## Neues Kapitel")
+                + _vo("de", "weird", "# Sprechertext copy"),  # companion id != slide id
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(default="# ## X")
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        # Not silently baselined: the mismatched companion forces a deferral.
+        assert result.deferred >= 1
+        assert result.watermark_recorded is False

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -9,6 +9,7 @@ from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_apply import apply_plan
 from clm.slides.sync_plan import PlanIssue, Proposal, SyncPlan, build_sync_plan, ordered_sync_cells
+from clm.slides.sync_translate import StaticSlideTranslator
 from clm.slides.sync_writeback import FileState
 
 # ---------------------------------------------------------------------------
@@ -496,3 +497,329 @@ class TestApplyMove:
         assert result.deferred >= 1
         assert result.watermark_recorded is False
         assert _slide_order(en_path) == ["a", "b"]  # EN untouched
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — add (Phase 3: translate + mint + insert)
+# ---------------------------------------------------------------------------
+
+
+def _slide_idless(lang: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"]\n{body}\n'
+
+
+def _vo_idless(lang: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"]\n{body}\n'
+
+
+def _cell_for(path: Path, slide_id: str, role: str = "slide"):
+    for c in parse_cells(path.read_text(encoding="utf-8")):
+        if c.metadata.slide_id == slide_id and role in c.tags:
+            return c
+    return None
+
+
+class TestApplyAdd:
+    def test_idless_slide_add_mints_en_id_on_both_decks(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author appends a brand-new id-less slide on DE.
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neues Thema"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("add") == 1
+            translator = StaticSlideTranslator(mapping={"# ## Neues Thema": "# ## New Topic"})
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 1
+        # EN-authority: the id is slugged from the EN (translated) heading and
+        # written to BOTH decks.
+        de_new = _cell_for(de_path, "new-topic")
+        en_new = _cell_for(en_path, "new-topic")
+        assert de_new is not None and en_new is not None
+        assert "Neues Thema" in de_new.content  # source body unchanged, just stamped
+        assert "New Topic" in en_new.content  # translated counterpart
+        assert _slide_order(en_path) == ["a", "new-topic"]
+        assert en_path.read_text(encoding="utf-8").endswith("\n")
+        assert plan2.is_noop  # idempotent: the stamped cell is no longer id-less
+
+    def test_en_to_de_add_slugs_from_en_source(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide_idless("en", "# ## New Topic"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(mapping={"# ## New Topic": "# ## Neues Thema"})
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 1
+        de_new = _cell_for(de_path, "new-topic")
+        assert de_new is not None
+        assert "Neues Thema" in de_new.content  # DE counterpart translated
+        assert _slide_order(de_path) == ["a", "new-topic"]
+
+    def test_narrative_companion_inherits_slide_id(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A")
+                + _slide_idless("de", "# ## Neu")
+                + _vo_idless("de", "# Sprechertext"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(
+                mapping={"# ## Neu": "# ## New", "# Sprechertext": "# Narration"}
+            )
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 2
+        en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+        sync_ids = [(c.metadata.slide_id, c.tags[0]) for c in en_cells if c.metadata.slide_id]
+        assert sync_ids == [("a", "slide"), ("new", "slide"), ("new", "voiceover")]
+        # The DE voiceover inherited the slide's minted id too.
+        assert _cell_for(de_path, "new", "voiceover") is not None
+
+    def test_add_in_the_middle_is_anchored(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B"),
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A")
+                + _slide_idless("de", "# ## Mid")
+                + _slide("de", "b", "# ## B"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(mapping={"# ## Mid": "# ## Middle"})
+            apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert _slide_order(en_path) == ["a", "middle", "b"]
+
+    def test_collision_resolves_against_existing_ids(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "new", "# ## Something"), _slide("en", "new", "# ## Something")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "new", "# ## Something") + _slide_idless("de", "# ## Neu"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            # "Neu" -> "New" -> slug "new", which collides with the existing id.
+            translator = StaticSlideTranslator(mapping={"# ## Neu": "# ## New"})
+            apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert _cell_for(en_path, "new-2") is not None
+        assert _cell_for(de_path, "new-2") is not None
+
+    def test_add_without_translator_is_deferred(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result = apply_plan(plan, judge=None, translator=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 0
+        assert result.deferred >= 1
+        assert result.watermark_recorded is False
+        assert _slide_order(en_path) == ["a"]  # nothing inserted
+
+    def test_translation_failure_defers_the_add(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator()  # no mapping, no default -> raises
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 0
+        assert result.has_errors
+        assert result.watermark_recorded is False
+        assert _slide_order(en_path) == ["a"]  # EN untouched
+        # The DE source cell stays id-less, so it is re-detected next run.
+        assert any(
+            c.metadata.slide_id is None and "slide" in c.tags
+            for c in parse_cells(de_path.read_text(encoding="utf-8"))
+        )
+
+    def test_bold_heading_mints_meaningful_id(self, tmp_path: Path):
+        # A heading with a bold lead-in must still yield an EN-derived slug,
+        # not a generic "slide" id.
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Wichtig"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(
+                mapping={"# ## Wichtig": "# ## **Important** Concept"}
+            )
+            apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert _cell_for(en_path, "important-concept") is not None
+        assert _cell_for(de_path, "important-concept") is not None
+
+    def test_parallel_idless_adds_on_both_decks_are_deferred(self, tmp_path: Path):
+        # The author mistakenly added a new slide id-less on BOTH decks. Pairing
+        # is out of scope; the engine must defer rather than duplicate.
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu"), encoding="utf-8"
+            )
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide_idless("en", "# ## New"), encoding="utf-8"
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(
+                mapping={"# ## Neu": "# ## New", "# ## New": "# ## Neu"}
+            )
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 0
+        assert result.deferred >= 2
+        assert result.watermark_recorded is False
+        # No duplication: each deck still has exactly its slide + one id-less new.
+        assert len(_slide_order(de_path)) == 2  # "a" + one id-less
+        assert len(_slide_order(en_path)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Blank-separated decks (realistic spacing): inserts/moves must stay byte-clean
+# ---------------------------------------------------------------------------
+
+
+def _bcell(lang: str, body: str, sid: str | None = None) -> str:
+    head = f'# %% [markdown] lang="{lang}" tags=["slide"]'
+    if sid is not None:
+        head += f' slide_id="{sid}"'
+    return f"{head}\n{body}"
+
+
+def _bjoin(*cells: str) -> str:
+    """Join cells with a blank-line separator and a terminal newline."""
+    return "\n\n".join(cells) + "\n"
+
+
+class TestBlankSeparatedDecks:
+    def test_add_in_middle_is_byte_clean(self, tmp_path: Path):
+        de = _bjoin(_bcell("de", "# ## A", "a"), _bcell("de", "# ## B", "b"))
+        en = _bjoin(_bcell("en", "# ## A", "a"), _bcell("en", "# ## B", "b"))
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _bjoin(
+                    _bcell("de", "# ## A", "a"),
+                    _bcell("de", "# ## Mid"),
+                    _bcell("de", "# ## B", "b"),
+                ),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(mapping={"# ## Mid": "# ## Middle"})
+            apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        expected = _bjoin(
+            _bcell("en", "# ## A", "a"),
+            _bcell("en", "# ## Middle", "middle"),
+            _bcell("en", "# ## B", "b"),
+        )
+        assert en_path.read_text(encoding="utf-8") == expected
+
+    def test_reorder_is_byte_clean(self, tmp_path: Path):
+        slides = [("a", "# ## A"), ("b", "# ## B"), ("c", "# ## C")]
+        de = _bjoin(*[_bcell("de", body, sid) for sid, body in slides])
+        en = _bjoin(*[_bcell("en", body, sid) for sid, body in slides])
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _bjoin(
+                    _bcell("de", "# ## C", "c"),
+                    _bcell("de", "# ## A", "a"),
+                    _bcell("de", "# ## B", "b"),
+                ),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        expected = _bjoin(
+            _bcell("en", "# ## C", "c"),
+            _bcell("en", "# ## A", "a"),
+            _bcell("en", "# ## B", "b"),
+        )
+        assert en_path.read_text(encoding="utf-8") == expected

--- a/tests/slides/test_sync_plan.py
+++ b/tests/slides/test_sync_plan.py
@@ -219,18 +219,46 @@ class TestMove:
         assert plan.in_sync_count == 3
 
 
-class TestCollision:
-    def test_duplicate_id_in_one_deck_is_error(self):
+class TestDuplicateId:
+    def test_copy_paste_is_detected_and_renamed(self):
+        # The watermark identifies the original (matches the baseline hash);
+        # the other duplicate is a copy → a rename proposal, not an error.
         plan = classify(
-            [cur(0, "dup", "h0"), cur(1, "dup", "h1")],
+            [cur(0, "dup", "h0"), cur(1, "dup", "hNEW")],  # original h0 + edited copy
+            [cur(0, "dup", "e0")],
+            [base(0, "dup", "h0")],
+            [base(0, "dup", "e0")],
+        )
+        assert not plan.has_errors
+        renames = [p for p in plan.proposals if p.kind == "rename"]
+        assert len(renames) == 1
+        assert renames[0].slide_id == "dup"
+        assert renames[0].direction == "de->en"
+        assert renames[0].content_hash == "hNEW"  # the copy, not the original
+        assert plan.in_sync_count == 1  # the original pairs normally
+
+    def test_ambiguous_duplicate_both_drifted_is_error(self):
+        # Neither duplicate matches the baseline → can't tell which is original.
+        plan = classify(
+            [cur(0, "dup", "hA"), cur(1, "dup", "hB")],
             [cur(0, "dup", "e0")],
             [base(0, "dup", "h0")],
             [base(0, "dup", "e0")],
         )
         assert plan.has_errors
-        errors = [i for i in plan.issues if i.severity == "error"]
-        assert len(errors) == 1
-        assert errors[0].slide_id == "dup"
+        assert plan.count("rename") == 0
+
+    def test_duplicate_with_no_baseline_is_error(self):
+        # Cold start: no baseline to identify the original → error, not a guess.
+        plan = classify(
+            [cur(0, "dup", "h0"), cur(1, "dup", "h1")],
+            [cur(0, "dup", "e0")],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.has_errors
+        assert plan.count("rename") == 0
 
 
 class TestColdStart:

--- a/tests/slides/test_sync_plan.py
+++ b/tests/slides/test_sync_plan.py
@@ -1,0 +1,437 @@
+"""Tests for :mod:`clm.slides.sync_plan` (Issue #166, Phase 1 classifier)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import (
+    BaselineCell,
+    CurrentCell,
+    build_sync_plan,
+    classify_changes,
+    ordered_sync_cells,
+    render_plan,
+)
+
+DE = Path("a.de.py")
+EN = Path("a.en.py")
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def cur(pos: int, sid: str | None, h: str, role: str = "slide", line: int = 1) -> CurrentCell:
+    return CurrentCell(position=pos, slide_id=sid, role=role, content_hash=h, line_number=line)
+
+
+def base(pos: int, sid: str | None, h: str, role: str = "slide") -> BaselineCell:
+    return BaselineCell(position=pos, slide_id=sid, role=role, content_hash=h)
+
+
+def classify(de_cur, en_cur, de_base, en_base, source: str = "watermark"):
+    return classify_changes(
+        de_cur, en_cur, de_base, en_base, de_path=DE, en_path=EN, baseline_source=source
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core classification (pure, no IO)
+# ---------------------------------------------------------------------------
+
+
+class TestInSync:
+    def test_unchanged_pair_is_noop(self):
+        plan = classify(
+            [cur(0, "intro", "d0")],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.is_noop
+        assert plan.proposals == []
+        assert plan.in_sync_count == 1
+        assert "already" in plan.summary()
+
+
+class TestAdd:
+    def test_idless_cell_on_de_is_add_de_to_en(self):
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, None, "dNEW")],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.count("add") == 1
+        add = next(p for p in plan.proposals if p.kind == "add")
+        assert add.direction == "de->en"
+        assert add.slide_id is None
+        assert add.translation_pending is True
+        assert plan.in_sync_count == 1
+
+    def test_idless_cell_on_en_is_add_en_to_de(self):
+        plan = classify(
+            [cur(0, "intro", "d0")],
+            [cur(0, "intro", "e0"), cur(1, None, "eNEW")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        add = next(p for p in plan.proposals if p.kind == "add")
+        assert add.direction == "en->de"
+        assert add.slide_id is None
+
+    def test_idless_survives_commit_semantics(self):
+        """An id-less cell is 'new' even if the baseline already lists the
+        deck — i.e. it is detected by absence of an id, not by git state."""
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, None, "x")],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.count("add") == 1
+
+    def test_missing_counterpart_is_add(self):
+        plan = classify(
+            [cur(0, "solo", "d0")],
+            [],
+            [base(0, "solo", "d0")],
+            [],
+        )
+        assert plan.count("add") == 1
+        add = next(p for p in plan.proposals if p.kind == "add")
+        assert add.direction == "de->en"
+        assert add.slide_id == "solo"
+
+
+class TestEdit:
+    def test_edit_on_de_only(self):
+        plan = classify(
+            [cur(0, "intro", "dNEW")],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "dOLD")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.count("edit") == 1
+        edit = plan.proposals[0]
+        assert edit.direction == "de->en"
+        assert edit.slide_id == "intro"
+
+    def test_edit_on_en_only(self):
+        plan = classify(
+            [cur(0, "intro", "d0")],
+            [cur(0, "intro", "eNEW")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "eOLD")],
+        )
+        assert plan.proposals[0].direction == "en->de"
+
+
+class TestConflict:
+    def test_both_edited_is_conflict(self):
+        plan = classify(
+            [cur(0, "intro", "dNEW")],
+            [cur(0, "intro", "eNEW")],
+            [base(0, "intro", "dOLD")],
+            [base(0, "intro", "eOLD")],
+        )
+        assert plan.count("conflict") == 1
+        conflict = plan.proposals[0]
+        assert conflict.direction is None
+        assert conflict.slide_id == "intro"
+
+    def test_removed_de_but_edited_en_is_conflict(self):
+        plan = classify(
+            [],
+            [cur(0, "intro", "eNEW")],
+            [base(0, "intro", "dOLD")],
+            [base(0, "intro", "eOLD")],
+        )
+        assert plan.count("conflict") == 1
+        assert "removed on DE but edited on EN" in plan.proposals[0].reason
+
+
+class TestRemove:
+    def test_remove_de_propagates_to_en(self):
+        plan = classify(
+            [],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.count("remove") == 1
+        remove = plan.proposals[0]
+        assert remove.direction == "de->en"
+        assert remove.slide_id == "intro"
+
+    def test_remove_en_propagates_to_de(self):
+        plan = classify(
+            [cur(0, "intro", "d0")],
+            [],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.proposals[0].direction == "en->de"
+
+
+class TestMove:
+    def test_reorder_on_de_only_is_move(self):
+        # baseline order a,b,c ; DE now c,a,b ; EN unchanged.
+        de_cur = [cur(0, "c", "hc"), cur(1, "a", "ha"), cur(2, "b", "hb")]
+        en_cur = [cur(0, "a", "ea"), cur(1, "b", "eb"), cur(2, "c", "ec")]
+        de_base = [base(0, "a", "ha"), base(1, "b", "hb"), base(2, "c", "hc")]
+        en_base = [base(0, "a", "ea"), base(1, "b", "eb"), base(2, "c", "ec")]
+        plan = classify(de_cur, en_cur, de_base, en_base)
+        assert plan.count("move") == 1
+        move = next(p for p in plan.proposals if p.kind == "move")
+        assert move.slide_id == "c"
+        assert move.direction == "de->en"
+        assert plan.in_sync_count == 2
+
+    def test_reorder_on_both_decks_is_order_conflict(self):
+        # baseline a,b,c,d ; both decks reorder to a,c,b,d identically.
+        de_cur = [cur(0, "a", "ha"), cur(1, "c", "hc"), cur(2, "b", "hb"), cur(3, "d", "hd")]
+        en_cur = [cur(0, "a", "ea"), cur(1, "c", "ec"), cur(2, "b", "eb"), cur(3, "d", "ed")]
+        de_base = [base(0, "a", "ha"), base(1, "b", "hb"), base(2, "c", "hc"), base(3, "d", "hd")]
+        en_base = [base(0, "a", "ea"), base(1, "b", "eb"), base(2, "c", "ec"), base(3, "d", "ed")]
+        plan = classify(de_cur, en_cur, de_base, en_base)
+        assert plan.count("move") == 0
+        assert any("order drifted on both" in i.reason for i in plan.issues)
+        assert plan.in_sync_count == 4
+
+    def test_insert_in_middle_is_not_a_spurious_move(self):
+        # An id-less slide inserted between b and c shifts positions but must
+        # NOT be read as a reorder of the unchanged cells.
+        de_cur = [cur(0, "a", "ha"), cur(1, "b", "hb"), cur(2, None, "new"), cur(3, "c", "hc")]
+        en_cur = [cur(0, "a", "ea"), cur(1, "b", "eb"), cur(2, "c", "ec")]
+        de_base = [base(0, "a", "ha"), base(1, "b", "hb"), base(2, "c", "hc")]
+        en_base = [base(0, "a", "ea"), base(1, "b", "eb"), base(2, "c", "ec")]
+        plan = classify(de_cur, en_cur, de_base, en_base)
+        assert plan.count("move") == 0
+        assert plan.count("add") == 1
+        assert plan.in_sync_count == 3
+
+
+class TestCollision:
+    def test_duplicate_id_in_one_deck_is_error(self):
+        plan = classify(
+            [cur(0, "dup", "h0"), cur(1, "dup", "h1")],
+            [cur(0, "dup", "e0")],
+            [base(0, "dup", "h0")],
+            [base(0, "dup", "e0")],
+        )
+        assert plan.has_errors
+        errors = [i for i in plan.issues if i.severity == "error"]
+        assert len(errors) == 1
+        assert errors[0].slide_id == "dup"
+
+
+class TestColdStart:
+    def test_shared_id_counts_as_in_sync(self):
+        plan = classify(
+            [cur(0, "intro", "d0")],
+            [cur(0, "intro", "e0")],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.in_sync_count == 1
+        assert plan.count("add") == 0
+        assert "baseline=none" in plan.summary()
+
+    def test_idless_add_in_cold_start(self):
+        plan = classify(
+            [cur(0, None, "dNEW")],
+            [],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.count("add") == 1
+        assert plan.proposals[0].slide_id is None
+
+    def test_one_side_only_id_is_cold_add(self):
+        plan = classify(
+            [cur(0, "solo", "d0")],
+            [],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.count("add") == 1
+        assert "one side only" in plan.proposals[0].reason
+
+    def test_no_baseline_summary_is_explicit(self):
+        plan = classify([], [], None, None, source="none")
+        assert plan.is_noop
+        summary = plan.summary()
+        assert "baseline=none" in summary
+        assert "cannot detect" in summary
+
+
+# ---------------------------------------------------------------------------
+# build_sync_plan (IO wrapper: baseline resolution)
+# ---------------------------------------------------------------------------
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n'
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )
+
+
+class TestBuildSyncPlanWatermark:
+    def test_edit_detected_against_watermark(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung\n#\n# - Punkt eins")
+        en = _slide("en", "intro", "# ## Introduction\n#\n# - Point one")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author edits the DE deck (adds a bullet).
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung\n#\n# - Punkt eins\n# - Punkt zwei"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert plan.baseline_source == "watermark"
+        assert plan.count("edit") == 1
+        assert plan.proposals[0].direction == "de->en"
+
+    def test_idless_add_detected_against_watermark(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author appends a brand-new, id-less slide on the DE side.
+            de_path.write_text(
+                de + _slide_idless("de", "# ## Neues Thema"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert plan.baseline_source == "watermark"
+        assert plan.count("add") == 1
+        assert plan.proposals[0].slide_id is None
+        assert plan.proposals[0].direction == "de->en"
+
+
+def _slide_idless(lang: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"]\n{body}\n'
+
+
+class TestBuildSyncPlanNoBaseline:
+    def test_no_watermark_no_git_is_baseline_none(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung") + _slide_idless("de", "# ## Neu")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+
+        plan = build_sync_plan(de_path, en_path, allow_git_fallback=False)
+
+        assert plan.baseline_source == "none"
+        # id-less add is still found; intro pairs as in-sync.
+        assert plan.count("add") == 1
+        assert plan.in_sync_count == 1
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+class TestBuildSyncPlanGitFallback:
+    def _git(self, cwd: Path, *args: str) -> None:
+        subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+    def test_git_head_used_when_no_watermark(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+
+        self._git(tmp_path, "init", "-q")
+        self._git(tmp_path, "config", "user.email", "t@example.com")
+        self._git(tmp_path, "config", "user.name", "Test")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+
+        # After committing the baseline, append a new id-less slide on DE.
+        de_path.write_text(de + _slide_idless("de", "# ## Neues Thema"), encoding="utf-8")
+
+        plan = build_sync_plan(de_path, en_path)  # no watermark cache → git HEAD
+
+        assert plan.baseline_source == "git-head"
+        assert plan.count("add") == 1
+        assert plan.proposals[0].slide_id is None
+
+    def test_commit_after_edit_still_detects_idless_add(self, tmp_path: Path):
+        """The named failure mode: committing the edited deck before syncing
+        does not hide the add — id-less-ness is git-immune."""
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+
+        self._git(tmp_path, "init", "-q")
+        self._git(tmp_path, "config", "user.email", "t@example.com")
+        self._git(tmp_path, "config", "user.name", "Test")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+
+        # Author adds an id-less slide AND commits before syncing.
+        de_path.write_text(de + _slide_idless("de", "# ## Neues Thema"), encoding="utf-8")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "added slide")
+
+        plan = build_sync_plan(de_path, en_path)
+
+        # HEAD now contains the add, so git-diff-HEAD would miss it — but the
+        # id-less marker still flags it.
+        assert plan.count("add") == 1
+        assert plan.proposals[0].slide_id is None
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+class TestRender:
+    def test_render_lists_proposals_and_summary(self):
+        plan = classify(
+            [cur(0, "intro", "dNEW"), cur(1, None, "x")],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "dOLD")],
+            [base(0, "intro", "e0")],
+        )
+        text = render_plan(plan)
+        assert "edit de->en intro/slide" in text
+        assert "translation pending" in text
+        assert "baseline=watermark" in text

--- a/tests/slides/test_sync_plan_walker.py
+++ b/tests/slides/test_sync_plan_walker.py
@@ -1,0 +1,598 @@
+"""Tests for :mod:`clm.slides.sync_plan_walker` (Issue #166, Phase 4 part 2).
+
+The walker renders every proposal kind, prompts per proposal, and drives one
+atomic :func:`apply_plan`. These tests use synthetic plans for the decision
+routing (focused and fast) and ``build_sync_plan`` for a couple of end-to-end
+paths (add / move) where the classifier's real output matters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_apply import ApplyResult
+from clm.slides.sync_plan import (
+    PlanIssue,
+    Proposal,
+    SyncPlan,
+    build_sync_plan,
+    ordered_sync_cells,
+)
+from clm.slides.sync_plan_walker import (
+    APPLY,
+    AUTO,
+    DE_WINS,
+    EN_WINS,
+    QUIT,
+    SKIP,
+    PlanWalkResult,
+    WalkerOptions,
+    render_proposal,
+    run_plan_walker,
+)
+from clm.slides.sync_translate import StaticSlideTranslator
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n'
+
+
+def _vo(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n{body}\n'
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )
+
+
+def _update_judge(text: str) -> StaticSyncJudge:
+    return StaticSyncJudge(default_proposal=SyncProposal(verdict="update", proposed_text=text))
+
+
+def _scripted(answers: list[str]):
+    """A prompt_fn that returns each answer in order."""
+    it: Iterator[str] = iter(answers)
+
+    def prompt(_message: str) -> str:
+        return next(it)
+
+    return prompt
+
+
+def _walk(
+    plan: SyncPlan,
+    answers: list[str],
+    *,
+    judge: StaticSyncJudge | None = None,
+    translator: StaticSlideTranslator | None = None,
+    cache: SyncWatermarkCache | None = None,
+) -> tuple[PlanWalkResult, list[str]]:
+    lines: list[str] = []
+    options = WalkerOptions(prompt_fn=_scripted(answers), echo=lines.append)
+    result = run_plan_walker(
+        plan,
+        judge=judge,
+        translator=translator,
+        watermark_cache=cache,
+        options=options,
+    )
+    return result, lines
+
+
+def _synthetic(de_path: Path, en_path: Path, *proposals: Proposal) -> SyncPlan:
+    plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+    plan.proposals.extend(proposals)
+    return plan
+
+
+def _slide_ids(path: Path) -> list[str]:
+    return [
+        c.metadata.slide_id for c in parse_cells(path.read_text("utf-8")) if c.metadata.slide_id
+    ]
+
+
+def _slide_order(path: Path) -> list[str]:
+    return [
+        c.metadata.slide_id
+        for c in parse_cells(path.read_text("utf-8"))
+        if c.metadata.is_slide_start and c.metadata.slide_id
+    ]
+
+
+# ---------------------------------------------------------------------------
+# render_proposal
+# ---------------------------------------------------------------------------
+
+
+class TestRenderProposal:
+    def test_edit_render_has_two_up(self):
+        p = Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")
+        text = render_proposal(p, {("a", "slide"): "# ## A-de"}, {("a", "slide"): "# ## A-en"})
+        assert "edit de->en a/slide" in text
+        assert "--- DE (current) ---" in text
+        assert "# ## A-de" in text
+        assert "# ## A-en" in text
+
+    def test_conflict_render_has_two_up_and_label(self):
+        p = Proposal(kind="conflict", role="slide", direction=None, slide_id="a")
+        text = render_proposal(p, {("a", "slide"): "# ## DE!"}, {("a", "slide"): "# ## EN!"})
+        assert "CONFLICT a/slide" in text
+        assert "# ## DE!" in text
+        assert "# ## EN!" in text
+
+    def test_remove_render_is_one_line(self):
+        p = Proposal(kind="remove", role="slide", direction="de->en", slide_id="a")
+        text = render_proposal(p, {}, {})
+        assert "remove de->en a/slide" in text
+        assert "--- DE" not in text  # structural kinds get no two-up
+
+    def test_add_render_marks_translation_pending(self):
+        p = Proposal(
+            kind="add", role="slide", direction="de->en", slide_id=None, translation_pending=True
+        )
+        text = render_proposal(p, {}, {})
+        assert "(id-less)/slide" in text
+        assert "[translation pending]" in text
+
+
+# ---------------------------------------------------------------------------
+# Gated kinds — apply / skip
+# ---------------------------------------------------------------------------
+
+
+class TestGatedApplySkip:
+    def test_apply_edit_writes_and_advances_watermark(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A-de"), _slide("en", "a", "# ## A-en")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = _synthetic(
+                de_path,
+                en_path,
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"),
+            )
+            judge = _update_judge("# ## A-en-updated")
+            result, _ = _walk(plan, ["a"], judge=judge, cache=cache)
+            recorded = cache.has_pair(str(de_path), str(en_path))
+        finally:
+            cache.close()
+
+        assert result.apply_result.applied_edit == 1
+        assert result.accepted == 1
+        assert result.exit_code == 0
+        assert result.apply_result.watermark_recorded is True
+        assert recorded is True
+        assert "# ## A-en-updated" in en_path.read_text("utf-8")
+
+    def test_skip_edit_defers_and_holds_watermark(self, tmp_path: Path):
+        # The core 2a safety property: skipping a proposal must NOT advance the
+        # watermark, so the un-applied edit re-surfaces rather than vanishing.
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A-de"), _slide("en", "a", "# ## A-en")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = _synthetic(
+                de_path,
+                en_path,
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"),
+            )
+            judge = _update_judge("# ## SHOULD-NOT-BE-WRITTEN")
+            result, _ = _walk(plan, ["s"], judge=judge, cache=cache)
+            recorded = cache.has_pair(str(de_path), str(en_path))
+        finally:
+            cache.close()
+
+        assert result.apply_result.applied_edit == 0
+        assert result.apply_result.deferred == 1
+        assert result.skipped == 1
+        assert result.exit_code == 1
+        assert result.apply_result.watermark_recorded is False
+        assert recorded is False
+        assert "SHOULD-NOT-BE-WRITTEN" not in en_path.read_text("utf-8")
+
+    def test_apply_remove_deletes_target(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A"),
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+        )
+        plan = _synthetic(
+            de_path,
+            en_path,
+            Proposal(kind="remove", role="slide", direction="de->en", slide_id="b"),
+        )
+        result, _ = _walk(plan, ["a"])
+        assert result.apply_result.applied_remove == 1
+        assert _slide_ids(en_path) == ["a"]
+
+    def test_skip_remove_keeps_target(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A"),
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+        )
+        plan = _synthetic(
+            de_path,
+            en_path,
+            Proposal(kind="remove", role="slide", direction="de->en", slide_id="b"),
+        )
+        result, _ = _walk(plan, ["s"])
+        assert result.apply_result.applied_remove == 0
+        assert result.apply_result.deferred == 1
+        assert _slide_ids(en_path) == ["a", "b"]
+
+    def test_unknown_choice_reprompts(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A-de"), _slide("en", "a", "# ## A-en")
+        )
+        plan = _synthetic(
+            de_path, en_path, Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")
+        )
+        judge = _update_judge("# ## A-en-updated")
+        result, lines = _walk(plan, ["x", "a"], judge=judge)
+        assert result.apply_result.applied_edit == 1
+        assert any("unknown choice" in line for line in lines)
+
+    def test_mixed_accept_then_skip_holds_watermark(self, tmp_path: Path):
+        # The decisive safety case: one edit accepted AND one skipped in the same
+        # pass. A partial apply must NOT advance the watermark (deferred > 0), so
+        # the skipped edit re-surfaces rather than being silently baselined. This
+        # is the regression a naive "advance if anything applied" gate would hit.
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A-de") + _slide("de", "b", "# ## B-de"),
+            _slide("en", "a", "# ## A-en") + _slide("en", "b", "# ## B-en"),
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = _synthetic(
+                de_path,
+                en_path,
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"),
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="b"),
+            )
+            judge = _update_judge("# ## UPDATED")
+            result, _ = _walk(plan, ["a", "s"], judge=judge, cache=cache)
+            recorded = cache.has_pair(str(de_path), str(en_path))
+        finally:
+            cache.close()
+
+        assert result.apply_result.applied_edit == 1  # 'a' applied
+        assert result.apply_result.deferred == 1  # 'b' skipped
+        assert result.accepted == 1
+        assert result.skipped == 1
+        assert result.apply_result.watermark_recorded is False  # held despite a partial apply
+        assert recorded is False
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Conflicts — de-wins / en-wins / skip
+# ---------------------------------------------------------------------------
+
+
+class TestConflict:
+    def _conflict_pair(self, tmp_path: Path) -> tuple[Path, Path]:
+        return _write_pair(
+            tmp_path, _slide("de", "a", "# ## A-de-edited"), _slide("en", "a", "# ## A-en-edited")
+        )
+
+    def test_de_wins_updates_en(self, tmp_path: Path):
+        de_path, en_path = self._conflict_pair(tmp_path)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = _synthetic(
+                de_path,
+                en_path,
+                Proposal(kind="conflict", role="slide", direction=None, slide_id="a"),
+            )
+            judge = _update_judge("# ## A-reconciled-en")
+            result, _ = _walk(plan, ["d"], judge=judge, cache=cache)
+        finally:
+            cache.close()
+
+        assert result.conflicts_resolved == 1
+        assert result.apply_result.applied_edit == 1
+        assert result.apply_result.deferred == 0
+        assert result.exit_code == 0
+        assert result.apply_result.watermark_recorded is True
+        assert "# ## A-reconciled-en" in en_path.read_text("utf-8")
+        assert "# ## A-de-edited" in de_path.read_text("utf-8")  # winner untouched
+
+    def test_en_wins_updates_de(self, tmp_path: Path):
+        de_path, en_path = self._conflict_pair(tmp_path)
+        plan = _synthetic(
+            de_path, en_path, Proposal(kind="conflict", role="slide", direction=None, slide_id="a")
+        )
+        judge = _update_judge("# ## A-reconciled-de")
+        result, _ = _walk(plan, ["e"], judge=judge)
+        assert result.conflicts_resolved == 1
+        assert "# ## A-reconciled-de" in de_path.read_text("utf-8")
+        assert "# ## A-en-edited" in en_path.read_text("utf-8")  # winner untouched
+
+    def test_skip_conflict_touches_nothing(self, tmp_path: Path):
+        de_path, en_path = self._conflict_pair(tmp_path)
+        before_de = de_path.read_text("utf-8")
+        before_en = en_path.read_text("utf-8")
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = _synthetic(
+                de_path,
+                en_path,
+                Proposal(kind="conflict", role="slide", direction=None, slide_id="a"),
+            )
+            judge = _update_judge("# ## NOPE")
+            result, _ = _walk(plan, ["s"], judge=judge, cache=cache)
+            recorded = cache.has_pair(str(de_path), str(en_path))
+        finally:
+            cache.close()
+
+        assert result.conflicts_resolved == 0
+        assert result.apply_result.deferred == 1
+        assert result.skipped == 1
+        assert result.exit_code == 1
+        assert result.apply_result.watermark_recorded is False
+        assert recorded is False
+        assert de_path.read_text("utf-8") == before_de
+        assert en_path.read_text("utf-8") == before_en
+
+
+# ---------------------------------------------------------------------------
+# Quit
+# ---------------------------------------------------------------------------
+
+
+class TestQuit:
+    def test_quit_defers_remaining_gated(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A-de") + _slide("de", "b", "# ## B-de"),
+            _slide("en", "a", "# ## A-en") + _slide("en", "b", "# ## B-en"),
+        )
+        plan = _synthetic(
+            de_path,
+            en_path,
+            Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"),
+            Proposal(kind="edit", role="slide", direction="de->en", slide_id="b"),
+        )
+        judge = _update_judge("# ## should-not-write")
+        result, _ = _walk(plan, ["q"], judge=judge)
+
+        assert result.apply_result.applied_edit == 0
+        assert result.apply_result.deferred == 2
+        assert result.unvisited == 2
+        assert result.exit_code == 1
+        assert "should-not-write" not in en_path.read_text("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Auto-applied kinds — add (end to end via the classifier)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoAdd:
+    def test_idless_add_is_auto_applied(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author appends a brand-new id-less slide on DE.
+            de_path.write_text(
+                _slide("de", "a", "# ## A")
+                + '# %% [markdown] lang="de" tags=["slide"]\n# ## Neues Thema\n',
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("add") == 1
+            translator = StaticSlideTranslator(mapping={"# ## Neues Thema": "# ## New Topic"})
+            # No prompt is consumed for an auto-applied add.
+            result, _ = _walk(plan, [], translator=translator, cache=cache)
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.auto_applied == 1
+        assert result.apply_result.applied_add == 1
+        assert result.exit_code == 0
+        assert "# ## New Topic" in en_path.read_text("utf-8")
+        assert plan2.is_noop  # minted id + advanced watermark -> idempotent
+
+    def test_add_without_translator_errors_exit_2(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A")
+                + '# %% [markdown] lang="de" tags=["slide"]\n# ## Neu\n',
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result, _ = _walk(plan, [], translator=None, cache=cache)
+        finally:
+            cache.close()
+
+        assert result.apply_result.has_errors
+        assert result.exit_code == 2
+
+    def test_idcarrying_add_is_deferred_not_auto(self, tmp_path: Path):
+        # An id-carrying "missing counterpart" add (a slide_id present on one
+        # deck only) is out of v1 scope: apply_plan defers it unconditionally.
+        # The walker must NOT label it auto-applied or promise a git diff that
+        # was never written — it records a DEFERRED action instead.
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B-de"),
+            _slide("en", "a", "# ## A"),
+        )
+        # Cold start (no watermark, git fallback disabled) -> baseline=none, so
+        # DE's lone slide "b" surfaces as an id-CARRYING add.
+        plan = build_sync_plan(de_path, en_path, allow_git_fallback=False)
+        add = next(p for p in plan.proposals if p.kind == "add")
+        assert add.slide_id == "b"  # id-carrying, not id-less
+
+        translator = StaticSlideTranslator(mapping={"# ## B-de": "# ## B-en"})  # fully mapped
+        before_en = en_path.read_text("utf-8")
+        result, lines = _walk(plan, [], translator=translator)
+
+        assert result.auto_applied == 0  # NOT counted as auto-applied
+        assert result.apply_result.applied_add == 0
+        assert result.apply_result.deferred >= 1
+        assert any("deferred (id-carrying add" in line for line in lines)
+        assert not any("will auto-apply" in line for line in lines)
+        assert en_path.read_text("utf-8") == before_en  # deck untouched
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Move routing (skip via walker; apply end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestMove:
+    def test_apply_move_reorders_target(self, tmp_path: Path):
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B") + _slide("de", "c", "# ## C")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B") + _slide("en", "c", "# ## C")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "c", "# ## C")
+                + _slide("de", "a", "# ## A")
+                + _slide("de", "b", "# ## B"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("move") >= 1
+            answers = ["a"] * plan.count("move")
+            result, _ = _walk(plan, answers, cache=cache)
+        finally:
+            cache.close()
+
+        assert result.apply_result.applied_move >= 1
+        assert _slide_order(en_path) == ["c", "a", "b"]
+
+    def test_skip_move_leaves_order(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B"),
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+        )
+        plan = _synthetic(
+            de_path,
+            en_path,
+            Proposal(kind="move", role="slide", direction="de->en", slide_id="a"),
+        )
+        result, _ = _walk(plan, ["s"])
+        assert result.apply_result.applied_move == 0
+        assert result.apply_result.deferred == 1
+        assert _slide_order(en_path) == ["a", "b"]  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Exit codes & summary
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodesAndSummary:
+    def test_edit_without_judge_is_exit_2(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A-de"), _slide("en", "a", "# ## A-en")
+        )
+        plan = _synthetic(
+            de_path, en_path, Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")
+        )
+        result, _ = _walk(plan, ["a"], judge=None)  # accept, but no judge -> error
+        assert result.apply_result.has_errors
+        assert result.exit_code == 2
+
+    def test_plan_error_is_exit_2(self, tmp_path: Path):
+        # A structural plan issue (e.g. an unresolvable duplicate id) is exit 2
+        # even when the walk applied nothing.
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+        plan.issues.append(PlanIssue(severity="error", slide_id="a", reason="duplicate"))
+        result, _ = _walk(plan, [])
+        assert result.exit_code == 2
+
+    def test_noop_plan_is_exit_0(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        plan = _synthetic(de_path, en_path)  # no proposals
+        result, _ = _walk(plan, [])
+        assert result.exit_code == 0
+        assert result.actions == []
+
+    def test_summary_has_two_lines_with_counts(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A-de"), _slide("en", "a", "# ## A-en")
+        )
+        plan = _synthetic(
+            de_path, en_path, Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")
+        )
+        judge = _update_judge("# ## A-en-updated")
+        result, _ = _walk(plan, ["a"], judge=judge)
+        lines = result.summary()
+        assert len(lines) == 2
+        assert "1 accepted" in lines[0]  # decisions line
+        assert "1 edit" in lines[1]  # outcomes line
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_empty_answer_defaults_to_skip(tmp_path: Path):
+    de_path, en_path = _write_pair(
+        tmp_path, _slide("de", "a", "# ## A-de"), _slide("en", "a", "# ## A-en")
+    )
+    plan = _synthetic(
+        de_path, en_path, Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")
+    )
+    judge = _update_judge("# ## nope")
+    result, _ = _walk(plan, [""], judge=judge)
+    assert result.apply_result.applied_edit == 0
+    assert result.skipped == 1
+
+
+def test_apply_result_type(tmp_path: Path):
+    de_path, en_path = _write_pair(
+        tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+    )
+    plan = _synthetic(de_path, en_path)
+    result, _ = _walk(plan, [])
+    assert isinstance(result.apply_result, ApplyResult)


### PR DESCRIPTION
## Summary

Reworks `clm slides sync` into the **single-language authoring workflow** from issue #166. Edit **one** half of a language-split deck (`<deck>.de.py` / `<deck>.en.py`) and a single pass brings the other half into sync:

- **edits** are propagated cell-by-cell,
- **brand-new slides** are translated (OpenRouter, `--translation-model`, default `anthropic/claude-sonnet-4-6`) and inserted,
- **removed** slides are dropped,
- **reorders** are mirrored, and
- a shared **`slide_id`** is minted onto both decks (EN-authority).

Direction is decided **per cell** by diffing each deck against a new ordered, per-language structural **watermark** (`sync_watermarks`), so one pass can carry edits in both directions; a cell edited on both decks is isolated as a **conflict** rather than guessed.

Closes #166.

## Breaking changes

- **Default flipped from dry-run to writing the working tree.** A bare `clm slides sync de en` now applies changes (nothing is committed — review with `git diff`). Pass `--dry-run` for the old preview.
- **`--source-lang` removed.** Direction is per-cell from the watermark; passing it is now a usage error.
- **`--apply` / `--trivial` removed.** The default already applies; use `--interactive` to gate proposals one by one.
- `sync_snapshots` is no longer written or read by `sync` (replaced by `sync_watermarks`).

See `clm info migration` (and the CHANGELOG) for the full before/after table and migration recipes.

## What's new

- `--translation-model TEXT` drives the new-slide add path (needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`; without a key, add proposals defer and everything else still applies).
- `--interactive` walker: `[a]pply / [s]kip / [q]uit`, plus `[d]e-wins / [e]n-wins` on a conflict, before a single atomic apply.
- JSON report carries `mode` / `exit_code` / `plan` / `apply` / `walker` blocks.

## How it's built (phased)

1. Design note + model-config investigation
2. Change classifier + structural watermark
3. Apply engine for remove/edit + watermark; slide-group reorder (move-apply)
4. New-slide translation + EN-authority id minting
5. Graceful copy-paste duplicate-id resolution; interactive review walker + conflict UX; per-cell partial watermark advance
6. Default-flip + docs + CHANGELOG (this phase rewires the CLI onto the new engine)

New engine modules: `slides/sync_plan.py`, `slides/sync_apply.py`, `slides/sync_plan_walker.py`, `slides/sync_translate.py`, plus `SyncWatermarkCache` in `infrastructure/llm/cache.py`.

## Testing

- `ruff (lint)`, `ruff (format)`, `mypy`, and the **full pre-commit suite** pass.
- Targeted sync + MCP suites green on the rebased tree: **200 passed** across `test_slides_sync`, `test_suggest_sync`, `test_sync_cache`, `test_sync_apply`, `test_sync_plan`, `test_sync_plan_walker`, `test_tools`.

## Follow-up (not in this PR)

The legacy engine modules (`sync.py`, `sync_walker.py`, `sync_trivial.py`, `sync_direction.py`) are left **dormant** (still unit-tested) — nothing in `src` imports them now. Pruning them is a deliberate follow-up so this PR's diff stays focused on the CLI + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
