### PR TITLE
test: fix missing vcr dep, serialize + isolate contention-prone tests

### DIFF
--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -140,6 +140,38 @@ pytest -m e2e --log-cli-level=CRITICAL
 pytest -m e2e -v
 ```
 
+## Parallelism and the `serial` marker
+
+The suite runs in parallel via `pytest-xdist` (`-n auto`, capped to 8 workers
+in the pre-commit hook by `scripts/run_pytest_hook.py`). The default scheduler
+is `--dist loadgroup` (set in `pyproject.toml` `addopts`): it load-balances as
+usual but keeps any tests sharing an `xdist_group` on the **same** worker.
+
+A handful of tests spawn heavyweight external processes — a mitmdump proxy
+(`tests/infrastructure/test_http_replay_mitm.py`), a mock worker pool
+(`tests/infrastructure/workers/test_lifecycle_mock.py`). When many xdist
+workers launch those simultaneously they oversubscribe the box and flake
+(readiness ceilings expiring, worker-registration starvation, port races —
+issues #163/#184). Such tests carry the project's `serial` marker:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.serial  # whole module, or use @pytest.mark.serial per-test
+```
+
+`tests/conftest.py` maps `serial` onto a single shared `xdist_group`, so every
+serial-marked test runs one-at-a-time on one dedicated worker while the rest of
+the suite stays fully parallel. **Reach for `serial` when a new test launches a
+real subprocess or otherwise contends for a global resource** (a fixed port, a
+shared daemon) — it is the cheap, surgical alternative to widening timeouts.
+It is a no-op under `-n0`.
+
+> The HTTP-replay / cassette tests need the `replay` extra (`vcrpy`,
+> `filelock`). It is included in the auto-synced `dev` dependency group, so
+> `uv sync` / `uv run pytest` always has it; without it those tests
+> `importorskip`-skip rather than run.
+
 ## Troubleshooting
 
 ### "I don't see any logs during test execution"

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -182,6 +182,7 @@ set DRAWIO_EXECUTABLE="C:\Program Files\draw.io\draw.io.exe"
 |----------|-------------|---------|
 | `CLM_LOGGING__LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR) | `INFO` |
 | `CLM_LOGGING__ENABLE_TEST_LOGGING` | Enable logging during tests | `false` |
+| `CLM_LOG_DIR` | Directory for `clm.log` and `workers/` logs. Overrides the platform default (Windows: `%LOCALAPPDATA%/clm/Logs`; macOS: `~/Library/Logs/clm`; Linux: `~/.local/state/clm/log`). Useful to relocate logs, or to give parallel processes their own log file so they don't race to open/rotate the shared one. | platform default |
 
 ### Git
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,10 +283,23 @@ markers = [
     "e2e: mark tests as end-to-end tests that test full course conversion",
     "docker: mark tests that require Docker daemon (excluded by default)",
     "recordings: mark tests for the recordings module",
+    # ``serial`` pins a test onto a single xdist worker (via the ``--dist
+    # loadgroup`` scheduler below). Use it for tests that spawn heavyweight
+    # external processes — a mitmdump proxy, a Jupyter kernel, a worker pool —
+    # whose simultaneous startup across many xdist workers oversubscribes the
+    # box and produces contention flakes (readiness ceilings expiring, worker
+    # registration starvation, port races). All ``serial`` tests share one
+    # group, so xdist runs them one-at-a-time on a dedicated worker while the
+    # rest of the suite stays fully parallel. The mapping marker -> xdist_group
+    # lives in ``tests/conftest.py`` (``pytest_collection_modifyitems``).
+    "serial: pin a heavy/contention-prone test to a single xdist worker",
 ]
-# Run fast unit tests by default, skip db_only, integration, slow, e2e, and docker tests
-# Use -n auto for parallel execution via pytest-xdist (pass -n0 to disable)
-addopts = "-v -n auto -m 'not slow and not db_only and not integration and not e2e and not docker'"
+# Run fast unit tests by default, skip db_only, integration, slow, e2e, and docker tests.
+# Use -n auto for parallel execution via pytest-xdist (pass -n0 to disable).
+# --dist loadgroup keeps the default load-balancing scheduler but honours the
+# ``xdist_group`` mark that the ``serial`` marker maps to, so contention-prone
+# tests are serialized onto one worker instead of racing each other.
+addopts = "-v -n auto --dist loadgroup -m 'not slow and not db_only and not integration and not e2e and not docker'"
 # Timeout configuration - prevents tests from hanging indefinitely
 timeout = 600  # 10 minutes default timeout for all tests
 timeout_method = "thread"  # Works better with asyncio tests
@@ -451,9 +464,15 @@ version = "{new_version}\""""
 #      from the [notebook] extra), so without them `uv sync` would
 #      leave the fast suite broken. `ml` is deliberately excluded
 #      because it's huge and blocked on Python 3.14.
+#      `replay` (vcrpy + filelock) is included so the HTTP-replay /
+#      cassette tests actually *run* in the fast suite instead of
+#      silently `pytest.importorskip`-skipping: without it, `uv sync`
+#      leaves vcr absent and the whole http-replay surface goes
+#      untested in the pre-commit gate (and a fresh sync surprises with
+#      "No module named 'vcr'").
 # See docs/proposals/PRE_COMMIT_HOOK_HARDENING.md (Fix 1) for rationale.
 dev = [
-    "coding-academy-lecture-manager[notebook,plantuml,drawio,recordings,slides,mcp,summarize,voiceover,jupyterlite,tui,web]",
+    "coding-academy-lecture-manager[notebook,plantuml,drawio,recordings,slides,mcp,summarize,voiceover,jupyterlite,replay,tui,web]",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",

--- a/src/clm/infrastructure/logging/log_paths.py
+++ b/src/clm/infrastructure/logging/log_paths.py
@@ -4,21 +4,39 @@ This module provides consistent log file paths across all CLM components,
 including the main CLI and worker processes.
 """
 
+import os
 from pathlib import Path
 
 import platformdirs
+
+#: Environment variable that overrides the log directory. When set, CLM writes
+#: ``clm.log`` (and ``workers/``) under this directory instead of the system
+#: default. This exists so that processes which must not share the single
+#: global log file can each point at their own directory — most importantly the
+#: test suite under pytest-xdist, where many worker processes would otherwise
+#: race to open/rotate the same ``clm.log`` and hit ``PermissionError`` on
+#: Windows. It is also a convenient way to relocate logs in production.
+LOG_DIR_ENV_VAR = "CLM_LOG_DIR"
 
 
 def get_log_dir() -> Path:
     """Get the system-appropriate log directory for CLM.
 
+    If the ``CLM_LOG_DIR`` environment variable is set, that directory is used
+    verbatim (created if needed); otherwise the platform default is used.
+
     Returns:
         Path to the log directory (created if it doesn't exist)
+        - ``CLM_LOG_DIR`` if set
         - Windows: %LOCALAPPDATA%/clm/Logs
         - macOS: ~/Library/Logs/clm
         - Linux: ~/.local/state/clm/log
     """
-    log_dir = Path(platformdirs.user_log_dir("clm", appauthor=False))
+    override = os.environ.get(LOG_DIR_ENV_VAR)
+    if override:
+        log_dir = Path(override)
+    else:
+        log_dir = Path(platformdirs.user_log_dir("clm", appauthor=False))
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,40 @@ if TYPE_CHECKING:
 
 
 # ====================================================================
+# Per-worker log isolation
+# ====================================================================
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_clm_log_dir(tmp_path_factory):
+    """Give each pytest-xdist worker its own CLM log directory.
+
+    Without this, every worker process writes to the single global
+    ``clm.log`` (``%LOCALAPPDATA%/clm/Logs`` on Windows). When many workers
+    open or rotate that one file concurrently, Windows intermittently raises
+    ``PermissionError`` and fails whichever CLI test happened to be inside
+    ``setup_logging`` at that moment — a pure cross-worker contention flake.
+    Pointing each worker at its own temp directory removes the sharing at the
+    root. ``tmp_path_factory.getbasetemp()`` is already per-worker under
+    xdist, so the directories never collide. Honoured via the ``CLM_LOG_DIR``
+    override in ``clm.infrastructure.logging.log_paths`` (which subprocess
+    workers spawned during a test inherit through the environment too).
+    """
+    from clm.infrastructure.logging.log_paths import LOG_DIR_ENV_VAR
+
+    log_dir = tmp_path_factory.mktemp("clm-logs")
+    previous = os.environ.get(LOG_DIR_ENV_VAR)
+    os.environ[LOG_DIR_ENV_VAR] = str(log_dir)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(LOG_DIR_ENV_VAR, None)
+        else:
+            os.environ[LOG_DIR_ENV_VAR] = previous
+
+
+# ====================================================================
 # Tool Availability Detection
 # ====================================================================
 
@@ -481,8 +515,14 @@ def pytest_configure(config):
         logging.getLogger(logger_name).setLevel(logging.WARNING)
 
 
+# ``tryfirst`` so the ``serial`` -> ``xdist_group`` mapping below runs before
+# pytest-xdist's own (unordered) ``pytest_collection_modifyitems`` in
+# ``xdist/remote.py``, which appends the ``@group`` suffix to each nodeid by
+# reading the ``xdist_group`` mark. If we added the mark after that hook, the
+# suffix would be missing and ``--dist loadgroup`` would scatter the tests.
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
-    """Auto-skip tests based on tool availability."""
+    """Auto-skip tests based on tool availability; map ``serial`` to a group."""
     tool_status = get_tool_availability()
 
     # Count tests by marker for reporting
@@ -569,6 +609,16 @@ def pytest_collection_modifyitems(config, items):
         if "docker" in markers:
             if not tool_status["docker"]:
                 item.add_marker(skip_docker)
+
+        # Map the project's ``serial`` marker onto an xdist load group so the
+        # ``--dist loadgroup`` scheduler (see pyproject ``addopts``) pins every
+        # serial-marked test onto a single worker. Contention-prone tests that
+        # spawn heavyweight external processes (a mitmdump proxy, a worker
+        # pool) thereby run one-at-a-time instead of racing each other across
+        # workers and oversubscribing the box. A no-op when xdist is disabled
+        # (``-n0``), since there is then only one worker anyway.
+        if "serial" in markers:
+            item.add_marker(pytest.mark.xdist_group("serial"))
 
 
 @pytest.fixture(scope="function")

--- a/tests/infrastructure/logging/test_log_paths.py
+++ b/tests/infrastructure/logging/test_log_paths.py
@@ -1,0 +1,76 @@
+"""Tests for CLM log-path resolution, including the ``CLM_LOG_DIR`` override.
+
+The override exists so that pytest-xdist workers (and any other processes that
+must not share the single global ``clm.log``) can each point at their own
+directory. See ``clm.infrastructure.logging.log_paths``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.logging import log_paths
+from clm.infrastructure.logging.log_paths import (
+    LOG_DIR_ENV_VAR,
+    get_log_dir,
+    get_main_log_path,
+    get_worker_log_dir,
+)
+
+
+def test_get_log_dir_honours_env_override(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "custom-logs"
+    monkeypatch.setenv(LOG_DIR_ENV_VAR, str(target))
+
+    result = get_log_dir()
+
+    assert result == target
+    assert result.is_dir()  # created on access
+
+
+def test_get_log_dir_creates_nested_override_dir(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "a" / "b" / "logs"
+    monkeypatch.setenv(LOG_DIR_ENV_VAR, str(target))
+
+    assert not target.exists()
+    assert get_log_dir() == target
+    assert target.is_dir()
+
+
+def test_main_and_worker_paths_follow_override(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "logs"
+    monkeypatch.setenv(LOG_DIR_ENV_VAR, str(target))
+
+    assert get_main_log_path() == target / "clm.log"
+    assert get_worker_log_dir() == target / "workers"
+
+
+def test_empty_override_falls_back_to_platform_default(monkeypatch, tmp_path: Path) -> None:
+    # An empty value is falsy and must not redirect to the current directory
+    # (``Path("")``); it falls back to the platform default instead.
+    monkeypatch.setenv(LOG_DIR_ENV_VAR, "")
+    sentinel = tmp_path / "platform-default"
+    monkeypatch.setattr(
+        log_paths.platformdirs,
+        "user_log_dir",
+        lambda *a, **k: str(sentinel),
+    )
+
+    result = get_log_dir()
+
+    assert result == sentinel
+    assert result != Path("")
+
+
+def test_no_override_uses_platformdirs(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(LOG_DIR_ENV_VAR, raising=False)
+    sentinel = tmp_path / "platform-default"
+    monkeypatch.setattr(
+        log_paths.platformdirs,
+        "user_log_dir",
+        lambda *a, **k: str(sentinel),
+    )
+
+    assert get_log_dir() == sentinel

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -35,6 +35,14 @@ from clm.infrastructure.http_replay_mitm.proxy_manager import (
     _locate_mitmdump,
 )
 
+# Every test here launches a real mitmdump subprocess (proxy startup +
+# port bind). Pin the module onto one xdist worker so these spawns run
+# one-at-a-time instead of racing each other across workers and
+# oversubscribing the box (the documented #184 contention family). See the
+# ``serial`` marker in pyproject and its xdist_group mapping in
+# ``tests/conftest.py``.
+pytestmark = pytest.mark.serial
+
 # Skip the whole module if mitmdump isn't reachable — the [mitmproxy]
 # extra installs the Python package but the executable lookup may still
 # fail on some environments.

--- a/tests/infrastructure/workers/test_lifecycle_mock.py
+++ b/tests/infrastructure/workers/test_lifecycle_mock.py
@@ -19,6 +19,14 @@ import pytest
 
 from tests.fixtures.mock_workers import MockWorker, MockWorkerConfig, MockWorkerPool
 
+# These tests start worker threads and poll committed SQLite registration
+# state. Under heavy xdist load the worker threads can be starved long enough
+# that registration appears to stall (issue #163). The polling helpers already
+# use generous timeouts; pinning the module onto one xdist worker additionally
+# stops it from racing other heavy tests for CPU. See the ``serial`` marker in
+# pyproject and its xdist_group mapping in ``tests/conftest.py``.
+pytestmark = pytest.mark.serial
+
 
 class TestMockWorkerBasics:
     """Test basic mock worker functionality."""

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ web = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "coding-academy-lecture-manager", extra = ["drawio", "jupyterlite", "mcp", "notebook", "plantuml", "recordings", "slides", "summarize", "tui", "voiceover", "web"] },
+    { name = "coding-academy-lecture-manager", extra = ["drawio", "jupyterlite", "mcp", "notebook", "plantuml", "recordings", "replay", "slides", "summarize", "tui", "voiceover", "web"] },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -1318,7 +1318,7 @@ provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summa
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "coding-academy-lecture-manager", extras = ["notebook", "plantuml", "drawio", "recordings", "slides", "mcp", "summarize", "voiceover", "jupyterlite", "tui", "web"] },
+    { name = "coding-academy-lecture-manager", extras = ["notebook", "plantuml", "drawio", "recordings", "slides", "mcp", "summarize", "voiceover", "jupyterlite", "replay", "tui", "web"] },
     { name = "hypothesis", specifier = ">=6.148.2" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pre-commit", specifier = ">=4.5.0" },


### PR DESCRIPTION
## Summary

Three fast-suite reliability fixes targeting the recurring pre-commit flake family. Investigated both symptoms the maintainer reported (tests failing on a "missing vcr dependency", and tests failing under resource contention) and fixed the root causes.

### 1. Missing `vcr` → silent skips, untested http-replay surface
The auto-synced `[dependency-groups] dev` (installed by `uv run`/`uv sync`) listed the self-referencing test extras but **omitted `replay`**, so `vcrpy` was never installed. The whole http-replay/cassette surface then silently `pytest.importorskip`-skipped — the "failing because vcr is missing" symptom is actually a *skip*, and a fresh `uv sync` surprised with `No module named 'vcr'`. Added `replay` to the dev group; fast-suite skips dropped **~28 → 3** (those tests now actually run).

### 2. Spawn contention → `serial` marker
Added a project `serial` marker mapped (in `tests/conftest.py`, `tryfirst=True`) onto a single shared `xdist_group`, and switched the scheduler to `--dist loadgroup`. Tagged the two confirmed heavy fast-suite spawners — the real mitmdump proxy tests (`test_http_replay_mitm.py`, #184) and the mock worker-pool lifecycle tests (`test_lifecycle_mock.py`, #163). They now run one-at-a-time on a dedicated worker instead of racing each other across workers and oversubscribing the box, while the rest of the suite stays fully parallel.

> **Gotcha encoded in the diff:** the conftest mapping hook *must* be `tryfirst=True` — xdist's own (unordered) `pytest_collection_modifyitems` in `xdist/remote.py` appends the `@group` suffix to each nodeid by reading the mark; adding the mark after it silently scatters the tests across workers.

### 3. Shared-log contention → `CLM_LOG_DIR` + per-worker isolation
Every xdist worker wrote to the single global `clm.log` (`%LOCALAPPDATA%/clm/Logs` on Windows). Concurrent open/rotate intermittently raised `PermissionError [Errno 13]` and failed whichever CLI test was inside `setup_logging` (`ResilientRotatingFileHandler` only guards `doRollover`, not construction-time `_open()`). Added a `CLM_LOG_DIR` override to `get_log_dir()` plus a session-autouse fixture that points each worker at its own temp log dir, removing the sharing at the root. This flake was surfaced by the pre-commit hook itself during this work.

The per-test brittleness fixes those spawn families needed (30s mitm startup + ephemeral port, 30s registration timeout + committed-DB polling, heartbeat slow-write threshold patch, port-8765 mocking) already shipped in prior PRs — this adds the missing *"don't run them all at once"* and *"don't share one global file"* levers (complements the worker cap in #185).

## Changes
- `pyproject.toml` — `replay` added to dev group; `serial` marker; `--dist loadgroup`
- `tests/conftest.py` — `serial`→`xdist_group` mapping (tryfirst); per-worker log-dir autouse fixture
- `src/clm/infrastructure/logging/log_paths.py` — `CLM_LOG_DIR` override
- `tests/infrastructure/test_http_replay_mitm.py`, `tests/infrastructure/workers/test_lifecycle_mock.py` — `pytestmark = pytest.mark.serial`
- `tests/infrastructure/logging/test_log_paths.py` — new coverage for the override
- `docs/developer-guide/testing.md`, `docs/user-guide/configuration.md` — docs

## Testing
- Full fast suite green via the pre-commit wrapper: **6359 passed, 3 skipped, 1 xfailed** (~100s)
- Verified serial tests pin to one worker (`[gw0]` + `@serial` nodeid suffix)
- `-n0` still works (loadgroup is a no-op when xdist is disabled)
- ruff + mypy clean; commit passed all pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)