### PR TITLE
feat(slides): clm slides sync single-path contract — derive the twin from one half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides sync` accepts a single path (§8 single-path contract).** `EN_PATH`
+  is now optional: pass one half (`clm slides sync slides_x.de.py`) and the twin is
+  derived from disk, or pass the bilingual deck stem (`slides_x.py`, when it still
+  exists on disk) to derive both halves. Derivation is prefix-agnostic (`apis.de.py` works) and the resolved pair
+  still runs through the pairing guard; a missing twin is a clear usage error (sync
+  never invents a translated half). The two-path form is unchanged. Directory
+  *batch* mode (`sync DIR`) remains a planned follow-up.
 - **`clm voiceover extract` auto-pairs on a split half (§8 paired extract).**
   When the target is a split half (`<deck>.de.py` / `<deck>.en.py`) whose twin
   exists on disk, both companions are extracted in one op: the two halves are

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -471,7 +471,7 @@ agent/script plumbing, or **(G)** harden with a guard.
 | `slides split` | Unaware of voiceover companions; extract-then-split silently orphans them. | **G — DONE (2026-06-03).** First-class companion split: `split_in_file` splits a sibling `voiceover_*.py` in lockstep into `voiceover_*.de.py`/`.en.py`, routing cells by `lang`, preserving `for_slide`/`vo_anchor`. Atomic `--force` over deck+companion; byte-identical round trip. |
 | `slides unify` | Ignores companions; can't recombine voiceover. | **G — DONE (2026-06-03).** `unify_in_file` recombines the companion halves into `voiceover_*.py` (inverse of split; missing half treated as empty so narration is never dropped). |
 | `slides suggest-sync` | Old single-file read-only suggester; coexists confusingly with the split-pair `sync` (different file layout, opposite write semantics). | **H — DONE (2026-06-03).** Hidden (`hidden=True`), not removed: it is the *safe* read-only member, retains unique value for the pre-split **bilingual** single-file layout `sync` does not cover, and is a live `suggest_sync` MCP contract. Docstring + `commands.md` reframed as plumbing, steering split-deck users to `sync`. Revisit removal only when the bilingual format is retired (with an MCP deprecation window). |
-| `slides sync` (the funnel) | Two bare path args, no pairing guard, writes by default. | **G — pairing guard DONE (2026-06-03)**; single-path / batch DEFERRED. The guard (`_resolve_sync_pair`, prefix-agnostic via `pairing.order_split_pair`) rejects same-file / same-language / cross-deck pairs and auto-corrects a swapped order before any read/write. The **single-path contract** (pass one half / the deck stem; derive the twin + companion) and a directory/spec **batch mode** remain deferred additive UX (never remove the two-path form). |
+| `slides sync` (the funnel) | Two bare path args, no pairing guard, writes by default. | **G — pairing guard + single-path DONE (2026-06-03)**; batch DEFERRED. The guard (`_resolve_sync_pair`, prefix-agnostic via `pairing.order_split_pair`) rejects same-file / same-language / cross-deck pairs and auto-corrects a swapped order before any read/write. The **single-path contract** (`_resolve_single_path`): `EN_PATH` is optional — one half derives its twin via `pairing.derive_split_twin`, a bilingual stem derives both via `derive_split_pair_from_stem`, both funnelled through `_resolve_sync_pair`; missing twin → clear `UsageError` (never invents a half); two-path form unchanged. A directory/spec **batch mode** (`sync DIR` + continue-on-error + `--yes`, pre-decided) remains the deferred follow-up. |
 
 **Mechanism for "hide as plumbing."** Click supports `hidden=True` on commands (kept
 functional, omitted from `--help`); or move plumbing under a `clm _internal …` / `clm
@@ -634,11 +634,15 @@ corpus no-op invariant + real-deck round-trip **skip**. To build justified confi
    (EN-authority pre-mint → extract both → atomic four-file write; `--both` /
    `--single`; CLI + MCP + paired JSON; refuses a non-alignable pair); the
    shared `atomic_write_all` was promoted to `path_utils` and reused by
