### PR TITLE
feat(slides): sync tag-only edits on id-less localized cells (#198 Tier C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides sync` now mirrors a tag-only edit across split halves
+  (#198).** Adding or removing a role-preserving tag (`keep`, `alt`, …) on
+  one half of a split deck used to be silently dropped — the body-hash
+  classifier reported the cell as in sync and the other half was never
+  updated. Sync now emits a dedicated `retag` proposal when a matched cell's
+  tag set drifted from the watermark baseline on **exactly one** side, and
+  mirrors it onto the twin with a header-only rewrite (no LLM — tags are
+  language-independent); a both-sides change is surfaced as a warning rather
+  than guessed. Tier C extends this to **id-less localized cells** (a `lang=`
+  code/markdown cell with no `slide_id`, e.g. the `response = llm.invoke(...)`
+  cell the report hit): they have no per-cell `(slide_id, role)` key, so they
+  are paired by position in their language's cell stream (the membership-widened
+  watermark identity, #190 item 3) and guarded by a per-cell body-hash anchor so
+  a reorder or body edit never mis-mirrors a tag. `clm validate` already flags a
+  committed tag asymmetry it can no longer attribute to one side.
 - **`clm slides sync --provider {openrouter,local}`** (and the
   `$CLM_SYNC_PROVIDER` default) to choose the edit-reconciliation judge
   backend. The edit judge now **defaults to Claude Sonnet via OpenRouter**

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -700,6 +700,18 @@ signal and is not propagated (an author virtually always also touches a
 slide/voiceover); and an unchanged **id-less** localized code cell inside a group
 rebuilt for another reason is re-translated (churn, not corruption).
 
+> **Tag-only edits (Issue #198).** A role-preserving tag edit (`keep`/`alt`) is
+> invisible to the body-hash classifier, so it was dropped on the way across the
+> split halves. This is now handled by a dedicated `retag` proposal: an id-carrying
+> cell mirrors via its `(slide_id, role)` key, and an **id-less localized** cell
+> (the gap this design left — `role_of` is `None`, so the per-cell engine never saw
+> it) is paired by its position in the membership-widened watermark (#190 item 3)
+> and guarded by a per-cell body-hash anchor (a tag-only edit never changes the
+> body, so a hash mismatch means a reorder/body-edit and is declined). Tags are
+> language-independent, so the mirror is a header-only rewrite with no LLM. See
+> `slides/sync_plan.py::_classify_localized_idless_retags` and
+> `slides/sync_apply.py::_apply_retag_idless`.
+
 ### Dependency graph
 
 ```

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -486,11 +486,13 @@ def _apply_retag(
     """Mirror a tag-only edit (#198) by copying the source cell's tags to the target.
 
     Tags are language-independent, so this is a pure header rewrite — no judge or
-    translator. The cell is matched on both decks by ``(slide_id, role)``, so the
-    role tag is carried verbatim and the target's role never changes.
+    translator. An id-carrying cell is matched on both decks by ``(slide_id,
+    role)``, so the role tag is carried verbatim and the target's role never
+    changes. An **id-less localized** cell (Tier C) has no key, so it is targeted
+    by the carried position + tag set instead (:func:`_apply_retag_idless`).
     """
     if proposal.slide_id is None:
-        result.errors.append(f"retag {proposal.role}: proposal has no slide_id")
+        _apply_retag_idless(proposal, de_state, en_state, result)
         return
     sid = proposal.slide_id
     if proposal.direction == "de->en":
@@ -505,6 +507,41 @@ def _apply_retag(
         result.applied_retag += 1
     else:
         result.errors.append(f"retag {sid}/{proposal.role}: target cell not found")
+
+
+def _apply_retag_idless(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    result: ApplyResult,
+) -> None:
+    """Mirror a tag-only edit onto an id-less localized twin (Tier C, #198).
+
+    The cell has no ``slide_id``, so the classifier identified it by position
+    among its language's non-j2 cells and carried both the target position and the
+    desired tag set on the proposal (a header rewrite, no LLM). The target is the
+    side that did *not* change; its position equals the source's because the
+    classifier only emits this when the localized streams are structurally aligned
+    (no add/remove/move). :meth:`FileState.replace_idless_localized_tags` refuses
+    if the cell at that position is not id-less localized, so a stream that drifted
+    after planning errors rather than retagging the wrong cell.
+    """
+    if proposal.tags is None or proposal.target_position is None:
+        result.errors.append(f"retag (id-less {proposal.role}): proposal missing tags/position")
+        return
+    if proposal.direction == "de->en":
+        target_state, target_lang = en_state, "en"
+    else:
+        target_state, target_lang = de_state, "de"
+    if target_state.replace_idless_localized_tags(
+        target_lang, proposal.target_position, list(proposal.tags)
+    ):
+        result.applied_retag += 1
+    else:
+        result.errors.append(
+            f"retag (id-less {proposal.role}) at {target_lang} #{proposal.target_position}: "
+            "target cell not found or not id-less localized"
+        )
 
 
 def _apply_edit(

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -141,6 +142,13 @@ class Proposal:
     ``content_hash`` is set on a ``rename`` proposal: it identifies which of the
     duplicate-id cells is the copy (the apply re-mints the cell matching this
     hash, leaving the original alone).
+
+    ``tags`` is set on an **id-less localized** ``retag`` (Issue #198 Tier C):
+    such a cell has no ``slide_id``, so the apply cannot find its twin by
+    ``(slide_id, role)`` and instead targets the ``target_position``-th non-j2
+    cell of the target language and writes exactly this tag set onto it. ``None``
+    for an id-carrying ``retag`` (whose tags are read from the matched source
+    cell) and for every other kind.
     """
 
     kind: str
@@ -154,6 +162,7 @@ class Proposal:
     old_position: int | None = None
     new_position: int | None = None
     content_hash: str | None = None  # the copy's hash, for ``rename``
+    tags: tuple[str, ...] | None = None  # desired tag set for an id-less localized ``retag``
 
 
 @dataclass
@@ -1102,6 +1111,39 @@ def _edit(
     )
 
 
+def _retag_direction(
+    de_now: frozenset[str],
+    en_now: frozenset[str],
+    de_base: frozenset[str] | None,
+    en_base: frozenset[str] | None,
+) -> str | None:
+    """Which side a one-sided tag drift came from: the retag decision rule.
+
+    Returns ``"de->en"`` / ``"en->de"`` when exactly one side's tag set drifted
+    from its baseline (that side is the source), ``"both"`` when both drifted
+    (a tag conflict the caller surfaces as a warning), or ``None`` when there is
+    nothing to mirror: the halves already agree, a baseline tag set is unknown (a
+    pre-#198 watermark — direction undeterminable, so never guessed), or neither
+    side changed (a pre-existing divergence the validator flags, not this edit's
+    doing). Shared by the id-carrying (:func:`_maybe_retag`) and the id-less
+    localized (:func:`_classify_localized_idless_retags`) retag paths so the two
+    can never disagree about what counts as a one-sided drift.
+    """
+    if de_now == en_now:
+        return None  # already consistent — nothing to mirror
+    if de_base is None or en_base is None:
+        return None  # no tag baseline to attribute the drift — degrade gracefully
+    de_changed = de_now != de_base
+    en_changed = en_now != en_base
+    if de_changed and not en_changed:
+        return "de->en"
+    if en_changed and not de_changed:
+        return "en->de"
+    if de_changed and en_changed:
+        return "both"
+    return None
+
+
 def _maybe_retag(
     plan: SyncPlan,
     key: tuple[str, str],
@@ -1111,28 +1153,25 @@ def _maybe_retag(
     de_base: BaselineCell | None,
     en_base: BaselineCell | None,
 ) -> None:
-    """Emit a ``retag`` when a cell's tag set drifted on exactly one side.
+    """Emit a ``retag`` when an id'd cell's tag set drifted on exactly one side.
 
     Tags are language-independent, so a synced pair carries identical tag sets;
-    the content hash is blind to a tag-only edit (Issue #198). When the halves'
-    tags now disagree, the side whose tags changed from its baseline is the
-    source and its set is mirrored onto the other. Both-sides-changed is a tag
-    conflict, surfaced as a warning rather than guessed. Skipped silently when a
-    baseline tag set is unknown (a pre-#198 watermark) — direction is
-    undeterminable, so we never guess — or when neither side changed (a
-    pre-existing divergence not caused by this edit; the validator flags it).
+    the content hash is blind to a tag-only edit (Issue #198). Delegates the
+    one-sided-drift decision to :func:`_retag_direction` and mirrors the changed
+    side's tags onto the other; a both-sides-changed tag conflict is surfaced as a
+    warning rather than guessed.
     """
-    if de_now.tags == en_now.tags:
-        return  # already consistent — nothing to mirror
-    if de_base is None or en_base is None or de_base.tags is None or en_base.tags is None:
-        return  # no tag baseline to attribute the drift — degrade gracefully
-    de_changed = de_now.tags != de_base.tags
-    en_changed = en_now.tags != en_base.tags
-    if de_changed and not en_changed:
+    direction = _retag_direction(
+        de_now.tags,
+        en_now.tags,
+        de_base.tags if de_base is not None else None,
+        en_base.tags if en_base is not None else None,
+    )
+    if direction == "de->en":
         plan.proposals.append(_retag(key[0], role, "de->en", de_now, en_now))
-    elif en_changed and not de_changed:
+    elif direction == "en->de":
         plan.proposals.append(_retag(key[0], role, "en->de", en_now, de_now))
-    elif de_changed and en_changed:
+    elif direction == "both":
         plan.issues.append(
             PlanIssue(
                 severity="warning",
@@ -1160,6 +1199,174 @@ def _retag(
         source_position=source.position,
         target_position=target.position,
     )
+
+
+# ---------------------------------------------------------------------------
+# id-less localized tag mirroring (Issue #198 Tier C / #190 item 3)
+# ---------------------------------------------------------------------------
+
+
+def _localized_lang_cells(cells: list[Cell], lang: str) -> list[Cell]:
+    """Non-j2 cells of ``lang`` in document order — the watermark ``lang`` partition.
+
+    Mirrors :func:`watermark_rows`' partitioning exactly (``meta.lang == lang`` and
+    not j2), so the *i*-th cell here lines up with watermark position *i* of that
+    language. Includes both id-carrying localized cells (which anchor the
+    alignment) and the id-less ones whose tags this pass mirrors.
+    """
+    return [c for c in cells if not c.metadata.is_j2 and c.metadata.lang == lang]
+
+
+def _streams_aligned(de_loc: list[Cell], en_loc: list[Cell]) -> bool:
+    """Whether the two localized streams are positional twins (cell-by-cell).
+
+    Requires each positionally-paired ``(de, en)`` cell to agree on per-cell role,
+    cell type, and ``slide_id`` (both id-less, or the *same* id). A reorder or a
+    structural edit breaks this — at which point positional pairing of the id-less
+    cells would be unsound, so the pass declines (the validator's split-tag-parity
+    check still surfaces any standing asymmetry). Lengths are equal by the caller's
+    gate; ``strict=True`` makes that an assertion rather than a silent truncation.
+    """
+    for de_cell, en_cell in zip(de_loc, en_loc, strict=True):
+        if role_of(de_cell.metadata) != role_of(en_cell.metadata):
+            return False
+        if de_cell.metadata.cell_type != en_cell.metadata.cell_type:
+            return False
+        if (de_cell.metadata.slide_id or None) != (en_cell.metadata.slide_id or None):
+            return False
+    return True
+
+
+def _retag_idless(
+    source_cell: Cell, direction: str, position: int, tags: frozenset[str]
+) -> Proposal:
+    """An id-less localized ``retag`` — targets the twin by position, carries tags."""
+    kind_label = "code" if source_cell.metadata.cell_type == "code" else "markdown"
+    return Proposal(
+        kind="retag",
+        role=kind_label,
+        direction=direction,
+        slide_id=None,
+        reason=f"tags changed on {direction.split('->')[0].upper()} "
+        f"({sorted(tags)}) — id-less localized {kind_label}",
+        source_position=position,
+        target_position=position,
+        tags=tuple(source_cell.metadata.tags),
+    )
+
+
+def _classify_localized_idless_retags(
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    watermark_cache: SyncWatermarkCache,
+    de_path: Path,
+    en_path: Path,
+    plan: SyncPlan,
+) -> None:
+    """Mirror a tag-only edit on an **id-less localized** cell across the halves.
+
+    Issue #198 Tier C (with #190 item 3): the per-cell engine cannot reach an
+    id-less localized cell — ``role_of`` is ``None`` because it has no
+    ``slide_id`` — so a one-sided tag edit on such a cell (the exact cell the #198
+    report hit: a ``lang=`` code cell with no id that gained ``keep``) is invisible
+    to :func:`_maybe_retag`. This pass gives those cells a cross-language identity
+    by **position** in their language's cell stream (the #190 item-3 identity,
+    already recorded in the membership-widened watermark) and applies the same
+    one-sided-drift rule (:func:`_retag_direction`) against the watermark's recorded
+    tag set, emitting an id-less ``retag`` the apply targets by position.
+
+    Conservative by construction — any doubt declines either the whole pass or the
+    individual cell rather than risk mirroring a tag onto the wrong cell:
+
+    - **watermark baseline only** (the caller gates on ``source == "watermark"``):
+      the git-HEAD baseline records no tags for id-less cells, so direction would
+      be undeterminable;
+    - **no ``move``**: a reorder invalidates positional pairing;
+    - **structural alignment**: each language's localized stream must have the same
+      length as the other *and* as its own baseline (so position *i* still names the
+      same cell), and every positionally-paired cell must be a true twin
+      (:func:`_streams_aligned`);
+    - **per-cell body-hash anchor**: even within an aligned, same-length stream, two
+      *id-less* localized cells (both ``role_of`` ``None``, same kind, no id) could be
+      swapped without tripping :func:`_streams_aligned` — and a body edit leaves the
+      ``("L", kind)`` signature unchanged. So a cell is retagged only when **both**
+      halves' current body hash still equals the baseline body hash recorded at that
+      position: a tag-only edit never changes the body, so a hash mismatch means the
+      position now names a *different* (reordered) or *body-edited* cell — leave it to
+      the structural pass / validator instead of guessing;
+    - **body-uniqueness anchor**: the per-position hash check is defeated when two
+      cells share a body (an identical-body swap leaves every position's hash
+      matching), so a position is retagged only when its body hash is **unique** in its
+      language's stream on both the current and the baseline side — the non-unique-anchor
+      guard used throughout the structural pass. Two byte-identical id-less cells are
+      therefore never auto-mirrored (the validator flags any standing asymmetry).
+
+    A both-sides tag change is surfaced as a warning, mirroring the id-carrying path.
+    (Like every classifier warning, a ``both`` tag conflict holds the whole-deck
+    watermark until resolved — a pre-existing property shared with the id-carrying
+    ``_maybe_retag`` ``both`` path and the reorder/ambiguity warnings; see #198.)
+    """
+    if plan.count("move") > 0:
+        return  # a reorder this pass — positional pairing is unsound
+    de_loc = _localized_lang_cells(de_cells, "de")
+    en_loc = _localized_lang_cells(en_cells, "en")
+    de_rows = watermark_cache.get_deck(str(de_path), str(en_path), "de")
+    en_rows = watermark_cache.get_deck(str(de_path), str(en_path), "en")
+    if not (len(de_loc) == len(en_loc) == len(de_rows) == len(en_rows)):
+        return  # structural drift — positions unreliable; validator flags asymmetry
+    if not _streams_aligned(de_loc, en_loc):
+        return  # reordered / mismatched twins — do not trust positional pairing
+
+    de_base_hash = {pos: chash for (pos, _sid, _role, chash, _construct) in de_rows}
+    en_base_hash = {pos: chash for (pos, _sid, _role, chash, _construct) in en_rows}
+    de_cur_hash = [cell_content_hash(c.content) for c in de_loc]
+    en_cur_hash = [cell_content_hash(c.content) for c in en_loc]
+    # A body hash shared by two cells of a language's stream (current OR baseline)
+    # cannot anchor a position against a reorder: two id-less cells with the *same*
+    # body are interchangeable to the per-position hash check, so swapping them would
+    # masquerade as a tag edit and could mirror a tag onto the wrong twin. Decline any
+    # non-unique-bodied position — the same non-unique-anchor guard the structural pass
+    # applies (``_find_by_anchor`` / ``_baseline_anchor_hashes``' ``Counter``). The
+    # validator's split-tag-parity check still flags any standing asymmetry.
+    de_cur_counts = Counter(de_cur_hash)
+    en_cur_counts = Counter(en_cur_hash)
+    de_base_counts = Counter(de_base_hash.values())
+    en_base_counts = Counter(en_base_hash.values())
+    de_base_tags = watermark_cache.get_deck_tags(str(de_path), str(en_path), "de")
+    en_base_tags = watermark_cache.get_deck_tags(str(de_path), str(en_path), "en")
+    for i, (de_cell, en_cell) in enumerate(zip(de_loc, en_loc, strict=True)):
+        # Only the id-less localized cells; id-carrying twins ride the per-cell path.
+        if role_of(de_cell.metadata) is not None or role_of(en_cell.metadata) is not None:
+            continue
+        # Body unchanged on BOTH halves vs the recorded baseline at this position —
+        # else position i no longer names the same cell (reorder) or the body itself
+        # was edited (the structural pass's job), so a tag mirror would be unsound.
+        if de_cur_hash[i] != de_base_hash.get(i) or en_cur_hash[i] != en_base_hash.get(i):
+            continue
+        # ...and that body uniquely anchors the position on BOTH halves (current and
+        # baseline). A duplicated body defeats the hash anchor (an identical-body swap
+        # leaves every position's hash matching), so leave it to the validator.
+        if de_cur_counts[de_cur_hash[i]] != 1 or de_base_counts[de_cur_hash[i]] != 1:
+            continue
+        if en_cur_counts[en_cur_hash[i]] != 1 or en_base_counts[en_cur_hash[i]] != 1:
+            continue
+        de_now = frozenset(de_cell.metadata.tags)
+        en_now = frozenset(en_cell.metadata.tags)
+        direction = _retag_direction(de_now, en_now, de_base_tags.get(i), en_base_tags.get(i))
+        if direction == "de->en":
+            plan.proposals.append(_retag_idless(de_cell, "de->en", i, de_now))
+        elif direction == "en->de":
+            plan.proposals.append(_retag_idless(en_cell, "en->de", i, en_now))
+        elif direction == "both":
+            plan.issues.append(
+                PlanIssue(
+                    severity="warning",
+                    slide_id=None,
+                    reason=f"id-less localized cell #{i} tags changed on both decks "
+                    f"(de={sorted(de_now)}, en={sorted(en_now)}); "
+                    "not propagated — reconcile tags manually",
+                )
+            )
 
 
 _KIND_ORDER = {
@@ -1265,6 +1472,17 @@ def build_sync_plan(
             _apply_divergence(plan, de_path, en_path, forced=alignment.direction)
         else:
             plan.anchor_direction = alignment.direction
+
+    # Tier C (Issue #198 / #190 item 3): mirror a tag-only edit on an id-less
+    # localized cell — the per-cell engine cannot key it (no slide_id) and the
+    # body-hash classifier is blind to a tag change. Only against a real watermark
+    # baseline (the git-HEAD baseline records no id-less tags). Appends id-less
+    # ``retag`` proposals, then re-sorts so they interleave with the keyed plan.
+    if source == "watermark" and watermark_cache is not None:
+        _classify_localized_idless_retags(
+            de_cells, en_cells, watermark_cache, de_path, en_path, plan
+        )
+        plan.proposals.sort(key=_proposal_sort_key)
 
     return plan
 

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -181,7 +181,8 @@ class PlanWalkResult:
             f"{self.conflicts_resolved} conflict(s) resolved, "
             f"{self.skipped} skipped, "
             f"{self.unvisited} unvisited (quit).",
-            f"applied: {r.applied_edit} edit, {r.applied_remove} remove, "
+            f"applied: {r.applied_edit} edit, {r.applied_retag} retag, "
+            f"{r.applied_remove} remove, "
             f"{r.applied_move} move, {r.applied_add} add, {r.applied_rename} rename; "
             f"{r.in_sync} already in sync; {r.deferred} deferred; "
             f"{len(r.errors)} error(s); "

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -389,6 +389,43 @@ class FileState:
             self.dirty = True
         return True
 
+    def replace_idless_localized_tags(
+        self, lang: str, position: int, new_tags: Sequence[str]
+    ) -> bool:
+        """Set the tags of the ``position``-th ``lang`` cell, if it is id-less localized.
+
+        Tier C of Issue #198: an id-less localized cell (a ``lang=`` cell with no
+        ``slide_id``, so :func:`role_of` is ``None``) has no ``(slide_id, role)``
+        key, so :meth:`replace_cell_tags` cannot find it. The classifier instead
+        identifies it by its **position** among the deck's non-j2 ``lang`` cells —
+        the same per-language ordinal the watermark records — and this method
+        rewrites only that cell's ``tags=[…]`` (body, ``lang``, cell type, trailing
+        blanks verbatim), exactly like :meth:`replace_cell_tags`.
+
+        Returns ``False`` (and dirties nothing) when ``position`` is out of range
+        **or** the cell there is *not* id-less localized — a mismatch means the
+        stream drifted since the plan was built, so the caller surfaces it as an
+        error rather than retagging the wrong cell. ``True`` when the cell is
+        found (a no-op if its tags already match ``new_tags``).
+        """
+        idx = -1
+        for cell in self.cells:
+            meta = cell.metadata
+            if meta.is_j2 or meta.lang != lang:
+                continue
+            idx += 1
+            if idx != position:
+                continue
+            if role_of(meta) is not None:
+                return False  # an id-carrying cell sits here — stream drifted; refuse
+            new_header = set_header_tags(cell.lines[0], new_tags)
+            if new_header != cell.lines[0]:
+                cell.lines[0] = new_header
+                cell.metadata = parse_cell_header(new_header)
+                self.dirty = True
+            return True
+        return False
+
     def delete_cell(self, slide_id: str, role: str) -> bool:
         """Remove the ``(slide_id, role)`` cell, lines and all.
 

--- a/tests/slides/test_sync_tag_sync.py
+++ b/tests/slides/test_sync_tag_sync.py
@@ -19,8 +19,11 @@ from clm.slides.sync_plan import (
     CurrentCell,
     SyncPlan,
     _maybe_retag,  # noqa: PLC2701 (white-box unit)
+    _retag_direction,  # noqa: PLC2701 (white-box unit)
     build_sync_plan,
     ordered_sync_cells,
+    watermark_rows,
+    watermark_tag_map,
 )
 from clm.slides.sync_writeback import FileState, set_header_tags
 
@@ -68,9 +71,48 @@ def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path, *, 
         )
 
 
+def _seed_widened(
+    cache: SyncWatermarkCache, de_path: Path, en_path: Path, *, record_tags: bool = True
+):
+    """Record the current on-disk state as the **membership-widened** watermark.
+
+    Mirrors ``sync_apply._record_watermark`` exactly (every non-j2 cell, the
+    neutral cells once under ``shared``), so the baseline carries the id-less
+    localized cells the Tier C pass keys on — which ``_seed_watermark`` (built from
+    ``ordered_sync_cells``) deliberately omits. ``record_tags=False`` simulates a
+    pre-#198 watermark with no recorded tag sets.
+    """
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_rows, en_rows = watermark_rows(de_cells), watermark_rows(en_cells)
+    de_tags, en_tags = watermark_tag_map(de_cells), watermark_tag_map(en_cells)
+    for lang, rows, tags in (
+        ("de", de_rows["de"], de_tags["de"]),
+        ("en", en_rows["en"], en_tags["en"]),
+        ("shared", de_rows["shared"], de_tags["shared"]),
+    ):
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=rows,
+            tags=tags if record_tags else None,
+        )
+
+
 def _tags_of(path: Path, sid: str) -> set[str]:
     cell = next(
         c for c in parse_cells(path.read_text(encoding="utf-8")) if c.metadata.slide_id == sid
+    )
+    return set(cell.metadata.tags)
+
+
+def _idless_code_tags(path: Path, needle: str) -> set[str]:
+    """Tags of the (id-less) code cell whose body contains ``needle``."""
+    cell = next(
+        c
+        for c in parse_cells(path.read_text(encoding="utf-8"))
+        if c.metadata.cell_type == "code" and needle in c.content
     )
     return set(cell.metadata.tags)
 
@@ -317,3 +359,365 @@ class TestMaybeRetag:
             _base({"slide"}),
         )
         assert plan.proposals == []
+
+
+class TestRetagDirection:
+    """The shared one-sided-drift decision rule (id'd and id-less paths)."""
+
+    def test_de_only_change(self):
+        assert _retag_direction(frozenset({"keep"}), frozenset(), frozenset(), frozenset()) == (
+            "de->en"
+        )
+
+    def test_en_only_change(self):
+        assert _retag_direction(frozenset(), frozenset({"keep"}), frozenset(), frozenset()) == (
+            "en->de"
+        )
+
+    def test_both_changed(self):
+        assert (
+            _retag_direction(frozenset({"keep"}), frozenset({"alt"}), frozenset(), frozenset())
+            == "both"
+        )
+
+    def test_already_consistent(self):
+        assert _retag_direction(frozenset({"keep"}), frozenset({"keep"}), frozenset(), None) is None
+
+    def test_unknown_baseline(self):
+        assert _retag_direction(frozenset({"keep"}), frozenset(), None, frozenset()) is None
+
+    def test_preexisting_divergence_neither_moved(self):
+        # de differs from en, but each matches its own baseline → not this edit.
+        assert (
+            _retag_direction(frozenset({"keep"}), frozenset(), frozenset({"keep"}), frozenset())
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier C — id-less localized cells (Issue #198 / #190 item 3)
+# ---------------------------------------------------------------------------
+
+# The exact #198 hit: an id-less localized code cell (``response = llm.invoke(...)``
+# with different prose per language) that gained ``keep`` on one half. The per-cell
+# engine can't key it (no slide_id), so the tag was dropped until Tier C.
+_DE_INVOKE = 'response = llm.invoke("Was steht in Kapitel 3 über lineare Regression?")'
+_EN_INVOKE = 'response = llm.invoke("What does Chapter 3 say about linear regression?")'
+
+
+class TestIdlessLocalizedRetagClassification:
+    def test_idless_localized_code_tag_add_is_retag(self, tmp_path: Path):
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            # Author adds keep to EN only (would previously be dropped).
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["keep"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 1
+            assert plan.count("edit") == 0
+            (p,) = [p for p in plan.proposals if p.kind == "retag"]
+            assert p.direction == "en->de"
+            assert p.slide_id is None  # id-less
+            assert p.role == "code"
+            assert p.tags == ("keep",)
+        finally:
+            cache.close()
+
+    def test_idless_localized_markdown_tag_add_is_retag(self, tmp_path: Path):
+        # An id-less localized markdown cell (lang set, no slide_id, no narrative tag).
+        de = _md("de", "s", ["slide"], "# ## S") + '# %% [markdown] lang="de"\n# Hinweis\n'
+        en = _md("en", "s", ["slide"], "# ## S") + '# %% [markdown] lang="en"\n# Note\n'
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            de_path.write_text(
+                _md("de", "s", ["slide"], "# ## S")
+                + '# %% [markdown] lang="de" tags=["alt"]\n# Hinweis\n',
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 1
+            (p,) = [p for p in plan.proposals if p.kind == "retag"]
+            assert p.direction == "de->en"
+            assert p.role == "markdown"
+            assert p.tags == ("alt",)
+        finally:
+            cache.close()
+
+    def test_idless_localized_both_sides_is_warning(self, tmp_path: Path):
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            de_path.write_text(
+                _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, ["keep"], _DE_INVOKE),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["alt"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0
+            assert any(
+                "id-less localized" in i.reason and "both decks" in i.reason for i in plan.issues
+            )
+        finally:
+            cache.close()
+
+    def test_pre_198_watermark_skips_idless_retag(self, tmp_path: Path):
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path, record_tags=False)
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["keep"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0  # no tag baseline → direction undeterminable
+        finally:
+            cache.close()
+
+    def test_structural_drift_skips_idless_retag(self, tmp_path: Path):
+        # A tag edit AND a new id-less localized cell on the same side: the stream
+        # length no longer matches the baseline, so positional pairing is unsound
+        # and the tag is conservatively not mirrored (the validator still flags it).
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG")
+                + _code("en", None, ["keep"], _EN_INVOKE)
+                + _code("en", None, [], "print(response)"),  # a NEW id-less localized cell
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0
+        finally:
+            cache.close()
+
+    def test_no_change_no_idless_retag(self, tmp_path: Path):
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, ["keep"], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["keep"], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0
+            assert plan.is_noop
+        finally:
+            cache.close()
+
+    def test_body_edit_skips_idless_retag(self, tmp_path: Path):
+        # A combined body + tag edit on an id-less localized cell: the body hash no
+        # longer matches the baseline, so the tag is NOT mirrored here (the
+        # structural pass re-translates the body and carries the source tags along).
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG")
+                + _code(
+                    "en", None, ["keep"], 'response = llm.invoke("a totally rewritten prompt")'
+                ),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0  # body changed → not a tag-only drift
+        finally:
+            cache.close()
+
+    def test_identical_body_idless_cells_are_not_auto_mirrored(self, tmp_path: Path):
+        # Two id-less localized code cells with BYTE-IDENTICAL bodies. The body-hash
+        # anchor cannot tell them apart (a swap leaves every position's hash matching),
+        # so even a clean one-sided tag edit is declined for safety — mirroring it could
+        # write the tag onto the wrong twin after an undetectable reorder. The validator
+        # surfaces the resulting asymmetry instead.
+        de = (
+            _md("de", "s", ["slide"], "# ## S")
+            + _code("de", None, [], "dup = 1")
+            + _code("de", None, [], "dup = 1")
+        )
+        en = (
+            _md("en", "s", ["slide"], "# ## S")
+            + _code("en", None, [], "dup = 1")
+            + _code("en", None, [], "dup = 1")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "s", ["slide"], "# ## S")
+                + _code("en", None, ["keep"], "dup = 1")
+                + _code("en", None, [], "dup = 1"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0  # non-unique body → declined, not guessed
+        finally:
+            cache.close()
+
+    def test_identical_body_reorder_plus_concurrent_edit_no_wrong_mirror(self, tmp_path: Path):
+        # The reviewer's worst case: two identical-body id-less cells, one swapped on DE
+        # (a no-op visually, since bodies match) while EN independently edits a tag. The
+        # body-uniqueness guard declines both positions, so EN never gains a tag its
+        # author didn't write — no cross-deck divergence introduced by sync.
+        de = (
+            _md("de", "s", ["slide"], "# ## S")
+            + _code("de", None, ["keep"], "dup = 1")
+            + _code("de", None, [], "dup = 1")
+        )
+        en = (
+            _md("en", "s", ["slide"], "# ## S")
+            + _code("en", None, ["keep"], "dup = 1")
+            + _code("en", None, [], "dup = 1")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            # DE: swap the two identical-body cells (keep moves to the 2nd).
+            de_path.write_text(
+                _md("de", "s", ["slide"], "# ## S")
+                + _code("de", None, [], "dup = 1")
+                + _code("de", None, ["keep"], "dup = 1"),
+                encoding="utf-8",
+            )
+            # EN: independently add alt to the FIRST cell.
+            en_path.write_text(
+                _md("en", "s", ["slide"], "# ## S")
+                + _code("en", None, ["keep", "alt"], "dup = 1")
+                + _code("en", None, [], "dup = 1"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            assert result.applied_retag == 0  # nothing mirrored onto an ambiguous twin
+            # EN keeps exactly what its author wrote; sync introduced no divergence.
+            en_text = en_path.read_text(encoding="utf-8")
+            assert 'tags=["keep", "alt"]' in en_text
+        finally:
+            cache.close()
+
+    def test_reorder_with_differing_tags_never_mirrors_wrong_cell(self, tmp_path: Path):
+        # Two id-less localized code cells with DIFFERENT tags. _streams_aligned
+        # cannot tell them apart (both role-less code), so without the per-cell
+        # body-hash anchor a one-sided reorder would mirror the wrong tags. The
+        # anchor catches the body mismatch at each position and declines.
+        de_cells = (
+            _md("de", "s", ["slide"], "# ## S")
+            + _code("de", None, ["keep"], "xval = 1")
+            + _code("de", None, [], "yval = 2")
+        )
+        en_cells = (
+            _md("en", "s", ["slide"], "# ## S")
+            + _code("en", None, ["keep"], "xval = 1")
+            + _code("en", None, [], "yval = 2")
+        )
+        de_path, en_path = _write_pair(tmp_path, de_cells, en_cells)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            # Reorder EN's two id-less code cells (tags travel with their bodies).
+            en_path.write_text(
+                _md("en", "s", ["slide"], "# ## S")
+                + _code("en", None, [], "yval = 2")
+                + _code("en", None, ["keep"], "xval = 1"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 0  # no wrong mirror despite aligned streams
+        finally:
+            cache.close()
+
+
+class TestIdlessLocalizedRetagApply:
+    def test_apply_mirrors_idless_code_tag_and_advances(self, tmp_path: Path):
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["keep"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            assert result.applied_retag == 1
+            assert result.errors == []
+            assert result.watermark_recorded
+            # DE id-less code cell now carries keep; its (German) body is untouched.
+            assert _idless_code_tags(de_path, "Kapitel 3") == {"keep"}
+            assert "Kapitel 3" in de_path.read_text(encoding="utf-8")
+            # Second run is a no-op — the watermark recorded the mirrored tags.
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan2.count("retag") == 0
+            assert plan2.is_noop
+        finally:
+            cache.close()
+
+    def test_apply_mirrors_idless_tag_removal(self, tmp_path: Path):
+        # Symmetric: removing a tag on one half is mirrored too.
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, ["keep"], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["keep"], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            assert result.applied_retag == 1
+            assert result.errors == []
+            assert _idless_code_tags(de_path, "Kapitel 3") == set()
+        finally:
+            cache.close()
+
+    def test_mixed_idd_and_idless_retag_one_pass(self, tmp_path: Path):
+        # An id'd slide gains a tag AND an id-less code cell gains a tag, same
+        # direction, one pass — both mirror without a judge/translator.
+        de = _md("de", "rag", ["subslide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["subslide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            en_path.write_text(
+                _md("en", "rag", ["subslide", "keep"], "# ## RAG")
+                + _code("en", None, ["keep"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("retag") == 2  # one id'd (rag/subslide), one id-less (code)
+            result = apply_plan(plan, judge=None, watermark_cache=cache)
+            assert result.applied_retag == 2
+            assert result.errors == []
+            assert _tags_of(de_path, "rag") == {"subslide", "keep"}
+            assert _idless_code_tags(de_path, "Kapitel 3") == {"keep"}
+        finally:
+            cache.close()


### PR DESCRIPTION
Implements **Tier C** of #198 (the follow-up left open by #200).

## Problem

A role-preserving tag-only edit (`keep`/`alt`) is invisible to the body-hash
classifier, so it was never propagated across the split halves. #200 (Tier A+B)
fixed this for cells with a cross-language identity — id-carrying cells, mirrored
via a `(slide_id, role)`-keyed `retag`. But the **originating cell** of the report
is an *id-less localized* cell (a `lang=` code/markdown cell with **no** `slide_id`,
e.g. `response = llm.invoke(...)`): `role_of` is `None`, so the per-cell engine
never sees it, and its tag edit was still dropped. (The exact PythonCourses hit,
`989f74ec`, hand-added `tags=["keep"]` to **both** halves precisely because sync
would not carry it.)

## Fix

Id-less localized cells gain a cross-language identity by **position** in their
language's cell stream — the identity the membership-widened watermark already
records (#190 item 3). A new classifier pass `_classify_localized_idless_retags`
pairs the DE/EN localized streams positionally against the watermark's recorded tag
sets and applies the **same** one-sided-drift rule as the id-carrying path
(`_retag_direction`, refactored out of `_maybe_retag` so the two can't diverge),
emitting an id-less `retag` (`slide_id=None`, carrying the target position + the
desired tag set). Apply (`FileState.replace_idless_localized_tags` /
`_apply_retag_idless`) rewrites **only** that cell's `tags=[…]` — no LLM, since tags
are language-independent.

Conservative by construction — every guard must hold or the cell/pass is declined:

- **watermark baseline only** (the git-HEAD baseline records no id-less tags);
- **no `move`** in the pass (a reorder invalidates positional pairing);
- **structural alignment**: each language's localized stream equals the other *and*
  its own baseline in length, and every positionally-paired cell is a true twin
  (role / cell-type / `slide_id`);
- **per-cell body-hash anchor**: a tag-only edit never changes the body, so a cell is
  retagged only when both halves' current body hash equals the baseline hash at that
  position — a mismatch means a reorder or a body edit (the structural pass's job);
- **body-uniqueness anchor**: a body hash shared by two cells can't anchor a position
  against an identical-body swap, so a position is retagged only when its body hash is
  unique in its stream (current and baseline) — the non-unique-anchor guard used
  throughout the structural pass.

A both-sides tag change is surfaced as a warning, mirroring the id-carrying path.
`clm validate`'s split-tag-parity check (Tier A) remains the safety net for any
committed asymmetry sync declines.

Also: the interactive walker's summary line now surfaces `retag` (it was added to
`ApplyResult` / the CLI in #200 but missed in the walker summary).

## Adversarial review

A 4-lens adversarial review (classifier soundness, apply position-stability,
watermark idempotency, structural-pass integration) was run. Apply and
structural-pass lenses returned **ship**. Two findings:

1. **Fixed in this PR** — without a uniqueness guard, two id-less cells with
   *byte-identical bodies* defeat the body-hash anchor, so an identical-body reorder
   plus a concurrent edit could mirror a tag onto the wrong twin. Added the
   body-uniqueness guard above + regression tests (`test_identical_body_*`).

2. **Pre-existing, documented, NOT fixed here** — a `both`-sided tag conflict emits a
   warning, and (by existing design) **any** classifier warning holds the whole-deck
   watermark until resolved. If the same pass also applies an unrelated clean edit,
   that edit reaches disk but isn't baselined, so it re-surfaces as a phantom
   `conflict` until the tag conflict is resolved. This is **not introduced by Tier C**:
   it is shared identically by #200's id-carrying `_maybe_retag` `both` path and the
   older reorder/ambiguity warnings (`if … not plan.issues:` in `apply_plan`). It is
   loud (never silent) and self-clears once the conflict is resolved. A proper fix
   reworks the watermark-advance-over-warnings machinery (touching #200's path), so it
   is left for a focused follow-up rather than expanded into this PR. Tracked here for
   visibility.

## Tests

`tests/slides/test_sync_tag_sync.py`: the faithful `response = llm.invoke(...)`
repro; markdown + code id-less retag; both-sided → warning; pre-#198 watermark →
skip; structural-drift / body-edit / reorder / identical-body safety; apply mirrors +
advances watermark + idempotent; mixed id'd + id-less retag in one pass;
`_retag_direction` units.

Full `tests/slides` (912) + `tests/infrastructure`/`tests/mcp` (1189) + `tests/cli`
(1193) green. `ruff check`, `ruff format`, `mypy` clean. (The 3 pre-existing
`tests/cli/test_voiceover_*` Rich-rendering failures fail identically on
`origin/master` in this terminal — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
