### PR TITLE
fix(build): stop false 'duplicate output file' warnings for split decks

### DIFF
--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -1132,6 +1132,16 @@ class Course(NotebookMixin):
             for lang, format_, kind, output_dir in output_specs(
                 self, self.output_root, file.skip_html
             ):
+                # Phase 6: a split source file (``.de.py`` / ``.en.py``) only
+                # emits output for its tagged language, so it can never collide
+                # with its companion. Mirror the build-time gating in
+                # ``NotebookFile.get_processing_operation`` — without it, a
+                # split pair is falsely flagged as a duplicate because each
+                # file's single-language title fills both ``Text`` slots (see
+                # ``find_notebook_titles``).
+                if file.output_language_filter is not None and lang != file.output_language_filter:
+                    continue
+
                 ext = ext_for(format_, file.prog_lang)
                 file_name = file.file_name(lang, ext)
                 actual_output_dir = file.output_dir(output_dir, lang)

--- a/tests/build/test_split_sources.py
+++ b/tests/build/test_split_sources.py
@@ -63,6 +63,29 @@ BILINGUAL_DECK = dedent(
 )
 
 
+# A deck whose DE and EN titles are byte-identical. After ``split_in_file``
+# each companion carries only its own ``header_de`` / ``header_en`` macro, but
+# ``find_notebook_titles`` fills *both* ``Text`` slots from the single macro it
+# finds. So each split file reports the same DE-side filename — the exact shape
+# that made ``detect_duplicate_output_files`` raise a false "Duplicate output
+# file" warning for real-world decks like ``Video - Prompt Engineering``.
+IDENTICAL_TITLE_DECK = dedent(
+    """\
+    # j2 from "macros.j2" import header
+    # {{ header("Prompt Engineering", "Prompt Engineering") }}
+
+    # %% [markdown] lang="de" tags=["slide", "slide_id=intro"]
+    # ## Einführung
+
+    # %% [markdown] lang="en" tags=["slide", "slide_id=intro"]
+    # ## Introduction
+
+    # %%
+    x = 1
+    """
+)
+
+
 SPEC_XML = dedent(
     """\
     <course>
@@ -437,3 +460,64 @@ class TestBuildRefuses:
         assert reporter.finished is True
         assert reporter.cleaned is True
         assert any(e.category == "split_slide_dual_format" for e in reporter.errors)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-output detection must honour the per-language split filter
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateDetectionWithSplits:
+    """``detect_duplicate_output_files`` must not flag split companions.
+
+    A ``.de.py`` / ``.en.py`` pair emits to disjoint language directories, so
+    it can never collide on disk. Before the fix, the detector iterated *both*
+    languages for every file and ignored ``output_language_filter`` — so a
+    split pair whose DE and EN titles are identical was falsely reported as a
+    high-priority duplicate. Regression for that false positive.
+    """
+
+    def _split_course(self, tmp_path: Path) -> Course:
+        course_root, topic_dir = _scaffold_course(tmp_path)
+        source = topic_dir / "slides_prompt.py"
+        source.write_text(IDENTICAL_TITLE_DECK, encoding="utf-8")
+        split_in_file(source)
+        source.unlink()
+        course = _make_course(course_root, tmp_path)
+        assert course.loading_errors == []
+        return course
+
+    def test_identical_title_split_pair_not_flagged(self, tmp_path: Path) -> None:
+        course = self._split_course(tmp_path)
+
+        # Sanity: the pair really does share a number *and* a DE-side title,
+        # so each file would produce the same DE output filename.
+        notebooks = sorted(
+            (f for f in course.files if isinstance(f, NotebookFile)),
+            key=lambda f: f.path.name,
+        )
+        assert [f.path.name for f in notebooks] == [
+            "slides_prompt.de.py",
+            "slides_prompt.en.py",
+        ]
+        assert notebooks[0].file_name("de", ".html") == notebooks[1].file_name("de", ".html")
+
+        # The real method must report no duplicates: the filter routes each
+        # file to its own language directory.
+        assert course.detect_duplicate_output_files() == []
+
+    def test_filter_is_what_suppresses_the_false_positive(self, tmp_path: Path) -> None:
+        """Clearing the language filter reinstates the (false) collision.
+
+        This pins the suppression to ``output_language_filter`` and, by the
+        same token, proves the detector still catches genuine collisions among
+        files that carry no filter — the fix narrows scope, it doesn't disable
+        detection.
+        """
+        course = self._split_course(tmp_path)
+        for nb in (f for f in course.files if isinstance(f, NotebookFile)):
+            nb.output_language_filter = None
+
+        duplicates = course.detect_duplicate_output_files()
+        assert duplicates, "without the filter the identical-title pair collides"
+        assert all(d["files"] and len(d["files"]) > 1 for d in duplicates)


### PR DESCRIPTION
## Problem

Building a course that uses `.de.py` / `.en.py` split slide decks emits spurious **`[High Priority] Duplicate output file`** warnings, e.g.:

```
⚠ [High Priority] Duplicate output file '06 Video - Prompt Engineering.html' (lang=de, format=html, kind=code-along).
Multiple source files produce the same output:
  - .../slides_010v_prompt_engineering.de.py
  - .../slides_010v_prompt_engineering.en.py
```

These are **false positives** — the build output is correct. The German directory only ever receives the `.de.py` content and the English directory only the `.en.py` content; nothing overwrites anything.

## Root cause

`Course.detect_duplicate_output_files` looped over **both** languages for **every** notebook and ignored `output_language_filter`, so it pretended each `.en.py` also emits a German output (and vice-versa). The real build does *not* do this — `NotebookFile.get_processing_operation` gates on `output_language_filter` so each split companion emits only its tagged language to a disjoint language directory.

Two existing behaviours make this surface as an actual collision:

1. **Titles fill both language slots.** A split `.en.py` only contains `header_en("…")`; `find_notebook_titles` copies that single title into *both* the `de` and `en` `Text` slots (its docstring notes the wrong slot "is gated out by `output_language_filter` at routing time anyway" — the detector was the one place that didn't gate).
2. **Split companions share one slot number** (`Section.add_notebook_numbers`).

So whenever a split deck's DE and EN titles are identical (common for technical titles like *Video - Prompt Engineering*), both companions report the same `lang=de` filename and get flagged across every format/kind. When the titles differ, the phantom outputs land on different names and slip by — which is why only some slides warn.

## Fix

One guard in `detect_duplicate_output_files`, mirroring the build's own gating:

```python
if file.output_language_filter is not None and lang != file.output_language_filter:
    continue
```

A `.de.py` / `.en.py` pair emits to disjoint language directories, so it can never collide — the detector now skips the language each file doesn't actually produce. Genuine collisions among unfiltered (bilingual) files are still detected; the fix only narrows scope.

## Tests

Adds `TestDuplicateDetectionWithSplits` in `tests/build/test_split_sources.py`, using an identical-DE/EN-title split deck:

- `test_identical_title_split_pair_not_flagged` — reproduces the false positive; **fails without the fix** (30 phantom collisions, matching the real-world report) and passes with it.
- `test_filter_is_what_suppresses_the_false_positive` — clearing `output_language_filter` reinstates the (false) collision, pinning the suppression to the filter and proving genuine collisions among unfiltered files are still caught.

All existing duplicate-detection, build-reporting, core-course and split-source tests pass; ruff lint + format clean; full pre-commit fast suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)