-   `split`/`unify`. **Deferred:** the `slides sync` single-path contract +
-   directory/spec batch mode (additive UX) — single-path is next; batch is its
-   own follow-up (`sync DIR` + continue-on-error + `--yes`, pre-decided).
+   `split`/`unify`. **`slides sync` single-path DONE (2026-06-03):**
+   `_resolve_single_path` makes `EN_PATH` optional (one half derives its twin via
+   `derive_split_twin`; a bilingual stem derives both via
+   `derive_split_pair_from_stem`), funnelled through `_resolve_sync_pair`; missing
+   twin → clear `UsageError`; two-path form unchanged. **Deferred:** directory/spec
+   **batch mode** (`sync DIR` + continue-on-error(max) + `--yes` write gate,
+   pre-decided) is the remaining §8 follow-up.
 5. **Pre-commit gate** (§9) + voiceover hardening (§10) + verification additions (§11).
-6. **Sync CLI single-path / batch UX** (§8) on top of the shipped pairing guard.
+6. **Sync CLI batch UX** (§8 `sync DIR`) on top of the shipped pairing guard + single-path.
 7. Forward design: N-file atomicity for separated voiceover (§3 #6); `FileTopic`
    bypass guard (§3 #7).
 

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -65,7 +65,12 @@ from clm.infrastructure.llm.openrouter_client import (
     OpenRouterSyncJudge,
     has_openrouter_api_key,
 )
-from clm.slides.pairing import order_split_pair, split_lang_tag
+from clm.slides.pairing import (
+    derive_split_pair_from_stem,
+    derive_split_twin,
+    order_split_pair,
+    split_lang_tag,
+)
 from clm.slides.sync_apply import ApplyResult, apply_plan
 from clm.slides.sync_plan import (
     PlanIssue,
@@ -129,6 +134,54 @@ def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
     return ordered
 
 
+def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Path]:
+    """Single-path contract: when EN_PATH is omitted, derive the second half from
+    DE_PATH so the author can run ``clm slides sync <deck>.de.py``.
+
+    DE_PATH may be **one half** (``<deck>.de.py`` / ``<deck>.en.py``) — the twin
+    is derived from disk — or a **bilingual deck stem** (``<deck>.py``, no
+    ``.de``/``.en`` tag) whose two halves both exist. Derivation is prefix-agnostic
+    (so ``apis.de.py`` works) and the resolved pair is still funnelled through
+    :func:`_resolve_sync_pair` for the #162 pairing guard. Raises
+    :class:`click.UsageError` when the twin / halves are not found on disk — a
+    missing twin is almost always a typo or an un-split deck, so we error clearly
+    rather than invent a full translated half.
+    """
+    if en_path is not None:
+        return de_path, en_path
+    tag = split_lang_tag(de_path)
+    if tag is not None:
+        twin = derive_split_twin(de_path)
+        if twin is None:
+            if de_path.name.startswith("voiceover_"):
+                raise click.UsageError(
+                    f"{de_path.name} is a voiceover companion, not a deck half; "
+                    f"`clm slides sync` reconciles slide decks (<deck>.de.py / "
+                    f"<deck>.en.py), not their voiceover companions."
+                )
+            other = "EN" if tag == "de" else "DE"
+            raise click.UsageError(
+                f"no {other} twin found next to {de_path.name}; expected its sibling "
+                f"split half on disk. Pass both halves explicitly, or run "
+                f"`clm slides split` to produce the pair."
+            )
+        # Return already (de, en)-ordered so the pairing guard's swap note does not
+        # fire on a single derived path — the author supplied one path; nothing was
+        # "swapped". (derive_split_twin gives the OTHER half, so order by our tag.)
+        return (de_path, twin) if tag == "de" else (twin, de_path)
+    # No language tag → treat DE_PATH as a bilingual deck stem and derive both halves.
+    pair = derive_split_pair_from_stem(de_path)
+    if pair is None:
+        ext = de_path.suffix
+        stem = de_path.name[: -len(ext)] if ext else de_path.name
+        raise click.UsageError(
+            f"{de_path.name} is neither a split half (<deck>.de.py / <deck>.en.py) "
+            f"nor a deck stem with both halves present (expected {stem}.de{ext} and "
+            f"{stem}.en{ext} on disk). Pass the two halves explicitly."
+        )
+    return pair
+
+
 @click.command("sync")
 @click.argument(
     "de_path",
@@ -136,6 +189,8 @@ def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
 )
 @click.argument(
     "en_path",
+    required=False,
+    default=None,
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
 )
 @click.option(
@@ -268,7 +323,7 @@ def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def slides_sync_cmd(
     de_path: Path,
-    en_path: Path,
+    en_path: Path | None,
     dry_run: bool,
     interactive: bool,
     explain: bool,
@@ -287,7 +342,9 @@ def slides_sync_cmd(
     """Bring a split DE/EN deck pair into sync after editing one side.
 
     DE_PATH and EN_PATH are the two halves of a split-format deck
-    (``<deck>.de.py`` and ``<deck>.en.py``).
+    (``<deck>.de.py`` and ``<deck>.en.py``). EN_PATH is **optional**: pass just
+    one half (or the bilingual deck stem ``<deck>.py``) and the other half is
+    derived from disk — ``clm slides sync slides_x.de.py`` syncs the pair.
 
     \b
     Behavior:
@@ -323,6 +380,10 @@ def slides_sync_cmd(
             "--explain and --json are mutually exclusive "
             "(--explain is a human-readable diagnostic; use --dry-run --json for the structured plan)"
         )
+
+    # Single-path contract: when EN_PATH is omitted, derive the twin (or both
+    # halves from a deck stem) from disk before anything else.
+    de_path, en_path = _resolve_single_path(de_path, en_path)
 
     # Pairing guard (#162 Tier-2): reject a same-file / same-language / cross-deck
     # pair and auto-correct a swapped (en, de) order before anything reads or

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -752,6 +752,15 @@ twice, **two same-language** halves, **two different decks**, or a path that is
 usage error before any LLM call or write. This closes the #162 footgun where a
 mismatched pair could silently produce a divergent or no-op sync.
 
+**Single-path form (since CLM {version}).** `EN_PATH` is **optional**: pass just
+one half and the twin is derived from disk — `clm slides sync slides_x.de.py`
+syncs the pair. You may also pass the **bilingual deck stem** (`slides_x.py`, no
+`.de`/`.en` tag) when it still exists on disk, and both halves are derived. The
+derivation is prefix-agnostic (so `apis.de.py` works) and the resolved pair is
+still run through the pairing guard above. A missing twin is a clear usage error
+(exit 2) — sync never invents a translated half; run `clm slides split` first.
+The two-path form is unchanged.
+
 **Default behavior changed in CLM {version}: the command now writes to
 the working tree.** A bare `clm slides sync de en` applies the agreed
 changes (it no longer just prints a diff). Nothing is committed —
@@ -842,7 +851,7 @@ Use `--explain` to see the anchor-level view (per-cell anchor + drift, the
 propagation direction, drifted ids) for any pair.
 
 ```
-clm slides sync [OPTIONS] DE_PATH EN_PATH
+clm slides sync [OPTIONS] DE_PATH [EN_PATH]
 ```
 
 | Option | Description |
@@ -886,6 +895,9 @@ Examples:
 ```bash
 # Edit intro.de.py, then bring intro.en.py into sync (writes to the tree).
 clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py
+
+# Single-path: pass one half, the twin is derived from disk.
+clm slides sync slides/topic/intro.de.py
 
 # Preview the plan first — write nothing.
 clm slides sync intro.de.py intro.en.py --dry-run

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -212,6 +212,12 @@ the safe one — no command was removed and every tool stays fully invocable.
   invocable, and still the `suggest_sync` MCP tool). It coexisted confusingly with
   the split-pair `sync`. *Migration:* for split-format decks use `clm slides sync`;
   `suggest-sync` remains for the pre-split bilingual layout and agent/MCP use.
+- **`clm slides sync` accepts a single path.** `EN_PATH` is now optional: pass one
+  half (`clm slides sync slides_x.de.py`) and the twin is derived from disk, or
+  pass the bilingual deck stem (`slides_x.py`, when it still exists) to derive both
+  halves. A missing twin is a clear usage error (exit 2); sync never invents a
+  translated half. *Migration:* purely additive — the two-path form is unchanged,
+  so existing invocations and scripts keep working.
 
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 

--- a/src/clm/slides/pairing.py
+++ b/src/clm/slides/pairing.py
@@ -244,3 +244,26 @@ def derive_split_pair(path: Path) -> tuple[Path, Path] | None:
     if twin is None:
         return None
     return order_split_pair(path, twin)
+
+
+def derive_split_pair_from_stem(path: Path) -> tuple[Path, Path] | None:
+    """Ordered ``(de_path, en_path)`` for a bilingual/deck-stem ``path`` (one
+    that carries **no** ``.de``/``.en`` tag, e.g. ``slides_x.py``) — derives
+    ``<stem>.de<ext>`` / ``<stem>.en<ext>`` and returns them iff **both** exist
+    on disk; else ``None``.
+
+    The prefix-agnostic, disk-aware companion of :func:`derive_split_pair` for
+    the ``clm slides sync`` single-path contract's "pass the deck stem" form. A
+    voiceover companion (``voiceover_*``) is never a deck stem.
+    """
+    # An extensionless path has no program extension to build halves from, and
+    # would otherwise yield ``<name>.de`` / ``<name>.en`` that the pairing guard
+    # then rejects as not-a-split-half (a contradictory double error). A real
+    # deck stem always carries a ``.py``/``.cpp``/… extension.
+    if path.suffix == "" or path.name.startswith("voiceover_") or split_lang_tag(path) is not None:
+        return None
+    ext = path.suffix
+    stem = path.name[: -len(ext)]
+    de = path.with_name(f"{stem}.de{ext}")
+    en = path.with_name(f"{stem}.en{ext}")
+    return (de, en) if de.exists() and en.exists() else None

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -694,3 +694,77 @@ class TestPairingGuard:
         )
         assert result.exit_code == 0, _combined(result)
         assert "swapped" not in _combined(result)
+
+
+class TestSinglePath:
+    """`clm slides sync` single-path contract: EN_PATH is optional and the twin
+    (or both halves from a deck stem) is derived from disk. The two-path form
+    stays valid (backward compatible).
+    """
+
+    def test_single_half_derives_twin(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, _en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(slides_sync_cmd, [str(de_path), "--dry-run", "--no-cache"])
+        assert result.exit_code == 0, _combined(result)
+
+    def test_single_half_prefix_less(self, cli_runner: CliRunner, tmp_path: Path):
+        # Prefix-agnostic: an un-prefixed deck (apis.de.py) derives its twin too.
+        de_path, _en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE, stem="apis")
+        result = cli_runner.invoke(slides_sync_cmd, [str(de_path), "--dry-run", "--no-cache"])
+        assert result.exit_code == 0, _combined(result)
+
+    def test_single_en_half_derives_twin_no_swap_note(self, cli_runner: CliRunner, tmp_path: Path):
+        # The .en half alone derives the .de twin. The derived pair is returned
+        # already (de, en)-ordered, so the pairing guard's "swapped" note must NOT
+        # fire (the author passed a single path — nothing was swapped).
+        _de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(slides_sync_cmd, [str(en_path), "--dry-run", "--no-cache"])
+        assert result.exit_code == 0, _combined(result)
+        assert "swapped" not in _combined(result)
+
+    def test_deck_stem_derives_both_halves(self, cli_runner: CliRunner, tmp_path: Path):
+        _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        stem = tmp_path / "slides_intro.py"  # bilingual stem present on disk
+        stem.write_text(_DE_BASE + _EN_BASE, encoding="utf-8")
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(stem), "--dry-run", "--json", "--no-cache"]
+        )
+        assert result.exit_code == 0, _combined(result)
+        # The plan acted on the derived split halves, not the stem itself.
+        data = _json_payload(result)
+        assert data["de_path"].endswith("slides_intro.de.py")
+        assert data["en_path"].endswith("slides_intro.en.py")
+
+    def test_missing_twin_errors(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path = tmp_path / "slides_intro.de.py"
+        de_path.write_text(_DE_BASE, encoding="utf-8")  # no .en twin on disk
+        result = cli_runner.invoke(slides_sync_cmd, [str(de_path), "--dry-run", "--no-cache"])
+        assert result.exit_code != 0
+        assert "twin" in _combined(result)
+
+    def test_deck_stem_missing_half_errors(self, cli_runner: CliRunner, tmp_path: Path):
+        # An untagged stem whose halves are not both present → the Branch-B usage
+        # error naming both expected halves (not a silent or contradictory failure).
+        stem = tmp_path / "slides_intro.py"
+        stem.write_text(_DE_BASE + _EN_BASE, encoding="utf-8")
+        (tmp_path / "slides_intro.de.py").write_text(_DE_BASE, encoding="utf-8")  # no .en
+        result = cli_runner.invoke(slides_sync_cmd, [str(stem), "--dry-run", "--no-cache"])
+        assert result.exit_code != 0
+        out = _combined(result)
+        assert ".de.py" in out and ".en.py" in out
+
+    def test_companion_alone_errors_with_hint(self, cli_runner: CliRunner, tmp_path: Path):
+        # A voiceover companion is never a sync target; passing one alone gives a
+        # companion-specific error (sync never derives a twin for a companion).
+        comp = tmp_path / "voiceover_intro.de.py"
+        comp.write_text(_DE_BASE, encoding="utf-8")
+        result = cli_runner.invoke(slides_sync_cmd, [str(comp), "--dry-run", "--no-cache"])
+        assert result.exit_code != 0
+        assert "companion" in _combined(result)
+
+    def test_two_path_form_still_works(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
+        )
+        assert result.exit_code == 0, _combined(result)

--- a/tests/slides/test_pairing.py
+++ b/tests/slides/test_pairing.py
@@ -17,6 +17,7 @@ from clm.slides.pairing import (
     build_slide_groups,
     build_slide_pairs,
     derive_split_pair,
+    derive_split_pair_from_stem,
     derive_split_twin,
     is_title_macro_cell,
     order_split_pair,
@@ -326,3 +327,39 @@ class TestDeriveSplitTwin:
         en.write_text("# en\n", encoding="utf-8")
         assert derive_split_twin(de) is None
         assert derive_split_pair(de) is None
+
+
+class TestDeriveSplitPairFromStem:
+    """``derive_split_pair_from_stem`` — the deck-stem form of the sync
+    single-path contract (pass ``<deck>.py``, derive both halves)."""
+
+    def test_stem_derives_both_halves(self, tmp_path: Path):
+        de = tmp_path / "apis.de.py"
+        en = tmp_path / "apis.en.py"
+        de.write_text("# de\n", encoding="utf-8")
+        en.write_text("# en\n", encoding="utf-8")
+        stem = tmp_path / "apis.py"
+        assert derive_split_pair_from_stem(stem) == (de, en)
+
+    def test_none_when_a_half_missing(self, tmp_path: Path):
+        (tmp_path / "apis.de.py").write_text("# de\n", encoding="utf-8")  # no en
+        assert derive_split_pair_from_stem(tmp_path / "apis.py") is None
+
+    def test_none_for_a_tagged_half(self, tmp_path: Path):
+        # A path that is itself a .de/.en half is not a stem.
+        assert derive_split_pair_from_stem(tmp_path / "apis.de.py") is None
+
+    def test_none_for_companion_stem(self, tmp_path: Path):
+        de = tmp_path / "voiceover_x.de.py"
+        en = tmp_path / "voiceover_x.en.py"
+        de.write_text("# de\n", encoding="utf-8")
+        en.write_text("# en\n", encoding="utf-8")
+        assert derive_split_pair_from_stem(tmp_path / "voiceover_x.py") is None
+
+    def test_none_for_extensionless_path(self, tmp_path: Path):
+        # An extensionless path has no program extension to build halves from;
+        # it must not construct dotted ``deck.de``/``deck.en`` "halves" that the
+        # pairing guard would then reject with a contradictory error.
+        (tmp_path / "deck.de").write_text("# de\n", encoding="utf-8")
+        (tmp_path / "deck.en").write_text("# en\n", encoding="utf-8")
+        assert derive_split_pair_from_stem(tmp_path / "deck") is None


### PR DESCRIPTION
The §8 single-path contract: `EN_PATH` is now **optional**. Pass one half (`clm slides sync slides_x.de.py`) and the twin is derived from disk, or pass the bilingual deck stem (`slides_x.py`, when it still exists) to derive both halves. The two-path form is unchanged (backward-compatible).

(Follows #209, whose `derive_split_twin` this reuses — `7cf990a` is already on master, so this PR diffs cleanly to the single-path change.)

## What changed
- **`slides_sync.py`**: `EN_PATH` → `required=False, default=None`. New `_resolve_single_path(de_path, en_path)` runs **before** the pairing guard: a tagged half derives its twin via `pairing.derive_split_twin`; an untagged stem derives both via `derive_split_pair_from_stem`. The derived pair is returned already `(de, en)`-ordered (so the guard's swap note never fires on a single path) and still funnelled through `_resolve_sync_pair`. A missing twin is a clear `UsageError` (exit 2) — sync never invents a translated half; a voiceover companion passed alone gets a companion-specific hint.
- **`pairing.derive_split_pair_from_stem(path)`**: prefix-agnostic, disk-aware deck-stem → `(de, en)` derivation (both halves must exist); rejects tagged, `voiceover_*`, and extensionless paths.

## Verification
- ruff + mypy clean; pre-commit full fast suite green; 2226 slides+cli tests pass.
- **Adversarial 2-lens review (10 findings → 2 refuted, 8 confirmed minor/nit, all fixed):**
  - EN-half-alone no longer emits a spurious `arguments look swapped` note (derived pair returned pre-ordered).
  - Extensionless stem returns `None` instead of constructing a contradictory `deck.de`/`deck.en` pair.
  - Companion-passed-alone gives a companion-specific error (the safety invariant — sync never derives a twin for a companion — already held).
  - CHANGELOG `when it still exists on disk` caveat aligned with the info topics.

## Tests
`TestSinglePath` (DE-half, prefix-less DE-half, EN-half-alone with no-swap assertion, deck-stem via `--json` pinning the derived halves, missing-twin, deck-stem-missing-half, companion-alone, two-path regression); `TestDeriveSplitPairFromStem` (both-exist, one-missing, tagged-rejected, companion-rejected, extensionless-rejected).

## Info topics
`commands.md` (usage `DE_PATH [EN_PATH]` + single-path paragraph + example), `migration.md`, CHANGELOG, design doc §8/§12/§13.

## Deferred (the one remaining §8 item)
Directory **batch mode** (`clm slides sync DIR` + continue-on-error/max exit + `--yes` write gate) — contract pre-decided; its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)