### PR TITLE
feat(slides): deterministic def-my-fun id-migration (#190 Phase 4)

### DIFF
--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -458,6 +458,18 @@ invariant. Gate releases on `pytest -m "not docker"`.
      edit, are §10 territory.
 4. **Deterministic `def-my-fun` id-migration** (§9): the one gated file-write,
    strictly scoped to already-id'd, drifted cells; symmetric localized chokepoint.
+   - **✅ Shipped (neutral case).** `_migrate_drifted_ids` (sync_apply) runs on the
+     propagation **source** deck before the structural pass: a language-neutral
+     code cell wearing a `slide_id` whose *current* construct ≠ the watermark's
+     baseline construct for that id, **and** a unique id-less cell carrying the
+     baseline construct → move the id onto that cell (`_stamp_slide_id`) and mint a
+     fresh content slug on the orphan. One header write each, no LLM; the corrected
+     ids ride to the twin via the §7 propagation (so both byte-identical neutral
+     copies stay consistent). Gated by the same uniqueness guard as the other
+     anchor paths (no/duplicate construct match → skip). Residuals deferred to §10:
+     **localized** id'd cells (need the symmetric both-deck `_slide_ids_pair`
+     chokepoint) and a co-occurring **function rename** (the construct match also
+     fails). `result.applied_migrate` counts the moves.
 5. **Bounded Opus recovery** (§10): `sync_alignments` table; `--llm-recover`
    (default off); validate-and-safe-abort.
 6. **Docs + `--explain`** (§13): info topics, migration entry, anchor-diff dump.

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -1126,22 +1126,26 @@ def _effective_direction(plan: SyncPlan) -> str | None:
     return plan.anchor_direction
 
 
