### PR TITLE
fix(slides): refuse mismatched-id twins on a committed baseline, never double (#226)

### DIFF
--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -371,9 +371,13 @@ the safe one — no command was removed and every tool stays fully invocable.
   committed un-bootstrapped pair has a git-HEAD baseline that carries no ids, so
   it is treated as a cold start the same as a never-committed one — it mints/adopts
   rather than reading the id-less side as "missing every slide" (which would have
-  doubled the deck). *Migration:* for a refused pair, sync one direction at a time
-  (author one half, sync, then the other), or run `clm slides assign-ids <dir>` to
-  mint shared ids across the pair first; then re-run sync.
+  doubled the deck). A committed pair that **shares some ids but gives one slide a
+  different `slide_id` on each half** (the same content id'd divergently) is likewise
+  **refused** rather than cross-added in both directions (#226) — `sync` cannot tell a
+  divergent-id twin from a genuinely one-sided slide by id alone, so it declines
+  instead of risking a duplicate. *Migration:* for a refused pair, sync one direction
+  at a time (author one half, sync, then the other), reconcile the divergent ids so
+  both halves share one id, or run `clm slides assign-ids <dir>`; then re-run sync.
 - **`clm slides assign-ids` is now plumbing (hidden).** Per-file id minting on a
   *single* split half can mint a divergent slug — the #1 silent #162 break. It is
   hidden from `clm slides --help` but stays invocable by name for agents/scripts

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -1052,6 +1052,7 @@ def classify_changes(
 
     _append_idless_adds(plan, de_idless, en_idless)
     _refuse_idless_both_directions(plan)
+    _refuse_idcarrying_mismatched(plan, de_base, en_base, baseline_source)
     plan.proposals.sort(key=_proposal_sort_key)
     return plan
 
@@ -1207,9 +1208,11 @@ def _refuse_idless_both_directions(plan: SyncPlan) -> None:
     and inserting both would cross-add (each deck gets the other's untranslatable
     twin). This is the situation the old apply-time guard deferred; deciding it
     here, at plan time, is what makes the dry-run show it. id-*carrying*
-    both-direction adds are left as adds: against a real baseline their ids were
-    absent from it, so they are genuinely distinct new slides (not a mismatched
-    pair) and apply correctly.
+    both-direction adds are handled separately by
+    :func:`_refuse_idcarrying_mismatched`: against a *watermark* baseline their ids
+    were absent from it, so they are genuinely distinct new slides and apply; against
+    a committed *git-HEAD* baseline that already carried them they may be a
+    mismatched-id pair and are refused (#226).
     """
     idless = [p for p in plan.proposals if p.kind == "add" and p.slide_id is None]
     if len({p.direction for p in idless}) <= 1:
@@ -1219,6 +1222,61 @@ def _refuse_idless_both_directions(plan: SyncPlan) -> None:
         idless,
         "id-less new slides on both decks — edit one deck at a time "
         "(no slide_id to pair the halves; #216)",
+    )
+
+
+def _refuse_idcarrying_mismatched(
+    plan: SyncPlan,
+    de_base: dict[tuple[str, str], BaselineCell],
+    en_base: dict[tuple[str, str], BaselineCell],
+    baseline_source: str,
+) -> None:
+    """Refuse id-carrying both-direction adds whose ids were already committed (#226).
+
+    Against a *git-HEAD* baseline, an id'd slide present on one deck and absent on the
+    other — and whose id was **already in that deck's baseline** ("same" / "edited"
+    state, i.e. committed before this sync) — is ambiguous. It may be a genuinely
+    one-sided slide (whose missing twin should be translated and added) **or** one
+    half of a *mismatched-id* pair (the same content id'd differently on each deck —
+    e.g. a per-half ``assign-ids``). When such adds appear in **both** directions,
+    applying them would translate-and-insert content the other deck may already carry
+    → silently **double** it. ``slide_id`` alone cannot tell the two apart — only
+    cross-language content correspondence can (the planned strategy-B follow-up, #226)
+    — so refuse rather than guess.
+
+    Precise, conservative gating that leaves every safe path untouched:
+
+    - **git-HEAD only.** A *watermark* baseline records both decks, so a slide added
+      since the last sync reads as "added" (id absent from the watermark) and stays a
+      genuine cross-add — the by-design distinct-new-slides behavior
+      (:func:`_refuse_idless_both_directions`' note). A committed never-synced deck
+      has no such signal. (A pair sharing **no** ids is already routed to the cold
+      path by :func:`_pair_is_unbootstrapped`, #225; this catches the *partial-overlap*
+      pair that shares one id and so kept its git-HEAD baseline.)
+    - **id already in the baseline.** A genuinely-new id'd slide (id *absent* from the
+      git-HEAD baseline — e.g. authored but not yet committed) still cross-adds; only a
+      committed one-sided slide is suspect.
+    - **both directions.** A one-sided add in a single direction is the ordinary
+      "translate the missing counterpart" sync and is kept.
+    """
+    if baseline_source != "git-head":
+        return
+    suspects = [
+        p
+        for p in plan.proposals
+        if p.kind == "add"
+        and p.slide_id is not None
+        and (p.slide_id, p.role) in (de_base if p.direction == "de->en" else en_base)
+    ]
+    if len({p.direction for p in suspects}) <= 1:
+        return
+    _replace_adds_with_refusals(
+        plan,
+        suspects,
+        "id'd slides present on one deck only, in both directions, against a committed "
+        "baseline — possibly the same content carrying divergent slide_ids, which would "
+        "double on apply. Reconcile the slide_ids (make both halves share one id) or "
+        "sync one deck at a time (#226)",
     )
 
 

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -1231,20 +1231,29 @@ def _refuse_idcarrying_mismatched(
     en_base: dict[tuple[str, str], BaselineCell],
     baseline_source: str,
 ) -> None:
-    """Refuse id-carrying both-direction adds whose ids were already committed (#226).
+    """Refuse ambiguous one-sided adds against a committed baseline (#226).
 
-    Against a *git-HEAD* baseline, an id'd slide present on one deck and absent on the
-    other — and whose id was **already in that deck's baseline** ("same" / "edited"
-    state, i.e. committed before this sync) — is ambiguous. It may be a genuinely
-    one-sided slide (whose missing twin should be translated and added) **or** one
-    half of a *mismatched-id* pair (the same content id'd differently on each deck —
-    e.g. a per-half ``assign-ids``). When such adds appear in **both** directions,
-    applying them would translate-and-insert content the other deck may already carry
-    → silently **double** it. ``slide_id`` alone cannot tell the two apart — only
-    cross-language content correspondence can (the planned strategy-B follow-up, #226)
-    — so refuse rather than guess.
+    Against a *git-HEAD* baseline, an add that puts content the other deck **may
+    already carry** onto it is ambiguous when it cannot be content-matched by id:
 
-    Precise, conservative gating that leaves every safe path untouched:
+    - a **committed id'd** slide present on one deck only whose id was already in that
+      deck's baseline ("same" / "edited" state) — a genuinely one-sided slide, **or**
+      one half of a *mismatched-id* pair (same content, divergent ids: per-half
+      ``assign-ids``);
+    - an **id-less** new slide — a genuinely new cell, **or** a hand-typed
+      counterpart of a slide the other deck already carries id'd (the *half-id'd
+      sharing-a-key* shape: id'd "B" on one deck, id-less "B" on the other).
+
+    These two buckets are considered **together**: when adds across **both** of them
+    span both directions, applying them would translate-and-insert content the other
+    deck already has → silently **double** it. ``slide_id`` alone cannot tell a twin
+    from a genuinely-distinct slide — only cross-language content correspondence can
+    (the planned strategy-B follow-up, #226) — so refuse the whole ambiguous set
+    rather than guess. (Considering the buckets separately misses the *mixed* case,
+    where the id'd half and the id-less half each flow in a single — but opposite —
+    direction.)
+
+    Conservative gating that leaves every safe path untouched:
 
     - **git-HEAD only.** A *watermark* baseline records both decks, so a slide added
       since the last sync reads as "added" (id absent from the watermark) and stays a
@@ -1253,30 +1262,34 @@ def _refuse_idcarrying_mismatched(
       has no such signal. (A pair sharing **no** ids is already routed to the cold
       path by :func:`_pair_is_unbootstrapped`, #225; this catches the *partial-overlap*
       pair that shares one id and so kept its git-HEAD baseline.)
-    - **id already in the baseline.** A genuinely-new id'd slide (id *absent* from the
-      git-HEAD baseline — e.g. authored but not yet committed) still cross-adds; only a
-      committed one-sided slide is suspect.
-    - **both directions.** A one-sided add in a single direction is the ordinary
-      "translate the missing counterpart" sync and is kept.
+    - **committed id, or id-less.** A genuinely-new *id'd* slide (id *absent* from the
+      git-HEAD baseline — authored but not yet committed) is **not** suspect and still
+      cross-adds; only a committed id'd slide, or an id-less one, can be a twin.
+    - **both directions.** A one-sided add (id'd or id-less) in a single direction is
+      the ordinary "translate the missing counterpart" sync and is kept; the
+      both-directions id-less-only case is already refused upstream
+      (:func:`_refuse_idless_both_directions`).
     """
     if baseline_source != "git-head":
         return
-    suspects = [
+    ambiguous = [
         p
         for p in plan.proposals
         if p.kind == "add"
-        and p.slide_id is not None
-        and (p.slide_id, p.role) in (de_base if p.direction == "de->en" else en_base)
+        and (
+            p.slide_id is None
+            or (p.slide_id, p.role) in (de_base if p.direction == "de->en" else en_base)
+        )
     ]
-    if len({p.direction for p in suspects}) <= 1:
+    if len({p.direction for p in ambiguous}) <= 1:
         return
     _replace_adds_with_refusals(
         plan,
-        suspects,
-        "id'd slides present on one deck only, in both directions, against a committed "
-        "baseline — possibly the same content carrying divergent slide_ids, which would "
-        "double on apply. Reconcile the slide_ids (make both halves share one id) or "
-        "sync one deck at a time (#226)",
+        ambiguous,
+        "slides present on one deck only, in both directions, against a committed "
+        "baseline — possibly the same content carrying divergent (or one-sided id-less) "
+        "slide_ids, which would double on apply. Reconcile the slide_ids (make both "
+        "halves share one id) or sync one deck at a time (#226)",
     )
 
 

--- a/tests/slides/test_sync_apply.py
+++ b/tests/slides/test_sync_apply.py
@@ -1366,6 +1366,23 @@ class TestColdStartCommittedPair:
         assert _slide_order(de_path) == ["s1", "s2"]
         assert en_path.read_text(encoding="utf-8") == en_before
 
+    def test_committed_partial_overlap_mismatched_does_not_double(self, tmp_path: Path):
+        # #226: a committed pair sharing `s1` but with a mismatched-id "B" slide
+        # (`d1`/`e1`) is refused, not cross-added, so applying it writes NOTHING and
+        # never doubles "B" — even with a translator available.
+        de = _slide("de", "s1", "# ## A") + _slide("de", "d1", "# ## B")
+        en = _slide("en", "s1", "# ## A") + _slide("en", "e1", "# ## B")
+        de_path, en_path = self._commit_pair(tmp_path, de, en)
+        plan = build_sync_plan(de_path, en_path, provider_available=True)
+        translator = StaticSlideTranslator(default="# ## X")
+        result = apply_plan(plan, judge=None, translator=translator, watermark_cache=None)
+        assert result.applied_add == 0
+        assert result.deferred == 2  # the two mismatched adds refused
+        assert de_path.read_text(encoding="utf-8") == de  # "B" not duplicated
+        assert en_path.read_text(encoding="utf-8") == en
+        assert len(_slide_order(de_path)) == 2
+        assert len(_slide_order(en_path)) == 2
+
     def test_committed_half_idd_pair_does_not_double_without_translator(self, tmp_path: Path):
         # The pre-#225 failure mode: with no provider the committed half-id'd pair fell
         # to the keyed baseline path and emitted both-direction adds → applying them

--- a/tests/slides/test_sync_plan.py
+++ b/tests/slides/test_sync_plan.py
@@ -442,6 +442,23 @@ class TestBothDirectionsRefusal:
         assert plan.count("add") == 2
         assert plan.count("refuse") == 0
 
+    def test_git_head_mixed_idd_idless_both_directions_refuses(self):
+        # #226 (mixed variant): a COMMITTED id'd "B" on DE and an id-less "B" on EN
+        # (sharing `intro`) — the half-id'd-sharing-a-key shape. The committed-id'd add
+        # (de->en) and the id-less add (en->de) each flow in a single but OPPOSITE
+        # direction, so partitioning by id-presence misses it; considered together they
+        # span both directions → refuse (else "B" doubles on both decks).
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, "d1", "dB")],
+            [cur(0, "intro", "e0"), cur(1, None, "eB")],
+            [base(0, "intro", "d0"), base(1, "d1", "dB")],
+            [base(0, "intro", "e0")],
+            source="git-head",
+        )
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 2
+        assert plan.in_sync_count == 1
+
 
 # ---------------------------------------------------------------------------
 # build_sync_plan (IO wrapper: baseline resolution)
@@ -686,6 +703,21 @@ class TestBuildSyncPlanGitFallback:
         assert plan.count("add") == 0  # the doubling adds are gone
         assert plan.count("refuse") == 2
         assert plan.in_sync_count == 1  # s1 still pairs
+
+    def test_committed_mixed_idd_idless_partial_overlap_refuses(self, tmp_path: Path):
+        # #226 mixed variant end-to-end: share `s1`, but "B" is committed id'd on DE
+        # (`d1`) and committed id-less on EN. Was a silent double (id'd add de->en +
+        # id-less add en->de, neither caught by a single-bucket guard); now refused.
+        de_path, en_path = self._commit_pair(
+            tmp_path,
+            _slide("de", "s1", "# ## A") + _slide("de", "d1", "# ## B"),
+            _slide("en", "s1", "# ## A") + _slide_idless("en", "# ## B"),
+        )
+        plan = build_sync_plan(de_path, en_path, provider_available=True)
+        assert plan.baseline_source == "git-head"  # shares s1 → keeps its baseline
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 2
+        assert plan.in_sync_count == 1
 
     def test_committed_one_directional_idcarrying_add_still_propagates(self, tmp_path: Path):
         # REGRESSION: the common "add the missing counterpart" — a committed id'd slide

--- a/tests/slides/test_sync_plan.py
+++ b/tests/slides/test_sync_plan.py
@@ -385,6 +385,63 @@ class TestBothDirectionsRefusal:
         assert plan.count("add") == 2
         assert plan.count("refuse") == 0
 
+    def test_git_head_idcarrying_both_directions_committed_refuses(self):
+        # #226: against a COMMITTED (git-head) baseline, an id'd slide present on one
+        # deck only whose id was ALREADY in that deck's baseline is ambiguous — a
+        # genuinely one-sided slide, or one half of a mismatched-id pair (same content,
+        # divergent ids). Both directions → refuse rather than risk doubling on apply.
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, "d1", "dB")],
+            [cur(0, "intro", "e0"), cur(1, "e1", "eB")],
+            [base(0, "intro", "d0"), base(1, "d1", "dB")],
+            [base(0, "intro", "e0"), base(1, "e1", "eB")],
+            source="git-head",
+        )
+        assert plan.count("add") == 0
+        assert plan.count("refuse") == 2
+        assert plan.in_sync_count == 1
+
+    def test_git_head_idcarrying_added_state_still_adds(self):
+        # Git-head too, but the one-sided id'd slides are genuinely NEW — their ids are
+        # ABSENT from the baseline (authored, not yet committed) — so they are distinct
+        # new slides and still cross-add (only a *committed* one-sided slide is suspect).
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, "newde", "dNEW")],
+            [cur(0, "intro", "e0"), cur(1, "newen", "eNEW")],
+            [base(0, "intro", "d0")],
+            [base(0, "intro", "e0")],
+            source="git-head",
+        )
+        assert plan.count("add") == 2
+        assert plan.count("refuse") == 0
+
+    def test_git_head_idcarrying_one_direction_still_adds(self):
+        # The common "add the missing counterpart" sync: a one-sided id'd slide in a
+        # SINGLE direction (committed) is propagated, not refused.
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, "d1", "dB")],
+            [cur(0, "intro", "e0")],
+            [base(0, "intro", "d0"), base(1, "d1", "dB")],
+            [base(0, "intro", "e0")],
+            source="git-head",
+        )
+        assert plan.count("add") == 1
+        assert plan.count("refuse") == 0
+
+    def test_watermark_idcarrying_committed_both_directions_still_adds(self):
+        # The #226 refusal is git-HEAD-only: a watermark records BOTH decks, so it
+        # never legitimately holds a one-sided 'same'-state slide; that path keeps its
+        # by-design cross-add and is untouched by the git-head ambiguity guard.
+        plan = classify(
+            [cur(0, "intro", "d0"), cur(1, "d1", "dB")],
+            [cur(0, "intro", "e0"), cur(1, "e1", "eB")],
+            [base(0, "intro", "d0"), base(1, "d1", "dB")],
+            [base(0, "intro", "e0"), base(1, "e1", "eB")],
+            source="watermark",
+        )
+        assert plan.count("add") == 2
+        assert plan.count("refuse") == 0
+
 
 # ---------------------------------------------------------------------------
 # build_sync_plan (IO wrapper: baseline resolution)
