### PR TITLE
feat(slides): clm slides sync DIR — directory batch mode (§8a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm slides sync DIR` — directory batch mode (§8a).** Pass a directory and
+  every `.de`/`.en` deck pair under the tree is synced in one pass. Enumeration is
+  prefix-agnostic (un-prefixed decks like `apis.de.py` count too) and descends the
+  whole subtree; voiceover companions (`voiceover_*`) are ignored. A half with **no
+  twin** under the tree is **skipped with a warning**, never synced against a
+  phantom empty twin. The sweep **continues past a failing pair** (recording it as
+  errored) and the process exit code is the **worst** over all pairs (`0` clean <
+  `1` review < `2` error); a per-pair one-liner plus a `N pair(s): X clean, Y
+  review, Z errored` rollup is printed. A **writing** directory run requires
+  **`--yes`** (or an interactive confirm) since it writes to every pair at once;
+  `--dry-run` / `--explain` directory runs are unprompted. `--interactive` stays
+  single-pair only. `--json` over a directory returns an envelope
+  `{ "mode", "root", "exit_code", "pairs": [ … ] }`, each `pairs` entry being one
+  single-pair object. Additive — passing a single file or a pair is unchanged.
 - **`clm slides sync` accepts a single path (§8 single-path contract).** `EN_PATH`
   is now optional: pass one half (`clm slides sync slides_x.de.py`) and the twin is
   derived from disk, or pass the bilingual deck stem (`slides_x.py`, when it still
   exists on disk) to derive both halves. Derivation is prefix-agnostic (`apis.de.py` works) and the resolved pair
   still runs through the pairing guard; a missing twin is a clear usage error (sync
-  never invents a translated half). The two-path form is unchanged. Directory
-  *batch* mode (`sync DIR`) remains a planned follow-up.
+  never invents a translated half). The two-path form is unchanged.
 - **`clm voiceover extract` auto-pairs on a split half (§8 paired extract).**
   When the target is a split half (`<deck>.de.py` / `<deck>.en.py`) whose twin
   exists on disk, both companions are extracted in one op: the two halves are

--- a/docs/claude/design/split-voiceover-hardening.md
+++ b/docs/claude/design/split-voiceover-hardening.md
@@ -496,6 +496,65 @@ a `{version}` substitution, no Click introspection), so `hidden=True` is invisib
 *default* surface only offers operations that keep both halves consistent. Sharp tools
 remain reachable for agents/scripts but are not the path of least resistance.
 
+### 8a. Batch mode (`clm slides sync DIR`) — SHIPPED
+
+**Status: shipped.** All of B1–B7 below landed, plus three review-driven hardening
+fixes (an adversarial find→verify pass over the diff confirmed them):
+
+- **Ignored-dir prune.** The enumerator skips `.git` / `.venv` / `build` / `dist` /
+  `__pycache__` / … (`is_ignored_dir_for_course`, the course-scan convention), so a
+  vendored or archived `.de`/`.en` copy is never enumerated and thus never *written*
+  on a writing batch. The test is applied to each file's path **relative to the
+  root**, so an ignored component in the root's own prefix (a tree under `build/`)
+  cannot falsely exclude everything; the single-file branch stays exempt.
+- **Per-deck `.env` discovery.** A writing batch loads `.env` from the root **and
+  from each deck's directory** (`load_env_files(root, *deck_dirs)`), so a `.env`
+  above a deck buried below the root is found — matching the documented single-pair
+  rule, not just a root-only search.
+- **Resolved watermark key parity.** The single-pair surface now `.resolve()`s its
+  pair before `build_sync_plan`, so it keys the watermark by the same absolute
+  string the batch enumerator produces — otherwise the *same* pair acquired two keys
+  across surfaces and a batch run silently missed a single-pair run's watermark.
+
+Original **pre-decided contract (maintainer):** a directory arg
+triggers batch (`dir_okay=True` on the first positional, branch on
+`de_path.is_dir()` — *not* a separate `sync-all` subcommand, for one funnel);
+**continue-on-error** with a **max-severity** aggregate exit code (0 < 1 < 2); a
+writing batch requires **`--yes`** (a `--dry-run`/`--explain` batch runs ungated, as
+it uses no LLM and fans out no cost). Implementation plan (from the 2026-06-03 spec):
+
+- **B1 — prefix-agnostic enumerator (the central trap).** Do **not** reuse
+  `topic_resolver.find_slide_files_recursive` / `is_slides_file` / `split_twin` /
+  `split_lang_suffix` — they are all gated on the `slides_`/`topic_`/`project_`
+  routing prefix, so they would *silently skip* every prefix-less deck (`apis.de.py`)
+  the rest of this feature deliberately supports — a #162-class silent miss. Add a
+  `find_split_slide_files_recursive(path)` that mirrors the file/topic-dir/`rglob`
+  descent shape but filters on `split_lang_tag(f) is not None and f.suffix in
+  SUPPORTED_PROG_LANG_EXTENSIONS`. Resolve paths (`.resolve()`) for stable watermark
+  keys (the watermark is keyed by the `(de_path, en_path)` *strings*).
+- **B2 — pair iterator.** `iter_split_pairs(paths)` cloning
+  `assign_ids_in_directory`'s `fileset`/`handled` skeleton but using the
+  prefix-agnostic `pairing.derive_split_twin` (already rejects `voiceover_*`); a
+  solo half with no twin under the tree is **skipped with a warning**, never synced
+  against a phantom empty twin (same rationale as single-path's missing-twin error).
+- **B3/B4 — loop.** Open **one** `SyncWatermarkCache` (+ alignment), build **one**
+  judge/translator/recoverer, iterate pairs, per-pair `build_sync_plan` +
+  apply/dry-run/explain inside a single try/finally that closes caches once. Per-pair
+  `_apply_exit_code`/`_plan_exit_code`; aggregate = `max` over pairs. Continue-on-error,
+  collect a per-pair error rollup.
+- **B5 — output.** Human: a per-pair one-liner + a final rollup (`N pairs: X clean,
+  Y review, Z errored`). `--json`: a **new envelope** `{mode, exit_code, pairs:[<existing
+  _to_dict per pair>]}` — must NOT leak into the single-pair path (existing
+  `test_dry_run_json_shape`/`test_apply_json_shape` assert the flat single-pair object;
+  keep `_to_dict` for single, the envelope for batch).
+- **B6 — cost gate.** A writing batch (default apply) requires `--yes` or an
+  interactive confirm; `--dry-run`/`--explain` run freely.
+- **B7 — tests/docs.** A tmp-tree fixture with ≥2 prefix-less pairs + a solo half
+  (assert solo skipped+warned, both pairs synced, aggregate exit code, batch `--json`
+  envelope shape). Reuse the gold-judge monkeypatch from `test_sync_code_e2e.py`. Update
+  `commands.md` (the `sync` usage/`DIR` mode + examples) and `migration.md` per the Info
+  Topics rule.
+
 ---
 
 ## 9. The pre-commit gate (the chosen enforcement)

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
+from attrs import define
 
 from clm.infrastructure.llm.cache import (
     SyncAlignmentCache,
@@ -68,6 +69,8 @@ from clm.infrastructure.llm.openrouter_client import (
 from clm.slides.pairing import (
     derive_split_pair_from_stem,
     derive_split_twin,
+    find_split_slide_files_recursive,
+    iter_split_pairs,
     order_split_pair,
     split_lang_tag,
 )
@@ -84,8 +87,11 @@ from clm.slides.sync_recover import DEFAULT_RECOVERY_MODEL, OpenRouterAlignmentR
 from clm.slides.sync_translate import DEFAULT_TRANSLATION_MODEL, OpenRouterSlideTranslator
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from clm.infrastructure.llm.ollama_client import SyncJudge
     from clm.slides.sync_recover import AlignmentRecoverer
+    from clm.slides.sync_translate import SlideTranslator
 
 CACHE_DB_NAME = "clm-llm.sqlite"
 
@@ -185,7 +191,7 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
 @click.command("sync")
 @click.argument(
     "de_path",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    type=click.Path(exists=True, dir_okay=True, path_type=Path),
 )
 @click.argument(
     "en_path",
@@ -320,6 +326,19 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
         ".env are available to the judge and translator."
     ),
 )
+@click.option(
+    "--yes",
+    "-y",
+    "yes",
+    is_flag=True,
+    default=False,
+    help=(
+        "Batch (DIR) only: confirm a writing run over a whole directory without "
+        "the interactive prompt. A directory apply writes to every pair under the "
+        "tree, so it is gated; --dry-run / --explain batches run freely. Ignored "
+        "for a single pair."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def slides_sync_cmd(
     de_path: Path,
@@ -337,6 +356,7 @@ def slides_sync_cmd(
     cache_dir: Path | None,
     no_cache: bool,
     no_env_file: bool,
+    yes: bool,
     as_json: bool,
 ) -> None:
     """Bring a split DE/EN deck pair into sync after editing one side.
@@ -345,6 +365,15 @@ def slides_sync_cmd(
     (``<deck>.de.py`` and ``<deck>.en.py``). EN_PATH is **optional**: pass just
     one half (or the bilingual deck stem ``<deck>.py``) and the other half is
     derived from disk — ``clm slides sync slides_x.de.py`` syncs the pair.
+
+    \b
+    DE_PATH may also be a **directory** — batch mode: every ``.de``/``.en`` deck
+    pair under the tree is synced in one pass (prefix-agnostic, so un-prefixed
+    decks count too). A half with no twin under the tree is skipped with a
+    warning. The run continues past a failing pair and the exit code is the
+    worst over all pairs (0 clean < 1 review < 2 error). A *writing* directory
+    run needs --yes (or an interactive confirm); --dry-run / --explain run
+    freely. --interactive is single-pair only.
 
     \b
     Behavior:
@@ -381,6 +410,36 @@ def slides_sync_cmd(
             "(--explain is a human-readable diagnostic; use --dry-run --json for the structured plan)"
         )
 
+    # Batch mode: a directory triggers a sweep over every split pair under the
+    # tree (one funnel — no separate `sync-all` subcommand). Branch here, before
+    # the single-path / pairing-guard resolution (which both assume a file).
+    if de_path.is_dir():
+        if en_path is not None:
+            raise click.UsageError(
+                f"{de_path} is a directory (batch mode), which takes a single "
+                "directory argument; do not pass a second path."
+            )
+        if interactive:
+            raise click.UsageError(
+                "--interactive cannot be combined with a directory (it walks one "
+                "pair's proposals). Sync a single deck/half interactively, or use "
+                "--dry-run / --explain over the directory."
+            )
+        batch_mode = "explain" if explain else ("dry-run" if dry_run else "apply")
+        _run_batch(
+            de_path,
+            mode=batch_mode,
+            as_json=as_json,
+            yes=yes,
+            no_cache=no_cache,
+            no_env_file=no_env_file,
+            cache_dir=cache_dir,
+            make_judge=lambda: _resolve_judge(provider, llm_model, ollama_url, llm_timeout),
+            make_translator=lambda: OpenRouterSlideTranslator(model=translation_model),
+            make_recoverer=lambda: _resolve_recoverer(llm_recover, recovery_model),
+        )
+        return  # _run_batch always sys.exit()s; this is just for the type-checker.
+
     # Single-path contract: when EN_PATH is omitted, derive the twin (or both
     # halves from a deck stem) from disk before anything else.
     de_path, en_path = _resolve_single_path(de_path, en_path)
@@ -390,6 +449,14 @@ def slides_sync_cmd(
     # writes. Runs for every mode (incl. --dry-run/--explain) so the footgun is
     # caught even on read-only passes.
     de_path, en_path = _resolve_sync_pair(de_path, en_path)
+
+    # Canonicalize to absolute, resolved paths. The watermark is keyed by the
+    # (de_path, en_path) *strings*, so the single-path surface must key by the
+    # same form the directory-batch surface does (its enumerator resolves every
+    # file) — otherwise the SAME pair acquires two watermark keys across surfaces
+    # (a relative single-path run vs. a resolved batch run) and the second silently
+    # misses the first's watermark and re-baselines off git HEAD.
+    de_path, en_path = de_path.resolve(), en_path.resolve()
 
     # Load the project .env before resolving the judge/translator, so keys kept
     # only in .env (the usual course-repo layout) are found. Without this, every
@@ -473,6 +540,288 @@ def slides_sync_cmd(
         _print_human(plan, apply_result, walk, mode=mode)
 
     sys.exit(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Batch mode (`clm slides sync DIR`)
+#
+# A directory sweeps every split deck pair under the tree in one pass, sharing a
+# single watermark cache + judge/translator/recoverer. Continue-on-error: a pair
+# that raises is recorded as errored (exit 2) and the sweep proceeds; the process
+# exit is the worst per-pair code. A writing sweep is gated behind --yes (or an
+# interactive confirm); --dry-run / --explain run freely.
+# ---------------------------------------------------------------------------
+
+
+@define
+class _PairResult:
+    """The outcome of syncing one deck pair inside a directory batch.
+
+    ``plan``/``apply_result`` are ``None`` only when the pair raised before
+    producing them (``error`` set) — every clean/review pair carries a plan.
+    """
+
+    de_path: Path
+    en_path: Path
+    plan: SyncPlan | None
+    apply_result: ApplyResult | None
+    explain_text: str | None
+    exit_code: int
+    error: str | None
+
+
+def _run_batch(
+    root: Path,
+    *,
+    mode: str,
+    as_json: bool,
+    yes: bool,
+    no_cache: bool,
+    no_env_file: bool,
+    cache_dir: Path | None,
+    make_judge: Callable[[], SyncJudge | None],
+    make_translator: Callable[[], SlideTranslator],
+    make_recoverer: Callable[[], AlignmentRecoverer | None],
+) -> None:
+    """Sync every split deck pair under ``root`` in one pass, then ``sys.exit`` the
+    worst per-pair exit code (0 clean < 1 review < 2 error)."""
+    pairs, solos = iter_split_pairs(find_split_slide_files_recursive(root))
+    for solo in solos:
+        tag = split_lang_tag(solo)
+        other = "EN" if tag == "de" else "DE"
+        click.echo(
+            f"warning: skipping {solo.name} — no {other} twin found under {root}.",
+            err=True,
+        )
+    if not pairs:
+        if as_json:
+            click.echo(
+                json.dumps({"mode": mode, "root": str(root), "exit_code": 0, "pairs": []}, indent=2)
+            )
+        else:
+            click.echo(f"no split-format deck pairs found under {root}.")
+        sys.exit(0)
+
+    writing = mode == "apply"
+    if writing and not yes:
+        # A directory apply writes to every pair under the tree — gate it. With
+        # --json there is no usable prompt, so require the explicit flag.
+        if as_json:
+            raise click.UsageError(
+                f"a writing batch over {len(pairs)} pair(s) needs --yes (cannot prompt "
+                "with --json); add --yes, or preview with --dry-run."
+            )
+        click.confirm(
+            f"About to sync {len(pairs)} deck pair(s) under {root} — this writes to "
+            "the working tree. Continue?",
+            abort=True,
+        )
+
+    # One env load + one cache + one judge/translator/recoverer for the whole sweep.
+    # Discover .env from the root AND from each deck's own directory (like the
+    # single-pair path), so a project .env at the root and a nested .env above a
+    # deck buried below it are both found — load_env_files de-dups by file, and
+    # root-first keeps a top-level project .env authoritative.
+    if writing and not no_env_file:
+        from clm.cli.env_loading import load_env_files
+
+        deck_dirs = [d for de_p, en_p in pairs for d in (de_p.parent, en_p.parent)]
+        load_env_files(root, *deck_dirs)
+
+    cache_root: Path | None = None
+    watermark_cache: SyncWatermarkCache | None = None
+    alignment_cache: SyncAlignmentCache | None = None
+    if not no_cache:
+        cache_root = resolve_cache_dir(cli_override=cache_dir)
+        watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
+
+    judge: SyncJudge | None = None
+    translator: SlideTranslator | None = None
+    recoverer: AlignmentRecoverer | None = None
+    if writing:
+        judge = make_judge()
+        translator = make_translator()
+        recoverer = make_recoverer()
+        if recoverer is not None and cache_root is not None:
+            alignment_cache = SyncAlignmentCache(cache_root / CACHE_DB_NAME)
+
+    results: list[_PairResult] = []
+    try:
+        for de_path, en_path in pairs:
+            results.append(
+                _sync_one_pair(
+                    de_path,
+                    en_path,
+                    mode=mode,
+                    watermark_cache=watermark_cache,
+                    alignment_cache=alignment_cache,
+                    judge=judge,
+                    translator=translator,
+                    recoverer=recoverer,
+                )
+            )
+    finally:
+        if watermark_cache is not None:
+            watermark_cache.close()
+        if alignment_cache is not None:
+            alignment_cache.close()
+
+    exit_code = max((r.exit_code for r in results), default=0)
+    _emit_batch(root, mode, results, exit_code, as_json=as_json)
+    sys.exit(exit_code)
+
+
+def _sync_one_pair(
+    de_path: Path,
+    en_path: Path,
+    *,
+    mode: str,
+    watermark_cache: SyncWatermarkCache | None,
+    alignment_cache: SyncAlignmentCache | None,
+    judge: SyncJudge | None,
+    translator: SlideTranslator | None,
+    recoverer: AlignmentRecoverer | None,
+) -> _PairResult:
+    """Sync one pair for the batch, catching any failure so the sweep continues."""
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=watermark_cache)
+        apply_result: ApplyResult | None = None
+        explain_text: str | None = None
+        if mode == "explain":
+            explain_text = render_explain(
+                de_path, en_path, plan=plan, watermark_cache=watermark_cache
+            )
+        elif mode == "apply":
+            apply_result = apply_plan(
+                plan,
+                judge=judge,
+                translator=translator,
+                watermark_cache=watermark_cache,
+                recoverer=recoverer,
+                alignment_cache=alignment_cache,
+            )
+        # else dry-run: classify only, write nothing.
+        exit_code = (
+            _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
+        )
+        return _PairResult(de_path, en_path, plan, apply_result, explain_text, exit_code, None)
+    except Exception as exc:  # continue-on-error: one bad pair must not abort the sweep
+        return _PairResult(de_path, en_path, None, None, None, 2, f"{type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Batch output (human one-liners + rollup; JSON envelope)
+# ---------------------------------------------------------------------------
+
+_BATCH_STATUS = {0: "OK    ", 1: "REVIEW", 2: "ERROR "}
+
+
+def _deck_label(de_path: Path, root: Path) -> str:
+    """The DE half's path relative to the batch root (bare name if not under it)."""
+    try:
+        return str(de_path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return de_path.name
+
+
+def _counts_str(plan: SyncPlan) -> str:
+    kinds = ("add", "edit", "retag", "move", "remove", "conflict", "rename")
+    parts = [f"{plan.count(k)} {k}" for k in kinds if plan.count(k)]
+    return ", ".join(parts) if parts else "0"
+
+
+def _batch_pair_detail(r: _PairResult) -> str:
+    if r.apply_result is None:  # dry-run / explain — describe the plan
+        plan = r.plan
+        assert plan is not None  # a non-error pair always carries a plan
+        if plan.has_errors:
+            return f"{_counts_str(plan)} (classifier error)"
+        if plan.proposals:
+            return f"would change: {_counts_str(plan)}"
+        return "nothing to do"
+    res = r.apply_result
+    parts: list[str] = []
+    if res.applied:
+        parts.append(f"applied {res.applied}")
+    if res.deferred:
+        parts.append(f"{res.deferred} deferred")
+    if res.errors:
+        parts.append(f"{len(res.errors)} error(s)")
+    return ", ".join(parts) if parts else "in sync"
+
+
+def _batch_pair_line(r: _PairResult, root: Path) -> str:
+    label = _deck_label(r.de_path, root)
+    if r.error is not None:
+        return f"{_BATCH_STATUS[2]} {label}: {r.error}"
+    return f"{_BATCH_STATUS[r.exit_code]} {label}: {_batch_pair_detail(r)}"
+
+
+def _batch_rollup(results: list[_PairResult]) -> str:
+    clean = sum(1 for r in results if r.exit_code == 0)
+    review = sum(1 for r in results if r.exit_code == 1)
+    errored = sum(1 for r in results if r.exit_code == 2)
+    return f"{len(results)} pair(s): {clean} clean, {review} review, {errored} errored."
+
+
+def _emit_batch(
+    root: Path,
+    mode: str,
+    results: list[_PairResult],
+    exit_code: int,
+    *,
+    as_json: bool,
+) -> None:
+    if as_json:
+        click.echo(json.dumps(_batch_to_dict(root, mode, results, exit_code), indent=2))
+        return
+    if mode == "explain":
+        for r in results:
+            click.echo("")
+            click.echo(f"=== {_deck_label(r.de_path, root)} ===")
+            click.echo(f"  error: {r.error}" if r.error is not None else r.explain_text)
+        click.echo("")
+        click.echo(_batch_rollup(results))
+        return
+    # dry-run / apply: a scannable one-liner per pair, then the rollup.
+    for r in results:
+        click.echo(_batch_pair_line(r, root))
+    # Surface each pair's apply-time errors in full (the one-liner only counts them).
+    for r in results:
+        if r.apply_result is not None and r.apply_result.errors:
+            label = _deck_label(r.de_path, root)
+            for err in r.apply_result.errors:
+                click.echo(f"  {label}: error: {err}")
+    click.echo("")
+    click.echo(_batch_rollup(results))
+    if mode == "apply" and any(
+        r.apply_result is not None and r.apply_result.applied for r in results
+    ):
+        click.echo("Review the propagated changes with `git diff` before committing.")
+
+
+def _batch_to_dict(root: Path, mode: str, results: list[_PairResult], exit_code: int) -> dict:
+    return {
+        "mode": mode,
+        "root": str(root),
+        "exit_code": exit_code,
+        "pairs": [_batch_pair_dict(r, mode) for r in results],
+    }
+
+
+def _batch_pair_dict(r: _PairResult, mode: str) -> dict:
+    if r.error is not None:
+        return {
+            "de_path": str(r.de_path),
+            "en_path": str(r.en_path),
+            "mode": mode,
+            "exit_code": r.exit_code,
+            "error": r.error,
+        }
+    assert r.plan is not None
+    # Each non-errored pair reuses the single-pair object shape verbatim, so a
+    # consumer can treat ``pairs[i]`` exactly like one ``clm slides sync --json``.
+    return _to_dict(r.plan, r.apply_result, None, mode, r.exit_code)
 
 
 # Provider-aware default per-call timeout. A large local reasoning model

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -761,6 +761,21 @@ still run through the pairing guard above. A missing twin is a clear usage error
 (exit 2) — sync never invents a translated half; run `clm slides split` first.
 The two-path form is unchanged.
 
+**Batch mode (since CLM {version}).** `DE_PATH` may also be a **directory** —
+every `.de`/`.en` deck pair under the tree is synced in one pass. Enumeration is
+prefix-agnostic (un-prefixed decks like `apis.de.py` count too) and descends the
+whole subtree; voiceover companions (`voiceover_*`) are ignored. A half with **no
+twin** under the tree is **skipped with a warning**, never synced against a
+phantom empty twin. The sweep **continues past a failing pair** (recording it as
+errored) and the process exit code is the **worst** over all pairs (`0` clean <
+`1` review < `2` error). A summary one-liner per pair plus a final rollup
+(`N pair(s): X clean, Y review, Z errored`) is printed; `--dry-run` and
+`--explain` behave as for a single pair, applied to each. A **writing** directory
+run requires **`--yes`** (or an interactive confirm), since it writes to every
+pair at once; `--dry-run` / `--explain` directory runs are unprompted.
+`--interactive` is single-pair only (it walks one pair's proposals) and is
+rejected with a directory. Do **not** pass a second path with a directory.
+
 **Default behavior changed in CLM {version}: the command now writes to
 the working tree.** A bare `clm slides sync de en` applies the agreed
 changes (it no longer just prints a diff). Nothing is committed —
@@ -852,6 +867,7 @@ propagation direction, drifted ids) for any pair.
 
 ```
 clm slides sync [OPTIONS] DE_PATH [EN_PATH]
+clm slides sync [OPTIONS] DIR          # batch: sync every pair under DIR
 ```
 
 | Option | Description |
@@ -869,6 +885,7 @@ clm slides sync [OPTIONS] DE_PATH [EN_PATH]
 | `--cache-dir PATH` | Directory holding the structural watermark. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
 | `--no-cache` | Do not read or write the watermark. Every run then re-derives its baseline from git `HEAD` and no synced state is persisted. |
 | `--no-env-file` | Do not auto-load a `.env` file. By default sync loads the first `.env` found above each deck (without overriding already-set variables), so keys kept in the project `.env` reach the judge/translator. |
+| `--yes`, `-y` | **Batch (`DIR`) only.** Confirm a writing directory run without the interactive prompt. A directory apply writes to every pair under the tree, so it is gated; `--dry-run` / `--explain` directory runs are unprompted. Ignored for a single pair. |
 | `--json` | Emit a JSON report instead of human-readable lines. |
 
 Exit codes: `0` clean (every change applied, or nothing to do, with no
@@ -890,6 +907,13 @@ The JSON report carries `mode` (`dry-run` / `apply` / `interactive`),
 accept/skip/defer counters under `--interactive`. These counters are the
 pilot accept-rate instrumentation.
 
+In **batch (`DIR`) mode** the `--json` report is instead an envelope
+`{ "mode", "root", "exit_code", "pairs": [ … ] }`, where each entry of
+`pairs` is exactly one single-pair object as above (so a tool can treat
+`pairs[i]` like an individual `clm slides sync --json`); a pair that errored
+appears as `{ "de_path", "en_path", "mode", "exit_code", "error" }`. A writing
+batch with `--json` requires `--yes` (there is no prompt to fall back to).
+
 Examples:
 
 ```bash
@@ -898,6 +922,12 @@ clm slides sync slides/topic/intro.de.py slides/topic/intro.en.py
 
 # Single-path: pass one half, the twin is derived from disk.
 clm slides sync slides/topic/intro.de.py
+
+# Batch: preview every pair under a directory (unprompted, writes nothing).
+clm slides sync slides/ --dry-run
+
+# Batch: sync every pair under a directory (writing → needs --yes).
+clm slides sync slides/ --yes
 
 # Preview the plan first — write nothing.
 clm slides sync intro.de.py intro.en.py --dry-run

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -218,6 +218,19 @@ the safe one — no command was removed and every tool stays fully invocable.
   halves. A missing twin is a clear usage error (exit 2); sync never invents a
   translated half. *Migration:* purely additive — the two-path form is unchanged,
   so existing invocations and scripts keep working.
+- **`clm slides sync` accepts a directory (batch mode).** Pass a directory and
+  every `.de`/`.en` deck pair under the tree is synced in one pass (prefix-agnostic
+  enumeration, voiceover companions ignored). A half with no twin under the tree is
+  **skipped with a warning**; the sweep **continues past a failing pair** and the
+  exit code is the **worst** over all pairs (`0` < `1` < `2`). A **writing**
+  directory run requires **`--yes`** (or an interactive confirm) since it writes to
+  every pair at once; `--dry-run` / `--explain` directory runs are unprompted.
+  `--interactive` stays single-pair only, and a second path with a directory is a
+  usage error. `--json` over a directory returns an envelope
+  `{ "mode", "root", "exit_code", "pairs": [ … ] }` (each `pairs` entry is one
+  single-pair object). *Migration:* purely additive — passing a single file or a
+  pair is unchanged; only a directory argument (previously rejected) now triggers
+  the sweep.
 
 ## Slide format redesign: `clm validate` enforces `slide_id` (warning now, error in 1.7)
 

--- a/src/clm/slides/pairing.py
+++ b/src/clm/slides/pairing.py
@@ -12,11 +12,15 @@ helpers operate on any cell-like object that exposes ``metadata`` and
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Protocol
 
-from clm.infrastructure.utils.path_utils import split_lang_suffix
+from clm.infrastructure.utils.path_utils import (
+    SUPPORTED_PROG_LANG_EXTENSIONS,
+    is_ignored_dir_for_course,
+    split_lang_suffix,
+)
 from clm.notebooks.slide_parser import CellMetadata
 
 # Title-slide anchors:
@@ -267,3 +271,100 @@ def derive_split_pair_from_stem(path: Path) -> tuple[Path, Path] | None:
     de = path.with_name(f"{stem}.de{ext}")
     en = path.with_name(f"{stem}.en{ext}")
     return (de, en) if de.exists() and en.exists() else None
+
+
+# ---------------------------------------------------------------------------
+# Directory enumeration (the ``clm slides sync DIR`` batch surface)
+#
+# Prefix-agnostic by design, like the rest of the CLI-facing split helpers
+# above. Reusing ``topic_resolver.find_slide_files_recursive`` /
+# ``is_slides_file`` here would silently skip every prefix-less deck
+# (``apis.de.py``) the sync surface deliberately supports — a #162-class silent
+# miss — because those are gated on the ``slides_``/``topic_``/``project_``
+# build-routing prefix.
+# ---------------------------------------------------------------------------
+
+
+def _is_split_slide_file(path: Path) -> bool:
+    """A file is a sync-able split half iff it carries a ``.de``/``.en`` tag and a
+    supported program extension — and is **not** a voiceover companion.
+
+    Prefix-agnostic (uses :func:`split_lang_tag`, not
+    :func:`~clm.infrastructure.utils.path_utils.is_slides_file`). Voiceover
+    companions (``voiceover_*``) carry a language tag and a ``.py`` extension but
+    are extract *output*, never decks — excluding them here keeps them from being
+    enumerated and then warned about as phantom solo halves.
+    """
+    if path.name.startswith("voiceover_"):
+        return False
+    return split_lang_tag(path) is not None and path.suffix in SUPPORTED_PROG_LANG_EXTENSIONS
+
+
+def find_split_slide_files_recursive(path: Path) -> list[Path]:
+    """Every split-format slide half (``*.de.<ext>`` / ``*.en.<ext>``) at or under
+    ``path``, **prefix-agnostic** — recognises ``apis.de.py`` as well as
+    ``slides_x.de.py``.
+
+    Unlike :func:`clm.core.topic_resolver.find_slide_files_recursive` (gated on the
+    ``slides_``/``topic_``/``project_`` routing prefix, and early-exiting on a topic
+    dir's direct children), this descends the **whole** subtree and keeps any file
+    matching :func:`_is_split_slide_file`. The prefix gate is deliberately dropped
+    and the early-exit is *not* mirrored: ``clm slides sync`` reconciles whatever
+    split decks the author keeps wherever they keep them, so a stray top-level deck
+    must not stop the walk from reaching nested module dirs (that would be a silent
+    miss). Paths are resolved so the per-pair watermark key (the
+    ``(de_path, en_path)`` strings) is stable regardless of how ``path`` was spelled.
+
+    Directories the course scan ignores (``.git``, ``.venv``, ``build``, ``dist``,
+    ``__pycache__`` …) are pruned, so a vendored or archived ``.de``/``.en`` copy
+    under one of them is never enumerated — and thus never **written** on a writing
+    batch. The ignored-dir test is applied to each file's path *relative to*
+    ``path``, so an ignored component in ``path``'s own prefix (e.g. a tree that
+    itself lives under ``build/``) cannot falsely exclude everything. The
+    single-file branch is exempt: an explicitly named file is always honoured.
+    """
+    if path.is_file():
+        return [path.resolve()] if _is_split_slide_file(path) else []
+    if not path.is_dir():
+        return []
+    return sorted(
+        f.resolve()
+        for f in path.rglob("*")
+        if f.is_file()
+        and _is_split_slide_file(f)
+        and not is_ignored_dir_for_course(f.parent.relative_to(path))
+    )
+
+
+def iter_split_pairs(paths: Iterable[Path]) -> tuple[list[tuple[Path, Path]], list[Path]]:
+    """Partition split-slide ``paths`` into ordered ``(de, en)`` pairs and leftover
+    solo halves.
+
+    Mirrors :func:`clm.slides.assign_ids.assign_ids_in_directory`'s
+    ``fileset``/``handled`` skeleton but pairs through the prefix-agnostic
+    :func:`derive_split_pair` (which already rejects ``voiceover_*``). A half whose
+    twin is **not among ``paths``** (no sibling under the enumerated tree) is
+    returned in the solo list — the caller decides how to report it (``clm slides
+    sync`` warns and skips it, never syncing against a phantom empty twin, the same
+    rationale as the single-path missing-twin error). Deterministic: input is
+    sorted, each pair's DE half comes first, and every path lands in exactly one of
+    the two lists.
+    """
+    files = sorted(set(paths))
+    fileset = set(files)
+    handled: set[Path] = set()
+    pairs: list[tuple[Path, Path]] = []
+    solos: list[Path] = []
+    for f in files:
+        if f in handled:
+            continue
+        pair = derive_split_pair(f)
+        if pair is None or pair[0] not in fileset or pair[1] not in fileset:
+            solos.append(f)
+            handled.add(f)
+            continue
+        de_path, en_path = pair
+        pairs.append((de_path, en_path))
+        handled.add(de_path)
+        handled.add(en_path)
+    return pairs, solos

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -768,3 +768,286 @@ class TestSinglePath:
             slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
         )
         assert result.exit_code == 0, _combined(result)
