### PR TITLE
feat(validate): companion for_slide-parity detective + --fail-on gate (#162)

### DIFF
--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -390,13 +390,16 @@ within one bilingual file.
 
 - **Detective (= the pre-commit gate, §9):** ✅ **BUILT 2026-06-03** — enforce the
   invariant every "silent break" row violates — across `.de`/`.en`, equal `slide_id`
-  sets in equal order (companion `for_slide` sets still to add). Shipped as a `clm validate`
-  `pairing`-group warning: `_check_split_slide_id_parity` in `validator.py`, wired at
-  dir/course scope **and** the single-file path (`validate_file(cross_file_parity=True)` when
-  a twin exists on disk, so the pre-commit gate / PostToolUse path catch it). Harness
-  `commit-without-sync` flipped break-silent → break-loud ("detective CATCHES it"). 6 new
-  unit tests. Companion `for_slide` parity (the both-language voiceover compatibility check)
-  is the small remaining extension.
+  sets in equal order **and** equal companion `for_slide` sets. Shipped as `clm validate`
+  `pairing`-group warnings: `_check_split_slide_id_parity` (deck join key) and
+  `_check_split_companion_for_slide_parity` (the both-language voiceover compatibility
+  check) in `validator.py`, both wired at dir/course scope **and** the single-file path
+  (`validate_file(cross_file_parity=True)` when a twin exists on disk, so the pre-commit
+  gate / PostToolUse path catch it). The companion check compares the `!`-stripped
+  `for_slide` *set* (not order/multiplicity — one language may split a narration across more
+  cells) and also flags a one-sided companion. Harness `commit-without-sync` and
+  `commit-companion-divergence` are both break-loud ("detective CATCHES it"). 6 + 9 unit
+  tests (`TestSplitSlideIdParity` / `TestSplitCompanionForSlideParity`).
 - **Defensive:** ✅ **`assign-ids` BUILT 2026-06-03** — the highest-frequency break.
   `assign_ids_in_file` is now twin-aware: on a split half whose twin exists on disk
   with a matching slide count, an **id-less** slide adopts the twin's id
@@ -470,13 +473,20 @@ remain reachable for agents/scripts but are not the path of least resistance.
 Lives in the **course repo** (e.g. PythonCourses `.pre-commit-config.yaml`), not CLM
 itself — CLM provides the check command. It runs over the staged set:
 - the **#162 detective**: cross-file `slide_id` set+order equality across each
-  `.de`/`.en` pair, and companion `for_slide`-set equality;
+  `.de`/`.en` pair (`_check_split_slide_id_parity`), and companion `for_slide`-set
+  equality (`_check_split_companion_for_slide_parity`) — **both DONE 2026-06-03**;
 - `validate` (dir-scoped, so cross-file parity actually fires) — **with `--fail-on
-  warning`** (or a split-critical-categories strict mode), because today
+  warning`** (**DONE 2026-06-03**: `clm validate ... --fail-on {error,warning}` in
+  `validate_slides.py` / `validate.py`, threshold-driven `SystemExit`, governs `--json`
+  too when set; opt-in so default exit behavior is unchanged), because today
   missing-`slide_id`, tag-parity asymmetry, slug-format, and pair-id mismatch are all
-  *warnings* (exit 0, `validator.py:753-769`), so a naive `validate && commit` lets
-  them through;
+  *warnings* (exit 0), so a naive `validate && commit` lets them through;
 - `sync --dry-run` to fail on an unsynced half (`--check`-style exit code).
+
+The **CLM half** of the gate (the `--fail-on warning` flag + the parity detectives)
+is now built; the **course-repo half** (wiring the hook into
+`.pre-commit-config.yaml` and the error-vs-warning-on-first-run rollout decision,
+§7 Q2) is the remaining work and lives in the course repo.
 
 `build` stays permissive for now (decision #2). If the gate proves leaky, revisit
 build-time refusal later.
@@ -499,7 +509,11 @@ Required hardening:
   voiceover layer. Well-defined because #162 guarantees `de_id==en_id`. The
   `extract-then-split` harness row flipped break-silent → preserve.
 - **Both-language compatibility check** = companion `for_slide`-set equality across
-  `.de`/`.en` (same invariant as the slide check; part of the detective gate).
+  `.de`/`.en` — **DONE (2026-06-03)**: `_check_split_companion_for_slide_parity` in
+  `validator.py`, wired alongside the `slide_id` parity detective (dir/course + single-file
+  with twin). Compares the `!`-stripped `for_slide` set; surfaces a divergent set or a
+  one-sided companion as a `pairing` warning. Harness `commit-companion-divergence` =
+  break-loud.
 - **Build-time escalation** of unmatched `for_slide` from log-only to a surfaced
   finding (respecting a fail-on policy), and surface inline **relocations** at build
   time (today discarded in `merge_voiceover_text`).
@@ -549,9 +563,14 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
      `for_slide`/`vo_anchor`, byte-identical round trip; lazy `companion_path` import; CLI +
      `--json` report companions; info topics updated). `extract-then-split` harness row flipped
      break-silent → preserve; `tests/slides/test_split.py::TestCompanionSplit`/`TestCompanionUnify`.
-   - **Next:** `extract-voiceover` twin-awareness + companion `for_slide` parity (the both-language
-     voiceover compat check, extends the detective); then the build-merge observe-only escalation
-     (the one remaining break-silent row).
+   - **Companion `for_slide` parity ✅ DONE 2026-06-03** (§7/§9/§10) — the both-language
+     voiceover compatibility check, `_check_split_companion_for_slide_parity` in `validator.py`,
+     wired alongside the `slide_id` parity detective (dir/course + single-file with twin). New
+     harness row `commit-companion-divergence` = break-loud; `TestSplitCompanionForSlideParity`
+     (9 tests). Harness now 14 preserve / 2 break-loud / 1 break-silent.
+   - **Next:** `extract-voiceover` twin-awareness (a paired/twin-aware extraction so the two
+     companions are produced together rather than per-file); then the build-merge observe-only
+     escalation (the one remaining break-silent row, `build-merge-unmatched`).
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.
@@ -587,8 +606,11 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
   `:87-100`, `is_ignored_file_for_output` `:244-262`); `output_sweep.py`
   (`:43-52,160-166,264-276`); `notebook_processor.py` (strips slide_id/for_slide
   `:1586-1592`).
-- Validator: `validator.py` (slide_ids `:696-876`; cross-file parity `:879-1014`,
-  wired only at dir/course `:1433-1436,1486-1489`; `validate_quick` `:1364-1398`).
+- Validator: `validator.py` (slide_ids `:696-876`; cross-file parity `:879-1014`;
+  `_check_split_slide_id_parity` (#162 deck detective) + `_check_split_companion_for_slide_parity`
+  (#162 companion `for_slide`-parity / both-language voiceover compat — lazy `companion_path`
+  import), wired at dir/course **and** the single-file-with-twin path
+  (`validate_file(cross_file_parity=True)`, `_split_twin_pair`); `validate_quick` `:1364-1398`).
 - Tests/harness: `tests/slides/test_split.py` (round-trip property),
   `test_voiceover_tools.py` (extract/inline, positional anchors),
   `test_sync_limitations.py` + `test_sync_anchor.py` (item-2/3 fix, CI),

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -129,6 +129,14 @@ def voiceover_cell(lang: str, *, sid: str, text: str | None = None) -> str:
     return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n#\n# {body}\n\n'
 
 
+def companion_cell(lang: str, *, for_slide: str, text: str | None = None) -> str:
+    """A voiceover cell *inside a companion file* (carries for_slide, not slide_id)."""
+    body = text if text is not None else f"Voiceover {lang.upper()} for {for_slide}"
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["voiceover"] for_slide="{for_slide}"\n#\n# {body}\n\n'
+    )
+
+
 def shared_code(name: str = "x", value: str = "1") -> str:
     """A language-neutral shared code cell (no lang attribute)."""
     return f'# %% tags=["keep"]\n{name} = {value}\n\n'
@@ -565,6 +573,35 @@ def m_commit_without_sync(workdir: Path) -> _RetTuple:
     )
 
 
+def m_commit_companion_divergence(workdir: Path) -> _RetTuple:
+    # Author extracts voiceover for both halves but the EN companion narrates
+    # fewer slides than DE (e.g. EN voiceover not finished), then commits. The
+    # decks are in slide_id parity, so the slide_id detective is clean; the new
+    # companion `for_slide`-parity arm of the #162 detective is what must catch
+    # the divergence loudly (break-loud), or one language silently ships with
+    # missing narration at build.
+    base = _base()  # decks in slide_id parity (intro/setup/demo)
+    pair = SplitPair(
+        de=base.de,
+        en=base.en,
+        de_companion=companion_cell("de", for_slide="intro")
+        + companion_cell("de", for_slide="setup"),
+        en_companion=companion_cell("en", for_slide="intro"),  # missing `setup`
+    )
+    de_path, _ = pair.write(workdir)
+    assert pair.de_companion is not None and pair.en_companion is not None
+    diverged = set(for_slides(pair.de_companion)) != set(for_slides(pair.en_companion))
+    findings = validate_file(de_path).findings
+    caught = any(f.category == "pairing" and "voiceover companion" in f.message for f in findings)
+    return (
+        (["companion_for_slide_parity"] if diverged else []),
+        caught,
+        "validate (detective) reports companion for_slide divergence" if caught else "",
+        f"de={for_slides(pair.de_companion)} en={for_slides(pair.en_companion)}; "
+        f"detective {'CATCHES it' if caught else 'misses it'}",
+    )
+
+
 # --- voiceover round-trip (expected: preserve) -----------------------------
 
 
@@ -773,6 +810,12 @@ MUTATIONS: list[Mutation] = [
     # #162 detective landed: the pre-commit gate (`clm validate`) now catches a
     # committed split-half divergence — break-silent -> break-loud.
     Mutation("commit-without-sync", "no-gate", BREAK_LOUD, True, m_commit_without_sync),
+    # Companion arm of the #162 detective: `clm validate` flags a split pair
+    # whose voiceover companions narrate different slide sets (for_slide parity),
+    # so a half-finished EN companion can't silently ship missing narration.
+    Mutation(
+        "commit-companion-divergence", "no-gate", BREAK_LOUD, True, m_commit_companion_divergence
+    ),
     # Companion split/unify path landed: `split` splits a sibling voiceover
     # companion in lockstep (and `unify` recombines it), so extract-then-split
     # no longer orphans the narration — break-silent -> preserve.

--- a/src/clm/cli/commands/validate.py
+++ b/src/clm/cli/commands/validate.py
@@ -82,6 +82,16 @@ def _infer_kind(path: Path) -> str | None:
     is_flag=True,
     help=('Spec-only: validate sections marked enabled="false". Not valid with --kind=slides.'),
 )
+@click.option(
+    "--fail-on",
+    type=click.Choice(["error", "warning"], case_sensitive=False),
+    default=None,
+    help=(
+        "Slides-only: exit non-zero when findings reach this severity. "
+        "'warning' makes the cross-file slide_id / voiceover for_slide parity "
+        "warnings fail a pre-commit gate. Not valid with --kind=spec."
+    ),
+)
 @click.pass_context
 def validate_cmd(
     ctx: click.Context,
@@ -92,6 +102,7 @@ def validate_cmd(
     checks: str | None,
     quick: bool,
     include_disabled: bool,
+    fail_on: str | None,
 ) -> None:
     """Validate a course spec file or slide files.
 
@@ -110,9 +121,9 @@ def validate_cmd(
         )
 
     if resolved_kind == "spec":
-        if checks or quick:
+        if checks or quick or fail_on:
             raise click.UsageError(
-                "--checks and --quick are slides-only; not valid with --kind=spec."
+                "--checks, --quick, and --fail-on are slides-only; not valid with --kind=spec."
             )
         if not path.is_file() or path.suffix.lower() != ".xml":
             # Spec validator expects a single XML file; refuse anything
@@ -135,4 +146,5 @@ def validate_cmd(
             quick=quick,
             as_json=as_json,
             data_dir=data_dir,
+            fail_on=fail_on,
         )

--- a/src/clm/cli/commands/validate_slides.py
+++ b/src/clm/cli/commands/validate_slides.py
@@ -10,6 +10,7 @@ import click
 from clm.slides.validator import (
     ALL_CHECKS,
     ALL_DETERMINISTIC_CHECKS,
+    Finding,
     ValidationResult,
     validate_course,
     validate_directory,
@@ -52,12 +53,26 @@ from clm.slides.validator import (
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Course data directory (contains slides/). For course spec validation.",
 )
+@click.option(
+    "--fail-on",
+    type=click.Choice(["error", "warning"], case_sensitive=False),
+    default=None,
+    help=(
+        "Exit non-zero when findings reach this severity. "
+        "'error' fails on errors only (the default exit behavior); "
+        "'warning' also fails on warnings — use it for a pre-commit gate so the "
+        "cross-file slide_id / voiceover for_slide parity warnings block a "
+        "commit. When set, --fail-on governs the exit code with --json too; "
+        "without it, JSON mode always exits 0."
+    ),
+)
 def validate_slides_cmd(
     path: Path,
     checks: str | None,
     quick: bool,
     as_json: bool,
     data_dir: Path | None,
+    fail_on: str | None,
 ):
     """Validate slide files for format, tag, and pairing correctness.
 
@@ -72,6 +87,7 @@ def validate_slides_cmd(
         clm validate course-specs/python-basics.xml
         clm validate slides/topic/slides_intro.py --quick
         clm validate slides/topic/slides_intro.py --json
+        clm validate slides/ --fail-on warning            # pre-commit gate
     """
     if quick:
         if not path.is_file():
@@ -83,12 +99,29 @@ def validate_slides_cmd(
 
     if as_json:
         click.echo(json.dumps(_result_to_dict(result), indent=2))
-        return
+    else:
+        _print_human_readable(result)
 
-    _print_human_readable(result)
+    _raise_on_findings(result.findings, fail_on, as_json)
 
-    errors = [f for f in result.findings if f.severity == "error"]
-    if errors:
+
+def _raise_on_findings(findings: list[Finding], fail_on: str | None, as_json: bool) -> None:
+    """Exit non-zero according to the ``--fail-on`` threshold.
+
+    ``--fail-on`` unset (``None``) keeps the legacy behavior: human output
+    fails on ``error`` findings, JSON output never sets an exit code (machine
+    consumers read the findings list). ``--fail-on error`` fails on errors in
+    either output mode; ``--fail-on warning`` fails on errors *or* warnings —
+    the pre-commit-gate setting, so the cross-file slide_id / voiceover
+    for_slide parity warnings (and the rest of the warning family) block.
+    """
+    if fail_on is None:
+        blocking = set() if as_json else {"error"}
+    elif fail_on == "warning":
+        blocking = {"error", "warning"}
+    else:  # "error"
+        blocking = {"error"}
+    if any(f.severity in blocking for f in findings):
         raise SystemExit(1)
 
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -517,8 +517,18 @@ clm validate [OPTIONS] PATH
 | `--quick` | Fast syntax-only check (format + tags + slide_ids). Useful for PostToolUse hooks |
 | `--json` | Output as JSON |
 | `--data-dir DIR` | Course data directory (contains slides/) |
+| `--fail-on {error,warning}` | (since CLM {version}) Exit non-zero when findings reach this severity. Unset: legacy behavior (human output fails on errors; JSON exits 0). `error`: fail on errors in either mode. `warning`: fail on errors **or** warnings — the pre-commit-gate setting, so the cross-file `slide_id` / voiceover `for_slide` parity warnings block a commit. |
 
 `PATH` can be a single slide file, a topic directory, or a course spec XML file.
+
+Since CLM {version}, `clm validate slides/ --fail-on warning` is the
+pre-commit gate: by default the `pairing` warnings (missing/divergent
+`slide_id`, tag-parity asymmetry, the cross-file `slide_id` / voiceover
+`for_slide` parity detectives) surface but exit 0, so a naive
+`clm validate && git commit` lets them through. `--fail-on warning`
+escalates the exit code so a hook fails on them; it governs the exit code
+with `--json` too (without `--fail-on`, JSON mode always exits 0 for
+backward compatibility).
 
 Since CLM {version}, the **`voiceover` coverage check is opt-in** (issue #176).
 Voiceover is now optional per deck, so the check — which reports a gap for every
@@ -540,6 +550,7 @@ adjacency, and — since CLM {version} — **`slide_id` metadata**:
 | voiceover/notes `slide_id` ≠ preceding `slide`/`subslide` anchor | `error` | Walk-back skips j2, code, shared (lang-less), and cross-language narrative cells. The j2 `header()` macro anchors `slide_id="title"` for narrative cells that follow it. |
 | paired DE/EN slides carry mismatched bare `slide_id`s | `warning` | Suggested fix: `clm slides assign-ids --force`. |
 | split pair `.de.py` / `.en.py` carry a different `slide_id` set or order | `warning` | **Cross-file** (issue #162): `slide_id` is the cross-language join key for voiceover `for_slide`, `clm slides unify`, and extract/inline. Route structural changes through `clm slides sync`; avoid per-file `clm slides assign-ids` on a split half. Runs on a directory/course validate, and on a single-file validate when the twin exists on disk. |
+| split pair voiceover companions narrate different slides (`for_slide` set differs) | `warning` | **Cross-file** (issue #162, the both-language voiceover compatibility check): a narration cell's `for_slide` is the `slide_id` of the slide it covers, so the `.de` / `.en` companions (`voiceover_X.de.py` / `voiceover_X.en.py`) must narrate the same set of slides — otherwise one language ships with missing voiceover. A one-sided companion (one language has voiceover, the other none) is flagged too. Runs on a directory/course validate, and on a single-file validate when the twin exists on disk. |
 | `slide_id` is not a valid kebab-case ASCII slug (≤30 chars) | `warning` | The leading `!` preserve marker is permitted and does not count toward the length cap. |
 
 Since CLM {version}, the **bilingual** `pairing` sub-checks (DE/EN cell
@@ -554,8 +565,11 @@ still applied when validating a directory or course spec. Since CLM
 {version} the cross-file **`slide_id` parity** check (issue #162) is applied
 the same way — and additionally on a single-file validate when the twin
 exists on disk, so the pre-commit gate and the PostToolUse path catch a
-divergent join key. Bilingual decks (no `.de` / `.en` suffix) are
-unaffected — the full pairing check still runs.
+divergent join key. The companion **`for_slide` parity** check (the
+both-language voiceover compatibility check) is applied alongside it, so a
+split deck's `voiceover_X.de.py` / `voiceover_X.en.py` companions can't
+silently narrate different slide sets. Bilingual decks (no `.de` / `.en`
+suffix) are unaffected — the full pairing check still runs.
 
 Since CLM {version}, the `tags` check group also verifies **workshop
 scope** (issue #78). The `partial` output kind leaves a workshop's code

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -101,6 +101,26 @@ directory/course validate **and** on a single-file validate when the twin
 exists on disk — so a pre-commit hook (`clm validate slides/ --fail-on warning`,
 or per-file in a PostToolUse hook) catches a divergence before it ships.
 
+The same join key governs **separated voiceover**: each narration cell's
+`for_slide` is the `slide_id` of the slide it covers. CLM {version} extends the
+detective with a companion **`for_slide` parity** check (the both-language
+voiceover compatibility check) — it flags a split deck whose
+`voiceover_<name>.de.py` / `voiceover_<name>.en.py` companions narrate
+different sets of slides (`for_slide` sets differ), or where only one language
+has a companion at all. Without it, a half-finished EN companion silently ships
+the EN slides with missing narration at build time. It is wired the same way
+as the `slide_id` parity check (directory/course, plus single-file when the
+twin exists on disk) and compares the bare (`!`-stripped) `for_slide` *set* —
+one language may legitimately split a slide's narration across a different
+number of cells.
+
+Both detectives are `warning`-severity, so by default `clm validate` reports
+them but still exits 0. CLM {version} adds `clm validate --fail-on {error,warning}`
+to make them gate-able: `clm validate slides/ --fail-on warning` exits non-zero
+on any warning (the parity detectives included), which is what a pre-commit hook
+needs. `--fail-on` governs the exit code with `--json` too; without it, behavior
+is unchanged (human output fails on errors, JSON exits 0).
+
 Since CLM {version} `clm slides assign-ids` keeps the two halves consistent
 automatically. A **directory / course run** mints **EN-authority** ids across a
 `.de.py` / `.en.py` pair at once (the #162 *generative*): the slug derives from

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -1100,6 +1100,105 @@ def _check_split_slide_id_parity(de_path: Path, en_path: Path) -> list[Finding]:
     return findings
 
 
+def _check_split_companion_for_slide_parity(de_path: Path, en_path: Path) -> list[Finding]:
+    """Verify the voiceover companions of a split pair narrate the same slides.
+
+    Separated voiceover lives in sibling companion files
+    (``voiceover_X.de.py`` / ``voiceover_X.en.py``); every narration cell is
+    bound to its owning slide by ``for_slide`` (= that slide's ``slide_id``).
+    The build merge resolves ``for_slide`` against the *same-language* deck
+    half, so if one companion narrates a slide its twin does not, that language
+    ships with missing narration and nothing says so. This is the
+    **both-language voiceover compatibility check** — the companion arm of the
+    #162 detective and part of the pre-commit gate (design §9/§10). It is the
+    natural extension of :func:`_check_split_slide_id_parity`: the slide_id
+    parity guards the join key on the deck; this guards the same key on the
+    companions that reference it.
+
+    Compares the *set* of ``for_slide`` references (preserve-marker stripped),
+    not their order or multiplicity — one language may legitimately split a
+    slide's narration across a different number of cells. Fires only when a
+    companion exists on at least one side; a deck pair with no voiceover at all
+    is clean. A one-sided companion (one language has voiceover, the other
+    none) is surfaced too — that is just the degenerate divergence where one
+    set is empty. Findings are ``warning`` severity, consistent with the rest
+    of the slide_id family (the gate runs with ``--fail-on warning``).
+    """
+    # ``companion_path`` lives in the voiceover layer, which sits *above* the
+    # validator/split layer; import it lazily (as ``split.py`` does for the
+    # companion seam) so the validator carries no hard dependency on the
+    # optional voiceover tooling.
+    from clm.slides.voiceover_tools import companion_path
+
+    de_comp = companion_path(de_path)
+    en_comp = companion_path(en_path)
+    de_exists, en_exists = de_comp.exists(), en_comp.exists()
+    if not de_exists and not en_exists:
+        return []
+
+    # One-sided companion: the language without a companion ships no narration.
+    if de_exists != en_exists:
+        present, absent = (de_comp, en_comp) if de_exists else (en_comp, de_comp)
+        missing_lang = "EN" if de_exists else "DE"
+        return [
+            Finding(
+                severity="warning",
+                category="pairing",
+                file=str(present),
+                line=1,
+                message=(
+                    f"voiceover companion {present.name} exists but its twin "
+                    f"{absent.name} does not — the {missing_lang} half ships "
+                    f"without narration"
+                ),
+                suggestion=(
+                    "Separated voiceover must be present (or absent) on both "
+                    "halves of a split deck. Extract voiceover for the missing "
+                    f"language ({missing_lang}) too, or remove the lone "
+                    "companion."
+                ),
+            )
+        ]
+
+    def _for_slide_set(path: Path) -> set[str]:
+        return {
+            strip_preserve_marker(c.metadata.for_slide)
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.for_slide
+        }
+
+    de_set = _for_slide_set(de_comp)
+    en_set = _for_slide_set(en_comp)
+    if de_set == en_set:
+        return []
+
+    only_de = sorted(de_set - en_set)
+    only_en = sorted(en_set - de_set)
+    detail = ""
+    if only_de:
+        detail += f"; only on DE: {only_de}"
+    if only_en:
+        detail += f"; only on EN: {only_en}"
+    return [
+        Finding(
+            severity="warning",
+            category="pairing",
+            file=str(de_comp),
+            line=1,
+            message=(
+                f"split pair voiceover companion for_slide sets diverge between "
+                f"{de_comp.name} and {en_comp.name}{detail}"
+            ),
+            suggestion=(
+                "Each narration cell's for_slide is the slide_id of the slide it "
+                "narrates; the DE/EN companions must cover the same set of slides, "
+                "or one language ships with missing voiceover. Add the missing "
+                "narration, or route the change through `clm slides sync`."
+            ),
+        )
+    ]
+
+
 def _split_twin_pair(path: Path) -> tuple[Path, Path] | None:
     """If ``path`` is a split half whose twin exists on disk, return the ordered
     ``(de_path, en_path)`` pair; else ``None``.
@@ -1425,9 +1524,11 @@ def validate_file(
         cross_file_parity: When ``True`` (the default for standalone callers —
             the CLI single-file path, MCP, the pre-commit gate) and ``path`` is
             a split half whose twin exists on disk, run the #162 cross-file
-            ``slide_id`` parity detective against the twin. Directory/course
-            entrypoints pass ``False`` and run that parity once at their own
-            scope instead, so a directory run does not duplicate the finding.
+            parity detectives against the twin: ``slide_id`` set/order parity on
+            the deck, and ``for_slide`` set parity on the voiceover companions
+            (the both-language voiceover compatibility check). Directory/course
+            entrypoints pass ``False`` and run those once at their own scope
+            instead, so a directory run does not duplicate the findings.
 
     Returns:
         A :class:`ValidationResult` with findings and optional review material.
@@ -1464,6 +1565,7 @@ def validate_file(
             pair = _split_twin_pair(path)
             if pair is not None:
                 findings.extend(_check_split_slide_id_parity(*pair))
+                findings.extend(_check_split_companion_for_slide_parity(*pair))
 
     # Review material extraction
     review_checks = check_set & ALL_REVIEW_CHECKS
@@ -1560,6 +1662,7 @@ def validate_directory(
             all_findings.extend(_check_shared_cell_parity(de_path, en_path))
             all_findings.extend(_check_split_tag_parity(de_path, en_path))
             all_findings.extend(_check_split_slide_id_parity(de_path, en_path))
+            all_findings.extend(_check_split_companion_for_slide_parity(de_path, en_path))
 
     return ValidationResult(
         files_checked=len(slide_files),
@@ -1615,6 +1718,7 @@ def validate_course(
                     all_findings.extend(_check_shared_cell_parity(de_path, en_path))
                     all_findings.extend(_check_split_tag_parity(de_path, en_path))
                     all_findings.extend(_check_split_slide_id_parity(de_path, en_path))
+                    all_findings.extend(_check_split_companion_for_slide_parity(de_path, en_path))
 
     return ValidationResult(
         files_checked=files_checked,

--- a/tests/cli/test_validate_slides.py
+++ b/tests/cli/test_validate_slides.py
@@ -222,6 +222,75 @@ class TestValidateSlidesCommand:
         assert result.exit_code != 0
         assert "Unknown check" in result.output
 
+    def _warning_pair(self, tmp_path: Path) -> Path:
+        # A balanced DE/EN pair, both slides missing slide_id -> warning-only
+        # findings (missing slide_id is a warning; no errors).
+        return _write_slide(
+            tmp_path,
+            "slides_warn.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"]
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"]
+            # ## Title
+            """,
+        )
+
+    def test_warning_without_fail_on_exits_zero(self, tmp_path):
+        p = self._warning_pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p)])
+        assert result.exit_code == 0
+        assert "WARN" in result.output
+
+    def test_fail_on_warning_exits_nonzero(self, tmp_path):
+        p = self._warning_pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--fail-on", "warning"])
+        assert result.exit_code == 1
+        assert "WARN" in result.output
+
+    def test_fail_on_warning_clean_exits_zero(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "slides_ok.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="title"
+            # ## Title
+            """,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--fail-on", "warning"])
+        assert result.exit_code == 0
+
+    def test_fail_on_error_with_warnings_exits_zero(self, tmp_path):
+        # --fail-on error must NOT escalate on warning-only findings.
+        p = self._warning_pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--fail-on", "error"])
+        assert result.exit_code == 0
+
+    def test_fail_on_warning_json_exits_nonzero(self, tmp_path):
+        # When --fail-on is explicit, it governs the exit code in JSON mode too.
+        p = self._warning_pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--json", "--fail-on", "warning"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert any(f["severity"] == "warning" for f in data["findings"])
+
+    def test_fail_on_not_valid_with_spec(self, tmp_path):
+        spec_path = tmp_path / "course.xml"
+        spec_path.write_text("<course></course>", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(spec_path), "--fail-on", "warning"])
+        assert result.exit_code != 0
+        assert "slides-only" in result.output
+
     def test_review_material_in_json(self, tmp_path):
         p = _write_slide(
             tmp_path,

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -1030,6 +1030,217 @@ class TestSplitSlideIdParity:
         assert self._id_findings(result) == []
 
 
+class TestSplitCompanionForSlideParity:
+    """Cross-file ``for_slide`` parity for voiceover companions — the companion
+    arm of the #162 detective (the both-language voiceover compatibility check).
+
+    Separated voiceover lives in ``voiceover_X.de.py`` / ``voiceover_X.en.py``;
+    each narration cell's ``for_slide`` names the slide it narrates. If one
+    companion narrates a slide its twin does not, that language ships without
+    narration silently — this check makes it loud.
+    """
+
+    @staticmethod
+    def _companion_findings(result):
+        return [
+            f
+            for f in result.findings
+            if f.severity == "warning" and "voiceover companion" in f.message
+        ]
+
+    def _slide_pair(self, parent):
+        # Two slide-start cells in slide_id parity, so the slide_id detective is
+        # clean and only the companion check can fire.
+        _write_slide(
+            parent,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="setup"
+            # ## Aufbau
+            """,
+        )
+        _write_slide(
+            parent,
+            "slides_intro.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="setup"
+            # ## Setup
+            """,
+        )
+
+    @staticmethod
+    def _vo(lang: str, *pairs: tuple[str, str]) -> str:
+        """Build companion text: each ``(for_slide, body)`` is one narration cell."""
+        cells = []
+        for for_slide, body in pairs:
+            cells.append(
+                f'# %% [markdown] lang="{lang}" tags=["voiceover"] '
+                f'for_slide="{for_slide}"\n#\n# {body}\n'
+            )
+        return "\n".join(cells) + "\n"
+
+    def test_matching_for_slides_are_clean(self, tmp_path):
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE"), ("setup", "Setup DE")),
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN"), ("setup", "Setup EN")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        assert self._companion_findings(result) == []
+
+    def test_companion_set_mismatch_is_flagged(self, tmp_path):
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE"), ("setup", "Setup DE")),
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        findings = self._companion_findings(result)
+        assert len(findings) == 1
+        assert "for_slide sets diverge" in findings[0].message
+        assert "setup" in findings[0].message
+        assert "only on DE" in findings[0].message
+
+    def test_multiplicity_difference_is_clean(self, tmp_path):
+        # One language may split a slide's narration across more cells; the
+        # *set* of for_slide is equal, so this is not a divergence.
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE part 1"), ("intro", "Intro DE part 2")),
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        assert self._companion_findings(result) == []
+
+    def test_one_sided_companion_is_flagged(self, tmp_path):
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        findings = self._companion_findings(result)
+        assert len(findings) == 1
+        assert "does not" in findings[0].message
+        assert "EN half ships without narration" in findings[0].message
+
+    def test_one_sided_companion_en_only_is_flagged(self, tmp_path):
+        # Symmetric to the DE-only case: the EN companion exists alone, so the
+        # DE half ships without narration. Pins the language ternary direction.
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        findings = self._companion_findings(result)
+        assert len(findings) == 1
+        assert "DE half ships without narration" in findings[0].message
+        assert findings[0].file.endswith("voiceover_intro.en.py")
+
+    def test_no_companions_is_clean(self, tmp_path):
+        self._slide_pair(tmp_path)
+        result = validate_directory(tmp_path, checks=["pairing"])
+        assert self._companion_findings(result) == []
+
+    def test_set_mismatch_reported_once_in_directory_run(self, tmp_path):
+        # The per-file pass runs with cross_file_parity=False, so a directory
+        # run reports the divergence exactly once (not once per half).
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE"), ("setup", "Setup DE")),
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        assert len(self._companion_findings(result)) == 1
+
+    def test_single_file_with_twin_catches_companion_divergence(self, tmp_path):
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE"), ("setup", "Setup DE")),
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN")),
+        )
+        result_de = validate_file(tmp_path / "slides_intro.de.py", checks=["pairing"])
+        assert len(self._companion_findings(result_de)) == 1
+        # Symmetric: validating the EN deck half catches it too.
+        result_en = validate_file(tmp_path / "slides_intro.en.py", checks=["pairing"])
+        assert len(self._companion_findings(result_en)) == 1
+
+    def test_single_file_without_twin_is_silent(self, tmp_path):
+        # A lone .de.py deck half with no .en.py twin: the cross-file parity
+        # never runs (no twin), so a lone DE companion is not flagged here.
+        _write_slide(
+            tmp_path,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+            """,
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("intro", "Intro DE")),
+        )
+        result = validate_file(tmp_path / "slides_intro.de.py", checks=["pairing"])
+        assert self._companion_findings(result) == []
+
+    def test_preserve_marker_equivalence(self, tmp_path):
+        # for_slide referencing a preserve-marked id (!intro) on one side and
+        # the bare id on the other is the same join key after stripping.
+        self._slide_pair(tmp_path)
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.de.py",
+            self._vo("de", ("!intro", "Intro DE"), ("setup", "Setup DE")),
+        )
+        _write_slide(
+            tmp_path,
+            "voiceover_intro.en.py",
+            self._vo("en", ("intro", "Intro EN"), ("setup", "Setup EN")),
+        )
+        result = validate_directory(tmp_path, checks=["pairing"])
+        assert self._companion_findings(result) == []
+
+
 class TestSplitTagParity:
     """Cross-language tag-set parity for split pairs (Issue #198)."""
 


### PR DESCRIPTION
## What

Extends the #162 cross-language detective to **voiceover companions**, and adds the gate flag that makes the warning-family checks enforceable.

A split deck's `voiceover_<name>.de.py` / `.en.py` companions must narrate the same set of slides: each narration cell's `for_slide` is the `slide_id` of its owning slide, and the build merge resolves `for_slide` against the **same-language** deck half — so a one-sided or divergent companion silently ships a language with missing narration.

### Detective (the both-language voiceover compatibility check)
- `_check_split_companion_for_slide_parity` in `validator.py` — compares the `!`-stripped `for_slide` **set** across the two companions:
  - multiplicity-tolerant (one language may legitimately split a narration across more cells);
  - flags a divergent set **or** a one-sided companion (missing companion = empty set → "the EN/DE half ships without narration");
  - `pairing` warning, finding points at the companion file; lazy `companion_path` import (mirrors `split.py`).
- Wired alongside `_check_split_slide_id_parity` at all three sites (single-file-with-twin, directory, course); directory/course pass `cross_file_parity=False` so it fires exactly once per pair.

### `clm validate --fail-on {error,warning}` (makes the gate real)
The detective is a `warning`; previously `clm validate` exited 0 on warnings, so the documented pre-commit hook (`clm validate slides/ --fail-on warning`) referenced a flag that did not exist. This adds it:
- `default=None` preserves legacy behavior (human output fails on errors; `--json` exits 0);
- when set, it governs the exit code in **both** output modes (`warning` → fail on errors *or* warnings) — the pre-commit-gate setting that lets the whole `slide_id` / `for_slide` parity warning family block a commit;
- slides-only (`UsageError` with `--kind=spec`).

## Why
Closes the companion arm of the #162 detective (design `split-voiceover-hardening.md` §7/§9/§10) and the CLM half of the pre-commit gate (§9). The course-repo half (wiring the hook + the error-vs-warning rollout decision) stays in the course repo.

## Verification
- New `commit-companion-divergence` harness row → **break-loud** (detective catches it); table now 14 preserve / 2 break-loud / 1 break-silent.
- `TestSplitCompanionForSlideParity` (10 tests, incl. both one-sided directions) + 6 `--fail-on` CLI tests.
- Full fast suite **6237 passed**; mypy + ruff clean.
- Reviewed by an adversarial 3-lens pass (correctness / wiring / gate-UX), each finding independently verified — the `--fail-on` gap was the load-bearing finding and is fixed here.

## Docs
Info topics (`commands.md` validate options + gate paragraph + the new `for_slide` parity row; `migration.md` #162 section + `--fail-on` paragraph) and the design doc (§7/§9/§10/§12/§13) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)