@@ -613,6 +670,35 @@ class TestBuildSyncPlanGitFallback:
             assert plan.count("refuse") == 4
             assert plan.count("mint") == 0
             assert plan.count("adopt") == 0
+
+    def test_committed_partial_overlap_mismatched_refuses_never_doubles(self, tmp_path: Path):
+        # #226: the halves SHARE `s1` (so the pair is bootstrapped and keeps its
+        # git-HEAD baseline — not demoted by #225), but a different slide carries
+        # mismatched ids (`d1` on DE / `e1` on EN, same content "B"). The keyed path
+        # used to emit both as adds → translate-insert → DOUBLE "B". Now refused.
+        de_path, en_path = self._commit_pair(
+            tmp_path,
+            _slide("de", "s1", "# ## A") + _slide("de", "d1", "# ## B"),
+            _slide("en", "s1", "# ## A") + _slide("en", "e1", "# ## B"),
+        )
+        plan = build_sync_plan(de_path, en_path, provider_available=True)
+        assert plan.baseline_source == "git-head"  # shares s1 → keeps its baseline
+        assert plan.count("add") == 0  # the doubling adds are gone
+        assert plan.count("refuse") == 2
+        assert plan.in_sync_count == 1  # s1 still pairs
+
+    def test_committed_one_directional_idcarrying_add_still_propagates(self, tmp_path: Path):
+        # REGRESSION: the common "add the missing counterpart" — a committed id'd slide
+        # present on DE only (single direction) — must still propagate, not refuse.
+        de_path, en_path = self._commit_pair(
+            tmp_path,
+            _slide("de", "s1", "# ## A") + _slide("de", "d1", "# ## B"),
+            _slide("en", "s1", "# ## A"),
+        )
+        plan = build_sync_plan(de_path, en_path, provider_available=True)
+        assert plan.baseline_source == "git-head"
+        assert plan.count("add") == 1
+        assert plan.count("refuse") == 0
 
     def test_committed_idd_pair_edit_still_uses_git_head(self, tmp_path: Path):
         # REGRESSION: a fully-id'd committed pair keeps its real git-HEAD baseline —


