### PR TITLE
test: lower pre-commit xdist worker cap 16 → 8

### DIFF
--- a/scripts/run_pytest_hook.py
+++ b/scripts/run_pytest_hook.py
@@ -48,6 +48,12 @@ LEAKING_GIT_VARS = (
 # wall-clock is flat/noise-dominated in this range, so capping costs no real
 # speed while removing the contention that drives the flakes.
 #
+# Cap lowered 16 -> 8 (2026-06-04): a 16-worker run *hard-deadlocked* the fast
+# suite during the 1.7.0 release bump's pre-commit commit (worker-registration
+# contention, hung > 5 min, not mere slowness); re-running at 8 committed
+# cleanly. Since wall-clock is flat across this range, 8 trades no real speed for
+# materially more headroom against the contention deadlock.
+#
 # ``xdist`` honours ``PYTEST_XDIST_AUTO_NUM_WORKERS`` to decide what ``auto``
 # becomes, so we set it here for the hook only. This:
 #   * is a no-op on machines with <= ``_MAX_AUTO_WORKERS`` logical CPUs (their
@@ -57,7 +63,7 @@ LEAKING_GIT_VARS = (
 #   * leaves a manual ``pytest`` run untouched;
 #   * respects an explicit ``PYTEST_XDIST_AUTO_NUM_WORKERS`` the developer has
 #     already exported (``setdefault``).
-_MAX_AUTO_WORKERS = 16
+_MAX_AUTO_WORKERS = 8
 
 
 def main() -> int:


### PR DESCRIPTION
## What

Lowers `_MAX_AUTO_WORKERS` in `scripts/run_pytest_hook.py` from **16 → 8**, so the pre-commit fast suite caps `-n auto` at 8 workers on high-core dev machines.

## Why

During the **1.7.0 release**, `bump-my-version`'s version-bump `git commit` triggered the pre-commit fast-suite hook. Even with the existing 16-worker cap applied, the suite **hard-deadlocked** (worker-registration contention — hung > 5 min, not mere slowness; required killing the process tree and resetting). Re-running the bump with `PYTEST_XDIST_AUTO_NUM_WORKERS=8` committed and tagged cleanly.

Prior benchmarking already showed fast-suite wall-clock is flat/noise-dominated across 12–64 workers, so **8 costs no real speed** while giving materially more headroom against the contention-flake family (mitmdump readiness, worker-registration starvation #163, heartbeat slow-write, port clashes).

## Scope / safety

- One constant + a comment. No logic change.
- `scripts/`-only, so it triggers **no** pre-commit hook (all are scoped to `src/`/`tests/`/`pyproject`/`uv.lock`) — verified manually with `py_compile` and confirmed the cap resolves to `8` on the dev box.
- Local-only effect: CI doesn't run this wrapper (resolves `auto` to its ~2–4 vCPUs), and a manual `pytest` / an explicitly-exported `PYTEST_XDIST_AUTO_NUM_WORKERS` are untouched (`setdefault`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)