### PR TITLE
fix(http-replay): widen + make configurable mitmdump readiness timeout (#184)

### DIFF
--- a/docs/claude/issue-165-p5-readiness.md
+++ b/docs/claude/issue-165-p5-readiness.md
@@ -186,6 +186,12 @@ $env:CLM_HTTP_REPLAY_TRANSPORT = "mitmproxy"
 $Repro = "C:\Users\tc\Programming\Python\Tests\clm-bug-repros\issue-143-cassette-connection-pool-deadlock"
 ```
 
+Optional tuning: `CLM_MITM_STARTUP_TIMEOUT` (seconds) overrides the proxy
+readiness budget. The default is 30s; raise it only if `mitmdump did not become
+ready` fires on a loaded host. The timeout error names this var, and
+distinguishes an overloaded-but-still-starting proxy from a genuine crash
+(issue #184).
+
 | Gate | How to run | PASS criterion |
 |---|---|---|
 | 3 byte-identity, 4 tooling | `pytest tests/infrastructure/test_http_replay_mitm_cassette_format.py` | green (skip-safe w/o mitmdump) |

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -34,9 +34,48 @@ logger = logging.getLogger(__name__)
 # Path to the addon module so we can pass it to ``mitmdump --scripts``.
 _ADDON_PATH = Path(__file__).parent / "addon.py"
 
-# How long we wait for the proxy to accept TCP connections before
-# giving up. Local startup is typically <500ms; cap conservatively.
-_STARTUP_TIMEOUT_SECONDS = 10.0
+# How long we wait for the proxy to accept TCP connections before giving up.
+# Local mitmdump startup is typically <500ms, but a loaded host — heavy xdist
+# parallelism, or background OS work like Windows installing updates — can push
+# the port-bind well past that. The readiness poll returns the instant the port
+# accepts, so a generous default is nearly free on the happy path; the full
+# budget only elapses for an *alive-but-not-yet-listening* process (a genuine
+# crash short-circuits via ``poll()``). ``CLM_MITM_STARTUP_TIMEOUT`` (seconds)
+# overrides it for CI or build hosts that need more headroom.
+_DEFAULT_STARTUP_TIMEOUT_SECONDS = 30.0
+_STARTUP_TIMEOUT_ENV = "CLM_MITM_STARTUP_TIMEOUT"
+
+
+def _startup_timeout_seconds() -> float:
+    """Resolve the proxy-readiness budget, honouring ``CLM_MITM_STARTUP_TIMEOUT``.
+
+    Returns the env override when it parses to a positive number, otherwise
+    ``_DEFAULT_STARTUP_TIMEOUT_SECONDS``. An unparseable or non-positive value
+    is ignored with a warning so a typo can't silently disable the wait.
+    """
+    raw = os.environ.get(_STARTUP_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_STARTUP_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-numeric %s=%r; using default %.1fs.",
+            _STARTUP_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_STARTUP_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_STARTUP_TIMEOUT_SECONDS
+    if value <= 0:
+        logger.warning(
+            "Ignoring non-positive %s=%r; using default %.1fs.",
+            _STARTUP_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_STARTUP_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_STARTUP_TIMEOUT_SECONDS
+    return value
+
 
 # How long we wait for graceful shutdown before sending SIGKILL/terminate.
 # mitmdump flushes flow streams on exit, so we want enough time for that.
@@ -305,7 +344,8 @@ class MitmproxyManager:
         assert self._process is not None
         assert self.listen_port is not None
 
-        deadline = time.monotonic() + _STARTUP_TIMEOUT_SECONDS
+        timeout = _startup_timeout_seconds()
+        deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if self._process.poll() is not None:
                 output = self._drain_output()
@@ -318,8 +358,19 @@ class MitmproxyManager:
             except OSError:
                 time.sleep(0.05)
         output = self._drain_output()
+        # Distinguish the two ways the budget can elapse so the error is
+        # actionable. A still-running process bound too slowly — the host is
+        # likely overloaded and the remedy is more time, not a code change. A
+        # process that has since exited is a genuine startup failure.
+        if self._process.poll() is None:
+            raise MitmproxyError(
+                f"mitmdump did not become ready within {timeout:.1f}s and is still "
+                f"starting — the host may be overloaded. Set {_STARTUP_TIMEOUT_ENV} "
+                f"(seconds) to allow more time if this recurs.\n{output}"
+            )
         raise MitmproxyError(
-            f"mitmdump did not become ready within {_STARTUP_TIMEOUT_SECONDS:.1f}s:\n{output}"
+            f"mitmdump exited (rc={self._process.returncode}) without becoming ready "
+            f"within {timeout:.1f}s:\n{output}"
         )
 
     def _drain_output(self) -> str:

--- a/tests/infrastructure/test_http_replay_mitm_manager.py
+++ b/tests/infrastructure/test_http_replay_mitm_manager.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import time
 
+import pytest
+
 from clm.infrastructure.http_replay_mitm import proxy_manager
 from clm.infrastructure.http_replay_mitm.proxy_manager import MitmproxyManager
 
@@ -143,3 +145,90 @@ class TestStartCommandTraceDir:
     def test_no_trace_dir_omits_clm_trace_dir_set(self, monkeypatch) -> None:
         cmd = self._captured_cmd(monkeypatch)
         assert not any("clm_trace_dir=" in str(part) for part in cmd)
+
+
+def _raise_oserror(*_args, **_kwargs):
+    """Stand-in for ``socket.create_connection`` that always refuses."""
+    raise OSError("connection refused")
+
+
+class _ReadyFakeProc:
+    """Minimal ``Popen`` stand-in for ``_wait_for_ready`` diagnostics.
+
+    ``rc=None`` models an alive-but-not-listening process (the overload case);
+    a non-None ``rc`` models a process that has already exited.
+    """
+
+    def __init__(self, rc: int | None = None) -> None:
+        self._rc = rc
+        self.returncode = rc
+
+    def poll(self) -> int | None:
+        return self._rc
+
+
+class TestStartupTimeoutResolution:
+    """``_startup_timeout_seconds`` honours ``CLM_MITM_STARTUP_TIMEOUT`` (issue #184).
+
+    The readiness budget is generous by default because a loaded host can bind
+    the port well past the old 10s, but it stays overridable for hosts that
+    need even more headroom. A typo must not silently disable the wait.
+    """
+
+    def test_default_when_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv(proxy_manager._STARTUP_TIMEOUT_ENV, raising=False)
+        assert (
+            proxy_manager._startup_timeout_seconds()
+            == proxy_manager._DEFAULT_STARTUP_TIMEOUT_SECONDS
+        )
+
+    def test_valid_override_is_used(self, monkeypatch) -> None:
+        monkeypatch.setenv(proxy_manager._STARTUP_TIMEOUT_ENV, "45")
+        assert proxy_manager._startup_timeout_seconds() == 45.0
+
+    def test_non_numeric_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv(proxy_manager._STARTUP_TIMEOUT_ENV, "soon")
+        assert (
+            proxy_manager._startup_timeout_seconds()
+            == proxy_manager._DEFAULT_STARTUP_TIMEOUT_SECONDS
+        )
+
+    def test_non_positive_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv(proxy_manager._STARTUP_TIMEOUT_ENV, "0")
+        assert (
+            proxy_manager._startup_timeout_seconds()
+            == proxy_manager._DEFAULT_STARTUP_TIMEOUT_SECONDS
+        )
+
+
+class TestWaitForReadyDiagnostics:
+    """The readiness timeout message distinguishes overload from a crash (issue #184)."""
+
+    def test_overloaded_process_still_starting_points_to_env_knob(self, monkeypatch) -> None:
+        # Tiny budget + a port that never accepts exercises the timeout path
+        # without waiting the real default.
+        monkeypatch.setenv(proxy_manager._STARTUP_TIMEOUT_ENV, "0.2")
+        monkeypatch.setattr(proxy_manager.socket, "create_connection", _raise_oserror)
+        mgr = _manager()
+        mgr._process = _ReadyFakeProc(rc=None)  # alive, never binds
+        mgr.listen_port = 65000
+
+        with pytest.raises(proxy_manager.MitmproxyError) as excinfo:
+            mgr._wait_for_ready()
+        msg = str(excinfo.value)
+        assert "overloaded" in msg.lower()
+        assert proxy_manager._STARTUP_TIMEOUT_ENV in msg
+        assert "0.2s" in msg  # reports the resolved budget, not the default
+
+    def test_exited_process_reports_crash_not_overload(self, monkeypatch) -> None:
+        monkeypatch.setattr(proxy_manager.socket, "create_connection", _raise_oserror)
+        mgr = _manager()
+        mgr._process = _ReadyFakeProc(rc=7)  # already exited
+        mgr.listen_port = 65000
+
+        with pytest.raises(proxy_manager.MitmproxyError) as excinfo:
+            mgr._wait_for_ready()
+        msg = str(excinfo.value)
+        assert "exited during startup" in msg
+        assert "rc=7" in msg
+        assert "overloaded" not in msg.lower()


### PR DESCRIPTION
Fixes #184.

## Problem

The mitmproxy readiness budget was a hardcoded **10s** (`proxy_manager.py`). Local `mitmdump` startup is typically <500ms, but a loaded host — heavy xdist parallelism, or background OS work (the failing run coincided with Windows installing updates) — can push the port-bind past 10s, raising `mitmdump did not become ready within 10.0s`.

This isn't only the flaky `test_proxy_starts_and_routes_traffic` smoke test. The **same ceiling gates a real `clm build --http-replay`** via the mitmproxy transport (`build.py:230` constructs the same `MitmproxyManager` → `start()` → `_wait_for_ready()`), so an overloaded build host could fail a production build the same way.

## Why widen, not mark-as-slow

Widening the budget is the correct lever here, not masking:

- The readiness poll **returns the instant the port accepts** (`_wait_for_ready` polls every 50ms), so a generous ceiling is nearly free on the happy path.
- A **genuine crash already short-circuits** via the per-iteration `poll()` check — the full budget only elapses for an *alive-but-not-yet-listening* (i.e. starved) process, which is exactly the case we want to tolerate.

## Changes

- **Default 10s → 30s.**
- **`CLM_MITM_STARTUP_TIMEOUT`** (seconds) overrides it. A non-numeric or non-positive value is ignored with a warning so a typo can't silently disable the wait. Env-var only — no constructor param — to keep the API surface small; fits the existing `CLM_MITM*` env family (`CLM_MITMDUMP`).
- **Actionable timeout diagnostic.** The error now distinguishes an overloaded-but-still-starting proxy (and names the env knob) from a process that has exited (a real crash) — turning a confusing flake into a message that tells you what to do.

## Tests

New unit tests in `test_http_replay_mitm_manager.py` (no real `mitmdump` needed):
- `TestStartupTimeoutResolution` — default, valid override, non-numeric → default, non-positive → default.
- `TestWaitForReadyDiagnostics` — overloaded (alive) path names `CLM_MITM_STARTUP_TIMEOUT` and reports the resolved budget; exited path says "exited during startup (rc=…)" and not "overloaded".

Verified: full fast suite passes (including the real-mitmdump round-trip smoke test) — notably **at 64-way parallelism on this branch** (no worker cap here), confirming the 30s default survives the contention that triggered #184. ruff + mypy clean.

## Notes

- Complements PR #185 (caps pre-commit xdist workers): #185 reduces contention *frequency* locally; this makes the readiness wait *robust* for CI slow-days, overloaded build hosts, and manual full-parallel runs. They're independent.
- Shutdown grace (`_SHUTDOWN_GRACE_SECONDS`) left unchanged — no evidence it's been tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)