### PR TITLE
feat(slides): atomic sync writes + no-op corpus harness (#190 Phase 0)

### DIFF
--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -94,6 +94,25 @@ course, and authoring style can be adjusted to *reduce* the localized-id-less
 population if that smooths the process — so the design should make the
 language-neutral path the cheap, dominant one and keep the localized path simple.
 
+**Phase-0 measured baseline (2026-06-01, `scripts/sync_corpus_harness.py`).** The
+harness reproduces the §3 census exactly (md 10,861; code 8,926; localized
+744 id-less + 192 id'd = 936; def-my-fun neutral+localized id'd = 356 + 192 =
+548; cells-with-id 6,638; 20,635 cells − 848 `# j2` = 19,787), and pins the
+churn the two serious limitations expose today:
+
+| Baseline | Count | Phase that drives it to 0 |
+|---|--:|---|
+| **item 2** silent-drop exposure (neutral cells with no per-cell role) | **8,014** (7,634 neutral id-less code + 356 neutral id'd code + 24 neutral md) | Phase 3 |
+| **item 3** needless-re-translation exposure (id-less localized cells) | **1,702** (744 code + 958 md) | Phase 2 |
+| item-3 blast radius | 948 groups expose ≥1, max 10 in one group | — |
+| no-op invariant | 81 / 212 pairs already post-sync-clean; **0 violations** | every phase must hold |
+
+(The other 131 pairs are *not yet synced* — they carry 3,793 id-less narrative
+cells that predate #166 adoption, a data condition, not engine churn.) The
+mechanism for each limitation is pinned as a fast, synthetic flip-test in
+`tests/slides/test_sync_limitations.py`; the corpus invariant + magnitude in the
+`slow`/`integration` `tests/slides/test_sync_corpus_noop.py`.
+
 ## 4. Core decision — identity in the DB, via content anchors
 
 **Give every cell a content-derived *anchor*, computed at sync time and stored in
@@ -319,6 +338,17 @@ protects the *watermark* advance, not the disk write. Wrap the two flushes in a
 on any error, write nothing and surface the deferral. This is a clean
 prerequisite that every later phase relies on.
 
+**Shipped (Phase 0).** `FileState.render()` factors the exact flush bytes out of
+`flush()` (no behaviour change for the v1/v2 walkers that still call `flush`),
+and `apply_plan` now calls `_flush_states_atomically(de_state, en_state)` —
+gated on `not result.has_errors` — which renders both decks in memory and swaps
+each in with `_atomic_write_text` (same-dir temp file + `os.replace`, utf-8/LF,
+byte-identical to the old path). A deferred-but-error-free pass still writes (the
+applied edits + partial-advance are the designed outcome); only a genuine error
+rolls the whole pass back. The one residual gap — the window *between* the two
+`os.replace` calls — is as small as a two-file write allows. Interactive
+`--interactive` inherits this (the walker routes through `apply_plan`).
+
 ## 12. Guardrails & failure modes
 
 | Situation | Handling |
@@ -353,11 +383,13 @@ prerequisite that every later phase relies on.
 Each phase is independently testable in the fast suite and preserves the no-op
 invariant. Gate releases on `pytest -m "not docker"`.
 
-0. **Atomicity + harness.** Buffered temp-swap (§11). A no-op regression harness
-   over the real 212-deck / ~20k-cell corpus asserting a clean re-run writes zero
-   bytes and makes zero LLM calls. *This is the make-or-break invariant every
-   later phase must preserve* — and it doubles as a measurement of how much churn
-   items 2 & 3 produce today.
+0. **Atomicity + harness. ✅ Shipped (2026-06-01).** Buffered temp-swap (§11).
+   A no-op regression harness (`scripts/sync_corpus_harness.py`) over the real
+   212-deck / ~20k-cell corpus asserting a clean re-run writes zero bytes and
+   makes zero LLM calls — backstop in `tests/slides/test_sync_corpus_noop.py`
+   (`slow`/`integration`), mechanism flip-tests in
+   `tests/slides/test_sync_limitations.py` (fast). Measured baseline in §3:
+   item-2 exposure 8,014, item-3 exposure 1,702, 0 invariant violations.
 1. **Widen the watermark** (§5): `construct` migration, 5-tuples, `"shared"`
    partition, membership. `anchor_of` chokepoint. No behavior change yet.
 2. **Item 3 first** (§8): anchor+hash verbatim reuse in `sync_code`. Highest

--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -1,0 +1,402 @@
+# Content-Anchor Cell Identity for Sync — Design Note
+
+**Status**: Design agreed with the maintainer (pre-implementation)
+**Author**: Claude (Opus 4.8), with the maintainer
+**Date**: 2026-06-01
+**Scope**: `src/clm/slides/sync_plan.py`, `sync_code.py`, `sync_apply.py`,
+`sync_writeback.py`, `src/clm/infrastructure/llm/cache.py`
+(`SyncWatermarkCache`), and the `clm slides sync` CLI
+**Issues**: [#190](https://github.com/hoelzl/clm/issues/190) (the three known
+limitations) · builds on [#166](https://github.com/hoelzl/clm/issues/166) (the
+single-language authoring workflow) · serves
+[#162](https://github.com/hoelzl/clm/issues/162) (the cross-language `slide_id`
+invariant)
+
+Companion to `single-language-authoring-sync.md` (the #166 engine this extends).
+That note built the per-`(slide_id, role)` engine; this one fixes the three
+limitations #190 tracks **without changing that engine's contracts** — it is
+additive.
+
+---
+
+## 1. The three limitations (and which are serious)
+
+From #190, against the engine shipped in #166 Phase 6:
+
+1. **Partial-apply atomicity.** A pass that errors mid-way (e.g. an LLM failure)
+   still flushes the edits that succeeded. State is reviewable via `git diff` and
+   the watermark is held, but the write is not transactional. *(Maintainer: not
+   bothersome; a buffered temp-swap is fine.)*
+2. **A code-only change with no narrative/id'd signal is not propagated.** The
+   structural pass takes its direction from the run's narrative proposals; a pass
+   that edits *only* a shared/language-neutral code cell has no proposal, so no
+   direction, so nothing propagates. *(Maintainer: **serious** — this happens
+   **frequently** when fine-tuning a deck.)*
+3. **An unchanged id-less localized code cell is re-translated on a rebuild.**
+   When a slide group is rebuilt for any reason, every id-less localized code
+   cell in it is re-translated, because its structural signature `("L", kind)`
+   cannot prove it is unchanged. *(Maintainer: **not acceptable** — they go to
+   great lengths to keep content byte-identical across translations.)*
+
+## 2. Root cause — two gates, not one
+
+Cell identity is decided by **one predicate**, `sync_writeback.role_of()`: a
+cell participates in per-cell reconciliation only if it is narrative markdown, an
+id-carrying aux markdown cell, or a **localized** code cell (has *both* `lang=`
+*and* `slide_id`). Everything else returns `None` and is handled — coarsely — by
+the structural pass in `sync_code.py`.
+
+But broadening `role_of` is **not sufficient**, because there is a **second
+gate** the obvious fix misses:
+
+- `sync_plan.ordered_sync_cells()` drops every cell whose `lang != expected_lang`
+  (sync_plan.py:211). A **language-neutral** cell (`lang is None`) is therefore
+  dropped from *both* the `de` and `en` cell lists.
+- The classifier only computes `edit` / `move` / `remove` for cells that **carry
+  a `slide_id`** (`_index_by_key` routes id-less cells to an "idless" list;
+  `_baseline_index` skips `slide_id is None`). An id-less cell can only ever
+  become an `add`.
+
+> **Consequence:** stamping a `slide_id` onto a language-neutral code cell does
+> **not** make the engine see it. It is still dropped by the `lang` filter, and
+> still modeled as a `de`/`en` *pair* when it is really *one shared cell*.
+
+This is why the intuitive fix — *"before anything else, assign a unique id to
+every cell"* — is the right **goal** but the wrong **mechanism**. §3 measures the
+cost; §4 picks the mechanism.
+
+## 3. What the real decks look like
+
+Census of the PythonCourses course repo (`slides/`, 212 split decks, 19,787
+cells), 2026-06-01:
+
+| Population | Count | Relevance |
+|---|--:|---|
+| markdown cells | 10,861 | mostly already handled |
+| code cells | 8,926 | — |
+|   • language-neutral, id-less (`# %%`, `tags=["keep"]`) | ~6,700 | **item 2** (~89.5% of code) |
+|   • localized (`lang=`), of which ~740 id-less | 936 | **item 3** |
+|   • code already carrying `slide_id` | 548 | the `def-my-fun` pattern — real, ~6% |
+| **any** cell already carrying `slide_id` | 6,638 | author has already adopted ids widely |
+
+Two facts drive the design:
+
+- **A blanket "id on every cell" is a ~13,000-id write** (≈66.5% of all cells) —
+  a one-line `git diff` on two-thirds of every deck, i.e. exactly the churn on
+  content-unchanged cells the author wants to avoid. The cure becomes the
+  disease.
+- **Both failure populations are large and want different treatment.** Item 2 is
+  ~6,700 *shared* cells (copy verbatim); item 3 is ~740 *localized* cells
+  (translate once, then never again). A fix must serve both.
+
+Maintainer note: the neutral fraction is ~90% here, perhaps 80–85% on the AZAV ML
+course, and authoring style can be adjusted to *reduce* the localized-id-less
+population if that smooths the process — so the design should make the
+language-neutral path the cheap, dominant one and keep the localized path simple.
+
+## 4. Core decision — identity in the DB, via content anchors
+
+**Give every cell a content-derived *anchor*, computed at sync time and stored in
+the watermark. Never write ids into id-less cells.**
+
+```
+anchor(cell):
+    1. hand-authored slide_id           # top precedence — the author keeps full control
+    2. extract_from_code() construct     # "function my_fun", "class X", "import time" — deterministic AST name
+    3. sha256(stripped body)             # fallback for output / magic / unparsable cells
+```
+
+`extract_from_code` (already used by `assign-ids`) yields a stable, deterministic
+construct name by AST precedence (class → def → assign → import → call). The
+anchor is a **pure function of content**, so it is always re-derivable,
+git-commit-immune, and adds **zero** header churn.
+
+**Why the DB, not the file** (id-visibility call): the anchor is re-derivable and
+the watermark already plays exactly this baseline-snapshot role (written only on
+a clean apply, immune to commit cadence). Storing identity in the file would mean
+the ~13k-id churn of §3 *and* a `unify` hazard (§7). The **only** time sync
+writes a `slide_id` into a file is a genuine, author-wanted *correction* (§9) —
+never a bulk stamp.
+
+Honest costs of going invisible, all judged acceptable:
+
+- a stale hand-authored id can sit on the "wrong" cell until a correction fires
+  (cosmetic; sync stays correct);
+- identity can drift from a file edited entirely outside the tool — covered by
+  the existing `_baseline_from_git_head` re-deriving anchors from HEAD;
+- "why did it sync that way" needs a `clm slides sync --explain` that dumps the
+  anchor diff, since the `.py` no longer tells the whole story.
+
+Crucially, because anchors are re-derivable and hand-ids are top-precedence,
+**authors who want stable readable ids keep full control** — the scheme is
+additive, never a replacement.
+
+## 5. Data model — the widened watermark
+
+Today `sync_watermarks` (cache.py:506) stores only `role_of != None` cells, as
+4-tuples `(position, slide_id, role, content_hash)`, partitioned by `lang ∈
+{de, en}`. Three additive changes:
+
+1. **A `construct` column** (nullable TEXT). `SyncWatermarkCache._migrate`
+   currently handles only the empty-table case — add the additive branch:
+   `if "construct" not in columns: ALTER TABLE sync_watermarks ADD COLUMN
+   construct TEXT`. Widen `get_deck` / `put_deck` to 5-tuples
+   `(position, slide_id, role, content_hash, construct)`.
+2. **A `"shared"` partition** for language-neutral cells — the single-entity
+   model. Neutral cells are tracked **once** (not duplicated under `de` and
+   `en`), under `lang="shared"`. Relax the `put_deck` guard from
+   `lang in ("de","en")` to `lang in ("de","en","shared")`. The invariant on the
+   shared partition: the `.de.py` and `.en.py` physical copies are byte-identical
+   (the same invariant `unify` enforces — §7); a divergence is the item-2a
+   heal/conflict case.
+3. **Membership widening** — the watermark records *every* non-`j2` cell, not just
+   `role_of != None` ones. A neutral cell's row carries `slide_id` (it may have a
+   hand-id, e.g. the 548), `role` = a synthetic kind (`"neutral-code"` /
+   `"neutral-markdown"`), `content_hash`, and `construct`. A localized id-less
+   cell carries `slide_id = NULL`, `role` = `"localized-code"` /
+   `"localized-markdown"`, plus `construct`.
+
+The anchor is **derived** from a row (`slide_id or construct-slug or
+content_hash`), so no separate `anchor` column is needed.
+
+Schema/path hygiene (recurring CLM hazards): the anchor's `sha256` must hash the
+**same canonical stripped form** as `cell_content_hash` (or CRLF/LF flapping
+re-introduces item-3 churn), and `de_path`/`en_path` must be normalized
+identically to the other caches at every touch (Windows casing/separators).
+
+## 6. The new anchor-keyed diff pass (the load-bearing piece)
+
+The missing component every naive approach assumes but none specifies: a diff
+pass that runs **alongside** the existing `(slide_id, role)` classifier and emits
+into the **same `SyncPlan`** the apply engine already consumes — because the
+keyed classifier *structurally cannot* see id-less or language-neutral cells
+(§2).
+
+```
+align_anchored(current_cells, baseline_rows, partition) -> proposals
+  - extract every non-j2 cell with its anchor + content_hash + kind + lang
+  - diff current-vs-baseline BY ANCHOR:
+        same anchor, same content_hash   -> UNCHANGED  (reuse verbatim — fixes item 3)
+        same anchor, diff content_hash   -> EDIT
+        anchor in baseline, gone         -> REMOVE
+        anchor new                       -> ADD
+  - reuse the existing LCS / _moved_keys machinery on the stable-anchor subset
+        for MOVE detection (unchanged content, repositioned)
+  - feed edit/move/add/remove Proposals into the SAME SyncPlan
+```
+
+This runs for the cells the keyed classifier cannot reach (the `"shared"`
+partition + localized id-less cells); the keyed classifier keeps owning narrative
++ id'd cells unchanged. The two passes are reconciled **at the proposal level**
+(one `SyncPlan`), and the §11 corpus-wide no-op harness guards against
+double-emission or drops.
+
+## 7. Item 2 — code-only changes propagate
+
+Split by cell class, because they want different handling:
+
+### 7a. Language-neutral shared cell, edited one side (≈90% of code) — no LLM
+
+`unify` requires a no-lang shared cell to be **byte-identical** across decks
+(split.py:377 → `UnifyError`). So an author editing a shared `# %%` cell in
+`.de.py` only has put the pair into a **unify-violating** state. The fix is not
+translation or direction inference — it is a **deterministic verbatim copy** to
+the twin, restoring the invariant. The anchor diff (§6, `"shared"` partition)
+detects "edited on the deck that drifted from baseline" with no narrative signal
+needed.
+
+**Divergence (both sides edited the shared cell differently since baseline)** —
+the genuine conflict. Maintainer decision: **auto-heal + warning**, with a config
+fallback to hard-error.
+
+- Winner selection: (i) the run's established edit direction if one exists (the
+  deck the author touched this session — the common case); else (ii) the
+  newer-mtime file as a tiebreak; else (iii) no signal at all → treat as an error
+  even in auto-heal mode (cannot heal without a winner).
+- Always emit a `warning` naming the cell.
+- Knob `[tool.clm] sync.shared_divergence = auto-heal | error` (env
+  `CLM_SYNC__SHARED_DIVERGENCE`), default `auto-heal`. Flip to `error` if
+  auto-heal proves problematic in the pilot.
+
+### 7b. Localized id-less code cell, edited (≈740 cells) — translate, with direction
+
+Genuinely needs translation. Direction comes from the source the engine already
+trusts for narrative — the per-pair `SyncSnapshotCache` direction auto-detection
+/ explicit `--direction` — **not git** (§10). The anchor diff classifies it as an
+`edit`; the apply re-translates only that cell.
+
+## 8. Item 3 — unchanged localized code is never re-translated
+
+The cheapest, highest-value change, doable first and in isolation:
+
+- In `sync_code._signature`, replace `("L", kind)` with `("L", anchor)` so the
+  signature carries identity, not just kind.
+- In `sync_code._rebuild_region`, add an **anchor + content_hash reuse path**:
+  when a source cell's anchor and content_hash match the existing target twin
+  (located by anchor, the data §5 now stores), splice the **existing target
+  `RawCell` verbatim** — no `_translate` call.
+
+A group rebuilt for a *sibling's* sake now re-translates **only** the genuinely
+changed cell. This uses only data the widened watermark already stores and
+touches one well-isolated function.
+
+## 9. The `def-my-fun` split — deterministic id-migration
+
+The maintainer's real example: an author adds an `import` by splitting a cell,
+leaving the existing `slide_id="def-my-fun"` on the *import* half:
+
+```
+BEFORE                                   AFTER
+# %% tags=[...] slide_id="def-my-fun"     # %% tags=[...] slide_id="def-my-fun"
+def my_fun():                             import time
+    print("foo")                          # %% tags=["keep"]
+                                          def my_fun():
+                                              time.sleep(1)
+                                              print("foo")
+```
+
+Handled deterministically, no LLM, **one** targeted header write:
+
+1. Baseline records id `def-my-fun` on a cell whose `construct` is
+   `function my_fun`.
+2. After the edit the cell *wearing* `def-my-fun` has `construct` `import time`
+   (id says def, content says import), while a different, id-less current cell has
+   `construct` `function my_fun`, matching the baseline.
+3. This **id-vs-construct mismatch** is unambiguous — the id follows the
+   construct. So: move `slide_id="def-my-fun"` down to the def cell
+   (`_write_slide_id`, lines[0]-only, byte-contract-safe), and mint a fresh
+   content-slug (`import-time`) on the orphaned import cell.
+4. The def cell here is **language-neutral** (no `lang` in the example), so it is
+   byte-identical in both files including the id — the move is one logical edit
+   applied identically to both physical copies; `unify` byte-identity is
+   preserved with **no asymmetry**. *(If the cell were **localized** (`lang=`),
+   the move+mint must be applied symmetrically to both decks' twins so
+   `_slide_ids_pair`'s `de_id == en_id` holds — route every localized id-write
+   through one paired chokepoint.)*
+5. The def **body** changed (`time.sleep(1)`), so it is a legitimate `edit`,
+   translated once if localized; every other cell in the group, proven unchanged
+   by anchor+hash, is reused verbatim (§8).
+
+Maintainer decision: this id-move **writes to the file by default** — it corrects
+an id the author already placed onto the content it belongs to; it only ever
+touches already-id'd, drifted cells. Escalation to the LLM tier (§10) happens
+*only* if the author also renamed the function in the same edit (so the construct
+match also fails) — a genuine ambiguity.
+
+## 10. Bounded LLM (Opus) recovery — the residue only
+
+For the genuine residue — simultaneous rename, true N:1 merge/split, ambiguous
+ties (two `def my_fun`, many bare imports) — escalate to Claude, **bounded**:
+
+- A new `sync_alignments` cache table, keyed by
+  `(base_region_hash, current_region_hash, prompt_version)`.
+- A **body-free, alignment-only** call: the model returns an id↔cell *map*, never
+  free-form edits. Validate every map (each current cell mapped once; ids reused
+  only from the base set; unchanged-anchors pinned; kind/lang-compatible) and
+  **safe-abort to no-change-plus-flag** on any validation failure.
+- Maintainer decision: **defer-by-default** — an ambiguous group is left
+  untouched and re-surfaces next run; the LLM fires only under an explicit
+  `--llm-recover`.
+
+Change-signal reliability (the maintainer asked which sources to trust):
+
+| Signal | Use |
+|---|---|
+| **watermark** | primary baseline |
+| **content anchors** | the new identity spine (§4) |
+| **git HEAD of the file** | cold-start corroborator only (already used) |
+| **git inter-commit (`HEAD~1`)** | **avoid** — CLM squash-merges collapse it; rename detection across squashes is fragile |
+| **`SyncCache` translation memo** | **avoid as identity** — keyed by `source_hash→translation`; it is a memo, not a twin *index*; it cannot locate a cross-language counterpart |
+| **Claude (Opus) alignment** | bounded last tier (above) |
+
+## 11. Atomicity (item 1)
+
+`sync_apply.apply_plan` calls `de_state.flush()` / `en_state.flush()`
+unconditionally (sync_apply.py:225-226); the error guard at line 240 only
+protects the *watermark* advance, not the disk write. Wrap the two flushes in a
+**buffered temp-swap**: build both decks' new text in memory, and write
+(temp-file + atomic replace, per deck) **only if the whole pass is error-free**;
+on any error, write nothing and surface the deferral. This is a clean
+prerequisite that every later phase relies on.
+
+## 12. Guardrails & failure modes
+
+| Situation | Handling |
+|---|---|
+| Shared cell edited one side | Verbatim copy to twin (restores `unify` invariant) — §7a |
+| Shared cell diverged both sides | Auto-heal to winner + warning; `sync.shared_divergence=error` to harden — §7a |
+| Unchanged localized code, group rebuilt | Anchor+hash match → spliced verbatim, no translate — §8 |
+| Id drifted onto wrong content (split) | Deterministic id-migration, one header write — §9 |
+| Localized id-write | Symmetric both-deck chokepoint (`de_id==en_id`) — §9 |
+| Non-unique construct (two `def f`, many imports) | `content_hash` tiebreak (order-invariant); else escalate — §10 |
+| `sha256`-fallback cells (unnameable output/magic) | Churn on every edit (look like remove+add); honest residual — hand-id the rare ones |
+| Author commits before sync | Anchors survive (content-derived); watermark immune — §4 |
+| Re-run after clean sync | Zero writes, zero LLM, zero churn (the §11 harness invariant) |
+| Cold start / first post-upgrade run | `_baseline_from_git_head` re-derives anchors; HEAD-identical cells treated as `same` |
+| File edited outside the tool | Identity re-derived from content; git-HEAD fallback corroborates |
+
+## 13. Component changes
+
+| Module | Change |
+|---|---|
+| `infrastructure/llm/cache.py` | `SyncWatermarkCache`: additive `construct` migration; 5-tuple `get_deck`/`put_deck`; accept `"shared"` partition; membership widened to all non-j2 cells. |
+| `slides/sync_writeback.py` | `role_of` unchanged (keystone preserved); add an `anchor_of(cell)` chokepoint (`hand-id > construct > sha256`); synthetic kinds for neutral/localized-id-less. |
+| `slides/sync_plan.py` | New `align_anchored` pass (§6) feeding the same `SyncPlan`; `ordered_all_cells` (broad extraction) alongside `ordered_sync_cells`; single-entity neutral model in `classify_changes`. |
+| `slides/sync_code.py` | `_signature` `("L", anchor)`; `_rebuild_region` anchor+hash verbatim-reuse; consume the shared-partition heal. |
+| `slides/sync_apply.py` | Buffered temp-swap atomicity (§11); deterministic id-migration apply (§9); symmetric localized id-write chokepoint. |
+| New `sync_recover.py` (Phase 5) | Bounded, validated, cached Opus alignment recovery; `sync_alignments` table. |
+| `cli/commands/slides_sync.py` | `--llm-recover` (default off); `--explain` (anchor-diff dump); `sync.shared_divergence` knob. |
+| `cli/info_topics/{commands,migration}.md` | Per the **Info Topics Maintenance Rule** — new flags + the auto-heal behavior. |
+
+## 14. Phased implementation plan
+
+Each phase is independently testable in the fast suite and preserves the no-op
+invariant. Gate releases on `pytest -m "not docker"`.
+
+0. **Atomicity + harness.** Buffered temp-swap (§11). A no-op regression harness
+   over the real 212-deck / ~20k-cell corpus asserting a clean re-run writes zero
+   bytes and makes zero LLM calls. *This is the make-or-break invariant every
+   later phase must preserve* — and it doubles as a measurement of how much churn
+   items 2 & 3 produce today.
+1. **Widen the watermark** (§5): `construct` migration, 5-tuples, `"shared"`
+   partition, membership. `anchor_of` chokepoint. No behavior change yet.
+2. **Item 3 first** (§8): anchor+hash verbatim reuse in `sync_code`. Highest
+   value, lowest risk, one isolated function.
+3. **Item 2** (§7): the `align_anchored` pass (§6) + single-entity neutral model
+   + auto-heal/warn. The largest new module; default-on-overridable (mirroring
+   the #166 default-flip).
+4. **Deterministic `def-my-fun` id-migration** (§9): the one gated file-write,
+   strictly scoped to already-id'd, drifted cells; symmetric localized chokepoint.
+5. **Bounded Opus recovery** (§10): `sync_alignments` table; `--llm-recover`
+   (default off); validate-and-safe-abort.
+6. **Docs + `--explain`** (§13): info topics, migration entry, anchor-diff dump.
+
+## 15. Open / deferred
+
+- **Non-unique construct anchors** in multi-code groups (1,211 groups have 2+
+  code cells): `content_hash` tiebreak handles most; deliberate reorders of
+  *byte-identical* boilerplate cells are invisible to content-anchors (accepted —
+  re-pairing by position is fine).
+- **`sha256`-fallback cells** churn on every edit; reduce by encouraging a hand-id
+  or a nameable first statement (authoring-style lever the maintainer is open to).
+- **Full 3-way LLM merge** for true content conflicts — the watermark is the
+  ancestor; out of scope here (tracked in `single-language-authoring-sync.md`
+  §10).
+
+## 16. Relationship to #166 / #162
+
+- This note is **additive** to the #166 engine: same `SyncPlan`, same apply
+  pipeline, same watermark file — a new diff pass + a richer baseline + three
+  scoped apply behaviors. It does not rewrite `sync.py`/`sync_walker.py`/etc.
+- It realizes #162's generative direction for *code* cells: identity minted at
+  sync time, EN-authority preserved, written to files only on correction.
+
+## 17. Decisions locked with the maintainer (2026-06-01)
+
+1. **Neutral fraction ~90%** (perhaps 80–85% on AZAV ML, not lower); authoring
+   style can be adapted to cut the localized-id-less population. → make the
+   language-neutral verbatim path the cheap, dominant one.
+2. **`def-my-fun` id-move writes to the file by default.**
+3. **Diverged shared cell → auto-heal + warning**, with a config fallback to
+   hard-error if it proves problematic.
+4. **Opus recovery is defer-by-default** (`--llm-recover` opt-in).

--- a/scripts/sync_corpus_harness.py
+++ b/scripts/sync_corpus_harness.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Read-only ``clm slides sync`` corpus harness for Issue #190 (Phase 0).
+
+Two jobs over the real PythonCourses split decks (≈212 ``*.de.py`` / ``*.en.py``
+pairs, ≈20k cells):
+
+1. **No-op invariant** — the regression backstop every later #190 phase must
+   preserve. For a pair that is already in *post-sync-clean* shape, a clean
+   re-run of the sync engine must write **zero bytes** and make **zero LLM
+   calls**. We establish "already synced" by seeding the structural watermark
+   from the pair's *current* state, then run the real
+   :func:`~clm.slides.sync_plan.build_sync_plan` + :func:`~clm.slides.sync_apply.apply_plan`
+   over a **temp copy** with a **counting, no-LLM** translator/judge, and check
+   the bytes are unchanged and no translate/judge call fired.
+
+2. **Churn baseline** — the measurement Phases 2-3 are proven against. A static
+   census of the cell populations the two *serious* #190 limitations expose:
+
+   * **item 2** (a code-only change is not propagated): *language-neutral*
+     cells, which produce no proposal when edited alone — so a sync silently
+     drops the edit and leaves the split halves byte-divergent;
+   * **item 3** (an unchanged localized code cell is re-translated): *id-less
+     localized* cells, which a group rebuild re-translates because their
+     ``("L", kind)`` structural signature cannot prove they are unchanged — plus
+     the per-group *blast radius* (how many such cells one sibling-triggered
+     rebuild re-translates).
+
+This **never mutates the course repo**: every probe runs on a temp copy with a
+temp watermark DB, and the translator/judge are mocked (no network).
+
+Usage::
+
+    python scripts/sync_corpus_harness.py [--corpus DIR] [--json] [--limit N]
+
+The corpus dir defaults to ``$CLM_SYNC_CORPUS_DIR``, then the known PythonCourses
+``slides`` path. Exits 0 when the no-op invariant holds for every no-op-shaped
+pair; 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Allow running both as a script (``python scripts/sync_corpus_harness.py``) and
+# as an importable module from the pytest backstop.
+if __package__ in (None, ""):  # pragma: no cover - import shim
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache  # noqa: E402
+from clm.infrastructure.llm.ollama_client import SyncProposal  # noqa: E402
+from clm.notebooks.slide_parser import Cell, parse_cells  # noqa: E402
+from clm.slides.sync_apply import apply_plan  # noqa: E402
+from clm.slides.sync_plan import build_sync_plan, ordered_sync_cells  # noqa: E402
+from clm.slides.sync_writeback import role_of  # noqa: E402
+
+# Default corpus location (overridable via --corpus or $CLM_SYNC_CORPUS_DIR).
+_DEFAULT_CORPUS = Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides")
+
+
+# ---------------------------------------------------------------------------
+# Counting (no-LLM) translator / judge
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CountingTranslator:
+    """Deterministic stand-in translator that records every call (no network).
+
+    Returns the source body verbatim — enough to drive the apply path while we
+    only care about *how many* translations a sync would trigger. A non-zero
+    call count on a supposedly-no-op pair is exactly the item-3 churn we measure.
+    """
+
+    prompt_version: str = "counting"
+    calls: list[tuple[str, str, str, str]] = field(default_factory=list)
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.calls.append((role, source_lang, target_lang, source_body))
+        return source_body
+
+
+@dataclass
+class CountingJudge:
+    """Stand-in edit judge that records every call and never rewrites (no network)."""
+
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def propose(
+        self, source_body: str, target_body: str, *, source_lang: str, target_lang: str
+    ) -> SyncProposal:
+        self.calls.append((source_lang, target_lang))
+        return SyncProposal(verdict="in_sync", proposed_text=target_body)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_pairs(root: Path) -> list[tuple[Path, Path]]:
+    """Return every ``(de_path, en_path)`` split pair under ``root`` (recursive).
+
+    A pair is a ``*.de.py`` with a sibling ``*.en.py`` of the same stem. Files
+    without a counterpart are skipped (an unmatched half is not a sync pair).
+    Sorted for a stable, reproducible report.
+    """
+    pairs: list[tuple[Path, Path]] = []
+    for de_path in sorted(root.rglob("*.de.py")):
+        en_path = de_path.with_name(de_path.name[: -len(".de.py")] + ".en.py")
+        if en_path.exists():
+            pairs.append((de_path, en_path))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# No-op probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NoopResult:
+    """Outcome of seeding a pair's watermark from its current state and re-running."""
+
+    name: str
+    plan_is_noop: bool
+    de_bytes_changed: bool
+    en_bytes_changed: bool
+    translate_calls: int
+    judge_calls: int
+    applied: int
+    deferred: int
+    proposal_kinds: Counter  # kind -> count (why a pair is NOT no-op)
+    issue_count: int
+
+    @property
+    def is_violation(self) -> bool:
+        """A *no-op-shaped* pair that nonetheless wrote bytes or called the LLM.
+
+        This is the pure engine-invariant breach the backstop guards: a plan
+        with nothing to do must apply as a true no-op. (A pair that is simply
+        not yet synced — ``plan_is_noop`` False — is a data condition, reported
+        separately, never a violation.)
+        """
+        return self.plan_is_noop and (
+            self.de_bytes_changed
+            or self.en_bytes_changed
+            or self.translate_calls > 0
+            or self.judge_calls > 0
+        )
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    """Record the pair's current sync-cell state as the watermark baseline."""
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )
+
+
+def noop_probe(de_path: Path, en_path: Path) -> NoopResult:
+    """Seed a pair's watermark from its current state and re-run sync on a copy.
+
+    Operates entirely on a temp copy with a temp watermark DB, so the corpus is
+    never touched. Returns the bytes-changed / LLM-call tallies plus the plan's
+    shape (so non-no-op pairs can be explained without failing the invariant).
+    """
+    with tempfile.TemporaryDirectory(prefix="clm-sync-noop-") as tmp:
+        tmp_dir = Path(tmp)
+        de_tmp = tmp_dir / de_path.name
+        en_tmp = tmp_dir / en_path.name
+        shutil.copyfile(de_path, de_tmp)
+        shutil.copyfile(en_path, en_tmp)
+        de_before = de_tmp.read_bytes()
+        en_before = en_tmp.read_bytes()
+
+        cache = SyncWatermarkCache(tmp_dir / "clm-llm.sqlite")
+        translator = CountingTranslator()
+        judge = CountingJudge()
+        try:
+            _seed_watermark(cache, de_tmp, en_tmp)
+            # No git fallback: the temp copy is not a repo, and we have a
+            # watermark, so the baseline is unambiguous.
+            plan = build_sync_plan(de_tmp, en_tmp, watermark_cache=cache, allow_git_fallback=False)
+            result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        return NoopResult(
+            name=_pair_name(de_path),
+            plan_is_noop=plan.is_noop,
+            de_bytes_changed=de_tmp.read_bytes() != de_before,
+            en_bytes_changed=en_tmp.read_bytes() != en_before,
+            translate_calls=len(translator.calls),
+            judge_calls=len(judge.calls),
+            applied=result.applied,
+            deferred=result.deferred,
+            proposal_kinds=Counter(p.kind for p in plan.proposals),
+            issue_count=len(plan.issues),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Static census (item-2 / item-3 exposure populations)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Census:
+    """Per-corpus static cell-population counts (summed across all deck files)."""
+
+    deck_files: int = 0
+    cells_total: int = 0
+    md_total: int = 0
+    code_total: int = 0
+    j2_total: int = 0
+    any_slide_id: int = 0
+
+    # item-2 territory: language-neutral cells (no proposal when edited alone).
+    code_neutral_idless: int = 0  # the ~6,700 shared `# %%` / tags=["keep"] cells
+    code_neutral_idd: int = 0  # neutral code carrying a slide_id (the def-my-fun shape)
+    md_neutral_structural: int = 0  # neutral markdown with no per-cell role (structural)
+
+    # item-3 territory: id-less localized cells (re-translated on a group rebuild).
+    code_localized_idless: int = 0  # the ~740 — the headline item-3 population
+    code_localized_idd: int = 0  # localized code with a slide_id (reconciled per-cell)
+    md_localized_idless: int = 0  # id-less localized markdown (also rebuilt-and-translated)
+
+    @property
+    def item2_population(self) -> int:
+        """Cells a code-only edit would silently fail to propagate (neutral cells)."""
+        return self.code_neutral_idless + self.code_neutral_idd + self.md_neutral_structural
+
+    @property
+    def item3_population(self) -> int:
+        """Cells a group rebuild would needlessly re-translate (id-less localized)."""
+        return self.code_localized_idless + self.md_localized_idless
+
+
+def _is_structural_localized_idless(cell: Cell) -> bool:
+    """Whether ``cell`` is the id-less localized kind a rebuild re-translates.
+
+    Mirrors the ``elif meta.lang == source_lang:`` branch of
+    :func:`clm.slides.sync_code._rebuild_region`: a cell the per-cell engine does
+    not own (``role_of`` is ``None``) that nonetheless carries a language — so a
+    rebuild translates it even when its content is byte-unchanged.
+    """
+    meta = cell.metadata
+    return not meta.is_j2 and role_of(meta) is None and meta.lang is not None
+
+
+def census_file(path: Path, census: Census) -> None:
+    """Accumulate one deck file's cell populations into ``census``."""
+    census.deck_files += 1
+    for cell in parse_cells(path.read_text(encoding="utf-8")):
+        meta = cell.metadata
+        if meta.is_j2:
+            census.j2_total += 1
+            census.cells_total += 1
+            continue
+        census.cells_total += 1
+        has_id = meta.slide_id is not None
+        if has_id:
+            census.any_slide_id += 1
+        is_code = meta.cell_type == "code"
+        if is_code:
+            census.code_total += 1
+            if meta.lang is None:
+                if has_id:
+                    census.code_neutral_idd += 1
+                else:
+                    census.code_neutral_idless += 1
+            elif has_id:
+                census.code_localized_idd += 1
+            else:
+                census.code_localized_idless += 1
+        else:
+            census.md_total += 1
+            if role_of(meta) is None:
+                # No per-cell sync role -> handled only structurally.
+                if meta.lang is None:
+                    census.md_neutral_structural += 1
+                else:
+                    census.md_localized_idless += 1
+
+
+def item3_blast_radius(path: Path) -> list[int]:
+    """Per-slide-group count of id-less localized cells in one deck file.
+
+    Each value is how many cells a single rebuild of that group would
+    re-translate today (item 3). A group is a slide/subslide cell plus the cells
+    up to the next one; cells before the first slide form the head.
+    """
+    cells = parse_cells(path.read_text(encoding="utf-8"))
+    groups: list[list[Cell]] = []
+    current: list[Cell] = []
+    groups.append(current)  # head
+    for cell in cells:
+        if cell.metadata.is_slide_start:
+            current = [cell]
+            groups.append(current)
+        else:
+            current.append(cell)
+    return [sum(1 for c in g if _is_structural_localized_idless(c)) for g in groups]
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CorpusReport:
+    corpus: str
+    total_pairs: int
+    noop_pairs: int
+    non_noop_pairs: int
+    violations: list[str]
+    non_noop_reasons: Counter  # proposal-kind -> count across non-no-op pairs
+    census: Census
+    blast_groups_with_idless: int  # groups exposing >=1 item-3 cell
+    blast_max_in_one_group: int
+    blast_total_cells: int
+
+    def to_dict(self) -> dict:
+        c = self.census
+        return {
+            "corpus": self.corpus,
+            "pairs": {
+                "total": self.total_pairs,
+                "noop": self.noop_pairs,
+                "non_noop": self.non_noop_pairs,
+                "non_noop_reasons": dict(self.non_noop_reasons),
+                "violations": self.violations,
+            },
+            "census": {
+                "deck_files": c.deck_files,
+                "cells_total": c.cells_total,
+                "md_total": c.md_total,
+                "code_total": c.code_total,
+                "j2_total": c.j2_total,
+                "any_slide_id": c.any_slide_id,
+                "item2_population": c.item2_population,
+                "item2_breakdown": {
+                    "code_neutral_idless": c.code_neutral_idless,
+                    "code_neutral_idd": c.code_neutral_idd,
+                    "md_neutral_structural": c.md_neutral_structural,
+                },
+                "item3_population": c.item3_population,
+                "item3_breakdown": {
+                    "code_localized_idless": c.code_localized_idless,
+                    "md_localized_idless": c.md_localized_idless,
+                    "code_localized_idd": c.code_localized_idd,
+                },
+            },
+            "item3_blast_radius": {
+                "groups_with_idless": self.blast_groups_with_idless,
+                "max_in_one_group": self.blast_max_in_one_group,
+                "total_cells": self.blast_total_cells,
+            },
+        }
+
+    def render(self) -> str:
+        c = self.census
+        lines = [
+            f"sync corpus harness — {self.corpus}",
+            "",
+            "NO-OP INVARIANT",
+            f"  pairs                : {self.total_pairs}",
+            f"  already-synced (noop): {self.noop_pairs}",
+            f"  not-yet-synced       : {self.non_noop_pairs}"
+            + (f"  reasons={dict(self.non_noop_reasons)}" if self.non_noop_reasons else ""),
+            f"  invariant violations : {len(self.violations)}",
+        ]
+        for v in self.violations:
+            lines.append(f"     ! {v}")
+        lines += [
+            "",
+            "CENSUS (summed across all deck files)",
+            f"  deck files           : {c.deck_files}",
+            f"  cells (total)        : {c.cells_total}  (md={c.md_total} code={c.code_total} j2={c.j2_total})",
+            f"  cells with slide_id  : {c.any_slide_id}",
+            "",
+            "ITEM 2 — code-only change not propagated (neutral cells, silent drop)",
+            f"  exposure population  : {c.item2_population}",
+            f"    code neutral idless: {c.code_neutral_idless}",
+            f"    code neutral id'd  : {c.code_neutral_idd}",
+            f"    md   neutral struct: {c.md_neutral_structural}",
+            "",
+            "ITEM 3 — unchanged localized code re-translated on rebuild",
+            f"  exposure population  : {c.item3_population}",
+            f"    code localized idl.: {c.code_localized_idless}",
+            f"    md   localized idl.: {c.md_localized_idless}",
+            f"    (code localized id'd, reconciled per-cell: {c.code_localized_idd})",
+            f"  blast radius         : {self.blast_groups_with_idless} groups expose >=1 "
+            f"(max {self.blast_max_in_one_group} in one group; {self.blast_total_cells} cells total)",
+        ]
+        return "\n".join(lines)
+
+
+def run(root: Path, *, limit: int | None = None) -> CorpusReport:
+    """Run the no-op probe + census over the corpus and aggregate a report."""
+    pairs = discover_pairs(root)
+    if limit is not None:
+        pairs = pairs[:limit]
+
+    noop_pairs = 0
+    non_noop = 0
+    violations: list[str] = []
+    reasons: Counter = Counter()
+    census = Census()
+    blast_groups = 0
+    blast_max = 0
+    blast_total = 0
+
+    for de_path, en_path in pairs:
+        res = noop_probe(de_path, en_path)
+        if res.plan_is_noop:
+            noop_pairs += 1
+        else:
+            non_noop += 1
+            reasons.update(res.proposal_kinds)
+        if res.is_violation:
+            violations.append(
+                f"{res.name}: noop plan but de_changed={res.de_bytes_changed} "
+                f"en_changed={res.en_bytes_changed} translate={res.translate_calls} "
+                f"judge={res.judge_calls}"
+            )
+        for path in (de_path, en_path):
+            census_file(path, census)
+            for count in item3_blast_radius(path):
+                if count > 0:
+                    blast_groups += 1
+                    blast_total += count
+                    blast_max = max(blast_max, count)
+
+    return CorpusReport(
+        corpus=str(root),
+        total_pairs=len(pairs),
+        noop_pairs=noop_pairs,
+        non_noop_pairs=non_noop,
+        violations=violations,
+        non_noop_reasons=reasons,
+        census=census,
+        blast_groups_with_idless=blast_groups,
+        blast_max_in_one_group=blast_max,
+        blast_total_cells=blast_total,
+    )
+
+
+def _pair_name(de_path: Path) -> str:
+    return de_path.name[: -len(".de.py")]
+
+
+def resolve_corpus(cli_value: str | None) -> Path:
+    """Corpus dir: --corpus, then $CLM_SYNC_CORPUS_DIR, then the known default."""
+    if cli_value:
+        return Path(cli_value)
+    env = os.environ.get("CLM_SYNC_CORPUS_DIR")
+    if env:
+        return Path(env)
+    return _DEFAULT_CORPUS
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--corpus",
+        default=None,
+        help="corpus root (default: $CLM_SYNC_CORPUS_DIR or the PythonCourses slides path)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a human report")
+    parser.add_argument(
+        "--limit", type=int, default=None, help="probe only the first N pairs (quick run)"
+    )
+    args = parser.parse_args(argv)
+
+    root = resolve_corpus(args.corpus)
+    if not root.is_dir():
+        print(f"corpus not found: {root}", file=sys.stderr)
+        return 2
+
+    report = run(root, limit=args.limit)
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(report.render())
+    return 1 if report.violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -22,16 +22,23 @@ Scope of this engine:
   silent.
 
 Atomicity: each proposal is all-or-nothing for its target cell; the two decks
-are flushed once at the end. The **watermark advances only on a complete,
-clean apply** (no deferred proposals, no errors) — so un-applied work can
-never be silently baked into the baseline and lost.
+are persisted once at the end, via a buffered temp-swap (Issue #190 item 1)
+that writes **nothing** unless the whole pass is error-free — so a mid-pass
+failure (e.g. an LLM error) can never leave a half-applied deck on disk. Each
+deck's new text is rendered in memory and swapped in with an atomic
+``os.replace``. The **watermark advances only on a complete, clean apply** (no
+deferred proposals, no errors) — so un-applied work can never be silently baked
+into the baseline and lost.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import re
+import tempfile
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.llm.ollama_client import OllamaError
@@ -50,8 +57,6 @@ from clm.slides.sync_writeback import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from clm.infrastructure.llm.cache import SyncWatermarkCache
     from clm.infrastructure.llm.ollama_client import SyncJudge
     from clm.slides.sync_translate import SlideTranslator
@@ -125,8 +130,10 @@ def apply_plan(
     records each edit as an error). ``translator`` produces the counterpart for
     a brand-new id-less slide (``None`` defers adds). Applies remove / edit /
     move / id-less add; conflicts and id-carrying adds are ``deferred``. The two
-    decks are flushed once; the watermark advances only on a clean, complete
-    apply.
+    decks are persisted once at the end via a buffered temp-swap, but **only on
+    an error-free pass** (no apply-time or classifier error) — an erroring pass
+    writes neither deck (Issue #190 item 1). The watermark advances only on a
+    clean, complete apply.
 
     ``decisions`` drives interactive review (``None`` = the batch default, which
     applies every deterministic kind and defers conflicts). When provided, it
@@ -196,7 +203,9 @@ def apply_plan(
 
     # Adds run before moves so a freshly-inserted slide takes part in any
     # reorder. Adds are sticky via the stamped id (a re-run no longer sees an
-    # id-less cell), so unlike moves they do not require a clean pass.
+    # id-less cell), so unlike moves they apply even on a *deferred* (non-clean)
+    # pass — but, like every cell, the stamped id only reaches disk on an
+    # error-free pass (the end-of-pass flush is gated on no errors).
     _apply_adds(de_state, en_state, result, plan, translator)
 
     # Moves are applied last, and only if the rest of the pass is clean (so the
@@ -222,8 +231,21 @@ def apply_plan(
     if not result.errors and result.deferred == 0 and not plan.has_errors:
         _flag_cross_deck_orphans(de_state, en_state, result)
 
-    de_state.flush()
-    en_state.flush()
+    # Buffered temp-swap (Issue #190 item 1): persist both decks atomically, and
+    # ONLY when the whole pass is error-free — neither an apply-time error
+    # (``result.has_errors``) nor a classifier error (``plan.has_errors``, e.g. an
+    # unresolvable duplicate id). This matches design §11 ("write only if the
+    # whole pass is error-free") and future-proofs the later phases that add new
+    # classifier errors (§6/§10) which are *not* backed by a physical residual
+    # duplicate, so they would otherwise slip the result-error fail-safe. A
+    # *deferred*-but-error-free pass still writes — applying the deterministic
+    # edits and partial-advancing the watermark is the designed outcome; only a
+    # genuine error rolls the whole pass back, so a mid-pass LLM failure never
+    # leaves a half-applied deck on disk. The watermark advance below
+    # independently declines on any plan issue / error, so "wrote nothing" and
+    # "held the watermark" stay consistent.
+    if not result.has_errors and not plan.has_errors:
+        _flush_states_atomically(de_state, en_state)
 
     # Watermark advance. A fully clean pass advances the whole deck. A
     # *content-only* partial pass (edits/conflicts only, so structure is
@@ -523,8 +545,10 @@ def _apply_adds(
       defeat it) is re-minted to a fresh id — its companions follow by
       group-adjacency — leaving the original alone, then handled like an add.
 
-    All cases are sticky (the id is on disk afterward), so they apply regardless
-    of whether the rest of the pass is clean.
+    All cases are sticky: the id is stamped into the in-memory deck and reaches
+    disk on any error-free pass, so they apply even on a *deferred* pass. An
+    erroring pass writes nothing (the end-of-pass flush is error-gated) and the
+    add simply re-surfaces next run.
     """
     add_props = [p for p in plan.proposals if p.kind == "add"]
     rename_props = [p for p in plan.proposals if p.kind == "rename"]
@@ -978,6 +1002,47 @@ def _group_reorder(cells: list[RawCell], source_order: list[str]) -> list[RawCel
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _flush_states_atomically(de_state: FileState, en_state: FileState) -> None:
+    """Persist both decks via a per-deck temp-file + atomic ``os.replace`` swap.
+
+    Issue #190 item 1: the previous code called :meth:`FileState.flush` on each
+    deck unconditionally, so a pass that errored mid-way still persisted the edits
+    that happened to succeed. Here both decks' new text is rendered in memory
+    first and each file is replaced in a single atomic step, so a crash can never
+    leave a half-written deck. (The two files are still two writes — the only
+    residual non-atomic window is the gap between the two ``os.replace`` calls,
+    narrowed as far as a two-file swap allows.) The caller gates this on an
+    error-free pass, so an erroring pass writes nothing at all.
+
+    Bytes are identical to the old per-deck ``flush`` path: :meth:`FileState.render`
+    reuses flush's reconstruct + terminal-newline contract, and the swap writes
+    utf-8 / LF with no newline translation.
+    """
+    pending = [(state, state.render()) for state in (de_state, en_state) if state.dirty]
+    for state, text in pending:
+        _atomic_write_text(state.path, text)
+        state.dirty = False
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Atomically write ``text`` to ``path`` via a same-directory temp file.
+
+    Same byte contract as :meth:`FileState.flush` (utf-8, LF, no translation).
+    The temp file is created in ``path``'s own directory so ``os.replace`` is a
+    true same-filesystem atomic swap (incl. on Windows, where it replaces an
+    existing destination); on any failure the temp file is removed and the
+    destination is left untouched.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    os.close(fd)
+    try:
+        Path(tmp_name).write_text(text, encoding="utf-8", newline="\n")
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
 
 
 def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -384,16 +384,26 @@ class FileState:
             return
         _set_trailing_blanks(original_last, sep)
 
-    def flush(self) -> None:
-        if not self.dirty:
-            return
+    def render(self) -> str:
+        """The exact text :meth:`flush` would write, computed without touching disk.
+
+        Factored out of :meth:`flush` so a buffered / atomic writer (the Issue
+        #190 temp-swap in :mod:`clm.slides.sync_apply`) can reproduce the same
+        bytes and swap the file in a single step. Mirrors flush's terminal-newline
+        restoration exactly; only meaningful to persist when :attr:`dirty`.
+        """
         text = reconstruct(self.preamble, self.cells)
         # Deleting the file's last cell drops the trailing-newline element
         # that ``split_cells`` parked on it; restore the original terminal
         # newline so a remove never emits a "No newline at end of file" diff.
         if self.ends_with_newline and not text.endswith("\n"):
             text += "\n"
-        self.path.write_text(text, encoding="utf-8", newline="\n")
+        return text
+
+    def flush(self) -> None:
+        if not self.dirty:
+            return
+        self.path.write_text(self.render(), encoding="utf-8", newline="\n")
         self.dirty = False
 
     @staticmethod

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -298,7 +298,11 @@ class TestDeferredAndWatermark:
 
     def test_one_edit_error_does_not_block_a_remove(self, tmp_path: Path):
         # A plan with a remove (deterministic) and an edit that errors (no
-        # judge): the remove still applies; the error is recorded.
+        # judge): the per-proposal loop is not aborted by the edit error — the
+        # remove is still *processed* in memory (applied_remove == 1). But the
+        # buffered temp-swap (Issue #190 item 1) makes the *disk write* atomic:
+        # because the pass errored, NEITHER deck is written, so the (in-memory)
+        # remove is rolled back on disk and EN keeps both slides.
         de_path, en_path = _write_pair(
             tmp_path,
             _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B"),
@@ -311,14 +315,134 @@ class TestDeferredAndWatermark:
         plan.proposals.append(Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"))
         result = apply_plan(plan, judge=None, watermark_cache=None)
 
-        assert result.applied_remove == 1
+        assert result.applied_remove == 1  # processed in memory (loop not aborted)
         assert result.has_errors  # the edit had no judge
         en_ids = [
             c.metadata.slide_id
             for c in parse_cells(en_path.read_text("utf-8"))
             if c.metadata.slide_id
         ]
-        assert en_ids == ["a"]
+        assert en_ids == ["a", "b"]  # erroring pass writes nothing — remove not persisted
+
+
+# ---------------------------------------------------------------------------
+# apply_plan — buffered temp-swap atomicity (Issue #190 item 1)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrites:
+    def test_render_matches_flush_bytes(self, tmp_path: Path):
+        # The temp-swap writes FileState.render() verbatim; it must reproduce
+        # flush()'s exact bytes, or the "clean path is byte-identical to today"
+        # contract breaks.
+        path = tmp_path / "deck.en.py"
+        path.write_text(
+            _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B"),
+            encoding="utf-8",
+        )
+        state = FileState.load(path)
+        assert state.replace_cell_body("a", "slide", "# ## A\n# - one") is True
+        rendered = state.render()
+        state.flush()
+        assert path.read_bytes() == rendered.encode("utf-8")
+
+    def test_clean_pass_persists_and_leaves_no_temp_file(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung\n# - eins")
+        en = _slide("en", "intro", "# ## Introduction\n# - one")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung\n# - eins\n# - zwei"), encoding="utf-8"
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            judge = _update_judge("# ## Introduction\n# - one\n# - two")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert not result.has_errors
+        assert result.applied_edit == 1
+        assert "- two" in en_path.read_text(encoding="utf-8")
+        # The atomic os.replace must leave no stray temp file behind.
+        assert [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"] == []
+
+    def test_clean_add_writes_both_decks(self, tmp_path: Path):
+        # An id-less add mints an id onto the DE source AND inserts the twin on
+        # EN, so a clean pass must persist BOTH decks through the temp-swap.
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        de_before = de_path.read_bytes()
+        en_before = en_path.read_bytes()
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = StaticSlideTranslator(mapping={"# ## Neu": "# ## New"})
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert not result.has_errors
+        assert result.applied_add == 1
+        assert de_path.read_bytes() != de_before  # DE got the minted id
+        assert en_path.read_bytes() != en_before  # EN got the inserted twin
+        assert "# ## New" in en_path.read_text(encoding="utf-8")
+        assert [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"] == []
+
+    def test_erroring_pass_writes_neither_deck(self, tmp_path: Path):
+        # A successful edit (dirties EN in memory) followed by a proposal that
+        # errors: the buffered swap rolls the WHOLE pass back, so the successful
+        # edit is not persisted. Pre-#190 the code flushed it.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        de_before = de_path.read_bytes()
+        en_before = en_path.read_bytes()
+
+        plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+        # edit "a": the judge rewrites it -> succeeds, dirties EN in memory.
+        plan.proposals.append(Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"))
+        # remove a ghost cell: target not found -> apply-time error.
+        plan.proposals.append(
+            Proposal(kind="remove", role="slide", direction="de->en", slide_id="ghost")
+        )
+        result = apply_plan(plan, judge=_update_judge("# ## A (updated)"), watermark_cache=None)
+
+        assert result.has_errors
+        assert result.applied_edit == 1  # the edit succeeded in memory...
+        assert en_path.read_bytes() == en_before  # ...but the erroring pass wrote nothing
+        assert de_path.read_bytes() == de_before
+        assert [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"] == []
+
+    def test_classifier_error_also_rolls_back_a_valid_edit(self, tmp_path: Path):
+        # A *classifier* error (plan.has_errors, e.g. an unresolvable duplicate id)
+        # coexisting with a valid edit: the whole pass rolls back even though no
+        # apply-time error occurred. This honors design §11 ("write only if the
+        # whole pass is error-free") and future-proofs the later phases that add
+        # classifier errors not backed by a physical residual-duplicate fail-safe.
+        de = _slide("de", "a", "# ## A") + _slide("de", "b", "# ## B")
+        en = _slide("en", "a", "# ## A") + _slide("en", "b", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        en_before = en_path.read_bytes()
+
+        plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="watermark")
+        plan.issues.append(
+            PlanIssue(severity="error", slide_id="b", reason="duplicate slide_id (synthetic)")
+        )
+        plan.proposals.append(Proposal(kind="edit", role="slide", direction="de->en", slide_id="a"))
+        result = apply_plan(plan, judge=_update_judge("# ## A (updated)"), watermark_cache=None)
+
+        assert plan.has_errors
+        assert not result.has_errors  # no APPLY-time error
+        assert result.applied_edit == 1  # the edit succeeded in memory...
+        assert en_path.read_bytes() == en_before  # ...but the classifier-error pass wrote nothing
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_corpus_noop.py
+++ b/tests/slides/test_sync_corpus_noop.py
@@ -1,0 +1,128 @@
+"""Corpus-wide no-op backstop for ``clm slides sync`` (Issue #190, Phase 0).
+
+Runs the read-only :mod:`scripts.sync_corpus_harness` over the real PythonCourses
+split decks and asserts the **no-op invariant** every later #190 phase must
+preserve: a plan with nothing to do applies as a true no-op — **zero bytes
+written, zero LLM calls**. The harness operates on temp copies with a counting
+(no-network) translator/judge, so the course repo is never touched.
+
+This is the regression backstop that de-risks the anchor-identity work in
+Phases 1-3: if a future phase makes an already-synced pair churn (re-translate
+or rewrite), the no-op-pair count craters or a violation appears here.
+
+Marked ``slow`` + ``integration`` (≈18 s over 212 pairs) and **skipped** when
+the corpus is absent (CI, fresh clone) — point it at a corpus with
+``CLM_SYNC_CORPUS_DIR``.
+
+The same harness doubles as the churn *measurement* (item-2 / item-3 exposure
+populations); run it directly for the numbers::
+
+    python scripts/sync_corpus_harness.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+# Phase-0 measurement (2026-06-01): 81 of 212 pairs are already in post-sync-clean
+# shape; the other 131 carry id-less narrative cells that predate #166 adoption.
+# The floor guards against a *catastrophic* engine regression (a phase that makes
+# synced pairs churn) while tolerating ordinary course-repo edits; it is well
+# below the measured 81.
+_PHASE0_NOOP_PAIRS = 81
+_NOOP_FLOOR = 40
+
+
+def _corpus_dir() -> Path | None:
+    """The sync corpus root, or ``None`` when unavailable (skip).
+
+    Requires at least one *real* ``.de.py`` / ``.en.py`` pair (not merely a
+    ``.de.py``), so the skip predicate agrees with ``discover_pairs``: a de-only
+    or unpaired tree skips cleanly instead of running an empty harness that would
+    trip ``test_corpus_discovered``'s ``total_pairs >= 100`` floor.
+    """
+    candidates: list[Path] = []
+    env = os.environ.get("CLM_SYNC_CORPUS_DIR")
+    if env:
+        candidates.append(Path(env))
+    candidates.append(Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides"))
+    for cand in candidates:
+        if not cand.is_dir():
+            continue
+        for de_path in cand.rglob("*.de.py"):
+            en_path = de_path.with_name(de_path.name[: -len(".de.py")] + ".en.py")
+            if en_path.exists():
+                return cand  # at least one real pair -> usable corpus
+    return None
+
+
+_CORPUS = _corpus_dir()
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.integration,
+    pytest.mark.skipif(_CORPUS is None, reason="PythonCourses sync corpus not available"),
+]
+
+
+@pytest.fixture(scope="module")
+def report():
+    """Run the corpus harness once; all assertions share the single result."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    import sync_corpus_harness as harness
+
+    assert _CORPUS is not None  # guarded by the module skipif
+    result = harness.run(_CORPUS)
+    if result.total_pairs == 0:  # defense-in-depth: no real pairs -> skip, don't fail
+        pytest.skip(f"no de/en pairs under corpus root {_CORPUS}")
+    return result
+
+
+def test_corpus_discovered(report):
+    # Sanity: the harness actually found a substantial corpus (else every other
+    # assertion is vacuously true).
+    assert report.total_pairs >= 100, report.render()
+    assert report.census.code_total > 0
+    assert report.census.md_total > 0
+
+
+def test_noop_plans_apply_with_zero_bytes_and_zero_llm(report):
+    # THE backstop: any pair whose seeded plan is a no-op must apply as a true
+    # no-op — no bytes written, no translate/judge call. A violation is a pure
+    # engine bug (a "nothing to do" plan that nonetheless did something).
+    assert report.violations == [], report.render()
+
+
+def test_noop_pairs_do_not_catastrophically_regress(report):
+    # If a later phase makes already-synced pairs churn, they stop classifying
+    # as no-op and this floor trips. (Phase-0 measured 81; floor has headroom for
+    # ordinary course-repo edits.)
+    assert report.noop_pairs >= _NOOP_FLOOR, (
+        f"only {report.noop_pairs} no-op pairs (Phase-0 baseline {_PHASE0_NOOP_PAIRS}); "
+        "a phase may have made synced pairs churn\n" + report.render()
+    )
+
+
+def test_churn_baseline_populations_present(report):
+    # The measurement half: the item-2 (neutral, silent-drop) and item-3 (id-less
+    # localized, re-translated) exposure populations are what Phases 2-3 must
+    # drive to zero. Guard that the harness still measures them (a non-zero,
+    # plausible magnitude), so a refactor can't silently zero the baseline out.
+    c = report.census
+    assert c.item2_population > 1000, report.render()  # Phase-0: ~8,014
+    assert c.item3_population > 100, report.render()  # Phase-0: ~1,702
+    # The per-group blast radius pins the GROUPING (not just the predicate): a
+    # broken _split_groups would collapse cells into too few groups (inflating
+    # max_in_one_group) or shatter them (deflating it). `blast_total ==
+    # item3_population` is true by construction (same predicate, same cells), so
+    # assert the grouping-shaped quantities instead.
+    assert report.blast_groups_with_idless > 100, report.render()  # Phase-0: ~948
+    assert 1 <= report.blast_max_in_one_group <= 50, report.render()  # Phase-0: ~10
+    assert report.blast_max_in_one_group <= report.census.item3_population

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1,0 +1,169 @@
+"""Executable documentation of the two *serious* ``clm slides sync`` limitations
+(Issue #190 items 2 & 3) as they behave **today**.
+
+These tests pin the broken-today behavior so the Phase 2/3 fixes have a precise
+flip-point and the no-op corpus harness has a mechanism to point at:
+
+* **item 2** — a code-only edit to a *language-neutral* shared cell produces no
+  proposal, so the sync silently fails to propagate it and the two split halves
+  diverge. Phase 3 (the anchor-keyed diff + deterministic copy-to-twin) makes
+  the edit propagate; flip ``test_item2_*`` then.
+* **item 3** — when a slide group is rebuilt for a *sibling's* sake, an unchanged
+  id-less localized code cell in it is re-translated, because its ``("L", kind)``
+  structural signature cannot prove it is unchanged. Phase 2 (anchor + content
+  hash verbatim reuse) splices it without translating; flip ``test_item3_*`` then.
+
+Tiny synthetic decks, fast suite, no corpus, no network (the translator/judge
+are counting stand-ins).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import SyncProposal
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_plan import build_sync_plan, ordered_sync_cells
+
+# ---------------------------------------------------------------------------
+# Deck builders + no-LLM spies
+# ---------------------------------------------------------------------------
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n'
+
+
+def _code_shared(body: str) -> str:
+    """A language-neutral shared code cell (item-2 territory)."""
+    return f'# %% tags=["keep"]\n{body}\n'
+
+
+def _code_localized_idless(lang: str, body: str) -> str:
+    """An id-less localized code cell (item-3 territory)."""
+    return f'# %% lang="{lang}"\n{body}\n'
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+        )
+
+
+@dataclass
+class CountingTranslator:
+    prompt_version: str = "counting"
+    calls: list[tuple[str, str, str, str]] = field(default_factory=list)
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.calls.append((role, source_lang, target_lang, source_body))
+        return source_body
+
+
+@dataclass
+class CountingJudge:
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def propose(
+        self, source_body: str, target_body: str, *, source_lang: str, target_lang: str
+    ) -> SyncProposal:
+        self.calls.append((source_lang, target_lang))
+        return SyncProposal(verdict="in_sync", proposed_text=target_body)
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — a code-only change to a neutral shared cell is not propagated
+# ---------------------------------------------------------------------------
+
+
+def test_item2_neutral_code_only_edit_is_silently_dropped(tmp_path: Path):
+    de = _slide("de", "a", "# ## A") + _code_shared("import time")
+    en = _slide("en", "a", "# ## A") + _code_shared("import time")
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        # Author edits ONLY the shared, language-neutral code cell on DE.
+        de_path.write_text(
+            _slide("de", "a", "# ## A") + _code_shared("import time\nx = 1"),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    # TODAY: the edit is invisible to the engine — no proposal, no direction.
+    assert plan.is_noop
+    assert result.applied == 0
+    assert translator.calls == []
+    # The shared code on EN is NOT updated, so the split halves now diverge.
+    assert "x = 1" not in en_path.read_text(encoding="utf-8")
+    # (Phase 3 propagates this; flip the four assertions above then.)
+
+
+# ---------------------------------------------------------------------------
+# Item 3 — an unchanged id-less localized code cell is re-translated on rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_item3_group_rebuild_retranslates_unchanged_localized_code(tmp_path: Path):
+    de = (
+        _slide("de", "g", "# ## G")
+        + _code_shared("import time")
+        + _code_localized_idless("de", "# Kommentar\nx = 1")
+    )
+    en = (
+        _slide("en", "g", "# ## G")
+        + _code_shared("import time")
+        + _code_localized_idless("en", "# Comment\nx = 1")
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        # Edit the narrative (gives the structural pass a de->en direction) AND the
+        # neutral shared code (changes the group's signature -> rebuild), leaving
+        # the localized code cell byte-identical.
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")
+            + _code_shared("import time\nimport os")
+            + _code_localized_idless("de", "# Kommentar\nx = 1"),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    # The narrative edit is the only per-cell proposal; it supplies the direction.
+    assert plan.count("edit") == 1
+    # TODAY: the unchanged localized code cell is re-translated as a bystander of
+    # the sibling-triggered group rebuild.
+    retranslated = [body for (role, _sl, _tl, body) in translator.calls if "Kommentar" in body]
+    assert retranslated, (
+        f"expected the unchanged localized code to be re-translated; got {translator.calls}"
+    )
+    # (Phase 2 splices it verbatim by anchor+hash; assert `retranslated == []` then.)


### PR DESCRIPTION
## Issue #190 — Phase 0 (atomicity + no-op corpus harness)

Phase 0 of the content-anchor sync redesign (design note: `docs/claude/design/sync-content-anchor-identity.md`). Two **independent, additive** deliverables — both green, lint/type-clean, and run through a 4-dimension adversarial review.

### 1. Atomicity (issue #190 item 1)
`apply_plan` previously flushed both decks **unconditionally**, so a pass that errored mid-way still persisted the edits that happened to succeed.

- `FileState.render()` factors flush's exact bytes out of `flush()` — **byte-identical**; the v1/v2 walkers that still call `flush()` are untouched.
- `apply_plan` now calls `_flush_states_atomically` (per-deck temp-file + `os.replace`), gated on `not result.has_errors and not plan.has_errors`. The stricter both-error gate honors design §11 ("write only if the whole pass is error-free") and future-proofs the §6/§10 phases that add classifier errors not backed by the residual-duplicate fail-safe.
- A **deferred-but-error-free** pass still writes (the partial-advance design is preserved); only a genuine error rolls the whole pass back. Interactive `--interactive` inherits it (the walker routes through `apply_plan`).

### 2. No-op corpus harness + churn measurement
`scripts/sync_corpus_harness.py` (runnable + importable) seeds each pair's watermark from its current state on a **temp copy** with a counting (no-network) translator/judge, and asserts the **no-op invariant**: a clean re-run writes **zero bytes** and makes **zero LLM calls**. It also measures the item-2/item-3 churn the two serious limitations expose. The course repo is never mutated.

- Backstop: `tests/slides/test_sync_corpus_noop.py` (`slow`/`integration`, skip-if-absent, ~18s).
- Mechanism flip-tests: `tests/slides/test_sync_limitations.py` (fast) — document items 2 & 3 today; Phases 2/3 will flip them.

### Measured baseline (212 pairs; reproduces design §3 census **to the cell**)

| Limitation | Exposure today | Driven to 0 by |
|---|--:|---|
| **Item 2** — code-only change not propagated (neutral cells) | **8,014** (7,634 neutral id-less code · 356 neutral id'd · 24 md) | Phase 3 |
| **Item 3** — unchanged localized code re-translated on rebuild | **1,702** (744 code · 958 md) | Phase 2 |
| Item-3 blast radius | 948 groups expose ≥1, max **10**/group | — |
| No-op invariant | **81 / 212** already-synced, **0 violations** | every phase must hold |

(The other 131 pairs are *not-yet-synced* — id-less narrative cells predating #166, a data condition, not churn.)

### Tests
- Full fast suite: **6030 passed**, 3 skipped, 1 xfailed. Ruff + mypy clean (pre-commit hooks passed).
- New: `TestAtomicWrites` (render==flush bytes; clean pass persists + no temp leftover; clean add writes both decks; erroring pass writes neither; classifier-error rollback); corpus backstop (4 tests); item-2/3 flip-tests (2 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)