### PR TITLE
fix(slides): sync code cells + aux markdown, load .env, retry judge (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm slides sync` now propagates code cells and auxiliary markdown, not
+  only narrative markdown.** The single-language sync previously classified and
+  propagated *only* `slide` / `subslide` / `voiceover` / `notes` markdown; every
+  code cell and every untagged / `alt` markdown cell was silently dropped — a
+  workshop rewrite would leave the translated heading sitting over the **old**
+  code, and a new slide's runnable code never reached the other half. Sync now
+  handles the full cell set: a **language-neutral** code cell (no `lang=`) is
+  copied **verbatim** across both halves; a **localized** code cell (`lang=`,
+  with a `slide_id`) is **twinned and re-translated** on an edit (only its
+  string literals/comments change — the code stays byte-identical); an id-less
+  localized code cell is translated; auxiliary markdown (`alt` or untagged,
+  carrying a `slide_id`) syncs like narrative; a new slide brings its code
+  along; and code an author **moves between slide groups** follows. A new
+  structural pass rebuilds the cell order of each *changed* slide group from the
+  edited side, leaving untouched groups byte-for-byte intact. Also implements
+  **id-carrying adds** (a new slide/cell authored with a `slide_id` already on
+  it, present on one side only) — translated and inserted under the same id
+  rather than deferred.
+- **`clm slides sync` now loads the project `.env`.** It checked only the
+  process environment for the OpenRouter/OpenAI key, so a key kept in `.env`
+  (the usual course-repo layout, read by notebooks via `load_dotenv()`) was
+  invisible and every brand-new-slide translation silently deferred. Sync now
+  walks up from each deck's directory and loads the first `.env` it finds
+  (without overriding already-exported variables) before resolving the
+  judge/translator. Add `--no-env-file` to opt out; `--dry-run` never loads it.
+- **A transient edit-judge / translation failure no longer drops a cell.** A
+  single timeout or rate-limit on a hosted call previously errored the cell
+  outright and the run proceeded with a partial result; the OpenRouter judge and
+  translator now retry with bounded exponential backoff, and the **local**
+  `--llm-timeout` default is raised to 300s (a large local reasoning model can
+  legitimately spend minutes on a substantial cell, which the 120s default
+  starved). A persistently-unavailable backend is still surfaced as an error,
+  never guessed.
 - **Cross-references (`clm:`) now actually render as working links
   ([#17](https://github.com/hoelzl/clm/issues/17)).** Two defects made the
   feature a no-op end-to-end as first merged: (1) the notebook worker

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -655,6 +655,51 @@ Original Phase 5 spec (for reference):
 - **Exit:** the one-command workflow is live end-to-end, docs are
   version-accurate, and `pytest -m "not docker"` is green.
 
+### Phase 6 — Code cells + auxiliary markdown (the structural pass)
+
+**Status: ✅ implemented 2026-06-01.** Phases 1–5 scoped sync to narrative
+`(slide_id, role)` markdown only; a real editing pass (the `review_w01_w06`
+repro) showed that dropping every **code cell** and every untagged / `alt`
+markdown cell makes the result incoherent (translated headings over stale code).
+Phase 6 closes that gap **without changing the watermark schema**:
+
+- **Role extension** (`sync_writeback.role_of`, the one predicate the classifier
+  and apply engine both use): a **localized** code cell (`lang=` *and*
+  `slide_id`) gets the synthetic role `"code"`; an **aux** markdown cell (a
+  `slide_id` but no narrative tag) gets its first tag, else `"markdown"`. These
+  flow through the existing per-cell add/edit/move/conflict machinery. A code
+  `edit` is reconciled by **re-translating** the source body (a code-aware
+  translator prompt), not the markdown judge.
+- **id-carrying adds** (`sync_apply._add_idcarrying_one_direction`): a new cell
+  minted with a `slide_id` on one side only is translated and inserted under the
+  **same** id (no minting, no collision). Previously deferred as out-of-scope.
+- **Structural pass** (`sync_code.apply_code_structure`), run after the per-cell
+  apply: for each slide group whose **structural signature** drifted from the
+  edited side, rebuild its cell order from the source — **language-neutral**
+  cells (no `lang`) copied verbatim, **id-less localized** cells translated, and
+  every per-cell-synced cell pulled back in by `(slide_id, role)`. The signature
+  is language-agnostic (`("R", role)` for sync cells, `("S", body)` for shared,
+  `("L", kind)` for id-less localized, `("J",)` for a j2 header) so a narrative
+  edit or a `header_en`/`header_de` difference never triggers a rebuild, while a
+  code/shared change or a cross-group code move does. Untouched groups stay
+  byte-for-byte. Direction comes from the run's proposals (uniform `en->de` /
+  `de->en`); a pass with no single direction skips the structural step.
+
+Key invariants kept: language-neutral / id-less code is **never** minted a
+`slide_id` (so re-runs stay no-ops via the source-vs-target signature, not the
+watermark), and the j2 header macro is treated as language-specific
+(target's own header is kept). Also in this phase: `clm slides sync` loads the
+project `.env` (`cli/env_loading.py`, shared with `clm build`) so keys kept in
+`.env` reach the judge/translator; the OpenRouter judge/translator retry
+transient failures with backoff (`infrastructure/llm/retry.py`); and the local
+`--llm-timeout` default is provider-aware (300s).
+
+Known limitations (documented, surfaced — not silent): a *code-only* change with
+**no** narrative/id'd proposal and identical shared cells provides no direction
+signal and is not propagated (an author virtually always also touches a
+slide/voiceover); and an unchanged **id-less** localized code cell inside a group
+rebuilt for another reason is re-translated (churn, not corruption).
+
 ### Dependency graph
 
 ```
@@ -663,5 +708,6 @@ Phase 1 (watermark + classifier)
    │      └── Phase 3 (translation + minting)  ← also needs the translator/prompt suite
    │             └── Phase 4 (walker + conflict UX)
    │                    └── Phase 5 (default-flip + docs)
+   │                           └── Phase 6 (code cells + aux markdown; structural pass)
    └── (per-cell direction lands in Phase 1; old-inference deprecation in Phase 5)
 ```

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -278,18 +278,13 @@ def _maybe_start_mitmproxy_transport(
 def _find_env_file(start_dir: Path) -> Path | None:
     """Walk up from start_dir looking for a .env file.
 
-    Returns the path to the first .env file found, or None.
+    Returns the path to the first .env file found, or None. Thin wrapper over
+    the shared :func:`clm.cli.env_loading.find_env_file` (kept under this name
+    for the build command's existing callers and tests).
     """
-    search_dir = start_dir
-    while True:
-        candidate = search_dir / ".env"
-        if candidate.is_file():
-            return candidate
-        parent = search_dir.parent
-        if parent == search_dir:
-            break
-        search_dir = parent
-    return None
+    from clm.cli.env_loading import find_env_file
+
+    return find_env_file(start_dir)
 
 
 @dataclass

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -131,9 +131,13 @@ CACHE_DB_NAME = "clm-llm.sqlite"
 @click.option(
     "--llm-timeout",
     type=float,
-    default=120.0,
-    show_default=True,
-    help="Per-call timeout (seconds) for the edit judge.",
+    default=None,
+    show_default="120 (openrouter) / 300 (local)",
+    help=(
+        "Per-call timeout (seconds) for the edit judge. Defaults are "
+        "provider-aware: 120s for openrouter (fast hosted model) and 300s for "
+        "local (a large local reasoning model can spend minutes 'thinking')."
+    ),
 )
 @click.option(
     "--translation-model",
@@ -161,6 +165,17 @@ CACHE_DB_NAME = "clm-llm.sqlite"
         "baseline from git HEAD and no synced state is persisted."
     ),
 )
+@click.option(
+    "--no-env-file",
+    is_flag=True,
+    default=False,
+    help=(
+        "Do not auto-load a .env file. By default sync walks up from each deck's "
+        "directory and loads the first .env found (without overriding already-set "
+        "variables), so $OPENROUTER_API_KEY / $OPENAI_API_KEY kept in the project "
+        ".env are available to the judge and translator."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def slides_sync_cmd(
     de_path: Path,
@@ -170,10 +185,11 @@ def slides_sync_cmd(
     provider: str,
     llm_model: str | None,
     ollama_url: str | None,
-    llm_timeout: float,
+    llm_timeout: float | None,
     translation_model: str,
     cache_dir: Path | None,
     no_cache: bool,
+    no_env_file: bool,
     as_json: bool,
 ) -> None:
     """Bring a split DE/EN deck pair into sync after editing one side.
@@ -203,6 +219,16 @@ def slides_sync_cmd(
             "--interactive and --dry-run are mutually exclusive "
             "(--dry-run writes nothing; --interactive applies after prompting)"
         )
+
+    # Load the project .env before resolving the judge/translator, so keys kept
+    # only in .env (the usual course-repo layout) are found. Without this, every
+    # add defers and every edit errors as "LLM unavailable" even though the keys
+    # exist on disk (the reported sync bug). Skipped for --dry-run (no LLM) and
+    # when --no-env-file is given.
+    if not no_env_file and not dry_run:
+        from clm.cli.env_loading import load_env_files
+
+        load_env_files(de_path.parent, en_path.parent)
 
     watermark_cache: SyncWatermarkCache | None = None
     if not no_cache:
@@ -257,24 +283,42 @@ def slides_sync_cmd(
     sys.exit(exit_code)
 
 
+# Provider-aware default per-call timeout. A large local reasoning model
+# (qwen3:30b) can legitimately spend minutes on a substantial cell, so the
+# 120s default that the hosted model is fine with starved the local judge and
+# dropped most edits (the reported sync bug); give local a wider budget.
+_DEFAULT_TIMEOUT_OPENROUTER = 120.0
+_DEFAULT_TIMEOUT_LOCAL = 300.0
+
+
+def _resolve_timeout(value: float | None, default: float) -> float:
+    """The effective per-call timeout: ``value`` if positive, else ``default``.
+
+    A non-positive timeout is meaningless and is rejected by ``urllib`` (a
+    negative one raises an uncaught ``ValueError`` on the local path), so a
+    ``<= 0`` value falls back to the provider default rather than crashing.
+    """
+    return value if value is not None and value > 0 else default
+
+
 def _resolve_judge(
     provider: str,
     llm_model: str | None,
     ollama_url: str | None,
-    llm_timeout: float,
+    llm_timeout: float | None,
 ) -> SyncJudge | None:
     """Construct the edit judge for ``provider``, or ``None`` (with a warning).
 
     A ``None`` judge records each edit proposal as an LLM-unavailable error, so
     the run still completes and surfaces exactly what could not be reconciled.
-    The ``--llm-model`` default is resolved per provider here so a bare run
-    picks the right model for the chosen backend.
+    The ``--llm-model`` and ``--llm-timeout`` defaults are resolved per provider
+    here so a bare run picks the right model and timeout for the chosen backend.
     """
     if provider == "local":
         ollama_judge = OllamaSyncJudge(
             model=llm_model or DEFAULT_SYNC_MODEL,
             base_url=ollama_url,
-            timeout=llm_timeout,
+            timeout=_resolve_timeout(llm_timeout, _DEFAULT_TIMEOUT_LOCAL),
         )
         if is_available(ollama_judge):
             return ollama_judge
@@ -295,7 +339,10 @@ def _resolve_judge(
             err=True,
         )
         return None
-    return OpenRouterSyncJudge(model=llm_model or DEFAULT_SYNC_JUDGE_MODEL, timeout=llm_timeout)
+    return OpenRouterSyncJudge(
+        model=llm_model or DEFAULT_SYNC_JUDGE_MODEL,
+        timeout=_resolve_timeout(llm_timeout, _DEFAULT_TIMEOUT_OPENROUTER),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/cli/env_loading.py
+++ b/src/clm/cli/env_loading.py
@@ -1,0 +1,67 @@
+"""Shared ``.env`` discovery + loading for CLI commands.
+
+Several commands need the project's ``.env`` (API keys, model overrides) on the
+process environment before they run. A typical course checkout keeps keys in a
+``.env`` at the project root and **does not export them** — the notebooks read
+them via ``load_dotenv()``. A CLI command that only inspects ``os.environ``
+therefore silently behaves as if no key were configured (Issue: ``clm slides
+sync`` deferring every add because ``OPENROUTER_API_KEY`` lived only in ``.env``).
+
+``find_env_file`` walks up from a starting directory; ``load_env_files`` loads
+the first ``.env`` found for each starting directory (de-duplicated) without
+overriding values already present in the environment. ``clm build`` and
+``clm slides sync`` share this so the discovery rule stays in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["find_env_file", "load_env_files"]
+
+
+def find_env_file(start_dir: Path) -> Path | None:
+    """Walk up from ``start_dir`` looking for a ``.env`` file.
+
+    Returns the path to the first ``.env`` found, or ``None``. The spec/deck
+    file is often in a subdirectory (e.g. ``slides/.../topic_.../``) while
+    ``.env`` sits at the project root, so we ascend until the filesystem root.
+    """
+    search_dir = start_dir
+    while True:
+        candidate = search_dir / ".env"
+        if candidate.is_file():
+            return candidate
+        parent = search_dir.parent
+        if parent == search_dir:
+            break
+        search_dir = parent
+    return None
+
+
+def load_env_files(*start_dirs: Path, override: bool = False) -> list[Path]:
+    """Discover and load a ``.env`` for each starting directory.
+
+    For every directory in ``start_dirs`` the first ``.env`` found by
+    :func:`find_env_file` (ascending) is loaded into ``os.environ``. Duplicate
+    files (the common case where both deck halves live in the same directory)
+    are loaded once. ``override`` is passed through to ``python-dotenv``; the
+    default ``False`` means an already-exported value wins over the file. Returns
+    the list of ``.env`` files actually loaded, in discovery order.
+    """
+    from dotenv import load_dotenv
+
+    loaded: list[Path] = []
+    seen: set[Path] = set()
+    for start in start_dirs:
+        env_file = find_env_file(start.resolve())
+        if env_file is None or env_file in seen:
+            continue
+        seen.add(env_file)
+        if load_dotenv(env_file, override=override):
+            loaded.append(env_file)
+            logger.info("Loaded environment from %s", env_file)
+    return loaded

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -719,10 +719,29 @@ add proposals defer. When the judge backend is unavailable (Ollama
 unreachable, or no OpenRouter key), edit proposals are recorded as
 errors (exit 2) rather than guessed.
 
-Cells synced: markdown `slide` / `subslide` cells and narrative
-`voiceover` / `notes` cells. Shared code cells are intentionally
-excluded — split companions must keep them byte-identical, enforced by
-the split-source validator instead.
+**`.env` is loaded automatically.** Before resolving the judge and
+translator, sync walks up from each deck's directory and loads the first
+`.env` it finds (without overriding already-exported variables), so
+`$OPENROUTER_API_KEY` / `$OPENAI_API_KEY` kept in the project `.env` (the
+usual course-repo layout) are picked up. Pass `--no-env-file` to skip
+this; `--dry-run` never loads `.env` (it uses no LLM).
+
+Cells synced: **all** sync-relevant cells, not only narrative markdown:
+
+- markdown `slide` / `subslide` cells and narrative `voiceover` / `notes`
+  cells (reconciled by the judge);
+- **auxiliary markdown** carrying a `slide_id` but no narrative tag (an
+  `alt` solution note, an untagged explanatory cell) — twinned/translated
+  like narrative;
+- **code cells**: a **language-neutral** code cell (no `lang=`) is copied
+  **verbatim** across both halves; a **localized** code cell (`lang=` —
+  e.g. one whose string literals are shown to the learner) is **twinned and
+  translated**, keeping the code itself byte-identical. New slides bring
+  their code along, and code an author moves between slide groups follows.
+
+A localized code cell with a `slide_id` is reconciled per cell (its body
+re-translated on an edit); language-neutral and id-less code is propagated
+structurally, so it is **not** minted a `slide_id`.
 
 ```
 clm slides sync [OPTIONS] DE_PATH EN_PATH
@@ -735,10 +754,11 @@ clm slides sync [OPTIONS] DE_PATH EN_PATH
 | `--provider [openrouter\|local]` | Backend for the edit-reconciliation judge: `openrouter` (Claude Sonnet via OpenRouter, the default — needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`) or `local` (the Ollama daemon — offline, slower). Overridable with `$CLM_SYNC_PROVIDER`. |
 | `--llm-model TEXT` | Model for the edit-reconciliation judge. Default depends on `--provider`: `anthropic/claude-sonnet-4-6` (openrouter) or `qwen3:30b` (local). |
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (only used with `--provider local`; default: `$OLLAMA_URL` or `http://localhost:11434`). |
-| `--llm-timeout SECONDS` | Per-call timeout for the edit judge (default: 120s — cold-load on a 30B local model can exceed 60s). |
+| `--llm-timeout SECONDS` | Per-call timeout for the edit judge. Provider-aware default: 120s for `openrouter` (fast hosted model), 300s for `local` (a large local reasoning model can spend minutes "thinking"). |
 | `--translation-model TEXT` | OpenRouter model used to translate brand-new slides for the add path (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`; adds defer when absent. |
 | `--cache-dir PATH` | Directory holding the structural watermark. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
 | `--no-cache` | Do not read or write the watermark. Every run then re-derives its baseline from git `HEAD` and no synced state is persisted. |
+| `--no-env-file` | Do not auto-load a `.env` file. By default sync loads the first `.env` found above each deck (without overriding already-set variables), so keys kept in the project `.env` reach the judge/translator. |
 | `--json` | Emit a JSON report instead of human-readable lines. |
 
 Exit codes: `0` clean (every change applied, or nothing to do, with no

--- a/src/clm/infrastructure/llm/openrouter_client.py
+++ b/src/clm/infrastructure/llm/openrouter_client.py
@@ -36,6 +36,7 @@ from clm.infrastructure.llm.ollama_client import (
     SyncProposal,
     parse_sync_response,
 )
+from clm.infrastructure.llm.retry import call_with_retries
 from clm.infrastructure.llm.sync_prompts import (
     SYNC_PROMPT_VERSION,
     SYNC_SYSTEM_PROMPT,
@@ -137,8 +138,9 @@ class OpenRouterSyncJudge:
             source_lang=source_lang,
             target_lang=target_lang,
         )
-        try:
-            response = build_openrouter_client(
+
+        def _create():  # pragma: no cover - thin network adapter
+            return build_openrouter_client(
                 api_base=self.api_base,
                 api_key=self.api_key,
                 timeout=self.timeout,
@@ -150,6 +152,13 @@ class OpenRouterSyncJudge:
                 ],
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
+            )
+
+        # Retry transient failures (rate-limit / connection blip / 5xx) so one
+        # flaky call does not drop the edit; a persistent failure still raises.
+        try:
+            response = call_with_retries(
+                _create, exc=Exception, label=f"OpenRouter sync judge ({self.model})"
             )
         except Exception as exc:  # noqa: BLE001 - normalize to the protocol's error type
             raise OllamaError(f"OpenRouter sync judge call failed: {exc}") from exc

--- a/src/clm/infrastructure/llm/retry.py
+++ b/src/clm/infrastructure/llm/retry.py
@@ -1,0 +1,75 @@
+"""Bounded retry-with-backoff for the synchronous sync/translation LLM calls.
+
+Issue (reported sync bug): a single transient failure on the edit judge (e.g. an
+Ollama generation timing out, a momentary network blip, or an OpenRouter
+rate-limit) **dropped that cell entirely** — the run proceeded and produced a
+partial, incoherent result. One flaky call should not silently lose an edit.
+
+This helper retries a callable a small number of times with exponential backoff,
+re-raising the last error if every attempt fails (so a genuinely-down backend is
+still surfaced as an error, never guessed). It is intentionally tiny and pure —
+the ``sleep`` and ``exc`` types are injectable so it is unit-testable without a
+real clock or network, and the real judge/translator clients (network adapters,
+excluded from coverage) wrap their single call site with it.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DEFAULT_ATTEMPTS", "call_with_retries"]
+
+T = TypeVar("T")
+
+# Three attempts (two retries) balances resilience against a flaky call with not
+# stalling a run when the backend is genuinely unavailable.
+DEFAULT_ATTEMPTS = 3
+
+
+def call_with_retries(
+    fn: Callable[[], T],
+    *,
+    exc: type[BaseException] | tuple[type[BaseException], ...],
+    attempts: int = DEFAULT_ATTEMPTS,
+    base_delay: float = 1.0,
+    max_delay: float = 16.0,
+    sleep: Callable[[float], None] = time.sleep,
+    label: str = "LLM call",
+) -> T:
+    """Call ``fn`` with bounded retries on ``exc``, backing off between attempts.
+
+    Returns ``fn()``'s value on the first success. On the ``attempts``-th
+    failure the last exception is re-raised unchanged (callers keep their
+    existing "record this as an error" handling). ``base_delay * 2**i`` (capped
+    at ``max_delay``) is slept between attempts; ``sleep`` is injectable so tests
+    run instantly. Only ``exc`` is retried — a deterministic failure type (e.g. a
+    parse error) should be passed a narrower ``exc`` so it is not retried in
+    vain.
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+    last: BaseException | None = None
+    for i in range(attempts):
+        try:
+            return fn()
+        except exc as err:
+            last = err
+            if i == attempts - 1:
+                break
+            delay = min(max_delay, base_delay * (2**i))
+            logger.info(
+                "%s failed (attempt %d/%d: %s); retrying in %.1fs",
+                label,
+                i + 1,
+                attempts,
+                err,
+                delay,
+            )
+            sleep(delay)
+    assert last is not None  # loop ran at least once (attempts >= 1)
+    raise last

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -38,9 +38,16 @@ from clm.infrastructure.llm.ollama_client import OllamaError
 from clm.notebooks.slide_parser import parse_cell_header, parse_cells
 from clm.slides.raw_cells import RawCell
 from clm.slides.slug import resolve_collision, slugify
+from clm.slides.sync_code import apply_code_structure
 from clm.slides.sync_plan import Proposal, SyncPlan, ordered_sync_cells
 from clm.slides.sync_translate import TranslationError
-from clm.slides.sync_writeback import FileState, cell_content_hash, role_of
+from clm.slides.sync_writeback import (
+    CODE_ROLE,
+    FileState,
+    build_twin_cell,
+    cell_content_hash,
+    role_of,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -160,7 +167,9 @@ def apply_plan(
                 _note_deferred(deferred_keys, proposal)
         elif kind == "edit":
             if _accepted(decisions, proposal):
-                _apply_edit(proposal, de_state, en_state, de_content, en_content, judge, result)
+                _apply_edit(
+                    proposal, de_state, en_state, de_content, en_content, judge, translator, result
+                )
             else:
                 result.deferred += 1
                 _note_deferred(deferred_keys, proposal)
@@ -179,6 +188,7 @@ def apply_plan(
                 de_content,
                 en_content,
                 judge,
+                translator,
                 result,
                 deferred_keys,
             )
@@ -193,6 +203,14 @@ def apply_plan(
     # watermark will advance and the reorder stays idempotent).
     if moves:
         _apply_moves(moves, de_state, en_state, result, plan)
+
+    # Structural pass: propagate the cells the per-(slide_id, role) walk does not
+    # reach — language-neutral code (copied verbatim across halves), id-less
+    # localized code (translated) — and rebuild the cell order of changed slide
+    # groups, reusing the narrative / aux / id'd-code twins the steps above just
+    # placed. Cross-group code moves fall out of rebuilding both groups from the
+    # source. Runs after adds/moves so every twin it pulls is in place.
+    apply_code_structure(plan, de_state, en_state, translator, result)
 
     # Fail-safe: a complete resolution leaves no duplicate id behind. If one
     # survives (a should-not-happen bug), error so the watermark cannot advance
@@ -281,6 +299,7 @@ def _apply_conflict(
     de_content: dict[tuple[str, str], str],
     en_content: dict[tuple[str, str], str],
     judge: SyncJudge | None,
+    translator: SlideTranslator | None,
     result: ApplyResult,
     deferred_keys: set[tuple[str, str]],
 ) -> None:
@@ -300,6 +319,7 @@ def _apply_conflict(
             de_content,
             en_content,
             judge,
+            translator,
             result,
         )
     elif decision == DECISION_EN_WINS:
@@ -310,6 +330,7 @@ def _apply_conflict(
             de_content,
             en_content,
             judge,
+            translator,
             result,
         )
     else:
@@ -390,27 +411,36 @@ def _apply_edit(
     de_content: dict[tuple[str, str], str],
     en_content: dict[tuple[str, str], str],
     judge: SyncJudge | None,
+    translator: SlideTranslator | None,
     result: ApplyResult,
 ) -> None:
     if proposal.slide_id is None:
         result.errors.append(f"edit {proposal.role}: proposal has no slide_id")
         return
-    key = (proposal.slide_id, proposal.role)
+    sid = proposal.slide_id
+    key = (sid, proposal.role)
     if proposal.direction == "de->en":
         source_lang, target_lang = "de", "en"
         source_body = de_content.get(key, "")
         target_body = en_content.get(key, "")
-        target_state = en_state
+        source_state, target_state = de_state, en_state
     else:
         source_lang, target_lang = "en", "de"
         source_body = en_content.get(key, "")
         target_body = de_content.get(key, "")
-        target_state = de_state
+        source_state, target_state = en_state, de_state
+
+    # A localized code cell is reconciled by re-translating the source body (the
+    # markdown judge's prompt does not fit runnable code); only the human-facing
+    # string literals / comments differ across languages.
+    if proposal.role == CODE_ROLE:
+        _apply_code_edit(
+            sid, source_state, target_state, source_lang, target_lang, translator, result
+        )
+        return
 
     if judge is None:
-        result.errors.append(
-            f"edit {proposal.slide_id}/{proposal.role}: no judge (LLM unavailable)"
-        )
+        result.errors.append(f"edit {sid}/{proposal.role}: no judge (LLM unavailable)")
         return
 
     try:
@@ -418,20 +448,51 @@ def _apply_edit(
             source_body, target_body, source_lang=source_lang, target_lang=target_lang
         )
     except OllamaError as exc:
-        logger.info("edit judge failed on %s/%s: %s", proposal.slide_id, proposal.role, exc)
-        result.errors.append(f"edit {proposal.slide_id}/{proposal.role}: {exc}")
+        logger.info("edit judge failed on %s/%s: %s", sid, proposal.role, exc)
+        result.errors.append(f"edit {sid}/{proposal.role}: {exc}")
         return
 
     if sync_proposal.verdict != "update":
         result.in_sync += 1
         return
 
-    if target_state.replace_cell_body(
-        proposal.slide_id, proposal.role, sync_proposal.proposed_text
-    ):
+    if target_state.replace_cell_body(sid, proposal.role, sync_proposal.proposed_text):
         result.applied_edit += 1
     else:
-        result.errors.append(f"edit {proposal.slide_id}/{proposal.role}: target cell not found")
+        result.errors.append(f"edit {sid}/{proposal.role}: target cell not found")
+
+
+def _apply_code_edit(
+    sid: str,
+    source_state: FileState,
+    target_state: FileState,
+    source_lang: str,
+    target_lang: str,
+    translator: SlideTranslator | None,
+    result: ApplyResult,
+) -> None:
+    """Reconcile a localized code cell edit by re-translating the source body."""
+    if translator is None:
+        result.errors.append(f"edit {sid}/code: no translator (LLM unavailable)")
+        return
+    src_cell = source_state.find_cell(sid, CODE_ROLE)
+    if src_cell is None:
+        result.errors.append(f"edit {sid}/code: source cell not found")
+        return
+    try:
+        new_body = translator.translate(
+            source_body=src_cell.body.rstrip("\n"),
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=CODE_ROLE,
+        )
+    except TranslationError as exc:
+        result.errors.append(f"edit {sid}/code: translation failed: {exc}")
+        return
+    if target_state.replace_cell_body(sid, CODE_ROLE, new_body):
+        result.applied_edit += 1
+    else:
+        result.errors.append(f"edit {sid}/code: target cell not found")
 
 
 # ---------------------------------------------------------------------------
@@ -446,10 +507,14 @@ def _apply_adds(
     plan: SyncPlan,
     translator: SlideTranslator | None,
 ) -> None:
-    """Translate, mint, and insert counterparts for new and copy-pasted slides.
+    """Translate and insert counterparts for new and copy-pasted cells.
 
-    One deck walk per direction handles two cases:
+    Three cases:
 
+    - **id-carrying add**: a new cell already minted with a ``slide_id`` on one
+      side only — translate and insert the twin under the *same* id at its
+      source anchor (:func:`_add_idcarrying_one_direction`). Covers a new id'd
+      slide, narrative companion, aux-markdown cell, or localized code cell.
     - **add** (id-less cell): a new slide mints a fresh EN-authority id stamped
       onto *both* siblings; a narrative companion inherits the preceding slide's
       id; the translated counterpart is inserted on the other deck.
@@ -458,9 +523,8 @@ def _apply_adds(
       defeat it) is re-minted to a fresh id — its companions follow by
       group-adjacency — leaving the original alone, then handled like an add.
 
-    id-carrying "missing counterpart" adds are out of scope and deferred. Both
-    cases are sticky via the stamp, so they apply regardless of whether the rest
-    of the pass is clean.
+    All cases are sticky (the id is on disk afterward), so they apply regardless
+    of whether the rest of the pass is clean.
     """
     add_props = [p for p in plan.proposals if p.kind == "add"]
     rename_props = [p for p in plan.proposals if p.kind == "rename"]
@@ -468,15 +532,31 @@ def _apply_adds(
         return
 
     idd = [p for p in add_props if p.slide_id is not None]
-    if idd:
-        result.deferred += len(idd)  # missing-counterpart adds: a follow-up
-
     idless = [p for p in add_props if p.slide_id is None]
-    if len(idless) + len(rename_props) == 0:
-        return
+
     if translator is None:
-        result.deferred += len(idless) + len(rename_props)
+        result.deferred += len(idd) + len(idless) + len(rename_props)
         result.errors.append("add/rename present but no translator available")
+        return
+
+    # id-carrying adds: a new cell (slide / subslide / narrative / aux markdown /
+    # localized code) already minted with a slide_id on one side only — e.g. a
+    # deck whose ids were assigned before the split, where the author then adds a
+    # new id'd slide on one half. Translate and insert the twin under the *same*
+    # id (no minting, no collision) at its source-order anchor.
+    if idd:
+        de_keys = {(p.slide_id, p.role) for p in idd if p.direction == "de->en"}
+        en_keys = {(p.slide_id, p.role) for p in idd if p.direction == "en->de"}
+        if de_keys:
+            _add_idcarrying_one_direction(
+                de_state, en_state, "de", "en", de_keys, translator, result
+            )
+        if en_keys:
+            _add_idcarrying_one_direction(
+                en_state, de_state, "en", "de", en_keys, translator, result
+            )
+
+    if len(idless) + len(rename_props) == 0:
         return
 
     process_idless = True
@@ -508,6 +588,48 @@ def _apply_adds(
     _add_one_direction(
         en_state, de_state, "en", "de", translator, used_ids, result, en_copy_ids, process_idless
     )
+
+
+def _add_idcarrying_one_direction(
+    source_state: FileState,
+    target_state: FileState,
+    source_lang: str,
+    target_lang: str,
+    add_keys: set[tuple[str | None, str]],
+    translator: SlideTranslator,
+    result: ApplyResult,
+) -> None:
+    """Insert the twin of each id-carrying new cell, under the same id, at anchor.
+
+    Walks the source deck once. A sync cell whose ``(slide_id, role)`` is in
+    ``add_keys`` is brand-new (present on the source only): translate it, build
+    a twin that preserves its id, tags, and cell type (markdown vs code) with the
+    language swapped, and insert it after the previously-seen cell that already
+    exists on the target. Any other sync cell is an existing one whose twin is
+    already on the target and serves as the running anchor. Language-neutral /
+    id-less cells are skipped here (handled structurally by
+    :mod:`clm.slides.sync_code`); the structural pass later rebuilds the order of
+    every changed group, so the anchor here only needs to be *near* right.
+    """
+    anchor: tuple[str, str] | None = None
+    for cell in list(source_state.cells):
+        role = role_of(cell.metadata)
+        if role is None or cell.metadata.lang != source_lang:
+            continue
+        sid = cell.metadata.slide_id
+        if sid is None:
+            continue
+        key = (sid, role)
+        if key not in add_keys:
+            anchor = key  # an existing cell already twinned on the target
+            continue
+        target_body = _translate(cell, source_lang, target_lang, translator, role, result)
+        if target_body is None:
+            continue  # _translate recorded the deferral/error; keep the anchor
+        twin = build_twin_cell(cell, target_lang, target_body)
+        _insert_at_anchor(target_state, anchor, twin)
+        result.applied_add += 1
+        anchor = key
 
 
 def _identify_copy_slides(

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -1,0 +1,344 @@
+"""Structural code-cell / cell-order propagation for single-language sync.
+
+Phase 6 of Issue #166 — the reported *"sync never propagates CODE cells"* bug.
+The per-``(slide_id, role)`` engine in :mod:`clm.slides.sync_apply` reconciles
+narrative markdown, auxiliary markdown, and **localized id'd** code cells. It
+cannot reach two other kinds of cell, nor place them in the right order:
+
+- **language-neutral** cells (no ``lang=``): code or markdown shared *verbatim*
+  between the two halves of a split deck — imports, setup, plain output cells;
+- **id-less localized** cells (a ``lang=`` cell with no ``slide_id``): a one-off
+  demo/output cell that needs translating but has no stable identity.
+
+This module runs **after** the per-cell apply, when the narrative / aux /
+id'd-code twins are already on the target deck, and rebuilds the cell order of
+each *changed* slide group from the source deck:
+
+- a cell reconciled per-cell (``role_of`` is not ``None``) is pulled back in by
+  its ``(slide_id, role)`` — its content was already reconciled, just reposition;
+- a **language-neutral** cell is copied verbatim;
+- an **id-less localized** cell is translated.
+
+A group is rebuilt only when its *structural signature* (the order of role
+cells, the verbatim text of shared cells, and the kinds of id-less localized
+cells — all language-agnostic) differs between source and target. A pure
+narrative edit leaves the signature unchanged, so narrative-only passes never
+touch a group here. Cells the author **moved between groups** fall out for free,
+because each group is rebuilt from its current source membership.
+
+Direction is taken from the run's narrative proposals (the single-language
+workflow edits one deck): a uniform ``en->de`` / ``de->en`` selects the source.
+A pass with no determinable single direction (cold start, or cells edited both
+ways) skips this structural step.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from clm.slides.raw_cells import RawCell
+from clm.slides.sync_translate import TranslationError
+from clm.slides.sync_writeback import CODE_ROLE, FileState, build_twin_cell, role_of
+
+if TYPE_CHECKING:
+    from clm.slides.sync_apply import ApplyResult
+    from clm.slides.sync_plan import SyncPlan
+    from clm.slides.sync_translate import SlideTranslator
+
+__all__ = ["apply_code_structure"]
+
+
+def apply_code_structure(
+    plan: SyncPlan,
+    de_state: FileState,
+    en_state: FileState,
+    translator: SlideTranslator | None,
+    result: ApplyResult,
+) -> None:
+    """Propagate language-neutral / id-less-localized cells and fix group order.
+
+    Mutates the target deck's :class:`FileState` in place (and marks it dirty)
+    for every slide group whose structure drifted from the source. No-op when
+    the run has no single propagation direction.
+    """
+    direction = _single_direction(plan)
+    if direction is None:
+        return
+    if direction == "en->de":
+        source_state, target_state, source_lang, target_lang = en_state, de_state, "en", "de"
+    else:
+        source_state, target_state, source_lang, target_lang = de_state, en_state, "de", "en"
+
+    src_head, src_groups = _split_groups(source_state.cells)
+    tgt_head, tgt_groups = _split_groups(target_state.cells)
+
+    # First source group per id (a copy-paste duplicate is resolved upstream).
+    src_group_by_id: dict[str, list[RawCell]] = {}
+    for group in src_groups:
+        sid = group[0].metadata.slide_id
+        if sid is not None:
+            src_group_by_id.setdefault(sid, group)
+
+    sep = target_state.separator_blanks()  # read before we swap cells out
+    new_cells: list[RawCell] = []
+    rebuilt_ids: set[int] = set()
+
+    def emit(region: list[RawCell], *, was_rebuilt: bool) -> None:
+        new_cells.extend(region)
+        if was_rebuilt:
+            rebuilt_ids.update(id(c) for c in region)
+
+    def reconcile(src_region: list[RawCell], tgt_region: list[RawCell]) -> None:
+        if _signature(src_region) == _signature(tgt_region):
+            emit(tgt_region, was_rebuilt=False)
+            return
+        rebuilt = _rebuild_region(
+            src_region, tgt_region, target_state, source_lang, target_lang, translator, result
+        )
+        if rebuilt is None:
+            # A translation needed for the rebuild failed (no translator, or it
+            # raised). Keep the target region byte-for-byte rather than commit a
+            # partial rebuild that would DROP a pre-existing target cell; the
+            # failure is already recorded (deferred + error), so the watermark
+            # holds and the region re-attempts on the next run.
+            emit(tgt_region, was_rebuilt=False)
+        else:
+            emit(rebuilt, was_rebuilt=True)
+
+    # Head region (cells before the first slide) — same rule as a group.
+    reconcile(src_head, tgt_head)
+
+    for tgt_group in tgt_groups:
+        sid = tgt_group[0].metadata.slide_id
+        src_group = src_group_by_id.get(sid) if sid is not None else None
+        if src_group is None:
+            emit(tgt_group, was_rebuilt=False)
+        else:
+            reconcile(src_group, tgt_group)
+
+    if rebuilt_ids:
+        _normalize_separators(
+            new_cells, sep, rebuilt_ids, ends_with_newline=target_state.ends_with_newline
+        )
+        target_state.cells = new_cells
+        target_state.dirty = True
+
+
+# ---------------------------------------------------------------------------
+# Direction
+# ---------------------------------------------------------------------------
+
+
+def _single_direction(plan: SyncPlan) -> str | None:
+    """The one propagation direction of the plan, or ``None`` if not unambiguous."""
+    directions = {p.direction for p in plan.proposals if p.direction in ("de->en", "en->de")}
+    if len(directions) == 1:
+        return next(iter(directions))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Grouping + structural signature
+# ---------------------------------------------------------------------------
+
+
+def _split_groups(cells: list[RawCell]) -> tuple[list[RawCell], list[list[RawCell]]]:
+    """Split ``cells`` into a head (before the first slide) and slide groups.
+
+    A group is a slide/subslide cell plus every following cell until the next
+    slide/subslide.
+    """
+    head: list[RawCell] = []
+    groups: list[list[RawCell]] = []
+    current: list[RawCell] | None = None
+    for cell in cells:
+        if cell.metadata.is_slide_start:
+            current = [cell]
+            groups.append(current)
+        elif current is None:
+            head.append(cell)
+        else:
+            current.append(cell)
+    return head, groups
+
+
+def _signature(cells: list[RawCell]) -> list[tuple]:
+    """A language-agnostic structural fingerprint of a region.
+
+    Per cell:
+
+    - **per-cell-synced** (``role_of`` set): ``("R", role)`` — a position marker
+      *without* the slide_id. Its identity and content are the per-cell pass's
+      and the move logic's job; the structural pass must not react to a narrative
+      content edit, nor to a narrative cell reassigned to a different slide (a
+      move the engine may have deliberately deferred). Only the *role* is kept,
+      so a code/shared cell relocating relative to its narrative anchors is still
+      detected;
+    - **language-neutral** (no ``lang``): ``("S", body)`` — shared verbatim, so
+      its text is comparable across decks;
+    - **id-less localized** (``lang`` set): ``("L", kind)`` — body is
+      language-specific (not comparable), so only its presence/kind/order count;
+    - **j2 directive**: ``("J",)`` — position marker only. A header macro is
+      language-specific (``header_en`` vs ``header_de``) without a ``lang=``
+      attribute, so its body must NOT count: a differing header is correct, not
+      drift, and must never trigger a rebuild that would copy it across.
+
+    Two regions with equal signatures are structurally in sync; a difference is
+    an added / removed / relocated code or shared cell that the structural pass
+    must reconcile.
+    """
+    sig: list[tuple] = []
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2:
+            sig.append(("J",))
+            continue
+        role = role_of(meta)
+        if role is not None:
+            sig.append(("R", role))
+        elif meta.lang is None:
+            sig.append(("S", cell.body))
+        else:
+            sig.append(("L", "code" if meta.cell_type == "code" else "markdown"))
+    return sig
+
+
+# ---------------------------------------------------------------------------
+# Region rebuild
+# ---------------------------------------------------------------------------
+
+
+def _rebuild_region(
+    src_cells: list[RawCell],
+    tgt_cells: list[RawCell],
+    target_state: FileState,
+    source_lang: str,
+    target_lang: str,
+    translator: SlideTranslator | None,
+    result: ApplyResult,
+) -> list[RawCell] | None:
+    """Rebuild a target region to mirror the source region's cell order.
+
+    Walks the source region in order, emitting for each cell its target-side
+    counterpart: a pulled twin (per-cell-synced), a verbatim copy (shared), or a
+    fresh translation (id-less localized). The source order becomes the target
+    order, so cross-group moves and intra-group reorders are resolved here.
+
+    Returns ``None`` if any required translation fails (no translator, or it
+    raised). Aborting — rather than returning a partial list — is essential:
+    the caller replaces the *whole* target region with the result, so dropping
+    one cell from a partial rebuild would delete a pre-existing target cell from
+    disk. The failure is recorded (deferred + error) before returning ``None``.
+    """
+    tgt_j2 = [c for c in tgt_cells if c.metadata.is_j2]
+    j2_seen = 0
+    out: list[RawCell] = []
+    for cell in src_cells:
+        meta = cell.metadata
+        if meta.is_j2:
+            # A j2 header is language-specific (header_en / header_de) but not via
+            # a lang attribute, so keep the TARGET deck's own header rather than
+            # copying the source's. Match by ordinal; fall back to a verbatim copy
+            # only if the target somehow has fewer j2 cells.
+            twin = tgt_j2[j2_seen] if j2_seen < len(tgt_j2) else None
+            out.append(twin if twin is not None else _copy_cell(cell))
+            j2_seen += 1
+            continue
+        role = role_of(meta)
+        if role is not None:
+            twin = _find(tgt_cells, meta.slide_id, role)
+            if twin is None and meta.slide_id is not None:
+                twin = target_state.find_cell(meta.slide_id, role)
+            if twin is not None:
+                out.append(twin)
+            else:
+                # The per-cell pass should have placed this twin (add/edit). If it
+                # is missing (e.g. translation deferred), translate as a fallback;
+                # on failure, abort the whole region rather than drop the cell.
+                body = _translate(cell, source_lang, target_lang, role, translator, result)
+                if body is None:
+                    return None
+                out.append(build_twin_cell(cell, target_lang, body))
+        elif meta.lang is None:
+            out.append(_copy_cell(cell))  # language-neutral: shared verbatim
+        elif meta.lang == source_lang:
+            kind = CODE_ROLE if meta.cell_type == "code" else "markdown"
+            body = _translate(cell, source_lang, target_lang, kind, translator, result)
+            if body is None:
+                return None
+            out.append(build_twin_cell(cell, target_lang, body))
+        # else: an other-language cell in the source deck — should not occur; skip.
+    return out
+
+
+def _translate(
+    cell: RawCell,
+    source_lang: str,
+    target_lang: str,
+    role: str,
+    translator: SlideTranslator | None,
+    result: ApplyResult,
+) -> str | None:
+    """Translate a cell body for the structural pass, recording failures."""
+    if translator is None:
+        result.deferred += 1
+        result.errors.append(f"code-structure: no translator for a {role} cell")
+        return None
+    try:
+        return translator.translate(
+            source_body=cell.body.rstrip("\n"),
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=role,
+        )
+    except TranslationError as exc:
+        result.deferred += 1
+        result.errors.append(f"code-structure: translate {role} cell failed: {exc}")
+        return None
+
+
+def _copy_cell(cell: RawCell) -> RawCell:
+    """A verbatim copy of a language-neutral source cell for the other deck."""
+    return RawCell(lines=list(cell.lines), line_number=0, metadata=cell.metadata)
+
+
+def _find(cells: list[RawCell], slide_id: str | None, role: str) -> RawCell | None:
+    for cell in cells:
+        if cell.metadata.slide_id == slide_id and role_of(cell.metadata) == role:
+            return cell
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Separators
+# ---------------------------------------------------------------------------
+
+
+def _normalize_separators(
+    cells: list[RawCell], sep: int, rebuilt_ids: set[int], *, ends_with_newline: bool
+) -> None:
+    """Give every rebuilt non-last cell the deck's separator; clear the last's.
+
+    Only the cells the structural pass produced or reordered (``rebuilt_ids``)
+    are touched, so an untouched group keeps its exact bytes. Built twins arrive
+    with no trailing blanks and copied/pulled cells carry their own; normalising
+    the rebuilt cells to the deck's gap keeps them byte-consistent with the rest.
+    ``j2`` header cells are skipped — a header macro often sits tight against its
+    sibling (gap 0) while the deck is otherwise blank-separated. The final cell's
+    trailing blank is the terminal-newline artifact, restored by
+    :meth:`FileState.flush`.
+    """
+    last = len(cells) - 1
+    for i, cell in enumerate(cells):
+        if cell.metadata.is_j2 or id(cell) not in rebuilt_ids:
+            continue
+        want = 0 if (i == last and ends_with_newline) else sep
+        _set_trailing_blanks(cell, want)
+
+
+def _set_trailing_blanks(cell: RawCell, n: int) -> None:
+    body = cell.lines[1:]
+    while body and body[-1] == "":
+        body.pop()
+    body.extend([""] * n)
+    cell.lines = [cell.lines[0], *body]

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.notebooks.slide_parser import Cell, parse_cells
-from clm.slides.sync_writeback import cell_content_hash
+from clm.slides.sync_writeback import cell_content_hash, role_of
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.cache import SyncWatermarkCache
@@ -52,18 +52,8 @@ __all__ = [
     "render_plan",
 ]
 
-# Roles that participate in cross-language sync. Mirrors
-# ``clm.slides.sync._ROLE_TAGS`` (duplicated to keep this module independent of
-# the engine module and avoid a circular import).
-_ROLE_TAGS = {
-    "slide": "slide",
-    "subslide": "subslide",
-    "voiceover": "voiceover",
-    "notes": "notes",
-}
-
-# Roles that lead a slide group; narrative roles (voiceover/notes) belong to the
-# most recent slide group rather than starting their own.
+# Roles that lead a slide group; narrative roles (voiceover/notes/code/aux)
+# belong to the most recent slide group rather than starting their own.
 _SLIDE_ROLES = {"slide", "subslide"}
 
 
@@ -197,15 +187,12 @@ class SyncPlan:
 
 
 def _role_for_cell(cell: Cell) -> str | None:
-    if cell.metadata.is_j2:
-        return None
-    if cell.metadata.cell_type != "markdown":
-        return None
-    for tag in cell.metadata.tags:
-        role = _ROLE_TAGS.get(tag)
-        if role is not None:
-            return role
-    return None
+    """Per-cell sync role of ``cell`` (delegates to the canonical predicate).
+
+    Kept as a thin wrapper so the classifier and the apply engine can never
+    disagree about which cells participate in per-cell reconciliation.
+    """
+    return role_of(cell.metadata)
 
 
 def ordered_sync_cells(cells: list[Cell], expected_lang: str) -> list[CurrentCell]:

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -56,7 +56,6 @@ __all__ = [
     "APPLY",
     "AUTO",
     "DE_WINS",
-    "DEFERRED",
     "EN_WINS",
     "QUIT",
     "SKIP",
@@ -74,8 +73,7 @@ SKIP = "skip"
 QUIT = "quit"
 DE_WINS = "de-wins"
 EN_WINS = "en-wins"
-AUTO = "auto"  # id-less add / rename, applied without prompting
-DEFERRED = "deferred"  # id-carrying add — apply_plan defers it (follow-up scope)
+AUTO = "auto"  # add (id-less or id-carrying) / rename, applied without prompting
 
 _GATED_KINDS = {"edit", "remove", "move"}
 _AUTO_KINDS = {"add", "rename"}
@@ -141,11 +139,10 @@ class PlanWalkResult:
 
     @property
     def auto_applied(self) -> int:
-        """id-less add / rename proposals routed for auto-apply.
+        """add / rename proposals routed for auto-apply (id-less or id-carrying).
 
-        Excludes id-carrying adds, which the engine defers (they carry the
-        :data:`DEFERRED` action). Reflects what was *routed*; what was actually
-        written is ``apply_result.applied_add + apply_result.applied_rename``.
+        Reflects what was *routed*; what was actually written is
+        ``apply_result.applied_add + apply_result.applied_rename``.
         """
         return self._count(action=AUTO)
 
@@ -222,16 +219,12 @@ def run_plan_walker(
 
         if kind in _AUTO_KINDS:
             echo(render_proposal(proposal, de_bodies, en_bodies))
-            # An id-carrying "add" is a missing-counterpart case that apply_plan
-            # defers unconditionally (out of v1 scope) — never claim it was
-            # applied. id-less adds and renames are auto-applied (and reviewed in
-            # the resulting git diff).
-            if kind == "add" and proposal.slide_id is not None:
-                echo("  → deferred (id-carrying add; missing-counterpart follow-up)")
-                actions.append(_action(proposal, DEFERRED))
-            else:
-                echo("  → will auto-apply (add/rename; counterpart reviewed in git diff)")
-                actions.append(_action(proposal, AUTO))
+            # add (id-less or id-carrying) and rename are non-destructive, so
+            # they auto-apply (translate + insert; the counterpart is reviewed in
+            # the resulting git diff). An id-carrying add inserts the twin under
+            # the existing id; an id-less add mints one.
+            echo("  → will auto-apply (add/rename; counterpart reviewed in git diff)")
+            actions.append(_action(proposal, AUTO))
             continue
 
         if quitting:

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -21,6 +21,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
+from clm.infrastructure.llm.retry import call_with_retries
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -121,13 +123,14 @@ class OpenRouterSlideTranslator:
         target_lang: str,
         role: str,
     ) -> str:  # pragma: no cover - exercised via mocked client / integration
-        system = _SYSTEM_PROMPT.format(
+        system = _system_prompt_for(role).format(
             source_lang=_LANG_NAMES.get(source_lang, source_lang),
             target_lang=_LANG_NAMES.get(target_lang, target_lang),
             role=role,
         )
-        try:
-            response = self._client().chat.completions.create(
+
+        def _create():
+            return self._client().chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system},
@@ -135,6 +138,12 @@ class OpenRouterSlideTranslator:
                 ],
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
+            )
+
+        # Retry transient failures so one flaky call does not defer a new slide.
+        try:
+            response = call_with_retries(
+                _create, exc=Exception, label=f"slide translation ({self.model})"
             )
         except Exception as exc:
             raise TranslationError(f"translation LLM call failed: {exc}") from exc
@@ -157,3 +166,25 @@ _SYSTEM_PROMPT = (
     "spans and identifiers, URLs, and slide directives. Do not add, drop, or reorder "
     "lines. Return only the translated cell body, no commentary, no code fences."
 )
+
+# Code cells are NOT comment-prefixed: they are runnable Python. Only the
+# human-facing text inside them (string literals shown to the learner, comments)
+# differs across languages; the code itself is language-neutral and must stay
+# byte-identical so the cell still runs and the two decks share one logic.
+_CODE_SYSTEM_PROMPT = (
+    "You localize a single Python code cell of a {source_lang} programming-course "
+    "slide deck into its {target_lang} counterpart. Return runnable Python, NOT "
+    "Markdown. Translate ONLY human-facing natural-language text: the contents of "
+    "string literals that are shown to a learner (e.g. example prompts, questions, "
+    "user-visible messages) and code comments. Keep EVERYTHING else byte-identical: "
+    "all identifiers, function/variable/class names, keywords, imports, attribute "
+    "and method names, dict keys, operators, numbers, structure, indentation, and "
+    "string literals that are technical (model names, URLs, format strings, JSON "
+    'keys like "role"/"content"/"system"/"user"). Do not add, drop, reorder, '
+    "or reformat lines. Return only the cell body, no commentary, no code fences."
+)
+
+
+def _system_prompt_for(role: str) -> str:
+    """Pick the system prompt for a cell ``role`` (code cells are not Markdown)."""
+    return _CODE_SYSTEM_PROMPT if role == "code" else _SYSTEM_PROMPT

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -19,11 +19,12 @@ the same primitives the v2 walker shipped with — extracted so a
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from clm.notebooks.slide_parser import CellMetadata
+from clm.notebooks.slide_parser import CellMetadata, parse_cell_header
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
 
 if TYPE_CHECKING:
@@ -32,32 +33,63 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "CODE_ROLE",
     "FileState",
+    "build_twin_cell",
     "cell_content_hash",
     "record_snapshot",
     "role_of",
+    "swap_lang",
     "target_path_for_outcome",
 ]
 
-# Tags that identify a sync-relevant cell's role. Duplicated from
+# Markdown tags that name a narrative sync role. Duplicated from
 # ``clm.slides.sync`` / ``clm.slides.sync_plan`` to keep this low-level
 # write module free of an import cycle (sync_plan imports this module).
 _SYNC_ROLE_TAGS = {"slide", "subslide", "voiceover", "notes"}
 
+# The synthetic role for a localized (``lang=``) code cell that also carries a
+# ``slide_id``: it has a stable cross-language identity, so it is reconciled
+# per-cell like a narrative cell (its body translated rather than judged — see
+# ``sync_apply._apply_edit``). Language-neutral or id-less code is handled
+# structurally by :mod:`clm.slides.sync_code`, not through a role.
+CODE_ROLE = "code"
+
 
 def role_of(metadata: CellMetadata) -> str | None:
-    """Return the sync role of a cell from its metadata, or ``None``.
+    """Return the per-cell sync role of a cell from its metadata, or ``None``.
 
-    Public so :mod:`clm.slides.sync_apply` reuses the exact same predicate
-    instead of keeping its own copy.
+    The cells reconciled **per (slide_id, role)** by the Issue #166 engine:
+
+    - narrative markdown tagged ``slide`` / ``subslide`` / ``voiceover`` /
+      ``notes`` → that tag;
+    - auxiliary markdown carrying a ``slide_id`` but **no** narrative tag (an
+      ``alt`` solution note, or an untagged explanatory cell) → its first tag,
+      else ``"markdown"`` — so it too has a stable per-cell identity;
+    - a **localized** code cell (has both ``lang`` and ``slide_id``) →
+      :data:`CODE_ROLE`.
+
+    Everything else (j2 headers, language-neutral code, id-less code) returns
+    ``None``: it is not reconciled per-cell. Language-neutral / id-less code is
+    propagated structurally by :mod:`clm.slides.sync_code`. Public so
+    :mod:`clm.slides.sync_apply` and :mod:`clm.slides.sync_plan` reuse the exact
+    same predicate instead of keeping divergent copies.
     """
     if metadata.is_j2:
         return None
-    if metadata.cell_type != "markdown":
+    if metadata.cell_type == "code":
+        # A localized id'd code cell is twinned per-cell; bare/id-less code is
+        # structural (handled by sync_code), so it has no per-cell role.
+        if metadata.lang is not None and metadata.slide_id is not None:
+            return CODE_ROLE
         return None
+    # markdown: a narrative tag wins; otherwise an id-carrying aux cell still
+    # syncs under a per-cell role derived from its (non-narrative) tag.
     for tag in metadata.tags:
         if tag in _SYNC_ROLE_TAGS:
             return tag
+    if metadata.slide_id is not None:
+        return metadata.tags[0] if metadata.tags else "markdown"
     return None
 
 
@@ -103,6 +135,40 @@ def cell_content_hash(text: str) -> str:
     the same way before hashing so re-runs find a matching cache row.
     """
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+_LANG_ATTR_RE = re.compile(r'lang="[^"]*"')
+
+
+def swap_lang(header: str, lang: str) -> str:
+    """Return ``header`` with its ``lang="…"`` set to ``lang`` (inserted if absent).
+
+    Used to build a target-language twin of a source cell while keeping its
+    slide_id, tags, and markdown-vs-code cell type verbatim.
+    """
+    if _LANG_ATTR_RE.search(header):
+        return _LANG_ATTR_RE.sub(f'lang="{lang}"', header)
+    if "[markdown]" in header:
+        return header.replace("[markdown]", f'[markdown] lang="{lang}"', 1)
+    return header.replace("# %%", f'# %% lang="{lang}"', 1)
+
+
+def build_twin_cell(source_cell: RawCell, target_lang: str, target_body: str) -> RawCell:
+    """Build the target-language twin of ``source_cell``.
+
+    Preserves the source header verbatim except for the language attribute (so
+    slide_id, tags, and the markdown-vs-code cell type carry over), and uses the
+    translated ``target_body`` bare (no leading/trailing blank lines) — the
+    caller's insert primitive grants the deck's separator based on final
+    position.
+    """
+    header = swap_lang(source_cell.lines[0], target_lang)
+    body_lines = target_body.split("\n")
+    while body_lines and body_lines[0] == "":
+        body_lines.pop(0)
+    while body_lines and body_lines[-1] == "":
+        body_lines.pop()
+    return RawCell(lines=[header, *body_lines], line_number=0, metadata=parse_cell_header(header))
 
 
 def record_snapshot(
@@ -233,15 +299,23 @@ class FileState:
     def separator_blanks(self) -> int:
         """The deck's inter-cell blank-line gap (0 = tight, 1 = blank-separated).
 
-        Read from the first cell, which is always non-last when there are two
-        or more cells, so its trailing-blank count reflects the *separator*
-        convention rather than the terminal-newline artifact the last cell
-        carries. Compute it **before** a structural mutation. Non-uniform
-        decks fall back to the first gap (documented limitation).
+        The **most common** trailing-blank count among the non-last cells, with
+        j2 header cells excluded. The first cell is often a ``# j2`` header that
+        sits tight against its sibling macro call (gap 0) even though the rest of
+        the deck is blank-separated (gap 1); reading only ``cells[0]`` then
+        mis-reports the convention as tight. The last cell is excluded because it
+        carries the terminal-newline artifact, not a separator. Compute **before**
+        a structural mutation. A genuinely non-uniform deck falls back to its
+        dominant gap (documented limitation).
         """
         if len(self.cells) < 2:
             return 0
-        return _trailing_blanks(self.cells[0])
+        from collections import Counter
+
+        counts = [_trailing_blanks(c) for c in self.cells[:-1] if not c.metadata.is_j2]
+        if not counts:
+            counts = [_trailing_blanks(self.cells[0])]
+        return Counter(counts).most_common(1)[0][0]
 
     def insert_after(self, slide_id: str, role: str, new_cell: RawCell) -> bool:
         """Insert ``new_cell`` immediately after the ``(slide_id, role)`` cell.

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -456,6 +456,119 @@ class TestProvider:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def restore_api_keys():
+    """Snapshot and restore key env vars a ``.env`` load would mutate.
+
+    ``load_dotenv`` writes straight into ``os.environ`` (monkeypatch can't undo
+    that), so without this a loaded test key would leak into later tests.
+    """
+    import os
+
+    keys = ("OPENROUTER_API_KEY", "OPENAI_API_KEY")
+    saved = {k: os.environ.get(k) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+class TestEnvFileLoading:
+    """Bug: sync checked only the process env, so keys kept in the project
+    ``.env`` (the usual course-repo layout, read by notebooks via
+    ``load_dotenv``) were invisible — every add deferred and every edit errored
+    as 'LLM unavailable'."""
+
+    def _swap_openrouter_judge(self, monkeypatch) -> None:
+        from clm.cli.commands import slides_sync as cmd
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+        proposal = SyncProposal(verdict="update", proposed_text=_EN_PROPOSAL, reason="")
+        monkeypatch.setattr(
+            cmd, "OpenRouterSyncJudge", lambda **_kw: StaticSyncJudge(default_proposal=proposal)
+        )
+
+    def test_key_in_dotenv_is_loaded_so_default_judge_runs(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch, restore_api_keys
+    ):
+        # Key lives ONLY in .env, not exported. Before the fix the openrouter
+        # judge sees no key → records the edit as an error (exit 2). After the
+        # fix .env is loaded → the judge runs → the edit applies (exit 0).
+        monkeypatch.delenv("CLM_SYNC_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        self._swap_openrouter_judge(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-from-dotenv\n", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert "Point one" in en_path.read_text(encoding="utf-8")
+        assert "applied: 1 edit" in result.output
+
+    def test_dotenv_found_by_walking_up_from_deck_dir(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch, restore_api_keys
+    ):
+        # .env at the project root, decks in a nested topic dir (the real layout).
+        monkeypatch.delenv("CLM_SYNC_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        self._swap_openrouter_judge(monkeypatch)
+        (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-root\n", encoding="utf-8")
+        deck_dir = tmp_path / "slides" / "topic_010"
+        deck_dir.mkdir(parents=True)
+        cache_dir = tmp_path / "cache"
+        de_path, en_path = _write_pair(deck_dir, _DE_EDITED, _EN_BASE)
+        _seed_watermark(cache_dir, de_path, en_path, de_text=_DE_BASE, en_text=_EN_BASE)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert "applied: 1 edit" in result.output
+
+    def test_no_env_file_flag_skips_dotenv(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch, restore_api_keys
+    ):
+        # With --no-env-file the .env key stays invisible → judge unavailable.
+        monkeypatch.delenv("CLM_SYNC_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        self._swap_openrouter_judge(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-from-dotenv\n", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--no-env-file", "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 2, _combined(result)
+        assert "OPENROUTER_API_KEY" in (result.stderr or "")
+
+
+class TestResolveTimeout:
+    """A non-positive --llm-timeout must fall back to the provider default
+    (a negative value would otherwise crash urllib with an uncaught ValueError
+    on the local path)."""
+
+    def test_clamps_non_positive_to_provider_default(self):
+        from clm.cli.commands.slides_sync import _resolve_timeout
+
+        assert _resolve_timeout(None, 120.0) == 120.0
+        assert _resolve_timeout(0, 120.0) == 120.0
+        assert _resolve_timeout(-5.0, 300.0) == 300.0
+        assert _resolve_timeout(45.0, 120.0) == 45.0  # a positive value is honored
+
+
 class TestNoBaseline:
     def test_no_watermark_no_git_reports_baseline_none(self, cli_runner: CliRunner, tmp_path: Path):
         # Identical ids on both sides, no watermark, tmp dir is not a git repo:

--- a/tests/infrastructure/llm/test_retry.py
+++ b/tests/infrastructure/llm/test_retry.py
@@ -1,0 +1,114 @@
+"""Unit tests for the bounded retry-with-backoff helper.
+
+These exercise the retry policy directly (with an injected ``sleep`` so they run
+instantly), demonstrating the fix for the reported sync bug where a single
+transient judge/translator failure dropped a cell with no retry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.infrastructure.llm.retry import call_with_retries
+
+
+class _Boom(Exception):
+    pass
+
+
+class _Other(Exception):
+    pass
+
+
+def test_returns_first_success_without_sleeping():
+    slept: list[float] = []
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        return "ok"
+
+    out = call_with_retries(fn, exc=_Boom, sleep=slept.append)
+    assert out == "ok"
+    assert calls["n"] == 1
+    assert slept == []  # no retry, no backoff
+
+
+def test_retries_then_succeeds():
+    slept: list[float] = []
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise _Boom("transient")
+        return "recovered"
+
+    out = call_with_retries(fn, exc=_Boom, base_delay=1.0, sleep=slept.append)
+    assert out == "recovered"
+    assert attempts["n"] == 3
+    # Exponential backoff between the two failed attempts: 1.0s then 2.0s.
+    assert slept == [1.0, 2.0]
+
+
+def test_reraises_last_error_after_exhausting_attempts():
+    slept: list[float] = []
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        raise _Boom(f"fail-{attempts['n']}")
+
+    with pytest.raises(_Boom, match="fail-3"):
+        call_with_retries(fn, exc=_Boom, attempts=3, sleep=slept.append)
+    assert attempts["n"] == 3
+    assert slept == [1.0, 2.0]  # slept between attempts 1->2 and 2->3, not after the last
+
+
+def test_backoff_is_capped_at_max_delay():
+    slept: list[float] = []
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        raise _Boom("always")
+
+    with pytest.raises(_Boom):
+        call_with_retries(
+            fn, exc=_Boom, attempts=5, base_delay=1.0, max_delay=3.0, sleep=slept.append
+        )
+    # 1, 2, then capped at 3, 3 (four sleeps for five attempts).
+    assert slept == [1.0, 2.0, 3.0, 3.0]
+
+
+def test_does_not_retry_unlisted_exception():
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        raise _Other("not retryable")
+
+    with pytest.raises(_Other):
+        call_with_retries(fn, exc=_Boom, sleep=lambda _d: None)
+    assert attempts["n"] == 1  # raised immediately, never retried
+
+
+def test_retries_on_a_tuple_of_exception_types():
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise _Boom("first")
+        if attempts["n"] == 2:
+            raise _Other("second")
+        return "ok"
+
+    out = call_with_retries(fn, exc=(_Boom, _Other), sleep=lambda _d: None)
+    assert out == "ok"
+    assert attempts["n"] == 3
+
+
+def test_attempts_must_be_at_least_one():
+    with pytest.raises(ValueError, match="attempts"):
+        call_with_retries(lambda: None, exc=_Boom, attempts=0)

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -1024,11 +1024,13 @@ class TestApplyRename:
         assert result.watermark_recorded is False
         assert en_path.read_text(encoding="utf-8") == before_en  # EN untouched
 
-    def test_malformed_copy_companion_is_safe(self, tmp_path: Path):
+    def test_malformed_copy_companion_is_propagated_consistently(self, tmp_path: Path):
         # A copied group whose companion carries a DIFFERENT id than its slide.
-        # The slide renames, but the mismatched companion is left to normal
-        # pairing (an id-carrying add -> deferred), so the watermark cannot
-        # advance over the divergence.
+        # The slide renames; the mismatched companion is a cell present on DE
+        # only with an id unknown to the baseline, so it is now an *id-carrying
+        # add* and is propagated to EN (id-carrying adds used to be out of scope
+        # and deferred). The safety property holds the new way: the decks end
+        # with a CONSISTENT key set rather than a silent cross-deck divergence.
         de = _slide("de", "intro", "# ## Einleitung") + _vo("de", "intro", "# Sprechertext")
         en = _slide("en", "intro", "# ## Introduction") + _vo("en", "intro", "# Narration")
         de_path, en_path = _write_pair(tmp_path, de, en)
@@ -1048,9 +1050,13 @@ class TestApplyRename:
         finally:
             cache.close()
 
-        # Not silently baselined: the mismatched companion forces a deferral.
-        assert result.deferred >= 1
-        assert result.watermark_recorded is False
+        # No silent cross-deck divergence: both decks carry the same sync keys,
+        # including the once-orphaned companion now propagated to EN.
+        assert not result.has_errors, result.errors
+        de_keys = set(_keys_of(de_path, "de"))
+        en_keys = set(_keys_of(en_path, "en"))
+        assert de_keys == en_keys
+        assert ("weird", "voiceover") in en_keys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_code_cells.py
+++ b/tests/slides/test_sync_code_cells.py
@@ -1,0 +1,500 @@
+"""Unit tests for code-cell + auxiliary-markdown sync (Issue #166, Phase 6).
+
+The reported bug: ``clm slides sync`` only ever classified / propagated narrative
+markdown (``slide`` / ``subslide`` / ``voiceover`` / ``notes``). Code cells and
+untagged / ``alt`` markdown were invisible end to end. These tests demonstrate
+each individual failure on small split-deck inputs and pin the fix:
+
+- a **localized id'd** code cell (``lang=`` + ``slide_id``) is reconciled per
+  cell — translated, never run through the markdown judge;
+- an **id-carrying add** (a new id'd cell present on one side only) is
+  translated and inserted under the same id;
+- a **language-neutral** code cell (no ``lang``) is propagated verbatim;
+- an **id-less localized** code cell is translated;
+- **auxiliary markdown** (untagged or ``alt``, carrying a slide_id) syncs too;
+- a code cell **moved between slide groups** follows;
+- a **narrative-only** edit never churns a group's code, and a second run is a
+  no-op.
+
+All drive the engine with a seeded watermark + static judge/translator, so no
+live LLM is touched. ``role_of`` (the predicate the whole engine keys off) is
+tested directly too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import OllamaError, StaticSyncJudge, SyncProposal
+from clm.notebooks.slide_parser import parse_cell_header, parse_cells
+from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_plan import build_sync_plan, ordered_sync_cells
+from clm.slides.sync_translate import StaticSlideTranslator
+from clm.slides.sync_writeback import CODE_ROLE, role_of
+
+# ---------------------------------------------------------------------------
+# Cell builders
+# ---------------------------------------------------------------------------
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n\n'
+
+
+def _vo(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n{body}\n\n'
+
+
+def _aux(lang: str, sid: str, body: str, *, tag: str | None = None) -> str:
+    tags = f' tags=["{tag}"]' if tag else ""
+    return f'# %% [markdown] lang="{lang}"{tags} slide_id="{sid}"\n{body}\n\n'
+
+
+def _code_shared(body: str, *, sid: str | None = None) -> str:
+    sid_attr = f' slide_id="{sid}"' if sid else ""
+    return f'# %% tags=["keep"]{sid_attr}\n{body}\n\n'
+
+
+def _code_loc(lang: str, body: str, *, sid: str | None = None) -> str:
+    sid_attr = f' slide_id="{sid}"' if sid else ""
+    return f'# %% lang="{lang}"{sid_attr}\n{body}\n\n'
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    """Record the current on-disk decks as the last-synced baseline."""
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )
+
+
+class _DictTranslator:
+    """Translator double: replace EN substrings with DE ones (protocol-shaped)."""
+
+    prompt_version = "test"
+
+    def __init__(self, replacements: dict[str, str]):
+        self.replacements = replacements
+        self.calls: list[tuple[str, str]] = []  # (role, source_body)
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.calls.append((role, source_body))
+        out = source_body
+        for en, de in self.replacements.items():
+            out = out.replace(en, de)
+        return out
+
+
+class _ExplodingJudge:
+    """A judge that fails if ever asked — proves the judge was NOT used."""
+
+    prompt_version = "test"
+
+    def propose(self, *_args, **_kwargs):
+        raise AssertionError("the markdown judge must not be called for a code cell")
+
+
+def _bodies(path: Path, lang: str) -> dict[tuple[str | None, str], str]:
+    """Map (slide_id, kind) -> raw cell body for assertions, kind ∈ code/markdown."""
+    out: dict[tuple[str | None, str], str] = {}
+    text = path.read_text(encoding="utf-8")
+    # Re-split into raw cells to read code-cell bodies verbatim.
+    from clm.slides.raw_cells import split_cells
+
+    _, cells = split_cells(text)
+    for c in cells:
+        kind = "code" if c.metadata.cell_type == "code" else "markdown"
+        out[(c.metadata.slide_id, kind)] = c.body
+    return out
+
+
+def _sync_keys(path: Path, lang: str) -> list[tuple[str | None, str]]:
+    return [
+        (c.slide_id, c.role) for c in ordered_sync_cells(parse_cells(path.read_text("utf-8")), lang)
+    ]
+
+
+def _apply(tmp_path, de, en, *, mutate_en=None, mutate_de=None, judge=None, translator=None):
+    """Seed a baseline from (de, en), mutate one side, sync, return (de_path, en_path, result)."""
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed_watermark(cache, de_path, en_path)
+        if mutate_en is not None:
+            en_path.write_text(mutate_en, encoding="utf-8")
+        if mutate_de is not None:
+            de_path.write_text(mutate_de, encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+    return de_path, en_path, result
+
+
+# ---------------------------------------------------------------------------
+# role_of predicate
+# ---------------------------------------------------------------------------
+
+
+class TestRoleOf:
+    def _meta(self, header: str):
+        return parse_cell_header(header)
+
+    def test_localized_idd_code_is_role_code(self):
+        assert role_of(self._meta('# %% lang="en" slide_id="x"')) == CODE_ROLE
+
+    def test_shared_code_has_no_role(self):
+        assert role_of(self._meta('# %% tags=["keep"]')) is None
+        assert role_of(self._meta('# %% tags=["keep"] slide_id="x"')) is None  # no lang -> shared
+
+    def test_idless_localized_code_has_no_role(self):
+        assert role_of(self._meta('# %% lang="en"')) is None
+
+    def test_untagged_markdown_with_id_is_role_markdown(self):
+        assert role_of(self._meta('# %% [markdown] lang="en" slide_id="x"')) == "markdown"
+
+    def test_alt_markdown_is_role_alt(self):
+        assert role_of(self._meta('# %% [markdown] lang="en" tags=["alt"] slide_id="x"')) == "alt"
+
+    def test_narrative_tag_wins(self):
+        assert (
+            role_of(self._meta('# %% [markdown] lang="en" tags=["slide"] slide_id="x"')) == "slide"
+        )
+
+    def test_markdown_without_id_or_role_is_none(self):
+        assert role_of(self._meta('# %% [markdown] lang="en"')) is None
+
+
+# ---------------------------------------------------------------------------
+# Localized id'd code edit — translated, not judged
+# ---------------------------------------------------------------------------
+
+
+class TestLocalizedCodeEdit:
+    def test_idd_code_edit_uses_translator_not_judge(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie") + _code_loc("de", 'msg = "Hallo"', sid="setup")
+        en = _slide("en", "s", "# ## Slide") + _code_loc("en", 'msg = "Hello"', sid="setup")
+        # Author edits the EN code cell's string.
+        en2 = _slide("en", "s", "# ## Slide") + _code_loc("en", 'msg = "Goodbye"', sid="setup")
+
+        translator = _DictTranslator({'"Goodbye"': '"Auf Wiedersehen"'})
+        de_path, en_path, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=_ExplodingJudge(), translator=translator
+        )
+
+        assert not result.has_errors, result.errors
+        assert result.applied_edit == 1
+        de_code = _bodies(de_path, "de")[("setup", "code")]
+        assert 'msg = "Auf Wiedersehen"' in de_code  # translated, code structure kept
+        assert ("code", 'msg = "Goodbye"') in translator.calls  # translator drove it
+
+
+# ---------------------------------------------------------------------------
+# id-carrying add of a localized code cell
+# ---------------------------------------------------------------------------
+
+
+class TestIdCarryingCodeAdd:
+    def test_new_idd_code_cell_is_translated_and_twinned(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie")
+        en = _slide("en", "s", "# ## Slide")
+        # Author adds a new id'd localized code cell on EN.
+        en2 = _slide("en", "s", "# ## Slide") + _code_loc("en", 'q = "What is a list?"', sid="demo")
+
+        translator = _DictTranslator({'"What is a list?"': '"Was ist eine Liste?"'})
+        de_path, en_path, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=StaticSyncJudge(), translator=translator
+        )
+
+        assert not result.has_errors, result.errors
+        de_code = _bodies(de_path, "de").get(("demo", "code"))
+        assert de_code is not None  # the twin was inserted under the same id
+        assert 'q = "Was ist eine Liste?"' in de_code
+        # Same id on both halves, role "code".
+        assert ("demo", CODE_ROLE) in _sync_keys(de_path, "de")
+        assert ("demo", CODE_ROLE) in _sync_keys(en_path, "en")
+
+
+# ---------------------------------------------------------------------------
+# Language-neutral code — propagated verbatim (no translation)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedCode:
+    def test_new_shared_code_cell_copied_verbatim(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie") + _vo("de", "s", "# Sprechertext")
+        en = _slide("en", "s", "# ## Slide") + _vo("en", "s", "# Narration")
+        # EN gains a shared code cell AND edits the voiceover (establishes direction).
+        en2 = (
+            _slide("en", "s", "# ## Slide")
+            + _code_shared("import os\nx = os.getcwd()")
+            + _vo("en", "s", "# Narration extended")
+        )
+
+        translator = _DictTranslator({})
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(
+                verdict="update", proposed_text="# Sprechertext erweitert"
+            )
+        )
+        de_path, en_path, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=translator
+        )
+
+        assert not result.has_errors, result.errors
+        de_text = de_path.read_text("utf-8")
+        assert "import os\nx = os.getcwd()" in de_text  # verbatim, untranslated
+        assert translator.calls == []  # a shared cell is never translated
+
+    def test_edited_shared_code_propagates_verbatim(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie") + _code_shared("VALUE = 1") + _vo("de", "s", "# T")
+        en = _slide("en", "s", "# ## Slide") + _code_shared("VALUE = 1") + _vo("en", "s", "# N")
+        en2 = (
+            _slide("en", "s", "# ## Slide") + _code_shared("VALUE = 2") + _vo("en", "s", "# N more")
+        )
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# T mehr")
+        )
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=_DictTranslator({})
+        )
+        assert not result.has_errors, result.errors
+        de_text = de_path.read_text("utf-8")
+        assert "VALUE = 2" in de_text
+        assert "VALUE = 1" not in de_text
+
+
+# ---------------------------------------------------------------------------
+# id-less localized code — translated
+# ---------------------------------------------------------------------------
+
+
+class TestIdlessLocalizedCode:
+    def test_new_idless_localized_code_translated(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie") + _vo("de", "s", "# T")
+        en = _slide("en", "s", "# ## Slide") + _vo("en", "s", "# N")
+        en2 = (
+            _slide("en", "s", "# ## Slide")
+            + _code_loc("en", 'run("a question")')  # id-less localized
+            + _vo("en", "s", "# N+")
+        )
+        translator = _DictTranslator({'"a question"': '"eine Frage"'})
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# T+")
+        )
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=translator
+        )
+        assert not result.has_errors, result.errors
+        de_text = de_path.read_text("utf-8")
+        assert 'run("eine Frage")' in de_text  # translated
+        assert ("code", 'run("a question")') in translator.calls
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary markdown (untagged / alt)
+# ---------------------------------------------------------------------------
+
+
+class TestAuxMarkdown:
+    def test_new_untagged_markdown_with_id_is_added(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie")
+        en = _slide("en", "s", "# ## Slide")
+        en2 = _slide("en", "s", "# ## Slide") + _aux("en", "note", "# - a side note")
+        translator = _DictTranslator({"a side note": "eine Randnotiz"})
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=StaticSyncJudge(), translator=translator
+        )
+        assert not result.has_errors, result.errors
+        assert ("note", "markdown") in _sync_keys(de_path, "de")
+        assert "eine Randnotiz" in de_path.read_text("utf-8")
+
+    def test_alt_markdown_edit_is_reconciled_by_judge(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie") + _aux("de", "s", "# Lösung alt", tag="alt")
+        en = _slide("en", "s", "# ## Slide") + _aux("en", "s", "# Solution old", tag="alt")
+        en2 = _slide("en", "s", "# ## Slide") + _aux("en", "s", "# Solution new", tag="alt")
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# Lösung neu")
+        )
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=_DictTranslator({})
+        )
+        assert not result.has_errors, result.errors
+        assert result.applied_edit == 1
+        assert "Lösung neu" in de_path.read_text("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Cross-group code move
+# ---------------------------------------------------------------------------
+
+
+class TestCrossGroupCodeMove:
+    def test_shared_code_moves_between_groups(self, tmp_path: Path):
+        # SETUP shared code sits under slide A; the author moves it under slide B
+        # (and edits both slide headings so direction is established per group).
+        de = _slide("de", "a", "# ## A") + _code_shared("SETUP = 1") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _code_shared("SETUP = 1") + _slide("en", "b", "# ## B")
+        en2 = (
+            _slide("en", "a", "# ## A2") + _slide("en", "b", "# ## B2") + _code_shared("SETUP = 1")
+        )
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# (de)")
+        )
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=_DictTranslator({})
+        )
+        assert not result.has_errors, result.errors
+        # The DE deck must now have SETUP under group B, not group A.
+        from clm.slides.raw_cells import split_cells
+
+        _, cells = split_cells(de_path.read_text("utf-8"))
+        order = [
+            (c.metadata.slide_id, c.metadata.cell_type)
+            for c in cells
+            if c.metadata.is_slide_start or c.metadata.cell_type == "code"
+        ]
+        # slide a, slide b, then the code (moved under b).
+        assert order == [("a", "markdown"), ("b", "markdown"), (None, "code")]
+        assert de_path.read_text("utf-8").count("SETUP = 1") == 1  # not duplicated
+
+
+# ---------------------------------------------------------------------------
+# Narrative-only edit does not churn code; idempotent re-run
+# ---------------------------------------------------------------------------
+
+
+class TestNoChurn:
+    def test_narrative_only_edit_leaves_code_untouched(self, tmp_path: Path):
+        de = (
+            _slide("de", "s", "# ## Folie")
+            + _code_shared("KEEP = 1")
+            + _code_loc("de", 'msg = "Hallo"', sid="m")
+            + _vo("de", "s", "# T")
+        )
+        en = (
+            _slide("en", "s", "# ## Slide")
+            + _code_shared("KEEP = 1")
+            + _code_loc("en", 'msg = "Hello"', sid="m")
+            + _vo("en", "s", "# N")
+        )
+        # Only the EN voiceover changes — no code change anywhere.
+        en2 = (
+            _slide("en", "s", "# ## Slide")
+            + _code_shared("KEEP = 1")
+            + _code_loc("en", 'msg = "Hello"', sid="m")
+            + _vo("en", "s", "# N updated")
+        )
+        before_de_code = _bodies(_write_pair(tmp_path, de, en)[0], "de")
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# T aktualisiert")
+        )
+        translator = _DictTranslator({"SHOULD-NOT": "BE-CALLED"})
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=translator
+        )
+        assert not result.has_errors, result.errors
+        after = _bodies(de_path, "de")
+        # The localized code twin was NOT re-translated, the shared code untouched.
+        assert after[("m", "code")] == before_de_code[("m", "code")]
+        assert translator.calls == []
+        assert "KEEP = 1" in de_path.read_text("utf-8")
+
+    def test_full_sync_then_rerun_is_noop(self, tmp_path: Path):
+        de = _slide("de", "s", "# ## Folie") + _vo("de", "s", "# T")
+        en = _slide("en", "s", "# ## Slide") + _vo("en", "s", "# N")
+        en2 = (
+            _slide("en", "s", "# ## Slide")
+            + _code_shared("import os")
+            + _code_loc("en", 'p = "x"', sid="c")
+            + _vo("en", "s", "# N+")
+        )
+        translator = _DictTranslator({'"x"': '"y"'})
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# T+")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(en2, encoding="utf-8")
+            plan1 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            r1 = apply_plan(plan1, judge=judge, translator=translator, watermark_cache=cache)
+            assert not r1.has_errors, r1.errors
+            de_after_first = de_path.read_text("utf-8")
+            # Second run: the watermark advanced; nothing left to do.
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            r2 = apply_plan(plan2, judge=judge, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+        assert plan2.is_noop, [(p.kind, p.slide_id, p.role) for p in plan2.proposals]
+        assert r2.applied == 0
+        assert de_path.read_text("utf-8") == de_after_first  # byte-identical, no churn
+
+
+# ---------------------------------------------------------------------------
+# A failed translation during a structural rebuild must not drop a target cell
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildTranslationFailure:
+    def test_failed_translation_preserves_existing_target_cell(self, tmp_path: Path):
+        # A group rebuild (triggered by a new shared cell) needs to re-translate
+        # an id-less localized code cell. If the translator can't, the rebuild
+        # must be ABORTED — the pre-existing target-deck cell is kept, never
+        # silently dropped from disk — and the failure surfaced (watermark held).
+        de = (
+            _slide("de", "s", "# ## Folie")
+            + _code_loc("de", 'frage("Wie viele?")')
+            + _vo("de", "s", "# T")
+        )
+        en = (
+            _slide("en", "s", "# ## Slide")
+            + _code_loc("en", 'ask("How many?")')
+            + _vo("en", "s", "# N")
+        )
+        # EN adds a NEW shared cell (forces the group's signature to drift -> a
+        # rebuild) and edits the voiceover (establishes the en->de direction).
+        en2 = (
+            _slide("en", "s", "# ## Slide")
+            + _code_shared("import os")
+            + _code_loc("en", 'ask("How many?")')
+            + _vo("en", "s", "# N more")
+        )
+        judge = StaticSyncJudge(
+            default_proposal=SyncProposal(verdict="update", proposed_text="# T mehr")
+        )
+        # An empty StaticSlideTranslator raises TranslationError for every body.
+        de_path, _en, result = _apply(
+            tmp_path, de, en, mutate_en=en2, judge=judge, translator=StaticSlideTranslator()
+        )
+
+        de_text = de_path.read_text("utf-8")
+        # The crucial invariant: the pre-existing DE code cell was NOT dropped.
+        assert 'frage("Wie viele?")' in de_text
+        # The failure is surfaced, not silent; the watermark is held.
+        assert result.has_errors
+        assert any("code-structure" in e for e in result.errors)
+        assert result.watermark_recorded is False
+        # The region was kept intact, so the un-translatable rebuild did not add
+        # the new shared cell this pass (it re-attempts on the next run).
+        assert "import os" not in de_text
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/slides/test_sync_code_e2e.py
+++ b/tests/slides/test_sync_code_e2e.py
@@ -1,0 +1,401 @@
+"""End-to-end ``clm slides sync`` test for the code-cell / aux-markdown fix.
+
+Mirrors the *structure* of the real-world repro that motivated Issue #166 Phase 6
+(a single-language editing pass that adds new slides with code, rewrites a
+workshop, moves shared setup code between slide groups, and twins localized
+code) on a small, **non-proprietary** "Web APIs" deck. It drives the live
+``slides_sync_cmd`` with a judge + translator derived from the gold pairing, so
+the whole pipeline runs — classify, reconcile edits, translate + insert new
+cells, copy language-neutral code verbatim, fix group order — and the synced DE
+half is asserted byte-identical to the hand-authored gold.
+
+Before the fix the sync only touched narrative markdown: every code cell and the
+untagged / ``alt`` markdown below were silently dropped, leaving German headings
+sitting over stale English code. This test fails hard in that world.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides_sync import CACHE_DB_NAME, slides_sync_cmd
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import SyncProposal
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import ordered_sync_cells
+from clm.slides.sync_translate import TranslationError
+from clm.slides.sync_writeback import role_of
+
+# ---------------------------------------------------------------------------
+# Deck assembly
+# ---------------------------------------------------------------------------
+
+
+def _deck(*blocks: str) -> str:
+    """Assemble cell blocks into a deck (j2 header tight, cells blank-separated)."""
+    return "\n\n".join(blocks) + "\n"
+
+
+def _j2(lang: str, title: str) -> str:
+    return f"# j2 from 'macros.j2' import header_{lang}\n# {{{{ header_{lang}(\"{title}\") }}}}"
+
+
+def _md(lang: str, sid: str, tag: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["{tag}"] slide_id="{sid}"\n{body}'
+
+
+def _aux_untagged(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" slide_id="{sid}"\n{body}'
+
+
+def _code_shared(body: str) -> str:
+    return f'# %% tags=["keep"]\n{body}'
+
+
+def _code_idd(lang: str, sid: str, body: str) -> str:
+    return f'# %% lang="{lang}" tags=["keep"] slide_id="{sid}"\n{body}'
+
+
+def _code_idless(lang: str, body: str) -> str:
+    return f'# %% lang="{lang}"\n{body}'
+
+
+# --- original (committed) baseline -----------------------------------------
+
+
+def _original(lang: str) -> str:
+    de = lang == "de"
+    return _deck(
+        _j2(lang, "Web-APIs" if de else "Web APIs"),
+        _md(
+            lang,
+            "intro",
+            "voiceover",
+            "# - Willkommen zu Web-APIs" if de else "# - Welcome to web APIs",
+        ),
+        _md(
+            lang,
+            "get",
+            "slide",
+            "# ## Eine GET-Anfrage stellen\n#\n# - Ein GET holt Daten"
+            if de
+            else "# ## Making a GET request\n#\n# - A GET fetches data",
+        ),
+        _code_shared("import requests"),
+        _code_idd(
+            lang,
+            "get-call",
+            'label = "Geholte Einträge"\nresp = requests.get("https://api.example.com/items")'
+            if de
+            else 'label = "Fetched items"\nresp = requests.get("https://api.example.com/items")',
+        ),
+        _md(
+            lang,
+            "get",
+            "voiceover",
+            "# - Wir rufen requests.get mit einer URL auf"
+            if de
+            else "# - We call requests.get with a URL",
+        ),
+        _md(
+            lang,
+            "workshop",
+            "slide",
+            "# ## Workshop: Holen und Ausgeben\n#\n# - Aufgabe: Einträge holen, Anzahl ausgeben"
+            if de
+            else "# ## Workshop: Fetch and Print\n#\n# - Task: fetch items, print the count",
+        ),
+        _code_idd(
+            lang,
+            "ws-setup",
+            'URL = "https://api.example.com/items"\nTITLE = "Alle Einträge"'
+            if de
+            else 'URL = "https://api.example.com/items"\nTITLE = "All items"',
+        ),
+        _md(lang, "ws-task", "subslide", "# ### Aufgabe: zählen" if de else "# ### Task: count"),
+        _code_idless(
+            lang,
+            'data = requests.get(URL).json()\nprint("Anzahl:", len(data))'
+            if de
+            else 'data = requests.get(URL).json()\nprint("count:", len(data))',
+        ),
+        _md(
+            lang,
+            "ws-task",
+            "alt",
+            "# ### Lösungshinweise\n#\n# - len(data) verwenden"
+            if de
+            else "# ### Solution notes\n#\n# - Use len(data)",
+        ),
+    )
+
+
+# --- after the single-language editing pass --------------------------------
+#
+# EN is the edited source; DE is the gold a correct sync must produce. They are
+# structurally parallel (same cell sequence, language swapped, prose translated).
+
+
+def _modified(lang: str) -> str:
+    de = lang == "de"
+    return _deck(
+        _j2(lang, "Web-APIs" if de else "Web APIs"),
+        _md(
+            lang,
+            "intro",
+            "voiceover",
+            "# - Willkommen zu Web-APIs" if de else "# - Welcome to web APIs",
+        ),
+        # NEW slide group (id-carrying add): a POST theme, inserted before GET.
+        _md(
+            lang,
+            "post",
+            "slide",
+            "# ## Eine POST-Anfrage stellen\n#\n# - Ein POST sendet Daten"
+            if de
+            else "# ## Making a POST request\n#\n# - A POST sends data",
+        ),
+        _code_shared("import requests"),  # MOVED here from the GET group
+        _code_shared("import json"),  # NEW language-neutral cell
+        _code_idd(  # NEW localized id'd code cell
+            lang,
+            "post-body",
+            'payload = {"name": "Ein neuer Eintrag"}' if de else 'payload = {"name": "A new item"}',
+        ),
+        _code_shared('resp = requests.post("https://api.example.com/items", json=payload)'),  # NEW
+        _aux_untagged(  # NEW untagged aux markdown
+            lang, "post-note", "# - Ein POST-Body ist JSON" if de else "# - A POST body is JSON"
+        ),
+        _md(
+            lang,
+            "post",
+            "voiceover",
+            "# - Wir senden Daten mit requests.post"
+            if de
+            else "# - We send data with requests.post",
+        ),
+        # EDITED slide (extra bullet) — import requests no longer in this group.
+        _md(
+            lang,
+            "get",
+            "slide",
+            "# ## Eine GET-Anfrage stellen\n#\n# - Ein GET holt Daten\n# - GET ist das häufigste Verb"
+            if de
+            else "# ## Making a GET request\n#\n# - A GET fetches data\n# - GET is the most common verb",
+        ),
+        _code_idd(  # EDITED localized id'd code (string changed)
+            lang,
+            "get-call",
+            'label = "Einen Eintrag geholt"\nresp = requests.get("https://api.example.com/items")'
+            if de
+            else 'label = "Fetched one item"\nresp = requests.get("https://api.example.com/items")',
+        ),
+        _md(
+            lang,
+            "get",
+            "voiceover",
+            "# - Wir rufen requests.get mit einer URL auf\n# - Die Antwort hat .json()"
+            if de
+            else "# - We call requests.get with a URL\n# - The response has .json()",
+        ),
+        # Rewritten workshop.
+        _md(
+            lang,
+            "workshop",
+            "slide",
+            "# ## Workshop: Einen Eintrag anlegen\n#\n# - Aufgabe: per POST anlegen, dann per GET holen"
+            if de
+            else "# ## Workshop: Create an Item\n#\n# - Task: POST a new item, then GET the list",
+        ),
+        _code_idd(  # EDITED localized id'd code
+            lang,
+            "ws-setup",
+            'URL = "https://api.example.com/items"\nNEW_ITEM = {"name": "Widget"}'
+            if de
+            else 'URL = "https://api.example.com/items"\nNEW_ITEM = {"name": "Widget"}',
+        ),
+        _md(
+            lang,
+            "ws-task",
+            "subslide",
+            "# ### Aufgabe: anlegen, dann auflisten" if de else "# ### Task: create then list",
+        ),
+        _code_idless(  # EDITED id-less localized code
+            lang,
+            'requests.post(URL, json=NEW_ITEM)\nprint("angelegt:", NEW_ITEM["name"])'
+            if de
+            else 'requests.post(URL, json=NEW_ITEM)\nprint("created:", NEW_ITEM["name"])',
+        ),
+        _code_shared("items = requests.get(URL).json()"),  # NEW language-neutral cell
+        _md(
+            lang,
+            "ws-task",
+            "alt",
+            "# ### Lösungshinweise\n#\n# - POST, dann GET zur Bestätigung"
+            if de
+            else "# ### Solution notes\n#\n# - POST then GET to confirm",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gold-derived judge + translator (no live LLM)
+# ---------------------------------------------------------------------------
+
+
+def _gold_map(modified_en: str, gold_de: str) -> dict[str, str]:
+    """Map each EN cell's stripped content -> the gold DE cell's content."""
+    en_cells = parse_cells(modified_en)
+    de_cells = parse_cells(gold_de)
+    assert len(en_cells) == len(de_cells), (len(en_cells), len(de_cells))
+    mapping: dict[str, str] = {}
+    for i, (en, de) in enumerate(zip(en_cells, de_cells, strict=True)):
+        if en.metadata.is_j2:
+            continue
+        assert en.metadata.slide_id == de.metadata.slide_id, i
+        assert role_of(en.metadata) == role_of(de.metadata), i
+        mapping[en.content.strip()] = de.content
+    return mapping
+
+
+class _GoldJudge:
+    prompt_version = "gold"
+
+    def __init__(self, mapping: dict[str, str]):
+        self._m = mapping
+
+    def propose(self, source_text, target_text, *, source_lang, target_lang):
+        gold = self._m.get(source_text.strip())
+        if gold is None:
+            return SyncProposal(verdict="in_sync", proposed_text=target_text)
+        return SyncProposal(verdict="update", proposed_text=gold)
+
+
+class _GoldTranslator:
+    prompt_version = "gold"
+
+    def __init__(self, mapping: dict[str, str]):
+        self._m = mapping
+
+    def translate(self, *, source_body, source_lang, target_lang, role):
+        gold = self._m.get(source_body.strip())
+        if gold is None:
+            raise TranslationError(f"no gold translation for {source_body[:60]!r}")
+        return gold
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+def _seed_watermark(cache_dir: Path, de_path: Path, en_path: Path, de: str, en: str) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    wm = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
+    try:
+        for lang, text in (("de", de), ("en", en)):
+            cells = ordered_sync_cells(parse_cells(text), lang)
+            wm.put_deck(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                lang=lang,
+                cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            )
+    finally:
+        wm.close()
+
+
+# ---------------------------------------------------------------------------
+# The test
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCodeE2E:
+    def test_single_language_pass_reproduces_gold_de(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        orig_de, orig_en = _original("de"), _original("en")
+        mod_en, gold_de = _modified("en"), _modified("de")
+        mapping = _gold_map(mod_en, gold_de)
+
+        cache_dir = tmp_path / "cache"
+        de_path = tmp_path / "apis.de.py"
+        en_path = tmp_path / "apis.en.py"
+        de_path.write_text(orig_de, encoding="utf-8")
+        en_path.write_text(orig_en, encoding="utf-8")
+        _seed_watermark(cache_dir, de_path, en_path, orig_de, orig_en)
+        # The author's edit: overwrite EN, leave DE at the baseline.
+        en_path.write_text(mod_en, encoding="utf-8")
+
+        # Inject the gold-derived judge + translator into the live command.
+        from clm.cli.commands import slides_sync as cmd
+
+        monkeypatch.setattr(cmd, "_resolve_judge", lambda *_a, **_k: _GoldJudge(mapping))
+        monkeypatch.setattr(cmd, "OpenRouterSlideTranslator", lambda **_k: _GoldTranslator(mapping))
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--no-env-file", "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0, (result.stderr or "") + (result.output or "")
+        produced = de_path.read_text(encoding="utf-8")
+        if produced != gold_de:  # pragma: no cover - diagnostic on failure
+            import difflib
+
+            diff = "".join(
+                difflib.unified_diff(
+                    gold_de.splitlines(keepends=True),
+                    produced.splitlines(keepends=True),
+                    "gold",
+                    "produced",
+                )
+            )
+            pytest.fail(f"synced DE != gold:\n{diff}")
+        # EN (the edited source) is never rewritten by an en->de pass.
+        assert en_path.read_text(encoding="utf-8") == mod_en
+
+    def test_rerun_after_pass_is_idempotent(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        orig_de, orig_en = _original("de"), _original("en")
+        mod_en, gold_de = _modified("en"), _modified("de")
+        mapping = _gold_map(mod_en, gold_de)
+        cache_dir = tmp_path / "cache"
+        de_path = tmp_path / "apis.de.py"
+        en_path = tmp_path / "apis.en.py"
+        de_path.write_text(orig_de, encoding="utf-8")
+        en_path.write_text(orig_en, encoding="utf-8")
+        _seed_watermark(cache_dir, de_path, en_path, orig_de, orig_en)
+        en_path.write_text(mod_en, encoding="utf-8")
+
+        from clm.cli.commands import slides_sync as cmd
+
+        monkeypatch.setattr(cmd, "_resolve_judge", lambda *_a, **_k: _GoldJudge(mapping))
+        monkeypatch.setattr(cmd, "OpenRouterSlideTranslator", lambda **_k: _GoldTranslator(mapping))
+
+        first = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--no-env-file", "--cache-dir", str(cache_dir)],
+        )
+        assert first.exit_code == 0, (first.stderr or "") + (first.output or "")
+        de_after_first = de_path.read_text(encoding="utf-8")
+
+        # Second run: the watermark advanced to the synced state -> nothing to do.
+        second = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--no-env-file", "--json", "--cache-dir", str(cache_dir)],
+        )
+        assert second.exit_code == 0, (second.stderr or "") + (second.output or "")
+        assert de_path.read_text(encoding="utf-8") == de_after_first  # no churn

--- a/tests/slides/test_sync_plan_walker.py
+++ b/tests/slides/test_sync_plan_walker.py
@@ -444,11 +444,11 @@ class TestAutoAdd:
         assert result.apply_result.has_errors
         assert result.exit_code == 2
 
-    def test_idcarrying_add_is_deferred_not_auto(self, tmp_path: Path):
-        # An id-carrying "missing counterpart" add (a slide_id present on one
-        # deck only) is out of v1 scope: apply_plan defers it unconditionally.
-        # The walker must NOT label it auto-applied or promise a git diff that
-        # was never written — it records a DEFERRED action instead.
+    def test_idcarrying_add_is_auto_applied(self, tmp_path: Path):
+        # An id-carrying add (a slide_id present on one deck only, unknown to the
+        # baseline) is a brand-new slide the author wrote with an id already on
+        # it. The walker auto-applies it: translate + insert the twin under the
+        # SAME id, reviewed in the resulting git diff.
         de_path, en_path = _write_pair(
             tmp_path,
             _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B-de"),
@@ -461,16 +461,16 @@ class TestAutoAdd:
         assert add.slide_id == "b"  # id-carrying, not id-less
 
         translator = StaticSlideTranslator(mapping={"# ## B-de": "# ## B-en"})  # fully mapped
-        before_en = en_path.read_text("utf-8")
         result, lines = _walk(plan, [], translator=translator)
 
-        assert result.auto_applied == 0  # NOT counted as auto-applied
-        assert result.apply_result.applied_add == 0
-        assert result.apply_result.deferred >= 1
-        assert any("deferred (id-carrying add" in line for line in lines)
-        assert not any("will auto-apply" in line for line in lines)
-        assert en_path.read_text("utf-8") == before_en  # deck untouched
-        assert result.exit_code == 1
+        assert result.auto_applied == 1
+        assert result.apply_result.applied_add == 1
+        assert result.apply_result.deferred == 0
+        assert any("will auto-apply" in line for line in lines)
+        en_text = en_path.read_text("utf-8")
+        assert "# ## B-en" in en_text  # translated counterpart inserted
+        assert 'slide_id="b"' in en_text  # under the same id (no minting)
+        assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

A real single-language editing pass (the `review_w01_w06` repro) surfaced four bugs in `clm slides sync`. The most serious: sync only ever classified/propagated **narrative markdown** (`slide`/`subslide`/`voiceover`/`notes`). Every **code cell** and every untagged/`alt` markdown cell was silently dropped — a workshop rewrite left the translated German heading sitting over the **old** code, and a new slide's runnable code never reached the other half. This is Phase 6 of the #166 single-language authoring sync (the design deliberately scoped Phases 1–5 to narrative markdown).

## What

### Bug 1 — code cells + auxiliary markdown now sync
- `role_of` recognizes a **localized id'd** code cell (`lang=` *and* `slide_id`) as role `"code"` — reconciled per-cell, edits **re-translated** via a code-aware prompt (not the markdown judge) — and **aux markdown** (a `slide_id` but no narrative tag, e.g. `alt` notes). `sync_plan._role_for_cell` now delegates to `role_of` so the classifier and apply engine can't disagree.
- **id-carrying adds** (a new cell minted with a `slide_id` on one side only) are now **applied** under the same id instead of deferred; the interactive walker auto-applies them.
- New `slides/sync_code.py` **structural pass** rebuilds the cell order of each slide group whose *language-agnostic signature* drifted: **language-neutral** code (no `lang=`) copied **verbatim** across both halves, **id-less localized** code translated, and per-cell-synced cells pulled back in by `(slide_id, role)`. Cross-group code moves fall out for free; **untouched groups stay byte-for-byte**; code cells are **never minted a `slide_id`** (so re-runs stay no-ops). `FileState.separator_blanks()` now uses the dominant gap over non-`j2` cells (a tight `# j2` header first cell previously mis-reported the deck as tight).

### Bug 2 — a transient judge/translation failure no longer drops a cell
Bounded retry-with-backoff (`infrastructure/llm/retry.py`) on the OpenRouter judge + translator; the **local** `--llm-timeout` default is now 300s (a large local reasoning model legitimately exceeds 120s), and a non-positive value falls back to the provider default rather than crashing `urllib`.

### Bug 3 — `clm slides sync` now loads the project `.env`
It checked only the process environment, so a key kept in `.env` (the usual course-repo layout) was invisible and every new-slide translation silently deferred. Shared `cli/env_loading.py` (also adopted by `clm build`) loads the first `.env` above each deck before resolving the judge/translator. `--no-env-file` opts out; `--dry-run` never loads it.

## Verification

- **Byte-identical** reproduction of the proprietary `review_w01_w06` gold DE deck via a gold-derived judge/translator (`8 add, 14 edit, 0 deferred, 0 errors`).
- **18** code-cell unit tests (`tests/slides/test_sync_code_cells.py`) — one per failure category on small inputs — plus **2** CLI-driven e2e tests on a non-proprietary "Web APIs" deck mirroring the repro's structure (`test_sync_code_e2e.py`), retry tests, and a translation-failure data-loss regression test.
- Full non-docker fast suite **6023 passed**; `ruff check` + `ruff format` + `mypy` clean; all pre-commit hooks passed.
- A 16-agent adversarial review caught **2 real issues**, both fixed + regression-tested: a failed translation mid-rebuild could drop a pre-existing target cell (rebuild now aborts and keeps the region intact); a negative `--llm-timeout` crashed `urllib`.

## Notes / scope

- No watermark-schema change. Info topic (`commands.md` sync section), `CHANGELOG.md`, and the design note (new "Phase 6") updated per the Info Topics Maintenance Rule.
- Known limitations (documented + surfaced, never silent): a *code-only* change with no narrative/id'd proposal and identical shared cells provides no direction signal and is not propagated; an unchanged id-less localized code cell inside a group rebuilt for another reason is re-translated (churn, not corruption); per-pass partial-write atomicity is unchanged (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
