### PR TITLE
feat(voiceover): twin-aware slide_id generation in extract (#162)

### DIFF
--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -408,8 +408,15 @@ within one bilingual file.
   it). Both assign-ids harness rows flipped break-silent → preserve; 5 new
   `TestSplitTwinAware` tests. Run-order decides the winning slug when both halves are
   id-less (parity holds either way); true EN-authority is the generative step / `sync`.
-  (`extract-voiceover` twin-awareness still TODO; strongly related to §8 — arguably
-  these per-file ops should not be normal user commands at all.)
+  **`extract-voiceover` twin-awareness ✅ DONE 2026-06-03**: `extract`'s `_ensure_slide_ids`
+  now threads `twin_ids` (via `assign_ids._twin_ids_for`) into `_apply_slide_ids`, so an id-less
+  slide on a split half adopts the sibling's id before extraction rather than minting a divergent
+  slug — extracting `.de`/`.en` separately keeps `de_id == en_id` and the two companions'
+  `for_slide` sets agree. Twin is read-only (mismatched slide counts mint normally); bilingual
+  `extract` unaffected (`twin_ids=None`). Harness `extract-per-language-twin-aware` = preserve;
+  `TestExtractTwinAware` (4 tests). A *paired* extract that produces both companions in one op
+  (generative EN-authority) remains a §8 command-surface item — not needed for parity, since
+  `assign-ids <dir>` then per-language `extract` already covers EN-authority.
 - **Generative:** ✅ **BUILT 2026-06-03** — pair-aware `assign-ids` over *both* halves.
   `assign_ids_in_split_pair` reconstructs the bilingual deck (`unify`), runs the existing
   paired EN-authority assign over it, and routes the ids back (`split`); `assign_ids_in_directory`
@@ -568,9 +575,15 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
      wired alongside the `slide_id` parity detective (dir/course + single-file with twin). New
      harness row `commit-companion-divergence` = break-loud; `TestSplitCompanionForSlideParity`
      (9 tests). Harness now 14 preserve / 2 break-loud / 1 break-silent.
-   - **Next:** `extract-voiceover` twin-awareness (a paired/twin-aware extraction so the two
-     companions are produced together rather than per-file); then the build-merge observe-only
-     escalation (the one remaining break-silent row, `build-merge-unmatched`).
+   - **`extract-voiceover` twin-awareness ✅ DONE 2026-06-03** (§7 defensive) — `_ensure_slide_ids`
+     threads `twin_ids` into `_apply_slide_ids`, so a per-language extract adopts the sibling's id
+     instead of minting a divergent slug (keeps `de_id == en_id`; the companions' `for_slide` sets
+     agree). Harness `extract-per-language-twin-aware` = preserve; `TestExtractTwinAware` (4 tests).
+     Harness now 15 preserve / 2 break-loud / 1 break-silent.
+   - **Next:** the build-merge observe-only escalation (the one remaining break-silent row,
+     `build-merge-unmatched`: `merge_voiceover_text` returns the unmatched ids but the `build`
+     consumer is log-only/exit-0 — surface it as a finding honoring a fail-on policy). Then the
+     §8 command-surface rethink (incl. a *paired* extract that produces both companions in one op).
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.
@@ -593,8 +606,9 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
 - IDs: `assign_ids.py` (slug/minting; `group_slug` `:301-339`; refusals `:545-568`),
   `slug.py` (`resolve_collision` `:189-201`).
 - Voiceover (slide-side): `voiceover_tools.py` (`companion_path` `:122-136`; extract
-  `:349-424`; inline `:706-802`; `merge_voiceover_text` `:432-485`; `vo_anchor`
-  `:204-256`).
+  `:349-424`; `_ensure_slide_ids` — twin-aware id gen, threads `twin_ids` via
+  `assign_ids._twin_ids_for` into `normalizer._apply_slide_ids`; inline `:706-802`;
+  `merge_voiceover_text` `:432-485`; `vo_anchor` `:204-256`).
 - Split/unify: `split.py` (`split_text`; `unify_texts`; `_slide_ids_pair`; force guards;
   companion seam `_plan_companion_split` / `_plan_companion_unify` — lazy `companion_path`
   import, reuse `split_text`/`unify_texts`; `SplitResult`/`UnifyResult` companion fields).

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -394,6 +394,24 @@ def born_split_pair(de_title: str = "Mein Thema", en_title: str = "My Topic") ->
     return SplitPair.from_bilingual(bilingual)
 
 