### PR DESCRIPTION
## What & why

The partial-overlap sibling of #225. A **committed** split pair whose halves **share** some `slide_id`s (so it keeps its git-HEAD baseline — *not* demoted by #225) but give one slide a **different id on each half** (same content, divergent ids — e.g. a per-half `assign-ids`) used to emit both sides as adds and translate-insert them → silently **double** that slide. Two variants:

- **both id'd** — `d1` "B" on DE, `e1` "B" on EN;
- **mixed** — `d1` "B" on DE (id'd), id-less "B" on EN (the half-id'd-sharing-a-key shape).

## Why ids alone can't resolve it

A one-sided id'd slide against a git-HEAD baseline is genuinely two different things the keyed engine can't tell apart: a **mismatched twin** (reconcile, don't double) or a **genuinely one-sided slide** (cross-add the missing twin — a core sync feature). Only cross-language content correspondence separates them. The distinguishing signal that *is* available: the **baseline state** — a twin's id is already *in* the committed baseline ("same"/"edited"), whereas a genuinely-new slide's id is *absent* ("added", still cross-adds correctly). This was discussed with the maintainer; **strategy A (detect & refuse)** was chosen now, with **strategy B (verify & reconcile, EN-authority)** filed as a follow-up (#228).

## Fix (strategy A)

`_refuse_idcarrying_mismatched` (`classify_changes`). Under a **git-HEAD baseline only**, it refuses the **combined** ambiguous add set — *committed id'd one-sided adds* (id already in the own-side baseline) **∪** *id-less adds* — when their directions span both ways. Considering the two buckets together is essential: an adversarial review found that handling them separately missed the **mixed** variant (the id'd and id-less halves each flow in a single but *opposite* direction, so neither single-bucket guard saw the cross-partner — fixed in the second commit).

