### PR TITLE
feat(slides): default `clm slides sync` edit-judge to Claude Sonnet via OpenRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides sync --provider {openrouter,local}`** (and the
+  `$CLM_SYNC_PROVIDER` default) to choose the edit-reconciliation judge
+  backend. The edit judge now **defaults to Claude Sonnet via OpenRouter**
+  (much faster than the local Ollama model that was the only option before);
+  pass `--provider local` for the offline Ollama judge. The OpenRouter backend
+  needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`); without a key, edits are
+  recorded as errors (exit 2) instead of guessed. `--llm-model`'s default now
+  depends on `--provider` (`anthropic/claude-sonnet-4-6` for openrouter,
+  `qwen3:30b` for local). The OpenRouter client construction is shared with the
+  new-slide translator. A step toward per-purpose model configurability
+  (#167).
 - **`clm completion <shell>`.** New command that emits a shell completion
   activation script for `bash`, `zsh`, `fish`, or `powershell`. Bash/Zsh/Fish
   use Click's native completion generator; **PowerShell** support (the gap in

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -25,9 +25,12 @@ Modes:
   ``[a]pply`` / ``[s]kip`` / ``[q]uit`` (``[d]e-wins`` / ``[e]n-wins`` for a
   conflict) before a single atomic apply.
 
-Edits are reconciled by the local Ollama :class:`SyncJudge`; brand-new slides are
-translated by an OpenRouter :class:`SlideTranslator` (Claude Sonnet). When the
-judge is unreachable, edits are recorded as errors; when no translator key is
+Edits are reconciled by a :class:`SyncJudge` whose backend is selectable with
+``--provider`` (or ``$CLM_SYNC_PROVIDER``): ``openrouter`` (the default — Claude
+Sonnet via OpenRouter, fast) or ``local`` (the offline Ollama model, slower).
+Brand-new slides are always translated by an OpenRouter :class:`SlideTranslator`
+(Claude Sonnet). When the judge backend is unavailable (Ollama unreachable, or
+no OpenRouter key), edits are recorded as errors; when no translator key is
 configured, adds defer.
 
 Exit codes:
@@ -40,6 +43,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -51,6 +55,11 @@ from clm.infrastructure.llm.ollama_client import (
     DEFAULT_SYNC_MODEL,
     OllamaSyncJudge,
     is_available,
+)
+from clm.infrastructure.llm.openrouter_client import (
+    DEFAULT_SYNC_JUDGE_MODEL,
+    OpenRouterSyncJudge,
+    has_openrouter_api_key,
 )
 from clm.slides.sync_apply import ApplyResult, apply_plan
 from clm.slides.sync_plan import PlanIssue, SyncPlan, build_sync_plan, render_plan
@@ -92,15 +101,32 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     ),
 )
 @click.option(
+    "--provider",
+    type=click.Choice(["openrouter", "local"]),
+    default=lambda: os.environ.get("CLM_SYNC_PROVIDER") or "openrouter",
+    show_default="openrouter (or $CLM_SYNC_PROVIDER)",
+    help=(
+        "Backend for the edit-reconciliation judge: 'openrouter' (Claude Sonnet "
+        "via OpenRouter — fast, needs $OPENROUTER_API_KEY or $OPENAI_API_KEY) or "
+        "'local' (the Ollama daemon — offline, slower). Overridable with "
+        "$CLM_SYNC_PROVIDER."
+    ),
+)
+@click.option(
     "--llm-model",
-    default=DEFAULT_SYNC_MODEL,
-    show_default=True,
-    help="Ollama model used for the edit-reconciliation judge.",
+    default=None,
+    help=(
+        "Model for the edit-reconciliation judge. Default depends on --provider: "
+        f"'{DEFAULT_SYNC_JUDGE_MODEL}' for openrouter, '{DEFAULT_SYNC_MODEL}' for local."
+    ),
 )
 @click.option(
     "--ollama-url",
     default=None,
-    help="Base URL of the Ollama daemon. Defaults to $OLLAMA_URL or http://localhost:11434.",
+    help=(
+        "Base URL of the Ollama daemon (only used with --provider local). "
+        "Defaults to $OLLAMA_URL or http://localhost:11434."
+    ),
 )
 @click.option(
     "--llm-timeout",
@@ -141,7 +167,8 @@ def slides_sync_cmd(
     en_path: Path,
     dry_run: bool,
     interactive: bool,
-    llm_model: str,
+    provider: str,
+    llm_model: str | None,
     ollama_url: str | None,
     llm_timeout: float,
     translation_model: str,
@@ -160,9 +187,10 @@ def slides_sync_cmd(
         state) to classify per-cell add / edit / move / remove / conflict
         changes — direction is decided per cell, not globally.
       * Default: writes the agreed changes to the working tree in one pass
-        (edits reconciled by the local LLM, new slides translated + inserted,
-        a shared slide_id minted onto both decks) and advances the watermark.
-        Nothing is committed — review with ``git diff``.
+        (edits reconciled by the selected judge — Claude Sonnet via OpenRouter
+        by default, or local Ollama with --provider local — new slides
+        translated + inserted, a shared slide_id minted onto both decks) and
+        advances the watermark. Nothing is committed — review with ``git diff``.
       * --dry-run: prints the plan and writes nothing.
       * --interactive: prompts per proposal before a single atomic apply.
       * A cell edited on both sides since the last sync is isolated as a
@@ -191,7 +219,7 @@ def slides_sync_cmd(
             mode = "dry-run"
         elif interactive:
             mode = "interactive"
-            judge = _resolve_judge(llm_model, ollama_url, llm_timeout)
+            judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(model=translation_model)
             for issue in plan.issues:
                 click.echo(_issue_line(issue))
@@ -205,7 +233,7 @@ def slides_sync_cmd(
             apply_result = walk.apply_result
         else:
             mode = "apply"
-            judge = _resolve_judge(llm_model, ollama_url, llm_timeout)
+            judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(model=translation_model)
             apply_result = apply_plan(
                 plan,
@@ -229,21 +257,45 @@ def slides_sync_cmd(
     sys.exit(exit_code)
 
 
-def _resolve_judge(llm_model: str, ollama_url: str | None, llm_timeout: float) -> SyncJudge | None:
-    """Construct the edit judge, or ``None`` (with a warning) when unreachable.
+def _resolve_judge(
+    provider: str,
+    llm_model: str | None,
+    ollama_url: str | None,
+    llm_timeout: float,
+) -> SyncJudge | None:
+    """Construct the edit judge for ``provider``, or ``None`` (with a warning).
 
     A ``None`` judge records each edit proposal as an LLM-unavailable error, so
     the run still completes and surfaces exactly what could not be reconciled.
+    The ``--llm-model`` default is resolved per provider here so a bare run
+    picks the right model for the chosen backend.
     """
-    judge = OllamaSyncJudge(model=llm_model, base_url=ollama_url, timeout=llm_timeout)
-    if is_available(judge):
-        return judge
-    click.echo(
-        f"warning: Ollama is not reachable at {judge.base_url}; "
-        "every edit will be recorded as an LLM-unavailable error.",
-        err=True,
-    )
-    return None
+    if provider == "local":
+        ollama_judge = OllamaSyncJudge(
+            model=llm_model or DEFAULT_SYNC_MODEL,
+            base_url=ollama_url,
+            timeout=llm_timeout,
+        )
+        if is_available(ollama_judge):
+            return ollama_judge
+        click.echo(
+            f"warning: Ollama is not reachable at {ollama_judge.base_url}; "
+            "every edit will be recorded as an LLM-unavailable error. "
+            "Set --provider openrouter (the default) to use a hosted model.",
+            err=True,
+        )
+        return None
+
+    # provider == "openrouter"
+    if not has_openrouter_api_key():
+        click.echo(
+            "warning: OPENROUTER_API_KEY (or OPENAI_API_KEY) is not set; "
+            "every edit will be recorded as an LLM-unavailable error. "
+            "Set a key, or use --provider local for the offline Ollama judge.",
+            err=True,
+        )
+        return None
+    return OpenRouterSyncJudge(model=llm_model or DEFAULT_SYNC_JUDGE_MODEL, timeout=llm_timeout)
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -706,13 +706,18 @@ surfaced as a `conflict`: both decks are left untouched and it is listed
 in the summary. Resolve it with `--interactive` (`[d]e-wins` /
 `[e]n-wins`) or by editing one side and re-running.
 
-**Two LLMs.** Edits are reconciled by the local Ollama judge
-(`--llm-model`, default `qwen3:30b`). Brand-new slides are translated by
-an OpenRouter model (`--translation-model`, default
-`anthropic/claude-sonnet-4-6`), which needs `$OPENROUTER_API_KEY` (or
-`$OPENAI_API_KEY`); without a key, add proposals defer. When Ollama is
-unreachable, edit proposals are recorded as errors (exit 2) rather than
-guessed.
+**Two LLMs.** Edits are reconciled by a judge whose backend you pick
+with `--provider`: **`openrouter`** (the default — Claude Sonnet via
+OpenRouter, fast) or **`local`** (the Ollama daemon — offline but
+slower). Set a persistent default with `$CLM_SYNC_PROVIDER`. The judge
+model is `--llm-model` (default `anthropic/claude-sonnet-4-6` for
+openrouter, `qwen3:30b` for local). The OpenRouter backend needs
+`$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`). Brand-new slides are
+always translated by an OpenRouter model (`--translation-model`, default
+`anthropic/claude-sonnet-4-6`), which needs the same key; without a key,
+add proposals defer. When the judge backend is unavailable (Ollama
+unreachable, or no OpenRouter key), edit proposals are recorded as
+errors (exit 2) rather than guessed.
 
 Cells synced: markdown `slide` / `subslide` cells and narrative
 `voiceover` / `notes` cells. Shared code cells are intentionally
@@ -727,8 +732,9 @@ clm slides sync [OPTIONS] DE_PATH EN_PATH
 |--------|-------------|
 | `--dry-run` | Classify only: print the plan and write nothing. (The default, without this flag, writes the agreed changes to the working tree.) |
 | `--interactive` | Walk each proposal and choose `[a]pply / [s]kip / [q]uit` (`[d]e-wins / [e]n-wins` for a conflict) before a single atomic apply. Mutually exclusive with `--dry-run` and `--json`. |
-| `--llm-model TEXT` | Ollama model for the edit-reconciliation judge (default: `qwen3:30b`). |
-| `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
+| `--provider [openrouter\|local]` | Backend for the edit-reconciliation judge: `openrouter` (Claude Sonnet via OpenRouter, the default — needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`) or `local` (the Ollama daemon — offline, slower). Overridable with `$CLM_SYNC_PROVIDER`. |
+| `--llm-model TEXT` | Model for the edit-reconciliation judge. Default depends on `--provider`: `anthropic/claude-sonnet-4-6` (openrouter) or `qwen3:30b` (local). |
+| `--ollama-url TEXT` | Base URL of the Ollama daemon (only used with `--provider local`; default: `$OLLAMA_URL` or `http://localhost:11434`). |
 | `--llm-timeout SECONDS` | Per-call timeout for the edit judge (default: 120s — cold-load on a 30B local model can exceed 60s). |
 | `--translation-model TEXT` | OpenRouter model used to translate brand-new slides for the add path (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`; adds defer when absent. |
 | `--cache-dir PATH` | Directory holding the structural watermark. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
@@ -765,6 +771,9 @@ clm slides sync intro.de.py intro.en.py --dry-run
 
 # Walk each proposal, resolving conflicts as you go.
 clm slides sync intro.de.py intro.en.py --interactive
+
+# Use the offline local Ollama judge instead of OpenRouter.
+clm slides sync intro.de.py intro.en.py --provider local
 
 # Machine-readable plan for tooling.
 clm slides sync intro.de.py intro.en.py --dry-run --json
@@ -2105,6 +2114,8 @@ Create and manage ZIP archives of course output.
 | `CLM_LLM__API_BASE` | API base URL (e.g. `https://openrouter.ai/api/v1`) |
 | `CLM_LLM__MAX_CONCURRENT` | Max parallel LLM calls (default: 3) |
 | `CLM_LLM__TEMPERATURE` | LLM sampling temperature (default: 0.3) |
+| `CLM_SYNC_PROVIDER` | Default edit-judge backend for `clm slides sync`: `openrouter` (default) or `local`. Overridden by `--provider`. |
+| `OPENROUTER_API_KEY` | OpenRouter API key for `clm slides sync` (edit judge + new-slide translation); falls back to `OPENAI_API_KEY`. |
 | `CLM_RECORDINGS__OBS_OUTPUT_DIR` | Directory where OBS saves recordings |
 | `CLM_RECORDINGS__ACTIVE_COURSE` | Currently active course ID |
 | `CLM_RECORDINGS__AUTO_PROCESS` | Auto-process recordings when detected (default: false) |

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -209,15 +209,26 @@ both decks.
 
 - The pair arguments (`DE_PATH EN_PATH`), `--interactive`, `--json`,
   `--llm-model`, `--ollama-url`, `--llm-timeout`, `--cache-dir`, and
-  `--no-cache` are unchanged in spelling. `--interactive` still prompts
-  per proposal (now `[a]pply / [s]kip / [q]uit`, plus
-  `[d]e-wins / [e]n-wins` on a conflict) before a single atomic apply.
+  `--no-cache` are unchanged in spelling (but see What's new — the
+  `--llm-model` *default* now depends on the new `--provider`).
+  `--interactive` still prompts per proposal (now
+  `[a]pply / [s]kip / [q]uit`, plus `[d]e-wins / [e]n-wins` on a
+  conflict) before a single atomic apply.
 - Exit codes keep their buckets: `0` clean, `1` something left for
   review (a skipped proposal / unresolved conflict), `2` a structural
   error (classifier error, missing target cell, or the edit LLM down).
 
 ### What's new
 
+- `--provider [openrouter|local]` (default `openrouter`) selects the
+  edit-reconciliation judge backend, and `$CLM_SYNC_PROVIDER` sets a
+  persistent default. The edit judge previously was always the local
+  Ollama model; it now defaults to **Claude Sonnet via OpenRouter** (much
+  faster), which needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`). Pass
+  `--provider local` for the offline Ollama judge. The judge model is
+  still `--llm-model`, but its default now depends on `--provider`
+  (`anthropic/claude-sonnet-4-6` for openrouter, `qwen3:30b` for local).
+  See Issue #167.
 - `--translation-model TEXT` (default `anthropic/claude-sonnet-4-6`)
   picks the OpenRouter model that translates brand-new slides on the add
   path. It needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`); without a

--- a/src/clm/infrastructure/llm/openrouter_client.py
+++ b/src/clm/infrastructure/llm/openrouter_client.py
@@ -1,0 +1,160 @@
+"""Shared OpenRouter (OpenAI-compatible) client + the remote sync edit judge.
+
+CLM reaches OpenRouter through the OpenAI SDK — OpenRouter speaks the OpenAI
+chat-completions wire format. Several paths already do this: the voiceover
+propagate / merge / compare steps, ``clm summarize``, ``clm polish``, and the
+new-slide :class:`~clm.slides.sync_translate.OpenRouterSlideTranslator`. This
+module centralizes the construction (:func:`build_openrouter_client`,
+:func:`resolve_openrouter_api_key`) so every call site resolves the key and
+base URL the same way.
+
+It also adds :class:`OpenRouterSyncJudge` — a remote (Claude Sonnet by default)
+implementation of the edit-reconciliation
+:class:`~clm.infrastructure.llm.ollama_client.SyncJudge`. ``clm slides sync``
+defaults to this judge because the local Ollama model is slow; ``--provider
+local`` selects the offline Ollama path. This is a step toward per-purpose
+model configurability (Issue #167).
+
+The judge reuses the *exact* prompts and JSON parser as the local
+:class:`~clm.infrastructure.llm.ollama_client.OllamaSyncJudge`
+(:data:`SYNC_SYSTEM_PROMPT`, :func:`build_sync_user_prompt`,
+:func:`parse_sync_response`) so a proposal is identical regardless of backend,
+and raises :class:`OllamaError` on failure so the apply engine
+(``sync_apply._apply_edit``) handles both backends through one ``except``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from clm.infrastructure.llm.ollama_client import (
+    DEFAULT_TIMEOUT_SECONDS,
+    OllamaError,
+    SyncProposal,
+    parse_sync_response,
+)
+from clm.infrastructure.llm.sync_prompts import (
+    SYNC_PROMPT_VERSION,
+    SYNC_SYSTEM_PROMPT,
+    build_sync_user_prompt,
+)
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+
+# Claude Sonnet via OpenRouter — same default model the new-slide translator
+# uses (:data:`clm.slides.sync_translate.DEFAULT_TRANSLATION_MODEL`). Kept as a
+# distinct constant so the edit judge and the translator can be tuned
+# independently (Issue #167).
+DEFAULT_SYNC_JUDGE_MODEL = "anthropic/claude-sonnet-4-6"
+
+
+def resolve_openrouter_api_key(explicit: str | None = None) -> str | None:
+    """Return the OpenRouter/OpenAI key, preferring ``explicit`` then env vars.
+
+    Resolution order matches every other OpenRouter call site in CLM:
+    ``explicit`` → ``$OPENROUTER_API_KEY`` → ``$OPENAI_API_KEY``. Returns
+    ``None`` when none is set, so callers can warn and degrade gracefully
+    rather than crash.
+    """
+    return explicit or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
+
+
+def has_openrouter_api_key(explicit: str | None = None) -> bool:
+    """Whether an OpenRouter/OpenAI key is configured.
+
+    Thin predicate over :func:`resolve_openrouter_api_key` used by callers
+    (e.g. ``clm slides sync``) to decide up front whether a remote judge can
+    run, before constructing it.
+    """
+    return bool(resolve_openrouter_api_key(explicit))
+
+
+def build_openrouter_client(
+    *,
+    api_base: str | None = OPENROUTER_API_BASE,
+    api_key: str | None = None,
+    timeout: float | None = None,
+) -> OpenAI:  # pragma: no cover - thin network adapter
+    """Build a synchronous OpenAI client pointed at OpenRouter.
+
+    Shared by :class:`OpenRouterSyncJudge` and
+    :class:`~clm.slides.sync_translate.OpenRouterSlideTranslator`. ``api_key``
+    falls back to the usual env vars via :func:`resolve_openrouter_api_key`.
+    """
+    import openai
+
+    key = resolve_openrouter_api_key(api_key)
+    if timeout is None:
+        return openai.OpenAI(base_url=api_base, api_key=key)
+    return openai.OpenAI(base_url=api_base, api_key=key, timeout=timeout)
+
+
+@dataclass
+class OpenRouterSyncJudge:
+    """Remote edit-reconciliation judge (OpenRouter, Claude Sonnet by default).
+
+    A drop-in for :class:`~clm.infrastructure.llm.ollama_client.OllamaSyncJudge`:
+    same :meth:`propose` signature, same prompts, same JSON parser, and the same
+    :class:`OllamaError` on failure — so ``clm slides sync`` can swap backends
+    without the apply engine knowing. The command defaults to this judge because
+    the local Ollama model is slow; pass ``--provider local`` for the offline
+    path. See Issue #167 (per-purpose model configurability).
+    """
+
+    model: str = DEFAULT_SYNC_JUDGE_MODEL
+    api_base: str | None = OPENROUTER_API_BASE
+    api_key: str | None = None
+    temperature: float = 0.2
+    max_tokens: int = 4096
+    timeout: float = DEFAULT_TIMEOUT_SECONDS
+    prompt_version: str = SYNC_PROMPT_VERSION
+
+    def propose(
+        self,
+        source_text: str,
+        target_text: str,
+        *,
+        source_lang: str,
+        target_lang: str,
+    ) -> SyncProposal:
+        """Propose a target-cell body reflecting edits made on the source side.
+
+        Mirrors :meth:`OllamaSyncJudge.propose`. Raises :class:`OllamaError` on
+        any transport/parse failure (the protocol's standard error), so callers
+        treat it as "skip this pair with an error", not as fatal.
+        """
+        user_prompt = build_sync_user_prompt(
+            source_text=source_text,
+            target_text=target_text,
+            source_lang=source_lang,
+            target_lang=target_lang,
+        )
+        try:
+            response = build_openrouter_client(
+                api_base=self.api_base,
+                api_key=self.api_key,
+                timeout=self.timeout,
+            ).chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": SYNC_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001 - normalize to the protocol's error type
+            raise OllamaError(f"OpenRouter sync judge call failed: {exc}") from exc
+
+        text = (response.choices[0].message.content or "").strip()
+        if not text:
+            raise OllamaError("OpenRouter sync judge returned an empty response")
+        return parse_sync_response(text)

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -108,14 +108,10 @@ class OpenRouterSlideTranslator:
     prompt_version: str = "translate-v1"
 
     def _client(self):  # pragma: no cover - thin network adapter
-        import os
+        # Shared with the edit judge so key/base resolution stays in one place.
+        from clm.infrastructure.llm.openrouter_client import build_openrouter_client
 
-        import openai
-
-        key = (
-            self.api_key or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        )
-        return openai.OpenAI(base_url=self.api_base, api_key=key)
+        return build_openrouter_client(api_base=self.api_base, api_key=self.api_key)
 
     def translate(
         self,

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -86,16 +86,20 @@ def _seed_watermark(
 def _stub_judge(
     monkeypatch, proposed_text: str, *, verdict: str = "update", reason: str = ""
 ) -> None:
-    """Patch the CLI to skip the Ollama liveness check and use a static judge."""
+    """Patch the CLI's judge factory to return a static judge.
+
+    Provider-agnostic: it replaces ``_resolve_judge`` itself, so these tests
+    exercise the engine wiring identically whether the (now default) OpenRouter
+    backend or ``--provider local`` is selected, with no live LLM.
+    """
     from clm.cli.commands import slides_sync as cmd
     from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 
     proposal = SyncProposal(verdict=verdict, proposed_text=proposed_text, reason=reason)
-    monkeypatch.setattr(cmd, "is_available", lambda _judge: True)
     monkeypatch.setattr(
         cmd,
-        "OllamaSyncJudge",
-        lambda **_kw: StaticSyncJudge(default_proposal=proposal),
+        "_resolve_judge",
+        lambda *_args, **_kwargs: StaticSyncJudge(default_proposal=proposal),
     )
 
 
@@ -342,6 +346,8 @@ class TestOllamaUnavailable:
             [
                 str(de_path),
                 str(en_path),
+                "--provider",
+                "local",
                 "--ollama-url",
                 "http://127.0.0.1:1",  # nothing listens here
                 "--llm-timeout",
@@ -356,6 +362,93 @@ class TestOllamaUnavailable:
         assert "Ollama is not reachable" in (result.stderr or "")
         assert "1 error(s)" in result.output
         assert "watermark held" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Provider switch (openrouter default, local opt-in)
+# ---------------------------------------------------------------------------
+
+
+class TestProvider:
+    def test_default_provider_is_openrouter_and_needs_key(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # No --provider → openrouter; with no key the judge is unavailable, so
+        # the lone edit is recorded as an error (exit 2) and the watermark holds.
+        monkeypatch.delenv("CLM_SYNC_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 2, result.output
+        assert "OPENROUTER_API_KEY" in (result.stderr or "")
+        assert "1 error(s)" in result.output
+        assert "watermark held" in result.output
+
+    def test_default_provider_openrouter_with_key_applies(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # With a key present the default openrouter branch builds an
+        # OpenRouterSyncJudge (here swapped for a static one) and applies.
+        from clm.cli.commands import slides_sync as cmd
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+        monkeypatch.delenv("CLM_SYNC_PROVIDER", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        proposal = SyncProposal(verdict="update", proposed_text=_EN_PROPOSAL, reason="")
+        monkeypatch.setattr(
+            cmd, "OpenRouterSyncJudge", lambda **_kw: StaticSyncJudge(default_proposal=proposal)
+        )
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Point one" in en_path.read_text(encoding="utf-8")
+        assert "applied: 1 edit" in result.output
+
+    def test_env_var_selects_local_backend(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # $CLM_SYNC_PROVIDER=local routes to Ollama even without --provider; an
+        # unreachable daemon proves the local branch (not openrouter) was taken.
+        monkeypatch.setenv("CLM_SYNC_PROVIDER", "local")
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--ollama-url",
+                "http://127.0.0.1:1",
+                "--llm-timeout",
+                "1.0",
+                "--cache-dir",
+                str(cache_dir),
+            ],
+        )
+
+        assert result.exit_code == 2, result.output
+        assert "Ollama is not reachable" in (result.stderr or "")
+
+    def test_unknown_provider_is_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--provider", "bogus", "--no-cache"],
+        )
+        assert result.exit_code == 2
+        combined = _combined(result).lower()
+        assert "invalid" in combined or "bogus" in combined
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infrastructure/llm/test_openrouter_client.py
+++ b/tests/infrastructure/llm/test_openrouter_client.py
@@ -1,0 +1,133 @@
+"""Unit tests for the shared OpenRouter client helpers + the remote sync judge.
+
+These never touch the network: :func:`build_openrouter_client` is monkeypatched
+to return a fake OpenAI-shaped client, and the key-resolution helpers are pure.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clm.infrastructure.llm import openrouter_client as orc
+from clm.infrastructure.llm.ollama_client import OllamaError, SyncProposal
+
+# ---------------------------------------------------------------------------
+# Fakes (OpenAI client shape: client.chat.completions.create -> resp)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletions:
+    def __init__(self, content: str | None = None, exc: Exception | None = None):
+        self._content = content
+        self._exc = exc
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        message = type("Msg", (), {"content": self._content})()
+        choice = type("Choice", (), {"message": message})()
+        return type("Resp", (), {"choices": [choice]})()
+
+
+class _FakeChat:
+    def __init__(self, completions: _FakeCompletions):
+        self.completions = completions
+
+
+class _FakeClient:
+    def __init__(self, content: str | None = None, exc: Exception | None = None):
+        self.completions = _FakeCompletions(content, exc)
+        self.chat = _FakeChat(self.completions)
+
+
+def _patch_client(monkeypatch, **kw) -> _FakeClient:
+    client = _FakeClient(**kw)
+    monkeypatch.setattr(orc, "build_openrouter_client", lambda **_kwargs: client)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Key resolution
+# ---------------------------------------------------------------------------
+
+
+class TestKeyResolution:
+    def test_explicit_wins(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "env-or")
+        monkeypatch.setenv("OPENAI_API_KEY", "env-oa")
+        assert orc.resolve_openrouter_api_key("explicit") == "explicit"
+
+    def test_openrouter_preferred_over_openai(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "env-oa")
+        assert orc.resolve_openrouter_api_key() == "env-oa"
+        monkeypatch.setenv("OPENROUTER_API_KEY", "env-or")
+        assert orc.resolve_openrouter_api_key() == "env-or"
+
+    def test_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert orc.resolve_openrouter_api_key() is None
+        assert orc.has_openrouter_api_key() is False
+
+    def test_has_key_true_when_set(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "x")
+        assert orc.has_openrouter_api_key() is True
+
+
+# ---------------------------------------------------------------------------
+# OpenRouterSyncJudge.propose
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterSyncJudge:
+    def test_propose_parses_update(self, monkeypatch):
+        payload = json.dumps(
+            {"verdict": "update", "proposed_text": "# ## Hello", "reason": "drift"}
+        )
+        client = _patch_client(monkeypatch, content=payload)
+        judge = orc.OpenRouterSyncJudge()
+
+        proposal = judge.propose("# ## Quelle", "# ## Old", source_lang="de", target_lang="en")
+
+        assert isinstance(proposal, SyncProposal)
+        assert proposal.verdict == "update"
+        assert proposal.proposed_text == "# ## Hello"
+        # The call used the default model and carried a system + user message.
+        sent = client.completions.calls[0]
+        assert sent["model"] == orc.DEFAULT_SYNC_JUDGE_MODEL
+        roles = [m["role"] for m in sent["messages"]]
+        assert roles == ["system", "user"]
+
+    def test_propose_tolerates_fenced_json(self, monkeypatch):
+        body = json.dumps({"verdict": "in_sync", "proposed_text": "# ## Old", "reason": ""})
+        _patch_client(monkeypatch, content=f"```json\n{body}\n```")
+        judge = orc.OpenRouterSyncJudge(model="anthropic/claude-x")
+
+        proposal = judge.propose("a", "# ## Old", source_lang="en", target_lang="de")
+
+        assert proposal.verdict == "in_sync"
+
+    def test_propose_empty_response_raises(self, monkeypatch):
+        _patch_client(monkeypatch, content="")
+        judge = orc.OpenRouterSyncJudge()
+        with pytest.raises(OllamaError):
+            judge.propose("a", "b", source_lang="de", target_lang="en")
+
+    def test_propose_client_error_is_normalized(self, monkeypatch):
+        _patch_client(monkeypatch, exc=RuntimeError("boom"))
+        judge = orc.OpenRouterSyncJudge()
+        with pytest.raises(OllamaError):
+            judge.propose("a", "b", source_lang="de", target_lang="en")
+
+    def test_prompt_version_matches_local_judge(self):
+        # Same prompts as the Ollama judge → same version constant, so a proposal
+        # is interchangeable regardless of backend.
+        from clm.infrastructure.llm.sync_prompts import SYNC_PROMPT_VERSION
+
+        assert orc.OpenRouterSyncJudge().prompt_version == SYNC_PROMPT_VERSION


### PR DESCRIPTION
## Why

`clm slides sync` reconciled per-cell edits with a **local Ollama model** (`qwen3:30b`), which is slow. The new-slide *translation* step was already on OpenRouter — only the edit-reconciliation judge ran locally. This makes the judge backend selectable and flips the default to the fast hosted model.

## What

Add an easy switch between **Claude Sonnet via OpenRouter** (new default) and the **local Ollama** model:

```bash
clm slides sync intro.de.py intro.en.py                  # OpenRouter / Claude Sonnet (default, fast)
clm slides sync intro.de.py intro.en.py --provider local # local Ollama (offline, slower)
export CLM_SYNC_PROVIDER=local                            # persistent default
```

- **`--provider {openrouter,local}`**, default `openrouter`, overridable via `$CLM_SYNC_PROVIDER`.
- **`--llm-model`** default is now provider-aware: `anthropic/claude-sonnet-4-6` (openrouter) / `qwen3:30b` (local).
- New **`OpenRouterSyncJudge`** reuses the local judge's *exact* prompts + JSON parser and raises `OllamaError`, so the apply engine handles both backends through one code path (a proposal is identical regardless of backend). With no `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`, edits are recorded as errors (exit 2) rather than guessed — same "unavailable" handling as an unreachable Ollama.
- OpenRouter client construction (key + base-URL resolution) is **shared** between the judge and the existing new-slide translator (`OpenRouterSlideTranslator`), per the "we already use OpenRouter elsewhere" note.

A step toward per-purpose model configurability (**#167**).

## Notes / scope

- The voiceover/summarize LLM steps use a *separate, async, Langfuse-wrapped* client (`infrastructure/llm/client.py`). The sync apply engine is synchronous, so this PR consolidates the **sync** OpenRouter path only; unifying both is a reasonable follow-up.
- Required by the project's info-topics rule: updated `commands.md` (sync section + env-var table) and `migration.md` (What's new), plus `CHANGELOG.md`.

## Testing

- `ruff check` + `ruff format --check`: clean · `mypy`: clean
- New `tests/infrastructure/llm/test_openrouter_client.py` (judge parse/error paths + key resolution) and new provider-switch CLI tests in `tests/cli/test_slides_sync.py`
- Sync engine + llm subset: **220 passed**; `test_info.py`: **14 passed**
- All pre-commit hooks (ruff, mypy, fast pytest) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
