### PR TITLE
Sync: resolve-then-apply + cold-start id bootstrap (#216)

### DIFF
--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -16,7 +16,15 @@ structural translate remain inline as **explicitly-deferred follow-ups** (§10).
 **Phase 3.1 (id-less cold-pair minting) DONE** — `build_sync_plan` emits a `pending`
 mint candidate, `apply_plan` verifies via the new `CorrespondenceVerifier` and mints
 via `assign_ids_in_split_pair`; `--verify-cold-pairs` default-on with a provider.
-**Phase 3.2 (half-id'd adopt) is next** (§12).
+**Phase 3.2 (half-id'd adopt) DONE** — `build_sync_plan` emits a `pending` **`adopt`**
+candidate for a half-id'd pair (`_cold_adopt_authority` / `_maybe_emit_cold_adopt`,
+run right after the mint pass and mutually exclusive with it); `apply_plan` verifies
+the same way and stamps the id'd half's *existing* ids onto the id-less twin
+(`_apply_cold_adopt` / `_adopt_ids_in_split_pair` — an explicit per-cell header stamp,
+**not** `assign_ids_in_split_pair`, which cannot pair an id-less cell with an id'd
+one). Mismatched-id and mixed-authority stay `refuse`. The whole #216 cluster is now
+resolved end-to-end; the only remaining items are the Phase-2 deferred follow-ups
+(the id-migration recoverer + `sync_code` structural translate).
 
 ---
 
@@ -242,14 +250,15 @@ follow-ups (call models inline still):** the id-migration recoverer and the
 (the two materialize seams suffice, and the add seam is ordering-sensitive).
 
 **Phase 3 — Cold-start minting + correspondence gate. [3.1 (id-less) DONE; 3.2
-(half-id'd) NEXT — see §12].** `build_sync_plan` emits a `pending` mint candidate for
+(half-id'd) DONE — see §12].** `build_sync_plan` emits a `pending` mint candidate for
 a provider-available, unifiable cold pair; a `CorrespondenceVerifier` (2b) confirms
 the heading/snippet pairs; the mint delegates to `assign_ids_in_split_pair`.
-**3.1 done** (id-less; mismatched-id stays `refuse`). **3.2** adds the half-id'd
-*adopt* — separate from `assign_ids_in_split_pair`, which **cannot** adopt because
-`unify` does not pair an id-less cell with an id'd one (`_slide_ids_pair` is
-`de_id == en_id`). Unblocks the **1.8 PythonCourses gate** (~200 id-less split
-halves; see `#158`).
+**3.1 done** (id-less; mismatched-id stays `refuse`). **3.2 done** — the half-id'd
+*adopt* (`kind="adopt"`), an **explicit** path **separate from
+`assign_ids_in_split_pair`**, which **cannot** adopt because `unify` does not pair an
+id-less cell with an id'd one (`_slide_ids_pair` is `de_id == en_id`): apply stamps the
+id'd half's existing ids onto the id-less twin per-cell. Unblocks the **1.8
+PythonCourses gate** (~200 id-less split halves; see `#158`).
 
 ## 11. Open questions / deferred
 
@@ -304,13 +313,17 @@ halves; see `#158`).
    abort / no verifier** → downgrade to `refuse` (deferred, watermark held — the one
    disclosed Q-A divergence). Conservative: a single mismatched pair means the streams
    are not a clean translation → refuse the whole pair, never bake a wrong shared id.
-5. **execute (3) — mint.** A confirmed mint delegates to
+5. **execute (3) — mint *or* adopt.** A confirmed **mint** (both-id-less) delegates to
    **`assign_ids_in_split_pair(de_path, en_path, options)`** (`assign_ids.py`):
-   byte-faithful EN-authority shared-id minting that handles id-less *and*, via
-   `unify→assign→split`, the half-id'd adopt. Its own "not unifiable → `None`" return
-   is a second safety net → `refuse`. A cold pair carries no other apply ops, so this
-   file-level write does not conflict with the FileState buffer (states are never
-   dirtied; the flush is a no-op) and the watermark records from the minted files.
+   byte-faithful EN-authority shared-id minting (id-less only — see the corrected note
+   below; it does **not** adopt a half-id'd pair). Its own "not unifiable → `None`"
+   return is a second safety net → `refuse`. A confirmed **adopt** (half-id'd) takes a
+   separate path (`_apply_cold_adopt` / `_adopt_ids_in_split_pair`): it walks the two
+   halves' localized streams positionally and stamps each authority slide_id onto its
+   id-less twin (`_stamp_slide_id`, the same byte-faithful header rewrite assign-ids
+   uses), writing only the id-less half. Either is the whole plan and carries no other
+   apply ops, so the file-level write does not conflict with the FileState buffer and
+   the watermark records from the post-write files.
 
 **New `CorrespondenceVerifier`** (`sync_recover.py`, mirroring `AlignmentRecoverer`):
 
@@ -350,3 +363,32 @@ per-pair marker; apply re-derives the aligned `(de, en)` slide pairs from the
 `_resolve_correspondence` (mirrors `_resolve_alignment`) verifies + caches. The mint
 short-circuits the whole `apply_plan` (a cold pair has no other ops). Verifier inputs
 are heading + the lines *after* the heading (a short lead snippet) + role.
+
+**3.2 implementation notes (shipped):** the half-id'd **adopt** mirrors the mint
+shape but takes its own classifier candidate and apply path:
+
+- **Candidacy (`_cold_adopt_authority` + `_maybe_emit_cold_adopt`, `sync_plan.py`).**
+  Runs in `build_sync_plan` right after `_maybe_emit_cold_mint`, gated on the same
+  `source == "none" and provider_available`. Mutually exclusive with mint **by
+  construction**: mint, when it fires, removes the refusals (emptying `plan.refusals`),
+  so adopt's `if not refusals: return` bails. `_cold_adopt_authority` walks the full
+  positional localized stream and returns the fully-id'd side (`"de"`/`"en"`) only when:
+  every pair agrees on `role_of` and cell-type; every **sync** pair (`role_of != None`)
+  is XOR (exactly one side id'd) with a **consistent** authority; every **non-sync**
+  pair (id-less localized code, `role_of None`) is id-less on both. Any other shape →
+  `None` → the refuse stands. Because `role_of` of an aux-markdown or a localized-code
+  cell *depends on* its `slide_id`, an id'd-vs-id-less twin of those has mismatched
+  `role_of` → adopt declines (only narrative-tagged cells, whose role is
+  id-independent, adopt — a documented, conservative boundary). Emits a single
+  `kind="adopt"`, `disposition="pending"`, `direction="{authority}->{other}"`.
+- **Apply (`_apply_cold_adopt` + `_adopt_ids_in_split_pair`, `sync_apply.py`).** A
+  second short-circuit beside the mint one. Builds the slide pairs and verifies them
+  exactly like the mint (reusing `_build_slide_pairs` / `_resolve_correspondence`); on
+  **all-yes** stamps each authority slide_id onto its positional id-less twin, loading
+  **both** halves with the same `FileState.load` parser (so candidacy/apply parser
+  consistency holds) and flushing only the id-less half. Per-cell guards (`role_of`
+  match, target is id'd, twin is id-less, equal stream lengths) make a post-plan drift
+  return `0` stamped → deferral, never a mis-stamp. `applied_adopt` counts it.
+- **Why not `assign_ids_in_split_pair`:** it mints fresh slugs and cannot pair an
+  id-less cell with an id'd one (the `_slide_ids_pair` `de_id == en_id` gate), so it
+  would create *new, divergent* ids instead of adopting the authority's existing ones.

--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -8,7 +8,9 @@ found investigating **#216** (cold-start id-less doubling) and the **dry-run /
 apply divergence** it exposed.
 
 **Status:** design accepted (2 forks settled — see §3); implementation phased
-(§10). Tests pinning the target behavior already landed as `xfail(strict)` (§9).
+(§10). **Phase 1 DONE** (the `refuse` disposition + both-directions guard moved to
+the resolver; all 5 parity/doubling xfails flipped to passing — §9). Phases 2–3
+pending.
 
 ---
 
@@ -174,27 +176,45 @@ classifier invariant.
 | `slides_sync.py` (CLI) | dry-run renders the resolved plan (incl. `refuse`/`pending`); exit codes derive from dispositions, so `_plan_exit_code` and `_apply_exit_code` converge by construction. New `--verify-cold-pairs` (default: on when a provider is set) gates 2b correspondence. |
 | watermark | stage 3 advances it only over `apply`-disposition cells; `refuse`/`conflict`/`blocked` cells hold at baseline (the existing #202 per-cell partial-advance, simplified — the held set is now explicit in the plan). |
 
-## 9. Tests already pinning this (committed)
+## 9. Tests pinning this
 
-Landed as `xfail(strict=True)` so they self-remove when the fix flips them:
+Originally landed as `xfail(strict=True)`; **Phase 1 flipped all five to passing**
+(the markers are removed and the assertions now read the refusal outcome):
 
-- `tests/slides/test_sync_dry_run_parity.py` — parity helper (`_assert_dry_run_predicts_apply`); 3 passing (noop / single-add / edit) + 2 xfail (cold-start id-less; watermark both-sides id-less).
-- `tests/cli/test_slides_sync.py::TestDryRunApplyParity` — 1 passing + 1 xfail at the CLI surface (+ `_stub_translator`).
-- `tests/slides/test_sync_apply.py` — 2 xfail for the id-carrying doubling (mismatched-id, half-id'd).
+- `tests/slides/test_sync_dry_run_parity.py` — parity helper
+  (`_assert_dry_run_predicts_apply`); `TestColdStartRefusalParity` (was
+  `…KnownBugs`) now asserts the cold-start id-less and watermark both-sides
+  cases **refuse** (`N refuse`, dry=apply=exit 1, decks byte-unchanged).
+- `tests/cli/test_slides_sync.py::TestDryRunApplyParity::test_dry_run_promise_matches_apply_for_parallel_idless`
+  — passes at the CLI surface: dry and apply both exit 1, `refuse` shown.
+- `tests/slides/test_sync_apply.py` — the two id-carrying doubling cases
+  (mismatched-id, half-id'd) now assert `applied_add == 0`, `refuse == 4`, no
+  duplication, no error.
+- `tests/slides/test_sync_plan.py::TestBothDirectionsRefusal` — **new** unit
+  cases on `classify_changes` directly: cold parallel id-less / mismatched-id /
+  half-id'd all refuse; one-directional cold start and id-carrying both-directions
+  *against a baseline* still **add** (the key distinctions).
 
-The parity assertion is already written to survive either fix shape (it checks
-"a writing-run error must have been foreseen by the dry-run"), so it needs no
-edits when the redesign lands — only the `xfail` markers come off.
+The parity assertion was written to survive either fix shape (it checks "a
+writing-run error must have been foreseen by the dry-run"), so it needed no edits
+when the redesign landed — only the `xfail` markers came off.
 
 ## 10. Phased implementation
 
 Each phase is independently shippable and flips a named subset of the xfails.
 
 **Phase 1 — `Refuse` as a first-class disposition; move the structural guards to
-2a.** Introduce the disposition field; relocate the both-directions refusal
-(idless **and** idd) and conflict isolation from `apply_plan` into the resolver.
-Apply stops re-deciding those. *Flips:* the dry-run-honesty xfails + the
-id-carrying doubling xfails (4 of 5). Lowest risk; no LLM, no new minting.
+2a. [DONE]** Introduced `Proposal.disposition` (`"apply"` | `"refuse"`) and a
+`refuse` kind; relocated the both-directions refusal (idless **and** the
+previously-unguarded idd) from `apply_plan` into the resolver (`classify_changes`
+→ `_refuse_cold_both_directions` / `_refuse_idless_both_directions`). `apply_plan`
+now executes a `refuse` as a deferred no-op; the old `_apply_adds` guard and the
+`process_idless` plumbing are deleted. *Flipped all 5 xfails* (the main-path
+id-less refusal also covers the watermark both-sides case, so it was **5 of 5**,
+not the 4 first estimated). No LLM, no new minting; the watermark holds over a
+refusal. Also surfaced in `render_plan` / `--json` (`counts.refuse`,
+`proposals[].disposition`), the walker (a `REFUSE` action, never prompted), and
+the `migration.md` info topic.
 
 **Phase 2 — Split apply into materialize (2b) + execute (3).** Formalize
 `MaterializedPlan`; make execute decision-free; fold translation/judge into 2b

--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -158,11 +158,12 @@ plan-time input):
 
 **2b (LLM, opt-in tier — mirror `--llm-recover`).** A `CorrespondenceVerifier`
 mirroring `AlignmentRecoverer` (`sync_recover.py`): a cheap model (Haiku-class),
-**body-free** inputs (position / role / content-hash, like region fingerprints),
-**cached** by pair fingerprint + prompt version, **validated**, **safe-abort**.
-Per pair it returns, for each candidate, correspond = yes/no. A "yes" → the
-`mint_shared_id` / `adopt_id` op materializes; a "no" → that pair downgrades to
-`refuse`. One call per cold-start deck, cached → re-runs are free.
+**heading + short-body-snippet** inputs per aligned pair (**not** body-free — unlike
+the recoverer, cross-language correspondence needs the heading *text*, since two
+translated headings have different content hashes; see §12), **cached** by pair
+fingerprint + prompt version, **validated**, **safe-abort**. It returns, per pair,
+correspond = yes/no. All "yes" → the mint materializes; any "no" → the pair
+downgrades to `refuse`. One call per cold-start deck, cached → re-runs are free.
 
 **Classifier stays pure.** The verifier lives in stage 2b (apply-side tier),
 never in `sync_plan.py`. This honors the base design's "pure analysis — no LLM"
@@ -237,11 +238,13 @@ follow-ups (call models inline still):** the id-migration recoverer and the
 `sync_code` structural translate; and a single bundled `MaterializedPlan` object
 (the two materialize seams suffice, and the add seam is ordering-sensitive).
 
-**Phase 3 — Cold-start minting + correspondence gate.** `mint_shared_id` /
-`adopt_id` candidates in 2a (provider-aware); `CorrespondenceVerifier` in 2b;
-delegate stamping to `assign_ids_in_split_pair`. *Flips:* the remaining #216
-bootstrap xfails. Unblocks the **1.8 PythonCourses gate** (~200 id-less split
-halves; see `#158`).
+**Phase 3 — Cold-start minting + correspondence gate. [NEXT — finalized plan in
+§12].** `build_sync_plan` emits a `pending` mint candidate for a provider-available,
+unifiable cold pair; a `CorrespondenceVerifier` (2b) confirms the heading/snippet
+pairs; the mint delegates to `assign_ids_in_split_pair` (handles id-less + half-id'd;
+mismatched-id stays `refuse`). *Flips:* the `TestColdStartRefusalParity` cases to
+mint-under-a-confirming-verifier. Unblocks the **1.8 PythonCourses gate** (~200
+id-less split halves; see `#158`).
 
 ## 11. Open questions / deferred
 
@@ -254,5 +257,81 @@ halves; see `#158`).
   id, neutral code is byte-identical, id-less code rides the structural pass.
   The gate targets id-less *narrative markdown* only.
 - **Mismatched-id pairs with a provider** — Phase 3 may offer to *reconcile*
-  (pick a source-lang, adopt one side's ids) instead of only refusing; start with
-  refuse, revisit with pilot data.
+  (pick a source-lang, adopt one side's ids) instead of only refusing; **decided:
+  stays `refuse` in Phase 3 v1** (§12), revisit with pilot data.
+
+---
+
+## 12. Phase 3 — finalized implementation plan (decisions 2026-06-04)
+
+**Decisions (settled with the maintainer):**
+
+- **Scope:** mint **id-less** both-directions cold pairs (the #158 case) **and**
+  **half-id'd** pairs (the id-less half adopts the id'd half's ids). **Mismatched-id**
+  pairs (both id'd, *different* ids) stay `refuse`.
+- **Verifier inputs:** per aligned slide, the **heading + a short body snippet**
+  (~first 1–2 lines) + role. A **Haiku-class** model (a tunable constant, cf. the
+  recoverer's Opus). One cached call per cold deck. **Not body-free** — two translated
+  headings have different content hashes carrying no cross-language signal, so
+  confirming correspondence needs the heading *text* (the §7 "body-free" note is
+  corrected here; only the *code* alignment could be hash-only, and code is not what
+  is being paired).
+- **Gate:** the verifier is a **required gate, default-on when a provider is
+  configured** (`--verify-cold-pairs`); no provider → `refuse`. Honors §3.2.
+
+**Architecture (keeps the purity boundary):**
+
+1. **`classify_changes` (pure) — unchanged.** Still emits `refuse` for a
+   both-directions cold pair (Phase 1).
+2. **`build_sync_plan` (has files + a new `provider_available: bool`) — candidacy.**
+   When the plan's refusals are the cold-start both-directions kind, `provider_available`
+   is true, and the pair is **unifiable** (a read-only `unify→split` byte-faithful
+   round-trip — the same guard `assign_ids_in_split_pair` uses), replace the refusals
+   with a single **`pending` mint candidate** (`kind="mint"`, `disposition="pending"`,
+   carrying the aligned `(de, en)` heading/snippet pairs from the unified deck). Else
+   keep `refuse`. `provider_available` is an env fact (`OPENROUTER_API_KEY` /
+   `OPENAI_API_KEY`), identical in dry-run and apply, so the two still agree.
+3. **dry-run (1 + 2a)** shows `N pair — pending verification` (exit 1) when a candidate
+   exists, else `refuse` (exit 1). No model call (Q-A).
+4. **`apply_plan` (2b materialize) — verify.** For a `pending` mint candidate, if a
+   `CorrespondenceVerifier` is configured: verify the heading/snippet pairs (cached,
+   validated, safe-abort). **All pairs "yes"** → materialize the mint; **any "no" /
+   abort / no verifier** → downgrade to `refuse` (deferred, watermark held — the one
+   disclosed Q-A divergence). Conservative: a single mismatched pair means the streams
+   are not a clean translation → refuse the whole pair, never bake a wrong shared id.
+5. **execute (3) — mint.** A confirmed mint delegates to
+   **`assign_ids_in_split_pair(de_path, en_path, options)`** (`assign_ids.py`):
+   byte-faithful EN-authority shared-id minting that handles id-less *and*, via
+   `unify→assign→split`, the half-id'd adopt. Its own "not unifiable → `None`" return
+   is a second safety net → `refuse`. A cold pair carries no other apply ops, so this
+   file-level write does not conflict with the FileState buffer (states are never
+   dirtied; the flush is a no-op) and the watermark records from the minted files.
+
+**New `CorrespondenceVerifier`** (`sync_recover.py`, mirroring `AlignmentRecoverer`):
+
+- `@runtime_checkable Protocol` with `prompt_version` + `verify(*, pairs) -> dict[int, bool]`.
+- `SlidePair` (frozen): `de_heading`, `en_heading`, `de_snippet`, `en_snippet`, `role`.
+- `correspondence_fingerprint(pairs)` → sha256 over the exact serialization the model
+  sees (cache-key soundness).
+- `validate_correspondence(verdicts, pairs)` → total over the pairs, booleans only;
+  `CorrespondenceInvalid` on any failure → safe-abort → treat as "no" → refuse.
+- `StaticCorrespondenceVerifier` (tests; `.calls` counter) + `OpenRouterCorrespondenceVerifier`
+  (Haiku default, `response_format=json_object`, retry, fingerprint-cached via a new
+  `SyncCorrespondenceCache` or a sibling table on the existing cache DB).
+
+**CLI (`slides_sync.py`):** `--verify-cold-pairs / --no-verify-cold-pairs` (default on
+when a provider is set), resolving the verifier like `_resolve_recoverer`; pass
+`provider_available` into `build_sync_plan`.
+
+**Tests:** `TestColdStartRefusalParity` cases become — mint under a confirming
+`StaticCorrespondenceVerifier`, refuse under a denying one, refuse with no provider;
+plus a half-id'd adopt case, a not-unifiable→refuse case, and verifier caching
+(calls==1 on re-run). Dry-run shows pending; apply mints or downgrades.
+
+**Open implementation checks (resolve while building):**
+
+- Confirm `assign_ids_in_split_pair` / `unify` propagates an existing id onto the
+  id-less twin for the **half-id'd** case. If not, add an explicit `adopt_id` stamp.
+- Choose the verifier cache (extend `SyncAlignmentCache` vs a sibling table).
+- `provider_available` detection helper (env-based; reuse the judge/translator key
+  resolution).

--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -1,0 +1,221 @@
+# Sync: Resolve-then-Apply — Design Note
+
+Companion to [`single-language-authoring-sync.md`](single-language-authoring-sync.md)
+(the #166 engine). This note re-architects the **plan / apply boundary** so that
+`clm slides sync` decides *what will happen* once, at plan time, and applying is
+a decision-free mechanical replay. It is the clean design for the bug cluster
+found investigating **#216** (cold-start id-less doubling) and the **dry-run /
+apply divergence** it exposed.
+
+**Status:** design accepted (2 forks settled — see §3); implementation phased
+(§10). Tests pinning the target behavior already landed as `xfail(strict)` (§9).
+
+---
+
+## 1. The problem: apply does much more than apply
+
+Today the pipeline is two stages:
+
+```
+build_sync_plan / classify_changes   →  SyncPlan (proposals)        [pure]
+apply_plan                           →  writes + ApplyResult        [decides AND executes]
+```
+
+`apply_plan` is not an executor — it is a **second decision-maker**. It re-runs
+structural logic the plan never captured:
+
+- the both-directions id-less **refusal** (`sync_apply.py:710-718`: defer + error);
+- the **absence** of that refusal for id-*carrying* both-directions adds
+  (`sync_apply.py:695-705`: applies both → silent doubling);
+- translation success/failure → defer (`_translate`, `_add_one_direction`);
+- `process_idless` gating, move-after-add ordering, watermark advance gating.
+
+Because those decisions live in the executor, **the plan is not a faithful
+description of what will happen.** Every symptom below is one cause:
+
+| Symptom (this session) | Why |
+|---|---|
+| `--dry-run` prints `N add`, the writing run defers all and writes nothing (exit 1 vs 2) | the refusal is an apply-time decision, invisible to the plan |
+| cold-start **mismatched-id** / **half-id'd** pairs silently **double** both decks (`errors=[]`) | the both-directions guard covers only id-*less* adds; the id-*carrying* path is unguarded |
+| `#216` cannot bootstrap a fresh deck | the plan emits N bidirectional adds; apply refuses; neither pairs |
+
+(The id-less *symmetric* case the issue cites is in fact already *refused* by the
+guard — so it is a dry-run-honesty + missing-feature bug, **not** the data
+corruption the issue claimed. The real corruption is the id-carrying sibling.)
+
+## 2. The principle: decide at resolve time, execute mechanically
+
+Split the work by **what kind of thing it is**, with a sharp purity boundary:
+
+```
+1. Classify   [pure]            structural diff vs. baseline → raw observations
+2. Resolve                      turn observations into a COMPLETE, executable plan
+   2a. structural  [pure*]      decide every disposition: add / pair / refuse /
+                                defer / conflict / order  (no "maybe" remains)
+   2b. materialize [LLM/IO]     fill in generated content: translate / rewrite /
+                                correspondence-confirm  → attach, or mark Blocked
+3. Apply      [mechanical]      replay the resolved steps. No decisions, no LLM,
+                                no "can this apply?". It cannot defer or refuse.
+```
+
+`*` "pure" = deterministic, read-only, **no LLM**. 2a may read file state (the
+classifier already reads both decks); it must not write or call a model.
+
+The one load-bearing property: **`--dry-run` = stages 1 + 2a**, which is pure and
+**shared byte-for-byte with the writing run.** A dry-run and an apply therefore
+cannot disagree on any *structural* decision — the refusal, the pairing, the
+deferral, and the exit class all become plan items the preview prints.
+
+## 3. Decisions settled
+
+**Q-A — dry-run faithfulness: structural-faithful, no LLM.** `--dry-run` runs
+1 + 2a and prints every structural disposition, marking generated content
+`pending` rather than calling the model. Same cost as today's dry-run. The *only*
+permitted apply-time divergence is a `pending` item the model could not
+materialize/verify at write time → it downgrades to `blocked`/`refused`, and
+because the preview labeled it `pending`, the downgrade is never a surprise.
+(A future `--dry-run --with-content` may opt into running 2b for an exact preview.)
+
+**Q-B — cold-start pairing: mint when correspondence confirmed, else refuse.**
+A never-id'd, structurally-aligned pair is a *pairing candidate*. When a provider
+is configured, a cheap, cached LLM gate (§7) confirms the halves actually
+correspond, then mints shared ids; with no provider, or on a "no" verdict, it
+**refuses** with a clear message. This supplies the cross-language signal that
+[§3.2 of the base design](single-language-authoring-sync.md) deliberately lacked
+("we do not *similarity-guess* cross-language identity") — an explicit semantic
+**verification** is not a blind structural guess, so the new behavior extends
+that principle rather than breaking it.
+
+## 4. Data model: dispositions, `pending`, and `Refuse` as a first-class item
+
+Today a `Proposal` is implicitly "a thing apply will attempt." Replace the
+implicit contract with an explicit **disposition** — the resolved verdict 2a
+assigns to every item:
+
+| Disposition | Meaning | Stage-3 action |
+|---|---|---|
+| `apply` | a concrete mechanical op (insert / replace-body / mint-id / adopt-id / delete / move / retag) | execute it |
+| `refuse(reason)` | a structural decision **not** to act (both-directions cold-start, mismatched-id pair) | no-op; hold watermark for the scoped cells; **shown in the plan** |
+| `conflict(reason)` | same id drifted both sides (§3.4 isolate-and-refuse) | leave untouched; hold |
+| `pending(kind)` | structurally decided, awaiting 2b content/verification (translate / correspondence) | resolved before stage 3; downgrades to `blocked`/`refused` only if 2b fails |
+
+Key change vs. today: `refuse` and `pending` are **plan items with a reason**,
+not apply-time strings. The new mechanical op kinds the redesign introduces:
+
+- **`mint_shared_id(de_cell, en_cell, id)`** — stamp a *fresh* shared id onto two
+  *existing* positionally-paired id-less cells. No translation, no insertion.
+  (Today **no such op exists**; the only minter, `_add_one_direction` /
+  `_place_new_cell`, is fundamentally translate-and-insert.)
+- **`adopt_id(src_id → target_cell)`** — copy an existing id from the id'd half
+  onto its id-less twin (the half-id'd case; safer than minting — the id already
+  exists on one side).
+
+`mint_shared_id` / `adopt_id` may delegate their byte-level work to the proven
+`assign_ids_in_split_pair` machinery (`assign_ids.py:823`, round-trip-verified
+EN-authority paired minting) rather than re-implementing slug derivation.
+
+## 5. The faithfulness contract (the testable invariant)
+
+> For any input, a `--dry-run` and a writing run **agree on every structural
+> disposition** — what is added / paired / refused / deferred / conflicted, and
+> the resulting exit class. The writing run may additionally downgrade a
+> `pending` item to `blocked`/`refused` **iff** the model is unavailable or a
+> correspondence check returns "no" — and the preview labels every such item
+> `pending`, so the downgrade is disclosed in advance.
+
+This is exactly what the parity tests in §9 assert; the redesign flips them from
+`xfail` to pass.
+
+## 6. How each found issue dissolves
+
+| Issue | Resolution under this design |
+|---|---|
+| dry-run dishonesty (id-less symmetric) | 2a emits a visible `refuse` (no provider) or `pending` pair candidate (provider) → dry-run shows it; exit classes match |
+| id-carrying silent doubling (mismatched-id) | 2a sees a both-direction id divergence with no baseline → `refuse` (or `conflict`), **never** a bidirectional translate-insert |
+| half-id'd doubling | 2a → `adopt_id` (correspondence-gated) onto the id-less half; never doubles |
+| #216 bootstrap | 2a → `mint_shared_id` candidates; 2b confirms; stage 3 stamps. `clm slides sync` becomes the proper cold-start minter (no separate `assign-ids` step) |
+| "no similarity-guess" (§3.2) | preserved: pairing requires an explicit 2b **verification**, not structural similarity alone |
+
+## 7. Cold-start pairing & the correspondence gate
+
+**2a (pure, provider-aware).** A cold-start pair is a *candidate* only when it is
+structurally alignable — equal length, equal role/cell-type sequence, and
+id-less-only (no interleaved id'd cells that would move the positional anchor).
+Reuse the alignment idea behind `_streams_aligned`, adapted to the cold path's
+role-filtered cells. 2a branches on **provider availability** (a structural,
+plan-time input):
+
+- provider configured → emit `pending(correspondence)` pair candidates (dry-run
+  shows "N pair — pending verification", exit 1);
+- no provider → emit `refuse("cold-start pair; no provider to verify
+  correspondence; run with a provider or `assign-ids`")` (exit 2). Dry-run and
+  apply agree, because both know there is no provider.
+
+**2b (LLM, opt-in tier — mirror `--llm-recover`).** A `CorrespondenceVerifier`
+mirroring `AlignmentRecoverer` (`sync_recover.py`): a cheap model (Haiku-class),
+**body-free** inputs (position / role / content-hash, like region fingerprints),
+**cached** by pair fingerprint + prompt version, **validated**, **safe-abort**.
+Per pair it returns, for each candidate, correspond = yes/no. A "yes" → the
+`mint_shared_id` / `adopt_id` op materializes; a "no" → that pair downgrades to
+`refuse`. One call per cold-start deck, cached → re-runs are free.
+
+**Classifier stays pure.** The verifier lives in stage 2b (apply-side tier),
+never in `sync_plan.py`. This honors the base design's "pure analysis — no LLM"
+classifier invariant.
+
+## 8. Module changes
+
+| Module | Change |
+|---|---|
+| `sync_plan.py` | becomes Classify + Resolve-2a. Owns *all* structural dispositions, incl. the both-directions refusal (idless **and** idd) and cold-start pair candidacy — **moved out of apply**. `build_sync_plan` returns a `ResolvedPlan` whose every item carries a disposition. |
+| `sync_apply.py` | splits into **2b materialize** (the LLM calls — translate / judge / correspondence) producing a `MaterializedPlan`, and **3 execute** (decision-free writes). `_apply_adds`' guard logic is deleted (now in 2a). Execute never re-decides. |
+| `sync_recover.py` | gains `CorrespondenceVerifier` beside `AlignmentRecoverer` (same opt-in/cached/validated/safe-abort shape). |
+| `assign_ids.py` | `assign_ids_in_split_pair` reused by `mint_shared_id` / `adopt_id` for byte-level stamping. |
+| `slides_sync.py` (CLI) | dry-run renders the resolved plan (incl. `refuse`/`pending`); exit codes derive from dispositions, so `_plan_exit_code` and `_apply_exit_code` converge by construction. New `--verify-cold-pairs` (default: on when a provider is set) gates 2b correspondence. |
+| watermark | stage 3 advances it only over `apply`-disposition cells; `refuse`/`conflict`/`blocked` cells hold at baseline (the existing #202 per-cell partial-advance, simplified — the held set is now explicit in the plan). |
+
+## 9. Tests already pinning this (committed)
+
+Landed as `xfail(strict=True)` so they self-remove when the fix flips them:
+
+- `tests/slides/test_sync_dry_run_parity.py` — parity helper (`_assert_dry_run_predicts_apply`); 3 passing (noop / single-add / edit) + 2 xfail (cold-start id-less; watermark both-sides id-less).
+- `tests/cli/test_slides_sync.py::TestDryRunApplyParity` — 1 passing + 1 xfail at the CLI surface (+ `_stub_translator`).
+- `tests/slides/test_sync_apply.py` — 2 xfail for the id-carrying doubling (mismatched-id, half-id'd).
+
+The parity assertion is already written to survive either fix shape (it checks
+"a writing-run error must have been foreseen by the dry-run"), so it needs no
+edits when the redesign lands — only the `xfail` markers come off.
+
+## 10. Phased implementation
+
+Each phase is independently shippable and flips a named subset of the xfails.
+
+**Phase 1 — `Refuse` as a first-class disposition; move the structural guards to
+2a.** Introduce the disposition field; relocate the both-directions refusal
+(idless **and** idd) and conflict isolation from `apply_plan` into the resolver.
+Apply stops re-deciding those. *Flips:* the dry-run-honesty xfails + the
+id-carrying doubling xfails (4 of 5). Lowest risk; no LLM, no new minting.
+
+**Phase 2 — Split apply into materialize (2b) + execute (3).** Formalize
+`MaterializedPlan`; make execute decision-free; fold translation/judge into 2b
+with `blocked` on failure. Behavior-preserving refactor that locks the boundary.
+
+**Phase 3 — Cold-start minting + correspondence gate.** `mint_shared_id` /
+`adopt_id` candidates in 2a (provider-aware); `CorrespondenceVerifier` in 2b;
+delegate stamping to `assign_ids_in_split_pair`. *Flips:* the remaining #216
+bootstrap xfails. Unblocks the **1.8 PythonCourses gate** (~200 id-less split
+halves; see `#158`).
+
+## 11. Open questions / deferred
+
+- **`--dry-run --with-content`** (run 2b in preview for an exact diff) — deferred;
+  the structural-faithful default covers the reported pain.
+- **Serializable resolved plan** (`--plan-only` → file → `--apply-plan FILE`) —
+  not required; in-memory resolve→materialize→apply plus the existing
+  translation/alignment caches already give replay-cheapness.
+- **Correspondence on code cells** — out of scope: localized code is matched by
+  id, neutral code is byte-identical, id-less code rides the structural pass.
+  The gate targets id-less *narrative markdown* only.
+- **Mismatched-id pairs with a provider** — Phase 3 may offer to *reconcile*
+  (pick a source-lang, adopt one side's ids) instead of only refusing; start with
+  refuse, revisit with pilot data.

--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -9,8 +9,11 @@ apply divergence** it exposed.
 
 **Status:** design accepted (2 forks settled — see §3); implementation phased
 (§10). **Phase 1 DONE** (the `refuse` disposition + both-directions guard moved to
-the resolver; all 5 parity/doubling xfails flipped to passing — §9). Phases 2–3
-pending.
+the resolver; all 5 parity/doubling xfails flipped — §9). **Phase 2 DONE (scoped):**
+the edit and add paths are materialize-then-execute (the model calls moved to 2b;
+execute writes mechanically). The id-migration recoverer and the `sync_code`
+structural translate remain inline as **explicitly-deferred follow-ups** (§10).
+Phase 3 pending.
 
 ---
 
@@ -170,7 +173,7 @@ classifier invariant.
 | Module | Change |
 |---|---|
 | `sync_plan.py` | becomes Classify + Resolve-2a. Owns *all* structural dispositions, incl. the both-directions refusal (idless **and** idd) and cold-start pair candidacy — **moved out of apply**. `build_sync_plan` returns a `ResolvedPlan` whose every item carries a disposition. |
-| `sync_apply.py` | splits into **2b materialize** (the LLM calls — translate / judge / correspondence) producing a `MaterializedPlan`, and **3 execute** (decision-free writes). `_apply_adds`' guard logic is deleted (now in 2a). Execute never re-decides. |
+| `sync_apply.py` | **2b materialize** (the LLM calls) is split from **3 execute** (decision-free writes) for the edit + add paths: `_materialize_edits` → `_EditOutcome` (judge / code re-translate), and `_materialize_idcarrying` / `_materialize_idless` → `_TransOutcome` cache (add translations). `_apply_edit` and the two add walks then write mechanically; a model-failure is a `blocked`/error outcome decided in 2b. `_apply_adds`' both-directions guard is deleted (now in 2a, Phase 1). **Still inline (deferred):** the id-migration recoverer (`--llm-recover`) and the `sync_code` structural translate — they call models inside their own helpers; a single bundled `MaterializedPlan` object was judged not worth the churn given the add materialize is ordering-sensitive (it must run between the id-carrying and id-less walks). |
 | `sync_recover.py` | gains `CorrespondenceVerifier` beside `AlignmentRecoverer` (same opt-in/cached/validated/safe-abort shape). |
 | `assign_ids.py` | `assign_ids_in_split_pair` reused by `mint_shared_id` / `adopt_id` for byte-level stamping. |
 | `slides_sync.py` (CLI) | dry-run renders the resolved plan (incl. `refuse`/`pending`); exit codes derive from dispositions, so `_plan_exit_code` and `_apply_exit_code` converge by construction. New `--verify-cold-pairs` (default: on when a provider is set) gates 2b correspondence. |
@@ -199,6 +202,11 @@ The parity assertion was written to survive either fix shape (it checks "a
 writing-run error must have been foreseen by the dry-run"), so it needed no edits
 when the redesign landed — only the `xfail` markers came off.
 
+**Phase 2 boundary tests** (`tests/slides/test_sync_apply.py`): the judge is invoked
+exactly once per edit and the translator exactly once per add cell — both in the
+materialize pass, never re-called in execute. A higher count would mean the
+execute walk fell back to the model (a leak across the 2b/3 boundary).
+
 ## 10. Phased implementation
 
 Each phase is independently shippable and flips a named subset of the xfails.
@@ -216,9 +224,18 @@ refusal. Also surfaced in `render_plan` / `--json` (`counts.refuse`,
 `proposals[].disposition`), the walker (a `REFUSE` action, never prompted), and
 the `migration.md` info topic.
 
-**Phase 2 — Split apply into materialize (2b) + execute (3).** Formalize
-`MaterializedPlan`; make execute decision-free; fold translation/judge into 2b
-with `blocked` on failure. Behavior-preserving refactor that locks the boundary.
+**Phase 2 — Split apply into materialize (2b) + execute (3). [DONE — scoped to
+edit + add].** The edit path materializes via `_materialize_edits` → `_EditOutcome`
+(`update` / `in_sync` / `blocked`); `_apply_edit` writes mechanically (boundary
+test: judge called once, in materialize). The add path materializes via
+`_materialize_idcarrying` / `_materialize_idless` → a `_TransOutcome` cache keyed by
+source-cell id; the two add walks read the cache through `_translate`, with a
+model fallback for a cache miss that never fires because the materialize walks
+enumerate a **superset** of what execute translates (boundary test: translator
+called once per cell). Behavior-preserving (1106 sync tests green). **Deferred
+follow-ups (call models inline still):** the id-migration recoverer and the
+`sync_code` structural translate; and a single bundled `MaterializedPlan` object
+(the two materialize seams suffice, and the add seam is ordering-sensitive).
 
 **Phase 3 — Cold-start minting + correspondence gate.** `mint_shared_id` /
 `adopt_id` candidates in 2a (provider-aware); `CorrespondenceVerifier` in 2b;

--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -13,7 +13,10 @@ the resolver; all 5 parity/doubling xfails flipped — §9). **Phase 2 DONE (sco
 the edit and add paths are materialize-then-execute (the model calls moved to 2b;
 execute writes mechanically). The id-migration recoverer and the `sync_code`
 structural translate remain inline as **explicitly-deferred follow-ups** (§10).
-Phase 3 pending.
+**Phase 3.1 (id-less cold-pair minting) DONE** — `build_sync_plan` emits a `pending`
+mint candidate, `apply_plan` verifies via the new `CorrespondenceVerifier` and mints
+via `assign_ids_in_split_pair`; `--verify-cold-pairs` default-on with a provider.
+**Phase 3.2 (half-id'd adopt) is next** (§12).
 
 ---
 
@@ -238,13 +241,15 @@ follow-ups (call models inline still):** the id-migration recoverer and the
 `sync_code` structural translate; and a single bundled `MaterializedPlan` object
 (the two materialize seams suffice, and the add seam is ordering-sensitive).
 
-**Phase 3 — Cold-start minting + correspondence gate. [NEXT — finalized plan in
-§12].** `build_sync_plan` emits a `pending` mint candidate for a provider-available,
-unifiable cold pair; a `CorrespondenceVerifier` (2b) confirms the heading/snippet
-pairs; the mint delegates to `assign_ids_in_split_pair` (handles id-less + half-id'd;
-mismatched-id stays `refuse`). *Flips:* the `TestColdStartRefusalParity` cases to
-mint-under-a-confirming-verifier. Unblocks the **1.8 PythonCourses gate** (~200
-id-less split halves; see `#158`).
+**Phase 3 — Cold-start minting + correspondence gate. [3.1 (id-less) DONE; 3.2
+(half-id'd) NEXT — see §12].** `build_sync_plan` emits a `pending` mint candidate for
+a provider-available, unifiable cold pair; a `CorrespondenceVerifier` (2b) confirms
+the heading/snippet pairs; the mint delegates to `assign_ids_in_split_pair`.
+**3.1 done** (id-less; mismatched-id stays `refuse`). **3.2** adds the half-id'd
+*adopt* — separate from `assign_ids_in_split_pair`, which **cannot** adopt because
+`unify` does not pair an id-less cell with an id'd one (`_slide_ids_pair` is
+`de_id == en_id`). Unblocks the **1.8 PythonCourses gate** (~200 id-less split
+halves; see `#158`).
 
 ## 11. Open questions / deferred
 
@@ -328,10 +333,20 @@ when a provider is set), resolving the verifier like `_resolve_recoverer`; pass
 plus a half-id'd adopt case, a not-unifiable→refuse case, and verifier caching
 (calls==1 on re-run). Dry-run shows pending; apply mints or downgrades.
 
-**Open implementation checks (resolve while building):**
+**Open implementation checks — RESOLVED (3.1):**
 
-- Confirm `assign_ids_in_split_pair` / `unify` propagates an existing id onto the
-  id-less twin for the **half-id'd** case. If not, add an explicit `adopt_id` stamp.
-- Choose the verifier cache (extend `SyncAlignmentCache` vs a sibling table).
-- `provider_available` detection helper (env-based; reuse the judge/translator key
-  resolution).
+- **Half-id'd: `assign_ids_in_split_pair` / `unify` does NOT adopt.** `unify`'s
+  `_slide_ids_pair(de, en)` is `de_id == en_id`, so an id-less cell never pairs with
+  an id'd one — the minter would mint *separate* ids, not adopt. So **3.2 needs an
+  explicit `adopt` path** (positional-stream pairing + stamp the id'd side's id onto
+  the id-less twin). Both-id-less *does* pair (`None == None` → adjacency), which is
+  why 3.1's id-less mint works through `assign_ids_in_split_pair`.
+- Verifier cache = a new `SyncCorrespondenceCache` (sibling table `sync_correspondences`).
+- `provider_available` = `has_openrouter_api_key()` (`openrouter_client.py`).
+
+**3.1 implementation notes (shipped):** the `pending` `mint` candidate is one
+per-pair marker; apply re-derives the aligned `(de, en)` slide pairs from the
+(unchanged) files by positional zip of the slide cells (`_build_slide_pairs`), then
+`_resolve_correspondence` (mirrors `_resolve_alignment`) verifies + caches. The mint
+short-circuits the whole `apply_plan` (a cold pair has no other ops). Verifier inputs
+are heading + the lines *after* the heading (a short lead snippet) + role.

--- a/docs/claude/sync-plan-resolve-apply-handover.md
+++ b/docs/claude/sync-plan-resolve-apply-handover.md
@@ -4,7 +4,7 @@
 **Design note:** `docs/claude/design/sync-plan-resolve-apply.md` (the canonical spec)
 **Base design:** `docs/claude/design/single-language-authoring-sync.md` (the #166 engine)
 **Memory:** `project-sync-coldstart-idless-bug` (corrected framing + verified findings)
-**Status:** design accepted, both forks settled; **Phase 1 DONE** (all 5 xfails flipped to passing); Phase 2 is next.
+**Status:** design accepted, both forks settled; **Phase 1 DONE** (all 5 xfails flipped); **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3 is next** (cold-start minting — the actual #158 unblock).
 
 ---
 
@@ -141,15 +141,29 @@ The original TODO recipe (kept for reference):
   markers (strict will force this — they become XPASS failures otherwise).
 - **Risk:** low. No LLM, no new minting; pure relocation + a new disposition.
 
-### Phase 2 — Split apply into materialize (2b) + execute (3)  **[TODO]**
-- **Goal:** make apply decision-free. Formalize a `MaterializedPlan`; fold
-  translation (`_translate`, `_add_one_direction`) and the edit judge into a 2b
-  pass that attaches content or marks an item `blocked`; the execute pass does
-  only mechanical writes (insert / replace-body / stamp-id / delete / move).
-- **Files:** `src/clm/slides/sync_apply.py` (the bulk), possibly a new module for
-  the execute primitives.
-- **Acceptance:** behavior-preserving refactor; full sync suite stays green; the
-  boundary is enforced (execute makes no decisions, calls no model).
+### Phase 2 — Split apply into materialize (2b) + execute (3)  **[DONE — scoped to edit + add]**
+- **Delivered** (commits `6e34368` edit / `879b61b` add): the model calls for the
+  edit and add paths moved into materialize passes; the execute walks write
+  mechanically.
+  - **Edit** (2.1): `_materialize_edits` resolves every edit + won conflict into an
+    `_EditOutcome` (`update` / `in_sync` / `blocked`); `_apply_edit` writes from it
+    with no judge/translator (`_apply_code_edit` folded into `_resolve_edit`).
+  - **Add** (2.2): `_materialize_idcarrying` / `_materialize_idless` pre-translate
+    every add/rename source cell into a `_TransOutcome` cache keyed by source-cell
+    `id`; `_add_one_direction` / `_add_idcarrying_one_direction` keep their exact
+    structure but read the cache via `_translate` (which has a never-fires model
+    fallback — the materialize walks enumerate a **superset** of what execute
+    translates). Materialize calls sit right before their walks to preserve the
+    state-mutation ordering and copy-id detection.
+  - **Boundary tests** (`test_sync_apply.py`): judge called once per edit,
+    translator once per add cell — both in materialize, never re-called in execute.
+- **Behavior-preserving:** `tests/slides` + CLI sync = 1106 passed; ruff + mypy clean.
+- **Deferred follow-ups (still call models inline):** the id-migration recoverer
+  (`--llm-recover`, `_migrate_drifted_ids` subsystem) and the `sync_code` structural
+  translate (`apply_code_structure`, id-less localized code). A single bundled
+  `MaterializedPlan` object was judged not worth the churn (the two materialize
+  seams suffice; the add seam is ordering-sensitive, so it can't simply hoist to
+  the top of `apply_plan`).
 
 ### Phase 3 — Cold-start minting + correspondence gate  **[TODO]**
 - **Goal:** `clm slides sync` becomes the proper cold-start id minter.
@@ -177,13 +191,16 @@ The original TODO recipe (kept for reference):
 ## 4. Current Status
 
 ### Done (committed on the branch)
-- **Phase 1 implementation** (this session): the `refuse` disposition + the
-  both-directions guard relocated to the resolver. Touches
+- **Phase 2 implementation** (commits `6e34368` edit-path / `879b61b` add-path):
+  edit + add paths are materialize-then-execute (see Phase 2 above). Touches only
+  `src/clm/slides/sync_apply.py` + `tests/slides/test_sync_apply.py` (2 boundary
+  tests). `tests/slides` + CLI sync = 1106 passed; ruff + mypy clean.
+- **Phase 1 implementation** (commit `de038a7`, docs `033db03`): the `refuse`
+  disposition + the both-directions guard relocated to the resolver. Touches
   `src/clm/slides/sync_plan.py`, `sync_apply.py`, `sync_plan_walker.py`,
   `src/clm/cli/commands/slides_sync.py`, `src/clm/cli/info_topics/migration.md`,
   and the four test files (markers removed, assertions rewritten to the refusal
-  outcome, `TestBothDirectionsRefusal` added). `tests/slides` = 1048 passed,
-  2 skipped; ruff + mypy clean.
+  outcome, `TestBothDirectionsRefusal` added).
 - `93d5e59` — **test spec** (originally 4 pass / 5 xfail; the 5 xfails are now
   passing after Phase 1):
   - `tests/slides/test_sync_dry_run_parity.py` (NEW): parity helper
@@ -223,35 +240,40 @@ has **no guard** (`sync_apply.py:695-705`).
   mismatched-id pairs with a provider — start with refuse).
 
 ### Test state
-- After Phase 1: the 9 parity tests all pass (the 5 xfail markers removed),
-  `TestBothDirectionsRefusal` added (6 cases). Full `tests/slides` green
-  (1048 passed, 2 skipped); `tests/cli/test_slides_sync.py` green. ruff + mypy
-  clean on the changed modules.
+- After Phase 2: `tests/slides` + `tests/cli/test_slides_sync.py` = **1106 passed,
+  2 skipped**; ruff + mypy clean. Phase 1's 9 parity tests + `TestBothDirectionsRefusal`
+  (6 cases) all pass; Phase 2 added 2 boundary tests (judge-once / translator-once).
+  All pre-commit hooks green on both Phase 2 commits.
 
 ---
 
 ## 5. Next Steps
 
-**Phase 1 is DONE.** Start **Phase 2 — split apply into materialize (2b) +
-execute (3)** (design note §10). The goal is to make `apply_plan` decision-free:
+**Phases 1 and 2 are DONE.** Start **Phase 3 — cold-start minting + correspondence
+gate** (design §3-Q-B, §7; Phase 3 above). This is the larger payoff: it lets a
+confirmed cold-start pair *mint* a shared id instead of refusing, **unblocking the
+1.8 PythonCourses gate (`#158`)**. Concretely:
 
-1. Formalize a `MaterializedPlan` (or a per-proposal `materialized_*` payload):
-   a pass that, for each `add` / `rename` / `edit` / `retag`, attaches the
-   already-generated content (the translated body / the judge's rewrite) or marks
-   the item `blocked` when the model is unavailable/fails — instead of today's
-   inline `_translate` (`sync_apply.py` ~870) and `judge.propose` (~590) calls
-   that decide *and* write in one step.
-2. Make the **execute** pass mechanical: insert / replace-body / stamp-id / delete
-   / move only, no `translator`/`judge` reference, no `result.deferred`/`errors`
-   decisions of its own (those become `blocked` dispositions decided in 2b).
-3. Keep it behavior-preserving — the full sync suite must stay green; the boundary
-   is the deliverable (assert execute calls no model). No new user-visible
-   behavior; this just locks in what Phase 1 started.
+1. **2a (resolver, provider-aware)** — for a structurally-aligned cold-start pair
+   (the case Phase 1 currently `refuse`s), emit `mint_shared_id` (both id-less) /
+   `adopt_id` (half-id'd) **candidates** *when a provider is configured*, else keep
+   `refuse`. Provider availability is a plan-time input, so dry-run and apply still
+   agree. The alignment predicate adapts the idea behind `_streams_aligned`
+   (`sync_plan.py`) — **not a drop-in** (it consumes raw `Cell`s incl. code, while
+   the cold path holds role-filtered `CurrentCell`s; see Session Notes).
+2. **2b (apply-side tier)** — a `CorrespondenceVerifier` beside `AlignmentRecoverer`
+   in `sync_recover.py`: cheap model (Haiku-class), body-free inputs, cached by pair
+   fingerprint + prompt version, validated, safe-abort. "yes" → materialize the
+   mint/adopt (reuse the `_TransOutcome`/`_EditOutcome` materialize pattern from
+   Phase 2); "no" → downgrade the candidate to `refuse`.
+3. Delegate the byte-level stamping to `assign_ids_in_split_pair` (`assign_ids.py`).
+4. CLI: `--verify-cold-pairs` (default on when a provider is set).
+5. Tests: the two `TestColdStartRefusalParity` cases become "mints under a
+   confirming stub verifier, refuses under a denying one."
 
-Phase 3 (cold-start minting + `CorrespondenceVerifier`) remains the larger payoff
-— see §3 of this handover and design §7. It is what finally lets a confirmed
-cold-start pair *mint* instead of refuse, unblocking the 1.8 PythonCourses gate
-(`#158`). Until then the Phase 1 refusal is the safe, honest default.
+**Also remaining (lower priority, Phase 2 follow-ups):** materialize the
+id-migration recoverer and the `sync_code` structural translate so execute is
+*fully* model-free (today only the edit + add paths are). Not required for Phase 3.
 
 **Prereqs / setup (IMPORTANT — see Gotchas):**
 - This worktree's venv was incomplete. Run **`uv sync --extra all`** before

--- a/docs/claude/sync-plan-resolve-apply-handover.md
+++ b/docs/claude/sync-plan-resolve-apply-handover.md
@@ -1,0 +1,316 @@
+# Handover: Sync Resolve-then-Apply redesign (#216)
+
+**Branch:** `claude/sync-plan-resolve-apply-redesign` (off `master` @ `1a105f6`)
+**Design note:** `docs/claude/design/sync-plan-resolve-apply.md` (the canonical spec)
+**Base design:** `docs/claude/design/single-language-authoring-sync.md` (the #166 engine)
+**Memory:** `project-sync-coldstart-idless-bug` (corrected framing + verified findings)
+**Status:** design accepted, both forks settled, test spec committed; **Phase 1 not started.**
+
+---
+
+## 1. Feature Overview
+
+`clm slides sync` reconciles a split `.de.py`/`.en.py` deck pair. Today it runs in
+two stages — `build_sync_plan` (pure classifier → `SyncPlan`) then `apply_plan`
+(writes). The bug this redesign fixes: **`apply_plan` is a second decision-maker,
+not an executor.** It re-runs structural logic the plan never captured (deferrals,
+guards, refusals), so the `SyncPlan` is *not* a faithful description of what will
+happen. Every symptom found this session is one cause.
+
+The redesign re-architects the plan/apply boundary into **decide once at plan
+time, then mechanically replay**: a pure structural *resolve* stage assigns every
+item a final *disposition* (apply / refuse / defer / pair / conflict / pending),
+an LLM *materialize* stage fills in generated content, and a decision-free
+*apply* stage executes. Because `--dry-run` becomes the pure resolve stage shared
+byte-for-byte with the writing run, the two can no longer diverge.
+
+**Why it matters:** the divergence misleads authors (a dry-run promising changes
+the writing run refuses), and a sibling of the same root cause **silently doubles
+decks** (data corruption). It also blocks the **CLM 1.8 PythonCourses gate**
+(`#158`): ~200 id-less split halves need `clm slides sync` to be a correct
+cold-start id minter, which it currently is not.
+
+**Issues:** `#216` (cold-start id-less; the entry point), `#158` (1.8 gate, blocked).
+
+---
+
+## 2. Design Decisions
+
+### The core reframing (user's, confirmed)
+Apply does much more than apply. The decisions hiding in `apply_plan` must move to
+plan creation; applying must be mechanical. Refined into **three stages with a
+hard purity boundary**:
+
+```
+1. Classify   [pure]            structural diff vs. baseline → raw observations
+2. Resolve
+   2a. structural  [pure, no LLM, may read files]   decide EVERY disposition
+   2b. materialize [LLM/IO]                          translate / rewrite / verify
+3. Apply      [mechanical]      replay; cannot defer or refuse
+```
+
+`--dry-run` = stages **1 + 2a** (pure, shared with the writing run) → structural
+parity is guaranteed by construction.
+
+### Two forks settled by the user (do NOT re-litigate)
+- **Dry-run faithfulness → "structural-faithful, no LLM."** Dry-run runs 1+2a,
+  shows every structural disposition, marks generated content `pending` (no model
+  call). The only permitted apply-time divergence is a `pending` item the model
+  can't materialize/verify → downgrades to `blocked`/`refused`, disclosed because
+  the preview already said `pending`. (A future `--dry-run --with-content` may opt
+  into running 2b — deferred.)
+- **Cold-start pairing → "mint when correspondence confirmed, else refuse."** A
+  never-id'd aligned pair is a *candidate*; with a provider, a cheap cached LLM
+  gate confirms the halves correspond, then mints shared ids; with no provider or
+  a "no" verdict, it **refuses** with a clear message. **Provider availability is a
+  plan-time (structural) input**, so dry-run and apply agree even here.
+
+### Why these over the alternatives
+- **Mint on structural alignment alone** (the issue's literal proposal) was
+  **rejected**: two coincidentally same-length/same-role halves (one rewritten or
+  reordered) pass alignment yet aren't translations → a silently-wrong shared id,
+  *worse* than today's visible refuse. The base design's **§3.2 "no
+  similarity-guess"** principle forbids it. The chosen policy supplies the missing
+  cross-language signal via an explicit *verification*, not a blind guess — a
+  principled evolution, not a violation.
+- **Fully-faithful dry-run (runs the LLM)** was rejected as the default: it makes
+  every preview cost money/latency. Structural-faithful covers the reported pain.
+- **Build all-new minting machinery vs. delegate**: the resolver's
+  `mint_shared_id`/`adopt_id` ops should **delegate byte-level work to the
+  existing, proven `assign_ids_in_split_pair`** (`assign_ids.py:823`,
+  round-trip-verified EN-authority paired minting) rather than re-implement slug
+  derivation. The maintainer's "no unify→assign→split *workaround*" means don't
+  make the *author* run it manually — `sync` calling it internally is fine.
+
+### Constraint: the classifier stays pure
+`sync_plan.py` is documented "pure analysis — no LLM, no writes." The LLM
+correspondence gate lives in **stage 2b (apply-side tier)**, mirroring the
+existing opt-in `--llm-recover` / `AlignmentRecoverer` pattern in `sync_recover.py`
+(opt-in flag, cached, validated, safe-abort). 2a only needs to know *whether* a
+provider is configured.
+
+---
+
+## 3. Phase Breakdown
+
+### Phase 1 — `Refuse` as a first-class disposition; move structural guards to 2a  **[TODO — NEXT]**
+- **Goal:** relocate every *structural* decision from `apply_plan` into the
+  resolver so the plan is faithful and apply stops re-deciding.
+- **Work:**
+  - Add a `disposition` concept to the plan (a field on `Proposal`, or a new
+    plan-item type) with values `apply` / `refuse(reason)` / `conflict(reason)`
+    (and later `pending`). `refuse` must render in `render_plan` / `--dry-run`
+    output and JSON, and drive `_plan_exit_code`.
+  - In `classify_changes` (cold path, `sync_plan.py:879-883` and
+    `_append_idless_adds` ~1104): when id-less adds would span **both directions**
+    (the parallel cold-start case), emit a single `refuse` item instead of N
+    bidirectional adds. This is the both-directions guard, **moved from apply**.
+  - Cover the **id-carrying** sibling too: a cold-start pair emitting *id-carrying*
+    adds in both directions (mismatched-id / half-id'd) must also `refuse` — this
+    is the currently-**unguarded** doubling path.
+  - In `apply_plan` (`sync_apply.py`): delete the both-directions guard at
+    `_apply_adds:710-718` and the `process_idless` branching; apply now just
+    executes whatever disposition the plan carries (refuse → no-op + hold
+    watermark).
+  - Make `_plan_exit_code` / `_apply_exit_code` (`slides_sync.py:913/922`) derive
+    from dispositions so they converge.
+- **Files:** `src/clm/slides/sync_plan.py`, `src/clm/slides/sync_apply.py`,
+  `src/clm/cli/commands/slides_sync.py`.
+- **Acceptance:** flips **4 of 5** xfails — both dry-run parity xfails
+  (`test_sync_dry_run_parity.py`, `TestDryRunApplyParity`) and both id-carrying
+  doubling xfails (`test_sync_apply.py`). Remove their `xfail(strict=True)`
+  markers (strict will force this — they become XPASS failures otherwise).
+- **Risk:** low. No LLM, no new minting; pure relocation + a new disposition.
+
+### Phase 2 — Split apply into materialize (2b) + execute (3)  **[TODO]**
+- **Goal:** make apply decision-free. Formalize a `MaterializedPlan`; fold
+  translation (`_translate`, `_add_one_direction`) and the edit judge into a 2b
+  pass that attaches content or marks an item `blocked`; the execute pass does
+  only mechanical writes (insert / replace-body / stamp-id / delete / move).
+- **Files:** `src/clm/slides/sync_apply.py` (the bulk), possibly a new module for
+  the execute primitives.
+- **Acceptance:** behavior-preserving refactor; full sync suite stays green; the
+  boundary is enforced (execute makes no decisions, calls no model).
+
+### Phase 3 — Cold-start minting + correspondence gate  **[TODO]**
+- **Goal:** `clm slides sync` becomes the proper cold-start id minter.
+- **Work:**
+  - 2a (provider-aware): for a structurally-aligned cold-start pair, emit
+    `mint_shared_id(de_cell, en_cell)` (both id-less) or `adopt_id(src_id →
+    twin)` (half-id'd) **candidates** when a provider is configured (else
+    `refuse`). Alignment predicate adapted from the idea behind
+    `_streams_aligned` (`sync_plan.py:1267`) — note it is **not** a drop-in (see
+    Gotchas).
+  - 2b: a `CorrespondenceVerifier` beside `AlignmentRecoverer` in
+    `sync_recover.py` — cheap model (Haiku-class), body-free inputs, cached by
+    pair fingerprint + prompt version, validated, safe-abort. "yes" → materialize
+    the mint/adopt; "no" → downgrade to `refuse`.
+  - Delegate the byte-level stamping to `assign_ids_in_split_pair`
+    (`assign_ids.py:823`).
+  - CLI: `--verify-cold-pairs` (default on when a provider is set).
+- **Acceptance:** flips the remaining #216 bootstrap xfails (the two
+  `test_sync_dry_run_parity.py::TestDryRunMatchesApplyKnownBugs` cases, once
+  Phase 1 has them refusing they'll need updating to assert *mint* under a stub
+  verifier). Unblocks the 1.8 PythonCourses gate.
+
+---
+
+## 4. Current Status
+
+### Done (committed on the branch)
+- `93d5e59` — **test spec** (9 tests, all green as 4 pass / 5 xfail):
+  - `tests/slides/test_sync_dry_run_parity.py` (NEW): parity helper
+    `_assert_dry_run_predicts_apply` + `_dry_then_apply`; `TestDryRunMatchesApply`
+    (3 pass: noop / single-side id-less add / one-side edit);
+    `TestDryRunMatchesApplyKnownBugs` (2 xfail: cold-start parallel id-less;
+    watermark both-sides id-less).
+  - `tests/cli/test_slides_sync.py`: `TestDryRunApplyParity` (1 pass + 1 xfail) +
+    helpers `_stub_translator`, `_idless_slide`.
+  - `tests/slides/test_sync_apply.py`: `import pytest` added; 2 xfail
+    (`test_cold_start_mismatched_ids_must_not_double`,
+    `test_cold_start_half_idd_must_not_double`) for the id-carrying doubling.
+- `cff8e85` — **design note** `docs/claude/design/sync-plan-resolve-apply.md`.
+
+### Verified findings (the truth table — reproduced empirically + a 7-agent verification workflow)
+| Cold-start scenario | Behavior today | Disposition |
+|---|---|---|
+| **A** symmetric id-less (issue's literal repro) | apply **defers** all, errors, writes nothing | SAFE (guarded). Only the **dry-run lies** (`N add`/exit 1 vs apply exit 2) |
+| **B** asymmetric (id-less on one side only) | apply translates + inserts | correct (legit "new on one side") |
+| **C** half-id'd (one half id-less, other id'd) | **both decks DOUBLE, errors=[]** | **silent corruption** (unguarded idd both-directions) |
+| **D** mismatched-id (both id'd, different ids) | **both decks DOUBLE, errors=[]** | **silent corruption** (same root cause as C) |
+| **E** id-less code + id-less narrative | narrative adds **deferred** | SAFE (code rides structural pass) |
+
+**Key correction:** the issue's "silent doubling of the id-less case" is **wrong** —
+that case is *refused* (guard at `sync_apply.py:710-718`, added 2026-05-31,
+predates the issue). The real doubling is the **id-carrying sibling** (C/D), which
+has **no guard** (`sync_apply.py:695-705`).
+
+### Blockers / open questions
+- None blocking Phase 1. Open design refinements live in the design note §11
+  (`--dry-run --with-content`; serializable resolved plan; reconcile-vs-refuse for
+  mismatched-id pairs with a provider — start with refuse).
+
+### Test state
+- New 9 tests: 4 pass, 5 xfail (as designed). Full sync suite green
+  (`138 passed, 5 xfailed` across the four sync test modules).
+
+---
+
+## 5. Next Steps
+
+**Start Phase 1.** Concretely, in order:
+1. Add the `disposition` to the plan model in `sync_plan.py` (`Proposal` ~130 /
+   `SyncPlan` ~205). Decide: a `disposition: str` + `reason` on `Proposal`, or a
+   dedicated `Refuse` item. Ensure `render_plan` (~1583), `_plan_dict`
+   (`slides_sync.py:1008`), and `_plan_exit_code` (~913) all handle `refuse`.
+2. In `classify_changes` cold path (`sync_plan.py:879-883`): replace the
+   unconditional `_append_idless_adds` (~1104) both-directions emission with a
+   `refuse` when id-less adds span both directions. Do the same for id-carrying
+   both-directions adds (`_classify_cold` ~1074 emits these via `_add(..., cold=True)`).
+3. In `apply_plan` (`sync_apply.py`): delete `_apply_adds:710-718` guard and the
+   `process_idless` plumbing; route `refuse` items to a no-op that holds the
+   watermark for their cells.
+4. Remove the four now-passing `xfail` markers (run the suite; strict xfail will
+   fail loudly if you miss one).
+
+**Prereqs / setup (IMPORTANT — see Gotchas):**
+- This worktree's venv was incomplete. Run **`uv sync --extra all`** before
+  testing (vcrpy / `[replay]` was missing → `import vcr` ModuleNotFoundError broke
+  the pre-commit suite).
+- When committing, export **`PYTEST_XDIST_AUTO_NUM_WORKERS=4`** (the pre-commit
+  wrapper `scripts/run_pytest_hook.py` `setdefault`s it; 8 flakes the
+  mitm/worker-lifecycle contention tests on this 64-thread box).
+
+---
+
+## 6. Key Files & Architecture
+
+### Source (to change)
+- `src/clm/slides/sync_plan.py` — the classifier; becomes Classify + Resolve-2a.
+  - `classify_changes` ~841; cold path `879-883`; `_classify_cold` ~1074 (pairs by
+    shared id only, `in_sync_count += 1` — **does not mint**); `_append_idless_adds`
+    ~1104 (the unconditional both-directions emission — the bug source);
+    `_streams_aligned` ~1267; `build_sync_plan` ~1448 (has the raw `de_cells`/
+    `en_cells`; baseline = watermark → git-head → none); `ordered_sync_cells` ~304;
+    `Proposal` ~130; `SyncPlan` ~205.
+- `src/clm/slides/sync_apply.py` — becomes Materialize-2b + Apply-3.
+  - `apply_plan` ~147 (persists both decks once, **only on an error-free pass**);
+    `_apply_adds` ~649 (**guard 710-718 = idless only**; **idd both-directions
+    695-705 = unguarded**); `_add_idcarrying_one_direction` ~741; `_add_one_direction`
+    ~820 (the minter — translate+insert); `_place_new_cell` ~930.
+- `src/clm/slides/sync_writeback.py` — `role_of` ~66 (the predicate that decides
+  what's sync-relevant — see Gotchas).
+- `src/clm/slides/assign_ids.py` — `assign_ids_in_split_pair` ~823 (reuse for
+  Phase 3 stamping).
+- `src/clm/slides/sync_recover.py` — `AlignmentRecoverer` / `--llm-recover`
+  pattern to mirror for the Phase 3 `CorrespondenceVerifier`.
+- `src/clm/cli/commands/slides_sync.py` — `_plan_exit_code` ~913, `_apply_exit_code`
+  ~922, dry-run/apply branching ~493/512, `_print_human` ~956, `_plan_dict` ~1008.
+
+### Tests (the executable spec — already committed)
+- `tests/slides/test_sync_dry_run_parity.py` — parity invariant (NEW).
+- `tests/cli/test_slides_sync.py` — `TestDryRunApplyParity` + `_stub_translator`.
+- `tests/slides/test_sync_apply.py` — id-carrying doubling regressions.
+
+### Docs
+- `docs/claude/design/sync-plan-resolve-apply.md` — the design (authoritative).
+- `docs/claude/design/single-language-authoring-sync.md` — base #166 design
+  (§3.2 no-similarity-guess, §3.4 isolate-and-refuse).
+
+### Pattern to continue
+- **Dispositions are first-class and shown in the plan.** Any decision that
+  affects whether/what apply writes belongs in 2a (pure) and must render in
+  `--dry-run`. Never let apply make a structural decision the plan didn't record.
+- The parity assertion (`_assert_dry_run_predicts_apply`) is written to survive
+  *either* fix shape ("a writing-run error must have been foreseen by the
+  dry-run"), so it needs no edits — only the markers come off.
+
+---
+
+## 7. Testing Approach
+
+- **Unit (fast):** `tests/slides/test_sync_plan.py`, `test_sync_apply.py`,
+  `test_sync_dry_run_parity.py`; **CLI:** `tests/cli/test_slides_sync.py`.
+- **The invariant under test:** a `--dry-run` and a writing run agree on every
+  structural disposition (add/pair/refuse/defer/conflict + exit class); the only
+  permitted apply-time divergence is a `pending` item the model couldn't
+  materialize/verify. Asserted by `_assert_dry_run_predicts_apply` using the real
+  CLI exit-code helpers and a non-failing static translator/judge.
+- **Run the relevant tests:**
+  ```
+  uv run python -m pytest tests/slides/test_sync_dry_run_parity.py \
+    tests/slides/test_sync_apply.py tests/slides/test_sync_plan.py \
+    tests/cli/test_slides_sync.py -o addopts="-n auto" -q
+  ```
+  (single test serially: add `-o addopts="-n0"`).
+- **Still needs tests (Phase 3):** the *mint* path under a stub
+  `CorrespondenceVerifier` (yes → mints shared id; no → refuses); the two
+  `TestDryRunMatchesApplyKnownBugs` cases will change from "must not lie" to "mints
+  under a confirming verifier" once Phase 3 lands.
+
+---
+
+## 8. Session Notes
+
+- **`role_of` subtlety (load-bearing):** `sync_writeback.py:66`. A markdown cell
+  with a narrative tag (slide/subslide/voiceover/notes) gets a role **regardless of
+  slide_id** → id-less *narrative markdown* IS sync-relevant (these are the
+  `de_idless`/`en_idless` cells). A localized code cell needs **both** lang and
+  slide_id → id-less code returns `None` and rides the structural `sync_code` pass.
+  So the cold-start adds are narrative-markdown only.
+- **`_streams_aligned` is NOT a drop-in for the cold path.** It consumes raw
+  `Cell`s (incl. code) from `_localized_lang_cells`; `classify_changes` only holds
+  role-filtered `CurrentCell`s (narrative markdown) and **is not passed the raw
+  cells** (`build_sync_plan` has them). Phase 3's alignment predicate must be
+  adapted, or build_sync_plan must forward raw cells.
+- **The issue's premise was partly wrong** — verified empirically: the id-less
+  symmetric case is *refused*, not doubled; the doubling is the id-carrying
+  sibling. The corrected story is in memory `project-sync-coldstart-idless-bug`.
+- **Env gotchas that cost time this session** (so the next session doesn't repeat):
+  `uv sync --extra all` first; `PYTEST_XDIST_AUTO_NUM_WORKERS=4` when committing.
+  A backgrounded `git commit` reporting "exit 0" was **misleading** — always
+  confirm with `git log` (a pre-commit-rejected commit can mislead the wrapper).
+- **User preferences observed:** wants the comprehensive clean design (not a quick
+  patch); approved the plan/apply separation as the organizing principle; expects
+  dry-run to be honest; standing permission to commit at sensible checkpoints
+  (push still needs a request). Work stays on this branch.

--- a/docs/claude/sync-plan-resolve-apply-handover.md
+++ b/docs/claude/sync-plan-resolve-apply-handover.md
@@ -4,7 +4,7 @@
 **Design note:** `docs/claude/design/sync-plan-resolve-apply.md` (the canonical spec)
 **Base design:** `docs/claude/design/single-language-authoring-sync.md` (the #166 engine)
 **Memory:** `project-sync-coldstart-idless-bug` (corrected framing + verified findings)
-**Status:** design accepted, both forks settled, test spec committed; **Phase 1 not started.**
+**Status:** design accepted, both forks settled; **Phase 1 DONE** (all 5 xfails flipped to passing); Phase 2 is next.
 
 ---
 
@@ -93,7 +93,26 @@ provider is configured.
 
 ## 3. Phase Breakdown
 
-### Phase 1 — `Refuse` as a first-class disposition; move structural guards to 2a  **[TODO — NEXT]**
+### Phase 1 — `Refuse` as a first-class disposition; move structural guards to 2a  **[DONE]**
+
+*Implemented.* `Proposal` gained a `disposition` field (`"apply"` | `"refuse"`)
+and a `refuse` kind (`SyncPlan.refusals`, `_KIND_ORDER`, the `summary()` headline,
+`count("refuse")`). The both-directions refusal moved into `classify_changes`:
+`_refuse_cold_both_directions` (cold path — refuses when the combined idd+idless
+adds span both directions: parallel id-less, mismatched-id, half-id'd) and
+`_refuse_idless_both_directions` (baseline path — refuses only id-less
+both-direction adds; id-carrying both-direction adds stay adds, since against a
+real baseline they are distinct new slides). `apply_plan` executes a `refuse` as a
+deferred no-op (`result.deferred += 1`, watermark holds, **no error → exit 1**);
+the old `_apply_adds:710-718` guard and the `process_idless` parameter/branches in
+`_add_one_direction` are deleted. The CLI (`_plan_dict` counts + `disposition`),
+the interactive walker (`REFUSE` action, shown-not-prompted, `refused` summary),
+and the `migration.md` info topic were all updated. **All 5 xfails flipped to
+passing** (the main-path refusal also fixed the watermark both-sides case, so 5,
+not the 4 first estimated); a new `TestBothDirectionsRefusal` pins the classifier
+behavior directly. `tests/slides` green (1048 passed), ruff + mypy clean.
+
+The original TODO recipe (kept for reference):
 - **Goal:** relocate every *structural* decision from `apply_plan` into the
   resolver so the plan is faithful and apply stops re-deciding.
 - **Work:**
@@ -158,7 +177,15 @@ provider is configured.
 ## 4. Current Status
 
 ### Done (committed on the branch)
-- `93d5e59` — **test spec** (9 tests, all green as 4 pass / 5 xfail):
+- **Phase 1 implementation** (this session): the `refuse` disposition + the
+  both-directions guard relocated to the resolver. Touches
+  `src/clm/slides/sync_plan.py`, `sync_apply.py`, `sync_plan_walker.py`,
+  `src/clm/cli/commands/slides_sync.py`, `src/clm/cli/info_topics/migration.md`,
+  and the four test files (markers removed, assertions rewritten to the refusal
+  outcome, `TestBothDirectionsRefusal` added). `tests/slides` = 1048 passed,
+  2 skipped; ruff + mypy clean.
+- `93d5e59` — **test spec** (originally 4 pass / 5 xfail; the 5 xfails are now
+  passing after Phase 1):
   - `tests/slides/test_sync_dry_run_parity.py` (NEW): parity helper
     `_assert_dry_run_predicts_apply` + `_dry_then_apply`; `TestDryRunMatchesApply`
     (3 pass: noop / single-side id-less add / one-side edit);
@@ -180,6 +207,11 @@ provider is configured.
 | **D** mismatched-id (both id'd, different ids) | **both decks DOUBLE, errors=[]** | **silent corruption** (same root cause as C) |
 | **E** id-less code + id-less narrative | narrative adds **deferred** | SAFE (code rides structural pass) |
 
+> **Phase 1 resolved A / C / D** (and the watermark both-sides id-less case): all
+> now emit `refuse` proposals at plan time — dry-run and apply agree (exit 1,
+> nothing written, watermark held). The "Behavior today" column above is the
+> *pre-Phase-1* state, kept for the record.
+
 **Key correction:** the issue's "silent doubling of the id-less case" is **wrong** —
 that case is *refused* (guard at `sync_apply.py:710-718`, added 2026-05-31,
 predates the issue). The real doubling is the **id-carrying sibling** (C/D), which
@@ -191,27 +223,35 @@ has **no guard** (`sync_apply.py:695-705`).
   mismatched-id pairs with a provider — start with refuse).
 
 ### Test state
-- New 9 tests: 4 pass, 5 xfail (as designed). Full sync suite green
-  (`138 passed, 5 xfailed` across the four sync test modules).
+- After Phase 1: the 9 parity tests all pass (the 5 xfail markers removed),
+  `TestBothDirectionsRefusal` added (6 cases). Full `tests/slides` green
+  (1048 passed, 2 skipped); `tests/cli/test_slides_sync.py` green. ruff + mypy
+  clean on the changed modules.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 1.** Concretely, in order:
-1. Add the `disposition` to the plan model in `sync_plan.py` (`Proposal` ~130 /
-   `SyncPlan` ~205). Decide: a `disposition: str` + `reason` on `Proposal`, or a
-   dedicated `Refuse` item. Ensure `render_plan` (~1583), `_plan_dict`
-   (`slides_sync.py:1008`), and `_plan_exit_code` (~913) all handle `refuse`.
-2. In `classify_changes` cold path (`sync_plan.py:879-883`): replace the
-   unconditional `_append_idless_adds` (~1104) both-directions emission with a
-   `refuse` when id-less adds span both directions. Do the same for id-carrying
-   both-directions adds (`_classify_cold` ~1074 emits these via `_add(..., cold=True)`).
-3. In `apply_plan` (`sync_apply.py`): delete `_apply_adds:710-718` guard and the
-   `process_idless` plumbing; route `refuse` items to a no-op that holds the
-   watermark for their cells.
-4. Remove the four now-passing `xfail` markers (run the suite; strict xfail will
-   fail loudly if you miss one).
+**Phase 1 is DONE.** Start **Phase 2 — split apply into materialize (2b) +
+execute (3)** (design note §10). The goal is to make `apply_plan` decision-free:
+
+1. Formalize a `MaterializedPlan` (or a per-proposal `materialized_*` payload):
+   a pass that, for each `add` / `rename` / `edit` / `retag`, attaches the
+   already-generated content (the translated body / the judge's rewrite) or marks
+   the item `blocked` when the model is unavailable/fails — instead of today's
+   inline `_translate` (`sync_apply.py` ~870) and `judge.propose` (~590) calls
+   that decide *and* write in one step.
+2. Make the **execute** pass mechanical: insert / replace-body / stamp-id / delete
+   / move only, no `translator`/`judge` reference, no `result.deferred`/`errors`
+   decisions of its own (those become `blocked` dispositions decided in 2b).
+3. Keep it behavior-preserving — the full sync suite must stay green; the boundary
+   is the deliverable (assert execute calls no model). No new user-visible
+   behavior; this just locks in what Phase 1 started.
+
+Phase 3 (cold-start minting + `CorrespondenceVerifier`) remains the larger payoff
+— see §3 of this handover and design §7. It is what finally lets a confirmed
+cold-start pair *mint* instead of refuse, unblocking the 1.8 PythonCourses gate
+(`#158`). Until then the Phase 1 refusal is the safe, honest default.
 
 **Prereqs / setup (IMPORTANT — see Gotchas):**
 - This worktree's venv was incomplete. Run **`uv sync --extra all`** before

--- a/docs/claude/sync-plan-resolve-apply-handover.md
+++ b/docs/claude/sync-plan-resolve-apply-handover.md
@@ -4,7 +4,7 @@
 **Design note:** `docs/claude/design/sync-plan-resolve-apply.md` (the canonical spec)
 **Base design:** `docs/claude/design/single-language-authoring-sync.md` (the #166 engine)
 **Memory:** `project-sync-coldstart-idless-bug` (corrected framing + verified findings)
-**Status:** design accepted; **Phase 1 DONE**; **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3.1 (id-less cold-pair minting) DONE** — the id-less half of the #158 unblock; **Phase 3.2 (half-id'd adopt) is NEXT** (see Phase 3 below — `unify` won't pair half-id'd, so it needs an explicit adopt path).
+**Status:** design accepted; **Phase 1 DONE**; **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3.1 (id-less cold-pair minting) DONE**; **Phase 3.2 (half-id'd adopt) DONE** — the half-id'd half of the #158 unblock, via an explicit `adopt` path (`unify`/`assign_ids` cannot pair an id-less cell with an id'd one). The whole #216 cold-start cluster is resolved end-to-end; the only remaining items are the Phase-2 deferred follow-ups (id-migration recoverer + `sync_code` structural translate).
 
 ---
 
@@ -165,7 +165,7 @@ The original TODO recipe (kept for reference):
   seams suffice; the add seam is ordering-sensitive, so it can't simply hoist to
   the top of `apply_plan`).
 
-### Phase 3 — Cold-start minting + correspondence gate  **[3.1 (id-less) DONE; 3.2 (half-id'd) NEXT]**
+### Phase 3 — Cold-start minting + correspondence gate  **[3.1 (id-less) DONE; 3.2 (half-id'd) DONE]**
 
 **3.1a/3.1b SHIPPED** (commits `5bdf4d4` verifier tier + the id-less wiring commit):
 `clm slides sync` now bootstraps a never-id'd **both-id-less** cold pair end-to-end
@@ -186,13 +186,23 @@ unifiable pair; `apply_plan` verifies via `CorrespondenceVerifier` (in
 - `provider_available` helper = `has_openrouter_api_key()` (`openrouter_client.py`).
 - Verifier cache = a new `SyncCorrespondenceCache` sibling table (`sync_correspondences`).
 
-**3.2 — half-id'd adopt (NEXT):** in `_maybe_emit_cold_mint`, the half-id'd refusal
-(mixed id-less + id'd) currently bails (any `slide_id is not None` → skip). Add an
-`adopt` candidacy + an `_apply_cold_adopt` that positionally pairs the id'd and
-id-less localized streams and stamps the existing id onto the id-less twin (no
-translation — both bodies exist), gated by the same `CorrespondenceVerifier`. New
-tests: half-id'd confirmed→adopt / denied→refuse. `TestColdStartMint::test_half_idd_pair_keeps_refuse_in_phase_3_1`
-flips to an adopt assertion.
+**3.2 — half-id'd adopt (SHIPPED):** `build_sync_plan` now runs `_maybe_emit_cold_adopt`
+right after `_maybe_emit_cold_mint` (same `source=="none" and provider_available` gate,
+mutually exclusive — mint empties `plan.refusals` when it fires). `_cold_adopt_authority`
+(`sync_plan.py`) walks the full positional localized stream and returns the fully-id'd
+side only for a clean half-id'd shape (every pair role/cell-type-matched; sync pairs XOR
+with a consistent authority; non-sync pairs id-less both sides), emitting a single
+`kind="adopt"`, `disposition="pending"`, `direction="{authority}->{other}"`. Apply has a
+second short-circuit beside the mint: `_apply_cold_adopt` verifies the slide pairs (reusing
+`_build_slide_pairs` / `_resolve_correspondence`), then `_adopt_ids_in_split_pair` loads
+**both** halves via `FileState.load`, walks them positionally, and stamps each authority
+slide_id onto its id-less twin (`_stamp_slide_id`), flushing only the id-less half;
+per-cell guards make a post-plan drift return `0` → deferral. `adopt` kind +
+`applied_adopt` counter wired through `ApplyResult`, the walker, and the CLI
+(`_counts_str`/`_plan_dict`/`_apply_dict`/`_outcome_line`). Mismatched-id and
+mixed-authority stay `refuse`. `TestColdStartMint::test_half_idd_pair_keeps_refuse_in_phase_3_1`
+became `test_half_idd_pair_is_adopt_not_mint`; new `TestColdStartAdopt` (10 cases) +
+CLI `test_half_idd_pair_adopts_when_verified`. **1109 slides + 213 sync/CLI tests green.**
 
 - **Goal (overall):** `clm slides sync` becomes the proper cold-start id minter — the
   actual #158 unblock. **The authoritative, decision-baked plan is design note §12.**

--- a/docs/claude/sync-plan-resolve-apply-handover.md
+++ b/docs/claude/sync-plan-resolve-apply-handover.md
@@ -4,7 +4,7 @@
 **Design note:** `docs/claude/design/sync-plan-resolve-apply.md` (the canonical spec)
 **Base design:** `docs/claude/design/single-language-authoring-sync.md` (the #166 engine)
 **Memory:** `project-sync-coldstart-idless-bug` (corrected framing + verified findings)
-**Status:** design accepted, both forks settled; **Phase 1 DONE** (all 5 xfails flipped); **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3 is next** (cold-start minting — the actual #158 unblock).
+**Status:** design accepted; **Phase 1 DONE** (all 5 xfails flipped); **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3 design FINALIZED** (decisions baked — design note §12 + Phase 3 below), implementation not started — the actual #158 unblock.
 
 ---
 
@@ -165,26 +165,42 @@ The original TODO recipe (kept for reference):
   seams suffice; the add seam is ordering-sensitive, so it can't simply hoist to
   the top of `apply_plan`).
 
-### Phase 3 — Cold-start minting + correspondence gate  **[TODO]**
-- **Goal:** `clm slides sync` becomes the proper cold-start id minter.
-- **Work:**
-  - 2a (provider-aware): for a structurally-aligned cold-start pair, emit
-    `mint_shared_id(de_cell, en_cell)` (both id-less) or `adopt_id(src_id →
-    twin)` (half-id'd) **candidates** when a provider is configured (else
-    `refuse`). Alignment predicate adapted from the idea behind
-    `_streams_aligned` (`sync_plan.py:1267`) — note it is **not** a drop-in (see
-    Gotchas).
-  - 2b: a `CorrespondenceVerifier` beside `AlignmentRecoverer` in
-    `sync_recover.py` — cheap model (Haiku-class), body-free inputs, cached by
-    pair fingerprint + prompt version, validated, safe-abort. "yes" → materialize
-    the mint/adopt; "no" → downgrade to `refuse`.
-  - Delegate the byte-level stamping to `assign_ids_in_split_pair`
-    (`assign_ids.py:823`).
-  - CLI: `--verify-cold-pairs` (default on when a provider is set).
-- **Acceptance:** flips the remaining #216 bootstrap xfails (the two
-  `test_sync_dry_run_parity.py::TestDryRunMatchesApplyKnownBugs` cases, once
-  Phase 1 has them refusing they'll need updating to assert *mint* under a stub
-  verifier). Unblocks the 1.8 PythonCourses gate.
+### Phase 3 — Cold-start minting + correspondence gate  **[NEXT — design finalized]**
+- **Goal:** `clm slides sync` becomes the proper cold-start id minter — the actual
+  #158 unblock. **The authoritative, decision-baked plan is design note §12**; the
+  summary below mirrors it.
+- **Decisions (settled 2026-06-04 with the maintainer):**
+  - **Scope:** mint **id-less** both-directions cold pairs (the #158 case) **and**
+    **half-id'd** pairs (id-less half adopts the id'd half's ids); **mismatched-id**
+    (both id'd, different ids) stays `refuse`.
+  - **Verifier inputs:** per aligned slide, **heading + a short body snippet**
+    (~first 1–2 lines) + role; **Haiku-class** model; one cached call per deck.
+    **Not body-free** (cross-language correspondence needs the heading text).
+  - **Gate:** the verifier is a **required gate, default-on when a provider is
+    configured** (`--verify-cold-pairs`); no provider → `refuse`.
+- **Architecture (keeps the purity boundary; see §12 for detail):**
+  - `classify_changes` unchanged (still `refuse`). `build_sync_plan` (with files +
+    a new `provider_available: bool`) converts a both-directions cold refusal into a
+    `pending` mint candidate when `provider_available` **and** the pair is
+    **unifiable** (read-only `unify→split` round-trip); else keeps `refuse`.
+  - `apply_plan` (2b) verifies the candidate's heading/snippet pairs with a new
+    `CorrespondenceVerifier` (mirrors `AlignmentRecoverer`: Protocol + Static +
+    OpenRouter, fingerprint-cached, validated, safe-abort). All "yes" → mint; any
+    "no"/abort/no-verifier → downgrade to `refuse` (the disclosed Q-A divergence).
+  - execute delegates to `assign_ids_in_split_pair` (`assign_ids.py`) — byte-faithful
+    EN-authority minting; its own "not unifiable → None" is a second safety net. A
+    cold pair carries no other apply ops, so the file-level write doesn't fight the
+    FileState buffer.
+  - CLI: `--verify-cold-pairs` (default on when provider set); pass `provider_available`
+    into `build_sync_plan`.
+- **Acceptance:** the `TestColdStartRefusalParity` cases become mint-under-a-confirming
+  -`StaticCorrespondenceVerifier` / refuse-under-a-denying-one / refuse-with-no-provider;
+  + a half-id'd adopt case, a not-unifiable→refuse case, and verifier caching. Unblocks
+  the 1.8 PythonCourses gate (`#158`).
+- **Open implementation checks:** confirm `assign_ids_in_split_pair`/`unify` propagates
+  an existing id onto the id-less twin for **half-id'd** (else add an explicit `adopt_id`
+  stamp); pick the verifier cache (extend `SyncAlignmentCache` vs sibling table);
+  `provider_available` env helper.
 
 ---
 
@@ -249,31 +265,38 @@ has **no guard** (`sync_apply.py:695-705`).
 
 ## 5. Next Steps
 
-**Phases 1 and 2 are DONE.** Start **Phase 3 — cold-start minting + correspondence
-gate** (design §3-Q-B, §7; Phase 3 above). This is the larger payoff: it lets a
-confirmed cold-start pair *mint* a shared id instead of refusing, **unblocking the
-1.8 PythonCourses gate (`#158`)**. Concretely:
+**Phases 1 and 2 are DONE; Phase 3's design is finalized.** Implement **Phase 3 —
+cold-start minting + correspondence gate** per the **decision-baked plan in design
+note §12** (mirrored in the Phase 3 breakdown above). It lets a confirmed cold-start
+pair *mint* a shared id instead of refusing — **the actual #158 unblock**. Build
+order:
 
-1. **2a (resolver, provider-aware)** — for a structurally-aligned cold-start pair
-   (the case Phase 1 currently `refuse`s), emit `mint_shared_id` (both id-less) /
-   `adopt_id` (half-id'd) **candidates** *when a provider is configured*, else keep
-   `refuse`. Provider availability is a plan-time input, so dry-run and apply still
-   agree. The alignment predicate adapts the idea behind `_streams_aligned`
-   (`sync_plan.py`) — **not a drop-in** (it consumes raw `Cell`s incl. code, while
-   the cold path holds role-filtered `CurrentCell`s; see Session Notes).
-2. **2b (apply-side tier)** — a `CorrespondenceVerifier` beside `AlignmentRecoverer`
-   in `sync_recover.py`: cheap model (Haiku-class), body-free inputs, cached by pair
-   fingerprint + prompt version, validated, safe-abort. "yes" → materialize the
-   mint/adopt (reuse the `_TransOutcome`/`_EditOutcome` materialize pattern from
-   Phase 2); "no" → downgrade the candidate to `refuse`.
-3. Delegate the byte-level stamping to `assign_ids_in_split_pair` (`assign_ids.py`).
-4. CLI: `--verify-cold-pairs` (default on when a provider is set).
-5. Tests: the two `TestColdStartRefusalParity` cases become "mints under a
-   confirming stub verifier, refuses under a denying one."
+1. **Data model** (`sync_plan.py`): add the `pending` disposition value and a `mint`
+   proposal kind (carries the aligned heading/snippet pairs). Render/JSON/exit-code
+   like `refuse` (a pending mint is exit 1, "changes pending").
+2. **2a candidacy** (`build_sync_plan`, +`provider_available: bool`): when the cold
+   refusals are convertible and the pair is **unifiable** (read-only `unify→split`
+   round-trip) and a provider is set → emit the `pending` mint candidate; else keep
+   `refuse`. Keep `classify_changes` pure.
+3. **Verifier** (`sync_recover.py`): `CorrespondenceVerifier` Protocol + `SlidePair`
+   + `correspondence_fingerprint` + `validate_correspondence` + `Static…` / `OpenRouter…`
+   (Haiku), mirroring `AlignmentRecoverer`. **Heading + short body snippet** inputs
+   (NOT body-free). Cache + validate + safe-abort.
+4. **2b verify + 3 mint** (`sync_apply.py`): for a `pending` mint, verify; all-yes →
+   `assign_ids_in_split_pair` (handles id-less + half-id'd); any-no/abort/no-verifier →
+   downgrade to `refuse`.
+5. **CLI** (`slides_sync.py`): `--verify-cold-pairs` (default on when provider set);
+   pass `provider_available` into `build_sync_plan`.
+6. **Tests:** rewrite `TestColdStartRefusalParity` (mint / refuse-on-no / no-provider),
+   add half-id'd adopt + not-unifiable→refuse + verifier-cache cases.
 
-**Also remaining (lower priority, Phase 2 follow-ups):** materialize the
-id-migration recoverer and the `sync_code` structural translate so execute is
-*fully* model-free (today only the edit + add paths are). Not required for Phase 3.
+**Watch (open checks, §12):** confirm `assign_ids_in_split_pair`/`unify` propagates an
+existing id onto the id-less twin for **half-id'd** (else add an explicit `adopt_id`);
+choose the verifier cache; `provider_available` env helper.
+
+**Also remaining (lower priority, Phase 2 follow-ups):** materialize the id-migration
+recoverer and the `sync_code` structural translate so execute is *fully* model-free
+(today only the edit + add paths are). Not required for Phase 3.
 
 **Prereqs / setup (IMPORTANT — see Gotchas):**
 - This worktree's venv was incomplete. Run **`uv sync --extra all`** before

--- a/docs/claude/sync-plan-resolve-apply-handover.md
+++ b/docs/claude/sync-plan-resolve-apply-handover.md
@@ -4,7 +4,7 @@
 **Design note:** `docs/claude/design/sync-plan-resolve-apply.md` (the canonical spec)
 **Base design:** `docs/claude/design/single-language-authoring-sync.md` (the #166 engine)
 **Memory:** `project-sync-coldstart-idless-bug` (corrected framing + verified findings)
-**Status:** design accepted; **Phase 1 DONE** (all 5 xfails flipped); **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3 design FINALIZED** (decisions baked — design note §12 + Phase 3 below), implementation not started — the actual #158 unblock.
+**Status:** design accepted; **Phase 1 DONE**; **Phase 2 DONE (scoped: edit + add materialized)**; **Phase 3.1 (id-less cold-pair minting) DONE** — the id-less half of the #158 unblock; **Phase 3.2 (half-id'd adopt) is NEXT** (see Phase 3 below — `unify` won't pair half-id'd, so it needs an explicit adopt path).
 
 ---
 
@@ -165,10 +165,37 @@ The original TODO recipe (kept for reference):
   seams suffice; the add seam is ordering-sensitive, so it can't simply hoist to
   the top of `apply_plan`).
 
-### Phase 3 — Cold-start minting + correspondence gate  **[NEXT — design finalized]**
-- **Goal:** `clm slides sync` becomes the proper cold-start id minter — the actual
-  #158 unblock. **The authoritative, decision-baked plan is design note §12**; the
-  summary below mirrors it.
+### Phase 3 — Cold-start minting + correspondence gate  **[3.1 (id-less) DONE; 3.2 (half-id'd) NEXT]**
+
+**3.1a/3.1b SHIPPED** (commits `5bdf4d4` verifier tier + the id-less wiring commit):
+`clm slides sync` now bootstraps a never-id'd **both-id-less** cold pair end-to-end
+— `build_sync_plan(provider_available=...)` emits a `pending` `mint` candidate for a
+unifiable pair; `apply_plan` verifies via `CorrespondenceVerifier` (in
+`sync_recover.py`, mirroring `AlignmentRecoverer`; `SyncCorrespondenceCache` in
+`cache.py`) and mints via `assign_ids_in_split_pair`; `--verify-cold-pairs`
+(default-on when `has_openrouter_api_key()`) wires it through single/batch/walker.
+`mint` kind + `pending` disposition + `applied_mint` added. **17 verifier unit tests
++ 7 engine mint tests + 1 CLI mint test; 1131 sync tests green.**
+
+**Resolved open checks (record these):**
+- **Half-id'd is NOT handled by `assign_ids_in_split_pair`.** `unify`'s
+  `_slide_ids_pair` returns `de_id == en_id`, so a half-id'd pair (`None` vs an id)
+  does **not** pair under unify → the minter would mint *separate* ids, not adopt.
+  So **3.2 needs an explicit `adopt` path** (positional-stream pairing + stamp the
+  id'd side's id onto the id-less twin). Both-id-less *does* pair (`None==None`).
+- `provider_available` helper = `has_openrouter_api_key()` (`openrouter_client.py`).
+- Verifier cache = a new `SyncCorrespondenceCache` sibling table (`sync_correspondences`).
+
+**3.2 — half-id'd adopt (NEXT):** in `_maybe_emit_cold_mint`, the half-id'd refusal
+(mixed id-less + id'd) currently bails (any `slide_id is not None` → skip). Add an
+`adopt` candidacy + an `_apply_cold_adopt` that positionally pairs the id'd and
+id-less localized streams and stamps the existing id onto the id-less twin (no
+translation — both bodies exist), gated by the same `CorrespondenceVerifier`. New
+tests: half-id'd confirmed→adopt / denied→refuse. `TestColdStartMint::test_half_idd_pair_keeps_refuse_in_phase_3_1`
+flips to an adopt assertion.
+
+- **Goal (overall):** `clm slides sync` becomes the proper cold-start id minter — the
+  actual #158 unblock. **The authoritative, decision-baked plan is design note §12.**
 - **Decisions (settled 2026-06-04 with the maintainer):**
   - **Scope:** mint **id-less** both-directions cold pairs (the #158 case) **and**
     **half-id'd** pairs (id-less half adopts the id'd half's ids); **mismatched-id**

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -1011,7 +1011,7 @@ def _plan_dict(plan: SyncPlan) -> dict:
         "in_sync": plan.in_sync_count,
         "counts": {
             kind: plan.count(kind)
-            for kind in ("add", "edit", "retag", "move", "remove", "conflict", "rename")
+            for kind in ("add", "edit", "retag", "move", "remove", "conflict", "rename", "refuse")
         },
         "proposals": [
             {
@@ -1021,6 +1021,7 @@ def _plan_dict(plan: SyncPlan) -> dict:
                 "slide_id": p.slide_id,
                 "reason": p.reason,
                 "translation_pending": p.translation_pending,
+                "disposition": p.disposition,
             }
             for p in plan.proposals
         ],

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -784,7 +784,18 @@ def _deck_label(de_path: Path, root: Path) -> str:
 
 
 def _counts_str(plan: SyncPlan) -> str:
-    kinds = ("add", "edit", "retag", "move", "remove", "conflict", "rename", "refuse", "mint")
+    kinds = (
+        "add",
+        "edit",
+        "retag",
+        "move",
+        "remove",
+        "conflict",
+        "rename",
+        "refuse",
+        "mint",
+        "adopt",
+    )
     parts = [f"{plan.count(k)} {k}" for k in kinds if plan.count(k)]
     return ", ".join(parts) if parts else "0"
 
@@ -1019,7 +1030,8 @@ def _outcome_line(result: ApplyResult) -> str:
         f"applied: {result.applied_edit} edit, {result.applied_retag} retag, "
         f"{result.applied_remove} remove, "
         f"{result.applied_move} move, {result.applied_add} add, "
-        f"{result.applied_rename} rename; {result.in_sync} already in sync; "
+        f"{result.applied_rename} rename, {result.applied_mint} mint, "
+        f"{result.applied_adopt} adopt; {result.in_sync} already in sync; "
         f"{result.deferred} deferred; {len(result.errors)} error(s); "
         f"watermark {'advanced' if result.watermark_recorded else 'held'}."
     )
@@ -1093,6 +1105,7 @@ def _plan_dict(plan: SyncPlan) -> dict:
                 "rename",
                 "refuse",
                 "mint",
+                "adopt",
             )
         },
         "proposals": [
@@ -1123,6 +1136,8 @@ def _apply_dict(result: ApplyResult) -> dict:
             "move": result.applied_move,
             "add": result.applied_add,
             "rename": result.applied_rename,
+            "mint": result.applied_mint,
+            "adopt": result.applied_adopt,
             "total": result.applied,
         },
         "in_sync": result.in_sync,

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -53,6 +53,7 @@ from attrs import define
 
 from clm.infrastructure.llm.cache import (
     SyncAlignmentCache,
+    SyncCorrespondenceCache,
     SyncWatermarkCache,
     resolve_cache_dir,
 )
@@ -83,14 +84,18 @@ from clm.slides.sync_plan import (
     render_plan,
 )
 from clm.slides.sync_plan_walker import PlanWalkResult, WalkerOptions, run_plan_walker
-from clm.slides.sync_recover import DEFAULT_RECOVERY_MODEL, OpenRouterAlignmentRecoverer
+from clm.slides.sync_recover import (
+    DEFAULT_RECOVERY_MODEL,
+    OpenRouterAlignmentRecoverer,
+    OpenRouterCorrespondenceVerifier,
+)
 from clm.slides.sync_translate import DEFAULT_TRANSLATION_MODEL, OpenRouterSlideTranslator
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from clm.infrastructure.llm.ollama_client import SyncJudge
-    from clm.slides.sync_recover import AlignmentRecoverer
+    from clm.slides.sync_recover import AlignmentRecoverer, CorrespondenceVerifier
     from clm.slides.sync_translate import SlideTranslator
 
 CACHE_DB_NAME = "clm-llm.sqlite"
@@ -299,6 +304,18 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
     help="OpenRouter model for --llm-recover alignment (a strong reasoning model).",
 )
 @click.option(
+    "--verify-cold-pairs/--no-verify-cold-pairs",
+    "verify_cold_pairs",
+    default=None,
+    help=(
+        "Bootstrap a never-id'd split pair by minting shared slide_ids — but only "
+        "after a cheap LLM (Haiku, via OpenRouter) confirms the two halves actually "
+        "correspond (#216). Default: on when $OPENROUTER_API_KEY (or $OPENAI_API_KEY) "
+        "is set. With no provider, or --no-verify-cold-pairs, such a pair is refused "
+        "(sync one direction at a time, or run `clm slides assign-ids`)."
+    ),
+)
+@click.option(
     "--cache-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -353,6 +370,7 @@ def slides_sync_cmd(
     translation_model: str,
     llm_recover: bool,
     recovery_model: str,
+    verify_cold_pairs: bool | None,
     cache_dir: Path | None,
     no_cache: bool,
     no_env_file: bool,
@@ -410,6 +428,13 @@ def slides_sync_cmd(
             "(--explain is a human-readable diagnostic; use --dry-run --json for the structured plan)"
         )
 
+    # Cold-start minting (#216 §12): a verifier is on by default when a provider is
+    # configured; --no-verify-cold-pairs forces it off (cold pairs then refuse).
+    # ``provider_available`` is a plan-time fact (identical in dry-run and apply), so
+    # the two agree on whether a cold pair is a `pending` mint candidate or a `refuse`.
+    verify_enabled = verify_cold_pairs is not False
+    provider_available = verify_enabled and has_openrouter_api_key()
+
     # Batch mode: a directory triggers a sweep over every split pair under the
     # tree (one funnel — no separate `sync-all` subcommand). Branch here, before
     # the single-path / pairing-guard resolution (which both assume a file).
@@ -434,9 +459,11 @@ def slides_sync_cmd(
             no_cache=no_cache,
             no_env_file=no_env_file,
             cache_dir=cache_dir,
+            provider_available=provider_available,
             make_judge=lambda: _resolve_judge(provider, llm_model, ollama_url, llm_timeout),
             make_translator=lambda: OpenRouterSlideTranslator(model=translation_model),
             make_recoverer=lambda: _resolve_recoverer(llm_recover, recovery_model),
+            make_verifier=lambda: _resolve_verifier(verify_enabled),
         )
         return  # _run_batch always sys.exit()s; this is just for the type-checker.
 
@@ -470,18 +497,23 @@ def slides_sync_cmd(
 
     watermark_cache: SyncWatermarkCache | None = None
     alignment_cache: SyncAlignmentCache | None = None
+    correspondence_cache: SyncCorrespondenceCache | None = None
     if not no_cache:
         cache_root = resolve_cache_dir(cli_override=cache_dir)
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
         if llm_recover and not dry_run:
             alignment_cache = SyncAlignmentCache(cache_root / CACHE_DB_NAME)
+        if provider_available and not dry_run:
+            correspondence_cache = SyncCorrespondenceCache(cache_root / CACHE_DB_NAME)
 
     plan: SyncPlan
     apply_result: ApplyResult | None = None
     walk: PlanWalkResult | None = None
     explain_text: str | None = None
     try:
-        plan = build_sync_plan(de_path, en_path, watermark_cache=watermark_cache)
+        plan = build_sync_plan(
+            de_path, en_path, watermark_cache=watermark_cache, provider_available=provider_available
+        )
 
         if explain:
             mode = "explain"
@@ -497,6 +529,7 @@ def slides_sync_cmd(
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(model=translation_model)
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
+            verifier = _resolve_verifier(verify_enabled)
             for issue in plan.issues:
                 click.echo(_issue_line(issue))
             walk = run_plan_walker(
@@ -507,6 +540,8 @@ def slides_sync_cmd(
                 options=WalkerOptions(),
                 recoverer=recoverer,
                 alignment_cache=alignment_cache,
+                verifier=verifier,
+                correspondence_cache=correspondence_cache,
             )
             apply_result = walk.apply_result
         else:
@@ -514,6 +549,7 @@ def slides_sync_cmd(
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(model=translation_model)
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
+            verifier = _resolve_verifier(verify_enabled)
             apply_result = apply_plan(
                 plan,
                 judge=judge,
@@ -521,12 +557,16 @@ def slides_sync_cmd(
                 watermark_cache=watermark_cache,
                 recoverer=recoverer,
                 alignment_cache=alignment_cache,
+                verifier=verifier,
+                correspondence_cache=correspondence_cache,
             )
     finally:
         if watermark_cache is not None:
             watermark_cache.close()
         if alignment_cache is not None:
             alignment_cache.close()
+        if correspondence_cache is not None:
+            correspondence_cache.close()
 
     exit_code = (
         _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
@@ -579,9 +619,11 @@ def _run_batch(
     no_cache: bool,
     no_env_file: bool,
     cache_dir: Path | None,
+    provider_available: bool,
     make_judge: Callable[[], SyncJudge | None],
     make_translator: Callable[[], SlideTranslator],
     make_recoverer: Callable[[], AlignmentRecoverer | None],
+    make_verifier: Callable[[], CorrespondenceVerifier | None],
 ) -> None:
     """Sync every split deck pair under ``root`` in one pass, then ``sys.exit`` the
     worst per-pair exit code (0 clean < 1 review < 2 error)."""
@@ -631,6 +673,7 @@ def _run_batch(
     cache_root: Path | None = None
     watermark_cache: SyncWatermarkCache | None = None
     alignment_cache: SyncAlignmentCache | None = None
+    correspondence_cache: SyncCorrespondenceCache | None = None
     if not no_cache:
         cache_root = resolve_cache_dir(cli_override=cache_dir)
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
@@ -638,12 +681,16 @@ def _run_batch(
     judge: SyncJudge | None = None
     translator: SlideTranslator | None = None
     recoverer: AlignmentRecoverer | None = None
+    verifier: CorrespondenceVerifier | None = None
     if writing:
         judge = make_judge()
         translator = make_translator()
         recoverer = make_recoverer()
+        verifier = make_verifier()
         if recoverer is not None and cache_root is not None:
             alignment_cache = SyncAlignmentCache(cache_root / CACHE_DB_NAME)
+        if verifier is not None and cache_root is not None:
+            correspondence_cache = SyncCorrespondenceCache(cache_root / CACHE_DB_NAME)
 
     results: list[_PairResult] = []
     try:
@@ -658,6 +705,9 @@ def _run_batch(
                     judge=judge,
                     translator=translator,
                     recoverer=recoverer,
+                    provider_available=provider_available,
+                    verifier=verifier,
+                    correspondence_cache=correspondence_cache,
                 )
             )
     finally:
@@ -665,6 +715,8 @@ def _run_batch(
             watermark_cache.close()
         if alignment_cache is not None:
             alignment_cache.close()
+        if correspondence_cache is not None:
+            correspondence_cache.close()
 
     exit_code = max((r.exit_code for r in results), default=0)
     _emit_batch(root, mode, results, exit_code, as_json=as_json)
@@ -681,10 +733,15 @@ def _sync_one_pair(
     judge: SyncJudge | None,
     translator: SlideTranslator | None,
     recoverer: AlignmentRecoverer | None,
+    provider_available: bool,
+    verifier: CorrespondenceVerifier | None,
+    correspondence_cache: SyncCorrespondenceCache | None,
 ) -> _PairResult:
     """Sync one pair for the batch, catching any failure so the sweep continues."""
     try:
-        plan = build_sync_plan(de_path, en_path, watermark_cache=watermark_cache)
+        plan = build_sync_plan(
+            de_path, en_path, watermark_cache=watermark_cache, provider_available=provider_available
+        )
         apply_result: ApplyResult | None = None
         explain_text: str | None = None
         if mode == "explain":
@@ -699,6 +756,8 @@ def _sync_one_pair(
                 watermark_cache=watermark_cache,
                 recoverer=recoverer,
                 alignment_cache=alignment_cache,
+                verifier=verifier,
+                correspondence_cache=correspondence_cache,
             )
         # else dry-run: classify only, write nothing.
         exit_code = (
@@ -725,7 +784,7 @@ def _deck_label(de_path: Path, root: Path) -> str:
 
 
 def _counts_str(plan: SyncPlan) -> str:
-    kinds = ("add", "edit", "retag", "move", "remove", "conflict", "rename")
+    kinds = ("add", "edit", "retag", "move", "remove", "conflict", "rename", "refuse", "mint")
     parts = [f"{plan.count(k)} {k}" for k in kinds if plan.count(k)]
     return ", ".join(parts) if parts else "0"
 
@@ -905,6 +964,19 @@ def _resolve_recoverer(llm_recover: bool, recovery_model: str) -> AlignmentRecov
     return OpenRouterAlignmentRecoverer(model=recovery_model)
 
 
+def _resolve_verifier(verify_enabled: bool) -> CorrespondenceVerifier | None:
+    """The cold-start correspondence verifier (#216 §12), or ``None``.
+
+    ``None`` (—-no-verify-cold-pairs, or no OpenRouter key) makes a cold both-id-less
+    pair **refuse** instead of mint — and the plan already showed it as `refuse`,
+    because ``provider_available`` folds in the same two checks, so dry-run and apply
+    agree. On by default when a key is configured.
+    """
+    if not verify_enabled or not has_openrouter_api_key():
+        return None
+    return OpenRouterCorrespondenceVerifier()
+
+
 # ---------------------------------------------------------------------------
 # Exit codes
 # ---------------------------------------------------------------------------
@@ -1011,7 +1083,17 @@ def _plan_dict(plan: SyncPlan) -> dict:
         "in_sync": plan.in_sync_count,
         "counts": {
             kind: plan.count(kind)
-            for kind in ("add", "edit", "retag", "move", "remove", "conflict", "rename", "refuse")
+            for kind in (
+                "add",
+                "edit",
+                "retag",
+                "move",
+                "remove",
+                "conflict",
+                "rename",
+                "refuse",
+                "mint",
+            )
         },
         "proposals": [
             {

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -347,6 +347,19 @@ the safe one — no command was removed and every tool stays fully invocable.
   silently produce a divergent or no-op sync. *Migration:* none for well-formed
   invocations; a script that relied on passing a mismatched pair will now get a
   clear usage error instead of a surprising write.
+- **A both-directions cold-start pair is now refused, never doubled (#216).**
+  When changes would have to flow in *both* directions with no way to pair the
+  halves — a freshly-split parallel pair (all cells id-less), a per-half
+  `assign-ids` run (both halves id'd but with **mismatched** ids), or a half-id'd
+  pair — `clm slides sync` emits **`refuse`** items in the plan instead of adding
+  every cell on both sides. Previously the id-less form deferred with an error
+  (exit 2) and the id-carrying form silently **doubled** both decks; now both are
+  decided at plan time, so `--dry-run` shows exactly what a writing run does
+  (`N refuse`, exit 1 — "changes pending"), nothing is written, and the watermark
+  holds. *Migration:* sync one direction at a time (edit/author a single half,
+  sync, then the other), or run `clm slides assign-ids <dir>` to mint shared ids
+  across the pair first; then re-run sync. Automatic cold-start pairing (minting a
+  shared id once the halves are confirmed to correspond) is a planned follow-up.
 - **`clm slides assign-ids` is now plumbing (hidden).** Per-file id minting on a
   *single* split half can mint a divergent slug — the #1 silent #162 break. It is
   hidden from `clm slides --help` but stays invocable by name for agents/scripts

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -356,15 +356,20 @@ the safe one — no command was removed and every tool stays fully invocable.
   minted one shared `slide_id` per slide** — but only after a cheap, cached LLM
   **correspondence check** confirms the two halves actually translate each other
   (default-on when an OpenRouter key is configured; turn it off with
-  `--no-verify-cold-pairs`). Without a provider, or if the check returns "no" or
-  cannot run, the pair is **refused** rather than guessed. Pairs that still can't
-  be paired unambiguously — both halves id'd with **mismatched** ids, or a
-  **half-id'd** pair — are **refused** too. A refusal emits **`refuse`** items,
+  `--no-verify-cold-pairs`). A **half-id'd pair** — one half fully id'd, the
+  other fully id-less (e.g. ids were assigned on only one half) — is **paired
+  and the id-less half adopts the id'd half's *existing* slide_ids** (no fresh
+  minting, no translation; the same correspondence check gates it). Without a
+  provider, or if the check returns "no" or cannot run, the pair is **refused**
+  rather than guessed. A pair that still cannot be paired unambiguously — both
+  halves id'd with **mismatched** ids, or **mixed authority** (different halves
+  id'd on different slides) — is **refused**. A refusal emits **`refuse`** items,
   writes nothing, holds the watermark, and `--dry-run` shows exactly what a
-  writing run does (`N refuse`, exit 1 — "changes pending"). *Migration:* for a
-  refused pair, sync one direction at a time (author one half, sync, then the
-  other), or run `clm slides assign-ids <dir>` to mint shared ids across the pair
-  first; then re-run sync.
+  writing run does (`N refuse`, exit 1 — "changes pending"); a confirmed
+  bootstrap shows `1 mint`/`1 adopt` instead (also exit 1 until applied).
+  *Migration:* for a refused pair, sync one direction at a time (author one half,
+  sync, then the other), or run `clm slides assign-ids <dir>` to mint shared ids
+  across the pair first; then re-run sync.
 - **`clm slides assign-ids` is now plumbing (hidden).** Per-file id minting on a
   *single* split half can mint a divergent slug — the #1 silent #162 break. It is
   hidden from `clm slides --help` but stays invocable by name for agents/scripts

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -347,19 +347,24 @@ the safe one — no command was removed and every tool stays fully invocable.
   silently produce a divergent or no-op sync. *Migration:* none for well-formed
   invocations; a script that relied on passing a mismatched pair will now get a
   clear usage error instead of a surprising write.
-- **A both-directions cold-start pair is now refused, never doubled (#216).**
-  When changes would have to flow in *both* directions with no way to pair the
-  halves — a freshly-split parallel pair (all cells id-less), a per-half
-  `assign-ids` run (both halves id'd but with **mismatched** ids), or a half-id'd
-  pair — `clm slides sync` emits **`refuse`** items in the plan instead of adding
-  every cell on both sides. Previously the id-less form deferred with an error
-  (exit 2) and the id-carrying form silently **doubled** both decks; now both are
-  decided at plan time, so `--dry-run` shows exactly what a writing run does
-  (`N refuse`, exit 1 — "changes pending"), nothing is written, and the watermark
-  holds. *Migration:* sync one direction at a time (edit/author a single half,
-  sync, then the other), or run `clm slides assign-ids <dir>` to mint shared ids
-  across the pair first; then re-run sync. Automatic cold-start pairing (minting a
-  shared id once the halves are confirmed to correspond) is a planned follow-up.
+- **Cold-start pairs are reconciled or refused — never doubled (#216).** When a
+  split pair has changes that would have to flow in *both* directions with no
+  shared ids to pair the halves, `clm slides sync` now decides at plan time
+  instead of adding every cell on both sides (which previously errored at exit 2
+  for an all-id-less pair, or silently **doubled** both decks for an id-carrying
+  one). A **freshly-split parallel pair** (all cells id-less) is **paired and
+  minted one shared `slide_id` per slide** — but only after a cheap, cached LLM
+  **correspondence check** confirms the two halves actually translate each other
+  (default-on when an OpenRouter key is configured; turn it off with
+  `--no-verify-cold-pairs`). Without a provider, or if the check returns "no" or
+  cannot run, the pair is **refused** rather than guessed. Pairs that still can't
+  be paired unambiguously — both halves id'd with **mismatched** ids, or a
+  **half-id'd** pair — are **refused** too. A refusal emits **`refuse`** items,
+  writes nothing, holds the watermark, and `--dry-run` shows exactly what a
+  writing run does (`N refuse`, exit 1 — "changes pending"). *Migration:* for a
+  refused pair, sync one direction at a time (author one half, sync, then the
+  other), or run `clm slides assign-ids <dir>` to mint shared ids across the pair
+  first; then re-run sync.
 - **`clm slides assign-ids` is now plumbing (hidden).** Per-file id minting on a
   *single* split half can mint a divergent slug — the #1 silent #162 break. It is
   hidden from `clm slides --help` but stays invocable by name for agents/scripts

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -475,6 +475,65 @@ class SyncAlignmentCache:
         self._conn.close()
 
 
+class SyncCorrespondenceCache:
+    """Cache cold-start *correspondence* verdicts for the sync engine.
+
+    Issue #216 Phase 3 (design §12). When ``clm slides sync`` bootstraps a
+    never-id'd split pair, it asks a cheap LLM whether the two structurally-aligned
+    halves actually correspond (are translations) before minting a shared
+    ``slide_id`` onto each pair. A row memoizes *"the verifier was asked about this
+    set of aligned heading/snippet pairs, and here are the (validated) yes/no
+    verdicts"*, so a re-run over the same deck short-circuits to the cached verdicts
+    and never re-spends on the LLM.
+
+    Keyed by ``(pairs_hash, prompt_version)`` — the pair fingerprint
+    (:func:`clm.slides.sync_recover.correspondence_fingerprint`) fully determines the
+    question, and the prompt version (which folds in the model) invalidates the
+    cache when the prompt/model contract changes. Only *successfully validated*
+    verdict maps are cached: a safe-aborted verification records nothing, so a fixed
+    prompt re-derives it next run. Shares the SQLite file; lives in its own table.
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._conn = sqlite3.connect(str(db_path))
+        self._migrate()
+
+    def _migrate(self) -> None:
+        cursor = self._conn.execute("PRAGMA table_info(sync_correspondences)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if not columns:
+            self._conn.execute(
+                """CREATE TABLE sync_correspondences (
+                    pairs_hash      TEXT NOT NULL,
+                    prompt_version  TEXT NOT NULL,
+                    verdicts        TEXT NOT NULL,
+                    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (pairs_hash, prompt_version)
+                )"""
+            )
+            self._conn.commit()
+
+    def get(self, pairs_hash: str, prompt_version: str) -> str | None:
+        """Return the cached verdict JSON for the pair set, or ``None``."""
+        row = self._conn.execute(
+            "SELECT verdicts FROM sync_correspondences WHERE pairs_hash=? AND prompt_version=?",
+            (pairs_hash, prompt_version),
+        ).fetchone()
+        return row[0] if row else None
+
+    def put(self, pairs_hash: str, prompt_version: str, verdicts: str) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO sync_correspondences
+               (pairs_hash, prompt_version, verdicts) VALUES (?, ?, ?)""",
+            (pairs_hash, prompt_version, verdicts),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+
 class SyncSnapshotCache:
     """Per-(file, slide_id, role) snapshot of the last accepted sync state.
 

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -23,6 +23,13 @@ Scope of this engine:
 - **refuse** — a structural decision the resolver made at plan time *not* to act
   (the both-directions cold-start / id-less case, #216); executed as a no-op
   ``deferred`` so the watermark holds and the dry-run preview matches the run.
+- **mint** / **adopt** — the two cold-start id-bootstrap candidates (#216 §12),
+  each the whole plan and short-circuited before any ``FileState`` load: ``mint``
+  confirms a both-id-less pair corresponds, then mints fresh shared ids via
+  ``assign_ids_in_split_pair``; ``adopt`` confirms a *half-id'd* pair, then stamps
+  the id'd half's *existing* ids onto its id-less twin. Either downgrades to a
+  ``deferred`` no-op when correspondence is not confirmed (a "no", a safe-abort, or
+  no verifier), so nothing wrong ever reaches disk.
 
 Atomicity: each proposal is all-or-nothing for its target cell; the two decks
 are persisted once at the end, via a buffered temp-swap (Issue #190 item 1)
@@ -136,7 +143,8 @@ class ApplyResult:
     applied_add: int = 0
     applied_rename: int = 0
     applied_migrate: int = 0  # a drifted slide_id moved back onto its construct (§9)
-    applied_mint: int = 0  # a confirmed cold-start pair minted shared ids (#216 §12)
+    applied_mint: int = 0  # a confirmed both-id-less cold pair minted shared ids (#216 §12)
+    applied_adopt: int = 0  # a confirmed half-id'd cold pair adopted the id'd half's ids (#216 §12)
     in_sync: int = 0  # an edit the judge decided needed no change
     deferred: int = 0  # conflict (or moves/adds declined this pass)
     watermark_recorded: bool = False
@@ -153,6 +161,7 @@ class ApplyResult:
             + self.applied_rename
             + self.applied_migrate
             + self.applied_mint
+            + self.applied_adopt
         )
 
     @property
@@ -244,6 +253,14 @@ def apply_plan(
     # advance read the freshly-minted files, with no buffered-write to coordinate.
     if any(p.kind == "mint" for p in plan.proposals):
         _apply_cold_mint(plan, verifier, correspondence_cache, watermark_cache, result)
+        return result
+
+    # Stage 2b/3 for a cold-start *adopt* (#216 §12): a half-id'd cold pair (one
+    # half fully id'd, the other fully id-less) whose id-less half adopts the id'd
+    # half's existing ids. Like the mint above it is the whole plan, verified then
+    # stamped on its own path, before any FileState load.
+    if any(p.kind == "adopt" for p in plan.proposals):
+        _apply_cold_adopt(plan, verifier, correspondence_cache, watermark_cache, result)
         return result
 
     # Pre-apply content (parser-stripped) for the judge, keyed by (slide_id,
@@ -776,7 +793,16 @@ def _apply_cold_mint(
     shared EN-authority ids via :func:`assign_ids_in_split_pair` and advance the
     watermark; on **any-no / safe-abort / no-verifier** downgrade to a deferral —
     the dry-run already disclosed this item as ``pending`` — writing nothing.
+
+    Defers (writes nothing) on a **classifier error** — the same gate the normal
+    flush path applies (``not plan.has_errors``). The candidacy guard already
+    declines to emit a candidate for an errored plan, so this is defense in depth
+    at the write boundary (a fully-id-less mint pair cannot carry such an error, but
+    the guard keeps the short-circuit honest if one ever reaches here).
     """
+    if plan.has_errors:
+        result.deferred += 1
+        return
     pairs = _build_slide_pairs(plan.de_path, plan.en_path)
     if verifier is None:
         result.deferred += 1  # no verifier (e.g. --no-verify): pending → refuse
@@ -878,6 +904,99 @@ def _resolve_correspondence(
     if cache is not None:
         cache.put(fp, pv, encode_verdicts(verdicts))
     return verdicts
+
+
+# ---------------------------------------------------------------------------
+# Cold-start adopt (#216 Phase 3.2 §12): verify, then stamp the id'd half's ids
+# ---------------------------------------------------------------------------
+
+
+def _apply_cold_adopt(
+    plan: SyncPlan,
+    verifier: CorrespondenceVerifier | None,
+    correspondence_cache: SyncCorrespondenceCache | None,
+    watermark_cache: SyncWatermarkCache | None,
+    result: ApplyResult,
+) -> None:
+    """Confirm a half-id'd cold pair corresponds, then stamp the id'd half's ids onto its twin.
+
+    The plan carries a single ``pending`` ``adopt`` candidate whose ``direction`` is
+    ``"{authority}->{other}"`` (the authority is the fully-id'd half). Build the
+    aligned slide pairs from the files and verify them (cached, validated,
+    safe-abort); on **all-yes** stamp each authority slide_id onto its id-less
+    positional twin — a header rewrite, **no translation** (both bodies already
+    exist) — and advance the watermark; on **any-no / safe-abort / no-verifier**
+    downgrade to a deferral, writing nothing (the dry-run disclosed it as
+    ``pending``). Unlike the mint, ``assign_ids`` cannot do this: its
+    ``_slide_ids_pair`` is ``de_id == en_id``, so an id-less cell never pairs with
+    an id'd one — hence the explicit per-cell stamp.
+
+    Defers (writes nothing) on a **classifier error** — the same gate the normal
+    flush path applies (``not plan.has_errors``). This is the critical safety net:
+    a half-id'd pair whose *authority* half carries a duplicated id (e.g. a slide
+    with two same-id voiceover companions) would otherwise stamp that duplicate onto
+    the id-less twin and advance the watermark over the corruption. The candidacy
+    guard already declines such a plan; this defends the write boundary too.
+    """
+    if plan.has_errors:
+        result.deferred += 1
+        return
+    adopt = next(p for p in plan.proposals if p.kind == "adopt")
+    authority = (adopt.direction or "en->de").split("->")[0]
+    pairs = _build_slide_pairs(plan.de_path, plan.en_path)
+    if verifier is None:
+        result.deferred += 1  # no verifier (e.g. --no-verify): pending → refuse
+        return
+    verdicts = _resolve_correspondence(verifier, correspondence_cache, pairs)
+    if verdicts is None or not all(verdicts.get(i, False) for i in range(len(pairs))):
+        result.deferred += 1  # a "no" or a safe-abort → refuse the pair (never a wrong id)
+        return
+    stamped = _adopt_ids_in_split_pair(plan.de_path, plan.en_path, authority)
+    if stamped == 0:  # the streams drifted since candidacy (a race) → refuse
+        result.deferred += 1
+        return
+    result.applied_adopt += 1
+    if watermark_cache is not None:
+        _record_watermark(watermark_cache, plan.de_path, plan.en_path)
+        result.watermark_recorded = True
+
+
+def _adopt_ids_in_split_pair(de_path: Path, en_path: Path, authority: str) -> int:
+    """Stamp the ``authority`` half's slide_ids onto its id-less twin, in place.
+
+    Walks both halves' localized cell streams positionally (the candidacy gate
+    proved them aligned): wherever the authority cell carries a slide_id and its
+    positional twin is id-less, write that id onto the twin's header
+    (:func:`_stamp_slide_id` — the same byte-faithful rewrite assign-ids uses).
+    Both halves are loaded with the *same* parser (:meth:`FileState.load`); only the
+    id-less half is flushed. Returns the number of cells stamped — ``0`` when the
+    streams no longer align (a race vs the plan) or a positional role drifted, so the
+    caller refuses rather than mis-stamping a wrong id.
+    """
+    if authority == "en":
+        idd_state, idless_state = FileState.load(en_path), FileState.load(de_path)
+        idd_lang, idless_lang = "en", "de"
+    else:
+        idd_state, idless_state = FileState.load(de_path), FileState.load(en_path)
+        idd_lang, idless_lang = "de", "en"
+    idd_loc = [c for c in idd_state.cells if not c.metadata.is_j2 and c.metadata.lang == idd_lang]
+    idless_loc = [
+        c for c in idless_state.cells if not c.metadata.is_j2 and c.metadata.lang == idless_lang
+    ]
+    if len(idd_loc) != len(idless_loc):
+        return 0  # streams drifted since the plan — refuse rather than mis-stamp
+    stamped = 0
+    for idd_cell, idless_cell in zip(idd_loc, idless_loc, strict=False):
+        if role_of(idd_cell.metadata) != role_of(idless_cell.metadata):
+            return 0  # a positional role drifted — refuse
+        target_id = idd_cell.metadata.slide_id
+        if target_id and not idless_cell.metadata.slide_id:
+            _stamp_slide_id(idless_cell, target_id)
+            stamped += 1
+    if stamped:
+        idless_state.dirty = True
+        idless_state.flush()
+    return stamped
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -20,6 +20,9 @@ Scope of this engine:
   slide's id. id-carrying "missing counterpart" adds are a follow-up.
 - **conflict** — isolated by design; counted as ``deferred`` so nothing is
   silent.
+- **refuse** — a structural decision the resolver made at plan time *not* to act
+  (the both-directions cold-start / id-less case, #216); executed as a no-op
+  ``deferred`` so the watermark holds and the dry-run preview matches the run.
 
 Atomicity: each proposal is all-or-nothing for its target cell; the two decks
 are persisted once at the end, via a buffered temp-swap (Issue #190 item 1)
@@ -242,6 +245,15 @@ def apply_plan(
                 result,
                 deferred_keys,
             )
+        elif kind == "refuse":
+            # A structural refusal the resolver decided at plan time (#216): the
+            # engine never acts on it — it is *deferred* so the watermark holds
+            # for these cells and the exit code is "needs review", exactly what
+            # the dry-run preview promised. (This is the both-directions
+            # cold-start / id-less case; the old apply-time guard that re-decided
+            # it — and that the id-carrying path silently bypassed — is gone.)
+            result.deferred += 1
+            _note_deferred(deferred_keys, proposal)
         # "add" / "rename" are handled by _apply_adds below (always applied).
 
     # Adds run before moves so a freshly-inserted slide takes part in any
@@ -707,16 +719,11 @@ def _apply_adds(
     if len(idless) + len(rename_props) == 0:
         return
 
-    process_idless = True
-    if idless and len({p.direction for p in idless}) > 1:
-        # id-less new slides on BOTH decks: off the single-language path. Defer
-        # the adds (renames are independent and still apply).
-        result.deferred += len(idless)
-        result.errors.append(
-            "id-less new slides on both decks — edit one deck at a time (deferred)"
-        )
-        process_idless = False
-
+    # The both-directions id-less refusal that used to live here (a deck-doubling
+    # guard, plus the unguarded id-carrying sibling that bypassed it) is now a
+    # plan-time decision in the resolver (#216): such adds reach apply as
+    # ``refuse`` proposals, deferred above. Every ``add`` that survives to here is
+    # therefore a single-direction add that applies mechanically.
     de_copy_ids = _identify_copy_slides(
         de_state, "de", [p for p in rename_props if p.direction == "de->en"]
     )
@@ -730,12 +737,8 @@ def _apply_adds(
         for cell in state.cells
         if cell.metadata.slide_id
     }
-    _add_one_direction(
-        de_state, en_state, "de", "en", translator, used_ids, result, de_copy_ids, process_idless
-    )
-    _add_one_direction(
-        en_state, de_state, "en", "de", translator, used_ids, result, en_copy_ids, process_idless
-    )
+    _add_one_direction(de_state, en_state, "de", "en", translator, used_ids, result, de_copy_ids)
+    _add_one_direction(en_state, de_state, "en", "de", translator, used_ids, result, en_copy_ids)
 
 
 def _add_idcarrying_one_direction(
@@ -826,7 +829,6 @@ def _add_one_direction(
     used_ids: set[str],
     result: ApplyResult,
     copy_slide_ids: set[int],
-    process_idless: bool,
 ) -> None:
     """Walk the source deck, minting ids for new and copy-pasted slides.
 
@@ -836,6 +838,9 @@ def _add_one_direction(
     copy slide's old id so each following same-id companion inherits the freshly
     minted id — rather than by a per-companion hash match (which identical
     companions defeat).
+
+    Every id-less cell here is a single-direction add (the both-directions case is
+    refused at plan time, #216), so it always mints and places — no gating.
     """
     current_slide_id: str | None = None
     renaming_from: str | None = None  # old id of a copy slide whose companions follow
@@ -853,9 +858,6 @@ def _add_one_direction(
                 renaming_from = None
                 anchor = (sid, role)
                 continue
-            if sid is None and not process_idless:
-                renaming_from = None
-                continue  # deferred parallel id-less add
             # id-less add OR copy slide: translate, mint EN-authority id, place.
             target_body = _translate(cell, source_lang, target_lang, translator, role, result)
             if target_body is None:
@@ -880,8 +882,6 @@ def _add_one_direction(
         is_copy_companion = renaming_from is not None and sid is not None and sid == renaming_from
         if sid is not None and not is_copy_companion:
             anchor = (sid, role)  # existing companion (of a non-copied slide)
-            continue
-        if sid is None and not process_idless:
             continue
         if current_slide_id is None:
             result.deferred += 1

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -168,6 +168,21 @@ class _EditOutcome:
     error: str | None = None
 
 
+@dataclass
+class _TransOutcome:
+    """The materialized translation of one add/rename source cell (#216 2b).
+
+    Computed by :func:`_materialize_idcarrying` / :func:`_materialize_idless` so the
+    add execute walks call no translator: ``body`` is the translated counterpart, or
+    ``error`` is the deferral message to record (the translation raised). Exactly one
+    is set. Keyed by ``id(cell)`` of the source cell (stable: both decks load once
+    and the walks hold the same cell objects).
+    """
+
+    body: str | None = None
+    error: str | None = None
+
+
 def apply_plan(
     plan: SyncPlan,
     *,
@@ -763,6 +778,17 @@ def _apply_adds(
         result.errors.append("add/rename present but no translator available")
         return
 
+    # Stage 2b for the add path (#216 resolve-then-apply): every translation is
+    # materialized into ``translations`` (keyed by source-cell id) just before the
+    # execute walk that consumes it, the only place the add path calls the
+    # translator. The walks below mint ids (deterministic) and insert twins,
+    # reading the cache; the ``translator`` they still receive is only a safety
+    # fallback for a cache miss (the materialize walks are built to enumerate a
+    # superset of what the execute walks translate, so a miss never happens). The
+    # materialize calls sit right before their walks so cell identity — and the
+    # post-id-carrying state the id-less walk reads — match exactly.
+    translations: dict[int, _TransOutcome] = {}
+
     # id-carrying adds: a new cell (slide / subslide / narrative / aux markdown /
     # localized code) already minted with a slide_id on one side only — e.g. a
     # deck whose ids were assigned before the split, where the author then adds a
@@ -771,13 +797,15 @@ def _apply_adds(
     if idd:
         de_keys = {(p.slide_id, p.role) for p in idd if p.direction == "de->en"}
         en_keys = {(p.slide_id, p.role) for p in idd if p.direction == "en->de"}
+        _materialize_idcarrying(de_state, "de", "en", de_keys, translator, translations)
+        _materialize_idcarrying(en_state, "en", "de", en_keys, translator, translations)
         if de_keys:
             _add_idcarrying_one_direction(
-                de_state, en_state, "de", "en", de_keys, translator, result
+                de_state, en_state, "de", "en", de_keys, translator, result, translations
             )
         if en_keys:
             _add_idcarrying_one_direction(
-                en_state, de_state, "en", "de", en_keys, translator, result
+                en_state, de_state, "en", "de", en_keys, translator, result, translations
             )
 
     if len(idless) + len(rename_props) == 0:
@@ -795,14 +823,110 @@ def _apply_adds(
         en_state, "en", [p for p in rename_props if p.direction == "en->de"]
     )
 
+    _materialize_idless(de_state, "de", "en", de_copy_ids, translator, translations)
+    _materialize_idless(en_state, "en", "de", en_copy_ids, translator, translations)
+
     used_ids = {
         cell.metadata.slide_id
         for state in (de_state, en_state)
         for cell in state.cells
         if cell.metadata.slide_id
     }
-    _add_one_direction(de_state, en_state, "de", "en", translator, used_ids, result, de_copy_ids)
-    _add_one_direction(en_state, de_state, "en", "de", translator, used_ids, result, en_copy_ids)
+    _add_one_direction(
+        de_state, en_state, "de", "en", translator, used_ids, result, de_copy_ids, translations
+    )
+    _add_one_direction(
+        en_state, de_state, "en", "de", translator, used_ids, result, en_copy_ids, translations
+    )
+
+
+def _cache_translation(
+    cell: RawCell,
+    source_lang: str,
+    target_lang: str,
+    role: str,
+    translator: SlideTranslator,
+    cache: dict[int, _TransOutcome],
+) -> None:
+    """Translate one add source cell into ``cache`` (no ``result`` accounting here).
+
+    The deferral/error counting for a failed translation happens later, in the
+    execute walk's :func:`_translate`, so its order matches the legacy inline pass.
+    """
+    if id(cell) in cache:
+        return
+    try:
+        body = translator.translate(
+            source_body=cell.body.rstrip("\n"),
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=role,
+        )
+        cache[id(cell)] = _TransOutcome(body=body)
+    except TranslationError as exc:
+        cache[id(cell)] = _TransOutcome(error=f"{role}: translation failed: {exc}")
+
+
+def _materialize_idcarrying(
+    source_state: FileState,
+    source_lang: str,
+    target_lang: str,
+    add_keys: set[tuple[str | None, str]],
+    translator: SlideTranslator,
+    cache: dict[int, _TransOutcome],
+) -> None:
+    """Pre-translate every id-carrying add cell (those :func:`_add_idcarrying_one_direction` translates)."""
+    for cell in list(source_state.cells):
+        role = role_of(cell.metadata)
+        if role is None or cell.metadata.lang != source_lang:
+            continue
+        sid = cell.metadata.slide_id
+        if sid is None or (sid, role) not in add_keys:
+            continue
+        _cache_translation(cell, source_lang, target_lang, role, translator, cache)
+
+
+def _materialize_idless(
+    source_state: FileState,
+    source_lang: str,
+    target_lang: str,
+    copy_slide_ids: set[int],
+    translator: SlideTranslator,
+    cache: dict[int, _TransOutcome],
+) -> None:
+    """Pre-translate every cell :func:`_add_one_direction` will translate.
+
+    Mirrors that walk's *translate selection* exactly — a new or copied slide, and
+    a narrative companion that is id-less or copy-pasted with a preceding slide —
+    without minting or mutating. It tracks ``has_slide`` / ``renaming_from`` the
+    same way but assumes each translation succeeds, so it enumerates a **superset**
+    of what the execute walk actually translates (an upstream failure can only make
+    the walk translate *fewer* cells). A superset means the execute walk never
+    misses the cache; the surplus entries are simply never read.
+    """
+    renaming_from: str | None = None
+    has_slide = False
+    for cell in list(source_state.cells):
+        role = role_of(cell.metadata)
+        if role is None or cell.metadata.lang != source_lang:
+            continue
+        sid = cell.metadata.slide_id
+        if role in _SLIDE_ROLES:
+            is_copy = id(cell) in copy_slide_ids
+            has_slide = True
+            if sid is not None and not is_copy:
+                renaming_from = None  # existing slide — anchors, not translated
+                continue
+            renaming_from = sid if is_copy else None
+            _cache_translation(cell, source_lang, target_lang, role, translator, cache)
+            continue
+        # narrative
+        is_copy_companion = renaming_from is not None and sid is not None and sid == renaming_from
+        if sid is not None and not is_copy_companion:
+            continue  # existing companion — anchors, not translated
+        if not has_slide:
+            continue  # orphan companion — errors before translate, never translated
+        _cache_translation(cell, source_lang, target_lang, role, translator, cache)
 
 
 def _add_idcarrying_one_direction(
@@ -813,6 +937,7 @@ def _add_idcarrying_one_direction(
     add_keys: set[tuple[str | None, str]],
     translator: SlideTranslator,
     result: ApplyResult,
+    translations: dict[int, _TransOutcome],
 ) -> None:
     """Insert the twin of each id-carrying new cell, under the same id, at anchor.
 
@@ -838,7 +963,9 @@ def _add_idcarrying_one_direction(
         if key not in add_keys:
             anchor = key  # an existing cell already twinned on the target
             continue
-        target_body = _translate(cell, source_lang, target_lang, translator, role, result)
+        target_body = _translate(
+            cell, source_lang, target_lang, translator, role, result, translations
+        )
         if target_body is None:
             continue  # _translate recorded the deferral/error; keep the anchor
         twin = build_twin_cell(cell, target_lang, target_body)
@@ -893,6 +1020,7 @@ def _add_one_direction(
     used_ids: set[str],
     result: ApplyResult,
     copy_slide_ids: set[int],
+    translations: dict[int, _TransOutcome],
 ) -> None:
     """Walk the source deck, minting ids for new and copy-pasted slides.
 
@@ -923,7 +1051,9 @@ def _add_one_direction(
                 anchor = (sid, role)
                 continue
             # id-less add OR copy slide: translate, mint EN-authority id, place.
-            target_body = _translate(cell, source_lang, target_lang, translator, role, result)
+            target_body = _translate(
+                cell, source_lang, target_lang, translator, role, result, translations
+            )
             if target_body is None:
                 renaming_from = None
                 continue
@@ -951,7 +1081,9 @@ def _add_one_direction(
             result.deferred += 1
             result.errors.append(f"add {role}: narrative with no preceding slide — deferred")
             continue
-        target_body = _translate(cell, source_lang, target_lang, translator, role, result)
+        target_body = _translate(
+            cell, source_lang, target_lang, translator, role, result, translations
+        )
         if target_body is None:
             continue
         # Companions inherit the slide's id (the freshly minted one for a copy).
@@ -972,12 +1104,24 @@ def _translate(
     translator: SlideTranslator,
     role: str,
     result: ApplyResult,
+    translations: dict[int, _TransOutcome],
 ) -> str | None:
-    """Translate a cell body, recording a deferral + error on failure.
+    """Return the materialized translation of a cell, recording a deferral on failure.
 
-    rstrip drops the terminal-newline artifact so the translator input does not
-    depend on cell position.
+    The translation was computed up front (#216 2b) and read from ``translations``
+    here, in walk order, so the deferral/error accounting matches the legacy inline
+    pass exactly. A cache miss falls back to translating now — a safety net that
+    keeps behavior correct even if the materialize walk under-enumerated; it is not
+    expected to fire (the materialize walks enumerate a superset). rstrip drops the
+    terminal-newline artifact so the translator input does not depend on position.
     """
+    cached = translations.get(id(cell))
+    if cached is not None:
+        if cached.error is not None:
+            result.deferred += 1
+            result.errors.append(cached.error)
+            return None
+        return cached.body
     try:
         return translator.translate(
             source_body=cell.body.rstrip("\n"),

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -64,12 +64,19 @@ from clm.slides.sync_recover import (
     NEW,
     NONE,
     AlignmentInvalid,
+    CorrespondenceError,
+    CorrespondenceInvalid,
     RecoveryError,
     RegionCell,
+    SlidePair,
+    correspondence_fingerprint,
     decode_mapping,
+    decode_verdicts,
     encode_mapping,
+    encode_verdicts,
     region_fingerprint,
     validate_alignment,
+    validate_correspondence,
 )
 from clm.slides.sync_translate import TranslationError
 from clm.slides.sync_writeback import (
@@ -83,9 +90,13 @@ from clm.slides.sync_writeback import (
 )
 
 if TYPE_CHECKING:
-    from clm.infrastructure.llm.cache import SyncAlignmentCache, SyncWatermarkCache
+    from clm.infrastructure.llm.cache import (
+        SyncAlignmentCache,
+        SyncCorrespondenceCache,
+        SyncWatermarkCache,
+    )
     from clm.infrastructure.llm.ollama_client import SyncJudge
-    from clm.slides.sync_recover import AlignmentRecoverer
+    from clm.slides.sync_recover import AlignmentRecoverer, CorrespondenceVerifier
     from clm.slides.sync_translate import SlideTranslator
 
 _SLIDE_ID_RE = re.compile(r'\s*slide_id="[^"]*"')
@@ -125,6 +136,7 @@ class ApplyResult:
     applied_add: int = 0
     applied_rename: int = 0
     applied_migrate: int = 0  # a drifted slide_id moved back onto its construct (§9)
+    applied_mint: int = 0  # a confirmed cold-start pair minted shared ids (#216 §12)
     in_sync: int = 0  # an edit the judge decided needed no change
     deferred: int = 0  # conflict (or moves/adds declined this pass)
     watermark_recorded: bool = False
@@ -140,6 +152,7 @@ class ApplyResult:
             + self.applied_add
             + self.applied_rename
             + self.applied_migrate
+            + self.applied_mint
         )
 
     @property
@@ -192,6 +205,8 @@ def apply_plan(
     decisions: dict[int, str] | None = None,
     recoverer: AlignmentRecoverer | None = None,
     alignment_cache: SyncAlignmentCache | None = None,
+    verifier: CorrespondenceVerifier | None = None,
+    correspondence_cache: SyncCorrespondenceCache | None = None,
 ) -> ApplyResult:
     """Apply ``plan``'s proposals to the decks and advance the watermark.
 
@@ -221,6 +236,15 @@ def apply_plan(
     (the default) leaves the ambiguous region untouched to re-surface next run.
     """
     result = ApplyResult()
+
+    # Stage 2b/3 for a cold-start mint (#216 §12): a `pending` mint candidate is the
+    # whole plan (a cold pair carries no other ops), so handle it on its own path —
+    # verify correspondence, then mint shared ids via the file-level minter — and
+    # return. Done before loading FileState so the file-level mint and the watermark
+    # advance read the freshly-minted files, with no buffered-write to coordinate.
+    if any(p.kind == "mint" for p in plan.proposals):
+        _apply_cold_mint(plan, verifier, correspondence_cache, watermark_cache, result)
+        return result
 
     # Pre-apply content (parser-stripped) for the judge, keyed by (slide_id,
     # role). Read before FileState mutates anything.
@@ -730,6 +754,130 @@ def _apply_edit(
         result.applied_edit += 1
     else:
         result.errors.append(f"edit {sid}/{proposal.role}: target cell not found")
+
+
+# ---------------------------------------------------------------------------
+# Cold-start mint (#216 Phase 3 §12): verify correspondence, then mint shared ids
+# ---------------------------------------------------------------------------
+
+
+def _apply_cold_mint(
+    plan: SyncPlan,
+    verifier: CorrespondenceVerifier | None,
+    correspondence_cache: SyncCorrespondenceCache | None,
+    watermark_cache: SyncWatermarkCache | None,
+    result: ApplyResult,
+) -> None:
+    """Confirm a cold-start pair corresponds, then mint shared ids onto both halves.
+
+    The plan carries a single ``pending`` ``mint`` candidate (a both-id-less,
+    unifiable cold pair the resolver admitted). Build the aligned slide pairs from
+    the files, verify them (cached, validated, safe-abort); on **all-yes** mint the
+    shared EN-authority ids via :func:`assign_ids_in_split_pair` and advance the
+    watermark; on **any-no / safe-abort / no-verifier** downgrade to a deferral —
+    the dry-run already disclosed this item as ``pending`` — writing nothing.
+    """
+    pairs = _build_slide_pairs(plan.de_path, plan.en_path)
+    if verifier is None:
+        result.deferred += 1  # no verifier (e.g. --no-verify): pending → refuse
+        return
+    verdicts = _resolve_correspondence(verifier, correspondence_cache, pairs)
+    if verdicts is None or not all(verdicts.get(i, False) for i in range(len(pairs))):
+        result.deferred += 1  # a "no" or a safe-abort → refuse the pair (never a wrong id)
+        return
+
+    from clm.slides.assign_ids import AssignOptions, assign_ids_in_split_pair
+
+    minted = assign_ids_in_split_pair(
+        plan.de_path, plan.en_path, AssignOptions(accept_content_derived=True)
+    )
+    if minted is None:  # not unifiable after all (a race vs candidacy) → refuse
+        result.deferred += 1
+        return
+    result.applied_mint += 1
+    if watermark_cache is not None:
+        _record_watermark(watermark_cache, plan.de_path, plan.en_path)
+        result.watermark_recorded = True
+
+
+def _slide_cells(path: Path, lang: str) -> list[Cell]:
+    """The slide/subslide cells of ``lang`` — the units a cold mint stamps an id onto."""
+    return [
+        c
+        for c in parse_cells(path.read_text(encoding="utf-8"))
+        if c.metadata.lang == lang and role_of(c.metadata) in _SLIDE_ROLES
+    ]
+
+
+def _build_slide_pairs(de_path: Path, en_path: Path) -> list[SlidePair]:
+    """Positionally pair the slide cells of the two cold-start halves for the verifier.
+
+    Both halves are fully id-less and structurally aligned (the candidacy gate), so
+    the i-th sync slide of DE pairs with the i-th of EN. Slides are the unit of
+    correspondence (companions follow their slide); each pair carries the heading +
+    a short body snippet of each side.
+    """
+    de_slides = _slide_cells(de_path, "de")
+    en_slides = _slide_cells(en_path, "en")
+    pairs: list[SlidePair] = []
+    # Equal length by the candidacy gate (_streams_aligned); strict=False is a
+    # defensive no-crash fallback — the assign_ids unify guard backs correctness.
+    for de_c, en_c in zip(de_slides, en_slides, strict=False):
+        pairs.append(
+            SlidePair(
+                de_heading=_heading_line(de_c.content),
+                en_heading=_heading_line(en_c.content),
+                de_snippet=_snippet(de_c.content),
+                en_snippet=_snippet(en_c.content),
+                role=role_of(de_c.metadata) or "slide",
+            )
+        )
+    return pairs
+
+
+def _heading_line(body: str) -> str:
+    """The first non-blank line of a cell body (the slide heading)."""
+    for line in body.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def _snippet(body: str, max_lines: int = 2) -> str:
+    """The lines just after the heading (a short lead-in for the verifier)."""
+    lines = [ln.strip() for ln in body.splitlines() if ln.strip()]
+    return "\n".join(lines[1 : 1 + max_lines])
+
+
+def _resolve_correspondence(
+    verifier: CorrespondenceVerifier,
+    cache: SyncCorrespondenceCache | None,
+    pairs: list[SlidePair],
+) -> dict[int, bool] | None:
+    """Verify ``pairs`` (cached, validated), or ``None`` on a safe-abort.
+
+    Mirrors :func:`_resolve_alignment`: caches only a *validated* verdict map, keyed
+    by the pair fingerprint + the verifier's prompt version. Any failure — transport,
+    parse, or a map that fails validation — returns ``None`` so the caller refuses
+    (a wrong shared id is worse than a deferred pair), and nothing is cached so a
+    fixed prompt re-derives it next run.
+    """
+    fp = correspondence_fingerprint(pairs)
+    pv = verifier.prompt_version
+    if cache is not None:
+        hit = cache.get(fp, pv)
+        if hit is not None:
+            try:
+                return validate_correspondence(decode_verdicts(hit), pairs)
+            except CorrespondenceInvalid:
+                pass  # corrupt cache row — re-derive
+    try:
+        verdicts = validate_correspondence(verifier.verify(pairs=pairs), pairs)
+    except (CorrespondenceError, CorrespondenceInvalid):
+        return None
+    if cache is not None:
+        cache.put(fp, pv, encode_verdicts(verdicts))
+    return verdicts
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -147,6 +147,27 @@ class ApplyResult:
         return bool(self.errors)
 
 
+@dataclass
+class _EditOutcome:
+    """The materialized result of one edit (#216 resolve-then-apply, stage 2b).
+
+    Computed by :func:`_materialize_edits` so the execute pass writes mechanically
+    and calls no model for an edit:
+
+    - ``"update"`` — apply ``proposed_text`` to the target cell;
+    - ``"in_sync"`` — the judge decided no change is needed (counts as in-sync);
+    - ``"blocked"`` — the model was unavailable / failed, or the proposal was
+      malformed; ``error`` is the message to record (the edit is not applied).
+
+    Mirrors exactly what the former inline ``_apply_edit`` / ``_apply_code_edit``
+    decided, so moving the decision earlier is behavior-preserving.
+    """
+
+    verdict: str  # "update" | "in_sync" | "blocked"
+    proposed_text: str | None = None
+    error: str | None = None
+
+
 def apply_plan(
     plan: SyncPlan,
     *,
@@ -194,6 +215,15 @@ def apply_plan(
     de_state = FileState.load(plan.de_path)
     en_state = FileState.load(plan.en_path)
 
+    # Stage 2b (edit path): resolve every edit — and every conflict the caller
+    # chose to win — into a materialized outcome up front, the only place an edit
+    # touches the judge/translator. The execute walk below then writes each edit
+    # mechanically (#216 resolve-then-apply). Read against the pre-mutation
+    # snapshots/state, exactly as the inline edit appliers used to.
+    edit_outcomes = _materialize_edits(
+        plan, decisions, de_state, en_state, de_content, en_content, judge, translator
+    )
+
     moves: list[Proposal] = []
     # (slide_id, role) of every TRUE deferral this pass: an unresolved conflict
     # or a user-skipped edit/remove/move. The per-cell partial watermark advance
@@ -214,9 +244,7 @@ def apply_plan(
                 _note_deferred(deferred_keys, proposal)
         elif kind == "edit":
             if _accepted(decisions, proposal):
-                _apply_edit(
-                    proposal, de_state, en_state, de_content, en_content, judge, translator, result
-                )
+                _apply_edit(proposal, de_state, en_state, edit_outcomes[id(proposal)], result)
             else:
                 result.deferred += 1
                 _note_deferred(deferred_keys, proposal)
@@ -234,16 +262,7 @@ def apply_plan(
                 _note_deferred(deferred_keys, proposal)
         elif kind == "conflict":
             _apply_conflict(
-                proposal,
-                decisions,
-                de_state,
-                en_state,
-                de_content,
-                en_content,
-                judge,
-                translator,
-                result,
-                deferred_keys,
+                proposal, decisions, de_state, en_state, edit_outcomes, result, deferred_keys
             )
         elif kind == "refuse":
             # A structural refusal the resolver decided at plan time (#216): the
@@ -387,19 +406,17 @@ def _apply_conflict(
     decisions: dict[int, str] | None,
     de_state: FileState,
     en_state: FileState,
-    de_content: dict[tuple[str, str], str],
-    en_content: dict[tuple[str, str], str],
-    judge: SyncJudge | None,
-    translator: SlideTranslator | None,
+    edit_outcomes: dict[int, _EditOutcome],
     result: ApplyResult,
     deferred_keys: set[tuple[str, str]],
 ) -> None:
     """Resolve a conflict per its decision, or defer it.
 
     ``de-wins`` / ``en-wins`` propagate the winning side as an ordinary edit
-    (the judge rewrites the losing side to match); any other decision defers,
-    recording the key so the per-cell advance keeps its pre-conflict baseline
-    and the conflict re-surfaces next run.
+    (the judge's rewrite of the losing side was materialized up front by
+    :func:`_materialize_edits`, keyed by this conflict proposal's id); any other
+    decision defers, recording the key so the per-cell advance keeps its
+    pre-conflict baseline and the conflict re-surfaces next run.
     """
     decision = _conflict_decision(decisions, proposal)
     if decision == DECISION_DE_WINS:
@@ -407,10 +424,7 @@ def _apply_conflict(
             _conflict_as_edit(proposal, "de->en"),
             de_state,
             en_state,
-            de_content,
-            en_content,
-            judge,
-            translator,
+            edit_outcomes[id(proposal)],
             result,
         )
     elif decision == DECISION_EN_WINS:
@@ -418,10 +432,7 @@ def _apply_conflict(
             _conflict_as_edit(proposal, "en->de"),
             de_state,
             en_state,
-            de_content,
-            en_content,
-            judge,
-            translator,
+            edit_outcomes[id(proposal)],
             result,
         )
     else:
@@ -562,7 +573,52 @@ def _apply_retag_idless(
         )
 
 
-def _apply_edit(
+def _materialize_edits(
+    plan: SyncPlan,
+    decisions: dict[int, str] | None,
+    de_state: FileState,
+    en_state: FileState,
+    de_content: dict[tuple[str, str], str],
+    en_content: dict[tuple[str, str], str],
+    judge: SyncJudge | None,
+    translator: SlideTranslator | None,
+) -> dict[int, _EditOutcome]:
+    """Resolve every edit (and every conflict the caller chose to win) up front.
+
+    Stage 2b for the edit path (#216 resolve-then-apply): the only model calls for
+    edits happen here, keyed by ``id(proposal)``, so the execute walk writes
+    mechanically. A conflict resolved ``de-wins`` / ``en-wins`` is materialized as
+    the directed edit it becomes (keyed by the *conflict* proposal's id, since the
+    execute pass synthesizes a fresh edit proposal each run); a skipped or
+    undecided conflict is left out so the execute walk simply defers it.
+
+    Runs before any cell mutation, exactly where the inline appliers used to read
+    their inputs (markdown from the ``content_index`` snapshots, localized code
+    from the loaded state), so the move is behavior-preserving.
+    """
+    outcomes: dict[int, _EditOutcome] = {}
+    for proposal in plan.proposals:
+        if proposal.kind == "edit":
+            outcomes[id(proposal)] = _resolve_edit(
+                proposal, de_state, en_state, de_content, en_content, judge, translator
+            )
+        elif proposal.kind == "conflict":
+            decision = _conflict_decision(decisions, proposal)
+            if decision in (DECISION_DE_WINS, DECISION_EN_WINS):
+                direction = "de->en" if decision == DECISION_DE_WINS else "en->de"
+                outcomes[id(proposal)] = _resolve_edit(
+                    _conflict_as_edit(proposal, direction),
+                    de_state,
+                    en_state,
+                    de_content,
+                    en_content,
+                    judge,
+                    translator,
+                )
+    return outcomes
+
+
+def _resolve_edit(
     proposal: Proposal,
     de_state: FileState,
     en_state: FileState,
@@ -570,87 +626,95 @@ def _apply_edit(
     en_content: dict[tuple[str, str], str],
     judge: SyncJudge | None,
     translator: SlideTranslator | None,
-    result: ApplyResult,
-) -> None:
+) -> _EditOutcome:
+    """Resolve one edit to a materialized :class:`_EditOutcome` (the model call).
+
+    Mirrors the former inline ``_apply_edit`` / ``_apply_code_edit`` decision logic
+    exactly — same verdicts, same error strings — but returns the outcome instead
+    of writing, so the execute pass is mechanical. A localized **code** cell is
+    reconciled by re-translating the source body (the markdown judge's prompt does
+    not fit runnable code); a markdown cell goes through the judge.
+    """
     if proposal.slide_id is None:
-        result.errors.append(f"edit {proposal.role}: proposal has no slide_id")
-        return
+        return _EditOutcome("blocked", error=f"edit {proposal.role}: proposal has no slide_id")
     sid = proposal.slide_id
     key = (sid, proposal.role)
     if proposal.direction == "de->en":
         source_lang, target_lang = "de", "en"
         source_body = de_content.get(key, "")
         target_body = en_content.get(key, "")
-        source_state, target_state = de_state, en_state
+        source_state = de_state
     else:
         source_lang, target_lang = "en", "de"
         source_body = en_content.get(key, "")
         target_body = de_content.get(key, "")
-        source_state, target_state = en_state, de_state
+        source_state = en_state
 
-    # A localized code cell is reconciled by re-translating the source body (the
-    # markdown judge's prompt does not fit runnable code); only the human-facing
-    # string literals / comments differ across languages.
     if proposal.role == CODE_ROLE:
-        _apply_code_edit(
-            sid, source_state, target_state, source_lang, target_lang, translator, result
-        )
-        return
+        if translator is None:
+            return _EditOutcome(
+                "blocked", error=f"edit {sid}/code: no translator (LLM unavailable)"
+            )
+        src_cell = source_state.find_cell(sid, CODE_ROLE)
+        if src_cell is None:
+            return _EditOutcome("blocked", error=f"edit {sid}/code: source cell not found")
+        try:
+            new_body = translator.translate(
+                source_body=src_cell.body.rstrip("\n"),
+                source_lang=source_lang,
+                target_lang=target_lang,
+                role=CODE_ROLE,
+            )
+        except TranslationError as exc:
+            return _EditOutcome("blocked", error=f"edit {sid}/code: translation failed: {exc}")
+        return _EditOutcome("update", proposed_text=new_body)
 
     if judge is None:
-        result.errors.append(f"edit {sid}/{proposal.role}: no judge (LLM unavailable)")
-        return
-
+        return _EditOutcome(
+            "blocked", error=f"edit {sid}/{proposal.role}: no judge (LLM unavailable)"
+        )
     try:
         sync_proposal = judge.propose(
             source_body, target_body, source_lang=source_lang, target_lang=target_lang
         )
     except OllamaError as exc:
         logger.info("edit judge failed on %s/%s: %s", sid, proposal.role, exc)
-        result.errors.append(f"edit {sid}/{proposal.role}: {exc}")
-        return
-
+        return _EditOutcome("blocked", error=f"edit {sid}/{proposal.role}: {exc}")
     if sync_proposal.verdict != "update":
+        return _EditOutcome("in_sync")
+    return _EditOutcome("update", proposed_text=sync_proposal.proposed_text)
+
+
+def _apply_edit(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    outcome: _EditOutcome,
+    result: ApplyResult,
+) -> None:
+    """Write a pre-materialized edit (mechanical — no judge/translator here).
+
+    The model call (markdown judge / code re-translation) already happened in
+    :func:`_materialize_edits`; this only records the outcome: ``blocked`` → its
+    error, ``in_sync`` → the judge's no-change verdict, ``update`` → replace the
+    target cell's body (the target is the non-source deck; ``proposal.role`` is the
+    cell's role, ``"code"`` for a localized code cell).
+    """
+    if outcome.verdict == "blocked":
+        result.errors.append(outcome.error or f"edit {proposal.role}: blocked")
+        return
+    if outcome.verdict == "in_sync":
         result.in_sync += 1
         return
-
-    if target_state.replace_cell_body(sid, proposal.role, sync_proposal.proposed_text):
+    sid = proposal.slide_id
+    if sid is None:  # unreachable: an id-less edit resolves to "blocked" above
+        result.errors.append(f"edit {proposal.role}: proposal has no slide_id")
+        return
+    target_state = en_state if proposal.direction == "de->en" else de_state
+    if target_state.replace_cell_body(sid, proposal.role, outcome.proposed_text or ""):
         result.applied_edit += 1
     else:
         result.errors.append(f"edit {sid}/{proposal.role}: target cell not found")
-
-
-def _apply_code_edit(
-    sid: str,
-    source_state: FileState,
-    target_state: FileState,
-    source_lang: str,
-    target_lang: str,
-    translator: SlideTranslator | None,
-    result: ApplyResult,
-) -> None:
-    """Reconcile a localized code cell edit by re-translating the source body."""
-    if translator is None:
-        result.errors.append(f"edit {sid}/code: no translator (LLM unavailable)")
-        return
-    src_cell = source_state.find_cell(sid, CODE_ROLE)
-    if src_cell is None:
-        result.errors.append(f"edit {sid}/code: source cell not found")
-        return
-    try:
-        new_body = translator.translate(
-            source_body=src_cell.body.rstrip("\n"),
-            source_lang=source_lang,
-            target_lang=target_lang,
-            role=CODE_ROLE,
-        )
-    except TranslationError as exc:
-        result.errors.append(f"edit {sid}/code: translation failed: {exc}")
-        return
-    if target_state.replace_cell_body(sid, CODE_ROLE, new_body):
-        result.applied_edit += 1
-    else:
-        result.errors.append(f"edit {sid}/code: target cell not found")
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -132,13 +132,24 @@ class Proposal:
     """One cross-language change the sync would make.
 
     ``kind`` is ``add`` / ``edit`` / ``retag`` / ``move`` / ``remove`` /
-    ``conflict`` / ``rename``. ``direction`` is ``"de->en"`` / ``"en->de"`` (the
-    side that drifted is the source), or ``None`` for a conflict. ``slide_id`` is
-    ``None`` for an id-less add, and the *duplicated* id for a ``rename``. A
-    ``retag`` mirrors a tag-only edit (the content hash is unchanged) onto the
-    other half (Issue #198). Positions are 0-based indices among sync-relevant
-    cells and are best-effort context for later phases (anchoring, walker
-    rendering).
+    ``conflict`` / ``rename`` / ``refuse``. ``direction`` is ``"de->en"`` /
+    ``"en->de"`` (the side that drifted is the source), or ``None`` for a
+    conflict. ``slide_id`` is ``None`` for an id-less add, and the *duplicated* id
+    for a ``rename``. A ``retag`` mirrors a tag-only edit (the content hash is
+    unchanged) onto the other half (Issue #198). Positions are 0-based indices
+    among sync-relevant cells and are best-effort context for later phases
+    (anchoring, walker rendering).
+
+    ``disposition`` is the resolved verdict the classifier assigns (the
+    resolve-then-apply redesign, #216): ``"apply"`` (the default — apply executes
+    a concrete mechanical op) or ``"refuse"`` (a structural decision *not* to act,
+    surfaced in the plan and held at the baseline). A ``refuse`` proposal carries
+    ``kind == "refuse"`` and ``disposition == "refuse"`` so it renders in the plan,
+    drives the dry-run exit code, and is deferred — never applied — by the engine.
+    Moving this decision to plan time is what makes ``--dry-run`` predict the
+    writing run instead of diverging from it (the apply engine used to re-decide
+    a both-directions refusal that the plan never recorded). Later phases add
+    ``"pending"`` / ``"conflict"`` dispositions to apply-kind items.
 
     ``content_hash`` is set on a ``rename`` proposal: it identifies which of the
     duplicate-id cells is the copy (the apply re-mints the cell matching this
@@ -164,6 +175,7 @@ class Proposal:
     new_position: int | None = None
     content_hash: str | None = None  # the copy's hash, for ``rename``
     tags: tuple[str, ...] | None = None  # desired tag set for an id-less localized ``retag``
+    disposition: str = "apply"  # "apply" | "refuse" — the resolved verdict (#216)
 
 
 @dataclass(frozen=True)
@@ -242,6 +254,17 @@ class SyncPlan:
         return [i.tag_hold for i in self.issues if i.tag_hold is not None]
 
     @property
+    def refusals(self) -> list[Proposal]:
+        """Structural ``refuse`` items (#216): decisions NOT to act, shown in the plan.
+
+        A refusal is resolved at plan time (the both-directions cold-start /
+        id-less case), so the dry-run preview lists it and a writing run defers
+        it — never silently doubling a deck the way the old apply-time guard
+        could be bypassed for id-carrying adds.
+        """
+        return [p for p in self.proposals if p.kind == "refuse"]
+
+    @property
     def is_noop(self) -> bool:
         """True when there is nothing to apply (and nothing went wrong).
 
@@ -267,6 +290,7 @@ class SyncPlan:
                 f"{self.count('move')} move",
                 f"{self.count('remove')} remove",
                 f"{self.count('conflict')} conflict",
+                f"{self.count('refuse')} refuse",
             ]
             tail = f"; {len(self.issues)} issue(s)" if self.issues else ""
             return (
@@ -879,6 +903,7 @@ def classify_changes(
     if not has_baseline:
         _classify_cold(plan, de_by_key, en_by_key, de_idless, en_idless, set())
         _append_idless_adds(plan, de_idless, en_idless)
+        _refuse_cold_both_directions(plan)
         plan.proposals.sort(key=_proposal_sort_key)
         return plan
 
@@ -1015,6 +1040,7 @@ def classify_changes(
         # (de removed & en absent/removed, or mirror) falls through to no-op.
 
     _append_idless_adds(plan, de_idless, en_idless)
+    _refuse_idless_both_directions(plan)
     plan.proposals.sort(key=_proposal_sort_key)
     return plan
 
@@ -1110,6 +1136,79 @@ def _append_idless_adds(
         plan.proposals.append(_add(None, cell.role, "de->en", cell))
     for cell in en_idless:
         plan.proposals.append(_add(None, cell.role, "en->de", cell))
+
+
+def _refuse(source: Proposal, reason: str) -> Proposal:
+    """A structural ``refuse`` standing in for an add we decline to apply (#216).
+
+    Keeps the source cell's identity (direction / slide_id / source_position) so
+    the plan can show *which* cell was refused, but carries ``kind="refuse"`` /
+    ``disposition="refuse"`` so it is never counted as an ``add`` and never
+    applied — the engine defers it and the watermark holds at the baseline.
+    """
+    return Proposal(
+        kind="refuse",
+        role=source.role,
+        direction=source.direction,
+        slide_id=source.slide_id,
+        reason=reason,
+        source_position=source.source_position,
+        disposition="refuse",
+    )
+
+
+def _replace_adds_with_refusals(plan: SyncPlan, doomed: list[Proposal], reason: str) -> None:
+    """Swap the ``doomed`` add proposals out of the plan for ``refuse`` items."""
+    doomed_ids = {id(p) for p in doomed}
+    plan.proposals = [p for p in plan.proposals if id(p) not in doomed_ids]
+    plan.proposals.extend(_refuse(p, reason) for p in doomed)
+
+
+def _refuse_cold_both_directions(plan: SyncPlan) -> None:
+    """Cold start: if adds would flow BOTH ways, refuse them all (#216).
+
+    With no baseline, adds in both directions mean each half carries content the
+    other lacks: a freshly-split parallel pair (all id-less), a per-half
+    ``assign-ids`` run (both id'd, *mismatched* ids), or a half-id'd pair. None
+    can be safely auto-paired *here* — pairing structurally-parallel halves is the
+    cross-language similarity-guess the base design forbids (§3.2 of
+    ``single-language-authoring-sync``). Applying both directions would
+    translate-and-insert both sets and silently **double** both decks, so refuse
+    instead. (Phase 3's provider-gated correspondence check may later mint shared
+    ids for a confirmed pair.) A one-directional cold start — new content on one
+    side only — keeps its adds and applies normally.
+    """
+    adds = [p for p in plan.proposals if p.kind == "add"]
+    if len({p.direction for p in adds}) <= 1:
+        return
+    _replace_adds_with_refusals(
+        plan,
+        adds,
+        "cold-start pair drifted on both decks (no baseline to pair against) — "
+        "sync one direction at a time, or assign shared slide_ids first (#216)",
+    )
+
+
+def _refuse_idless_both_directions(plan: SyncPlan) -> None:
+    """Baseline path: id-less adds on BOTH decks can't be paired — refuse them (#216).
+
+    An id-less new cell on each side has no ``slide_id`` to pair on, so translating
+    and inserting both would cross-add (each deck gets the other's untranslatable
+    twin). This is the situation the old apply-time guard deferred; deciding it
+    here, at plan time, is what makes the dry-run show it. id-*carrying*
+    both-direction adds are left as adds: against a real baseline their ids were
+    absent from it, so they are genuinely distinct new slides (not a mismatched
+    pair) and apply correctly.
+    """
+    idless = [p for p in plan.proposals if p.kind == "add" and p.slide_id is None]
+    if len({p.direction for p in idless}) <= 1:
+        return
+    _replace_adds_with_refusals(
+        plan,
+        idless,
+        "id-less new slides on both decks — edit one deck at a time "
+        "(no slide_id to pair the halves; #216)",
+    )
 
 
 def _add(
@@ -1428,6 +1527,7 @@ _KIND_ORDER = {
     "move": 4,
     "add": 5,
     "rename": 6,
+    "refuse": 7,
 }
 
 

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -291,6 +291,7 @@ class SyncPlan:
                 f"{self.count('remove')} remove",
                 f"{self.count('conflict')} conflict",
                 f"{self.count('refuse')} refuse",
+                f"{self.count('mint')} mint",
             ]
             tail = f"; {len(self.issues)} issue(s)" if self.issues else ""
             return (
@@ -1528,6 +1529,7 @@ _KIND_ORDER = {
     "add": 5,
     "rename": 6,
     "refuse": 7,
+    "mint": 8,
 }
 
 
@@ -1551,11 +1553,20 @@ def build_sync_plan(
     *,
     watermark_cache: SyncWatermarkCache | None = None,
     allow_git_fallback: bool = True,
+    provider_available: bool = False,
 ) -> SyncPlan:
     """Resolve the baseline and classify the pair into a :class:`SyncPlan`.
 
     Baseline priority: watermark → git HEAD → none (see module docstring).
     Reads the two files; writes nothing.
+
+    ``provider_available`` (#216 Phase 3, design §12) is the plan-time fact "a
+    correspondence verifier will be available at apply time" (an LLM provider is
+    configured **and** ``--verify-cold-pairs`` is on). When true, a cold-start
+    both-id-less refusal over a *unifiable* pair is upgraded to a ``pending`` mint
+    candidate instead of a `refuse`; the verifier (stage 2b, in apply) confirms the
+    halves correspond before a shared id is minted. Identical in dry-run and apply,
+    so the two agree on `refuse`-vs-`pending`.
     """
     de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
     en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
@@ -1635,7 +1646,78 @@ def build_sync_plan(
         )
         plan.proposals.sort(key=_proposal_sort_key)
 
+    # Phase 3 (#216 §12): a cold-start, both-id-less, *unifiable* refusal becomes a
+    # `pending` mint candidate when a provider/verifier is available — apply (2b)
+    # then confirms correspondence before minting. Cold start only (so apply can
+    # short-circuit the whole pair; the watermark-baseline both-sides-idless case
+    # keeps refusing, a documented future extension).
+    if source == "none" and provider_available:
+        _maybe_emit_cold_mint(plan, de_cells, en_cells, de_path, en_path)
+
     return plan
+
+
+def _maybe_emit_cold_mint(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    de_path: Path,
+    en_path: Path,
+) -> None:
+    """Upgrade an all-id-less cold refusal to a ``pending`` mint candidate (#216 §12).
+
+    Gated three ways, conservative by construction: every refusal must be id-less
+    (the both-id-less cold pair — a mismatched-id or half-id'd refusal is left
+    alone), the localized streams must be positionally aligned (so the verifier and
+    the minter pair the same cells), and the pair must be **unifiable** (a read-only
+    ``unify→split`` byte-faithful round-trip — the same guard
+    :func:`assign_ids_in_split_pair` applies before it writes). Any gate failing
+    keeps the `refuse`. Emits a single ``mint`` proposal (``disposition="pending"``)
+    standing for the whole pair; the aligned heading/snippet pairs are rebuilt in
+    apply from the (unchanged) files.
+    """
+    refusals = plan.refusals
+    if not refusals or any(r.slide_id is not None for r in refusals):
+        return
+    de_loc = _localized_lang_cells(de_cells, "de")
+    en_loc = _localized_lang_cells(en_cells, "en")
+    if len(de_loc) != len(en_loc) or not _streams_aligned(de_loc, en_loc):
+        return
+    if not _is_unifiable(de_path, en_path):
+        return
+    refused_ids = {id(r) for r in refusals}
+    plan.proposals = [p for p in plan.proposals if id(p) not in refused_ids]
+    plan.proposals.append(
+        Proposal(
+            kind="mint",
+            role="slide",
+            direction=None,
+            slide_id=None,
+            reason="cold-start pair — pending correspondence verification (#216)",
+            disposition="pending",
+        )
+    )
+    plan.proposals.sort(key=_proposal_sort_key)
+
+
+def _is_unifiable(de_path: Path, en_path: Path) -> bool:
+    """Read-only: does ``unify→split`` round-trip byte-faithfully? (the mint guard).
+
+    Mirrors :func:`assign_ids_in_split_pair`'s own gate, so a `pending` candidate
+    this admits is one the minter will actually be able to write. A pair that does
+    not round-trip (structurally misaligned, divergent shared cell) is not mintable,
+    so the candidacy declines and the `refuse` stands.
+    """
+    from clm.slides.split import SplitError, UnifyError, split_text, unify_texts
+
+    de_text = de_path.read_text(encoding="utf-8")
+    en_text = en_path.read_text(encoding="utf-8")
+    try:
+        unified = unify_texts(de_text, en_text)
+        rt_de, rt_en = split_text(unified)
+    except (SplitError, UnifyError):
+        return False
+    return (rt_de, rt_en) == (de_text, en_text)
 
 
 def _apply_divergence(

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -132,13 +132,22 @@ class Proposal:
     """One cross-language change the sync would make.
 
     ``kind`` is ``add`` / ``edit`` / ``retag`` / ``move`` / ``remove`` /
-    ``conflict`` / ``rename`` / ``refuse``. ``direction`` is ``"de->en"`` /
-    ``"en->de"`` (the side that drifted is the source), or ``None`` for a
-    conflict. ``slide_id`` is ``None`` for an id-less add, and the *duplicated* id
-    for a ``rename``. A ``retag`` mirrors a tag-only edit (the content hash is
-    unchanged) onto the other half (Issue #198). Positions are 0-based indices
-    among sync-relevant cells and are best-effort context for later phases
-    (anchoring, walker rendering).
+    ``conflict`` / ``rename`` / ``refuse`` / ``mint`` / ``adopt``. ``direction``
+    is ``"de->en"`` / ``"en->de"`` (the side that drifted is the source), or
+    ``None`` for a conflict / ``mint``. ``slide_id`` is ``None`` for an id-less
+    add, and the *duplicated* id for a ``rename``. A ``retag`` mirrors a tag-only
+    edit (the content hash is unchanged) onto the other half (Issue #198).
+    Positions are 0-based indices among sync-relevant cells and are best-effort
+    context for later phases (anchoring, walker rendering).
+
+    ``mint`` and ``adopt`` are the two cold-start id-bootstrap candidates (#216
+    §12; ``disposition == "pending"``): a ``mint`` stands for a both-id-less
+    cold pair whose halves get a *fresh* shared ``slide_id`` per slide; an
+    ``adopt`` stands for a *half-id'd* cold pair (one half fully id'd, the other
+    fully id-less) where the id-less half **adopts** the id'd half's *existing*
+    ids — its ``direction`` is ``"{authority}->{other}"`` (the id-bearing side
+    first). Both are confirmed by the apply-time correspondence verifier before
+    any id reaches disk; an unconfirmed candidate downgrades to a deferral.
 
     ``disposition`` is the resolved verdict the classifier assigns (the
     resolve-then-apply redesign, #216): ``"apply"`` (the default — apply executes
@@ -292,6 +301,7 @@ class SyncPlan:
                 f"{self.count('conflict')} conflict",
                 f"{self.count('refuse')} refuse",
                 f"{self.count('mint')} mint",
+                f"{self.count('adopt')} adopt",
             ]
             tail = f"; {len(self.issues)} issue(s)" if self.issues else ""
             return (
@@ -1530,12 +1540,13 @@ _KIND_ORDER = {
     "rename": 6,
     "refuse": 7,
     "mint": 8,
+    "adopt": 9,
 }
 
 
 def _proposal_sort_key(p: Proposal) -> tuple:
     return (
-        _KIND_ORDER.get(p.kind, 9),
+        _KIND_ORDER.get(p.kind, 10),
         p.source_position if p.source_position is not None else 1_000_000,
         p.slide_id or "",
         p.role,
@@ -1646,13 +1657,18 @@ def build_sync_plan(
         )
         plan.proposals.sort(key=_proposal_sort_key)
 
-    # Phase 3 (#216 §12): a cold-start, both-id-less, *unifiable* refusal becomes a
-    # `pending` mint candidate when a provider/verifier is available — apply (2b)
-    # then confirms correspondence before minting. Cold start only (so apply can
+    # Phase 3 (#216 §12): a cold-start refusal becomes a `pending` bootstrap
+    # candidate when a provider/verifier is available — apply (2b) then confirms
+    # correspondence before any id reaches disk. Two shapes, mutually exclusive:
+    # a both-id-less *unifiable* pair → `mint` (fresh shared ids); a *half-id'd*
+    # pair (one half fully id'd, the other fully id-less) → `adopt` (the id-less
+    # half adopts the id'd half's existing ids). Cold start only (so apply can
     # short-circuit the whole pair; the watermark-baseline both-sides-idless case
-    # keeps refusing, a documented future extension).
+    # keeps refusing, a documented future extension). `adopt` runs after `mint`
+    # and is a no-op when `mint` already consumed the refusals.
     if source == "none" and provider_available:
         _maybe_emit_cold_mint(plan, de_cells, en_cells, de_path, en_path)
+        _maybe_emit_cold_adopt(plan, de_cells, en_cells, de_path, en_path)
 
     return plan
 
@@ -1667,15 +1683,24 @@ def _maybe_emit_cold_mint(
     """Upgrade an all-id-less cold refusal to a ``pending`` mint candidate (#216 §12).
 
     Gated three ways, conservative by construction: every refusal must be id-less
-    (the both-id-less cold pair — a mismatched-id or half-id'd refusal is left
-    alone), the localized streams must be positionally aligned (so the verifier and
-    the minter pair the same cells), and the pair must be **unifiable** (a read-only
+    (the both-id-less cold pair — a mismatched-id refusal is left to stand and a
+    half-id'd refusal is handled by :func:`_maybe_emit_cold_adopt` instead), the
+    localized streams must be positionally aligned (so the verifier and the minter
+    pair the same cells), and the pair must be **unifiable** (a read-only
     ``unify→split`` byte-faithful round-trip — the same guard
     :func:`assign_ids_in_split_pair` applies before it writes). Any gate failing
     keeps the `refuse`. Emits a single ``mint`` proposal (``disposition="pending"``)
     standing for the whole pair; the aligned heading/snippet pairs are rebuilt in
     apply from the (unchanged) files.
+
+    Never offered when the plan already carries a **classifier error** (e.g. an
+    unresolvable duplicate id): bootstrapping ids onto a structurally-broken pair
+    would bake the error in — the same posture as the apply-time flush gate, which
+    writes nothing on ``plan.has_errors``. (Unreachable for a true both-id-less pair,
+    which has no id-carrying cells to collide — kept for symmetry with adopt.)
     """
+    if plan.has_errors:
+        return
     refusals = plan.refusals
     if not refusals or any(r.slide_id is not None for r in refusals):
         return
@@ -1718,6 +1743,120 @@ def _is_unifiable(de_path: Path, en_path: Path) -> bool:
     except (SplitError, UnifyError):
         return False
     return (rt_de, rt_en) == (de_text, en_text)
+
+
+def _cold_adopt_authority(de_loc: list[Cell], en_loc: list[Cell]) -> str | None:
+    """The fully-id'd side of a half-id'd cold pair (``"de"``/``"en"``), or ``None``.
+
+    A half-id'd pair is one positionally-aligned localized stream where the
+    *sync-relevant* cells are id'd on exactly one side (the **authority**) and
+    id-less on the other, while the non-sync cells (id-less localized code) are
+    id-less on both. The id-less half can then **adopt** the authority's existing
+    ids verbatim (:func:`clm.slides.sync_apply._apply_cold_adopt`) — no minting,
+    no translation. Returns the authority language, or ``None`` when the pair is
+    not a clean half-id'd shape (so the cold refusal stands):
+
+    - **lengths differ** — the streams are not positionally comparable;
+    - **role / cell-type mismatch** at any position — the streams are not twins,
+      so positional pairing would be unsound (this also excludes an aux-markdown or
+      a localized-code half-id'd cell, whose ``role_of`` *depends on* the
+      ``slide_id`` and so differs across an id'd/id-less twin — those stay refused
+      rather than guessing an adopt);
+    - **a sync pair that is not XOR** — both id-less (the :func:`_maybe_emit_cold_mint`
+      case, not adopt) or both id'd (a mismatched-id pair → refuse);
+    - **mixed authority** — some sync pairs id'd on DE, others on EN → refuse;
+    - **an id on a non-sync cell** — unexpected; refuse rather than mis-stamp.
+
+    Conservative by construction: any doubt returns ``None`` and the visible-in-git
+    refuse stands, exactly the safety posture of the mint candidacy (§3.2 of
+    ``single-language-authoring-sync``: never bake an id from a similarity guess).
+    """
+    if not de_loc or len(de_loc) != len(en_loc):
+        return None
+    authority: str | None = None
+    saw_xor = False
+    for de_cell, en_cell in zip(de_loc, en_loc, strict=True):
+        de_role = role_of(de_cell.metadata)
+        en_role = role_of(en_cell.metadata)
+        if de_role != en_role:
+            return None
+        if de_cell.metadata.cell_type != en_cell.metadata.cell_type:
+            return None
+        de_id = de_cell.metadata.slide_id or None
+        en_id = en_cell.metadata.slide_id or None
+        if de_role is None:
+            # A non-sync localized cell (id-less code) — must be id-less on both.
+            if de_id is not None or en_id is not None:
+                return None
+            continue
+        # A sync-relevant pair: exactly one side must carry the id (XOR).
+        if (de_id is None) == (en_id is None):
+            return None  # both id-less (mint's job) or both id'd (mismatched → refuse)
+        side = "en" if en_id is not None else "de"
+        if authority is None:
+            authority = side
+        elif authority != side:
+            return None  # mixed authority → refuse
+        saw_xor = True
+    return authority if saw_xor else None
+
+
+def _maybe_emit_cold_adopt(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    de_path: Path,
+    en_path: Path,
+) -> None:
+    """Upgrade a half-id'd cold refusal to a ``pending`` adopt candidate (#216 §12).
+
+    The sibling of :func:`_maybe_emit_cold_mint` for the *half-id'd* shape (one half
+    fully id'd, the other fully id-less): the id-less half adopts the id'd half's
+    *existing* ids rather than minting fresh ones — ``unify``/``assign_ids`` cannot
+    do this (its ``_slide_ids_pair`` is ``de_id == en_id``, so an id-less cell never
+    pairs with an id'd one), so apply takes an explicit stamp path. Runs **after**
+    the mint pass and no-ops when mint already consumed the refusals (its removal
+    empties ``plan.refusals``), so the two are mutually exclusive. The authority is
+    decided by :func:`_cold_adopt_authority`; any non-clean shape leaves the refusal
+    standing. Emits a single ``adopt`` proposal (``disposition="pending"``,
+    ``direction="{authority}->{other}"``); apply rebuilds the aligned heading/snippet
+    pairs from the (unchanged) files and verifies them before stamping.
+
+    Never offered when the plan already carries a **classifier error** — most
+    importantly a *duplicated id on the authority half* (e.g. a slide whose two
+    voiceover companions share its id, which :func:`_resolve_duplicates` flags as a
+    "lone duplicated companion"). Stamping the authority's id positionally onto the
+    id-less twin would then propagate the duplicate onto the previously-clean half
+    and advance the watermark over the corruption. Declining on ``plan.has_errors``
+    matches the apply-time flush gate (which writes nothing on a classifier error)
+    and keeps the dry-run honest (it shows the error + refusals, exit 2, not a
+    phantom "adopt pending").
+    """
+    if plan.has_errors:
+        return
+    refusals = plan.refusals
+    if not refusals:
+        return
+    de_loc = _localized_lang_cells(de_cells, "de")
+    en_loc = _localized_lang_cells(en_cells, "en")
+    authority = _cold_adopt_authority(de_loc, en_loc)
+    if authority is None:
+        return
+    other = "en" if authority == "de" else "de"
+    refused_ids = {id(r) for r in refusals}
+    plan.proposals = [p for p in plan.proposals if id(p) not in refused_ids]
+    plan.proposals.append(
+        Proposal(
+            kind="adopt",
+            role="slide",
+            direction=f"{authority}->{other}",
+            slide_id=None,
+            reason=f"half-id'd cold-start pair — {authority.upper()} ids pending "
+            "correspondence verification (#216)",
+            disposition="pending",
+        )
+    )
+    plan.proposals.sort(key=_proposal_sort_key)
 
 
 def _apply_divergence(

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -46,10 +46,14 @@ from clm.slides.sync_apply import (
 )
 
 if TYPE_CHECKING:
-    from clm.infrastructure.llm.cache import SyncAlignmentCache, SyncWatermarkCache
+    from clm.infrastructure.llm.cache import (
+        SyncAlignmentCache,
+        SyncCorrespondenceCache,
+        SyncWatermarkCache,
+    )
     from clm.infrastructure.llm.ollama_client import SyncJudge
     from clm.slides.sync_plan import Proposal, SyncPlan
-    from clm.slides.sync_recover import AlignmentRecoverer
+    from clm.slides.sync_recover import AlignmentRecoverer, CorrespondenceVerifier
     from clm.slides.sync_translate import SlideTranslator
 
 
@@ -207,6 +211,8 @@ def run_plan_walker(
     options: WalkerOptions | None = None,
     recoverer: AlignmentRecoverer | None = None,
     alignment_cache: SyncAlignmentCache | None = None,
+    verifier: CorrespondenceVerifier | None = None,
+    correspondence_cache: SyncCorrespondenceCache | None = None,
 ) -> PlanWalkResult:
     """Walk ``plan``'s proposals, prompt per proposal, then apply once.
 
@@ -248,6 +254,15 @@ def run_plan_walker(
             actions.append(_action(proposal, REFUSE))
             continue
 
+        if kind == "mint":
+            # A cold-start mint candidate (#216 §12): correspondence is verified in
+            # apply (2b), not here — show it and let the engine mint or downgrade to
+            # refuse. Never prompted (the author reviews the minted ids in git diff).
+            echo(render_proposal(proposal, de_bodies, en_bodies))
+            echo("  → pending correspondence verification (will mint shared ids if confirmed)")
+            actions.append(_action(proposal, AUTO))
+            continue
+
         if quitting:
             decisions[id(proposal)] = DECISION_SKIP
             actions.append(_action(proposal, QUIT))
@@ -278,6 +293,8 @@ def run_plan_walker(
         decisions=decisions,
         recoverer=recoverer,
         alignment_cache=alignment_cache,
+        verifier=verifier,
+        correspondence_cache=correspondence_cache,
     )
     return PlanWalkResult(plan=plan, apply_result=apply_result, actions=actions)
 

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -254,12 +254,15 @@ def run_plan_walker(
             actions.append(_action(proposal, REFUSE))
             continue
 
-        if kind == "mint":
-            # A cold-start mint candidate (#216 §12): correspondence is verified in
-            # apply (2b), not here — show it and let the engine mint or downgrade to
-            # refuse. Never prompted (the author reviews the minted ids in git diff).
+        if kind in ("mint", "adopt"):
+            # A cold-start bootstrap candidate (#216 §12): correspondence is verified
+            # in apply (2b), not here — show it and let the engine mint/adopt or
+            # downgrade to refuse. Never prompted (the author reviews the resulting
+            # ids in git diff). `mint` creates fresh shared ids for a both-id-less
+            # pair; `adopt` stamps the id'd half's existing ids onto its id-less twin.
             echo(render_proposal(proposal, de_bodies, en_bodies))
-            echo("  → pending correspondence verification (will mint shared ids if confirmed)")
+            verb = "mint shared" if kind == "mint" else "adopt the id'd half's"
+            echo(f"  → pending correspondence verification (will {verb} ids if confirmed)")
             actions.append(_action(proposal, AUTO))
             continue
 

--- a/src/clm/slides/sync_plan_walker.py
+++ b/src/clm/slides/sync_plan_walker.py
@@ -59,6 +59,7 @@ __all__ = [
     "DE_WINS",
     "EN_WINS",
     "QUIT",
+    "REFUSE",
     "SKIP",
     "PlanWalkResult",
     "WalkerAction",
@@ -75,6 +76,7 @@ QUIT = "quit"
 DE_WINS = "de-wins"
 EN_WINS = "en-wins"
 AUTO = "auto"  # add (id-less or id-carrying) / rename, applied without prompting
+REFUSE = "refuse"  # a structural refusal (#216): shown, never prompted, deferred
 
 _GATED_KINDS = {"edit", "retag", "remove", "move"}
 _AUTO_KINDS = {"add", "rename"}
@@ -148,6 +150,11 @@ class PlanWalkResult:
         return self._count(action=AUTO)
 
     @property
+    def refused(self) -> int:
+        """Structural refusals shown but not acted on (#216) — deferred by design."""
+        return self._count(action=REFUSE)
+
+    @property
     def unvisited(self) -> int:
         """Proposals not reached because the author quit the walk."""
         return self._count(action=QUIT)
@@ -180,6 +187,7 @@ class PlanWalkResult:
             f"walker decisions: {self.accepted} accepted, "
             f"{self.conflicts_resolved} conflict(s) resolved, "
             f"{self.skipped} skipped, "
+            f"{self.refused} refused, "
             f"{self.unvisited} unvisited (quit).",
             f"applied: {r.applied_edit} edit, {r.applied_retag} retag, "
             f"{r.applied_remove} remove, "
@@ -229,6 +237,15 @@ def run_plan_walker(
             # the existing id; an id-less add mints one.
             echo("  → will auto-apply (add/rename; counterpart reviewed in git diff)")
             actions.append(_action(proposal, AUTO))
+            continue
+
+        if kind == "refuse":
+            # A structural refusal the resolver decided at plan time (#216): there
+            # is no decision to make — show it and let the apply engine defer it
+            # (the watermark holds, exit code is "needs review"). Never prompted.
+            echo(render_proposal(proposal, de_bodies, en_bodies))
+            echo("  → refused (structural; sync one direction at a time)")
+            actions.append(_action(proposal, REFUSE))
             continue
 
         if quitting:

--- a/src/clm/slides/sync_recover.py
+++ b/src/clm/slides/sync_recover.py
@@ -44,21 +44,34 @@ from clm.infrastructure.llm.retry import call_with_retries
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "CORRESPONDENCE_PROMPT_VERSION",
+    "DEFAULT_CORRESPONDENCE_MODEL",
     "DEFAULT_RECOVERY_MODEL",
     "NEW",
     "NONE",
     "RECOVERY_PROMPT_VERSION",
     "AlignmentInvalid",
     "AlignmentRecoverer",
+    "CorrespondenceError",
+    "CorrespondenceInvalid",
+    "CorrespondenceVerifier",
     "OpenRouterAlignmentRecoverer",
+    "OpenRouterCorrespondenceVerifier",
     "RecoveryError",
     "RegionCell",
+    "SlidePair",
     "StaticAlignmentRecoverer",
+    "StaticCorrespondenceVerifier",
+    "build_correspondence_user_prompt",
     "build_recovery_user_prompt",
+    "correspondence_fingerprint",
     "decode_mapping",
+    "decode_verdicts",
     "encode_mapping",
+    "encode_verdicts",
     "region_fingerprint",
     "validate_alignment",
+    "validate_correspondence",
 ]
 
 # Claude Opus via OpenRouter — the design's "escalate to Claude (Opus)" tier. A
@@ -443,3 +456,252 @@ def _strip_fences(text: str) -> str:
             lines = lines[:-1]
         stripped = "\n".join(lines).strip()
     return stripped
+
+
+# ---------------------------------------------------------------------------
+# Cold-start correspondence verification (#216 Phase 3, design §12)
+# ---------------------------------------------------------------------------
+#
+# When `clm slides sync` bootstraps a never-id'd split pair, it must confirm the
+# two structurally-aligned halves actually *correspond* (are translations of each
+# other) before minting a shared slide_id onto each pair — otherwise two
+# coincidentally same-shaped non-translation decks would get a silently-wrong
+# shared id (the base design's §3.2 "no similarity-guess"). This tier mirrors the
+# AlignmentRecoverer above — opt-in, cached, validated, safe-abort — but, unlike
+# it, is NOT body-free: two translated headings have different content hashes, so
+# the cross-language signal lives in the heading *text*. The verifier therefore
+# sees, per aligned slide, the heading + a short body snippet of each half.
+
+
+DEFAULT_CORRESPONDENCE_MODEL = "anthropic/claude-haiku-4-5"  # the cheap "are these twins?" tier
+CORRESPONDENCE_PROMPT_VERSION = "correspond-v1"
+
+
+class CorrespondenceError(Exception):
+    """The verifier could not produce verdicts (transport/parse failure)."""
+
+
+class CorrespondenceInvalid(Exception):
+    """Returned verdicts failed validation; the caller safe-aborts (treat as 'no')."""
+
+
+@dataclass(frozen=True)
+class SlidePair:
+    """One positionally-aligned ``(de, en)`` cold-start slide candidate.
+
+    Content-bearing (the heading + a short body snippet of each half) so the model
+    can judge whether the two halves are the same slide in two languages. ``role``
+    is the per-cell sync role (``slide`` / ``subslide`` / ``voiceover`` / …) so the
+    model knows what it is comparing.
+    """
+
+    de_heading: str
+    en_heading: str
+    de_snippet: str
+    en_snippet: str
+    role: str
+
+
+@runtime_checkable
+class CorrespondenceVerifier(Protocol):
+    """Confirms that each aligned ``(de, en)`` cold-start pair corresponds.
+
+    ``prompt_version`` participates in the cache key so a prompt/model change
+    invalidates stale verdicts.
+    """
+
+    prompt_version: str
+
+    def verify(self, *, pairs: list[SlidePair]) -> dict[int, bool]:
+        """Return ``{pair_index: corresponds?}`` for every pair.
+
+        Raises :class:`CorrespondenceError` on failure. The result is *not*
+        trusted — the caller runs :func:`validate_correspondence` before using it.
+        """
+        ...
+
+
+def correspondence_fingerprint(pairs: list[SlidePair]) -> str:
+    """Stable sha256 over the exact pair serialization the verifier sees.
+
+    The cache key half: a cached verdict map is a sound function of this
+    fingerprint + the prompt version, since the fingerprint captures every byte the
+    model is shown (both headings, both snippets, the role, in order).
+    """
+    payload = [[p.de_heading, p.en_heading, p.de_snippet, p.en_snippet, p.role] for p in pairs]
+    blob = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def encode_verdicts(verdicts: dict[int, bool]) -> str:
+    """Serialize a ``{int: bool}`` verdict map to canonical JSON (string keys, sorted)."""
+    return json.dumps(
+        {str(k): verdicts[k] for k in sorted(verdicts)},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def decode_verdicts(text: str) -> dict[int, bool]:
+    """Parse a JSON object back into a ``{int: bool}`` verdict map.
+
+    Raises :class:`CorrespondenceInvalid` on any malformed payload (a non-object, a
+    non-integer key, or a non-boolean value) so a corrupt cache row or a stray LLM
+    response is a validation failure (→ safe-abort → 'no'), never a crash.
+    """
+    try:
+        raw = json.loads(text)
+    except (ValueError, TypeError) as exc:
+        raise CorrespondenceInvalid(f"correspondence map is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise CorrespondenceInvalid("correspondence map must be a JSON object")
+    out: dict[int, bool] = {}
+    for key, value in raw.items():
+        try:
+            idx = int(key)
+        except (ValueError, TypeError) as exc:
+            raise CorrespondenceInvalid(f"correspondence key {key!r} is not an integer") from exc
+        if not isinstance(value, bool):
+            raise CorrespondenceInvalid(f"correspondence value for {key!r} is not a boolean")
+        out[idx] = value
+    return out
+
+
+def validate_correspondence(verdicts: dict[int, bool], pairs: list[SlidePair]) -> dict[int, bool]:
+    """Return ``verdicts`` unchanged if total over ``pairs``, else raise.
+
+    The single hard gate before the engine trusts a verdict map: the keys must be
+    exactly ``{0 … len(pairs)-1}`` (one boolean per pair, no missing or stray
+    index). Any failure raises :class:`CorrespondenceInvalid` and the caller
+    safe-aborts to "no" (refuse) — minting a wrong shared id is worse than refusing.
+    """
+    n = len(pairs)
+    if set(verdicts) != set(range(n)):
+        raise CorrespondenceInvalid(
+            f"verdicts must cover pair indices 0..{n - 1} exactly, got {sorted(verdicts)}"
+        )
+    return verdicts
+
+
+@dataclass
+class StaticCorrespondenceVerifier:
+    """A deterministic verifier for tests and offline runs.
+
+    Returns ``verdicts.get(i, default)`` for each pair index. With ``raise_error``
+    it raises :class:`CorrespondenceError` to exercise the safe-abort path.
+    ``calls`` counts invocations so a test can assert the cache short-circuited a
+    second run.
+    """
+
+    verdicts: dict[int, bool] = field(default_factory=dict)
+    default: bool = True
+    raise_error: bool = False
+    prompt_version: str = "static"
+    calls: int = 0
+
+    def verify(self, *, pairs: list[SlidePair]) -> dict[int, bool]:
+        self.calls += 1
+        if self.raise_error:
+            raise CorrespondenceError("static verifier configured to fail")
+        return {i: self.verdicts.get(i, self.default) for i in range(len(pairs))}
+
+
+_CORRESPONDENCE_SYSTEM_PROMPT = (
+    "You verify that the two halves of a split bilingual programming-course slide "
+    "deck line up: a German (DE) deck and an English (EN) deck that should be "
+    "translations of each other, slide for slide. You are given an ordered list of "
+    "candidate PAIRS; each pair has the DE and the EN slide's heading and a short "
+    "body snippet, and a role.\n\n"
+    "Return ONLY a JSON object mapping each pair index (a string) to a boolean:\n"
+    "  - true  when the DE and EN slide are the SAME slide in the two languages "
+    "(a translation / counterpart — same topic and intent);\n"
+    "  - false when they are NOT the same slide (different topics — the decks are "
+    "misaligned at this position).\n\n"
+    "Judge by meaning, not surface form: a faithful translation has different words "
+    "but the same topic. When genuinely unsure, return false — a wrong pairing bakes "
+    "a wrong shared identifier, which is worse than asking the author to pair by hand.\n"
+    "Map EVERY pair index exactly once. Return only the JSON object, no commentary, "
+    "no code fences."
+)
+
+
+def _serialize_pairs(pairs: list[SlidePair]) -> str:
+    """Render the aligned pairs as a compact, indexed list for the prompt."""
+    rows = [
+        {
+            "index": idx,
+            "role": p.role,
+            "de_heading": p.de_heading,
+            "en_heading": p.en_heading,
+            "de_snippet": p.de_snippet,
+            "en_snippet": p.en_snippet,
+        }
+        for idx, p in enumerate(pairs)
+    ]
+    return "PAIRS:\n" + json.dumps(rows, ensure_ascii=False, indent=2)
+
+
+def build_correspondence_user_prompt(pairs: list[SlidePair]) -> str:
+    """Build the user prompt: the serialized aligned pairs."""
+    return _serialize_pairs(pairs)
+
+
+@dataclass
+class OpenRouterCorrespondenceVerifier:
+    """LLM-backed verifier (synchronous OpenAI client, Claude Haiku by default).
+
+    Sends the heading/snippet pairs and parses the returned ``{index: bool}`` map.
+    Raises :class:`CorrespondenceError` on any transport/parse failure so the caller
+    safe-aborts (→ refuse) rather than crashing the sync. The result is *not*
+    trusted — :func:`validate_correspondence` gates it before it is used.
+
+    ``prompt_version`` folds in the ``model`` (like the recoverer) so switching the
+    model does not serve another model's cached verdicts.
+    """
+
+    model: str = DEFAULT_CORRESPONDENCE_MODEL
+    api_base: str | None = "https://openrouter.ai/api/v1"
+    api_key: str | None = None
+    temperature: float = 0.0
+    max_tokens: int = 1024
+    timeout: float = 60.0
+    prompt_version: str = CORRESPONDENCE_PROMPT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.prompt_version == CORRESPONDENCE_PROMPT_VERSION:
+            self.prompt_version = f"{CORRESPONDENCE_PROMPT_VERSION}:{self.model}"
+
+    def _client(self):  # pragma: no cover - thin network adapter
+        from clm.infrastructure.llm.openrouter_client import build_openrouter_client
+
+        return build_openrouter_client(
+            api_base=self.api_base, api_key=self.api_key, timeout=self.timeout
+        )
+
+    def verify(
+        self, *, pairs: list[SlidePair]
+    ) -> dict[int, bool]:  # pragma: no cover - exercised via mocked client / integration
+        user = build_correspondence_user_prompt(pairs)
+
+        def _create():
+            return self._client().chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": _CORRESPONDENCE_SYSTEM_PROMPT},
+                    {"role": "user", "content": user},
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                response_format={"type": "json_object"},
+            )
+
+        try:
+            response = call_with_retries(
+                _create, exc=Exception, label=f"correspondence ({self.model})"
+            )
+        except Exception as exc:  # noqa: BLE001 - normalize to the protocol's error
+            raise CorrespondenceError(f"correspondence call failed: {exc}") from exc
+        content = response.choices[0].message.content
+        if not content or not content.strip():
+            raise CorrespondenceError("correspondence returned empty content")
+        return decode_verdicts(_strip_fences(content))

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -1113,16 +1113,13 @@ class TestDryRunApplyParity:
         assert "1 add" in applied.output
         assert "# ## Neu" in de_path.read_text(encoding="utf-8")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#216: for a cold-start parallel id-less pair the dry-run promises "
-        "N adds and exits 1 (changes pending), but a writing run defers them all "
-        "with an error and exits 2, writing nothing — the preview misleads. The fix "
-        "must make the plan honest (pair-and-mint, or surface the refusal as an issue).",
-    )
     def test_dry_run_promise_matches_apply_for_parallel_idless(
         self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
     ):
+        # A cold-start parallel id-less pair: the resolver refuses the
+        # both-directions adds at plan time (#216), so the dry-run shows the
+        # refusal (exit 1, "changes pending") and a writing run defers it
+        # (exit 1) — they agree, and nothing is written.
         de = _idless_slide("de", "# ## Eins") + _idless_slide("de", "# ## Zwei")
         en = _idless_slide("en", "# ## One") + _idless_slide("en", "# ## Two")
         de_path, en_path = _write_pair(tmp_path, de, en, stem="cold")
@@ -1132,17 +1129,16 @@ class TestDryRunApplyParity:
         )
         assert dry.exit_code == 1, _combined(dry)  # "changes pending"
         assert "baseline=none" in dry.output
+        assert "refuse" in dry.output  # the refusal is shown in the preview
 
         _stub_judge(monkeypatch, _EN_PROPOSAL)
         _stub_translator(monkeypatch)
         applied = cli_runner.invoke(slides_sync_cmd, [str(de_path), str(en_path), "--no-cache"])
-        # Whatever happens, the writing run must not corrupt the decks.
+        # The writing run does not corrupt the decks...
         assert de_path.read_text(encoding="utf-8") == de
         assert en_path.read_text(encoding="utf-8") == en
-        # The contract the fix must restore: a writing-run error (exit 2) must have
-        # been foreseen by the dry-run (also exit 2). Today dry=1, apply=2 -> xfail.
-        if applied.exit_code == 2:
-            assert dry.exit_code == 2, (
-                f"writing run errored (exit 2) but dry-run reported exit "
-                f"{dry.exit_code}: {_combined(applied)}"
-            )
+        # ...and the dry-run preview matched it: both "needs review" (exit 1), the
+        # refusal foreseen — never a clean/pending preview that errors on write.
+        assert applied.exit_code == 1, _combined(applied)
+        assert applied.exit_code == dry.exit_code
+        assert "refuse" in applied.output

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -105,6 +105,26 @@ def _stub_judge(
     )
 
 
+def _stub_translator(monkeypatch, *, default: str = "# ## Translated\n#\n# - point") -> None:
+    """Patch the CLI's translator factory to a non-failing static translator.
+
+    Mirrors :func:`_stub_judge`: it replaces the ``OpenRouterSlideTranslator``
+    symbol the command constructs, so a writing run translates id-less adds
+    offline. A translator that always succeeds means a deferral can only come from
+    the engine's own decision, never a missing translation.
+    """
+    from clm.cli.commands import slides_sync as cmd
+    from clm.slides.sync_translate import StaticSlideTranslator
+
+    monkeypatch.setattr(
+        cmd, "OpenRouterSlideTranslator", lambda **_kwargs: StaticSlideTranslator(default=default)
+    )
+
+
+def _idless_slide(lang: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"]\n{body}\n'
+
+
 def _combined(result) -> str:
     return (result.stderr or "") + (result.output or "")
 
@@ -1051,3 +1071,78 @@ class TestBatchMode:
         # the nested .env was missed → judge unavailable → exit 2.
         assert result.exit_code == 0, _combined(result)
         assert "Point one" in en_path.read_text(encoding="utf-8")
+
+
+class TestDryRunApplyParity:
+    """``--dry-run`` must predict the writing run (#216).
+
+    A preview that promises changes a writing run silently refuses (or that exits
+    "clean / changes-pending" when the writing run errors and writes nothing) is a
+    misleading preview. These tests drive the real command twice — once with
+    ``--dry-run``, once writing — over the same fixture, with the judge/translator
+    stubbed so the only thing under test is whether the preview matches the act.
+    """
+
+    def test_dry_run_add_count_matches_apply(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # Watermark baseline; the author appends ONE id-less slide on DE only.
+        cache_dir = tmp_path / "cache"
+        de_base = _cell("de", "a", "# ## A")
+        en_base = _cell("en", "a", "# ## A")
+        de_path, en_path = _write_pair(tmp_path, de_base, en_base, stem="parity")
+        _seed_watermark(
+            cache_dir, de_path.resolve(), en_path.resolve(), de_text=de_base, en_text=en_base
+        )
+        de_path.write_text(de_base + _idless_slide("de", "# ## Neu"), encoding="utf-8")
+
+        dry = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--dry-run", "--cache-dir", str(cache_dir)],
+        )
+        assert dry.exit_code == 1, _combined(dry)  # one change pending
+        assert "1 add" in dry.output
+
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        _stub_translator(monkeypatch)
+        applied = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+        # The preview's promise (1 add, applicable) is what the writing run did.
+        assert applied.exit_code == 0, _combined(applied)
+        assert "1 add" in applied.output
+        assert "# ## Neu" in de_path.read_text(encoding="utf-8")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#216: for a cold-start parallel id-less pair the dry-run promises "
+        "N adds and exits 1 (changes pending), but a writing run defers them all "
+        "with an error and exits 2, writing nothing — the preview misleads. The fix "
+        "must make the plan honest (pair-and-mint, or surface the refusal as an issue).",
+    )
+    def test_dry_run_promise_matches_apply_for_parallel_idless(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        de = _idless_slide("de", "# ## Eins") + _idless_slide("de", "# ## Zwei")
+        en = _idless_slide("en", "# ## One") + _idless_slide("en", "# ## Two")
+        de_path, en_path = _write_pair(tmp_path, de, en, stem="cold")
+
+        dry = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
+        )
+        assert dry.exit_code == 1, _combined(dry)  # "changes pending"
+        assert "baseline=none" in dry.output
+
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        _stub_translator(monkeypatch)
+        applied = cli_runner.invoke(slides_sync_cmd, [str(de_path), str(en_path), "--no-cache"])
+        # Whatever happens, the writing run must not corrupt the decks.
+        assert de_path.read_text(encoding="utf-8") == de
+        assert en_path.read_text(encoding="utf-8") == en
+        # The contract the fix must restore: a writing-run error (exit 2) must have
+        # been foreseen by the dry-run (also exit 2). Today dry=1, apply=2 -> xfail.
+        if applied.exit_code == 2:
+            assert dry.exit_code == 2, (
+                f"writing run errored (exit 2) but dry-run reported exit "
+                f"{dry.exit_code}: {_combined(applied)}"
+            )

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -1186,3 +1186,28 @@ class TestDryRunApplyParity:
         en_after = en_path.read_text(encoding="utf-8")
         assert 'slide_id="' in de_after  # both halves now carry minted ids
         assert 'slide_id="' in en_after
+
+    def test_half_idd_pair_adopts_when_verified(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # A half-id'd cold pair (EN assign-ids'd, DE id-less — the common 1.8-gate
+        # shape): dry-run shows a pending adopt, the writing run stamps EN's EXISTING
+        # ids onto the DE twin verbatim — no minting, no translation (#216 §12, 3.2).
+        de = _idless_slide("de", "# ## Einleitung") + _idless_slide("de", "# ## Variablen")
+        en = _cell("en", "intro", "# ## Introduction") + _cell("en", "vars", "# ## Variables")
+        de_path, en_path = _write_pair(tmp_path, de, en, stem="coldadopt")
+        _stub_verifier(monkeypatch, default=True)
+
+        dry = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
+        )
+        assert dry.exit_code == 1, _combined(dry)  # a pending adopt is "changes pending"
+        assert "adopt" in dry.output
+
+        applied = cli_runner.invoke(slides_sync_cmd, [str(de_path), str(en_path), "--no-cache"])
+        assert applied.exit_code == 0, _combined(applied)  # adopted cleanly
+        de_after = parse_cells(de_path.read_text(encoding="utf-8"))
+        de_ids = [c.metadata.slide_id for c in de_after if c.metadata.is_slide_start]
+        # The DE half adopted EN's ids verbatim, not freshly-minted heading slugs.
+        assert de_ids == ["intro", "vars"]
+        assert en_path.read_text(encoding="utf-8") == en  # the id'd half is untouched

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -121,6 +121,24 @@ def _stub_translator(monkeypatch, *, default: str = "# ## Translated\n#\n# - poi
     )
 
 
+def _stub_verifier(monkeypatch, *, default: bool = True) -> None:
+    """Make a provider look configured and stub the cold-start verifier (#216 §12).
+
+    Patches ``has_openrouter_api_key`` to True (so ``provider_available`` is set and a
+    cold pair becomes a pending mint candidate) and the ``OpenRouterCorrespondenceVerifier``
+    factory to a deterministic static verifier, so the mint path runs offline.
+    """
+    from clm.cli.commands import slides_sync as cmd
+    from clm.slides.sync_recover import StaticCorrespondenceVerifier
+
+    monkeypatch.setattr(cmd, "has_openrouter_api_key", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        cmd,
+        "OpenRouterCorrespondenceVerifier",
+        lambda **_k: StaticCorrespondenceVerifier(default=default),
+    )
+
+
 def _idless_slide(lang: str, body: str) -> str:
     return f'# %% [markdown] lang="{lang}" tags=["slide"]\n{body}\n'
 
@@ -1124,16 +1142,18 @@ class TestDryRunApplyParity:
         en = _idless_slide("en", "# ## One") + _idless_slide("en", "# ## Two")
         de_path, en_path = _write_pair(tmp_path, de, en, stem="cold")
 
-        dry = cli_runner.invoke(
-            slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
-        )
+        # --no-verify-cold-pairs forces the refusal path regardless of whether a
+        # provider key is set in this env (with a key + the default, this pair would
+        # instead become a pending mint — see test_cold_pair_mints_when_verified).
+        base = [str(de_path), str(en_path), "--no-cache", "--no-verify-cold-pairs"]
+        dry = cli_runner.invoke(slides_sync_cmd, [*base, "--dry-run"])
         assert dry.exit_code == 1, _combined(dry)  # "changes pending"
         assert "baseline=none" in dry.output
         assert "refuse" in dry.output  # the refusal is shown in the preview
 
         _stub_judge(monkeypatch, _EN_PROPOSAL)
         _stub_translator(monkeypatch)
-        applied = cli_runner.invoke(slides_sync_cmd, [str(de_path), str(en_path), "--no-cache"])
+        applied = cli_runner.invoke(slides_sync_cmd, base)
         # The writing run does not corrupt the decks...
         assert de_path.read_text(encoding="utf-8") == de
         assert en_path.read_text(encoding="utf-8") == en
@@ -1142,3 +1162,27 @@ class TestDryRunApplyParity:
         assert applied.exit_code == 1, _combined(applied)
         assert applied.exit_code == dry.exit_code
         assert "refuse" in applied.output
+
+    def test_cold_pair_mints_when_verified(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # With a provider configured (stubbed) and the verifier confirming, a
+        # cold-start pair is bootstrapped: dry-run shows a pending mint, the writing
+        # run mints shared ids onto both halves (#216 §12).
+        de = _idless_slide("de", "# ## Einleitung") + _idless_slide("de", "# ## Variablen")
+        en = _idless_slide("en", "# ## Introduction") + _idless_slide("en", "# ## Variables")
+        de_path, en_path = _write_pair(tmp_path, de, en, stem="coldmint")
+        _stub_verifier(monkeypatch, default=True)
+
+        dry = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--dry-run", "--no-cache"]
+        )
+        assert dry.exit_code == 1, _combined(dry)  # a pending mint is "changes pending"
+        assert "mint" in dry.output
+
+        applied = cli_runner.invoke(slides_sync_cmd, [str(de_path), str(en_path), "--no-cache"])
+        assert applied.exit_code == 0, _combined(applied)  # minted cleanly
+        de_after = de_path.read_text(encoding="utf-8")
+        en_after = en_path.read_text(encoding="utf-8")
+        assert 'slide_id="' in de_after  # both halves now carry minted ids
+        assert 'slide_id="' in en_after

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -44,6 +44,20 @@ def _update_judge(text: str) -> StaticSyncJudge:
     return StaticSyncJudge(default_proposal=SyncProposal(verdict="update", proposed_text=text))
 
 
+class _CountingTranslator:
+    """Wraps a StaticSlideTranslator and counts translate() calls (#216 2b boundary)."""
+
+    prompt_version = "counting"
+
+    def __init__(self, inner: StaticSlideTranslator) -> None:
+        self._inner = inner
+        self.calls = 0
+
+    def translate(self, **kwargs) -> str:
+        self.calls += 1
+        return self._inner.translate(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # FileState primitives
 # ---------------------------------------------------------------------------
@@ -750,6 +764,35 @@ class TestApplyAdd:
         assert sync_ids == [("a", "slide"), ("new", "slide"), ("new", "voiceover")]
         # The DE voiceover inherited the slide's minted id too.
         assert _cell_for(de_path, "new", "voiceover") is not None
+
+    def test_translator_called_once_per_cell_in_materialize(self, tmp_path: Path):
+        # The add path's translations are materialized up front (#216 2b); the
+        # execute walk mints + inserts reading the cache, never re-calling the
+        # translator. Two new cells (slide + voiceover) => exactly two calls.
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "a", "# ## A")
+                + _slide_idless("de", "# ## Neu")
+                + _vo_idless("de", "# Sprechertext"),
+                encoding="utf-8",
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            translator = _CountingTranslator(
+                StaticSlideTranslator(
+                    mapping={"# ## Neu": "# ## New", "# Sprechertext": "# Narration"}
+                )
+            )
+            result = apply_plan(plan, judge=None, translator=translator, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_add == 2
+        assert translator.calls == 2  # materialized once each; execute read the cache
 
     def test_add_in_the_middle_is_anchored(self, tmp_path: Path):
         de_path, en_path = _write_pair(

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -153,6 +153,30 @@ class TestApplyEdit:
 
         assert plan2.is_noop
 
+    def test_edit_judge_called_once_in_materialize_not_in_execute(self, tmp_path: Path):
+        # The model call for an edit happens exactly once, in the materialize pass
+        # (#216 resolve-then-apply 2b); the execute pass writes mechanically and
+        # never re-invokes the judge.
+        de = _slide("de", "intro", "# ## Einleitung\n# - eins")
+        en = _slide("en", "intro", "# ## Introduction\n# - one")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung\n# - eins\n# - zwei"), encoding="utf-8"
+            )
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+            assert plan.count("edit") == 1
+            # StaticSyncJudge records every propose() call in .calls.
+            judge = _update_judge("# ## Introduction\n# - one\n# - two")
+            result = apply_plan(plan, judge=judge, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        assert result.applied_edit == 1
+        assert len(judge.calls) == 1  # materialized once; execute did not re-call
+
     def test_edit_in_sync_verdict_writes_nothing(self, tmp_path: Path):
         de = _slide("de", "intro", "# ## Einleitung")
         en = _slide("en", "intro", "# ## Introduction")

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
@@ -875,44 +873,41 @@ class TestApplyAdd:
         assert len(_slide_order(de_path)) == 2  # "a" + one id-less
         assert len(_slide_order(en_path)) == 2
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#216 (id-CARRYING sibling): the both-directions guard at "
-        "sync_apply.py:710-718 covers only id-LESS adds. A cold-start pair whose "
-        "halves carry DIFFERENT slide_ids (e.g. assign-ids run per half) makes the "
-        "classifier emit id-carrying adds in BOTH directions, which "
-        "_add_idcarrying_one_direction applies unconditionally — silently DOUBLING "
-        "both decks with no error. The guard must cover idd both-directions too.",
-    )
     def test_cold_start_mismatched_ids_must_not_double(self, tmp_path: Path):
-        # Both halves carry slide_ids, but DIFFERENT ones, and there is no baseline.
+        # Both halves carry slide_ids, but DIFFERENT ones, and there is no baseline
+        # (e.g. assign-ids run per half). The resolver refuses both directions
+        # rather than translate-and-insert both sets (which would DOUBLE both
+        # decks); #216, the id-CARRYING sibling of the id-less case below.
         de = _slide("de", "d1", "# ## A") + _slide("de", "d2", "# ## B")
         en = _slide("en", "e1", "# ## A") + _slide("en", "e2", "# ## B")
         de_path, en_path = _write_pair(tmp_path, de, en)
         plan = build_sync_plan(de_path, en_path, watermark_cache=None)
+        # Plan time: all four would-be adds become refusals; nothing to apply.
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 4
         translator = StaticSlideTranslator(default="# ## X")
         result = apply_plan(plan, judge=None, translator=translator, watermark_cache=None)
-        # Desired: a cold-start mismatched pair is NOT auto-applied (it would
-        # duplicate every cell on both halves). Currently applies 4 -> xfail.
         assert result.applied_add == 0
-        assert len(_slide_order(de_path)) == 2
+        assert result.has_errors is False  # a refusal is not an error
+        assert result.deferred == 4
+        assert len(_slide_order(de_path)) == 2  # no duplication
         assert len(_slide_order(en_path)) == 2
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#216 (id-CARRYING sibling): a cold-start HALF-id'd pair (one half "
-        "id-less, the other id'd) doubles both decks — the id-less half adds de->en "
-        "(id-less, guarded only if the other direction is also id-less) while the "
-        "id'd half adds en->de (id-carrying, never guarded), so both sets apply.",
-    )
     def test_cold_start_half_idd_must_not_double(self, tmp_path: Path):
+        # A half-id'd cold-start pair (one half id-less, the other id'd): the
+        # id-less half would add de->en and the id'd half en->de — adds in both
+        # directions, so the resolver refuses them all rather than doubling (#216).
         de = _slide_idless("de", "# ## A") + _slide_idless("de", "# ## B")
         en = _slide("en", "s1", "# ## A") + _slide("en", "s2", "# ## B")
         de_path, en_path = _write_pair(tmp_path, de, en)
         plan = build_sync_plan(de_path, en_path, watermark_cache=None)
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 4
         translator = StaticSlideTranslator(default="# ## X")
         result = apply_plan(plan, judge=None, translator=translator, watermark_cache=None)
         assert result.applied_add == 0
+        assert result.has_errors is False
+        assert result.deferred == 4
         assert len(_slide_order(de_path)) == 2
         assert len(_slide_order(en_path)) == 2
 

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.cache import SyncCorrespondenceCache, SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_apply import DECISION_APPLY, DECISION_SKIP, apply_plan
 from clm.slides.sync_plan import PlanIssue, Proposal, SyncPlan, build_sync_plan, ordered_sync_cells
+from clm.slides.sync_recover import StaticCorrespondenceVerifier
 from clm.slides.sync_translate import StaticSlideTranslator
 from clm.slides.sync_writeback import FileState
 
@@ -977,6 +978,94 @@ class TestApplyAdd:
         assert result.deferred == 4
         assert len(_slide_order(de_path)) == 2
         assert len(_slide_order(en_path)) == 2
+
+
+class TestColdStartMint:
+    """A both-id-less cold pair mints shared ids once correspondence is confirmed (#216 §12)."""
+
+    def _cold_pair(self, tmp_path: Path) -> tuple[Path, Path]:
+        de = _slide_idless("de", "# ## Einleitung") + _slide_idless("de", "# ## Variablen")
+        en = _slide_idless("en", "# ## Introduction") + _slide_idless("en", "# ## Variables")
+        return _write_pair(tmp_path, de, en)
+
+    def test_confirmed_pair_is_minted(self, tmp_path: Path):
+        de_path, en_path = self._cold_pair(tmp_path)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        # The refusals became one pending mint candidate.
+        assert plan.count("mint") == 1
+        assert plan.count("refuse") == 0
+        verifier = StaticCorrespondenceVerifier(default=True)
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_mint == 1
+        assert result.deferred == 0
+        assert result.has_errors is False
+        assert verifier.calls == 1
+        # Both halves now carry the SAME (EN-authority) ids on every slide.
+        de_ids, en_ids = _slide_order(de_path), _slide_order(en_path)
+        assert de_ids == en_ids
+        assert all(de_ids) and len(de_ids) == 2  # every slide got a real id
+
+    def test_denied_pair_refuses_and_writes_nothing(self, tmp_path: Path):
+        de_path, en_path = self._cold_pair(tmp_path)
+        before_de = de_path.read_text(encoding="utf-8")
+        before_en = en_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        verifier = StaticCorrespondenceVerifier(default=False)  # all "no"
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_mint == 0
+        assert result.deferred == 1
+        assert de_path.read_text(encoding="utf-8") == before_de
+        assert en_path.read_text(encoding="utf-8") == before_en
+
+    def test_no_verifier_refuses(self, tmp_path: Path):
+        de_path, en_path = self._cold_pair(tmp_path)
+        before_de = de_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        result = apply_plan(plan, judge=None, verifier=None, watermark_cache=None)
+        assert result.applied_mint == 0
+        assert result.deferred == 1
+        assert de_path.read_text(encoding="utf-8") == before_de
+
+    def test_no_provider_keeps_refuse(self, tmp_path: Path):
+        de_path, en_path = self._cold_pair(tmp_path)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=False)
+        assert plan.count("mint") == 0
+        assert plan.count("refuse") == 4  # 2 de + 2 en id-less, both directions
+
+    def test_mismatched_id_pair_keeps_refuse_even_with_provider(self, tmp_path: Path):
+        # Both id'd with different ids: never a mint candidate (design §12 — refuse).
+        de = _slide("de", "d1", "# ## A") + _slide("de", "d2", "# ## B")
+        en = _slide("en", "e1", "# ## A") + _slide("en", "e2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("mint") == 0
+        assert plan.count("refuse") == 4
+
+    def test_half_idd_pair_keeps_refuse_in_phase_3_1(self, tmp_path: Path):
+        # Half-id'd is the adopt case (3.2); 3.1 leaves it refusing (mixed refusals).
+        de = _slide_idless("de", "# ## A") + _slide_idless("de", "# ## B")
+        en = _slide("en", "s1", "# ## A") + _slide("en", "s2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("mint") == 0
+        assert plan.count("refuse") == 4
+
+    def test_verifier_result_is_cached(self, tmp_path: Path):
+        # The verdict map is memoized by pair fingerprint: a second resolve over the
+        # same pairs short-circuits the model (calls stays 1).
+        from clm.slides.sync_apply import _resolve_correspondence
+        from clm.slides.sync_recover import SlidePair
+
+        cache = SyncCorrespondenceCache(tmp_path / "clm-llm.sqlite")
+        try:
+            pairs = [SlidePair("# ## A", "# ## A", "", "", "slide")]
+            verifier = StaticCorrespondenceVerifier(default=True)
+            first = _resolve_correspondence(verifier, cache, pairs)
+            second = _resolve_correspondence(verifier, cache, pairs)
+            assert first == {0: True} == second
+            assert verifier.calls == 1  # the second resolve hit the cache
+        finally:
+            cache.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -1041,14 +1041,17 @@ class TestColdStartMint:
         assert plan.count("mint") == 0
         assert plan.count("refuse") == 4
 
-    def test_half_idd_pair_keeps_refuse_in_phase_3_1(self, tmp_path: Path):
-        # Half-id'd is the adopt case (3.2); 3.1 leaves it refusing (mixed refusals).
+    def test_half_idd_pair_is_adopt_not_mint(self, tmp_path: Path):
+        # Half-id'd is the adopt case (3.2), never a mint: it becomes ONE shared-id
+        # candidate, but `adopt` (reuse the id'd half's existing ids), not `mint`
+        # (fresh ids). Full adopt behavior is covered in TestColdStartAdopt.
         de = _slide_idless("de", "# ## A") + _slide_idless("de", "# ## B")
         en = _slide("en", "s1", "# ## A") + _slide("en", "s2", "# ## B")
         de_path, en_path = _write_pair(tmp_path, de, en)
         plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
         assert plan.count("mint") == 0
-        assert plan.count("refuse") == 4
+        assert plan.count("adopt") == 1
+        assert plan.count("refuse") == 0
 
     def test_verifier_result_is_cached(self, tmp_path: Path):
         # The verdict map is memoized by pair fingerprint: a second resolve over the
@@ -1066,6 +1069,242 @@ class TestColdStartMint:
             assert verifier.calls == 1  # the second resolve hit the cache
         finally:
             cache.close()
+
+
+class TestColdStartAdopt:
+    """A half-id'd cold pair adopts the id'd half's *existing* ids once confirmed (#216 §12, 3.2).
+
+    Distinct from a mint: one half is fully id'd, the other fully id-less, and the
+    id-less half adopts the id'd half's ids verbatim (a header stamp — no
+    translation, no fresh slug), gated by the same correspondence verifier.
+    """
+
+    def _half_idd_pair(self, tmp_path: Path, *, idd: str = "en") -> tuple[Path, Path]:
+        # The common 1.8-gate shape: one half assign-ids'd (s1, s2), the twin id-less.
+        idless = _slide_idless("__", "# ## A") + _slide_idless("__", "# ## B")
+        idd_text = _slide("__", "s1", "# ## A") + _slide("__", "s2", "# ## B")
+        if idd == "en":
+            return _write_pair(tmp_path, idless.replace("__", "de"), idd_text.replace("__", "en"))
+        return _write_pair(tmp_path, idd_text.replace("__", "de"), idless.replace("__", "en"))
+
+    def test_half_idd_becomes_adopt_candidate(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 1
+        assert plan.count("mint") == 0
+        assert plan.count("refuse") == 0
+        adopt = next(p for p in plan.proposals if p.kind == "adopt")
+        assert adopt.direction == "en->de"  # EN is the fully-id'd authority
+        assert adopt.disposition == "pending"
+
+    def test_confirmed_pair_adopts_authority_ids(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        en_before = en_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        verifier = StaticCorrespondenceVerifier(default=True)
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_adopt == 1
+        assert result.applied_mint == 0
+        assert result.deferred == 0
+        assert result.has_errors is False
+        assert verifier.calls == 1
+        # The id-less DE half adopted EN's EXISTING ids verbatim — NOT fresh slugs
+        # (a mint would derive "introduction"/"variables" from the headings).
+        assert _slide_order(de_path) == ["s1", "s2"]
+        assert _slide_order(en_path) == ["s1", "s2"]
+        # Only the id-less half was written; the id'd half is byte-identical.
+        assert en_path.read_text(encoding="utf-8") == en_before
+
+    def test_de_authority_is_adopted_onto_en(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path, idd="de")
+        de_before = de_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        adopt = next(p for p in plan.proposals if p.kind == "adopt")
+        assert adopt.direction == "de->en"  # DE is the authority
+        verifier = StaticCorrespondenceVerifier(default=True)
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_adopt == 1
+        assert _slide_order(de_path) == ["s1", "s2"]
+        assert _slide_order(en_path) == ["s1", "s2"]
+        assert de_path.read_text(encoding="utf-8") == de_before  # the id'd half untouched
+
+    def test_denied_pair_refuses_and_writes_nothing(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        before_de = de_path.read_text(encoding="utf-8")
+        before_en = en_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        verifier = StaticCorrespondenceVerifier(default=False)  # all "no"
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_adopt == 0
+        assert result.deferred == 1
+        assert de_path.read_text(encoding="utf-8") == before_de
+        assert en_path.read_text(encoding="utf-8") == before_en
+
+    def test_no_verifier_refuses(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        before_de = de_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        result = apply_plan(plan, judge=None, verifier=None, watermark_cache=None)
+        assert result.applied_adopt == 0
+        assert result.deferred == 1
+        assert de_path.read_text(encoding="utf-8") == before_de
+
+    def test_no_provider_keeps_refuse(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=False)
+        assert plan.count("adopt") == 0
+        assert plan.count("refuse") == 4  # 2 id-less de + 2 id'd en, both directions
+
+    def test_mismatched_ids_never_adopt(self, tmp_path: Path):
+        # Both id'd with DIFFERENT ids: not a half-id'd pair → refuse, never adopt.
+        de = _slide("de", "d1", "# ## A") + _slide("de", "d2", "# ## B")
+        en = _slide("en", "e1", "# ## A") + _slide("en", "e2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 0
+        assert plan.count("mint") == 0
+        assert plan.count("refuse") == 4
+
+    def test_mixed_authority_keeps_refuse(self, tmp_path: Path):
+        # DE id'd on slide A, EN id'd on slide B — inconsistent authority → refuse.
+        de = _slide("de", "s1", "# ## A") + _slide_idless("de", "# ## B")
+        en = _slide_idless("en", "# ## A") + _slide("en", "s2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 0
+        assert plan.count("refuse") == 4
+
+    def test_adopt_advances_watermark_and_second_run_is_noop(self, tmp_path: Path):
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache, provider_available=True)
+            verifier = StaticCorrespondenceVerifier(default=True)
+            result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=cache)
+            assert result.applied_adopt == 1
+            assert result.watermark_recorded is True
+            # The watermark recorded the POST-stamp state (both halves now id'd), so a
+            # second run sees a synced pair and proposes nothing.
+            plan2 = build_sync_plan(
+                de_path, en_path, watermark_cache=cache, provider_available=True
+            )
+            assert plan2.count("adopt") == 0
+            assert plan2.is_noop
+        finally:
+            cache.close()
+
+    def test_adopt_with_voiceover_companion_adopts_group(self, tmp_path: Path):
+        # A slide + its voiceover companion: the id'd half carries the slide id on
+        # both cells; the id-less twin adopts both, so the group stays paired.
+        de = (
+            _slide_idless("de", "# ## A")
+            + _vo_idless("de", "# Sprechertext A")
+            + _slide_idless("de", "# ## B")
+        )
+        en = (
+            _slide("en", "s1", "# ## A")
+            + '# %% [markdown] lang="en" tags=["voiceover"] slide_id="s1"\n# Narration A\n'
+            + _slide("en", "s2", "# ## B")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 1
+        verifier = StaticCorrespondenceVerifier(default=True)
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_adopt == 1
+        # The DE voiceover companion adopted the slide's id too (group kept intact).
+        assert _cell_for(de_path, "s1", role="voiceover") is not None
+        assert _slide_order(de_path) == ["s1", "s2"]
+
+    def test_classifier_error_on_authority_blocks_adopt(self, tmp_path: Path):
+        # The authority half has a *duplicated* companion id (slide s1 + TWO voiceovers
+        # both s1) → `_resolve_duplicates` raises a "lone duplicated companion" error
+        # (plan.has_errors). A bootstrap that stamped s1 onto both id-less DE
+        # voiceovers would bake a DUPLICATE id and advance the watermark over the
+        # corruption — so a classifier error must block the adopt entirely.
+        en = (
+            _slide("en", "s1", "# ## A")
+            + '# %% [markdown] lang="en" tags=["voiceover"] slide_id="s1"\n# VO1\n'
+            + '# %% [markdown] lang="en" tags=["voiceover"] slide_id="s1"\n# VO2\n'
+        )
+        de = _slide_idless("de", "# ## A") + _vo_idless("de", "# S1") + _vo_idless("de", "# S2")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        before_de = de_path.read_text(encoding="utf-8")
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache, provider_available=True)
+            assert plan.has_errors is True
+            assert plan.count("adopt") == 0  # candidacy bails on a classifier error
+            verifier = StaticCorrespondenceVerifier(default=True)
+            result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=cache)
+            assert result.applied_adopt == 0
+            assert de_path.read_text(encoding="utf-8") == before_de  # nothing stamped
+            assert result.watermark_recorded is False  # watermark held over the error
+        finally:
+            cache.close()
+
+    def test_apply_defers_adopt_when_plan_has_errors(self, tmp_path: Path):
+        # Defense in depth: even if an `adopt` candidate coexists with a classifier
+        # error (here injected after planning), the apply-time short-circuit must defer
+        # it and write nothing — mirroring the normal flush gate's `not plan.has_errors`.
+        de_path, en_path = self._half_idd_pair(tmp_path)
+        before_de = de_path.read_text(encoding="utf-8")
+        before_en = en_path.read_text(encoding="utf-8")
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 1  # a clean half-id'd pair → an adopt candidate
+        plan.issues.append(PlanIssue(severity="error", slide_id=None, reason="injected error"))
+        verifier = StaticCorrespondenceVerifier(default=True)
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_adopt == 0
+        assert result.deferred == 1
+        assert de_path.read_text(encoding="utf-8") == before_de
+        assert en_path.read_text(encoding="utf-8") == before_en
+
+    def test_adopt_skips_idless_localized_code_cells(self, tmp_path: Path):
+        # An id-less localized CODE cell (role_of None) interleaved between the
+        # slides: candidacy treats it as an aligned non-sync pair (both id-less) and
+        # the stamp walk skips it, so only the slides adopt ids — the code cell stays
+        # id-less, never mis-stamped.
+        de = (
+            _slide_idless("de", "# ## A")
+            + '# %% lang="de"\nx = 1\n'
+            + _slide_idless("de", "# ## B")
+        )
+        en = _slide("en", "s1", "# ## A") + '# %% lang="en"\nx = 1\n' + _slide("en", "s2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 1
+        verifier = StaticCorrespondenceVerifier(default=True)
+        result = apply_plan(plan, judge=None, verifier=verifier, watermark_cache=None)
+        assert result.applied_adopt == 1
+        assert _slide_order(de_path) == ["s1", "s2"]
+        assert en_path.read_text(encoding="utf-8") == en  # the id'd half untouched
+        # The id-less localized code cell was NOT stamped — it stays id-less.
+        de_code = [
+            c
+            for c in parse_cells(de_path.read_text(encoding="utf-8"))
+            if c.metadata.cell_type == "code" and c.metadata.lang == "de"
+        ]
+        assert len(de_code) == 1
+        assert de_code[0].metadata.slide_id is None
+
+    def test_idd_localized_code_on_one_side_refuses(self, tmp_path: Path):
+        # If the code cell is id'd on the authority half but id-less on the twin, the
+        # two have different role_of (CODE_ROLE vs None) → the streams are not clean
+        # twins → adopt declines and the refusal stands (never a guessed code-id stamp).
+        de = (
+            _slide_idless("de", "# ## A")
+            + '# %% lang="de"\nx = 1\n'
+            + _slide_idless("de", "# ## B")
+        )
+        en = (
+            _slide("en", "s1", "# ## A")
+            + '# %% lang="en" slide_id="c1"\nx = 1\n'
+            + _slide("en", "s2", "# ## B")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=True)
+        assert plan.count("adopt") == 0  # role mismatch on the code pair → refuse
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.notebooks.slide_parser import parse_cells
@@ -871,6 +873,47 @@ class TestApplyAdd:
         assert result.watermark_recorded is False
         # No duplication: each deck still has exactly its slide + one id-less new.
         assert len(_slide_order(de_path)) == 2  # "a" + one id-less
+        assert len(_slide_order(en_path)) == 2
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#216 (id-CARRYING sibling): the both-directions guard at "
+        "sync_apply.py:710-718 covers only id-LESS adds. A cold-start pair whose "
+        "halves carry DIFFERENT slide_ids (e.g. assign-ids run per half) makes the "
+        "classifier emit id-carrying adds in BOTH directions, which "
+        "_add_idcarrying_one_direction applies unconditionally — silently DOUBLING "
+        "both decks with no error. The guard must cover idd both-directions too.",
+    )
+    def test_cold_start_mismatched_ids_must_not_double(self, tmp_path: Path):
+        # Both halves carry slide_ids, but DIFFERENT ones, and there is no baseline.
+        de = _slide("de", "d1", "# ## A") + _slide("de", "d2", "# ## B")
+        en = _slide("en", "e1", "# ## A") + _slide("en", "e2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None)
+        translator = StaticSlideTranslator(default="# ## X")
+        result = apply_plan(plan, judge=None, translator=translator, watermark_cache=None)
+        # Desired: a cold-start mismatched pair is NOT auto-applied (it would
+        # duplicate every cell on both halves). Currently applies 4 -> xfail.
+        assert result.applied_add == 0
+        assert len(_slide_order(de_path)) == 2
+        assert len(_slide_order(en_path)) == 2
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#216 (id-CARRYING sibling): a cold-start HALF-id'd pair (one half "
+        "id-less, the other id'd) doubles both decks — the id-less half adds de->en "
+        "(id-less, guarded only if the other direction is also id-less) while the "
+        "id'd half adds en->de (id-carrying, never guarded), so both sets apply.",
+    )
+    def test_cold_start_half_idd_must_not_double(self, tmp_path: Path):
+        de = _slide_idless("de", "# ## A") + _slide_idless("de", "# ## B")
+        en = _slide("en", "s1", "# ## A") + _slide("en", "s2", "# ## B")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=None)
+        translator = StaticSlideTranslator(default="# ## X")
+        result = apply_plan(plan, judge=None, translator=translator, watermark_cache=None)
+        assert result.applied_add == 0
+        assert len(_slide_order(de_path)) == 2
         assert len(_slide_order(en_path)) == 2
 
 

--- a/tests/slides/test_sync_correspondence.py
+++ b/tests/slides/test_sync_correspondence.py
@@ -1,0 +1,128 @@
+"""Unit tests for the cold-start CorrespondenceVerifier tier (#216 Phase 3).
+
+The verifier confirms that the two structurally-aligned halves of a never-id'd
+split pair actually correspond (are translations) before `clm slides sync` mints a
+shared slide_id onto each pair. These tests pin the body-of-the-tier — fingerprint,
+(de)serialization, validation, the static stand-in, and the cache — in isolation;
+the engine wiring is exercised in the apply/CLI suites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncCorrespondenceCache
+from clm.slides.sync_recover import (
+    CorrespondenceError,
+    CorrespondenceInvalid,
+    SlidePair,
+    StaticCorrespondenceVerifier,
+    correspondence_fingerprint,
+    decode_verdicts,
+    encode_verdicts,
+    validate_correspondence,
+)
+
+
+def _pair(de_h: str, en_h: str, role: str = "slide") -> SlidePair:
+    return SlidePair(de_heading=de_h, en_heading=en_h, de_snippet="", en_snippet="", role=role)
+
+
+class TestFingerprint:
+    def test_stable_for_equal_pairs(self):
+        a = [_pair("# ## Variablen", "# ## Variables"), _pair("# ## Schleifen", "# ## Loops")]
+        b = [_pair("# ## Variablen", "# ## Variables"), _pair("# ## Schleifen", "# ## Loops")]
+        assert correspondence_fingerprint(a) == correspondence_fingerprint(b)
+
+    def test_sensitive_to_heading_change(self):
+        a = [_pair("# ## Variablen", "# ## Variables")]
+        b = [_pair("# ## Variablen", "# ## Functions")]
+        assert correspondence_fingerprint(a) != correspondence_fingerprint(b)
+
+    def test_sensitive_to_order(self):
+        a = [_pair("# ## A", "# ## A"), _pair("# ## B", "# ## B")]
+        b = [_pair("# ## B", "# ## B"), _pair("# ## A", "# ## A")]
+        assert correspondence_fingerprint(a) != correspondence_fingerprint(b)
+
+
+class TestVerdictCodec:
+    def test_round_trip(self):
+        verdicts = {0: True, 1: False, 2: True}
+        assert decode_verdicts(encode_verdicts(verdicts)) == verdicts
+
+    def test_encode_sorts_keys(self):
+        assert encode_verdicts({2: True, 0: False}) == '{"0":false,"2":true}'
+
+    def test_decode_rejects_non_json(self):
+        with pytest.raises(CorrespondenceInvalid):
+            decode_verdicts("not json")
+
+    def test_decode_rejects_non_object(self):
+        with pytest.raises(CorrespondenceInvalid):
+            decode_verdicts("[true, false]")
+
+    def test_decode_rejects_non_bool_value(self):
+        # An id-like string where a boolean is required must not slip through.
+        with pytest.raises(CorrespondenceInvalid):
+            decode_verdicts('{"0": "yes"}')
+
+    def test_decode_rejects_non_int_key(self):
+        with pytest.raises(CorrespondenceInvalid):
+            decode_verdicts('{"a": true}')
+
+
+class TestValidate:
+    def test_total_map_passes(self):
+        pairs = [_pair("a", "a"), _pair("b", "b")]
+        verdicts = {0: True, 1: False}
+        assert validate_correspondence(verdicts, pairs) == verdicts
+
+    def test_missing_index_raises(self):
+        pairs = [_pair("a", "a"), _pair("b", "b")]
+        with pytest.raises(CorrespondenceInvalid):
+            validate_correspondence({0: True}, pairs)
+
+    def test_stray_index_raises(self):
+        pairs = [_pair("a", "a")]
+        with pytest.raises(CorrespondenceInvalid):
+            validate_correspondence({0: True, 1: True}, pairs)
+
+
+class TestStaticVerifier:
+    def test_default_true_for_all(self):
+        v = StaticCorrespondenceVerifier()
+        pairs = [_pair("a", "a"), _pair("b", "b")]
+        assert v.verify(pairs=pairs) == {0: True, 1: True}
+        assert v.calls == 1
+
+    def test_explicit_verdicts_override_default(self):
+        v = StaticCorrespondenceVerifier(verdicts={1: False}, default=True)
+        pairs = [_pair("a", "a"), _pair("b", "b"), _pair("c", "c")]
+        assert v.verify(pairs=pairs) == {0: True, 1: False, 2: True}
+
+    def test_raise_error_path(self):
+        v = StaticCorrespondenceVerifier(raise_error=True)
+        with pytest.raises(CorrespondenceError):
+            v.verify(pairs=[_pair("a", "a")])
+
+
+class TestCache:
+    def test_put_get_round_trip(self, tmp_path: Path):
+        cache = SyncCorrespondenceCache(tmp_path / "clm-llm.sqlite")
+        try:
+            cache.put("fp1", "correspond-v1", '{"0":true}')
+            assert cache.get("fp1", "correspond-v1") == '{"0":true}'
+        finally:
+            cache.close()
+
+    def test_miss_returns_none(self, tmp_path: Path):
+        cache = SyncCorrespondenceCache(tmp_path / "clm-llm.sqlite")
+        try:
+            assert cache.get("absent", "correspond-v1") is None
+            # A different prompt version is a miss even for the same fingerprint.
+            cache.put("fp1", "correspond-v1", '{"0":true}')
+            assert cache.get("fp1", "correspond-v2") is None
+        finally:
+            cache.close()

--- a/tests/slides/test_sync_dry_run_parity.py
+++ b/tests/slides/test_sync_dry_run_parity.py
@@ -10,22 +10,19 @@ the dry-run exit code, ``_apply_exit_code`` is the writing-run exit code, and a
 **non-failing** static translator/judge is injected so that any divergence is the
 plan-vs-apply disagreement under test, never a translation/judge failure.
 
-Known divergence (#216): when *both* halves of a split pair carry id-less cells
-(a freshly-authored or freshly-split parallel deck), the classifier emits an
-``add`` per cell on *both* sides, so the plan promises ``N add`` and dry-run
-exits 1 ("changes pending"). But ``apply`` cannot pair parallel id-less halves,
-so it defers every add with an error and exits 2, writing nothing. The dry-run
-preview is therefore a lie. The two ``xfail(strict=True)`` tests below encode the
-fixed contract; when #216 teaches the classifier to pair-and-mint (or to surface
-the refusal as a plan issue), they flip to passing and the strict marker forces
-its own removal.
+Fixed in the resolve-then-apply redesign (#216): when adds would flow in *both*
+directions with no way to pair the halves — a freshly-split parallel deck (all
+id-less), a per-half ``assign-ids`` (mismatched ids), or a half-id'd pair — the
+classifier now emits ``refuse`` proposals at plan time instead of bidirectional
+adds the apply engine would silently double (id-carrying) or defer with an error
+(id-less). So the dry-run lists the refusal (exit 1, "changes pending") and a
+writing run defers it (exit 1), writing nothing — the preview and the act agree.
+The ``TestColdStartRefusalParity`` cases below pin that agreement.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-
-import pytest
 
 from clm.cli.commands.slides_sync import _apply_exit_code, _plan_exit_code
 from clm.infrastructure.llm.cache import SyncWatermarkCache
@@ -209,17 +206,11 @@ class TestDryRunMatchesApply:
 
 
 # ---------------------------------------------------------------------------
-# Parity is BROKEN (#216): the dry-run preview lies about a parallel id-less pair
+# Parity holds for a both-directions cold-start pair: the resolver refuses (#216)
 # ---------------------------------------------------------------------------
 
 
-class TestDryRunMatchesApplyKnownBugs:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#216: cold-start parallel id-less pair — dry-run promises N adds "
-        "(exit 1) but apply defers all with an error (exit 2), writing nothing. "
-        "Fix must pair-and-mint or surface the refusal in the plan.",
-    )
+class TestColdStartRefusalParity:
     def test_cold_start_parallel_idless_pair(self, tmp_path: Path):
         # A freshly-authored / freshly-split pair: structurally parallel, prose
         # differs by language, ZERO slide_ids, no watermark and (tmp dir) no git.
@@ -237,19 +228,18 @@ class TestDryRunMatchesApplyKnownBugs:
         plan, dry_exit, result, apply_exit = _dry_then_apply(
             de_path, en_path, cache=None, translator=_forgiving_translator(), judge=None
         )
-        # Establish the divergence is the #216 cold-start one, not something else.
+        # The resolver refuses both directions rather than promising 6 adds it
+        # cannot apply: 3 de->en + 3 en->de become 6 refusals, nothing to add.
         assert plan.baseline_source == "none"
-        assert plan.count("add") == 6  # 3 de->en + 3 en->de: the misleading promise
-        assert dry_exit == 1  # dry-run says "6 changes pending"
-        # The contract the fix must restore (currently false -> xfail):
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 6
+        assert dry_exit == 1  # "changes pending" (the refusal needs the author)
+        assert apply_exit == 1  # ...deferred, not errored
+        # Nothing written: both halves are byte-identical after the writing run.
+        assert de_path.read_text(encoding="utf-8") == de
+        assert en_path.read_text(encoding="utf-8") == en
         _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#216: both halves carry an id-less cell even against a watermark "
-        "baseline — dry-run promises 2 adds (exit 1) but apply defers both with an "
-        "error (exit 2), writing nothing.",
-    )
     def test_watermark_baseline_both_sides_idless(self, tmp_path: Path):
         de_path, en_path = _write_pair(
             tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
@@ -257,18 +247,22 @@ class TestDryRunMatchesApplyKnownBugs:
         cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
         try:
             _seed_watermark(cache, de_path, en_path)
-            # An id-less new slide added on BOTH halves (the isolated #216 case).
-            de_path.write_text(
-                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu"), encoding="utf-8"
-            )
-            en_path.write_text(
-                _slide("en", "a", "# ## A") + _slide_idless("en", "# ## New"), encoding="utf-8"
-            )
+            # An id-less new slide added on BOTH halves (the isolated #216 case):
+            # against a real baseline this still cannot be paired, so it refuses.
+            de_after = _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu")
+            en_after = _slide("en", "a", "# ## A") + _slide_idless("en", "# ## New")
+            de_path.write_text(de_after, encoding="utf-8")
+            en_path.write_text(en_after, encoding="utf-8")
             plan, dry_exit, result, apply_exit = _dry_then_apply(
                 de_path, en_path, cache=cache, translator=_forgiving_translator(), judge=None
             )
-            assert plan.count("add") == 2
+            assert plan.count("add") == 0
+            assert plan.count("refuse") == 2
             assert dry_exit == 1
+            assert apply_exit == 1
+            assert result.watermark_recorded is False  # held over the refusal
+            assert de_path.read_text(encoding="utf-8") == de_after
+            assert en_path.read_text(encoding="utf-8") == en_after
             _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
         finally:
             cache.close()

--- a/tests/slides/test_sync_dry_run_parity.py
+++ b/tests/slides/test_sync_dry_run_parity.py
@@ -1,0 +1,274 @@
+"""`clm slides sync --dry-run` must predict the real (writing) run (#216).
+
+A ``--dry-run`` that reports proposals a writing run silently refuses — or that
+exits "changes pending / clean" when the writing run errors and writes nothing —
+is worse than useless: an author cannot trust the preview. These tests pin the
+contract that *the plan an author previews is what a writing run actually does*.
+
+They assert it the way the CLI itself decides outcomes: ``_plan_exit_code`` is
+the dry-run exit code, ``_apply_exit_code`` is the writing-run exit code, and a
+**non-failing** static translator/judge is injected so that any divergence is the
+plan-vs-apply disagreement under test, never a translation/judge failure.
+
+Known divergence (#216): when *both* halves of a split pair carry id-less cells
+(a freshly-authored or freshly-split parallel deck), the classifier emits an
+``add`` per cell on *both* sides, so the plan promises ``N add`` and dry-run
+exits 1 ("changes pending"). But ``apply`` cannot pair parallel id-less halves,
+so it defers every add with an error and exits 2, writing nothing. The dry-run
+preview is therefore a lie. The two ``xfail(strict=True)`` tests below encode the
+fixed contract; when #216 teaches the classifier to pair-and-mint (or to surface
+the refusal as a plan issue), they flip to passing and the strict marker forces
+its own removal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.cli.commands.slides_sync import _apply_exit_code, _plan_exit_code
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_apply import ApplyResult, apply_plan
+from clm.slides.sync_plan import SyncPlan, build_sync_plan, ordered_sync_cells
+from clm.slides.sync_translate import StaticSlideTranslator
+
+# Proposal kinds that a writing run is expected to apply automatically. A
+# ``conflict`` is excluded: the plan labels it as a conflict and apply defers it
+# by design, so a dry-run that shows "1 conflict" honestly predicts the deferral.
+AUTO_APPLY_KINDS = ("add", "edit", "retag", "move", "remove", "rename")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n'
+
+
+def _slide_idless(lang: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"]\n{body}\n'
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.py"
+    en_path = tmp_path / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    for lang, path in (("de", de_path), ("en", en_path)):
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8")), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
+        )
+
+
+def _forgiving_translator() -> StaticSlideTranslator:
+    """A translator that succeeds for *any* body, so a deferral can only mean the
+    plan/apply disagreement under test — never a missing translation."""
+    return StaticSlideTranslator(default="# ## Translated\n#\n# - point")
+
+
+def _forgiving_judge() -> StaticSyncJudge:
+    return StaticSyncJudge(
+        default_proposal=SyncProposal(verdict="update", proposed_text="# ## Translated\n# - point")
+    )
+
+
+def _assert_dry_run_predicts_apply(
+    plan: SyncPlan, dry_exit: int, result: ApplyResult, apply_exit: int
+) -> None:
+    """The dry-run preview of ``plan`` must match what applying ``plan`` did.
+
+    With a non-failing translator/judge:
+
+    1. apply must not surface an error the dry-run plan did not already carry;
+    2. every auto-applying proposal the plan promised must actually be applied;
+    3. a writing-run *error* (exit 2) must have been foreseen by the dry-run
+       (also exit 2) — a dry-run that looks clean/pending (exit 0/1) turning into
+       an apply error is exactly the misleading-preview bug this guards against.
+    """
+    assert result.has_errors == plan.has_errors, (
+        f"dry-run plan reported has_errors={plan.has_errors} but apply "
+        f"has_errors={result.has_errors}: {result.errors}"
+    )
+    for kind in AUTO_APPLY_KINDS:
+        applied = getattr(result, f"applied_{kind}")
+        promised = plan.count(kind)
+        assert applied == promised, (
+            f"dry-run promised {promised} {kind}(s) but the writing run applied {applied}"
+        )
+    if apply_exit == 2:
+        assert dry_exit == 2, (
+            f"the writing run errored (exit 2) on a plan the dry-run reported as "
+            f"exit {dry_exit} (not an error): {result.errors}"
+        )
+
+
+def _dry_then_apply(
+    de_path: Path,
+    en_path: Path,
+    *,
+    cache: SyncWatermarkCache | None,
+    translator: StaticSlideTranslator | None,
+    judge: StaticSyncJudge | None,
+) -> tuple[SyncPlan, int, ApplyResult, int]:
+    """Classify once (the dry-run preview), then apply that same plan (the writing
+    run) — exactly the CLI's internal flow — and return both exit codes."""
+    plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+    dry_exit = _plan_exit_code(plan)
+    de_before = de_path.read_text(encoding="utf-8")
+    en_before = en_path.read_text(encoding="utf-8")
+    result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    apply_exit = _apply_exit_code(plan, result)
+    # A writing run that *errors* must leave both decks byte-identical (#190 item
+    # 1: an erroring pass writes neither deck) — so a misleading dry-run is never
+    # also a corrupting one.
+    if result.has_errors:
+        assert de_path.read_text(encoding="utf-8") == de_before
+        assert en_path.read_text(encoding="utf-8") == en_before
+    return plan, dry_exit, result, apply_exit
+
+
+# ---------------------------------------------------------------------------
+# Parity holds: the dry-run preview matches the writing run
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunMatchesApply:
+    def test_noop_is_clean_in_both(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)  # current == baseline -> no-op
+            plan, dry_exit, result, apply_exit = _dry_then_apply(
+                de_path, en_path, cache=cache, translator=_forgiving_translator(), judge=None
+            )
+        finally:
+            cache.close()
+        assert dry_exit == 0  # nothing to do
+        assert apply_exit == 0
+        _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
+
+    def test_single_side_idless_add_is_delivered(self, tmp_path: Path):
+        de = _slide("de", "a", "# ## A")
+        en = _slide("en", "a", "# ## A")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author appends ONE new id-less slide on DE only.
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neues Thema"),
+                encoding="utf-8",
+            )
+            plan, dry_exit, result, apply_exit = _dry_then_apply(
+                de_path, en_path, cache=cache, translator=_forgiving_translator(), judge=None
+            )
+        finally:
+            cache.close()
+        assert plan.count("add") == 1
+        assert dry_exit == 1  # one change pending
+        assert apply_exit == 0  # ...and it applied cleanly
+        assert result.applied_add == 1
+        _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
+
+    def test_one_side_edit_is_delivered(self, tmp_path: Path):
+        de = _slide("de", "intro", "# ## Einleitung")
+        en = _slide("en", "intro", "# ## Introduction")
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # Author edits the DE deck; EN unchanged -> a one-directional edit.
+            de_path.write_text(
+                _slide("de", "intro", "# ## Einleitung\n# - Punkt eins"), encoding="utf-8"
+            )
+            plan, dry_exit, result, apply_exit = _dry_then_apply(
+                de_path, en_path, cache=cache, translator=None, judge=_forgiving_judge()
+            )
+        finally:
+            cache.close()
+        assert plan.count("edit") == 1
+        assert dry_exit == 1
+        assert apply_exit == 0
+        assert result.applied_edit == 1
+        _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
+
+
+# ---------------------------------------------------------------------------
+# Parity is BROKEN (#216): the dry-run preview lies about a parallel id-less pair
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunMatchesApplyKnownBugs:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#216: cold-start parallel id-less pair — dry-run promises N adds "
+        "(exit 1) but apply defers all with an error (exit 2), writing nothing. "
+        "Fix must pair-and-mint or surface the refusal in the plan.",
+    )
+    def test_cold_start_parallel_idless_pair(self, tmp_path: Path):
+        # A freshly-authored / freshly-split pair: structurally parallel, prose
+        # differs by language, ZERO slide_ids, no watermark and (tmp dir) no git.
+        de = (
+            _slide_idless("de", "# ## Einleitung")
+            + _slide_idless("de", "# ## Variablen")
+            + _slide_idless("de", "# ## Schleifen")
+        )
+        en = (
+            _slide_idless("en", "# ## Introduction")
+            + _slide_idless("en", "# ## Variables")
+            + _slide_idless("en", "# ## Loops")
+        )
+        de_path, en_path = _write_pair(tmp_path, de, en)
+        plan, dry_exit, result, apply_exit = _dry_then_apply(
+            de_path, en_path, cache=None, translator=_forgiving_translator(), judge=None
+        )
+        # Establish the divergence is the #216 cold-start one, not something else.
+        assert plan.baseline_source == "none"
+        assert plan.count("add") == 6  # 3 de->en + 3 en->de: the misleading promise
+        assert dry_exit == 1  # dry-run says "6 changes pending"
+        # The contract the fix must restore (currently false -> xfail):
+        _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#216: both halves carry an id-less cell even against a watermark "
+        "baseline — dry-run promises 2 adds (exit 1) but apply defers both with an "
+        "error (exit 2), writing nothing.",
+    )
+    def test_watermark_baseline_both_sides_idless(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path, _slide("de", "a", "# ## A"), _slide("en", "a", "# ## A")
+        )
+        cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+        try:
+            _seed_watermark(cache, de_path, en_path)
+            # An id-less new slide added on BOTH halves (the isolated #216 case).
+            de_path.write_text(
+                _slide("de", "a", "# ## A") + _slide_idless("de", "# ## Neu"), encoding="utf-8"
+            )
+            en_path.write_text(
+                _slide("en", "a", "# ## A") + _slide_idless("en", "# ## New"), encoding="utf-8"
+            )
+            plan, dry_exit, result, apply_exit = _dry_then_apply(
+                de_path, en_path, cache=cache, translator=_forgiving_translator(), judge=None
+            )
+            assert plan.count("add") == 2
+            assert dry_exit == 1
+            _assert_dry_run_predicts_apply(plan, dry_exit, result, apply_exit)
+        finally:
+            cache.close()

--- a/tests/slides/test_sync_plan.py
+++ b/tests/slides/test_sync_plan.py
@@ -304,6 +304,88 @@ class TestColdStart:
         assert "cannot detect" in summary
 
 
+class TestBothDirectionsRefusal:
+    """Adds that would flow both ways become ``refuse`` proposals (#216).
+
+    The resolver decides at plan time that a both-directions cold-start / id-less
+    pair cannot be auto-paired, so it emits ``refuse`` items instead of
+    bidirectional adds the apply engine would double (id-carrying) or defer with
+    an error (id-less). A one-directional case keeps its adds.
+    """
+
+    def test_cold_start_parallel_idless_refuses(self):
+        plan = classify(
+            [cur(0, None, "d0"), cur(1, None, "d1")],
+            [cur(0, None, "e0"), cur(1, None, "e1")],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 4
+        assert all(p.disposition == "refuse" for p in plan.refusals)
+        assert {p.direction for p in plan.refusals} == {"de->en", "en->de"}
+
+    def test_cold_start_mismatched_ids_refuses(self):
+        plan = classify(
+            [cur(0, "d1", "d0"), cur(1, "d2", "d1h")],
+            [cur(0, "e1", "e0"), cur(1, "e2", "e1h")],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 4
+
+    def test_cold_start_half_idd_refuses(self):
+        plan = classify(
+            [cur(0, None, "d0"), cur(1, None, "d1")],
+            [cur(0, "s1", "e0"), cur(1, "s2", "e1")],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 4
+
+    def test_cold_start_one_direction_still_adds(self):
+        # New content on one side only is the legitimate single-language case —
+        # never refused.
+        plan = classify(
+            [cur(0, None, "d0"), cur(1, None, "d1")],
+            [],
+            None,
+            None,
+            source="none",
+        )
+        assert plan.count("add") == 2
+        assert plan.count("refuse") == 0
+
+    def test_baseline_both_sides_idless_refuses(self):
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, None, "dNEW")],
+            [cur(0, "intro", "e0"), cur(1, None, "eNEW")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 2
+        assert plan.in_sync_count == 1
+
+    def test_baseline_idcarrying_both_directions_still_adds(self):
+        # Against a real baseline, two new id'd slides (one per side) are genuinely
+        # distinct — their ids were absent from the baseline — not a mismatched
+        # pair, so they apply rather than refuse.
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, "newde", "dNEW")],
+            [cur(0, "intro", "e0"), cur(1, "newen", "eNEW")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+        )
+        assert plan.count("add") == 2
+        assert plan.count("refuse") == 0
+
+
 # ---------------------------------------------------------------------------
 # build_sync_plan (IO wrapper: baseline resolution)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Fixes the **#216 cold-start bug cluster** in `clm slides sync` and the dry-run/apply divergence it exposed, by re-architecting the **plan/apply boundary** so the command decides *what will happen* once, at plan time, and applying is a decision-free mechanical replay.

The original symptoms:
- A never-synced (no-watermark) split pair with all id-less cells printed `N add` on `--dry-run` but a writing run **deferred everything and wrote nothing** — a misleading preview.
- The id-**carrying** sibling (a half-id'd or mismatched-id cold pair) was **unguarded** and could silently **double both decks**.
- There was no way to actually *bootstrap* ids onto a freshly-split deck through `sync` — the intended tool for the ~200 id-less split halves blocking the 1.8 gate (#158).

## Architecture

Three stages with a hard boundary (design note: `docs/claude/design/sync-plan-resolve-apply.md`):

1. **Classify** (pure, no IO/LLM) → typed proposals.
2. **Resolve** — every proposal gets a *disposition* (`apply` / `refuse` / `pending`) at plan time, so `--dry-run` predicts the writing run exactly.
3. **Apply** — mechanical replay; model calls are materialized up front (2b), never mid-write.

## Phases (all in this PR)

- **Phase 1** — moved the both-directions refusal from apply into the classifier (`refuse` disposition). All 5 doubling/parity xfails flipped to passing.
- **Phase 2 (scoped)** — the **edit** and **add** paths are materialize-then-execute (model calls moved to stage 2b; execute writes mechanically).
- **Phase 3.1** — **cold-start mint**: a both-id-less unifiable pair is bootstrapped with *fresh* shared ids via `assign_ids_in_split_pair`, gated by a new cached, validated, safe-abort `CorrespondenceVerifier` (Haiku) that confirms the halves actually translate each other. `--verify-cold-pairs` (default-on when a provider key is set).
- **Phase 3.2** — **cold-start adopt**: a *half-id'd* pair (one half fully id'd, the other fully id-less) has the id-less half **adopt** the id'd half's *existing* ids verbatim (a per-cell header stamp, no translation), gated by the same verifier. `assign_ids_in_split_pair` cannot do this (`_slide_ids_pair` is `de_id == en_id`, so an id-less cell never pairs with an id'd one), so it takes an explicit `adopt` path.

**Mismatched-id** (both id'd, different ids) and **mixed-authority** cold pairs stay `refuse` by design (visible in git, never a guessed id).

## Safety

The whole design exists to never bake a wrong/duplicate `slide_id` or double a deck. Two safety nets worth calling out:
- The verifier is a **required gate** — a "no", a safe-abort, or no provider downgrades the candidate to a deferral (writes nothing); a wrong shared id is worse than a visible refuse.
- An **adversarial multi-agent review** of Phase 3.2 caught a real bug, fixed in the same commit: the mint/adopt short-circuits bypassed the `plan.has_errors` flush gate, so a half-id'd pair whose authority half carried a duplicated id (a slide with two same-id voiceover companions) would stamp the duplicate onto the id-less twin and advance the watermark over the corruption. Both candidacy and apply now decline on `plan.has_errors`, mirroring the normal flush gate, with regression coverage.

## Tests

New: `TestColdStartMint`, `TestColdStartAdopt` (14 cases), `test_sync_correspondence.py`, `test_sync_dry_run_parity.py`, CLI cold-start mint/adopt tests, plan-time refusal/candidacy tests. Local sweep: **1171 slides + CLI sync tests green**, ruff + mypy clean; the pre-push fast suite passed on push.

## Docs

`clm info migration` (cold-start section), design note §12, and the handover are updated to current behavior.

Closes #216.
Unblocks #158 (the 1.8 PythonCourses slide-id gate — now bootstrappable for both id-less and half-id'd split halves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)