Every safe path is left untouched (verified): a one-directional "add the missing counterpart" still propagates; genuinely-new *uncommitted* distinct slides (ids absent from the baseline) still cross-add; the by-design watermark path is unchanged (a watermark records both decks, so it never legitimately holds a one-sided "same"-state slide).

## Scope / accepted limitation

Strategy A is conservative: on a never-synced partial-overlap deck, a committed one-sided id'd slide plus an *unrelated* new id-less add will also refuse (the two can't be separated without content correspondence). That precise separation — and actually *reconciling* a confirmed twin by rewriting the loser id to the EN-authority id — is **#228** (strategy B).

## Verification

- Empirically traced across every variant + regression over real temp git repos.
- New tests: `TestBothDirectionsRefusal` (git-head both-id'd → refuse, mixed → refuse, added-state → add, one-direction → add, watermark-exemption); `TestBuildSyncPlanGitFallback` + `TestColdStartCommittedPair` (committed partial-overlap both-id'd / mixed → refuse with end-to-end no-double, one-directional-add regression).
- **1189 slides + CLI tests green**, ruff + mypy clean; pre-push fast suite passed.
- Adversarial review applied (it found and we closed the mixed-variant gap).
- Docs: `clm info migration`.

Closes #226. Follow-up enhancement: #228 (verify-and-reconcile). Builds on #225 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)