### PR TITLE
docs(migration): note code-cell/aux sync + .env auto-load (#166 Phase 6)

### DIFF
--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -233,6 +233,23 @@ both decks.
   picks the OpenRouter model that translates brand-new slides on the add
   path. It needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`); without a
   key, add proposals defer (everything else still applies).
+- **Code cells and auxiliary markdown now sync too** (previously only
+  `slide` / `subslide` / `voiceover` / `notes` markdown was propagated). A
+  **language-neutral** code cell (no `lang=`) is copied **verbatim** across
+  both halves; a **localized** code cell (`lang=`) and `alt` / untagged
+  markdown are twinned and translated; a new slide brings its code along, and
+  code moved between slide groups follows. If you used to hand-edit code on
+  both halves to keep them in step, sync now does it for you — new code cells
+  are **not** minted a `slide_id` (they stay id-less, kept consistent
+  structurally).
+- **The project `.env` is loaded automatically.** Sync walks up from each
+  deck and loads the first `.env` it finds (without overriding already-set
+  variables), so an `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY` kept in `.env`
+  (not exported) is now found — previously every brand-new-slide translation
+  silently deferred. Pass `--no-env-file` to skip it.
+- A transient judge / translation failure now **retries with backoff** instead
+  of dropping the cell, and the `--llm-timeout` default is provider-aware
+  (120s for `openrouter`, 300s for `local`).
 
 ### How to migrate
 


### PR DESCRIPTION
## Why

Follow-up to #188. That PR made `clm slides sync` propagate code cells and auxiliary markdown, auto-load the project `.env`, and retry transient LLM failures. The change is additive (no break), but it is a real workflow change for course authors, so it belongs in the `clm info migration` sync section's **"What's new"** (which already documents the earlier additive provider switch from #187).

## What

Adds three "What's new" bullets to `src/clm/cli/info_topics/migration.md`:

- code cells + `alt`/untagged markdown now sync (language-neutral copied verbatim, localized twinned/translated, new code id-less);
- the project `.env` is auto-loaded (`--no-env-file` to opt out);
- transient judge/translation failures retry with backoff; `--llm-timeout` default is provider-aware.

Docs-only; `clm info migration` renders cleanly (`test_info.py` green). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
