### PR TITLE
feat(voiceover): paired one-op extract — auto-pair both companions with EN-authority ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm voiceover extract` auto-pairs on a split half (§8 paired extract).**
+  When the target is a split half (`<deck>.de.py` / `<deck>.en.py`) whose twin
+  exists on disk, both companions are extracted in one op: the two halves are
+  first minted with **EN-authority** `slide_id`s across both at once, then each
+  is extracted, and all writes commit atomically — so the two companions'
+  `for_slide` sets agree by construction (closing the footgun where extracting
+  each half by hand could mint divergent slugs). `--single` opts out (legacy
+  single-half behavior), `--both` forces the paired form, and a structurally
+  non-alignable pair is **refused** rather than risk divergence. The `--json`
+  output for a paired extract carries `"paired": true` + a `"companions"` array;
+  the MCP `extract_voiceover` tool gains matching `both` / `single` params. (This
+  is a behavior change to a bare `extract <deck>.de.py` — see `clm info
+  migration`.)
 - **`clm slides sync` now mirrors a tag-only edit across split halves
   (#198).** Adding or removing a role-preserving tag (`keep`, `alt`, …) on
   one half of a split deck used to be silently dropped — the body-hash

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -466,7 +466,7 @@ agent/script plumbing, or **(G)** harden with a guard.
 | Command | Why it's risky | Disposition (proposed) |
 |---|---|---|
 | `assign-ids` (per file) | Per-file run on a split half mints **divergent** ids — the #1 silent #162 break. Its core job (id minting) is already done *consistently* by `sync`. | **F + H — DONE (2026-06-03).** F was already real (minting is shared via the `clm.slides.assign_ids` engine, reused by `normalize` and the generative `assign_ids_in_split_pair`). H: `hidden=True` on the command — invocable by name for agents/scripts, gone from `clm slides --help`; docstring + `commands.md`/`migration.md`/README reframed as plumbing, pointing to `sync`/`normalize` as the canonical authoring path. |
-| `voiceover extract` | Single-file, clobbers companion w/o `--force`; per-language only; no cross-language check. | **G now, F later** — add `--force`/guard immediately; longer-term fold extraction into a paired, twin-aware operation (or under `sync`'s umbrella). |
+| `voiceover extract` | Single-file, clobbers companion w/o `--force`; per-language only; no cross-language check. | **G + F — DONE.** G (2026-06-03): `--force`/refuse-clobber. F (2026-06-03): `extract_voiceover_pair` — on a split half whose twin exists, extract **auto-pairs** both companions in one op, minting **EN-authority** ids across both halves first (via `assign_ids_in_split_pair`) so `for_slide` sets agree by construction, then writing all four files via the shared `atomic_write_all`; `--single` opts out, `--both` forces, a non-alignable pair is refused. CLI + MCP (`both`/`single`) + paired JSON shape. NOT folded under `sync` (kept a sibling op — `sync` is deck-identity, extract is narration-relocation). |
 | `voiceover inline` | Destructive: unlinks companion even on unmatched, exit 0, no backup. | **G** — preserve/backup on unmatched, non-zero exit, `--dry-run` default. |
 | `slides split` | Unaware of voiceover companions; extract-then-split silently orphans them. | **G — DONE (2026-06-03).** First-class companion split: `split_in_file` splits a sibling `voiceover_*.py` in lockstep into `voiceover_*.de.py`/`.en.py`, routing cells by `lang`, preserving `for_slide`/`vo_anchor`. Atomic `--force` over deck+companion; byte-identical round trip. |
 | `slides unify` | Ignores companions; can't recombine voiceover. | **G — DONE (2026-06-03).** `unify_in_file` recombines the companion halves into `voiceover_*.py` (inverse of split; missing half treated as empty so narration is never dropped). |
@@ -629,9 +629,14 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
    (`split_twin` / `split_twin_pair` + the prefix-agnostic `order_split_pair` /
    `split_lang_tag`); `clm slides sync` **pairing guard**; `assign-ids` and
    `suggest-sync` **hidden as plumbing** (`hidden=True`), with `commands.md` /
-   `migration.md` / README updated. **Deferred:** the paired one-op `voiceover
-   extract --both` (auto-pair on a split half; pre-decided surface), and the
-   `slides sync` single-path contract + directory/spec batch mode (additive UX).
+   `migration.md` / README updated. **Paired `voiceover extract` DONE
+   (2026-06-03):** `extract_voiceover_pair` auto-pairs on a split half
+   (EN-authority pre-mint → extract both → atomic four-file write; `--both` /
+   `--single`; CLI + MCP + paired JSON; refuses a non-alignable pair); the
+   shared `atomic_write_all` was promoted to `path_utils` and reused by
+   `split`/`unify`. **Deferred:** the `slides sync` single-path contract +
+   directory/spec batch mode (additive UX) — single-path is next; batch is its
+   own follow-up (`sync DIR` + continue-on-error + `--yes`, pre-decided).
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
 6. **Sync CLI single-path / batch UX** (§8) on top of the shipped pairing guard.
 7. Forward design: N-file atomicity for separated voiceover (§3 #6); `FileTopic`
@@ -661,10 +666,17 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
   `cell_content_hash`), `pairing.py`.
 - IDs: `assign_ids.py` (slug/minting; `group_slug` `:301-339`; refusals `:545-568`),
   `slug.py` (`resolve_collision` `:189-201`).
-- Voiceover (slide-side): `voiceover_tools.py` (`companion_path` `:122-136`; extract
-  `:349-424`; `_ensure_slide_ids` — twin-aware id gen, threads `twin_ids` via
-  `assign_ids._twin_ids_for` into `normalizer._apply_slide_ids`; inline `:706-802`;
-  `merge_voiceover_text` `:432-485`; `vo_anchor` `:204-256`).
+- Voiceover (slide-side): `voiceover_tools.py` (`companion_path`; `_plan_extraction`
+  (write-free planner) + thin `extract_voiceover`; **`extract_voiceover_pair`** —
+  paired auto-pair op: `order_split_pair` → all-or-nothing companion guard →
+  `assign_ids_in_split_pair` EN-authority pre-mint (refuse on `None`) → `_plan_extraction`
+  per half → one `atomic_write_all`; `PairedExtractionResult`; `_ensure_slide_ids`
+  twin-aware; inline; `merge_voiceover_text`; `vo_anchor`). Auto-pair derivation:
+  `pairing.derive_split_pair` (prefix-agnostic, disk-aware). CLI `--both`/`--single`
+  + `_paired_extraction_to_dict`; MCP twin + `_paired_extraction_result_to_dict` (kept
+  byte-aligned).
+- Cross-file atomic write: `path_utils.atomic_write_all` (promoted from `split._atomic_write_all`;
+  reused by `split`/`unify` and `extract_voiceover`/`extract_voiceover_pair`).
 - Split/unify: `split.py` (`split_text`; `unify_texts`; `_slide_ids_pair`; force guards;
   companion seam `_plan_companion_split` / `_plan_companion_unify` — lazy `companion_path`
   import, reuse `split_text`/`unify_texts`; `SplitResult`/`UnifyResult` companion fields).

--- a/scripts/edit_dynamics_harness.py
+++ b/scripts/edit_dynamics_harness.py
@@ -65,6 +65,7 @@ from clm.slides.voiceover_tools import (  # noqa: E402
     VoiceoverError,
     companion_path,
     extract_voiceover,
+    extract_voiceover_pair,
     inline_voiceover,
     merge_voiceover_text,
 )
@@ -751,6 +752,36 @@ def m_extract_per_language_twin_aware(workdir: Path) -> _RetTuple:
     )
 
 
+def m_extract_pair_both_companions(workdir: Path) -> _RetTuple:
+    # Born-split pair (both halves id-less) with inline voiceover. The author
+    # runs the ONE-OP paired extract: EN-authority ids are minted across both
+    # halves first, then each is extracted, so the two companions' for_slide
+    # sets agree by construction — stronger (order-independent) than the
+    # per-language path's twin-adoption parity.
+    pair = born_split_with_voiceover()
+    de_path, en_path = pair.write(workdir)
+    extract_voiceover_pair(de_path, en_path)
+    de_comp = companion_path(de_path)
+    en_comp = companion_path(en_path)
+    if not (de_comp.exists() and en_comp.exists()):
+        return ["companion_missing"], False, "", "paired extract did not produce both companions"
+    de_after = de_path.read_text(encoding="utf-8")
+    en_after = en_path.read_text(encoding="utf-8")
+    de_fs = for_slides(de_comp.read_text(encoding="utf-8"))
+    en_fs = for_slides(en_comp.read_text(encoding="utf-8"))
+    violated: list[str] = []
+    if slide_ids(de_after) != slide_ids(en_after):
+        violated.append("id_parity")
+    if set(de_fs) != set(en_fs):
+        violated.append("for_slide_parity")
+    return (
+        violated,
+        False,
+        "",
+        f"slide_ids de={slide_ids(de_after)} en={slide_ids(en_after)}; for_slide de={de_fs} en={en_fs}",
+    )
+
+
 def m_inline_after_rename(workdir: Path) -> _RetTuple:
     de, _ = split_text(baseline_bilingual(with_voiceover=("intro",)))
     slide = workdir / "slides_demo.de.py"
@@ -911,6 +942,17 @@ MUTATIONS: list[Mutation] = [
         PRESERVE,
         True,
         m_extract_per_language_twin_aware,
+    ),
+    # Paired one-op extract landed (§8 'F later'): `extract` on a split half
+    # auto-pairs, minting EN-authority ids across both halves before extracting,
+    # so the two companions' for_slide sets agree by construction (order-
+    # independent, unlike the per-language row above).
+    Mutation(
+        "extract-pair-both-companions",
+        "extract",
+        PRESERVE,
+        True,
+        m_extract_pair_both_companions,
     ),
     # Tier-1 data-loss fixes landed: inline now retains the companion with the
     # unmatched cell (recoverable) and exits non-zero; extract refuses to clobber

--- a/src/clm/cli/commands/voiceover_tools.py
+++ b/src/clm/cli/commands/voiceover_tools.py
@@ -7,12 +7,15 @@ from pathlib import Path
 
 import click
 
+from clm.slides.pairing import derive_split_pair
 from clm.slides.voiceover_tools import (
     ExtractionResult,
     InlineResult,
+    PairedExtractionResult,
     VoiceoverError,
     companion_path,
     extract_voiceover,
+    extract_voiceover_pair,
     inline_voiceover,
 )
 
@@ -30,6 +33,19 @@ from clm.slides.voiceover_tools import (
     "in the companion; without --force an existing companion is left untouched.",
 )
 @click.option(
+    "--both",
+    is_flag=True,
+    help="Extract BOTH companions of a split deck in one op (the EN-authority "
+    "paired extract). Auto-detected when PATH is a split half whose twin exists; "
+    "passing --both forces it and errors if there is no twin.",
+)
+@click.option(
+    "--single",
+    is_flag=True,
+    help="Extract only PATH's own companion, even on a split half whose twin "
+    "exists — opt out of the default auto-pairing.",
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Preview changes without modifying files.",
@@ -43,6 +59,8 @@ from clm.slides.voiceover_tools import (
 def extract_voiceover_cmd(
     path: Path,
     force: bool,
+    both: bool,
+    single: bool,
     dry_run: bool,
     as_json: bool,
 ):
@@ -53,22 +71,45 @@ def extract_voiceover_cmd(
     slide_id get auto-generated IDs before extraction.  Refuses to
     overwrite an existing companion unless --force is given.
 
+    On a split half (``<deck>.de.py`` / ``<deck>.en.py``) whose twin exists on
+    disk, both companions are extracted in one op by default: the two halves are
+    first minted with EN-authority slide_ids so the companions' for_slide sets
+    agree, then each half is extracted and all writes commit atomically. Pass
+    --single to extract only this half; --both forces the paired form (and errors
+    if there is no twin). A bilingual deck (no .de/.en twin) always extracts a
+    single companion.
+
     \b
     Examples:
         clm voiceover extract slides/topic/slides_intro.py --dry-run
-        clm voiceover extract slides/topic/slides_intro.py
+        clm voiceover extract slides/topic/slides_intro.de.py          # auto-pairs
+        clm voiceover extract slides/topic/slides_intro.de.py --single # this half only
         clm voiceover extract slides/topic/slides_intro.py --force
-        clm voiceover extract slides/topic/slides_intro.py --json
+        clm voiceover extract slides/topic/slides_intro.de.py --json
     """
+    if both and single:
+        raise click.UsageError("--both and --single are mutually exclusive")
+
+    pair = None if single else derive_split_pair(path)
+    if both and pair is None:
+        raise click.ClickException(
+            f"--both needs a split deck: '{path.name}' has no <deck>.de.py / "
+            f"<deck>.en.py twin on disk."
+        )
+
     try:
-        result = extract_voiceover(path, force=force, dry_run=dry_run)
+        if pair is not None:
+            paired = extract_voiceover_pair(pair[0], pair[1], force=force, dry_run=dry_run)
+            payload = _paired_extraction_to_dict(paired)
+            summary = paired.summary
+        else:
+            result = extract_voiceover(path, force=force, dry_run=dry_run)
+            payload = _extraction_to_dict(result)
+            summary = result.summary
     except VoiceoverError as e:
         raise click.ClickException(str(e)) from e
 
-    if as_json:
-        click.echo(json.dumps(_extraction_to_dict(result), indent=2))
-    else:
-        click.echo(result.summary)
+    click.echo(json.dumps(payload, indent=2) if as_json else summary)
 
 
 @click.command("inline-voiceover")
@@ -148,6 +189,20 @@ def _extraction_to_dict(result: ExtractionResult) -> dict:
         "cells_extracted": result.cells_extracted,
         "ids_generated": result.ids_generated,
         "dry_run": result.dry_run,
+        "summary": result.summary,
+    }
+
+
+def _paired_extraction_to_dict(result: PairedExtractionResult) -> dict:
+    """JSON shape for a paired extract. The ``"paired": true`` discriminator
+    lets consumers branch; ``"companions"`` reuses the single-file dict per half
+    (DE first, EN second). A single-file extract keeps emitting the flat dict
+    (no ``paired`` key), so existing ``--json`` consumers are unaffected."""
+    return {
+        "paired": True,
+        "dry_run": result.dry_run,
+        "ids_minted": result.ids_minted,
+        "companions": [_extraction_to_dict(r) for r in result.results],
         "summary": result.summary,
     }
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1134,9 +1134,25 @@ divergent slug (the #162 defensive). This keeps `de_id == en_id` when you
 extract the two halves separately, so their companions' `for_slide` sets agree
 — without it, per-language extraction would mint independent slugs and one
 language would silently ship with missing narration (which `clm validate`'s
-#162 detectives now flag). For deterministic EN-authority ids across a pair,
-run `clm slides assign-ids <dir>` before extracting; bilingual decks are
-unaffected.
+#162 detectives now flag). Bilingual decks are unaffected.
+
+**Paired extract (auto-pairing), since CLM {version}.** When `FILE` is a split
+half (`<deck>.de.py` / `<deck>.en.py`) whose twin exists on disk, both
+companions are extracted in **one op** by default: the two halves are first
+minted with **EN-authority** `slide_id`s across both at once (the slug comes
+from the EN heading, stamped identically on both halves), then each half is
+extracted, and all writes commit atomically. This is stronger than extracting
+the halves one at a time — the `for_slide` sets agree *by construction* and the
+result is independent of which half you point at. The routing prefix is not
+required, so `apis.de.py` / `apis.en.py` pairs too. Pass `--single` to extract
+only `FILE`'s own companion (the legacy per-half behavior); `--both` forces the
+paired form and errors if there is no twin. If the two halves are not
+structurally alignable (divergent shared cells / mismatched cell count), the
+paired extract **refuses** rather than risk divergence — reconcile them first
+(e.g. `clm slides sync`). A bilingual deck (no `.de`/`.en` twin) always extracts
+a single companion. The `--json` output for a paired extract carries
+`"paired": true` and a `"companions"` array (one entry per half); a single
+extract keeps the flat object.
 
 Since CLM {version}, each extracted cell also records a `vo_anchor`
 attribute identifying its **immediate predecessor cell** — `id:<slide_id>`
@@ -1161,16 +1177,20 @@ clm voiceover extract [OPTIONS] FILE
 
 | Option | Description |
 |--------|-------------|
-| `--force` | Overwrite an existing companion (rebuilds it from the slide's voiceover cells, discarding companion-only content). Without it, an existing companion is left untouched and the command errors. |
+| `--force` | Overwrite an existing companion (rebuilds it from the slide's voiceover cells, discarding companion-only content). Without it, an existing companion is left untouched and the command errors. For a paired extract this is **all-or-nothing**: it refuses if *either* companion exists. |
+| `--both` | Force the paired extract (both companions of a split deck). Auto-detected on a split half whose twin exists; passing `--both` errors if there is no twin. |
+| `--single` | Extract only `FILE`'s own companion, even on a split half whose twin exists — opt out of the default auto-pairing. |
 | `--dry-run` | Preview changes without modifying files |
 | `--json` | Output as JSON |
 
 Examples:
 
 ```bash
