### PR TITLE
test: force --workers direct in manifest build tests (fix CI flake)

### DIFF
--- a/tests/snapshot/test_manifest_suppressed.py
+++ b/tests/snapshot/test_manifest_suppressed.py
@@ -70,7 +70,15 @@ def _invoke_build(args, tmp_path: Path):
         "CACHE_DB_PATH": tmp_path / "cache.db",
         "JOBS_DB_PATH": tmp_path / "jobs.db",
     }
-    return CliRunner().invoke(build_module.build, args, obj=obj)
+    # Force Direct execution mode explicitly. These are dir-group-only builds that
+    # never spawn workers, but the worker-config loader mutates the process-global
+    # ``get_config()`` singleton's ``default_execution_mode`` in place — so an
+    # earlier Docker-mode build/test on the same xdist worker can leave the default
+    # at ``"docker"``, and a build here that did not override it would then fail with
+    # "Docker execution mode requires 'image'" (a real, order-dependent flake seen on
+    # CI). Overriding ``--workers direct`` makes this test immune to that leak. See
+    # the load_worker_config singleton-mutation issue tracked separately.
+    return CliRunner().invoke(build_module.build, [*args, "--workers", "direct"], obj=obj)
 
 
 def _manifests_under(root: Path) -> list[Path]:


### PR DESCRIPTION
## What

`tests/snapshot/test_manifest_suppressed.py`'s three builds now pass `--workers direct`, making them immune to the worker-config execution-mode leak.

## Why

The builds in this file are **dir-group-only** (no topics, no workers needed) but didn't pin the execution mode. `load_worker_config()` mutates the process-global `get_config()` singleton's `default_execution_mode` **in place**, so an earlier Docker-mode build/test on the same `pytest-xdist` worker can leave the default at `"docker"`. A build here that didn't override it then resolved to Docker mode and failed:

```
ValueError: Docker execution mode requires 'image' to be specified
```

This is a real, **order-dependent** CI flake — it hit Python 3.11 on #222 and passed on retry (it's not a 3.11 incompatibility; the same global state leaks regardless of Python version). Forcing `--workers direct` overrides whatever mode leaked, so the test is deterministic.

## Verification

All three tests in the file pass; `--workers direct` is a documented build option (`click.Choice(["direct", "docker"])`). The pre-push fast suite passed.

## Follow-up

The underlying isolation hazard — `load_worker_config` mutating the shared `get_config()` singleton — is tracked in #223 for a root-cause fix (copy-on-write in the loader, or a config-reset autouse fixture). This PR only hardens the flaky test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)