-def _baseline_constructs(
+def _baseline_shared(
     cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
-) -> dict[str, str]:
-    """Per-slide-id baseline AST construct slug from the widened watermark (§9).
+) -> tuple[dict[str, str], set[str]]:
+    """Baseline ``{slide_id: construct}`` and the set of content hashes, ``shared`` only.
 
-    A cell wearing an id whose *current* construct no longer matches this baseline
-    has drifted off its content — the signal the id-migration keys on.
+    The §9 migration only touches language-neutral code cells, which live in the
+    ``shared`` partition — so the baseline is read from there alone (a slide_id
+    reused across partitions must not borrow another partition's construct). The
+    content-hash set lets the migration tell a genuine split-product (a *new* cell)
+    from a pre-existing cell that merely shares a construct name.
     """
-    out: dict[str, str] = {}
+    constructs: dict[str, str] = {}
+    hashes: set[str] = set()
     if cache is None:
-        return out
-    for lang in ("de", "en", "shared"):
-        for _pos, sid, _role, _chash, construct in cache.get_deck(str(de_path), str(en_path), lang):
-            if sid is not None and construct is not None:
-                out.setdefault(sid, construct)
-    return out
+        return constructs, hashes
+    for _pos, sid, _role, chash, construct in cache.get_deck(str(de_path), str(en_path), "shared"):
+        hashes.add(chash)
+        if sid is not None and construct is not None:
+            constructs.setdefault(sid, construct)
+    return constructs, hashes
 
 
 def _migrate_drifted_ids(
@@ -1155,32 +1159,46 @@ def _migrate_drifted_ids(
 
     Scoped to language-**neutral** code cells (the maintainer's def-my-fun example):
     when the author splits an id'd cell — e.g. adds an ``import`` above a ``def``,
-    leaving the id on the import — the id wears the wrong construct while a
-    *different* id-less cell carries the construct the id names in the baseline. The
-    mismatch is unambiguous, so move the id down and mint a fresh content slug on the
-    orphan: one targeted header write each, no LLM. Runs on the propagation **source**
-    deck only; the structural pass then carries the corrected ids to the twin.
-    Ambiguous cases — no/duplicate construct match (the recurring non-uniqueness
-    guard) or a co-occurring function rename — are left untouched for §10 recovery.
-    (Localized id'd cells need a symmetric both-deck write; deferred.)
-    """
-    direction = _effective_direction(plan)
-    if direction is None:
-        return
-    source = de_state if direction == "de->en" else en_state
-    baseline = _baseline_constructs(cache, plan.de_path, plan.en_path)
-    if not baseline:
-        return
+    leaving the id on the import — the id wears the wrong construct while a *new*
+    id-less cell carries the construct the id names in the baseline. Move the id
+    down and mint a fresh content slug on the orphan: one targeted header write each,
+    no LLM.
 
-    used_ids = {
-        cell.metadata.slide_id
-        for st in (de_state, en_state)
-        for cell in st.cells
-        if cell.metadata.slide_id
-    }
+    Applied to **both** decks (not just the propagation source): neutral cells are
+    byte-identical across the split halves, so the move is deterministic on each,
+    and the structural pass — which keys on the cell *body*, blind to a header-only
+    id change — cannot be relied on to carry a migrated id to the twin (it would
+    leave a silent cross-deck slide_id divergence). The direction merely gates
+    *whether* a migration pass is active (so an idle no-op never writes).
+
+    The matched id-less cell must be **new** (its content hash absent from the
+    baseline), which distinguishes a real split-product from an unrelated
+    pre-existing cell that coincidentally shares the construct name (the Phase 4
+    review's false-move finding). Ambiguous cases — a non-unique construct (the
+    recurring guard) or a co-occurring function rename — are left for §10 recovery.
+    (Localized id'd cells, which need a symmetric paired ``de_id==en_id`` write, are
+    deferred.)
+    """
+    if _effective_direction(plan) is None:
+        return
+    baseline_constructs, baseline_hashes = _baseline_shared(cache, plan.de_path, plan.en_path)
+    if not baseline_constructs:
+        return
+    _migrate_one_deck(de_state, baseline_constructs, baseline_hashes, result)
+    _migrate_one_deck(en_state, baseline_constructs, baseline_hashes, result)
+
+
+def _migrate_one_deck(
+    state: FileState,
+    baseline_constructs: dict[str, str],
+    baseline_hashes: set[str],
+    result: ApplyResult,
+) -> None:
+    """Apply the §9 id-migration to one deck's neutral code cells (see caller)."""
+    used_ids = {cell.metadata.slide_id for cell in state.cells if cell.metadata.slide_id}
     idless_by_construct: dict[str, list[RawCell]] = {}
     construct_count: Counter = Counter()
-    for cell in source.cells:
+    for cell in state.cells:
         meta = cell.metadata
         if meta.is_j2 or meta.lang is not None:
             continue  # neutral cells only
@@ -1191,11 +1209,11 @@ def _migrate_drifted_ids(
         if meta.slide_id is None:
             idless_by_construct.setdefault(construct, []).append(cell)
 
-    for cell in list(source.cells):
+    for cell in list(state.cells):
         meta = cell.metadata
         if meta.is_j2 or meta.lang is not None or meta.slide_id is None:
             continue
-        base_construct = baseline.get(meta.slide_id)
+        base_construct = baseline_constructs.get(meta.slide_id)
         current_construct = construct_of(meta, cell.body)
         if (
             base_construct is None
@@ -1203,15 +1221,23 @@ def _migrate_drifted_ids(
             or current_construct == base_construct
         ):
             continue  # the id still names its content (or there is nothing to key on)
-        targets = idless_by_construct.get(base_construct, [])
-        if len(targets) != 1 or construct_count[base_construct] != 1:
-            continue  # ambiguous (no/duplicate match) -> defer to §10 recovery
+        if construct_count[base_construct] != 1:
+            continue  # the construct is not unique in this deck -> ambiguous, defer
+        # The target must be a NEW cell (a split-product), not a pre-existing one
+        # that merely shares the construct name (the review's false-move finding).
+        targets = [
+            c
+            for c in idless_by_construct.get(base_construct, [])
+            if cell_content_hash(c.body) not in baseline_hashes
+        ]
+        if len(targets) != 1:
+            continue
         sid = meta.slide_id
         _stamp_slide_id(targets[0], sid)  # the id follows its construct
         new_slug = resolve_collision(current_construct, used_ids)
         used_ids.add(new_slug)
         _stamp_slide_id(cell, new_slug)  # the orphan gets a fresh content slug
-        source.dirty = True
+        state.dirty = True
         result.applied_migrate += 1
         idless_by_construct.pop(base_construct, None)  # at most one migration per construct
 

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -60,6 +60,7 @@ from clm.slides.sync_writeback import (
     FileState,
     build_twin_cell,
     cell_content_hash,
+    construct_of,
     role_of,
     row_anchor,
 )
@@ -104,6 +105,7 @@ class ApplyResult:
     applied_move: int = 0
     applied_add: int = 0
     applied_rename: int = 0
+    applied_migrate: int = 0  # a drifted slide_id moved back onto its construct (§9)
     in_sync: int = 0  # an edit the judge decided needed no change
     deferred: int = 0  # conflict (or moves/adds declined this pass)
     watermark_recorded: bool = False
@@ -117,6 +119,7 @@ class ApplyResult:
             + self.applied_move
             + self.applied_add
             + self.applied_rename
+            + self.applied_migrate
         )
 
     @property
@@ -227,6 +230,12 @@ def apply_plan(
     # groups, reusing the narrative / aux / id'd-code twins the steps above just
     # placed. Cross-group code moves fall out of rebuilding both groups from the
     # source. Runs after adds/moves so every twin it pulls is in place.
+    # Deterministic id-migration (Issue #190 §9): if the author split an id'd code
+    # cell, the slide_id is left on the wrong half. Move it back onto the cell whose
+    # construct it names BEFORE the structural pass propagates, so the corrected ids
+    # ride along to the twin.
+    _migrate_drifted_ids(plan, de_state, en_state, watermark_cache, result)
+
     baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan.de_path, plan.en_path)
     apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
 
@@ -1107,6 +1116,104 @@ def _baseline_anchor_hashes(
             if counts[anchor] == 1:
                 out[lang][anchor] = chash
     return out
+
+
+def _effective_direction(plan: SyncPlan) -> str | None:
+    """The pass's single propagation direction: keyed proposals, else anchor diff."""
+    keyed = {p.direction for p in plan.proposals if p.direction in ("de->en", "en->de")}
+    if len(keyed) == 1:
+        return next(iter(keyed))
+    return plan.anchor_direction
+
+
+def _baseline_constructs(
+    cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
+) -> dict[str, str]:
+    """Per-slide-id baseline AST construct slug from the widened watermark (§9).
+
+    A cell wearing an id whose *current* construct no longer matches this baseline
+    has drifted off its content — the signal the id-migration keys on.
+    """
+    out: dict[str, str] = {}
+    if cache is None:
+        return out
+    for lang in ("de", "en", "shared"):
+        for _pos, sid, _role, _chash, construct in cache.get_deck(str(de_path), str(en_path), lang):
+            if sid is not None and construct is not None:
+                out.setdefault(sid, construct)
+    return out
+
+
+def _migrate_drifted_ids(
+    plan: SyncPlan,
+    de_state: FileState,
+    en_state: FileState,
+    cache: SyncWatermarkCache | None,
+    result: ApplyResult,
+) -> None:
+    """Move a slide_id that drifted off its construct back onto the right cell (§9).
+
+    Scoped to language-**neutral** code cells (the maintainer's def-my-fun example):
+    when the author splits an id'd cell — e.g. adds an ``import`` above a ``def``,
+    leaving the id on the import — the id wears the wrong construct while a
+    *different* id-less cell carries the construct the id names in the baseline. The
+    mismatch is unambiguous, so move the id down and mint a fresh content slug on the
+    orphan: one targeted header write each, no LLM. Runs on the propagation **source**
+    deck only; the structural pass then carries the corrected ids to the twin.
+    Ambiguous cases — no/duplicate construct match (the recurring non-uniqueness
+    guard) or a co-occurring function rename — are left untouched for §10 recovery.
+    (Localized id'd cells need a symmetric both-deck write; deferred.)
+    """
+    direction = _effective_direction(plan)
+    if direction is None:
+        return
+    source = de_state if direction == "de->en" else en_state
+    baseline = _baseline_constructs(cache, plan.de_path, plan.en_path)
+    if not baseline:
+        return
+
+    used_ids = {
+        cell.metadata.slide_id
+        for st in (de_state, en_state)
+        for cell in st.cells
+        if cell.metadata.slide_id
+    }
+    idless_by_construct: dict[str, list[RawCell]] = {}
+    construct_count: Counter = Counter()
+    for cell in source.cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.lang is not None:
+            continue  # neutral cells only
+        construct = construct_of(meta, cell.body)
+        if construct is None:
+            continue
+        construct_count[construct] += 1
+        if meta.slide_id is None:
+            idless_by_construct.setdefault(construct, []).append(cell)
+
+    for cell in list(source.cells):
+        meta = cell.metadata
+        if meta.is_j2 or meta.lang is not None or meta.slide_id is None:
+            continue
+        base_construct = baseline.get(meta.slide_id)
+        current_construct = construct_of(meta, cell.body)
+        if (
+            base_construct is None
+            or current_construct is None
+            or current_construct == base_construct
+        ):
+            continue  # the id still names its content (or there is nothing to key on)
+        targets = idless_by_construct.get(base_construct, [])
+        if len(targets) != 1 or construct_count[base_construct] != 1:
+            continue  # ambiguous (no/duplicate match) -> defer to §10 recovery
+        sid = meta.slide_id
+        _stamp_slide_id(targets[0], sid)  # the id follows its construct
+        new_slug = resolve_collision(current_construct, used_ids)
+        used_ids.add(new_slug)
+        _stamp_slide_id(cell, new_slug)  # the orphan gets a fresh content slug
+        source.dirty = True
+        result.applied_migrate += 1
+        idless_by_construct.pop(base_construct, None)  # at most one migration per construct
 
 
 def _record_watermark(

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -45,6 +45,11 @@ def _code_localized_idless(lang: str, body: str) -> str:
     return f'# %% lang="{lang}"\n{body}\n'
 
 
+def _code_idd_neutral(sid: str, body: str) -> str:
+    """A language-neutral code cell carrying a slide_id (the def-my-fun shape)."""
+    return f'# %% tags=["keep"] slide_id="{sid}"\n{body}\n'
+
+
 def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
     de_path = tmp_path / "deck.de.py"
     en_path = tmp_path / "deck.en.py"
@@ -293,6 +298,85 @@ def test_independent_cross_cell_edits_error_without_reverting(tmp_path: Path, mo
     assert plan.anchor_direction is None
     assert "x = 1" in de_path.read_text(encoding="utf-8")  # DE's edit preserved
     assert "y = 2" in en_path.read_text(encoding="utf-8")  # EN's edit NOT reverted
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — deterministic def-my-fun id-migration (§9)
+# ---------------------------------------------------------------------------
+
+
+def test_phase4_def_my_fun_id_migration(tmp_path: Path):
+    # The author splits an id'd neutral code cell — adds `import time` above the
+    # def, leaving slide_id="def-my-fun" on the import. The id has drifted off its
+    # construct; a different id-less cell now carries `function my_fun`. The sync
+    # deterministically moves the id back to the def cell and mints a content slug
+    # on the orphan import — no LLM — and propagates the corrected ids to the twin.
+    de = _slide("de", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    en = _slide("en", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "s", "# ## S")
+            + _code_idd_neutral("def-my-fun", "import time")  # id left on the import half
+            + _code_shared('def my_fun():\n    time.sleep(1)\n    print("foo")'),  # id-less def
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 1
+    assert translator.calls == []  # deterministic, no LLM
+    for path in (de_path, en_path):  # corrected ids on BOTH decks (neutral -> symmetric)
+        by_id = {
+            c.metadata.slide_id: c
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.slide_id
+        }
+        assert "def my_fun" in by_id["def-my-fun"].content  # id followed its construct
+        assert "time.sleep(1)" in by_id["def-my-fun"].content  # the edited body came too
+        assert "import time" in by_id["import-time"].content  # orphan got a content slug
+
+
+def test_phase4_no_migration_without_matching_idless_cell(tmp_path: Path):
+    # The id drifted (def -> import on the SAME cell) but there is NO id-less cell
+    # carrying the old construct (no split — a genuine replacement). The migration
+    # must NOT fire (it is not an unambiguous id-move); the cell is left for the
+    # ordinary edit/structural path.
+    de = _slide("de", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    en = _slide("en", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "s", "# ## S")
+            + _code_idd_neutral("def-my-fun", "import time"),  # replaced
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0  # no id-less construct match -> no migration
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -379,6 +379,96 @@ def test_phase4_no_migration_without_matching_idless_cell(tmp_path: Path):
     assert result.applied_migrate == 0  # no id-less construct match -> no migration
 
 
+def test_phase4_no_false_move_to_unrelated_preexisting_cell(tmp_path: Path):
+    # An id'd cell's construct changes via a legitimate edit (import os -> config),
+    # and an UNRELATED, pre-existing id-less cell happens to carry the old construct
+    # (import os). The migration must NOT move the id onto that unrelated cell — it
+    # is not a split-product (its content is in the baseline). (Review finding.)
+    de = (
+        _slide("de", "s", "# ## S")
+        + _code_idd_neutral("setup", "import os\nsetup_run()")
+        + _code_shared("import os\nother_run()")  # unrelated, id-less, same construct
+    )
+    en = (
+        _slide("en", "s", "# ## S")
+        + _code_idd_neutral("setup", "import os\nsetup_run()")
+        + _code_shared("import os\nother_run()")
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "s", "# ## S")
+            + _code_idd_neutral("setup", "config = load()\nsetup_run()")  # construct changed
+            + _code_shared("import os\nother_run()"),  # unrelated cell unchanged
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0  # no false move
+    by_id = {
+        c.metadata.slide_id: c
+        for c in parse_cells(de_path.read_text(encoding="utf-8"))
+        if c.metadata.slide_id
+    }
+    assert "config = load()" in by_id["setup"].content  # the id stayed on the edited cell
+
+
+def test_phase4_id_migration_is_symmetric_across_decks(tmp_path: Path):
+    # The def-my-fun split is present byte-identically on BOTH decks (and a narrative
+    # edit supplies the direction). The migration must write BOTH decks — the
+    # structural pass keys on the body and can't carry a header-only id change — so
+    # the corrected ids must NOT diverge across de/en. (Review finding, critical.)
+    base_def = 'def my_fun():\n    print("foo")'
+    new_def = 'def my_fun():\n    time.sleep(1)\n    print("foo")'
+    de0 = _slide("de", "g", "# ## G") + _code_idd_neutral("def-my-fun", base_def)
+    en0 = _slide("en", "g", "# ## G") + _code_idd_neutral("def-my-fun", base_def)
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        # Both decks split identically; only DE's narrative changes (the direction).
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")
+            + _code_idd_neutral("def-my-fun", "import time")
+            + _code_shared(new_def),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "g", "# ## G")
+            + _code_idd_neutral("def-my-fun", "import time")
+            + _code_shared(new_def),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 2  # migrated on BOTH decks
+    ids = []
+    for path in (de_path, en_path):
+        by_id = {
+            c.metadata.slide_id: c
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.slide_id
+        }
+        assert "def my_fun" in by_id["def-my-fun"].content
+        assert "import time" in by_id["import-time"].content
+        ids.append(sorted(by_id))
+    assert ids[0] == ids[1]  # identical slide_ids on both decks — no divergence
+
+
 # ---------------------------------------------------------------------------
 # Item 3 — FIXED (Phase 2): an unchanged id-less localized code cell is spliced
 # verbatim on a sibling-triggered rebuild, never re-translated.


### PR DESCRIPTION
Phase 4 of the content-anchor sync redesign (Issue #190 §9). Builds on #191/#192/#193.

## What

When an author splits an id'd code cell — e.g. adds an `import` above a `def`, leaving the existing `slide_id` on the *import* half — the `slide_id` now drifts off the construct it names. This PR moves it back deterministically, with **no LLM** and one targeted header write each:

- `_migrate_drifted_ids` (sync_apply) runs on the propagation source before the structural pass. A language-**neutral** code cell whose current construct ≠ the watermark's baseline construct for its id, **and** a unique *new* id-less cell carrying that baseline construct → move the id onto that cell and mint a fresh content slug on the orphan.
- Applied to **both** decks (neutral cells are byte-identical across halves): the structural pass keys on the cell *body* and is blind to a header-only id change, so relying on it to carry the migrated id to the twin would leave a silent cross-deck `slide_id` divergence.
- The matched id-less cell must be **new** (its content hash absent from the baseline), distinguishing a real split-product from an unrelated pre-existing cell that merely shares the construct name.

Ambiguous cases — a non-unique construct, or a co-occurring function rename — are deferred to the §10 recovery tier (a later phase). `result.applied_migrate` counts the moves.

## Review

An adversarial review found two real bugs, both fixed in `df58417`:
- **critical** cross-deck divergence: the migration stamped only the source deck and trusted the body-keyed structural pass to propagate, which it cannot for a header-only change → permanent `de_id != en_id`. Fixed by migrating **both** decks symmetrically.
- **high** false move: keying on the construct *name* alone let an unrelated pre-existing cell steal the id. Fixed by requiring the matched cell to be a genuine (new) split-product.

## Validation

`pytest -m "not docker"` green; the Issue #190 no-op corpus harness holds at 81/212, 0 invariant violations; ruff + mypy clean. New regression tests cover the maintainer's def-my-fun example, the symmetric both-deck write, the no-false-move case, and the no-migration-without-a-matching-cell case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)