-clm voiceover extract slides_intro.py
+clm voiceover extract slides_intro.py                 # bilingual: single companion
+clm voiceover extract slides_intro.de.py              # split half: auto-pairs both companions
+clm voiceover extract slides_intro.de.py --single     # split half: this half only
 clm voiceover extract slides_intro.py --dry-run
-clm voiceover extract slides_intro.py --force
+clm voiceover extract slides_intro.de.py --force
 ```
 
 ### `clm voiceover inline`
@@ -1274,7 +1294,7 @@ The MCP server exposes 11 tools over stdio transport:
 | `normalize_slides` | Apply mechanical fixes (tag migration, interleaving, slide IDs) |
 | `get_language_view` | Extract single-language view with line annotations |
 | `suggest_sync` | Detect asymmetric bilingual edits vs git HEAD |
-| `extract_voiceover` | Move voiceover cells to companion file |
+| `extract_voiceover` | Move voiceover cells to a companion file; on a split half auto-pairs both companions (`both`/`single` params, `"paired"` JSON) |
 | `inline_voiceover` | Merge voiceover cells back from companion file |
 | `course_authoring_rules` | Look up merged authoring rules for a course |
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -65,6 +65,27 @@ relied on the old behavior may need a flag or an exit-code check.
 These are also surfaced by the new fast-suite `tests/slides/test_edit_dynamics.py`
 cross-command harness (`scripts/edit_dynamics_harness.py`).
 
+## `clm voiceover extract` auto-pairs on a split half ({version})
+
+CLM {version} makes `clm voiceover extract` produce **both** companions of a
+split deck in one op. When `FILE` is a split half (`<deck>.de.py` /
+`<deck>.en.py`) whose twin exists on disk, extract now mints EN-authority
+`slide_id`s across both halves and extracts both, so the two companions'
+`for_slide` sets agree by construction (closing the per-language footgun where
+extracting each half by hand could mint divergent slugs).
+
+*Migration (behavior change):* a bare `clm voiceover extract <deck>.de.py` that
+used to write only `voiceover_<deck>.de.py` now also writes
+`voiceover_<deck>.en.py`, and the EN-authority pre-mint may stamp `slide_id`s on
+**both** slide halves (so `git diff` shows the `.en` half too). To keep the old
+single-half behavior, pass `--single`. The `--json` output for a paired extract
+is a new shape — `{"paired": true, "companions": [<de>, <en>], …}` — so a
+consumer that reads top-level `cells_extracted` should branch on the `paired`
+key (a single-file/bilingual extract still emits the flat object). A pair that
+is not structurally alignable makes extract **refuse** (reconcile with
+`clm slides sync` first). Bilingual decks (no `.de`/`.en` twin) are unchanged.
+The MCP `extract_voiceover` tool gains matching `both` / `single` parameters.
+
 ## `slides split` / `unify` carry the voiceover companion ({version})
 
 Previously `clm slides split` only split the deck — a sibling voiceover

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -225,6 +225,37 @@ def slide_family_key(input_path: Path) -> str | None:
     return input_path.name
 
 
+def atomic_write_all(writes: list[tuple[Path, str]]) -> None:
+    """Write several ``(path, text)`` outputs as atomically as the FS allows.
+
+    Every text is first written to a sibling ``*.tmp`` file; only after **all**
+    temp writes succeed are they ``os.replace``-d into place back-to-back. A
+    failure during the temp phase (the common one — disk full, permission)
+    therefore leaves every real target untouched; the replace phase has only a
+    tiny residual window, and leftover temps are cleaned up either way.
+
+    Shared by the slide rewriters that emit several coupled files in one op —
+    ``split`` / ``unify`` (a deck plus its voiceover companion) and the paired
+    ``voiceover extract`` (two slide halves plus two companions). With plain
+    per-file writes a mid-operation failure could leave a one-sided companion
+    (the very orphaning these seams prevent). Cross-file atomicity is not
+    achievable without a journal, but this upgrades direct per-file writes so
+    the likely failure is safe.
+    """
+    temps: list[tuple[Path, Path]] = []
+    try:
+        for path, text in writes:
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text(text, encoding="utf-8", newline="\n")
+            temps.append((tmp, path))
+        for tmp, path in temps:
+            os.replace(tmp, path)
+    finally:
+        for tmp, _ in temps:
+            if tmp.exists():
+                tmp.unlink()
+
+
 def is_ignored_dir_for_course(dir_path: Path) -> bool:
     for part in dir_path.parts:
         if part in SKIP_DIRS_FOR_COURSE:

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -249,6 +249,8 @@ def create_server(data_dir: Path) -> FastMCP:
         file: str,
         force: bool = False,
         dry_run: bool = False,
+        both: bool = False,
+        single: bool = False,
     ) -> str:
         """Extract voiceover cells from a slide file to a companion file.
 
@@ -258,14 +260,23 @@ def create_server(data_dir: Path) -> FastMCP:
         Refuses to overwrite an existing companion unless force is set
         (returns an ``{"error": ...}`` object in that case).
 
+        On a split half (<deck>.de.py / <deck>.en.py) whose twin exists on
+        disk, BOTH companions are extracted in one EN-authority paired op by
+        default (the result carries ``"paired": true``). Pass single=True to
+        extract only this half; both=True forces the paired form.
+
         Args:
             file: Path to the slide file (absolute, or relative to the
                 data directory).
             force: Overwrite an existing companion (rebuilds it from the
                 slide's voiceover cells, discarding companion-only content).
             dry_run: If True, preview without writing files.
+            both: Force the paired extract (both companions of a split deck).
+            single: Extract only this file's companion, even on a split half.
         """
-        return await handle_extract_voiceover(file, data_dir, force=force, dry_run=dry_run)
+        return await handle_extract_voiceover(
+            file, data_dir, force=force, dry_run=dry_run, both=both, single=single
+        )
 
     @mcp.tool()
     async def inline_voiceover(

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -28,6 +28,7 @@ from clm.slides.normalizer import NormalizationResult
 from clm.slides.normalizer import normalize_course as _normalize_course
 from clm.slides.normalizer import normalize_directory as _normalize_directory
 from clm.slides.normalizer import normalize_file as _normalize_file
+from clm.slides.pairing import derive_split_pair as _derive_split_pair
 from clm.slides.search import SearchResult
 from clm.slides.search import search_slides as _search_slides
 from clm.slides.spec_validator import SpecValidationResult
@@ -36,8 +37,14 @@ from clm.slides.validator import ValidationResult
 from clm.slides.validator import validate_course as _validate_course
 from clm.slides.validator import validate_directory as _validate_directory
 from clm.slides.validator import validate_file as _validate_file
-from clm.slides.voiceover_tools import ExtractionResult, InlineResult, VoiceoverError
+from clm.slides.voiceover_tools import (
+    ExtractionResult,
+    InlineResult,
+    PairedExtractionResult,
+    VoiceoverError,
+)
 from clm.slides.voiceover_tools import extract_voiceover as _extract_voiceover
+from clm.slides.voiceover_tools import extract_voiceover_pair as _extract_voiceover_pair
 from clm.slides.voiceover_tools import inline_voiceover as _inline_voiceover
 
 logger = logging.getLogger(__name__)
@@ -600,14 +607,34 @@ def _extraction_result_to_dict(result: ExtractionResult) -> dict:
     }
 
 
+def _paired_extraction_result_to_dict(result: PairedExtractionResult) -> dict:
+    """Paired-extract JSON shape — byte-aligned with the CLI's
+    ``_paired_extraction_to_dict`` (the two serializers are a contract). The
+    ``"paired": true`` discriminator lets consumers branch; a single-file
+    extract keeps emitting the flat dict (no ``paired`` key)."""
+    return {
+        "paired": True,
+        "dry_run": result.dry_run,
+        "ids_minted": result.ids_minted,
+        "companions": [_extraction_result_to_dict(r) for r in result.results],
+        "summary": result.summary,
+    }
+
+
 async def handle_extract_voiceover(
     file: str,
     data_dir: Path,
     *,
     force: bool = False,
     dry_run: bool = False,
+    both: bool = False,
+    single: bool = False,
 ) -> str:
     """Extract voiceover cells from a slide file to a companion file.
+
+    On a split half whose twin exists on disk, both companions are extracted in
+    one EN-authority paired op by default (mirrors the CLI). ``single`` opts out;
+    ``both`` forces the paired form (errors if there is no twin).
 
     Args:
         file: Path to the slide file (absolute or relative to data_dir).
@@ -615,16 +642,32 @@ async def handle_extract_voiceover(
         force: Overwrite an existing companion file (rebuilds it from the
             slide's voiceover cells, discarding companion-only content).
         dry_run: If ``True``, preview without writing files.
+        both: Force the paired extract (both companions of a split deck).
+        single: Extract only ``file``'s own companion, even on a split half.
 
     Returns:
-        JSON string with extraction results, or a ``{"error": ...}`` object
-        when an existing companion would be clobbered without ``force``.
+        JSON string with extraction results (a paired shape carries
+        ``"paired": true``), or a ``{"error": ...}`` object when an existing
+        companion would be clobbered without ``force`` or the pair is invalid.
     """
     target = Path(file)
     if not target.is_absolute():
         target = data_dir / target
 
+    if both and single:
+        return json.dumps({"error": "both and single are mutually exclusive"}, indent=2)
+
+    pair = None if single else _derive_split_pair(target)
+    if both and pair is None:
+        return json.dumps(
+            {"error": f"both requested but '{target.name}' has no split twin on disk"},
+            indent=2,
+        )
+
     try:
+        if pair is not None:
+            paired = _extract_voiceover_pair(pair[0], pair[1], force=force, dry_run=dry_run)
+            return json.dumps(_paired_extraction_result_to_dict(paired), indent=2)
         result = _extract_voiceover(target, force=force, dry_run=dry_run)
     except VoiceoverError as e:
         return json.dumps({"error": str(e)}, indent=2)

--- a/src/clm/slides/pairing.py
+++ b/src/clm/slides/pairing.py
@@ -201,3 +201,46 @@ def order_split_pair(a: Path, b: Path) -> tuple[Path, Path] | None:
     if _split_family(a) != _split_family(b):
         return None
     return (a, b) if ta == "de" else (b, a)
+
+
+def derive_split_twin(path: Path) -> Path | None:
+    """The sibling split half on disk, **prefix-agnostic** (unlike
+    :func:`split_twin`, which is gated on the ``slides_``/``topic_``/``project_``
+    routing prefix). Swaps the ``.de`` ↔ ``.en`` tag in the filename and returns
+    the twin only if it exists on disk; ``None`` when ``path`` carries no
+    ``.de``/``.en`` tag or the twin is absent.
+
+    This is the disk-aware sibling of :func:`order_split_pair`, for the
+    prefix-agnostic CLI surfaces — ``voiceover extract`` auto-pairing and the
+    ``clm slides sync`` single-path contract — which must recognise any
+    ``<deck>.de``/``.en`` pair the author hands over, not just routing-prefixed
+    course files. A **voiceover companion** (``voiceover_*.py``) is deliberately
+    *not* treated as a deck half: it carries a ``.de``/``.en`` tag, but it is the
+    *output* of an extract, never a deck to auto-pair — so a companion passed by
+    mistake derives no twin (preventing a re-extract that would empty both
+    companions).
+    """
+    if path.name.startswith("voiceover_"):
+        return None
+    tag = split_lang_tag(path)
+    if tag is None:
+        return None
+    other = "en" if tag == "de" else "de"
+    parts = path.name.split(".")
+    parts[-2] = other
+    twin = path.with_name(".".join(parts))
+    return twin if twin.exists() else None
+
+
+def derive_split_pair(path: Path) -> tuple[Path, Path] | None:
+    """Ordered ``(de_path, en_path)`` for a split half whose twin exists on disk
+    — the prefix-agnostic, disk-aware analogue of :func:`split_twin_pair`.
+
+    Returns ``None`` when ``path`` is not a ``.de``/``.en`` half or its twin is
+    absent. The result is validated and ordered through :func:`order_split_pair`,
+    so a degenerate non-pair (e.g. cross-family) still yields ``None``.
+    """
+    twin = derive_split_twin(path)
+    if twin is None:
+        return None
+    return order_split_pair(path, twin)

--- a/src/clm/slides/split.py
+++ b/src/clm/slides/split.py
@@ -60,42 +60,12 @@ layer.
 
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from clm.infrastructure.utils.path_utils import atomic_write_all
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
-
-
-def _atomic_write_all(writes: list[tuple[Path, str]]) -> None:
-    """Write several ``(path, text)`` outputs as atomically as the FS allows.
-
-    Every text is first written to a sibling ``*.tmp`` file; only after **all**
-    temp writes succeed are they ``os.replace``-d into place back-to-back. A
-    failure during the temp phase (the common one — disk full, permission)
-    therefore leaves every real target untouched; the replace phase has only a
-    tiny residual window, and leftover temps are cleaned up either way.
-
-    This matters for the companion seam: ``split``/``unify`` write up to four
-    files, and a mid-operation failure with plain per-file writes could leave a
-    split deck without its companion — the very orphaning this seam prevents.
-    Cross-file atomicity is not achievable without a journal, but this upgrades
-    the previous direct per-file writes so the likely failure is safe.
-    """
-    temps: list[tuple[Path, Path]] = []
-    try:
-        for path, text in writes:
-            tmp = path.with_name(path.name + ".tmp")
-            tmp.write_text(text, encoding="utf-8", newline="\n")
-            temps.append((tmp, path))
-        for tmp, path in temps:
-            os.replace(tmp, path)
-    finally:
-        for tmp, _ in temps:
-            if tmp.exists():
-                tmp.unlink()
-
 
 # ---------------------------------------------------------------------------
 # Errors
@@ -398,7 +368,7 @@ def split_in_file(
         if companion is not None:
             writes.append((companion.de_path, companion.de_text))
             writes.append((companion.en_path, companion.en_text))
-        _atomic_write_all(writes)
+        atomic_write_all(writes)
 
     return SplitResult(
         source=str(source),
@@ -725,7 +695,7 @@ def unify_in_file(
         writes = [(target, unified)]
         if companion is not None:
             writes.append((companion.target, companion.text))
-        _atomic_write_all(writes)
+        atomic_write_all(writes)
 
     return UnifyResult(
         de_source=str(de_source),

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -22,6 +22,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from clm.infrastructure.utils.path_utils import atomic_write_all
 from clm.notebooks.slide_parser import parse_cell_header, parse_cells
 from clm.slides.normalizer import (
     _apply_slide_ids,
@@ -29,6 +30,7 @@ from clm.slides.normalizer import (
     _reconstruct,
     _split_raw_cells,
 )
+from clm.slides.pairing import order_split_pair
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -64,6 +66,44 @@ class ExtractionResult:
             parts.append(f"{prefix}No voiceover cells found.")
         if self.ids_generated:
             parts.append(f"{self.ids_generated} slide_id(s) auto-generated")
+        return "; ".join(parts)
+
+
+@dataclass
+class PairedExtractionResult:
+    """Result of a paired extraction over both halves of a split deck.
+
+    Holds the two per-half :class:`ExtractionResult`s (``results[0]`` is the DE
+    half, ``results[1]`` the EN half, by construction) plus the count of
+    EN-authority ``slide_id``s minted across both halves by the pre-extraction
+    pass. The two companions' ``for_slide`` sets agree by construction (the
+    EN-authority mint stamped the same ids on both halves before extraction).
+    """
+
+    results: list[ExtractionResult]
+    ids_minted: int = 0
+    dry_run: bool = False
+
+    @property
+    def de(self) -> ExtractionResult:
+        return self.results[0]
+
+    @property
+    def en(self) -> ExtractionResult:
+        return self.results[1]
+
+    @property
+    def summary(self) -> str:
+        prefix = "[DRY RUN] " if self.dry_run else ""
+        total = sum(r.cells_extracted for r in self.results)
+        comps = [r.companion_file for r in self.results if r.cells_extracted]
+        if comps:
+            head = f"{prefix}paired extract: {total} voiceover cell(s) → {', '.join(comps)}"
+        else:
+            head = f"{prefix}paired extract: no voiceover cells found in either half."
+        parts = [head]
+        if self.ids_minted:
+            parts.append(f"{self.ids_minted} EN-authority slide_id(s) minted across both halves")
         return "; ".join(parts)
 
 
@@ -372,38 +412,44 @@ def _find_owning_slide_id(cells: list[_RawCell], voiceover_idx: int) -> str | No
     return None
 
 
-def extract_voiceover(
-    path: Path,
-    *,
-    force: bool = False,
-    dry_run: bool = False,
-) -> ExtractionResult:
-    """Extract voiceover cells from a slide file to a companion file.
+def _has_voiceover_cells(path: Path) -> bool:
+    """True iff ``path`` contains at least one voiceover/notes cell."""
+    _preamble, cells = _split_raw_cells(path.read_text(encoding="utf-8"))
+    return any(_is_voiceover_cell(c) for c in cells)
 
-    Content cells without ``slide_id`` get auto-generated IDs before
-    extraction.  Voiceover cells are linked to their owning slide via
-    ``for_slide`` metadata. On a split half whose twin exists on disk with a
-    matching slide count, that id generation is **twin-aware** (#162): an
-    id-less slide adopts the twin's id rather than minting a divergent slug, so
-    extracting the ``.de`` and ``.en`` halves separately keeps their companions'
-    ``for_slide`` sets in agreement (see :func:`_ensure_slide_ids`).
 
-    The companion is *rebuilt* from the voiceover cells currently in the slide
-    file. If a companion already exists it would be overwritten, discarding any
-    hand-edits (or previously-extracted cells) that live only in the companion —
-    so, like ``split_in_file``, this refuses without ``force``.
+def _slide_start_ids_of(path: Path) -> list[str | None]:
+    """Ordered ``slide_id``s of the slide/subslide cells in ``path`` (``None``
+    where a slide carries no id)."""
+    return [
+        c.metadata.slide_id
+        for c in parse_cells(path.read_text(encoding="utf-8"))
+        if c.metadata.is_slide_start
+    ]
 
-    Args:
-        path: Path to the ``.py`` slide file.
-        force: Overwrite an existing companion file. Without it, an existing
-            companion raises :class:`VoiceoverError` rather than clobbering it.
-        dry_run: If ``True``, preview without writing files.
 
-    Returns:
-        An :class:`ExtractionResult` describing what was done.
+def _slide_ids_in_parity(de_path: Path, en_path: Path) -> bool:
+    """True iff both halves carry the **same** ordered ``slide_id``s with none
+    missing — the precondition for skipping the EN-authority pre-mint
+    (``mint_ids=False``). An id-less or divergent pair fails this, so the caller
+    refuses rather than letting the per-half mint diverge (#162)."""
+    de_ids = _slide_start_ids_of(de_path)
+    en_ids = _slide_start_ids_of(en_path)
+    return de_ids == en_ids and all(de_ids)
 
-    Raises:
-        VoiceoverError: a companion already exists and ``force`` is not set.
+
+def _plan_extraction(
+    path: Path, *, dry_run: bool
+) -> tuple[ExtractionResult, list[tuple[Path, str]]]:
+    """Compute the extraction result and the ``(path, text)`` writes WITHOUT
+    writing anything.
+
+    Returns ``(result, writes)``. ``writes`` is empty when there are no
+    voiceover cells (nothing to do) or under ``dry_run`` — so an empty list
+    means "do not touch disk". The caller owns the existing-companion force
+    check and the actual commit (via :func:`atomic_write_all`), so the paired
+    path can guard *both* companions up front and write all four files in one
+    atomic batch.
     """
     comp = companion_path(path)
     result = ExtractionResult(
@@ -418,7 +464,7 @@ def extract_voiceover(
     # Check if there are any voiceover cells at all
     vo_indices = [i for i, c in enumerate(cells) if _is_voiceover_cell(c)]
     if not vo_indices:
-        return result
+        return result, []
 
     # Auto-generate slide_ids for cells that need them (twin-aware on a split
     # half so a per-language extract keeps de_id == en_id; see _ensure_slide_ids).
@@ -449,13 +495,59 @@ def extract_voiceover(
 
     result.cells_extracted = len(companion_cells)
 
+    if dry_run:
+        return result, []
+
     # Remove voiceover cells from the slide file
     remaining_cells = [c for i, c in enumerate(cells) if i not in set(vo_indices)]
+    new_slide_text = _reconstruct(preamble, remaining_cells)
+    # Clean up double blank lines left by removal
+    new_slide_text = re.sub(r"\n{3,}", "\n\n", new_slide_text)
+    companion_text = _reconstruct("", companion_cells)
+    return result, [(path, new_slide_text), (comp, companion_text)]
 
-    if not dry_run:
-        # Refuse to clobber an existing companion *before* touching the slide
-        # file — otherwise a raise here would strip voiceover from the slide
-        # and leave no companion (data loss). ``force`` opts into the rebuild.
+
+def extract_voiceover(
+    path: Path,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> ExtractionResult:
+    """Extract voiceover cells from a slide file to a companion file.
+
+    Content cells without ``slide_id`` get auto-generated IDs before
+    extraction.  Voiceover cells are linked to their owning slide via
+    ``for_slide`` metadata. On a split half whose twin exists on disk with a
+    matching slide count, that id generation is **twin-aware** (#162): an
+    id-less slide adopts the twin's id rather than minting a divergent slug, so
+    extracting the ``.de`` and ``.en`` halves separately keeps their companions'
+    ``for_slide`` sets in agreement (see :func:`_ensure_slide_ids`). For a
+    one-op, EN-authority paired extract over *both* halves, see
+    :func:`extract_voiceover_pair`.
+
+    The companion is *rebuilt* from the voiceover cells currently in the slide
+    file. If a companion already exists it would be overwritten, discarding any
+    hand-edits (or previously-extracted cells) that live only in the companion —
+    so, like ``split_in_file``, this refuses without ``force``.
+
+    Args:
+        path: Path to the ``.py`` slide file.
+        force: Overwrite an existing companion file. Without it, an existing
+            companion raises :class:`VoiceoverError` rather than clobbering it.
+        dry_run: If ``True``, preview without writing files.
+
+    Returns:
+        An :class:`ExtractionResult` describing what was done.
+
+    Raises:
+        VoiceoverError: a companion already exists and ``force`` is not set.
+    """
+    result, writes = _plan_extraction(path, dry_run=dry_run)
+    if writes:
+        # Refuse to clobber an existing companion *before* any write — otherwise
+        # the slide rewrite would strip voiceover and leave no companion (data
+        # loss). ``force`` opts into the rebuild. The two writes commit together.
+        comp = companion_path(path)
         if comp.exists() and not force:
             raise VoiceoverError(
                 f"refusing to overwrite existing companion '{comp.name}' "
@@ -463,18 +555,136 @@ def extract_voiceover(
                 f"voiceover cells; this discards content present only in the "
                 f"companion)"
             )
-
-        # Write the slide file without voiceover cells
-        new_slide_text = _reconstruct(preamble, remaining_cells)
-        # Clean up double blank lines left by removal
-        new_slide_text = re.sub(r"\n{3,}", "\n\n", new_slide_text)
-        path.write_text(new_slide_text, encoding="utf-8", newline="\n")
-
-        # Write the companion file
-        companion_text = _reconstruct("", companion_cells)
-        comp.write_text(companion_text, encoding="utf-8", newline="\n")
-
+        atomic_write_all(writes)
     return result
+
+
+def extract_voiceover_pair(
+    de_path: Path,
+    en_path: Path,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    mint_ids: bool = True,
+) -> PairedExtractionResult:
+    """Extract voiceover from *both* halves of a split deck in one op.
+
+    The companion footgun this closes: running ``extract`` once per language by
+    hand can mint divergent slugs on id-less slides, so the two companions'
+    ``for_slide`` sets disagree. Here the two halves are first minted with
+    **EN-authority** ``slide_id``s across both at once
+    (:func:`~clm.slides.assign_ids.assign_ids_in_split_pair`), so each
+    companion's ``for_slide`` set agrees by construction; then each half is
+    extracted and all writes commit in one atomic batch.
+
+    Refuses **loudly** (:class:`VoiceoverError`) when the two halves are not
+    structurally alignable (divergent shared cells / mismatched cell count): the
+    EN-authority pre-mint cannot then guarantee parity, and a silent per-half
+    fallback would reintroduce the exact divergence this op exists to prevent.
+    Reconcile the pair first (e.g. ``clm slides sync``) and retry.
+
+    Args:
+        de_path, en_path: the two halves, in either order (reordered defensively).
+        force: overwrite existing companions — **all-or-nothing** over both
+            halves (refuses if *either* companion exists and ``force`` is unset).
+        dry_run: preview without writing (the pre-mint runs report-only, so no
+            slide ids are written either).
+        mint_ids: run the EN-authority pre-mint (default on). Set ``False`` only
+            when the pair is already known to be in ``slide_id`` parity — chiefly
+            for tests isolating the extraction from the minting.
+
+    Raises:
+        VoiceoverError: the paths are not a valid same-deck ``.de``/``.en`` pair;
+            an existing companion would be clobbered without ``force``; or the
+            pair is not structurally alignable for the EN-authority mint.
+    """
+    ordered = order_split_pair(de_path, en_path)
+    if ordered is None:
+        raise VoiceoverError(
+            f"'{de_path.name}' and '{en_path.name}' are not the two halves of one "
+            f"split deck (expected <deck>.de.py and <deck>.en.py of the same deck); "
+            f"cannot paired-extract."
+        )
+    de_path, en_path = ordered
+
+    # Match single-extract's no-op-on-empty contract FIRST (before the force
+    # guard): if neither half has any voiceover cells there is nothing to
+    # extract, so do nothing — don't refuse on a stale companion and don't
+    # id-stamp a deck with nothing to extract (a per-half extract no-ops here).
+    if not _has_voiceover_cells(de_path) and not _has_voiceover_cells(en_path):
+        return PairedExtractionResult(
+            results=[
+                ExtractionResult(
+                    slide_file=str(de_path),
+                    companion_file=str(companion_path(de_path)),
+                    dry_run=dry_run,
+                ),
+                ExtractionResult(
+                    slide_file=str(en_path),
+                    companion_file=str(companion_path(en_path)),
+                    dry_run=dry_run,
+                ),
+            ],
+            dry_run=dry_run,
+        )
+
+    # All-or-nothing companion guard, before any write (mirrors split_in_file):
+    # refuse if *either* companion exists and not force.
+    if not dry_run:
+        blockers = [c for c in (companion_path(de_path), companion_path(en_path)) if c.exists()]
+        if blockers and not force:
+            names = ", ".join(f"'{b.name}'" for b in blockers)
+            raise VoiceoverError(
+                f"refusing to overwrite existing companion(s): {names} "
+                f"(pass force=True / --force to rebuild them from the current "
+                f"voiceover cells; this discards content present only in the companion)"
+            )
+
+    # EN-authority slide_id mint across both halves first, so the two companions'
+    # for_slide sets agree by construction. report_only on a dry run writes nothing.
+    ids_minted = 0
+    if mint_ids:
+        from clm.slides.assign_ids import AssignOptions, assign_ids_in_split_pair
+
+        pre = assign_ids_in_split_pair(de_path, en_path, AssignOptions(report_only=dry_run))
+        if pre is None:
+            raise VoiceoverError(
+                f"cannot paired-extract '{de_path.name}' / '{en_path.name}': the two "
+                f"halves are not structurally aligned (divergent shared cells / cell "
+                f"count), so EN-authority slide_id parity cannot be guaranteed. "
+                f"Reconcile them first (e.g. `clm slides sync`), then retry."
+            )
+        # Distinct slide_ids stamped on slide-role cells. The same id lands on
+        # both halves, so the set dedups to one entry per logical slide;
+        # narrative ``voiceover-inherit`` writes are not minted ids.
+        ids_minted = len({a.slide_id for a in pre.assignments if a.source != "voiceover-inherit"})
+    elif not _slide_ids_in_parity(de_path, en_path):
+        # Without the pre-mint, the per-half _ensure_slide_ids would mint
+        # independently on an id-less pair and silently diverge (#162). Enforce
+        # the documented mint_ids=False contract loudly instead of breaking it.
+        raise VoiceoverError(
+            f"mint_ids=False requires '{de_path.name}' / '{en_path.name}' to be already "
+            f"in slide_id parity (every slide id'd and de_id == en_id); run with "
+            f"mint_ids=True (the default) to mint EN-authority ids."
+        )
+
+    de_result, de_writes = _plan_extraction(de_path, dry_run=dry_run)
+    en_result, en_writes = _plan_extraction(en_path, dry_run=dry_run)
+    writes = [*de_writes, *en_writes]
+    if writes:
+        atomic_write_all(writes)
+
+    # On the paired path the EN-authority pre-mint owns id generation; the per-half
+    # extract mints nothing in a real run (ids are already on disk). Report the
+    # count via ``ids_minted`` only, and zero the per-half ``ids_generated`` so the
+    # dry-run preview — where the report-only pre-mint writes nothing and
+    # ``_plan_extraction`` re-mints in memory — matches the real run.
+    for r in (de_result, en_result):
+        r.ids_generated = 0
+
+    return PairedExtractionResult(
+        results=[de_result, en_result], ids_minted=ids_minted, dry_run=dry_run
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_voiceover_tools.py
+++ b/tests/cli/test_voiceover_tools.py
@@ -116,3 +116,80 @@ def test_inline_voiceover_json(tmp_path: Path):
     data = json.loads(result.output)
     assert data["cells_inlined"] == 2
     assert data["companion_deleted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Paired extract (auto-pair on a split half) — §8 'F later'
+# ---------------------------------------------------------------------------
+
+_DE_HALF = (
+    '# %% [markdown] lang="de" tags=["slide"]\n# ## Thema\n\n'
+    '# %% [markdown] lang="de" tags=["voiceover"]\n# VO DE\n'
+)
+_EN_HALF = (
+    '# %% [markdown] lang="en" tags=["slide"]\n# ## Topic\n\n'
+    '# %% [markdown] lang="en" tags=["voiceover"]\n# VO EN\n'
+)
+
+
+def _write_split_pair(tmp_path: Path) -> tuple[Path, Path]:
+    de = tmp_path / "slides_x.de.py"
+    en = tmp_path / "slides_x.en.py"
+    de.write_text(_DE_HALF, encoding="utf-8")
+    en.write_text(_EN_HALF, encoding="utf-8")
+    return de, en
+
+
+class TestExtractPaired:
+    def test_auto_pairs_on_split_half(self, tmp_path: Path):
+        de, _en = _write_split_pair(tmp_path)
+        result = CliRunner().invoke(extract_voiceover_cmd, [str(de)])
+        assert result.exit_code == 0, result.output
+        assert "paired extract" in result.output
+        assert (tmp_path / "voiceover_x.de.py").exists()
+        assert (tmp_path / "voiceover_x.en.py").exists()
+
+    def test_single_opts_out(self, tmp_path: Path):
+        de, _en = _write_split_pair(tmp_path)
+        result = CliRunner().invoke(extract_voiceover_cmd, [str(de), "--single"])
+        assert result.exit_code == 0, result.output
+        assert "paired extract" not in result.output
+        assert (tmp_path / "voiceover_x.de.py").exists()
+        assert not (tmp_path / "voiceover_x.en.py").exists()
+
+    def test_both_and_single_mutually_exclusive(self, tmp_path: Path):
+        de, _en = _write_split_pair(tmp_path)
+        result = CliRunner().invoke(extract_voiceover_cmd, [str(de), "--both", "--single"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_both_without_twin_errors(self, tmp_path: Path):
+        # A bilingual deck has no .de/.en twin; --both cannot pair.
+        bilingual = tmp_path / "slides_x.py"
+        bilingual.write_text(_DE_HALF + _EN_HALF, encoding="utf-8")
+        result = CliRunner().invoke(extract_voiceover_cmd, [str(bilingual), "--both"])
+        assert result.exit_code != 0
+        assert "no" in result.output.lower() and "twin" in result.output.lower()
+
+    def test_paired_json_shape(self, tmp_path: Path):
+        import json
+
+        de, _en = _write_split_pair(tmp_path)
+        result = CliRunner().invoke(extract_voiceover_cmd, [str(de), "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["paired"] is True
+        assert len(data["companions"]) == 2
+        assert all("cells_extracted" in c for c in data["companions"])
+
+    def test_bilingual_stays_flat_json(self, tmp_path: Path):
+        # Backward compat: a bilingual (twin-less) deck keeps the flat shape.
+        import json
+
+        bilingual = tmp_path / "slides_x.py"
+        bilingual.write_text(_DE_HALF + _EN_HALF, encoding="utf-8")
+        result = CliRunner().invoke(extract_voiceover_cmd, [str(bilingual), "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "paired" not in data
+        assert "cells_extracted" in data

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -801,6 +801,63 @@ class TestExtractVoiceover:
         assert data["dry_run"] is True
         assert data["cells_extracted"] == 1
 
+    @staticmethod
+    def _split_pair(course_tree):
+        topic = course_tree / "slides" / "module_100_basics" / "topic_010_intro"
+        de = topic / "slides_pair.de.py"
+        en = topic / "slides_pair.en.py"
+        de.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Thema\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO DE\n',
+            encoding="utf-8",
+        )
+        en.write_text(
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## Topic\n\n'
+            '# %% [markdown] lang="en" tags=["voiceover"]\n# VO EN\n',
+            encoding="utf-8",
+        )
+        return de, en
+
+    async def test_extract_auto_pairs_split_half(self, course_tree):
+        de, _en = self._split_pair(course_tree)
+        result = await handle_extract_voiceover(str(de), course_tree)
+        data = json.loads(result)
+        assert data["paired"] is True
+        assert len(data["companions"]) == 2
+        assert (de.parent / "voiceover_pair.de.py").exists()
+        assert (de.parent / "voiceover_pair.en.py").exists()
+
+    async def test_extract_single_opts_out(self, course_tree):
+        de, _en = self._split_pair(course_tree)
+        result = await handle_extract_voiceover(str(de), course_tree, single=True)
+        data = json.loads(result)
+        assert "paired" not in data
+        assert data["cells_extracted"] == 1
+        assert not (de.parent / "voiceover_pair.en.py").exists()
+
+    def test_paired_serializer_matches_cli(self, tmp_path):
+        # The MCP and CLI paired serializers are a contract — keep them byte-equal.
+        from clm.cli.commands.voiceover_tools import (
+            _paired_extraction_to_dict as cli_dict,
+        )
+        from clm.mcp.tools import _paired_extraction_result_to_dict as mcp_dict
+        from clm.slides.voiceover_tools import extract_voiceover_pair
+
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Thema\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO DE\n',
+            encoding="utf-8",
+        )
+        en.write_text(
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## Topic\n\n'
+            '# %% [markdown] lang="en" tags=["voiceover"]\n# VO EN\n',
+            encoding="utf-8",
+        )
+        result = extract_voiceover_pair(de, en)
+        assert cli_dict(result) == mcp_dict(result)
+
 
 class TestInlineVoiceover:
     async def test_inline_returns_json(self, course_tree):

--- a/tests/slides/test_pairing.py
+++ b/tests/slides/test_pairing.py
@@ -16,6 +16,8 @@ from clm.slides.pairing import (
     TITLE_SLIDE_ID,
     build_slide_groups,
     build_slide_pairs,
+    derive_split_pair,
+    derive_split_twin,
     is_title_macro_cell,
     order_split_pair,
     split_lang_tag,
@@ -265,3 +267,62 @@ class TestOrderSplitPair:
         assert split_lang_tag(Path("slides_x.en.py")) == "en"
         assert split_lang_tag(Path("apis.py")) is None
         assert split_lang_tag(Path("a.b.c.en.py")) == "en"
+
+
+class TestDeriveSplitTwin:
+    """``derive_split_twin`` / ``derive_split_pair`` — the PREFIX-AGNOSTIC,
+    disk-aware twin derivation for the single-arg CLI surfaces (voiceover extract
+    auto-pair, sync single-path). Unlike ``split_twin`` they work on prefix-less
+    deck names too.
+    """
+
+    def test_twin_found_prefix_less(self, tmp_path: Path):
+        de = tmp_path / "apis.de.py"
+        en = tmp_path / "apis.en.py"
+        de.write_text("# de\n", encoding="utf-8")
+        en.write_text("# en\n", encoding="utf-8")
+        # split_twin (prefix-gated) sees nothing; derive_split_twin does.
+        assert split_twin(de) is None
+        assert derive_split_twin(de) == en
+        assert derive_split_twin(en) == de
+
+    def test_twin_found_with_prefix(self, tmp_path: Path):
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text("# de\n", encoding="utf-8")
+        en.write_text("# en\n", encoding="utf-8")
+        assert derive_split_twin(de) == en
+
+    def test_twin_none_when_missing(self, tmp_path: Path):
+        de = tmp_path / "apis.de.py"
+        de.write_text("# de\n", encoding="utf-8")
+        assert derive_split_twin(de) is None
+
+    def test_twin_none_for_non_split(self, tmp_path: Path):
+        bilingual = tmp_path / "apis.py"
+        bilingual.write_text("# both\n", encoding="utf-8")
+        assert derive_split_twin(bilingual) is None
+
+    def test_pair_orders_de_first(self, tmp_path: Path):
+        de = tmp_path / "apis.de.py"
+        en = tmp_path / "apis.en.py"
+        de.write_text("# de\n", encoding="utf-8")
+        en.write_text("# en\n", encoding="utf-8")
+        assert derive_split_pair(de) == (de, en)
+        assert derive_split_pair(en) == (de, en)
+
+    def test_pair_none_when_twin_missing(self, tmp_path: Path):
+        en = tmp_path / "apis.en.py"
+        en.write_text("# en\n", encoding="utf-8")
+        assert derive_split_pair(en) is None
+
+    def test_companion_is_not_a_deck_half(self, tmp_path: Path):
+        # A voiceover companion carries a .de/.en tag but is the OUTPUT of an
+        # extract, not a deck to auto-pair — deriving a twin must return None so
+        # an extract pointed at a companion can't empty both companions.
+        de = tmp_path / "voiceover_x.de.py"
+        en = tmp_path / "voiceover_x.en.py"
+        de.write_text("# de\n", encoding="utf-8")
+        en.write_text("# en\n", encoding="utf-8")
+        assert derive_split_twin(de) is None
+        assert derive_split_pair(de) is None

--- a/tests/slides/test_voiceover_tools.py
+++ b/tests/slides/test_voiceover_tools.py
@@ -6,17 +6,37 @@ from pathlib import Path
 
 import pytest
 
+from clm.notebooks.slide_parser import parse_cells
 from clm.slides.split import split_text
 from clm.slides.voiceover_tools import (
+    PairedExtractionResult,
     VoiceoverError,
     companion_path,
     extract_voiceover,
+    extract_voiceover_pair,
     inline_voiceover,
     merge_voiceover_text,
     read_companion_baselines,
     render_companion_update,
     update_companion_narrative,
 )
+
+
+def _for_slide_set(path: Path) -> set[str]:
+    return {
+        c.metadata.for_slide
+        for c in parse_cells(path.read_text(encoding="utf-8"))
+        if c.metadata.for_slide
+    }
+
+
+def _slide_ids(path: Path) -> list[str]:
+    return [
+        c.metadata.slide_id
+        for c in parse_cells(path.read_text(encoding="utf-8"))
+        if c.metadata.is_slide_start
+    ]
+
 
 # ---------------------------------------------------------------------------
 # companion_path
@@ -1038,6 +1058,198 @@ class TestExtractTwinAware:
         res = extract_voiceover(p)
         assert res.cells_extracted == 1
         assert 'slide_id="mein-thema"' in p.read_text(encoding="utf-8")
+
+
+class TestPairedExtract:
+    """``extract_voiceover_pair`` — one-op, EN-authority extraction over both
+    halves of a split deck (the §8 'F later' paired extract).
+    """
+
+    @staticmethod
+    def _born_split_with_vo(tmp_path: Path) -> tuple[Path, Path]:
+        """A born-split (both halves id-less) pair, DE heading 'Mein Thema',
+        EN heading 'My Topic', one voiceover per half. Written via split_text so
+        the headers are real."""
+        de_vo = '# %% [markdown] lang="de" tags=["voiceover"]\n#\n# VO DE\n\n'
+        en_vo = '# %% [markdown] lang="en" tags=["voiceover"]\n#\n# VO EN\n\n'
+        bilingual = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("Titel", "Title") }}\n\n'
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n\n'
+            + de_vo
+            + '# %% [markdown] lang="en" tags=["slide"]\n# ## My Topic\n\n'
+            + en_vo
+        )
+        de_text, en_text = split_text(bilingual)
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(de_text, encoding="utf-8", newline="\n")
+        en.write_text(en_text, encoding="utf-8", newline="\n")
+        return de, en
+
+    def test_writes_both_companions_with_for_slide_parity(self, tmp_path: Path):
+        de, en = self._born_split_with_vo(tmp_path)
+        result = extract_voiceover_pair(de, en)
+
+        assert isinstance(result, PairedExtractionResult)
+        de_comp = tmp_path / "voiceover_x.de.py"
+        en_comp = tmp_path / "voiceover_x.en.py"
+        assert de_comp.exists() and en_comp.exists()
+        # for_slide sets agree across the two companions (the whole point).
+        assert _for_slide_set(de_comp) == _for_slide_set(en_comp)
+        # slide_id parity on the slide files (#162 invariant).
+        assert _slide_ids(de) == _slide_ids(en)
+
+    def test_en_authority_regardless_of_order(self, tmp_path: Path):
+        # The slug comes from the EN heading ('My Topic' -> 'my-topic') and is
+        # stamped on BOTH halves — unlike the per-language path, which is
+        # DE-authority-by-order (see TestExtractTwinAware). Passing the halves in
+        # either order yields the same EN-authority id.
+        de, en = self._born_split_with_vo(tmp_path)
+        extract_voiceover_pair(en, de)  # deliberately swapped order
+
+        assert 'slide_id="my-topic"' in de.read_text(encoding="utf-8")
+        assert 'slide_id="my-topic"' in en.read_text(encoding="utf-8")
+        assert 'slide_id="mein-thema"' not in de.read_text(encoding="utf-8")
+
+    def test_force_is_all_or_nothing(self, tmp_path: Path):
+        # A pre-existing DE companion must block the paired extract even though
+        # the EN companion does not exist yet — all-or-nothing over both halves.
+        de, en = self._born_split_with_vo(tmp_path)
+        (tmp_path / "voiceover_x.de.py").write_text("# stale\n", encoding="utf-8")
+        assert not (tmp_path / "voiceover_x.en.py").exists()
+
+        with pytest.raises(VoiceoverError):
+            extract_voiceover_pair(de, en)
+
+        # --force rebuilds both from the current slide voiceover cells.
+        result = extract_voiceover_pair(de, en, force=True)
+        assert (tmp_path / "voiceover_x.de.py").exists()
+        assert (tmp_path / "voiceover_x.en.py").exists()
+        assert result.de.cells_extracted >= 1 and result.en.cells_extracted >= 1
+        assert _for_slide_set(tmp_path / "voiceover_x.de.py") == _for_slide_set(
+            tmp_path / "voiceover_x.en.py"
+        )
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path):
+        de, en = self._born_split_with_vo(tmp_path)
+        de_before = de.read_text(encoding="utf-8")
+        en_before = en.read_text(encoding="utf-8")
+
+        result = extract_voiceover_pair(de, en, dry_run=True)
+
+        assert result.dry_run
+        # No companions, and the slide files (incl. their ids) are untouched —
+        # the pre-mint runs report-only under dry_run.
+        assert not (tmp_path / "voiceover_x.de.py").exists()
+        assert not (tmp_path / "voiceover_x.en.py").exists()
+        assert de.read_text(encoding="utf-8") == de_before
+        assert en.read_text(encoding="utf-8") == en_before
+
+    def test_refuses_non_round_trippable_pair(self, tmp_path: Path):
+        # Divergent SHARED (no-lang) cells -> unify is not byte-faithful -> the
+        # EN-authority mint can't guarantee parity -> refuse loudly.
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(
+            "# %%\nx = 1\n\n"
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## A\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        en.write_text(
+            "# %%\nx = 2\n\n"  # divergent shared cell -> unify refuses
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## A\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        de_before, en_before = de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8")
+        with pytest.raises(VoiceoverError, match="not structurally aligned"):
+            extract_voiceover_pair(de, en)
+        # Nothing written: no companions and the slide halves are byte-unchanged
+        # (the refuse fires before any id-stamp or extraction).
+        assert not (tmp_path / "voiceover_x.de.py").exists()
+        assert not (tmp_path / "voiceover_x.en.py").exists()
+        assert de.read_text(encoding="utf-8") == de_before
+        assert en.read_text(encoding="utf-8") == en_before
+
+    def test_no_op_when_no_voiceover_even_with_stale_companion(self, tmp_path: Path):
+        # A split deck with a pre-existing companion but zero voiceover cells (the
+        # idempotent post-extract state) is a clean no-op — the no-VO short-circuit
+        # runs BEFORE the all-or-nothing force guard, matching the single-file path.
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="t"\n# ## Thema\n', encoding="utf-8"
+        )
+        en.write_text(
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="t"\n# ## Topic\n', encoding="utf-8"
+        )
+        (tmp_path / "voiceover_x.de.py").write_text("# stale\n", encoding="utf-8")
+
+        result = extract_voiceover_pair(de, en)  # no force, but no VO → no raise
+        assert all(r.cells_extracted == 0 for r in result.results)
+
+    def test_mint_ids_false_rejects_non_parity_pair(self, tmp_path: Path):
+        # mint_ids=False skips the EN-authority pre-mint; on an id-less pair the
+        # per-half mint would diverge (#162), so it must refuse loudly rather than
+        # silently violate the documented "already in parity" contract.
+        de, en = self._born_split_with_vo(tmp_path)  # both halves id-less
+        with pytest.raises(VoiceoverError, match="slide_id parity"):
+            extract_voiceover_pair(de, en, mint_ids=False)
+
+    def test_dry_run_and_real_report_same_ids(self, tmp_path: Path):
+        # Per-half ids_generated is 0 on the paired path (the pre-mint owns id
+        # minting, reported via ids_minted) — identical in dry-run and real, so a
+        # dry-run preview does not over-report ids the real run won't produce.
+        de, en = self._born_split_with_vo(tmp_path)
+        dry = extract_voiceover_pair(de, en, dry_run=True)
+        assert all(r.ids_generated == 0 for r in dry.results)
+        real = extract_voiceover_pair(de, en)
+        assert all(r.ids_generated == 0 for r in real.results)
+        assert dry.ids_minted == real.ids_minted == 1  # one distinct slide_id
+
+    def test_rejects_invalid_pair(self, tmp_path: Path):
+        # Two same-language halves are not a valid de/en pair.
+        a = tmp_path / "slides_x.de.py"
+        b = tmp_path / "slides_y.de.py"
+        a.write_text('# %% [markdown] lang="de" tags=["slide"]\n# ## A\n', encoding="utf-8")
+        b.write_text('# %% [markdown] lang="de" tags=["slide"]\n# ## B\n', encoding="utf-8")
+        with pytest.raises(VoiceoverError):
+            extract_voiceover_pair(a, b)
+
+    def test_no_voiceover_is_noop(self, tmp_path: Path):
+        # Neither half has voiceover cells: do nothing — don't id-stamp either.
+        de = tmp_path / "slides_x.de.py"
+        en = tmp_path / "slides_x.en.py"
+        de.write_text(
+            '# %% [markdown] lang="de" tags=["slide"]\n# ## Mein Thema\n', encoding="utf-8"
+        )
+        en.write_text('# %% [markdown] lang="en" tags=["slide"]\n# ## My Topic\n', encoding="utf-8")
+        de_before, en_before = de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8")
+
+        result = extract_voiceover_pair(de, en)
+
+        assert all(r.cells_extracted == 0 for r in result.results)
+        assert not (tmp_path / "voiceover_x.de.py").exists()
+        # No id-stamping side effect.
+        assert de.read_text(encoding="utf-8") == de_before
+        assert en.read_text(encoding="utf-8") == en_before
+
+    def test_mint_ids_false_skips_premint(self, tmp_path: Path):
+        # With ids already in parity, mint_ids=False just extracts both halves.
+        de, en = self._born_split_with_vo(tmp_path)
+        # Pre-id both halves to parity via the generative pass directly.
+        from clm.slides.assign_ids import AssignOptions, assign_ids_in_split_pair
+
+        assign_ids_in_split_pair(de, en, AssignOptions())
+        result = extract_voiceover_pair(de, en, force=True, mint_ids=False)
+
+        assert result.ids_minted == 0
+        assert _for_slide_set(tmp_path / "voiceover_x.de.py") == _for_slide_set(
+            tmp_path / "voiceover_x.en.py"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The §8 "F later" item: `clm voiceover extract` on a split half whose twin exists now extracts **both** companions in one op, closing the per-language footgun where extracting each half by hand could mint divergent slugs and leave one language silently missing narration.

## What changed

- **New engine fn `extract_voiceover_pair(de, en, *, force, dry_run, mint_ids=True)`** (`voiceover_tools.py`): orders/validates the pair, no-op-on-empty short-circuit, **all-or-nothing** companion force-guard, **EN-authority `slide_id` pre-mint** across both halves (`assign_ids_in_split_pair`) so the two companions' `for_slide` sets agree *by construction*, then extracts each half and commits all writes **atomically**. **Refuses loudly** (`VoiceoverError`) on a non-structurally-alignable pair rather than risk divergence.
- **`extract_voiceover` refactored** around a write-free `_plan_extraction`; single-file behavior is unchanged but now commits its two files via the shared atomic writer.
- **`atomic_write_all` promoted** from `split._atomic_write_all` to `path_utils.atomic_write_all`; reused by split/unify and the paired extract (no duplicate temp-swap).
- **`pairing.derive_split_twin` / `derive_split_pair`** — prefix-agnostic, disk-aware twin derivation (recognises `apis.de.py` pairs, not just routing-prefixed files). A `voiceover_*` companion is deliberately **not** treated as a deck half, so an extract pointed at a companion can't empty both companions.
- **CLI**: auto-pair by default on a split half + `--single` opt-out + `--both`; paired `--json` carries `"paired": true` + a `"companions"` array (a bilingual/single extract keeps the flat shape — backward-compatible). **MCP** `extract_voiceover` gains matching `both`/`single` params; the CLI and MCP serializers are kept byte-aligned (a test pins this).

## Maintainer decisions (pre-agreed)
Auto-pair by default + `--single` opt-out; refuse-loudly on a non-alignable pair. **This is a documented behavior change** to a bare `extract <deck>.de.py` (now writes both companions and may stamp ids on both halves) — see `clm info migration`.

## Verification
- Full fast suite **6295 green**; ruff + mypy clean; pre-commit hooks pass.
- Edit-dynamics harness: new `extract-pair-both-companions` row = **preserve** (16 preserve / 3 break-loud / 0 break-silent).
- **Adversarial 3-lens review (11 findings → 3 refuted, 8 confirmed minor/nit, all fixed):**
  1. No-op short-circuit moved before the force guard (idempotent re-run is a clean no-op, matching single-file).
  2. `ids_minted` now counts **distinct** minted slide_ids (was raw assignment records — ~4× over-count).
  3. Per-half `ids_generated` zeroed on the paired path → dry-run preview matches the real run.
  4. `mint_ids=False` now **asserts slide_id parity** and refuses otherwise (defense-in-depth for #162).
  5. **Companion-as-PATH guard** (the amplified footgun: a companion read as a `.de` half would empty both).
  6. Stale MCP tools-table row updated.
  7. Refuse test now pins slide-file **byte-stability** (not just companion absence).

## Tests
`TestPairedExtract` (engine: both companions + EN-authority parity + order-independence + force all-or-nothing + dry-run-no-write + refuse-on-non-alignable + mint_ids=False parity guard + dry-vs-real id consistency + no-op-with-stale-companion); `TestDeriveSplitTwin` incl. the companion guard; CLI `TestExtractPaired`; MCP paired path + serializer-equality test.

## Info topics (Info Topics Maintenance Rule)
`commands.md` (extract section + MCP table row), `migration.md` (new behavior-change section), CHANGELOG `[Unreleased]`, design doc §8/§12/§13.

## Deferred (next)
`clm slides sync` single-path contract (then directory batch mode as its own follow-up — `sync DIR` + continue-on-error + `--yes`, pre-decided).

🤖 Generated with [Claude Code](https://claude.com/claude-code)