+def born_split_with_voiceover() -> SplitPair:
+    """A born-split pair (both halves id-less) with one inline voiceover cell per
+    half — the shape a per-language ``extract`` runs on. Built by splitting an
+    id-less bilingual deck so the split headers are exactly what ``split``
+    produces.
+    """
+    de_vo = '# %% [markdown] lang="de" tags=["voiceover"]\n#\n# Voiceover DE\n\n'
+    en_vo = '# %% [markdown] lang="en" tags=["voiceover"]\n#\n# Voiceover EN\n\n'
+    bilingual = (
+        HEADER_PREAMBLE
+        + slide_cell("de", "Mein Thema")
+        + de_vo
+        + slide_cell("en", "My Topic")
+        + en_vo
+    )
+    return SplitPair.from_bilingual(bilingual)
+
+
 def _sync_signaled(out: SyncOutcome) -> tuple[bool, str]:
     if out.result.errors:
         return True, f"errors={out.result.errors}"
@@ -684,6 +702,37 @@ def m_extract_then_split(workdir: Path) -> _RetTuple:
     )
 
 
+def m_extract_per_language_twin_aware(workdir: Path) -> _RetTuple:
+    # Born-split pair (both halves id-less) with inline voiceover. The author
+    # extracts each half separately. Twin-aware id assignment (#162 defensive in
+    # extract) makes the second extract adopt the first half's freshly-minted
+    # ids, so the two companions end up with matching for_slide sets (parity)
+    # instead of minting divergent DE/EN slugs.
+    pair = born_split_with_voiceover()
+    de_path, en_path = pair.write(workdir)
+    extract_voiceover(de_path)
+    extract_voiceover(en_path)
+    de_comp = companion_path(de_path)
+    en_comp = companion_path(en_path)
+    if not (de_comp.exists() and en_comp.exists()):
+        return ["companion_missing"], False, "", "extract did not produce both companions"
+    de_after = de_path.read_text(encoding="utf-8")
+    en_after = en_path.read_text(encoding="utf-8")
+    de_fs = for_slides(de_comp.read_text(encoding="utf-8"))
+    en_fs = for_slides(en_comp.read_text(encoding="utf-8"))
+    violated: list[str] = []
+    if slide_ids(de_after) != slide_ids(en_after):
+        violated.append("id_parity")
+    if set(de_fs) != set(en_fs):
+        violated.append("for_slide_parity")
+    return (
+        violated,
+        False,
+        "",
+        f"slide_ids de={slide_ids(de_after)} en={slide_ids(en_after)}; for_slide de={de_fs} en={en_fs}",
+    )
+
+
 def m_inline_after_rename(workdir: Path) -> _RetTuple:
     de, _ = split_text(baseline_bilingual(with_voiceover=("intro",)))
     slide = workdir / "slides_demo.de.py"
