### PR TITLE
fix(slides): scope a tag-only sync conflict to its own cell, not the whole watermark (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`clm slides sync` no longer re-surfaces a clean edit as a phantom conflict
+  when a tag-only conflict also warns (#202).** A both-decks tag conflict (the
+  `both` branch of the #198/#200/#201 retag paths — the same role-preserving tag
+  changed on *both* halves) used to hold the **whole-deck** watermark: any clean
+  edit applied in the same pass reached disk but was never baselined, so it
+  re-appeared as a spurious `conflict` on every subsequent run until the unrelated
+  tag conflict was resolved by hand (loud and lossless, but non-idempotent). A
+  tag-only conflict touches no cell *body*, so sync now scopes the hold to just
+  that one cell's tags — pinning them at the old baseline so the conflict still
+  re-surfaces — while the partial watermark advance banks the co-applied edit (and
+  every other reconciled cell). Both the id-carrying (#200, keyed by
+  `(slide_id, role)`) and id-less (#201, keyed by position) `both` paths are fixed
+  together. Structural warnings (both-decks reorder, ambiguous de/en state,
+  shared-cell auto-heal) still hold the whole watermark, as before.
+
 ## [1.7.0] - 2026-06-04
 
 ### Added

--- a/docs/claude/design/single-language-authoring-sync.md
+++ b/docs/claude/design/single-language-authoring-sync.md
@@ -597,6 +597,27 @@ monotonically safe (it only adds holds, never advances). 12
 Lesson logged: never seed an adversarial review with an unproven invariant — it
 manufactures false positives.
 
+**Part 2b refinement — tag-only conflicts are scoped, not whole-deck holds (#202,
+✅ 2026-06-04).** The `not plan.issues` gate above is correct for *structural*
+warnings (a both-decks reorder, an ambiguous de/en state, a shared-cell auto-heal)
+— their order/ambiguity can't be partially advanced, so they must hold the whole
+watermark. But it was too broad for a **tag-only both-decks conflict** (the `both`
+branch of the #198/#200/#201 retag paths): such a warning touches no cell *body*,
+yet it held the entire deck's baseline hostage, so a clean edit applied in the same
+pass reached disk but never baselined and re-surfaced as a *phantom `conflict`*
+every run until the unrelated tag conflict was resolved by hand (non-idempotent).
+Fix: a `both` tag warning now carries a `PlanIssue.tag_hold` (`TagHold` — keyed by
+`(slide_id, role)` for an id-carrying cell, by position for an id-less localized
+one). `SyncPlan.blocking_issues` excludes tag-hold issues, so the advance gate
+(top-level + `_eligible_for_partial_advance`) ignores them and the partial advance
+runs; `_record_watermark_partial` then pins **only the held cell's tags** to their
+old baseline (on both halves) — banking every body baseline and the co-applied
+edit, while the tag conflict still re-surfaces (no silent baselining). A tag hold
+also makes a content-only pass eligible on its own, since a co-applied clean edit
+may have `deferred == 0`. The id-carrying (#200) and id-less (#201) `both` paths
+are fixed together. See `sync_plan.py::TagHold` / `SyncPlan.blocking_issues` and
+`sync_apply.py::_record_watermark_partial` / `_tag_hold_position`.
+
 Live `clm slides sync` STILL UNCHANGED (Phase 5 wires the engine + flips the
 default).
 

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -43,7 +43,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.llm.ollama_client import OllamaError
-from clm.notebooks.slide_parser import parse_cell_header, parse_cells
+from clm.notebooks.slide_parser import Cell, parse_cell_header, parse_cells
 from clm.slides.raw_cells import RawCell
 from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_code import apply_code_structure
@@ -52,6 +52,7 @@ from clm.slides.sync_plan import (
     NEUTRAL_CODE_ROLE,
     Proposal,
     SyncPlan,
+    TagHold,
     ordered_sync_cells,
     watermark_rows,
     watermark_tag_map,
@@ -305,13 +306,18 @@ def apply_plan(
     # forces every reconciled edit to re-surface next run. Any other partial
     # pass holds the whole watermark (nothing un-applied is ever baselined).
     #
-    # ``not plan.issues`` gates BOTH paths: a both-decks reorder or an ambiguous
-    # de/en state is emitted as a *warning* (no proposal, no error) whose order/
-    # ambiguity is deliberately not reconciled. Advancing over it — on either the
-    # full or the partial path — would bake the new positions and silently lose
-    # the "resolve manually" signal, so any issue holds the whole watermark.
-    if watermark_cache is not None and not plan.issues:
-        if _pass_is_clean(plan, result):
+    # ``not plan.blocking_issues`` gates BOTH paths: a both-decks reorder, an
+    # ambiguous de/en state, or a shared-cell auto-heal is emitted as a *warning*
+    # (no proposal, no error) whose order/ambiguity is deliberately not reconciled.
+    # Advancing over it — on either path — would bake the new positions and
+    # silently lose the "resolve manually" signal, so any such issue holds the
+    # whole watermark. A *tag-only* both-decks conflict (Issue #202), by contrast,
+    # touches no body and is scoped to one cell's tags: it does NOT block, but it
+    # forces the partial path (the full path would record the divergent tags and
+    # silently baseline them), where its own cell's tags are pinned at the old
+    # baseline so the conflict re-surfaces while everything else banks.
+    if watermark_cache is not None and not plan.blocking_issues:
+        if _pass_is_clean(plan, result) and not plan.tag_holds:
             _record_watermark(watermark_cache, plan.de_path, plan.en_path)
             result.watermark_recorded = True
         elif (
@@ -322,7 +328,7 @@ def apply_plan(
             # key), hold the whole watermark rather than risk advancing over it.
             and len(deferred_keys) == result.deferred
             and _record_watermark_partial(
-                watermark_cache, plan.de_path, plan.en_path, deferred_keys
+                watermark_cache, plan.de_path, plan.en_path, deferred_keys, plan.tag_holds
             )
         ):
             result.watermark_recorded = True
@@ -1739,24 +1745,32 @@ def _eligible_for_partial_advance(plan: SyncPlan, result: ApplyResult) -> bool:
     """Whether a per-cell partial watermark advance is safe for this pass.
 
     Restricted to a **content-only** partial pass: every proposal is an
-    ``edit`` or ``conflict`` (no add / remove / move / rename) AND the plan
-    carries **no issues**. The no-issues guard matters: a both-decks reorder or
-    an ambiguous de/en state is emitted as a *warning* (not a proposal and not
-    an error), and its order/ambiguity is deliberately not reconciled — so a
-    pass carrying any issue must hold the whole watermark, else that
-    un-propagated signal would be silently baselined. With neither structural
-    proposals nor issues, both decks' ordered ``(slide_id, role)`` structure is
-    unchanged, so current positions equal baseline positions.
+    ``edit`` / ``conflict`` / ``retag`` (no add / remove / move / rename) AND the
+    plan carries **no blocking issues**. The blocking-issue guard matters: a
+    both-decks reorder or an ambiguous de/en state is emitted as a *warning* (not
+    a proposal and not an error), and its order/ambiguity is deliberately not
+    reconciled — so a pass carrying any such issue must hold the whole watermark,
+    else that un-propagated signal would be silently baselined. A *tag-only*
+    both-decks conflict (Issue #202) is **not** blocking: it touches no body, so
+    the body baseline (and current positions) are unchanged and the partial
+    advance can bank everything while pinning just that cell's tags. With neither
+    structural proposals nor blocking issues, both decks' ordered ``(slide_id,
+    role)`` structure is unchanged, so current positions equal baseline positions.
 
-    Requires a real baseline, no errors, no issues, at least one deferral (a
-    clean pass already did a full advance), and at least one *reconciled write*
-    (``applied_edit > 0``) — there is nothing to bank in a pass that only
-    deferred, so it just holds. Any other partial pass falls back to holding the
-    whole watermark — safe, just noisier on the next run.
+    Requires a real baseline, no errors, and *something to bank*: either a
+    reconciled write co-existing with a deferral (``applied_edit > 0`` and
+    ``deferred > 0`` — a clean pass with neither already did a full advance), or a
+    tag-only hold to pin (Issue #202). Any other partial pass falls back to
+    holding the whole watermark — safe, just noisier on the next run.
     """
-    if not plan.has_baseline or plan.issues or result.errors:
+    if not plan.has_baseline or plan.blocking_issues or result.errors:
         return False
-    if result.deferred <= 0 or result.applied_edit <= 0:
+    # A tag-only hold (#202) is itself a per-cell deferral the partial path banks
+    # around, so it makes the pass eligible on its own (a co-applied clean edit may
+    # have ``deferred == 0``). Absent a tag hold, fall back to the original
+    # content-conflict rule: bank only when a reconciled write and a true deferral
+    # co-exist — there is nothing to bank in a pass that only deferred.
+    if not plan.tag_holds and (result.deferred <= 0 or result.applied_edit <= 0):
         return False
     structural = (
         plan.count("add") + plan.count("remove") + plan.count("move") + plan.count("rename")
@@ -1764,30 +1778,63 @@ def _eligible_for_partial_advance(plan: SyncPlan, result: ApplyResult) -> bool:
     return structural == 0
 
 
+def _tag_hold_position(cells: list[Cell], lang: str, hold: TagHold) -> int | None:
+    """The membership-partition index of the cell a :class:`TagHold` pins (#202).
+
+    An id-less hold carries its ``position`` directly — the watermark ``lang``
+    partition index, identical on both aligned halves (the classifier emits it only
+    once :func:`_streams_aligned` holds). An id-carrying hold is located by
+    ``(slide_id, role)`` among the language's non-j2 cells, counting in the exact
+    per-partition order :func:`watermark_rows` / :func:`watermark_tag_map` assign.
+    Returns ``None`` when an id-carrying cell is absent (so the caller can hold the
+    whole watermark rather than pin the wrong cell).
+    """
+    if hold.position is not None:
+        return hold.position
+    pos = 0
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.lang != lang:
+            continue
+        if meta.slide_id == hold.slide_id and role_of(meta) == hold.role:
+            return pos
+        pos += 1
+    return None
+
+
 def _record_watermark_partial(
     cache: SyncWatermarkCache,
     de_path: Path,
     en_path: Path,
     preserve_keys: set[tuple[str, str]],
+    tag_holds: list[TagHold],
 ) -> bool:
     """Advance the watermark per-cell, holding the true deferrals at baseline.
 
     Records the **current** state for every cell — the reconciliation default,
-    matching the full advance — EXCEPT for any ``(slide_id, role)`` in
-    ``preserve_keys`` (an unresolved conflict or a user-skipped edit), which
-    keeps its **old** baseline hash so it re-surfaces next run instead of being
-    silently baselined. An ``in_sync`` edit is *not* a deferral — the judge
-    reconciled it — so it banks like an applied edit.
+    matching the full advance — EXCEPT for two kinds of held cell:
 
-    Valid only on a content-only, issue-free pass (see
+    - any ``(slide_id, role)`` in ``preserve_keys`` (an unresolved conflict or a
+      user-skipped edit) keeps its **old** baseline *body hash* so it re-surfaces
+      next run instead of being silently baselined; and
+    - any cell named by a ``tag_hold`` (Issue #202 — a tag-only both-decks
+      conflict) keeps its **old** baseline *tags* on both halves, so the tag
+      conflict re-surfaces while its body baseline — and every other cell,
+      including a co-applied clean edit — still banks.
+
+    An ``in_sync`` edit is *not* a deferral — the judge reconciled it — so it banks
+    like an applied edit.
+
+    Valid only on a content-only pass with no *blocking* issues (see
     :func:`_eligible_for_partial_advance`): structure is unchanged, so current
     positions equal baseline positions. Returns ``False`` without writing if any
     preserved key is absent from *either* deck's old baseline **or** current
-    cells. The current-cell check matters: a "removed on one deck / edited on the
-    other" collision is classified as a ``conflict`` (not a ``remove``), so it
-    slips the structural gate, yet the cell is gone from the removing deck — we
-    cannot faithfully preserve it there, so we hold the whole watermark and let
-    the conflict re-surface instead of dropping it.
+    cells, or if a tag hold cannot be faithfully located / lacks an old baseline
+    tag set on either half. The current-cell check matters: a "removed on one deck
+    / edited on the other" collision is classified as a ``conflict`` (not a
+    ``remove``), so it slips the structural gate, yet the cell is gone from the
+    removing deck — we cannot faithfully preserve it there, so we hold the whole
+    watermark and let the conflict re-surface instead of dropping it.
     """
     parsed = {
         "de": parse_cells(de_path.read_text(encoding="utf-8")),
@@ -1822,8 +1869,24 @@ def _record_watermark_partial(
     # membership rows re-derive faithfully from the current files.
     widened = {"de": watermark_rows(parsed["de"]), "en": watermark_rows(parsed["en"])}
     # Issue #198: a content-only pass leaves every cell's tags as they are on disk,
-    # so the current tag map is the right baseline for every recorded cell.
+    # so the current tag map is the right baseline for every recorded cell — EXCEPT
+    # the Issue #202 tag holds, whose tags we rewind to the old baseline below.
     tag_map = {"de": watermark_tag_map(parsed["de"]), "en": watermark_tag_map(parsed["en"])}
+    if tag_holds:
+        old_tags = {
+            "de": cache.get_deck_tags(str(de_path), str(en_path), "de"),
+            "en": cache.get_deck_tags(str(de_path), str(en_path), "en"),
+        }
+        for hold in tag_holds:
+            for lang in ("de", "en"):
+                pos = _tag_hold_position(parsed[lang], lang, hold)
+                # A both-decks tag conflict only ever fires with a known baseline on
+                # both halves, so a missing position / tag here means the held cell
+                # could not be faithfully re-located — hold the whole watermark
+                # rather than risk pinning (or silently advancing) the wrong cell.
+                if pos is None or pos not in old_tags[lang]:
+                    return False
+                tag_map[lang][lang][pos] = old_tags[lang][pos]
     for lang in ("de", "en"):
         rows: list[tuple[int, str | None, str, str, str | None]] = []
         for pos, sid, role, chash, construct in widened[lang][lang]:

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -58,6 +58,7 @@ __all__ = [
     "PlanIssue",
     "Proposal",
     "SyncPlan",
+    "TagHold",
     "align_anchored",
     "build_sync_plan",
     "classify_changes",
@@ -165,6 +166,26 @@ class Proposal:
     tags: tuple[str, ...] | None = None  # desired tag set for an id-less localized ``retag``
 
 
+@dataclass(frozen=True)
+class TagHold:
+    """A tag-only both-decks conflict to pin at its old baseline (Issue #202).
+
+    A both-sides tag drift (the ``both`` branch of :func:`_retag_direction`) never
+    touches a cell body, so the body baseline is safe to advance for every cell
+    while *this one cell's tags* are held at the old baseline value — so the
+    conflict re-surfaces next run instead of being silently baselined, yet a
+    co-applied clean edit still banks. Identifies the held cell the same two ways
+    the retag paths do: ``(slide_id, role)`` for an id-carrying cell
+    (:func:`_maybe_retag`, #200) or ``position`` — the watermark partition index,
+    identical on both halves under stream alignment — for an id-less localized cell
+    (:func:`_classify_localized_idless_retags`, #201). Exactly one identity is set.
+    """
+
+    slide_id: str | None = None
+    role: str | None = None
+    position: int | None = None
+
+
 @dataclass
 class PlanIssue:
     """A structural situation the classifier will not turn into a proposal."""
@@ -172,6 +193,13 @@ class PlanIssue:
     severity: str  # "warning" | "error"
     slide_id: str | None
     reason: str
+    # Issue #202: set only on a *tag-only* both-decks conflict, which is scoped to
+    # one cell's tags and touches no body. A warning carrying a ``tag_hold`` no
+    # longer holds the whole-deck watermark: the partial advance banks everything
+    # else and pins just this cell's tags at the old baseline. ``None`` for every
+    # structural warning (reorder, ambiguous de/en state, shared-cell auto-heal),
+    # which must keep holding the whole watermark.
+    tag_hold: TagHold | None = None
 
 
 @dataclass
@@ -196,6 +224,22 @@ class SyncPlan:
     @property
     def has_errors(self) -> bool:
         return any(i.severity == "error" for i in self.issues)
+
+    @property
+    def blocking_issues(self) -> list[PlanIssue]:
+        """Issues that hold the whole-deck watermark (Issue #202).
+
+        Every issue *except* a tag-only both-decks conflict (one carrying a
+        :class:`TagHold`): errors, both-decks reorders, ambiguous de/en states,
+        and the shared-cell auto-heal warning all concern structure that cannot be
+        partially advanced safely, so any of them holds the whole watermark.
+        """
+        return [i for i in self.issues if i.tag_hold is None]
+
+    @property
+    def tag_holds(self) -> list[TagHold]:
+        """The per-cell tag-only conflicts safe to hold while the rest advances (#202)."""
+        return [i.tag_hold for i in self.issues if i.tag_hold is not None]
 
     @property
     def is_noop(self) -> bool:
@@ -1179,6 +1223,9 @@ def _maybe_retag(
                 reason=f"role={role!r} tags changed on both decks "
                 f"(de={sorted(de_now.tags)}, en={sorted(en_now.tags)}); "
                 "not propagated — reconcile tags manually",
+                # Issue #202: tag-only, body untouched — pin this cell's tags at the
+                # old baseline (by id) while the rest of the pass advances.
+                tag_hold=TagHold(slide_id=key[0], role=role),
             )
         )
 
@@ -1365,6 +1412,10 @@ def _classify_localized_idless_retags(
                     reason=f"id-less localized cell #{i} tags changed on both decks "
                     f"(de={sorted(de_now)}, en={sorted(en_now)}); "
                     "not propagated — reconcile tags manually",
+                    # Issue #202: tag-only, body untouched — pin this cell's tags at
+                    # the old baseline (by position, identical on both aligned
+                    # halves) while the rest of the pass advances.
+                    tag_hold=TagHold(position=i),
                 )
             )
 

--- a/tests/slides/test_sync_tag_sync.py
+++ b/tests/slides/test_sync_tag_sync.py
@@ -12,12 +12,20 @@ from __future__ import annotations
 from pathlib import Path
 
 from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
-from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_apply import (
+    ApplyResult,
+    _eligible_for_partial_advance,  # noqa: PLC2701 (white-box unit)
+    apply_plan,
+)
 from clm.slides.sync_plan import (
     BaselineCell,
     CurrentCell,
+    PlanIssue,
+    Proposal,
     SyncPlan,
+    TagHold,
     _maybe_retag,  # noqa: PLC2701 (white-box unit)
     _retag_direction,  # noqa: PLC2701 (white-box unit)
     build_sync_plan,
@@ -26,6 +34,12 @@ from clm.slides.sync_plan import (
     watermark_tag_map,
 )
 from clm.slides.sync_writeback import FileState, set_header_tags
+
+
+def _update_judge(text: str) -> StaticSyncJudge:
+    """A judge that rewrites every edited cell to ``text`` (no Ollama)."""
+    return StaticSyncJudge(default_proposal=SyncProposal(verdict="update", proposed_text=text))
+
 
 # ---------------------------------------------------------------------------
 # Builders
@@ -719,5 +733,231 @@ class TestIdlessLocalizedRetagApply:
             assert result.errors == []
             assert _tags_of(de_path, "rag") == {"subslide", "keep"}
             assert _idless_code_tags(de_path, "Kapitel 3") == {"keep"}
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #202 — a both-decks tag conflict no longer holds the whole watermark
+# ---------------------------------------------------------------------------
+
+
+class TestPlanIssueScoping:
+    """A tag-only ``both`` conflict carries a :class:`TagHold` and is *not* blocking;
+    every structural warning (reorder, ambiguity, auto-heal) stays blocking."""
+
+    def _plan(self) -> SyncPlan:
+        return SyncPlan(
+            de_path=Path("d.de.py"), en_path=Path("d.en.py"), baseline_source="watermark"
+        )
+
+    def test_tag_hold_issue_is_not_blocking(self):
+        plan = self._plan()
+        plan.issues.append(
+            PlanIssue("warning", "x", "tags changed on both decks", tag_hold=TagHold("x", "slide"))
+        )
+        assert plan.blocking_issues == []
+        assert [h.slide_id for h in plan.tag_holds] == ["x"]
+
+    def test_idless_tag_hold_carries_position(self):
+        plan = self._plan()
+        plan.issues.append(
+            PlanIssue("warning", None, "id-less ... both decks", tag_hold=TagHold(position=3))
+        )
+        assert plan.blocking_issues == []
+        assert [h.position for h in plan.tag_holds] == [3]
+
+    def test_structural_warning_stays_blocking(self):
+        plan = self._plan()
+        plan.issues.append(PlanIssue("warning", None, "cell order drifted on both decks"))
+        assert len(plan.blocking_issues) == 1
+        assert plan.tag_holds == []
+
+    def test_mixed_issues_partition_cleanly(self):
+        plan = self._plan()
+        plan.issues.append(PlanIssue("warning", None, "auto-healed toward de->en"))  # blocking
+        plan.issues.append(PlanIssue("warning", None, "tag", tag_hold=TagHold(position=0)))
+        plan.issues.append(PlanIssue("error", None, "duplicate id"))  # blocking (and an error)
+        assert len(plan.blocking_issues) == 2
+        assert len(plan.tag_holds) == 1
+
+
+class TestPartialAdvanceEligibilityWithTagHold:
+    """White-box: a tag hold makes a content-only pass eligible; a blocking issue does not."""
+
+    def _plan(self, *issues: PlanIssue, proposals=()) -> SyncPlan:
+        plan = SyncPlan(
+            de_path=Path("d.de.py"), en_path=Path("d.en.py"), baseline_source="watermark"
+        )
+        plan.issues.extend(issues)
+        plan.proposals.extend(proposals)
+        return plan
+
+    def test_tag_hold_eligible_even_with_no_deferral(self):
+        # #202: a co-applied clean edit may have deferred == 0; the tag hold itself
+        # makes the pass eligible so the edit can bank.
+        plan = self._plan(
+            PlanIssue("warning", None, "tag", tag_hold=TagHold(position=0)),
+            proposals=[Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")],
+        )
+        assert _eligible_for_partial_advance(plan, ApplyResult(applied_edit=1, deferred=0)) is True
+
+    def test_blocking_issue_makes_ineligible(self):
+        plan = self._plan(
+            PlanIssue("warning", None, "cell order drifted on both decks"),
+            proposals=[Proposal(kind="edit", role="slide", direction="de->en", slide_id="a")],
+        )
+        assert _eligible_for_partial_advance(plan, ApplyResult(applied_edit=1, deferred=1)) is False
+
+    def test_structural_proposal_makes_ineligible_even_with_tag_hold(self):
+        plan = self._plan(
+            PlanIssue("warning", None, "tag", tag_hold=TagHold(position=0)),
+            proposals=[Proposal(kind="move", role="slide", direction="de->en", slide_id="a")],
+        )
+        assert _eligible_for_partial_advance(plan, ApplyResult(applied_edit=0, deferred=0)) is False
+
+    def test_no_tag_hold_keeps_original_edit_plus_deferral_rule(self):
+        plan = self._plan()  # no issues, no proposals
+        assert _eligible_for_partial_advance(plan, ApplyResult(applied_edit=1, deferred=0)) is False
+        assert _eligible_for_partial_advance(plan, ApplyResult(applied_edit=0, deferred=1)) is False
+        assert _eligible_for_partial_advance(plan, ApplyResult(applied_edit=1, deferred=1)) is True
+
+
+class TestWatermarkAdvanceOverTagWarning:
+    """Issue #202: a co-applied clean edit banks even when a both-decks tag conflict
+    warns. The warning re-surfaces every run (no silent baselining) but no longer
+    forces the applied edit to re-appear as a phantom conflict."""
+
+    def test_idless_both_tag_warning_with_clean_edit_converges(self, tmp_path: Path):
+        # The faithful repro: an id'd slide `a` edited cleanly on DE, alongside a
+        # genuine both-sides tag conflict on an id-less localized code cell.
+        de = _md("de", "a", ["slide"], "# ## A_OLD") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "a", ["slide"], "# ## A_OLD_EN") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            de_path.write_text(
+                _md("de", "a", ["slide"], "# ## A_NEW") + _code("de", None, ["keep"], _DE_INVOKE),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _md("en", "a", ["slide"], "# ## A_OLD_EN") + _code("en", None, ["alt"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan0 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan0.count("edit") == 1
+            assert len(plan0.tag_holds) == 1  # the both-tag conflict is scoped, not blocking
+            assert plan0.blocking_issues == []
+            res0 = apply_plan(plan0, judge=_update_judge("## A_NEW_EN"), watermark_cache=cache)
+            assert res0.applied_edit == 1
+            assert res0.errors == []
+            assert res0.watermark_recorded is True  # #202: edit banks despite the warning
+            assert any("both decks" in i.reason for i in plan0.issues)
+            # Pass 1: NO further edits. The edit must NOT re-surface as a phantom
+            # conflict; the tag warning persists (not silently baselined).
+            plan1 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan1.count("conflict") == 0
+            assert plan1.count("edit") == 0
+            assert len(plan1.tag_holds) == 1
+            # Pass 2: still converged.
+            plan2 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan2.count("conflict") == 0
+        finally:
+            cache.close()
+
+    def test_idcarrying_both_tag_warning_with_clean_edit_converges(self, tmp_path: Path):
+        # Same hazard on an id-carrying localized code cell (`code` role via slide_id).
+        de = _md("de", "a", ["slide"], "# ## A_OLD") + _code("de", "inv", [], 'x = q("Frage")')
+        en = _md("en", "a", ["slide"], "# ## A_OLD_EN") + _code(
+            "en", "inv", [], 'x = q("question")'
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            de_path.write_text(
+                _md("de", "a", ["slide"], "# ## A_NEW")
+                + _code("de", "inv", ["keep"], 'x = q("Frage")'),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _md("en", "a", ["slide"], "# ## A_OLD_EN")
+                + _code("en", "inv", ["alt"], 'x = q("question")'),
+                encoding="utf-8",
+            )
+            plan0 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan0.count("edit") == 1
+            assert len(plan0.tag_holds) == 1
+            assert plan0.tag_holds[0].slide_id == "inv"  # located by id, not position
+            assert plan0.tag_holds[0].role == "code"
+            assert plan0.blocking_issues == []
+            res0 = apply_plan(plan0, judge=_update_judge("## A_NEW_EN"), watermark_cache=cache)
+            assert res0.applied_edit == 1
+            assert res0.watermark_recorded is True
+            plan1 = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan1.count("conflict") == 0
+            assert plan1.count("edit") == 0
+            assert len(plan1.tag_holds) == 1  # the id'd both-tag warning still surfaces
+        finally:
+            cache.close()
+
+    def test_pure_both_tag_warning_is_idempotent(self, tmp_path: Path):
+        # No co-applied edit — only the tag conflict. The pass advances (banking the
+        # unchanged body baseline) yet pins the conflict, so it persists every run and
+        # never degenerates into a phantom body conflict.
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            de_path.write_text(
+                _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, ["keep"], _DE_INVOKE),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["alt"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            for _ in range(3):
+                plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+                assert plan.count("conflict") == 0
+                assert plan.count("edit") == 0
+                assert len(plan.tag_holds) == 1  # warning persists, never silenced
+                apply_plan(plan, judge=None, watermark_cache=cache)
+        finally:
+            cache.close()
+
+    def test_resolving_tag_conflict_clears_warning(self, tmp_path: Path):
+        # After the conflict, the author reconciles the tags by hand (both -> keep).
+        # The next run is a clean no-op: the warning is gone.
+        de = _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, [], _DE_INVOKE)
+        en = _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, [], _EN_INVOKE)
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_widened(cache, de_path, en_path)
+            de_path.write_text(
+                _md("de", "rag", ["slide"], "# ## RAG") + _code("de", None, ["keep"], _DE_INVOKE),
+                encoding="utf-8",
+            )
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["alt"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            apply_plan(
+                build_sync_plan(de_path, en_path, watermark_cache=cache),
+                judge=None,
+                watermark_cache=cache,
+            )
+            # Author resolves the conflict: set BOTH halves to keep.
+            en_path.write_text(
+                _md("en", "rag", ["slide"], "# ## RAG") + _code("en", None, ["keep"], _EN_INVOKE),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.tag_holds == []
+            assert plan.is_noop
         finally:
             cache.close()


### PR DESCRIPTION
## Summary

Fixes #202. A **both-decks tag conflict** in `clm slides sync` — the `both` branch of the #198/#200/#201 retag paths, where the same role-preserving tag (`keep`/`alt`/…) was changed on *both* halves of a split deck — used to hold the **whole-deck** watermark. Any clean edit applied in the *same* pass reached disk (the flush is gated only on errors) but was never baselined, so it re-surfaced as a spurious `conflict` on every subsequent run until the unrelated tag conflict was resolved by hand. The behavior was loud and lossless, but **non-idempotent** — it broke the tool's "re-run to converge" contract.

## Root cause

The watermark-advance gate declined on **any** issue (`not plan.issues`), and `_eligible_for_partial_advance` likewise bailed on `plan.issues`. So a single tag-only *warning* blocked both the full and the partial advance for the entire deck, even though the warning concerns just one cell's tags.

## Fix

A tag-only conflict touches **no cell body**, so every body baseline (and the co-applied edit) is safe to advance — only the one conflicting cell's *tags* must be held so the conflict re-surfaces.

- `PlanIssue` gains `tag_hold: TagHold | None`. The two `both`-tag warning sites set it — id-carrying keyed by `(slide_id, role)` (#200), id-less by position (#201).
- `SyncPlan.blocking_issues` / `SyncPlan.tag_holds` partition issues. The advance gate and `_eligible_for_partial_advance` now key on `blocking_issues`, so a tag-hold no longer blocks; a tag hold also makes a content-only pass eligible on its own (a co-applied clean edit may have `deferred == 0`).
- `_record_watermark_partial` pins **only** the held cell's tags to the old baseline on both halves (located via `_tag_hold_position`), banking every body baseline and the co-applied edit while the tag conflict re-surfaces. If a hold can't be faithfully located, it conservatively holds the whole watermark.

The id-carrying (#200) and id-less (#201) `both` paths are fixed together. **Structural** warnings — both-decks reorder, ambiguous de/en state, shared-cell auto-heal — keep `tag_hold=None`, stay in `blocking_issues`, and still hold the whole watermark (the auto-heal hold is deliberately preserved).

## Acceptance (all met)

- A pass that applies a clean edit **and** raises a `both` tag warning advances the watermark for the edit → it does **not** re-surface as a phantom conflict next run.
- The `both` tag warning still re-surfaces until the tag conflict is resolved (no silent baselining).
- The `_apply_divergence` auto-heal hold and the reorder/ambiguous-state holds are not regressed.

## Tests

11 new tests in `test_sync_tag_sync.py`:
- `TestPlanIssueScoping` — tag-hold vs structural issue partitioning.
- `TestPartialAdvanceEligibilityWithTagHold` — eligibility with/without a tag hold; blocking issues and structural proposals stay ineligible.
- `TestWatermarkAdvanceOverTagWarning` — id-carrying and id-less both-tag warnings co-applied with a clean edit → 2nd pass converges with the warning persisting; a pure tag conflict is idempotent across 3 passes; resolving the conflict clears the warning.

Full tag-sync + sync-apply + sync-plan suites green; ruff + mypy clean; the standalone repro converges on the released base.

## Notes

Surfaced by the adversarial review of #201 (#198 Tier C, finding 2) and deliberately scoped out of that PR; filed as #202 for the hardening pass. Design rationale documented in `docs/claude/design/single-language-authoring-sync.md` (Part 2b refinement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)