### PR TITLE
feat(slides): content-anchor watermark + item-3 verbatim reuse (#190 Phase 1+2)

### DIFF
--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -414,6 +414,22 @@ invariant. Gate releases on `pytest -m "not docker"`.
      byte-stable. Until then nothing consumes the `"shared"` partition.
 2. **Item 3 first** (§8): anchor+hash verbatim reuse in `sync_code`. Highest
    value, lowest risk, one isolated function.
+   - **✅ Shipped.** `_rebuild_region` gained a reuse path: an id-less localized
+     code cell whose anchor is in the baseline with the *same* content hash is
+     spliced verbatim from the current target twin (located by the same
+     construct-based anchor) instead of re-translated. Plumbed via
+     `_baseline_anchor_hashes` (built from the widened watermark) →
+     `apply_code_structure(..., baseline_anchors)` → `_rebuild_region`. The
+     `("L", kind)` signature was **left as-is** (deliberately): the reuse path
+     alone fixes the core item-3 churn, and making the signature content-aware
+     can't help without a language-specific hash (which breaks cross-language
+     matching) — propagating a *changed* localized cell whose group signature is
+     otherwise stable is Phase 3's anchor-diff job, not this one. Construct-based
+     anchors are language-agnostic so de/en twins share them; hash-fallback cells
+     never reuse (the honest §12 residual). No-watermark runs translate as before.
+     Verified: `test_sync_limitations.py` flips (unchanged → reused, changed →
+     still re-translated), and the no-op harness holds at 81/212, 0 violations
+     with a membership-widened seed.
 3. **Item 2** (§7): the `align_anchored` pass (§6) + single-entity neutral model
    + auto-heal/warn. The largest new module; default-on-overridable (mirroring
    the #166 default-flip).

--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -392,6 +392,26 @@ invariant. Gate releases on `pytest -m "not docker"`.
    item-2 exposure 8,014, item-3 exposure 1,702, 0 invariant violations.
 1. **Widen the watermark** (§5): `construct` migration, 5-tuples, `"shared"`
    partition, membership. `anchor_of` chokepoint. No behavior change yet.
+   - **Phase 1a ✅ shipped.** Additive `construct` column (`_migrate` ALTER for
+     legacy tables); `get_deck`/`put_deck` 5-tuples
+     `(position, slide_id, role, content_hash, construct)`; `put_deck` accepts
+     the `"shared"` partition; `anchor_of`/`construct_of` chokepoint in
+     `sync_writeback` (`hand id > construct slug > sha256`, prefixed so the three
+     namespaces can't collide); `CurrentCell.construct` populated via
+     `ordered_sync_cells` and written by `_record_watermark[_partial]`. The
+     recorded **row set is unchanged** (still `role_of != None`), so positions —
+     and thus move detection — are untouched: the no-op corpus harness still
+     reports 81/212 noop, 0 violations. `construct` flows end-to-end (real
+     values like `function-run-chatbot` on localized id'd code).
+   - **Phase 1b (deferred — needs a design call).** *Membership widening* —
+     recording every non-j2 cell (neutral under `"shared"`, localized id-less
+     under its lang with a synthetic role). **Trap:** the classifier keys move
+     detection on `position` among the `role_of != None` subset; naively
+     recording *more* cells shifts those positions and would manufacture spurious
+     moves (a real behavior change the harness would catch). Phase 1b must give
+     the widened rows a **separate position space** (or have the classifier
+     re-derive positions from the filtered subset) so the legacy view is
+     byte-stable. Until then nothing consumes the `"shared"` partition.
 2. **Item 3 first** (§8): anchor+hash verbatim reuse in `sync_code`. Highest
    value, lowest risk, one isolated function.
 3. **Item 2** (§7): the `align_anchored` pass (§6) + single-entity neutral model

--- a/scripts/strip_cassette_hosts.py
+++ b/scripts/strip_cassette_hosts.py
@@ -74,7 +74,9 @@ def strip_cassette(
     try:
         requests, responses = FilesystemPersister.load_cassette(path, serializer=yamlserializer)
     except Exception as exc:  # noqa: BLE001 — defensive
-        print(f"  ! skipping {path.name}: load failed ({type(exc).__name__}: {exc})", file=sys.stderr)
+        print(
+            f"  ! skipping {path.name}: load failed ({type(exc).__name__}: {exc})", file=sys.stderr
+        )
         return (0, 0)
 
     before = len(requests)

--- a/scripts/sync_corpus_harness.py
+++ b/scripts/sync_corpus_harness.py
@@ -165,7 +165,7 @@ def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> 
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 

--- a/scripts/sync_corpus_harness.py
+++ b/scripts/sync_corpus_harness.py
@@ -58,7 +58,7 @@ from clm.infrastructure.llm.cache import SyncWatermarkCache  # noqa: E402
 from clm.infrastructure.llm.ollama_client import SyncProposal  # noqa: E402
 from clm.notebooks.slide_parser import Cell, parse_cells  # noqa: E402
 from clm.slides.sync_apply import apply_plan  # noqa: E402
-from clm.slides.sync_plan import build_sync_plan, ordered_sync_cells  # noqa: E402
+from clm.slides.sync_plan import build_sync_plan, watermark_rows  # noqa: E402
 from clm.slides.sync_writeback import role_of  # noqa: E402
 
 # Default corpus location (overridable via --corpus or $CLM_SYNC_CORPUS_DIR).
@@ -158,15 +158,18 @@ class NoopResult:
 
 
 def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
-    """Record the pair's current sync-cell state as the watermark baseline."""
-    for lang, path in (("de", de_path), ("en", en_path)):
-        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
-        cache.put_deck(
-            de_path=str(de_path),
-            en_path=str(en_path),
-            lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
-        )
+    """Record the pair's current state as the watermark baseline.
+
+    Mirrors ``sync_apply._record_watermark``: the membership-widened de/en/shared
+    partitions, so the seeded baseline matches what a real clean apply records.
+    """
+    de_rows = watermark_rows(parse_cells(de_path.read_text(encoding="utf-8")))
+    en_rows = watermark_rows(parse_cells(en_path.read_text(encoding="utf-8")))
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="de", cells=de_rows["de"])
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="en", cells=en_rows["en"])
+    cache.put_deck(
+        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=de_rows["shared"]
+    )
 
 
 def noop_probe(de_path: Path, en_path: Path) -> NoopResult:

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -511,10 +511,16 @@ class SyncWatermarkCache:
                     slide_id     TEXT,
                     role         TEXT NOT NULL,
                     content_hash TEXT NOT NULL,
+                    construct    TEXT,
                     synced_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (de_path, en_path, lang, position)
                 )"""
             )
+            self._conn.commit()
+        elif "construct" not in columns:
+            # Additive migration (Issue #190 §5): the content-anchor construct
+            # slug. Nullable, so existing rows backfill to NULL harmlessly.
+            self._conn.execute("ALTER TABLE sync_watermarks ADD COLUMN construct TEXT")
             self._conn.commit()
 
     def get_deck(
@@ -522,19 +528,19 @@ class SyncWatermarkCache:
         de_path: str,
         en_path: str,
         lang: str,
-    ) -> list[tuple[int, str | None, str, str]]:
+    ) -> list[tuple[int, str | None, str, str, str | None]]:
         """Return the watermark for one deck, ordered by position.
 
-        Tuples are ``(position, slide_id, role, content_hash)``;
-        ``slide_id`` is ``None`` for id-less rows. An empty list means the
-        deck has no watermark (cold start for this pair).
+        Tuples are ``(position, slide_id, role, content_hash, construct)``;
+        ``slide_id`` and ``construct`` are ``None`` for id-less / non-code rows.
+        An empty list means the deck has no watermark (cold start for this pair).
         """
         rows = self._conn.execute(
-            "SELECT position, slide_id, role, content_hash FROM sync_watermarks "
+            "SELECT position, slide_id, role, content_hash, construct FROM sync_watermarks "
             "WHERE de_path=? AND en_path=? AND lang=? ORDER BY position",
             (de_path, en_path, lang),
         ).fetchall()
-        return [(r[0], r[1], r[2], r[3]) for r in rows]
+        return [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
 
     def put_deck(
         self,
@@ -542,17 +548,19 @@ class SyncWatermarkCache:
         de_path: str,
         en_path: str,
         lang: str,
-        cells: list[tuple[int, str | None, str, str]],
+        cells: list[tuple[int, str | None, str, str, str | None]],
     ) -> None:
         """Replace the watermark for one deck atomically.
 
         ``cells`` is an ordered list of ``(position, slide_id, role,
-        content_hash)``. The whole ``(de_path, en_path, lang)`` slice is
-        deleted and rewritten in a single transaction so a deck's watermark
-        is never observed half-updated.
+        content_hash, construct)``. ``lang`` is ``de`` / ``en`` for localized
+        decks or ``shared`` for the single-entity language-neutral partition
+        (Issue #190 §5). The whole ``(de_path, en_path, lang)`` slice is deleted
+        and rewritten in a single transaction so a deck's watermark is never
+        observed half-updated.
         """
-        if lang not in ("de", "en"):
-            raise ValueError(f"lang must be 'de' or 'en', got {lang!r}")
+        if lang not in ("de", "en", "shared"):
+            raise ValueError(f"lang must be 'de', 'en', or 'shared', got {lang!r}")
         with self._conn:  # single transaction (BEGIN/COMMIT or ROLLBACK)
             self._conn.execute(
                 "DELETE FROM sync_watermarks WHERE de_path=? AND en_path=? AND lang=?",
@@ -560,11 +568,11 @@ class SyncWatermarkCache:
             )
             self._conn.executemany(
                 "INSERT INTO sync_watermarks "
-                "(de_path, en_path, lang, position, slide_id, role, content_hash) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "(de_path, en_path, lang, position, slide_id, role, content_hash, construct) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 [
-                    (de_path, en_path, lang, position, slide_id, role, content_hash)
-                    for (position, slide_id, role, content_hash) in cells
+                    (de_path, en_path, lang, position, slide_id, role, content_hash, construct)
+                    for (position, slide_id, role, content_hash, construct) in cells
                 ],
             )
 
@@ -585,18 +593,21 @@ class SyncWatermarkCache:
         self._conn.commit()
         return cursor.rowcount
 
-    def iter_entries(self) -> list[tuple[str, str, str, int, str | None, str, str, str]]:
+    def iter_entries(
+        self,
+    ) -> list[tuple[str, str, str, int, str | None, str, str, str | None, str]]:
         """Return every watermark row for a future ``sync --dump``.
 
         Tuples are ``(de_path, en_path, lang, position, slide_id, role,
-        content_hash, synced_at)`` ordered by pair, language, and position.
+        content_hash, construct, synced_at)`` ordered by pair, language, and
+        position.
         """
         rows = self._conn.execute(
             "SELECT de_path, en_path, lang, position, slide_id, role, "
-            "content_hash, synced_at "
+            "content_hash, construct, synced_at "
             "FROM sync_watermarks ORDER BY de_path, en_path, lang, position"
         ).fetchall()
-        return [(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]) for r in rows]
+        return [(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]) for r in rows]
 
     def close(self) -> None:
         self._conn.close()

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -225,7 +225,8 @@ def apply_plan(
     # groups, reusing the narrative / aux / id'd-code twins the steps above just
     # placed. Cross-group code moves fall out of rebuilding both groups from the
     # source. Runs after adds/moves so every twin it pulls is in place.
-    apply_code_structure(plan, de_state, en_state, translator, result)
+    baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan.de_path, plan.en_path)
+    apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
 
     # Fail-safe: a complete resolution leaves no duplicate id behind. If one
     # survives (a should-not-happen bug), error so the watermark cannot advance
@@ -1072,6 +1073,42 @@ def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
             continue
         index.setdefault((sid, role), cell.content)
     return index
+
+
+def _row_anchor(slide_id: str | None, construct: str | None, content_hash: str) -> str:
+    """The content anchor of a watermark row (mirrors :func:`sync_writeback.anchor_of`).
+
+    Derives the same ``id: > construct: > hash:`` identity from a stored row that
+    ``anchor_of`` derives from a live cell, so the structural pass can match a
+    current cell against its baseline by anchor.
+    """
+    if slide_id is not None:
+        return f"id:{slide_id}"
+    if construct is not None:
+        return f"construct:{construct}"
+    return f"hash:{content_hash}"
+
+
+def _baseline_anchor_hashes(
+    cache: SyncWatermarkCache | None,
+    de_path: Path,
+    en_path: Path,
+) -> dict[str, dict[str, str]]:
+    """Per-language ``{anchor: content_hash}`` of the last-synced state.
+
+    Built from the widened watermark (every non-j2 cell). The structural pass
+    uses it to tell an UNCHANGED id-less localized code cell (anchor present with
+    the same hash) from an edited one, so the former is reused verbatim instead of
+    re-translated (Issue #190 item 3 / §8). Empty when there is no watermark — the
+    structural pass then translates as before.
+    """
+    out: dict[str, dict[str, str]] = {"de": {}, "en": {}}
+    if cache is None:
+        return out
+    for lang in ("de", "en"):
+        for _pos, sid, _role, chash, construct in cache.get_deck(str(de_path), str(en_path), lang):
+            out[lang][_row_anchor(sid, construct, chash)] = chash
+    return out
 
 
 def _record_watermark(

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -46,7 +46,13 @@ from clm.notebooks.slide_parser import parse_cell_header, parse_cells
 from clm.slides.raw_cells import RawCell
 from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_code import apply_code_structure
-from clm.slides.sync_plan import Proposal, SyncPlan, ordered_sync_cells
+from clm.slides.sync_plan import (
+    MEMBERSHIP_ROLES,
+    Proposal,
+    SyncPlan,
+    ordered_sync_cells,
+    watermark_rows,
+)
 from clm.slides.sync_translate import TranslationError
 from clm.slides.sync_writeback import (
     CODE_ROLE,
@@ -1073,15 +1079,24 @@ def _record_watermark(
     de_path: Path,
     en_path: Path,
 ) -> None:
-    """Record both decks' post-apply state as the new baseline."""
-    for lang, path in (("de", de_path), ("en", en_path)):
-        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
-        cache.put_deck(
-            de_path=str(de_path),
-            en_path=str(en_path),
-            lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
-        )
+    """Record both decks' post-apply state as the new baseline.
+
+    Membership-widened (Issue #190 §5.3): every non-j2 cell is recorded — the
+    per-cell-synced cells under ``de``/``en`` and the language-neutral cells once
+    under ``shared`` — so the Phase 2 anchor pass can locate id-less localized and
+    shared cells. The classifier still reads only the real-role rows
+    (``_baseline_from_watermark`` filters the synthetic membership roles), so this
+    does not change its behavior.
+    """
+    de_rows = watermark_rows(parse_cells(de_path.read_text(encoding="utf-8")))
+    en_rows = watermark_rows(parse_cells(en_path.read_text(encoding="utf-8")))
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="de", cells=de_rows["de"])
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="en", cells=en_rows["en"])
+    # Neutral cells are byte-identical across halves (the unify invariant), so the
+    # single-entity "shared" partition is recorded once from the DE file.
+    cache.put_deck(
+        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=de_rows["shared"]
+    )
 
 
 def _eligible_for_partial_advance(plan: SyncPlan, result: ApplyResult) -> bool:
