### PR TITLE
feat(slides): sync --explain anchor-diff + #190 info topics (#190 Phase 6)

### DIFF
--- a/docs/claude/design/sync-content-anchor-identity.md
+++ b/docs/claude/design/sync-content-anchor-identity.md
@@ -505,6 +505,20 @@ invariant. Gate releases on `pytest -m "not docker"`.
      construction. The no-op corpus harness held at 81/212, 0 violations through all
      of Phase 5 (recovery is opt-in; the default path is untouched).
 6. **Docs + `--explain`** (§13): info topics, migration entry, anchor-diff dump.
+   - **✅ Shipped.** `clm slides sync --explain` (`render_explain` in `sync_plan.py`)
+     — a read-only anchor-diff dump: per-cell anchor (`id:`/`construct:`/`hash:`)
+     with `=`/`~`/`+`/`-` status vs the watermark, per partition (de/en/shared),
+     plus the neutral propagation direction and the drifted-`slide_id`
+     (id-migration) candidates, then the ordinary plan. Mutually exclusive with
+     `--interactive`/`--json`; writes nothing and uses no LLM (rendered while the
+     watermark cache is still open). **Info topics** (the Maintenance Rule): a
+     "Content-anchor sync (Issue #190)" prose block + the `--explain` /
+     `--llm-recover` / `--recovery-model` rows and examples in
+     `info_topics/commands.md`; an additive-no-break "Content-anchor sync" section
+     in `info_topics/migration.md` (the behavior improvements + the watermark
+     `construct` column auto-migration); and a "Slide Sync" env-var subsection in
+     `docs/user-guide/configuration.md` documenting `CLM_SYNC_PROVIDER` and
+     `CLM_SYNC__SHARED_DIVERGENCE`.
 
 ## 15. Open / deferred
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -212,6 +212,18 @@ Can also be set in `[git]` section of config files or `<remote-template>` in cou
 Set `CLM_LLM__API_BASE` to your provider's OpenAI-compatible endpoint
 and `CLM_LLM__API_KEY` (or `OPENAI_API_KEY`) to authenticate.
 
+### Slide Sync (`clm slides sync`)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CLM_SYNC_PROVIDER` | Default backend for the edit-reconciliation judge: `openrouter` (Claude Sonnet via OpenRouter) or `local` (the offline Ollama daemon). The `--provider` flag overrides it. | `openrouter` |
+| `CLM_SYNC__SHARED_DIVERGENCE` | How to handle a **language-neutral** code cell edited *differently* on both decks (a divergence the single-entity model would otherwise have to guess). `auto-heal` propagates the winning side (keyed direction, else newer file) and emits a **warning**; `error` surfaces it and writes nothing, so you resolve it by hand. | `auto-heal` |
+
+The OpenRouter backends (the judge, the brand-new-slide translator, and the
+opt-in `--llm-recover` alignment recoverer) authenticate with
+`OPENROUTER_API_KEY` (or `OPENAI_API_KEY`), which `clm slides sync` also picks up
+from a project `.env` automatically (pass `--no-env-file` to skip).
+
 ### Performance
 
 | Variable | Description | Default |

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -66,7 +66,13 @@ from clm.infrastructure.llm.openrouter_client import (
     has_openrouter_api_key,
 )
 from clm.slides.sync_apply import ApplyResult, apply_plan
-from clm.slides.sync_plan import PlanIssue, SyncPlan, build_sync_plan, render_plan
+from clm.slides.sync_plan import (
+    PlanIssue,
+    SyncPlan,
+    build_sync_plan,
+    render_explain,
+    render_plan,
+)
 from clm.slides.sync_plan_walker import PlanWalkResult, WalkerOptions, run_plan_walker
 from clm.slides.sync_recover import DEFAULT_RECOVERY_MODEL, OpenRouterAlignmentRecoverer
 from clm.slides.sync_translate import DEFAULT_TRANSLATION_MODEL, OpenRouterSlideTranslator