+
+    def test_keys_watermark_by_resolved_path(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # The single-path surface must hand build_sync_plan **resolved** paths, so
+        # its watermark key matches the directory-batch surface (whose enumerator
+        # resolves every file). Otherwise the same pair gets two keys across
+        # surfaces and the second silently misses the first's watermark.
+        from clm.cli.commands import slides_sync as cmd
+
+        captured: dict[str, Path] = {}
+        real = cmd.build_sync_plan
+
+        def cap(de_path, en_path, **kw):
+            captured["de"], captured["en"] = de_path, en_path
+            return real(de_path, en_path, **kw)
+
+        monkeypatch.setattr(cmd, "build_sync_plan", cap)
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
+        )
+        assert result.exit_code == 0, _combined(result)
+        assert captured["de"] == de_path.resolve()
+        assert captured["en"] == en_path.resolve()
+
+
+class TestBatchMode:
+    """`clm slides sync DIR` — sweep every split pair under a directory (§8a).
+
+    A directory triggers batch mode: prefix-agnostic enumeration, solo halves
+    skipped with a warning, continue-on-error, a max-severity aggregate exit
+    code, a `--yes` gate on writes, and a `{mode, root, exit_code, pairs:[...]}`
+    JSON envelope whose per-pair entries reuse the single-pair object shape.
+    """
+
+    def _make_tree(
+        self, tmp_path: Path, *, with_solo: bool = True
+    ) -> tuple[Path, Path, dict[str, tuple[Path, Path]]]:
+        """A directory holding two prefix-less pairs (``apis`` in sync, ``web``
+        with DE edited vs the watermark) and — optionally — a solo DE half.
+
+        Watermarks are seeded with **resolved** paths because batch enumeration
+        resolves every file (so the watermark key matches what ``build_sync_plan``
+        looks up). Returns ``(root, cache_dir, {stem: (de, en)})``.
+        """
+        root = tmp_path / "decks"
+        root.mkdir()
+        cache_dir = tmp_path / "cache"
+        apis_de, apis_en = _write_pair(root, _DE_BASE, _EN_BASE, stem="apis")
+        web_de, web_en = _write_pair(root, _DE_EDITED, _EN_BASE, stem="web")
+        _seed_watermark(
+            cache_dir, apis_de.resolve(), apis_en.resolve(), de_text=_DE_BASE, en_text=_EN_BASE
+        )
+        _seed_watermark(
+            cache_dir, web_de.resolve(), web_en.resolve(), de_text=_DE_BASE, en_text=_EN_BASE
+        )
+        if with_solo:
+            (root / "orphan.de.py").write_text(_DE_BASE, encoding="utf-8")
+        return root, cache_dir, {"apis": (apis_de, apis_en), "web": (web_de, web_en)}
+
+    def test_dry_run_json_envelope_skips_solo_and_aggregates(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        root, cache_dir, _decks = self._make_tree(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--dry-run", "--json", "--cache-dir", str(cache_dir)],
+        )
+
+        # apis is in sync (0), web has a DE edit (1) -> aggregate max == 1.
+        assert result.exit_code == 1, _combined(result)
+        # The solo half is skipped with a warning, never synced against a phantom.
+        assert "skipping orphan.de.py" in (result.stderr or "")
+        payload = _json_payload(result)
+        assert payload["mode"] == "dry-run"
+        assert payload["root"] == str(root)
+        assert payload["exit_code"] == 1
+        assert len(payload["pairs"]) == 2
+        by_stem = {Path(p["de_path"]).name: p for p in payload["pairs"]}
+        # Each pair entry is the single-pair object shape verbatim.
+        assert by_stem["apis.de.py"]["plan"]["counts"]["edit"] == 0
+        assert by_stem["apis.de.py"]["exit_code"] == 0
+        assert by_stem["web.de.py"]["plan"]["counts"]["edit"] == 1
+        assert by_stem["web.de.py"]["plan"]["proposals"][0]["direction"] == "de->en"
+        assert by_stem["web.de.py"]["exit_code"] == 1
+
+    def test_dry_run_human_one_liner_and_rollup(self, cli_runner: CliRunner, tmp_path: Path):
+        root, cache_dir, _decks = self._make_tree(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--dry-run", "--cache-dir", str(cache_dir)],
+        )
+
+        out = result.output
+        assert result.exit_code == 1, _combined(result)
+        assert "OK     apis.de.py: nothing to do" in out
+        assert "REVIEW web.de.py: would change: 1 edit" in out
+        assert "2 pair(s): 1 clean, 1 review, 0 errored." in out
+
+    def test_apply_writes_every_pair_with_yes(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        # Both pairs edited so both apply.
+        root = tmp_path / "decks"
+        root.mkdir()
+        cache_dir = tmp_path / "cache"
+        a_de, a_en = _write_pair(root, _DE_EDITED, _EN_BASE, stem="apis")
+        w_de, w_en = _write_pair(root, _DE_EDITED, _EN_BASE, stem="web")
+        _seed_watermark(
+            cache_dir, a_de.resolve(), a_en.resolve(), de_text=_DE_BASE, en_text=_EN_BASE
+        )
+        _seed_watermark(
+            cache_dir, w_de.resolve(), w_en.resolve(), de_text=_DE_BASE, en_text=_EN_BASE
+        )
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--yes", "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert "Point one" in a_en.read_text(encoding="utf-8")
+        assert "Point one" in w_en.read_text(encoding="utf-8")
+        assert "2 pair(s): 2 clean, 0 review, 0 errored." in result.output
+        assert "Review the propagated changes with `git diff`" in result.output
+
+    def test_apply_without_yes_and_json_errors(self, cli_runner: CliRunner, tmp_path: Path):
+        root, cache_dir, _decks = self._make_tree(tmp_path, with_solo=False)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--json", "--cache-dir", str(cache_dir)],
+        )
+        assert result.exit_code != 0
+        assert "needs --yes" in _combined(result)
+
+    def test_apply_without_yes_prompts_and_abort_writes_nothing(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        root, cache_dir, decks = self._make_tree(tmp_path, with_solo=False)
+        before = {stem: en.read_text(encoding="utf-8") for stem, (_de, en) in decks.items()}
+
+        # Decline the confirm: the sweep aborts before any write.
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--cache-dir", str(cache_dir)],
+            input="n\n",
+        )
+
+        assert result.exit_code != 0
+        for stem, (_de, en) in decks.items():
+            assert en.read_text(encoding="utf-8") == before[stem]
+
+    def test_continue_on_error_aggregates_and_isolates(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # One pair raises during classification; the sweep records it as errored
+        # (exit 2) and still processes the other pair.
+        from clm.cli.commands import slides_sync as cmd
+
+        root, cache_dir, _decks = self._make_tree(tmp_path, with_solo=False)
+        real_build = cmd.build_sync_plan
+
+        def flaky_build(de_path, en_path, **kw):
+            if "web" in de_path.name:
+                raise RuntimeError("boom")
+            return real_build(de_path, en_path, **kw)
+
+        monkeypatch.setattr(cmd, "build_sync_plan", flaky_build)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--dry-run", "--cache-dir", str(cache_dir)],
+        )
+
+        out = result.output
+        assert result.exit_code == 2, _combined(result)
+        assert "OK     apis.de.py: nothing to do" in out
+        assert "ERROR  web.de.py: RuntimeError: boom" in out
+        assert "2 pair(s): 1 clean, 0 review, 1 errored." in out
+
+    def test_explain_prints_per_pair_anchor_diff(self, cli_runner: CliRunner, tmp_path: Path):
+        root, cache_dir, _decks = self._make_tree(tmp_path, with_solo=False)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(root), "--explain", "--cache-dir", str(cache_dir)],
+        )
+        out = _combined(result)
+        assert result.exit_code in (0, 1), out
+        assert "=== apis.de.py ===" in out
+        assert "=== web.de.py ===" in out
+        assert "anchor diff" in out
+        assert "2 pair(s):" in out
+
+    def test_empty_directory_reports_nothing(self, cli_runner: CliRunner, tmp_path: Path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        result = cli_runner.invoke(slides_sync_cmd, [str(empty), "--dry-run", "--no-cache"])
+        assert result.exit_code == 0, _combined(result)
+        assert "no split-format deck pairs found" in result.output
+
+    def test_empty_directory_json_envelope(self, cli_runner: CliRunner, tmp_path: Path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(empty), "--dry-run", "--json", "--no-cache"]
+        )
+        assert result.exit_code == 0, _combined(result)
+        payload = _json_payload(result)
+        assert payload["pairs"] == []
+        assert payload["exit_code"] == 0
+
+    def test_directory_with_second_path_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        root = tmp_path / "decks"
+        root.mkdir()
+        de_path, en_path = _write_pair(root, _DE_BASE, _EN_BASE, stem="apis")
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(root), str(en_path), "--dry-run", "--no-cache"]
+        )
+        assert result.exit_code != 0
+        assert "single" in _combined(result) and "directory" in _combined(result)
+
+    def test_directory_with_interactive_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        root = tmp_path / "decks"
+        root.mkdir()
+        _write_pair(root, _DE_BASE, _EN_BASE, stem="apis")
+        result = cli_runner.invoke(slides_sync_cmd, [str(root), "--interactive", "--no-cache"])
+        assert result.exit_code != 0
+        assert "--interactive" in _combined(result)
+
+    def test_excludes_pairs_under_ignored_dirs(self, cli_runner: CliRunner, tmp_path: Path):
+        # A vendored deck under .venv must not be synced by a directory run.
+        root = tmp_path / "decks"
+        root.mkdir()
+        _write_pair(root, _DE_BASE, _EN_BASE, stem="real")
+        vend = root / ".venv" / "pkg"
+        vend.mkdir(parents=True)
+        _write_pair(vend, _DE_BASE, _EN_BASE, stem="vendored")
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(root), "--dry-run", "--json", "--no-cache"]
+        )
+        assert result.exit_code == 0, _combined(result)
+        payload = _json_payload(result)
+        names = {Path(p["de_path"]).name for p in payload["pairs"]}
+        assert names == {"real.de.py"}  # vendored.de.py under .venv is pruned
+
+    def test_loads_env_from_nested_deck_dir(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch, restore_api_keys
+    ):
+        # A .env above a nested deck (but below root, with no root .env) must be
+        # found in batch mode — the writing path searches per-deck, not only root.
+        monkeypatch.delenv("CLM_SYNC_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from clm.cli.commands import slides_sync as cmd
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+        proposal = SyncProposal(verdict="update", proposed_text=_EN_PROPOSAL, reason="")
+        monkeypatch.setattr(
+            cmd, "OpenRouterSyncJudge", lambda **_kw: StaticSyncJudge(default_proposal=proposal)
+        )
+        root = tmp_path / "decks"
+        deck_dir = root / "mod" / "topic"
+        deck_dir.mkdir(parents=True)
+        cache_dir = tmp_path / "cache"
+        de_path, en_path = _write_pair(deck_dir, _DE_EDITED, _EN_BASE, stem="apis")
+        _seed_watermark(
+            cache_dir, de_path.resolve(), en_path.resolve(), de_text=_DE_BASE, en_text=_EN_BASE
+        )
+        # The key lives only in a .env beside the nested deck; root has none.
+        (deck_dir / ".env").write_text("OPENROUTER_API_KEY=sk-nested\n", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(root), "--yes", "--cache-dir", str(cache_dir)]
+        )
+
+        # Key found → the judge runs → the edit applies (exit 0). Before the fix
+        # the nested .env was missed → judge unavailable → exit 2.
+        assert result.exit_code == 0, _combined(result)
+        assert "Point one" in en_path.read_text(encoding="utf-8")