@@ -1138,11 +1153,15 @@ def _record_watermark_partial(
     cannot faithfully preserve it there, so we hold the whole watermark and let
     the conflict re-surface instead of dropping it.
     """
-    old: dict[str, dict[tuple[str, str], str]] = {}
-    cells_by_lang = {
-        "de": ordered_sync_cells(parse_cells(de_path.read_text(encoding="utf-8")), "de"),
-        "en": ordered_sync_cells(parse_cells(en_path.read_text(encoding="utf-8")), "en"),
+    parsed = {
+        "de": parse_cells(de_path.read_text(encoding="utf-8")),
+        "en": parse_cells(en_path.read_text(encoding="utf-8")),
     }
+    cells_by_lang = {
+        "de": ordered_sync_cells(parsed["de"], "de"),
+        "en": ordered_sync_cells(parsed["en"], "en"),
+    }
+    old: dict[str, dict[tuple[str, str], str]] = {}
     current: dict[str, set[tuple[str, str]]] = {}
     for lang in ("de", "en"):
         old[lang] = {
@@ -1150,7 +1169,7 @@ def _record_watermark_partial(
             for (_pos, sid, role, chash, _construct) in cache.get_deck(
                 str(de_path), str(en_path), lang
             )
-            if sid is not None
+            if sid is not None and role not in MEMBERSHIP_ROLES
         }
         current[lang] = {
             (c.slide_id, c.role) for c in cells_by_lang[lang] if c.slide_id is not None
@@ -1161,14 +1180,20 @@ def _record_watermark_partial(
         if key not in current["de"] or key not in current["en"]:
             return False
 
+    # Re-record the membership-widened watermark (Issue #190 §5.3), holding only
+    # the legacy deferred keys at their pre-conflict baseline. A content-only pass
+    # leaves structure (and every neutral / id-less cell) unchanged, so the
+    # membership rows re-derive faithfully from the current files.
+    widened = {"de": watermark_rows(parsed["de"]), "en": watermark_rows(parsed["en"])}
     for lang in ("de", "en"):
         rows: list[tuple[int, str | None, str, str, str | None]] = []
-        for c in cells_by_lang[lang]:
-            if c.slide_id is not None and (c.slide_id, c.role) in preserve_keys:
+        for pos, sid, role, chash, construct in widened[lang][lang]:
+            if role not in MEMBERSHIP_ROLES and sid is not None and (sid, role) in preserve_keys:
                 # Hold the deferral at its pre-conflict baseline so it re-surfaces.
-                chash = old[lang][(c.slide_id, c.role)]
-            else:
-                chash = c.content_hash  # bank: applied / in_sync / unchanged
-            rows.append((c.position, c.slide_id, c.role, chash, c.construct))
+                chash = old[lang][(sid, role)]
+            rows.append((pos, sid, role, chash, construct))
         cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang=lang, cells=rows)
+    cache.put_deck(
+        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=widened["de"]["shared"]
+    )
     return True

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -1080,7 +1080,7 @@ def _record_watermark(
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 
@@ -1147,7 +1147,9 @@ def _record_watermark_partial(
     for lang in ("de", "en"):
         old[lang] = {
             (sid, role): chash
-            for (_pos, sid, role, chash) in cache.get_deck(str(de_path), str(en_path), lang)
+            for (_pos, sid, role, chash, _construct) in cache.get_deck(
+                str(de_path), str(en_path), lang
+            )
             if sid is not None
         }
         current[lang] = {
@@ -1160,13 +1162,13 @@ def _record_watermark_partial(
             return False
 
     for lang in ("de", "en"):
-        rows: list[tuple[int, str | None, str, str]] = []
+        rows: list[tuple[int, str | None, str, str, str | None]] = []
         for c in cells_by_lang[lang]:
             if c.slide_id is not None and (c.slide_id, c.role) in preserve_keys:
                 # Hold the deferral at its pre-conflict baseline so it re-surfaces.
                 chash = old[lang][(c.slide_id, c.role)]
             else:
                 chash = c.content_hash  # bank: applied / in_sync / unchanged
-            rows.append((c.position, c.slide_id, c.role, chash))
+            rows.append((c.position, c.slide_id, c.role, chash, c.construct))
         cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang=lang, cells=rows)
     return True

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -37,6 +37,7 @@ import logging
 import os
 import re
 import tempfile
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1106,8 +1107,18 @@ def _baseline_anchor_hashes(
     if cache is None:
         return out
     for lang in ("de", "en"):
-        for _pos, sid, _role, chash, construct in cache.get_deck(str(de_path), str(en_path), lang):
-            out[lang][_row_anchor(sid, construct, chash)] = chash
+        rows = cache.get_deck(str(de_path), str(en_path), lang)
+        anchors = [_row_anchor(sid, construct, chash) for (_p, sid, _r, chash, construct) in rows]
+        # A construct anchor is only a *name* (``extract_from_code``), so it is not
+        # content-unique: two cells sharing it (two ``import os``, two
+        # ``def solution``) cannot be told apart by anchor. Admit an anchor to the
+        # reuse set only when it occurs exactly once — a non-unique anchor cannot
+        # reliably locate a twin, so its cells re-translate (the honest §12
+        # residual) rather than risk a wrong-twin splice (Issue #190 review).
+        counts = Counter(anchors)
+        for anchor, (_p, _sid, _r, chash, _c) in zip(anchors, rows, strict=True):
+            if counts[anchor] == 1:
+                out[lang][anchor] = chash
     return out
 
 

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -325,10 +325,20 @@ def _reuse_unchanged_twin(
 
 
 def _find_by_anchor(cells: list[RawCell], anchor: str) -> RawCell | None:
-    for cell in cells:
-        if not cell.metadata.is_j2 and anchor_of(cell.metadata, cell.body) == anchor:
-            return cell
-    return None
+    """The single target cell carrying ``anchor``, or ``None`` if absent/ambiguous.
+
+    Returns ``None`` when *more than one* cell matches: a construct anchor is only
+    a name, so a duplicate (two ``import os``, two ``def greet``) cannot reliably
+    name a twin — splicing an arbitrary first match would drop one cell and
+    duplicate the other (silent cross-deck corruption). The ambiguous cells then
+    translate normally (Issue #190 review).
+    """
+    matches = [
+        cell
+        for cell in cells
+        if not cell.metadata.is_j2 and anchor_of(cell.metadata, cell.body) == anchor
+    ]
+    return matches[0] if len(matches) == 1 else None
 
 
 def _translate(

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -38,7 +38,14 @@ from typing import TYPE_CHECKING
 
 from clm.slides.raw_cells import RawCell
 from clm.slides.sync_translate import TranslationError
-from clm.slides.sync_writeback import CODE_ROLE, FileState, build_twin_cell, role_of
+from clm.slides.sync_writeback import (
+    CODE_ROLE,
+    FileState,
+    anchor_of,
+    build_twin_cell,
+    cell_content_hash,
+    role_of,
+)
 
 if TYPE_CHECKING:
     from clm.slides.sync_apply import ApplyResult
@@ -54,12 +61,19 @@ def apply_code_structure(
     en_state: FileState,
     translator: SlideTranslator | None,
     result: ApplyResult,
+    baseline_anchors: dict[str, dict[str, str]] | None = None,
 ) -> None:
     """Propagate language-neutral / id-less-localized cells and fix group order.
 
     Mutates the target deck's :class:`FileState` in place (and marks it dirty)
     for every slide group whose structure drifted from the source. No-op when
     the run has no single propagation direction.
+
+    ``baseline_anchors`` is the per-language ``{anchor: content_hash}`` of the
+    last-synced state (from the widened watermark). When a rebuilt id-less
+    localized code cell is **unchanged** (its source-side anchor is in the
+    baseline with the same content hash), the existing target twin is spliced
+    verbatim instead of re-translated — Issue #190 item 3 (§8).
     """
     direction = _single_direction(plan)
     if direction is None:
@@ -68,6 +82,7 @@ def apply_code_structure(
         source_state, target_state, source_lang, target_lang = en_state, de_state, "en", "de"
     else:
         source_state, target_state, source_lang, target_lang = de_state, en_state, "de", "en"
+    src_anchors = (baseline_anchors or {}).get(source_lang, {})
 
     src_head, src_groups = _split_groups(source_state.cells)
     tgt_head, tgt_groups = _split_groups(target_state.cells)
@@ -93,7 +108,14 @@ def apply_code_structure(
             emit(tgt_region, was_rebuilt=False)
             return
         rebuilt = _rebuild_region(
-            src_region, tgt_region, target_state, source_lang, target_lang, translator, result
+            src_region,
+            tgt_region,
+            target_state,
+            source_lang,
+            target_lang,
+            translator,
+            result,
+            src_anchors,
         )
         if rebuilt is None:
             # A translation needed for the rebuild failed (no translator, or it
@@ -216,6 +238,7 @@ def _rebuild_region(
     target_lang: str,
     translator: SlideTranslator | None,
     result: ApplyResult,
+    src_anchors: dict[str, str] | None = None,
 ) -> list[RawCell] | None:
     """Rebuild a target region to mirror the source region's cell order.
 
@@ -262,6 +285,15 @@ def _rebuild_region(
         elif meta.lang is None:
             out.append(_copy_cell(cell))  # language-neutral: shared verbatim
         elif meta.lang == source_lang:
+            # Item-3 reuse (§8): an UNCHANGED id-less localized cell keeps its
+            # existing target twin verbatim instead of being re-translated. It is
+            # "unchanged" iff its source-side anchor is in the baseline with the
+            # same content hash; the twin is located in the current target region
+            # by the same (language-agnostic, construct-based) anchor.
+            reused = _reuse_unchanged_twin(cell, tgt_cells, src_anchors)
+            if reused is not None:
+                out.append(reused)
+                continue
             kind = CODE_ROLE if meta.cell_type == "code" else "markdown"
             body = _translate(cell, source_lang, target_lang, kind, translator, result)
             if body is None:
@@ -269,6 +301,34 @@ def _rebuild_region(
             out.append(build_twin_cell(cell, target_lang, body))
         # else: an other-language cell in the source deck — should not occur; skip.
     return out
+
+
+def _reuse_unchanged_twin(
+    cell: RawCell, tgt_cells: list[RawCell], src_anchors: dict[str, str] | None
+) -> RawCell | None:
+    """Return the existing target twin to splice verbatim, or ``None`` to translate.
+
+    Reuse fires only when (a) the source cell's anchor is in the baseline with the
+    *same* content hash — proving the source is unchanged since the last sync — and
+    (b) the current target region holds a cell with that same anchor (the twin).
+    A construct-based anchor is language-agnostic, so the de/en copies of the same
+    code share it; a hash-fallback anchor differs across languages, so such cells
+    never reuse (they translate, the honest §12 residual). ``None`` ``src_anchors``
+    (no watermark) disables reuse — the pre-#190 always-translate behavior.
+    """
+    if not src_anchors:
+        return None
+    anchor = anchor_of(cell.metadata, cell.body)
+    if src_anchors.get(anchor) != cell_content_hash(cell.body):
+        return None
+    return _find_by_anchor(tgt_cells, anchor)
+
+
+def _find_by_anchor(cells: list[RawCell], anchor: str) -> RawCell | None:
+    for cell in cells:
+        if not cell.metadata.is_j2 and anchor_of(cell.metadata, cell.body) == anchor:
+            return cell
+    return None
 
 
 def _translate(

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -34,13 +34,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.notebooks.slide_parser import Cell, CellMetadata, parse_cells
 from clm.slides.sync_writeback import cell_content_hash, construct_of, role_of
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.cache import SyncWatermarkCache
 
 __all__ = [
+    "MEMBERSHIP_ROLES",
     "BaselineCell",
     "CurrentCell",
     "PlanIssue",
@@ -50,11 +51,33 @@ __all__ = [
     "classify_changes",
     "ordered_sync_cells",
     "render_plan",
+    "watermark_rows",
 ]
 
 # Roles that lead a slide group; narrative roles (voiceover/notes/code/aux)
 # belong to the most recent slide group rather than starting their own.
 _SLIDE_ROLES = {"slide", "subslide"}
+
+# Synthetic roles for the *membership-widened* rows (Issue #190 §5.3): cells the
+# per-cell engine does not own (``role_of`` is ``None``) but which the watermark
+# now records so the anchor pass can locate them. The classifier filters these
+# out (:func:`_baseline_from_watermark`), so move detection / pairing is
+# unchanged; only the Phase 2+ anchor reuse reads them.
+NEUTRAL_CODE_ROLE = "neutral-code"
+NEUTRAL_MARKDOWN_ROLE = "neutral-markdown"
+LOCALIZED_CODE_ROLE = "localized-code"
+LOCALIZED_MARKDOWN_ROLE = "localized-markdown"
+MEMBERSHIP_ROLES = frozenset(
+    {NEUTRAL_CODE_ROLE, NEUTRAL_MARKDOWN_ROLE, LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE}
+)
+
+
+def _membership_role(metadata: CellMetadata) -> str:
+    """The synthetic membership role for a non-j2 cell with no per-cell role."""
+    is_code = metadata.cell_type == "code"
+    if metadata.lang is None:
+        return NEUTRAL_CODE_ROLE if is_code else NEUTRAL_MARKDOWN_ROLE
+    return LOCALIZED_CODE_ROLE if is_code else LOCALIZED_MARKDOWN_ROLE
 
 
 # ---------------------------------------------------------------------------
@@ -225,14 +248,60 @@ def ordered_sync_cells(cells: list[Cell], expected_lang: str) -> list[CurrentCel
     return out
 
 
+def watermark_rows(
+    cells: list[Cell],
+) -> dict[str, list[tuple[int, str | None, str, str, str | None]]]:
+    """Every non-j2 cell as watermark 5-tuples, partitioned by ``de``/``en``/``shared``.
+
+    Membership widening (Issue #190 §5.3): the watermark records *every* non-j2
+    cell, not just the per-cell-synced ones. A cell with a real role
+    (``role_of != None``) keeps it; a membership-only cell gets a synthetic role
+    (:data:`MEMBERSHIP_ROLES`). The partition is the cell's language — ``shared``
+    for language-neutral cells, which the single-entity model tracks once.
+    Positions are per-partition file order; only their *relative* order is load-
+    bearing (the classifier sorts by it), so interleaved membership rows do not
+    perturb the legacy view once they are filtered out
+    (:func:`_baseline_from_watermark`).
+    """
+    out: dict[str, list[tuple[int, str | None, str, str, str | None]]] = {
+        "de": [],
+        "en": [],
+        "shared": [],
+    }
+    pos = {"de": 0, "en": 0, "shared": 0}
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2:
+            continue
+        real = role_of(meta)
+        role = real if real is not None else _membership_role(meta)
+        partition = meta.lang if meta.lang in ("de", "en") else "shared"
+        out[partition].append(
+            (
+                pos[partition],
+                meta.slide_id,
+                role,
+                cell_content_hash(cell.content),
+                construct_of(meta, cell.content),
+            )
+        )
+        pos[partition] += 1
+    return out
+
+
 def _baseline_from_watermark(
     rows: list[tuple[int, str | None, str, str, str | None]],
 ) -> list[BaselineCell]:
-    # ``construct`` (5th element) is stored for the Issue #190 anchor pass but is
-    # not yet consumed by this classifier (Phase 1a populates; Phase 2 consumes).
+    # Filter out the membership-widened rows (Issue #190 §5.3): the classifier
+    # reconciles only the per-cell-synced (real-role) cells, exactly as before
+    # the widening. The synthetic rows interleave by position, but only their
+    # relative order matters to move detection — and that is preserved — so the
+    # legacy diff is byte-stable. ``construct`` is carried for the Phase 2 anchor
+    # reuse but not consumed here.
     return [
         BaselineCell(position=pos, slide_id=sid, role=role, content_hash=chash)
         for (pos, sid, role, chash, _construct) in rows
+        if role not in MEMBERSHIP_ROLES
     ]
 
 

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -292,16 +292,24 @@ def watermark_rows(
 def _baseline_from_watermark(
     rows: list[tuple[int, str | None, str, str, str | None]],
 ) -> list[BaselineCell]:
-    # Filter out the membership-widened rows (Issue #190 §5.3): the classifier
-    # reconciles only the per-cell-synced (real-role) cells, exactly as before
-    # the widening. The synthetic rows interleave by position, but only their
-    # relative order matters to move detection — and that is preserved — so the
-    # legacy diff is byte-stable. ``construct`` is carried for the Phase 2 anchor
-    # reuse but not consumed here.
-    return [
-        BaselineCell(position=pos, slide_id=sid, role=role, content_hash=chash)
-        for (pos, sid, role, chash, _construct) in rows
+    # Drop the membership-widened rows (Issue #190 §5.3) and **re-index** the
+    # survivors into the legacy-only position space. The stored positions count
+    # *all* non-j2 cells of the partition, but the classifier compares baseline
+    # positions against ``ordered_sync_cells`` positions, which count only the
+    # real-role cells. Most consumers read position through a sort (relative
+    # order), but ``_resolve_duplicates`` compares it by *absolute* difference —
+    # so the spaces must match. The rows are in file order, so ``enumerate``
+    # reproduces exactly the indices ``ordered_sync_cells`` (and
+    # ``_baseline_from_git_head``) assign. ``construct`` is carried in the raw
+    # watermark for the Phase 2 anchor reuse but is not consumed by the classifier.
+    legacy = [
+        (sid, role, chash)
+        for (_pos, sid, role, chash, _construct) in rows
         if role not in MEMBERSHIP_ROLES
+    ]
+    return [
+        BaselineCell(position=i, slide_id=sid, role=role, content_hash=chash)
+        for i, (sid, role, chash) in enumerate(legacy)
     ]
 
 

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.notebooks.slide_parser import Cell, parse_cells
-from clm.slides.sync_writeback import cell_content_hash, role_of
+from clm.slides.sync_writeback import cell_content_hash, construct_of, role_of
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.cache import SyncWatermarkCache
@@ -81,6 +81,7 @@ class CurrentCell:
     role: str
     content_hash: str
     line_number: int  # 1-based header line, for anchoring / messaging
+    construct: str | None = None  # AST construct slug (Issue #190 §4); None for non-code
 
 
 @dataclass
@@ -217,6 +218,7 @@ def ordered_sync_cells(cells: list[Cell], expected_lang: str) -> list[CurrentCel
                 role=role,
                 content_hash=cell_content_hash(cell.content),
                 line_number=cell.line_number,
+                construct=construct_of(cell.metadata, cell.content),
             )
         )
         position += 1
@@ -224,11 +226,13 @@ def ordered_sync_cells(cells: list[Cell], expected_lang: str) -> list[CurrentCel
 
 
 def _baseline_from_watermark(
-    rows: list[tuple[int, str | None, str, str]],
+    rows: list[tuple[int, str | None, str, str, str | None]],
 ) -> list[BaselineCell]:
+    # ``construct`` (5th element) is stored for the Issue #190 anchor pass but is
+    # not yet consumed by this classifier (Phase 1a populates; Phase 2 consumes).
     return [
         BaselineCell(position=pos, slide_id=sid, role=role, content_hash=chash)
-        for (pos, sid, role, chash) in rows
+        for (pos, sid, role, chash, _construct) in rows
     ]
 
 

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -25,7 +25,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.notebooks.slide_parser import CellMetadata, parse_cell_header
+from clm.slides.code_cell_extract import extract_from_code
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
+from clm.slides.slug import slugify
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.cache import SyncSnapshotCache
@@ -35,8 +37,10 @@ if TYPE_CHECKING:
 __all__ = [
     "CODE_ROLE",
     "FileState",
+    "anchor_of",
     "build_twin_cell",
     "cell_content_hash",
+    "construct_of",
     "record_snapshot",
     "role_of",
     "swap_lang",
@@ -135,6 +139,45 @@ def cell_content_hash(text: str) -> str:
     the same way before hashing so re-runs find a matching cache row.
     """
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def construct_of(metadata: CellMetadata, body: str) -> str | None:
+    """The deterministic *construct* component of a cell's content anchor.
+
+    For a code cell, the AST construct name from :func:`extract_from_code`
+    slugified — ``"function my_fun"`` → ``"function-my-fun"``, ``"class X"`` →
+    ``"class-x"``, ``"import time"`` → ``"import-time"``. ``None`` for non-code,
+    j2, or unparsable cells (shell escapes, magic, half-finished stubs) — the
+    anchor then falls back to the slide_id or the content hash. A pure function
+    of content, so it is always re-derivable and adds no header churn
+    (Issue #190 §4). ``body`` is the cell body as the parser yields it (a code
+    cell's raw Python, no ``# `` prefix).
+    """
+    if metadata.is_j2 or metadata.cell_type != "code":
+        return None
+    extraction = extract_from_code(body)
+    if extraction is None:
+        return None
+    return slugify(extraction.text) or None
+
+
+def anchor_of(metadata: CellMetadata, body: str) -> str:
+    """The content-derived identity of a cell: ``hand slide_id > construct > hash``.
+
+    The Issue #190 §4 anchor — stable across translations and immune to the git
+    commit cadence, and **never written into the file**. The three components are
+    prefixed (``id:`` / ``construct:`` / ``hash:``) so a hand id ``"foo"`` and a
+    construct slug ``"foo"`` can never collide. The hash branch reuses
+    :func:`cell_content_hash`, so it hashes the *same* canonical stripped form as
+    the watermark's ``content_hash`` (else CRLF/LF drift would re-introduce the
+    item-3 churn this anchor exists to remove).
+    """
+    if metadata.slide_id is not None:
+        return f"id:{metadata.slide_id}"
+    construct = construct_of(metadata, body)
+    if construct is not None:
+        return f"construct:{construct}"
+    return f"hash:{cell_content_hash(body)}"
 
 
 _LANG_ATTR_RE = re.compile(r'lang="[^"]*"')

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -77,7 +77,9 @@ def _seed_watermark(
                 de_path=str(de_path),
                 en_path=str(en_path),
                 lang=lang,
-                cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+                cells=[
+                    (c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells
+                ],
             )
     finally:
         wm.close()

--- a/tests/infrastructure/llm/test_sync_cache.py
+++ b/tests/infrastructure/llm/test_sync_cache.py
@@ -238,66 +238,87 @@ class TestSyncWatermarkCache:
 
     def test_put_and_get_deck_ordered(self, watermarks):
         cells = [
-            (0, "intro", "slide", "h0"),
-            (1, "intro", "voiceover", "h1"),
-            (2, "topic", "slide", "h2"),
+            (0, "intro", "slide", "h0", None),
+            (1, "intro", "voiceover", "h1", None),
+            (2, "topic", "slide", "h2", None),
         ]
         watermarks.put_deck(de_path="a.de.py", en_path="a.en.py", lang="de", cells=cells)
         assert watermarks.get_deck("a.de.py", "a.en.py", "de") == cells
         assert watermarks.has_pair("a.de.py", "a.en.py") is True
 
     def test_nullable_slide_id(self, watermarks):
-        cells = [(0, None, "slide", "h0"), (1, "topic", "slide", "h1")]
+        cells = [(0, None, "slide", "h0", None), (1, "topic", "slide", "h1", None)]
         watermarks.put_deck(de_path="a.de.py", en_path="a.en.py", lang="en", cells=cells)
         got = watermarks.get_deck("a.de.py", "a.en.py", "en")
         assert got[0][1] is None
         assert got == cells
 
+    def test_construct_roundtrips(self, watermarks):
+        # The Issue #190 §5 anchor construct column: stored and returned as the
+        # 5th tuple element; nullable for non-code rows.
+        cells = [
+            (0, None, "localized-code", "h0", "function-my-fun"),
+            (1, "intro", "slide", "h1", None),
+        ]
+        watermarks.put_deck(de_path="a.de.py", en_path="a.en.py", lang="de", cells=cells)
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == cells
+
+    def test_shared_partition_accepted(self, watermarks):
+        # Language-neutral cells are tracked once under the "shared" partition.
+        cells = [(0, None, "neutral-code", "h0", "import-time")]
+        watermarks.put_deck(de_path="a.de.py", en_path="a.en.py", lang="shared", cells=cells)
+        assert watermarks.get_deck("a.de.py", "a.en.py", "shared") == cells
+        # "shared" is isolated from the localized partitions.
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == []
+
     def test_languages_are_isolated(self, watermarks):
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "dh")]
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "dh", None)]
         )
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="en", cells=[(0, "x", "slide", "eh")]
+            de_path="a.de.py", en_path="a.en.py", lang="en", cells=[(0, "x", "slide", "eh", None)]
         )
-        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "dh")]
-        assert watermarks.get_deck("a.de.py", "a.en.py", "en") == [(0, "x", "slide", "eh")]
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "dh", None)]
+        assert watermarks.get_deck("a.de.py", "a.en.py", "en") == [(0, "x", "slide", "eh", None)]
 
     def test_put_deck_replaces_atomically(self, watermarks):
         watermarks.put_deck(
             de_path="a.de.py",
             en_path="a.en.py",
             lang="de",
-            cells=[(0, "a", "slide", "h0"), (1, "b", "slide", "h1")],
+            cells=[(0, "a", "slide", "h0", None), (1, "b", "slide", "h1", None)],
         )
         # Rewrite with a shorter, different deck — old rows must be gone.
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "c", "slide", "h2")]
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "c", "slide", "h2", None)]
         )
-        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "c", "slide", "h2")]
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "c", "slide", "h2", None)]
 
     def test_invalid_lang_raises(self, watermarks):
         with pytest.raises(ValueError, match="lang must be"):
             watermarks.put_deck(
-                de_path="a.de.py", en_path="a.en.py", lang="fr", cells=[(0, "x", "slide", "h")]
+                de_path="a.de.py",
+                en_path="a.en.py",
+                lang="fr",
+                cells=[(0, "x", "slide", "h", None)],
             )
 
     def test_pairs_are_isolated(self, watermarks):
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "ah")]
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "ah", None)]
         )
         watermarks.put_deck(
-            de_path="b.de.py", en_path="b.en.py", lang="de", cells=[(0, "y", "slide", "bh")]
+            de_path="b.de.py", en_path="b.en.py", lang="de", cells=[(0, "y", "slide", "bh", None)]
         )
-        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "ah")]
-        assert watermarks.get_deck("b.de.py", "b.en.py", "de") == [(0, "y", "slide", "bh")]
+        assert watermarks.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "ah", None)]
+        assert watermarks.get_deck("b.de.py", "b.en.py", "de") == [(0, "y", "slide", "bh", None)]
 
     def test_clear_pair(self, watermarks):
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h", None)]
         )
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="en", cells=[(0, "x", "slide", "h")]
+            de_path="a.de.py", en_path="a.en.py", lang="en", cells=[(0, "x", "slide", "h", None)]
         )
         removed = watermarks.clear_pair("a.de.py", "a.en.py")
         assert removed == 2
@@ -307,14 +328,42 @@ class TestSyncWatermarkCache:
         path = tmp_path / "clm-llm.sqlite"
         first = SyncWatermarkCache(path)
         first.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h", "c0")]
         )
         first.close()
         second = SyncWatermarkCache(path)
         try:
-            assert second.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h")]
+            assert second.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h", "c0")]
         finally:
             second.close()
+
+    def test_construct_column_migrates_onto_legacy_table(self, tmp_path: Path):
+        # A pre-#190 table (no construct column) must gain it additively, with
+        # existing rows backfilling to NULL — not a wipe.
+        import sqlite3
+
+        path = tmp_path / "clm-llm.sqlite"
+        legacy = sqlite3.connect(str(path))
+        legacy.execute(
+            """CREATE TABLE sync_watermarks (
+                de_path TEXT NOT NULL, en_path TEXT NOT NULL, lang TEXT NOT NULL,
+                position INTEGER NOT NULL, slide_id TEXT, role TEXT NOT NULL,
+                content_hash TEXT NOT NULL, synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (de_path, en_path, lang, position)
+            )"""
+        )
+        legacy.execute(
+            "INSERT INTO sync_watermarks (de_path, en_path, lang, position, slide_id, role, "
+            "content_hash) VALUES ('a.de.py', 'a.en.py', 'de', 0, 'x', 'slide', 'h')"
+        )
+        legacy.commit()
+        legacy.close()
+
+        migrated = SyncWatermarkCache(path)  # _migrate runs the ALTER
+        try:
+            assert migrated.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h", None)]
+        finally:
+            migrated.close()
 
     def test_coexists_with_other_caches(self, tmp_path: Path):
         path = tmp_path / "clm-llm.sqlite"
@@ -322,7 +371,10 @@ class TestSyncWatermarkCache:
         snap = SyncSnapshotCache(path)
         try:
             wm.put_deck(
-                de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+                de_path="a.de.py",
+                en_path="a.en.py",
+                lang="de",
+                cells=[(0, "x", "slide", "h", None)],
             )
             snap.put(
                 de_path="a.de.py",
@@ -333,7 +385,7 @@ class TestSyncWatermarkCache:
                 en_hash="eh",
                 direction="de->en",
             )
-            assert wm.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h")]
+            assert wm.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h", None)]
             assert snap.get("a.de.py", "a.en.py", "x", "slide") == ("dh", "eh", "de->en")
         finally:
             snap.close()
@@ -341,9 +393,9 @@ class TestSyncWatermarkCache:
 
     def test_iter_entries(self, watermarks):
         watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h")]
+            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h", "c0")]
         )
         rows = watermarks.iter_entries()
         assert len(rows) == 1
-        # (de_path, en_path, lang, position, slide_id, role, content_hash, synced_at)
-        assert rows[0][:7] == ("a.de.py", "a.en.py", "de", 0, "x", "slide", "h")
+        # (de_path, en_path, lang, position, slide_id, role, content_hash, construct, synced_at)
+        assert rows[0][:8] == ("a.de.py", "a.en.py", "de", 0, "x", "slide", "h", "c0")

--- a/tests/slides/test_sync_anchor.py
+++ b/tests/slides/test_sync_anchor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_plan import (
     MEMBERSHIP_ROLES,
+    _baseline_from_watermark,
     ordered_sync_cells,
     watermark_rows,
 )
@@ -125,3 +126,19 @@ class TestWatermarkRows:
         legacy = [(r[1], r[2]) for r in watermark_rows(cells)["de"] if r[2] not in MEMBERSHIP_ROLES]
         expected = [(c.slide_id, c.role) for c in ordered_sync_cells(cells, "de")]
         assert legacy == expected
+
+    def test_baseline_reindexes_legacy_positions_past_membership_rows(self):
+        # _baseline_from_watermark must re-index the real-role survivors into the
+        # legacy-only position space (0,1,...), NOT pass the membership-inflated
+        # stored positions through — else _resolve_duplicates' abs(pos - base.pos)
+        # picks the wrong copy as "original" (Issue #190 review finding 2).
+        rows = [
+            (0, None, "localized-code", "h0", "x"),  # membership row, dropped
+            (1, "dup", "slide", "h1", None),  # legacy: stored pos 1 -> re-indexed 0
+            (2, "dup", "voiceover", "h2", None),  # legacy: stored pos 2 -> re-indexed 1
+        ]
+        base = _baseline_from_watermark(rows)
+        assert [(b.position, b.slide_id, b.role) for b in base] == [
+            (0, "dup", "slide"),
+            (1, "dup", "voiceover"),
+        ]

--- a/tests/slides/test_sync_anchor.py
+++ b/tests/slides/test_sync_anchor.py
@@ -1,0 +1,81 @@
+"""Tests for the Issue #190 §4 content-anchor chokepoint (Phase 1a).
+
+``construct_of`` / ``anchor_of`` derive a cell's content-anchor identity
+(``hand slide_id > AST construct slug > sha256``) without ever writing to the
+file. ``ordered_sync_cells`` now populates ``CurrentCell.construct`` so the
+widened watermark can store it.
+"""
+
+from __future__ import annotations
+
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import ordered_sync_cells
+from clm.slides.sync_writeback import anchor_of, cell_content_hash, construct_of
+
+
+def _meta(text: str):
+    cell = parse_cells(text)[0]
+    return cell.metadata, cell.content
+
+
+class TestConstructOf:
+    def test_class_beats_function(self):
+        meta, body = _meta('# %% lang="de"\nclass Widget:\n    def go(self): ...\n')
+        assert construct_of(meta, body) == "class-widget"
+
+    def test_function(self):
+        meta, body = _meta('# %% lang="de"\ndef my_fun():\n    print(1)\n')
+        assert construct_of(meta, body) == "function-my-fun"
+
+    def test_import(self):
+        meta, body = _meta('# %% tags=["keep"]\nimport time\n')
+        assert construct_of(meta, body) == "import-time"
+
+    def test_markdown_is_none(self):
+        meta, body = _meta('# %% [markdown] lang="de"\n# Hello\n')
+        assert construct_of(meta, body) is None
+
+    def test_unparsable_code_is_none(self):
+        meta, body = _meta('# %% lang="de"\n%matplotlib inline\n!ls\n')
+        assert construct_of(meta, body) is None
+
+    def test_j2_is_none(self):
+        meta, body = _meta("# j2 from 'macros.j2' import header_de\n# {{ header_de(\"X\") }}\n")
+        assert construct_of(meta, body) is None
+
+
+class TestAnchorOf:
+    def test_hand_id_wins_over_construct(self):
+        meta, body = _meta('# %% lang="de" slide_id="my-id"\ndef my_fun(): ...\n')
+        assert anchor_of(meta, body) == "id:my-id"
+
+    def test_construct_when_idless(self):
+        meta, body = _meta('# %% tags=["keep"]\nimport os\n')
+        assert anchor_of(meta, body) == "construct:import-os"
+
+    def test_hash_fallback_for_unnameable(self):
+        meta, body = _meta('# %% lang="de"\n%timeit work()\n')
+        assert anchor_of(meta, body) == f"hash:{cell_content_hash(body)}"
+
+    def test_hand_id_markdown(self):
+        meta, body = _meta('# %% [markdown] lang="de" slide_id="intro"\n# Hi\n')
+        assert anchor_of(meta, body) == "id:intro"
+
+    def test_id_and_construct_slugs_cannot_collide(self):
+        # A hand id literally "import-time" must not collide with the construct
+        # slug of `import time` (the prefixes keep the namespaces disjoint).
+        id_meta, id_body = _meta('# %% lang="de" slide_id="import-time"\nx = 1\n')
+        con_meta, con_body = _meta('# %% tags=["keep"]\nimport time\n')
+        assert anchor_of(id_meta, id_body) != anchor_of(con_meta, con_body)
+
+
+class TestOrderedSyncCellsPopulatesConstruct:
+    def test_localized_code_cell_carries_construct(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## Titel\n'
+            '# %% lang="de" tags=["keep"] slide_id="demo"\ndef greet():\n    pass\n'
+        )
+        cells = ordered_sync_cells(parse_cells(text), "de")
+        by_role = {c.role: c for c in cells}
+        assert by_role["slide"].construct is None  # markdown -> no construct
+        assert by_role["code"].construct == "function-greet"

--- a/tests/slides/test_sync_anchor.py
+++ b/tests/slides/test_sync_anchor.py
@@ -9,7 +9,11 @@ widened watermark can store it.
 from __future__ import annotations
 
 from clm.notebooks.slide_parser import parse_cells
-from clm.slides.sync_plan import ordered_sync_cells
+from clm.slides.sync_plan import (
+    MEMBERSHIP_ROLES,
+    ordered_sync_cells,
+    watermark_rows,
+)
 from clm.slides.sync_writeback import anchor_of, cell_content_hash, construct_of
 
 
@@ -79,3 +83,45 @@ class TestOrderedSyncCellsPopulatesConstruct:
         by_role = {c.role: c for c in cells}
         assert by_role["slide"].construct is None  # markdown -> no construct
         assert by_role["code"].construct == "function-greet"
+
+
+class TestWatermarkRows:
+    def test_partitions_and_synthetic_roles(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## Titel\n'  # legacy de
+            '# %% tags=["keep"]\nimport time\n'  # neutral -> shared, synthetic
+            '# %% lang="de"\ndef greet():\n    pass\n'  # localized id-less -> de, synthetic
+            '# %% lang="de" tags=["keep"] slide_id="demo"\nx = 1\n'  # localized id'd -> de, legacy
+        )
+        rows = watermark_rows(parse_cells(text))
+
+        de = rows["de"]
+        shared = rows["shared"]
+        assert rows["en"] == []
+
+        # de partition: the slide (legacy), the id-less localized code (synthetic),
+        # and the id'd localized code (legacy CODE_ROLE), in file order.
+        assert [(r[1], r[2]) for r in de] == [
+            ("s", "slide"),
+            (None, "localized-code"),
+            ("demo", "code"),
+        ]
+        # The id-less localized code carries its construct anchor.
+        assert de[1][4] == "function-greet"
+        # shared partition: the neutral code, recorded once with a synthetic role.
+        assert [(r[1], r[2], r[4]) for r in shared] == [(None, "neutral-code", "import-time")]
+
+    def test_legacy_subset_matches_ordered_sync_cells(self):
+        # The classifier filters MEMBERSHIP_ROLES, so the legacy subset of the de
+        # partition must reproduce ordered_sync_cells's (slide_id, role) order
+        # exactly — this is the no-behavior-change guarantee.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## T\n'
+            '# %% tags=["keep"]\nimport os\n'
+            '# %% lang="de"\nprint("hi")\n'
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="s"\n# VO\n'
+        )
+        cells = parse_cells(text)
+        legacy = [(r[1], r[2]) for r in watermark_rows(cells)["de"] if r[2] not in MEMBERSHIP_ROLES]
+        expected = [(c.slide_id, c.role) for c in ordered_sync_cells(cells, "de")]
+        assert legacy == expected

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -36,7 +36,7 @@ def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> 
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 
@@ -1368,7 +1368,7 @@ class TestPartialWatermarkAdvance:
             plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
             apply_plan(plan, judge=_update_judge("# ## A-en2"), watermark_cache=cache)
             wm_de = [
-                (p, s, r) for (p, s, r, _h) in cache.get_deck(str(de_path), str(en_path), "de")
+                (p, s, r) for (p, s, r, _h, _c) in cache.get_deck(str(de_path), str(en_path), "de")
             ]
         finally:
             cache.close()

--- a/tests/slides/test_sync_code_cells.py
+++ b/tests/slides/test_sync_code_cells.py
@@ -79,7 +79,7 @@ def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> 
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 

--- a/tests/slides/test_sync_code_e2e.py
+++ b/tests/slides/test_sync_code_e2e.py
@@ -310,7 +310,9 @@ def _seed_watermark(cache_dir: Path, de_path: Path, en_path: Path, de: str, en: 
                 de_path=str(de_path),
                 en_path=str(en_path),
                 lang=lang,
-                cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+                cells=[
+                    (c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells
+                ],
             )
     finally:
         wm.close()

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -211,3 +211,46 @@ def test_item3_changed_localized_code_is_still_retranslated(tmp_path: Path):
     # matches), so the translator WAS called for it.
     retranslated = [body for (_role, _sl, _tl, body) in translator.calls if "print(x)" in body]
     assert retranslated, f"a changed localized cell must be re-translated; got {translator.calls}"
+
+
+def test_item3_duplicate_construct_does_not_splice_wrong_twin(tmp_path: Path):
+    # Two id-less localized code cells in one group share a construct anchor
+    # (both `result = ...` -> construct:result). The reuse path must NOT splice an
+    # arbitrary first-match twin (which dropped one cell and duplicated the other —
+    # Issue #190 review, the critical finding). A non-unique anchor disables reuse;
+    # both cells translate, so both EN twins survive verbatim.
+    de = (
+        _slide("de", "g", "# ## G")
+        + _code_shared("import time")
+        + _code_localized_idless("de", "# A\nresult = compute_a()")
+        + _code_localized_idless("de", "# B\nresult = compute_b()")
+    )
+    en = (
+        _slide("en", "g", "# ## G")
+        + _code_shared("import time")
+        + _code_localized_idless("en", "# A\nresult = compute_a()")
+        + _code_localized_idless("en", "# B\nresult = compute_b()")
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")  # narrative edit -> direction
+            + _code_shared("import time\nimport os")  # neutral edit -> rebuild
+            + _code_localized_idless("de", "# A\nresult = compute_a()")  # unchanged
+            + _code_localized_idless("de", "# B\nresult = compute_b()"),  # unchanged
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    en_text = en_path.read_text(encoding="utf-8")
+    # Neither cell is dropped or duplicated — both bodies survive exactly once.
+    assert en_text.count("compute_a()") == 1
+    assert en_text.count("compute_b()") == 1

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1,17 +1,15 @@
-"""Executable documentation of the two *serious* ``clm slides sync`` limitations
-(Issue #190 items 2 & 3) as they behave **today**.
+"""Behavioral tests for the two *serious* ``clm slides sync`` limitations
+(Issue #190 items 2 & 3).
 
-These tests pin the broken-today behavior so the Phase 2/3 fixes have a precise
-flip-point and the no-op corpus harness has a mechanism to point at:
-
-* **item 2** — a code-only edit to a *language-neutral* shared cell produces no
-  proposal, so the sync silently fails to propagate it and the two split halves
-  diverge. Phase 3 (the anchor-keyed diff + deterministic copy-to-twin) makes
-  the edit propagate; flip ``test_item2_*`` then.
-* **item 3** — when a slide group is rebuilt for a *sibling's* sake, an unchanged
-  id-less localized code cell in it is re-translated, because its ``("L", kind)``
-  structural signature cannot prove it is unchanged. Phase 2 (anchor + content
-  hash verbatim reuse) splices it without translating; flip ``test_item3_*`` then.
+* **item 2** — *still broken (Phase 3 will fix)*: a code-only edit to a
+  *language-neutral* shared cell produces no proposal, so the sync silently fails
+  to propagate it and the two split halves diverge. ``test_item2_*`` pins the
+  broken-today behavior; flip it when Phase 3 (the anchor-keyed diff +
+  deterministic copy-to-twin) lands.
+* **item 3** — *FIXED (Phase 2)*: when a slide group is rebuilt for a *sibling's*
+  sake, an unchanged id-less localized code cell is spliced verbatim by its
+  content anchor instead of being re-translated. ``test_item3_*`` asserts the fix
+  (the translator is never called for the unchanged cell).
 
 Tiny synthetic decks, fast suite, no corpus, no network (the translator/judge
 are counting stand-ins).
@@ -26,7 +24,7 @@ from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import SyncProposal
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_apply import apply_plan
-from clm.slides.sync_plan import build_sync_plan, ordered_sync_cells
+from clm.slides.sync_plan import build_sync_plan, watermark_rows
 
 # ---------------------------------------------------------------------------
 # Deck builders + no-LLM spies
@@ -56,14 +54,14 @@ def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
 
 
 def _seed(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
-    for lang, path in (("de", de_path), ("en", en_path)):
-        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
-        cache.put_deck(
-            de_path=str(de_path),
-            en_path=str(en_path),
-            lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
-        )
+    """Seed the membership-widened watermark exactly as ``_record_watermark`` does."""
+    de_rows = watermark_rows(parse_cells(de_path.read_text(encoding="utf-8")))
+    en_rows = watermark_rows(parse_cells(en_path.read_text(encoding="utf-8")))
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="de", cells=de_rows["de"])
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="en", cells=en_rows["en"])
+    cache.put_deck(
+        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=de_rows["shared"]
+    )
 
 
 @dataclass
@@ -122,11 +120,12 @@ def test_item2_neutral_code_only_edit_is_silently_dropped(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# Item 3 — an unchanged id-less localized code cell is re-translated on rebuild
+# Item 3 — FIXED (Phase 2): an unchanged id-less localized code cell is spliced
+# verbatim on a sibling-triggered rebuild, never re-translated.
 # ---------------------------------------------------------------------------
 
 
-def test_item3_group_rebuild_retranslates_unchanged_localized_code(tmp_path: Path):
+def test_item3_unchanged_localized_code_is_reused_not_retranslated(tmp_path: Path):
     de = (
         _slide("de", "g", "# ## G")
         + _code_shared("import time")
@@ -160,10 +159,55 @@ def test_item3_group_rebuild_retranslates_unchanged_localized_code(tmp_path: Pat
 
     # The narrative edit is the only per-cell proposal; it supplies the direction.
     assert plan.count("edit") == 1
-    # TODAY: the unchanged localized code cell is re-translated as a bystander of
-    # the sibling-triggered group rebuild.
-    retranslated = [body for (role, _sl, _tl, body) in translator.calls if "Kommentar" in body]
-    assert retranslated, (
-        f"expected the unchanged localized code to be re-translated; got {translator.calls}"
+    # FIXED: the unchanged localized code cell (anchor construct:x, same content
+    # hash as baseline) is spliced verbatim — the translator is never called for it.
+    retranslated = [body for (_role, _sl, _tl, body) in translator.calls if "Kommentar" in body]
+    assert retranslated == [], (
+        f"unchanged localized code must be spliced verbatim, not re-translated; "
+        f"got {translator.calls}"
     )
-    # (Phase 2 splices it verbatim by anchor+hash; assert `retranslated == []` then.)
+    # The EN twin is preserved verbatim (still its own '# Comment', not a verbatim
+    # copy of DE's '# Kommentar' that a re-translation stand-in would have produced).
+    en_text = en_path.read_text(encoding="utf-8")
+    assert "# Comment" in en_text
+    assert "# Kommentar" not in en_text
+    # The sibling that triggered the rebuild (neutral code) still propagated.
+    assert "import os" in en_text
+
+
+def test_item3_changed_localized_code_is_still_retranslated(tmp_path: Path):
+    # The reuse must NOT over-fire: a genuinely EDITED localized code cell — same
+    # construct anchor (construct:x), different content hash — is re-translated,
+    # not spliced from the stale target twin.
+    de = (
+        _slide("de", "g", "# ## G")
+        + _code_shared("import time")
+        + _code_localized_idless("de", "# Kommentar\nx = 1")
+    )
+    en = (
+        _slide("en", "g", "# ## G")
+        + _code_shared("import time")
+        + _code_localized_idless("en", "# Comment\nx = 1")
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")  # narrative edit -> direction
+            + _code_shared("import time\nimport os")  # neutral edit -> rebuild
+            + _code_localized_idless("de", "# Kommentar\nx = 1\nprint(x)"),  # CHANGED body
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    # The changed localized cell was re-translated (its baseline hash no longer
+    # matches), so the translator WAS called for it.
+    retranslated = [body for (_role, _sl, _tl, body) in translator.calls if "print(x)" in body]
+    assert retranslated, f"a changed localized cell must be re-translated; got {translator.calls}"

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -62,7 +62,7 @@ def _seed(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 

--- a/tests/slides/test_sync_plan.py
+++ b/tests/slides/test_sync_plan.py
@@ -328,7 +328,7 @@ def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> 
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 

--- a/tests/slides/test_sync_plan_walker.py
+++ b/tests/slides/test_sync_plan_walker.py
@@ -64,7 +64,7 @@ def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> 
             de_path=str(de_path),
             en_path=str(en_path),
             lang=lang,
-            cells=[(c.position, c.slide_id, c.role, c.content_hash) for c in cells],
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
         )
 
 


### PR DESCRIPTION
## Issue #190 — Phase 1 (widen the watermark) + Phase 2 (item-3 fix)

Builds on Phase 0 (#191, merged). Design note: `docs/claude/design/sync-content-anchor-identity.md` (§4–§8, §13). Four commits, all additive to the #166 engine; the no-op corpus harness from Phase 0 stays green at **81/212 noop, 0 violations** through every commit — the no-behavior-change backstop.

### Phase 1a — content-anchor foundation
- `anchor_of` / `construct_of` chokepoint (`sync_writeback`): a cell's content-derived identity — **hand `slide_id` > AST construct slug (`extract_from_code`) > `sha256`** — prefixed so the three namespaces can't collide, hash via `cell_content_hash` for CRLF safety. Never written into the file.
- `SyncWatermarkCache` widened: additive `construct` column (+ALTER migration for pre-#190 DBs), 5-tuple `get_deck`/`put_deck`, `"shared"` partition accepted.
- `CurrentCell.construct` populated by `ordered_sync_cells`. Recorded **row set unchanged** → positions untouched.

### Phase 1b — membership widening
- `watermark_rows` records **every** non-j2 cell (de/en/`shared`) with synthetic `MEMBERSHIP_ROLES` for non-legacy cells, so Phase 2 can locate id-less localized / neutral cells.
- `_baseline_from_watermark` filters the synthetic rows **and re-indexes** the survivors into the legacy-only position space, so the classifier is byte-identical to before.

### Phase 2 — item 3 FIXED (the maintainer's "unacceptable" churn)
- `_rebuild_region` reuse path: an **unchanged** id-less localized code cell (its anchor is in the baseline with the same content hash) is spliced verbatim from the current target twin instead of re-translated. Plumbed via `_baseline_anchor_hashes` → `apply_code_structure(baseline_anchors)`.
- A **changed** cell still re-translates; hash-fallback cells never reuse (the honest §12 residual); no watermark → translate as before.

### Adversarial review fixes (last commit)
A 7-agent review found two real bugs (one **critical**), both fixed:
1. **Duplicate construct anchor** (two `import os`, two `def solution`): the old `{anchor: hash}` + first-match lookup could splice the **wrong** twin (drop one cell / duplicate the other — silent cross-deck corruption) or re-translate an unchanged cell. Fix: reuse only when the anchor is **unique on both sides** (`Counter` guard in `_baseline_anchor_hashes`, unique-match guard in `_find_by_anchor`); a non-unique anchor translates.
2. **Position space**: `_resolve_duplicates` compares positions by *absolute* difference, so the widened baseline positions flipped copy-paste "original" selection — fixed by the re-index above.

### Tests
- `test_sync_limitations.py`: item-3 flipped (unchanged → reused, translator never called; changed → still re-translated) + the duplicate-construct corruption regression (both EN twins survive).
- `test_sync_anchor.py`: anchor precedence, `watermark_rows` partitioning, legacy-subset == `ordered_sync_cells`, baseline re-index.
- `test_sync_cache.py`: `construct` roundtrip + `"shared"` partition + legacy-table ALTER migration.
- Full fast suite **6050 passed**; ruff + mypy clean.

Note: one incidental 4-line `ruff format` normalization of the unrelated `scripts/strip_cassette_hosts.py` rode along (the pre-commit `ruff-format` hook enforces it on touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)