### PR TITLE
feat(build): escalate dropped companion voiceover to a fail-on-able error (#162)

### DIFF
--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -188,9 +188,14 @@ corrections are load-bearing for prioritization, so they are recorded explicitly
 ### Other confirmed issues
 
 - **Build silently drops/relocates voiceover** when `for_slide` doesn't resolve or
-  the anchor predecessor is gone — narration omitted from output (build merge:
-  log-only, exit 0; `process_notebook.py:285-296`); inline relocations are *discarded*
-  in the build merge path (`voiceover_tools.py:462-485`).
+  the anchor predecessor is gone — narration omitted from output. **Unmatched-drop
+  escalation ✅ DONE 2026-06-03**: the build consumer (`process_notebook.py`
+  `payload()`) now reports each dropped narration as a `voiceover`-category
+  `BuildError` via the build reporter (`report_voiceover_merge_issues`), so it
+  surfaces in the summary and fails under `--fail-on-error` (was log-only/exit-0).
+  *Residual (deferred):* inline **relocations** (anchor predecessor gone → group-end
+  fallback) are still discarded in `merge_voiceover_text` — narration is kept, just
+  repositioned, so it is a surfacing nicety, not data loss; a small follow-up.
 - **Validator cross-file parity is blind on a single file.**
   `_check_shared_cell_parity` / `_check_split_tag_parity` run *only* at dir/course
   scope (`validator.py:1433-1436,1486-1489`), never on a lone `.de.py`; and they go
@@ -369,6 +374,13 @@ counting judge is required to drive the apply path.
 behaviour probe): split-code-cell (def-my-fun), rename-function-while-splitting,
 edit-heading-then-force.
 
+> **Work-list fully drained 2026-06-03.** All seven break-silent rows have since been
+> hardened (see §12 step 2–3 + the build escalation). Two new rows were added
+> (`commit-companion-divergence`, `extract-per-language-twin-aware`). The catalogue is
+> now **15 preserve / 3 break-loud / 0 break-silent** — every footgun is loud. The
+> test backstop flipped from "known silent breaks still surfaced" to
+> `test_no_break_silent_rows_remain` (no new silent footgun may creep back).
+
 ---
 
 ## 7. The #162 design direction (the keystone)
@@ -522,8 +534,12 @@ Required hardening:
   one-sided companion as a `pairing` warning. Harness `commit-companion-divergence` =
   break-loud.
 - **Build-time escalation** of unmatched `for_slide` from log-only to a surfaced
