### PR TITLE
feat(slides): bounded LLM recovery + localized id-migration (#190 Phase 5)

### DIFF
--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -317,6 +317,13 @@ ties (two `def my_fun`, many bare imports) — escalate to Claude, **bounded**:
   untouched and re-surfaces next run; the LLM fires only under an explicit
   `--llm-recover`.
 
+**Shipped (Phase 5).** `slides/sync_recover.py` + the `sync_alignments` table; the
+recoverer is body-free (constructs/hashes/ids only — no source reaches the model),
+validated (`validate_alignment`, safe-abort on any failure), cached, and opt-in.
+It is wired to the **neutral** §9 escalation only; the deterministic localized
+chokepoint (§9, Phase 5d) handles the localized id-move without an LLM. See §14
+phase 5 for the component breakdown.
+
 Change-signal reliability (the maintainer asked which sources to trust):
 
 | Signal | Use |
@@ -472,6 +479,31 @@ invariant. Gate releases on `pytest -m "not docker"`.
      fails). `result.applied_migrate` counts the moves.
 5. **Bounded Opus recovery** (§10): `sync_alignments` table; `--llm-recover`
    (default off); validate-and-safe-abort.
+   - **✅ Shipped.** **5a:** `SyncAlignmentCache` (`infrastructure/llm/cache.py`) —
+     additive `sync_alignments` table keyed `(base_region_hash,
+     current_region_hash, prompt_version)`, storing only *validated* maps. **5b:**
+     new `slides/sync_recover.py` — the `AlignmentRecoverer` protocol
+     (`StaticAlignmentRecoverer` for tests, `OpenRouterAlignmentRecoverer` =
+     Claude Opus), a **body-free** `RegionCell` (slide_id / construct /
+     content_hash — never source), `region_fingerprint` (sound cache key), and
+     `validate_alignment` — the hard gate: total over the current cells, ids only
+     from the base set, injective on base ids, **bidirectional** unchanged-anchor
+     pinning (an unchanged id'd cell keeps its id; an unchanged *id-less* cell
+     stays id-less, so the model can't mint a spurious id onto unchanged content),
+     `new` only on a nameable cell. Any failure → `AlignmentInvalid`. **5c:** wired
+     to the §9 escalation — `_migrate_drifted_ids` fires `_recover_drifted_ids`
+     only when *every* deterministic tier was stuck (no move this pass; tiers are
+     never mixed), resolves a map **once** (cached) and applies it **symmetrically**
+     to both decks; any failure **safe-aborts** by marking the region `deferred`
+     (holds the watermark → re-surfaces next run) rather than erroring (which would
+     block the whole deck's write). `clm slides sync --llm-recover` (default off) +
+     `--recovery-model`, plumbed through batch + interactive apply; a missing key
+     degrades to a warning. **5d (localized chokepoint):** `_migrate_localized_paired`
+     extends the deterministic migration to **localized** id'd code cells via one
+     both-deck write (the twins differ by translation, so the body-keyed structural
+     pass can't carry a header-only id change) — keeping `de_id == en_id` by
+     construction. The no-op corpus harness held at 81/212, 0 violations through all
+     of Phase 5 (recovery is opt-in; the default path is untouched).
 6. **Docs + `--explain`** (§13): info topics, migration entry, anchor-diff dump.
 
 ## 15. Open / deferred

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -50,7 +50,11 @@ from typing import TYPE_CHECKING
 
 import click
 
-from clm.infrastructure.llm.cache import SyncWatermarkCache, resolve_cache_dir
+from clm.infrastructure.llm.cache import (
+    SyncAlignmentCache,
+    SyncWatermarkCache,
+    resolve_cache_dir,
+)
 from clm.infrastructure.llm.ollama_client import (
     DEFAULT_SYNC_MODEL,
     OllamaSyncJudge,
@@ -64,10 +68,12 @@ from clm.infrastructure.llm.openrouter_client import (
 from clm.slides.sync_apply import ApplyResult, apply_plan
 from clm.slides.sync_plan import PlanIssue, SyncPlan, build_sync_plan, render_plan
 from clm.slides.sync_plan_walker import PlanWalkResult, WalkerOptions, run_plan_walker
+from clm.slides.sync_recover import DEFAULT_RECOVERY_MODEL, OpenRouterAlignmentRecoverer
 from clm.slides.sync_translate import DEFAULT_TRANSLATION_MODEL, OpenRouterSlideTranslator
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.ollama_client import SyncJudge
+    from clm.slides.sync_recover import AlignmentRecoverer
 
 CACHE_DB_NAME = "clm-llm.sqlite"
 
@@ -149,6 +155,25 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     ),
 )
 @click.option(
+    "--llm-recover",
+    is_flag=True,
+    default=False,
+    help=(
+        "Opt into the bounded-LLM recovery tier (Issue #190 §10): when the "
+        "deterministic id-migration is stuck on an ambiguous drifted slide_id "
+        "(a function renamed while a cell was split, an unresolvable tie), ask "
+        "Claude (Opus, via OpenRouter) for a validated, body-free id↔cell "
+        "alignment. Default off — without it such a region is left untouched and "
+        "re-surfaces next run. Needs $OPENROUTER_API_KEY (or $OPENAI_API_KEY)."
+    ),
+)
+@click.option(
+    "--recovery-model",
+    default=DEFAULT_RECOVERY_MODEL,
+    show_default=True,
+    help="OpenRouter model for --llm-recover alignment (a strong reasoning model).",
+)
+@click.option(
     "--cache-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -187,6 +212,8 @@ def slides_sync_cmd(
     ollama_url: str | None,
     llm_timeout: float | None,
     translation_model: str,
+    llm_recover: bool,
+    recovery_model: str,
     cache_dir: Path | None,
     no_cache: bool,
     no_env_file: bool,
@@ -231,9 +258,12 @@ def slides_sync_cmd(
         load_env_files(de_path.parent, en_path.parent)
 
     watermark_cache: SyncWatermarkCache | None = None
+    alignment_cache: SyncAlignmentCache | None = None
     if not no_cache:
         cache_root = resolve_cache_dir(cli_override=cache_dir)
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
+        if llm_recover and not dry_run:
+            alignment_cache = SyncAlignmentCache(cache_root / CACHE_DB_NAME)
 
     plan: SyncPlan
     apply_result: ApplyResult | None = None
@@ -247,6 +277,7 @@ def slides_sync_cmd(
             mode = "interactive"
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(model=translation_model)
+            recoverer = _resolve_recoverer(llm_recover, recovery_model)
             for issue in plan.issues:
                 click.echo(_issue_line(issue))
             walk = run_plan_walker(
@@ -255,21 +286,28 @@ def slides_sync_cmd(
                 translator=translator,
                 watermark_cache=watermark_cache,
                 options=WalkerOptions(),
+                recoverer=recoverer,
+                alignment_cache=alignment_cache,
             )
             apply_result = walk.apply_result
         else:
             mode = "apply"
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(model=translation_model)
+            recoverer = _resolve_recoverer(llm_recover, recovery_model)
             apply_result = apply_plan(
                 plan,
                 judge=judge,
                 translator=translator,
                 watermark_cache=watermark_cache,
+                recoverer=recoverer,
+                alignment_cache=alignment_cache,
             )
     finally:
         if watermark_cache is not None:
             watermark_cache.close()
+        if alignment_cache is not None:
+            alignment_cache.close()
 
     exit_code = (
         _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
@@ -343,6 +381,25 @@ def _resolve_judge(
         model=llm_model or DEFAULT_SYNC_JUDGE_MODEL,
         timeout=_resolve_timeout(llm_timeout, _DEFAULT_TIMEOUT_OPENROUTER),
     )
+
+
+def _resolve_recoverer(llm_recover: bool, recovery_model: str) -> AlignmentRecoverer | None:
+    """The bounded-LLM alignment recoverer for ``--llm-recover``, or ``None``.
+
+    ``None`` (the default, or a missing key) leaves an ambiguous drifted-id region
+    untouched to re-surface next run — recovery is strictly opt-in and degrades
+    gracefully when no OpenRouter key is configured (warning, not error).
+    """
+    if not llm_recover:
+        return None
+    if not has_openrouter_api_key():
+        click.echo(
+            "warning: --llm-recover needs OPENROUTER_API_KEY (or OPENAI_API_KEY); "
+            "ambiguous id-migration regions will be left for review instead.",
+            err=True,
+        )
+        return None
+    return OpenRouterAlignmentRecoverer(model=recovery_model)
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -373,6 +373,108 @@ class SyncCache:
         self._conn.close()
 
 
+class SyncAlignmentCache:
+    """Cache bounded-LLM (Opus) *alignment* recoveries for the sync engine.
+
+    Issue #190 §10 / Phase 5. When the deterministic id-migration (§9) cannot
+    decide which ``slide_id`` belongs on which cell — a simultaneous function
+    rename, a true N:1 split/merge, ambiguous ties (two ``def my_fun``, many bare
+    imports) — the sync engine may escalate (only under ``--llm-recover``) to a
+    **body-free, alignment-only** model call that returns an ``id ↔ cell`` *map*,
+    never free-form edits. That map is validated and applied deterministically.
+
+    A row memoizes *"the recoverer was asked to align this base region against
+    this current region, and here is the (validated) map it returned"*, so a
+    re-run over the same region short-circuits to the cached map and never
+    re-spends on the LLM. Keyed by ``(base_region_hash, current_region_hash,
+    prompt_version)`` — the two region fingerprints fully determine the question,
+    and the prompt version invalidates the cache when the prompt/model contract
+    changes (cf. :class:`SyncCache`, :class:`TitleSuggestionCache`).
+
+    ``alignment`` is the recoverer's verbatim JSON map (a current-cell → base
+    ``slide_id`` / ``"new"`` mapping). Only *successfully validated* maps are
+    cached: a safe-aborted recovery records nothing, so a fixed prompt re-derives
+    it on the next run.
+
+    Shares the same SQLite file as the other LLM caches; lives in its own table.
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._conn = sqlite3.connect(str(db_path))
+        self._migrate()
+
+    def _migrate(self) -> None:
+        cursor = self._conn.execute("PRAGMA table_info(sync_alignments)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if not columns:
+            self._conn.execute(
+                """CREATE TABLE sync_alignments (
+                    base_region_hash    TEXT NOT NULL,
+                    current_region_hash TEXT NOT NULL,
+                    prompt_version      TEXT NOT NULL,
+                    alignment           TEXT NOT NULL,
+                    created_at          TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (base_region_hash, current_region_hash, prompt_version)
+                )"""
+            )
+            self._conn.commit()
+
+    def get(
+        self,
+        base_region_hash: str,
+        current_region_hash: str,
+        prompt_version: str,
+    ) -> str | None:
+        """Return the cached alignment JSON for the region pair, or ``None``."""
+        row = self._conn.execute(
+            "SELECT alignment FROM sync_alignments "
+            "WHERE base_region_hash=? AND current_region_hash=? AND prompt_version=?",
+            (base_region_hash, current_region_hash, prompt_version),
+        ).fetchone()
+        return row[0] if row else None
+
+    def put(
+        self,
+        base_region_hash: str,
+        current_region_hash: str,
+        prompt_version: str,
+        alignment: str,
+    ) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO sync_alignments
+               (base_region_hash, current_region_hash, prompt_version, alignment)
+               VALUES (?, ?, ?, ?)""",
+            (base_region_hash, current_region_hash, prompt_version, alignment),
+        )
+        self._conn.commit()
+
+    def invalidate_prompt_version(self, prompt_version: str) -> int:
+        """Delete entries whose prompt version no longer matches."""
+        cursor = self._conn.execute(
+            "DELETE FROM sync_alignments WHERE prompt_version!=?",
+            (prompt_version,),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def iter_entries(self) -> list[tuple[str, str, str, str, str]]:
+        """Return every cached entry, most-recent first.
+
+        Tuples are ``(base_region_hash, current_region_hash, prompt_version,
+        alignment, created_at)``.
+        """
+        rows = self._conn.execute(
+            "SELECT base_region_hash, current_region_hash, prompt_version, "
+            "alignment, created_at "
+            "FROM sync_alignments ORDER BY created_at DESC, base_region_hash"
+        ).fetchall()
+        return [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
+
+    def close(self) -> None:
+        self._conn.close()
+
+
 class SyncSnapshotCache:
     """Per-(file, slide_id, role) snapshot of the last accepted sync state.
 

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -1495,13 +1495,31 @@ def _recover_drifted_ids(
     """
     de_cells = _neutral_code_cells(de_state)
     en_cells = _neutral_code_cells(en_state)
-    if len(de_cells) != len(en_cells):
-        return  # neutral halves out of unify — not the migration's job to reconcile
     current_region = _region_of(de_cells)
+    # The map is derived from DE's region and applied to BOTH decks by index, so the
+    # two neutral regions must be byte-identical (the unify invariant). Require it
+    # explicitly — a content divergence with the *same* length would otherwise let a
+    # DE-derived map mis-stamp EN. A divergence is the align_anchored pass's job, not
+    # the migration's; defer rather than risk de_id != en_id.
+    if current_region != _region_of(en_cells):
+        return
     if not _has_drifted_id(baseline_constructs, current_region):
         return  # nothing genuinely drifted -> do not spend the LLM
     base_region = _shared_region(cache, plan.de_path, plan.en_path)
     if not base_region:
+        return
+    # Only escalate when there is a genuine realignment target: a *new* id-less
+    # neutral code cell (a split product — its content is absent from the baseline).
+    # A pure in-place rename has none (its only change is an id'd cell whose body
+    # changed), so there is nothing to realign — leaving it to re-baseline keeps its
+    # stable slide_id, instead of handing the region to the LLM, which could strip
+    # the id (Issue #190 Phase 5 review). validate_alignment is the hard backstop (it
+    # refuses to drop a worn id); this just avoids a pointless, re-surfacing LLM call
+    # when no split occurred.
+    baseline_hashes = {c.content_hash for c in base_region}
+    if not any(
+        c.slide_id is None and c.content_hash not in baseline_hashes for c in current_region
+    ):
         return
 
     mapping = _resolve_alignment(recoverer, alignment_cache, base_region, current_region)

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -1205,22 +1205,34 @@ def _migrate_drifted_ids(
     (Localized id'd cells, which need a symmetric paired ``de_id==en_id`` write, are
     deferred.)
 
-    When the deterministic pass is fully *stuck* on such an ambiguous region (it
-    made no move) and a ``recoverer`` is configured (``--llm-recover``), escalate to
-    the bounded-LLM alignment tier (:func:`_recover_drifted_ids`). If the
-    deterministic pass already resolved at least one id this region, the two tiers
-    are **not** mixed — any remaining ambiguity re-surfaces next run once the clean
-    moves are baselined.
+    **Localized** id'd code cells (``lang=``, Phase 5d) are migrated through a
+    separate *paired* chokepoint (:func:`_migrate_localized_paired`): their twins
+    differ across decks (translated bodies) and the structural pass cannot carry a
+    header-only id change between them, so the move is stamped onto **both** decks'
+    twins at once to keep ``de_id == en_id``.
+
+    When *every* deterministic tier is stuck on an ambiguous region (it made no
+    move) and a ``recoverer`` is configured (``--llm-recover``), escalate the
+    **neutral** region to the bounded-LLM alignment tier
+    (:func:`_recover_drifted_ids`). If any deterministic move landed this pass, the
+    tiers are **not** mixed — remaining ambiguity re-surfaces next run once the
+    clean moves are baselined.
     """
     if _effective_direction(plan) is None:
         return
-    baseline_constructs, baseline_hashes = _baseline_shared(cache, plan.de_path, plan.en_path)
-    if not baseline_constructs:
-        return
     before = result.applied_migrate
-    _migrate_one_deck(de_state, baseline_constructs, baseline_hashes, result)
-    _migrate_one_deck(en_state, baseline_constructs, baseline_hashes, result)
-    if recoverer is not None and result.applied_migrate == before:
+    baseline_constructs, baseline_hashes = _baseline_shared(cache, plan.de_path, plan.en_path)
+    if baseline_constructs:
+        _migrate_one_deck(de_state, baseline_constructs, baseline_hashes, result)
+        _migrate_one_deck(en_state, baseline_constructs, baseline_hashes, result)
+    loc_constructs, loc_de_hashes, loc_en_hashes = _baseline_localized(
+        cache, plan.de_path, plan.en_path
+    )
+    if loc_constructs:
+        _migrate_localized_paired(
+            de_state, en_state, loc_constructs, loc_de_hashes, loc_en_hashes, result
+        )
+    if recoverer is not None and baseline_constructs and result.applied_migrate == before:
         _recover_drifted_ids(
             plan, de_state, en_state, cache, baseline_constructs, recoverer, alignment_cache, result
         )
@@ -1278,6 +1290,120 @@ def _migrate_one_deck(
         state.dirty = True
         result.applied_migrate += 1
         idless_by_construct.pop(base_construct, None)  # at most one migration per construct
+
+
+def _baseline_localized(
+    cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
+) -> tuple[dict[str, str], set[str], set[str]]:
+    """Baseline ``{slide_id: construct}`` for localized id'd code, + per-deck hashes.
+
+    Localized cells live in the ``de``/``en`` partitions (not ``shared``): an id'd
+    one carries the real :data:`CODE_ROLE`. The construct of a given ``slide_id`` is
+    language-neutral (a function/class name does not translate), so the two decks
+    agree — it is read from the ``de`` partition. The per-deck content-hash sets
+    (every recorded row of each deck) let the paired migration tell a genuine
+    split-product (a *new* cell) from a pre-existing one (each deck checked against
+    its own baseline, since localized bodies differ across decks).
+    """
+    constructs: dict[str, str] = {}
+    de_hashes: set[str] = set()
+    en_hashes: set[str] = set()
+    if cache is None:
+        return constructs, de_hashes, en_hashes
+    for _pos, sid, role, chash, construct in cache.get_deck(str(de_path), str(en_path), "de"):
+        de_hashes.add(chash)
+        if role == CODE_ROLE and sid is not None and construct is not None:
+            constructs.setdefault(sid, construct)
+    for _pos, _sid, _role, chash, _construct in cache.get_deck(str(de_path), str(en_path), "en"):
+        en_hashes.add(chash)
+    return constructs, de_hashes, en_hashes
+
+
+def _localized_code_index(
+    state: FileState, baseline_hashes: set[str]
+) -> tuple[dict[str, RawCell], dict[str, list[RawCell]], Counter]:
+    """Index one deck's localized code cells for the paired migration.
+
+    Returns ``(idd_by_slide_id, new_idless_by_construct, construct_count)``: the
+    id'd cells keyed by their ``slide_id``, the **new** (hash absent from this
+    deck's baseline) id-less cells grouped by construct, and the per-construct count
+    over all localized code cells (the uniqueness guard).
+    """
+    idd: dict[str, RawCell] = {}
+    idless_by_construct: dict[str, list[RawCell]] = {}
+    construct_count: Counter = Counter()
+    for cell in state.cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.lang is None or meta.cell_type != "code":
+            continue  # localized code cells only
+        construct = construct_of(meta, cell.body)
+        if construct is None:
+            continue
+        construct_count[construct] += 1
+        if meta.slide_id is not None:
+            idd[meta.slide_id] = cell
+        elif cell_content_hash(cell.body) not in baseline_hashes:
+            idless_by_construct.setdefault(construct, []).append(cell)
+    return idd, idless_by_construct, construct_count
+
+
+def _migrate_localized_paired(
+    de_state: FileState,
+    en_state: FileState,
+    baseline_constructs: dict[str, str],
+    de_hashes: set[str],
+    en_hashes: set[str],
+    result: ApplyResult,
+) -> None:
+    """Move a drifted localized slide_id symmetrically on both decks (§9 / Phase 5d).
+
+    The localized analogue of :func:`_migrate_one_deck`: when an id'd localized code
+    cell is split on **both** decks — the id left wearing the wrong construct while a
+    new id-less twin carries the construct the id names — move the id onto both new
+    twins and mint one shared fresh slug onto both orphans. Both decks are written in
+    lockstep so ``_slide_ids_pair``'s ``de_id == en_id`` invariant holds (the
+    structural pass cannot carry a header-only change between the two translated,
+    non-byte-identical twins).
+
+    Conservative by construction — every guard must hold or the id is left for §10:
+    the id must be present and drifted on **both** decks, the two twins must have
+    drifted to the **same** construct, the baseline construct must be unique on each
+    deck, and each deck must have exactly one **new** id-less cell carrying it.
+    """
+    de_idd, de_idless, de_count = _localized_code_index(de_state, de_hashes)
+    en_idd, en_idless, en_count = _localized_code_index(en_state, en_hashes)
+    used_ids = {c.metadata.slide_id for c in de_state.cells if c.metadata.slide_id}
+    used_ids |= {c.metadata.slide_id for c in en_state.cells if c.metadata.slide_id}
+    for sid, base_construct in baseline_constructs.items():
+        de_cell = de_idd.get(sid)
+        en_cell = en_idd.get(sid)
+        if de_cell is None or en_cell is None:
+            continue  # the id must be a twinned pair present on both decks
+        de_cur = construct_of(de_cell.metadata, de_cell.body)
+        en_cur = construct_of(en_cell.metadata, en_cell.body)
+        if de_cur is None or en_cur is None:
+            continue
+        if de_cur == base_construct or en_cur == base_construct:
+            continue  # not drifted on both decks -> asymmetric or no-op, defer
+        if de_cur != en_cur:
+            continue  # twins drifted to different constructs -> ambiguous, defer
+        if de_count[base_construct] != 1 or en_count[base_construct] != 1:
+            continue  # base construct not unique on some deck -> ambiguous, defer
+        de_targets = de_idless.get(base_construct, [])
+        en_targets = en_idless.get(base_construct, [])
+        if len(de_targets) != 1 or len(en_targets) != 1:
+            continue  # no unique NEW split-product on both decks -> defer
+        _stamp_slide_id(de_targets[0], sid)  # the id follows its construct, on both decks
+        _stamp_slide_id(en_targets[0], sid)
+        new_slug = resolve_collision(de_cur, used_ids)  # de_cur == en_cur (neutral construct)
+        used_ids.add(new_slug)
+        _stamp_slide_id(de_cell, new_slug)  # both orphans get the same fresh slug
+        _stamp_slide_id(en_cell, new_slug)
+        de_state.dirty = True
+        en_state.dirty = True
+        result.applied_migrate += 2  # one logical move, written to two decks
+        de_idless.pop(base_construct, None)
+        en_idless.pop(base_construct, None)
 
 
 def _neutral_code_cells(state: FileState) -> list[RawCell]:

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -49,10 +49,22 @@ from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_code import apply_code_structure
 from clm.slides.sync_plan import (
     MEMBERSHIP_ROLES,
+    NEUTRAL_CODE_ROLE,
     Proposal,
     SyncPlan,
     ordered_sync_cells,
     watermark_rows,
+)
+from clm.slides.sync_recover import (
+    NEW,
+    NONE,
+    AlignmentInvalid,
+    RecoveryError,
+    RegionCell,
+    decode_mapping,
+    encode_mapping,
+    region_fingerprint,
+    validate_alignment,
 )
 from clm.slides.sync_translate import TranslationError
 from clm.slides.sync_writeback import (
@@ -66,8 +78,9 @@ from clm.slides.sync_writeback import (
 )
 
 if TYPE_CHECKING:
-    from clm.infrastructure.llm.cache import SyncWatermarkCache
+    from clm.infrastructure.llm.cache import SyncAlignmentCache, SyncWatermarkCache
     from clm.infrastructure.llm.ollama_client import SyncJudge
+    from clm.slides.sync_recover import AlignmentRecoverer
     from clm.slides.sync_translate import SlideTranslator
 
 _SLIDE_ID_RE = re.compile(r'\s*slide_id="[^"]*"')
@@ -134,6 +147,8 @@ def apply_plan(
     translator: SlideTranslator | None = None,
     watermark_cache: SyncWatermarkCache | None = None,
     decisions: dict[int, str] | None = None,
+    recoverer: AlignmentRecoverer | None = None,
+    alignment_cache: SyncAlignmentCache | None = None,
 ) -> ApplyResult:
     """Apply ``plan``'s proposals to the decks and advance the watermark.
 
@@ -154,6 +169,13 @@ def apply_plan(
     proposal is counted as ``deferred`` so the watermark cannot advance over it.
     Add / rename proposals are always applied (they are non-destructive and the
     counterpart is reviewed in the resulting ``git diff``).
+
+    ``recoverer`` (with ``alignment_cache``) is the opt-in bounded-LLM tier
+    (``--llm-recover``, Issue #190 §10 / Phase 5): when the deterministic
+    id-migration (§9) is stuck on an *ambiguous* drifted id — a function renamed
+    while a cell was split, an unresolvable tie — the recoverer re-identifies the
+    neutral code region with a validated, cached, body-free alignment map. ``None``
+    (the default) leaves the ambiguous region untouched to re-surface next run.
     """
     result = ApplyResult()
 
@@ -234,7 +256,9 @@ def apply_plan(
     # cell, the slide_id is left on the wrong half. Move it back onto the cell whose
     # construct it names BEFORE the structural pass propagates, so the corrected ids
     # ride along to the twin.
-    _migrate_drifted_ids(plan, de_state, en_state, watermark_cache, result)
+    _migrate_drifted_ids(
+        plan, de_state, en_state, watermark_cache, result, recoverer, alignment_cache
+    )
 
     baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan.de_path, plan.en_path)
     apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
@@ -1154,6 +1178,8 @@ def _migrate_drifted_ids(
     en_state: FileState,
     cache: SyncWatermarkCache | None,
     result: ApplyResult,
+    recoverer: AlignmentRecoverer | None = None,
+    alignment_cache: SyncAlignmentCache | None = None,
 ) -> None:
     """Move a slide_id that drifted off its construct back onto the right cell (§9).
 
@@ -1178,14 +1204,26 @@ def _migrate_drifted_ids(
     recurring guard) or a co-occurring function rename — are left for §10 recovery.
     (Localized id'd cells, which need a symmetric paired ``de_id==en_id`` write, are
     deferred.)
+
+    When the deterministic pass is fully *stuck* on such an ambiguous region (it
+    made no move) and a ``recoverer`` is configured (``--llm-recover``), escalate to
+    the bounded-LLM alignment tier (:func:`_recover_drifted_ids`). If the
+    deterministic pass already resolved at least one id this region, the two tiers
+    are **not** mixed — any remaining ambiguity re-surfaces next run once the clean
+    moves are baselined.
     """
     if _effective_direction(plan) is None:
         return
     baseline_constructs, baseline_hashes = _baseline_shared(cache, plan.de_path, plan.en_path)
     if not baseline_constructs:
         return
+    before = result.applied_migrate
     _migrate_one_deck(de_state, baseline_constructs, baseline_hashes, result)
     _migrate_one_deck(en_state, baseline_constructs, baseline_hashes, result)
+    if recoverer is not None and result.applied_migrate == before:
+        _recover_drifted_ids(
+            plan, de_state, en_state, cache, baseline_constructs, recoverer, alignment_cache, result
+        )
 
 
 def _migrate_one_deck(
@@ -1240,6 +1278,194 @@ def _migrate_one_deck(
         state.dirty = True
         result.applied_migrate += 1
         idless_by_construct.pop(base_construct, None)  # at most one migration per construct
+
+
+def _neutral_code_cells(state: FileState) -> list[RawCell]:
+    """The deck's language-neutral code cells in document order (the §9/§10 region).
+
+    Includes unparsable (``construct is None``) code cells so the region matches
+    the watermark's ``neutral-code`` rows one-to-one — both index by the same cell
+    set, so a recovery map's indices line up on either side.
+    """
+    return [
+        cell
+        for cell in state.cells
+        if not cell.metadata.is_j2
+        and cell.metadata.lang is None
+        and cell.metadata.cell_type == "code"
+    ]
+
+
+def _region_of(cells: list[RawCell]) -> list[RegionCell]:
+    """The body-free :class:`RegionCell` view of an ordered neutral-code cell list."""
+    return [
+        RegionCell(
+            slide_id=cell.metadata.slide_id,
+            construct=construct_of(cell.metadata, cell.body),
+            content_hash=cell_content_hash(cell.body),
+        )
+        for cell in cells
+    ]
+
+
+def _shared_region(
+    cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
+) -> list[RegionCell]:
+    """The baseline neutral-**code** region from the watermark ``shared`` partition.
+
+    Filters the membership-widened ``shared`` rows to the ``neutral-code`` role so
+    the base region covers exactly the cells :func:`_neutral_code_cells` yields live
+    (neutral markdown is excluded). Position order is preserved.
+    """
+    if cache is None:
+        return []
+    return [
+        RegionCell(slide_id=sid, construct=construct, content_hash=chash)
+        for (_pos, sid, role, chash, construct) in cache.get_deck(
+            str(de_path), str(en_path), "shared"
+        )
+        if role == NEUTRAL_CODE_ROLE
+    ]
+
+
+def _has_drifted_id(baseline_constructs: dict[str, str], region: list[RegionCell]) -> bool:
+    """Whether some current cell wears an id whose baseline construct it no longer names.
+
+    The escalation trigger: only a genuine id-vs-construct drift is worth the LLM —
+    a region with no drifted id has nothing to recover, so the recoverer never fires.
+    """
+    for cell in region:
+        if cell.slide_id is None:
+            continue
+        base = baseline_constructs.get(cell.slide_id)
+        if base is not None and cell.construct is not None and cell.construct != base:
+            return True
+    return False
+
+
+def _recover_drifted_ids(
+    plan: SyncPlan,
+    de_state: FileState,
+    en_state: FileState,
+    cache: SyncWatermarkCache | None,
+    baseline_constructs: dict[str, str],
+    recoverer: AlignmentRecoverer,
+    alignment_cache: SyncAlignmentCache | None,
+    result: ApplyResult,
+) -> None:
+    """Bounded-LLM recovery of an ambiguous drifted-id region (§10 / Phase 5).
+
+    Fires only when the deterministic §9 pass is stuck (its caller gates on
+    ``applied_migrate`` unchanged). Builds the body-free base/current regions, asks
+    the ``recoverer`` for a validated id↔cell map (cached by region fingerprints),
+    and applies it **symmetrically** to both decks (neutral cells are byte-identical
+    across halves, so the same map keeps ``de_id == en_id``).
+
+    Any failure — the decks out of unify, no real drift, the recoverer down, or a
+    map that fails :func:`validate_alignment` — **safe-aborts**: the region is left
+    untouched and the pass is marked ``deferred`` (which holds the watermark, so the
+    region re-surfaces next run) rather than erroring (which would block the whole
+    deck's write). A wrong id is worse than a deferred one.
+    """
+    de_cells = _neutral_code_cells(de_state)
+    en_cells = _neutral_code_cells(en_state)
+    if len(de_cells) != len(en_cells):
+        return  # neutral halves out of unify — not the migration's job to reconcile
+    current_region = _region_of(de_cells)
+    if not _has_drifted_id(baseline_constructs, current_region):
+        return  # nothing genuinely drifted -> do not spend the LLM
+    base_region = _shared_region(cache, plan.de_path, plan.en_path)
+    if not base_region:
+        return
+
+    mapping = _resolve_alignment(recoverer, alignment_cache, base_region, current_region)
+    if mapping is None:
+        # Safe-abort: leave the region untouched, hold the watermark so it
+        # re-surfaces. Not an error — that would block the whole pass's write.
+        result.deferred += 1
+        return
+    _apply_alignment(de_state, de_cells, mapping, result)
+    _apply_alignment(en_state, en_cells, mapping, result)
+
+
+def _resolve_alignment(
+    recoverer: AlignmentRecoverer,
+    alignment_cache: SyncAlignmentCache | None,
+    base_region: list[RegionCell],
+    current_region: list[RegionCell],
+) -> dict[int, str] | None:
+    """A validated alignment map for the region pair, or ``None`` to safe-abort.
+
+    Prefers a cached, re-validated map (no LLM spend); on a miss it calls the
+    recoverer once and caches only a *valid* result. Every path that cannot produce
+    a sound map returns ``None`` so the caller defers the region.
+    """
+    fp_base = region_fingerprint(base_region)
+    fp_cur = region_fingerprint(current_region)
+    pv = recoverer.prompt_version
+    if alignment_cache is not None:
+        cached = alignment_cache.get(fp_base, fp_cur, pv)
+        if cached is not None:
+            try:
+                return validate_alignment(decode_mapping(cached), base_region, current_region)
+            except AlignmentInvalid:
+                logger.warning("llm-recover: cached alignment failed validation; re-deriving")
+    try:
+        raw = recoverer.recover(base_region=base_region, current_region=current_region)
+        mapping = validate_alignment(raw, base_region, current_region)
+    except (RecoveryError, AlignmentInvalid) as exc:
+        logger.warning("llm-recover: alignment unavailable/invalid (%s); region deferred", exc)
+        return None
+    if alignment_cache is not None:
+        alignment_cache.put(fp_base, fp_cur, pv, encode_mapping(mapping))
+    return mapping
+
+
+def _apply_alignment(
+    state: FileState,
+    region_cells: list[RawCell],
+    mapping: dict[int, str],
+    result: ApplyResult,
+) -> None:
+    """Apply a validated alignment map to one deck's neutral-code region.
+
+    Each region cell is re-identified to the id the map assigns: a base ``slide_id``
+    (continuation), a freshly-minted content slug (:data:`NEW`), or no id
+    (:data:`NONE`). ``used_ids`` spans the whole deck so a minted slug never collides;
+    processing both decks with the same map and an identically-evolving ``used_ids``
+    keeps ``de_id == en_id``. Cells already carrying the assigned id are no-ops.
+    """
+    used_ids = {cell.metadata.slide_id for cell in state.cells if cell.metadata.slide_id}
+    for idx, cell in enumerate(region_cells):
+        target = mapping.get(idx)
+        if target is None:
+            continue  # defensive: validation guarantees total coverage
+        current_id = cell.metadata.slide_id
+        if target == NONE:
+            desired: str | None = None
+        elif target == NEW:
+            construct = construct_of(cell.metadata, cell.body)
+            if construct is None:
+                continue  # validation forbids NEW on a construct-less cell; defensive
+            desired = resolve_collision(construct, used_ids)
+        else:
+            desired = target  # a base id (continuation)
+        if desired == current_id:
+            continue
+        if desired is None:
+            _clear_slide_id(cell)
+        else:
+            used_ids.add(desired)
+            _stamp_slide_id(cell, desired)
+        state.dirty = True
+        result.applied_migrate += 1
+
+
+def _clear_slide_id(cell: RawCell) -> None:
+    """Remove any ``slide_id="…"`` from a cell header (the inverse of stamping)."""
+    header = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
+    cell.lines[0] = header
+    cell.metadata = parse_cell_header(header)
 
 
 def _record_watermark(

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -46,9 +46,10 @@ from clm.slides.sync_apply import (
 )
 
 if TYPE_CHECKING:
-    from clm.infrastructure.llm.cache import SyncWatermarkCache
+    from clm.infrastructure.llm.cache import SyncAlignmentCache, SyncWatermarkCache
     from clm.infrastructure.llm.ollama_client import SyncJudge
     from clm.slides.sync_plan import Proposal, SyncPlan
+    from clm.slides.sync_recover import AlignmentRecoverer
     from clm.slides.sync_translate import SlideTranslator
 
 
@@ -195,6 +196,8 @@ def run_plan_walker(
     translator: SlideTranslator | None = None,
     watermark_cache: SyncWatermarkCache | None = None,
     options: WalkerOptions | None = None,
+    recoverer: AlignmentRecoverer | None = None,
+    alignment_cache: SyncAlignmentCache | None = None,
 ) -> PlanWalkResult:
     """Walk ``plan``'s proposals, prompt per proposal, then apply once.
 
@@ -255,6 +258,8 @@ def run_plan_walker(
         translator=translator,
         watermark_cache=watermark_cache,
         decisions=decisions,
+        recoverer=recoverer,
+        alignment_cache=alignment_cache,
     )
     return PlanWalkResult(plan=plan, apply_result=apply_result, actions=actions)
 

--- a/src/clm/slides/sync_recover.py
+++ b/src/clm/slides/sync_recover.py
@@ -1,0 +1,408 @@
+"""Bounded LLM (Opus) *alignment* recovery for the sync engine.
+
+Issue #190 §10 / Phase 5. The deterministic id-migration (§9,
+:func:`clm.slides.sync_apply._migrate_drifted_ids`) moves a ``slide_id`` that
+drifted off its construct back onto the right cell — but only when the move is
+*unambiguous* (a unique, new, construct-matched cell). The genuine residue —
+a function renamed in the same edit that split a cell, a true N:1 merge/split,
+ambiguous ties (two ``def my_fun``, many bare imports) — is left for this tier.
+
+The recovery is deliberately **bounded**:
+
+- **Body-free.** The model never sees cell source. It is given two ordered lists
+  of code cells described only by their content **anchor** components — an AST
+  ``construct`` slug, a ``content_hash``, and any ``slide_id`` — and returns an
+  ``id ↔ cell`` *map*, never free-form edits. The map is applied deterministically
+  by the engine, so the LLM can only *re-identify* cells, never rewrite them.
+- **Validated.** Every returned map is checked by :func:`validate_alignment`
+  (total over the current cells; ids only from the base set; injective on base
+  ids; provably-unchanged cells pinned to their old id). Any failure raises
+  :class:`AlignmentInvalid`, and the caller **safe-aborts to no-change-plus-flag**
+  — a wrong id is worse than a deferred one.
+- **Cached.** Keyed by ``(base_region_fingerprint, current_region_fingerprint,
+  prompt_version)`` (:class:`clm.infrastructure.llm.cache.SyncAlignmentCache`),
+  so a re-run over the same region never re-spends on the LLM. The fingerprint is
+  the *exact* body-free serialization the model sees, so the cache key is sound.
+- **Opt-in.** ``clm slides sync --llm-recover`` (default off); without it an
+  ambiguous region is simply left untouched and re-surfaces next run.
+
+The engine depends only on the :class:`AlignmentRecoverer` protocol, so tests
+drive it with :class:`StaticAlignmentRecoverer` and never touch the network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from clm.infrastructure.llm.retry import call_with_retries
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_RECOVERY_MODEL",
+    "NEW",
+    "NONE",
+    "RECOVERY_PROMPT_VERSION",
+    "AlignmentInvalid",
+    "AlignmentRecoverer",
+    "OpenRouterAlignmentRecoverer",
+    "RecoveryError",
+    "RegionCell",
+    "StaticAlignmentRecoverer",
+    "build_recovery_user_prompt",
+    "decode_mapping",
+    "encode_mapping",
+    "region_fingerprint",
+    "validate_alignment",
+]
+
+# Claude Opus via OpenRouter — the design's "escalate to Claude (Opus)" tier. A
+# distinct constant (cf. the Sonnet judge/translator) so the rare, harder
+# alignment call can be tuned independently (Issue #167).
+DEFAULT_RECOVERY_MODEL = "anthropic/claude-opus-4"
+RECOVERY_PROMPT_VERSION = "recover-v1"
+
+# The two non-id assignments a recoverer may return for a current cell.
+NEW = "new"  # genuinely new content → mint a fresh content slug from its construct
+NONE = "none"  # the cell should remain without a slide_id
+
+
+class RecoveryError(Exception):
+    """The recoverer could not produce a map (transport/parse failure)."""
+
+
+class AlignmentInvalid(Exception):
+    """A returned map failed validation; the caller must safe-abort (no change)."""
+
+
+@dataclass(frozen=True)
+class RegionCell:
+    """One code cell in an alignment region, described **body-free**.
+
+    ``slide_id`` is the id the cell carries (in the current region) or carried (in
+    the base region), or ``None``. ``construct`` is the AST construct slug from
+    :func:`clm.slides.sync_writeback.construct_of` (``None`` for unnameable cells).
+    ``content_hash`` is :func:`clm.slides.sync_writeback.cell_content_hash` of the
+    body — it stands in for the body so the model (and the cache key) never need
+    the source.
+    """
+
+    slide_id: str | None
+    construct: str | None
+    content_hash: str
+
+
+@runtime_checkable
+class AlignmentRecoverer(Protocol):
+    """Re-identifies the cells of an ambiguous code region.
+
+    ``prompt_version`` participates in the cache key so a prompt/model change
+    invalidates stale maps.
+    """
+
+    prompt_version: str
+
+    def recover(
+        self,
+        *,
+        base_region: list[RegionCell],
+        current_region: list[RegionCell],
+    ) -> dict[int, str]:
+        """Return ``{current_index: assignment}`` for every current cell.
+
+        ``assignment`` is a base ``slide_id``, :data:`NEW`, or :data:`NONE`. Raises
+        :class:`RecoveryError` on failure. The map is *not* trusted — the caller
+        validates it with :func:`validate_alignment` before applying.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Region fingerprint + map (de)serialization — the cache-key + storage halves.
+# ---------------------------------------------------------------------------
+
+
+def region_fingerprint(region: list[RegionCell]) -> str:
+    """Stable sha256 over the body-free region serialization.
+
+    Captures *exactly* what the recoverer sees — the ordered ``(slide_id,
+    construct, content_hash)`` triples — so a cached map is a sound function of the
+    two region fingerprints. ``content_hash`` already encodes the body uniquely, so
+    the fingerprint is body-sensitive without exposing any source.
+    """
+    payload = [[c.slide_id, c.construct, c.content_hash] for c in region]
+    blob = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def encode_mapping(mapping: dict[int, str]) -> str:
+    """Serialize a ``{int: str}`` map to canonical JSON (string keys, sorted)."""
+    return json.dumps(
+        {str(k): mapping[k] for k in sorted(mapping)},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def decode_mapping(text: str) -> dict[int, str]:
+    """Parse a JSON object back into a ``{int: str}`` map.
+
+    Raises :class:`AlignmentInvalid` on any malformed payload (a non-object, a
+    non-integer key, or a non-string value) so a corrupt cache row or a stray LLM
+    response is treated as a validation failure, not a crash.
+    """
+    try:
+        raw = json.loads(text)
+    except (ValueError, TypeError) as exc:
+        raise AlignmentInvalid(f"alignment map is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise AlignmentInvalid("alignment map must be a JSON object")
+    out: dict[int, str] = {}
+    for key, value in raw.items():
+        try:
+            idx = int(key)
+        except (ValueError, TypeError) as exc:
+            raise AlignmentInvalid(f"alignment key {key!r} is not an integer") from exc
+        if not isinstance(value, str):
+            raise AlignmentInvalid(f"alignment value for {key!r} is not a string")
+        out[idx] = value
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Validation — the load-bearing safety net (safe-abort on ANY failure).
+# ---------------------------------------------------------------------------
+
+
+def _pinned_ids(base_region: list[RegionCell]) -> dict[str, str]:
+    """``content_hash → slide_id`` for base cells a hash can *unambiguously* pin.
+
+    A current cell byte-identical to such a base cell is provably unchanged and
+    must keep that id. A hash shared by two base cells, or by an id'd and an
+    id-less cell, is ambiguous and is excluded — the recurring content-anchor
+    non-uniqueness guard (cf. the Counter / ordered-sequence guards elsewhere).
+    """
+    by_hash: dict[str, set[str | None]] = {}
+    for cell in base_region:
+        by_hash.setdefault(cell.content_hash, set()).add(cell.slide_id)
+    pinned: dict[str, str] = {}
+    for chash, ids in by_hash.items():
+        if len(ids) == 1:
+            only = next(iter(ids))
+            if only is not None:
+                pinned[chash] = only
+    return pinned
+
+
+def validate_alignment(
+    mapping: dict[int, str],
+    base_region: list[RegionCell],
+    current_region: list[RegionCell],
+) -> dict[int, str]:
+    """Return ``mapping`` unchanged if sound, else raise :class:`AlignmentInvalid`.
+
+    The contract the engine relies on before it will apply an LLM-derived map
+    (Issue #190 §10). Every check is a *hard* gate — a single failure safe-aborts
+    the whole recovery to no-change-plus-flag:
+
+    1. **Total & well-formed** — the keys are exactly ``{0 … len(current)-1}`` (a
+       total function on the current cells, no missing or stray index).
+    2. **Ids from the base set** — every value is :data:`NEW`, :data:`NONE`, or a
+       ``slide_id`` that exists in the base region (no invented ids).
+    3. **Injective on base ids** — no base ``slide_id`` is assigned to two current
+       cells (an id identifies one cell).
+    4. **Unchanged-anchors pinned** — a current cell byte-identical to an
+       unambiguously-id'd base cell must be assigned that id (the model may not
+       reassign a provably-unchanged cell).
+    5. **``NEW`` is nameable** — :data:`NEW` is only valid on a cell with a
+       construct (there must be something to mint a slug from).
+    """
+    n = len(current_region)
+    if set(mapping) != set(range(n)):
+        raise AlignmentInvalid(
+            f"map must cover current indices 0..{n - 1} exactly, got {sorted(mapping)}"
+        )
+
+    base_ids = {c.slide_id for c in base_region if c.slide_id is not None}
+    for idx, value in mapping.items():
+        if value in (NEW, NONE):
+            if value == NEW and current_region[idx].construct is None:
+                raise AlignmentInvalid(f"index {idx} assigned {NEW!r} but has no construct")
+            continue
+        if value not in base_ids:
+            raise AlignmentInvalid(f"index {idx} assigned unknown base id {value!r}")
+
+    assigned = [v for v in mapping.values() if v not in (NEW, NONE)]
+    duplicated = sorted(x for x, count in Counter(assigned).items() if count > 1)
+    if duplicated:
+        raise AlignmentInvalid(f"base ids assigned to multiple current cells: {duplicated}")
+
+    pinned = _pinned_ids(base_region)
+    for idx, cell in enumerate(current_region):
+        forced = pinned.get(cell.content_hash)
+        if forced is not None and mapping[idx] != forced:
+            raise AlignmentInvalid(
+                f"index {idx} is byte-identical to base id {forced!r} "
+                f"but was mapped to {mapping[idx]!r}"
+            )
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Recoverers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StaticAlignmentRecoverer:
+    """A deterministic recoverer for tests and offline runs.
+
+    Returns ``mapping`` verbatim (a copy). With ``raise_error`` it raises
+    :class:`RecoveryError` to exercise the safe-abort path. ``calls`` counts
+    invocations so a test can assert the cache short-circuited a second run.
+    """
+
+    mapping: dict[int, str] = field(default_factory=dict)
+    raise_error: bool = False
+    prompt_version: str = "static"
+    calls: int = 0
+
+    def recover(
+        self,
+        *,
+        base_region: list[RegionCell],
+        current_region: list[RegionCell],
+    ) -> dict[int, str]:
+        self.calls += 1
+        if self.raise_error:
+            raise RecoveryError("static recoverer configured to fail")
+        return dict(self.mapping)
+
+
+_SYSTEM_PROMPT = (
+    "You realign stable identifiers (slide_id) onto the code cells of a "
+    "programming-course slide deck after an edit the deterministic tooling could "
+    "not resolve (a function renamed while a cell was split, an ambiguous "
+    "duplicate, a merge/split). You are given two ordered lists of CODE CELLS "
+    "described WITHOUT their source — only an AST 'construct' name, a content "
+    "hash, and any slide_id:\n"
+    "  BASE: the last-synced cells, each with the slide_id it carried.\n"
+    "  CURRENT: the cells as they are now; some lost their slide_id in the edit.\n\n"
+    "Return ONLY a JSON object mapping each CURRENT cell index (a string) to one "
+    "of:\n"
+    "  - a slide_id taken from BASE, when that current cell is the continuation "
+    "of that base cell (e.g. a renamed function keeps its id);\n"
+    '  - "new", when the current cell is genuinely new content that should get a '
+    "fresh id (it must have a construct);\n"
+    '  - "none", when the current cell should remain without an id.\n\n'
+    "Rules you MUST follow:\n"
+    "  - Map EVERY current index exactly once; assign each BASE slide_id to AT "
+    "MOST one current cell.\n"
+    "  - A current cell whose content hash EQUALS a base cell's is unchanged: "
+    'give it that base cell\'s slide_id (or "none" if the base cell had none).\n'
+    "  - Use construct-name and position similarity to spot a rename.\n"
+    '  - When unsure, return "none"/"new" rather than guess an id — a wrong id is '
+    "worse than none.\n"
+    "Return only the JSON object, no commentary, no code fences."
+)
+
+
+def _serialize_region(label: str, region: list[RegionCell]) -> str:
+    """Render one region as a compact, indexed, body-free list for the prompt."""
+    rows = [
+        {
+            "index": idx,
+            "slide_id": cell.slide_id,
+            "construct": cell.construct,
+            "content_hash": cell.content_hash,
+        }
+        for idx, cell in enumerate(region)
+    ]
+    return f"{label}:\n" + json.dumps(rows, ensure_ascii=False, indent=2)
+
+
+def build_recovery_user_prompt(
+    base_region: list[RegionCell],
+    current_region: list[RegionCell],
+) -> str:
+    """Build the body-free user prompt: the two serialized regions."""
+    return (
+        _serialize_region("BASE", base_region)
+        + "\n\n"
+        + _serialize_region("CURRENT", current_region)
+    )
+
+
+@dataclass
+class OpenRouterAlignmentRecoverer:
+    """LLM-backed recoverer (synchronous OpenAI client, Claude Opus by default).
+
+    Sends the body-free region serialization and parses the returned JSON map.
+    Raises :class:`RecoveryError` on any transport/parse failure so the caller
+    safe-aborts that region rather than crashing the whole sync. The result is
+    *not* trusted — :func:`validate_alignment` gates it before it is applied.
+    """
+
+    model: str = DEFAULT_RECOVERY_MODEL
+    api_base: str | None = "https://openrouter.ai/api/v1"
+    api_key: str | None = None
+    temperature: float = 0.0
+    max_tokens: int = 2048
+    timeout: float = 120.0
+    prompt_version: str = RECOVERY_PROMPT_VERSION
+
+    def _client(self):  # pragma: no cover - thin network adapter
+        from clm.infrastructure.llm.openrouter_client import build_openrouter_client
+
+        return build_openrouter_client(
+            api_base=self.api_base, api_key=self.api_key, timeout=self.timeout
+        )
+
+    def recover(
+        self,
+        *,
+        base_region: list[RegionCell],
+        current_region: list[RegionCell],
+    ) -> dict[int, str]:  # pragma: no cover - exercised via mocked client / integration
+        user = build_recovery_user_prompt(base_region, current_region)
+
+        def _create():
+            return self._client().chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user},
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                response_format={"type": "json_object"},
+            )
+
+        try:
+            response = call_with_retries(
+                _create, exc=Exception, label=f"alignment recovery ({self.model})"
+            )
+        except Exception as exc:  # noqa: BLE001 - normalize to the protocol's error
+            raise RecoveryError(f"alignment recovery call failed: {exc}") from exc
+        content = response.choices[0].message.content
+        if not content or not content.strip():
+            raise RecoveryError("alignment recovery returned empty content")
+        return decode_mapping(_strip_fences(content))
+
+
+def _strip_fences(text: str) -> str:
+    """Drop a leading/trailing ``` fence if the model wrapped its JSON in one."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    return stripped

--- a/src/clm/slides/sync_recover.py
+++ b/src/clm/slides/sync_recover.py
@@ -234,6 +234,12 @@ def validate_alignment(
        are left for the model.
     5. **``NEW`` is nameable** — :data:`NEW` is only valid on a cell with a
        construct (there must be something to mint a slug from).
+    6. **No stable id dropped** — every base ``slide_id`` *currently worn* by a
+       region cell must be reassigned somewhere in the map (kept or moved), never
+       silently replaced by a minted/``none`` slug. Without this a pure in-place
+       rename (the id'd cell's only change) could map the cell to ``new`` and strip
+       its ``slide_id`` — exactly the cross-reference/voiceover churn #190 exists to
+       prevent (Phase 5 review). Recovery re-identifies; it never destroys identity.
     """
     n = len(current_region)
     if set(mapping) != set(range(n)):
@@ -254,6 +260,13 @@ def validate_alignment(
     duplicated = sorted(x for x, count in Counter(assigned).items() if count > 1)
     if duplicated:
         raise AlignmentInvalid(f"base ids assigned to multiple current cells: {duplicated}")
+
+    worn = {c.slide_id for c in current_region if c.slide_id in base_ids}
+    dropped = sorted(worn - set(mapping.values()))
+    if dropped:
+        raise AlignmentInvalid(
+            f"map drops currently-worn base ids (would strip a stable id): {dropped}"
+        )
 
     pinned = _pinned_assignments(base_region)
     for idx, cell in enumerate(current_region):
@@ -359,6 +372,11 @@ class OpenRouterAlignmentRecoverer:
     Raises :class:`RecoveryError` on any transport/parse failure so the caller
     safe-aborts that region rather than crashing the whole sync. The result is
     *not* trusted — :func:`validate_alignment` gates it before it is applied.
+
+    ``prompt_version`` (the third component of the alignment cache key) folds in the
+    ``model`` so switching ``--recovery-model`` does not silently serve a different
+    model's cached map (Phase 5 review): the resolved version is
+    ``"{RECOVERY_PROMPT_VERSION}:{model}"`` unless an explicit version is passed.
     """
 
     model: str = DEFAULT_RECOVERY_MODEL
@@ -368,6 +386,12 @@ class OpenRouterAlignmentRecoverer:
     max_tokens: int = 2048
     timeout: float = 120.0
     prompt_version: str = RECOVERY_PROMPT_VERSION
+
+    def __post_init__(self) -> None:
+        # Bake the model into the cache identity so a model change re-queries
+        # instead of reusing another model's alignment (cache-key soundness).
+        if self.prompt_version == RECOVERY_PROMPT_VERSION:
+            self.prompt_version = f"{RECOVERY_PROMPT_VERSION}:{self.model}"
 
     def _client(self):  # pragma: no cover - thin network adapter
         from clm.infrastructure.llm.openrouter_client import build_openrouter_client

--- a/src/clm/slides/sync_recover.py
+++ b/src/clm/slides/sync_recover.py
@@ -179,13 +179,24 @@ def decode_mapping(text: str) -> dict[int, str]:
 # ---------------------------------------------------------------------------
 
 
-def _pinned_ids(base_region: list[RegionCell]) -> dict[str, str]:
-    """``content_hash → slide_id`` for base cells a hash can *unambiguously* pin.
+def _pinned_assignments(base_region: list[RegionCell]) -> dict[str, str]:
+    """``content_hash → required assignment`` for base cells a hash can pin.
 
-    A current cell byte-identical to such a base cell is provably unchanged and
-    must keep that id. A hash shared by two base cells, or by an id'd and an
-    id-less cell, is ambiguous and is excluded — the recurring content-anchor
-    non-uniqueness guard (cf. the Counter / ordered-sequence guards elsewhere).
+    A current cell byte-identical to an *unchanged* base cell is provably
+    unchanged and may not be re-identified by the model. The pin is
+    **bidirectional**:
+
+    - a hash that uniquely identifies an **id'd** base cell pins its ``slide_id``
+      (an unchanged id'd cell keeps its id), and
+    - a hash that uniquely identifies an **id-less** base cell pins :data:`NONE`
+      (an unchanged id-less cell stays id-less — the model may not mint a spurious
+      id onto unchanged content, which would re-introduce the churn the whole
+      design avoids).
+
+    A hash shared by two base cells, or by an id'd and an id-less cell, is
+    ambiguous and is excluded — the recurring content-anchor non-uniqueness guard
+    (cf. the Counter / ordered-sequence guards elsewhere). Only genuinely *changed*
+    cells (a new content hash) are left for the model to decide.
     """
     by_hash: dict[str, set[str | None]] = {}
     for cell in base_region:
@@ -194,8 +205,7 @@ def _pinned_ids(base_region: list[RegionCell]) -> dict[str, str]:
     for chash, ids in by_hash.items():
         if len(ids) == 1:
             only = next(iter(ids))
-            if only is not None:
-                pinned[chash] = only
+            pinned[chash] = only if only is not None else NONE
     return pinned
 
 
@@ -216,9 +226,12 @@ def validate_alignment(
        ``slide_id`` that exists in the base region (no invented ids).
     3. **Injective on base ids** — no base ``slide_id`` is assigned to two current
        cells (an id identifies one cell).
-    4. **Unchanged-anchors pinned** — a current cell byte-identical to an
-       unambiguously-id'd base cell must be assigned that id (the model may not
-       reassign a provably-unchanged cell).
+    4. **Unchanged-anchors pinned** (bidirectional) — a current cell
+       byte-identical to an unambiguously-identified base cell must keep that
+       cell's identity: its ``slide_id`` if the base cell had one, else
+       :data:`NONE` (an unchanged id-less cell stays id-less, so the model cannot
+       mint a spurious id onto unchanged content). Only genuinely *changed* cells
+       are left for the model.
     5. **``NEW`` is nameable** — :data:`NEW` is only valid on a cell with a
        construct (there must be something to mint a slug from).
     """
@@ -242,13 +255,13 @@ def validate_alignment(
     if duplicated:
         raise AlignmentInvalid(f"base ids assigned to multiple current cells: {duplicated}")
 
-    pinned = _pinned_ids(base_region)
+    pinned = _pinned_assignments(base_region)
     for idx, cell in enumerate(current_region):
         forced = pinned.get(cell.content_hash)
         if forced is not None and mapping[idx] != forced:
             raise AlignmentInvalid(
-                f"index {idx} is byte-identical to base id {forced!r} "
-                f"but was mapped to {mapping[idx]!r}"
+                f"index {idx} is byte-identical to an unchanged base cell pinned to "
+                f"{forced!r} but was mapped to {mapping[idx]!r}"
             )
     return mapping
 

--- a/tests/infrastructure/llm/test_sync_cache.py
+++ b/tests/infrastructure/llm/test_sync_cache.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from clm.infrastructure.llm.cache import SyncCache, SyncSnapshotCache, SyncWatermarkCache
+from clm.infrastructure.llm.cache import (
+    SyncAlignmentCache,
+    SyncCache,
+    SyncSnapshotCache,
+    SyncWatermarkCache,
+)
 
 
 @pytest.fixture
@@ -399,3 +404,99 @@ class TestSyncWatermarkCache:
         assert len(rows) == 1
         # (de_path, en_path, lang, position, slide_id, role, content_hash, construct, synced_at)
         assert rows[0][:8] == ("a.de.py", "a.en.py", "de", 0, "x", "slide", "h", "c0")
+
+
+# ---------------------------------------------------------------------------
+# SyncAlignmentCache (Issue #190, Phase 5 — bounded LLM recovery)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def alignments(tmp_path: Path):
+    c = SyncAlignmentCache(tmp_path / "clm-llm.sqlite")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+class TestSyncAlignmentCache:
+    def test_miss(self, alignments):
+        assert alignments.get("base", "current", "v1") is None
+
+    def test_round_trip(self, alignments):
+        alignments.put("base", "current", "v1", '{"0": "def-my-fun", "1": "new"}')
+        assert alignments.get("base", "current", "v1") == '{"0": "def-my-fun", "1": "new"}'
+
+    def test_overwrite_same_key(self, alignments):
+        alignments.put("base", "current", "v1", '{"0": "a"}')
+        alignments.put("base", "current", "v1", '{"0": "b"}')
+        assert alignments.get("base", "current", "v1") == '{"0": "b"}'
+
+    def test_base_region_hash_in_key(self, alignments):
+        alignments.put("base1", "current", "v1", '{"0": "p1"}')
+        alignments.put("base2", "current", "v1", '{"0": "p2"}')
+        assert alignments.get("base1", "current", "v1") == '{"0": "p1"}'
+        assert alignments.get("base2", "current", "v1") == '{"0": "p2"}'
+
+    def test_current_region_hash_in_key(self, alignments):
+        alignments.put("base", "current1", "v1", '{"0": "p1"}')
+        alignments.put("base", "current2", "v1", '{"0": "p2"}')
+        assert alignments.get("base", "current1", "v1") == '{"0": "p1"}'
+        assert alignments.get("base", "current2", "v1") == '{"0": "p2"}'
+
+    def test_prompt_version_in_key(self, alignments):
+        alignments.put("base", "current", "v1", '{"0": "v1"}')
+        alignments.put("base", "current", "v2", '{"0": "v2"}')
+        assert alignments.get("base", "current", "v1") == '{"0": "v1"}'
+        assert alignments.get("base", "current", "v2") == '{"0": "v2"}'
+
+    def test_invalidate_prompt_version(self, alignments):
+        alignments.put("b1", "c", "v1", '{"0": "p1"}')
+        alignments.put("b2", "c", "v1", '{"0": "p2"}')
+        alignments.put("b3", "c", "v2", '{"0": "p3"}')
+        removed = alignments.invalidate_prompt_version("v2")
+        assert removed == 2
+        assert alignments.get("b1", "c", "v1") is None
+        assert alignments.get("b3", "c", "v2") == '{"0": "p3"}'
+
+    def test_iter_entries_empty(self, alignments):
+        assert alignments.iter_entries() == []
+
+    def test_iter_entries_returns_all_rows(self, alignments):
+        alignments.put("b1", "c1", "v1", '{"0": "a"}')
+        alignments.put("b2", "c2", "v1", '{"0": "b"}')
+        rows = alignments.iter_entries()
+        assert len(rows) == 2
+        # (base_region_hash, current_region_hash, prompt_version, alignment, created_at)
+        keys = {(row[0], row[1]) for row in rows}
+        assert keys == {("b1", "c1"), ("b2", "c2")}
+
+    def test_survives_close_and_reopen(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        first = SyncAlignmentCache(path)
+        first.put("base", "current", "v1", '{"0": "kept"}')
+        first.close()
+        second = SyncAlignmentCache(path)
+        try:
+            assert second.get("base", "current", "v1") == '{"0": "kept"}'
+        finally:
+            second.close()
+
+    def test_coexists_with_other_caches(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        align = SyncAlignmentCache(path)
+        wm = SyncWatermarkCache(path)
+        try:
+            align.put("base", "current", "v1", '{"0": "align"}')
+            wm.put_deck(
+                de_path="a.de.py",
+                en_path="a.en.py",
+                lang="de",
+                cells=[(0, "x", "slide", "h", None)],
+            )
+            assert align.get("base", "current", "v1") == '{"0": "align"}'
+            assert wm.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h", None)]
+        finally:
+            wm.close()
+            align.close()

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -20,11 +20,16 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.cache import SyncAlignmentCache, SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import SyncProposal
 from clm.notebooks.slide_parser import parse_cells
-from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_apply import _resolve_alignment, apply_plan
 from clm.slides.sync_plan import build_sync_plan, watermark_rows
+from clm.slides.sync_recover import (
+    NEW,
+    RegionCell,
+    StaticAlignmentRecoverer,
+)
 
 # ---------------------------------------------------------------------------
 # Deck builders + no-LLM spies
@@ -467,6 +472,197 @@ def test_phase4_id_migration_is_symmetric_across_decks(tmp_path: Path):
         assert "import time" in by_id["import-time"].content
         ids.append(sorted(by_id))
     assert ids[0] == ids[1]  # identical slide_ids on both decks — no divergence
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — bounded LLM recovery of an ambiguous drifted-id region (§10)
+# ---------------------------------------------------------------------------
+
+
+def _split_renamed_both_decks(tmp_path: Path):
+    """Seed a watermark, then split+RENAME the def on both decks (de narrative
+    edit supplies the direction). Returns (de_path, en_path, cache). The rename
+    means the deterministic §9 construct match fails → recovery territory."""
+    base_def = 'def my_fun():\n    print("foo")'
+    de0 = _slide("de", "g", "# ## G") + _code_idd_neutral("def-my-fun", base_def)
+    en0 = _slide("en", "g", "# ## G") + _code_idd_neutral("def-my-fun", base_def)
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    _seed(cache, de_path, en_path)
+    # Both decks: import wears the id; the def is RENAMED (my_function) and id-less.
+    renamed = 'def my_function():\n    time.sleep(1)\n    print("foo")'
+    de_path.write_text(
+        _slide("de", "g", "# ## G erweitert")  # de narrative edit -> direction de->en
+        + _code_idd_neutral("def-my-fun", "import time")
+        + _code_shared(renamed),
+        encoding="utf-8",
+    )
+    en_path.write_text(
+        _slide("en", "g", "# ## G")
+        + _code_idd_neutral("def-my-fun", "import time")
+        + _code_shared(renamed),
+        encoding="utf-8",
+    )
+    return de_path, en_path, cache
+
+
+def test_phase5_llm_recover_resolves_renamed_split(tmp_path: Path):
+    # The deterministic §9 migration is stuck (the def was renamed, so no id-less
+    # cell carries the baseline construct). With --llm-recover, the recoverer maps
+    # the import as new and the renamed def as the def-my-fun continuation; the
+    # engine applies it symmetrically to both decks. Resolved ONCE, applied to both.
+    de_path, en_path, cache = _split_renamed_both_decks(tmp_path)
+    recoverer = StaticAlignmentRecoverer(mapping={0: NEW, 1: "def-my-fun"})
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan,
+            judge=CountingJudge(),
+            translator=CountingTranslator(),
+            watermark_cache=cache,
+            recoverer=recoverer,
+        )
+    finally:
+        cache.close()
+
+    assert recoverer.calls == 1  # resolved once, applied to both decks
+    assert result.applied_migrate == 4  # 2 cells re-identified on each of 2 decks
+    for path in (de_path, en_path):
+        by_id = {
+            c.metadata.slide_id: c
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.slide_id
+        }
+        assert "def my_function" in by_id["def-my-fun"].content  # id followed the rename
+        assert "import time" in by_id["import-time"].content  # orphan got a content slug
+
+
+def test_phase5_no_recover_leaves_region_untouched(tmp_path: Path):
+    # Without --llm-recover (recoverer=None), the ambiguous region is left for
+    # review: no migration, no error (the pre-Phase-5 behavior).
+    de_path, en_path, cache = _split_renamed_both_decks(tmp_path)
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0
+    by_id = {
+        c.metadata.slide_id: c
+        for c in parse_cells(de_path.read_text(encoding="utf-8"))
+        if c.metadata.slide_id
+    }
+    assert "import time" in by_id["def-my-fun"].content  # id still on the import (untouched)
+
+
+def test_phase5_invalid_map_safe_aborts(tmp_path: Path):
+    # A recoverer that returns an unsound map (an invented id) must safe-abort: the
+    # region is deferred and left untouched, never half-applied, and not an error
+    # (so the rest of the deck still writes).
+    de_path, en_path, cache = _split_renamed_both_decks(tmp_path)
+    recoverer = StaticAlignmentRecoverer(mapping={0: "not-a-base-id", 1: "def-my-fun"})
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan,
+            judge=CountingJudge(),
+            translator=CountingTranslator(),
+            watermark_cache=cache,
+            recoverer=recoverer,
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0
+    assert result.deferred >= 1  # safe-aborted -> region deferred, re-surfaces next run
+    assert result.errors == []  # a deferral, not a blocking error
+    assert not result.watermark_recorded  # held so the region re-surfaces
+
+
+def test_phase5_recoverer_failure_safe_aborts(tmp_path: Path):
+    # The recoverer being down (RecoveryError) safe-aborts the same way.
+    de_path, en_path, cache = _split_renamed_both_decks(tmp_path)
+    recoverer = StaticAlignmentRecoverer(raise_error=True)
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan,
+            judge=CountingJudge(),
+            translator=CountingTranslator(),
+            watermark_cache=cache,
+            recoverer=recoverer,
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0
+    assert result.deferred >= 1
+    assert result.errors == []
+
+
+def test_phase5_deterministic_case_does_not_call_recoverer(tmp_path: Path):
+    # When the deterministic §9 migration CAN resolve the split (the def keeps its
+    # name), the two tiers are not mixed — the recoverer is never consulted.
+    base_def = 'def my_fun():\n    print("foo")'
+    de0 = _slide("de", "g", "# ## G") + _code_idd_neutral("def-my-fun", base_def)
+    en0 = _slide("en", "g", "# ## G") + _code_idd_neutral("def-my-fun", base_def)
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    recoverer = StaticAlignmentRecoverer(raise_error=True)  # would blow up if called
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")
+            + _code_idd_neutral("def-my-fun", "import time")
+            + _code_shared('def my_fun():\n    time.sleep(1)\n    print("foo")'),  # SAME name
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "g", "# ## G")
+            + _code_idd_neutral("def-my-fun", "import time")
+            + _code_shared('def my_fun():\n    time.sleep(1)\n    print("foo")'),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan,
+            judge=CountingJudge(),
+            translator=CountingTranslator(),
+            watermark_cache=cache,
+            recoverer=recoverer,
+        )
+    finally:
+        cache.close()
+
+    assert recoverer.calls == 0  # deterministic handled it; LLM not consulted
+    assert result.applied_migrate == 2  # one move per deck (the def kept its name)
+
+
+def test_phase5_alignment_is_cached_and_reused(tmp_path: Path):
+    # The validated map is cached by region fingerprint: a second resolve with a
+    # recoverer that would FAIL still succeeds from the cache (no LLM re-spend).
+    base = [RegionCell("def-my-fun", "function-my-fun", "h0")]
+    current = [
+        RegionCell("def-my-fun", "import-time", "h1"),
+        RegionCell(None, "function-my-function", "h2"),
+    ]
+    align_cache = SyncAlignmentCache(tmp_path / "clm-llm.sqlite")
+    try:
+        r1 = StaticAlignmentRecoverer(mapping={0: NEW, 1: "def-my-fun"})
+        first = _resolve_alignment(r1, align_cache, base, current)
+        assert first == {0: NEW, 1: "def-my-fun"}
+        assert r1.calls == 1
+        assert len(align_cache.iter_entries()) == 1  # written through
+
+        r2 = StaticAlignmentRecoverer(raise_error=True)  # cache hit must avoid this
+        second = _resolve_alignment(r2, align_cache, base, current)
+        assert second == {0: NEW, 1: "def-my-fun"}
+        assert r2.calls == 0  # served from cache, recoverer never called
+    finally:
+        align_cache.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -646,6 +646,50 @@ def test_phase5_deterministic_case_does_not_call_recoverer(tmp_path: Path):
     assert result.applied_migrate == 2  # one move per deck (the def kept its name)
 
 
+def test_phase5_pure_rename_does_not_strip_id(tmp_path: Path):
+    # A pure IN-PLACE rename (no split, no new cell) must NOT escalate to the LLM:
+    # there is no realignment target, so the stable id is kept and re-baselined.
+    # Even a recoverer that WOULD strip the id (mapping {0: NEW}) is never consulted
+    # — and validate_alignment would reject that map anyway (Phase 5 review, HIGH).
+    base = 'def my_fun():\n    print("foo")'
+    de0 = _slide("de", "g", "# ## G") + _code_idd_neutral("def-my-fun", base)
+    en0 = _slide("en", "g", "# ## G") + _code_idd_neutral("def-my-fun", base)
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    recoverer = StaticAlignmentRecoverer(mapping={0: NEW})  # would strip the id if called
+    try:
+        _seed(cache, de_path, en_path)
+        renamed = 'def my_function():\n    print("foo")'  # renamed IN PLACE, no split
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert") + _code_idd_neutral("def-my-fun", renamed),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "g", "# ## G") + _code_idd_neutral("def-my-fun", renamed),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan,
+            judge=CountingJudge(),
+            translator=CountingTranslator(),
+            watermark_cache=cache,
+            recoverer=recoverer,
+        )
+    finally:
+        cache.close()
+
+    assert recoverer.calls == 0  # no split product -> recovery not even consulted
+    assert result.applied_migrate == 0  # the stable id is kept, not churned
+    for path in (de_path, en_path):
+        ids = {
+            c.metadata.slide_id
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.slide_id
+        }
+        assert "def-my-fun" in ids  # stable id preserved across the rename
+
+
 def test_phase5_alignment_is_cached_and_reused(tmp_path: Path):
     # The validated map is cached by region fingerprint: a second resolve with a
     # recoverer that would FAIL still succeeds from the cache (no LLM re-spend).

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -55,6 +55,11 @@ def _code_idd_neutral(sid: str, body: str) -> str:
     return f'# %% tags=["keep"] slide_id="{sid}"\n{body}\n'
 
 
+def _code_localized_idd(lang: str, sid: str, body: str) -> str:
+    """A localized code cell carrying a slide_id (the Phase 5d paired shape)."""
+    return f'# %% lang="{lang}" tags=["keep"] slide_id="{sid}"\n{body}\n'
+
+
 def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
     de_path = tmp_path / "deck.de.py"
     en_path = tmp_path / "deck.en.py"
@@ -663,6 +668,128 @@ def test_phase5_alignment_is_cached_and_reused(tmp_path: Path):
         assert r2.calls == 0  # served from cache, recoverer never called
     finally:
         align_cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5d — symmetric localized id-migration paired chokepoint (§9 localized)
+# ---------------------------------------------------------------------------
+
+
+def test_phase5d_localized_id_migration_is_paired(tmp_path: Path):
+    # A LOCALIZED id'd code cell (lang=) is split on both decks: the id is left on
+    # the new import while the def — translated differently per deck — is id-less.
+    # The paired chokepoint moves the id onto BOTH decks' def twins and mints one
+    # shared slug onto BOTH import orphans, keeping de_id == en_id (the structural
+    # pass cannot carry a header-only change between the two translated bodies).
+    de0 = _slide("de", "g", "# ## G") + _code_localized_idd(
+        "de", "greet", 'def greet():\n    print("Hallo")'
+    )
+    en0 = _slide("en", "g", "# ## G") + _code_localized_idd(
+        "en", "greet", 'def greet():\n    print("Hello")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")  # narrative edit -> direction de->en
+            + _code_localized_idd("de", "greet", "import time")  # id left on the import
+            + _code_localized_idless("de", 'def greet():\n    time.sleep(1)\n    print("Hallo")'),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "g", "# ## G")
+            + _code_localized_idd("en", "greet", "import time")
+            + _code_localized_idless("en", 'def greet():\n    time.sleep(1)\n    print("Hello")'),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 2  # one logical move, written to both decks
+    de_by_id = {
+        c.metadata.slide_id: c
+        for c in parse_cells(de_path.read_text(encoding="utf-8"))
+        if c.metadata.slide_id
+    }
+    en_by_id = {
+        c.metadata.slide_id: c
+        for c in parse_cells(en_path.read_text(encoding="utf-8"))
+        if c.metadata.slide_id
+    }
+    # The id followed its construct on BOTH decks, preserving the translated bodies.
+    assert "def greet" in de_by_id["greet"].content and "Hallo" in de_by_id["greet"].content
+    assert "def greet" in en_by_id["greet"].content and "Hello" in en_by_id["greet"].content
+    assert "import time" in de_by_id["import-time"].content
+    assert "import time" in en_by_id["import-time"].content
+    assert set(de_by_id) == set(en_by_id)  # de_id == en_id preserved (no divergence)
+
+
+def test_phase5d_no_migration_when_only_one_deck_split(tmp_path: Path):
+    # Asymmetric: only DE splits the localized cell; EN's twin still wears the id on
+    # the un-split def. The paired guard requires drift on BOTH decks, so no move.
+    de0 = _slide("de", "g", "# ## G") + _code_localized_idd(
+        "de", "greet", 'def greet():\n    print("Hallo")'
+    )
+    en0 = _slide("en", "g", "# ## G") + _code_localized_idd(
+        "en", "greet", 'def greet():\n    print("Hello")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")
+            + _code_localized_idd("de", "greet", "import time")
+            + _code_localized_idless("de", 'def greet():\n    time.sleep(1)\n    print("Hallo")'),
+            encoding="utf-8",
+        )
+        # EN untouched (greet still on the def).
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0  # asymmetric split -> paired guard declines
+
+
+def test_phase5d_no_false_move_localized_without_new_twin(tmp_path: Path):
+    # The localized id'd construct changes on both decks (genuine replacement), but
+    # there is NO new id-less twin carrying the old construct. The paired migration
+    # must not fire (it is not an unambiguous split).
+    de0 = _slide("de", "g", "# ## G") + _code_localized_idd(
+        "de", "greet", 'def greet():\n    print("Hallo")'
+    )
+    en0 = _slide("en", "g", "# ## G") + _code_localized_idd(
+        "en", "greet", 'def greet():\n    print("Hello")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")
+            + _code_localized_idd("de", "greet", "import time"),  # replaced, no def twin
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "g", "# ## G") + _code_localized_idd("en", "greet", "import time"),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0  # no id-less construct twin -> no migration
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_recover.py
+++ b/tests/slides/test_sync_recover.py
@@ -1,0 +1,218 @@
+"""Unit tests for :mod:`clm.slides.sync_recover` — bounded LLM alignment recovery.
+
+The validation gate is the load-bearing safety net (Issue #190 §10): an
+LLM-derived map is only applied if it is total over the current cells, draws ids
+only from the base set, is injective on those ids, and pins every provably
+unchanged cell to its old id. Every failure must safe-abort. These tests pin that
+contract with no network (the :class:`StaticAlignmentRecoverer`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides.sync_recover import (
+    NEW,
+    NONE,
+    AlignmentInvalid,
+    OpenRouterAlignmentRecoverer,
+    RecoveryError,
+    RegionCell,
+    StaticAlignmentRecoverer,
+    build_recovery_user_prompt,
+    decode_mapping,
+    encode_mapping,
+    region_fingerprint,
+    validate_alignment,
+)
+
+
+def _cell(slide_id: str | None, construct: str | None, content_hash: str) -> RegionCell:
+    return RegionCell(slide_id=slide_id, construct=construct, content_hash=content_hash)
+
+
+# ---------------------------------------------------------------------------
+# region_fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestRegionFingerprint:
+    def test_stable_for_equal_regions(self):
+        a = [_cell("x", "function-f", "h1"), _cell(None, "import-os", "h2")]
+        b = [_cell("x", "function-f", "h1"), _cell(None, "import-os", "h2")]
+        assert region_fingerprint(a) == region_fingerprint(b)
+
+    def test_order_sensitive(self):
+        a = [_cell("x", "function-f", "h1"), _cell(None, "import-os", "h2")]
+        b = [_cell(None, "import-os", "h2"), _cell("x", "function-f", "h1")]
+        assert region_fingerprint(a) != region_fingerprint(b)
+
+    def test_body_sensitive_via_hash(self):
+        a = [_cell("x", "function-f", "h1")]
+        b = [_cell("x", "function-f", "h2")]  # only the content hash changed
+        assert region_fingerprint(a) != region_fingerprint(b)
+
+    def test_id_sensitive(self):
+        a = [_cell("x", "function-f", "h1")]
+        b = [_cell("y", "function-f", "h1")]
+        assert region_fingerprint(a) != region_fingerprint(b)
+
+    def test_empty_region(self):
+        assert region_fingerprint([]) == region_fingerprint([])
+
+
+# ---------------------------------------------------------------------------
+# encode/decode mapping
+# ---------------------------------------------------------------------------
+
+
+class TestMappingCodec:
+    def test_round_trip(self):
+        mapping = {0: "def-my-fun", 1: NEW, 2: NONE}
+        assert decode_mapping(encode_mapping(mapping)) == mapping
+
+    def test_encode_sorts_keys(self):
+        assert encode_mapping({2: "c", 0: "a", 1: "b"}) == '{"0":"a","1":"b","2":"c"}'
+
+    def test_decode_rejects_non_object(self):
+        with pytest.raises(AlignmentInvalid):
+            decode_mapping("[1, 2, 3]")
+
+    def test_decode_rejects_bad_json(self):
+        with pytest.raises(AlignmentInvalid):
+            decode_mapping("{not json")
+
+    def test_decode_rejects_non_integer_key(self):
+        with pytest.raises(AlignmentInvalid):
+            decode_mapping('{"abc": "x"}')
+
+    def test_decode_rejects_non_string_value(self):
+        with pytest.raises(AlignmentInvalid):
+            decode_mapping('{"0": 5}')
+
+
+# ---------------------------------------------------------------------------
+# validate_alignment — the safety net
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAlignment:
+    def test_canonical_rename_split_is_valid(self):
+        # The §10 lead example: base def-my-fun (function-my-fun) split; current[0]
+        # is a new import, current[1] is the renamed def. Both bodies changed, so
+        # nothing is pinned and the model is free to align by construct similarity.
+        base = [_cell("def-my-fun", "function-my-fun", "h0")]
+        current = [
+            _cell("def-my-fun", "import-time", "h1"),  # id left on the import
+            _cell(None, "function-my-function", "h2"),  # the renamed def, id-less
+        ]
+        mapping = {0: NEW, 1: "def-my-fun"}
+        assert validate_alignment(mapping, base, current) == mapping
+
+    def test_missing_index_aborts(self):
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell("x", "function-f", "h0"), _cell(None, "g", "h1")]
+        with pytest.raises(AlignmentInvalid, match="cover current indices"):
+            validate_alignment({0: "x"}, base, current)
+
+    def test_extra_index_aborts(self):
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell("x", "function-f", "h0")]
+        with pytest.raises(AlignmentInvalid, match="cover current indices"):
+            validate_alignment({0: "x", 1: NONE}, base, current)
+
+    def test_unknown_base_id_aborts(self):
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell(None, "function-f", "h0")]
+        with pytest.raises(AlignmentInvalid, match="unknown base id"):
+            validate_alignment({0: "invented"}, base, current)
+
+    def test_duplicate_base_id_aborts(self):
+        base = [_cell("x", "function-f", "h0"), _cell("y", "function-g", "h1")]
+        current = [_cell(None, "function-f", "h2"), _cell(None, "function-g", "h3")]
+        with pytest.raises(AlignmentInvalid, match="multiple current cells"):
+            validate_alignment({0: "x", 1: "x"}, base, current)
+
+    def test_unchanged_cell_must_keep_its_id(self):
+        # current[0] is byte-identical (h0) to base id x → it MUST map to x.
+        base = [_cell("x", "function-f", "h0"), _cell("y", "function-g", "h1")]
+        current = [_cell("x", "function-f", "h0"), _cell(None, "function-g2", "h2")]
+        with pytest.raises(AlignmentInvalid, match="byte-identical"):
+            validate_alignment({0: "y", 1: NONE}, base, current)
+
+    def test_pinned_assignment_passes(self):
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell("x", "function-f", "h0")]
+        assert validate_alignment({0: "x"}, base, current) == {0: "x"}
+
+    def test_new_on_constructless_cell_aborts(self):
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell(None, None, "h1")]  # unnameable (no construct)
+        with pytest.raises(AlignmentInvalid, match="no construct"):
+            validate_alignment({0: NEW}, base, current)
+
+    def test_none_on_constructless_cell_is_fine(self):
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell(None, None, "h1")]
+        assert validate_alignment({0: NONE}, base, current) == {0: NONE}
+
+    def test_ambiguous_hash_is_not_pinned(self):
+        # Two base cells share a hash (one id'd, one id-less): the hash cannot
+        # pin, so the model is free — no AlignmentInvalid for a non-pinning hash.
+        base = [_cell("x", "function-f", "hsame"), _cell(None, "function-f", "hsame")]
+        current = [_cell(None, "function-f", "hsame")]
+        # Mapping to NONE is allowed because hsame does not unambiguously pin x.
+        assert validate_alignment({0: NONE}, base, current) == {0: NONE}
+
+    def test_empty_current_region_is_trivially_valid(self):
+        assert validate_alignment({}, [_cell("x", "f", "h0")], []) == {}
+
+
+# ---------------------------------------------------------------------------
+# StaticAlignmentRecoverer
+# ---------------------------------------------------------------------------
+
+
+class TestStaticRecoverer:
+    def test_returns_mapping_copy(self):
+        rec = StaticAlignmentRecoverer(mapping={0: "x"})
+        out = rec.recover(base_region=[], current_region=[])
+        assert out == {0: "x"}
+        out[0] = "mutated"
+        assert rec.mapping == {0: "x"}  # internal mapping untouched
+
+    def test_counts_calls(self):
+        rec = StaticAlignmentRecoverer(mapping={0: NONE})
+        rec.recover(base_region=[], current_region=[])
+        rec.recover(base_region=[], current_region=[])
+        assert rec.calls == 2
+
+    def test_raise_error_mode(self):
+        rec = StaticAlignmentRecoverer(raise_error=True)
+        with pytest.raises(RecoveryError):
+            rec.recover(base_region=[], current_region=[])
+
+
+# ---------------------------------------------------------------------------
+# Prompt building — must be body-free
+# ---------------------------------------------------------------------------
+
+
+class TestPromptBuilding:
+    def test_prompt_has_both_regions_and_no_source(self):
+        base = [_cell("def-my-fun", "function-my-fun", "h0")]
+        current = [_cell(None, "function-my-function", "h2")]
+        prompt = build_recovery_user_prompt(base, current)
+        assert "BASE:" in prompt and "CURRENT:" in prompt
+        # The anchor components are present...
+        assert "function-my-fun" in prompt
+        assert "h0" in prompt and "h2" in prompt
+        # ...but never any cell source (only hashes stand in for bodies).
+        assert "def " not in prompt
+        assert "print(" not in prompt
+
+    def test_openrouter_recoverer_has_prompt_version(self):
+        # The default model/version are wired for the cache key.
+        rec = OpenRouterAlignmentRecoverer()
+        assert rec.prompt_version
+        assert rec.model

--- a/tests/slides/test_sync_recover.py
+++ b/tests/slides/test_sync_recover.py
@@ -134,11 +134,13 @@ class TestValidateAlignment:
             validate_alignment({0: "x", 1: "x"}, base, current)
 
     def test_unchanged_cell_must_keep_its_id(self):
-        # current[0] is byte-identical (h0) to base id x → it MUST map to x.
+        # current[0] is byte-identical (h0) to base id x → it MUST map to x. The map
+        # tries to move x onto the changed cell[1] and blank cell[0]; x is still
+        # reassigned (so the drop-check passes), isolating the PIN violation.
         base = [_cell("x", "function-f", "h0"), _cell("y", "function-g", "h1")]
         current = [_cell("x", "function-f", "h0"), _cell(None, "function-g2", "h2")]
         with pytest.raises(AlignmentInvalid, match="byte-identical"):
-            validate_alignment({0: "y", 1: NONE}, base, current)
+            validate_alignment({0: NONE, 1: "x"}, base, current)
 
     def test_pinned_assignment_passes(self):
         base = [_cell("x", "function-f", "h0")]
@@ -180,6 +182,23 @@ class TestValidateAlignment:
 
     def test_empty_current_region_is_trivially_valid(self):
         assert validate_alignment({}, [_cell("x", "f", "h0")], []) == {}
+
+    def test_rejects_dropping_a_worn_base_id(self):
+        # A current cell wears base id 'x' (renamed in place, hash changed so it is
+        # not pinned) but the map sends it to NEW without reassigning 'x' anywhere —
+        # that would silently strip a stable id. Reject (Phase 5 review, the HIGH
+        # finding). Recovery re-identifies; it never destroys identity.
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell("x", "function-g", "h1")]  # still wears x, body changed
+        with pytest.raises(AlignmentInvalid, match="drops currently-worn base ids"):
+            validate_alignment({0: NEW}, base, current)
+
+    def test_allows_moving_a_worn_base_id_to_a_split_product(self):
+        # Moving 'x' onto a new id-less twin (a genuine split) is fine — 'x' is
+        # reassigned, not dropped.
+        base = [_cell("x", "function-f", "h0")]
+        current = [_cell("x", "import-t", "h1"), _cell(None, "function-f2", "h2")]
+        assert validate_alignment({0: NEW, 1: "x"}, base, current) == {0: NEW, 1: "x"}
 
 
 # ---------------------------------------------------------------------------
@@ -230,3 +249,21 @@ class TestPromptBuilding:
         rec = OpenRouterAlignmentRecoverer()
         assert rec.prompt_version
         assert rec.model
+
+
+# ---------------------------------------------------------------------------
+# Cache-key soundness — the model is folded into prompt_version (Phase 5 review)
+# ---------------------------------------------------------------------------
+
+
+class TestModelInCacheKey:
+    def test_model_is_folded_into_prompt_version(self):
+        a = OpenRouterAlignmentRecoverer(model="anthropic/claude-opus-4")
+        b = OpenRouterAlignmentRecoverer(model="anthropic/claude-sonnet-4-6")
+        # A model switch must change the cache key, else run B serves run A's map.
+        assert a.prompt_version != b.prompt_version
+        assert "claude-opus-4" in a.prompt_version
+
+    def test_explicit_prompt_version_is_respected(self):
+        rec = OpenRouterAlignmentRecoverer(model="m", prompt_version="pinned")
+        assert rec.prompt_version == "pinned"

--- a/tests/slides/test_sync_recover.py
+++ b/tests/slides/test_sync_recover.py
@@ -145,6 +145,20 @@ class TestValidateAlignment:
         current = [_cell("x", "function-f", "h0")]
         assert validate_alignment({0: "x"}, base, current) == {0: "x"}
 
+    def test_unchanged_idless_cell_must_stay_idless(self):
+        # current[0] is byte-identical (h0) to an unchanged *id-less* base cell, so
+        # it must map to NONE — the model may not mint a spurious id onto unchanged
+        # content (that would re-introduce the churn the design avoids).
+        base = [_cell(None, "function-f", "h0"), _cell("x", "function-g", "h1")]
+        current = [_cell(None, "function-f", "h0")]
+        with pytest.raises(AlignmentInvalid, match="pinned to 'none'"):
+            validate_alignment({0: "x"}, base, current)
+
+    def test_unchanged_idless_cell_mapped_none_passes(self):
+        base = [_cell(None, "function-f", "h0")]
+        current = [_cell(None, "function-f", "h0")]
+        assert validate_alignment({0: NONE}, base, current) == {0: NONE}
+
     def test_new_on_constructless_cell_aborts(self):
         base = [_cell("x", "function-f", "h0")]
         current = [_cell(None, None, "h1")]  # unnameable (no construct)


### PR DESCRIPTION
Phase 5 of the content-anchor sync redesign (Issue #190 §9 localized + §10).

> **Stacked on #194 (Phase 4).** Base is `claude/issue-190-phase4-id-migration`; review the [Phase 5 commits only](https://github.com/hoelzl/clm/compare/claude/issue-190-phase4-id-migration...claude/issue-190-phase5-llm-recovery). GitHub will retarget this PR to `master` automatically once #194 merges.

## What

Two things complete the def-my-fun id-migration story:

**5d — localized id-migration paired chokepoint (deterministic, default-on).** `_migrate_localized_paired` extends the §9 migration to **localized** (`lang=`) id'd code cells. Their twins differ across decks (translated bodies), and the body-keyed structural pass cannot carry a header-only id change between them — so the move is written to **both** decks at once, keeping `de_id == en_id` by construction. Conservative guards mirror the neutral case (drift on both decks, same construct, unique per deck, exactly one new id-less twin).

**5a–5c — bounded LLM (Opus) recovery (§10), opt-in via `--llm-recover` (default off).** When the deterministic pass is fully stuck on an *ambiguous* drifted id (a function renamed while a cell was split, an unresolvable tie), the engine may escalate to a **body-free, alignment-only** model call that returns an `id ↔ cell` map, never free-form edits:
- `SyncAlignmentCache` — a `sync_alignments` table keyed by region fingerprints + prompt version (stores only validated maps).
- `sync_recover.py` — the `AlignmentRecoverer` protocol (`StaticAlignmentRecoverer` for tests, `OpenRouterAlignmentRecoverer` = Claude Opus). The model sees only each cell's content-anchor components (construct slug, content hash, any slide_id) — **never the source**.
- `validate_alignment` is a hard gate (total over the current cells, ids only from the base set, injective, unchanged cells pinned bidirectionally, and **never drops a currently-worn id**). Any failure **safe-aborts**: the region is left untouched and deferred (the watermark holds, so it re-surfaces next run) rather than erroring — a wrong id is worse than a deferred one. Resolved once, applied symmetrically to both decks.

The recovery is wired ONLY when every deterministic tier was stuck (the tiers are never mixed). `--recovery-model` selects the model; a missing OpenRouter key degrades to a warning.

## Review

An adversarial review (9 agents) confirmed two findings, both fixed in `cb6ce3d`:
- **high** — `--llm-recover` could strip a stable `slide_id` on a plain in-place rename (the LLM answering "new"). Fixed in two layers: `validate_alignment` now refuses to drop a currently-worn base id, and escalation only fires when the region holds a genuine split product.
- **low** — the alignment cache key omitted the model, so `--recovery-model B` served model A's map; now folded into the prompt version.

## Validation

`pytest -m "not docker"` green; the no-op corpus harness holds at 81/212, 0 invariant violations (recovery is opt-in; the default path is byte-unchanged); ruff + mypy clean. The `sync_recover` validation gate, the cache, the wiring (resolve-once/apply-both, safe-abort, pure-rename guard), and the localized paired chokepoint are all covered by new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)