### PR TITLE
feat(slides): sync tag-only edits across split halves (#198)

### DIFF
--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -483,7 +483,8 @@ def _issue_line(issue: PlanIssue) -> str:
 
 def _outcome_line(result: ApplyResult) -> str:
     return (
-        f"applied: {result.applied_edit} edit, {result.applied_remove} remove, "
+        f"applied: {result.applied_edit} edit, {result.applied_retag} retag, "
+        f"{result.applied_remove} remove, "
         f"{result.applied_move} move, {result.applied_add} add, "
         f"{result.applied_rename} rename; {result.in_sync} already in sync; "
         f"{result.deferred} deferred; {len(result.errors)} error(s); "
@@ -549,7 +550,7 @@ def _plan_dict(plan: SyncPlan) -> dict:
         "in_sync": plan.in_sync_count,
         "counts": {
             kind: plan.count(kind)
-            for kind in ("add", "edit", "move", "remove", "conflict", "rename")
+            for kind in ("add", "edit", "retag", "move", "remove", "conflict", "rename")
         },
         "proposals": [
             {
@@ -573,6 +574,7 @@ def _apply_dict(result: ApplyResult) -> dict:
     return {
         "applied": {
             "edit": result.applied_edit,
+            "retag": result.applied_retag,
             "remove": result.applied_remove,
             "move": result.applied_move,
             "add": result.applied_add,

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -575,6 +575,21 @@ class SyncSnapshotCache:
         self._conn.close()
 
 
+def _serialize_tags(tags: frozenset[str]) -> str:
+    """Canonical wire form of a cell's tag set for the watermark ``tags`` column.
+
+    Sorted and comma-joined; tag names are identifiers so a comma never appears
+    inside one. The empty set serializes to ``""`` — a *known* empty set, stored
+    distinctly from a NULL (undeterminable) column. Issue #198.
+    """
+    return ",".join(sorted(tags))
+
+
+def _deserialize_tags(raw: str) -> frozenset[str]:
+    """Inverse of :func:`_serialize_tags`; ``""`` -> the empty set (not ``{""}``)."""
+    return frozenset(raw.split(",")) if raw else frozenset()
+
+
 class SyncWatermarkCache:
     """Ordered, per-language structural watermark of the last synced deck state.
 
@@ -614,15 +629,22 @@ class SyncWatermarkCache:
                     role         TEXT NOT NULL,
                     content_hash TEXT NOT NULL,
                     construct    TEXT,
+                    tags         TEXT,
                     synced_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (de_path, en_path, lang, position)
                 )"""
             )
             self._conn.commit()
-        elif "construct" not in columns:
-            # Additive migration (Issue #190 §5): the content-anchor construct
-            # slug. Nullable, so existing rows backfill to NULL harmlessly.
-            self._conn.execute("ALTER TABLE sync_watermarks ADD COLUMN construct TEXT")
+        else:
+            # Additive migrations: nullable columns, so existing rows backfill to
+            # NULL harmlessly. ``construct`` (Issue #190 §5) is the content-anchor
+            # slug; ``tags`` (Issue #198) is the cell's tag set, recorded so a
+            # later run can detect a tag-only edit (invisible to the content hash)
+            # and mirror it across the split halves.
+            if "construct" not in columns:
+                self._conn.execute("ALTER TABLE sync_watermarks ADD COLUMN construct TEXT")
+            if "tags" not in columns:
+                self._conn.execute("ALTER TABLE sync_watermarks ADD COLUMN tags TEXT")
             self._conn.commit()
 
     def get_deck(
@@ -651,6 +673,7 @@ class SyncWatermarkCache:
         en_path: str,
         lang: str,
         cells: list[tuple[int, str | None, str, str, str | None]],
+        tags: dict[int, frozenset[str]] | None = None,
     ) -> None:
         """Replace the watermark for one deck atomically.
 
@@ -660,9 +683,16 @@ class SyncWatermarkCache:
         (Issue #190 §5). The whole ``(de_path, en_path, lang)`` slice is deleted
         and rewritten in a single transaction so a deck's watermark is never
         observed half-updated.
+
+        ``tags`` (Issue #198) optionally maps a cell's ``position`` to its tag
+        set, stored in the additive ``tags`` column so a later run can detect a
+        tag-only edit. A position absent from ``tags`` (or ``tags=None``) stores
+        NULL — "tag set unknown" — which the classifier reads as "tag direction
+        undeterminable" and skips, so a pre-#198 watermark degrades gracefully.
         """
         if lang not in ("de", "en", "shared"):
             raise ValueError(f"lang must be 'de', 'en', or 'shared', got {lang!r}")
+        tag_for = tags or {}
         with self._conn:  # single transaction (BEGIN/COMMIT or ROLLBACK)
             self._conn.execute(
                 "DELETE FROM sync_watermarks WHERE de_path=? AND en_path=? AND lang=?",
@@ -670,13 +700,37 @@ class SyncWatermarkCache:
             )
             self._conn.executemany(
                 "INSERT INTO sync_watermarks "
-                "(de_path, en_path, lang, position, slide_id, role, content_hash, construct) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "(de_path, en_path, lang, position, slide_id, role, content_hash, construct, tags) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 [
-                    (de_path, en_path, lang, position, slide_id, role, content_hash, construct)
+                    (
+                        de_path,
+                        en_path,
+                        lang,
+                        position,
+                        slide_id,
+                        role,
+                        content_hash,
+                        construct,
+                        _serialize_tags(tag_for[position]) if position in tag_for else None,
+                    )
                     for (position, slide_id, role, content_hash, construct) in cells
                 ],
             )
+
+    def get_deck_tags(self, de_path: str, en_path: str, lang: str) -> dict[int, frozenset[str]]:
+        """Return ``{position: tag_set}`` for the rows that recorded a tag set.
+
+        Only rows whose ``tags`` column is non-NULL appear, so the caller can
+        distinguish a *known* empty tag set (present, ``frozenset()``) from an
+        *undeterminable* one (absent — a pre-#198 watermark row). Issue #198.
+        """
+        rows = self._conn.execute(
+            "SELECT position, tags FROM sync_watermarks "
+            "WHERE de_path=? AND en_path=? AND lang=? AND tags IS NOT NULL ORDER BY position",
+            (de_path, en_path, lang),
+        ).fetchall()
+        return {r[0]: _deserialize_tags(r[1]) for r in rows}
 
     def has_pair(self, de_path: str, en_path: str) -> bool:
         """Return True when any watermark row exists for the pair."""

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -54,6 +54,7 @@ from clm.slides.sync_plan import (
     SyncPlan,
     ordered_sync_cells,
     watermark_rows,
+    watermark_tag_map,
 )
 from clm.slides.sync_recover import (
     NEW,
@@ -114,6 +115,7 @@ class ApplyResult:
     """Outcome of applying a :class:`SyncPlan`."""
 
     applied_edit: int = 0
+    applied_retag: int = 0  # a tag-only edit mirrored across the split halves (#198)
     applied_remove: int = 0
     applied_move: int = 0
     applied_add: int = 0
@@ -128,6 +130,7 @@ class ApplyResult:
     def applied(self) -> int:
         return (
             self.applied_edit
+            + self.applied_retag
             + self.applied_remove
             + self.applied_move
             + self.applied_add
@@ -210,6 +213,12 @@ def apply_plan(
                 _apply_edit(
                     proposal, de_state, en_state, de_content, en_content, judge, translator, result
                 )
+            else:
+                result.deferred += 1
+                _note_deferred(deferred_keys, proposal)
+        elif kind == "retag":
+            if _accepted(decisions, proposal):
+                _apply_retag(proposal, de_state, en_state, result)
             else:
                 result.deferred += 1
                 _note_deferred(deferred_keys, proposal)
@@ -466,6 +475,36 @@ def _apply_remove(
         result.applied_remove += 1
     else:
         result.errors.append(f"remove {proposal.slide_id}/{proposal.role}: target cell not found")
+
+
+def _apply_retag(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    result: ApplyResult,
+) -> None:
+    """Mirror a tag-only edit (#198) by copying the source cell's tags to the target.
+
+    Tags are language-independent, so this is a pure header rewrite — no judge or
+    translator. The cell is matched on both decks by ``(slide_id, role)``, so the
+    role tag is carried verbatim and the target's role never changes.
+    """
+    if proposal.slide_id is None:
+        result.errors.append(f"retag {proposal.role}: proposal has no slide_id")
+        return
+    sid = proposal.slide_id
+    if proposal.direction == "de->en":
+        source_state, target_state = de_state, en_state
+    else:
+        source_state, target_state = en_state, de_state
+    source_cell = source_state.find_cell(sid, proposal.role)
+    if source_cell is None:
+        result.errors.append(f"retag {sid}/{proposal.role}: source cell not found")
+        return
+    if target_state.replace_cell_tags(sid, proposal.role, list(source_cell.metadata.tags)):
+        result.applied_retag += 1
+    else:
+        result.errors.append(f"retag {sid}/{proposal.role}: target cell not found")
 
 
 def _apply_edit(
@@ -1626,14 +1665,36 @@ def _record_watermark(
     (``_baseline_from_watermark`` filters the synthetic membership roles), so this
     does not change its behavior.
     """
-    de_rows = watermark_rows(parse_cells(de_path.read_text(encoding="utf-8")))
-    en_rows = watermark_rows(parse_cells(en_path.read_text(encoding="utf-8")))
-    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="de", cells=de_rows["de"])
-    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="en", cells=en_rows["en"])
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_rows = watermark_rows(de_cells)
+    en_rows = watermark_rows(en_cells)
+    # Issue #198: record each cell's tag set alongside its row so a later run can
+    # detect a tag-only edit (invisible to the content hash) and mirror it.
+    de_tags = watermark_tag_map(de_cells)
+    en_tags = watermark_tag_map(en_cells)
+    cache.put_deck(
+        de_path=str(de_path),
+        en_path=str(en_path),
+        lang="de",
+        cells=de_rows["de"],
+        tags=de_tags["de"],
+    )
+    cache.put_deck(
+        de_path=str(de_path),
+        en_path=str(en_path),
+        lang="en",
+        cells=en_rows["en"],
+        tags=en_tags["en"],
+    )
     # Neutral cells are byte-identical across halves (the unify invariant), so the
     # single-entity "shared" partition is recorded once from the DE file.
     cache.put_deck(
-        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=de_rows["shared"]
+        de_path=str(de_path),
+        en_path=str(en_path),
+        lang="shared",
+        cells=de_rows["shared"],
+        tags=de_tags["shared"],
     )
 
 
@@ -1723,6 +1784,9 @@ def _record_watermark_partial(
     # leaves structure (and every neutral / id-less cell) unchanged, so the
     # membership rows re-derive faithfully from the current files.
     widened = {"de": watermark_rows(parsed["de"]), "en": watermark_rows(parsed["en"])}
+    # Issue #198: a content-only pass leaves every cell's tags as they are on disk,
+    # so the current tag map is the right baseline for every recorded cell.
+    tag_map = {"de": watermark_tag_map(parsed["de"]), "en": watermark_tag_map(parsed["en"])}
     for lang in ("de", "en"):
         rows: list[tuple[int, str | None, str, str, str | None]] = []
         for pos, sid, role, chash, construct in widened[lang][lang]:
@@ -1730,8 +1794,18 @@ def _record_watermark_partial(
                 # Hold the deferral at its pre-conflict baseline so it re-surfaces.
                 chash = old[lang][(sid, role)]
             rows.append((pos, sid, role, chash, construct))
-        cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang=lang, cells=rows)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=rows,
+            tags=tag_map[lang][lang],
+        )
     cache.put_deck(
-        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=widened["de"]["shared"]
+        de_path=str(de_path),
+        en_path=str(en_path),
+        lang="shared",
+        cells=widened["de"]["shared"],
+        tags=tag_map["de"]["shared"],
     )
     return True

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -64,6 +64,7 @@ __all__ = [
     "render_explain",
     "render_plan",
     "watermark_rows",
+    "watermark_tag_map",
 ]
 
 # Roles that lead a slide group; narrative roles (voiceover/notes/code/aux)
@@ -105,6 +106,10 @@ class BaselineCell:
     slide_id: str | None
     role: str
     content_hash: str
+    # Tag set at the last sync (Issue #198). ``None`` means "undeterminable" — a
+    # pre-#198 watermark row that recorded no tags — so the classifier never
+    # guesses a tag direction from it. An empty frozenset is a *known* no-tags cell.
+    tags: frozenset[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -117,18 +122,21 @@ class CurrentCell:
     content_hash: str
     line_number: int  # 1-based header line, for anchoring / messaging
     construct: str | None = None  # AST construct slug (Issue #190 §4); None for non-code
+    tags: frozenset[str] = frozenset()  # current tag set (Issue #198)
 
 
 @dataclass
 class Proposal:
     """One cross-language change the sync would make.
 
-    ``kind`` is ``add`` / ``edit`` / ``move`` / ``remove`` / ``conflict`` /
-    ``rename``. ``direction`` is ``"de->en"`` / ``"en->de"`` (the side that
-    drifted is the source), or ``None`` for a conflict. ``slide_id`` is ``None``
-    for an id-less add, and the *duplicated* id for a ``rename``. Positions are
-    0-based indices among sync-relevant cells and are best-effort context for
-    later phases (anchoring, walker rendering).
+    ``kind`` is ``add`` / ``edit`` / ``retag`` / ``move`` / ``remove`` /
+    ``conflict`` / ``rename``. ``direction`` is ``"de->en"`` / ``"en->de"`` (the
+    side that drifted is the source), or ``None`` for a conflict. ``slide_id`` is
+    ``None`` for an id-less add, and the *duplicated* id for a ``rename``. A
+    ``retag`` mirrors a tag-only edit (the content hash is unchanged) onto the
+    other half (Issue #198). Positions are 0-based indices among sync-relevant
+    cells and are best-effort context for later phases (anchoring, walker
+    rendering).
 
     ``content_hash`` is set on a ``rename`` proposal: it identifies which of the
     duplicate-id cells is the copy (the apply re-mints the cell matching this
@@ -202,6 +210,7 @@ class SyncPlan:
             parts = [
                 f"{self.count('add')} add",
                 f"{self.count('edit')} edit",
+                f"{self.count('retag')} retag",
                 f"{self.count('move')} move",
                 f"{self.count('remove')} remove",
                 f"{self.count('conflict')} conflict",
@@ -262,6 +271,7 @@ def ordered_sync_cells(cells: list[Cell], expected_lang: str) -> list[CurrentCel
                 content_hash=cell_content_hash(cell.content),
                 line_number=cell.line_number,
                 construct=construct_of(cell.metadata, cell.content),
+                tags=frozenset(cell.metadata.tags),
             )
         )
         position += 1
@@ -305,6 +315,27 @@ def watermark_rows(
                 construct_of(meta, cell.content),
             )
         )
+        pos[partition] += 1
+    return out
+
+
+def watermark_tag_map(cells: list[Cell]) -> dict[str, dict[int, frozenset[str]]]:
+    """Per-cell tag sets, partitioned and positioned exactly like :func:`watermark_rows`.
+
+    Issue #198: the watermark records each non-j2 cell's tag set (keyed by the
+    same per-partition position ``watermark_rows`` assigns) so a later sync can
+    detect a tag-only edit — invisible to the content hash — and mirror it across
+    the split halves. Kept beside ``watermark_rows`` and iterating identically so
+    the two never drift out of position lock-step.
+    """
+    out: dict[str, dict[int, frozenset[str]]] = {"de": {}, "en": {}, "shared": {}}
+    pos = {"de": 0, "en": 0, "shared": 0}
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2:
+            continue
+        partition = meta.lang if meta.lang in ("de", "en") else "shared"
+        out[partition][pos[partition]] = frozenset(meta.tags)
         pos[partition] += 1
     return out
 
@@ -472,6 +503,7 @@ def _resolve_divergence_winner(plan: SyncPlan, de_path: Path, en_path: Path) -> 
 
 def _baseline_from_watermark(
     rows: list[tuple[int, str | None, str, str, str | None]],
+    tags_by_position: dict[int, frozenset[str]] | None = None,
 ) -> list[BaselineCell]:
     # Drop the membership-widened rows (Issue #190 §5.3) and **re-index** the
     # survivors into the legacy-only position space. The stored positions count
@@ -483,14 +515,18 @@ def _baseline_from_watermark(
     # reproduces exactly the indices ``ordered_sync_cells`` (and
     # ``_baseline_from_git_head``) assign. ``construct`` is carried in the raw
     # watermark for the Phase 2 anchor reuse but is not consumed by the classifier.
+    # ``tags_by_position`` (Issue #198) maps the *stored* position to the recorded
+    # tag set; ``None`` for a row absent from it (a pre-#198 watermark) leaves the
+    # cell's baseline tags undeterminable so no tag direction is ever guessed.
+    tbp = tags_by_position or {}
     legacy = [
-        (sid, role, chash)
-        for (_pos, sid, role, chash, _construct) in rows
+        (pos, sid, role, chash)
+        for (pos, sid, role, chash, _construct) in rows
         if role not in MEMBERSHIP_ROLES
     ]
     return [
-        BaselineCell(position=i, slide_id=sid, role=role, content_hash=chash)
-        for i, (sid, role, chash) in enumerate(legacy)
+        BaselineCell(position=i, slide_id=sid, role=role, content_hash=chash, tags=tbp.get(pos))
+        for i, (pos, sid, role, chash) in enumerate(legacy)
     ]
 
 
@@ -533,6 +569,7 @@ def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
             slide_id=c.slide_id,
             role=c.role,
             content_hash=c.content_hash,
+            tags=c.tags,
         )
         for c in ordered_sync_cells(cells, lang)
     ]
@@ -832,6 +869,9 @@ def classify_changes(
             elif en_st == "edited" and de_st == "same":
                 plan.proposals.append(_edit(sid, role, "en->de", en_now, de_now))
             elif de_st == "same" and en_st == "same":
+                # Content is in sync, but a tag-only edit (invisible to the hash)
+                # may have drifted on one side — mirror it (Issue #198).
+                _maybe_retag(plan, key, role, de_now, en_now, de_base.get(key), en_base.get(key))
                 _emit_same(
                     plan,
                     key,
@@ -1062,7 +1102,75 @@ def _edit(
     )
 
 
-_KIND_ORDER = {"conflict": 0, "remove": 1, "edit": 2, "move": 3, "add": 4, "rename": 5}
+def _maybe_retag(
+    plan: SyncPlan,
+    key: tuple[str, str],
+    role: str,
+    de_now: CurrentCell,
+    en_now: CurrentCell,
+    de_base: BaselineCell | None,
+    en_base: BaselineCell | None,
+) -> None:
+    """Emit a ``retag`` when a cell's tag set drifted on exactly one side.
+
+    Tags are language-independent, so a synced pair carries identical tag sets;
+    the content hash is blind to a tag-only edit (Issue #198). When the halves'
+    tags now disagree, the side whose tags changed from its baseline is the
+    source and its set is mirrored onto the other. Both-sides-changed is a tag
+    conflict, surfaced as a warning rather than guessed. Skipped silently when a
+    baseline tag set is unknown (a pre-#198 watermark) — direction is
+    undeterminable, so we never guess — or when neither side changed (a
+    pre-existing divergence not caused by this edit; the validator flags it).
+    """
+    if de_now.tags == en_now.tags:
+        return  # already consistent — nothing to mirror
+    if de_base is None or en_base is None or de_base.tags is None or en_base.tags is None:
+        return  # no tag baseline to attribute the drift — degrade gracefully
+    de_changed = de_now.tags != de_base.tags
+    en_changed = en_now.tags != en_base.tags
+    if de_changed and not en_changed:
+        plan.proposals.append(_retag(key[0], role, "de->en", de_now, en_now))
+    elif en_changed and not de_changed:
+        plan.proposals.append(_retag(key[0], role, "en->de", en_now, de_now))
+    elif de_changed and en_changed:
+        plan.issues.append(
+            PlanIssue(
+                severity="warning",
+                slide_id=key[0],
+                reason=f"role={role!r} tags changed on both decks "
+                f"(de={sorted(de_now.tags)}, en={sorted(en_now.tags)}); "
+                "not propagated — reconcile tags manually",
+            )
+        )
+
+
+def _retag(
+    slide_id: str,
+    role: str,
+    direction: str,
+    source: CurrentCell,
+    target: CurrentCell,
+) -> Proposal:
+    return Proposal(
+        kind="retag",
+        role=role,
+        direction=direction,
+        slide_id=slide_id,
+        reason=f"tags changed on {direction.split('->')[0].upper()} ({sorted(source.tags)})",
+        source_position=source.position,
+        target_position=target.position,
+    )
+
+
+_KIND_ORDER = {
+    "conflict": 0,
+    "remove": 1,
+    "edit": 2,
+    "retag": 3,
+    "move": 4,
+    "add": 5,
+    "rename": 6,
+}
 
 
 def _proposal_sort_key(p: Proposal) -> tuple:
@@ -1103,10 +1211,12 @@ def build_sync_plan(
 
     if watermark_cache is not None and watermark_cache.has_pair(str(de_path), str(en_path)):
         de_baseline = _baseline_from_watermark(
-            watermark_cache.get_deck(str(de_path), str(en_path), "de")
+            watermark_cache.get_deck(str(de_path), str(en_path), "de"),
+            watermark_cache.get_deck_tags(str(de_path), str(en_path), "de"),
         )
         en_baseline = _baseline_from_watermark(
-            watermark_cache.get_deck(str(de_path), str(en_path), "en")
+            watermark_cache.get_deck(str(de_path), str(en_path), "en"),
+            watermark_cache.get_deck_tags(str(de_path), str(en_path), "en"),
         )
         # Ordered content hashes of the baseline's neutral cells (position order),
         # matching _shared_hashes — see align_anchored for why this is a sequence,

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -76,7 +76,7 @@ DE_WINS = "de-wins"
 EN_WINS = "en-wins"
 AUTO = "auto"  # add (id-less or id-carrying) / rename, applied without prompting
 
-_GATED_KINDS = {"edit", "remove", "move"}
+_GATED_KINDS = {"edit", "retag", "remove", "move"}
 _AUTO_KINDS = {"add", "rename"}
 
 

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -44,6 +45,7 @@ __all__ = [
     "record_snapshot",
     "role_of",
     "row_anchor",
+    "set_header_tags",
     "swap_lang",
     "target_path_for_outcome",
 ]
@@ -196,6 +198,31 @@ def row_anchor(slide_id: str | None, construct: str | None, content_hash: str) -
 
 
 _LANG_ATTR_RE = re.compile(r'lang="[^"]*"')
+_TAGS_ATTR_RE = re.compile(r"tags=\[[^\]]*\]")
+
+
+def set_header_tags(header: str, tags: Sequence[str]) -> str:
+    """Return ``header`` with its ``tags=[…]`` set to exactly ``tags``.
+
+    Replaces an existing ``tags=[…]`` block in place (keeping its position
+    relative to ``lang=`` / ``slide_id=``), inserts one at the end when absent,
+    or drops the block entirely when ``tags`` is empty. Used to mirror a tag set
+    onto a target cell during a ``retag`` apply (Issue #198) without disturbing
+    the rest of the header (slide_id, lang, markdown-vs-code) or the body. Tag
+    order is preserved from ``tags`` (the source cell's order), matching the
+    ``tags=["a", "b"]`` serialization the normalizer emits.
+    """
+    block = ("tags=[" + ", ".join(f'"{t}"' for t in tags) + "]") if tags else ""
+    match = _TAGS_ATTR_RE.search(header)
+    if match:
+        if block:
+            return header[: match.start()] + block + header[match.end() :]
+        # Removing the block can leave a doubled space; tidy it.
+        stripped = header[: match.start()] + header[match.end() :]
+        return re.sub(r"  +", " ", stripped).rstrip()
+    if not block:
+        return header
+    return header.rstrip() + " " + block
 
 
 def swap_lang(header: str, lang: str) -> str:
@@ -338,6 +365,28 @@ class FileState:
             return False
         self._rewrite_cell_body(cell, new_text)
         self.dirty = True
+        return True
+
+    def replace_cell_tags(self, slide_id: str, role: str, new_tags: Sequence[str]) -> bool:
+        """Set the ``(slide_id, role)`` cell's tag set to ``new_tags`` in place.
+
+        Rewrites only the header's ``tags=[…]`` (Issue #198 tag mirroring),
+        keeping slide_id, lang, cell-type, body, and trailing blanks verbatim —
+        the header-only counterpart of :meth:`replace_cell_body`. Returns
+        ``False`` when no such cell exists; ``True`` (a no-op, not dirtied) when
+        the header already carries exactly ``new_tags``. Because a ``retag`` only
+        ever targets a cell matched by the same ``(slide_id, role)`` key, the
+        role-defining tag is part of ``new_tags`` (or the role is tag-independent,
+        as for a localized code cell), so the cell's role never changes.
+        """
+        cell = self.find_cell(slide_id, role)
+        if cell is None:
+            return False
+        new_header = set_header_tags(cell.lines[0], new_tags)
+        if new_header != cell.lines[0]:
+            cell.lines[0] = new_header
+            cell.metadata = parse_cell_header(new_header)
+            self.dirty = True
         return True
 
     def delete_cell(self, slide_id: str, role: str) -> bool:

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -953,6 +953,67 @@ def _check_shared_cell_parity(de_path: Path, en_path: Path) -> list[Finding]:
     return findings
 
 
+def _check_split_tag_parity(de_path: Path, en_path: Path) -> list[Finding]:
+    """Flag any tag-set asymmetry between the cross-language twins of a split pair.
+
+    A split deck's two halves carry the same cells in the same order — shared
+    (no-``lang``) cells byte-identical, localized cells as language twins. Tags
+    are language-independent, so each cell and its twin must carry the same tag
+    set. A one-sided tag edit (e.g. adding ``keep`` to one half) is invisible to
+    the content *and* to :func:`_check_shared_cell_parity` (which compares only
+    shared cells, so it never sees a localized cell's tags). This check pairs the
+    halves' non-j2 cells positionally and warns on any tag-set mismatch — covering
+    localized markdown *and* id-less localized code (the cell the #198 report hit).
+
+    When the two non-j2 streams differ in length — a structural edit mid-flight,
+    or an add/remove not yet synced — it stays silent rather than mis-pair across
+    the offset; the count itself is a separate concern surfaced by the shared-cell
+    parity check. Issue #198: ``clm slides sync`` mirrors a *recent* one-sided tag
+    edit automatically; this check is the safety net for a committed asymmetry sync
+    can no longer attribute to one side.
+    """
+    findings: list[Finding] = []
+    _, de_cells = split_raw_cells(de_path.read_text(encoding="utf-8"))
+    _, en_cells = split_raw_cells(en_path.read_text(encoding="utf-8"))
+    de_nonj2 = [c for c in de_cells if not c.metadata.is_j2]
+    en_nonj2 = [c for c in en_cells if not c.metadata.is_j2]
+    if len(de_nonj2) != len(en_nonj2):
+        return findings  # structural mismatch — not a tag-parity question
+
+    for i, (de_cell, en_cell) in enumerate(zip(de_nonj2, en_nonj2, strict=True)):
+        de_tags = set(de_cell.metadata.tags)
+        en_tags = set(en_cell.metadata.tags)
+        if de_tags == en_tags:
+            continue
+        only_de = sorted(de_tags - en_tags)
+        only_en = sorted(en_tags - de_tags)
+        detail = ""
+        if only_de:
+            detail += f"; only on DE: {only_de}"
+        if only_en:
+            detail += f"; only on EN: {only_en}"
+        findings.append(
+            Finding(
+                severity="warning",
+                category="pairing",
+                file=str(de_path),
+                line=de_cell.line_number,
+                message=(
+                    f"split pair cell {i + 1} has mismatched tags between "
+                    f"'.de.py' (line {de_cell.line_number}, {sorted(de_tags)}) and "
+                    f"'.en.py' (line {en_cell.line_number} in {en_path.name}, "
+                    f"{sorted(en_tags)}){detail}"
+                ),
+                suggestion=(
+                    "Tags are language-independent and must match across the DE/EN "
+                    "twins. Run `clm slides sync` to mirror a recent one-sided tag "
+                    "edit, or align the tags manually."
+                ),
+            )
+        )
+    return findings
+
+
 def _slide_files_to_split_pairs(slide_files: list[Path]) -> list[tuple[Path, Path]]:
     """Return every detected ``(de_path, en_path)`` pair in ``slide_files``.
 
@@ -1372,6 +1433,7 @@ def validate_directory(
     if "pairing" in check_set:
         for de_path, en_path in _slide_files_to_split_pairs(slide_files):
             all_findings.extend(_check_shared_cell_parity(de_path, en_path))
+            all_findings.extend(_check_split_tag_parity(de_path, en_path))
 
     return ValidationResult(
         files_checked=len(slide_files),
@@ -1424,6 +1486,7 @@ def validate_course(
             if "pairing" in check_set:
                 for de_path, en_path in _slide_files_to_split_pairs(slide_files):
                     all_findings.extend(_check_shared_cell_parity(de_path, en_path))
+                    all_findings.extend(_check_split_tag_parity(de_path, en_path))
 
     return ValidationResult(
         files_checked=files_checked,

--- a/tests/slides/test_sync_tag_sync.py
+++ b/tests/slides/test_sync_tag_sync.py
@@ -1,0 +1,319 @@
+"""Tests for cross-language tag-only sync — the ``retag`` proposal (Issue #198).
+
+A tag-only edit (e.g. adding ``keep``/``alt``) is invisible to the content hash,
+so the body-diff classifier reports the cell as ``same``. These tests cover the
+dedicated ``retag`` path that detects such a one-sided tag drift against the
+watermark's recorded tag set and mirrors it onto the other half — no LLM, since
+tags are language-independent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_plan import (
+    BaselineCell,
+    CurrentCell,
+    SyncPlan,
+    _maybe_retag,  # noqa: PLC2701 (white-box unit)
+    build_sync_plan,
+    ordered_sync_cells,
+)
+from clm.slides.sync_writeback import FileState, set_header_tags
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _md(lang: str, sid: str, tags: list[str], body: str) -> str:
+    taglist = ", ".join(f'"{t}"' for t in tags)
+    return f'# %% [markdown] lang="{lang}" tags=[{taglist}] slide_id="{sid}"\n{body}\n'
+
+
+def _code(lang: str, sid: str | None, tags: list[str], body: str) -> str:
+    attrs = f'lang="{lang}"'
+    if tags:
+        attrs += " tags=[" + ", ".join(f'"{t}"' for t in tags) + "]"
+    if sid:
+        attrs += f' slide_id="{sid}"'
+    return f"# %% {attrs}\n{body}\n"
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path, *, tags: bool = True):
+    """Record the current on-disk state as the watermark baseline.
+
+    With ``tags=True`` the tag set is recorded too (the #198 column), keyed by the
+    same position the row uses. ``tags=False`` simulates a pre-#198 watermark.
+    """
+    for lang, path in (("de", de_path), ("en", en_path)):
+        synced = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in synced],
+            tags={c.position: c.tags for c in synced} if tags else None,
+        )
+
+
+def _tags_of(path: Path, sid: str) -> set[str]:
+    cell = next(
+        c for c in parse_cells(path.read_text(encoding="utf-8")) if c.metadata.slide_id == sid
+    )
+    return set(cell.metadata.tags)
+
+
+# ---------------------------------------------------------------------------
+# Classifier — retag detection
+# ---------------------------------------------------------------------------
+
+
+class TestRetagClassification:
+    def test_one_sided_markdown_tag_add_is_retag(self, tmp_path: Path):
+        de = _md("de", "vec", ["subslide"], "# ## Vektoren\n# - Punkt")
+        en = _md("en", "vec", ["subslide"], "# ## Vectors\n# - point")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "vec", ["subslide", "keep"], "# ## Vectors\n# - point"), encoding="utf-8"
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 1
+            assert plan.count("edit") == 0
+            (p,) = [p for p in plan.proposals if p.kind == "retag"]
+            assert p.direction == "en->de"
+            assert p.slide_id == "vec"
+        finally:
+            cache.close()
+
+    def test_localized_code_tag_add_is_retag(self, tmp_path: Path):
+        # An id'd localized code cell (CODE_ROLE) — the same shape as the #198 hit,
+        # promoted with a slide_id so it has a cross-language identity.
+        de = _md("de", "s", ["slide"], "# ## S") + _code("de", "inv", [], 'a = invoke("Frage")')
+        en = _md("en", "s", ["slide"], "# ## S") + _code("en", "inv", [], 'a = invoke("question")')
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "s", ["slide"], "# ## S")
+                + _code("en", "inv", ["keep"], 'a = invoke("question")'),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 1
+            (p,) = [p for p in plan.proposals if p.kind == "retag"]
+            assert p.direction == "en->de"
+            assert p.role == "code"
+        finally:
+            cache.close()
+
+    def test_both_sides_tag_change_is_warning_not_retag(self, tmp_path: Path):
+        de = _md("de", "vec", ["subslide"], "# ## Vektoren")
+        en = _md("en", "vec", ["subslide"], "# ## Vectors")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(_md("de", "vec", ["subslide", "keep"], "# ## Vektoren"), "utf-8")
+            en_path.write_text(_md("en", "vec", ["subslide", "alt"], "# ## Vectors"), "utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0
+            assert any("tags changed on both decks" in i.reason for i in plan.issues)
+        finally:
+            cache.close()
+
+    def test_pre_198_watermark_without_tags_skips_retag(self, tmp_path: Path):
+        de = _md("de", "vec", ["subslide"], "# ## Vektoren")
+        en = _md("en", "vec", ["subslide"], "# ## Vectors")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path, tags=False)  # no recorded tags
+            en_path.write_text(_md("en", "vec", ["subslide", "keep"], "# ## Vectors"), "utf-8")
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            # Direction undeterminable without a tag baseline → never guessed.
+            assert plan.count("retag") == 0
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Apply — retag writes only the header, mirrors tags, advances watermark
+# ---------------------------------------------------------------------------
+
+
+class TestRetagApply:
+    def test_retag_mirrors_tags_and_advances_watermark(self, tmp_path: Path):
+        de = _md("de", "vec", ["subslide"], "# ## Vektoren\n# - Punkt")
+        en = _md("en", "vec", ["subslide"], "# ## Vectors\n# - point")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "vec", ["subslide", "keep"], "# ## Vectors\n# - point"), "utf-8"
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            # No judge / translator needed — a tag mirror is language-independent.
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            assert result.applied_retag == 1
+            assert result.errors == []
+            assert result.watermark_recorded
+            # DE now carries the keep tag; its body is untouched.
+            assert _tags_of(de_path, "vec") == {"subslide", "keep"}
+            assert "# - Punkt" in de_path.read_text(encoding="utf-8")
+        finally:
+            cache.close()
+
+    def test_retag_is_idempotent(self, tmp_path: Path):
+        de = _md("de", "vec", ["subslide"], "# ## Vektoren")
+        en = _md("en", "vec", ["subslide"], "# ## Vectors")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            en_path.write_text(_md("en", "vec", ["subslide", "keep"], "# ## Vectors"), "utf-8")
+            apply_plan(
+                build_sync_plan(de_path, en_path, watermark_cache=cache),
+                judge=None,
+                watermark_cache=cache,
+            )
+            # Second run: both halves now agree and the watermark recorded the tags.
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan2.count("retag") == 0
+            assert plan2.is_noop
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Header / FileState primitives
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderTagPrimitives:
+    def test_set_header_tags_insert_replace_remove(self):
+        assert set_header_tags('# %% lang="de"', ["keep"]) == '# %% lang="de" tags=["keep"]'
+        assert (
+            set_header_tags(
+                '# %% [markdown] lang="de" tags=["subslide"] slide_id="x"', ["subslide", "keep"]
+            )
+            == '# %% [markdown] lang="de" tags=["subslide", "keep"] slide_id="x"'
+        )
+        assert set_header_tags('# %% lang="de" tags=["keep"]', []) == '# %% lang="de"'
+
+    def test_replace_cell_tags_keeps_body_and_slide_id(self, tmp_path: Path):
+        path = tmp_path / "deck.de.py"
+        path.write_text(_md("de", "vec", ["subslide"], "# ## Vektoren\n# - Punkt"), "utf-8")
+        state = FileState.load(path)
+        assert state.replace_cell_tags("vec", "subslide", ["subslide", "keep"]) is True
+        state.flush()
+        text = path.read_text(encoding="utf-8")
+        assert 'tags=["subslide", "keep"]' in text
+        assert 'slide_id="vec"' in text
+        assert "# - Punkt" in text
+
+    def test_replace_cell_tags_missing_returns_false(self, tmp_path: Path):
+        path = tmp_path / "deck.de.py"
+        path.write_text(_md("de", "vec", ["subslide"], "# ## Vektoren"), "utf-8")
+        state = FileState.load(path)
+        assert state.replace_cell_tags("nope", "subslide", ["keep"]) is False
+        assert state.dirty is False
+
+
+# ---------------------------------------------------------------------------
+# _maybe_retag — direct unit coverage of the decision rules
+# ---------------------------------------------------------------------------
+
+
+def _cur(tags: set[str]) -> CurrentCell:
+    return CurrentCell(
+        position=0,
+        slide_id="x",
+        role="slide",
+        content_hash="h",
+        line_number=1,
+        tags=frozenset(tags),
+    )
+
+
+def _base(tags: set[str] | None) -> BaselineCell:
+    t = frozenset(tags) if tags is not None else None
+    return BaselineCell(position=0, slide_id="x", role="slide", content_hash="h", tags=t)
+
+
+class TestMaybeRetag:
+    def _plan(self) -> SyncPlan:
+        return SyncPlan(
+            de_path=Path("d.de.py"), en_path=Path("d.en.py"), baseline_source="watermark"
+        )
+
+    def test_de_changed_emits_de_to_en(self):
+        plan = self._plan()
+        _maybe_retag(
+            plan,
+            ("x", "slide"),
+            "slide",
+            _cur({"slide", "keep"}),
+            _cur({"slide"}),
+            _base({"slide"}),
+            _base({"slide"}),
+        )
+        assert [p.kind for p in plan.proposals] == ["retag"]
+        assert plan.proposals[0].direction == "de->en"
+
+    def test_no_change_no_proposal(self):
+        plan = self._plan()
+        _maybe_retag(
+            plan,
+            ("x", "slide"),
+            "slide",
+            _cur({"slide"}),
+            _cur({"slide"}),
+            _base({"slide"}),
+            _base({"slide"}),
+        )
+        assert plan.proposals == []
+
+    def test_unknown_baseline_skips(self):
+        plan = self._plan()
+        _maybe_retag(
+            plan,
+            ("x", "slide"),
+            "slide",
+            _cur({"slide", "keep"}),
+            _cur({"slide"}),
+            _base(None),
+            _base({"slide"}),
+        )
+        assert plan.proposals == []
+
+    def test_preexisting_divergence_neither_changed_no_proposal(self):
+        # Halves already differed at baseline and neither moved — not this edit's
+        # doing, so retag stays out of it (the validator flags the standing drift).
+        plan = self._plan()
+        _maybe_retag(
+            plan,
+            ("x", "slide"),
+            "slide",
+            _cur({"slide", "keep"}),
+            _cur({"slide"}),
+            _base({"slide", "keep"}),
+            _base({"slide"}),
+        )
+        assert plan.proposals == []

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -880,6 +880,131 @@ class TestSplitFilePairing:
         assert len(parity_errors) == 1
 
 
+class TestSplitTagParity:
+    """Cross-language tag-set parity for split pairs (Issue #198)."""
+
+    @staticmethod
+    def _tag_warnings(result):
+        return [
+            f for f in result.findings if f.severity == "warning" and "mismatched tags" in f.message
+        ]
+
+    def test_mismatched_localized_code_tag_warns(self, tmp_path):
+        # The exact #198 case: a localized (lang) code cell with no slide_id whose
+        # `keep` tag was added on one half only. _check_shared_cell_parity never
+        # sees it (it's not a shared cell); the tag-parity check must catch it.
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        _write_slide(
+            topic,
+            "slides_rag.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% lang="de" tags=["keep"]
+            antwort = invoke("Frage")
+            """,
+        )
+        _write_slide(
+            topic,
+            "slides_rag.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% lang="en"
+            answer = invoke("question")
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        warnings = self._tag_warnings(result)
+        assert len(warnings) == 1
+        assert "only on DE: ['keep']" in warnings[0].message
+
+    def test_mismatched_markdown_tag_warns(self, tmp_path):
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        _write_slide(
+            topic,
+            "slides_a.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["subslide", "keep"] slide_id="vec"
+            # ## Vektoren
+            """,
+        )
+        _write_slide(
+            topic,
+            "slides_a.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["subslide"] slide_id="vec"
+            # ## Vectors
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        warnings = self._tag_warnings(result)
+        assert len(warnings) == 1
+        assert "only on DE: ['keep']" in warnings[0].message
+
+    def test_matched_tags_clean(self, tmp_path):
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        _write_slide(
+            topic,
+            "slides_a.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["subslide", "keep"] slide_id="vec"
+            # ## Vektoren
+
+            # %% lang="de" tags=["keep"]
+            antwort = invoke("Frage")
+            """,
+        )
+        _write_slide(
+            topic,
+            "slides_a.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["keep", "subslide"] slide_id="vec"
+            # ## Vectors
+
+            # %% lang="en" tags=["keep"]
+            answer = invoke("question")
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        # Tag order differs ("subslide","keep" vs "keep","subslide") but the sets
+        # match, so no warning.
+        assert self._tag_warnings(result) == []
+
+    def test_length_mismatch_is_silent_on_tags(self, tmp_path):
+        # A structural divergence (an extra cell on one half) must not produce a
+        # tag-parity warning — positional pairing would be unreliable, so the
+        # check bows out (the count itself is the shared-cell parity's concern).
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        _write_slide(
+            topic,
+            "slides_a.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="a"
+            # ## A
+
+            # %% [markdown] lang="de" tags=["subslide", "keep"] slide_id="b"
+            # ## B
+            """,
+        )
+        _write_slide(
+            topic,
+            "slides_a.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="a"
+            # ## A
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        assert self._tag_warnings(result) == []
+
+
 class TestCheckOrdering:
     """DE/EN adjacency checks (canonical layout)."""
 


### PR DESCRIPTION
Fixes #198.

## Problem

A role-preserving **tag-only** edit (adding `keep`/`alt`, etc.) to one half of a split deck was never propagated to the other half — and `clm slides sync` reported it as **"0 changes — decks already consistent"**, silently leaving the halves divergent. Three layers conspired:

1. Change detection keys on `content_hash = sha256(cell.content)`, and `cell.content` is the **body** — the `# %% … tags=[…]` header is parsed separately, so a tag-only edit hashes identically and classifies as `same`.
2. The edit writeback (`_rewrite_cell_body`) preserves `cell.lines[0]` (the header) verbatim, so even a detected edit couldn't carry tags.
3. The watermark stored no tag set to diff against.

## Fix

### Tier B — directional, LLM-free tag sync in `clm slides sync`

- **Watermark**: additive `tags` column on `sync_watermarks` (same migration pattern as `construct`) + `get_deck_tags`, recorded via the new `watermark_tag_map`. Tags are keyed by the same position as the row. A pre-#198 row reads back as *unknown* (NULL) so the classifier never guesses a direction from it — graceful degradation.
- **Classifier**: a new `retag` proposal when a matched `(slide_id, role)` cell's content is in sync but its tag set drifted from baseline on **exactly one** side (that side is the source). Both sides changed → a *warning*, not a guess. Tags compared as a set, so order (`["subslide","keep"]` vs `["keep","subslide"]`) is not a spurious diff.
- **Apply**: `FileState.replace_cell_tags` / `set_header_tags` rewrite **only** the header's `tags=[…]`, leaving slide_id / lang / cell-type / body / trailing blanks verbatim. Tags are language-independent, so the retag path uses **no judge and no translator**. New `ApplyResult.applied_retag` counter, surfaced in the CLI/JSON output and the interactive walker (gated apply/skip like an edit).

Covers all id-carrying sync cells (markdown slides / sub / voiceover / notes / aux + localized id'd code). Works off the watermark baseline and, with `--no-cache`, the git-HEAD baseline.

### Tier A — validator safety net

- `_check_split_tag_parity` warns on any cross-language tag-set mismatch between the positionally-matched cells of a split pair. Unlike `_check_shared_cell_parity` (shared cells only), this covers **localized** cells — including the id-less localized code cell the #198 report hit, which the per-cell engine can't reach. Stays silent on a length mismatch (a structural edit mid-flight) so it never mis-pairs across an add/remove.

## Behavior

Before → after, on the exact #198 case (add `keep` to one half, body unchanged):

```
# before
baseline=git-head: 0 changes — decks already consistent (1 cell(s) in sync).

# after
retag en->de vec/subslide — tags changed on EN (['keep', 'subslide'])
retag en->de inv/code     — tags changed on EN (['keep'])
applied: 0 edit, 2 retag, 0 remove, 0 move, 0 add, 0 rename; 0 error(s).
# git diff: DE markdown cell gains "keep"; DE code cell gains tags=["keep"]; bodies untouched.
```

## Not in scope (follow-up)

Automatic **sync** of an *id-less* localized code cell's tags (the exact #198 cell) still isn't possible — it has no cross-language identity for the per-cell engine. Tier A surfaces it in `validate`; the principled sync fix piggybacks on #190 item 3 (track id-less localized cells in the watermark by position + hash) and is left as a follow-up. Workaround: give the cell a `slide_id`, or hand-mirror.

## Tests

- `tests/slides/test_sync_tag_sync.py` (new): classifier retag detection (markdown + localized id'd code), both-sides → warning, pre-#198 watermark → skip; apply mirrors tags + advances watermark + idempotent re-run; `set_header_tags` / `replace_cell_tags` primitives; direct `_maybe_retag` decision-rule coverage.
- `tests/slides/test_validator.py` (`TestSplitTagParity`): mismatched localized-code / markdown tags warn; set-equal (order-different) tags clean; length mismatch silent.

Full `tests/slides` + `tests/infrastructure` + `tests/cli` + `tests/mcp` green; `ruff check`, `ruff format`, and `mypy` clean. (The 10 unrelated `tests/cli/test_voiceover_*` / `tests/recordings/*` Rich-rendering failures seen locally are pre-existing — they fail identically on the base commit and pass under a non-narrow, `NO_COLOR` terminal.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