-  finding (respecting a fail-on policy), and surface inline **relocations** at build
-  time (today discarded in `merge_voiceover_text`).
+  finding (respecting a fail-on policy) — **✅ DONE 2026-06-03**: `process_notebook.py`
+  `report_voiceover_merge_issues` reports each dropped narration as a `voiceover`
+  `BuildError` through the build reporter (client-side, so no new worker payload field
+  / #17 landmine), governed by the existing `--fail-on-error` policy. Surfacing inline
+  **relocations** at build time (today discarded in `merge_voiceover_text`) is the
+  deferred residual — not data loss (narration kept, repositioned).
 - **Validator companion-integrity check** (dir/course scope): every `for_slide`
   resolves; warn on orphan companions / a slide that lost its companion / contradictory
   companion sets (bilingual + split coexisting).
@@ -580,10 +596,23 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
      instead of minting a divergent slug (keeps `de_id == en_id`; the companions' `for_slide` sets
      agree). Harness `extract-per-language-twin-aware` = preserve; `TestExtractTwinAware` (4 tests).
      Harness now 15 preserve / 2 break-loud / 1 break-silent.
-   - **Next:** the build-merge observe-only escalation (the one remaining break-silent row,
-     `build-merge-unmatched`: `merge_voiceover_text` returns the unmatched ids but the `build`
-     consumer is log-only/exit-0 — surface it as a finding honoring a fail-on policy). Then the
-     §8 command-surface rethink (incl. a *paired* extract that produces both companions in one op).
+   - **Build-merge unmatched escalation ✅ DONE 2026-06-03** (§3 / §10) — the build consumer
+     (`process_notebook.py` `payload()` → `report_voiceover_merge_issues`) reports each dropped
+     narration as a `voiceover` `BuildError`, surfaced in the summary and failing under
+     `--fail-on-error` (client-side; no worker payload field). Harness `build-merge-unmatched`
+     flipped break-silent → break-loud; catalogue now **15 preserve / 3 break-loud / 0
+     break-silent** — fully loud. `TestVoiceoverMergeEscalation` (5 tests) + `TestEscalationWiring`
+     (3 end-to-end tests: real `payload()`/`execute()` so a dropped `getattr(backend,
+     "build_reporter")` regression fails loudly — from the adversarial review); backstop is now
+     `test_no_break_silent_rows_remain`. The review also surfaced a *pre-existing*
+     `BuildSummary` flaw it made easy to hit — `failed_files`/`successful_files` counted error
+     *entries* not distinct files (N drops in one file → `successful_files` could go negative);
+     fixed to count distinct error `file_path`s + clamp ≥ 0 (also fixes the latent xref/timeout
+     over-count).
+   - **Next:** the §8 command-surface rethink (fold/hide/guard per-file ops; incl. a *paired*
+     extract producing both companions in one op), then the pre-commit gate wiring in the course
+     repo (§9 course-repo half) + remaining verification additions (§11). Deferred residual:
+     surface build-time inline **relocations** (not data loss).
 4. **Command-surface rethink** (§8) — fold/hide/guard, with info-topic updates.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI pairing guard** (§3 Tier-2) + single-path/batch UX.
@@ -615,7 +644,9 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
 - Build: `build.py` (split-routing abort `:1117-1132`); `topic.py`
   (`add_files_in_dir`/`_add_slide_units` `:318-408`; `FileTopic` `:426-445`);
   `notebook_file.py` (`output_language_filter`, `companion_voiceover_path` `:108-114`);
-  `process_notebook.py` (`compute_other_files` `:110-134`; vo merge `:283-296`);
+  `process_notebook.py` (`compute_other_files`; vo merge in `payload(build_reporter=…)`;
+  `report_voiceover_merge_issues` — escalates dropped narration to a `voiceover` `BuildError`
+  via the reporter from `execute()`'s backend, honoring `--fail-on-error`);
   `data_file.py` (`get_processing_operation` `:37-52`); `path_utils.py` (SKIP lists
   `:87-100`, `is_ignored_file_for_output` `:244-262`); `output_sweep.py`
   (`:43-52,160-166,264-276`); `notebook_processor.py` (strips slide_id/for_slide

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -40,6 +40,9 @@ from pathlib import Path
 if __package__ in (None, ""):  # pragma: no cover - import shim
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from clm.core.operations.process_notebook import (  # noqa: E402
+    report_voiceover_merge_issues,
+)
 from clm.infrastructure.llm.cache import SyncWatermarkCache  # noqa: E402
 from clm.infrastructure.llm.ollama_client import SyncProposal  # noqa: E402
 from clm.notebooks.slide_parser import parse_cells  # noqa: E402
@@ -102,6 +105,21 @@ class CountingJudge:
     ) -> SyncProposal:
         self.calls.append((source_lang, target_lang))
         return SyncProposal(verdict="in_sync", proposed_text=target_body)
+
+
+@dataclass
+class RecordingReporter:
+    """Minimal stand-in for the build reporter — records escalations so the
+    harness can model the `build` consumer arm without a full build."""
+
+    errors: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+
+    def report_error(self, error: object) -> None:
+        self.errors.append(error)
+
+    def report_warning(self, warning: object) -> None:
+        self.warnings.append(warning)
 
 
 # ---------------------------------------------------------------------------
@@ -806,12 +824,26 @@ def m_build_merge_unmatched(workdir: Path) -> _RetTuple:
     )
     merged, unmatched = merge_voiceover_text(slide_renamed, comp.read_text(encoding="utf-8"))
     dropped = "Voiceover DE for intro" not in merged
-    # merge_voiceover_text RETURNS unmatched; the build consumer is log-only/exit-0.
+    # The build consumer now escalates each unmatched for_slide to a BuildError
+    # (surfaced in the summary; fails under --fail-on-error, default-on in CI /
+    # replay). Model that consumer arm with a recording reporter.
+    reporter = RecordingReporter()
+    report_voiceover_merge_issues(
+        reporter,
+        slide_name=slide.name,
+        companion_name=comp.name,
+        file_path=str(slide),
+        unmatched=unmatched,
+    )
+    signaled = len(reporter.errors) > 0
     return (
         (["narration_drop"] if dropped else []),
-        False,
-        "",
-        f"VO dropped from output; unmatched={unmatched}; build merge is log-only",
+        signaled,
+        "build merge escalates unmatched to a BuildError (fails under --fail-on-error)"
+        if signaled
+        else "",
+        f"VO dropped from output; unmatched={unmatched}; "
+        f"build consumer reports {len(reporter.errors)} error(s)",
     )
 
 
@@ -891,8 +923,11 @@ MUTATIONS: list[Mutation] = [
         True,
         m_re_extract_over_edited_companion,
     ),
-    # Observe-only — the build-merge primitive reports; the `build` arm is TODO.
-    Mutation("build-merge-unmatched", "build-merge", BREAK_SILENT, False, m_build_merge_unmatched),
+    # Build-merge escalation landed: the build consumer reports each unmatched
+    # for_slide as a BuildError (fails under --fail-on-error) instead of a bare
+    # log line — break-silent -> break-loud. This was the last silent footgun;
+    # the catalogue is now fully loud.
+    Mutation("build-merge-unmatched", "build-merge", BREAK_LOUD, True, m_build_merge_unmatched),
 ]
 
 # Deferred catalogue entries (design §6) — added once their behaviour is verified