@@ -820,6 +869,17 @@ MUTATIONS: list[Mutation] = [
     # companion in lockstep (and `unify` recombines it), so extract-then-split
     # no longer orphans the narration — break-silent -> preserve.
     Mutation("extract-then-split", "extract+split", PRESERVE, True, m_extract_then_split),
+    # extract-voiceover twin-awareness landed: id generation during a per-language
+    # extract adopts the sibling half's ids (#162 defensive), so extracting both
+    # halves separately keeps slide_id + for_slide parity instead of minting
+    # divergent slugs.
+    Mutation(
+        "extract-per-language-twin-aware",
+        "extract",
+        PRESERVE,
+        True,
+        m_extract_per_language_twin_aware,
+    ),
     # Tier-1 data-loss fixes landed: inline now retains the companion with the
     # unmatched cell (recoverable) and exits non-zero; extract refuses to clobber
     # an existing companion without --force. Both flipped break-silent -> preserve.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1084,6 +1084,17 @@ Extract voiceover and notes cells from a slide file to a companion
 `voiceover_*.py` file, linked via `slide_id`/`for_slide` metadata.
 Content cells without `slide_id` get auto-generated IDs before extraction.
 
+Since CLM {version}, that ID generation is **twin-aware** on a split half
+(`*.de.py` / `*.en.py`): when the sibling exists on disk with a matching slide
+count, an id-less slide adopts the twin's `slide_id` instead of minting a
+divergent slug (the #162 defensive). This keeps `de_id == en_id` when you
+extract the two halves separately, so their companions' `for_slide` sets agree
+— without it, per-language extraction would mint independent slugs and one
+language would silently ship with missing narration (which `clm validate`'s
+#162 detectives now flag). For deterministic EN-authority ids across a pair,
+run `clm slides assign-ids <dir>` before extracting; bilingual decks are
+unaffected.
+
 Since CLM {version}, each extracted cell also records a `vo_anchor`
 attribute identifying its **immediate predecessor cell** — `id:<slide_id>`
 when that cell carries an id, otherwise `fp:<body-fingerprint>` — with a

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -133,6 +133,13 @@ EN-authority). A pair that is not byte-faithfully unifiable (divergent shared
 cells) falls back to the per-file path, and `clm validate`'s #162 detective
 flags any residual divergence.
 
+`clm voiceover extract` shares this defensive: since CLM {version} the
+`slide_id`s it auto-generates before extraction are twin-aware on a split half,
+so extracting the `.de` and `.en` halves separately keeps them in parity and
+the two companions narrate the same slides. (No migration required — extract on
+bilingual decks is unchanged.) For deterministic EN-authority ids, run
+`clm slides assign-ids <dir>` on the pair before extracting.
+
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 
 CLM {version} also ships **Phase 3** of the slide-format-redesign:

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -575,6 +575,8 @@ def _apply_slide_ids(
     cells: list[_RawCell],
     path: Path,
     options: AssignOptions | None = None,
+    *,
+    twin_ids: list[str | None] | None = None,
 ) -> tuple[list[Change], list[ReviewItem]]:
     """Assign ``slide_id`` metadata using the shared assign-ids engine.
 
@@ -588,6 +590,11 @@ def _apply_slide_ids(
     the cell headers). We translate its ``AssignedId`` records into the
     normalizer's :class:`Change` records and its ``Refusal`` records
     into :class:`ReviewItem` records.
+
+    ``twin_ids`` is forwarded verbatim to
+    :func:`~clm.slides.assign_ids.assign_ids_for_cells` (the #162 defensive):
+    when supplied, an id-less slide adopts the positionally-corresponding
+    sibling-half id instead of minting a divergent slug.
     """
     from clm.slides.assign_ids import AssignOptions as _AO
     from clm.slides.assign_ids import assign_ids_for_cells
@@ -595,7 +602,7 @@ def _apply_slide_ids(
     if options is None:
         options = _AO()
 
-    result = assign_ids_for_cells(cells, path, options)
+    result = assign_ids_for_cells(cells, path, options, twin_ids=twin_ids)
 
     changes = [
         Change(

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -158,13 +158,27 @@ def _is_voiceover_cell(cell: _RawCell) -> bool:
     return cell.metadata.is_narrative
 
 
-def _ensure_slide_ids(cells: list[_RawCell], path: Path) -> int:
+def _ensure_slide_ids(cells: list[_RawCell], path: Path, text: str) -> int:
     """Auto-generate slide_ids for content cells that lack them.
 
-    Delegates to the shared assign-ids engine (via the normalizer
-    adapter). Returns the number of ids assigned.
+    Delegates to the shared assign-ids engine (via the normalizer adapter).
+    Returns the number of ids assigned.
+
+    Twin-aware (#162 defensive): on a split half (``*.de.py`` / ``*.en.py``)
+    whose twin exists on disk with a matching slide count, an **id-less** slide
+    adopts the twin's id for the corresponding slide instead of minting a
+    divergent slug from its own heading. This keeps ``de_id == en_id`` across a
+    per-language extract — without it, extracting each half separately would
+    mint independent slugs and the two companions' ``for_slide`` sets would
+    diverge (which ``clm validate``'s #162 detective would then flag). The twin
+    is read-only; when it has no id for a slide, minting falls back to the
+    normal EN-derived slug. Bilingual files (no ``.de`` / ``.en`` suffix) pass
+    ``twin_ids=None`` and are unaffected.
     """
-    changes, _refusals = _apply_slide_ids(cells, path)
+    from clm.slides.assign_ids import _twin_ids_for
+
+    twin_ids = _twin_ids_for(path, text)
+    changes, _refusals = _apply_slide_ids(cells, path, twin_ids=twin_ids)
     return len(changes)
 
 
@@ -368,7 +382,11 @@ def extract_voiceover(
 
     Content cells without ``slide_id`` get auto-generated IDs before
     extraction.  Voiceover cells are linked to their owning slide via
-    ``for_slide`` metadata.
+    ``for_slide`` metadata. On a split half whose twin exists on disk with a
+    matching slide count, that id generation is **twin-aware** (#162): an
+    id-less slide adopts the twin's id rather than minting a divergent slug, so
+    extracting the ``.de`` and ``.en`` halves separately keeps their companions'
+    ``for_slide`` sets in agreement (see :func:`_ensure_slide_ids`).
 
     The companion is *rebuilt* from the voiceover cells currently in the slide
     file. If a companion already exists it would be overwritten, discarding any
@@ -402,8 +420,9 @@ def extract_voiceover(
     if not vo_indices:
         return result
 
-    # Auto-generate slide_ids for cells that need them
-    result.ids_generated = _ensure_slide_ids(cells, path)
+    # Auto-generate slide_ids for cells that need them (twin-aware on a split
+    # half so a per-language extract keeps de_id == en_id; see _ensure_slide_ids).
+    result.ids_generated = _ensure_slide_ids(cells, path, text)
 
     # Build companion cells with for_slide metadata (owning slide) and a
     # vo_anchor (immediate predecessor, occurrence-qualified) so inline can

--- a/tests/slides/test_voiceover_tools.py
+++ b/tests/slides/test_voiceover_tools.py
@@ -934,6 +934,112 @@ class TestSplitDeckVoiceover:
         assert _lang_cell_count(en_final, "de") == 0
 
 
+class TestExtractTwinAware:
+    """``extract`` id generation is twin-aware on a split half (#162 defensive).
+
+    Extracting the ``.de`` and ``.en`` halves separately must not mint
+    divergent slide_ids — otherwise the two companions' ``for_slide`` sets
+    diverge and one language silently ships missing narration at build.
+    """
+
+    @staticmethod
+    def _born_split_with_vo(tmp_path: Path) -> tuple[Path, Path]:
+        """A born-split (both halves id-less) pair with one inline voiceover
+        per half, written via ``split_text`` so the headers are real."""
+        de_vo = '# %% [markdown] lang="de" tags=["voiceover"]\n#\n# VO DE\n\n'
+        en_vo = '# %% [markdown] lang="en" tags=["voiceover"]\n#\n# VO EN\n\n'
+        bilingual = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("Titel", "Title") }}\n\n'
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n\n'
+            + de_vo
+            + '# %% [markdown] lang="en" tags=["slide"]\n# ## My Topic\n\n'
+            + en_vo
+        )
+        de_text, en_text = split_text(bilingual)
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(de_text, encoding="utf-8", newline="\n")
+        en.write_text(en_text, encoding="utf-8", newline="\n")
+        return de, en
+
+    def test_per_language_extract_converges_to_parity(self, tmp_path: Path):
+        de, en = self._born_split_with_vo(tmp_path)
+        extract_voiceover(de)
+        extract_voiceover(en)  # twin-aware: adopts the DE half's freshly-minted id
+
+        de_after = de.read_text(encoding="utf-8")
+        en_after = en.read_text(encoding="utf-8")
+        # Both halves end on the same id (DE-authority here, since DE was
+        # extracted first) — the #162 invariant holds.
+        assert 'slide_id="mein-thema"' in de_after
+        assert 'slide_id="mein-thema"' in en_after
+        assert 'slide_id="my-topic"' not in en_after
+
+        de_comp = (tmp_path / "voiceover_x.de.py").read_text(encoding="utf-8")
+        en_comp = (tmp_path / "voiceover_x.en.py").read_text(encoding="utf-8")
+        assert 'for_slide="mein-thema"' in de_comp
+        assert 'for_slide="mein-thema"' in en_comp
+
+    def test_adopts_existing_twin_id(self, tmp_path: Path):
+        # EN half already has an id; the id-less DE half must adopt it on
+        # extract rather than minting "mein-thema" from its own heading.
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO DE\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        en.write_text(
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="custom-id"\n# ## My Topic\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        extract_voiceover(de)
+
+        assert 'slide_id="custom-id"' in de.read_text(encoding="utf-8")
+        de_comp = (tmp_path / "voiceover_x.de.py").read_text(encoding="utf-8")
+        assert 'for_slide="custom-id"' in de_comp
+
+    def test_mismatched_slide_count_mints_normally(self, tmp_path: Path):
+        # Structurally misaligned halves (different slide counts): positional
+        # reuse is unsafe, so extract mints normally (no crash, no wrong id) —
+        # the validator's #162 detective surfaces the divergence instead.
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO DE\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        en.write_text(
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="a"\n# ## A\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="b"\n# ## B\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        extract_voiceover(de)  # must not raise
+        de_after = de.read_text(encoding="utf-8")
+        assert 'slide_id="mein-thema"' in de_after  # minted from its own heading
+
+    def test_bilingual_extract_unaffected(self, tmp_path: Path):
+        # A bilingual (non-split) file has no twin; twin_ids is None and id
+        # generation is unchanged.
+        p = tmp_path / "slides_x.py"
+        p.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO DE\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        res = extract_voiceover(p)
+        assert res.cells_extracted == 1
+        assert 'slide_id="mein-thema"' in p.read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Positional anchors (vo_anchor): restore voiceovers to their *exact*
 # position on inline, not just the end of their slide group.


### PR DESCRIPTION
## What
Makes `clm voiceover extract` **twin-aware** when it auto-generates `slide_id`s on a split half, closing the #162 *defensive* gap for the extract path.

`extract_voiceover` assigns ids to id-less content cells before extraction. On a split half it minted those ids independently of the sibling — so extracting the `.de` and `.en` halves separately could produce **divergent slugs** → divergent `for_slide` sets → one language silently shipping with missing narration. (The just-added #162 detectives *catch* this after the fact; this stops `extract` from *creating* it.)

- `_ensure_slide_ids` now threads `twin_ids` (via `assign_ids._twin_ids_for`) into `normalizer._apply_slide_ids`, so an id-less slide on a split half adopts the sibling's `slide_id` rather than minting a divergent slug — mirroring `assign_ids_in_file` (the existing #162 defensive). The twin is **read-only**; mismatched slide counts mint normally (the validator's detective then flags the divergence); bilingual `extract` is unaffected (`twin_ids=None`).
- `_apply_slide_ids` gains a `twin_ids` keyword forwarded to `assign_ids_for_cells`; the `normalize` caller is unchanged (passes `None`).

## Verification
- New harness row `extract-per-language-twin-aware` = **preserve** (extracting both halves of a born-split pair converges to `slide_id` + `for_slide` parity). Table now 15 preserve / 2 break-loud / 1 break-silent.
- `TestExtractTwinAware` (4 tests): per-language convergence to parity, adopt an existing twin id, mismatched-count mints normally (no crash/wrong id), bilingual extract unaffected.
- Full fast suite **6241 passed**; mypy + ruff clean.

## Notes
For deterministic **EN-authority** ids across a pair, run `clm slides assign-ids <dir>` before extracting — twin-aware single-file extract guarantees *parity*, not authority. A *paired* one-op extract (produce both companions together) remains a §8 command-surface item.

## Docs
Info topics (`commands.md` extract section, `migration.md` #162 section) and the design doc (§7 defensive / §12 / §13) updated.

---
**Stacked on #204** (`claude/companion-for-slide-parity`): this branch shares the harness / info-topic / design-doc edits from that PR, so its base is set to the #204 branch for a clean per-item diff. GitHub auto-retargets to `master` when #204 merges (or merge #204 first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)