--- a/tests/slides/test_pairing.py
+++ b/tests/slides/test_pairing.py
@@ -19,7 +19,9 @@ from clm.slides.pairing import (
     derive_split_pair,
     derive_split_pair_from_stem,
     derive_split_twin,
+    find_split_slide_files_recursive,
     is_title_macro_cell,
+    iter_split_pairs,
     order_split_pair,
     split_lang_tag,
     split_twin,
@@ -363,3 +365,148 @@ class TestDeriveSplitPairFromStem:
         (tmp_path / "deck.de").write_text("# de\n", encoding="utf-8")
         (tmp_path / "deck.en").write_text("# en\n", encoding="utf-8")
         assert derive_split_pair_from_stem(tmp_path / "deck") is None
+
+
+class TestFindSplitSlideFilesRecursive:
+    """``find_split_slide_files_recursive`` — the prefix-agnostic enumerator
+    behind ``clm slides sync DIR`` (§8a / B1)."""
+
+    def _touch(self, *paths: Path) -> None:
+        for p in paths:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# x\n", encoding="utf-8")
+
+    def test_single_split_file_returns_itself_resolved(self, tmp_path: Path):
+        f = tmp_path / "apis.de.py"
+        self._touch(f)
+        assert find_split_slide_files_recursive(f) == [f.resolve()]
+
+    def test_single_non_split_file_returns_empty(self, tmp_path: Path):
+        f = tmp_path / "apis.py"  # no .de/.en tag
+        self._touch(f)
+        assert find_split_slide_files_recursive(f) == []
+
+    def test_finds_prefix_less_and_prefixed_halves(self, tmp_path: Path):
+        a_de, a_en = tmp_path / "apis.de.py", tmp_path / "apis.en.py"
+        s_de, s_en = tmp_path / "slides_x.de.py", tmp_path / "slides_x.en.py"
+        self._touch(a_de, a_en, s_de, s_en)
+        found = find_split_slide_files_recursive(tmp_path)
+        assert set(found) == {a_de.resolve(), a_en.resolve(), s_de.resolve(), s_en.resolve()}
+
+    def test_descends_full_subtree_no_early_exit(self, tmp_path: Path):
+        # A stray top-level deck must NOT stop the walk from reaching nested dirs
+        # (the silent-miss trap that the prefix-gated early-exit helper falls into).
+        top_de, top_en = tmp_path / "top.de.py", tmp_path / "top.en.py"
+        nested_de = tmp_path / "mod" / "topic" / "deep.de.py"
+        nested_en = tmp_path / "mod" / "topic" / "deep.en.py"
+        self._touch(top_de, top_en, nested_de, nested_en)
+        found = set(find_split_slide_files_recursive(tmp_path))
+        assert nested_de.resolve() in found and nested_en.resolve() in found
+        assert top_de.resolve() in found
+
+    def test_excludes_voiceover_companions(self, tmp_path: Path):
+        self._touch(
+            tmp_path / "apis.de.py",
+            tmp_path / "apis.en.py",
+            tmp_path / "voiceover_apis.de.py",
+            tmp_path / "voiceover_apis.en.py",
+        )
+        found = find_split_slide_files_recursive(tmp_path)
+        assert all("voiceover_" not in p.name for p in found)
+        assert len(found) == 2
+
+    def test_excludes_unsupported_extensions_and_bilingual(self, tmp_path: Path):
+        self._touch(
+            tmp_path / "apis.de.py",
+            tmp_path / "apis.en.py",
+            tmp_path / "notes.de.txt",  # unsupported extension
+            tmp_path / "apis.py",  # bilingual stem (no tag)
+        )
+        found = find_split_slide_files_recursive(tmp_path)
+        assert {p.name for p in found} == {"apis.de.py", "apis.en.py"}
+
+    def test_other_languages_supported(self, tmp_path: Path):
+        c_de, c_en = tmp_path / "demo.de.cpp", tmp_path / "demo.en.cpp"
+        self._touch(c_de, c_en)
+        assert set(find_split_slide_files_recursive(tmp_path)) == {c_de.resolve(), c_en.resolve()}
+
+    def test_missing_path_returns_empty(self, tmp_path: Path):
+        assert find_split_slide_files_recursive(tmp_path / "nope") == []
+
+    def test_excludes_pairs_under_ignored_dirs(self, tmp_path: Path):
+        # A vendored/archived deck under .git/.venv/build/__pycache__ must never be
+        # enumerated (and thus never written on a directory apply).
+        legit_de = tmp_path / "module_x" / "topic_a" / "apis.de.py"
+        legit_en = tmp_path / "module_x" / "topic_a" / "apis.en.py"
+        self._touch(legit_de, legit_en)
+        for ignored in (".venv", ".git", "build", "__pycache__", "dist"):
+            self._touch(tmp_path / ignored / "vend.de.py", tmp_path / ignored / "vend.en.py")
+        found = find_split_slide_files_recursive(tmp_path)
+        assert set(found) == {legit_de.resolve(), legit_en.resolve()}
+
+    def test_root_under_ignored_component_still_enumerates(self, tmp_path: Path):
+        # The ignored-dir test is applied RELATIVE to the root, so a root that
+        # itself lives under a dir named like an ignored one (e.g. ``build/``)
+        # must not falsely exclude its own decks.
+        root = tmp_path / "build" / "decks"
+        de, en = root / "apis.de.py", root / "apis.en.py"
+        self._touch(de, en)
+        found = find_split_slide_files_recursive(root)
+        assert set(found) == {de.resolve(), en.resolve()}
+
+    def test_named_ignored_file_still_honoured(self, tmp_path: Path):
+        # The single-file branch is exempt from the ignored-dir prune: an
+        # explicitly named half is always honoured, even under .venv.
+        f = tmp_path / ".venv" / "apis.de.py"
+        self._touch(f)
+        assert find_split_slide_files_recursive(f) == [f.resolve()]
+
+
+class TestIterSplitPairs:
+    """``iter_split_pairs`` — partition split halves into ordered pairs + solos
+    (§8a / B2)."""
+
+    def _touch(self, *paths: Path) -> list[Path]:
+        for p in paths:
+            p.write_text("# x\n", encoding="utf-8")
+        return list(paths)
+
+    def test_pairs_ordered_de_first(self, tmp_path: Path):
+        de, en = tmp_path / "apis.de.py", tmp_path / "apis.en.py"
+        self._touch(de, en)
+        pairs, solos = iter_split_pairs([en, de])  # en passed first
+        assert pairs == [(de, en)]  # still (de, en)-ordered
+        assert solos == []
+
+    def test_solo_half_with_no_twin_is_isolated(self, tmp_path: Path):
+        de, en = tmp_path / "apis.de.py", tmp_path / "apis.en.py"
+        orphan = tmp_path / "orphan.de.py"
+        self._touch(de, en, orphan)
+        pairs, solos = iter_split_pairs([de, en, orphan])
+        assert pairs == [(de, en)]
+        assert solos == [orphan]
+
+    def test_twin_on_disk_but_not_in_paths_is_solo(self, tmp_path: Path):
+        # The twin exists on disk but was not handed in (caller passed a subset):
+        # it must be reported solo, not silently pulled in from outside the set.
+        de, en = tmp_path / "apis.de.py", tmp_path / "apis.en.py"
+        self._touch(de, en)
+        pairs, solos = iter_split_pairs([de])  # en omitted from the input set
+        assert pairs == []
+        assert solos == [de]
+
+    def test_multiple_pairs_deterministic_order(self, tmp_path: Path):
+        a_de, a_en = tmp_path / "apis.de.py", tmp_path / "apis.en.py"
+        w_de, w_en = tmp_path / "web.de.py", tmp_path / "web.en.py"
+        self._touch(a_de, a_en, w_de, w_en)
+        pairs, solos = iter_split_pairs([w_en, a_de, w_de, a_en])
+        assert pairs == [(a_de, a_en), (w_de, w_en)]  # sorted-input order
+        assert solos == []
+
+    def test_every_path_lands_in_exactly_one_list(self, tmp_path: Path):
+        de, en = tmp_path / "apis.de.py", tmp_path / "apis.en.py"
+        orphan = tmp_path / "orphan.en.py"
+        self._touch(de, en, orphan)
+        pairs, solos = iter_split_pairs([de, en, orphan])
+        flattened = [p for pair in pairs for p in pair] + solos
+        assert sorted(flattened) == sorted([de, en, orphan])


### PR DESCRIPTION
## Summary

`clm slides sync DIR` — the final item of the §8 command-surface rethink. Pass a **directory** and every `.de`/`.en` deck pair under the tree is synced in one pass. The single-file and two-path forms are unchanged (purely additive).

**Pre-decided contract:**
- A directory arg triggers batch (`dir_okay=True` + branch on `de_path.is_dir()` — one funnel, no `sync-all` subcommand).
- **Continue-on-error** with a **max-severity** aggregate exit code (`0` clean < `1` review < `2` error).
- A **writing** directory run requires **`--yes`** (or an interactive confirm); `--dry-run` / `--explain` directory runs are unprompted. `--interactive` stays single-pair only.
- Enumeration is **prefix-agnostic** (un-prefixed decks like `apis.de.py` count too), descends the whole subtree, excludes `voiceover_*` companions, and prunes ignored dirs (`.git`/`.venv`/`build`/…). A half with no twin under the tree is **skipped with a warning**, never synced against a phantom empty twin.
- `--json` over a directory returns an envelope `{mode, root, exit_code, pairs:[…]}` where each clean/review pair is one single-pair object (the flat single-pair `--json` shape is preserved) and an errored pair is `{de_path, en_path, mode, exit_code, error}`.

## What changed

- **`pairing.py`** — `find_split_slide_files_recursive` (prefix-agnostic, full-subtree, ignored-dir prune relative to root, `voiceover_*` excluded, `.resolve()`d for stable watermark keys) + `iter_split_pairs(paths) → (pairs, solos)` (pure, deterministic, solo halves isolated).
- **`slides_sync.py`** — `dir_okay=True` + `--yes`; `de_path.is_dir()` branch before the single-path resolution; `_run_batch` (one watermark/alignment cache + one judge/translator/recoverer, per-pair `build_sync_plan` + apply/dry-run/explain inside one try/finally, continue-on-error, max-severity aggregate exit, per-deck `.env` discovery) + batch human/JSON output helpers. The single-pair path now resolves its pair so its watermark key matches the batch surface.

## Adversarial review (find→verify)

A 3-lens review (silent-miss / safety-lifecycle / contract-compat, each finding checked by a default-to-refute verifier) surfaced 4 findings → 1 refuted, **3 confirmed and fixed**, each with a regression test:

| Severity | Finding | Fix |
|---|---|---|
| low | Enumerator descended ignored dirs → a vendored `.de`/`.en` copy could be *written* on a directory apply | Prune via `is_ignored_dir_for_course`, tested **relative to root** so an ignored component in root's own prefix can't falsely exclude everything; single-file branch exempt |
| low | Batch `.env` discovery searched only from root → a `.env` above a nested deck was missed | `load_env_files(root, *deck_dirs)` — per-deck discovery, matching the single-pair rule |
| medium | Batch enumerator resolves paths but the single-pair surface didn't → the *same* pair got two watermark keys across surfaces (silent re-baseline) | Single-pair now `.resolve()`s its pair before `build_sync_plan`, converging both surfaces on the absolute key |

## Tests

- 13 `TestBatchMode` CLI tests + 13 enumerator/iterator unit tests + the 3 review-fix regressions.
- `tests/slides` + `tests/cli` → **2256 passed, 3 skipped, 1 xfailed**; ruff + mypy clean; all pre-commit hooks passed.

## Docs

- `clm info commands` (sync `DIR` usage, `--yes` row, JSON-envelope paragraph, examples) and `clm info migration` (batch-mode section) updated per the Info Topics rule; `CHANGELOG.md` `[Unreleased]` entry; design doc §8a marked SHIPPED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)