--- a/src/clm/cli/build_data_classes.py
+++ b/src/clm/cli/build_data_classes.py
@@ -153,14 +153,21 @@ class BuildSummary:
     incomplete."""
 
     @property
-    def successful_files(self) -> int:
-        """Number of successfully processed files."""
-        return self.total_files - len([e for e in self.errors if e.severity == "error"])
+    def failed_files(self) -> int:
+        """Number of distinct source files that reported an error.
+
+        Counts unique ``file_path``s among error-severity findings, not raw
+        error entries: a single file can emit several errors (e.g. multiple
+        dropped voiceover narrations, or several missing cross-references), and
+        those must not inflate the file count — which previously could drive
+        :attr:`successful_files` negative.
+        """
+        return len({e.file_path for e in self.errors if e.severity == "error"})
 
     @property
-    def failed_files(self) -> int:
-        """Number of failed files."""
-        return len([e for e in self.errors if e.severity == "error"])
+    def successful_files(self) -> int:
+        """Number of source files that processed without an error (never < 0)."""
+        return max(0, self.total_files - self.failed_files)
 
     def has_errors(self) -> bool:
         """Check if build has any errors."""

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -63,7 +63,7 @@ Key options:
 | `--image-format [png\|svg]` | Image output format |
 | `--inline-images` | Embed images as base64 in notebooks |
 | `--http-replay [replay\|once\|new-episodes\|refresh\|disabled]` | HTTP replay record mode for topics with `http-replay="yes"` in the spec. `replay` requires a cassette (strict, CI default); `once` records on first run, replays thereafter (strict on new requests); `new-episodes` replays recorded requests and records any new ones (local default); `refresh` re-records every run; `disabled` bypasses replay. Defaults to `replay` when `CI=true`, else `new-episodes`. Also settable via `CLM_HTTP_REPLAY_MODE`. |
-| `--fail-on-error / --no-fail-on-error` | Exit with non-zero status when the build summary reports any cell or notebook error. Defaults to **on** under `--http-replay=replay` (incl. CI) and **off** under all other replay modes. Override via `CLM_FAIL_ON_ERROR={1,true,yes,0,false,no}`. See "Exit codes" below. |
+| `--fail-on-error / --no-fail-on-error` | Exit with non-zero status when the build summary reports any cell/notebook error **or a dropped companion voiceover** (a `for_slide` with no matching `slide_id`, since CLM {version}). Defaults to **on** under `--http-replay=replay` (incl. CI) and **off** under all other replay modes. Override via `CLM_FAIL_ON_ERROR={1,true,yes,0,false,no}`. See "Exit codes" below. |
 | `--fail-on-missing-xref / --no-fail-on-missing-xref` | Exit with non-zero status when a `clm:` cross-reference points at a topic not included in the build (issue #17). Defaults to **on** under `--http-replay=replay` (incl. CI) and **off** under all other replay modes (a missing target is then a warning and the link is dropped). Override via `CLM_FAIL_ON_MISSING_XREF={1,true,yes,0,false,no}`. See `clm info spec-files` → "Cross-references". |
 
 Examples:
@@ -296,6 +296,7 @@ summary listed the errors, but the process still exited 0.
 | Cell/notebook errors under `--http-replay=replay` (new default) | `1` |
 | Cell/notebook errors under non-replay modes | `0` (opt in with `--fail-on-error`) |
 | Cell/notebook errors with `--no-fail-on-error` (any mode) | `0` |
+| Dropped companion voiceover (unmatched `for_slide`) — same policy as cell errors (since CLM {version}) | `1` under `--fail-on-error`, else `0` |
 | Image filename collisions | non-zero `SystemExit` (existing, unchanged) |
 | Second `SIGTERM` while shutting down | `1` (existing, unchanged) |
 
@@ -318,6 +319,18 @@ The check fires **before** `--verify-against` comparison, so CI logs
 show the cell error as the cause rather than a downstream verification
 diff. If both a cell error and a verify diff are present, the cell
 error wins.
+
+Since CLM {version}, **dropped companion voiceover** is treated the same
+way. When a separated-voiceover companion (`voiceover_*.py`) has a
+`for_slide` that matches no `slide_id` in the slide it accompanies, that
+narration is dropped from the built output — usually because a `slide_id`
+was renamed out from under the companion. The build now reports each drop
+as a `voiceover`-category error in the summary (it used to be a bare log
+line), so it surfaces in the report and, under `--fail-on-error`, fails the
+build. Fix the `for_slide` / `slide_id` mismatch (`clm voiceover inline`
+then re-extract, or `clm slides sync`), or pass `--no-fail-on-error` to
+tolerate it. `clm validate`'s #162 detectives catch the underlying
+divergence earlier (pre-commit), before it reaches a build.
 
 ### `clm targets`
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -140,6 +140,28 @@ the two companions narrate the same slides. (No migration required — extract o
 bilingual decks is unchanged.) For deterministic EN-authority ids, run
 `clm slides assign-ids <dir>` on the pair before extracting.
 
+## `clm build` fails on dropped companion voiceover ({version})
+
+Separated voiceover lives in `voiceover_*.py` companions; the build merges each
+narration cell back next to the slide named by its `for_slide`. If a `for_slide`
+matches no `slide_id` in the slide (typically a renamed `slide_id`), that
+narration is **dropped** from the output. Previously the build only logged a
+warning and exited 0 — the loss was silent.
+
+Since CLM {version} each dropped narration is reported as a `voiceover`-category
+**error** in the build summary, governed by the **same `--fail-on-error`
+policy** as cell-execution errors: it fails the build under `--fail-on-error`
+(default-on in `--http-replay=replay` / CI) and is surfaced-but-non-fatal
+otherwise.
+
+*Migration:* a CI build (replay mode) that currently ships a deck with an
+unmatched companion `for_slide` will now **fail** instead of silently dropping
+the narration. Fix the `for_slide` / `slide_id` mismatch (`clm voiceover inline`
+then re-extract, or `clm slides sync`), or pass `--no-fail-on-error` /
+`CLM_FAIL_ON_ERROR=0` to tolerate it. Running `clm validate slides/ --fail-on
+warning` in a pre-commit hook catches the underlying `slide_id` / `for_slide`
+divergence before it ever reaches a build.
+
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 
 CLM {version} also ships **Phase 3** of the slide-format-redesign:

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -43,6 +43,55 @@ def _resolve_trace_dir_for_payload() -> str:
     return str(invocation_dir) if invocation_dir is not None else ""
 
 
+def report_voiceover_merge_issues(
+    build_reporter: Any,
+    *,
+    slide_name: str,
+    companion_name: str,
+    file_path: str,
+    unmatched: list[str],
+) -> None:
+    """Escalate unmatched companion voiceover at build time (#162 hardening).
+
+    When ``merge_voiceover_text`` cannot match a companion cell's ``for_slide``
+    to a ``slide_id`` in the slide, that narration is **dropped** from the built
+    output. This used to be log-only (exit 0) — a silent loss of a slide's
+    speaker notes, usually because a ``slide_id`` was renamed out from under the
+    companion. Each drop is now reported as a ``BuildError`` (``category=
+    "voiceover"``), so it is surfaced in the build summary and — under the
+    build's ``--fail-on-error`` policy (default-on in CI / replay mode) — fails
+    the build, exactly like a cell-execution error. A course-repo gate must not
+    silently ship a slide whose narration vanished.
+
+    ``build_reporter`` is duck-typed (anything exposing ``report_error``);
+    ``None`` (no reporter — e.g. a direct ``payload()`` call in a test) is a
+    no-op, as is an empty ``unmatched`` list.
+    """
+    if build_reporter is None or not unmatched:
+        return
+    from clm.cli.build_data_classes import BuildError
+
+    for for_slide in unmatched:
+        target = "(cell has no for_slide)" if for_slide == "<no for_slide>" else repr(for_slide)
+        build_reporter.report_error(
+            BuildError(
+                error_type="user",
+                category="voiceover",
+                severity="error",
+                file_path=file_path,
+                message=(
+                    f"companion voiceover {companion_name}: for_slide {target} has no "
+                    f"matching slide_id in {slide_name}; the narration is dropped from output"
+                ),
+                actionable_guidance=(
+                    "A slide_id was likely renamed out from under the companion. Re-align "
+                    "the for_slide / slide_id (run `clm voiceover inline` then re-extract, or "
+                    "`clm slides sync`), or pass --no-fail-on-error to tolerate the drop."
+                ),
+            )
+        )
+
+
 @frozen
 class ProcessNotebookOperation(Operation):
     input_file: "NotebookFile"
@@ -70,7 +119,7 @@ class ProcessNotebookOperation(Operation):
         file_path = self.input_file.relative_path
         try:
             logger.info(f"Processing notebook '{file_path}' to '{self.output_file}'")
-            payload = await self.payload()
+            payload = await self.payload(getattr(backend, "build_reporter", None))
             await backend.execute_operation(self, payload)
             self.input_file.generated_outputs.add(self.output_file)
         except Exception as e:
@@ -269,7 +318,7 @@ class ProcessNotebookOperation(Operation):
                 stems.append(file.path.stem)
         return stems
 
-    async def payload(self) -> NotebookPayload:
+    async def payload(self, build_reporter: Any = None) -> NotebookPayload:
         course = self.input_file.course
         correlation_id = await new_correlation_id()
 
@@ -294,6 +343,16 @@ class ProcessNotebookOperation(Operation):
                     f"unmatched for_slide='{for_slide_id}' "
                     f"(no slide_id match in '{self.input_file.path.name}')"
                 )
+            # Escalate the drop from log-only to a surfaced BuildError so it
+            # fails the build under --fail-on-error (the build consumer arm of
+            # the #162 / split-voiceover hardening). No-op without a reporter.
+            report_voiceover_merge_issues(
+                build_reporter,
+                slide_name=self.input_file.path.name,
+                companion_name=companion.name,
+                file_path=str(self.input_file.path),
+                unmatched=unmatched,
+            )
 
         payload = NotebookPayload(
             data=data,

--- a/tests/cli/test_build_output.py
+++ b/tests/cli/test_build_output.py
@@ -76,6 +76,29 @@ class TestBuildDataClasses:
         assert summary.failed_files == 1
         assert summary.successful_files == 99
 
+    def test_multiple_errors_one_file_count_once(self):
+        """A single source file emitting several errors (e.g. multiple dropped
+        voiceover narrations) counts as ONE failed file, and successful_files
+        never goes negative."""
+
+        def _err(message: str) -> BuildError:
+            return BuildError(
+                error_type="user",
+                category="voiceover",
+                severity="error",
+                file_path="slides_x.de.py",
+                message=message,
+                actionable_guidance="",
+            )
+
+        summary = BuildSummary(
+            duration=1.0,
+            total_files=1,
+            errors=[_err("for_slide 'a' dropped"), _err("for_slide 'b' dropped")],
+        )
+        assert summary.failed_files == 1  # distinct file_paths, not error count
+        assert summary.successful_files == 0  # clamped, never negative
+
 
 class TestErrorCategorizer:
     """Test error categorization logic."""

--- a/tests/slides/test_edit_dynamics.py
+++ b/tests/slides/test_edit_dynamics.py
@@ -12,10 +12,12 @@ Two kinds of guard, both diagnosable:
 * **Engine regression** — every ``sync`` mutation must stay ``preserve``. The
   safe funnel keeps both halves consistent; if a change makes it diverge, the
   ``sync``-path assertions fail with the offending row.
-* **Work-list drift** — the known silent breaks (per-file ``assign-ids``,
-  the voiceover seams, the missing commit gate) are frozen as ``break-silent``.
-  When a hardening fix lands and flips one to ``preserve``, ``test_no_drift``
-  fails *loudly* — the signal to update ``Mutation.expected`` in the harness.
+* **Work-list drift** — every ``(mutation, path)`` verdict is frozen via
+  ``Mutation.expected``; ``test_no_drift`` fails *loudly* on any change (a sync
+  regression, or a hardening fix flipping a row — then update the baseline). The
+  original break-silent work-list has now been fully drained (all rows hardened
+  to preserve or break-loud), so ``test_no_break_silent_rows_remain`` also guards
+  that no *new* silent footgun creeps back in.
 
 Pure-synthetic, so it runs in the fast suite (no markers). The real-deck arm
 (mutating corpus pairs) stays out of CI, like ``test_sync_corpus_noop``.
@@ -46,19 +48,19 @@ def outcomes(harness):
     return harness.run()
 
 
-# The known silent footguns the harness must keep surfacing — a refactor that
-# zeroes the work-list out (e.g. by neutering a runner) should fail here, not
-# quietly report "all green". Hardened so far: the two voiceover Tier-1 breaks
-# (now ``preserve``), ``commit-without-sync`` (now ``break-loud`` — the #162
-# detective gate catches it), the two per-file assign-ids breaks (now
-# ``preserve`` — the #162 defensive twin-aware reuse), and ``extract-then-split``
-# (now ``preserve`` — ``split``/``unify`` carry the voiceover companion in
-# lockstep). The one remaining documented break is the observe-only build-merge
-# arm: ``merge_voiceover_text`` returns the unmatched ids, but the ``build``
-# consumer is log-only/exit-0 (escalating that is the next work item).
-_KNOWN_SILENT_BREAKS = {
-    "build-merge-unmatched",
-}
+# The known silent footguns the harness must keep surfacing. Every one of the
+# original break-silent rows has now been hardened to preserve or break-loud:
+# the two voiceover Tier-1 breaks (``preserve``), ``commit-without-sync`` and
+# ``commit-companion-divergence`` (``break-loud`` — the #162 validate detectives
+# catch them), the two per-file assign-ids breaks + ``extract-per-language-twin-
+# aware`` (``preserve`` — the #162 defensive twin-aware reuse), ``extract-then-
+# split`` (``preserve`` — companion split/unify in lockstep), and finally
+# ``build-merge-unmatched`` (``break-loud`` — the build consumer escalates a
+# dropped narration to a BuildError that fails under ``--fail-on-error``). The
+# catalogue is now **fully loud**: zero break-silent rows. This set is therefore
+# empty, and ``test_no_break_silent_rows_remain`` enforces that no NEW silent
+# footgun (asserted or not) creeps back in.
+_KNOWN_SILENT_BREAKS: set[str] = set()
 
 
 def test_harness_runs_without_errors(harness, outcomes):
@@ -96,13 +98,13 @@ def test_voiceover_round_trips_preserve(harness, outcomes):
         assert o.verdict == harness.PRESERVE, f"{name}: {o.verdict} — {o.detail}"
 
 
-def test_known_silent_breaks_still_surfaced(harness, outcomes):
-    # Guard the work-list itself: the documented footguns must keep classifying
-    # as break-silent until they are actually hardened (then test_no_drift fires
-    # and the baseline is updated). Prevents a silent loss of coverage.
-    silent = {o.name for o in outcomes if o.verdict == harness.BREAK_SILENT}
-    missing = _KNOWN_SILENT_BREAKS - silent
-    assert missing == set(), (
-        f"these known silent breaks stopped being detected: {sorted(missing)}\n"
-        + harness.render(outcomes)
+def test_no_break_silent_rows_remain(harness, outcomes):
+    # The whole hardening arc's end state: every footgun in the catalogue is now
+    # LOUD (preserve or break-loud). A NEW break-silent row — a fresh silent
+    # footgun, or a regression that re-silences a hardened one — fails here even
+    # if it's a non-asserted observe-only row that test_no_drift wouldn't catch.
+    silent = sorted(o.name for o in outcomes if o.verdict == harness.BREAK_SILENT)
+    assert silent == [], f"new/regressed break-silent footgun(s): {silent}\n" + harness.render(
+        outcomes
     )
+    assert _KNOWN_SILENT_BREAKS == set()  # the work-list is fully drained

--- a/tests/workers/notebook/test_voiceover_build_integration.py
+++ b/tests/workers/notebook/test_voiceover_build_integration.py
@@ -146,6 +146,206 @@ class TestPayloadMerging:
         assert data == original_text
 
 
+class _RecordingReporter:
+    """Captures report_error / report_warning calls for assertions."""
+
+    def __init__(self) -> None:
+        self.errors: list = []
+        self.warnings: list = []
+
+    def report_error(self, error) -> None:
+        self.errors.append(error)
+
+    def report_warning(self, warning) -> None:
+        self.warnings.append(warning)
+
+
+class TestVoiceoverMergeEscalation:
+    """Build-time escalation of unmatched companion voiceover (#162 hardening).
+
+    Dropped narration (a companion ``for_slide`` with no matching ``slide_id``)
+    is reported as a ``BuildError`` so it surfaces in the summary and fails the
+    build under ``--fail-on-error``, instead of being a silent log line.
+    """
+
+    def test_unmatched_reported_as_build_error(self):
+        from clm.core.operations.process_notebook import report_voiceover_merge_issues
+
+        reporter = _RecordingReporter()
+        report_voiceover_merge_issues(
+            reporter,
+            slide_name="slides_x.de.py",
+            companion_name="voiceover_x.de.py",
+            file_path="/x/slides_x.de.py",
+            unmatched=["introduction"],
+        )
+
+        assert len(reporter.errors) == 1
+        err = reporter.errors[0]
+        assert err.category == "voiceover"
+        assert err.severity == "error"
+        assert err.error_type == "user"
+        assert "introduction" in err.message
+        assert err.file_path == "/x/slides_x.de.py"
+
+    def test_one_error_per_unmatched(self):
+        from clm.core.operations.process_notebook import report_voiceover_merge_issues
+
+        reporter = _RecordingReporter()
+        report_voiceover_merge_issues(
+            reporter,
+            slide_name="slides_x.de.py",
+            companion_name="voiceover_x.de.py",
+            file_path="/x/slides_x.de.py",
+            unmatched=["a", "b"],
+        )
+        assert len(reporter.errors) == 2
+
+    def test_no_for_slide_entry_renders_clean_message(self):
+        from clm.core.operations.process_notebook import report_voiceover_merge_issues
+
+        reporter = _RecordingReporter()
+        report_voiceover_merge_issues(
+            reporter,
+            slide_name="slides_x.de.py",
+            companion_name="voiceover_x.de.py",
+            file_path="/x/slides_x.de.py",
+            unmatched=["<no for_slide>"],
+        )
+        assert len(reporter.errors) == 1
+        assert "no for_slide" in reporter.errors[0].message
+
+    def test_empty_unmatched_reports_nothing(self):
+        from clm.core.operations.process_notebook import report_voiceover_merge_issues
+
+        reporter = _RecordingReporter()
+        report_voiceover_merge_issues(
+            reporter,
+            slide_name="s.py",
+            companion_name="v.py",
+            file_path="/x/s.py",
+            unmatched=[],
+        )
+        assert reporter.errors == []
+
+    def test_none_reporter_is_noop(self):
+        from clm.core.operations.process_notebook import report_voiceover_merge_issues
+
+        # No reporter (e.g. a direct payload() call in a test, or a backend
+        # without a build_reporter) must not raise.
+        report_voiceover_merge_issues(
+            None,
+            slide_name="s.py",
+            companion_name="v.py",
+            file_path="/x/s.py",
+            unmatched=["intro"],
+        )
+
+
+def _build_op_with_unmatched_companion(tmp_path: Path):
+    """Build a real ``ProcessNotebookOperation`` whose companion narrates a
+    slide_id that does not exist in the slide — so ``payload()`` / ``execute()``
+    exercise the dropped-narration escalation end to end (not just the helper)."""
+    from clm.core.course import Course
+    from clm.core.course_spec import CourseSpec, TopicSpec
+    from clm.core.operations.process_notebook import ProcessNotebookOperation
+    from clm.core.output_target import OutputTarget
+    from clm.core.section import Section
+    from clm.core.topic import Topic
+    from clm.core.utils.text_utils import Text
+
+    spec = CourseSpec(
+        name=Text(de="Test", en="Test"),
+        prog_lang="python",
+        description=Text(de="", en=""),
+        certificate=Text(de="", en=""),
+        sections=[],
+    )
+    course = Course(
+        spec=spec,
+        course_root=tmp_path,
+        output_root=tmp_path,
+        output_targets=[OutputTarget.default_target(tmp_path)],
+    )
+    slide = tmp_path / "slides_demo.py"
+    slide.write_text(
+        '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n# ## Intro\n',
+        encoding="utf-8",
+    )
+    # companion narrates "renamed" — no such slide_id in the slide -> dropped.
+    (tmp_path / "voiceover_demo.py").write_text(
+        '# %% [markdown] lang="en" tags=["voiceover"] for_slide="renamed"\n# Orphan narration.\n',
+        encoding="utf-8",
+    )
+    section = Section(name=Text(de="S", en="S"), course=course)
+    topic = Topic.from_spec(TopicSpec(id="t"), section=section, path=tmp_path)
+    topic.build_file_map()
+    section.topics.append(topic)
+    course.sections.append(section)
+    nb = next(f for f in topic.files if isinstance(f, NotebookFile))
+    return ProcessNotebookOperation(
+        input_file=nb,
+        output_file=tmp_path / "out.html",
+        language="en",
+        format="html",
+        kind="completed",
+        prog_lang="python",
+    )
+
+
+class TestEscalationWiring:
+    """End-to-end wiring of the escalation, beyond the helper in isolation.
+
+    Guards the two-hop path that makes the escalation fire in a real build:
+    ``execute()`` pulls ``build_reporter`` off the backend and ``payload()``
+    forwards it to the helper. A regression that drops either hop would leave
+    every helper-level test green while silently restoring the #162 data loss.
+    """
+
+    async def test_payload_reports_unmatched_to_reporter(self, tmp_path: Path):
+        op = _build_op_with_unmatched_companion(tmp_path)
+        reporter = _RecordingReporter()
+
+        payload = await op.payload(reporter)
+
+        # The orphan narration is dropped from the merged data...
+        assert "Orphan narration" not in payload.data
+        # ...but is surfaced as a voiceover BuildError instead of vanishing.
+        assert len(reporter.errors) == 1
+        assert reporter.errors[0].category == "voiceover"
+        assert reporter.errors[0].severity == "error"
+        assert "renamed" in reporter.errors[0].message
+
+    async def test_execute_pulls_reporter_off_backend(self, tmp_path: Path):
+        # The load-bearing wiring: execute() must read the reporter off the
+        # backend and thread it into payload(). Dropping the
+        # getattr(backend, "build_reporter", None) argument would fail here.
+        op = _build_op_with_unmatched_companion(tmp_path)
+        reporter = _RecordingReporter()
+
+        class _StubBackend:
+            def __init__(self, r):
+                self.build_reporter = r
+
+            async def execute_operation(self, operation, payload):
+                return None
+
+        await op.execute(_StubBackend(reporter))
+
+        assert len(reporter.errors) == 1
+        assert reporter.errors[0].category == "voiceover"
+
+    async def test_execute_without_reporter_does_not_raise(self, tmp_path: Path):
+        # A backend without a build_reporter (getattr -> None) must still work.
+        op = _build_op_with_unmatched_companion(tmp_path)
+
+        class _NoReporterBackend:
+            async def execute_operation(self, operation, payload):
+                return None
+
+        await op.execute(_NoReporterBackend())  # must not raise
+
+
 # ---------------------------------------------------------------------------
 # Voiceover cells in output specs
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
The final break-silent row of the split-voiceover hardening arc. When the build merges a separated-voiceover companion (`voiceover_*.py`) and a cell's `for_slide` matches no `slide_id` in the slide, that narration is **dropped from the output** — usually because a `slide_id` was renamed out from under the companion. This was **log-only / exit 0** (silent loss of a slide's speaker notes). It is now surfaced and gate-able.

- **`report_voiceover_merge_issues`** (`process_notebook.py`) reports each dropped narration as a `voiceover`-category **`BuildError`** through the build reporter, so it shows in the summary and **fails under the existing `--fail-on-error` policy** (default-on in CI / replay), exactly like a cell-execution error.
- Reporting is **client-side**: `ProcessNotebookOperation.payload()` gains an optional `build_reporter` that `execute()` pulls off the backend (`getattr(backend, "build_reporter", None)`). So **no new worker payload field** is needed — it sidesteps the #17 `model_validate` boundary landmine entirely.
- `merge_voiceover_text`'s `(merged, unmatched)` signature is **unchanged**. Surfacing build-time inline *relocations* (narration kept, repositioned — not data loss) is deferred.

## Edit-dynamics catalogue: now fully loud
The harness `build-merge-unmatched` row flips break-silent → **break-loud**. The whole catalogue is now **15 preserve / 3 break-loud / 0 break-silent** — every footgun the harness models is loud. The backstop became `test_no_break_silent_rows_remain` (asserts zero break-silent rows, guarding even non-asserted rows that `test_no_drift` wouldn't catch).

## Adversarial review follow-ups (folded into this PR)
A 3-lens review (build blast-radius / fail-on semantics / test fidelity, each finding independently verified) confirmed 3 of 8 and **correctly refuted the cache-staleness scare** — `payload()` runs unconditionally *before* the cache short-circuit, so the escalation fires on every build, hit or miss. Acted on:
- **(major) wiring gap** — every test hit the helper in isolation; nothing tested `execute()` → `payload(reporter)` → helper. Added **`TestEscalationWiring`** (3 end-to-end tests through a real `Course`/`NotebookFile` + a stub backend), so a regression dropping the `getattr(backend, "build_reporter")` argument fails loudly instead of silently restoring the data-loss bug.
- **(minor) pre-existing `BuildSummary` count flaw** this change made easy to hit — `failed_files`/`successful_files` counted error *entries*, not distinct files, so N drops in one file could drive `successful_files` **negative** (shown to users + in `--json`). Now counts distinct error `file_path`s and clamps `successful_files` at 0 (also fixes the latent cross-reference / job-timeout over-count).
- *(nit)* per-operation display repetition before summary dedup — accepted; matches the existing worker-error pattern.

## Verification
Full fast suite **6250 passed**; mypy + ruff clean. New: `TestEscalationWiring` (3), `TestVoiceoverMergeEscalation` (5), `BuildSummary` count test.

## Docs
Info topics (`commands.md` build exit-codes table + paragraph, `migration.md` new section) and the design doc (§3/§6/§10/§12/§13) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)