@@ -104,6 +110,19 @@ CACHE_DB_NAME = "clm-llm.sqlite"
         "Walk each proposal and choose [a]pply / [s]kip / [q]uit "
         "([d]e-wins / [e]n-wins for a conflict) before a single atomic apply. "
         "Mutually exclusive with --dry-run and --json."
+    ),
+)
+@click.option(
+    "--explain",
+    is_flag=True,
+    default=False,
+    help=(
+        "Diagnostic: print the content-anchor diff — each cell's anchor "
+        "(id:/construct:/hash:) and whether it is unchanged/edited/new/removed vs "
+        "the watermark, the neutral-cell propagation direction, and any drifted "
+        "slide_ids (id-migration candidates) — then the plan, and write nothing. A "
+        "read-only superset of --dry-run for understanding why a cell did or did not "
+        "sync (Issue #190). Mutually exclusive with --interactive and --json."
     ),
 )
 @click.option(
@@ -207,6 +226,7 @@ def slides_sync_cmd(
     en_path: Path,
     dry_run: bool,
     interactive: bool,
+    explain: bool,
     provider: str,
     llm_model: str | None,
     ollama_url: str | None,
@@ -235,6 +255,9 @@ def slides_sync_cmd(
         translated + inserted, a shared slide_id minted onto both decks) and
         advances the watermark. Nothing is committed — review with ``git diff``.
       * --dry-run: prints the plan and writes nothing.
+      * --explain: prints the content-anchor diff (per-cell anchor + drift,
+        the neutral propagation direction, drifted slide_ids) then the plan,
+        and writes nothing — a read-only diagnostic.
       * --interactive: prompts per proposal before a single atomic apply.
       * A cell edited on both sides since the last sync is isolated as a
         conflict (left untouched, listed in the summary) rather than guessed.
@@ -246,13 +269,22 @@ def slides_sync_cmd(
             "--interactive and --dry-run are mutually exclusive "
             "(--dry-run writes nothing; --interactive applies after prompting)"
         )
+    if explain and interactive:
+        raise click.UsageError(
+            "--explain and --interactive are mutually exclusive (--explain writes nothing)"
+        )
+    if explain and as_json:
+        raise click.UsageError(
+            "--explain and --json are mutually exclusive "
+            "(--explain is a human-readable diagnostic; use --dry-run --json for the structured plan)"
+        )
 
     # Load the project .env before resolving the judge/translator, so keys kept
     # only in .env (the usual course-repo layout) are found. Without this, every
     # add defers and every edit errors as "LLM unavailable" even though the keys
-    # exist on disk (the reported sync bug). Skipped for --dry-run (no LLM) and
-    # when --no-env-file is given.
-    if not no_env_file and not dry_run:
+    # exist on disk (the reported sync bug). Skipped for --dry-run / --explain (no
+    # LLM) and when --no-env-file is given.
+    if not no_env_file and not dry_run and not explain:
         from clm.cli.env_loading import load_env_files
 
         load_env_files(de_path.parent, en_path.parent)
@@ -268,10 +300,18 @@ def slides_sync_cmd(
     plan: SyncPlan
     apply_result: ApplyResult | None = None
     walk: PlanWalkResult | None = None
+    explain_text: str | None = None
     try:
         plan = build_sync_plan(de_path, en_path, watermark_cache=watermark_cache)
 
-        if dry_run:
+        if explain:
+            mode = "explain"
+            # Render while the watermark cache is still open (the finally closes it);
+            # --explain writes nothing and uses no LLM, like --dry-run.
+            explain_text = render_explain(
+                de_path, en_path, plan=plan, watermark_cache=watermark_cache
+            )
+        elif dry_run:
             mode = "dry-run"
         elif interactive:
             mode = "interactive"
@@ -313,7 +353,9 @@ def slides_sync_cmd(
         _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
     )
 
-    if as_json:
+    if mode == "explain":
+        click.echo(explain_text)
+    elif as_json:
         click.echo(json.dumps(_to_dict(plan, apply_result, walk, mode, exit_code), indent=2))
     else:
         _print_human(plan, apply_result, walk, mode=mode)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -743,6 +743,34 @@ A localized code cell with a `slide_id` is reconciled per cell (its body
 re-translated on an edit); language-neutral and id-less code is propagated
 structurally, so it is **not** minted a `slide_id`.
 
+**Content-anchor sync (Issue #190).** Cell identity is tracked in the watermark
+by a **content anchor** (`hand slide_id > construct slug > content hash`), never
+written into the file, so a deck stays id-light yet syncs precisely:
+
+- **Code-only edits propagate.** Editing *only* a language-neutral code cell on
+  one side — no narrative or id change — is now detected (the anchor diff sees
+  which half drifted) and copied verbatim to the twin. Previously such an edit was
+  silently dropped.
+- **Unchanged localized code is never re-translated.** When a slide group is
+  rebuilt for a sibling's sake, an unchanged id-less localized code cell is spliced
+  verbatim by its anchor instead of being re-translated — no churn, no LLM spend.
+- **A drifted `slide_id` is migrated back.** If you split an id'd code cell (e.g.
+  add an `import` above a `def`, leaving the id on the import half), the id is
+  moved back onto the cell whose construct it names and a fresh slug is minted on
+  the orphan — one targeted header write each, no LLM, symmetric across both decks
+  (`de_id == en_id` is preserved).
+- **A neutral cell edited *differently* on both decks auto-heals with a warning**
+  (the winning side is the one with a keyed direction, else the newer file). Set
+  `CLM_SYNC__SHARED_DIVERGENCE=error` to surface it as an error and write nothing
+  instead. A neutral cell edited *incompatibly* on both decks (different cells) is
+  an error — never silently reverted.
+- **Genuinely ambiguous id realignment** (a function renamed *while* a cell was
+  split, an unresolvable tie) is left untouched and re-surfaces next run, unless
+  you opt in with `--llm-recover` (above).
+
+Use `--explain` to see the anchor-level view (per-cell anchor + drift, the
+propagation direction, drifted ids) for any pair.
+
 ```
 clm slides sync [OPTIONS] DE_PATH EN_PATH
 ```
@@ -750,12 +778,15 @@ clm slides sync [OPTIONS] DE_PATH EN_PATH
 | Option | Description |
 |--------|-------------|
 | `--dry-run` | Classify only: print the plan and write nothing. (The default, without this flag, writes the agreed changes to the working tree.) |
+| `--explain` | Diagnostic: print the **content-anchor diff** — each cell's anchor (`id:` / `construct:` / `hash:`) and whether it is unchanged / edited / new / removed vs the watermark, the neutral-cell propagation direction, and any drifted `slide_id`s (id-migration candidates) — then the plan, and write nothing. A read-only superset of `--dry-run` for understanding *why* a cell did or did not sync. Mutually exclusive with `--interactive` and `--json`. |
 | `--interactive` | Walk each proposal and choose `[a]pply / [s]kip / [q]uit` (`[d]e-wins / [e]n-wins` for a conflict) before a single atomic apply. Mutually exclusive with `--dry-run` and `--json`. |
 | `--provider [openrouter\|local]` | Backend for the edit-reconciliation judge: `openrouter` (Claude Sonnet via OpenRouter, the default — needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`) or `local` (the Ollama daemon — offline, slower). Overridable with `$CLM_SYNC_PROVIDER`. |
 | `--llm-model TEXT` | Model for the edit-reconciliation judge. Default depends on `--provider`: `anthropic/claude-sonnet-4-6` (openrouter) or `qwen3:30b` (local). |
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (only used with `--provider local`; default: `$OLLAMA_URL` or `http://localhost:11434`). |
 | `--llm-timeout SECONDS` | Per-call timeout for the edit judge. Provider-aware default: 120s for `openrouter` (fast hosted model), 300s for `local` (a large local reasoning model can spend minutes "thinking"). |
 | `--translation-model TEXT` | OpenRouter model used to translate brand-new slides for the add path (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`; adds defer when absent. |
+| `--llm-recover` | **Opt into the bounded-LLM recovery tier (default off).** When the deterministic id-migration is stuck on an *ambiguous* drifted `slide_id` (a function renamed while a cell was split, an unresolvable tie), ask Claude (Opus, via OpenRouter) for a **validated, body-free** id↔cell alignment. Without this flag such a region is left untouched and re-surfaces next run. The model only ever sees content anchors (construct + hash + id), never cell source, and its map is validated (it can never drop a stable `slide_id`) before any header is written. Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`. |
+| `--recovery-model TEXT` | OpenRouter model for `--llm-recover` alignment (default: `anthropic/claude-opus-4`). |
 | `--cache-dir PATH` | Directory holding the structural watermark. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
 | `--no-cache` | Do not read or write the watermark. Every run then re-derives its baseline from git `HEAD` and no synced state is persisted. |
 | `--no-env-file` | Do not auto-load a `.env` file. By default sync loads the first `.env` found above each deck (without overriding already-set variables), so keys kept in the project `.env` reach the judge/translator. |
@@ -788,6 +819,12 @@ clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py
 
 # Preview the plan first — write nothing.
 clm slides sync intro.de.py intro.en.py --dry-run
+
+# Understand the anchor-level view (per-cell drift, direction, drifted ids).
+clm slides sync intro.de.py intro.en.py --explain
+
+# Let an LLM realign a genuinely ambiguous split (opt-in, off by default).
+clm slides sync intro.de.py intro.en.py --llm-recover
 
 # Walk each proposal, resolving conflicts as you go.
 clm slides sync intro.de.py intro.en.py --interactive

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -251,6 +251,39 @@ both decks.
   of dropping the cell, and the `--llm-timeout` default is provider-aware
   (120s for `openrouter`, 300s for `local`).
 
+### Content-anchor sync (Issue #190 — additive, no break)
+
+CLM {version} tracks cell identity in the watermark by a **content anchor**
+(`hand slide_id > construct slug > content hash`, never written into the file),
+which fixes the sync limitations that used to lose code edits or churn
+translations. These are behavior *improvements* — no change is required in a
+course repo — but agents driving `clm slides sync` should know:
+
+- **A code-only edit to a language-neutral code cell now propagates.** Editing
+  *only* a neutral (`# %%`, no `lang=`) code cell on one half — with no narrative
+  or id change — used to be **silently dropped**; it is now copied verbatim to the
+  twin. If a past sync left the two halves' code out of step, the next sync repairs
+  it.
+- **Unchanged localized code is no longer re-translated** when its slide group is
+  rebuilt for a sibling's sake — it is spliced verbatim by its anchor, so re-runs
+  are churn-free and spend no LLM.
+- **A drifted `slide_id` is migrated back deterministically.** Split an id'd code
+  cell (e.g. add an `import` above a `def`, leaving the id on the import) and the
+  next sync moves the id onto the cell whose construct it names, minting a fresh
+  slug on the orphan — symmetric across both decks (`de_id == en_id` preserved),
+  no LLM.
+- **A neutral cell edited differently on both decks auto-heals with a warning.**
+  Set `CLM_SYNC__SHARED_DIVERGENCE=error` (see `clm info` / the configuration
+  guide) to surface it as an error and write nothing instead.
+- **New flags:** `--explain` (a read-only content-anchor diff — see why a cell did
+  or did not sync), and the opt-in `--llm-recover` / `--recovery-model` (default
+  off) for *genuinely ambiguous* id realignment (a function renamed while a cell
+  was split). Without `--llm-recover`, an ambiguous region is left untouched and
+  re-surfaces next run.
+- **Watermark schema:** the `sync_watermarks` table gains a nullable `construct`
+  column, migrated automatically on first use; pre-#190 caches upgrade in place
+  (existing rows backfill to `NULL`). No action needed.
+
 ### How to migrate
 
 ```bash

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -43,6 +43,7 @@ from clm.slides.sync_writeback import (
     cell_content_hash,
     construct_of,
     role_of,
+    row_anchor,
 )
 
 if TYPE_CHECKING:
@@ -60,6 +61,7 @@ __all__ = [
     "build_sync_plan",
     "classify_changes",
     "ordered_sync_cells",
+    "render_explain",
     "render_plan",
     "watermark_rows",
 ]
@@ -1213,4 +1215,139 @@ def render_plan(plan: SyncPlan) -> str:
         lines.append(f"{p.kind}{direction} {sid}/{p.role}{suffix}{detail}")
     lines.append("")
     lines.append(plan.summary())
+    return "\n".join(lines)
+
+
+def _anchor_diff_section(
+    label: str,
+    base_rows: list[tuple[int, str | None, str, str, str | None]],
+    cur_rows: list[tuple[int, str | None, str, str, str | None]],
+) -> list[str]:
+    """Format one partition's anchor-keyed diff (the §6 pass, made visible).
+
+    Status per current cell against the watermark: ``=`` unchanged (anchor + hash
+    match), ``~`` edited (anchor matches, hash differs), ``+`` new (anchor absent
+    from the baseline). Anchors present in the baseline but gone from the current
+    deck are listed as ``-`` (removed). A construct anchor is not content-unique, so
+    matching is by anchor→{hashes} multimap (a diagnostic, last-writer-wins-free).
+    """
+    base_anchor_hashes: dict[str, set[str]] = {}
+    for _pos, sid, _role, chash, construct in base_rows:
+        base_anchor_hashes.setdefault(row_anchor(sid, construct, chash), set()).add(chash)
+
+    n = len(cur_rows)
+    lines = [f"{label} ({n} cell{'s' if n != 1 else ''}):"]
+    seen: set[str] = set()
+    for pos, sid, role, chash, construct in cur_rows:
+        anchor = row_anchor(sid, construct, chash)
+        seen.add(anchor)
+        if anchor in base_anchor_hashes:
+            status = "=" if chash in base_anchor_hashes[anchor] else "~"
+        else:
+            status = "+"
+        lines.append(f"  #{pos:<3} {status}  {anchor:<36} {role}")
+    for anchor in base_anchor_hashes:
+        if anchor not in seen:
+            lines.append(f"  ·    -  {anchor:<36} (removed)")
+    if not cur_rows and not base_anchor_hashes:
+        lines.append("  (none)")
+    return lines
+
+
+def _drifted_id_lines(
+    de_cells: list[Cell],
+    watermark_cache: SyncWatermarkCache | None,
+    de_path: Path,
+    en_path: Path,
+) -> list[str]:
+    """List id'd code cells whose construct drifted from the baseline (§9 candidates).
+
+    A cell wearing a ``slide_id`` whose *current* construct no longer matches the
+    construct the watermark recorded for that id is an id-migration candidate (the
+    author split or renamed it). Scans the DE file, which carries the neutral and
+    DE-localized id'd code; the EN twin shares the id (``de_id == en_id``).
+    """
+    if watermark_cache is None:
+        return []
+    base_construct: dict[str, str] = {}
+    for partition in ("de", "en", "shared"):
+        for _pos, sid, _role, _hash, construct in watermark_cache.get_deck(
+            str(de_path), str(en_path), partition
+        ):
+            if sid is not None and construct is not None:
+                base_construct.setdefault(sid, construct)
+    out: list[str] = []
+    for cell in de_cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.cell_type != "code" or meta.slide_id is None:
+            continue
+        current = construct_of(meta, cell.content)
+        base = base_construct.get(meta.slide_id)
+        if base is not None and current is not None and current != base:
+            out.append(f'  "{meta.slide_id}": was {base} → now {current}')
+    return out
+
+
+def render_explain(
+    de_path: Path,
+    en_path: Path,
+    *,
+    plan: SyncPlan,
+    watermark_cache: SyncWatermarkCache | None,
+) -> str:
+    """Anchor-level diagnostic for ``clm slides sync --explain`` (Issue #190 §13).
+
+    Dumps the content-anchor view the engine works in — every non-j2 cell's anchor
+    (``id:`` / ``construct:`` / ``hash:``) and whether it is unchanged / edited /
+    new / removed against the watermark baseline (the §6 anchor-keyed diff made
+    visible) — then the neutral-cell propagation direction, any drifted ``slide_id``s
+    (the §9 id-migration candidates), and finally the ordinary plan. Read-only:
+    ``--explain`` writes nothing, like ``--dry-run``.
+    """
+    lines = [
+        f"anchor diff — {de_path.name} / {en_path.name}",
+        f"baseline: {plan.baseline_source}",
+    ]
+    has_baseline = watermark_cache is not None and watermark_cache.has_pair(
+        str(de_path), str(en_path)
+    )
+    if not has_baseline:
+        lines.append("  (no watermark for this pair — every cell reads as new; legend +)")
+    lines.append("  legend: = unchanged  ~ edited  + new  - removed")
+    lines.append("")
+
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_current = watermark_rows(de_cells)
+    en_current = watermark_rows(en_cells)
+    current_by_partition = {
+        "de": de_current["de"],
+        "en": en_current["en"],
+        # Neutral cells are recorded once from DE under the single-entity partition.
+        "shared": de_current["shared"],
+    }
+    for label, partition in (
+        ("DE (localized + keyed)", "de"),
+        ("EN (localized + keyed)", "en"),
+        ("SHARED (language-neutral)", "shared"),
+    ):
+        base_rows = (
+            watermark_cache.get_deck(str(de_path), str(en_path), partition)
+            if watermark_cache is not None
+            else []
+        )
+        lines.extend(_anchor_diff_section(label, base_rows, current_by_partition[partition]))
+        lines.append("")
+
+    lines.append(
+        "neutral propagation direction: "
+        + (plan.anchor_direction if plan.anchor_direction else "none (halves agree)")
+    )
+    drifted = _drifted_id_lines(de_cells, watermark_cache, de_path, en_path)
+    lines.append("drifted slide_ids (id-migration candidates):")
+    lines.extend(drifted if drifted else ["  (none)"])
+    lines.append("")
+
+    lines.append("plan:")
+    lines.append(render_plan(plan))
     return "\n".join(lines)

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -583,3 +583,51 @@ class TestNoBaseline:
         )
         assert result.exit_code == 0, result.output
         assert "baseline=none" in result.output
+
+
+class TestExplain:
+    """`--explain` is a read-only anchor-diff diagnostic (Issue #190 Phase 6)."""
+
+    def test_explain_prints_anchor_diff_and_writes_nothing(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        before_de = de_path.read_text(encoding="utf-8")
+        before_en = en_path.read_text(encoding="utf-8")
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--explain", "--cache-dir", str(cache_dir)],
+        )
+        out = _combined(result)
+        assert result.exit_code in (0, 1), out  # read-only: clean / would-change
+        assert "anchor diff" in out
+        assert "legend:" in out
+        assert "plan:" in out
+        # Writes nothing — both decks are byte-identical afterwards.
+        assert de_path.read_text(encoding="utf-8") == before_de
+        assert en_path.read_text(encoding="utf-8") == before_en
+
+    def test_explain_and_interactive_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--explain",
+                "--interactive",
+                "--cache-dir",
+                str(cache_dir),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in _combined(result)
+
+    def test_explain_and_json_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--explain", "--json", "--cache-dir", str(cache_dir)],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in _combined(result)

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -24,7 +24,7 @@ from clm.infrastructure.llm.cache import SyncAlignmentCache, SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import SyncProposal
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_apply import _resolve_alignment, apply_plan
-from clm.slides.sync_plan import build_sync_plan, watermark_rows
+from clm.slides.sync_plan import build_sync_plan, render_explain, watermark_rows
 from clm.slides.sync_recover import (
     NEW,
     RegionCell,
@@ -971,3 +971,62 @@ def test_item3_duplicate_construct_does_not_splice_wrong_twin(tmp_path: Path):
     # Neither cell is dropped or duplicated — both bodies survive exactly once.
     assert en_text.count("compute_a()") == 1
     assert en_text.count("compute_b()") == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — `clm slides sync --explain` anchor-diff dump (§13)
+# ---------------------------------------------------------------------------
+
+
+def test_explain_dumps_anchor_diff(tmp_path: Path):
+    # The diagnostic shows each cell's content anchor + drift vs the watermark, the
+    # neutral propagation direction, and drifted slide_ids — read-only.
+    base_fn = "def fn():\n    pass"
+    de = (
+        _slide("de", "a", "# ## A") + _code_shared("import time") + _code_idd_neutral("fn", base_fn)
+    )
+    en = (
+        _slide("en", "a", "# ## A") + _code_shared("import time") + _code_idd_neutral("fn", base_fn)
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        # Edit the neutral shared cell (body change, construct stable) AND drift the
+        # id'd cell's construct (def fn -> import os) on DE only.
+        de_path.write_text(
+            _slide("de", "a", "# ## A")
+            + _code_shared("import time\nx = 1")  # ~ edited (construct import-time stable)
+            + _code_idd_neutral("fn", "import os"),  # construct drifted function-fn -> import-os
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        text = render_explain(de_path, en_path, plan=plan, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert "anchor diff" in text
+    assert "legend:" in text
+    assert "SHARED (language-neutral)" in text
+    assert "construct:import-time" in text  # the neutral cell's anchor
+    assert "neutral propagation direction: de->en" in text
+    assert "drifted slide_ids" in text
+    assert '"fn": was function-fn → now import-os' in text  # the §9 candidate
+    assert "plan:" in text
+
+
+def test_explain_without_watermark_reads_everything_as_new(tmp_path: Path):
+    # With no watermark for the pair, the dump still renders and marks every cell new.
+    de = _slide("de", "a", "# ## A") + _code_shared("import time")
+    en = _slide("en", "a", "# ## A") + _code_shared("import time")
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        text = render_explain(de_path, en_path, plan=plan, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert "no watermark for this pair" in text
+    assert "+  " in text  # at least one cell marked new


### PR DESCRIPTION
The final Issue #190 phase — the diagnostic surface and the downstream-facing docs. Closes out the content-anchor sync redesign (Phases 0–5 are all merged: #191, #192, #193, #194, #195).

## What

**`clm slides sync --explain`** — a read-only content-anchor dump. For each partition (de / en / shared) it lists every cell's anchor (`id:` / `construct:` / `hash:`) with its status vs the watermark (`=` unchanged, `~` edited, `+` new, `-` removed — the anchor-keyed diff made visible), then the neutral-cell propagation direction and the drifted-`slide_id` (id-migration) candidates, then the ordinary plan. It writes nothing and uses no LLM (rendered while the watermark cache is still open), and is mutually exclusive with `--interactive` / `--json`. It answers "why did this cell (not) sync?".

**Info topics (the Info Topics Maintenance Rule).** Downstream course-repo agents read these for current behavior, so they're updated for the whole #190 surface:
- `info_topics/commands.md`: a "Content-anchor sync (Issue #190)" prose block (code-only edits propagate, unchanged localized code is reused, drifted ids migrate, divergence auto-heals, ambiguous realignment is opt-in), the `--explain` / `--llm-recover` / `--recovery-model` option rows, and examples.
- `info_topics/migration.md`: an additive-no-break "Content-anchor sync" section (the behavior improvements + the `sync_watermarks.construct` column auto-migration).
- `docs/user-guide/configuration.md`: a "Slide Sync" env-var subsection for `CLM_SYNC_PROVIDER` and `CLM_SYNC__SHARED_DIVERGENCE`.

## Review

A focused adversarial review confirmed the `--explain` code (no reachable crash; correct status logic; genuinely read-only; cache rendered before close) and cross-checked **every** info-topic behavioral claim against the actual code — all accurate.

## Validation

`pytest -m "not docker"`-equivalent local runs green; slides suite 859 passed; CLI + info-topic suites 1255 passed; the Issue #190 no-op corpus harness holds at 81/212, 0 invariant violations; ruff + mypy clean. New tests cover `render_explain` (with a drifted id; the no-watermark case) and the CLI wiring (prints the diff, writes nothing, rejects `--interactive`/`--json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)