### PR TITLE
feat(slides): item 2 — code-only changes propagate (#190 Phase 3)

### DIFF
--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -433,6 +433,29 @@ invariant. Gate releases on `pytest -m "not docker"`.
 3. **Item 2** (§7): the `align_anchored` pass (§6) + single-entity neutral model
    + auto-heal/warn. The largest new module; default-on-overridable (mirroring
    the #166 default-flip).
+   - **✅ Shipped (3a/3b/3c).** Chosen mechanism: **structural-pass reuse**, not
+     proposal-emission — `align_anchored` produces a direction (and a divergence
+     verdict); the existing `apply_code_structure` does the propagation.
+     **3a (neutral, §7a):** `align_anchored` compares the `shared` partition as an
+     *ordered hash sequence* (`_shared_hashes`, **not** an anchor map — a construct
+     anchor isn't content-unique, so a map collapses duplicates last-writer-wins;
+     this is the recurring guard, applied here too). It gates first on whether the
+     halves even disagree (robust to a pre-1b / no-`shared` watermark), then on
+     which side drifted vs baseline → `anchor_direction`, consumed by the
+     structural pass as a fallback when the keyed walk has none; the neutral cell's
+     `("S", body)` signature already differs, so its group rebuilds and `_copy_cell`
+     splices it verbatim (no LLM). **3b (localized id-less, §7b):** a body edit
+     leaves the `("L", kind)` signature unchanged, so `apply_code_structure`
+     force-rebuilds a group when it holds a localized id-less cell whose anchor is
+     in the (Counter-deduped) baseline with a changed hash; the changed cell is
+     re-translated, unchanged siblings reused (Phase 2). **3c (divergence, §7a):**
+     a shared cell edited differently on both decks → `_resolve_divergence_winner`
+     (keyed direction → newer mtime → none); auto-heal propagates the winner with a
+     *warning* (default), `CLM_SYNC__SHARED_DIVERGENCE=error` surfaces it as an
+     error and (via the Phase 0 buffered swap) writes nothing. The no-op harness
+     held at 81/212, 0 violations through all three. Residuals: an *isolated*
+     localized-only edit with no other direction signal, and a construct-renaming
+     edit, are §10 territory.
 4. **Deterministic `def-my-fun` id-migration** (§9): the one gated file-write,
    strictly scoped to already-id'd, drifted cells; symmetric localized chokepoint.
 5. **Bounded Opus recovery** (§10): `sync_alignments` table; `--llm-recover`

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -61,6 +61,7 @@ from clm.slides.sync_writeback import (
     build_twin_cell,
     cell_content_hash,
     role_of,
+    row_anchor,
 )
 
 if TYPE_CHECKING:
@@ -1076,20 +1077,6 @@ def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
     return index
 
 
-def _row_anchor(slide_id: str | None, construct: str | None, content_hash: str) -> str:
-    """The content anchor of a watermark row (mirrors :func:`sync_writeback.anchor_of`).
-
-    Derives the same ``id: > construct: > hash:`` identity from a stored row that
-    ``anchor_of`` derives from a live cell, so the structural pass can match a
-    current cell against its baseline by anchor.
-    """
-    if slide_id is not None:
-        return f"id:{slide_id}"
-    if construct is not None:
-        return f"construct:{construct}"
-    return f"hash:{content_hash}"
-
-
 def _baseline_anchor_hashes(
     cache: SyncWatermarkCache | None,
     de_path: Path,
@@ -1108,7 +1095,7 @@ def _baseline_anchor_hashes(
         return out
     for lang in ("de", "en"):
         rows = cache.get_deck(str(de_path), str(en_path), lang)
-        anchors = [_row_anchor(sid, construct, chash) for (_p, sid, _r, chash, construct) in rows]
+        anchors = [row_anchor(sid, construct, chash) for (_p, sid, _r, chash, construct) in rows]
         # A construct anchor is only a *name* (``extract_from_code``), so it is not
         # content-unique: two cells sharing it (two ``import os``, two
         # ``def solution``) cannot be told apart by anchor. Admit an anchor to the

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -19,17 +19,21 @@ each *changed* slide group from the source deck:
 - a **language-neutral** cell is copied verbatim;
 - an **id-less localized** cell is translated.
 
-A group is rebuilt only when its *structural signature* (the order of role
-cells, the verbatim text of shared cells, and the kinds of id-less localized
-cells — all language-agnostic) differs between source and target. A pure
-narrative edit leaves the signature unchanged, so narrative-only passes never
-touch a group here. Cells the author **moved between groups** fall out for free,
-because each group is rebuilt from its current source membership.
+A group is rebuilt when its *structural signature* (the order of role cells, the
+verbatim text of shared cells, and the kinds of id-less localized cells — all
+language-agnostic) differs between source and target, **or** when it holds an
+id-less localized cell whose content drifted from the baseline (Issue #190 item
+2b: a body edit leaves the ``("L", kind)`` signature unchanged, so the drift is
+detected against the widened watermark instead). A pure narrative edit leaves
+both unchanged, so narrative-only passes never touch a group here. Cells the
+author **moved between groups** fall out for free, because each group is rebuilt
+from its current source membership.
 
-Direction is taken from the run's narrative proposals (the single-language
-workflow edits one deck): a uniform ``en->de`` / ``de->en`` selects the source.
-A pass with no determinable single direction (cold start, or cells edited both
-ways) skips this structural step.
+Direction is the run's single propagation direction: the keyed narrative
+proposals when present, else the ``anchor_direction`` the item-2 detector
+inferred from which half drifted its language-neutral cells (Issue #190 §7). A
+pass with no determinable direction (cold start, or cells edited both ways) skips
+this structural step.
 """
 
 from __future__ import annotations
@@ -111,7 +115,9 @@ def apply_code_structure(
             rebuilt_ids.update(id(c) for c in region)
 
     def reconcile(src_region: list[RawCell], tgt_region: list[RawCell]) -> None:
-        if _signature(src_region) == _signature(tgt_region):
+        if _signature(src_region) == _signature(tgt_region) and not _region_has_localized_drift(
+            src_region, src_anchors
+        ):
             emit(tgt_region, was_rebuilt=False)
             return
         rebuilt = _rebuild_region(
@@ -230,6 +236,33 @@ def _signature(cells: list[RawCell]) -> list[tuple]:
         else:
             sig.append(("L", "code" if meta.cell_type == "code" else "markdown"))
     return sig
+
+
+def _region_has_localized_drift(
+    src_region: list[RawCell], src_anchors: dict[str, str] | None
+) -> str | None:
+    """Whether the source region holds an id-less localized cell edited since baseline.
+
+    Item-2b (§7b). A localized id-less code cell that changed must be re-translated,
+    but its ``("L", kind)`` signature is unchanged by a body edit, so the group
+    would not otherwise rebuild. Detect the drift via the baseline anchor→hash map
+    (``baseline_anchors`` for the source language): the cell's anchor is recorded
+    but its current content hash differs. Returns the drifted cell's anchor (truthy)
+    or ``None``. ``src_anchors`` is already de-duplicated (the Phase 2 ``Counter``
+    guard), so a non-unique construct anchor is simply absent — that cell does not
+    force a rebuild (the honest §12 residual), never a wrong one.
+    """
+    if not src_anchors:
+        return None
+    for cell in src_region:
+        meta = cell.metadata
+        if meta.is_j2 or meta.lang is None or role_of(meta) is not None:
+            continue  # only id-less LOCALIZED cells (role_of None, lang set)
+        anchor = anchor_of(meta, cell.body)
+        baseline_hash = src_anchors.get(anchor)
+        if baseline_hash is not None and baseline_hash != cell_content_hash(cell.body):
+            return anchor
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -77,6 +77,13 @@ def apply_code_structure(
     """
     direction = _single_direction(plan)
     if direction is None:
+        # Item-2 fallback (Issue #190 §7): a code-only change to a language-neutral
+        # cell produces no keyed proposal, so the keyed walk yields no direction.
+        # The anchor diff (build_sync_plan) detected which half drifted — use it so
+        # the neutral cell is copied verbatim to its twin (the group's ("S", body)
+        # signature already differs, so it rebuilds).
+        direction = plan.anchor_direction
+    if direction is None:
         return
     if direction == "en->de":
         source_state, target_state, source_lang, target_lang = en_state, de_state, "en", "de"

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -35,18 +35,25 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.notebooks.slide_parser import Cell, CellMetadata, parse_cells
-from clm.slides.sync_writeback import cell_content_hash, construct_of, role_of
+from clm.slides.sync_writeback import (
+    cell_content_hash,
+    construct_of,
+    role_of,
+    row_anchor,
+)
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.cache import SyncWatermarkCache
 
 __all__ = [
     "MEMBERSHIP_ROLES",
+    "AnchorAlignment",
     "BaselineCell",
     "CurrentCell",
     "PlanIssue",
     "Proposal",
     "SyncPlan",
+    "align_anchored",
     "build_sync_plan",
     "classify_changes",
     "ordered_sync_cells",
@@ -155,6 +162,10 @@ class SyncPlan:
     proposals: list[Proposal] = field(default_factory=list)
     issues: list[PlanIssue] = field(default_factory=list)
     in_sync_count: int = 0
+    # Direction a code-only (language-neutral) change must propagate when the
+    # keyed classifier found none — the Issue #190 item-2 signal. ``None`` when
+    # no non-keyed cell drifted. Consumed by the structural pass (sync_code).
+    anchor_direction: str | None = None
 
     @property
     def has_baseline(self) -> bool:
@@ -166,8 +177,12 @@ class SyncPlan:
 
     @property
     def is_noop(self) -> bool:
-        """True when there is nothing to apply (and nothing went wrong)."""
-        return not self.proposals and not self.has_errors
+        """True when there is nothing to apply (and nothing went wrong).
+
+        A neutral code-only edit (item 2) produces no proposal but sets
+        ``anchor_direction``, so it is *not* a no-op even with an empty plan.
+        """
+        return not self.proposals and not self.has_errors and self.anchor_direction is None
 
     def count(self, kind: str) -> int:
         return sum(1 for p in self.proposals if p.kind == kind)
@@ -287,6 +302,61 @@ def watermark_rows(
         )
         pos[partition] += 1
     return out
+
+
+def _shared_anchor_map(cells: list[Cell]) -> dict[str, str]:
+    """``anchor -> content_hash`` for the language-neutral (``shared``) cells of a file.
+
+    The non-keyed half of the item-2 picture: cells the per-cell classifier never
+    sees. Keyed off the same partitioning as :func:`watermark_rows`, so a current
+    file and its watermark baseline are compared apples-to-apples.
+    """
+    return {
+        row_anchor(sid, construct, chash): chash
+        for (_pos, sid, _role, chash, construct) in watermark_rows(cells)["shared"]
+    }
+
+
+@dataclass(frozen=True)
+class AnchorAlignment:
+    """Which side's language-neutral cells drifted from the watermark baseline."""
+
+    direction: str | None  # "de->en" | "en->de" | None
+    diverged: bool  # both sides drifted the shared cells (the §7a conflict)
+
+
+def align_anchored(
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    baseline_shared: dict[str, str],
+) -> AnchorAlignment:
+    """Detect a code-only (language-neutral) change the keyed classifier missed.
+
+    Issue #190 item 2 (Phase 3a). A neutral shared cell is byte-identical across
+    the split halves (the ``unify`` invariant), and the keyed engine never sees
+    it — so an author editing one half alone yields no proposal and no direction,
+    and the change is silently dropped.
+
+    First gate on whether the halves even **disagree**: if every neutral cell is
+    byte-identical across de and en, ``unify`` holds and there is nothing to
+    propagate, *whatever the baseline says*. This is the common case and it keeps
+    the pass robust to a watermark with no recorded ``shared`` partition — a
+    deck with no neutral cells, or a baseline written by a pre-Phase-1b CLM — which
+    must not be mistaken for a divergence. Only when the halves disagree do we
+    consult the baseline to decide which side drifted (the propagation direction);
+    if the baseline can't disambiguate, it is a divergence (handled in Phase 3c).
+    """
+    de_shared = _shared_anchor_map(de_cells)
+    en_shared = _shared_anchor_map(en_cells)
+    if de_shared == en_shared:
+        return AnchorAlignment(direction=None, diverged=False)
+    de_drifted = de_shared != baseline_shared
+    en_drifted = en_shared != baseline_shared
+    if de_drifted and not en_drifted:
+        return AnchorAlignment(direction="de->en", diverged=False)
+    if en_drifted and not de_drifted:
+        return AnchorAlignment(direction="en->de", diverged=False)
+    return AnchorAlignment(direction=None, diverged=True)
 
 
 def _baseline_from_watermark(
@@ -917,6 +987,7 @@ def build_sync_plan(
 
     de_baseline: list[BaselineCell] | None = None
     en_baseline: list[BaselineCell] | None = None
+    baseline_shared: dict[str, str] | None = None
     source = "none"
 
     if watermark_cache is not None and watermark_cache.has_pair(str(de_path), str(en_path)):
@@ -926,6 +997,12 @@ def build_sync_plan(
         en_baseline = _baseline_from_watermark(
             watermark_cache.get_deck(str(de_path), str(en_path), "en")
         )
+        baseline_shared = {
+            row_anchor(sid, construct, chash): chash
+            for (_pos, sid, _role, chash, construct) in watermark_cache.get_deck(
+                str(de_path), str(en_path), "shared"
+            )
+        }
         source = "watermark"
     elif allow_git_fallback:
         gb_de = _baseline_from_git_head(de_path)
@@ -934,7 +1011,7 @@ def build_sync_plan(
             de_baseline, en_baseline = gb_de, gb_en
             source = "git-head"
 
-    return classify_changes(
+    plan = classify_changes(
         de_current,
         en_current,
         de_baseline,
@@ -943,6 +1020,27 @@ def build_sync_plan(
         en_path=en_path,
         baseline_source=source,
     )
+
+    # Item-2 (Phase 3a): detect a language-neutral code-only change the keyed
+    # classifier cannot see, and hand its direction to the structural pass. Only
+    # against a real (watermark) baseline; the keyed direction, when present,
+    # already drives the structural pass, so the anchor direction is a *fallback*.
+    if baseline_shared is not None:
+        alignment = align_anchored(de_cells, en_cells, baseline_shared)
+        if alignment.diverged:
+            plan.issues.append(
+                PlanIssue(
+                    severity="warning",
+                    slide_id=None,
+                    reason="a language-neutral cell drifted on both decks; not "
+                    "propagated (resolve manually) — shared-divergence auto-heal "
+                    "is pending Phase 3c",
+                )
+            )
+        else:
+            plan.anchor_direction = alignment.direction
+
+    return plan
 
 
 def render_plan(plan: SyncPlan) -> str:

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -39,7 +39,6 @@ from clm.slides.sync_writeback import (
     cell_content_hash,
     construct_of,
     role_of,
-    row_anchor,
 )
 
 if TYPE_CHECKING:
@@ -304,17 +303,22 @@ def watermark_rows(
     return out
 
 
-def _shared_anchor_map(cells: list[Cell]) -> dict[str, str]:
-    """``anchor -> content_hash`` for the language-neutral (``shared``) cells of a file.
+def _shared_hashes(cells: list[Cell]) -> list[str]:
+    """Ordered content hashes of the language-neutral (``shared``) cells of a file.
 
-    The non-keyed half of the item-2 picture: cells the per-cell classifier never
-    sees. Keyed off the same partitioning as :func:`watermark_rows`, so a current
-    file and its watermark baseline are compared apples-to-apples.
+    An **ordered sequence**, deliberately *not* an ``anchor -> hash`` map: a
+    construct anchor is only a name (``extract_from_code``), so it is not
+    content-unique — two neutral cells sharing one (two ``import os``, two
+    ``def solution``, two ``print(...)``) would collapse last-writer-wins in a map
+    and hide a one-sided edit to the non-last one, silently reintroducing the very
+    item-2 drop this detects (Issue #190 review). The ``shared`` partition is
+    intrinsically ordered (``watermark_rows`` records positions) and byte-identical
+    across halves under ``unify``, so an ordered-hash compare is simultaneously the
+    unify check (de == en) and the drift check (current vs baseline), with no
+    anchor-uniqueness assumption — mirroring the Counter / unique-match guards the
+    Phase 2 anchor paths already apply.
     """
-    return {
-        row_anchor(sid, construct, chash): chash
-        for (_pos, sid, _role, chash, construct) in watermark_rows(cells)["shared"]
-    }
+    return [chash for (_pos, _sid, _role, chash, _construct) in watermark_rows(cells)["shared"]]
 
 
 @dataclass(frozen=True)
@@ -328,7 +332,7 @@ class AnchorAlignment:
 def align_anchored(
     de_cells: list[Cell],
     en_cells: list[Cell],
-    baseline_shared: dict[str, str],
+    baseline_shared: list[str],
 ) -> AnchorAlignment:
     """Detect a code-only (language-neutral) change the keyed classifier missed.
 
@@ -346,8 +350,8 @@ def align_anchored(
     consult the baseline to decide which side drifted (the propagation direction);
     if the baseline can't disambiguate, it is a divergence (handled in Phase 3c).
     """
-    de_shared = _shared_anchor_map(de_cells)
-    en_shared = _shared_anchor_map(en_cells)
+    de_shared = _shared_hashes(de_cells)
+    en_shared = _shared_hashes(en_cells)
     if de_shared == en_shared:
         return AnchorAlignment(direction=None, diverged=False)
     de_drifted = de_shared != baseline_shared
@@ -987,7 +991,7 @@ def build_sync_plan(
 
     de_baseline: list[BaselineCell] | None = None
     en_baseline: list[BaselineCell] | None = None
-    baseline_shared: dict[str, str] | None = None
+    baseline_shared: list[str] | None = None
     source = "none"
 
     if watermark_cache is not None and watermark_cache.has_pair(str(de_path), str(en_path)):
@@ -997,12 +1001,15 @@ def build_sync_plan(
         en_baseline = _baseline_from_watermark(
             watermark_cache.get_deck(str(de_path), str(en_path), "en")
         )
-        baseline_shared = {
-            row_anchor(sid, construct, chash): chash
-            for (_pos, sid, _role, chash, construct) in watermark_cache.get_deck(
+        # Ordered content hashes of the baseline's neutral cells (position order),
+        # matching _shared_hashes — see align_anchored for why this is a sequence,
+        # not an anchor map.
+        baseline_shared = [
+            chash
+            for (_pos, _sid, _role, chash, _construct) in watermark_cache.get_deck(
                 str(de_path), str(en_path), "shared"
             )
-        }
+        ]
         source = "watermark"
     elif allow_git_fallback:
         gb_de = _baseline_from_git_head(de_path)

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -29,10 +29,14 @@ since the last sync* — a git-immune signal that survives committing the deck.
 
 from __future__ import annotations
 
+import logging
+import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 from clm.notebooks.slide_parser import Cell, CellMetadata, parse_cells
 from clm.slides.sync_writeback import (
@@ -361,6 +365,54 @@ def align_anchored(
     if en_drifted and not de_drifted:
         return AnchorAlignment(direction="en->de", diverged=False)
     return AnchorAlignment(direction=None, diverged=True)
+
+
+# ``CLM_SYNC__SHARED_DIVERGENCE`` (the §7a knob): how to handle a language-neutral
+# cell edited differently on both decks. ``auto-heal`` propagates the winning side
+# with a warning; ``error`` surfaces it and writes nothing.
+_SHARED_DIVERGENCE_ENV = "CLM_SYNC__SHARED_DIVERGENCE"
+
+
+def _shared_divergence_mode() -> str:
+    """The ``sync.shared_divergence`` mode: ``auto-heal`` (default) or ``error``."""
+    value = os.environ.get(_SHARED_DIVERGENCE_ENV, "auto-heal").strip().lower()
+    if value not in ("auto-heal", "error"):
+        logger.warning(
+            "%s=%r is invalid (expected 'auto-heal' or 'error'); using 'auto-heal'",
+            _SHARED_DIVERGENCE_ENV,
+            value,
+        )
+        return "auto-heal"
+    return value
+
+
+def _keyed_direction(plan: SyncPlan) -> str | None:
+    """The single keyed propagation direction of the plan, or ``None``."""
+    directions = {p.direction for p in plan.proposals if p.direction in ("de->en", "en->de")}
+    return next(iter(directions)) if len(directions) == 1 else None
+
+
+def _resolve_divergence_winner(plan: SyncPlan, de_path: Path, en_path: Path) -> str | None:
+    """Pick the winning direction for a diverged shared cell (§7a), or ``None``.
+
+    Precedence: (i) the run's established keyed edit direction (the deck the author
+    touched this session — the common case); else (ii) the newer-mtime file as a
+    tiebreak; else (iii) ``None`` — no signal, cannot heal, treat as an error even
+    in auto-heal mode.
+    """
+    keyed = _keyed_direction(plan)
+    if keyed is not None:
+        return keyed
+    try:
+        de_mtime = de_path.stat().st_mtime
+        en_mtime = en_path.stat().st_mtime
+    except OSError:
+        return None
+    if de_mtime > en_mtime:
+        return "de->en"
+    if en_mtime > de_mtime:
+        return "en->de"
+    return None
 
 
 def _baseline_from_watermark(
@@ -1035,19 +1087,49 @@ def build_sync_plan(
     if baseline_shared is not None:
         alignment = align_anchored(de_cells, en_cells, baseline_shared)
         if alignment.diverged:
-            plan.issues.append(
-                PlanIssue(
-                    severity="warning",
-                    slide_id=None,
-                    reason="a language-neutral cell drifted on both decks; not "
-                    "propagated (resolve manually) — shared-divergence auto-heal "
-                    "is pending Phase 3c",
-                )
-            )
+            _apply_divergence(plan, de_path, en_path)
         else:
             plan.anchor_direction = alignment.direction
 
     return plan
+
+
+def _apply_divergence(plan: SyncPlan, de_path: Path, en_path: Path) -> None:
+    """Resolve a both-decks shared-cell divergence per the §7a policy.
+
+    ``auto-heal`` (default): propagate the winning side (keyed direction → newer
+    mtime) and emit a *warning*; the heal is written but the watermark is held by
+    the issue, so a second run confirms it. ``error`` mode — or auto-heal with no
+    determinable winner — emits an *error* issue, so the buffered apply writes
+    nothing and the divergence is surfaced rather than guessed.
+    """
+    mode = _shared_divergence_mode()
+    winner = _resolve_divergence_winner(plan, de_path, en_path)
+    if winner is not None and mode == "auto-heal":
+        plan.anchor_direction = winner
+        plan.issues.append(
+            PlanIssue(
+                severity="warning",
+                slide_id=None,
+                reason=f"a language-neutral cell diverged on both decks; auto-healed "
+                f"toward {winner} (set CLM_SYNC__SHARED_DIVERGENCE=error to surface "
+                f"instead) — review the git diff",
+            )
+        )
+    else:
+        detail = (
+            "CLM_SYNC__SHARED_DIVERGENCE=error"
+            if winner is not None
+            else "no winner (edited on both decks, mtimes tie)"
+        )
+        plan.issues.append(
+            PlanIssue(
+                severity="error",
+                slide_id=None,
+                reason=f"a language-neutral cell diverged on both decks; {detail} — "
+                f"resolve manually",
+            )
+        )
 
 
 def render_plan(plan: SyncPlan) -> str:

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -327,10 +327,22 @@ def _shared_hashes(cells: list[Cell]) -> list[str]:
 
 @dataclass(frozen=True)
 class AnchorAlignment:
-    """Which side's language-neutral cells drifted from the watermark baseline."""
+    """How the language-neutral cells drifted, and what the sync should do.
 
-    direction: str | None  # "de->en" | "en->de" | None
-    diverged: bool  # both sides drifted the shared cells (the §7a conflict)
+    - ``direction`` set, ``diverged``/``irreconcilable`` false → a clean one-sided
+      drift to propagate.
+    - ``diverged`` → a *same-cell* §7a conflict (both decks edited the same neutral
+      cell differently); apply the §7a winner policy. ``direction``, if set, is the
+      only **safe** healing direction (the other side also has independent edits to
+      preserve); ``None`` means either direction is safe → use winner-selection.
+    - ``irreconcilable`` → the two decks edited **different** neutral cells, so no
+      single propagation direction can reconcile them without reverting one →
+      surface an error, never auto-heal (Issue #190 Phase 3c review).
+    """
+
+    direction: str | None
+    diverged: bool = False
+    irreconcilable: bool = False
 
 
 def align_anchored(
@@ -340,30 +352,71 @@ def align_anchored(
 ) -> AnchorAlignment:
     """Detect a code-only (language-neutral) change the keyed classifier missed.
 
-    Issue #190 item 2 (Phase 3a). A neutral shared cell is byte-identical across
+    Issue #190 item 2 (Phase 3a/3c). A neutral shared cell is byte-identical across
     the split halves (the ``unify`` invariant), and the keyed engine never sees
     it — so an author editing one half alone yields no proposal and no direction,
     and the change is silently dropped.
 
     First gate on whether the halves even **disagree**: if every neutral cell is
     byte-identical across de and en, ``unify`` holds and there is nothing to
-    propagate, *whatever the baseline says*. This is the common case and it keeps
-    the pass robust to a watermark with no recorded ``shared`` partition — a
-    deck with no neutral cells, or a baseline written by a pre-Phase-1b CLM — which
-    must not be mistaken for a divergence. Only when the halves disagree do we
-    consult the baseline to decide which side drifted (the propagation direction);
-    if the baseline can't disambiguate, it is a divergence (handled in Phase 3c).
+    propagate, *whatever the baseline says*. This keeps the pass robust to a
+    watermark with no recorded ``shared`` partition (a deck with no neutral cells,
+    or a pre-Phase-1b baseline), which must not be mistaken for a divergence.
+
+    When the halves disagree, classify **per cell** (positionally) against the
+    baseline — a whole-file verdict would conflate "de edited cell A, en edited a
+    *different* cell B" (two compatible edits) with a real conflict, and then
+    auto-healing one direction would silently revert the other's edit (the Phase 3c
+    review's data-loss finding). A *loser-only* drift (a cell one half changed and
+    the other left at baseline) cannot be overwritten safely; if both halves have
+    one, no single direction is safe → irreconcilable.
     """
     de_shared = _shared_hashes(de_cells)
     en_shared = _shared_hashes(en_cells)
     if de_shared == en_shared:
-        return AnchorAlignment(direction=None, diverged=False)
-    de_drifted = de_shared != baseline_shared
-    en_drifted = en_shared != baseline_shared
-    if de_drifted and not en_drifted:
-        return AnchorAlignment(direction="de->en", diverged=False)
-    if en_drifted and not de_drifted:
-        return AnchorAlignment(direction="en->de", diverged=False)
+        return AnchorAlignment(direction=None)
+
+    if not baseline_shared:
+        # The halves disagree but no ``shared`` baseline was recorded (a
+        # pre-Phase-1b watermark, or a deck synced before membership widening).
+        # We cannot tell which half drifted, so defer entirely to the keyed
+        # direction rather than inventing a divergence/error. A later clean sync
+        # records the partition, after which analysis proceeds normally.
+        return AnchorAlignment(direction=None)
+
+    # Positional classification needs the three sequences aligned; a length change
+    # means a neutral cell was added/removed. Then a one-sided structural change is
+    # a clean direction, but a both-sided one cannot be positionally reconciled.
+    if not (len(de_shared) == len(en_shared) == len(baseline_shared)):
+        de_drifted = de_shared != baseline_shared
+        en_drifted = en_shared != baseline_shared
+        if de_drifted and not en_drifted:
+            return AnchorAlignment(direction="de->en")
+        if en_drifted and not de_drifted:
+            return AnchorAlignment(direction="en->de")
+        return AnchorAlignment(direction=None, irreconcilable=True)
+
+    de_only = en_only = conflict = False
+    for d, e, b in zip(de_shared, en_shared, baseline_shared, strict=True):
+        if d == e:
+            continue
+        if d != b and e != b:
+            conflict = True  # same cell, both edited differently — the §7a case
+        elif d != b:
+            de_only = True  # de edited a cell en left at baseline
+        else:
+            en_only = True  # en edited a cell de left at baseline
+
+    if de_only and en_only:
+        # Independent edits to DIFFERENT neutral cells — a single direction would
+        # revert one. Refuse to guess.
+        return AnchorAlignment(direction=None, irreconcilable=True)
+    if de_only:
+        # de carries the only loser-safe edits; de->en is the one safe direction.
+        return AnchorAlignment(direction="de->en", diverged=conflict)
+    if en_only:
+        return AnchorAlignment(direction="en->de", diverged=conflict)
+    # Only same-cell conflicts: either direction is §7a-safe → winner-selection.
     return AnchorAlignment(direction=None, diverged=True)
 
 
@@ -1086,25 +1139,39 @@ def build_sync_plan(
     # already drives the structural pass, so the anchor direction is a *fallback*.
     if baseline_shared is not None:
         alignment = align_anchored(de_cells, en_cells, baseline_shared)
-        if alignment.diverged:
-            _apply_divergence(plan, de_path, en_path)
+        if alignment.irreconcilable:
+            plan.issues.append(
+                PlanIssue(
+                    severity="error",
+                    slide_id=None,
+                    reason="language-neutral cells were edited independently on both "
+                    "decks (different cells); a single-direction sync cannot reconcile "
+                    "them without reverting one — resolve manually",
+                )
+            )
+        elif alignment.diverged:
+            _apply_divergence(plan, de_path, en_path, forced=alignment.direction)
         else:
             plan.anchor_direction = alignment.direction
 
     return plan
 
 
-def _apply_divergence(plan: SyncPlan, de_path: Path, en_path: Path) -> None:
-    """Resolve a both-decks shared-cell divergence per the §7a policy.
+def _apply_divergence(
+    plan: SyncPlan, de_path: Path, en_path: Path, *, forced: str | None = None
+) -> None:
+    """Resolve a same-cell shared divergence per the §7a policy.
 
-    ``auto-heal`` (default): propagate the winning side (keyed direction → newer
-    mtime) and emit a *warning*; the heal is written but the watermark is held by
-    the issue, so a second run confirms it. ``error`` mode — or auto-heal with no
-    determinable winner — emits an *error* issue, so the buffered apply writes
-    nothing and the divergence is surfaced rather than guessed.
+    ``auto-heal`` (default): propagate the winning side and emit a *warning*; the
+    heal is written but the watermark is held by the issue, so a second run
+    confirms it. ``error`` mode — or auto-heal with no determinable winner — emits
+    an *error* issue, so the buffered apply writes nothing and the divergence is
+    surfaced rather than guessed. ``forced`` is the only loser-safe direction when
+    one side also carries independent edits; otherwise the winner is selected
+    (keyed direction → newer mtime).
     """
     mode = _shared_divergence_mode()
-    winner = _resolve_divergence_winner(plan, de_path, en_path)
+    winner = forced if forced is not None else _resolve_divergence_winner(plan, de_path, en_path)
     if winner is not None and mode == "auto-heal":
         plan.anchor_direction = winner
         plan.issues.append(

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -43,6 +43,7 @@ __all__ = [
     "construct_of",
     "record_snapshot",
     "role_of",
+    "row_anchor",
     "swap_lang",
     "target_path_for_outcome",
 ]
@@ -178,6 +179,20 @@ def anchor_of(metadata: CellMetadata, body: str) -> str:
     if construct is not None:
         return f"construct:{construct}"
     return f"hash:{cell_content_hash(body)}"
+
+
+def row_anchor(slide_id: str | None, construct: str | None, content_hash: str) -> str:
+    """The content anchor of a stored watermark row — the row-side :func:`anchor_of`.
+
+    Derives the same ``id: > construct: > hash:`` identity from a persisted row
+    that :func:`anchor_of` derives from a live cell, so the anchor passes can match
+    a current cell against its baseline. The two must stay in lockstep.
+    """
+    if slide_id is not None:
+        return f"id:{slide_id}"
+    if construct is not None:
+        return f"construct:{construct}"
+    return f"hash:{content_hash}"
 
 
 _LANG_ATTR_RE = re.compile(r'lang="[^"]*"')

--- a/tests/slides/test_sync_anchor.py
+++ b/tests/slides/test_sync_anchor.py
@@ -12,7 +12,7 @@ from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_plan import (
     MEMBERSHIP_ROLES,
     _baseline_from_watermark,
-    _shared_anchor_map,
+    _shared_hashes,
     align_anchored,
     ordered_sync_cells,
     watermark_rows,
@@ -162,7 +162,7 @@ class TestAlignAnchored:
         assert not a.diverged
 
     def test_de_drift_gives_de_to_en(self):
-        baseline = _shared_anchor_map(parse_cells(self._BASE))
+        baseline = _shared_hashes(parse_cells(self._BASE))
         de = '# %% tags=["keep"]\nimport time\nx = 1\n'  # DE edited the shared cell
         en = self._BASE  # EN unchanged
         a = align_anchored(parse_cells(de), parse_cells(en), baseline)
@@ -170,7 +170,7 @@ class TestAlignAnchored:
         assert not a.diverged
 
     def test_en_drift_gives_en_to_de(self):
-        baseline = _shared_anchor_map(parse_cells(self._BASE))
+        baseline = _shared_hashes(parse_cells(self._BASE))
         de = self._BASE
         en = '# %% tags=["keep"]\nimport time\nx = 1\n'
         a = align_anchored(parse_cells(de), parse_cells(en), baseline)
@@ -178,9 +178,22 @@ class TestAlignAnchored:
         assert not a.diverged
 
     def test_both_sides_drift_diverges(self):
-        baseline = _shared_anchor_map(parse_cells(self._BASE))
+        baseline = _shared_hashes(parse_cells(self._BASE))
         de = '# %% tags=["keep"]\nimport time\nx = 1\n'  # DE: -> construct x
         en = '# %% tags=["keep"]\nimport time\ny = 2\n'  # EN: -> construct y (differs)
         a = align_anchored(parse_cells(de), parse_cells(en), baseline)
         assert a.diverged
         assert a.direction is None
+
+    def test_duplicate_construct_non_last_edit_is_not_masked(self):
+        # Two neutral cells share construct:print. Editing the NON-LAST one on DE
+        # must still be detected — an anchor map would collapse last-writer-wins
+        # and silently drop it (Issue #190 review). The ordered-hash compare sees
+        # it.
+        base = '# %% tags=["keep"]\nprint("a")\n# %% tags=["keep"]\nprint("b")\n'
+        de = '# %% tags=["keep"]\nprint("z")\n# %% tags=["keep"]\nprint("b")\n'  # P1 edited
+        en = base  # EN unchanged
+        baseline = _shared_hashes(parse_cells(base))
+        a = align_anchored(parse_cells(de), parse_cells(en), baseline)
+        assert a.direction == "de->en"
+        assert not a.diverged

--- a/tests/slides/test_sync_anchor.py
+++ b/tests/slides/test_sync_anchor.py
@@ -185,6 +185,28 @@ class TestAlignAnchored:
         assert a.diverged
         assert a.direction is None
 
+    def test_empty_baseline_defers_even_when_halves_disagree(self):
+        # A pre-Phase-1b watermark (no shared partition) + a real one-sided neutral
+        # edit: we can't tell which half drifted, so defer to the keyed direction —
+        # NOT a divergence/error (which would falsely block a legit edit).
+        de = '# %% tags=["keep"]\nimport time\n'
+        en = '# %% tags=["keep"]\nimport time\nx = 1\n'  # halves disagree
+        a = align_anchored(parse_cells(de), parse_cells(en), [])  # empty baseline
+        assert a.direction is None
+        assert not a.diverged
+        assert not a.irreconcilable
+
+    def test_independent_cross_cell_edits_are_irreconcilable(self):
+        # DE edits cell A, EN edits a DIFFERENT cell B (positional): no single
+        # direction is safe -> irreconcilable (never silently revert one).
+        base = '# %% tags=["keep"]\nA = 1\n# %% tags=["keep"]\nB = 1\n'
+        de = '# %% tags=["keep"]\nA = 2\n# %% tags=["keep"]\nB = 1\n'  # DE edited A
+        en = '# %% tags=["keep"]\nA = 1\n# %% tags=["keep"]\nB = 2\n'  # EN edited B
+        baseline = _shared_hashes(parse_cells(base))
+        a = align_anchored(parse_cells(de), parse_cells(en), baseline)
+        assert a.irreconcilable
+        assert a.direction is None
+
     def test_duplicate_construct_non_last_edit_is_not_masked(self):
         # Two neutral cells share construct:print. Editing the NON-LAST one on DE
         # must still be detected — an anchor map would collapse last-writer-wins

--- a/tests/slides/test_sync_anchor.py
+++ b/tests/slides/test_sync_anchor.py
@@ -12,6 +12,8 @@ from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_plan import (
     MEMBERSHIP_ROLES,
     _baseline_from_watermark,
+    _shared_anchor_map,
+    align_anchored,
     ordered_sync_cells,
     watermark_rows,
 )
@@ -142,3 +144,43 @@ class TestWatermarkRows:
             (0, "dup", "slide"),
             (1, "dup", "voiceover"),
         ]
+
+
+class TestAlignAnchored:
+    """The Issue #190 item-2 direction detector (Phase 3a)."""
+
+    _BASE = '# %% tags=["keep"]\nimport time\n'
+
+    def test_halves_agree_is_noop_even_with_empty_baseline(self):
+        # The robustness gate: if both halves agree on every neutral cell (unify
+        # holds), there is nothing to propagate regardless of the baseline — incl.
+        # an empty baseline from a pre-Phase-1b watermark.
+        de = '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# T\n' + self._BASE
+        en = '# %% [markdown] lang="en" tags=["slide"] slide_id="s"\n# T\n' + self._BASE
+        a = align_anchored(parse_cells(de), parse_cells(en), {})
+        assert a.direction is None
+        assert not a.diverged
+
+    def test_de_drift_gives_de_to_en(self):
+        baseline = _shared_anchor_map(parse_cells(self._BASE))
+        de = '# %% tags=["keep"]\nimport time\nx = 1\n'  # DE edited the shared cell
+        en = self._BASE  # EN unchanged
+        a = align_anchored(parse_cells(de), parse_cells(en), baseline)
+        assert a.direction == "de->en"
+        assert not a.diverged
+
+    def test_en_drift_gives_en_to_de(self):
+        baseline = _shared_anchor_map(parse_cells(self._BASE))
+        de = self._BASE
+        en = '# %% tags=["keep"]\nimport time\nx = 1\n'
+        a = align_anchored(parse_cells(de), parse_cells(en), baseline)
+        assert a.direction == "en->de"
+        assert not a.diverged
+
+    def test_both_sides_drift_diverges(self):
+        baseline = _shared_anchor_map(parse_cells(self._BASE))
+        de = '# %% tags=["keep"]\nimport time\nx = 1\n'  # DE: -> construct x
+        en = '# %% tags=["keep"]\nimport time\ny = 2\n'  # EN: -> construct y (differs)
+        a = align_anchored(parse_cells(de), parse_cells(en), baseline)
+        assert a.diverged
+        assert a.direction is None

--- a/tests/slides/test_sync_code_e2e.py
+++ b/tests/slides/test_sync_code_e2e.py
@@ -25,7 +25,7 @@ from clm.cli.commands.slides_sync import CACHE_DB_NAME, slides_sync_cmd
 from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import SyncProposal
 from clm.notebooks.slide_parser import parse_cells
-from clm.slides.sync_plan import ordered_sync_cells
+from clm.slides.sync_plan import watermark_rows
 from clm.slides.sync_translate import TranslationError
 from clm.slides.sync_writeback import role_of
 
@@ -304,16 +304,15 @@ def _seed_watermark(cache_dir: Path, de_path: Path, en_path: Path, de: str, en: 
     cache_dir.mkdir(parents=True, exist_ok=True)
     wm = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
     try:
-        for lang, text in (("de", de), ("en", en)):
-            cells = ordered_sync_cells(parse_cells(text), lang)
-            wm.put_deck(
-                de_path=str(de_path),
-                en_path=str(en_path),
-                lang=lang,
-                cells=[
-                    (c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells
-                ],
-            )
+        # Membership-widened, mirroring sync_apply._record_watermark — so the
+        # baseline carries the "shared" partition the item-2 anchor diff needs.
+        de_rows = watermark_rows(parse_cells(de))
+        en_rows = watermark_rows(parse_cells(en))
+        wm.put_deck(de_path=str(de_path), en_path=str(en_path), lang="de", cells=de_rows["de"])
+        wm.put_deck(de_path=str(de_path), en_path=str(en_path), lang="en", cells=en_rows["en"])
+        wm.put_deck(
+            de_path=str(de_path), en_path=str(en_path), lang="shared", cells=de_rows["shared"]
+        )
     finally:
         wm.close()
 

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -16,6 +16,7 @@ are counting stand-ins).
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -177,6 +178,79 @@ def test_item2b_localized_idless_code_edit_is_retranslated(tmp_path: Path):
     # The drifted localized code cell was re-translated (group force-rebuilt).
     retranslated = [body for (_r, _sl, _tl, body) in translator.calls if 'print("b")' in body]
     assert retranslated, f"the edited localized code must be re-translated; got {translator.calls}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3c — shared-cell divergence (both decks edited the same neutral cell)
+# ---------------------------------------------------------------------------
+
+
+def _diverge(tmp_path: Path) -> tuple[Path, Path, SyncWatermarkCache]:
+    """Seed a synced pair, then edit the SAME neutral cell differently on both halves."""
+    de = _slide("de", "a", "# ## A") + _code_shared("import time")
+    en = _slide("en", "a", "# ## A") + _code_shared("import time")
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    _seed(cache, de_path, en_path)
+    de_path.write_text(
+        _slide("de", "a", "# ## A") + _code_shared("import time\nx = 1"), encoding="utf-8"
+    )
+    en_path.write_text(
+        _slide("en", "a", "# ## A") + _code_shared("import time\ny = 2"), encoding="utf-8"
+    )
+    return de_path, en_path, cache
+
+
+def test_shared_divergence_auto_heals_toward_newer_file(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLM_SYNC__SHARED_DIVERGENCE", raising=False)  # default auto-heal
+    de_path, en_path, cache = _diverge(tmp_path)
+    os.utime(en_path, (1_600_000_000, 1_600_000_000))  # EN older
+    os.utime(de_path, (1_600_000_900, 1_600_000_900))  # DE newer -> DE wins
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert plan.anchor_direction == "de->en"  # newer (DE) won
+    assert any(i.severity == "warning" for i in plan.issues)
+    assert not plan.has_errors
+    en_text = en_path.read_text(encoding="utf-8")
+    assert "x = 1" in en_text  # DE's version healed onto EN
+    assert "y = 2" not in en_text
+
+
+def test_shared_divergence_error_mode_surfaces_and_writes_nothing(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CLM_SYNC__SHARED_DIVERGENCE", "error")
+    de_path, en_path, cache = _diverge(tmp_path)
+    en_before = en_path.read_bytes()
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert plan.has_errors
+    assert plan.anchor_direction is None
+    assert en_path.read_bytes() == en_before  # error -> the buffered apply writes nothing
+
+
+def test_shared_divergence_no_winner_errors(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLM_SYNC__SHARED_DIVERGENCE", raising=False)
+    de_path, en_path, cache = _diverge(tmp_path)
+    os.utime(de_path, (1_600_000_000, 1_600_000_000))  # mtimes tie, no keyed edit
+    os.utime(en_path, (1_600_000_000, 1_600_000_000))
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+    finally:
+        cache.close()
+
+    assert plan.has_errors  # no winner -> error even in auto-heal mode
+    assert plan.anchor_direction is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1,11 +1,10 @@
 """Behavioral tests for the two *serious* ``clm slides sync`` limitations
-(Issue #190 items 2 & 3).
+(Issue #190 items 2 & 3) — both now FIXED.
 
-* **item 2** — *still broken (Phase 3 will fix)*: a code-only edit to a
-  *language-neutral* shared cell produces no proposal, so the sync silently fails
-  to propagate it and the two split halves diverge. ``test_item2_*`` pins the
-  broken-today behavior; flip it when Phase 3 (the anchor-keyed diff +
-  deterministic copy-to-twin) lands.
+* **item 2** — *FIXED (Phase 3a)*: a code-only edit to a *language-neutral*
+  shared cell is detected by the anchor diff (``align_anchored``) — which side
+  drifted from the watermark gives the direction — and the structural pass copies
+  it verbatim to the twin, no LLM. ``test_item2_*`` asserts the fix.
 * **item 3** — *FIXED (Phase 2)*: when a slide group is rebuilt for a *sibling's*
   sake, an unchanged id-less localized code cell is spliced verbatim by its
   content anchor instead of being re-translated. ``test_item3_*`` asserts the fix
@@ -86,11 +85,12 @@ class CountingJudge:
 
 
 # ---------------------------------------------------------------------------
-# Item 2 — a code-only change to a neutral shared cell is not propagated
+# Item 2 — FIXED (Phase 3a): a code-only change to a neutral shared cell is
+# detected by the anchor diff and copied verbatim to the twin (no LLM).
 # ---------------------------------------------------------------------------
 
 
-def test_item2_neutral_code_only_edit_is_silently_dropped(tmp_path: Path):
+def test_item2_neutral_code_only_edit_propagates_verbatim(tmp_path: Path):
     de = _slide("de", "a", "# ## A") + _code_shared("import time")
     en = _slide("en", "a", "# ## A") + _code_shared("import time")
     de_path, en_path = _write_pair(tmp_path, de, en)
@@ -100,23 +100,24 @@ def test_item2_neutral_code_only_edit_is_silently_dropped(tmp_path: Path):
     judge = CountingJudge()
     try:
         _seed(cache, de_path, en_path)
-        # Author edits ONLY the shared, language-neutral code cell on DE.
+        # Author edits ONLY the shared, language-neutral code cell on DE — no
+        # narrative or id'd change, so the keyed classifier produces no proposal.
         de_path.write_text(
             _slide("de", "a", "# ## A") + _code_shared("import time\nx = 1"),
             encoding="utf-8",
         )
         plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
-        result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
     finally:
         cache.close()
 
-    # TODAY: the edit is invisible to the engine — no proposal, no direction.
-    assert plan.is_noop
-    assert result.applied == 0
+    # FIXED: the anchor diff detects DE drifted -> de->en direction; no keyed
+    # proposal, so it is NOT a no-op.
+    assert not plan.is_noop
+    assert plan.anchor_direction == "de->en"
+    # A neutral cell is shared verbatim — copied to the EN twin, never translated.
     assert translator.calls == []
-    # The shared code on EN is NOT updated, so the split halves now diverge.
-    assert "x = 1" not in en_path.read_text(encoding="utf-8")
-    # (Phase 3 propagates this; flip the four assertions above then.)
+    assert "x = 1" in en_path.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -253,6 +253,48 @@ def test_shared_divergence_no_winner_errors(tmp_path: Path, monkeypatch):
     assert plan.anchor_direction is None
 
 
+def test_independent_cross_cell_edits_error_without_reverting(tmp_path: Path, monkeypatch):
+    # DE edits neutral cell A; EN edits a DIFFERENT neutral cell B (two compatible
+    # one-sided edits). A whole-file divergence verdict + auto-heal would pick one
+    # winner and silently REVERT the other's edit (Phase 3c review, the data-loss
+    # bug). Cell-precise classification makes this irreconcilable -> error -> the
+    # buffered apply writes nothing, so NEITHER edit is lost.
+    monkeypatch.delenv("CLM_SYNC__SHARED_DIVERGENCE", raising=False)  # default auto-heal
+    de = _slide("de", "a", "# ## A") + _code_shared("import time") + _code_shared("import os")
+    en = _slide("en", "a", "# ## A") + _code_shared("import time") + _code_shared("import os")
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "a", "# ## A")
+            + _code_shared("import time\nx = 1")
+            + _code_shared("import os"),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "a", "# ## A")
+            + _code_shared("import time")
+            + _code_shared("import os\ny = 2"),
+            encoding="utf-8",
+        )
+        os.utime(
+            de_path, (1_600_000_900, 1_600_000_900)
+        )  # DE newer -> would have won + reverted EN
+        os.utime(en_path, (1_600_000_000, 1_600_000_000))
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert plan.has_errors
+    assert plan.anchor_direction is None
+    assert "x = 1" in de_path.read_text(encoding="utf-8")  # DE's edit preserved
+    assert "y = 2" in en_path.read_text(encoding="utf-8")  # EN's edit NOT reverted
+
+
 # ---------------------------------------------------------------------------
 # Item 3 — FIXED (Phase 2): an unchanged id-less localized code cell is spliced
 # verbatim on a sibling-triggered rebuild, never re-translated.

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -120,6 +120,35 @@ def test_item2_neutral_code_only_edit_propagates_verbatim(tmp_path: Path):
     assert "x = 1" in en_path.read_text(encoding="utf-8")
 
 
+def test_item2_duplicate_construct_non_last_edit_propagates(tmp_path: Path):
+    # Two neutral cells share construct:print. Editing the NON-LAST one must still
+    # propagate — an anchor-keyed map would collapse them last-writer-wins and
+    # silently drop the edit (Issue #190 review). The ordered-hash detector sees it.
+    de = _slide("de", "a", "# ## A") + _code_shared('print("a")') + _code_shared('print("b")')
+    en = _slide("en", "a", "# ## A") + _code_shared('print("a")') + _code_shared('print("b")')
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "a", "# ## A") + _code_shared('print("z")') + _code_shared('print("b")'),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert plan.anchor_direction == "de->en"
+    en_text = en_path.read_text(encoding="utf-8")
+    assert 'print("z")' in en_text  # the non-last edit propagated
+    assert 'print("a")' not in en_text
+    assert 'print("b")' in en_text  # the unchanged sibling is intact
+
+
 # ---------------------------------------------------------------------------
 # Item 3 — FIXED (Phase 2): an unchanged id-less localized code cell is spliced
 # verbatim on a sibling-triggered rebuild, never re-translated.

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -149,6 +149,36 @@ def test_item2_duplicate_construct_non_last_edit_propagates(tmp_path: Path):
     assert 'print("b")' in en_text  # the unchanged sibling is intact
 
 
+def test_item2b_localized_idless_code_edit_is_retranslated(tmp_path: Path):
+    # An id-less LOCALIZED code cell edited (body changed, construct stable) must
+    # be re-translated. Its ("L", kind) signature is unchanged by a body edit, so
+    # the group is force-rebuilt because the cell drifted from baseline (Phase 3b).
+    # Direction comes from a co-occurring narrative edit (single-language workflow).
+    de = _slide("de", "g", "# ## G") + _code_localized_idless("de", '# Komm\nprint("a")')
+    en = _slide("en", "g", "# ## G") + _code_localized_idless("en", '# Comment\nprint("a")')
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")  # narrative edit -> keyed direction
+            + _code_localized_idless("de", '# Komm\nprint("b")'),  # localized code edited
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert plan.count("edit") == 1  # the narrative edit supplies the direction
+    # The drifted localized code cell was re-translated (group force-rebuilt).
+    retranslated = [body for (_r, _sl, _tl, body) in translator.calls if 'print("b")' in body]
+    assert retranslated, f"the edited localized code must be re-translated; got {translator.calls}"
+
+
 # ---------------------------------------------------------------------------
 # Item 3 — FIXED (Phase 2): an unchanged id-less localized code cell is spliced
 # verbatim on a sibling-triggered rebuild, never re-translated.


### PR DESCRIPTION
## Issue #190 — Phase 3 (item 2: code-only changes propagate)

Builds on Phase 1+2 (#192, merged). Design note: `docs/claude/design/sync-content-anchor-identity.md` §6–§7. With this, **both limitations the maintainer rated *serious* (items 2 & 3) are fixed.** Five commits; the no-op corpus harness held at **81/212, 0 violations** through every one.

Mechanism (chosen over proposal-emission): **structural-pass reuse** — `align_anchored` produces a direction / divergence verdict; the existing `apply_code_structure` does the propagation.

### 3a — neutral shared cell (§7a) · `1fd3451` + `f2cba42`
A code-only edit to a language-neutral cell produced no keyed proposal → no direction → silently dropped (the split halves diverge, a `unify` violation). `align_anchored` now detects which half drifted and hands the direction to the structural pass, which copies the cell verbatim to its twin — **no LLM**. It compares the `shared` partition as an **ordered hash sequence** (not an anchor-keyed dict — a construct anchor isn't content-unique, so a map would collapse duplicates and drop a non-last edit; this is the recurring guard, applied here too), and gates first on whether the halves even disagree (robust to a pre-1b / no-`shared` watermark).

### 3b — id-less localized code (§7b) · `b5caf82`
A localized id-less cell's `("L", kind)` signature is unchanged by a body edit, so its group never rebuilt. Now `apply_code_structure` force-rebuilds a group when it holds a localized id-less cell that drifted from the (Counter-deduped) baseline — the changed cell is re-translated, unchanged siblings reused (Phase 2). Restricted to localized id-less cells, so narrative/id'd edits cause no sibling churn.

### 3c — shared-cell divergence auto-heal (§7a) · `9ffb6a4` + `04bbae5`
When the **same** neutral cell is edited differently on both decks: `_resolve_divergence_winner` (keyed direction → newer mtime → none) auto-heals toward the winner with a *warning* (default), or `CLM_SYNC__SHARED_DIVERGENCE=error` surfaces it and writes nothing. The detector is **cell-precise**: independent edits to *different* neutral cells are irreconcilable → error (write nothing), never a silent revert of one side's edit.

### Adversarial review
Each sub-phase was adversarially reviewed; both confirmed findings are fixed in-branch:
- 3a: the duplicate-construct-anchor collapse (caught for the 3rd time across the issue) → ordered-hash compare.
- 3c: the cross-cell **data-loss** revert (high severity) → cell-precise classification + irreconcilable-errors.

### Residuals (Phase 5, §10)
An *isolated* localized-only edit with no other direction signal, and a construct-renaming edit, are bounded-LLM-recovery territory. The `CLM_SYNC__SHARED_DIVERGENCE` info-topic doc is Phase 6.

### Tests
Full fast suite **6063 passed**; no-op harness 81/212 / 0 violations; ruff + mypy clean; every commit cleared the pre-commit hook. New: item-2 verbatim propagation + duplicate-construct + cross-cell-no-revert + divergence auto-heal/error/no-winner + `align_anchored` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)