### PR TITLE
Split-voiceover hardening: edit-dynamics harness, voiceover data-loss fixes, #162 triad, companion split/unify seam

### DIFF
--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -407,10 +407,17 @@ within one bilingual file.
   id-less (parity holds either way); true EN-authority is the generative step / `sync`.
   (`extract-voiceover` twin-awareness still TODO; strongly related to §8 — arguably
   these per-file ops should not be normal user commands at all.)
-- **Generative:** pair-aware `assign-ids` over *both* halves — establish
-  correspondence (neutral=byte, code=construct, markdown=positional), mint EN-authority
-  ids onto both, deterministic for structurally-parallel decks, escalating to the
-  defensive refusal (or the existing #166 LLM sync path) on genuine misalignment.
+- **Generative:** ✅ **BUILT 2026-06-03** — pair-aware `assign-ids` over *both* halves.
+  `assign_ids_in_split_pair` reconstructs the bilingual deck (`unify`), runs the existing
+  paired EN-authority assign over it, and routes the ids back (`split`); `assign_ids_in_directory`
+  detects `.de.py`/`.en.py` pairs and routes them through it (deterministic EN-authority, not
+  order-dependent). **Safety: a byte-faithful round-trip check** — `split(unify(de,en)) == (de,en)`
+  — gates it; `unify` is best-effort for solos/misalignment, so the round-trip guard (not just
+  "unify raised") prevents assign→split from reordering/moving cells. Non-round-trippable pairs
+  (divergent shared cells) fall back to the per-file defensive; the detective flags residual
+  divergence. Harness `born-split-assign-ids-directory` = EN-authority parity (preserve); 5 new
+  `TestSplitGenerative` tests. Markdown-positional / construct correspondence is implicit in
+  `unify`'s structural matching (no separate anchor logic needed).
 
 **Open design questions for #162:**
 1. How often are real `.de`/`.en` pairs structurally parallel vs misaligned? (Answered
@@ -529,11 +536,12 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
    the harness (two rows flipped to preserve) + new unit tests; full fast suite green.
 3. **#162 keystone** (§7) — **detective ✅ DONE** (cross-file `slide_id` parity warning in
    `clm validate`, dir/course + single-file-with-twin; `commit-without-sync` → break-loud).
-   **defensive ✅ DONE 2026-06-03** (twin-aware `assign_ids_in_file`; both assign-ids rows →
-   preserve). **Next:** generative pair-aware minting for born-split (true EN-authority) +
-   `extract-voiceover` twin-awareness + companion `for_slide` parity (the both-language
-   voiceover compat check). Harness now 12 preserve / 1 break-loud / 2 break-silent
-   (extract-then-split + build-merge observe-only).
+   **defensive ✅ DONE** (twin-aware `assign_ids_in_file`) + **generative ✅ DONE 2026-06-03**
+   (`assign_ids_in_split_pair` / directory routing; EN-authority via unify→assign→split with a
+   byte-faithful round-trip guard). All three #162 legs landed. **Next:** `extract-voiceover`
+   twin-awareness + companion `for_slide` parity (the both-language voiceover compat check), and
+   the `extract-then-split` companion seam (§10). Harness now 13 preserve / 1 break-loud /
+   2 break-silent (extract-then-split + build-merge observe-only).
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -388,10 +388,15 @@ within one bilingual file.
 
 **The triad** (all three needed, per "both, long-term"):
 
-- **Detective (= the pre-commit gate, §9):** enforce the invariant every "silent
-  break" row violates — across `.de`/`.en`, equal `slide_id` sets in equal order
-  (extended to companion `for_slide` sets). This *is* the both-language voiceover
-  compatibility check, for free.
+- **Detective (= the pre-commit gate, §9):** ✅ **BUILT 2026-06-03** — enforce the
+  invariant every "silent break" row violates — across `.de`/`.en`, equal `slide_id`
+  sets in equal order (companion `for_slide` sets still to add). Shipped as a `clm validate`
+  `pairing`-group warning: `_check_split_slide_id_parity` in `validator.py`, wired at
+  dir/course scope **and** the single-file path (`validate_file(cross_file_parity=True)` when
+  a twin exists on disk, so the pre-commit gate / PostToolUse path catch it). Harness
+  `commit-without-sync` flipped break-silent → break-loud ("detective CATCHES it"). 6 new
+  unit tests. Companion `for_slide` parity (the both-language voiceover compatibility check)
+  is the small remaining extension.
 - **Defensive:** the highest-frequency break is **per-file `assign-ids` /
   `extract-voiceover`**. Make them twin-aware — on a split half, consult the sibling
   and refuse to mint a divergent id rather than running blind. (Strongly related to
@@ -516,8 +521,11 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
 2. ~~**Tier-1 data-loss fixes**~~ ✅ **DONE 2026-06-03** (§3) — vo output leak;
    inline retains-companion-on-unmatched + non-zero exit; extract `--force`. Verified by
    the harness (two rows flipped to preserve) + new unit tests; full fast suite green.
-3. **#162 keystone** (§7) — detective (the gate's core check) + defensive twin-aware
-   `assign-ids`/`extract`; generative pair-aware minting for born-split.
+3. **#162 keystone** (§7) — **detective ✅ DONE 2026-06-03** (cross-file `slide_id` parity
+   warning in `clm validate`, dir/course + single-file-with-twin; `commit-without-sync`
+   flipped break-silent → break-loud). **Next: defensive** twin-aware `assign-ids`/`extract`
+   (refuse to mint a divergent id on a split half) — clears the two assign-ids break-silent
+   rows; then generative pair-aware minting for born-split + companion `for_slide` parity.
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -1,0 +1,561 @@
+# Split-Language + Separated-Voiceover Hardening — Investigation & Design Direction
+
+**Status**: Investigation complete; pre-implementation. Direction agreed with the
+maintainer (2026-06-02).
+**Author**: Claude (Opus 4.8), with the maintainer.
+**Date**: 2026-06-02
+**Scope**: the perimeter of the split-language + separated-voiceover workflow —
+`clm slides sync`, `assign-ids`, `split`/`unify`, `voiceover extract`/`inline`, the
+build pipeline's treatment of split files + voiceover companions, the validator,
+and the verification/test surface. **Not** a rewrite of the sync diff/apply core.
+**Related**: `single-language-authoring-sync.md` (#166 engine), `sync-content-anchor-identity.md`
+(#190 identity), `validator-workshop-voiceover-suppression.md`; issues
+[#162](https://github.com/hoelzl/clm/issues/162) (the keystone, OPEN), #166, #190,
+#198, #199.
+**Provenance**: grounded in a 10-agent parallel code-read of the subsystems + a
+4-agent adversarial code-trace verification pass. Claims below are tagged
+**[verified]** (traced to code this session), **[corrected]** (a raw finding the
+verification pass refuted/refined), or **[design]** (proposed, not yet built).
+
+---
+
+## 1. Executive summary — the reframing
+
+The recent PR churn (#162/#163/#166/#190/#198/#199) makes the system *feel* brittle,
+but the investigation shows the opposite where it counts: **the sync diff/apply core
+is genuinely safety-conscious and mostly correct.** It has no-silent-no-op, per-cell
+direction, conflict-by-default-defer, a buffered atomic temp-swap gated on an
+error-free pass, a "never drop a worn id" *validated* LLM recovery tier that
+safe-aborts on any failure, content-anchor identity that survives commits, and a
+partial-watermark-advance path guarded by a completeness invariant.
+
+The brittleness that actually lost work lives at **four edges plus one structural
+fault line**:
+
+| Zone | What's exposed |
+|---|---|
+| **A. The `clm slides sync` CLI surface** | Two bare positional path args, no matched-pair guard, writes by default |
+| **B. Cross-command seams** (split/unify ↔ voiceover) | Commands are unaware of each other; ordering silently orphans data |
+| **C. Separated-voiceover anchoring + build** | The companion file *leaks into student output*; `inline` destroys its own source-of-truth |
+| **D. No enforced gate** | Every safety net (`validate`, `sync --dry-run`) depends on the author *remembering* to run it |
+| **★ `slide_id` as the cross-language join key (#162)** | The whole split+voiceover edifice rests on `de_id == en_id`; born-split / re-`assign-ids`'d halves diverge silently |
+
+**Strategic consequence:** don't rewrite the engine — armor its perimeter and the
+cross-command seams, resolve the join-key fault before born-split authoring is
+common, and **make `sync` the one safe funnel** (see §8). This is a far smaller,
+safer surface than "the sync engine is unreliable."
+
+---
+
+## 2. Decisions locked this session (maintainer)
+
+1. **Start with the #162 `slide_id` join-key fault** — the structural keystone; the
+   other two choices depend on it.
+2. **Gate philosophy = pre-commit only.** A course-repo pre-commit hook runs
+   `validate` + `sync --dry-run`; `build` stays permissive (no build-time refusal of
+   out-of-sync halves for now).
+3. **Voiceover file model = harden the current per-language convention**
+   (`voiceover_X.de.py` / `voiceover_X.en.py`, filename-inferred, `vo_anchor`-keyed) —
+   fix the leaks/guards + add a companion split/unify path + a both-language
+   compatibility check. Do *not* switch to a spec declaration or a single bilingual
+   companion now.
+4. **Deck lifecycle = both, long-term.** Some decks inherit ids from a bilingual
+   ancestor; new ones may be born split. So the full #162 triad (detective +
+   defensive + generative) is in scope eventually.
+5. **Next build target = the edit-dynamics fault-injection harness** (§6) — the
+   maintainer judges it "enormously valuable going forward." A *static* corpus census
+   was explicitly rejected as grounding because it mostly grades the splitter, not
+   what happens under real editing.
+6. **Rethink the command surface** (§8) — some problems arise because we expose
+   inherently-unsafe user-visible commands; fold their function into `sync` or hide
+   them as agent/script plumbing.
+
+---
+
+## 3. Verified hazard inventory (ranked: severity × likelihood)
+
+The verification pass **corrected several raw findings in both directions** — the
+corrections are load-bearing for prioritization, so they are recorded explicitly.
+
+### Tier 1 — confirmed data loss, cheap fixes (do first)
+
+1. **Voiceover companion leaks into student output.** **[verified, worse than first
+   reported].** `voiceover_*.py` is classified as a `DataFile`
+   (`course_file.py:152-163`; `is_slides_file` requires `slides_`/`topic_`/`project_`
+   prefix, `path_utils.py:160-165`) → `DataFile.get_processing_operation` emits a
+   `CopyFileOperation` into **every** output tree, student *and* speaker
+   (`data_file.py:37-52`). The "matched-companion exclusion"
+   (`process_notebook.py:110-134`, esp. `:133`) is **payload-only** — it governs the
+   worker `other_files` dict, never the output copy — so *even the normal matched
+   companion of a built slide is copied verbatim into student output*. It survives
+   the end-of-build sweep because the build itself wrote it (registry-tracked;
+   `output_sweep.py:43-52,160-166,264-276`). `SKIP_OUTPUT_FILE_PATTERNS` contains only
+   `*.http-cassette.yaml` (`path_utils.py:87-91`); no `voiceover_` entry.
+   - *Nuance:* this is a **file** leak, not a rendered-content leak — the merged
+     voiceover *cells* are correctly stripped from student kinds by `output_spec`
+     (CompletedOutput/CodeAlongOutput drop them; SpeakerOutput keeps them). It is the
+     raw `.py` source that lands beside the student deck.
+   - **Fix (one line):** add a `voiceover_` pattern to `SKIP_OUTPUT_FILE_PATTERNS` /
+     `is_ignored_file_for_output` (mirror the cassette handling) so
+     `DataFile.get_processing_operation` returns `NoOperation`. Fixes matched + orphan
+     at the copy site.
+
+2. **`inline_voiceover` deletes the companion unconditionally — even on stranded
+   cells.** **[verified; highest data-loss priority].** `comp.unlink()` runs on every
+   non-dry-run inline regardless of `unmatched_cells`/`relocated_cells`, no backup,
+   **exit 0** (`voiceover_tools.py:794-800`; CLI never sets a non-zero exit,
+   `cli/commands/voiceover_tools.py:76-115`). Unmatched content survives (appended at
+   EOF of the slide file) but the *clean, anchor-bearing companion* — the source of
+   truth to re-run against after fixing a renamed `slide_id` — is destroyed in the
+   same op. `--dry-run` exists (shows `!` relocated / `?` unmatched) but is not the
+   default.
+   - **Fix:** keep (or `.bak`) the companion when `unmatched_cells>0 or
+     relocated_cells>0`; return a non-zero exit on unmatched; consider `--dry-run`
+     default for `inline`.
+
+3. **`extract_voiceover` clobbers a hand-edited companion with no `--force`.**
+   **[verified; lower frequency].** Unconditional `comp.write_text`
+   (`voiceover_tools.py:413-422`), rebuilding the companion solely from voiceover
+   cells *currently in the slide file* — hand-edits and previously-extracted cells
+   whose owning slide was deleted are lost. *Mitigated* by an early-return when the
+   slide file has no voiceover cells (`:379-380`), so the danger is the partial /
+   re-extract case. Out of step with `split_in_file` / `unify_in_file`, which both
+   gate overwrites on `--force` (`split.py:271-281,558-560`).
+   - **Fix:** mirror the `--force` + existence guard.
+
+### Tier 2 — the scary one, downgraded
+
+4. **`clm slides sync` has no matched-pair guard → *possible* destructive write.**
+   **[corrected: MEDIUM, not "destructive by default"].** The literal claim
+   ("destructive rewrite by default for any mismatch") is **refuted**, but the
+   underlying concern is confirmed:
+   - There is genuinely no guard (no `.de.py`/`.en.py` suffix check, no same-stem
+     check, no `de_path != en_path`); default mode applies unconditionally
+     (`slides_sync.py:87-95, 333-345`).
+   - A *destructive* write requires a narrow combination: an **API key configured**
+     (the happy path — sync auto-loads `.env`, `slides_sync.py:282-290`) **+** two
+     decks sharing enough `slide_id`s to produce a *deterministic*
+     remove/move/id-migration on an **error-free** pass. The cross-deck-orphan
+     fail-safe runs *only on otherwise-clean passes* (`sync_apply.py:280-283,450-456`)
+     — so it is bypassed exactly when such a write lands. The atomic flush is
+     error-gated (`:298-299`), so any LLM failure (e.g. no key) makes the pass error
+     and writes nothing.
+   - **Swapped order** (the most likely fat-finger) is largely **self-defusing**: the
+     language filter empties both localized cell sets
+     (`ordered_sync_cells`, `sync_plan.py:251-278`), so the worst case is a verbatim
+     neutral-cell copy, not a rewrite; and the watermark won't resolve (path-string
+     keyed, `cache.py:735-741`) so it falls to git-HEAD/none.
+   - **Two unrelated decks** (cold baseline) produce only *additive* spurious inserts;
+     duplicate ids hard-error. **[corrected]** the raw finding's "cold baseline = mass
+     add" is wrong — `_classify_cold` (`sync_plan.py:1021-1048`) counts shared-id
+     pairs as `in_sync`, emits no edit/remove/move.
+   - **Fix (cheap & total):** an upfront `UsageError` in the CLI command (assert
+     suffixes, same deck stem, `de≠en`, per-file lang matches its suffix) closes the
+     whole class *before* any baseline/LLM/flush logic.
+
+### Tier 3 — structural / forward-looking
+
+5. **`slide_id` cross-language divergence (#162).** **[verified, structural, OPEN].**
+   The join key for voiceover sync, `unify` (`_slide_ids_pair` requires `de_id==en_id`,
+   `split.py:420-431`), and extract/inline `for_slide`. `assign-ids` only guarantees
+   `de_id==en_id` inside a *bilingual* file (EN-sibling slug source, `group_slug` cache,
+   `assign_ids.py:301-339`). A born-split deck has no bilingual ancestor → re-running
+   `assign-ids` per file slugs each from its own headings → silent divergence, masked
+   today only by inheritance from pre-split ancestors. See §7.
+
+6. **N-file atomicity for separated voiceover.** **[verified residual].** The atomic
+   swap is hardcoded around the 2-path `(de, en)` pair with a residual window between
+   the two `os.replace` calls (`sync_apply.py:1088-1127`). Separated voiceover means
+   3–4 files per logical deck — the window widens; the watermark schema/commit point
+   isn't modeled for it. Design up front.
+
+7. **`FileTopic` bypass.** **[verified].** A split `.de.py` that resolves as a
+   *single-file* topic skips **all** split routing (language filter, half-pair /
+   dual-format guards) and fans out to both languages
+   (`topic.py:426-445` vs `318-408`). Add a guard or refuse.
+
+### Other confirmed issues
+
+- **Build silently drops/relocates voiceover** when `for_slide` doesn't resolve or
+  the anchor predecessor is gone — narration omitted from output (build merge:
+  log-only, exit 0; `process_notebook.py:285-296`); inline relocations are *discarded*
+  in the build merge path (`voiceover_tools.py:462-485`).
+- **Validator cross-file parity is blind on a single file.**
+  `_check_shared_cell_parity` / `_check_split_tag_parity` run *only* at dir/course
+  scope (`validator.py:1433-1436,1486-1489`), never on a lone `.de.py`; and they go
+  **silent on any cell-count mismatch** (`:980-981`), so a localized add/remove on one
+  side is invisible. A single-file `validate slides_x.de.py` returns clean even if the
+  twin diverged — false confidence.
+- **Headingless slides strand their voiceover.** `extract`'s `_ensure_slide_ids` runs
+  `assign-ids` with default `AssignOptions` (`accept_content_derived=False`,
+  `voiceover_tools.py:149-156`), so a genuinely headingless, non-content-derivable
+  solo slide gets no id → no `for_slide` → EOF-stranded on inline; `ids_generated`
+  hides the skip. (A DE/EN sibling with a heading can still id it via the Phase-3
+  sibling fallback.)
+- **CI backstop reality.** **[corrected].** The per-cell engine fixes (item-2
+  propagate-verbatim-no-LLM; item-3 reuse-not-retranslate + over-fire guards;
+  def-my-fun migration; bounded recovery safe-abort) **do** run in CI as fast
+  synthetic tests (`tests/slides/test_sync_limitations.py`, `test_sync_anchor.py`, no
+  markers), as does the split/unify Hypothesis round-trip (80 examples,
+  `tests/slides/test_split.py`). What **skips** in CI (no PythonCourses corpus): the
+  corpus no-op zero-byte/zero-LLM invariant (81/212, floor 40,
+  `tests/slides/test_sync_corpus_noop.py`) and the real-deck round-trip. The corpus
+  "population > 1000/100" asserts guard the *measurement*, not the fix.
+- **Legacy walker is NOT live.** **[corrected].** The dangerous line-number-keyed,
+  per-accept-flush `sync_walker.run_interactive_walker` is **not** wired to the CLI
+  (`slides_sync.py` imports `run_plan_walker` from `sync_plan_walker`). Dead-code
+  cleanup candidate, not a live risk.
+
+---
+
+## 4. The cross-command questions, answered
+
+- **Extract a voiceover from a unified deck, then `split` → does the voiceover get
+  split? Do the split files recognize it?** No, and no. `split` has zero voiceover
+  awareness; the bilingual `voiceover_X.py` is orphaned. The split halves look up
+  `voiceover_X.de.py`/`.en.py` (name-derived, `voiceover_tools.py:122-136`), which
+  don't exist → build merges nothing, **no warning**, and the orphan still leaks to
+  output. **Only safe order today: split-first, then extract per language** (or
+  `inline` before `split`). Nothing tells the user this.
+- **Extracting on a split deck only does one language.** Correct — single-file CLI/MCP
+  surface. **No cross-language compatibility check** (same `for_slide` set, same vo
+  count, compatible anchors) exists between the `.de` and `.en` extractions.
+- **Does `unify` pull voiceover back?** No — `unify` ignores companions entirely;
+  `inline` into each half first, then `unify`.
+
+---
+
+## 5. The load-bearing thesis: correspondence is preserved *only if structural changes funnel through `sync`*
+
+Tracing the edit operations against code yields a clean invariant: **`de_id == en_id`
+is maintained as long as the author routes structural changes through `clm slides
+sync`, which mints/migrates ids onto *both* halves. It breaks precisely when the
+author steps *outside* that funnel** — and several of those exits are silent. This is
+the conceptual foundation for both the harness (§6) and the command-surface rethink
+(§8).
+
+### Edit-dynamics table (edit op → path → id-correspondence outcome → guardrail)
+
+| Edit a human makes to a split pair | Path | Outcome | Guardrail |
+|---|---|---|---|
+| Add a slide to one half | `sync` | ✅ Preserved — EN-authority id minted onto both (Phase 3) | — |
+| Add a slide, then `assign-ids` **that file only** | per-file `assign-ids` | ❌ **Silent break** — slugs from its own heading | Defensive: twin-aware assign-ids |
+| Born-split pair, `assign-ids` each half | per-file `assign-ids` | ❌ **Silent break** — each slugs independently | Generative: pair-aware minting |
+| Reorder / delete in one half | `sync` | ✅ Preserved (move/remove mirrored) | — |
+| Edit both halves of a slide | `sync` | ✅ Conflict-deferred (localized) / auto-heal+warn (neutral) | — |
+| Copy-paste a slide (dup id) | `sync` | ✅ **Preserved [verified this session]** — re-mint propagates to twin as an add-like op, EN-authority id stamped on both | — |
+| Split a code cell (`def-my-fun`) | `sync` | ✅ Deterministic id-migration on both halves | — |
+| Rename a function while splitting a cell | `sync` | ⚠️ Construct match fails → defers / `--llm-recover` (surfaced) | — |
+| Hand-edit an id in one half | any | ❌ **Silent break** — sync sees a new key; twin keeps old id | Detective gate |
+| Edit a heading, `assign-ids --force` per-file | per-file `--force` | ⚠️ Sticky id normally; `--force` can regenerate divergently | Defensive + stable collision suffix |
+| Add voiceover to a slide whose ids diverged | `extract` then build | ❌ **Silent** — `for_slide` matches one language; other's narration dropped | Detective + build escalation |
+| Build/commit before syncing | `build` | ❌ Ships divergence — no consistency check | Pre-commit detective gate |
+
+**Verified this session (the previously-open row):** the copy-paste `rename` is
+handled exactly like an `add` (`sync_apply.py:806-834`): the copy slide is re-minted
+with a fresh **EN-authority** id (`en_body = target_body if target_lang=="en" else
+source body`; `new_id = resolve_collision(_slug_or_default(en_body), used_ids)`,
+`:821-822`), that id is `_stamp_slide_id`'d onto the source copy **and** carried onto a
+freshly-translated twin inserted on the other deck (`_place_new_cell`, `:897-900`);
+companions inherit it by group-adjacency; `used_ids` spans both decks (`:684-689`).
+Safety exits are loud: no baseline-identifiable original → hard error, nothing written
+(`sync_plan.py:658-667`); no translator → deferred + error (`sync_apply.py:642-645`).
+So this row is **safe-via-sync**, strengthening the thesis: the break is the per-file
+`assign-ids` path, not sync.
+
+---
+
+## 6. The edit-dynamics fault-injection harness (BUILT 2026-06-02)
+
+**Purpose.** Ground every hardening decision in *editing dynamics* rather than static
+state. Not a census (which grades the splitter). The harness applies realistic edits
+to parallel decks, runs the command path a user would take, and asserts the
+correspondence/safety invariants — classifying each result **preserve / break-loud /
+break-silent**. It executably verifies the §5 table, pins down exactly which exits
+from the sync funnel are silent (= the precise spec for the §7 guardrails and the §8
+command rethink), and becomes the **cross-command property suite** CI lacks today.
+
+**Inputs.**
+- Synthetic parallel `.de.py`/`.en.py` pairs — extend the existing Hypothesis
+  generator in `tests/slides/test_split.py` (which today omits solo language cells; the
+  harness should *include* misaligned/solo shapes as negative cases).
+- Optionally **real** pairs mutated in place (the "dynamic" complement to the rejected
+  static census) — gated on the PythonCourses corpus being present, like the existing
+  corpus tests; never required for CI.
+
+**Mutation catalog** (each = one realistic author action): add-slide-one-half;
+add-then-assign-ids-per-file; born-split-assign-ids; reorder-one-half;
+delete-one-half; edit-both-halves (localized + neutral); copy-paste-dup;
+split-code-cell (def-my-fun); rename-function-while-splitting; hand-edit-id;
+edit-heading-then-force; add-voiceover-with-diverged-ids;
+extract-then-split; split-then-extract-per-language; inline-after-rename;
+re-extract-over-edited-companion; build-before-sync.
+
+**Command paths exercised.** `sync` (batch + the deterministic-only no-key path),
+per-file `assign-ids`, `extract`/`inline`, `split`/`unify`, and `build` (companion
+merge).
+
+**Invariants asserted after each (op, path).**
+1. `slide_id` set + order equal across `.de`/`.en` (the #162 invariant).
+2. `for_slide` set equal across `.de`/`.en` companions; every `for_slide` resolves.
+3. No voiceover EOF-stranding; no silent narration drop at build.
+4. No data loss: a cell present before is present after (somewhere), or its removal
+   was the explicit intent.
+5. Round-trip identities where they should hold: `unify(split(x)) == x`;
+   `split(unify(de,en)) == (de,en)`; extract→inline ≈ identity (modulo intended
+   relocation); and the composite `unify(split(extract→companion+slides))` restores
+   the original bilingual deck with voiceover.
+6. Every divergence is **loud** (error/warning/non-zero exit), never silent.
+
+**Output.** A classification table (op × path → preserve/break-loud/break-silent +
+the offending file:line). The **break-silent** rows are the work-list for §7/§8.
+
+**CI integration.** The synthetic arm runs in the fast suite (no corpus, no network),
+closing the "only static round-trips run in CI" gap. The real-deck arm stays
+`slow`/`integration`, dev-box-only. Consider vendoring a handful of redacted real
+split+voiceover decks under `tests/` so a representative dynamic suite runs in CI.
+
+**Engineering notes.** Reuse `clm.slides.pairing`, the `sync_plan`/`sync_apply`
+classifier+apply, the `construct:` anchor, and the existing `StaticSlideTranslator` /
+`judge=None` mocking so no live LLM is needed. Apply the recurring **non-unique-anchor
+guard** (never key a map on a construct anchor; use ordered-hash + occurrence ordinal)
+anywhere the harness pairs cells. Honor the byte-preserving split/unify contract in
+assertions (don't normalize whitespace).
+
+### Built — files, conventions, and the observed table (2026-06-02)
+
+Shipped as the established library + CI-backstop pair (mirrors
+`scripts/sync_corpus_harness.py` / `tests/slides/test_sync_corpus_noop.py`):
+
+- **`scripts/edit_dynamics_harness.py`** — runnable report + importable library:
+  split-pair/companion builders (incl. solo/misaligned shapes), the command-path
+  runners (`run_sync`, `run_assign_ids`, extract/inline/split/unify/build-merge), the
+  invariant checkers (`id_parity`, `for_slides`, round-trips), the mutation catalogue,
+  and the preserve/break-loud/break-silent classifier.
+  `python scripts/edit_dynamics_harness.py` prints the table (`--json` for machine
+  form, `--path X` to filter); it exits non-zero **only on drift** of an asserted row.
+- **`tests/slides/test_edit_dynamics.py`** — fast-suite backstop (no corpus, no network,
+  no markers): `test_no_drift` freezes the whole table; `test_sync_funnel_always_preserves`
+  is the engine-regression guard; `test_known_silent_breaks_still_surfaced` stops the
+  work-list being silently zeroed out.
+
+No-LLM mocking uses the `CountingTranslator` / `CountingJudge` stand-ins (verbatim from
+`test_sync_limitations.py`), watermark seeded via `watermark_rows` into a tmp SQLite DB,
+`build_sync_plan(..., allow_git_fallback=False)`. **Correction to the original note:**
+`judge=None` is *not* usable — it records every edit as an LLM-unavailable error; the
+counting judge is required to drive the apply path.
+
+**Observed classification (15 mutations — matches every §3/§5 prediction):**
+
+| Verdict | Mutations |
+|---|---|
+| **preserve** (8) | sync: add / reorder / delete one half; edit-both (conflict-deferred); copy-paste-dup; **hand-edit-id** — sync *heals* it via remove+add mirrored to the twin (en localized content is regenerated), **refining** the §5 prediction that it is a silent break (the break is only on the *never-synced* path); extract→inline round-trip; unify(split) round-trip |
+| **break-silent** (7) | assign-ids: per-file & born-split (divergent slugs, 0 refusals); commit-without-sync (no gate, build permissive); extract-then-split (bilingual companion orphaned, split silent); inline-after-rename (clean companion destroyed, 1 cell stranded, exit 0); re-extract-over-edited-companion (hand-edit clobbered, no `--force`); build-merge-unmatched (narration dropped — **observe-only**, the build arm) |
+| break-loud (0) | — every break is currently *silent*: that is the headline finding |
+
+**The work-list is exactly the seven break-silent rows** (drives §12 steps 2–5 and the
+§8 fold/hide/guard dispositions). Deferred catalogue rows (frozen verdict pending a
+behaviour probe): split-code-cell (def-my-fun), rename-function-while-splitting,
+edit-heading-then-force.
+
+---
+
+## 7. The #162 design direction (the keystone)
+
+**The hard part:** cross-language cell correspondence *without* a pre-existing shared
+id (can't pair by `slide_id` — that's circular). It decomposes by certainty:
+
+| Cell class | Correspondence signal | Certainty |
+|---|---|---|
+| Shared / language-neutral | Byte-identical across halves (the `unify` invariant) | Exact |
+| Localized code | The `construct:` anchor is language-agnostic; de/en twins share it (#190) | High (modulo the non-unique-construct guard) |
+| Localized markdown (headings/prose) | Position within the parallel slide-group structure | Positional only — fragile under structural drift |
+
+The slug stays **EN-authority** (derive from the EN heading, stamp the *same* id onto
+both). The only new thing vs. today is doing this across a *pair* of files rather than
+within one bilingual file.
+
+**The triad** (all three needed, per "both, long-term"):
+
+- **Detective (= the pre-commit gate, §9):** enforce the invariant every "silent
+  break" row violates — across `.de`/`.en`, equal `slide_id` sets in equal order
+  (extended to companion `for_slide` sets). This *is* the both-language voiceover
+  compatibility check, for free.
+- **Defensive:** the highest-frequency break is **per-file `assign-ids` /
+  `extract-voiceover`**. Make them twin-aware — on a split half, consult the sibling
+  and refuse to mint a divergent id rather than running blind. (Strongly related to
+  §8: arguably these per-file ops should not be normal user commands at all.)
+- **Generative:** pair-aware `assign-ids` over *both* halves — establish
+  correspondence (neutral=byte, code=construct, markdown=positional), mint EN-authority
+  ids onto both, deterministic for structurally-parallel decks, escalating to the
+  defensive refusal (or the existing #166 LLM sync path) on genuine misalignment.
+
+**Open design questions for #162:**
+1. How often are real `.de`/`.en` pairs structurally parallel vs misaligned? (Answered
+   empirically by the harness's real-deck arm, *under mutation* — not a static
+   census.) Determines how often generative covers the case vs the backstop fires.
+2. On the pre-commit gate's first run, does it fire as a hard error or warning?
+   (Today's per-file `assign-ids` may already have produced divergence → a hard error
+   would block commits immediately, possibly needing a one-time reconciliation pass.)
+3. Correspondence priority + ambiguity policy: refuse-and-surface (safe) vs.
+   LLM-assisted (the #166 path exists). Lean: deterministic for parallel,
+   refuse+surface otherwise, #166 sync as the opt-in heavy path.
+
+---
+
+## 8. Command-surface rethink (maintainer-requested)
+
+**Observation:** several footguns exist because we expose **inherently-unsafe
+user-visible commands** that operate outside the safe `sync` funnel. The §5 thesis
+gives the architectural principle: **`sync` is the one operation that keeps both
+halves consistent; sharp single-file tools that mutate identity or move content
+outside it are footguns.** For each, decide: **(F)** fold into `sync`, **(H)** hide as
+agent/script plumbing, or **(G)** harden with a guard.
+
+| Command | Why it's risky | Disposition (proposed) |
+|---|---|---|
+| `assign-ids` (per file) | Per-file run on a split half mints **divergent** ids — the #1 silent #162 break. Its core job (id minting) is already done *consistently* by `sync`. | **F + H** — fold consistent minting into `sync` / a pair-aware mode (§7 generative); demote the raw per-file command to plumbing (agents/scripts), not a normal authoring step. |
+| `voiceover extract` | Single-file, clobbers companion w/o `--force`; per-language only; no cross-language check. | **G now, F later** — add `--force`/guard immediately; longer-term fold extraction into a paired, twin-aware operation (or under `sync`'s umbrella). |
+| `voiceover inline` | Destructive: unlinks companion even on unmatched, exit 0, no backup. | **G** — preserve/backup on unmatched, non-zero exit, `--dry-run` default. |
+| `slides split` | Unaware of voiceover companions; extract-then-split silently orphans them. | **G** — refuse/warn when a sibling `voiceover_*.py` exists; add a first-class companion split (route vo cells by `lang`, preserve `for_slide`/`vo_anchor`). |
+| `slides unify` | Ignores companions; can't recombine voiceover. | **G** — companion unify path (the inverse of the above). |
+| `slides suggest-sync` | Old single-file read-only suggester; coexists confusingly with the split-pair `sync` (different file layout, opposite write semantics). | **H or remove** — hide as plumbing or retire; steer users to `sync`. |
+| `slides sync` (the funnel) | Two bare path args, no pairing guard, writes by default. | **G** — pairing guard (§3 Tier-2), and consider a **single-path contract** (pass one half or the deck stem; derive the twin + companion) + a directory/spec **batch mode** so the author can't fumble the pair or cross decks. |
+
+**Mechanism for "hide as plumbing."** Click supports `hidden=True` on commands (kept
+functional, omitted from `--help`); or move plumbing under a `clm _internal …` / `clm
+plumbing …` group, or behind a `--i-know-what-im-doing`-style gate. Agents and scripts
+that need the raw single-file ops still call them; normal authors only see the safe
+funnel. This preserves the dual-use value while removing the footgun from the everyday
+surface. **Per the Info Topics Maintenance Rule, any command removal/hiding/folding
+must update `info_topics/commands.md` and `migration.md`.**
+
+**Guiding UX principle:** the author writes content; the tooling owns identity; the
+*default* surface only offers operations that keep both halves consistent. Sharp tools
+remain reachable for agents/scripts but are not the path of least resistance.
+
+---
+
+## 9. The pre-commit gate (the chosen enforcement)
+
+Lives in the **course repo** (e.g. PythonCourses `.pre-commit-config.yaml`), not CLM
+itself — CLM provides the check command. It runs over the staged set:
+- the **#162 detective**: cross-file `slide_id` set+order equality across each
+  `.de`/`.en` pair, and companion `for_slide`-set equality;
+- `validate` (dir-scoped, so cross-file parity actually fires) — **with `--fail-on
+  warning`** (or a split-critical-categories strict mode), because today
+  missing-`slide_id`, tag-parity asymmetry, slug-format, and pair-id mismatch are all
+  *warnings* (exit 0, `validator.py:753-769`), so a naive `validate && commit` lets
+  them through;
+- `sync --dry-run` to fail on an unsynced half (`--check`-style exit code).
+
+`build` stays permissive for now (decision #2). If the gate proves leaky, revisit
+build-time refusal later.
+
+---
+
+## 10. Voiceover model: harden the current convention
+
+Keep `voiceover_X.de.py` / `voiceover_X.en.py` (filename-inferred, `vo_anchor`-keyed).
+Required hardening:
+- Stop the output leak (§3 Tier-1 #1).
+- Stop `inline` destroying its source-of-truth (§3 Tier-1 #2); `extract` `--force`
+  (§3 Tier-1 #3).
+- **Companion split/unify path** so extract-then-split / unify don't orphan voiceover
+  (§8): route companion cells by their owning slide's `lang`, preserving
+  `for_slide`/`vo_anchor`. This is well-defined *once* `de_id==en_id` is guaranteed
+  (depends on #162).
+- **Both-language compatibility check** = companion `for_slide`-set equality across
+  `.de`/`.en` (same invariant as the slide check; part of the detective gate).
+- **Build-time escalation** of unmatched `for_slide` from log-only to a surfaced
+  finding (respecting a fail-on policy), and surface inline **relocations** at build
+  time (today discarded in `merge_voiceover_text`).
+- **Validator companion-integrity check** (dir/course scope): every `for_slide`
+  resolves; warn on orphan companions / a slide that lost its companion / contradictory
+  companion sets (bilingual + split coexisting).
+- **Landmine for new payload fields:** if separated voiceover adds a field to
+  `NotebookPayload` routed to the build worker, the worker MUST `model_validate` the
+  whole dict — a hand-listed field is silently dropped at the boundary (the #17
+  landmine). Add a test that a synthetic unknown field survives.
+
+---
+
+## 11. Verification strategy (to convince ourselves & users)
+
+Honest CI picture: per-cell engine fixes + split/unify round-trip **run** in CI;
+corpus no-op invariant + real-deck round-trip **skip**. To build justified confidence:
+1. The **edit-dynamics harness** (§6) — synthetic arm in CI.
+2. **Companion-integrity validator check** + **wire cross-file parity into the
+   single-file path** when a twin exists on disk (so the per-file/PostToolUse path
+   isn't blind to twin divergence).
+3. **Promote `_check_split_tag_parity` to fire on cell-count mismatch** (today
+   self-silences, `validator.py:980-981`) + a localized-cell parity check.
+4. **CI-runnable golden corpus** — vendor a few redacted real split+voiceover decks.
+5. The **pre-commit gate** (§9) with `--fail-on warning`.
+6. Guard the **worker-payload boundary** (`model_validate`) before adding vo fields.
+
+---
+
+## 12. Sequencing / roadmap
+
+1. ~~**Build the edit-dynamics fault-injection harness**~~ ✅ **DONE 2026-06-02** (§6) —
+   `scripts/edit_dynamics_harness.py` + `tests/slides/test_edit_dynamics.py` (8 preserve /
+   7 break-silent / 0 error, no drift). The seven break-silent rows are the work-list for
+   steps 2–5; the sync funnel is now regression-guarded in the fast suite.
+2. **Tier-1 data-loss fixes** (§3) — vo output leak; inline unlink guard; extract
+   `--force`. Cheap, verified, immediate work-loss prevention.
+3. **#162 keystone** (§7) — detective (the gate's core check) + defensive twin-aware
+   `assign-ids`/`extract`; generative pair-aware minting for born-split.
+4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
+5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
+6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.
+7. Forward design: N-file atomicity for separated voiceover (§3 #6); `FileTopic`
+   bypass guard (§3 #7).
+
+---
+
+## 13. Key code-location map (for future sessions)
+
+- Sync CLI: `src/clm/cli/commands/slides_sync.py` (args `:87-95`; apply default
+  `:333-345`; `.env` load `:282-290`).
+- Sync engine: `sync_plan.py` (classifier; `ordered_sync_cells` lang filter `:251-278`;
+  `_resolve_duplicates` `:623-717`; cold path `:1021-1048`; baseline `:1190-1246`),
+  `sync_apply.py` (apply; atomic flush `:1088-1127`; flush gate `:298-299`; orphan
+  fail-safe `:280-283,450-456`; add/rename `:634-858`; id-migration
+  `:1214-1331,1389-1445`), `sync_recover.py` (validated LLM recovery `:212-279`),
+  `sync_code.py` (structural pass), `sync_writeback.py` (`role_of`, `anchor_of`,
+  `cell_content_hash`), `pairing.py`.
+- IDs: `assign_ids.py` (slug/minting; `group_slug` `:301-339`; refusals `:545-568`),
+  `slug.py` (`resolve_collision` `:189-201`).
+- Voiceover (slide-side): `voiceover_tools.py` (`companion_path` `:122-136`; extract
+  `:349-424`; inline `:706-802`; `merge_voiceover_text` `:432-485`; `vo_anchor`
+  `:204-256`).
+- Split/unify: `split.py` (`split_text`; `unify_texts`; `_slide_ids_pair` `:420-431`;
+  force guards `:271-281,558-560`).
+- Build: `build.py` (split-routing abort `:1117-1132`); `topic.py`
+  (`add_files_in_dir`/`_add_slide_units` `:318-408`; `FileTopic` `:426-445`);
+  `notebook_file.py` (`output_language_filter`, `companion_voiceover_path` `:108-114`);
+  `process_notebook.py` (`compute_other_files` `:110-134`; vo merge `:283-296`);
+  `data_file.py` (`get_processing_operation` `:37-52`); `path_utils.py` (SKIP lists
+  `:87-100`, `is_ignored_file_for_output` `:244-262`); `output_sweep.py`
+  (`:43-52,160-166,264-276`); `notebook_processor.py` (strips slide_id/for_slide
+  `:1586-1592`).
+- Validator: `validator.py` (slide_ids `:696-876`; cross-file parity `:879-1014`,
+  wired only at dir/course `:1433-1436,1486-1489`; `validate_quick` `:1364-1398`).
+- Tests/harness: `tests/slides/test_split.py` (round-trip property),
+  `test_voiceover_tools.py` (extract/inline, positional anchors),
+  `test_sync_limitations.py` + `test_sync_anchor.py` (item-2/3 fix, CI),
+  `test_sync_corpus_noop.py` + `scripts/sync_corpus_harness.py` (no-op invariant,
+  dev-box-only).
+
+---
+
+## 14. Open questions / things still UNVERIFIED
+
+- The harness real-deck arm should answer the structural-parallel-vs-misaligned
+  frequency (§7 Q1) **under mutation**, not statically.
+- N-file atomic commit point for separated voiceover (§3 #6) — design not started.
+- Whether `slides suggest-sync` has any remaining unique value before retiring it.
+- Whether two trainers syncing the same pair on different machines (per-machine
+  `clm-llm.sqlite` watermark) can produce conflicting clean-looking writes (raised by
+  an agent; not traced).

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -397,10 +397,16 @@ within one bilingual file.
   `commit-without-sync` flipped break-silent → break-loud ("detective CATCHES it"). 6 new
   unit tests. Companion `for_slide` parity (the both-language voiceover compatibility check)
   is the small remaining extension.
-- **Defensive:** the highest-frequency break is **per-file `assign-ids` /
-  `extract-voiceover`**. Make them twin-aware — on a split half, consult the sibling
-  and refuse to mint a divergent id rather than running blind. (Strongly related to
-  §8: arguably these per-file ops should not be normal user commands at all.)
+- **Defensive:** ✅ **`assign-ids` BUILT 2026-06-03** — the highest-frequency break.
+  `assign_ids_in_file` is now twin-aware: on a split half whose twin exists on disk
+  with a matching slide count, an **id-less** slide adopts the twin's id
+  (`twin_ids` threaded through `assign_ids_for_cells`/`_for_text`; `source="twin"`)
+  rather than minting a divergent slug; mismatched counts skip reuse (detective flags
+  it). Both assign-ids harness rows flipped break-silent → preserve; 5 new
+  `TestSplitTwinAware` tests. Run-order decides the winning slug when both halves are
+  id-less (parity holds either way); true EN-authority is the generative step / `sync`.
+  (`extract-voiceover` twin-awareness still TODO; strongly related to §8 — arguably
+  these per-file ops should not be normal user commands at all.)
 - **Generative:** pair-aware `assign-ids` over *both* halves — establish
   correspondence (neutral=byte, code=construct, markdown=positional), mint EN-authority
   ids onto both, deterministic for structurally-parallel decks, escalating to the
@@ -521,11 +527,13 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
 2. ~~**Tier-1 data-loss fixes**~~ ✅ **DONE 2026-06-03** (§3) — vo output leak;
    inline retains-companion-on-unmatched + non-zero exit; extract `--force`. Verified by
    the harness (two rows flipped to preserve) + new unit tests; full fast suite green.
-3. **#162 keystone** (§7) — **detective ✅ DONE 2026-06-03** (cross-file `slide_id` parity
-   warning in `clm validate`, dir/course + single-file-with-twin; `commit-without-sync`
-   flipped break-silent → break-loud). **Next: defensive** twin-aware `assign-ids`/`extract`
-   (refuse to mint a divergent id on a split half) — clears the two assign-ids break-silent
-   rows; then generative pair-aware minting for born-split + companion `for_slide` parity.
+3. **#162 keystone** (§7) — **detective ✅ DONE** (cross-file `slide_id` parity warning in
+   `clm validate`, dir/course + single-file-with-twin; `commit-without-sync` → break-loud).
+   **defensive ✅ DONE 2026-06-03** (twin-aware `assign_ids_in_file`; both assign-ids rows →
+   preserve). **Next:** generative pair-aware minting for born-split (true EN-authority) +
+   `extract-voiceover` twin-awareness + companion `for_slide` parity (the both-language
+   voiceover compat check). Harness now 12 preserve / 1 break-loud / 2 break-silent
+   (extract-then-split + build-merge observe-only).
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -446,8 +446,8 @@ agent/script plumbing, or **(G)** harden with a guard.
 | `assign-ids` (per file) | Per-file run on a split half mints **divergent** ids — the #1 silent #162 break. Its core job (id minting) is already done *consistently* by `sync`. | **F + H** — fold consistent minting into `sync` / a pair-aware mode (§7 generative); demote the raw per-file command to plumbing (agents/scripts), not a normal authoring step. |
 | `voiceover extract` | Single-file, clobbers companion w/o `--force`; per-language only; no cross-language check. | **G now, F later** — add `--force`/guard immediately; longer-term fold extraction into a paired, twin-aware operation (or under `sync`'s umbrella). |
 | `voiceover inline` | Destructive: unlinks companion even on unmatched, exit 0, no backup. | **G** — preserve/backup on unmatched, non-zero exit, `--dry-run` default. |
-| `slides split` | Unaware of voiceover companions; extract-then-split silently orphans them. | **G** — refuse/warn when a sibling `voiceover_*.py` exists; add a first-class companion split (route vo cells by `lang`, preserve `for_slide`/`vo_anchor`). |
-| `slides unify` | Ignores companions; can't recombine voiceover. | **G** — companion unify path (the inverse of the above). |
+| `slides split` | Unaware of voiceover companions; extract-then-split silently orphans them. | **G — DONE (2026-06-03).** First-class companion split: `split_in_file` splits a sibling `voiceover_*.py` in lockstep into `voiceover_*.de.py`/`.en.py`, routing cells by `lang`, preserving `for_slide`/`vo_anchor`. Atomic `--force` over deck+companion; byte-identical round trip. |
+| `slides unify` | Ignores companions; can't recombine voiceover. | **G — DONE (2026-06-03).** `unify_in_file` recombines the companion halves into `voiceover_*.py` (inverse of split; missing half treated as empty so narration is never dropped). |
 | `slides suggest-sync` | Old single-file read-only suggester; coexists confusingly with the split-pair `sync` (different file layout, opposite write semantics). | **H or remove** — hide as plumbing or retire; steer users to `sync`. |
 | `slides sync` (the funnel) | Two bare path args, no pairing guard, writes by default. | **G** — pairing guard (§3 Tier-2), and consider a **single-path contract** (pass one half or the deck stem; derive the twin + companion) + a directory/spec **batch mode** so the author can't fumble the pair or cross decks. |
 
@@ -490,10 +490,14 @@ Required hardening:
 - Stop the output leak (§3 Tier-1 #1).
 - Stop `inline` destroying its source-of-truth (§3 Tier-1 #2); `extract` `--force`
   (§3 Tier-1 #3).
-- **Companion split/unify path** so extract-then-split / unify don't orphan voiceover
-  (§8): route companion cells by their owning slide's `lang`, preserving
-  `for_slide`/`vo_anchor`. This is well-defined *once* `de_id==en_id` is guaranteed
-  (depends on #162).
+- **Companion split/unify path** — **DONE (2026-06-03)** so extract-then-split / unify
+  don't orphan voiceover (§8): `split_in_file`/`unify_in_file` carry a sibling
+  `voiceover_*.py` in lockstep, routing companion cells by their `lang` and preserving
+  `for_slide`/`vo_anchor`, byte-identically. Reuses `split_text`/`unify_texts` (a
+  companion has no header macro, so the per-language route is the same primitive); the
+  `companion_path` dependency is imported lazily so a plain deck split never touches the
+  voiceover layer. Well-defined because #162 guarantees `de_id==en_id`. The
+  `extract-then-split` harness row flipped break-silent → preserve.
 - **Both-language compatibility check** = companion `for_slide`-set equality across
   `.de`/`.en` (same invariant as the slide check; part of the detective gate).
 - **Build-time escalation** of unmatched `for_slide` from log-only to a surfaced
@@ -538,10 +542,16 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
    `clm validate`, dir/course + single-file-with-twin; `commit-without-sync` → break-loud).
    **defensive ✅ DONE** (twin-aware `assign_ids_in_file`) + **generative ✅ DONE 2026-06-03**
    (`assign_ids_in_split_pair` / directory routing; EN-authority via unify→assign→split with a
-   byte-faithful round-trip guard). All three #162 legs landed. **Next:** `extract-voiceover`
-   twin-awareness + companion `for_slide` parity (the both-language voiceover compat check), and
-   the `extract-then-split` companion seam (§10). Harness now 13 preserve / 1 break-loud /
-   2 break-silent (extract-then-split + build-merge observe-only).
+   byte-faithful round-trip guard). All three #162 legs landed. Harness now 14 preserve /
+   1 break-loud / 1 break-silent.
+   - **Companion split/unify seam ✅ DONE 2026-06-03** (§8/§10) — `split_in_file`/`unify_in_file`
+     carry a sibling `voiceover_*.py` in lockstep (route by `lang`, preserve
+     `for_slide`/`vo_anchor`, byte-identical round trip; lazy `companion_path` import; CLI +
+     `--json` report companions; info topics updated). `extract-then-split` harness row flipped
+     break-silent → preserve; `tests/slides/test_split.py::TestCompanionSplit`/`TestCompanionUnify`.
+   - **Next:** `extract-voiceover` twin-awareness + companion `for_slide` parity (the both-language
+     voiceover compat check, extends the detective); then the build-merge observe-only escalation
+     (the one remaining break-silent row).
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.
@@ -566,8 +576,9 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
 - Voiceover (slide-side): `voiceover_tools.py` (`companion_path` `:122-136`; extract
   `:349-424`; inline `:706-802`; `merge_voiceover_text` `:432-485`; `vo_anchor`
   `:204-256`).
-- Split/unify: `split.py` (`split_text`; `unify_texts`; `_slide_ids_pair` `:420-431`;
-  force guards `:271-281,558-560`).
+- Split/unify: `split.py` (`split_text`; `unify_texts`; `_slide_ids_pair`; force guards;
+  companion seam `_plan_companion_split` / `_plan_companion_unify` — lazy `companion_path`
+  import, reuse `split_text`/`unify_texts`; `SplitResult`/`UnifyResult` companion fields).
 - Build: `build.py` (split-routing abort `:1117-1132`); `topic.py`
   (`add_files_in_dir`/`_add_slide_units` `:318-408`; `FileTopic` `:426-445`);
   `notebook_file.py` (`output_language_filter`, `companion_voiceover_path` `:108-114`);

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -79,6 +79,17 @@ corrections are load-bearing for prioritization, so they are recorded explicitly
 
 ### Tier 1 — confirmed data loss, cheap fixes (do first)
 
+> **✅ ALL THREE FIXED (roadmap step 2, 2026-06-03).** (1) `voiceover_*.py` added to
+> `SKIP_OUTPUT_FILE_PATTERNS` + `SKIP_OUTPUT_FILE_GLOBS` (output-copy + recursive-dir-copy
+> vectors) — kept available as build source, suppressed only from output + kernel payload.
+> (2) `inline_voiceover` now retains the companion (rewritten to the unmatched remainder,
+> anchors intact) instead of unlinking it, and the CLI exits non-zero on unmatched. (3)
+> `extract_voiceover` gains `force=` / `--force` and refuses to clobber an existing companion
+> otherwise (checked *before* the slide is rewritten). New `VoiceoverError`; CLI/MCP wrap it.
+> Harness rows `inline-after-rename` + `re-extract-over-edited-companion` flipped break-silent →
+> preserve; new unit tests in `test_voiceover_tools.py` + `path_utils_test.py`. Original analysis
+> retained below.
+
 1. **Voiceover companion leaks into student output.** **[verified, worse than first
    reported].** `voiceover_*.py` is classified as a `DataFile`
    (`course_file.py:152-163`; `is_slides_file` requires `slides_`/`topic_`/`project_`
@@ -502,8 +513,9 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
    `scripts/edit_dynamics_harness.py` + `tests/slides/test_edit_dynamics.py` (8 preserve /
    7 break-silent / 0 error, no drift). The seven break-silent rows are the work-list for
    steps 2–5; the sync funnel is now regression-guarded in the fast suite.
-2. **Tier-1 data-loss fixes** (§3) — vo output leak; inline unlink guard; extract
-   `--force`. Cheap, verified, immediate work-loss prevention.
+2. ~~**Tier-1 data-loss fixes**~~ ✅ **DONE 2026-06-03** (§3) — vo output leak;
+   inline retains-companion-on-unmatched + non-zero exit; extract `--force`. Verified by
+   the harness (two rows flipped to preserve) + new unit tests; full fast suite green.
 3. **#162 keystone** (§7) — detective (the gate's core check) + defensive twin-aware
    `assign-ids`/`extract`; generative pair-aware minting for born-split.
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -53,6 +53,7 @@ from clm.slides.split import (  # noqa: E402
 )
 from clm.slides.sync_apply import ApplyResult, apply_plan  # noqa: E402
 from clm.slides.sync_plan import SyncPlan, build_sync_plan, watermark_rows  # noqa: E402
+from clm.slides.validator import validate_file  # noqa: E402
 from clm.slides.voiceover_tools import (  # noqa: E402
     VoiceoverError,
     companion_path,
@@ -489,14 +490,21 @@ def m_born_split_assign_ids(workdir: Path) -> _RetTuple:
 
 
 def m_commit_without_sync(workdir: Path) -> _RetTuple:
-    # Author adds a slide to one half and commits/builds without ever syncing.
+    # Author adds a slide to one half and commits without ever syncing. The
+    # #162 detective (the pre-commit gate runs `clm validate`) now catches the
+    # divergence loudly even though `build` itself stays permissive.
     base = _base()
     de = base.de + slide_cell("de", "Neuer Slide", sid="extra", bullet="- DE neu")
+    de_path, _ = SplitPair(de=de, en=base.en).write(workdir)
     detail = id_parity(de, base.en)
-    note = (
-        f"{detail}; no gate ran (build stays permissive) -> ships silently" if detail else "in sync"
+    findings = validate_file(de_path).findings
+    caught = any(f.category == "pairing" and "slide_id" in f.message for f in findings)
+    return (
+        (["id_parity"] if detail else []),
+        caught,
+        "validate (detective) reports slide_id divergence" if caught else "",
+        f"{detail}; detective {'CATCHES it' if caught else 'misses it'}" if detail else "in sync",
     )
-    return (["id_parity"] if detail else []), False, "", note
 
 
 # --- voiceover round-trip (expected: preserve) -----------------------------
@@ -669,7 +677,9 @@ MUTATIONS: list[Mutation] = [
         m_add_then_assign_ids_per_file,
     ),
     Mutation("born-split-assign-ids", "assign-ids", BREAK_SILENT, True, m_born_split_assign_ids),
-    Mutation("commit-without-sync", "no-gate", BREAK_SILENT, True, m_commit_without_sync),
+    # #162 detective landed: the pre-commit gate (`clm validate`) now catches a
+    # committed split-half divergence — break-silent -> break-loud.
+    Mutation("commit-without-sync", "no-gate", BREAK_LOUD, True, m_commit_without_sync),
     Mutation("extract-then-split", "extract+split", BREAK_SILENT, True, m_extract_then_split),
     # Tier-1 data-loss fixes landed: inline now retains the companion with the
     # unmatched cell (recoverable) and exits non-zero; extract refuses to clobber

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -600,26 +600,50 @@ def m_unify_split_round_trip(workdir: Path) -> _RetTuple:
     )
 
 
-# --- cross-command voiceover seams (expected: break-silent) ----------------
+# --- cross-command voiceover seams -----------------------------------------
 
 
 def m_extract_then_split(workdir: Path) -> _RetTuple:
+    # Fixed: `split` now splits a sibling bilingual companion in lockstep into
+    # voiceover_*.de.py / .en.py, preserving for_slide/vo_anchor, so the
+    # narration is never orphaned and the halves round-trip back to the
+    # original companion via `unify`.
     bil = baseline_bilingual(with_voiceover=("intro", "setup"))
     slide = workdir / "slides_demo.py"
     slide.write_text(bil, encoding="utf-8", newline="\n")
     extract_voiceover(slide)  # bilingual voiceover_demo.py
     bilingual_comp = companion_path(slide)
-    split_in_file(slide)  # slides_demo.de.py / .en.py
+    comp_before = bilingual_comp.read_text(encoding="utf-8")
+    split_in_file(slide)  # slides_demo.de.py / .en.py + companion split
     de_comp = companion_path(workdir / "slides_demo.de.py")
     en_comp = companion_path(workdir / "slides_demo.en.py")
-    orphaned = bilingual_comp.exists() and not de_comp.exists() and not en_comp.exists()
+
+    if not (de_comp.exists() and en_comp.exists()):
+        return ["companion_orphan"], False, "", "companion not split; bilingual orphaned"
+
+    de_txt = de_comp.read_text(encoding="utf-8")
+    en_txt = en_comp.read_text(encoding="utf-8")
+    try:
+        recombined = unify_texts(de_txt, en_txt)
+    except (SplitError, UnifyError) as e:
+        return ["companion_round_trip"], True, f"{type(e).__name__}: {e}", "companion unify raised"
+
+    violated: list[str] = []
+    if recombined != comp_before:
+        violated.append("companion_round_trip")
+    if for_slides(de_txt) != for_slides(en_txt):
+        violated.append("for_slide_parity")
+    anchors_kept = "vo_anchor=" in de_txt and "vo_anchor=" in en_txt
+    if not anchors_kept:
+        violated.append("vo_anchor_dropped")
+
     return (
-        (["companion_orphan"] if orphaned else []),
+        violated,
         False,
         "",
-        "bilingual voiceover_demo.py orphaned; no .de/.en companion; split is silent"
-        if orphaned
-        else "companion handled",
+        f"companion split de={for_slides(de_txt)} en={for_slides(en_txt)}; round-trips, anchors kept"
+        if not violated
+        else f"violations: {violated}",
     )
 
 
@@ -749,7 +773,10 @@ MUTATIONS: list[Mutation] = [
     # #162 detective landed: the pre-commit gate (`clm validate`) now catches a
     # committed split-half divergence — break-silent -> break-loud.
     Mutation("commit-without-sync", "no-gate", BREAK_LOUD, True, m_commit_without_sync),
-    Mutation("extract-then-split", "extract+split", BREAK_SILENT, True, m_extract_then_split),
+    # Companion split/unify path landed: `split` splits a sibling voiceover
+    # companion in lockstep (and `unify` recombines it), so extract-then-split
+    # no longer orphans the narration — break-silent -> preserve.
+    Mutation("extract-then-split", "extract+split", PRESERVE, True, m_extract_then_split),
     # Tier-1 data-loss fixes landed: inline now retains the companion with the
     # unmatched cell (recoverable) and exits non-zero; extract refuses to clobber
     # an existing companion without --force. Both flipped break-silent -> preserve.

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -43,7 +43,11 @@ if __package__ in (None, ""):  # pragma: no cover - import shim
 from clm.infrastructure.llm.cache import SyncWatermarkCache  # noqa: E402
 from clm.infrastructure.llm.ollama_client import SyncProposal  # noqa: E402
 from clm.notebooks.slide_parser import parse_cells  # noqa: E402
-from clm.slides.assign_ids import AssignOptions, assign_ids_in_file  # noqa: E402
+from clm.slides.assign_ids import (  # noqa: E402
+    AssignOptions,
+    assign_ids_in_directory,
+    assign_ids_in_file,
+)
 from clm.slides.split import (  # noqa: E402
     SplitError,
     UnifyError,
@@ -301,6 +305,20 @@ def run_assign_ids_pair(pair: SplitPair, workdir: Path, stem: str = "slides_demo
     )
 
 
+def run_assign_ids_directory(
+    pair: SplitPair, workdir: Path, stem: str = "slides_demo"
+) -> SplitPair:
+    """Write a split pair to disk and run directory ``assign-ids`` — the
+    generative EN-authority path: split pairs are minted across both halves at
+    once (the same id, derived from the EN heading)."""
+    de_path, en_path = pair.write(workdir, stem=stem)
+    assign_ids_in_directory(workdir, AssignOptions())
+    return SplitPair(
+        de=de_path.read_text(encoding="utf-8"),
+        en=en_path.read_text(encoding="utf-8"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Classification framework
 # ---------------------------------------------------------------------------
@@ -356,9 +374,16 @@ def _base() -> SplitPair:
     return SplitPair.from_bilingual(baseline_bilingual())
 
 
-def _split_header(macro: str) -> str:
-    """A split (single-language) preamble — replace the bilingual header macro."""
-    return HEADER_PREAMBLE.replace('# {{ header("Titel DE", "Title EN") }}', f"# {{{{ {macro} }}}}")
+def born_split_pair(de_title: str = "Mein Thema", en_title: str = "My Topic") -> SplitPair:
+    """A *born-split* pair (no bilingual ancestor) — both halves id-less, with
+    valid split headers. Built by splitting an id-less bilingual deck so the
+    header macros (``import header_de`` / ``header_en``) are exactly what
+    ``split`` produces (a hand-edited macro call alone leaves ``import header``
+    and breaks ``unify``). The two headings differ by language so EN-authority
+    is observable.
+    """
+    bilingual = HEADER_PREAMBLE + slide_cell("de", de_title) + slide_cell("en", en_title)
+    return SplitPair.from_bilingual(bilingual)
 
 
 def _sync_signaled(out: SyncOutcome) -> tuple[bool, str]:
@@ -491,15 +516,34 @@ def m_add_then_assign_ids_per_file(workdir: Path) -> _RetTuple:
 
 
 def m_born_split_assign_ids(workdir: Path) -> _RetTuple:
-    de = _split_header('header_de("Titel DE")') + slide_cell("de", "Mein Thema")
-    en = _split_header('header_en("Title EN")') + slide_cell("en", "My Topic")
-    result = run_assign_ids_pair(SplitPair(de=de, en=en), workdir)
+    # Born-split pair, both halves id-less, different headings. Per-file
+    # assign-ids (defensive): the first half mints, the second reuses -> parity.
+    result = run_assign_ids_pair(born_split_pair(), workdir)
     detail = id_parity(result.de, result.en)
     return (
         (["id_parity"] if detail else []),
         False,
         "",
         detail or f"twin-aware reuse: ids matched {slide_ids(result.de)}",
+    )
+
+
+def m_born_split_assign_ids_directory(workdir: Path) -> _RetTuple:
+    # Generative (#162): `assign-ids` over the directory mints EN-authority ids
+    # across both halves of a born-split pair at once (deterministic, not
+    # order-dependent). The EN heading "My Topic" -> "my-topic" wins on both.
+    result = run_assign_ids_directory(born_split_pair(), workdir)
+    detail = id_parity(result.de, result.en)
+    if detail:
+        return ["id_parity"], False, "", detail
+    en_authority = slide_ids(result.de) == ["my-topic"]
+    return (
+        ([] if en_authority else ["en_authority"]),
+        False,
+        "",
+        f"EN-authority parity: {slide_ids(result.de)}"
+        if en_authority
+        else f"parity but slug not EN-authority: {slide_ids(result.de)}",
     )
 
 
@@ -693,6 +737,15 @@ MUTATIONS: list[Mutation] = [
         m_add_then_assign_ids_per_file,
     ),
     Mutation("born-split-assign-ids", "assign-ids", PRESERVE, True, m_born_split_assign_ids),
+    # #162 generative: directory assign-ids mints EN-authority ids across both
+    # halves at once (deterministic, order-independent).
+    Mutation(
+        "born-split-assign-ids-directory",
+        "assign-ids",
+        PRESERVE,
+        True,
+        m_born_split_assign_ids_directory,
+    ),
     # #162 detective landed: the pre-commit gate (`clm validate`) now catches a
     # committed split-half divergence — break-silent -> break-loud.
     Mutation("commit-without-sync", "no-gate", BREAK_LOUD, True, m_commit_without_sync),

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -43,7 +43,7 @@ if __package__ in (None, ""):  # pragma: no cover - import shim
 from clm.infrastructure.llm.cache import SyncWatermarkCache  # noqa: E402
 from clm.infrastructure.llm.ollama_client import SyncProposal  # noqa: E402
 from clm.notebooks.slide_parser import parse_cells  # noqa: E402
-from clm.slides.assign_ids import AssignOptions, assign_ids_for_text  # noqa: E402
+from clm.slides.assign_ids import AssignOptions, assign_ids_in_file  # noqa: E402
 from clm.slides.split import (  # noqa: E402
     SplitError,
     UnifyError,
@@ -285,10 +285,20 @@ def run_sync(
     )
 
 
-def run_assign_ids(text: str, file_name: str, **opts: object) -> tuple[str, object]:
-    """Per-file ``assign-ids`` — mints ids from this file's headings alone."""
-    options = AssignOptions(**opts)  # type: ignore[arg-type]
-    return assign_ids_for_text(text, Path(file_name), options)
+def run_assign_ids_pair(pair: SplitPair, workdir: Path, stem: str = "slides_demo") -> SplitPair:
+    """Write a split pair to disk and run per-file ``assign-ids`` on each half.
+
+    Mirrors the realistic ``clm slides assign-ids slides/`` flow (sorted: the
+    ``.de.py`` half then ``.en.py``). On disk the twin-aware reuse (#162
+    defensive) can fire, so the second half adopts the first half's minted ids.
+    """
+    de_path, en_path = pair.write(workdir, stem=stem)
+    assign_ids_in_file(de_path, AssignOptions())
+    assign_ids_in_file(en_path, AssignOptions())
+    return SplitPair(
+        de=de_path.read_text(encoding="utf-8"),
+        en=en_path.read_text(encoding="utf-8"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -465,28 +475,32 @@ def m_hand_edit_id_then_sync(workdir: Path) -> _RetTuple:
 
 def m_add_then_assign_ids_per_file(workdir: Path) -> _RetTuple:
     # Author adds the SAME new slide to BOTH halves (id-less), then runs
-    # per-file assign-ids on each — divergent headings slug divergently.
+    # per-file assign-ids on each. Divergent headings would slug divergently —
+    # the #162 defensive (twin-aware reuse) keeps the id in parity.
     base = _base()
     de = base.de + slide_cell("de", "Neuer Abschnitt", bullet="- DE neu")
     en = base.en + slide_cell("en", "New Section", bullet="- EN new")
-    new_de, _ = run_assign_ids(de, "slides_demo.de.py")
-    new_en, _ = run_assign_ids(en, "slides_demo.en.py")
-    detail = id_parity(new_de, new_en)
+    result = run_assign_ids_pair(SplitPair(de=de, en=en), workdir)
+    detail = id_parity(result.de, result.en)
     return (
         (["id_parity"] if detail else []),
         False,
         "",
-        detail or f"ids matched: {slide_ids(new_de)}",
+        detail or f"twin-aware reuse: ids matched {slide_ids(result.de)}",
     )
 
 
 def m_born_split_assign_ids(workdir: Path) -> _RetTuple:
     de = _split_header('header_de("Titel DE")') + slide_cell("de", "Mein Thema")
     en = _split_header('header_en("Title EN")') + slide_cell("en", "My Topic")
-    new_de, _ = run_assign_ids(de, "slides_demo.de.py")
-    new_en, _ = run_assign_ids(en, "slides_demo.en.py")
-    detail = id_parity(new_de, new_en)
-    return (["id_parity"] if detail else []), False, "", detail or "headings slugged identically"
+    result = run_assign_ids_pair(SplitPair(de=de, en=en), workdir)
+    detail = id_parity(result.de, result.en)
+    return (
+        (["id_parity"] if detail else []),
+        False,
+        "",
+        detail or f"twin-aware reuse: ids matched {slide_ids(result.de)}",
+    )
 
 
 def m_commit_without_sync(workdir: Path) -> _RetTuple:
@@ -668,15 +682,17 @@ MUTATIONS: list[Mutation] = [
         "extract-inline-round-trip", "extract+inline", PRESERVE, True, m_extract_inline_round_trip
     ),
     Mutation("unify-split-round-trip", "split+unify", PRESERVE, True, m_unify_split_round_trip),
-    # The work-list — known silent breaks (flip to preserve when fixed).
+    # #162 defensive landed: per-file assign-ids on a split half is now
+    # twin-aware (adopts the sibling's id instead of minting a divergent slug),
+    # so both assign-ids rows flipped break-silent -> preserve.
     Mutation(
         "add-then-assign-ids-per-file",
         "assign-ids",
-        BREAK_SILENT,
+        PRESERVE,
         True,
         m_add_then_assign_ids_per_file,
     ),
-    Mutation("born-split-assign-ids", "assign-ids", BREAK_SILENT, True, m_born_split_assign_ids),
+    Mutation("born-split-assign-ids", "assign-ids", PRESERVE, True, m_born_split_assign_ids),
     # #162 detective landed: the pre-commit gate (`clm validate`) now catches a
     # committed split-half divergence — break-silent -> break-loud.
     Mutation("commit-without-sync", "no-gate", BREAK_LOUD, True, m_commit_without_sync),

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+"""Edit-dynamics fault-injection harness for the split-language + voiceover workflow.
+
+Where ``sync_corpus_harness.py`` measures *static* state over the real corpus,
+this harness probes *editing dynamics*: it applies a catalogue of realistic
+author edits to parallel ``.de.py`` / ``.en.py`` decks (and their voiceover
+companions), runs the command path a user would take, and classifies the result
+
+    preserve      — the correspondence/safety invariants still hold
+    break-loud    — an invariant broke, but the op signalled it (raised /
+                    non-zero exit / warning / deferred)
+    break-silent  — an invariant broke and the op reported success
+
+The **break-silent** rows are the work-list: every footgun where data diverges
+or is lost with no signal to the author. The harness executably verifies the
+"correspondence is preserved only if structural changes funnel through ``sync``"
+thesis (design doc §5) and is the cross-command property suite CI lacks.
+
+Design: ``docs/claude/design/split-voiceover-hardening.md`` §6.
+
+The synthetic arm is pure (no corpus, no network): the translator/judge are the
+same counting, no-LLM stand-ins the sync unit tests use. Run it for the table::
+
+    python scripts/edit_dynamics_harness.py            # human table
+    python scripts/edit_dynamics_harness.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Allow running both as a script and as an importable module (pytest backstop).
+if __package__ in (None, ""):  # pragma: no cover - import shim
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache  # noqa: E402
+from clm.infrastructure.llm.ollama_client import SyncProposal  # noqa: E402
+from clm.notebooks.slide_parser import parse_cells  # noqa: E402
+from clm.slides.assign_ids import AssignOptions, assign_ids_for_text  # noqa: E402
+from clm.slides.split import (  # noqa: E402
+    SplitError,
+    UnifyError,
+    split_in_file,
+    split_text,
+    unify_texts,
+)
+from clm.slides.sync_apply import ApplyResult, apply_plan  # noqa: E402
+from clm.slides.sync_plan import SyncPlan, build_sync_plan, watermark_rows  # noqa: E402
+from clm.slides.voiceover_tools import (  # noqa: E402
+    companion_path,
+    extract_voiceover,
+    inline_voiceover,
+    merge_voiceover_text,
+)
+
+# Verdict constants.
+PRESERVE = "preserve"
+BREAK_LOUD = "break-loud"
+BREAK_SILENT = "break-silent"
+ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# No-LLM mocks (verbatim from tests/slides/test_sync_limitations.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CountingTranslator:
+    """Records every call and returns the source body verbatim (no network)."""
+
+    prompt_version: str = "counting"
+    calls: list[tuple[str, str, str, str]] = field(default_factory=list)
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.calls.append((role, source_lang, target_lang, source_body))
+        return source_body
+
+
+@dataclass
+class CountingJudge:
+    """Records every call and never rewrites (no network)."""
+
+    prompt_version: str = "counting"
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def propose(
+        self, source_body: str, target_body: str, *, source_lang: str, target_lang: str
+    ) -> SyncProposal:
+        self.calls.append((source_lang, target_lang))
+        return SyncProposal(verdict="in_sync", proposed_text=target_body)
+
+
+# ---------------------------------------------------------------------------
+# Deck builders (split-format cells; matches tests/slides/test_split.py shapes)
+# ---------------------------------------------------------------------------
+
+# The bilingual preamble; ``split_text`` rewrites it to header_de / header_en.
+HEADER_PREAMBLE = (
+    '# j2 from \'macros.j2\' import header\n# {{ header("Titel DE", "Title EN") }}\n\n'
+)
+
+
+def slide_cell(lang: str, title: str, *, sid: str | None = None, bullet: str | None = None) -> str:
+    """A single localized slide cell in split form (optionally id-less)."""
+    id_attr = f' slide_id="{sid}"' if sid else ""
+    body = bullet if bullet is not None else f"- {lang.upper()} Bullet"
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["slide"]{id_attr}\n#\n# ## {title}\n#\n# {body}\n\n'
+    )
+
+
+def voiceover_cell(lang: str, *, sid: str, text: str | None = None) -> str:
+    """A voiceover cell *inside a slide file* (carries slide_id, not for_slide)."""
+    body = text if text is not None else f"Voiceover {lang.upper()} for {sid}"
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n#\n# {body}\n\n'
+
+
+def shared_code(name: str = "x", value: str = "1") -> str:
+    """A language-neutral shared code cell (no lang attribute)."""
+    return f'# %% tags=["keep"]\n{name} = {value}\n\n'
+
+
+def bilingual_pair(slug: str, de_title: str, en_title: str) -> str:
+    """A DE-then-EN slide pair with a shared slide_id and targetable bullets."""
+    return slide_cell("de", de_title, sid=slug, bullet=f"- DE {slug}") + slide_cell(
+        "en", en_title, sid=slug, bullet=f"- EN {slug}"
+    )
+
+
+def baseline_bilingual(
+    slugs: tuple[str, ...] = ("intro", "setup", "demo"),
+    *,
+    with_voiceover: tuple[str, ...] = (),
+    with_shared_code: bool = False,
+) -> str:
+    """A clean bilingual deck: the canonical ``unify``-able shape."""
+    parts: list[str] = [HEADER_PREAMBLE]
+    if with_shared_code:
+        parts.append(shared_code("api_key", '"k"'))
+    for s in slugs:
+        parts.append(bilingual_pair(s, f"Titel {s}", f"Title {s}"))
+        if s in with_voiceover:
+            parts.append(voiceover_cell("de", sid=s) + voiceover_cell("en", sid=s))
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# The split-pair under test
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SplitPair:
+    """A ``.de.py`` / ``.en.py`` pair, optionally with voiceover companions."""
+
+    de: str
+    en: str
+    de_companion: str | None = None
+    en_companion: str | None = None
+
+    @classmethod
+    def from_bilingual(cls, bilingual: str) -> SplitPair:
+        de, en = split_text(bilingual)
+        return cls(de=de, en=en)
+
+    def write(self, dirpath: Path, stem: str = "slides_demo") -> tuple[Path, Path]:
+        de_path = dirpath / f"{stem}.de.py"
+        en_path = dirpath / f"{stem}.en.py"
+        de_path.write_text(self.de, encoding="utf-8", newline="\n")
+        en_path.write_text(self.en, encoding="utf-8", newline="\n")
+        if self.de_companion is not None:
+            companion_path(de_path).write_text(self.de_companion, encoding="utf-8", newline="\n")
+        if self.en_companion is not None:
+            companion_path(en_path).write_text(self.en_companion, encoding="utf-8", newline="\n")
+        return de_path, en_path
+
+
+# ---------------------------------------------------------------------------
+# Inspectors — read invariant-relevant facts out of slide / companion text
+# ---------------------------------------------------------------------------
+
+
+def slide_ids(text: str) -> list[str | None]:
+    """Ordered slide_ids of slide-start cells (the #162 cross-language join key)."""
+    return [c.slide_id for c in parse_cells(text) if c.metadata.is_slide_start]
+
+
+def all_ids(text: str) -> list[str | None]:
+    """Ordered slide_ids of every id-bearing cell."""
+    return [c.slide_id for c in parse_cells(text) if c.slide_id is not None]
+
+
+def for_slides(text: str) -> list[str]:
+    """Ordered ``for_slide`` keys of every voiceover cell in a companion."""
+    return [c.metadata.for_slide for c in parse_cells(text) if c.metadata.for_slide is not None]
+
+
+def slide_titles(text: str, lang: str) -> list[str]:
+    """Ordered ``## …`` titles of slide-start cells of one language (data-loss probe)."""
+    out: list[str] = []
+    for c in parse_cells(text):
+        if not c.metadata.is_slide_start or c.lang not in (lang, None):
+            continue
+        for line in c.content.splitlines():
+            stripped = line.lstrip("# ").strip()
+            if stripped:
+                out.append(stripped)
+                break
+    return out
+
+
+def id_parity(de: str, en: str) -> str | None:
+    """Return a detail string if the #162 invariant is violated, else ``None``."""
+    de_ids, en_ids = slide_ids(de), slide_ids(en)
+    if de_ids == en_ids:
+        return None
+    return f"de_ids={de_ids} != en_ids={en_ids}"
+
+
+# ---------------------------------------------------------------------------
+# Command-path runners — each reproduces exactly what a user/agent would invoke
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SyncOutcome:
+    de: str
+    en: str
+    plan: SyncPlan
+    result: ApplyResult
+    translator: CountingTranslator
+    judge: CountingJudge
+
+
+def _seed(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    """Seed the membership-widened watermark exactly as ``_record_watermark`` does."""
+    de_rows = watermark_rows(parse_cells(de_path.read_text(encoding="utf-8")))
+    en_rows = watermark_rows(parse_cells(en_path.read_text(encoding="utf-8")))
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="de", cells=de_rows["de"])
+    cache.put_deck(de_path=str(de_path), en_path=str(en_path), lang="en", cells=en_rows["en"])
+    cache.put_deck(
+        de_path=str(de_path), en_path=str(en_path), lang="shared", cells=de_rows["shared"]
+    )
+
+
+def run_sync(
+    baseline: SplitPair, mutated: SplitPair, dirpath: Path, stem: str = "slides_demo"
+) -> SyncOutcome:
+    """Seed the watermark from ``baseline``, write ``mutated``, then plan+apply.
+
+    This is the safe funnel: the path that keeps both halves consistent.
+    """
+    de_path = dirpath / f"{stem}.de.py"
+    en_path = dirpath / f"{stem}.en.py"
+    de_path.write_text(baseline.de, encoding="utf-8", newline="\n")
+    en_path.write_text(baseline.en, encoding="utf-8", newline="\n")
+    cache = SyncWatermarkCache(dirpath / "clm-llm.sqlite")
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(mutated.de, encoding="utf-8", newline="\n")
+        en_path.write_text(mutated.en, encoding="utf-8", newline="\n")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+    return SyncOutcome(
+        de=de_path.read_text(encoding="utf-8"),
+        en=en_path.read_text(encoding="utf-8"),
+        plan=plan,
+        result=result,
+        translator=translator,
+        judge=judge,
+    )
+
+
+def run_assign_ids(text: str, file_name: str, **opts: object) -> tuple[str, object]:
+    """Per-file ``assign-ids`` — mints ids from this file's headings alone."""
+    options = AssignOptions(**opts)  # type: ignore[arg-type]
+    return assign_ids_for_text(text, Path(file_name), options)
+
+
+# ---------------------------------------------------------------------------
+# Classification framework
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Outcome:
+    """One (mutation, command-path) result, classified."""
+
+    name: str
+    path: str
+    verdict: str
+    violated: list[str] = field(default_factory=list)
+    signaled: bool = False
+    signal: str = ""
+    detail: str = ""
+    expected: str = ""
+    asserted: bool = True
+
+    @property
+    def drifted(self) -> bool:
+        """Observed verdict diverged from the frozen baseline (regression *or* fix)."""
+        return self.verdict != self.expected
+
+
+def classify(violated: list[str], signaled: bool) -> str:
+    if not violated:
+        return PRESERVE
+    return BREAK_LOUD if signaled else BREAK_SILENT
+
+
+def _fresh_dir() -> tempfile.TemporaryDirectory:
+    return tempfile.TemporaryDirectory(prefix="clm-edit-dyn-")
+
+
+# ---------------------------------------------------------------------------
+# Mutation catalogue
+#
+# Each mutation applies one realistic author edit, runs the command path the
+# author would take, and returns ``(violated, signaled, signal, detail)``:
+#   violated  — list of invariant names that broke ([] = held)
+#   signaled  — did the op signal the problem to the *user* (raise / non-zero
+#               exit / warning / deferred)? A counter buried in a result object
+#               the CLI ignores is NOT a user-facing signal.
+#   signal    — human description of the signal (empty when not signalled)
+#   detail    — what happened, for the table
+# ---------------------------------------------------------------------------
+
+_RetTuple = tuple[list[str], bool, str, str]
+
+
+def _base() -> SplitPair:
+    return SplitPair.from_bilingual(baseline_bilingual())
+
+
+def _split_header(macro: str) -> str:
+    """A split (single-language) preamble — replace the bilingual header macro."""
+    return HEADER_PREAMBLE.replace('# {{ header("Titel DE", "Title EN") }}', f"# {{{{ {macro} }}}}")
+
+
+def _sync_signaled(out: SyncOutcome) -> tuple[bool, str]:
+    if out.result.errors:
+        return True, f"errors={out.result.errors}"
+    if out.plan.has_errors:
+        return True, "plan has error issues"
+    if out.result.deferred:
+        return True, f"deferred={out.result.deferred}"
+    return False, ""
+
+
+# --- sync funnel (expected: preserve) --------------------------------------
+
+
+def m_add_one_half(workdir: Path) -> _RetTuple:
+    base = _base()
+    mutated = SplitPair(de=base.de + slide_cell("de", "Neuer Slide", bullet="- DE neu"), en=base.en)
+    out = run_sync(base, mutated, workdir)
+    detail = id_parity(out.de, out.en)
+    sig, msg = _sync_signaled(out)
+    return (
+        (["id_parity"] if detail else []),
+        sig,
+        msg,
+        detail or f"id minted on both: {slide_ids(out.de)}",
+    )
+
+
+def m_reorder_one_half(workdir: Path) -> _RetTuple:
+    base = _base()
+    de2, _ = split_text(
+        HEADER_PREAMBLE
+        + bilingual_pair("demo", "Titel demo", "Title demo")
+        + bilingual_pair("setup", "Titel setup", "Title setup")
+        + bilingual_pair("intro", "Titel intro", "Title intro")
+    )
+    out = run_sync(base, SplitPair(de=de2, en=base.en), workdir)
+    detail = id_parity(out.de, out.en)
+    sig, msg = _sync_signaled(out)
+    return (
+        (["id_parity"] if detail else []),
+        sig,
+        msg,
+        detail or f"move mirrored: {slide_ids(out.en)}",
+    )
+
+
+def m_delete_one_half(workdir: Path) -> _RetTuple:
+    base = _base()
+    de2, _ = split_text(
+        HEADER_PREAMBLE
+        + bilingual_pair("intro", "Titel intro", "Title intro")
+        + bilingual_pair("demo", "Titel demo", "Title demo")
+    )
+    out = run_sync(base, SplitPair(de=de2, en=base.en), workdir)
+    detail = id_parity(out.de, out.en)
+    sig, msg = _sync_signaled(out)
+    return (
+        (["id_parity"] if detail else []),
+        sig,
+        msg,
+        detail or f"remove mirrored: {slide_ids(out.en)}",
+    )
+
+
+def m_edit_both_halves(workdir: Path) -> _RetTuple:
+    base = _base()
+    mutated = SplitPair(
+        de=base.de.replace("- DE setup", "- DE setup EDITED"),
+        en=base.en.replace("- EN setup", "- EN setup EDITED"),
+    )
+    out = run_sync(base, mutated, workdir)
+    detail = id_parity(out.de, out.en)
+    sig, msg = _sync_signaled(out)
+    return (
+        (["id_parity"] if detail else []),
+        sig,
+        msg,
+        detail or f"conflict deferred={out.result.deferred}, no divergent write",
+    )
+
+
+def m_copy_paste_dup(workdir: Path) -> _RetTuple:
+    base = _base()
+    dup = slide_cell("de", "Titel setup", sid="setup", bullet="- DE setup")
+    out = run_sync(base, SplitPair(de=base.de + dup, en=base.en), workdir)
+    detail = id_parity(out.de, out.en)
+    sig, msg = _sync_signaled(out)
+    return (
+        (["id_parity"] if detail else []),
+        sig,
+        msg,
+        detail or f"re-mint on both: {slide_ids(out.de)}",
+    )
+
+
+def m_hand_edit_id_then_sync(workdir: Path) -> _RetTuple:
+    base = _base()
+    mutated = SplitPair(de=base.de.replace('slide_id="setup"', 'slide_id="renamed"'), en=base.en)
+    out = run_sync(base, mutated, workdir)
+    detail = id_parity(out.de, out.en)
+    sig, msg = _sync_signaled(out)
+    return (
+        (["id_parity"] if detail else []),
+        sig,
+        msg,
+        detail or "sync heals via remove+add mirrored to en (en localized content regenerated)",
+    )
+
+
+# --- per-file assign-ids + no-gate (expected: break-silent) ----------------
+
+
+def m_add_then_assign_ids_per_file(workdir: Path) -> _RetTuple:
+    # Author adds the SAME new slide to BOTH halves (id-less), then runs
+    # per-file assign-ids on each — divergent headings slug divergently.
+    base = _base()
+    de = base.de + slide_cell("de", "Neuer Abschnitt", bullet="- DE neu")
+    en = base.en + slide_cell("en", "New Section", bullet="- EN new")
+    new_de, _ = run_assign_ids(de, "slides_demo.de.py")
+    new_en, _ = run_assign_ids(en, "slides_demo.en.py")
+    detail = id_parity(new_de, new_en)
+    return (
+        (["id_parity"] if detail else []),
+        False,
+        "",
+        detail or f"ids matched: {slide_ids(new_de)}",
+    )
+
+
+def m_born_split_assign_ids(workdir: Path) -> _RetTuple:
+    de = _split_header('header_de("Titel DE")') + slide_cell("de", "Mein Thema")
+    en = _split_header('header_en("Title EN")') + slide_cell("en", "My Topic")
+    new_de, _ = run_assign_ids(de, "slides_demo.de.py")
+    new_en, _ = run_assign_ids(en, "slides_demo.en.py")
+    detail = id_parity(new_de, new_en)
+    return (["id_parity"] if detail else []), False, "", detail or "headings slugged identically"
+
+
+def m_commit_without_sync(workdir: Path) -> _RetTuple:
+    # Author adds a slide to one half and commits/builds without ever syncing.
+    base = _base()
+    de = base.de + slide_cell("de", "Neuer Slide", sid="extra", bullet="- DE neu")
+    detail = id_parity(de, base.en)
+    note = (
+        f"{detail}; no gate ran (build stays permissive) -> ships silently" if detail else "in sync"
+    )
+    return (["id_parity"] if detail else []), False, "", note
+
+
+# --- voiceover round-trip (expected: preserve) -----------------------------
+
+
+def m_extract_inline_round_trip(workdir: Path) -> _RetTuple:
+    de, _ = split_text(baseline_bilingual(with_voiceover=("intro", "setup")))
+    slide = workdir / "slides_demo.de.py"
+    slide.write_text(de, encoding="utf-8", newline="\n")
+    extract_voiceover(slide)
+    ires = inline_voiceover(slide)
+    after = slide.read_text(encoding="utf-8")
+    restored = after == de and not companion_path(slide).exists()
+    sig = ires.unmatched_cells > 0 or ires.relocated_cells > 0
+    return (
+        ([] if restored else ["round_trip"]),
+        sig,
+        "",
+        "byte-identical restore" if restored else f"diverged; unmatched={ires.unmatched_cells}",
+    )
+
+
+def m_unify_split_round_trip(workdir: Path) -> _RetTuple:
+    bil = baseline_bilingual(with_voiceover=("intro",), with_shared_code=True)
+    try:
+        de, en = split_text(bil)
+        rt = unify_texts(de, en)
+    except (SplitError, UnifyError) as e:
+        return ["round_trip"], True, f"{type(e).__name__}: {e}", "raised"
+    return (
+        ([] if rt == bil else ["round_trip"]),
+        False,
+        "",
+        "byte-identical" if rt == bil else "diverged",
+    )
+
+
+# --- cross-command voiceover seams (expected: break-silent) ----------------
+
+
+def m_extract_then_split(workdir: Path) -> _RetTuple:
+    bil = baseline_bilingual(with_voiceover=("intro", "setup"))
+    slide = workdir / "slides_demo.py"
+    slide.write_text(bil, encoding="utf-8", newline="\n")
+    extract_voiceover(slide)  # bilingual voiceover_demo.py
+    bilingual_comp = companion_path(slide)
+    split_in_file(slide)  # slides_demo.de.py / .en.py
+    de_comp = companion_path(workdir / "slides_demo.de.py")
+    en_comp = companion_path(workdir / "slides_demo.en.py")
+    orphaned = bilingual_comp.exists() and not de_comp.exists() and not en_comp.exists()
+    return (
+        (["companion_orphan"] if orphaned else []),
+        False,
+        "",
+        "bilingual voiceover_demo.py orphaned; no .de/.en companion; split is silent"
+        if orphaned
+        else "companion handled",
+    )
+
+
+def m_inline_after_rename(workdir: Path) -> _RetTuple:
+    de, _ = split_text(baseline_bilingual(with_voiceover=("intro",)))
+    slide = workdir / "slides_demo.de.py"
+    slide.write_text(de, encoding="utf-8", newline="\n")
+    extract_voiceover(slide)
+    comp = companion_path(slide)
+    txt = slide.read_text(encoding="utf-8").replace('slide_id="intro"', 'slide_id="introduction"')
+    slide.write_text(txt, encoding="utf-8", newline="\n")
+    ires = inline_voiceover(slide)
+    destroyed = ires.companion_deleted and not comp.exists() and ires.unmatched_cells > 0
+    return (
+        (["companion_destroyed"] if destroyed else []),
+        False,  # exit 0, raises nothing — silent to the user
+        "",
+        f"companion unlinked with unmatched={ires.unmatched_cells}; exit 0, no backup"
+        if destroyed
+        else f"unmatched={ires.unmatched_cells}, companion_deleted={ires.companion_deleted}",
+    )
+
+
+def m_re_extract_over_edited_companion(workdir: Path) -> _RetTuple:
+    de, _ = split_text(baseline_bilingual(with_voiceover=("intro",)))
+    slide = workdir / "slides_demo.de.py"
+    slide.write_text(de, encoding="utf-8", newline="\n")
+    extract_voiceover(slide)
+    comp = companion_path(slide)
+    comp.write_text(
+        comp.read_text(encoding="utf-8").replace("Voiceover DE for intro", "HAND EDITED narration"),
+        encoding="utf-8",
+        newline="\n",
+    )
+    # Re-add a voiceover cell to the slide so the empty-vo early-return does not fire.
+    slide.write_text(
+        slide.read_text(encoding="utf-8") + voiceover_cell("de", sid="setup", text="second VO"),
+        encoding="utf-8",
+        newline="\n",
+    )
+    extract_voiceover(slide)
+    lost = "HAND EDITED narration" not in comp.read_text(encoding="utf-8")
+    return (
+        (["companion_clobbered"] if lost else []),
+        False,
+        "",
+        "hand-edited companion content lost on re-extract (no --force/guard)"
+        if lost
+        else "edit preserved",
+    )
+
+
+# --- build-merge primitive (observe-only: the `build` command is the arm) ---
+
+
+def m_build_merge_unmatched(workdir: Path) -> _RetTuple:
+    de, _ = split_text(baseline_bilingual(with_voiceover=("intro",)))
+    slide = workdir / "slides_demo.de.py"
+    slide.write_text(de, encoding="utf-8", newline="\n")
+    extract_voiceover(slide)
+    comp = companion_path(slide)
+    slide_renamed = slide.read_text(encoding="utf-8").replace(
+        'slide_id="intro"', 'slide_id="introduction"'
+    )
+    merged, unmatched = merge_voiceover_text(slide_renamed, comp.read_text(encoding="utf-8"))
+    dropped = "Voiceover DE for intro" not in merged
+    # merge_voiceover_text RETURNS unmatched; the build consumer is log-only/exit-0.
+    return (
+        (["narration_drop"] if dropped else []),
+        False,
+        "",
+        f"VO dropped from output; unmatched={unmatched}; build merge is log-only",
+    )
+
+
+@dataclass
+class Mutation:
+    name: str
+    path: str
+    expected: str  # frozen baseline verdict (drift = regression or fix)
+    asserted: bool  # whether the CI backstop freezes this row + main() exits on its drift
+    run: Callable[[Path], _RetTuple]
+
+
+MUTATIONS: list[Mutation] = [
+    # The safe funnel — these MUST stay preserve (engine regression guard).
+    Mutation("add-slide-one-half", "sync", PRESERVE, True, m_add_one_half),
+    Mutation("reorder-one-half", "sync", PRESERVE, True, m_reorder_one_half),
+    Mutation("delete-one-half", "sync", PRESERVE, True, m_delete_one_half),
+    Mutation("edit-both-halves", "sync", PRESERVE, True, m_edit_both_halves),
+    Mutation("copy-paste-dup", "sync", PRESERVE, True, m_copy_paste_dup),
+    Mutation("hand-edit-id-then-sync", "sync", PRESERVE, True, m_hand_edit_id_then_sync),
+    Mutation(
+        "extract-inline-round-trip", "extract+inline", PRESERVE, True, m_extract_inline_round_trip
+    ),
+    Mutation("unify-split-round-trip", "split+unify", PRESERVE, True, m_unify_split_round_trip),
+    # The work-list — known silent breaks (flip to preserve when fixed).
+    Mutation(
+        "add-then-assign-ids-per-file",
+        "assign-ids",
+        BREAK_SILENT,
+        True,
+        m_add_then_assign_ids_per_file,
+    ),
+    Mutation("born-split-assign-ids", "assign-ids", BREAK_SILENT, True, m_born_split_assign_ids),
+    Mutation("commit-without-sync", "no-gate", BREAK_SILENT, True, m_commit_without_sync),
+    Mutation("extract-then-split", "extract+split", BREAK_SILENT, True, m_extract_then_split),
+    Mutation("inline-after-rename", "inline", BREAK_SILENT, True, m_inline_after_rename),
+    Mutation(
+        "re-extract-over-edited-companion",
+        "extract",
+        BREAK_SILENT,
+        True,
+        m_re_extract_over_edited_companion,
+    ),
+    # Observe-only — the build-merge primitive reports; the `build` arm is TODO.
+    Mutation("build-merge-unmatched", "build-merge", BREAK_SILENT, False, m_build_merge_unmatched),
+]
+
+# Deferred catalogue entries (design §6) — added once their behaviour is verified
+# so a frozen verdict is never a guess: ``split-code-cell`` (def-my-fun id
+# migration, expected preserve), ``rename-function-while-splitting`` (construct
+# match fails -> defer/recover, expected break-loud), ``edit-heading-then-force``
+# (per-file ``assign-ids --force`` regenerating divergently). Add as their own
+# Mutation rows; the framework above needs no change.
+
+
+def run(filter_path: str | None = None) -> list[Outcome]:
+    """Run the mutation catalogue, classifying each (mutation, path) result."""
+    outcomes: list[Outcome] = []
+    for m in MUTATIONS:
+        if filter_path is not None and m.path != filter_path:
+            continue
+        with _fresh_dir() as d:
+            workdir = Path(d)
+            try:
+                violated, signaled, signal, detail = m.run(workdir)
+                verdict = classify(violated, signaled)
+            except Exception as e:  # harness / engine bug — surfaced, never swallowed
+                verdict, violated, signaled, signal = ERROR, ["exception"], False, ""
+                detail = f"{type(e).__name__}: {e}"
+        outcomes.append(
+            Outcome(
+                name=m.name,
+                path=m.path,
+                verdict=verdict,
+                violated=violated,
+                signaled=signaled,
+                signal=signal,
+                detail=detail,
+                expected=m.expected,
+                asserted=m.asserted,
+            )
+        )
+    return outcomes
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def asserted_drift(outcomes: list[Outcome]) -> list[Outcome]:
+    """Asserted rows whose observed verdict diverged from the frozen baseline."""
+    return [o for o in outcomes if o.asserted and o.drifted]
+
+
+def to_dict(outcomes: list[Outcome]) -> dict:
+    return {
+        "counts": dict(Counter(o.verdict for o in outcomes)),
+        "drift": [o.name for o in asserted_drift(outcomes)],
+        "rows": [
+            {
+                "mutation": o.name,
+                "path": o.path,
+                "verdict": o.verdict,
+                "expected": o.expected,
+                "asserted": o.asserted,
+                "violated": o.violated,
+                "signaled": o.signaled,
+                "signal": o.signal,
+                "detail": o.detail,
+            }
+            for o in outcomes
+        ],
+    }
+
+
+def render(outcomes: list[Outcome]) -> str:
+    counts = Counter(o.verdict for o in outcomes)
+    lines = [
+        "edit-dynamics fault-injection harness",
+        "",
+        f"  preserve={counts.get(PRESERVE, 0)}  break-loud={counts.get(BREAK_LOUD, 0)}  "
+        f"break-silent={counts.get(BREAK_SILENT, 0)}  error={counts.get(ERROR, 0)}",
+        "",
+        f"  {'PATH':<16}{'MUTATION':<34}{'VERDICT':<14}NOTE",
+        f"  {'-' * 14:<16}{'-' * 32:<34}{'-' * 12:<14}{'-' * 30}",
+    ]
+    for o in outcomes:
+        marker = " !!DRIFT" if (o.asserted and o.drifted) else ("  (obs)" if not o.asserted else "")
+        verdict = o.verdict + (f"→{o.expected}" if (o.asserted and o.drifted) else "")
+        lines.append(f"  {o.path:<16}{o.name:<34}{verdict:<14}{o.detail}{marker}")
+
+    work = [o for o in outcomes if o.verdict == BREAK_SILENT]
+    if work:
+        lines += ["", "BREAK-SILENT work-list (footguns to harden):"]
+        for o in work:
+            lines.append(f"  · [{o.path}] {o.name} — {o.detail}")
+
+    drift = asserted_drift(outcomes)
+    if drift:
+        lines += ["", "DRIFT (asserted verdict changed — regression or a fix landed):"]
+        for o in drift:
+            lines.append(f"  ! {o.name}: expected {o.expected}, observed {o.verdict} — {o.detail}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a human table")
+    parser.add_argument("--path", default=None, help="run only mutations on this command path")
+    args = parser.parse_args(argv)
+
+    outcomes = run(filter_path=args.path)
+    if args.json:
+        print(json.dumps(to_dict(outcomes), indent=2))
+    else:
+        print(render(outcomes))
+    # Exit non-zero only on DRIFT of an asserted row: a safe-funnel mutation that
+    # regressed, or a known break that a fix flipped (update the baseline then).
+    return 1 if asserted_drift(outcomes) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -54,6 +54,7 @@ from clm.slides.split import (  # noqa: E402
 from clm.slides.sync_apply import ApplyResult, apply_plan  # noqa: E402
 from clm.slides.sync_plan import SyncPlan, build_sync_plan, watermark_rows  # noqa: E402
 from clm.slides.voiceover_tools import (  # noqa: E402
+    VoiceoverError,
     companion_path,
     extract_voiceover,
     inline_voiceover,
@@ -565,14 +566,18 @@ def m_inline_after_rename(workdir: Path) -> _RetTuple:
     txt = slide.read_text(encoding="utf-8").replace('slide_id="intro"', 'slide_id="introduction"')
     slide.write_text(txt, encoding="utf-8", newline="\n")
     ires = inline_voiceover(slide)
-    destroyed = ires.companion_deleted and not comp.exists() and ires.unmatched_cells > 0
+    # Fixed: the unmatched cell is retained in the companion (recoverable),
+    # not destroyed; the CLI also exits non-zero on unmatched.
+    vo_recoverable = comp.exists() and "Voiceover DE for intro" in comp.read_text(encoding="utf-8")
+    destroyed = ires.unmatched_cells > 0 and not vo_recoverable
+    signaled = ires.companion_retained or ires.unmatched_cells > 0
     return (
         (["companion_destroyed"] if destroyed else []),
-        False,  # exit 0, raises nothing — silent to the user
-        "",
-        f"companion unlinked with unmatched={ires.unmatched_cells}; exit 0, no backup"
-        if destroyed
-        else f"unmatched={ires.unmatched_cells}, companion_deleted={ires.companion_deleted}",
+        signaled,
+        "companion_retained + unmatched>0 (CLI exits non-zero)" if signaled else "",
+        f"companion retained with unmatched={ires.unmatched_cells}, recoverable"
+        if not destroyed
+        else f"companion unlinked with unmatched={ires.unmatched_cells}; data lost",
     )
 
 
@@ -593,15 +598,21 @@ def m_re_extract_over_edited_companion(workdir: Path) -> _RetTuple:
         encoding="utf-8",
         newline="\n",
     )
-    extract_voiceover(slide)
-    lost = "HAND EDITED narration" not in comp.read_text(encoding="utf-8")
+    # Fixed: re-extract refuses without force rather than clobbering the
+    # hand-edited companion.
+    try:
+        extract_voiceover(slide)
+        refused = False
+    except VoiceoverError:
+        refused = True
+    preserved = "HAND EDITED narration" in comp.read_text(encoding="utf-8")
     return (
-        (["companion_clobbered"] if lost else []),
-        False,
-        "",
-        "hand-edited companion content lost on re-extract (no --force/guard)"
-        if lost
-        else "edit preserved",
+        ([] if preserved else ["companion_clobbered"]),
+        refused,
+        "VoiceoverError: refused without --force" if refused else "",
+        "hand-edit preserved (extract refused without --force)"
+        if preserved
+        else "hand-edited companion content clobbered on re-extract",
     )
 
 
@@ -660,11 +671,14 @@ MUTATIONS: list[Mutation] = [
     Mutation("born-split-assign-ids", "assign-ids", BREAK_SILENT, True, m_born_split_assign_ids),
     Mutation("commit-without-sync", "no-gate", BREAK_SILENT, True, m_commit_without_sync),
     Mutation("extract-then-split", "extract+split", BREAK_SILENT, True, m_extract_then_split),
-    Mutation("inline-after-rename", "inline", BREAK_SILENT, True, m_inline_after_rename),
+    # Tier-1 data-loss fixes landed: inline now retains the companion with the
+    # unmatched cell (recoverable) and exits non-zero; extract refuses to clobber
+    # an existing companion without --force. Both flipped break-silent -> preserve.
+    Mutation("inline-after-rename", "inline", PRESERVE, True, m_inline_after_rename),
     Mutation(
         "re-extract-over-edited-companion",
         "extract",
-        BREAK_SILENT,
+        PRESERVE,
         True,
         m_re_extract_over_edited_companion,
     ),

--- a/src/clm/cli/commands/split.py
+++ b/src/clm/cli/commands/split.py
@@ -52,6 +52,13 @@ def split_cmd(source: Path, force: bool, report_only: bool, as_json: bool) -> No
     'macros.j2' import header`` import line is rewritten in parallel.
     Shared cells (no ``lang`` attribute) are copied verbatim to both
     outputs.
+
+    \b
+    If SOURCE has a sibling voiceover companion (``voiceover_<name>.py``),
+    it is split in lockstep into ``voiceover_<name>.de.py`` /
+    ``voiceover_<name>.en.py`` so the narration is never orphaned;
+    ``for_slide`` / ``vo_anchor`` are preserved. ``--force`` also covers
+    overwriting existing companion halves.
     """
     try:
         result = split_in_file(source, force=force, dry_run=report_only)
@@ -71,7 +78,10 @@ def split_cmd(source: Path, force: bool, report_only: bool, as_json: bool) -> No
 def _print_human(result: SplitResult, *, report_only: bool) -> None:
     prefix = "[report-only] " if report_only else ""
     verb = "would write" if report_only else "wrote"
-    for path in (result.de_path, result.en_path):
+    paths = [result.de_path, result.en_path]
+    if result.de_companion and result.en_companion:
+        paths += [result.de_companion, result.en_companion]
+    for path in paths:
         note = " (overwrote)" if path in result.overwrote else ""
         click.echo(f"{prefix}{verb} {path}{note}")
 
@@ -83,5 +93,8 @@ def _to_dict(result: SplitResult, *, report_only: bool) -> dict[str, object]:
         "en_path": result.en_path,
         "wrote": result.wrote,
         "overwrote": result.overwrote,
+        "source_companion": result.source_companion,
+        "de_companion": result.de_companion,
+        "en_companion": result.en_companion,
         "report_only": report_only,
     }

--- a/src/clm/cli/commands/unify.py
+++ b/src/clm/cli/commands/unify.py
@@ -66,6 +66,13 @@ def unify_cmd(
     the DE file without syncing to EN, or vice versa), unify refuses to
     write — Phase 6's validator extension will surface the same check at
     build time.
+
+    \b
+    If the pair has sibling voiceover companions
+    (``voiceover_<name>.de.py`` / ``voiceover_<name>.en.py``), they are
+    recombined in lockstep into ``voiceover_<name>.py`` — the inverse of
+    ``split``'s companion split. ``--force`` also covers overwriting an
+    existing companion target.
     """
     try:
         result = unify_in_file(
@@ -93,6 +100,9 @@ def _print_human(result: UnifyResult, *, report_only: bool) -> None:
     verb = "would write" if report_only else "wrote"
     note = " (overwrote)" if result.overwrote else ""
     click.echo(f"{prefix}{verb} {result.target}{note}")
+    if result.target_companion:
+        cnote = " (overwrote)" if result.companion_overwrote else ""
+        click.echo(f"{prefix}{verb} {result.target_companion}{cnote}")
 
 
 def _to_dict(result: UnifyResult, *, report_only: bool) -> dict[str, object]:
@@ -102,5 +112,7 @@ def _to_dict(result: UnifyResult, *, report_only: bool) -> dict[str, object]:
         "target": result.target,
         "wrote": result.wrote,
         "overwrote": result.overwrote,
+        "target_companion": result.target_companion,
+        "companion_overwrote": result.companion_overwrote,
         "report_only": report_only,
     }

--- a/src/clm/cli/commands/voiceover_tools.py
+++ b/src/clm/cli/commands/voiceover_tools.py
@@ -10,6 +10,7 @@ import click
 from clm.slides.voiceover_tools import (
     ExtractionResult,
     InlineResult,
+    VoiceoverError,
     companion_path,
     extract_voiceover,
     inline_voiceover,
@@ -20,6 +21,13 @@ from clm.slides.voiceover_tools import (
 @click.argument(
     "path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite an existing companion file. The companion is rebuilt from "
+    "the slide's current voiceover cells, discarding any content present only "
+    "in the companion; without --force an existing companion is left untouched.",
 )
 @click.option(
     "--dry-run",
@@ -34,6 +42,7 @@ from clm.slides.voiceover_tools import (
 )
 def extract_voiceover_cmd(
     path: Path,
+    force: bool,
     dry_run: bool,
     as_json: bool,
 ):
@@ -41,15 +50,20 @@ def extract_voiceover_cmd(
 
     Moves voiceover and notes cells to a companion voiceover_*.py file,
     linked via slide_id/for_slide metadata.  Content cells without
-    slide_id get auto-generated IDs before extraction.
+    slide_id get auto-generated IDs before extraction.  Refuses to
+    overwrite an existing companion unless --force is given.
 
     \b
     Examples:
         clm voiceover extract slides/topic/slides_intro.py --dry-run
         clm voiceover extract slides/topic/slides_intro.py
+        clm voiceover extract slides/topic/slides_intro.py --force
         clm voiceover extract slides/topic/slides_intro.py --json
     """
-    result = extract_voiceover(path, dry_run=dry_run)
+    try:
+        result = extract_voiceover(path, force=force, dry_run=dry_run)
+    except VoiceoverError as e:
+        raise click.ClickException(str(e)) from e
 
     if as_json:
         click.echo(json.dumps(_extraction_to_dict(result), indent=2))
@@ -82,7 +96,9 @@ def inline_voiceover_cmd(
 
     Merges voiceover cells from the companion voiceover_*.py file back
     into the slide file, matching via for_slide/slide_id metadata.
-    Deletes the companion file after successful inlining.
+    Deletes the companion only when every cell is placed; if any cell is
+    unmatched (e.g. its owning slide_id was renamed) the companion is kept
+    with the leftovers and the command exits non-zero.
 
     \b
     Examples:
@@ -107,12 +123,22 @@ def inline_voiceover_cmd(
             for p in result.placements:
                 if p.status == "unmatched":
                     click.echo(
-                        f"  ? {p.for_slide or '<no for_slide>'}: no matching slide — appended at end"
+                        f"  ? {p.for_slide or '<no for_slide>'}: no matching slide — kept in companion"
                     )
                 else:
                     where = f"after line {p.after_line}" if p.after_line else "at end"
                     marker = "!" if p.status == "relocated" else "+"
                     click.echo(f"  {marker} {p.for_slide}: {p.status} {where}")
+
+    # Unmatched cells are a partial failure: the companion was preserved with
+    # them (no data loss), but the author must act. Exit non-zero so a script
+    # or pre-commit hook notices instead of treating it as a clean inline.
+    if not dry_run and result.unmatched_cells:
+        raise click.ClickException(
+            f"{result.unmatched_cells} voiceover cell(s) had no matching slide; "
+            f"companion '{comp.name}' was kept with them. "
+            f"Fix the slide_id(s) and re-run inline."
+        )
 
 
 def _extraction_to_dict(result: ExtractionResult) -> dict:
@@ -134,6 +160,7 @@ def _inline_to_dict(result: InlineResult) -> dict:
         "unmatched_cells": result.unmatched_cells,
         "relocated_cells": result.relocated_cells,
         "companion_deleted": result.companion_deleted,
+        "companion_retained": result.companion_retained,
         "dry_run": result.dry_run,
         "summary": result.summary,
         "placements": [

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -646,6 +646,17 @@ Special cases:
 - An id prefixed with `!` (e.g. `slide_id="!intro"`) is the
   **preserve marker** — never regenerated, even under `--force`. The
   `!` is source-level only; references elsewhere use the bare form.
+- **Split-file twin awareness (since CLM {version}, issue #162).** On a
+  split half (`*.de.py` / `*.en.py`) whose twin exists on disk and has the
+  same number of slide/subslide cells, an **id-less** slide adopts the
+  twin's `slide_id` for the positionally-corresponding slide instead of
+  minting a divergent slug from its own heading — so the two halves stay in
+  `slide_id` parity (the cross-language join key). When both halves are
+  id-less, run order decides which language's slug wins, but parity holds;
+  for true EN-authoritative ids, route structural changes through
+  `clm slides sync`. When the halves have different slide counts the reuse
+  is skipped (positional correspondence is unreliable) and the divergence is
+  left for `clm validate`'s #162 detective to flag.
 
 ```
 clm slides assign-ids [OPTIONS] PATH

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -964,6 +964,17 @@ escalating to error in CLM 1.7) — `unify` pairs adjacent DE/EN cells
 by matching id. Currently Python-only: the slide parser recognises
 only `# %%` cell boundaries; non-Python prog_langs are deferred.
 
+**Voiceover companion.** If SOURCE has a sibling voiceover companion
+(`slides_<name>.py` → `voiceover_<name>.py`), `split` splits it in
+lockstep into `voiceover_<name>.de.py` / `voiceover_<name>.en.py`,
+routing each narration cell by its `lang` and preserving `for_slide` /
+`vo_anchor` verbatim. Without this the companion would be orphaned — the
+build would find no companion next to either split half. `--force`
+covers overwriting existing companion halves, and the refusal is atomic
+(if any deck or companion target exists without `--force`, nothing is
+written). Splitting a deck that has no companion creates no
+`voiceover_*` files.
+
 ### `clm slides unify`
 
 The inverse of `clm slides split`. Combine `<basename>.de.py` and
@@ -997,6 +1008,12 @@ diverges …`. The same divergence is surfaced by
 `clm validate <topic_dir>` and refused at build time — see
 "Split-source build routing" under `clm build` above for the
 build-time gate.
+
+**Voiceover companion.** If the pair has sibling voiceover companions
+(`voiceover_<name>.de.py` / `voiceover_<name>.en.py`), `unify` recombines
+them in lockstep into `voiceover_<name>.py` (next to the bilingual
+target) — the inverse of `split`'s companion split, byte-identical.
+`--force` also covers overwriting an existing companion target.
 
 ### `clm slides language-view`
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -646,17 +646,22 @@ Special cases:
 - An id prefixed with `!` (e.g. `slide_id="!intro"`) is the
   **preserve marker** — never regenerated, even under `--force`. The
   `!` is source-level only; references elsewhere use the bare form.
-- **Split-file twin awareness (since CLM {version}, issue #162).** On a
-  split half (`*.de.py` / `*.en.py`) whose twin exists on disk and has the
-  same number of slide/subslide cells, an **id-less** slide adopts the
-  twin's `slide_id` for the positionally-corresponding slide instead of
-  minting a divergent slug from its own heading — so the two halves stay in
-  `slide_id` parity (the cross-language join key). When both halves are
-  id-less, run order decides which language's slug wins, but parity holds;
-  for true EN-authoritative ids, route structural changes through
-  `clm slides sync`. When the halves have different slide counts the reuse
-  is skipped (positional correspondence is unreliable) and the divergence is
-  left for `clm validate`'s #162 detective to flag.
+- **Split-file id consistency (since CLM {version}, issue #162).** `slide_id`
+  is the cross-language join key, so the two halves of a split deck must agree
+  on it. assign-ids keeps that automatically, two ways:
+  - **Directory / course run** (`clm slides assign-ids slides/`) — a
+    `*.de.py` / `*.en.py` pair is minted **EN-authority** across *both*
+    halves at once: the slug derives from the EN heading and the same id is
+    stamped on both, deterministic regardless of file order (the same policy
+    as a bilingual file). A pair that is not byte-faithfully unifiable
+    (divergent shared cells) falls back to the per-file path below.
+  - **Single-file run** (`clm slides assign-ids slides_x.de.py`) — when the
+    twin exists on disk with a matching slide count, an **id-less** slide
+    adopts the twin's `slide_id` for the positionally-corresponding slide
+    instead of minting a divergent slug. When both halves are id-less the
+    first-assigned half's slug wins (parity still holds; for EN-authority use
+    the directory run or `clm slides sync`). Mismatched slide counts skip the
+    reuse and leave the divergence for `clm validate`'s #162 detective.
 
 ```
 clm slides assign-ids [OPTIONS] PATH

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -539,6 +539,7 @@ adjacency, and — since CLM {version} — **`slide_id` metadata**:
 | duplicate `slide_id` across slide groups | `error` | Group-aware: paired DE/EN cells sharing the EN-derived slug are not a duplicate. Bare-form comparison so `!intro` and `intro` collide. |
 | voiceover/notes `slide_id` ≠ preceding `slide`/`subslide` anchor | `error` | Walk-back skips j2, code, shared (lang-less), and cross-language narrative cells. The j2 `header()` macro anchors `slide_id="title"` for narrative cells that follow it. |
 | paired DE/EN slides carry mismatched bare `slide_id`s | `warning` | Suggested fix: `clm slides assign-ids --force`. |
+| split pair `.de.py` / `.en.py` carry a different `slide_id` set or order | `warning` | **Cross-file** (issue #162): `slide_id` is the cross-language join key for voiceover `for_slide`, `clm slides unify`, and extract/inline. Route structural changes through `clm slides sync`; avoid per-file `clm slides assign-ids` on a split half. Runs on a directory/course validate, and on a single-file validate when the twin exists on disk. |
 | `slide_id` is not a valid kebab-case ASCII slug (≤30 chars) | `warning` | The leading `!` preserve marker is permitted and does not count toward the length cap. |
 
 Since CLM {version}, the **bilingual** `pairing` sub-checks (DE/EN cell
@@ -549,8 +550,12 @@ checks would otherwise report a false `DE/EN cell count mismatch` on every
 converted deck (issue #160). The per-file `slide_id` integrity checks (and
 the `format` / `tags` groups) still run on split files unchanged, and the
 cross-file shared-cell parity diff between a `.de.py` / `.en.py` pair is
-still applied when validating a directory or course spec. Bilingual decks
-(no `.de` / `.en` suffix) are unaffected — the full pairing check still runs.
+still applied when validating a directory or course spec. Since CLM
+{version} the cross-file **`slide_id` parity** check (issue #162) is applied
+the same way — and additionally on a single-file validate when the twin
+exists on disk, so the pre-commit gate and the PostToolUse path catch a
+divergent join key. Bilingual decks (no `.de` / `.en` suffix) are
+unaffected — the full pairing check still runs.
 
 Since CLM {version}, the `tags` check group also verifies **workshop
 scope** (issue #78). The `partial` output kind leaves a workshop's code

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1042,12 +1042,20 @@ slide group. It is body-only and occurrence-qualified, so editing a
 sibling cell's tags, inserting unrelated slides, or the build's blank-line
 cleanup between extract and inline does not move the voiceover.
 
+Since CLM {version}, extract **refuses to overwrite an existing companion**
+unless `--force` is given (it raises rather than writing, leaving both files
+untouched). The companion is *rebuilt* from the slide's current voiceover
+cells, so a blind overwrite would discard anything that lives only in the
+companion (hand-edits, or cells whose owning slide was removed). This
+mirrors `clm slides split`'s `--force` contract.
+
 ```
 clm voiceover extract [OPTIONS] FILE
 ```
 
 | Option | Description |
 |--------|-------------|
+| `--force` | Overwrite an existing companion (rebuilds it from the slide's voiceover cells, discarding companion-only content). Without it, an existing companion is left untouched and the command errors. |
 | `--dry-run` | Preview changes without modifying files |
 | `--json` | Output as JSON |
 
@@ -1056,6 +1064,7 @@ Examples:
 ```bash
 clm voiceover extract slides_intro.py
 clm voiceover extract slides_intro.py --dry-run
+clm voiceover extract slides_intro.py --force
 ```
 
 ### `clm voiceover inline`
@@ -1063,23 +1072,32 @@ clm voiceover extract slides_intro.py --dry-run
 *Deprecated alias: `clm inline-voiceover` (removed in 1.7).*
 
 Inline voiceover cells from a companion `voiceover_*.py` file back into the
-slide file, deletes the companion file after successful inlining.
+slide file. The companion is deleted **only when every cell is placed**.
 
 Since CLM {version}, each voiceover is re-inserted immediately after the
 predecessor cell recorded in its `vo_anchor` (resolved within the owning
 slide group only — it never crosses into another slide). If that anchor
 cell was edited away or removed, inline falls back to the end of the
 `for_slide` group and counts the cell as **relocated**; if the owning slide
-is gone entirely, the cell is **unmatched** and appended at the end. Both
-cases are reported rather than silently misplaced:
+is gone entirely (e.g. its `slide_id` was renamed), the cell is
+**unmatched**. Both cases are reported rather than silently misplaced:
 
+- **Unmatched cells are no longer dumped at the end of the slide.** Since
+  CLM {version}, when any cell is unmatched the companion is **kept**,
+  rewritten to hold exactly the unmatched remainder (with `for_slide` /
+  `vo_anchor` intact), and the command **exits non-zero** — so a clean,
+  recoverable source of truth always survives. Fix the slide `slide_id`(s)
+  and re-run inline to place the rest. (Previously the companion was
+  deleted unconditionally and the leftovers stranded at EOF — a data-loss
+  footgun.)
 - The text summary appends `N cell(s) relocated …` / `N cell(s) could not
-  be matched …`.
+  be matched …` / `companion … retained …`.
 - `--dry-run` prints a per-cell placement line — `+` anchored, `!`
   relocated, `?` unmatched — with the target line, so you can confirm
   placement before writing.
-- `--json` adds `relocated_cells` and a `placements` array (each entry:
-  `for_slide`, `anchor`, `status`, `after_line`, `after_header`).
+- `--json` adds `relocated_cells`, `companion_retained`, and a `placements`
+  array (each entry: `for_slide`, `anchor`, `status`, `after_line`,
+  `after_header`).
 
 ```
 clm voiceover inline [OPTIONS] FILE
@@ -1088,7 +1106,7 @@ clm voiceover inline [OPTIONS] FILE
 | Option | Description |
 |--------|-------------|
 | `--dry-run` | Preview changes (incl. per-cell placement report) without modifying files |
-| `--json` | Output as JSON (incl. `relocated_cells` and `placements`) |
+| `--json` | Output as JSON (incl. `relocated_cells`, `companion_retained`, `placements`) |
 
 Examples:
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -80,10 +80,13 @@ directory/course validate **and** on a single-file validate when the twin
 exists on disk — so a pre-commit hook (`clm validate slides/ --fail-on warning`,
 or per-file in a PostToolUse hook) catches a divergence before it ships.
 
-*Recommended:* route structural changes through `clm slides sync` (which
-mints/migrates ids onto both halves consistently) rather than per-file
-`assign-ids`. A twin-aware `assign-ids` that refuses to mint a divergent id is
-the planned follow-up (the #162 defensive).
+Since CLM {version} `clm slides assign-ids` is also **twin-aware** on a split
+half (the #162 *defensive*): an id-less slide adopts the sibling file's
+`slide_id` for the positionally-corresponding slide instead of minting a
+divergent slug, when the twin exists on disk with a matching slide count. This
+keeps per-file `assign-ids` from silently diverging the halves; when both are
+id-less the first-assigned half's slug wins (parity still holds). For
+EN-authoritative ids across a born-split deck, prefer `clm slides sync`.
 
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -65,6 +65,27 @@ relied on the old behavior may need a flag or an exit-code check.
 These are also surfaced by the new fast-suite `tests/slides/test_edit_dynamics.py`
 cross-command harness (`scripts/edit_dynamics_harness.py`).
 
+## `slides split` / `unify` carry the voiceover companion ({version})
+
+Previously `clm slides split` only split the deck — a sibling voiceover
+companion (`slides_<name>.py` → `voiceover_<name>.py`) was left behind,
+orphaned: the build then found no companion next to either
+`slides_<name>.de.py` or `slides_<name>.en.py`, silently dropping the
+narration. CLM {version} splits the companion in lockstep into
+`voiceover_<name>.de.py` / `voiceover_<name>.en.py` (routing each cell by its
+`lang`, preserving `for_slide` / `vo_anchor`), and `clm slides unify`
+recombines them into `voiceover_<name>.py`. The companion round trip is
+byte-identical, the same trust property the deck split already guarantees;
+it relies on the #162 `de_id == en_id` invariant so each narration cell's
+owning slide exists in its language's half.
+
+*Migration:* none required — the behavior is additive and only fires when a
+companion is present. The `split`/`unify` `--force` flag now also covers the
+companion targets, and the refusal is atomic (no file is written if any deck
+*or* companion target exists without `--force`). `--json` output gains
+`source_companion` / `de_companion` / `en_companion` (split) and
+`target_companion` / `companion_overwrote` (unify).
+
 ## Cross-file `slide_id` parity detective for split decks ({version}, issue #162)
 
 `slide_id` is the cross-language join key for a split deck: voiceover

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -39,6 +39,32 @@ Voiceover and notes cells inherit the id of the preceding slide
 `clm info commands` → `clm slides assign-ids` for the full flag
 matrix.
 
+## Voiceover extract/inline: data-loss hardening ({version})
+
+CLM {version} closes two ways `clm voiceover extract` / `inline` could lose
+authored narration. Both are safe-by-default behavior changes; scripts that
+relied on the old behavior may need a flag or an exit-code check.
+
+- **`inline` no longer destroys the companion when a cell is unmatched.**
+  Previously, if a voiceover's owning `slide_id` had been renamed (so its
+  `for_slide` no longer matched), inline stranded that cell at the end of the
+  slide file (stripped of `for_slide`/`vo_anchor`) and **deleted the companion
+  anyway**, exit 0. Now inline places only the cells it can match, **keeps the
+  companion** rewritten to the unmatched remainder (anchors intact), and
+  **exits non-zero**. Recover by fixing the `slide_id`(s) and re-running
+  inline. *Migration:* a script that treated inline as "always consumes the
+  companion" must handle the non-zero exit / surviving companion; check
+  `companion_retained` / `unmatched_cells` in `--json`.
+
+- **`extract` refuses to overwrite an existing companion without `--force`.**
+  The companion is rebuilt from the slide's current voiceover cells, so a blind
+  re-extract discarded anything living only in the companion. Extract now
+  raises (writing nothing) unless `--force` is passed. *Migration:* add
+  `--force` to any pipeline that intentionally rebuilds the companion.
+
+These are also surfaced by the new fast-suite `tests/slides/test_edit_dynamics.py`
+cross-command harness (`scripts/edit_dynamics_harness.py`).
+
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 
 CLM {version} also ships **Phase 3** of the slide-format-redesign:

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -65,6 +65,26 @@ relied on the old behavior may need a flag or an exit-code check.
 These are also surfaced by the new fast-suite `tests/slides/test_edit_dynamics.py`
 cross-command harness (`scripts/edit_dynamics_harness.py`).
 
+## Cross-file `slide_id` parity detective for split decks ({version}, issue #162)
+
+`slide_id` is the cross-language join key for a split deck: voiceover
+`for_slide` resolution, `clm slides unify` (which requires `de_id == en_id`),
+and `extract`/`inline` all assume the `.de.py` and `.en.py` halves agree on the
+**set and order** of slide ids. A born-split deck, a per-file
+`clm slides assign-ids` run on one half, or a hand-edited id silently diverges
+them.
+
+CLM {version} adds a `clm validate` **`pairing`** check (warning) that flags a
+divergent `slide_id` set or order between a split pair. It runs on a
+directory/course validate **and** on a single-file validate when the twin
+exists on disk — so a pre-commit hook (`clm validate slides/ --fail-on warning`,
+or per-file in a PostToolUse hook) catches a divergence before it ships.
+
+*Recommended:* route structural changes through `clm slides sync` (which
+mints/migrates ids onto both halves consistently) rather than per-file
+`assign-ids`. A twin-aware `assign-ids` that refuses to mint a divergent id is
+the planned follow-up (the #162 defensive).
+
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 
 CLM {version} also ships **Phase 3** of the slide-format-redesign:

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -80,13 +80,17 @@ directory/course validate **and** on a single-file validate when the twin
 exists on disk — so a pre-commit hook (`clm validate slides/ --fail-on warning`,
 or per-file in a PostToolUse hook) catches a divergence before it ships.
 
-Since CLM {version} `clm slides assign-ids` is also **twin-aware** on a split
-half (the #162 *defensive*): an id-less slide adopts the sibling file's
-`slide_id` for the positionally-corresponding slide instead of minting a
-divergent slug, when the twin exists on disk with a matching slide count. This
-keeps per-file `assign-ids` from silently diverging the halves; when both are
-id-less the first-assigned half's slug wins (parity still holds). For
-EN-authoritative ids across a born-split deck, prefer `clm slides sync`.
+Since CLM {version} `clm slides assign-ids` keeps the two halves consistent
+automatically. A **directory / course run** mints **EN-authority** ids across a
+`.de.py` / `.en.py` pair at once (the #162 *generative*): the slug derives from
+the EN heading and the same id is stamped on both, deterministic regardless of
+file order. A **single-file run** is **twin-aware** (the #162 *defensive*): an
+id-less slide adopts the sibling's `slide_id` when the twin exists on disk with
+a matching slide count; when both halves are id-less the first-assigned half's
+slug wins (parity still holds — use the directory run or `clm slides sync` for
+EN-authority). A pair that is not byte-faithfully unifiable (divergent shared
+cells) falls back to the per-file path, and `clm validate`'s #162 detective
+flags any residual divergence.
 
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -88,6 +88,16 @@ SKIP_OUTPUT_FILE_PATTERNS = [
     re.compile(r".*\.http-cassette\.yaml$"),
     re.compile(r".*\.http-cassette\.yaml\.staging-.*$"),
     re.compile(r".*\.http-cassette\.yaml\.staging-.*\.completed$"),
+    # Separated-voiceover companions: ``voiceover_<stem>.py`` and its split
+    # ``.de.py`` / ``.en.py`` forms (see ``slides.voiceover_tools.companion_path``).
+    # Unlike cassettes these are NOT invisible everywhere — they stay available
+    # as *source*: the build merges their narration into the slide notebook at
+    # payload time (``ProcessNotebookOperation.payload`` reads the companion
+    # directly from source). They must only be kept out of (a) public/speaker
+    # OUTPUT and (b) the kernel ``other_files`` payload (the raw author file is
+    # never read at runtime). ``is_ignored_file_for_output`` governs exactly
+    # those two; source mounts do not consult it, so workers still see it.
+    re.compile(r"voiceover_.*\.py$"),
 ]
 
 # Parallel glob form of ``SKIP_OUTPUT_FILE_PATTERNS`` for consumers that
@@ -97,6 +107,7 @@ SKIP_OUTPUT_FILE_GLOBS = [
     "*.http-cassette.yaml",
     "*.http-cassette.yaml.staging-*",
     "*.http-cassette.yaml.staging-*.completed",
+    "voiceover_*.py",  # separated-voiceover companions — output-suppressed (see above)
 ]
 
 PLANTUML_EXTENSIONS = frozenset({".pu", ".puml", ".plantuml"})

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -247,6 +247,7 @@ def create_server(data_dir: Path) -> FastMCP:
     @mcp.tool()
     async def extract_voiceover(
         file: str,
+        force: bool = False,
         dry_run: bool = False,
     ) -> str:
         """Extract voiceover cells from a slide file to a companion file.
@@ -254,13 +255,17 @@ def create_server(data_dir: Path) -> FastMCP:
         Moves voiceover and notes cells to a companion voiceover_*.py
         file, linked via slide_id/for_slide metadata.  Content cells
         without slide_id get auto-generated IDs before extraction.
+        Refuses to overwrite an existing companion unless force is set
+        (returns an ``{"error": ...}`` object in that case).
 
         Args:
             file: Path to the slide file (absolute, or relative to the
                 data directory).
+            force: Overwrite an existing companion (rebuilds it from the
+                slide's voiceover cells, discarding companion-only content).
             dry_run: If True, preview without writing files.
         """
-        return await handle_extract_voiceover(file, data_dir, dry_run=dry_run)
+        return await handle_extract_voiceover(file, data_dir, force=force, dry_run=dry_run)
 
     @mcp.tool()
     async def inline_voiceover(
@@ -271,7 +276,9 @@ def create_server(data_dir: Path) -> FastMCP:
 
         Merges voiceover cells from the companion voiceover_*.py file
         back into the slide file, matching via for_slide/slide_id
-        metadata.  Deletes the companion file after successful inlining.
+        metadata.  Deletes the companion only when every cell is placed;
+        if any cell is unmatched the companion is kept with the leftovers
+        (see ``companion_retained`` / ``unmatched_cells`` in the result).
 
         Args:
             file: Path to the slide file (absolute, or relative to the

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -36,7 +36,7 @@ from clm.slides.validator import ValidationResult
 from clm.slides.validator import validate_course as _validate_course
 from clm.slides.validator import validate_directory as _validate_directory
 from clm.slides.validator import validate_file as _validate_file
-from clm.slides.voiceover_tools import ExtractionResult, InlineResult
+from clm.slides.voiceover_tools import ExtractionResult, InlineResult, VoiceoverError
 from clm.slides.voiceover_tools import extract_voiceover as _extract_voiceover
 from clm.slides.voiceover_tools import inline_voiceover as _inline_voiceover
 
@@ -604,6 +604,7 @@ async def handle_extract_voiceover(
     file: str,
     data_dir: Path,
     *,
+    force: bool = False,
     dry_run: bool = False,
 ) -> str:
     """Extract voiceover cells from a slide file to a companion file.
@@ -611,16 +612,22 @@ async def handle_extract_voiceover(
     Args:
         file: Path to the slide file (absolute or relative to data_dir).
         data_dir: Root data directory.
+        force: Overwrite an existing companion file (rebuilds it from the
+            slide's voiceover cells, discarding companion-only content).
         dry_run: If ``True``, preview without writing files.
 
     Returns:
-        JSON string with extraction results.
+        JSON string with extraction results, or a ``{"error": ...}`` object
+        when an existing companion would be clobbered without ``force``.
     """
     target = Path(file)
     if not target.is_absolute():
         target = data_dir / target
 
-    result = _extract_voiceover(target, dry_run=dry_run)
+    try:
+        result = _extract_voiceover(target, force=force, dry_run=dry_run)
+    except VoiceoverError as e:
+        return json.dumps({"error": str(e)}, indent=2)
     return json.dumps(_extraction_result_to_dict(result), indent=2)
 
 
@@ -638,6 +645,7 @@ def _inline_result_to_dict(result: InlineResult) -> dict:
         "unmatched_cells": result.unmatched_cells,
         "relocated_cells": result.relocated_cells,
         "companion_deleted": result.companion_deleted,
+        "companion_retained": result.companion_retained,
         "dry_run": result.dry_run,
         "summary": result.summary,
     }

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from clm.infrastructure.utils.path_utils import split_lang_suffix
 from clm.notebooks.slide_parser import parse_cell_header
 from clm.slides.code_cell_extract import extract_from_code
 from clm.slides.headingless import (
@@ -242,6 +243,8 @@ def assign_ids_for_cells(
     cells: list[_Cell],
     file_path: Path,
     options: AssignOptions,
+    *,
+    twin_ids: list[str | None] | None = None,
 ) -> AssignResult:
     """Apply the assign-ids policy to an existing cell list.
 
@@ -253,6 +256,14 @@ def assign_ids_for_cells(
     disk. This is the seam :mod:`clm.slides.normalizer` uses to fold
     assign-ids into a larger multi-operation pass without re-parsing the
     file.
+
+    ``twin_ids`` (the #162 defensive) is the positional list of bare
+    slide_ids of the *sibling* split half's slide/subslide cells (``None``
+    where the twin has no id). When supplied, an **id-less** slide on this
+    half adopts ``twin_ids[n]`` for the n-th slide instead of minting a
+    divergent slug from its own heading — keeping ``de_id == en_id`` across
+    a split pair. ``assign_ids_in_file`` supplies it only when a twin exists
+    on disk and the two halves have matching slide counts.
     """
     result = AssignResult()
 
@@ -287,6 +298,7 @@ def assign_ids_for_cells(
     # slide/subslide.
     current_slide_id: str | None = None
     file_str = str(file_path)
+    slide_seen = 0  # index among slide/subslide cells (for twin_ids correspondence)
 
     for idx, cell in enumerate(cells):
         role = _classify_for_assignment(cell)
@@ -298,6 +310,32 @@ def assign_ids_for_cells(
             continue
 
         if role == "slide":
+            twin_id = (
+                twin_ids[slide_seen]
+                if twin_ids is not None and slide_seen < len(twin_ids)
+                else None
+            )
+            slide_seen += 1
+            # Defensive (#162): on a split half, an id-less slide adopts the
+            # twin's id for the positionally-corresponding slide rather than
+            # minting a divergent slug from this half's heading. Only id-less
+            # cells are touched — existing ids keep their preserve/--force
+            # semantics below.
+            if twin_id is not None and not cell.metadata.slide_id:
+                if not options.report_only:
+                    _write_slide_id(cell, twin_id)
+                used_ids.add(twin_id)
+                result.assignments.append(
+                    AssignedId(
+                        file=file_str,
+                        line=cell.line_number,
+                        slide_id=twin_id,
+                        source="twin",
+                    )
+                )
+                current_slide_id = twin_id
+                continue
+
             slug_source_idx = pairs.get(idx, idx)
             slug_source = cells[slug_source_idx]
             alt_idx = alternate_of.get(slug_source_idx)
@@ -336,6 +374,8 @@ def assign_ids_for_text(
     text: str,
     file_path: Path,
     options: AssignOptions,
+    *,
+    twin_ids: list[str | None] | None = None,
 ) -> tuple[str, AssignResult]:
     """Apply the assign-ids policy to one file's text.
 
@@ -343,9 +383,12 @@ def assign_ids_for_text(
     written (refusals only, or no changes needed). In ``--report-only``
     mode the new text always equals the input but the result still lists
     *proposed* assignments and refusals.
+
+    ``twin_ids`` is forwarded to :func:`assign_ids_for_cells` (the #162
+    defensive split-half id reuse — see its docstring).
     """
     preamble, cells = _split_cells(text)
-    result = assign_ids_for_cells(cells, file_path, options)
+    result = assign_ids_for_cells(cells, file_path, options, twin_ids=twin_ids)
     result.files_visited = 1
 
     new_text = text
@@ -727,10 +770,62 @@ def _handle_narrative(
 # ---------------------------------------------------------------------------
 
 
+def _split_twin(path: Path) -> Path | None:
+    """The sibling split half (``.de.py`` <-> ``.en.py``) if it exists on disk."""
+    suffix = split_lang_suffix(path)
+    if suffix is None:
+        return None
+    other = "en" if suffix == "de" else "de"
+    parts = path.name.split(".")
+    # split_lang_suffix guarantees the form ``<stem>.<de|en>.<ext>``.
+    parts[-2] = other
+    twin = path.with_name(".".join(parts))
+    return twin if twin.exists() else None
+
+
+def _slide_start_ids(cells: list[_Cell]) -> list[str | None]:
+    """Ordered bare slide_ids of slide/subslide cells (``None`` where absent)."""
+    out: list[str | None] = []
+    for cell in cells:
+        if _classify_for_assignment(cell) == "slide":
+            sid = cell.metadata.slide_id
+            out.append(strip_preserve_marker(sid) if sid else None)
+    return out
+
+
+def _twin_ids_for(path: Path, text: str) -> list[str | None] | None:
+    """Positional twin slide_ids to reuse (#162 defensive), or ``None``.
+
+    Reuse applies only when the twin exists *and* both halves have the same
+    number of slide/subslide cells. When the counts differ the halves are
+    structurally misaligned and positional reuse could stamp the wrong id —
+    so we mint normally and let the validator's #162 detective flag the
+    divergence instead.
+    """
+    twin = _split_twin(path)
+    if twin is None:
+        return None
+    _, own_cells = _split_cells(text)
+    own_ids = _slide_start_ids(own_cells)
+    _, twin_cells = _split_cells(twin.read_text(encoding="utf-8"))
+    twin_ids = _slide_start_ids(twin_cells)
+    if len(twin_ids) != len(own_ids):
+        return None
+    return twin_ids
+
+
 def assign_ids_in_file(path: Path, options: AssignOptions) -> AssignResult:
-    """Process one ``.py`` slide file end-to-end."""
+    """Process one ``.py`` slide file end-to-end.
+
+    On a split half (``*.de.py`` / ``*.en.py``) whose twin exists on disk and
+    has the same number of slide/subslide cells, an id-less slide adopts the
+    twin's id for the corresponding slide instead of minting a divergent slug
+    (#162 defensive). Run order decides which half's slug wins when *both* are
+    id-less, but the two halves always end up in slide_id parity.
+    """
     text = path.read_text(encoding="utf-8")
-    new_text, result = assign_ids_for_text(text, path, options)
+    twin_ids = _twin_ids_for(path, text)
+    new_text, result = assign_ids_for_text(text, path, options, twin_ids=twin_ids)
     if not options.report_only and new_text != text:
         path.write_text(new_text, encoding="utf-8", newline="\n")
     return result

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -74,6 +74,7 @@ __all__ = [
     "assign_ids_for_text",
     "assign_ids_in_directory",
     "assign_ids_in_file",
+    "assign_ids_in_split_pair",
 ]
 
 
@@ -831,15 +832,105 @@ def assign_ids_in_file(path: Path, options: AssignOptions) -> AssignResult:
     return result
 
 
+def assign_ids_in_split_pair(
+    de_path: Path, en_path: Path, options: AssignOptions
+) -> AssignResult | None:
+    """Generative #162: mint **EN-authority** slide_ids onto *both* halves of a
+    split pair at once.
+
+    Reconstructs the bilingual deck (``unify``), runs the normal paired
+    assign-ids over it — which already derives each slide's slug from its EN
+    cell and stamps the *same* id onto the DE/EN twin — then routes the ids back
+    onto the two halves (``split``). Unlike the per-file defensive (which
+    preserves parity but lets the first-assigned half's slug win), this is
+    deterministic EN-authority regardless of order, matching how ids are minted
+    in a bilingual file.
+
+    Returns ``None`` when the pair is not unifiable (structurally misaligned or
+    divergent shared cells) so the caller can fall back to the per-file
+    defensive path; the validator's #162 detective then surfaces any residual
+    divergence.
+    """
+    from clm.slides.split import SplitError, UnifyError, split_text, unify_texts
+
+    de_text = de_path.read_text(encoding="utf-8")
+    en_text = en_path.read_text(encoding="utf-8")
+    try:
+        unified = unify_texts(de_text, en_text)
+        # Proceed only when unify is *byte-faithful*: split(unify(de, en)) == (de, en).
+        # ``unify`` is best-effort for solo / misaligned cells, so a structurally
+        # divergent pair can unify without raising — but then the assign->split
+        # round-trip could reorder or move cells. Verifying the id-less round-trip
+        # guarantees that adding ids and splitting back cannot corrupt the files;
+        # otherwise fall back to the per-file defensive (the #162 detective then
+        # surfaces the residual divergence).
+        rt_de, rt_en = split_text(unified)
+    except (SplitError, UnifyError):
+        return None
+    if (rt_de, rt_en) != (de_text, en_text):
+        return None
+
+    unified_new, result = assign_ids_for_text(unified, en_path, options)
+    result.files_visited = 2
+    result.files_modified = 0
+    if options.report_only or unified_new == unified:
+        return result
+
+    try:
+        de_new, en_new = split_text(unified_new)
+    except SplitError:  # pragma: no cover - unify succeeded, split should too
+        return None
+
+    if de_new != de_text:
+        de_path.write_text(de_new, encoding="utf-8", newline="\n")
+        result.files_modified += 1
+    if en_new != en_text:
+        en_path.write_text(en_new, encoding="utf-8", newline="\n")
+        result.files_modified += 1
+    return result
+
+
+def _merge_result(combined: AssignResult, result: AssignResult) -> None:
+    combined.files_visited += result.files_visited
+    combined.files_modified += result.files_modified
+    combined.assignments.extend(result.assignments)
+    combined.refusals.extend(result.refusals)
+
+
 def assign_ids_in_directory(path: Path, options: AssignOptions) -> AssignResult:
-    """Recurse over a directory and process every slide file we find."""
+    """Recurse over a directory and process every slide file we find.
+
+    Split ``.de.py`` / ``.en.py`` pairs are minted **EN-authority** across both
+    halves at once (:func:`assign_ids_in_split_pair`); a pair that is not
+    unifiable falls back to processing each half with the per-file twin-aware
+    path. Bilingual and unpaired files go through :func:`assign_ids_in_file`.
+    """
     from clm.core.topic_resolver import find_slide_files_recursive
 
     combined = AssignResult()
-    for slide_file in find_slide_files_recursive(path):
-        result = assign_ids_in_file(slide_file, options)
-        combined.files_visited += result.files_visited
-        combined.files_modified += result.files_modified
-        combined.assignments.extend(result.assignments)
-        combined.refusals.extend(result.refusals)
+    files = list(find_slide_files_recursive(path))
+    fileset = set(files)
+    handled: set[Path] = set()
+
+    for slide_file in files:
+        if slide_file in handled:
+            continue
+        twin = _split_twin(slide_file)
+        if twin is not None and twin in fileset:
+            de_path, en_path = (
+                (slide_file, twin) if split_lang_suffix(slide_file) == "de" else (twin, slide_file)
+            )
+            pair_result = assign_ids_in_split_pair(de_path, en_path, options)
+            if pair_result is not None:
+                _merge_result(combined, pair_result)
+            else:
+                # Not unifiable — fall back to the per-file defensive on each.
+                _merge_result(combined, assign_ids_in_file(de_path, options))
+                _merge_result(combined, assign_ids_in_file(en_path, options))
+            handled.add(de_path)
+            handled.add(en_path)
+        else:
+            _merge_result(combined, assign_ids_in_file(slide_file, options))
+            handled.add(slide_file)
+
     return combined

--- a/src/clm/slides/split.py
+++ b/src/clm/slides/split.py
@@ -40,15 +40,62 @@ in PythonCourses always pair tagged cells, so this restriction is
 invisible in practice. Phase 3's validator flags missing slide_id; once
 that promotes to error in 1.7, the canonical pattern is enforced
 upstream too.
+
+**Voiceover companion split (hardening 2026-06).** A slide file may have a
+sibling voiceover companion (``slides_X.py`` → ``voiceover_X.py``, see
+:func:`clm.slides.voiceover_tools.companion_path`). Splitting a bilingual
+deck without touching that companion would orphan it — the build would no
+longer find a companion next to either ``slides_X.de.py`` or
+``slides_X.en.py``. So ``split_in_file`` splits the companion in lockstep
+into ``voiceover_X.de.py`` / ``voiceover_X.en.py``, and ``unify_in_file``
+recombines them. A companion has no header macro — it is just voiceover
+cells carrying ``lang`` (and ``for_slide`` / ``vo_anchor``) — so the same
+:func:`split_text` / :func:`unify_texts` primitives route it by language
+and the round trip is byte-identical. This is well-defined because #162
+guarantees ``de_id == en_id``, so each companion cell's owning slide
+exists in its language's half. The companion dependency is imported
+lazily, so ``split``/``unify`` of a plain deck never touch the voiceover
+layer.
 """
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
+
+
+def _atomic_write_all(writes: list[tuple[Path, str]]) -> None:
+    """Write several ``(path, text)`` outputs as atomically as the FS allows.
+
+    Every text is first written to a sibling ``*.tmp`` file; only after **all**
+    temp writes succeed are they ``os.replace``-d into place back-to-back. A
+    failure during the temp phase (the common one — disk full, permission)
+    therefore leaves every real target untouched; the replace phase has only a
+    tiny residual window, and leftover temps are cleaned up either way.
+
+    This matters for the companion seam: ``split``/``unify`` write up to four
+    files, and a mid-operation failure with plain per-file writes could leave a
+    split deck without its companion — the very orphaning this seam prevents.
+    Cross-file atomicity is not achievable without a journal, but this upgrades
+    the previous direct per-file writes so the likely failure is safe.
+    """
+    temps: list[tuple[Path, Path]] = []
+    try:
+        for path, text in writes:
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text(text, encoding="utf-8", newline="\n")
+            temps.append((tmp, path))
+        for tmp, path in temps:
+            os.replace(tmp, path)
+    finally:
+        for tmp, _ in temps:
+            if tmp.exists():
+                tmp.unlink()
+
 
 # ---------------------------------------------------------------------------
 # Errors
@@ -74,24 +121,40 @@ class UnifyError(Exception):
 
 @dataclass
 class SplitResult:
-    """Outcome of one :func:`split_in_file` call."""
+    """Outcome of one :func:`split_in_file` call.
+
+    ``de_companion`` / ``en_companion`` are set only when ``source`` had a
+    sibling voiceover companion that was split alongside the deck;
+    ``source_companion`` records the bilingual companion that was read.
+    Companion overwrites are also listed in ``overwrote``.
+    """
 
     source: str
     de_path: str
     en_path: str
     wrote: bool = False
     overwrote: list[str] = field(default_factory=list)
+    source_companion: str | None = None
+    de_companion: str | None = None
+    en_companion: str | None = None
 
 
 @dataclass
 class UnifyResult:
-    """Outcome of one :func:`unify_in_file` call."""
+    """Outcome of one :func:`unify_in_file` call.
+
+    ``target_companion`` is set only when sibling voiceover companions were
+    recombined alongside the deck; ``companion_overwrote`` reports whether
+    that companion target already existed.
+    """
 
     de_source: str
     en_source: str
     target: str
     wrote: bool = False
     overwrote: bool = False
+    target_companion: str | None = None
+    companion_overwrote: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +311,45 @@ def _rewrite_import_to_en(cell: RawCell) -> RawCell:
     )
 
 
+@dataclass
+class _CompanionSplitPlan:
+    """A planned split of a sibling voiceover companion (read, not yet written)."""
+
+    source: Path
+    de_path: Path
+    en_path: Path
+    de_text: str
+    en_text: str
+
+
+def _plan_companion_split(source: Path, de_path: Path, en_path: Path) -> _CompanionSplitPlan | None:
+    """Plan splitting ``source``'s voiceover companion in lockstep with the deck.
+
+    Returns ``None`` when ``source`` has no sibling ``voiceover_*.py``.
+    Otherwise reads the bilingual companion and routes its cells by language
+    with the same :func:`split_text` primitive used for the deck — companions
+    carry no header macro, so this is a pure per-language route that preserves
+    each cell's ``for_slide`` / ``vo_anchor`` verbatim. Raising here (e.g. a
+    malformed companion) aborts the whole split before any file is written.
+
+    The ``voiceover_tools`` import is deferred so a plain deck split never
+    pulls in the voiceover layer.
+    """
+    from clm.slides.voiceover_tools import companion_path
+
+    companion = companion_path(source)
+    if not companion.exists():
+        return None
+    comp_de_text, comp_en_text = split_text(companion.read_text(encoding="utf-8"))
+    return _CompanionSplitPlan(
+        source=companion,
+        de_path=companion_path(de_path),
+        en_path=companion_path(en_path),
+        de_text=comp_de_text,
+        en_text=comp_en_text,
+    )
+
+
 def split_in_file(
     source: Path,
     *,
@@ -257,9 +359,13 @@ def split_in_file(
     """Split ``source`` (bilingual ``.py``) into adjacent ``.de.py`` /
     ``.en.py`` companions.
 
-    Refuses if either target exists unless ``force=True``. In ``dry_run``
-    mode no files are written; the result still reports what *would* have
-    been overwritten.
+    If ``source`` has a sibling voiceover companion (``voiceover_*.py``) it is
+    split in lockstep into ``voiceover_*.de.py`` / ``voiceover_*.en.py`` so the
+    deck split never orphans the narration; see the module docstring.
+
+    Refuses if any target (deck or companion half) exists unless ``force=True``.
+    In ``dry_run`` mode no files are written; the result still reports what
+    *would* have been overwritten.
     """
     source = source.resolve()
     de_path = _split_target(source, "de")
@@ -268,11 +374,18 @@ def split_in_file(
     text = source.read_text(encoding="utf-8")
     de_text, en_text = split_text(text)
 
+    companion = _plan_companion_split(source, de_path, en_path)
+
     overwrote: list[str] = []
     if de_path.exists():
         overwrote.append(str(de_path))
     if en_path.exists():
         overwrote.append(str(en_path))
+    if companion is not None:
+        if companion.de_path.exists():
+            overwrote.append(str(companion.de_path))
+        if companion.en_path.exists():
+            overwrote.append(str(companion.en_path))
 
     if overwrote and not force:
         raise SplitError(
@@ -281,8 +394,11 @@ def split_in_file(
         )
 
     if not dry_run:
-        de_path.write_text(de_text, encoding="utf-8", newline="\n")
-        en_path.write_text(en_text, encoding="utf-8", newline="\n")
+        writes = [(de_path, de_text), (en_path, en_text)]
+        if companion is not None:
+            writes.append((companion.de_path, companion.de_text))
+            writes.append((companion.en_path, companion.en_text))
+        _atomic_write_all(writes)
 
     return SplitResult(
         source=str(source),
@@ -290,6 +406,9 @@ def split_in_file(
         en_path=str(en_path),
         wrote=not dry_run,
         overwrote=overwrote,
+        source_companion=str(companion.source) if companion is not None else None,
+        de_companion=str(companion.de_path) if companion is not None else None,
+        en_companion=str(companion.en_path) if companion is not None else None,
     )
 
 
@@ -531,6 +650,36 @@ def _raise_alignment_error(de_cell: RawCell | None, en_cell: RawCell | None) -> 
     raise UnifyError(f"cannot align DE/EN cells — {de_desc}; {en_desc}")
 
 
+@dataclass
+class _CompanionUnifyPlan:
+    """A planned recombination of split voiceover companions (read, not written)."""
+
+    target: Path
+    text: str
+
+
+def _plan_companion_unify(
+    de_source: Path, en_source: Path, target: Path
+) -> _CompanionUnifyPlan | None:
+    """Plan recombining the split voiceover companions of a ``.de`` / ``.en`` pair.
+
+    Returns ``None`` when neither half has a sibling ``voiceover_*.<lang>.py``.
+    A half that is absent is treated as empty so the present narration is never
+    dropped (the inverse of :func:`_plan_companion_split`, which always writes
+    both halves). Raising here (divergent shared companion cell, misalignment)
+    aborts the whole unify before any file is written.
+    """
+    from clm.slides.voiceover_tools import companion_path
+
+    de_comp = companion_path(de_source)
+    en_comp = companion_path(en_source)
+    if not de_comp.exists() and not en_comp.exists():
+        return None
+    de_text = de_comp.read_text(encoding="utf-8") if de_comp.exists() else ""
+    en_text = en_comp.read_text(encoding="utf-8") if en_comp.exists() else ""
+    return _CompanionUnifyPlan(target=companion_path(target), text=unify_texts(de_text, en_text))
+
+
 def unify_in_file(
     de_source: Path,
     en_source: Path,
@@ -542,7 +691,12 @@ def unify_in_file(
     """Unify ``de_source`` + ``en_source`` into a bilingual ``target`` file.
 
     Default ``target`` is derived from ``de_source``: ``foo.de.py`` →
-    ``foo.py``. Refuses to overwrite an existing target unless
+    ``foo.py``. If the pair has sibling voiceover companions
+    (``voiceover_*.de.py`` / ``voiceover_*.en.py``) they are recombined in
+    lockstep into ``voiceover_*.py`` — the inverse of :func:`split_in_file`'s
+    companion split.
+
+    Refuses to overwrite an existing target (deck or companion) unless
     ``force=True``. In ``dry_run`` mode no file is written.
     """
     de_source = de_source.resolve()
@@ -555,12 +709,23 @@ def unify_in_file(
     en_text = en_source.read_text(encoding="utf-8")
     unified = unify_texts(de_text, en_text)
 
+    companion = _plan_companion_unify(de_source, en_source, target)
+
     overwrote = target.exists()
-    if overwrote and not force:
-        raise UnifyError(f"refusing to overwrite existing target without --force: {target}")
+    companion_overwrote = companion is not None and companion.target.exists()
+    if (overwrote or companion_overwrote) and not force:
+        blocking = [str(target)] if overwrote else []
+        if companion_overwrote:
+            blocking.append(str(companion.target))  # type: ignore[union-attr]
+        raise UnifyError(
+            "refusing to overwrite existing target without --force: " + ", ".join(blocking)
+        )
 
     if not dry_run:
-        target.write_text(unified, encoding="utf-8", newline="\n")
+        writes = [(target, unified)]
+        if companion is not None:
+            writes.append((companion.target, companion.text))
+        _atomic_write_all(writes)
 
     return UnifyResult(
         de_source=str(de_source),
@@ -568,6 +733,8 @@ def unify_in_file(
         target=str(target),
         wrote=not dry_run,
         overwrote=overwrote,
+        target_companion=str(companion.target) if companion is not None else None,
+        companion_overwrote=companion_overwrote,
     )
 
 

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -1014,6 +1014,113 @@ def _check_split_tag_parity(de_path: Path, en_path: Path) -> list[Finding]:
     return findings
 
 
+def _check_split_slide_id_parity(de_path: Path, en_path: Path) -> list[Finding]:
+    """Verify the ``.de.py`` / ``.en.py`` halves carry the same slide_id sequence.
+
+    ``slide_id`` is the cross-language join key (issue #162): voiceover
+    ``for_slide`` resolution, ``clm slides unify`` (which requires
+    ``de_id == en_id``), and ``extract`` / ``inline`` all rely on the two halves
+    agreeing on the **set and order** of slide ids. A born-split deck, a per-file
+    ``clm slides assign-ids`` on one half, or a hand-edited id silently diverges
+    them. This is the **detective** that makes that loud — the core check of the
+    #162 pre-commit gate.
+
+    Compares the bare (preserve-marker-stripped) slide_ids of slide-start cells
+    in source order. Findings are ``warning`` severity, consistent with the rest
+    of the slide_id family (the gate runs with ``--fail-on warning``); they may
+    become ``error`` in CLM 1.7 alongside the other slide_id checks.
+    """
+    findings: list[Finding] = []
+    de_file = str(de_path)
+
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+
+    def _ids(cells: list[Cell]) -> list[str]:
+        return [
+            strip_preserve_marker(c.metadata.slide_id)
+            for c in cells
+            if c.metadata.is_slide_start and c.metadata.slide_id
+        ]
+
+    de_ids = _ids(de_cells)
+    en_ids = _ids(en_cells)
+    anchor_line = next(
+        (c.line_number for c in de_cells if c.metadata.is_slide_start and c.metadata.slide_id),
+        1,
+    )
+    de_set, en_set = set(de_ids), set(en_ids)
+
+    if de_set != en_set:
+        only_de = sorted(de_set - en_set)
+        only_en = sorted(en_set - de_set)
+        detail = ""
+        if only_de:
+            detail += f"; only on DE: {only_de}"
+        if only_en:
+            detail += f"; only on EN: {only_en}"
+        findings.append(
+            Finding(
+                severity="warning",
+                category="pairing",
+                file=de_file,
+                line=anchor_line,
+                message=(
+                    f"split pair slide_id sets diverge between '.de.py' and "
+                    f"'.en.py' ({en_path.name}){detail}"
+                ),
+                suggestion=(
+                    "The .de.py / .en.py halves must carry the same slide_id set — "
+                    "it is the cross-language join key for voiceover for_slide, "
+                    "`clm slides unify`, and extract/inline. Route structural "
+                    "changes through `clm slides sync` (which mints/migrates ids "
+                    "onto both halves); avoid per-file `clm slides assign-ids` on a "
+                    "split half."
+                ),
+            )
+        )
+    elif de_ids != en_ids:
+        findings.append(
+            Finding(
+                severity="warning",
+                category="pairing",
+                file=de_file,
+                line=anchor_line,
+                message=(
+                    f"split pair slide_id order diverges: DE order {de_ids} != EN "
+                    f"order {en_ids} ({en_path.name})"
+                ),
+                suggestion=(
+                    "The slide_id sequence must match across the DE/EN halves. Run "
+                    "`clm slides sync` to mirror the reordering onto both."
+                ),
+            )
+        )
+
+    return findings
+
+
+def _split_twin_pair(path: Path) -> tuple[Path, Path] | None:
+    """If ``path`` is a split half whose twin exists on disk, return the ordered
+    ``(de_path, en_path)`` pair; else ``None``.
+
+    Used by the single-file validate path so a standalone
+    ``clm validate slides_x.de.py`` (and the pre-commit gate) catches twin
+    divergence even when not run over a whole directory.
+    """
+    suffix = split_lang_suffix(path)
+    if suffix is None:
+        return None
+    other = "en" if suffix == "de" else "de"
+    parts = path.name.split(".")
+    # split_lang_suffix guarantees the form ``<stem>.<de|en>.<ext>``.
+    parts[-2] = other
+    twin = path.with_name(".".join(parts))
+    if not twin.exists():
+        return None
+    return (path, twin) if suffix == "de" else (twin, path)
+
+
 def _slide_files_to_split_pairs(slide_files: list[Path]) -> list[tuple[Path, Path]]:
     """Return every detected ``(de_path, en_path)`` pair in ``slide_files``.
 
@@ -1300,6 +1407,8 @@ def _brief_cell_context(cell: Cell) -> str:
 def validate_file(
     path: Path,
     checks: list[str] | None = None,
+    *,
+    cross_file_parity: bool = True,
 ) -> ValidationResult:
     """Validate a single slide file.
 
@@ -1313,6 +1422,12 @@ def validate_file(
             ``"voiceover"`` is **opt-in** (issue #176): voiceover is optional
             per deck, so coverage runs only when you name it explicitly in
             ``checks`` — never as part of the default bundle.
+        cross_file_parity: When ``True`` (the default for standalone callers —
+            the CLI single-file path, MCP, the pre-commit gate) and ``path`` is
+            a split half whose twin exists on disk, run the #162 cross-file
+            ``slide_id`` parity detective against the twin. Directory/course
+            entrypoints pass ``False`` and run that parity once at their own
+            scope instead, so a directory run does not duplicate the finding.
 
     Returns:
         A :class:`ValidationResult` with findings and optional review material.
@@ -1341,6 +1456,14 @@ def validate_file(
         # has no DE/EN pairs to compare).
         if not is_split:
             findings.extend(_check_workshop_tag_symmetry(cells, file_str))
+        # #162 detective: when validating a split half standalone and its twin
+        # exists on disk, check cross-file slide_id parity (the join key). A
+        # directory/course run handles this once at that scope instead
+        # (cross_file_parity=False) so the finding is not duplicated per file.
+        if cross_file_parity and is_split:
+            pair = _split_twin_pair(path)
+            if pair is not None:
+                findings.extend(_check_split_slide_id_parity(*pair))
 
     # Review material extraction
     review_checks = check_set & ALL_REVIEW_CHECKS
@@ -1421,7 +1544,9 @@ def validate_directory(
     combined_review = ReviewMaterial() if (not checks or set(checks) & ALL_REVIEW_CHECKS) else None
 
     for sf in slide_files:
-        result = validate_file(sf, checks=checks)
+        # Cross-file parity is run once per pair below (not per file), so the
+        # per-file pass skips it to avoid duplicate findings.
+        result = validate_file(sf, checks=checks, cross_file_parity=False)
         all_findings.extend(result.findings)
         if combined_review is not None and result.review_material is not None:
             _merge_review_material(combined_review, result.review_material)
@@ -1434,6 +1559,7 @@ def validate_directory(
         for de_path, en_path in _slide_files_to_split_pairs(slide_files):
             all_findings.extend(_check_shared_cell_parity(de_path, en_path))
             all_findings.extend(_check_split_tag_parity(de_path, en_path))
+            all_findings.extend(_check_split_slide_id_parity(de_path, en_path))
 
     return ValidationResult(
         files_checked=len(slide_files),
@@ -1474,7 +1600,8 @@ def validate_course(
         for match in matches:
             slide_files = find_slide_files(match.path)
             for sf in slide_files:
-                result = validate_file(sf, checks=checks)
+                # Cross-file parity runs once per pair below, not per file.
+                result = validate_file(sf, checks=checks, cross_file_parity=False)
                 all_findings.extend(result.findings)
                 files_checked += 1
                 if combined_review is not None and result.review_material is not None:
@@ -1487,6 +1614,7 @@ def validate_course(
                 for de_path, en_path in _slide_files_to_split_pairs(slide_files):
                     all_findings.extend(_check_shared_cell_parity(de_path, en_path))
                     all_findings.extend(_check_split_tag_parity(de_path, en_path))
+                    all_findings.extend(_check_split_slide_id_parity(de_path, en_path))
 
     return ValidationResult(
         files_checked=files_checked,

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -35,6 +35,12 @@ from clm.slides.normalizer import (
 # ---------------------------------------------------------------------------
 
 
+class VoiceoverError(Exception):
+    """A voiceover extract/inline operation refused to proceed (e.g. to avoid
+    clobbering an existing companion). Mirrors ``split.SplitError`` — the caller
+    (CLI / MCP) turns it into a clean, non-zero-exit message."""
+
+
 @dataclass
 class ExtractionResult:
     """Result of extracting voiceover cells from a slide file."""
@@ -86,6 +92,7 @@ class InlineResult:
     unmatched_cells: int = 0
     relocated_cells: int = 0
     companion_deleted: bool = False
+    companion_retained: bool = False
     dry_run: bool = False
     placements: list[Placement] = field(default_factory=list)
 
@@ -111,6 +118,11 @@ class InlineResult:
             )
         if self.companion_deleted:
             parts.append("companion file deleted")
+        if self.companion_retained:
+            parts.append(
+                f"companion {self.companion_file} retained with the unmatched "
+                f"cell(s) — fix the slide_id(s) and re-run inline"
+            )
         return "; ".join(parts)
 
 
@@ -349,6 +361,7 @@ def _find_owning_slide_id(cells: list[_RawCell], voiceover_idx: int) -> str | No
 def extract_voiceover(
     path: Path,
     *,
+    force: bool = False,
     dry_run: bool = False,
 ) -> ExtractionResult:
     """Extract voiceover cells from a slide file to a companion file.
@@ -357,12 +370,22 @@ def extract_voiceover(
     extraction.  Voiceover cells are linked to their owning slide via
     ``for_slide`` metadata.
 
+    The companion is *rebuilt* from the voiceover cells currently in the slide
+    file. If a companion already exists it would be overwritten, discarding any
+    hand-edits (or previously-extracted cells) that live only in the companion —
+    so, like ``split_in_file``, this refuses without ``force``.
+
     Args:
         path: Path to the ``.py`` slide file.
+        force: Overwrite an existing companion file. Without it, an existing
+            companion raises :class:`VoiceoverError` rather than clobbering it.
         dry_run: If ``True``, preview without writing files.
 
     Returns:
         An :class:`ExtractionResult` describing what was done.
+
+    Raises:
+        VoiceoverError: a companion already exists and ``force`` is not set.
     """
     comp = companion_path(path)
     result = ExtractionResult(
@@ -411,6 +434,17 @@ def extract_voiceover(
     remaining_cells = [c for i, c in enumerate(cells) if i not in set(vo_indices)]
 
     if not dry_run:
+        # Refuse to clobber an existing companion *before* touching the slide
+        # file — otherwise a raise here would strip voiceover from the slide
+        # and leave no companion (data loss). ``force`` opts into the rebuild.
+        if comp.exists() and not force:
+            raise VoiceoverError(
+                f"refusing to overwrite existing companion '{comp.name}' "
+                f"(pass force=True / --force to rebuild it from the current "
+                f"voiceover cells; this discards content present only in the "
+                f"companion)"
+            )
+
         # Write the slide file without voiceover cells
         new_slide_text = _reconstruct(preamble, remaining_cells)
         # Clean up double blank lines left by removal
@@ -775,13 +809,11 @@ def inline_voiceover(
         )
         insertions.append((insert_after, vo_cell))
 
-    # Strip the author-only companion attributes before the cells land
-    # back in the slide file.
+    # Strip the author-only companion attributes from the cells about to land
+    # back in the slide file. Unmatched cells are NOT stripped: they stay in
+    # the companion (below) and must keep their for_slide / vo_anchor so a
+    # retry after fixing the slide_id can re-place them.
     for _, vo_cell in insertions:
-        clean_header = _strip_author_attrs(vo_cell.header)
-        vo_cell.lines[0] = clean_header
-        vo_cell.metadata = parse_cell_header(clean_header)
-    for vo_cell in unmatched:
         clean_header = _strip_author_attrs(vo_cell.header)
         vo_cell.lines[0] = clean_header
         vo_cell.metadata = parse_cell_header(clean_header)
@@ -792,12 +824,27 @@ def inline_voiceover(
         return result
 
     if not dry_run:
-        new_cells = _apply_insertions(slide_cells, insertions, unmatched)
-        new_text = _reconstruct(preamble, new_cells)
-        path.write_text(new_text, encoding="utf-8", newline="\n")
+        if insertions:
+            # Inline only the cells we could place. Unmatched cells are *not*
+            # dumped at the end of the slide (stripped of for_slide/anchor);
+            # they are preserved in the companion below so they stay placeable.
+            new_cells = _apply_insertions(slide_cells, insertions, [])
+            new_text = _reconstruct(preamble, new_cells)
+            path.write_text(new_text, encoding="utf-8", newline="\n")
 
-        comp.unlink()
-        result.companion_deleted = True
+        if unmatched:
+            # Some companion cells could not be matched — typically the owning
+            # slide_id was renamed. Rather than destroying the clean,
+            # anchor-bearing companion (the recoverable source of truth) and
+            # stranding the narration at EOF, rewrite the companion to the
+            # unmatched remainder and keep it. The author fixes the slide_id(s)
+            # and re-runs inline to place them.
+            remaining_text = _reconstruct("", unmatched)
+            comp.write_text(remaining_text, encoding="utf-8", newline="\n")
+            result.companion_retained = True
+        else:
+            comp.unlink()
+            result.companion_deleted = True
 
     return result
 

--- a/tests/infrastructure/utils/path_utils_test.py
+++ b/tests/infrastructure/utils/path_utils_test.py
@@ -478,6 +478,33 @@ class TestOutputFilePatterns:
         py.write_text("# ...")
         assert not is_ignored_file_for_output(py)
 
+    def test_voiceover_companion_regex_matches(self):
+        # Bilingual and split-per-language companion forms must all match so the
+        # raw author file never reaches public/speaker output (its narration is
+        # merged into the slide notebook at build time instead).
+        names = [
+            "voiceover_intro.py",
+            "voiceover_010v_topic.py",
+            "voiceover_intro.de.py",
+            "voiceover_intro.en.py",
+        ]
+        for name in names:
+            assert any(p.match(name) for p in SKIP_OUTPUT_FILE_PATTERNS), name
+
+    def test_voiceover_companion_regex_rejects_non_companion(self):
+        # Only files whose name *starts with* ``voiceover_`` are companions.
+        for name in ("slides_010v.py", "my_voiceover_helper.py", "voiceover.md"):
+            assert not any(p.match(name) for p in SKIP_OUTPUT_FILE_PATTERNS), name
+
+    def test_voiceover_companion_glob_parallels_regex(self):
+        assert "voiceover_*.py" in SKIP_OUTPUT_FILE_GLOBS
+
+    def test_is_ignored_file_for_output_voiceover_companion(self, tmp_path):
+        for name in ("voiceover_intro.py", "voiceover_intro.de.py", "voiceover_intro.en.py"):
+            comp = tmp_path / name
+            comp.write_text('# %% [markdown] tags=["voiceover"] for_slide="x"\n# vo\n')
+            assert is_ignored_file_for_output(comp), name
+
     def test_is_ignored_file_for_output_keras_suffix(self, tmp_path):
         # SKIP_FILE_SUFFIXES still applies via is_ignored_file_for_course.
         model = tmp_path / "model.keras"

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -11,8 +11,11 @@ from clm.notebooks.slide_parser import parse_cells
 from clm.slides.assign_ids import (
     AssignOptions,
     assign_ids_for_text,
+    assign_ids_in_directory,
     assign_ids_in_file,
+    assign_ids_in_split_pair,
 )
+from clm.slides.split import split_text
 
 
 def _write(tmp_path: Path, content: str, name: str = "slide.py") -> Path:
@@ -514,6 +517,103 @@ class TestSplitTwinAware:
         )
         assign_ids_in_file(de_path, AssignOptions())
         assert self._slide_ids(de_path) == ["de-own"]
+
+
+class TestSplitGenerative:
+    """#162 generative: directory ``assign-ids`` mints **EN-authority** ids
+    across both halves of a split pair at once — deterministic, order-independent
+    (contrast the per-file defensive, which is first-assigned-wins)."""
+
+    _HEADER = '# j2 from \'macros.j2\' import header\n# {{ header("DE", "EN") }}\n\n'
+
+    def _born_split(
+        self, tmp_path: Path, de_title: str = "Mein Thema", en_title: str = "My Topic"
+    ) -> tuple[Path, Path]:
+        # Build a valid id-less split pair by splitting an id-less bilingual deck
+        # (so the header macros are exactly what `split` produces and `unify`
+        # accepts). The two headings differ so EN-authority is observable.
+        bilingual = (
+            self._HEADER
+            + f'# %% [markdown] lang="de" tags=["slide"]\n# ## {de_title}\n\n'
+            + f'# %% [markdown] lang="en" tags=["slide"]\n# ## {en_title}\n\n'
+        )
+        de, en = split_text(bilingual)
+        return (
+            _write(tmp_path, de, "slides_x.de.py"),
+            _write(tmp_path, en, "slides_x.en.py"),
+        )
+
+    @staticmethod
+    def _ids(path: Path) -> list[str | None]:
+        return [
+            c.metadata.slide_id
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.is_slide_start
+        ]
+
+    def _divergent_shared_pair(self, tmp_path: Path) -> tuple[Path, Path]:
+        # A pair whose *shared* (no-lang) cell differs between the halves. unify
+        # raises on that, so the round-trip is not faithful -> generative bails.
+        bilingual = (
+            self._HEADER
+            + '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n\n'
+            + '# %% [markdown] lang="en" tags=["slide"]\n# ## My Topic\n\n'
+            + '# %% tags=["keep"]\nx = 1\n\n'
+        )
+        de, en = split_text(bilingual)
+        de = de.replace("x = 1", "x = 2")  # tamper the DE shared cell
+        return (
+            _write(tmp_path, de, "slides_x.de.py"),
+            _write(tmp_path, en, "slides_x.en.py"),
+        )
+
+    def test_split_pair_function_mints_en_authority(self, tmp_path: Path):
+        de_path, en_path = self._born_split(tmp_path)
+        result = assign_ids_in_split_pair(de_path, en_path, AssignOptions())
+        assert result is not None
+        assert self._ids(de_path) == self._ids(en_path) == ["my-topic"]
+
+    def test_directory_mints_en_authority(self, tmp_path: Path):
+        de_path, en_path = self._born_split(tmp_path)
+        assign_ids_in_directory(tmp_path, AssignOptions())
+        # EN heading "My Topic" -> "my-topic" wins on BOTH halves, not the DE
+        # "mein-thema" the per-file defensive would pick.
+        assert self._ids(de_path) == self._ids(en_path) == ["my-topic"]
+
+    def test_round_trippable_misalignment_is_not_corrupted(self, tmp_path: Path):
+        # An *extra* DE slide round-trips faithfully through unify/split, so the
+        # generative proceeds safely: the aligned slide gets the EN-authority id
+        # on both halves, the DE-only slide gets its own id, and the inherent
+        # divergence (extra only on DE) is left for the validator's detective.
+        de_path, en_path = self._born_split(tmp_path)
+        de_path.write_text(
+            de_path.read_text(encoding="utf-8")
+            + '# %% [markdown] lang="de" tags=["slide"]\n# ## Extra\n',
+            encoding="utf-8",
+        )
+        result = assign_ids_in_split_pair(de_path, en_path, AssignOptions())
+        assert result is not None
+        assert self._ids(de_path) == ["my-topic", "extra"]
+        assert self._ids(en_path) == ["my-topic"]
+
+    def test_divergent_shared_cell_returns_none(self, tmp_path: Path):
+        de_path, en_path = self._divergent_shared_pair(tmp_path)
+        assert assign_ids_in_split_pair(de_path, en_path, AssignOptions()) is None
+
+    def test_directory_falls_back_to_defensive_on_divergent_shared(self, tmp_path: Path):
+        # The generative bails (not round-trippable); the per-file defensive
+        # fallback still reaches slide_id parity on the aligned slide.
+        de_path, en_path = self._divergent_shared_pair(tmp_path)
+        assign_ids_in_directory(tmp_path, AssignOptions())
+        assert self._ids(de_path) == self._ids(en_path) == ["mein-thema"]
+
+    def test_report_only_writes_nothing(self, tmp_path: Path):
+        de_path, en_path = self._born_split(tmp_path)
+        before = (de_path.read_text(encoding="utf-8"), en_path.read_text(encoding="utf-8"))
+        result = assign_ids_in_split_pair(de_path, en_path, AssignOptions(report_only=True))
+        assert result is not None
+        assert result.assignments  # proposals are still reported
+        assert (de_path.read_text(encoding="utf-8"), en_path.read_text(encoding="utf-8")) == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from clm.infrastructure.llm.ollama_client import StaticTitleSuggester
+from clm.notebooks.slide_parser import parse_cells
 from clm.slides.assign_ids import (
     AssignOptions,
     assign_ids_for_text,
@@ -431,6 +432,88 @@ class TestFileLevel:
         assign_ids_in_file(path, AssignOptions(force=True))
         second = path.read_text(encoding="utf-8")
         assert first == second
+
+
+class TestSplitTwinAware:
+    """#162 defensive: per-file ``assign-ids`` on a split half adopts the twin's
+    ``slide_id`` instead of minting a divergent one, keeping ``de_id == en_id``.
+    """
+
+    @staticmethod
+    def _slide_ids(path: Path) -> list[str | None]:
+        return [
+            c.metadata.slide_id
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.is_slide_start
+        ]
+
+    def _pair(self, tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+        return (
+            _write(tmp_path, de, "slides_x.de.py"),
+            _write(tmp_path, en, "slides_x.en.py"),
+        )
+
+    def test_idless_half_adopts_twin_id(self, tmp_path: Path):
+        # EN already carries an id; the id-less DE adopts it rather than slugging
+        # "mein-thema" from its own heading.
+        de_path, _ = self._pair(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n',
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="my-topic"\n# ## My Topic\n',
+        )
+        result = assign_ids_in_file(de_path, AssignOptions())
+        assert self._slide_ids(de_path) == ["my-topic"]
+        assert any(a.source == "twin" for a in result.assignments)
+
+    def test_born_split_reaches_parity(self, tmp_path: Path):
+        # Both halves id-less with different headings. Assign DE then EN: the EN
+        # run adopts the DE-minted id, so the halves end up in parity.
+        de_path, en_path = self._pair(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n',
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## My Topic\n',
+        )
+        assign_ids_in_file(de_path, AssignOptions())
+        assign_ids_in_file(en_path, AssignOptions())
+        de_ids = self._slide_ids(de_path)
+        assert de_ids == self._slide_ids(en_path)
+        assert de_ids == ["mein-thema"]  # DE ran first, so its slug wins
+
+    def test_count_mismatch_skips_reuse(self, tmp_path: Path):
+        # Misaligned halves (DE has an extra slide): positional reuse is unsafe,
+        # so DE mints normally and the divergence is left for the validator's
+        # #162 detective.
+        de_path, _ = self._pair(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Intro\n'
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Extra\n',
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## Intro\n',
+        )
+        result = assign_ids_in_file(de_path, AssignOptions())
+        assert all(a.source != "twin" for a in result.assignments)
+        assert self._slide_ids(de_path) == ["intro", "extra"]
+
+    def test_no_twin_mints_normally(self, tmp_path: Path):
+        de_path = _write(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n',
+            "slides_x.de.py",
+        )
+        result = assign_ids_in_file(de_path, AssignOptions())
+        assert self._slide_ids(de_path) == ["mein-thema"]
+        assert all(a.source != "twin" for a in result.assignments)
+
+    def test_existing_divergent_id_not_touched_without_force(self, tmp_path: Path):
+        # The defensive only fills id-less cells. A pre-existing divergent id is
+        # left alone (the detective surfaces it); assign-ids must not silently
+        # rewrite it under the no-force default.
+        de_path, _ = self._pair(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="de-own"\n# ## Thema\n',
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="en-own"\n# ## Topic\n',
+        )
+        assign_ids_in_file(de_path, AssignOptions())
+        assert self._slide_ids(de_path) == ["de-own"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_edit_dynamics.py
+++ b/tests/slides/test_edit_dynamics.py
@@ -48,14 +48,14 @@ def outcomes(harness):
 
 # The known silent footguns the harness must keep surfacing — a refactor that
 # zeroes the work-list out (e.g. by neutering a runner) should fail here, not
-# quietly report "all green".
+# quietly report "all green". The two voiceover Tier-1 data-loss breaks
+# (inline-after-rename, re-extract-over-edited-companion) were hardened and now
+# classify ``preserve``; the remainder are the open work-list.
 _KNOWN_SILENT_BREAKS = {
     "add-then-assign-ids-per-file",
     "born-split-assign-ids",
     "commit-without-sync",
     "extract-then-split",
-    "inline-after-rename",
-    "re-extract-over-edited-companion",
 }
 
 

--- a/tests/slides/test_edit_dynamics.py
+++ b/tests/slides/test_edit_dynamics.py
@@ -48,13 +48,13 @@ def outcomes(harness):
 
 # The known silent footguns the harness must keep surfacing — a refactor that
 # zeroes the work-list out (e.g. by neutering a runner) should fail here, not
-# quietly report "all green". The two voiceover Tier-1 data-loss breaks
-# (inline-after-rename, re-extract-over-edited-companion) were hardened and now
-# classify ``preserve``; the remainder are the open work-list.
+# quietly report "all green". Hardened so far: the two voiceover Tier-1 breaks
+# (now ``preserve``) and ``commit-without-sync`` (now ``break-loud`` — the #162
+# detective gate catches it). The remainder are the open work-list; the two
+# per-file assign-ids breaks are the next target (the #162 defensive).
 _KNOWN_SILENT_BREAKS = {
     "add-then-assign-ids-per-file",
     "born-split-assign-ids",
-    "commit-without-sync",
     "extract-then-split",
 }
 

--- a/tests/slides/test_edit_dynamics.py
+++ b/tests/slides/test_edit_dynamics.py
@@ -1,0 +1,106 @@
+"""Fast cross-command property backstop for the split + voiceover workflow.
+
+Runs :mod:`scripts.edit_dynamics_harness` (synthetic arm: no corpus, no network)
+and freezes its classification of every ``(mutation, command-path)`` as
+**preserve / break-loud / break-silent**. This closes the gap the design doc
+(§6, §11) flags: today the per-cell sync fixes run in CI, but no test exercises
+the *editing dynamics* across commands — the silent footguns where a real author
+loses data or diverges the two halves.
+
+Two kinds of guard, both diagnosable:
+
+* **Engine regression** — every ``sync`` mutation must stay ``preserve``. The
+  safe funnel keeps both halves consistent; if a change makes it diverge, the
+  ``sync``-path assertions fail with the offending row.
+* **Work-list drift** — the known silent breaks (per-file ``assign-ids``,
+  the voiceover seams, the missing commit gate) are frozen as ``break-silent``.
+  When a hardening fix lands and flips one to ``preserve``, ``test_no_drift``
+  fails *loudly* — the signal to update ``Mutation.expected`` in the harness.
+
+Pure-synthetic, so it runs in the fast suite (no markers). The real-deck arm
+(mutating corpus pairs) stays out of CI, like ``test_sync_corpus_noop``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+@pytest.fixture(scope="module")
+def harness():
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    import edit_dynamics_harness as h
+
+    return h
+
+
+@pytest.fixture(scope="module")
+def outcomes(harness):
+    """Run the catalogue once; all assertions share the single result."""
+    return harness.run()
+
+
+# The known silent footguns the harness must keep surfacing — a refactor that
+# zeroes the work-list out (e.g. by neutering a runner) should fail here, not
+# quietly report "all green".
+_KNOWN_SILENT_BREAKS = {
+    "add-then-assign-ids-per-file",
+    "born-split-assign-ids",
+    "commit-without-sync",
+    "extract-then-split",
+    "inline-after-rename",
+    "re-extract-over-edited-companion",
+}
+
+
+def test_harness_runs_without_errors(harness, outcomes):
+    # An ERROR verdict means the harness (or the engine) raised — never a
+    # legitimate classification. Surface it, don't tolerate it.
+    errored = [o for o in outcomes if o.verdict == harness.ERROR]
+    assert errored == [], harness.render(outcomes)
+
+
+def test_no_drift(harness, outcomes):
+    # THE backstop: every asserted row matches its frozen baseline verdict. A
+    # drift is either a sync regression (preserve -> break) or a hardening fix
+    # landing (break-silent -> preserve). Both demand attention; on a fix, update
+    # the row's ``expected`` in scripts/edit_dynamics_harness.py.
+    drift = harness.asserted_drift(outcomes)
+    assert drift == [], harness.render(outcomes)
+
+
+def test_sync_funnel_always_preserves(harness, outcomes):
+    # The architectural invariant (design §5): structural edits routed through
+    # ``sync`` keep slide_id parity across both halves. This is the engine
+    # regression guard, stated per-path for a diagnosable failure.
+    offenders = [
+        (o.name, o.verdict, o.detail)
+        for o in outcomes
+        if o.path == "sync" and o.verdict != harness.PRESERVE
+    ]
+    assert offenders == [], f"sync funnel no longer preserves correspondence: {offenders}"
+
+
+def test_voiceover_round_trips_preserve(harness, outcomes):
+    by_name = {o.name: o for o in outcomes}
+    for name in ("extract-inline-round-trip", "unify-split-round-trip"):
+        o = by_name[name]
+        assert o.verdict == harness.PRESERVE, f"{name}: {o.verdict} — {o.detail}"
+
+
+def test_known_silent_breaks_still_surfaced(harness, outcomes):
+    # Guard the work-list itself: the documented footguns must keep classifying
+    # as break-silent until they are actually hardened (then test_no_drift fires
+    # and the baseline is updated). Prevents a silent loss of coverage.
+    silent = {o.name for o in outcomes if o.verdict == harness.BREAK_SILENT}
+    missing = _KNOWN_SILENT_BREAKS - silent
+    assert missing == set(), (
+        f"these known silent breaks stopped being detected: {sorted(missing)}\n"
+        + harness.render(outcomes)
+    )

--- a/tests/slides/test_edit_dynamics.py
+++ b/tests/slides/test_edit_dynamics.py
@@ -49,12 +49,11 @@ def outcomes(harness):
 # The known silent footguns the harness must keep surfacing — a refactor that
 # zeroes the work-list out (e.g. by neutering a runner) should fail here, not
 # quietly report "all green". Hardened so far: the two voiceover Tier-1 breaks
-# (now ``preserve``) and ``commit-without-sync`` (now ``break-loud`` — the #162
-# detective gate catches it). The remainder are the open work-list; the two
-# per-file assign-ids breaks are the next target (the #162 defensive).
+# (now ``preserve``), ``commit-without-sync`` (now ``break-loud`` — the #162
+# detective gate catches it), and the two per-file assign-ids breaks (now
+# ``preserve`` — the #162 defensive twin-aware reuse). The open work-list is the
+# cross-command voiceover companion seam.
 _KNOWN_SILENT_BREAKS = {
-    "add-then-assign-ids-per-file",
-    "born-split-assign-ids",
     "extract-then-split",
 }
 

--- a/tests/slides/test_edit_dynamics.py
+++ b/tests/slides/test_edit_dynamics.py
@@ -50,11 +50,14 @@ def outcomes(harness):
 # zeroes the work-list out (e.g. by neutering a runner) should fail here, not
 # quietly report "all green". Hardened so far: the two voiceover Tier-1 breaks
 # (now ``preserve``), ``commit-without-sync`` (now ``break-loud`` — the #162
-# detective gate catches it), and the two per-file assign-ids breaks (now
-# ``preserve`` — the #162 defensive twin-aware reuse). The open work-list is the
-# cross-command voiceover companion seam.
+# detective gate catches it), the two per-file assign-ids breaks (now
+# ``preserve`` — the #162 defensive twin-aware reuse), and ``extract-then-split``
+# (now ``preserve`` — ``split``/``unify`` carry the voiceover companion in
+# lockstep). The one remaining documented break is the observe-only build-merge
+# arm: ``merge_voiceover_text`` returns the unmatched ids, but the ``build``
+# consumer is log-only/exit-0 (escalating that is the next work item).
 _KNOWN_SILENT_BREAKS = {
-    "extract-then-split",
+    "build-merge-unmatched",
 }
 
 

--- a/tests/slides/test_split.py
+++ b/tests/slides/test_split.py
@@ -34,6 +34,11 @@ from clm.slides.split import (
     unify_in_file,
     unify_texts,
 )
+from clm.slides.voiceover_tools import (
+    companion_path,
+    extract_voiceover,
+    inline_voiceover,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers / building blocks
@@ -312,8 +317,253 @@ class TestUnifyInFile:
 
 
 # ---------------------------------------------------------------------------
-# Line-ending preservation (issue #132)
+# Voiceover companion split/unify in lockstep (hardening 2026-06)
+#
+# A slide file may have a sibling ``voiceover_*.py`` companion. Splitting the
+# deck without the companion orphans the narration (the build no longer finds a
+# companion next to either split half). ``split`` must split the companion too;
+# ``unify`` must recombine it — both byte-identically, preserving
+# ``for_slide`` / ``vo_anchor``.
 # ---------------------------------------------------------------------------
+
+
+def _deck_with_voiceover() -> str:
+    """Bilingual deck with interleaved DE/EN voiceover, the extract input."""
+    return (
+        HEADER_PREAMBLE
+        + _slide_pair("intro", "Einleitung", "Introduction")
+        + _voiceover_pair("intro")
+        + _slide_pair("setup", "Aufbau", "Setup")
+        + _voiceover_pair("setup")
+    )
+
+
+class TestCompanionSplit:
+    def test_splits_sibling_companion(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)  # -> voiceover_demo.py (bilingual)
+        assert (tmp_path / "voiceover_demo.py").is_file()
+
+        result = split_in_file(deck)
+
+        de_comp = tmp_path / "voiceover_demo.de.py"
+        en_comp = tmp_path / "voiceover_demo.en.py"
+        assert de_comp.is_file()
+        assert en_comp.is_file()
+        assert result.de_companion == str(de_comp)
+        assert result.en_companion == str(en_comp)
+        assert result.source_companion == str(tmp_path / "voiceover_demo.py")
+
+        de_text = de_comp.read_text(encoding="utf-8")
+        en_text = en_comp.read_text(encoding="utf-8")
+        # Each half carries only its own language's narration...
+        assert 'lang="de"' in de_text and 'lang="en"' not in de_text
+        assert 'lang="en"' in en_text and 'lang="de"' not in en_text
+        # ...with the author-only positional attributes preserved verbatim.
+        assert 'for_slide="intro"' in de_text and 'for_slide="setup"' in de_text
+        assert 'for_slide="intro"' in en_text and 'for_slide="setup"' in en_text
+        assert "vo_anchor=" in de_text and "vo_anchor=" in en_text
+
+    def test_companion_round_trips_via_unify_texts(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        comp_before = (tmp_path / "voiceover_demo.py").read_text(encoding="utf-8")
+
+        split_in_file(deck)
+
+        de_text = (tmp_path / "voiceover_demo.de.py").read_text(encoding="utf-8")
+        en_text = (tmp_path / "voiceover_demo.en.py").read_text(encoding="utf-8")
+        assert unify_texts(de_text, en_text) == comp_before
+
+    def test_no_companion_creates_no_voiceover_files(self, tmp_path: Path) -> None:
+        # A deck with no sibling companion must not spawn empty voiceover files.
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(HEADER_PREAMBLE + _slide_pair("a", "Eins", "One"), encoding="utf-8")
+        result = split_in_file(deck)
+        assert result.de_companion is None
+        assert result.en_companion is None
+        assert list(tmp_path.glob("voiceover_*.py")) == []
+
+    def test_refuses_when_companion_half_exists(self, tmp_path: Path) -> None:
+        # The deck halves do not exist yet, but a companion half does: split must
+        # still refuse without --force (atomic — nothing is written).
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        de_comp = tmp_path / "voiceover_demo.de.py"
+        de_comp.write_text("placeholder", encoding="utf-8")
+        with pytest.raises(SplitError, match="voiceover_demo.de.py"):
+            split_in_file(deck)
+        # Atomic: the deck halves were not written either.
+        assert not (tmp_path / "slides_demo.de.py").exists()
+        assert de_comp.read_text(encoding="utf-8") == "placeholder"
+
+    def test_force_overwrites_companion_half(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        (tmp_path / "voiceover_demo.de.py").write_text("placeholder", encoding="utf-8")
+        split_in_file(deck, force=True)
+        assert (tmp_path / "voiceover_demo.de.py").read_text(encoding="utf-8") != "placeholder"
+
+    def test_dry_run_writes_no_companion(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        result = split_in_file(deck, dry_run=True)
+        assert result.de_companion == str(tmp_path / "voiceover_demo.de.py")
+        assert not (tmp_path / "voiceover_demo.de.py").exists()
+        assert not (tmp_path / "voiceover_demo.en.py").exists()
+
+    def test_companion_halves_use_lf(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        split_in_file(deck)
+        assert b"\r\n" not in (tmp_path / "voiceover_demo.de.py").read_bytes()
+        assert b"\r\n" not in (tmp_path / "voiceover_demo.en.py").read_bytes()
+
+    def test_write_failure_leaves_no_partial_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The common write failure (disk full) happens during the temp phase,
+        # before any real target is replaced — so a failed split must leave NO
+        # deck half, NO companion half, and no stray .tmp files. This is the
+        # anti-orphan guarantee the companion seam exists to provide.
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+
+        real_write = Path.write_text
+        calls = {"n": 0}
+
+        def flaky(self: Path, *args: object, **kwargs: object) -> int:
+            if self.name.endswith(".tmp"):
+                calls["n"] += 1
+                if calls["n"] == 3:  # the first companion half's temp
+                    raise OSError("simulated disk full")
+            return real_write(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "write_text", flaky)
+        with pytest.raises(OSError, match="simulated disk full"):
+            split_in_file(deck)
+
+        for name in (
+            "slides_demo.de.py",
+            "slides_demo.en.py",
+            "voiceover_demo.de.py",
+            "voiceover_demo.en.py",
+        ):
+            assert not (tmp_path / name).exists()
+        assert list(tmp_path.glob("*.tmp")) == []
+
+
+class TestCompanionUnify:
+    def test_recombines_companions(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        comp_before = (tmp_path / "voiceover_demo.py").read_text(encoding="utf-8")
+        deck_extracted = deck.read_text(encoding="utf-8")
+        split_in_file(deck)
+
+        # Unify the deck halves back; the companions recombine in lockstep.
+        target = tmp_path / "rebuilt.py"
+        result = unify_in_file(
+            tmp_path / "slides_demo.de.py",
+            tmp_path / "slides_demo.en.py",
+            target=target,
+        )
+        assert result.target_companion == str(tmp_path / "voiceover_rebuilt.py")
+        assert target.read_text(encoding="utf-8") == deck_extracted
+        assert (tmp_path / "voiceover_rebuilt.py").read_text(encoding="utf-8") == comp_before
+
+    def test_one_companion_half_is_not_dropped(self, tmp_path: Path) -> None:
+        # Degenerate state: only the DE companion half exists (the EN half was
+        # deleted, or only DE narration was authored). Unify must NOT silently
+        # orphan it — the missing half is treated as empty and the present
+        # narration lands in the bilingual companion.
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        split_in_file(deck)
+        (tmp_path / "voiceover_demo.en.py").unlink()  # drop the EN half
+
+        result = unify_in_file(
+            tmp_path / "slides_demo.de.py",
+            tmp_path / "slides_demo.en.py",
+            target=tmp_path / "rebuilt.py",
+        )
+        rebuilt_comp = tmp_path / "voiceover_rebuilt.py"
+        assert result.target_companion == str(rebuilt_comp)
+        text = rebuilt_comp.read_text(encoding="utf-8")
+        assert "Voiceover DE für intro" in text
+        assert 'lang="en"' not in text
+
+    def test_no_companion_halves_no_target_companion(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(HEADER_PREAMBLE + _slide_pair("a", "Eins", "One"), encoding="utf-8")
+        split_in_file(deck)
+        result = unify_in_file(
+            tmp_path / "slides_demo.de.py",
+            tmp_path / "slides_demo.en.py",
+            target=tmp_path / "rebuilt.py",
+        )
+        assert result.target_companion is None
+        assert not (tmp_path / "voiceover_rebuilt.py").exists()
+
+    def test_refuses_existing_companion_target(self, tmp_path: Path) -> None:
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+        extract_voiceover(deck)
+        split_in_file(deck)
+        # Aim unify at a fresh deck target (does NOT exist) whose companion
+        # target DOES exist — proving the refusal is driven by the companion
+        # alone, not the deck.
+        target = tmp_path / "fresh.py"
+        (tmp_path / "voiceover_fresh.py").write_text("placeholder", encoding="utf-8")
+        with pytest.raises(UnifyError, match="voiceover_fresh.py"):
+            unify_in_file(
+                tmp_path / "slides_demo.de.py",
+                tmp_path / "slides_demo.en.py",
+                target=target,
+                force=False,
+            )
+        assert not target.exists()  # atomic: deck target not written either
+
+    def test_full_round_trip_extract_split_unify_inline(self, tmp_path: Path) -> None:
+        # The complete cross-command seam: a bilingual deck goes
+        # extract → split → unify → inline with no orphaned narration and no
+        # data loss. The deck + companion reconstruct byte-identically through
+        # split/unify; the final inline is a content check, not byte-identity —
+        # bilingual extract↔inline positioning is a separate seam (the
+        # single-language inline IS byte-identical: see the harness
+        # ``extract-inline-round-trip`` row).
+        deck = tmp_path / "slides_demo.py"
+        deck.write_text(_deck_with_voiceover(), encoding="utf-8")
+
+        extract_voiceover(deck)
+        deck_extracted = deck.read_text(encoding="utf-8")
+        comp_before = (tmp_path / "voiceover_demo.py").read_text(encoding="utf-8")
+
+        split_in_file(deck)
+        # Recombine the split halves over the original deck/companion paths.
+        unify_in_file(tmp_path / "slides_demo.de.py", tmp_path / "slides_demo.en.py", force=True)
+
+        # Deck and companion are reconstructed byte-identically; the companion is
+        # back next to the deck (never orphaned).
+        assert deck.read_text(encoding="utf-8") == deck_extracted
+        assert (tmp_path / "voiceover_demo.py").read_text(encoding="utf-8") == comp_before
+
+        # Inline consumes the companion and restores every narration cell.
+        inline_voiceover(deck)
+        merged = deck.read_text(encoding="utf-8")
+        assert "Voiceover DE für intro" in merged
+        assert "Voiceover EN for setup" in merged
+        assert "for_slide=" not in merged  # author-only attrs stripped on inline
+        assert not (tmp_path / "voiceover_demo.py").exists()
 
 
 class TestLineEndingsAreLF:

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -880,6 +880,156 @@ class TestSplitFilePairing:
         assert len(parity_errors) == 1
 
 
+class TestSplitSlideIdParity:
+    """Cross-file ``slide_id`` parity for split pairs — the #162 detective.
+
+    ``slide_id`` is the cross-language join key (voiceover ``for_slide``,
+    ``unify``, extract/inline). A born-split deck or a per-file ``assign-ids``
+    on one half silently diverges the two halves; this check makes it loud.
+    """
+
+    @staticmethod
+    def _id_findings(result):
+        return [
+            f
+            for f in result.findings
+            if f.severity == "warning" and "slide_id" in f.message and "diverge" in f.message
+        ]
+
+    def _pair(self, parent, de_body: str, en_body: str):
+        _write_slide(parent, "slides_intro.de.py", de_body)
+        _write_slide(parent, "slides_intro.en.py", en_body)
+
+    def test_matching_ids_are_clean(self, tmp_path):
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        self._pair(
+            topic,
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="setup"
+            # ## Aufbau
+            """,
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="setup"
+            # ## Setup
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        assert self._id_findings(result) == []
+
+    def test_set_mismatch_is_flagged(self, tmp_path):
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        self._pair(
+            topic,
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="extra"
+            # ## Extra
+            """,
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        findings = self._id_findings(result)
+        assert len(findings) == 1
+        assert "sets diverge" in findings[0].message
+        assert "extra" in findings[0].message
+
+    def test_order_mismatch_is_flagged(self, tmp_path):
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        self._pair(
+            topic,
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="a"
+            # ## A
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="b"
+            # ## B
+            """,
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="b"
+            # ## B
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="a"
+            # ## A
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        findings = self._id_findings(result)
+        assert len(findings) == 1
+        assert "order diverges" in findings[0].message
+
+    def test_set_mismatch_reported_once_in_directory_run(self, tmp_path):
+        # The per-file pass runs with cross_file_parity=False, so a directory
+        # run reports the divergence exactly once (not once per half).
+        topic = tmp_path / "topic"
+        topic.mkdir()
+        self._pair(
+            topic,
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="extra"
+            # ## Extra
+            """,
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+            """,
+        )
+        result = validate_directory(topic, checks=["pairing"])
+        assert len(self._id_findings(result)) == 1
+
+    def test_single_file_with_twin_catches_divergence(self, tmp_path):
+        # The single-file path (CLI standalone / pre-commit gate) catches twin
+        # divergence when the sibling exists on disk.
+        self._pair(
+            tmp_path,
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="extra"
+            # ## Extra
+            """,
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+            """,
+        )
+        result = validate_file(tmp_path / "slides_intro.de.py", checks=["pairing"])
+        assert len(self._id_findings(result)) == 1
+        # Symmetric: editing/validating the EN half catches it too.
+        result_en = validate_file(tmp_path / "slides_intro.en.py", checks=["pairing"])
+        assert len(self._id_findings(result_en)) == 1
+
+    def test_single_file_without_twin_is_silent(self, tmp_path):
+        # A lone .de.py with no .en.py on disk must not error or crash.
+        p = _write_slide(
+            tmp_path,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert self._id_findings(result) == []
+
+
 class TestSplitTagParity:
     """Cross-language tag-set parity for split pairs (Issue #198)."""
 

--- a/tests/slides/test_voiceover_tools.py
+++ b/tests/slides/test_voiceover_tools.py
@@ -8,6 +8,7 @@ import pytest
 
 from clm.slides.split import split_text
 from clm.slides.voiceover_tools import (
+    VoiceoverError,
     companion_path,
     extract_voiceover,
     inline_voiceover,
@@ -218,6 +219,49 @@ class TestExtractVoiceover:
         slide_text = slide_file.read_text(encoding="utf-8")
         assert "slide_id=" in slide_text
 
+    def test_refuses_to_clobber_existing_companion_without_force(self, tmp_path: Path):
+        """Re-extracting onto an existing companion would discard content that
+        lives only in the companion — refuse without ``force`` (Tier-1 fix)."""
+        slide_file = tmp_path / "slides_intro.py"
+        slide_file.write_text(SLIDE_WITH_VOICEOVER, encoding="utf-8")
+        extract_voiceover(slide_file)
+        comp = tmp_path / "voiceover_intro.py"
+        # A hand-edit that lives ONLY in the companion (not in the slide).
+        comp.write_text(
+            comp.read_text(encoding="utf-8")
+            + '\n# %% [markdown] lang="de" tags=["voiceover"] for_slide="x"\n# hand edit\n',
+            encoding="utf-8",
+        )
+        before = comp.read_text(encoding="utf-8")
+        # Re-add a voiceover cell so the empty-vo early-return does not fire.
+        slide_file.write_text(
+            slide_file.read_text(encoding="utf-8")
+            + '# %% [markdown] lang="de" tags=["voiceover"] slide_id="thema"\n# new vo\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(VoiceoverError, match="refusing to overwrite"):
+            extract_voiceover(slide_file)
+        # The companion (and its hand-edit) survives untouched.
+        assert comp.read_text(encoding="utf-8") == before
+
+    def test_force_rebuilds_existing_companion(self, tmp_path: Path):
+        slide_file = tmp_path / "slides_intro.py"
+        slide_file.write_text(SLIDE_WITH_VOICEOVER, encoding="utf-8")
+        extract_voiceover(slide_file)
+        comp = tmp_path / "voiceover_intro.py"
+        comp.write_text("# stale placeholder\n", encoding="utf-8")
+        # Re-add a voiceover cell so there is something to extract.
+        slide_file.write_text(
+            slide_file.read_text(encoding="utf-8")
+            + '# %% [markdown] lang="de" tags=["voiceover"] slide_id="thema"\n# fresh vo\n',
+            encoding="utf-8",
+        )
+        result = extract_voiceover(slide_file, force=True)
+        assert result.cells_extracted >= 1
+        rebuilt = comp.read_text(encoding="utf-8")
+        assert "stale placeholder" not in rebuilt
+        assert "fresh vo" in rebuilt
+
 
 # ---------------------------------------------------------------------------
 # inline_voiceover — basic
@@ -281,6 +325,42 @@ class TestInlineVoiceover:
 
         slide_text = slide_file.read_text(encoding="utf-8")
         assert "for_slide=" not in slide_text
+
+    def test_partial_inline_retains_only_unmatched(self, tmp_path: Path):
+        """Matched cells are inlined; the companion is rewritten to hold only the
+        unmatched remainder (recoverable), never destroyed (Tier-1 fix)."""
+        slide_file = tmp_path / "slides_intro.py"
+        slide_file.write_text(
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="one"\n# ## One\n'
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="one"\n# VO one\n'
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="two"\n# ## Two\n'
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="two"\n# VO two\n',
+            encoding="utf-8",
+        )
+        extract_voiceover(slide_file)
+        comp = tmp_path / "voiceover_intro.py"
+        # Rename slide "two" so its companion cell can no longer match.
+        slide_file.write_text(
+            slide_file.read_text(encoding="utf-8").replace(
+                'slide_id="two"', 'slide_id="renamed-two"'
+            ),
+            encoding="utf-8",
+        )
+
+        result = inline_voiceover(slide_file)
+
+        assert result.cells_inlined == 1
+        assert result.unmatched_cells == 1
+        assert result.companion_deleted is False
+        assert result.companion_retained is True
+
+        slide_text = slide_file.read_text(encoding="utf-8")
+        assert "VO one" in slide_text  # matched cell inlined
+        assert "VO two" not in slide_text  # unmatched NOT stranded in the slide
+
+        comp_text = comp.read_text(encoding="utf-8")
+        assert "VO two" in comp_text  # unmatched kept in companion
+        assert "VO one" not in comp_text  # matched removed from companion
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +474,8 @@ x = 1
         assert 'tags=["voiceover"]' not in slide_text
 
     def test_inline_with_unmatched_cells(self, tmp_path: Path):
-        """Companion cells with unknown for_slide are appended at the end."""
+        """Unmatched companion cells are *retained in the companion*, not dumped
+        into the slide nor destroyed (Tier-1 data-loss fix)."""
         slide_file = tmp_path / "slides_test.py"
         slide_text = """\
 # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
@@ -413,9 +494,13 @@ x = 1
 
         assert result.unmatched_cells == 1
         assert result.cells_inlined == 0
-        # Unmatched cells are appended at the end
-        final_text = slide_file.read_text(encoding="utf-8")
-        assert "This has no matching slide." in final_text
+        # The companion is preserved (recoverable source of truth), not deleted.
+        assert result.companion_deleted is False
+        assert result.companion_retained is True
+        assert comp.exists()
+        assert "This has no matching slide." in comp.read_text(encoding="utf-8")
+        # The unmatched narration is NOT stranded in the slide file.
+        assert "This has no matching slide." not in slide_file.read_text(encoding="utf-8")
 
     def test_j2_cells_untouched(self, tmp_path: Path):
         """j2 cells should not be extracted or have slide_ids."""
@@ -1244,6 +1329,7 @@ class TestAnchorAmbiguityAndScoping:
         f = tmp_path / "slides_x.py"
         f.write_text(deck, encoding="utf-8", newline="\n")
         extract_voiceover(f)
+        comp = companion_path(f)
         # Rename the owning slide between extract and inline.
         t = f.read_text(encoding="utf-8").replace('slide_id="two"', 'slide_id="two-renamed"')
         f.write_text(t, encoding="utf-8", newline="\n")
@@ -1253,8 +1339,12 @@ class TestAnchorAmbiguityAndScoping:
 
         assert res.unmatched_cells == 1
         assert res.relocated_cells == 0
-        # Appended at the end — never inserted into the foreign group one.
-        assert out.index("VO belongs to group TWO.") > out.index("## Group Two")
+        # Never inserted into the foreign group one — and, per the Tier-1 fix,
+        # not stranded in the slide at all: it is retained in the companion
+        # (recoverable) so the author can fix the slide_id and re-run inline.
+        assert res.companion_retained is True
+        assert "VO belongs to group TWO." not in out
+        assert "VO belongs to group TWO." in comp.read_text(encoding="utf-8")
 
     def test_renamed_for_slide_in_build_merge_reports_unmatched(self):
         """merge_voiceover_text must report the unmatched id, not silently


### PR DESCRIPTION
Hardens CLM's **split-language + separated-voiceover** slide workflow before pushing further on it. Guided by `docs/claude/design/split-voiceover-hardening.md` (self-contained: hazard inventory, edit-dynamics table, #162 triad, harness spec, command-surface rethink). The work is driven executably by a fault-injection harness — each fix flips a classified footgun from **break-silent → preserve/break-loud**, guarded against regression in the fast suite.

## Commits (sequential series)

1. **`test(slides)`: edit-dynamics fault-injection harness** — `scripts/edit_dynamics_harness.py` + `tests/slides/test_edit_dynamics.py`. Classifies each (mutation, command-path) as preserve / break-loud / break-silent; the break-silent rows are the work-list. No-LLM via `CountingTranslator`/`CountingJudge`.
2. **`fix(voiceover)`: stop companion data loss in extract/inline + output leak** (Tier-1) — `voiceover_*.py` no longer leaks into the output tree; `inline` retains the companion (anchors intact) on unmatched and exits non-zero instead of deleting it; `extract` gains `--force` and refuses to clobber an existing companion.
3. **`feat(validate)`: #162 cross-file `slide_id` parity detective** — `clm validate` warns when a split `.de`/`.en` pair diverges on `slide_id` set/order (the cross-language join key); wired at dir/course scope and single-file-with-twin, so a pre-commit gate catches a divergence before it ships.
4. **`feat(assign-ids)`: twin-aware reuse on split halves (#162 defensive)** — a per-file `assign-ids` run on one half adopts the sibling's ids instead of minting a divergent slug.
5. **`feat(assign-ids)`: EN-authority generative minting for split pairs (#162 generative)** — a directory run mints EN-authority ids across both halves at once (unify→assign→split), gated by a byte-faithful round-trip guard.
6. **`feat(slides)`: split/unify carry the voiceover companion in lockstep** — `split` splits a sibling `voiceover_X.py` into `voiceover_X.de.py`/`.en.py` (route by `lang`, preserve `for_slide`/`vo_anchor`); `unify` recombines them. Closes the extract-then-split orphaning footgun. Atomic write-all-temps-then-replace; `--force` covers deck+companion; reuses `split_text`/`unify_texts` (companions have no header macro).

## Verification

- Harness progressed **8/0/7 → 14 preserve / 1 break-loud / 1 break-silent** (only the observe-only `build-merge-unmatched` remains), with `test_no_drift` freezing every verdict.
- New unit tests across `test_voiceover_tools.py`, `test_validator.py`, `test_assign_ids.py`, and `TestCompanionSplit`/`TestCompanionUnify` in `test_split.py` (round-trip, atomicity, `--force`, dry-run, asymmetric half, full extract→split→unify→inline chain).
- Full fast suite **green (6202 passed)**; ruff + mypy clean; info topics (`commands.md`, `migration.md`) updated per the Info Topics Maintenance Rule.

## Notes

- The companion seam was put through a 3-lens adversarial review; the one substantive finding (multi-file write non-atomicity) is addressed via `_atomic_write_all`.
- Known separate seam (not regressed here): **bilingual** extract→inline isn't byte-identical (positioning/blank-lines); the single-language inline — the realistic path on a split half — is. No narration is lost.
- Remaining work-list (follow-ups): `extract-voiceover` twin-awareness + companion `for_slide` parity; build-merge unmatched escalation; command-surface rethink (§8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)