### PR TITLE
feat(cli): course-conversion tooling — gaps doc + Tool #1 (spec decks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`clm spec decks` and `clm slides referenced-by` — spec→deck resolution.**
+  `clm spec decks <spec.xml>` lists the decks a course spec actually pulls in
+  (its "shipping set"), mirroring the build's resolution exactly: a `<topic>`
+  resolves to a topic *directory* and **every** `slides_*.py` in it is a deck.
+  A deck-filename-stem heuristic silently misses decks (a topic dir name often
+  differs from its deck filenames), which is what motivated this command. Module
+  bindings resolve in their module; unbound duplicate IDs are first-occurrence-wins
+  (the shadowed matches surface in `--json`). `--lang de|en|both` filters split
+  halves (bilingual decks always survive); `--all-specs DIR` emits the union
+  shipping set across every spec annotated with the referencing spec(s).
+  `clm slides referenced-by <deck.py>` is the reverse lookup (or reports
+  `unreferenced`). First of the course-conversion tooling gaps documented in
+  `docs/claude/course-conversion-tooling-gaps.md`.
+
 ### Removed
 
 - **The flat top-level CLI aliases were removed (1.8 milestone, #158).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   that the plain directory walk misses. Second of the course-conversion tooling
   gaps. New public helper `clm.slides.validator.validate_files` validates an
   explicit deck list with the same per-pair parity as a directory walk.
+- **`clm course gate` — corpus readiness orchestrator.** Runs the mechanical
+  conversion passes (`tag_migration`, `workshop_tags`, `interleaving`,
+  content-derived `slide_id` minting) over a spec's shipping set (or a directory),
+  then splits the remaining work into **mechanical** (what the passes changed /
+  would change) versus **needs-author** (what the normalizer *refused* to touch:
+  a `slide_id` with no derivable heading, a DE/EN pair whose code diverged too far
+  to auto-interleave, or a DE/EN cell-count mismatch). Default is a dry run that
+  writes nothing; `--apply` writes the fixes and re-validates, reporting the
+  residual. Exits non-zero while author work (or a post-apply residual error)
+  remains, so it gates a conversion in CI — turning a validator bump into
+  `clm course gate <spec> --apply`. Third of the course-conversion tooling gaps;
+  the report a conversion agent previously hand-built. New `spec` and `course`
+  command groups accompany these tools.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   so EN-authority parity minting is preserved. Fourth of the course-conversion
   tooling gaps. New public helpers `clm.slides.assign_ids.assign_ids_in_files`,
   `clm.slides.normalizer.normalize_files`, and module `clm.slides.deck_scope`.
+- **`clm slides assign-ids --report-refusals [--context]` — a hand-authoring
+  worklist.** Hard refusals (a slide with no heading and no extractable content)
+  can only be cleared by hand-authoring a `slide_id`, and to write a good one you
+  need the cell's body and where it sits in the deck. `--report-refusals` emits a
+  worklist of the cells that could not be assigned — hard refusals first, then
+  soft (extractable, with a proposed slug) — instead of the assignment listing.
+  `--context` (which implies `--report-refusals`) attaches each refused cell's
+  marker line, full body, and the nearest preceding `slide_id`/heading so an
+  author or agent can fill the id without opening the file. Honors the same
+  scoping flags; `--json` emits it structured. Replaces the throwaway "dry-run
+  JSON → re-extract cell bodies and context with a script" step. Fifth of the
+  course-conversion tooling gaps. New module `clm.slides.refusal_report`
+  (`build_refusal_worklist` / `render_worklist` / `worklist_to_dict`).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `clm slides referenced-by <deck.py>` is the reverse lookup (or reports
   `unreferenced`). First of the course-conversion tooling gaps documented in
   `docs/claude/course-conversion-tooling-gaps.md`.
+- **`clm validate <spec> --deep`, `--summary`, and `--shipping-only` — deep /
+  scoped validation with a category rollup.** `clm validate <spec.xml>` validates
+  only the spec *structure* (topic resolution); it does **not** check the slide
+  content of the referenced decks, so "spec validates OK" never meant the decks
+  were clean. `--deep` now runs the full slide validator on every deck the spec
+  pulls in (resolved with the same build-faithful logic as `clm spec decks`) and
+  reports structure + content together, failing on either. `--summary` rolls
+  findings up into a category/kind histogram with per-deck counts (by-category is
+  exact; by-kind — `missing-slide_id`, `adjacency`, `count-mismatch`,
+  `start-completed`, … — is a heuristic message bucket with an `other` fallback)
+  instead of a flat list of thousands of lines; on a spec it implies `--deep`.
+  `--shipping-only` restricts a directory validate to the decks reachable from
+  course specs (`--specs-dir`, default `<course-root>/course-specs/`), skipping
+  archived / unreferenced decks — and, because it filters the resolved shipping
+  set rather than walking, it correctly covers non-`.py` decks (`.cs`, `.cpp`)
+  that the plain directory walk misses. Second of the course-conversion tooling
+  gaps. New public helper `clm.slides.validator.validate_files` validates an
+  explicit deck list with the same per-pair parity as a directory walk.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `by_issue` histograms. Exit code is always `0` (it's a report). Sixth of the
   course-conversion tooling gaps. New module `clm.slides.slug_quality`
   (`classify_slug` / `scan_slug_quality` / `render_report` / `report_to_dict`).
+- **`clm spec orphans` — decks reachable from no spec, plus cruft.** The inverse
+  of `clm spec decks`: scan every spec in a course and report the decks on disk
+  that no spec pulls in, grouped by likely intent so dead decks can be archived
+  without deleting intentional alternates — `superseded` (`_old` / `_bak` /
+  `_orig` / `_vN` / trailing `_N`, usually safe to archive), `alternate`
+  (`_partN` / `_short` / `_long`, probably-intentional content), and `unknown`
+  (no marker — review). Orphans are computed against the **union** of every spec
+  (a deck unreferenced by one spec may be pulled in by another), and the on-disk
+  walk is extension-complete (`.py` / `.cpp` / `.cs` / …) so a non-Python orphan
+  is not silently missed. Also surfaces gitignored `.ipynb_checkpoints/` cache
+  cruft, with `--clean-checkpoints` to delete it; `--kind` filters to one bucket;
+  `--json` adds `by_kind` counts. Exit code is always `0` (it's a report).
+  Seventh of the course-conversion tooling gaps. New module
+  `clm.core.spec_orphans` (`find_orphans` / `classify_orphan` /
+  `find_checkpoint_dirs` / `render_report` / `report_to_dict`).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   JSON → re-extract cell bodies and context with a script" step. Fifth of the
   course-conversion tooling gaps. New module `clm.slides.refusal_report`
   (`build_refusal_worklist` / `render_worklist` / `worklist_to_dict`).
+- **`clm slides slug-report` — flag low-quality content-derived slugs.** A bulk
+  `assign-ids --accept-content-derived` mints thousands of ids; most are fine but
+  a minority are low-information — single generic tokens (`data` / `true` /
+  `value`), very short code-identifier-shaped slugs (`cp` / `df` / `os`), or slugs
+  that hit the 30-char cap and lost their trailing words. `slug-report` classifies
+  each `slide_id` by cheap, source-independent heuristics and lists just the
+  flagged minority, with a `--min-severity low|medium|high` cutoff (`high` =
+  very-short / generic). `PATH` is a directory (with the same `--only` /
+  `--exclude` / `--shipping-only` scoping as `assign-ids`) or a spec `.xml`
+  (resolved to its shipping decks). Only slide-start cells are inspected and a
+  bilingual deck's DE/EN twins yield one finding; `--json` adds `by_severity` /
+  `by_issue` histograms. Exit code is always `0` (it's a report). Sixth of the
+  course-conversion tooling gaps. New module `clm.slides.slug_quality`
+  (`classify_slug` / `scan_slug_quality` / `render_report` / `report_to_dict`).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Seventh of the course-conversion tooling gaps. New module
   `clm.core.spec_orphans` (`find_orphans` / `classify_orphan` /
   `find_checkpoint_dirs` / `render_report` / `report_to_dict`).
+- **`clm slides coverage-report` — DE/EN completeness per deck.** Among
+  count-mismatch validation errors, a deck that exists in only one language
+  (needs translation) and a bilingual deck off by a cell or two (an alignment
+  fix) are very different jobs. This separates them by counting `lang="de"` vs
+  `lang="en"` slide cells per deck and classifying each as `de_only` /
+  `en_only` / `imbalanced` (shown with a `Δ`) / `balanced`. Split `*.de.py` /
+  `*.en.py` halves are scored as one pair — a half whose twin is absent counts
+  the missing language as zero — and only slide/subslide cells are counted, so
+  one-language speaker notes don't skew the result. `PATH` is a directory (with
+  the same `--only` / `--exclude` / `--shipping-only` scoping as `assign-ids`)
+  or a spec `.xml`; `--status` filters to one bucket; `--json` adds `by_status`
+  counts. Exit code is always `0` (it's a report). Eighth of the
+  course-conversion tooling gaps. New module `clm.slides.lang_coverage`
+  (`count_languages` / `classify_counts` / `scan_coverage` / `render_report` /
+  `report_to_dict`).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `clm course gate <spec> --apply`. Third of the course-conversion tooling gaps;
   the report a conversion agent previously hand-built. New `spec` and `course`
   command groups accompany these tools.
+- **`clm slides assign-ids` / `clm slides normalize` gained `--only`, `--exclude`,
+  and `--shipping-only` scoping.** A directory run can now be restricted to part
+  of the corpus: `--only bilingual|split` (touch only bilingual decks, or only
+  `.de`/`.en` split halves — e.g. mint bilingual decks while leaving split pairs
+  for `clm slides sync`), `--exclude GLOB` (skip decks matching a glob, matched
+  against the full path *and* each path component, so `--exclude _archive` skips
+  an `_archive/` dir; repeatable), and `--shipping-only` (`--specs-dir`, default
+  `<course-root>/course-specs/`) to touch only decks reachable from specs. This
+  replaces the "run over everything, then `git checkout` the files you shouldn't
+  have touched" workaround. Split pairs are still detected within the scoped set,
+  so EN-authority parity minting is preserved. Fourth of the course-conversion
+  tooling gaps. New public helpers `clm.slides.assign_ids.assign_ids_in_files`,
+  `clm.slides.normalizer.normalize_files`, and module `clm.slides.deck_scope`.
 
 ### Removed
 

--- a/docs/claude/course-conversion-tooling-gaps.md
+++ b/docs/claude/course-conversion-tooling-gaps.md
@@ -1,0 +1,173 @@
+# Tooling gaps observed during the 1.8 PythonCourses slide-id gate
+
+Captured 2026-06-04 while bringing the PythonCourses corpus up to the CLM 1.8
+validator (missing `slide_id` and DE/EN-adjacency escalated warning→error). The
+work involved minting ids across ~440 bilingual decks, hand-authoring ~117 ids,
+tag migration, spec-typo fixes, and triaging ~73 residual content errors.
+
+Several steps had **no CLI support and had to be reimplemented as throwaway
+Python scripts** (using `clm.core.topic_resolver.build_topic_map` +
+`clm.core.course_spec.CourseSpec` directly). They recur on every course
+conversion / corpus-wide validator bump, so they are good candidates for
+first-class `clm` tooling. Listed high-to-low value.
+
+---
+
+## 1. Spec → deck resolution and reverse lookup (HIGHEST VALUE)
+
+**What I did manually, repeatedly:** computed "which decks does a course spec
+actually pull in?" by walking `build_topic_map(slides)` + `CourseSpec.from_file`
+and unioning `TopicMatch.slide_files`.
+
+**Why it matters:** my first attempt used a *deck-filename-stem* heuristic to
+decide whether a deck was "shipping". That is **wrong** — a `<topic>` resolves to
+a topic *directory* and CLM builds **every** `slides_*.py` in it, and the dir name
+often differs from the deck filename (e.g. topic `observer` →
+`slides_020_observer_advanced.py`; topic `properties` → both `slides_properties.py`
+*and* `slides_property_setters.py`; topic `intro_deep_nets` →
+`slides_intro_deep_nets_part1..5.py`). The heuristic silently missed 20 shipping
+decks; I only caught it by switching to the resolver. A built-in command would
+have prevented the mistake entirely.
+
+**Proposed:**
+- `clm spec decks <spec.xml> [--lang de|en|both] [--json]` — list the resolved
+  deck file paths a spec pulls in (optionally per section/topic).
+- `clm spec decks --all-specs <specs-dir>` — the union across every spec
+  (the "shipping set"), with each deck annotated by which spec(s) reference it.
+- `clm slides referenced-by <deck.py>` — reverse lookup: which spec/topic pulls
+  this deck in (or "unreferenced").
+
+---
+
+## 2. Deep validation scoped to a spec / the shipping set, with a category rollup (HIGH VALUE)
+
+**What I did manually:** `clm validate slides --kind slides --json` over the whole
+tree, then a script to (a) drop `_archive`, (b) keep only decks in the shipping
+set, (c) bucket findings by category, (d) separate `bilingual` vs `.de/.en`.
+
+**Gap:** `clm validate <spec.xml>` validates only **spec structure / topic
+resolution** — it does *not* deep-validate the slide content of the decks the spec
+references. So "spec validates OK" does **not** mean "the decks are clean", which
+is a real footgun (I nearly concluded the gate was met on that basis).
+
+**Proposed:**
+- `clm validate <spec.xml> --deep` — after resolving topics, run the full slides
+  validator on each referenced deck and roll the findings up.
+- `clm validate <dir-or-spec> --summary` — a category histogram
+  (missing-slide_id / adjacency / cell-type-mismatch / count-mismatch / voiceover
+  / start-completed / malformed-marker …) with per-deck counts, instead of a flat
+  list of thousands of lines. Optionally `--shipping-only` to restrict to decks
+  reachable from specs.
+
+---
+
+## 3. A corpus "readiness gate" orchestrator (HIGH VALUE)
+
+**What I did manually:** the whole sequence — `assign-ids --accept-content-derived`
+→ `normalize --operations tag_migration` → (sync split pairs) → re-validate →
+categorize → decide mechanical-vs-author — by hand, iterating.
+
+**Proposed:** `clm course gate <spec-or-dir> [--apply]` that runs the mechanical
+passes in order and emits a **readiness report**:
+- counts cleared mechanically vs remaining,
+- splits remaining into *mechanically-fixable* vs *needs-author* (translation,
+  structural DE/EN divergence, corrupted markers),
+- names the specific decks/lines for the author bucket.
+
+This is essentially the report I hand-built as
+`docs/v18-remaining-validation-work.md` in the course repo; making it a command
+would make every future validator bump a one-liner.
+
+---
+
+## 4. Scoping mints to part of the corpus (MEDIUM-HIGH)
+
+**What I did manually:** to mint **only** bilingual decks (leaving `.de/.en` split
+pairs for `clm slides sync`, and skipping `_archive`), I ran
+`assign-ids slides --accept-content-derived` over everything and then
+`git checkout` to revert the split + archive files. Clumsy and error-prone.
+
+**Proposed flags on `assign-ids` / `normalize`:**
+- `--only bilingual|split` (or `--skip-split` / `--skip-bilingual`),
+- `--exclude <glob>` (e.g. `_archive`),
+- `--shipping-only <specs-dir>` (only touch decks reachable from specs).
+
+---
+
+## 5. Hard-refusal worklist with cell context for hand-authoring (MEDIUM-HIGH)
+
+**What I did manually:** `assign-ids --dry-run --json` gives the refused
+file:line, but to actually author a good `slide_id` I needed each cell's **body +
+the preceding heading/slide context**, which I extracted with a script, then
+applied edits with another script.
+
+**Proposed:**
+- `assign-ids --report-refusals [--context]` — for each hard refusal, emit the
+  cell marker, its body, and the nearest preceding `slide_id`/heading, so an
+  agent/author can fill ids efficiently.
+- An `assign-ids --interactive` mode that prompts for a slug per hard-refusal cell
+  (showing context), writing both DE/EN twins at once.
+
+---
+
+## 6. Slug-quality report for content-derived ids (MEDIUM)
+
+**What I did manually:** after `--accept-content-derived` minted ~3,000 ids, I
+scanned for low-quality slugs (one-word like `data`/`true`/`shell`, code-identifier
+derived like `cp`/`df`, mid-sentence truncations) to decide which to polish.
+
+**Proposed:** `clm slides assign-ids --flag-low-quality` (or a `clm slides
+slug-report`) listing content-derived ids that are single-token, code-identifier-
+shaped, or truncated — so the author can review just those rather than all 3,000.
+
+---
+
+## 7. Unreferenced / orphan / cruft detection (MEDIUM)
+
+**What I did manually:** found `.ipynb_checkpoints/` dirs, `*_old`/`*_2`/`*_partN`
+decks, and classified "not referenced by any spec" vs "intentional alternate"
+(length variants `_short`/`_long`, multi-part series) — the distinction matters
+because blindly archiving `_part1..5` would delete real content.
+
+**Proposed:** `clm spec orphans <specs-dir>` — list decks reachable from no spec,
+grouped by likely intent (explicit `_old` = superseded; `_short`/`_long`/`_partN`
+= probably intentional alternates), plus a flag to clean gitignored
+`.ipynb_checkpoints/` cruft.
+
+---
+
+## 8. DE/EN completeness report (MEDIUM)
+
+**What I did manually:** to separate "DE-only deck (needs translation)" from "1-cell
+imbalance" among count-mismatch errors, I counted `lang="de"` vs `lang="en"` cells
+per deck.
+
+**Proposed:** `clm slides coverage-report <dir-or-spec>` — per deck: DE-only,
+EN-only, balanced, or N-cell imbalance — to plan bilingual-completion / translation
+work at corpus scale.
+
+---
+
+## 9. Assisted interleave for structurally-diverged DE/EN (MEDIUM-LOW)
+
+**Observation:** `clm slides normalize --operations interleaving` correctly
+*refuses* to auto-reorder when the DE/EN code has diverged
+(`similarity_failure`), which is safe — but it leaves the author with adjacency
+errors and no assistance. An `--interactive` interleave (show the DE and EN cells,
+let the author confirm/adjust pairing) would help close these without risking a
+bad automatic reorder.
+
+---
+
+## Smaller notes
+
+- **Pair-fill awareness:** authoring a `slide_id` on one language's cell leaves the
+  twin missing; `assign-ids` *does* pair-fill on a re-run, but a lint/warning
+  ("you id'd one half of a DE/EN pair") would catch it sooner.
+- **Tag-migration side effect:** `normalize --operations tag_migration`
+  (alt→completed) can turn a clean deck into one with a `completed`-without-`start`
+  error when the start/completed structure isn't cleanly DE/EN-paired. Worth a
+  post-migration check or a warning.
+- **`validate <spec.xml>` vs deep:** see #2 — the dispatch on input type means a
+  spec only gets structural validation; this surprised me and is worth a docs note
+  even if `--deep` isn't added.

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -152,11 +152,27 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   on `assign-ids`/`normalize`).** `course gate` already scopes internally, so #4's
   predicates (`split_lang_tag`-based bilingual/split filter; glob exclude) could
   live in a shared helper both reuse.
+- 2026-06-05: **Tool #4 DONE**. `--only bilingual|split` / `--exclude GLOB` /
+  `--shipping-only` (+`--specs-dir`/`--data-dir`) on both `clm slides assign-ids`
+  and `clm slides normalize`. New `clm.slides.deck_scope` (`filter_decks`,
+  `course_root_for_path`, `resolve_shipping_set`); shared CLI helper
+  `cli/commands/shared.py::resolve_scoped_files` + `has_deck_scope`. Refactor:
+  extracted public `assign_ids_in_files` (from `assign_ids_in_directory`) and
+  `normalize_files` (from `normalize_directory`) — the directory funcs now
+  delegate, so split-pair parity is preserved on a scoped subset. Scoping is
+  directory-only (single file / spec → UsageError). 20 new tests
+  (`tests/slides/test_deck_scope.py`, `tests/cli/test_deck_scope_cli.py`);
+  144-test assign-ids/normalize/gate regression green. `commands.md` + CHANGELOG
+  updated. Smoke-tested on a crafted tree (bilingual/split/archive). **Next: Tool
+  #5 (hard-refusal worklist with cell context — `assign-ids --report-refusals
+  [--context]`).** Refusals already carry `file:line` + `proposed_slug/title`; #5
+  adds the cell body + nearest preceding heading/slide_id so an author/agent can
+  fill ids efficiently. Could also feed the gate's needs-author output.
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#3 are complete; **Tool #4 is
-next**; tools #5–#9 follow in priority order. Pushing: this worktree is on
+Pick up from the "Progress log" tail. Tools #1–#4 are complete; **Tool #5 is
+next**; tools #6–#9 follow in priority order. Pushing: this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -107,10 +107,19 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
 
 - 2026-06-04: gaps doc committed (`48bdf1c`); branch pushed; PR #230 opened.
 - 2026-06-04: handover written; codebase anchors verified. Starting Tool #1.
+- 2026-06-05: **Tool #1 DONE** (`cb720cb0`). `clm.core.spec_decks`
+  (`resolve_spec_decks` / `find_deck_references`) + `clm spec decks` (new `spec`
+  group) + `clm slides referenced-by`. `--lang`, `--all-specs`, `--json`. 18 tests
+  (`tests/core/test_spec_decks.py`, `tests/cli/test_spec_decks.py`); `commands.md`
+  + CHANGELOG updated. Smoke-tested on the CSharpCourses corpus (64-deck spec,
+  multi-spec union, reverse lookup). **Next: Tool #2 (deep/scoped validation).**
+  Reuse `resolve_spec_decks` to enumerate the shipping set, then run the slides
+  validator on each deck — see `cli/commands/validate.py` for how `validate`
+  currently dispatches spec-vs-slides.
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tool #1 is the active task; tools #2–#9 are
-queued in priority order. Each tool = core helper reuse + thin command(s) + tests +
+Pick up from the "Progress log" tail. Tool #1 is complete; **Tool #2 is next**;
+tools #3–#9 follow in priority order. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole
 point of gap #1 is that ad-hoc heuristics silently miss decks.

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -136,11 +136,27 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   mechanical passes (`assign-ids --accept-content-derived` → `normalize
   --operations tag_migration` → sync) and split remaining findings into
   mechanically-fixable vs needs-author.
+- 2026-06-05: **Tool #3 DONE**. `clm course gate <spec-or-dir> [--apply]` (new
+  `course` group). `clm.slides.course_gate.run_course_gate` drives the mechanical
+  passes via `normalize_file(operations=[tag_migration, workshop_tags,
+  interleaving, slide_ids], assign_options=accept_content_derived, dry_run=not
+  apply)` — the normalizer already orchestrates assign-ids + tag-migration and
+  surfaces **hard refusals / similarity_failure / count_mismatch as
+  `review_items`**, which IS the needs-author signal (no separate classifier
+  needed). Dry-run writes nothing; `--apply` writes + re-validates + reports
+  residual. Exit non-zero while author work / post-apply error remains (CI gate).
+  15 new tests (`tests/{slides,cli}/test_course_gate.py`); 135-test regression
+  (normalizer + assign-ids) green; `commands.md` + CHANGELOG updated. Smoke-tested
+  on CSharpCourses (dry-run clean, 0 writes confirmed via git status). **Next:
+  Tool #4 (scope mints — `--only bilingual|split` / `--exclude` / `--shipping-only`
+  on `assign-ids`/`normalize`).** `course gate` already scopes internally, so #4's
+  predicates (`split_lang_tag`-based bilingual/split filter; glob exclude) could
+  live in a shared helper both reuse.
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#2 are complete; **Tool #3 is
-next**; tools #4–#9 follow in priority order. Pushing: this worktree is on
+Pick up from the "Progress log" tail. Tools #1–#3 are complete; **Tool #4 is
+next**; tools #5–#9 follow in priority order. Pushing: this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -112,14 +112,36 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   group) + `clm slides referenced-by`. `--lang`, `--all-specs`, `--json`. 18 tests
   (`tests/core/test_spec_decks.py`, `tests/cli/test_spec_decks.py`); `commands.md`
   + CHANGELOG updated. Smoke-tested on the CSharpCourses corpus (64-deck spec,
-  multi-spec union, reverse lookup). **Next: Tool #2 (deep/scoped validation).**
-  Reuse `resolve_spec_decks` to enumerate the shipping set, then run the slides
-  validator on each deck — see `cli/commands/validate.py` for how `validate`
-  currently dispatches spec-vs-slides.
+  multi-spec union, reverse lookup).
+- 2026-06-05: consolidated onto PR #230 (rebased the 3 local commits onto the
+  gaps-doc commit `48bdf1c`, pushed as a fast-forward); PR title/body updated.
+  **Note:** PR branch `claude/course-conversion-tooling-gaps` is checked out in
+  the *sibling* worktree `encapsulated-nibbling-feigenbaum`, so it cannot be
+  checked out here. This worktree works on its own branch
+  `worktree-linked-honking-dolphin` and pushes with an explicit refspec:
+  `git push origin worktree-linked-honking-dolphin:claude/course-conversion-tooling-gaps`.
+- 2026-06-05: **Tool #2 DONE**. `clm validate <spec> --deep` (structure + deck
+  content over the shipping set, reusing `resolve_spec_decks`), `--summary`
+  (category/kind/per-deck rollup; new `clm.slides.validation_summary`),
+  `--shipping-only` + `--specs-dir` for directory validates (new
+  `clm.core.spec_decks.shipping_set` + `clm.slides.validator.validate_files`).
+  Found+handled a real bug: `find_slide_files_recursive` deep-walks `*.py` only,
+  so `--shipping-only` filters the resolved shipping set instead of walking
+  (covers `.cs`/`.cpp`). 27 new tests (`tests/slides/test_validation_summary.py`,
+  `tests/cli/test_validate_deep.py`); 203 existing validate tests still green;
+  `commands.md` + CHANGELOG updated. Smoke-tested on CSharpCourses (clean corpus →
+  0 findings; `--shipping-only` root=89 decks, one module=33). **Next: Tool #3
+  (course-gate orchestrator).** Reuse `resolve_spec_decks` (shipping set) +
+  `validate_course`/`validate_files` + `summarize_findings`; sequence the
+  mechanical passes (`assign-ids --accept-content-derived` → `normalize
+  --operations tag_migration` → sync) and split remaining findings into
+  mechanically-fixable vs needs-author.
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tool #1 is complete; **Tool #2 is next**;
-tools #3–#9 follow in priority order. Each tool = core helper reuse + thin command(s) + tests +
+Pick up from the "Progress log" tail. Tools #1–#2 are complete; **Tool #3 is
+next**; tools #4–#9 follow in priority order. Pushing: this worktree is on
+`worktree-linked-honking-dolphin`; push to the PR branch with the explicit
+refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole
 point of gap #1 is that ad-hoc heuristics silently miss decks.

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -1,0 +1,116 @@
+# Handover: course-conversion tooling gaps → first-class `clm` commands
+
+**Status:** in progress (started 2026-06-04)
+**Branch:** `claude/course-conversion-tooling-gaps`
+**PR:** [#230](https://github.com/hoelzl/clm/pull/230) (currently docs-only)
+**Source of work:** `docs/claude/course-conversion-tooling-gaps.md` (the 9 gaps)
+
+## Why this exists
+
+A conversion agent brought the PythonCourses corpus up to the CLM 1.8 validator
+(escalated `slide_id` / DE-EN-adjacency warnings → errors) and had to reimplement
+several recurring operations as **throwaway Python scripts** because CLM has no CLI
+for them. Each recurs on every course conversion / corpus-wide validator bump. The
+gaps doc (`course-conversion-tooling-gaps.md`) lists 9, high-to-low value. This
+handover tracks turning them into shipped commands.
+
+## The 9 gaps (priority order from the doc)
+
+1. **Spec → deck resolution + reverse lookup** (HIGHEST) — `clm spec decks`,
+   `clm slides referenced-by`. A deck-filename-stem heuristic silently missed 20
+   shipping decks because a `<topic>` resolves to a *directory* and CLM builds
+   **every** `slides_*.py` in it. ← **doing this first.**
+2. **Deep validation scoped to a spec / shipping set, + category rollup** —
+   `clm validate <spec> --deep` / `--shipping-only` / `--summary`. Today
+   `clm validate <spec.xml>` only checks spec structure + topic resolution, NOT
+   the slide content of the referenced decks (real footgun).
+3. **Corpus readiness-gate orchestrator** — `clm course gate <spec-or-dir>
+   [--apply]`: run mechanical passes in order, emit a mechanical-done-vs-needs-author
+   readiness report.
+4. **Scope mints to part of the corpus** — `--only bilingual|split`,
+   `--exclude <glob>`, `--shipping-only` on `assign-ids` / `normalize`.
+5. **Hard-refusal worklist with cell context** — `assign-ids --report-refusals
+   [--context]`, and/or an `--interactive` mint mode.
+6. **Slug-quality report** for content-derived ids — flag single-token,
+   code-identifier-shaped, truncated slugs.
+7. **Unreferenced / orphan / cruft detection** — `clm spec orphans <specs-dir>`,
+   grouped by likely intent (`_old` superseded vs `_short`/`_long`/`_partN` alternates).
+8. **DE/EN completeness report** — `clm slides coverage-report <dir-or-spec>`:
+   per-deck DE-only / EN-only / balanced / N-cell imbalance.
+9. **Assisted interleave** for structurally-diverged DE/EN (`--interactive`).
+
+Plus smaller notes in the doc: pair-fill lint, tag-migration `completed`-without-`start`
+side effect, and the `validate <spec>` vs `--deep` docs surprise.
+
+## Codebase anchors (verified this session)
+
+The exact APIs the throwaway scripts reinvented already exist — the work is wiring
+them to CLI commands, faithfully mirroring **build** resolution semantics so the
+"shipping set" is correct.
+
+- **Spec parse:** `clm.core.course_spec.CourseSpec.from_file(path)`. Iterate
+  bindings with `spec.iter_topic_bindings()` → `TopicBinding(section, topic_spec,
+  effective_module)` (per-topic `module=` overrides section default; `None` = unbound).
+- **Topic → decks:** `clm.core.topic_resolver.build_topic_map(slides_dir)` →
+  `dict[str, list[TopicMatch]]`; `TopicMatch.slide_files: list[Path]` is the decks
+  a topic dir contributes (every `slides_*.py`, via `find_slide_files`).
+- **Binding → matches:** `topic_resolver.matches_for_binding(full_map, topic_id,
+  module)`. **Build semantics (must mirror):** when *unbound* and a topic ID has
+  multiple matches across modules, build picks **first-occurrence-wins**
+  (`Course._build_topic_map`, `course.py:1005-1011` / `_topic_path_map[...] =
+  matches[0].path`). Module-bound references pick the match in that module.
+- **Paths:** `clm.core.course_paths.resolve_course_paths(spec_file, data_dir=None)`
+  → `(course_root, default_output_root)`; spec lives in a subdir so `course_root`
+  is the spec's grandparent. **`slides_dir = course_root / "slides"`.**
+- **Language tag of a deck file:** `clm.slides.pairing.split_lang_tag(path)` →
+  `"de"` / `"en"` / `None` (prefix-agnostic; `None` = bilingual deck serving both).
+- **Existing reference command:** `clm topic resolve` (`cli/commands/resolve_topic.py`)
+  already does single-topic resolution with `--course-spec` scoping and `--json` —
+  the new commands follow its shape.
+
+## CLI wiring conventions
+
+- Groups are defined in `cli/commands/_groups.py` and registered in `cli/main.py`
+  (`slides_group`, `topic_group`, `authoring_group` exist; **there is no `spec`
+  group yet** — add one). Top-level `validate` is registered at `main.py:140`.
+- `main.py:160-176` shows the `group.add_command(cmd, name="...")` pattern.
+- Tests live in `tests/cli/` (`test_resolve_topic.py`, `test_validate_spec.py` are
+  the closest models). Use Click `CliRunner`; see the
+  [[feedback-click-82-clirunner-compat]] memory — CI runs Click 8.2+ (no
+  `mix_stderr`), so locate JSON in `result.output` by braces, wrap the runner
+  constructor in try/except.
+- Info topics: update `src/clm/cli/info_topics/commands.md` for any new command
+  (CRITICAL per CLAUDE.md — downstream agents rely on it). Use `{version}`, never a
+  hardcoded number.
+- `CHANGELOG.md` → `## [Unreleased]` → `### Added`.
+
+## Plan for Tool #1 (in progress)
+
+A new shared core helper + two thin commands + a reverse lookup:
+
+1. **Core helper** (new module `clm/core/spec_decks.py`, or extend
+   `topic_resolver.py`): `resolve_spec_decks(spec, slides_dir) -> SpecDeckResolution`
+   that mirrors build semantics (first-occurrence-wins unbound, module-bound
+   otherwise), returning per-topic resolved deck files + any unresolved topics +
+   first-occurrence-shadowed duplicates. Single source of truth so #2/#3/#7 reuse it.
+2. **`clm spec decks <spec.xml> [--lang de|en|both] [--json]`** — list resolved
+   deck paths the spec pulls in. `--lang de` keeps bilingual (`None` tag) + `.de`
+   halves; `--lang en` keeps bilingual + `.en`; `both` (default) keeps all.
+3. **`clm spec decks --all-specs <specs-dir> [--json]`** — union "shipping set"
+   across every `*.xml` spec, each deck annotated with the referencing spec(s).
+4. **`clm slides referenced-by <deck.py> [--specs-dir DIR] [--json]`** — reverse
+   lookup: which spec/topic pulls a deck in (or "unreferenced").
+
+Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
+
+## Progress log
+
+- 2026-06-04: gaps doc committed (`48bdf1c`); branch pushed; PR #230 opened.
+- 2026-06-04: handover written; codebase anchors verified. Starting Tool #1.
+
+## Resuming
+
+Pick up from the "Progress log" tail. Tool #1 is the active task; tools #2–#9 are
+queued in priority order. Each tool = core helper reuse + thin command(s) + tests +
+`commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole
+point of gap #1 is that ad-hoc heuristics silently miss decks.

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -242,17 +242,22 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   (de_only/en_only) from "1-cell alignment" (imbalanced, shown with Δ) among
   count-mismatch errors. 19 new tests (`tests/slides/test_lang_coverage.py`,
   `tests/cli/test_coverage_report.py`); ruff/mypy clean; `commands.md` + CHANGELOG
-  updated. **Next: Tool #9 (assisted/`--interactive` interleave for
-  structurally-diverged DE/EN — the `similarity_failure` refusal case; LOW
-  priority, may be deferred). NOTE: #9 is interactive (prompts), harder to test +
-  out of character for the batch-report tools so far — consider proposing it as a
-  follow-up issue rather than building inline.**
+  updated.
+- 2026-06-05: **Tool #8 PUSHED** (`8362185c` → PR #230, fast suite green).
+- 2026-06-05: **Tool #9 FILED AS FOLLOW-UP ISSUE [#236](https://github.com/hoelzl/clm/issues/236)**
+  (user decision), not built inline. It is the assisted/`--interactive` interleave
+  for structurally-diverged DE/EN (`similarity_failure` refusal) — interactive,
+  hard to test, out of character with the eight non-interactive batch/report tools
+  here. The issue suggests a testable non-interactive first cut (emit the
+  DE↔EN pairing worklist with similarity scores, mirroring
+  `assign-ids --report-refusals`) with an `--interactive` loop layered on later.
+  **PR #230 is now feature-complete: 8 of 9 gaps delivered; gap #9 → #236.**
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#8 are complete; **Tool #9 is the
-last** (interactive interleave — see the caveat in the #8 log entry). Pushing:
-this worktree is on
+**This work is DONE** — Tools #1–#8 are complete and pushed to PR #230; gap #9 is
+tracked as issue #236. If revisiting, the natural remaining work is (a) getting PR
+#230 reviewed/merged, or (b) building issue #236. Pushing: this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -204,11 +204,34 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   updated. **Next: Tool #7 (`clm spec orphans <specs-dir>` — decks reachable from
   no spec, grouped by likely intent: `_old` superseded vs `_short`/`_long`/`_partN`
   intentional alternates; + flag gitignored `.ipynb_checkpoints/` cruft).**
+- 2026-06-05: **Tool #6 PUSHED** (`9b845ba3` → PR #230, fast suite green).
+- 2026-06-05: **Tool #7 DONE**. New `clm spec orphans SPECS_DIR` (spec group).
+  New core `clm.core.spec_orphans`: `find_orphans(spec_files, slides_dir) ->
+  OrphanReport` = inverse of Tool #1's `shipping_set` (orphans = `_all_decks -
+  shipping`). `classify_orphan(path) -> (OrphanKind, reason)` buckets by filename
+  intent — `alternate` (`_partN`/`_short`/`_long`) checked **before** `superseded`
+  (`_old\d*`/`_bak`/`_backup`/`_orig`/`_deprecated`/`_copy`/`_vN`/trailing `_\d+`)
+  so a `_part2` series is never mislabeled a numeric-dup; everything else
+  `unknown`. Two correctness choices: (1) `_all_decks` does its **own**
+  extension-complete `rglob("*")`+`is_slides_file` walk, NOT
+  `find_slide_files_recursive` (which is `*.py`-only → would miss `.cs`/`.cpp`
+  orphans — same trap as Tool #2); (2) checkpoint files are *excluded* from decks
+  (`.ipynb_checkpoints in path.parts`) and the dirs reported separately as cruft
+  (else `slides_x-checkpoint.py` counts as an orphan). `--clean-checkpoints`
+  rmtree's them (gitignored regenerable cache → safe; flag is the authorization,
+  no prompt); `--kind` filter; `--json`; exit 0 always. `_deck_stem` strips the
+  `.de`/`.en` tag before matching. 32 new tests
+  (`tests/core/test_spec_orphans.py`, `tests/cli/test_spec_orphans.py`); spec_decks
+  regression green; ruff/mypy clean; `commands.md` + CHANGELOG updated. **Next:
+  Tool #8 (`clm slides coverage-report <dir-or-spec>` — per deck: DE-only /
+  EN-only / balanced / N-cell imbalance, by counting `lang="de"` vs `lang="en"`
+  cells; separates "needs translation" from "1-cell imbalance" among
+  count-mismatch errors).**
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#6 are complete; **Tool #7 is
-next**; tools #8–#9 follow in priority order. Pushing: this worktree is on
+Pick up from the "Progress log" tail. Tools #1–#7 are complete; **Tool #8 is
+next**; tool #9 follows. Pushing: this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -184,11 +184,31 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   (slug-quality report for content-derived ids — `assign-ids --flag-low-quality`
   or `clm slides slug-report`: single-token / code-identifier-shaped / truncated
   slugs).**
+- 2026-06-05: **Tool #5 PUSHED** (`44cb9e35` → PR #230, fast suite green).
+- 2026-06-05: **Tool #6 DONE**. New `clm slides slug-report PATH` (dir or spec
+  `.xml`). New pure-heuristic core `clm.slides.slug_quality`: `classify_slug(slug)
+  -> [SlugIssue]` (`very_short` ≤3 chars / `generic` curated word set — both
+  *high*; `possibly_truncated` len ≥ 28 of the 30 cap — *medium*; `single_token`
+  — *low*), `scan_slug_quality(files) -> SlugReport`, `render_report` /
+  `report_to_dict`. Chose the **standalone command** over `assign-ids
+  --flag-low-quality` (the gap says "or") — works on already-minted corpora, the
+  user's actual scenario, and reuses Tool #1's `resolve_spec_decks` (spec PATH) +
+  Tool #4's `resolve_scoped_files` (`--only`/`--exclude`/`--shipping-only` on a
+  dir). Source-independent by design (on-disk ids don't record their source);
+  scans only `is_slide_start` cells and dedups a bilingual deck's DE/EN twin to one
+  finding. `--min-severity low|medium|high`; `--json` adds `by_severity`/`by_issue`.
+  Deliberately conservative to avoid false positives (no collision-suffix/numbered
+  -slide special-casing → `step-2`/`python-3` stay clean). Exit 0 always.
+  32 new tests (`tests/slides/test_slug_quality.py`,
+  `tests/cli/test_slug_report.py`); ruff/mypy clean; `commands.md` + CHANGELOG
+  updated. **Next: Tool #7 (`clm spec orphans <specs-dir>` — decks reachable from
+  no spec, grouped by likely intent: `_old` superseded vs `_short`/`_long`/`_partN`
+  intentional alternates; + flag gitignored `.ipynb_checkpoints/` cruft).**
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#5 are complete; **Tool #6 is
-next**; tools #7–#9 follow in priority order. Pushing: this worktree is on
+Pick up from the "Progress log" tail. Tools #1–#6 are complete; **Tool #7 is
+next**; tools #8–#9 follow in priority order. Pushing: this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -227,11 +227,32 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   EN-only / balanced / N-cell imbalance, by counting `lang="de"` vs `lang="en"`
   cells; separates "needs translation" from "1-cell imbalance" among
   count-mismatch errors).**
+- 2026-06-05: **Tool #7 PUSHED** (`0ef09839` → PR #230; commit amended to fix the
+  test count 64→32 BEFORE pushing, never on a pushed commit).
+- 2026-06-05: **Tool #8 DONE**. New `clm slides coverage-report PATH` (dir or
+  spec `.xml`). New core `clm.slides.lang_coverage`: `count_languages(text) ->
+  (de, en)` counts **only `is_slide_start`** cells by lang (narrative cells
+  inherit → excluded so one-language speaker notes don't skew); `classify_counts`
+  → BALANCED / DE_ONLY / EN_ONLY / IMBALANCED; `scan_coverage(files)` uses
+  `pairing.iter_split_pairs` to score split `.de`/`.en` halves as ONE pair (de=de-
+  half's de count, en=en-half's en count), bilingual files in place, and a lone
+  split half (twin absent) as that-lang-only (missing side = 0 → de_only/en_only).
+  Reuses Tool #1 resolver (spec) + Tool #4 `resolve_scoped_files` (dir);
+  `--status` filter; `--json`; exit 0. The point: separates "needs translation"
+  (de_only/en_only) from "1-cell alignment" (imbalanced, shown with Δ) among
+  count-mismatch errors. 19 new tests (`tests/slides/test_lang_coverage.py`,
+  `tests/cli/test_coverage_report.py`); ruff/mypy clean; `commands.md` + CHANGELOG
+  updated. **Next: Tool #9 (assisted/`--interactive` interleave for
+  structurally-diverged DE/EN — the `similarity_failure` refusal case; LOW
+  priority, may be deferred). NOTE: #9 is interactive (prompts), harder to test +
+  out of character for the batch-report tools so far — consider proposing it as a
+  follow-up issue rather than building inline.**
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#7 are complete; **Tool #8 is
-next**; tool #9 follows. Pushing: this worktree is on
+Pick up from the "Progress log" tail. Tools #1–#8 are complete; **Tool #9 is the
+last** (interactive interleave — see the caveat in the #8 log entry). Pushing:
+this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/docs/claude/course-conversion-tooling-handover.md
+++ b/docs/claude/course-conversion-tooling-handover.md
@@ -168,11 +168,27 @@ Tests, `commands.md`, and a CHANGELOG `Added` entry land with the code.
   [--context]`).** Refusals already carry `file:line` + `proposed_slug/title`; #5
   adds the cell body + nearest preceding heading/slide_id so an author/agent can
   fill ids efficiently. Could also feed the gate's needs-author output.
+- 2026-06-05: **Tool #5 DONE**. `clm slides assign-ids --report-refusals
+  [--context]`. New post-processing module `clm.slides.refusal_report`
+  (`build_refusal_worklist` / `render_worklist` / `worklist_to_dict`) layered over
+  `AssignResult.refusals` — the engine is unchanged. `--report-refusals` swaps the
+  assignment listing for a worklist (hard refusals first, then soft); `--context`
+  (implies `--report-refusals`) re-reads each affected file *once*, finds the
+  refused cell by `line_number`, and attaches its marker, body (trailing-blank
+  stripped), and the nearest preceding `slide_id`/heading (independent backward
+  scans via `extract_heading` + `strip_preserve_marker`). Without `--context` no
+  files are re-read. Honors scoping flags + `--json`; exit codes unchanged (2 on
+  hard refusal). 18 new tests (`tests/slides/test_refusal_report.py`,
+  `tests/cli/test_assign_ids_refusals.py`); 86-test assign-ids/scope regression
+  green; ruff/mypy clean. `commands.md` + CHANGELOG updated. **Next: Tool #6
+  (slug-quality report for content-derived ids — `assign-ids --flag-low-quality`
+  or `clm slides slug-report`: single-token / code-identifier-shaped / truncated
+  slugs).**
 
 ## Resuming
 
-Pick up from the "Progress log" tail. Tools #1–#4 are complete; **Tool #5 is
-next**; tools #6–#9 follow in priority order. Pushing: this worktree is on
+Pick up from the "Progress log" tail. Tools #1–#5 are complete; **Tool #6 is
+next**; tools #7–#9 follow in priority order. Pushing: this worktree is on
 `worktree-linked-honking-dolphin`; push to the PR branch with the explicit
 refspec noted in the 2026-06-05 consolidation entry above. Each tool = core helper reuse + thin command(s) + tests +
 `commands.md` + CHANGELOG. Keep mirroring build resolution semantics — the whole

--- a/src/clm/cli/commands/_groups.py
+++ b/src/clm/cli/commands/_groups.py
@@ -33,6 +33,11 @@ def spec_group() -> None:
     """Course-spec inspection: resolve the decks a spec pulls in."""
 
 
+@click.group("course")
+def course_group() -> None:
+    """Course-wide orchestration: readiness gate, mechanical conversion passes."""
+
+
 @click.group("authoring")
 def authoring_group() -> None:
     """Authoring-rules introspection."""

--- a/src/clm/cli/commands/_groups.py
+++ b/src/clm/cli/commands/_groups.py
@@ -28,6 +28,11 @@ def topic_group() -> None:
     """Topic resolution and inspection."""
 
 
+@click.group("spec")
+def spec_group() -> None:
+    """Course-spec inspection: resolve the decks a spec pulls in."""
+
+
 @click.group("authoring")
 def authoring_group() -> None:
     """Authoring-rules introspection."""

--- a/src/clm/cli/commands/assign_ids.py
+++ b/src/clm/cli/commands/assign_ids.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import click
 
+from clm.cli.commands.shared import has_deck_scope, resolve_scoped_files
 from clm.infrastructure.llm.cache import TitleSuggestionCache, resolve_cache_dir
 from clm.infrastructure.llm.ollama_client import (
     DEFAULT_TITLE_MODEL,
@@ -31,6 +32,7 @@ from clm.slides.assign_ids import (
     AssignResult,
     assign_ids_in_directory,
     assign_ids_in_file,
+    assign_ids_in_files,
 )
 
 CACHE_DB_NAME = "clm-llm.sqlite"
@@ -104,6 +106,38 @@ CACHE_DB_NAME = "clm-llm.sqlite"
         "tool.clm.cache_dir in pyproject.toml > <cwd>/.clm-cache/)."
     ),
 )
+@click.option(
+    "--only",
+    type=click.Choice(["bilingual", "split"]),
+    default=None,
+    help="Scope a directory run to only bilingual decks (no .de/.en tag) or only "
+    "split halves. E.g. --only bilingual mints bilingual decks while leaving "
+    ".de/.en pairs for `clm slides sync`.",
+)
+@click.option(
+    "--exclude",
+    multiple=True,
+    metavar="GLOB",
+    help="Skip decks matching GLOB (matched against the full path and each path "
+    "component, so `--exclude _archive` skips an _archive/ dir). Repeatable.",
+)
+@click.option(
+    "--shipping-only",
+    is_flag=True,
+    help="Scope a directory run to decks reachable from course specs (the shipping set).",
+)
+@click.option(
+    "--specs-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="For --shipping-only: directory of *.xml specs. Default: <course-root>/course-specs/.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Course data directory (contains slides/). For --shipping-only scope resolution.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def assign_ids_cmd(
     path: Path,
@@ -115,6 +149,11 @@ def assign_ids_cmd(
     ollama_url: str | None,
     llm_timeout: float,
     cache_dir: Path | None,
+    only: str | None,
+    exclude: tuple[str, ...],
+    shipping_only: bool,
+    specs_dir: Path | None,
+    data_dir: Path | None,
     as_json: bool,
 ) -> None:
     """Generate stable ``slide_id`` metadata for slide/subslide cells (plumbing).
@@ -173,8 +212,24 @@ def assign_ids_cmd(
         llm_cache=cache,
     )
 
+    scoped = has_deck_scope(only, exclude, shipping_only)
+    if scoped and not path.is_dir():
+        raise click.UsageError(
+            "--only / --exclude / --shipping-only apply to a directory, not a single file."
+        )
+
     try:
-        if path.is_dir():
+        if scoped:
+            files = resolve_scoped_files(
+                path,
+                only=only,
+                exclude=exclude,
+                shipping_only=shipping_only,
+                specs_dir=specs_dir,
+                data_dir=data_dir,
+            )
+            result = assign_ids_in_files(files, options)
+        elif path.is_dir():
             result = assign_ids_in_directory(path, options)
         elif path.is_file():
             result = assign_ids_in_file(path, options)

--- a/src/clm/cli/commands/assign_ids.py
+++ b/src/clm/cli/commands/assign_ids.py
@@ -34,6 +34,11 @@ from clm.slides.assign_ids import (
     assign_ids_in_file,
     assign_ids_in_files,
 )
+from clm.slides.refusal_report import (
+    build_refusal_worklist,
+    render_worklist,
+    worklist_to_dict,
+)
 
 CACHE_DB_NAME = "clm-llm.sqlite"
 
@@ -138,6 +143,19 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     default=None,
     help="Course data directory (contains slides/). For --shipping-only scope resolution.",
 )
+@click.option(
+    "--report-refusals",
+    is_flag=True,
+    help="Emit a hand-authoring worklist of the refusals (hard ones first) instead "
+    "of the assignment listing — the cells that still need a slide_id.",
+)
+@click.option(
+    "--context",
+    is_flag=True,
+    help="With --report-refusals, include each refused cell's marker, body, and the "
+    "nearest preceding slide_id/heading so you can author an id in place. Implies "
+    "--report-refusals.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def assign_ids_cmd(
     path: Path,
@@ -154,6 +172,8 @@ def assign_ids_cmd(
     shipping_only: bool,
     specs_dir: Path | None,
     data_dir: Path | None,
+    report_refusals: bool,
+    context: bool,
     as_json: bool,
 ) -> None:
     """Generate stable ``slide_id`` metadata for slide/subslide cells (plumbing).
@@ -239,7 +259,16 @@ def assign_ids_cmd(
         if cache is not None:
             cache.close()
 
-    if as_json:
+    # --context implies the refusal-worklist view.
+    report_refusals = report_refusals or context
+
+    if report_refusals:
+        worklist = build_refusal_worklist(result.refusals, with_context=context)
+        if as_json:
+            click.echo(json.dumps(worklist_to_dict(worklist), indent=2))
+        else:
+            click.echo(render_worklist(worklist))
+    elif as_json:
         click.echo(json.dumps(_to_dict(result), indent=2))
     else:
         _print_human(result, report_only=report_only)

--- a/src/clm/cli/commands/course_gate.py
+++ b/src/clm/cli/commands/course_gate.py
@@ -1,0 +1,111 @@
+"""``clm course gate`` — run the mechanical conversion passes and report readiness.
+
+Course-conversion tooling gap #3. Delegates to
+:func:`clm.slides.course_gate.run_course_gate`; see that module for the
+mechanical-vs-needs-author split.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from clm.slides.course_gate import (
+    DEFAULT_GATE_OPERATIONS,
+    render_report,
+    run_course_gate,
+)
+
+
+def _slides_dir_for_target(target: Path, data_dir: Path | None) -> Path:
+    """Resolve the ``slides/`` directory for a spec or a slides path."""
+    if data_dir is not None:
+        return data_dir / "slides"
+    if target.is_file() and target.suffix.lower() == ".xml":
+        from clm.core.course_paths import resolve_course_paths
+
+        course_root, _ = resolve_course_paths(target, None)
+        return course_root / "slides"
+    # A slides path: walk up to the 'slides' ancestor (or the dir itself).
+    resolved = target.resolve()
+    if resolved.name == "slides":
+        return resolved
+    for parent in resolved.parents:
+        if parent.name == "slides":
+            return parent
+    raise click.ClickException(
+        "Could not locate the slides/ directory from the path. Pass --data-dir explicitly."
+    )
+
+
+@click.command("gate")
+@click.argument("target", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    help="Write the mechanical fixes and re-validate. Without it, dry-run: report "
+    "what would change without touching disk.",
+)
+@click.option(
+    "--operations",
+    default=None,
+    help="Comma-separated mechanical passes to run "
+    f"(default: {','.join(DEFAULT_GATE_OPERATIONS)}). "
+    "Valid: tag_migration, workshop_tags, interleaving, slide_ids.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Course data directory (contains slides/). Default: inferred from the target.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def course_gate_cmd(
+    target: Path,
+    apply_changes: bool,
+    operations: str | None,
+    data_dir: Path | None,
+    as_json: bool,
+) -> None:
+    """Run the mechanical conversion passes over a course and report readiness.
+
+    TARGET is a course spec ``.xml`` (uses its shipping set) or a slides
+    directory. The gate runs tag migration, DE/EN interleaving, and
+    content-derived ``slide_id`` minting, then splits the remaining work into
+    what those passes cleared mechanically versus what still needs an author
+    (untranslatable ids, diverged DE/EN code, missing translations).
+
+    Exits non-zero when author work — or, after ``--apply``, a residual error —
+    remains, so it can gate a conversion in CI.
+
+    \b
+    Examples:
+        clm course gate course-specs/python.xml             # dry-run report
+        clm course gate course-specs/python.xml --apply     # fix + re-validate
+        clm course gate slides/module_100/ --apply
+        clm course gate course-specs/python.xml --json
+    """
+    slides_dir = _slides_dir_for_target(target, data_dir)
+    op_list = [o.strip() for o in operations.split(",") if o.strip()] if operations else None
+
+    try:
+        report = run_course_gate(
+            target,
+            slides_dir,
+            operations=op_list,
+            apply=apply_changes,
+        )
+    except ValueError as e:
+        raise click.ClickException(str(e)) from None
+
+    if as_json:
+        click.echo(json.dumps(report.to_dict(), indent=2))
+    else:
+        for line in render_report(report):
+            click.echo(line)
+
+    if not report.is_clean:
+        raise SystemExit(1)

--- a/src/clm/cli/commands/coverage_report.py
+++ b/src/clm/cli/commands/coverage_report.py
@@ -1,0 +1,152 @@
+"""``clm slides coverage-report`` — DE/EN completeness per deck (gap #8).
+
+Separates "deck exists in only one language (needs translation)" from
+"bilingual deck off by a cell or two (alignment fix)" among count-mismatch
+errors, by counting ``lang="de"`` vs ``lang="en"`` slide cells per deck.
+Accepts a directory (with the same ``--only`` / ``--exclude`` /
+``--shipping-only`` scoping as ``assign-ids``) or a spec ``.xml`` (resolved to
+the decks it pulls in). Delegates to :mod:`clm.slides.lang_coverage`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.cli.commands.shared import has_deck_scope, resolve_scoped_files
+from clm.slides.lang_coverage import (
+    CoverageStatus,
+    render_report,
+    report_to_dict,
+    scan_coverage,
+)
+
+_STATUS_CHOICES = [s.value for s in CoverageStatus]
+
+
+def _decks_for_spec(spec_file: Path, data_dir: Path | None) -> list[Path]:
+    from clm.core.course_spec import CourseSpec, CourseSpecError
+    from clm.core.spec_decks import resolve_spec_decks
+
+    slides_dir = (data_dir / "slides") if data_dir else (spec_file.parent.parent / "slides")
+    if not slides_dir.is_dir():
+        raise click.ClickException(
+            f"Could not locate the slides/ directory at {slides_dir}. Pass --data-dir."
+        )
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as exc:
+        raise click.ClickException(str(exc)) from None
+    return resolve_spec_decks(spec, slides_dir).deck_files
+
+
+@click.command("coverage-report")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--only",
+    type=click.Choice(["bilingual", "split"]),
+    default=None,
+    help="Scope a directory scan to only bilingual decks (no .de/.en tag) or only split halves.",
+)
+@click.option(
+    "--exclude",
+    multiple=True,
+    metavar="GLOB",
+    help="Skip decks matching GLOB (matched against the full path and each path component). "
+    "Repeatable.",
+)
+@click.option(
+    "--shipping-only",
+    is_flag=True,
+    help="Scope a directory scan to decks reachable from course specs (the shipping set).",
+)
+@click.option(
+    "--specs-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="For --shipping-only: directory of *.xml specs. Default: <course-root>/course-specs/.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Course data directory (contains slides/). For a spec PATH or --shipping-only.",
+)
+@click.option(
+    "--status",
+    type=click.Choice(_STATUS_CHOICES),
+    default=None,
+    help="Show only decks with this status (de_only / en_only / imbalanced / balanced).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def coverage_report_cmd(
+    path: Path,
+    only: str | None,
+    exclude: tuple[str, ...],
+    shipping_only: bool,
+    specs_dir: Path | None,
+    data_dir: Path | None,
+    status: str | None,
+    as_json: bool,
+) -> None:
+    """Report DE/EN completeness per deck.
+
+    PATH is a directory of slide files or a course spec ``.xml`` (its shipping
+    decks are scanned). Each deck is classified by its DE vs EN slide counts:
+
+    \b
+      de_only      DE present, EN missing — needs EN translation.
+      en_only      EN present, DE missing — needs DE translation.
+      imbalanced   both present, counts differ — an alignment fix.
+      balanced     equal DE/EN counts (not listed unless --status balanced).
+
+    Split ``.de.py`` / ``.en.py`` halves are scored as one pair; a half whose
+    twin is absent counts the missing language as zero. Only slide/subslide
+    cells are counted (narrative cells inherit their slide). Exit code is 0.
+    """
+    scoped = has_deck_scope(only, exclude, shipping_only)
+
+    if path.is_file():
+        if path.suffix != ".xml":
+            raise click.UsageError(
+                "A file PATH must be a spec .xml; pass a directory to scan slide files."
+            )
+        if scoped:
+            raise click.UsageError(
+                "--only / --exclude / --shipping-only apply to a directory, not a spec file."
+            )
+        files = _decks_for_spec(path, data_dir)
+        base: Path | None = None
+    elif path.is_dir():
+        base = path
+        if scoped:
+            files = resolve_scoped_files(
+                path,
+                only=only,
+                exclude=exclude,
+                shipping_only=shipping_only,
+                specs_dir=specs_dir,
+                data_dir=data_dir,
+            )
+        else:
+            from clm.core.topic_resolver import find_slide_files_recursive
+
+            files = list(find_slide_files_recursive(path))
+    else:  # pragma: no cover - click guards existence
+        raise click.ClickException(f"PATH must be a slide directory or spec .xml: {path}")
+
+    report = scan_coverage(files)
+
+    if status is not None:
+        wanted = CoverageStatus(status)
+        report.entries = [e for e in report.entries if e.status == wanted]
+
+    if as_json:
+        click.echo(json.dumps(report_to_dict(report), indent=2))
+    else:
+        click.echo(render_report(report, base=base))
+
+    sys.exit(0)

--- a/src/clm/cli/commands/normalize_slides.py
+++ b/src/clm/cli/commands/normalize_slides.py
@@ -8,12 +8,14 @@ from pathlib import Path
 
 import click
 
+from clm.cli.commands.shared import has_deck_scope, resolve_scoped_files
 from clm.slides.normalizer import (
     ALL_OPERATIONS,
     NormalizationResult,
     normalize_course,
     normalize_directory,
     normalize_file,
+    normalize_files,
 )
 
 
@@ -57,7 +59,33 @@ from clm.slides.normalizer import (
 @click.option(
     "--data-dir",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="Course data directory (contains slides/). For course spec normalization.",
+    help="Course data directory (contains slides/). For course spec normalization "
+    "and --shipping-only scope resolution.",
+)
+@click.option(
+    "--only",
+    type=click.Choice(["bilingual", "split"]),
+    default=None,
+    help="Scope a directory run to only bilingual decks (no .de/.en tag) or only "
+    "split halves (e.g. leave .de/.en pairs for `clm slides sync`).",
+)
+@click.option(
+    "--exclude",
+    multiple=True,
+    metavar="GLOB",
+    help="Skip decks matching GLOB (matched against the full path and each path "
+    "component, so `--exclude _archive` skips an _archive/ dir). Repeatable.",
+)
+@click.option(
+    "--shipping-only",
+    is_flag=True,
+    help="Scope a directory run to decks reachable from course specs (the shipping set).",
+)
+@click.option(
+    "--specs-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="For --shipping-only: directory of *.xml specs. Default: <course-root>/course-specs/.",
 )
 def normalize_slides_cmd(
     path: Path,
@@ -66,6 +94,10 @@ def normalize_slides_cmd(
     canonicalize_start_completed: bool,
     as_json: bool,
     data_dir: Path | None,
+    only: str | None,
+    exclude: tuple[str, ...],
+    shipping_only: bool,
+    specs_dir: Path | None,
 ):
     """Normalize slide files by applying mechanical fixes.
 
@@ -88,7 +120,29 @@ def normalize_slides_cmd(
         clm slides normalize course-specs/python-basics.xml
     """
     op_list = _parse_operations(operations)
-    result = _dispatch(path, op_list, dry_run, data_dir, canonicalize_start_completed)
+
+    if has_deck_scope(only, exclude, shipping_only):
+        if not path.is_dir():
+            raise click.UsageError(
+                "--only / --exclude / --shipping-only apply to a directory, not a "
+                "single file or spec."
+            )
+        files = resolve_scoped_files(
+            path,
+            only=only,
+            exclude=exclude,
+            shipping_only=shipping_only,
+            specs_dir=specs_dir,
+            data_dir=data_dir,
+        )
+        result = normalize_files(
+            files,
+            operations=op_list,
+            dry_run=dry_run,
+            canonicalize_start_completed=canonicalize_start_completed,
+        )
+    else:
+        result = _dispatch(path, op_list, dry_run, data_dir, canonicalize_start_completed)
 
     if as_json:
         click.echo(json.dumps(_result_to_dict(result), indent=2))

--- a/src/clm/cli/commands/shared.py
+++ b/src/clm/cli/commands/shared.py
@@ -6,7 +6,9 @@ This module contains utilities used by multiple CLI command modules.
 import locale
 import logging
 import sys
+from pathlib import Path
 
+import click
 from rich.console import Console
 from rich.logging import RichHandler
 
@@ -98,6 +100,65 @@ def print_separator(section: str = "", char: str = "="):
         cli_console.rule(f"[bold]{section}[/bold]", characters=char)
     else:
         cli_console.rule(characters=char)
+
+
+def has_deck_scope(only: str | None, exclude: tuple[str, ...], shipping_only: bool) -> bool:
+    """Whether any deck-scoping option is active (gap #4)."""
+    return bool(only) or bool(exclude) or shipping_only
+
+
+def resolve_scoped_files(
+    path: Path,
+    *,
+    only: str | None,
+    exclude: tuple[str, ...],
+    shipping_only: bool,
+    specs_dir: Path | None,
+    data_dir: Path | None,
+) -> list[Path]:
+    """Resolve a directory *path* to the scoped subset of slide files (gap #4).
+
+    Applies ``--only`` / ``--exclude`` / ``--shipping-only`` to the recursive
+    slide-file walk. Used by ``clm slides assign-ids`` and ``clm slides
+    normalize`` so both scope decks identically. Raises ``click`` errors on
+    misuse (non-directory path, unlocatable specs).
+    """
+    from clm.core.topic_resolver import find_slide_files_recursive
+    from clm.slides.deck_scope import (
+        course_root_for_path,
+        filter_decks,
+        resolve_shipping_set,
+    )
+
+    if not path.is_dir():
+        raise click.UsageError(
+            "--only / --exclude / --shipping-only apply to a directory, not a single file."
+        )
+
+    files = list(find_slide_files_recursive(path))
+
+    shipping: set[Path] | None = None
+    if shipping_only:
+        course_root = data_dir or course_root_for_path(path)
+        if course_root is None:
+            raise click.ClickException(
+                "Could not locate the course root (no 'slides/' ancestor) for "
+                "--shipping-only. Pass --data-dir or --specs-dir explicitly."
+            )
+        resolved_specs_dir = specs_dir or (course_root / "course-specs")
+        if not resolved_specs_dir.is_dir():
+            raise click.ClickException(
+                f"Specs directory not found: {resolved_specs_dir}. Pass --specs-dir explicitly."
+            )
+        slides_dir = (data_dir / "slides") if data_dir else (course_root / "slides")
+        shipping = resolve_shipping_set(resolved_specs_dir, slides_dir)
+        if not shipping:
+            raise click.ClickException(
+                f"No decks reachable from specs in {resolved_specs_dir} "
+                "(no *.xml specs, or none resolve)."
+            )
+
+    return filter_decks(files, only=only, exclude=exclude, shipping=shipping)
 
 
 def is_ci_environment() -> bool:

--- a/src/clm/cli/commands/slug_report.py
+++ b/src/clm/cli/commands/slug_report.py
@@ -1,0 +1,148 @@
+"""``clm slides slug-report`` — flag low-quality content-derived slugs (gap #6).
+
+After a bulk ``assign-ids --accept-content-derived`` mints thousands of ids,
+this reports just the ones worth reviewing: single generic tokens, very short
+code-identifier-shaped slugs, and slugs that hit the length cap and lost their
+trailing words. Accepts a directory (with the same ``--only`` / ``--exclude``
+/ ``--shipping-only`` scoping as ``assign-ids``) or a spec ``.xml`` (resolves
+to the decks the spec pulls in).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.cli.commands.shared import has_deck_scope, resolve_scoped_files
+from clm.slides.slug_quality import (
+    render_report,
+    report_to_dict,
+    scan_slug_quality,
+)
+
+_SEVERITIES = ["low", "medium", "high"]
+
+
+def _decks_for_spec(spec_file: Path, data_dir: Path | None) -> list[Path]:
+    from clm.core.course_spec import CourseSpec, CourseSpecError
+    from clm.core.spec_decks import resolve_spec_decks
+
+    slides_dir = (data_dir / "slides") if data_dir else (spec_file.parent.parent / "slides")
+    if not slides_dir.is_dir():
+        raise click.ClickException(
+            f"Could not locate the slides/ directory at {slides_dir}. Pass --data-dir."
+        )
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as exc:
+        raise click.ClickException(str(exc)) from None
+    return resolve_spec_decks(spec, slides_dir).deck_files
+
+
+@click.command("slug-report")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--only",
+    type=click.Choice(["bilingual", "split"]),
+    default=None,
+    help="Scope a directory scan to only bilingual decks (no .de/.en tag) or only split halves.",
+)
+@click.option(
+    "--exclude",
+    multiple=True,
+    metavar="GLOB",
+    help="Skip decks matching GLOB (matched against the full path and each path component). "
+    "Repeatable.",
+)
+@click.option(
+    "--shipping-only",
+    is_flag=True,
+    help="Scope a directory scan to decks reachable from course specs (the shipping set).",
+)
+@click.option(
+    "--specs-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="For --shipping-only: directory of *.xml specs. Default: <course-root>/course-specs/.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Course data directory (contains slides/). For a spec PATH or --shipping-only.",
+)
+@click.option(
+    "--min-severity",
+    type=click.Choice(_SEVERITIES),
+    default="low",
+    show_default=True,
+    help="Only show findings at or above this confidence (high = very-short / generic).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def slug_report_cmd(
+    path: Path,
+    only: str | None,
+    exclude: tuple[str, ...],
+    shipping_only: bool,
+    specs_dir: Path | None,
+    data_dir: Path | None,
+    min_severity: str,
+    as_json: bool,
+) -> None:
+    """Flag low-quality ``slide_id`` slugs for review.
+
+    PATH is a directory of slide files or a course spec ``.xml``. For a spec,
+    the decks it resolves to (its shipping set) are scanned. For a directory,
+    the ``--only`` / ``--exclude`` / ``--shipping-only`` flags scope the scan
+    the same way ``clm slides assign-ids`` does.
+
+    \b
+    Quality signals (a flag means "worth a look", not "wrong"):
+      very_short          one token <= 3 chars (cp / df / os).           [high]
+      generic             one content-free token (data / true / value).  [high]
+      possibly_truncated  hit the 30-char cap; trailing words lost.      [medium]
+      single_token        one token (often fine, e.g. introduction).     [low]
+
+    Exit code is 0; this is a report. Use --min-severity high to see only the
+    high-confidence cases.
+    """
+    scoped = has_deck_scope(only, exclude, shipping_only)
+
+    if path.is_file():
+        if path.suffix != ".xml":
+            raise click.UsageError(
+                "A file PATH must be a spec .xml; pass a directory to scan slide files."
+            )
+        if scoped:
+            raise click.UsageError(
+                "--only / --exclude / --shipping-only apply to a directory, not a spec file."
+            )
+        files = _decks_for_spec(path, data_dir)
+    elif path.is_dir():
+        if scoped:
+            files = resolve_scoped_files(
+                path,
+                only=only,
+                exclude=exclude,
+                shipping_only=shipping_only,
+                specs_dir=specs_dir,
+                data_dir=data_dir,
+            )
+        else:
+            from clm.core.topic_resolver import find_slide_files_recursive
+
+            files = list(find_slide_files_recursive(path))
+    else:  # pragma: no cover - click guards existence
+        raise click.ClickException(f"PATH must be a slide directory or spec .xml: {path}")
+
+    report = scan_slug_quality(files)
+
+    if as_json:
+        click.echo(json.dumps(report_to_dict(report), indent=2))
+    else:
+        click.echo(render_report(report, min_severity=min_severity))
+
+    sys.exit(0)

--- a/src/clm/cli/commands/spec_decks.py
+++ b/src/clm/cli/commands/spec_decks.py
@@ -1,0 +1,297 @@
+"""``clm spec decks`` and ``clm slides referenced-by``.
+
+Spec → deck resolution (gap #1). ``spec decks`` answers "which decks does this
+spec build?"; ``referenced-by`` is the reverse lookup. Both delegate to
+:mod:`clm.core.spec_decks`, which mirrors the build's resolution semantics so the
+shipping set is correct (a ``<topic>`` resolves to a directory and CLM builds
+**every** ``slides_*.py`` in it — filename-stem heuristics silently miss decks).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from clm.core.course_paths import resolve_course_paths
+from clm.core.course_spec import CourseSpec, CourseSpecError
+from clm.core.spec_decks import (
+    SpecDeckResolution,
+    find_deck_references,
+    resolve_spec_decks,
+)
+from clm.core.topic_resolver import build_topic_map
+from clm.slides.pairing import split_lang_tag
+
+
+def _slides_dir(data_dir: Path | None, spec_file: Path) -> Path:
+    """The ``slides/`` directory for *spec_file* (``--data-dir`` overrides)."""
+    course_root, _ = resolve_course_paths(spec_file, data_dir)
+    return course_root / "slides"
+
+
+def _deck_matches_lang(deck: Path, lang: str) -> bool:
+    """Whether *deck* serves *lang* (``de`` / ``en`` / ``both``).
+
+    Bilingual decks (no ``.de``/``.en`` tag) serve both languages; a split half
+    serves only its own language.
+    """
+    if lang == "both":
+        return True
+    tag = split_lang_tag(deck)
+    return tag is None or tag == lang
+
+
+def _rel(path: Path, base: Path) -> str:
+    """Display *path* relative to *base* when possible, else absolute."""
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return str(path)
+
+
+@click.command("decks")
+@click.argument(
+    "spec_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=False,
+)
+@click.option(
+    "--all-specs",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Resolve the union 'shipping set' across every *.xml spec in this "
+    "directory, annotating each deck with the spec(s) that reference it.",
+)
+@click.option(
+    "--lang",
+    type=click.Choice(["de", "en", "both"]),
+    default="both",
+    show_default=True,
+    help="Keep only decks serving this language (bilingual decks serve both).",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Course data directory (contains slides/). Default: inferred from the "
+    "spec file (its grandparent).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def spec_decks_cmd(
+    spec_file: Path | None,
+    all_specs: Path | None,
+    lang: str,
+    data_dir: Path | None,
+    as_json: bool,
+) -> None:
+    """List the deck files a course spec pulls in.
+
+    Resolution mirrors the build exactly: a ``<topic>`` resolves to a topic
+    *directory* and **every** ``slides_*.py`` in it is a deck (module-bound
+    references pick their module; unbound duplicates are first-occurrence-wins).
+    This is the reliable way to compute a spec's "shipping set" — do not guess
+    from deck filenames.
+
+    \b
+    Examples:
+        clm spec decks course-specs/python.xml
+        clm spec decks course-specs/python.xml --lang de --json
+        clm spec decks --all-specs course-specs/
+    """
+    if all_specs is not None and spec_file is not None:
+        raise click.UsageError("Pass either SPEC_FILE or --all-specs, not both.")
+    if all_specs is None and spec_file is None:
+        raise click.UsageError("Provide a SPEC_FILE or --all-specs DIR.")
+
+    if all_specs is not None:
+        _run_all_specs(all_specs, lang, data_dir, as_json)
+        return
+
+    assert spec_file is not None
+    slides_dir = _slides_dir(data_dir, spec_file)
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as e:
+        raise click.ClickException(f"Failed to parse course spec: {e}") from None
+
+    resolution = resolve_spec_decks(spec, slides_dir)
+    decks = [d for d in resolution.deck_files if _deck_matches_lang(d, lang)]
+
+    if as_json:
+        click.echo(json.dumps(_resolution_to_dict(resolution, decks, lang), indent=2))
+        return
+
+    base = slides_dir.parent
+    for deck in decks:
+        click.echo(_rel(deck, base))
+    if resolution.unresolved:
+        click.echo(
+            f"\nWARNING: {len(resolution.unresolved)} topic reference(s) "
+            "resolved to no directory on disk:",
+            err=True,
+        )
+        for topic in resolution.unresolved:
+            where = topic.requested_module or "any module"
+            click.echo(f"  {topic.topic_id} ({where}) — section {topic.section!r}", err=True)
+
+
+def _run_all_specs(
+    specs_dir: Path,
+    lang: str,
+    data_dir: Path | None,
+    as_json: bool,
+) -> None:
+    """Resolve the union shipping set across every spec in *specs_dir*."""
+    spec_files = sorted(specs_dir.glob("*.xml"))
+    if not spec_files:
+        raise click.ClickException(f"No *.xml specs found in {specs_dir}")
+
+    # All specs in one directory share a course root, so scan the filesystem once.
+    slides_dir = _slides_dir(data_dir, spec_files[0])
+    topic_map = build_topic_map(slides_dir)
+    base = slides_dir.parent
+
+    deck_to_specs: dict[Path, set[str]] = {}
+    parse_errors: list[tuple[Path, str]] = []
+    for spec_file in spec_files:
+        try:
+            spec = CourseSpec.from_file(spec_file)
+        except CourseSpecError as e:
+            parse_errors.append((spec_file, str(e)))
+            continue
+        resolution = resolve_spec_decks(spec, slides_dir, topic_map=topic_map)
+        for deck in resolution.deck_files:
+            if _deck_matches_lang(deck, lang):
+                deck_to_specs.setdefault(deck, set()).add(spec_file.name)
+
+    ordered = sorted(deck_to_specs, key=lambda p: str(p))
+
+    if as_json:
+        payload = {
+            "specs_dir": str(specs_dir),
+            "slides_dir": str(slides_dir),
+            "lang": lang,
+            "deck_count": len(ordered),
+            "decks": [
+                {"path": str(deck), "specs": sorted(deck_to_specs[deck])} for deck in ordered
+            ],
+            "parse_errors": [{"spec": str(p), "error": e} for p, e in parse_errors],
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    for deck in ordered:
+        specs = ", ".join(sorted(deck_to_specs[deck]))
+        click.echo(f"{_rel(deck, base)}\t{specs}")
+    if parse_errors:
+        click.echo(f"\nWARNING: {len(parse_errors)} spec(s) failed to parse:", err=True)
+        for spec_file, err in parse_errors:
+            click.echo(f"  {spec_file.name}: {err}", err=True)
+
+
+def _resolution_to_dict(resolution: SpecDeckResolution, decks: list[Path], lang: str) -> dict:
+    return {
+        "spec": str(resolution.spec_path),
+        "slides_dir": str(resolution.slides_dir),
+        "lang": lang,
+        "deck_count": len(decks),
+        "decks": [str(d) for d in decks],
+        "topics": [
+            {
+                "topic_id": t.topic_id,
+                "section": t.section,
+                "requested_module": t.requested_module,
+                "resolved_module": t.resolved_module,
+                "path": str(t.path) if t.path else None,
+                "found": t.found,
+                "slide_files": [str(d) for d in t.slide_files],
+                "shadowed": [str(m.path) for m in t.shadowed],
+            }
+            for t in resolution.topics
+        ],
+        "unresolved": [t.topic_id for t in resolution.unresolved],
+    }
+
+
+@click.command("referenced-by")
+@click.argument(
+    "deck",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--specs-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Directory of *.xml specs to search. Default: <course-root>/course-specs/.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Course data directory (contains slides/). Default: inferred from the deck.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def referenced_by_cmd(
+    deck: Path,
+    specs_dir: Path | None,
+    data_dir: Path | None,
+    as_json: bool,
+) -> None:
+    """Show which spec(s)/topic(s) pull DECK into their shipping set.
+
+    Reverse of ``clm spec decks``. A deck reachable from no spec is reported as
+    unreferenced — useful for spotting orphaned or superseded decks before a
+    corpus-wide change.
+
+    \b
+    Examples:
+        clm slides referenced-by slides/module_x/topic_y/slides_intro.py
+        clm slides referenced-by slides_intro.py --specs-dir course-specs/
+    """
+    deck = deck.resolve()
+    course_root = _course_root_for_deck(deck, data_dir)
+    slides_dir = course_root / "slides"
+    if specs_dir is None:
+        specs_dir = course_root / "course-specs"
+    if not specs_dir.is_dir():
+        raise click.ClickException(
+            f"Specs directory not found: {specs_dir}. Pass --specs-dir explicitly."
+        )
+
+    spec_files = sorted(specs_dir.glob("*.xml"))
+    references = find_deck_references(deck, spec_files, slides_dir)
+
+    if as_json:
+        payload = {
+            "deck": str(deck),
+            "specs_dir": str(specs_dir),
+            "referenced": bool(references),
+            "references": [
+                {
+                    "spec": str(r.spec_path),
+                    "topic_id": r.topic_id,
+                    "section": r.section,
+                    "resolved_module": r.resolved_module,
+                }
+                for r in references
+            ],
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    if not references:
+        click.echo(f"unreferenced: {deck.name} is pulled in by no spec in {specs_dir}")
+        return
+    for ref in references:
+        click.echo(f"{ref.spec_path.name}\t{ref.topic_id}\t{ref.section}")
+
+
+def _course_root_for_deck(deck: Path, data_dir: Path | None) -> Path:
+    """Infer the course root from a deck path (``…/slides/module_*/topic/deck``)."""
+    if data_dir is not None:
+        return data_dir
+    for parent in deck.parents:
+        if parent.name == "slides":
+            return parent.parent
+    raise click.ClickException(
+        "Could not infer the course root from the deck path (no 'slides/' "
+        "ancestor). Pass --data-dir explicitly."
+    )

--- a/src/clm/cli/commands/spec_orphans.py
+++ b/src/clm/cli/commands/spec_orphans.py
@@ -1,0 +1,127 @@
+"""``clm spec orphans`` — decks reachable from no spec, plus cruft (gap #7).
+
+The inverse of ``clm spec decks``: scan every spec in a course and report the
+decks on disk that *no* spec pulls in, grouped by likely intent (explicit
+``_old`` / ``_bak`` = superseded; ``_partN`` / ``_short`` / ``_long`` =
+probably-intentional alternate content; everything else = review). Also
+surfaces — and optionally removes — gitignored ``.ipynb_checkpoints/`` cruft.
+Delegates to :mod:`clm.core.spec_orphans`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import click
+
+from clm.core.spec_orphans import (
+    OrphanKind,
+    find_orphans,
+    render_report,
+    report_to_dict,
+)
+
+
+def _resolve_slides_dir(specs_dir: Path, slides_dir: Path | None, data_dir: Path | None) -> Path:
+    if slides_dir is not None:
+        return slides_dir
+    if data_dir is not None:
+        return data_dir / "slides"
+    return specs_dir.parent / "slides"
+
+
+@click.command("orphans")
+@click.argument(
+    "specs_dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--slides-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="The course's slides/ directory. Default: <specs-dir>/../slides.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Course data directory (contains slides/). Alternative to --slides-dir.",
+)
+@click.option(
+    "--kind",
+    type=click.Choice([k.value for k in OrphanKind]),
+    default=None,
+    help="Show only orphans of this intent (superseded / alternate / unknown).",
+)
+@click.option(
+    "--clean-checkpoints",
+    is_flag=True,
+    help="Delete the .ipynb_checkpoints/ directories found (gitignored cache cruft).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def spec_orphans_cmd(
+    specs_dir: Path,
+    slides_dir: Path | None,
+    data_dir: Path | None,
+    kind: str | None,
+    clean_checkpoints: bool,
+    as_json: bool,
+) -> None:
+    """List decks reachable from no spec, grouped by likely intent.
+
+    SPECS_DIR is the directory of course spec ``*.xml`` files. Orphans are
+    computed against the **union** of every spec (a deck unreferenced by one
+    spec may be pulled in by another).
+
+    \b
+    Buckets:
+      superseded   explicit _old / _bak / _orig / numeric duplicate — usually
+                   safe to archive.
+      alternate    _partN / _short / _long — probably intentional content; do
+                   NOT blindly archive.
+      unknown      no recognizable marker — review before acting.
+
+    Plus any gitignored .ipynb_checkpoints/ directories (regenerable cache
+    cruft); pass --clean-checkpoints to delete them. Exit code is 0 — this is
+    a report.
+    """
+    resolved_slides = _resolve_slides_dir(specs_dir, slides_dir, data_dir)
+    if not resolved_slides.is_dir():
+        raise click.ClickException(
+            f"Slides directory not found: {resolved_slides}. Pass --slides-dir or --data-dir."
+        )
+
+    spec_files = sorted(specs_dir.glob("*.xml"))
+    if not spec_files:
+        raise click.ClickException(f"No *.xml specs found in {specs_dir}.")
+
+    report = find_orphans(spec_files, resolved_slides)
+
+    removed: list[Path] = []
+    if clean_checkpoints:
+        for ckpt in report.checkpoints:
+            try:
+                shutil.rmtree(ckpt)
+                removed.append(ckpt)
+            except OSError as exc:
+                click.echo(f"warning: could not remove {ckpt}: {exc}", err=True)
+
+    if kind is not None:
+        wanted = OrphanKind(kind)
+        report.orphans = [o for o in report.orphans if o.kind == wanted]
+
+    if as_json:
+        payload = report_to_dict(report)
+        if clean_checkpoints:
+            payload["checkpoints_removed"] = [str(p) for p in removed]
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        click.echo(render_report(report, resolved_slides))
+        if clean_checkpoints:
+            click.echo()
+            click.echo(f"Removed {len(removed)} .ipynb_checkpoints/ director(ies).")
+
+    sys.exit(0)

--- a/src/clm/cli/commands/validate.py
+++ b/src/clm/cli/commands/validate.py
@@ -6,19 +6,40 @@ Override with ``--kind=slides|spec`` for ambiguous cases (e.g. an empty
 directory, or an ``.xml`` file you nonetheless want to feed to the
 slide validator).
 
-The two underlying commands (``validate-slides``, ``validate-spec``)
-remain available as deprecated aliases — this command consolidates
-them so 95% of users no longer have to remember which to use.
+Beyond the basic dispatch, three flags close the "structure-OK ≠ decks-clean"
+gap (course-conversion tooling gap #2):
+
+- ``--deep`` (spec): after structure validation, run the full slide validator
+  on every deck the spec pulls in (its shipping set) and report both.
+- ``--summary``: roll findings up into a category/kind histogram with per-deck
+  counts instead of a flat list of thousands of lines.
+- ``--shipping-only`` (directory): restrict a directory walk to the decks
+  reachable from course specs, so archived / unreferenced decks don't drown the
+  signal.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import click
 
-from clm.cli.commands.validate_slides import validate_slides_cmd
-from clm.cli.commands.validate_spec import validate_spec_cmd
+from clm.cli.commands.validate_slides import (
+    _parse_checks,
+    _print_human_readable,
+    _raise_on_findings,
+    validate_slides_cmd,
+)
+from clm.cli.commands.validate_slides import (
+    _result_to_dict as _slides_result_to_dict,
+)
+from clm.cli.commands.validate_spec import (
+    _result_to_dict as _spec_result_to_dict,
+)
+from clm.cli.commands.validate_spec import (
+    validate_spec_cmd,
+)
 
 
 def _infer_kind(path: Path) -> str | None:
@@ -36,6 +57,12 @@ def _infer_kind(path: Path) -> str | None:
         # spec validator. If you want to validate a spec, pass the .xml.
         return "slides"
     return None
+
+
+def _slides_dir_for_spec(data_dir: Path | None, spec_file: Path) -> Path:
+    if data_dir:
+        return data_dir / "slides"
+    return spec_file.parent.parent / "slides"
 
 
 @click.command("validate")
@@ -66,7 +93,7 @@ def _infer_kind(path: Path) -> str | None:
         "Slides-only: comma-separated list of checks. "
         "Deterministic: format, pairing, tags. "
         "Review: code_quality, voiceover, completeness. "
-        "Default: all deterministic checks. Not valid with --kind=spec."
+        "Default: all deterministic checks. Not valid with --kind=spec unless --deep."
     ),
 )
 @click.option(
@@ -89,8 +116,40 @@ def _infer_kind(path: Path) -> str | None:
     help=(
         "Slides-only: exit non-zero when findings reach this severity. "
         "'warning' makes the cross-file slide_id / voiceover for_slide parity "
-        "warnings fail a pre-commit gate. Not valid with --kind=spec."
+        "warnings fail a pre-commit gate. Not valid with --kind=spec unless --deep."
     ),
+)
+@click.option(
+    "--deep",
+    is_flag=True,
+    help=(
+        "Spec-only: after structure validation, run the full slide validator on "
+        "every deck the spec pulls in (its shipping set). 'Spec validates OK' does "
+        "not mean the decks are clean — this checks both."
+    ),
+)
+@click.option(
+    "--summary",
+    is_flag=True,
+    help=(
+        "Roll findings up into a category/kind histogram with per-deck counts "
+        "instead of a flat list. Works with --deep and with slides/directory "
+        "validation. On a bare spec it implies --deep."
+    ),
+)
+@click.option(
+    "--shipping-only",
+    is_flag=True,
+    help=(
+        "Slides directory only: restrict the walk to decks reachable from course "
+        "specs (the shipping set), skipping archived / unreferenced decks."
+    ),
+)
+@click.option(
+    "--specs-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="For --shipping-only: directory of *.xml specs. Default: <course-root>/course-specs/.",
 )
 @click.pass_context
 def validate_cmd(
@@ -103,13 +162,20 @@ def validate_cmd(
     quick: bool,
     include_disabled: bool,
     fail_on: str | None,
+    deep: bool,
+    summary: bool,
+    shipping_only: bool,
+    specs_dir: Path | None,
 ) -> None:
     """Validate a course spec file or slide files.
 
     \b
     Argument dispatch:
-        clm validate course.xml             # → spec validation
+        clm validate course.xml             # → spec validation (structure)
+        clm validate course.xml --deep      # → structure + every referenced deck
+        clm validate course.xml --summary   # → deep, rolled up into a histogram
         clm validate slides/                # → slide validation
+        clm validate slides/ --shipping-only --summary   # only decks that ship
         clm validate slides/x.py            # → slide validation
         clm validate something --kind=spec  # → forced spec validation
     """
@@ -121,14 +187,69 @@ def validate_cmd(
         )
 
     if resolved_kind == "spec":
-        if checks or quick or fail_on:
-            raise click.UsageError(
-                "--checks, --quick, and --fail-on are slides-only; not valid with --kind=spec."
-            )
-        if not path.is_file() or path.suffix.lower() != ".xml":
-            # Spec validator expects a single XML file; refuse anything
-            # else explicitly so the error doesn't come from deeper code.
-            raise click.UsageError(f"--kind=spec requires an .xml file, got {path}.")
+        _validate_spec_path(
+            ctx,
+            path,
+            data_dir=data_dir,
+            as_json=as_json,
+            checks=checks,
+            quick=quick,
+            include_disabled=include_disabled,
+            fail_on=fail_on,
+            deep=deep,
+            summary=summary,
+            shipping_only=shipping_only,
+        )
+    else:  # slides
+        _validate_slides_path(
+            ctx,
+            path,
+            data_dir=data_dir,
+            as_json=as_json,
+            checks=checks,
+            quick=quick,
+            include_disabled=include_disabled,
+            fail_on=fail_on,
+            deep=deep,
+            summary=summary,
+            shipping_only=shipping_only,
+            specs_dir=specs_dir,
+        )
+
+
+def _validate_spec_path(
+    ctx: click.Context,
+    path: Path,
+    *,
+    data_dir: Path | None,
+    as_json: bool,
+    checks: str | None,
+    quick: bool,
+    include_disabled: bool,
+    fail_on: str | None,
+    deep: bool,
+    summary: bool,
+    shipping_only: bool,
+) -> None:
+    if quick:
+        raise click.UsageError("--quick is slides-only; not valid with a spec.")
+    if shipping_only:
+        raise click.UsageError(
+            "--shipping-only applies to a slides directory; a spec already scopes "
+            "to its shipping set (use --deep)."
+        )
+    if not path.is_file() or path.suffix.lower() != ".xml":
+        raise click.UsageError(f"--kind=spec requires an .xml file, got {path}.")
+
+    # --summary on a spec is about the decks, so it implies a deep run.
+    deep = deep or summary
+    if (checks or fail_on) and not deep:
+        raise click.UsageError(
+            "--checks and --fail-on are slides-only; with a spec they require --deep."
+        )
+
+    if not deep:
+        # Unchanged structure-only behavior.
         ctx.invoke(
             validate_spec_cmd,
             spec_file=path,
@@ -136,9 +257,91 @@ def validate_cmd(
             as_json=as_json,
             include_disabled=include_disabled,
         )
-    else:  # slides
-        if include_disabled:
-            raise click.UsageError("--include-disabled is spec-only; not valid with --kind=slides.")
+        return
+
+    _run_deep_spec(
+        path,
+        data_dir=data_dir,
+        as_json=as_json,
+        checks=checks,
+        include_disabled=include_disabled,
+        fail_on=fail_on,
+        summary=summary,
+    )
+
+
+def _run_deep_spec(
+    spec_file: Path,
+    *,
+    data_dir: Path | None,
+    as_json: bool,
+    checks: str | None,
+    include_disabled: bool,
+    fail_on: str | None,
+    summary: bool,
+) -> None:
+    """Validate a spec's structure AND the content of every deck it pulls in."""
+    from clm.core.course_spec import CourseSpecError
+    from clm.slides.spec_validator import validate_spec
+    from clm.slides.validator import validate_course
+
+    slides_dir = _slides_dir_for_spec(data_dir, spec_file)
+    check_list = _parse_checks(checks)
+
+    try:
+        spec_result = validate_spec(spec_file, slides_dir, include_disabled=include_disabled)
+    except CourseSpecError as e:
+        raise click.ClickException(str(e)) from None
+
+    slides_result = validate_course(spec_file, slides_dir, checks=check_list)
+
+    if as_json:
+        payload: dict = {
+            "kind": "deep",
+            "spec": _spec_result_to_dict(spec_result),
+            "slides": _slides_result_to_dict(slides_result),
+        }
+        if summary:
+            from clm.slides.validation_summary import summarize_findings
+
+            payload["summary"] = summarize_findings(slides_result.findings).to_dict()
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        _print_spec_findings(spec_result)
+        click.echo()
+        if summary:
+            _print_summary(slides_result)
+        else:
+            _print_human_readable(slides_result)
+
+    spec_has_errors = any(f.severity == "error" for f in spec_result.findings)
+    if spec_has_errors:
+        raise SystemExit(1)
+    _raise_on_findings(slides_result.findings, fail_on, as_json)
+
+
+def _validate_slides_path(
+    ctx: click.Context,
+    path: Path,
+    *,
+    data_dir: Path | None,
+    as_json: bool,
+    checks: str | None,
+    quick: bool,
+    include_disabled: bool,
+    fail_on: str | None,
+    deep: bool,
+    summary: bool,
+    shipping_only: bool,
+    specs_dir: Path | None,
+) -> None:
+    if include_disabled:
+        raise click.UsageError("--include-disabled is spec-only; not valid with --kind=slides.")
+    if deep:
+        raise click.UsageError("--deep applies to a spec, not a slides path.")
+
+    if not (summary or shipping_only):
+        # Unchanged slide-validation behavior.
         ctx.invoke(
             validate_slides_cmd,
             path=path,
@@ -148,3 +351,110 @@ def validate_cmd(
             data_dir=data_dir,
             fail_on=fail_on,
         )
+        return
+
+    if quick:
+        raise click.UsageError("--quick is not compatible with --summary / --shipping-only.")
+
+    result = _run_slides(path, checks, shipping_only, specs_dir)
+
+    if as_json:
+        payload = _slides_result_to_dict(result)
+        if summary:
+            from clm.slides.validation_summary import summarize_findings
+
+            payload["summary"] = summarize_findings(result.findings).to_dict()
+        click.echo(json.dumps(payload, indent=2))
+    elif summary:
+        _print_summary(result)
+    else:
+        _print_human_readable(result)
+
+    _raise_on_findings(result.findings, fail_on, as_json)
+
+
+def _run_slides(
+    path: Path,
+    checks: str | None,
+    shipping_only: bool,
+    specs_dir: Path | None,
+):
+    """Run slide validation, optionally scoped to the shipping set."""
+    from clm.slides.validator import (
+        validate_directory,
+        validate_file,
+        validate_files,
+    )
+
+    check_list = _parse_checks(checks)
+
+    if not shipping_only:
+        if path.is_dir():
+            return validate_directory(path, checks=check_list)
+        return validate_file(path, checks=check_list)
+
+    if not path.is_dir():
+        raise click.UsageError("--shipping-only requires a directory path.")
+
+    course_root = _course_root_for_slides_path(path)
+    resolved_specs_dir = specs_dir or (course_root / "course-specs")
+    if not resolved_specs_dir.is_dir():
+        raise click.ClickException(
+            f"Specs directory not found: {resolved_specs_dir}. Pass --specs-dir explicitly."
+        )
+    spec_files = sorted(resolved_specs_dir.glob("*.xml"))
+    if not spec_files:
+        raise click.ClickException(f"No *.xml specs found in {resolved_specs_dir}.")
+
+    from clm.core.spec_decks import shipping_set
+
+    slides_dir = course_root / "slides"
+    ship = shipping_set(spec_files, slides_dir)
+    # The shipping set is already the resolved deck list (extension-aware via
+    # find_slide_files), so filter it to the decks under `path` directly rather
+    # than walking — validate_directory's deep walk is .py-only and would miss
+    # .cs / .cpp decks.
+    base = path.resolve()
+    kept = sorted(d for d in ship if d == base or base in d.parents)
+    return validate_files(kept, checks=check_list)
+
+
+def _course_root_for_slides_path(path: Path) -> Path:
+    """Infer the course root from a slides path (``…/slides/…`` or the root)."""
+    resolved = path.resolve()
+    if resolved.name == "slides":
+        return resolved.parent
+    for parent in resolved.parents:
+        if parent.name == "slides":
+            return parent.parent
+    raise click.ClickException(
+        "Could not infer the course root from the path (no 'slides/' ancestor). "
+        "Pass --specs-dir explicitly."
+    )
+
+
+def _print_spec_findings(spec_result) -> None:
+    """Print spec-structure findings (mirrors the validate-spec human output)."""
+    if not spec_result.findings:
+        click.echo(f"Spec structure: OK — {spec_result.topics_total} topics, no issues.")
+        return
+    click.echo("Spec structure:")
+    for f in spec_result.findings:
+        icon = {"error": "ERROR", "warning": "WARN", "info": "INFO"}.get(f.severity, "???")
+        click.echo(f"  [{icon}] {f.message}")
+        if f.suggestion:
+            click.echo(f"         {f.suggestion}")
+    errors = sum(1 for f in spec_result.findings if f.severity == "error")
+    warnings = sum(1 for f in spec_result.findings if f.severity == "warning")
+    click.echo(
+        f"  {spec_result.topics_total} topics checked: {errors} error(s), {warnings} warning(s)."
+    )
+
+
+def _print_summary(result) -> None:
+    """Print the rolled-up deck-content summary."""
+    from clm.slides.validation_summary import render_summary, summarize_findings
+
+    click.echo(f"Deck content ({result.files_checked} deck(s) checked):")
+    for line in render_summary(summarize_findings(result.findings)):
+        click.echo(line)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -908,6 +908,57 @@ clm slides assign-ids slides/ --accept-content-derived --shipping-only
 clm slides assign-ids slides/ --report-only --report-refusals --context
 ```
 
+### `clm slides slug-report`
+
+*Added in CLM {version}.*
+
+After a bulk `clm slides assign-ids --accept-content-derived` mints thousands
+of ids, **most are fine but a minority are low-information** — single generic
+tokens (`data` / `true` / `value`), very short code-identifier-shaped slugs
+(`cp` / `df` / `os`), or slugs that hit the 30-char cap and lost their trailing
+words. `slug-report` flags just those so you review the minority instead of
+scanning every id.
+
+```bash
+clm slides slug-report [OPTIONS] PATH
+```
+
+`PATH` is a directory of slide files **or** a course spec `.xml` (resolved to
+the decks it pulls in, via the same build-faithful logic as `clm spec decks`).
+
+| Option | Description |
+|--------|-------------|
+| `--min-severity low\|medium\|high` | Only show findings at or above this confidence (default `low` = all). `high` = very-short / generic only. |
+| `--only bilingual\|split` | Scope a **directory** scan to only bilingual decks (no `.de`/`.en` tag) or only split halves. |
+| `--exclude GLOB` | Skip decks matching `GLOB` (matched against the full path **and** each path component, so `--exclude _archive` skips an `_archive/` dir). Repeatable. |
+| `--shipping-only` | Scope a directory scan to decks reachable from course specs (the shipping set). |
+| `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`); used for a spec `PATH` or `--shipping-only`. |
+| `--json` | Emit a JSON report (per-finding issues + `by_severity` / `by_issue` histograms). |
+
+Quality signals — a flag means "worth a look", **not** "wrong" (`introduction`
+is a single token and perfectly good, so it's only `low`):
+
+| Signal | Meaning | Severity |
+|---|---|---|
+| `very_short` | one token ≤ 3 chars (`cp` / `df` / `os`) | high |
+| `generic` | one content-free token (`data` / `true` / `value`) | high |
+| `possibly_truncated` | length hit the 30-char cap; trailing words likely lost | medium |
+| `single_token` | one token (often fine, e.g. `introduction`) | low |
+
+Only slide/subslide *start* cells are inspected (narrative cells inherit their
+slide's id), and a bilingual deck's DE/EN twins — which share an id — yield a
+single finding. The exit code is always `0`; this is a report.
+
+Examples:
+
+```bash
+clm slides slug-report slides/module_010/                       # everything flagged
+clm slides slug-report slides/ --min-severity high              # just the high-confidence ids
+clm slides slug-report course-specs/python-course.xml --json    # only the decks that ship
+clm slides slug-report slides/ --exclude _archive --shipping-only
+```
+
 ### `clm slides sync`
 
 *Added in CLM {version}.*

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -498,12 +498,28 @@ Checks that all referenced topic IDs resolve to exactly one existing
 topic directory, that there are no duplicate topic references, and
 that referenced dir-group paths exist.
 
+> **Structure-OK is not decks-clean.** By default `clm validate <spec.xml>`
+> validates only the spec *structure* (topic resolution, duplicates, dir-group
+> paths) — it does **not** check the slide content of the decks the spec pulls
+> in. So a passing spec validation does not mean the decks are free of
+> missing-`slide_id` / adjacency / pairing errors. Use `--deep` to validate
+> both.
+
 | Option | Description |
 |--------|-------------|
 | `--kind [slides\|spec]` | Force a validator instead of inferring from the path (`.xml` → spec, `.py`/directory → slides). `--kind=spec` requires an `.xml` file. |
 | `--data-dir DIR` | Course data directory (contains slides/) |
 | `--json` | Output as JSON |
 | `--include-disabled` | Also validate sections marked `enabled="false"`; each finding from a disabled section has `(disabled)` appended to its message (default: disabled sections are skipped) |
+| `--deep` | After structure validation, run the full slide validator on **every deck the spec pulls in** (its shipping set) and report both. Exits non-zero on a structure error or a deck-content error (`--fail-on` governs the deck-content threshold). Resolves decks with the same build-faithful semantics as `clm spec decks`. |
+| `--summary` | Roll the deck-content findings up into a category/kind histogram with per-deck counts instead of a flat list (intended for corpus-scale validates that emit thousands of findings). On a spec, `--summary` implies `--deep`. |
+| `--checks LIST`, `--fail-on [error\|warning]` | Slides-validator options (see slides mode); valid on a spec only together with `--deep`, where they apply to the deck-content pass. |
+
+The `--summary` rollup has three axes: **by category** (`format`/`pairing`/`tags`
+× severity — the validator's own categories, exact), **by kind** (a finer,
+heuristic bucket derived from the message: `missing-slide_id`, `adjacency`,
+`count-mismatch`, `start-completed`, `malformed-marker`, … with an `other`
+fallback), and **by deck** (the decks with the most findings first).
 
 Examples:
 
@@ -511,6 +527,9 @@ Examples:
 clm validate course-specs/python-basics.xml
 clm validate course-specs/ml-azav.xml --json
 clm validate course-specs/ml-azav.xml --include-disabled
+clm validate course-specs/python.xml --deep              # structure + deck content
+clm validate course-specs/python.xml --summary           # deep, rolled up
+clm validate course-specs/python.xml --deep --fail-on warning
 ```
 
 ### `clm sync-includes`
@@ -595,8 +614,16 @@ clm validate [OPTIONS] PATH
 | `--json` | Output as JSON |
 | `--data-dir DIR` | Course data directory (contains slides/) |
 | `--fail-on {error,warning}` | (since CLM {version}) Exit non-zero when findings reach this severity. Unset: legacy behavior (human output fails on errors; JSON exits 0). `error`: fail on errors in either mode. `warning`: fail on errors **or** warnings — the pre-commit-gate setting, so the cross-file `slide_id` / voiceover `for_slide` parity warnings block a commit. |
+| `--summary` | (since CLM {version}) Roll findings up into a category/kind histogram with per-deck counts instead of a flat list — for corpus-scale validates that would otherwise print thousands of lines. |
+| `--shipping-only` | (since CLM {version}) Directory only: restrict the walk to decks reachable from course specs (the shipping set), skipping archived / unreferenced decks so they don't drown the signal. |
+| `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs to resolve the shipping set from. Default: `<course-root>/course-specs/`. |
 
 `PATH` can be a single slide file, a topic directory, or a course spec XML file.
+
+> `--shipping-only` resolves the shipping set with the same build-faithful logic
+> as `clm spec decks`, and filters that resolved deck list to the decks under
+> `PATH` — so it correctly includes non-`.py` decks (`.cs`, `.cpp`) that the
+> plain directory walk currently misses.
 
 Since CLM {version}, `clm validate slides/ --fail-on warning` is the
 pre-commit gate: by default the `pairing` warnings (missing/divergent

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -869,6 +869,8 @@ clm slides assign-ids [OPTIONS] PATH
 | `--shipping-only` | (since CLM {version}) Scope a directory run to decks reachable from course specs (the shipping set). |
 | `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
 | `--data-dir DIR` | Course data directory (contains `slides/`); used to resolve the `--shipping-only` scope. |
+| `--report-refusals` | (since CLM {version}) Emit a hand-authoring **worklist** of the refusals (hard ones first) instead of the assignment listing — the cells that still need a `slide_id`. |
+| `--context` | (since CLM {version}) With `--report-refusals`, include each refused cell's marker, body, and the nearest preceding `slide_id`/heading so you can author an id in place. Implies `--report-refusals`. |
 | `--json` | Emit a JSON report instead of human-readable lines. |
 
 The scoping options (`--only` / `--exclude` / `--shipping-only`) apply only to a
@@ -877,6 +879,16 @@ the files you shouldn't have touched" workaround. Split pairs are still detected
 *within* the scoped set, so EN-authority parity minting across a `.de`/`.en` pair
 is preserved; if only one half survives the filter, that half takes the per-file
 twin-aware path and the absent twin is never written.
+
+`--report-refusals` turns the run into a **worklist** for the cells that could
+*not* be assigned automatically: hard refusals (no heading and no extractable
+content — only a hand-authored id will do) sort first, then soft refusals
+(extractable, carrying a proposed slug). Add `--context` to attach each refused
+cell's marker line, full body, and the nearest preceding `slide_id`/heading so an
+author or agent can write the id without opening the file. The worklist honors the
+same scoping flags, and `--json` emits it as structured data. It replaces the
+throwaway "dry-run JSON → script that re-extracts cell bodies and surrounding
+context" step that course conversions repeatedly hand-rolled.
 
 Exit codes: `0` clean, `1` soft refusals (extractable cells awaiting
 author input), `2` at least one hard refusal.
@@ -892,6 +904,8 @@ clm slides assign-ids slides/module_010/ --force        # regenerate all derivab
 clm slides assign-ids slides/ --accept-content-derived --only bilingual --exclude _archive
 # Scope: only the decks that actually ship
 clm slides assign-ids slides/ --accept-content-derived --shipping-only
+# Worklist of cells that still need a hand-authored id, with body + context
+clm slides assign-ids slides/ --report-only --report-refusals --context
 ```
 
 ### `clm slides sync`

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -761,6 +761,15 @@ clm slides normalize [OPTIONS] PATH
 | `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--json` | Output as JSON |
 | `--data-dir DIR` | Course data directory (contains slides/) |
+| `--only bilingual\|split` | (since CLM {version}) Scope a **directory** run to only bilingual decks (no `.de`/`.en` tag) or only split halves — e.g. normalize the bilingual decks while leaving `.de`/`.en` pairs for `clm slides sync`. |
+| `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude _archive` skips an `_archive/` directory). Repeatable. |
+| `--shipping-only` | (since CLM {version}) Scope a directory run to decks reachable from course specs (the shipping set), skipping archived / unreferenced decks. |
+| `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
+
+The scoping options (`--only` / `--exclude` / `--shipping-only`) apply only to a
+directory `PATH`; using them with a single file or a spec is an error. They
+replace the old "run over everything, then `git checkout` the files you shouldn't
+have touched" workaround.
 
 Examples:
 
@@ -771,6 +780,10 @@ clm slides normalize slides/module_010/ --operations tag_migration
 clm slides normalize slides/module_010/ --operations slide_ids --json
 # Pre-conversion: canonicalize start/completed order so the split round-trips exactly
 clm slides normalize slides/module_010/topic_100_intro/ --operations interleaving --canonicalize-start-completed
+# Scope: mint ids on bilingual decks only, skipping an _archive/ dir
+clm slides normalize slides/ --operations slide_ids --only bilingual --exclude _archive
+# Scope: only the decks that actually ship
+clm slides normalize slides/ --shipping-only
 ```
 
 ### `clm slides assign-ids`
@@ -851,7 +864,19 @@ clm slides assign-ids [OPTIONS] PATH
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
 | `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B model can exceed 60s). |
 | `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
+| `--only bilingual\|split` | (since CLM {version}) Scope a **directory** run to only bilingual decks (no `.de`/`.en` tag) or only split halves — e.g. `--only bilingual` mints bilingual decks while leaving `.de`/`.en` pairs for `clm slides sync`. |
+| `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude _archive` skips an `_archive/` dir). Repeatable. |
+| `--shipping-only` | (since CLM {version}) Scope a directory run to decks reachable from course specs (the shipping set). |
+| `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`); used to resolve the `--shipping-only` scope. |
 | `--json` | Emit a JSON report instead of human-readable lines. |
+
+The scoping options (`--only` / `--exclude` / `--shipping-only`) apply only to a
+directory `PATH` and replace the old "run over everything, then `git checkout`
+the files you shouldn't have touched" workaround. Split pairs are still detected
+*within* the scoped set, so EN-authority parity minting across a `.de`/`.en` pair
+is preserved; if only one half survives the filter, that half takes the per-file
+twin-aware path and the absent twin is never written.
 
 Exit codes: `0` clean, `1` soft refusals (extractable cells awaiting
 author input), `2` at least one hard refusal.
@@ -863,6 +888,10 @@ clm slides assign-ids slides/module_010/topic_100/slides_intro.py --report-only
 clm slides assign-ids slides/module_010/ --accept-content-derived
 clm slides assign-ids slides/module_010/topic_100/slides_intro.py --llm-suggest
 clm slides assign-ids slides/module_010/ --force        # regenerate all derivable ids
+# Scope: mint only the bilingual decks, leaving split pairs for `clm slides sync`
+clm slides assign-ids slides/ --accept-content-derived --only bilingual --exclude _archive
+# Scope: only the decks that actually ship
+clm slides assign-ids slides/ --accept-content-derived --shipping-only
 ```
 
 ### `clm slides sync`

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -393,6 +393,64 @@ clm topic resolve intro --course-spec course-specs/python.xml
 clm topic resolve intro --module module_545_ml_azav_cohort_2026_04
 ```
 
+### `clm spec decks`
+
+List the deck files a course spec actually pulls in — its "shipping set".
+
+```
+clm spec decks [OPTIONS] [SPEC_FILE]
+```
+
+Resolution mirrors the build exactly, which is the point of the command: a
+`<topic>` resolves to a topic **directory** and CLM builds **every**
+`slides_*.py` in it. The directory name often differs from the deck filenames
+(e.g. topic `properties` → `slides_properties.py` **and**
+`slides_property_setters.py`), so a deck-filename-stem heuristic silently misses
+decks. Module-bound `<topic>`/`<section>` references resolve in their module;
+unbound topic IDs that match multiple modules are first-occurrence-wins (matching
+the build), and the shadowed matches are reported in `--json` output.
+
+| Option | Description |
+|--------|-------------|
+| `--all-specs DIR` | Resolve the union shipping set across every `*.xml` spec in `DIR`, annotating each deck with the spec(s) that reference it. Mutually exclusive with `SPEC_FILE`. |
+| `--lang de\|en\|both` | Keep only decks serving this language. Bilingual decks (no `.de`/`.en` tag) serve both, so they always survive the filter; split halves are kept only for their own language. Default: `both`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the spec file (its grandparent). |
+| `--json` | Output as JSON (includes per-topic resolution, unresolved topics, and first-occurrence-shadowed duplicates). |
+
+Topic references that resolve to no directory on disk are reported as a warning
+(stderr) but do not fail the command.
+
+Examples:
+
+```bash
+clm spec decks course-specs/python.xml
+clm spec decks course-specs/python.xml --lang de --json
+clm spec decks --all-specs course-specs/
+```
+
+### `clm slides referenced-by`
+
+Reverse of `clm spec decks`: show which spec(s)/topic(s) pull a given deck into
+their shipping set. A deck reachable from no spec is reported as `unreferenced` —
+useful for spotting orphaned or superseded decks before a corpus-wide change.
+
+```
+clm slides referenced-by [OPTIONS] DECK
+```
+
+| Option | Description |
+|--------|-------------|
+| `--specs-dir DIR` | Directory of `*.xml` specs to search. Default: `<course-root>/course-specs/`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the deck path (its `slides/` ancestor). |
+| `--json` | Output as JSON. |
+
+Examples:
+
+```bash
+clm slides referenced-by slides/module_x/topic_y/slides_intro.py
+clm slides referenced-by slides_intro.py --specs-dir course-specs/
+```
+
 ### `clm slides search`
 
 *Removed in CLM 1.8: the flat alias `clm search-slides` no longer exists — use this group-qualified form.*

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -451,6 +451,50 @@ clm slides referenced-by slides/module_x/topic_y/slides_intro.py
 clm slides referenced-by slides_intro.py --specs-dir course-specs/
 ```
 
+### `clm spec orphans`
+
+*Added in CLM {version}.*
+
+The inverse of `clm spec decks`: scan **every** spec in a course and report the
+decks on disk that *no* spec pulls in, grouped by likely intent — so you can
+archive the dead ones without deleting intentional alternates. Also surfaces
+(and optionally removes) gitignored `.ipynb_checkpoints/` cache cruft.
+
+```
+clm spec orphans [OPTIONS] SPECS_DIR
+```
+
+`SPECS_DIR` is the directory of course spec `*.xml` files. Orphans are computed
+against the **union** of every spec (a deck unreferenced by one spec may be
+pulled in by another). The on-disk walk is extension-complete (`.py` / `.cpp` /
+`.cs` / …), so a non-Python orphan is not silently missed.
+
+| Option | Description |
+|--------|-------------|
+| `--slides-dir DIR` | The course's `slides/` directory. Default: `<specs-dir>/../slides`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`); alternative to `--slides-dir`. |
+| `--kind superseded\|alternate\|unknown` | Show only orphans of this intent. |
+| `--clean-checkpoints` | Delete the `.ipynb_checkpoints/` directories found (regenerable cache cruft). |
+| `--json` | Emit a JSON report (`by_kind` counts + per-orphan `kind`/`reason`, plus `checkpoints`). |
+
+Intent buckets (the distinction matters — blindly archiving a `_part1..5` series
+would delete real content):
+
+| Bucket | Markers | Meaning |
+|---|---|---|
+| `superseded` | `_old` / `_oldN` / `_bak` / `_backup` / `_orig` / `_deprecated` / `_copy` / `_vN` / trailing `_N` | usually safe to archive |
+| `alternate` | `_partN` / `_short` / `_long` | probably intentional content — do **not** blindly archive |
+| `unknown` | no recognizable marker | review before acting |
+
+The exit code is always `0` — this is a report. Examples:
+
+```bash
+clm spec orphans course-specs/                                 # full orphan report
+clm spec orphans course-specs/ --kind superseded               # just the archivable ones
+clm spec orphans course-specs/ --clean-checkpoints             # report + delete checkpoint cruft
+clm spec orphans course-specs/ --slides-dir ../other/slides --json
+```
+
 ### `clm course gate`
 
 Run the mechanical conversion passes over a course and report **readiness** —

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -451,6 +451,49 @@ clm slides referenced-by slides/module_x/topic_y/slides_intro.py
 clm slides referenced-by slides_intro.py --specs-dir course-specs/
 ```
 
+### `clm course gate`
+
+Run the mechanical conversion passes over a course and report **readiness** —
+how much of a corpus is cleared by tooling versus how much still needs a human.
+Built for bringing a course up to a stricter validator (e.g. the 1.8 `slide_id`
+gate) without hand-driving the passes one at a time.
+
+```
+clm course gate [OPTIONS] TARGET
+```
+
+`TARGET` is a course spec `.xml` (validates and fixes its shipping set) or a
+slides directory. The gate runs the mechanical passes — `tag_migration`,
+`workshop_tags`, `interleaving`, and content-derived `slide_id` minting — then
+splits the remaining work into:
+
+- **mechanical** — what the passes changed (or, in a dry run, *would* change);
+- **needs-author** — what the normalizer **refused** to touch because a safe
+  automatic fix doesn't exist: a `slide_id` with no derivable heading (hard
+  refusal), a DE/EN pair whose code diverged too far to auto-interleave
+  (`similarity_failure`), or a DE/EN cell-count mismatch (a missing translation).
+
+| Option | Description |
+|--------|-------------|
+| `--apply` | Write the mechanical fixes and re-validate, reporting the residual. Without it, the gate is a **dry run**: it reports what *would* change and touches nothing on disk. |
+| `--operations LIST` | Comma-separated passes to run (default: `tag_migration,workshop_tags,interleaving,slide_ids`). Valid names: `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the target. |
+| `--json` | Output as JSON (baseline rollup, mechanical change counts, the needs-author list, and the post-apply residual rollup). |
+
+**Exit code:** non-zero when author work remains, or — after `--apply` — when a
+residual error remains; zero when the course is mechanically clean (no author
+work). This makes `clm course gate <spec>` usable as a conversion gate in CI:
+a dry run that exits 0 means `--apply` will fully clear the corpus.
+
+Examples:
+
+```bash
+clm course gate course-specs/python.xml            # dry-run readiness report
+clm course gate course-specs/python.xml --apply    # fix mechanically + re-validate
+clm course gate slides/module_100/ --apply
+clm course gate course-specs/python.xml --json
+```
+
 ### `clm slides search`
 
 *Removed in CLM 1.8: the flat alias `clm search-slides` no longer exists — use this group-qualified form.*

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1003,6 +1003,54 @@ clm slides slug-report course-specs/python-course.xml --json    # only the decks
 clm slides slug-report slides/ --exclude _archive --shipping-only
 ```
 
+### `clm slides coverage-report`
+
+*Added in CLM {version}.*
+
+Report **DE/EN completeness** per deck. Among count-mismatch validation errors,
+two very different situations hide — a deck that exists in only one language
+(needs *translation*, a big job) and a bilingual deck off by a cell or two (a
+small *alignment* fix). This separates them by counting `lang="de"` vs
+`lang="en"` slide cells per deck.
+
+```
+clm slides coverage-report [OPTIONS] PATH
+```
+
+`PATH` is a directory of slide files **or** a course spec `.xml` (resolved to
+its shipping decks). Each deck unit is classified:
+
+| Status | Meaning |
+|---|---|
+| `de_only` | DE present, EN missing — needs EN translation |
+| `en_only` | EN present, DE missing — needs DE translation |
+| `imbalanced` | both present, counts differ — an alignment fix (shown with `Δ`) |
+| `balanced` | equal DE/EN counts (not listed unless `--status balanced`) |
+
+Split `*.de.py` / `*.en.py` halves are scored as **one pair**; a half whose
+twin is absent counts the missing language as zero (so a lone `.de.py` reads as
+`de_only`). Only slide/subslide cells are counted — narrative (voiceover/notes)
+cells inherit their slide, so one-language speaker notes don't skew the result.
+
+| Option | Description |
+|--------|-------------|
+| `--status de_only\|en_only\|imbalanced\|balanced` | Show only decks with this status. |
+| `--only bilingual\|split` | Scope a **directory** scan to only bilingual decks or only split halves. |
+| `--exclude GLOB` | Skip decks matching `GLOB` (full path **and** each component; repeatable). |
+| `--shipping-only` | Scope a directory scan to decks reachable from course specs. |
+| `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
+| `--data-dir DIR` | Course data directory (contains `slides/`). For a spec `PATH` or `--shipping-only`. |
+| `--json` | Emit a JSON report (`by_status` counts + per-deck `de_cells`/`en_cells`/`delta`/`status`). |
+
+The exit code is always `0` — this is a report. Examples:
+
+```bash
+clm slides coverage-report slides/module_010/                   # everything not balanced
+clm slides coverage-report slides/ --status de_only             # just the untranslated decks
+clm slides coverage-report course-specs/python-course.xml --json
+clm slides coverage-report slides/ --exclude _archive --shipping-only
+```
+
 ### `clm slides sync`
 
 *Added in CLM {version}.*

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -68,6 +68,7 @@ def help(ctx):
 from clm.cli.commands._groups import (  # noqa: E402
     authoring_group,
     slides_group,
+    spec_group,
     topic_group,
 )
 from clm.cli.commands.assign_ids import assign_ids_cmd  # noqa: E402
@@ -93,6 +94,10 @@ from clm.cli.commands.release import release_group  # noqa: E402
 from clm.cli.commands.resolve_topic import resolve_topic_cmd  # noqa: E402
 from clm.cli.commands.search_slides import search_slides_cmd  # noqa: E402
 from clm.cli.commands.slides_sync import slides_sync_cmd  # noqa: E402
+from clm.cli.commands.spec_decks import (  # noqa: E402
+    referenced_by_cmd,
+    spec_decks_cmd,
+)
 from clm.cli.commands.split import split_cmd  # noqa: E402
 from clm.cli.commands.status import status  # noqa: E402
 from clm.cli.commands.suggest_sync import suggest_sync_cmd  # noqa: E402
@@ -167,10 +172,14 @@ slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
 slides_group.add_command(slides_sync_cmd, name="sync")
 slides_group.add_command(search_slides_cmd, name="search")
 slides_group.add_command(tidy_cmd, name="tidy")
+slides_group.add_command(referenced_by_cmd, name="referenced-by")
 cli.add_command(slides_group)
 
 topic_group.add_command(resolve_topic_cmd, name="resolve")
 cli.add_command(topic_group)
+
+spec_group.add_command(spec_decks_cmd, name="decks")
+cli.add_command(spec_group)
 
 authoring_group.add_command(authoring_rules_cmd, name="rules")
 cli.add_command(authoring_group)

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -83,6 +83,7 @@ from clm.cli.commands.completion import completion_cmd  # noqa: E402
 from clm.cli.commands.config import config  # noqa: E402
 from clm.cli.commands.course_gate import course_gate_cmd  # noqa: E402
 from clm.cli.commands.coverage import coverage_cmd  # noqa: E402
+from clm.cli.commands.coverage_report import coverage_report_cmd  # noqa: E402
 from clm.cli.commands.database import db, delete_database  # noqa: E402
 from clm.cli.commands.docker import docker_group  # noqa: E402
 from clm.cli.commands.git_ops import git_group  # noqa: E402
@@ -178,6 +179,7 @@ slides_group.add_command(search_slides_cmd, name="search")
 slides_group.add_command(tidy_cmd, name="tidy")
 slides_group.add_command(referenced_by_cmd, name="referenced-by")
 slides_group.add_command(slug_report_cmd, name="slug-report")
+slides_group.add_command(coverage_report_cmd, name="coverage-report")
 cli.add_command(slides_group)
 
 topic_group.add_command(resolve_topic_cmd, name="resolve")

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -101,6 +101,7 @@ from clm.cli.commands.spec_decks import (  # noqa: E402
     referenced_by_cmd,
     spec_decks_cmd,
 )
+from clm.cli.commands.spec_orphans import spec_orphans_cmd  # noqa: E402
 from clm.cli.commands.split import split_cmd  # noqa: E402
 from clm.cli.commands.status import status  # noqa: E402
 from clm.cli.commands.suggest_sync import suggest_sync_cmd  # noqa: E402
@@ -183,6 +184,7 @@ topic_group.add_command(resolve_topic_cmd, name="resolve")
 cli.add_command(topic_group)
 
 spec_group.add_command(spec_decks_cmd, name="decks")
+spec_group.add_command(spec_orphans_cmd, name="orphans")
 cli.add_command(spec_group)
 
 course_group.add_command(course_gate_cmd, name="gate")

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -67,6 +67,7 @@ def help(ctx):
 # Re-export commonly used functions for backwards compatibility with tests
 from clm.cli.commands._groups import (  # noqa: E402
     authoring_group,
+    course_group,
     slides_group,
     spec_group,
     topic_group,
@@ -80,6 +81,7 @@ from clm.cli.commands.build import (  # noqa: E402
 from clm.cli.commands.cassette import cassette_group  # noqa: E402
 from clm.cli.commands.completion import completion_cmd  # noqa: E402
 from clm.cli.commands.config import config  # noqa: E402
+from clm.cli.commands.course_gate import course_gate_cmd  # noqa: E402
 from clm.cli.commands.coverage import coverage_cmd  # noqa: E402
 from clm.cli.commands.database import db, delete_database  # noqa: E402
 from clm.cli.commands.docker import docker_group  # noqa: E402
@@ -180,6 +182,9 @@ cli.add_command(topic_group)
 
 spec_group.add_command(spec_decks_cmd, name="decks")
 cli.add_command(spec_group)
+
+course_group.add_command(course_gate_cmd, name="gate")
+cli.add_command(course_group)
 
 authoring_group.add_command(authoring_rules_cmd, name="rules")
 cli.add_command(authoring_group)

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -96,6 +96,7 @@ from clm.cli.commands.release import release_group  # noqa: E402
 from clm.cli.commands.resolve_topic import resolve_topic_cmd  # noqa: E402
 from clm.cli.commands.search_slides import search_slides_cmd  # noqa: E402
 from clm.cli.commands.slides_sync import slides_sync_cmd  # noqa: E402
+from clm.cli.commands.slug_report import slug_report_cmd  # noqa: E402
 from clm.cli.commands.spec_decks import (  # noqa: E402
     referenced_by_cmd,
     spec_decks_cmd,
@@ -175,6 +176,7 @@ slides_group.add_command(slides_sync_cmd, name="sync")
 slides_group.add_command(search_slides_cmd, name="search")
 slides_group.add_command(tidy_cmd, name="tidy")
 slides_group.add_command(referenced_by_cmd, name="referenced-by")
+slides_group.add_command(slug_report_cmd, name="slug-report")
 cli.add_command(slides_group)
 
 topic_group.add_command(resolve_topic_cmd, name="resolve")

--- a/src/clm/core/spec_decks.py
+++ b/src/clm/core/spec_decks.py
@@ -1,0 +1,196 @@
+"""Resolve a course spec to the deck files it actually pulls in.
+
+This is the operation a course-conversion agent had to reimplement as a
+throwaway script (gap #1 in ``docs/claude/course-conversion-tooling-gaps.md``):
+"which decks does this spec build?" The naive answer — guess from deck filename
+stems — is **wrong**, because a ``<topic>`` resolves to a topic *directory* and
+CLM builds **every** ``slides_*.py`` in it; the directory name often differs from
+the deck filenames (e.g. topic ``properties`` →
+``slides_properties.py`` *and* ``slides_property_setters.py``).
+
+The functions here mirror the build's resolution semantics exactly so the
+"shipping set" is correct:
+
+- topic → decks via :func:`clm.core.topic_resolver.build_topic_map` /
+  ``TopicMatch.slide_files`` (the same scan the build uses);
+- ``(topic_id, effective_module)`` binding via
+  :func:`clm.core.topic_resolver.matches_for_binding`;
+- **first-occurrence-wins** when an unbound topic ID matches multiple modules,
+  matching ``Course._build_topic_map``.
+
+Used by ``clm spec decks`` and ``clm slides referenced-by``; intended to be the
+single source of truth for the spec→deck operation that gaps #2 (deep validate),
+#3 (course gate), and #7 (orphans) will also need.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.core.course_spec import CourseSpec
+from clm.core.topic_resolver import (
+    TopicMatch,
+    build_topic_map,
+    matches_for_binding,
+)
+
+
+@dataclass
+class TopicDeckResolution:
+    """How one ``<topic>`` reference in a spec resolved to deck files."""
+
+    topic_id: str
+    section: str
+    """Human-readable section name (English) the topic was declared under."""
+    requested_module: str | None
+    """The effective module binding from the spec (``None`` = unbound)."""
+    path: Path | None = None
+    """The chosen topic directory/file (``None`` when unresolved)."""
+    resolved_module: str | None = None
+    """The module of the chosen match (``None`` when unresolved)."""
+    slide_files: list[Path] = field(default_factory=list)
+    """Deck files the chosen topic contributes, in build order."""
+    shadowed: list[TopicMatch] = field(default_factory=list)
+    """Other matches *not* chosen because of first-occurrence-wins."""
+
+    @property
+    def found(self) -> bool:
+        return self.path is not None
+
+
+@dataclass
+class SpecDeckResolution:
+    """The full set of decks a single spec pulls in."""
+
+    spec_path: Path
+    slides_dir: Path
+    topics: list[TopicDeckResolution] = field(default_factory=list)
+
+    @property
+    def unresolved(self) -> list[TopicDeckResolution]:
+        """Topic references that matched no directory on disk."""
+        return [t for t in self.topics if not t.found]
+
+    @property
+    def deck_files(self) -> list[Path]:
+        """Unique resolved deck paths across all topics, sorted by path.
+
+        A deck can legitimately be referenced by more than one topic only in
+        pathological specs; dedup keeps the shipping set honest either way.
+        """
+        seen: dict[Path, None] = {}
+        for topic in self.topics:
+            for deck in topic.slide_files:
+                seen.setdefault(deck, None)
+        return sorted(seen, key=lambda p: str(p))
+
+
+def resolve_spec_decks(
+    spec: CourseSpec,
+    slides_dir: Path,
+    *,
+    topic_map: dict[str, list[TopicMatch]] | None = None,
+) -> SpecDeckResolution:
+    """Resolve every ``<topic>`` in *spec* to its deck files.
+
+    Args:
+        spec: A parsed :class:`~clm.core.course_spec.CourseSpec`.
+        slides_dir: The course's ``slides/`` directory.
+        topic_map: A pre-built topic map (from
+            :func:`~clm.core.topic_resolver.build_topic_map`). Pass this when
+            resolving many specs against the same ``slides_dir`` to avoid
+            rescanning the filesystem per spec.
+
+    Returns:
+        A :class:`SpecDeckResolution` describing each topic reference and the
+        union of decks. Resolution mirrors the build: module-bound references
+        pick the match in that module; unbound references with multiple matches
+        pick the first (first-occurrence-wins), recording the rest as
+        ``shadowed``.
+    """
+    full_map = topic_map if topic_map is not None else build_topic_map(slides_dir)
+
+    topics: list[TopicDeckResolution] = []
+    for binding in spec.iter_topic_bindings():
+        topic_id = binding.topic_spec.id
+        module = binding.effective_module
+        candidates = matches_for_binding(full_map, topic_id, module)
+
+        resolution = TopicDeckResolution(
+            topic_id=topic_id,
+            section=binding.section.name.en,
+            requested_module=module,
+        )
+        if candidates:
+            chosen = candidates[0]
+            resolution.path = chosen.path
+            resolution.resolved_module = chosen.module
+            resolution.slide_files = list(chosen.slide_files)
+            resolution.shadowed = list(candidates[1:])
+        topics.append(resolution)
+
+    return SpecDeckResolution(
+        spec_path=spec_path_of(spec, slides_dir),
+        slides_dir=slides_dir,
+        topics=topics,
+    )
+
+
+def spec_path_of(spec: CourseSpec, slides_dir: Path) -> Path:
+    """Best-effort path label for a spec.
+
+    ``CourseSpec`` does not retain the file it was parsed from, so callers that
+    need the originating path should set it themselves. This returns the
+    ``slides_dir`` parent as a stable placeholder when nothing better is known.
+    """
+    return slides_dir.parent
+
+
+@dataclass
+class DeckReference:
+    """A spec/topic that pulls a given deck into its shipping set."""
+
+    spec_path: Path
+    topic_id: str
+    section: str
+    resolved_module: str | None
+
+
+def find_deck_references(
+    deck: Path,
+    spec_files: list[Path],
+    slides_dir: Path,
+    *,
+    topic_map: dict[str, list[TopicMatch]] | None = None,
+) -> list[DeckReference]:
+    """Reverse lookup: which specs/topics pull *deck* into their shipping set.
+
+    Args:
+        deck: A deck file to look up.
+        spec_files: Spec XML files to consider.
+        slides_dir: The shared ``slides/`` directory.
+        topic_map: Optional pre-built topic map (scanned once for all specs).
+
+    Returns:
+        One :class:`DeckReference` per (spec, topic) that resolves to *deck*.
+        Empty when the deck is unreferenced.
+    """
+    full_map = topic_map if topic_map is not None else build_topic_map(slides_dir)
+    target = deck.resolve()
+
+    references: list[DeckReference] = []
+    for spec_file in spec_files:
+        spec = CourseSpec.from_file(spec_file)
+        resolution = resolve_spec_decks(spec, slides_dir, topic_map=full_map)
+        for topic in resolution.topics:
+            if any(d.resolve() == target for d in topic.slide_files):
+                references.append(
+                    DeckReference(
+                        spec_path=spec_file,
+                        topic_id=topic.topic_id,
+                        section=topic.section,
+                        resolved_module=topic.resolved_module,
+                    )
+                )
+    return references

--- a/src/clm/core/spec_decks.py
+++ b/src/clm/core/spec_decks.py
@@ -194,3 +194,28 @@ def find_deck_references(
                     )
                 )
     return references
+
+
+def shipping_set(
+    spec_files: list[Path],
+    slides_dir: Path,
+    *,
+    topic_map: dict[str, list[TopicMatch]] | None = None,
+) -> set[Path]:
+    """The union of resolved deck paths across *spec_files*.
+
+    The "shipping set": every deck reachable from at least one spec, resolved
+    (so the members are absolute paths that compare equal to a deck found by a
+    filesystem walk). Specs that fail to parse are skipped. Reuses the same
+    build-faithful resolution as :func:`resolve_spec_decks`.
+    """
+    full_map = topic_map if topic_map is not None else build_topic_map(slides_dir)
+    decks: set[Path] = set()
+    for spec_file in spec_files:
+        try:
+            spec = CourseSpec.from_file(spec_file)
+        except Exception:
+            continue
+        resolution = resolve_spec_decks(spec, slides_dir, topic_map=full_map)
+        decks.update(d.resolve() for d in resolution.deck_files)
+    return decks

--- a/src/clm/core/spec_orphans.py
+++ b/src/clm/core/spec_orphans.py
@@ -1,0 +1,251 @@
+"""Find decks reachable from no spec, and classify them (gap #7).
+
+The inverse of :func:`clm.core.spec_decks.shipping_set`: given every spec in a
+course, which decks on disk does *no* spec pull in? Course conversions hit two
+flavours of orphan that must not be treated alike — an explicit ``_old`` /
+``_bak`` deck is superseded and safe to archive, but a ``_part1``…``_part5``
+series or a ``_short`` / ``_long`` length variant is **intentional alternate
+content** that blind archiving would delete. This module separates them by
+filename intent so the author can act on the right bucket, and surfaces
+gitignored ``.ipynb_checkpoints/`` cruft as its own category.
+
+Orphan detection is build-faithful: the shipping set comes from the same
+resolver the build uses, and the on-disk walk is extension-complete (``.py``,
+``.cpp``, ``.cs``, …) so it cannot miss a non-Python orphan the way a
+``*.py``-only walk would.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.core.spec_decks import shipping_set
+from clm.core.topic_resolver import TopicMatch, build_topic_map
+from clm.infrastructure.utils.path_utils import is_slides_file, split_lang_suffix
+
+__all__ = [
+    "CHECKPOINT_DIR_NAME",
+    "Orphan",
+    "OrphanKind",
+    "OrphanReport",
+    "classify_orphan",
+    "find_checkpoint_dirs",
+    "find_orphans",
+    "render_report",
+    "report_to_dict",
+]
+
+CHECKPOINT_DIR_NAME = ".ipynb_checkpoints"
+
+
+class OrphanKind(enum.Enum):
+    """Likely intent behind an unreferenced deck."""
+
+    SUPERSEDED = "superseded"  # explicit _old / _bak / numeric dup — safe to archive
+    ALTERNATE = "alternate"  # _partN / _short / _long — probably intentional
+    UNKNOWN = "unknown"  # no recognizable marker — needs a human look
+
+
+# Checked before the superseded patterns so a ``_part2`` is an alternate, never
+# a numeric-dup. Each entry: (compiled pattern on the lowercased stem, reason).
+_ALTERNATE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"_part\d+$"), "multi-part series (_partN)"),
+    (re.compile(r"_short$"), "length variant (_short)"),
+    (re.compile(r"_long$"), "length variant (_long)"),
+]
+
+_SUPERSEDED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"_old\d*$"), "explicit _old marker"),
+    (re.compile(r"_bak$"), "backup (_bak)"),
+    (re.compile(r"_backup$"), "backup (_backup)"),
+    (re.compile(r"_orig$"), "original (_orig)"),
+    (re.compile(r"_deprecated$"), "deprecated marker"),
+    (re.compile(r"_copy$"), "copy (_copy)"),
+    (re.compile(r"_v\d+$"), "old version (_vN)"),
+    (re.compile(r"_\d+$"), "numeric-suffixed duplicate"),
+]
+
+
+@dataclass
+class Orphan:
+    """An on-disk deck that no spec references."""
+
+    path: Path
+    kind: OrphanKind
+    reason: str
+
+
+@dataclass
+class OrphanReport:
+    """Outcome of an orphan scan over a course."""
+
+    orphans: list[Orphan] = field(default_factory=list)
+    checkpoints: list[Path] = field(default_factory=list)
+    total_decks: int = 0
+    shipping_count: int = 0
+
+    @property
+    def by_kind(self) -> dict[OrphanKind, list[Orphan]]:
+        out: dict[OrphanKind, list[Orphan]] = {k: [] for k in OrphanKind}
+        for orphan in self.orphans:
+            out[orphan.kind].append(orphan)
+        return out
+
+
+def _deck_stem(path: Path) -> str:
+    """Lowercased filename stem with the program-language and lang tag removed.
+
+    ``slides_intro_old.de.py`` → ``slides_intro_old`` so the marker patterns see
+    the authoring name, not the ``.de`` split tag.
+    """
+    name = path.name
+    suffix = path.suffix
+    stem = name[: -len(suffix)] if suffix else name
+    lang = split_lang_suffix(path)
+    if lang and stem.endswith(f".{lang}"):
+        stem = stem[: -(len(lang) + 1)]
+    return stem.lower()
+
+
+def classify_orphan(path: Path) -> tuple[OrphanKind, str]:
+    """Classify an orphan deck by filename intent.
+
+    Returns ``(kind, reason)``. Alternate patterns (``_partN`` / ``_short`` /
+    ``_long``) win over superseded ones so an intentional series is never
+    mislabeled as a numeric duplicate.
+    """
+    stem = _deck_stem(path)
+    for pattern, reason in _ALTERNATE_PATTERNS:
+        if pattern.search(stem):
+            return OrphanKind.ALTERNATE, reason
+    for pattern, reason in _SUPERSEDED_PATTERNS:
+        if pattern.search(stem):
+            return OrphanKind.SUPERSEDED, reason
+    return OrphanKind.UNKNOWN, "no recognizable marker"
+
+
+def _is_checkpoint(path: Path) -> bool:
+    return CHECKPOINT_DIR_NAME in path.parts
+
+
+def find_checkpoint_dirs(slides_dir: Path) -> list[Path]:
+    """Every ``.ipynb_checkpoints/`` directory under *slides_dir* (sorted)."""
+    return sorted(p.resolve() for p in slides_dir.rglob(CHECKPOINT_DIR_NAME) if p.is_dir())
+
+
+def _all_decks(slides_dir: Path) -> set[Path]:
+    """Every deck on disk under *slides_dir*, extension-complete, checkpoint-free.
+
+    Unlike ``find_slide_files_recursive`` (a ``*.py``-only rglob) this honours
+    every supported program-language extension via :func:`is_slides_file`, so a
+    ``.cs`` / ``.cpp`` orphan is not silently missed. Files inside a
+    ``.ipynb_checkpoints/`` dir are excluded — they are reported as cruft, not
+    as orphan decks.
+    """
+    return {
+        p.resolve()
+        for p in slides_dir.rglob("*")
+        if p.is_file() and is_slides_file(p) and not _is_checkpoint(p)
+    }
+
+
+def find_orphans(
+    spec_files: list[Path],
+    slides_dir: Path,
+    *,
+    topic_map: dict[str, list[TopicMatch]] | None = None,
+) -> OrphanReport:
+    """Scan a course for decks no spec references, plus checkpoint cruft.
+
+    *spec_files* is the **full** spec set (a deck unreferenced by one spec may
+    be pulled in by another, so orphans are computed against the union shipping
+    set). The returned :class:`OrphanReport` carries every orphan classified by
+    intent and every ``.ipynb_checkpoints/`` directory found.
+    """
+    full_map = topic_map if topic_map is not None else build_topic_map(slides_dir)
+    shipping = shipping_set(spec_files, slides_dir, topic_map=full_map)
+    decks = _all_decks(slides_dir)
+
+    orphans: list[Orphan] = []
+    for path in sorted(decks - shipping, key=str):
+        kind, reason = classify_orphan(path)
+        orphans.append(Orphan(path=path, kind=kind, reason=reason))
+
+    return OrphanReport(
+        orphans=orphans,
+        checkpoints=find_checkpoint_dirs(slides_dir),
+        total_decks=len(decks),
+        shipping_count=len(decks & shipping),
+    )
+
+
+def _rel(path: Path, base: Path) -> str:
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return str(path)
+
+
+_KIND_BLURB = {
+    OrphanKind.SUPERSEDED: "superseded (explicit _old / _bak / numeric dup — likely safe to archive)",
+    OrphanKind.ALTERNATE: "alternate (_partN / _short / _long — probably intentional content)",
+    OrphanKind.UNKNOWN: "unknown (no marker — review before archiving)",
+}
+
+
+def render_report(report: OrphanReport, base: Path) -> str:
+    """Human-readable orphan report, grouped by intent."""
+    lines: list[str] = []
+    by_kind = report.by_kind
+    for kind in (OrphanKind.UNKNOWN, OrphanKind.SUPERSEDED, OrphanKind.ALTERNATE):
+        group = by_kind[kind]
+        if not group:
+            continue
+        lines.append(f"## {_KIND_BLURB[kind]} — {len(group)}")
+        for orphan in group:
+            lines.append(f"  {_rel(orphan.path, base)}  ({orphan.reason})")
+        lines.append("")
+
+    if report.checkpoints:
+        lines.append(f"## .ipynb_checkpoints/ cruft — {len(report.checkpoints)}")
+        for ckpt in report.checkpoints:
+            lines.append(f"  {_rel(ckpt, base)}")
+        lines.append("")
+
+    if not report.orphans and not report.checkpoints:
+        return (
+            f"No orphans: all {report.total_decks} deck(s) are referenced by a spec, "
+            "and no .ipynb_checkpoints/ cruft found."
+        )
+
+    counts = {k: len(v) for k, v in by_kind.items()}
+    lines.append(
+        f"{report.total_decks} deck(s) on disk, {report.shipping_count} shipping, "
+        f"{len(report.orphans)} orphan(s) "
+        f"({counts[OrphanKind.UNKNOWN]} unknown, {counts[OrphanKind.SUPERSEDED]} superseded, "
+        f"{counts[OrphanKind.ALTERNATE]} alternate); "
+        f"{len(report.checkpoints)} checkpoint dir(s)."
+    )
+    return "\n".join(lines)
+
+
+def report_to_dict(report: OrphanReport) -> dict:
+    """JSON-serializable orphan report."""
+    return {
+        "total_decks": report.total_decks,
+        "shipping_count": report.shipping_count,
+        "orphan_count": len(report.orphans),
+        "by_kind": {kind.value: len(group) for kind, group in report.by_kind.items()},
+        "orphans": [
+            {
+                "path": str(o.path),
+                "kind": o.kind.value,
+                "reason": o.reason,
+            }
+            for o in report.orphans
+        ],
+        "checkpoints": [str(c) for c in report.checkpoints],
+    }

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -895,8 +895,20 @@ def assign_ids_in_directory(path: Path, options: AssignOptions) -> AssignResult:
     """
     from clm.core.topic_resolver import find_slide_files_recursive
 
+    return assign_ids_in_files(list(find_slide_files_recursive(path)), options)
+
+
+def assign_ids_in_files(files: list[Path], options: AssignOptions) -> AssignResult:
+    """Process an explicit list of slide files (the directory-walk body).
+
+    Factored out of :func:`assign_ids_in_directory` so callers that have already
+    selected a subset of decks — e.g. ``clm slides assign-ids --only bilingual``
+    / ``--exclude`` / ``--shipping-only`` — get the same split-pair-aware minting
+    without a second filesystem walk. Split pairs are still detected *within* the
+    given set: if only one half is present (e.g. its twin was excluded), that
+    half takes the per-file twin-aware path and the absent twin is never written.
+    """
     combined = AssignResult()
-    files = list(find_slide_files_recursive(path))
     fileset = set(files)
     handled: set[Path] = set()
 

--- a/src/clm/slides/course_gate.py
+++ b/src/clm/slides/course_gate.py
@@ -1,0 +1,258 @@
+"""Course readiness gate (course-conversion tooling gap #3).
+
+Runs the mechanical normalization passes a course conversion always needs — tag
+migration, DE/EN interleaving, and ``slide_id`` minting (content-derived) — over
+a spec's shipping decks (or a directory), then reports what was cleared
+mechanically versus what still needs a human.
+
+The split that matters: after the mechanical passes, the remaining work is either
+
+- **mechanically-fixable** — would be cleared by re-running the passes (it isn't,
+  in a dry run, because dry runs don't write); or
+- **needs-author** — the normalizer *refused* to touch it because doing so safely
+  needs a human: a ``slide_id`` with no derivable heading (hard refusal), a DE/EN
+  pair whose code diverged too far to auto-interleave (similarity failure), or a
+  DE/EN cell-count mismatch (a missing translation).
+
+This is the report a conversion agent hand-built as
+``docs/v18-remaining-validation-work.md``; making it a command turns every future
+validator bump into ``clm course gate <spec> --apply``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.slides.assign_ids import AssignOptions
+from clm.slides.normalizer import (
+    ALL_OPERATIONS,
+    Change,
+    NormalizationResult,
+    ReviewItem,
+    normalize_file,
+)
+from clm.slides.validation_summary import ValidationSummary, summarize_findings
+from clm.slides.validator import (
+    find_slide_files_recursive,
+    validate_files,
+)
+
+# The mechanical passes the gate runs by default, in normalizer order. Excludes
+# nothing safe: each either edits deterministically or refuses to a review item.
+DEFAULT_GATE_OPERATIONS: tuple[str, ...] = (
+    "tag_migration",
+    "workshop_tags",
+    "interleaving",
+    "slide_ids",
+)
+
+# ReviewItem.issue values that mean "a human must do this" — i.e. the normalizer
+# declined to act because a safe automatic fix does not exist.
+_NEEDS_AUTHOR_ISSUES = {
+    "slide_id_hard_refusal",
+    "count_mismatch",
+    "similarity_failure",
+}
+
+
+@dataclass
+class GateReport:
+    """The outcome of a course-gate run."""
+
+    scope: str
+    deck_count: int
+    applied: bool
+    operations: list[str]
+    baseline: ValidationSummary
+    changes: list[Change] = field(default_factory=list)
+    review_items: list[ReviewItem] = field(default_factory=list)
+    residual: ValidationSummary | None = None
+    """Post-apply validation rollup. ``None`` in a dry run (nothing was written)."""
+
+    @property
+    def changes_by_operation(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for c in self.changes:
+            counts[c.operation] = counts.get(c.operation, 0) + 1
+        return counts
+
+    @property
+    def needs_author(self) -> list[ReviewItem]:
+        """Review items that genuinely require a human (not soft, derivable cases)."""
+        return [
+            ri
+            for ri in self.review_items
+            if ri.issue in _NEEDS_AUTHOR_ISSUES or ri.issue.endswith("_hard_refusal")
+        ]
+
+    @property
+    def is_clean(self) -> bool:
+        """No author work and (if applied) no residual errors remain."""
+        if self.needs_author:
+            return False
+        if self.residual is not None and self.residual.by_severity.get("error", 0) > 0:
+            return False
+        return True
+
+    def to_dict(self) -> dict:
+        return {
+            "scope": self.scope,
+            "deck_count": self.deck_count,
+            "applied": self.applied,
+            "operations": self.operations,
+            "baseline": self.baseline.to_dict(),
+            "mechanical": {
+                "total": len(self.changes),
+                "by_operation": self.changes_by_operation,
+            },
+            "needs_author": [
+                {
+                    "file": ri.file,
+                    "issue": ri.issue,
+                    "suggestion": ri.suggestion,
+                    "line": ri.details.get("line"),
+                }
+                for ri in self.needs_author
+            ],
+            "residual": self.residual.to_dict() if self.residual is not None else None,
+            "is_clean": self.is_clean,
+        }
+
+
+def scope_decks(target: Path, slides_dir: Path) -> list[Path]:
+    """The decks a gate run covers: a spec's shipping set, or a directory walk."""
+    if target.is_file() and target.suffix.lower() == ".xml":
+        from clm.core.course_spec import CourseSpec
+        from clm.core.spec_decks import resolve_spec_decks
+
+        spec = CourseSpec.from_file(target)
+        return resolve_spec_decks(spec, slides_dir).deck_files
+    if target.is_dir():
+        return find_slide_files_recursive(target)
+    if target.is_file():
+        return [target]
+    return []
+
+
+def run_course_gate(
+    target: Path,
+    slides_dir: Path,
+    *,
+    operations: list[str] | None = None,
+    apply: bool = False,
+    checks: list[str] | None = None,
+) -> GateReport:
+    """Run the mechanical passes over *target* and report readiness.
+
+    Args:
+        target: A course spec ``.xml`` (uses its shipping set), a directory, or a
+            single deck file.
+        slides_dir: The course ``slides/`` directory.
+        operations: Mechanical passes to run (normalizer operation names).
+            Defaults to :data:`DEFAULT_GATE_OPERATIONS`.
+        apply: When ``True``, write the mechanical fixes and re-validate; when
+            ``False`` (default), run every pass in dry-run mode and report what
+            *would* change without touching disk.
+        checks: Validation checks to run (forwarded to the validator).
+
+    Returns:
+        A :class:`GateReport`.
+    """
+    ops = list(operations) if operations else list(DEFAULT_GATE_OPERATIONS)
+    invalid = set(ops) - set(ALL_OPERATIONS)
+    if invalid:
+        raise ValueError(
+            f"Unknown operation(s): {', '.join(sorted(invalid))}. "
+            f"Valid: {', '.join(sorted(ALL_OPERATIONS))}"
+        )
+
+    decks = scope_decks(target, slides_dir)
+    baseline = summarize_findings(validate_files(decks, checks=checks).findings)
+
+    # Content-derived minting is the whole point: a conversion accepts the
+    # heading-derived slug rather than refusing every id-less slide.
+    assign_options = AssignOptions(accept_content_derived=True)
+
+    combined = NormalizationResult()
+    for deck in decks:
+        result = normalize_file(
+            deck,
+            operations=ops,
+            dry_run=not apply,
+            assign_options=assign_options,
+        )
+        combined.files_modified += result.files_modified
+        combined.changes.extend(result.changes)
+        combined.review_items.extend(result.review_items)
+
+    residual = None
+    if apply:
+        residual = summarize_findings(validate_files(decks, checks=checks).findings)
+
+    return GateReport(
+        scope=str(target),
+        deck_count=len(decks),
+        applied=apply,
+        operations=ops,
+        baseline=baseline,
+        changes=combined.changes,
+        review_items=combined.review_items,
+        residual=residual,
+    )
+
+
+def render_report(report: GateReport, *, top_author: int = 40) -> list[str]:
+    """Render a :class:`GateReport` as human-readable lines."""
+    lines: list[str] = []
+    mode = "applied" if report.applied else "dry-run"
+    lines.append(f"Course gate ({mode}): {report.scope}")
+    lines.append(f"Scope: {report.deck_count} deck(s); operations: {', '.join(report.operations)}")
+
+    base = report.baseline.by_severity
+    lines.append("")
+    lines.append(f"Baseline: {base.get('error', 0)} error(s), {base.get('warning', 0)} warning(s)")
+
+    verb = "Applied" if report.applied else "Would apply"
+    lines.append("")
+    lines.append(f"Mechanical passes — {verb} {len(report.changes)} change(s):")
+    by_op = report.changes_by_operation
+    if by_op:
+        for op in sorted(by_op):
+            lines.append(f"  {op}: {by_op[op]}")
+    else:
+        lines.append("  (none)")
+
+    author = report.needs_author
+    lines.append("")
+    if author:
+        lines.append(f"Needs author — {len(author)} item(s):")
+        for ri in author[:top_author]:
+            line_no = ri.details.get("line")
+            loc = f"{ri.file}:{line_no}" if line_no else ri.file
+            lines.append(f"  [{ri.issue}] {loc}")
+            if ri.suggestion:
+                lines.append(f"      {ri.suggestion}")
+        remaining = len(author) - min(len(author), top_author)
+        if remaining > 0:
+            lines.append(f"  … and {remaining} more author item(s)")
+    else:
+        lines.append("Needs author — none.")
+
+    if report.residual is not None:
+        res = report.residual.by_severity
+        lines.append("")
+        lines.append(
+            f"Residual after apply: {res.get('error', 0)} error(s), "
+            f"{res.get('warning', 0)} warning(s)"
+        )
+
+    lines.append("")
+    if report.is_clean:
+        lines.append("Readiness: MECHANICALLY CLEAN — no author work detected.")
+    else:
+        n = len(author)
+        suffix = f"{n} author item(s)" if n else "residual errors remain"
+        lines.append(f"Readiness: NEEDS AUTHOR — {suffix}.")
+
+    return lines

--- a/src/clm/slides/deck_scope.py
+++ b/src/clm/slides/deck_scope.py
@@ -1,0 +1,112 @@
+"""Scope a set of deck files down to part of a corpus (gap #4).
+
+Conversions routinely want to touch only *part* of a slides tree — mint ids on
+the bilingual decks but leave ``.de.py`` / ``.en.py`` split pairs for
+``clm slides sync``; skip an ``_archive/`` directory; touch only the decks that
+actually ship. The agent that hit this did it by running over everything and then
+``git checkout``-ing the files it shouldn't have touched — clumsy and error-prone.
+
+This module centralizes the three predicates so ``clm slides assign-ids`` and
+``clm slides normalize`` (and anything else operating on a deck set) share one
+implementation:
+
+- ``--only bilingual|split`` — keep only bilingual decks (no ``.de``/``.en`` tag)
+  or only split halves;
+- ``--exclude GLOB`` — drop decks matching a glob (matched against the full path
+  *and* each path component, so ``--exclude _archive`` drops an ``_archive/`` dir);
+- ``--shipping-only`` — keep only decks reachable from a course spec.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from collections.abc import Iterable
+from pathlib import Path
+
+from clm.slides.pairing import split_lang_tag
+
+
+def _matches_any_glob(path: Path, patterns: Iterable[str]) -> bool:
+    """Whether *path* matches any of *patterns*.
+
+    A pattern matches if it globs the full POSIX path string or any single path
+    component — so a bare ``_archive`` drops every deck under an ``_archive/``
+    directory without the caller needing ``*/_archive/*``.
+    """
+    posix = path.as_posix()
+    parts = path.parts
+    for pat in patterns:
+        if fnmatch.fnmatch(posix, pat) or any(fnmatch.fnmatch(part, pat) for part in parts):
+            return True
+    return False
+
+
+def _keep_for_only(path: Path, only: str | None) -> bool:
+    """Apply the ``--only bilingual|split`` filter to a single deck."""
+    if only is None:
+        return True
+    tag = split_lang_tag(path)
+    if only == "bilingual":
+        return tag is None
+    if only == "split":
+        return tag is not None
+    raise ValueError(f"Unknown --only value: {only!r} (expected 'bilingual' or 'split')")
+
+
+def filter_decks(
+    files: Iterable[Path],
+    *,
+    only: str | None = None,
+    exclude: Iterable[str] = (),
+    shipping: set[Path] | None = None,
+) -> list[Path]:
+    """Return the decks in *files* that pass every active scope predicate.
+
+    Args:
+        files: Candidate deck paths.
+        only: ``"bilingual"``, ``"split"``, or ``None`` (no language filter).
+        exclude: Glob patterns; a deck matching any is dropped.
+        shipping: When given, keep only decks whose resolved path is in this set
+            (the shipping set from :func:`clm.core.spec_decks.shipping_set`).
+
+    Returns:
+        The surviving decks, order preserved.
+    """
+    exclude = tuple(exclude)
+    kept: list[Path] = []
+    for f in files:
+        if not _keep_for_only(f, only):
+            continue
+        if exclude and _matches_any_glob(f, exclude):
+            continue
+        if shipping is not None and f.resolve() not in shipping:
+            continue
+        kept.append(f)
+    return kept
+
+
+def course_root_for_path(path: Path) -> Path | None:
+    """Infer the course root (the parent of ``slides/``) from a slides path.
+
+    Returns ``None`` when no ``slides`` ancestor is found, so callers can fall
+    back to an explicit ``--specs-dir`` / ``--data-dir``.
+    """
+    resolved = path.resolve()
+    if resolved.name == "slides":
+        return resolved.parent
+    for parent in resolved.parents:
+        if parent.name == "slides":
+            return parent.parent
+    return None
+
+
+def resolve_shipping_set(specs_dir: Path, slides_dir: Path) -> set[Path]:
+    """The shipping set across every ``*.xml`` spec in *specs_dir*.
+
+    Thin wrapper over :func:`clm.core.spec_decks.shipping_set` so deck-scoping
+    callers don't each re-glob the specs directory.
+    """
+    from clm.core.spec_decks import shipping_set
+
+    spec_files = sorted(specs_dir.glob("*.xml"))
+    return shipping_set(spec_files, slides_dir)

--- a/src/clm/slides/lang_coverage.py
+++ b/src/clm/slides/lang_coverage.py
@@ -1,0 +1,234 @@
+"""DE/EN completeness report for slide decks (gap #8).
+
+Among count-mismatch validation errors, two very different situations hide:
+a deck that exists in only one language (needs *translation* — a big job) and
+a deck that is bilingual but off by a cell or two (a small *alignment* fix).
+Telling them apart at corpus scale means counting ``lang="de"`` vs ``lang="en"``
+slide cells per deck, which course conversions did with throwaway scripts.
+
+This module makes that a report. It handles both deck shapes:
+
+- **bilingual** decks (no ``.de``/``.en`` filename tag) carry both languages'
+  cells interleaved — we count each language within the file;
+- **split** decks (``*.de.py`` / ``*.en.py``) hold one language per file — we
+  count the pair's two halves together, and a half whose twin is absent counts
+  the missing side as zero (i.e. that language is untranslated).
+
+Only slide/subslide *start* cells are counted; narrative (voiceover/notes)
+cells inherit their slide and are excluded so a deck with one-language speaker
+notes is not misreported as imbalanced.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.slides.pairing import iter_split_pairs, split_lang_tag
+from clm.slides.raw_cells import split_cells
+
+__all__ = [
+    "CoverageEntry",
+    "CoverageReport",
+    "CoverageStatus",
+    "classify_counts",
+    "count_languages",
+    "render_report",
+    "report_to_dict",
+    "scan_coverage",
+]
+
+
+class CoverageStatus(enum.Enum):
+    """DE/EN completeness of one deck unit."""
+
+    BALANCED = "balanced"  # equal DE and EN slide counts (incl. 0/0)
+    DE_ONLY = "de_only"  # DE present, EN missing — needs EN translation
+    EN_ONLY = "en_only"  # EN present, DE missing — needs DE translation
+    IMBALANCED = "imbalanced"  # both present, counts differ — alignment fix
+
+
+def count_languages(text: str) -> tuple[int, int]:
+    """Return ``(de_cells, en_cells)`` — slide/subslide start cells by language.
+
+    Narrative cells and language-neutral cells (``lang`` unset) are not counted.
+    """
+    de = en = 0
+    _, cells = split_cells(text)
+    for cell in cells:
+        if not cell.metadata.is_slide_start:
+            continue
+        if cell.metadata.lang == "de":
+            de += 1
+        elif cell.metadata.lang == "en":
+            en += 1
+    return de, en
+
+
+def classify_counts(de: int, en: int) -> CoverageStatus:
+    """Classify a ``(de, en)`` slide-count pair."""
+    if de == en:
+        return CoverageStatus.BALANCED
+    if en == 0:
+        return CoverageStatus.DE_ONLY
+    if de == 0:
+        return CoverageStatus.EN_ONLY
+    return CoverageStatus.IMBALANCED
+
+
+@dataclass
+class CoverageEntry:
+    """DE/EN completeness of one deck unit (a file or a split pair)."""
+
+    label: str
+    kind: str  # "bilingual" / "split-pair" / "split-half"
+    de_cells: int
+    en_cells: int
+    status: CoverageStatus
+
+    @property
+    def delta(self) -> int:
+        return abs(self.de_cells - self.en_cells)
+
+
+@dataclass
+class CoverageReport:
+    """Outcome of a DE/EN coverage scan."""
+
+    entries: list[CoverageEntry] = field(default_factory=list)
+
+    @property
+    def by_status(self) -> dict[CoverageStatus, list[CoverageEntry]]:
+        out: dict[CoverageStatus, list[CoverageEntry]] = {s: [] for s in CoverageStatus}
+        for entry in self.entries:
+            out[entry.status].append(entry)
+        return out
+
+    @property
+    def incomplete(self) -> list[CoverageEntry]:
+        """Everything that is not balanced (needs translation or alignment)."""
+        return [e for e in self.entries if e.status != CoverageStatus.BALANCED]
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def scan_coverage(files: list[Path]) -> CoverageReport:
+    """Build a DE/EN coverage report over a set of slide files.
+
+    Split ``.de.py`` / ``.en.py`` halves present in *files* are scored as one
+    pair; a half whose twin is absent from *files* is scored alone (its missing
+    language counts as zero). Bilingual files are scored in place.
+    """
+    pairs, solos = iter_split_pairs(files)
+    report = CoverageReport()
+
+    for de_path, en_path in pairs:
+        de_text, en_text = _read(de_path), _read(en_path)
+        if de_text is None or en_text is None:
+            continue
+        de_cells = count_languages(de_text)[0]
+        en_cells = count_languages(en_text)[1]
+        report.entries.append(
+            CoverageEntry(
+                label=str(de_path),
+                kind="split-pair",
+                de_cells=de_cells,
+                en_cells=en_cells,
+                status=classify_counts(de_cells, en_cells),
+            )
+        )
+
+    for solo in solos:
+        text = _read(solo)
+        if text is None:
+            continue
+        tag = split_lang_tag(solo)
+        de_cells, en_cells = count_languages(text)
+        if tag is None:
+            kind = "bilingual"
+        else:
+            # A lone split half: only its own language is present on disk.
+            kind = "split-half"
+            de_cells, en_cells = (de_cells, 0) if tag == "de" else (0, en_cells)
+        report.entries.append(
+            CoverageEntry(
+                label=str(solo),
+                kind=kind,
+                de_cells=de_cells,
+                en_cells=en_cells,
+                status=classify_counts(de_cells, en_cells),
+            )
+        )
+
+    report.entries.sort(key=lambda e: e.label)
+    return report
+
+
+_STATUS_BLURB = {
+    CoverageStatus.EN_ONLY: "EN-only (needs DE translation)",
+    CoverageStatus.DE_ONLY: "DE-only (needs EN translation)",
+    CoverageStatus.IMBALANCED: "imbalanced (both languages present, counts differ)",
+}
+
+
+def _rel(label: str, base: Path | None) -> str:
+    if base is None:
+        return label
+    try:
+        return str(Path(label).relative_to(base))
+    except ValueError:
+        return label
+
+
+def render_report(report: CoverageReport, *, base: Path | None = None) -> str:
+    """Human-readable coverage report; balanced decks are summarized, not listed."""
+    by_status = report.by_status
+    if not report.incomplete:
+        return f"All {len(report.entries)} deck(s) are DE/EN balanced."
+
+    lines: list[str] = []
+    for status in (CoverageStatus.EN_ONLY, CoverageStatus.DE_ONLY, CoverageStatus.IMBALANCED):
+        group = by_status[status]
+        if not group:
+            continue
+        lines.append(f"## {_STATUS_BLURB[status]} — {len(group)}")
+        for entry in group:
+            extra = f", Δ{entry.delta}" if status == CoverageStatus.IMBALANCED else ""
+            lines.append(
+                f"  {_rel(entry.label, base)}  "
+                f"[{entry.kind}] de={entry.de_cells} en={entry.en_cells}{extra}"
+            )
+        lines.append("")
+
+    counts = {s: len(g) for s, g in by_status.items()}
+    lines.append(
+        f"{len(report.entries)} deck(s): {counts[CoverageStatus.BALANCED]} balanced, "
+        f"{counts[CoverageStatus.EN_ONLY]} EN-only, {counts[CoverageStatus.DE_ONLY]} DE-only, "
+        f"{counts[CoverageStatus.IMBALANCED]} imbalanced."
+    )
+    return "\n".join(lines)
+
+
+def report_to_dict(report: CoverageReport) -> dict:
+    """JSON-serializable coverage report."""
+    return {
+        "total": len(report.entries),
+        "by_status": {s.value: len(g) for s, g in report.by_status.items()},
+        "decks": [
+            {
+                "label": e.label,
+                "kind": e.kind,
+                "de_cells": e.de_cells,
+                "en_cells": e.en_cells,
+                "delta": e.delta,
+                "status": e.status.value,
+            }
+            for e in report.entries
+        ],
+    }

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -721,7 +721,29 @@ def normalize_directory(
     canonicalize_start_completed: bool = False,
 ) -> NormalizationResult:
     """Normalize all slide files in a directory (recursive)."""
-    slide_files = find_slide_files_recursive(path)
+    return normalize_files(
+        find_slide_files_recursive(path),
+        operations=operations,
+        dry_run=dry_run,
+        assign_options=assign_options,
+        canonicalize_start_completed=canonicalize_start_completed,
+    )
+
+
+def normalize_files(
+    slide_files: list[Path],
+    *,
+    operations: list[str] | None = None,
+    dry_run: bool = False,
+    assign_options: AssignOptions | None = None,
+    canonicalize_start_completed: bool = False,
+) -> NormalizationResult:
+    """Normalize an explicit list of slide files.
+
+    Factored out of :func:`normalize_directory` so a caller that has already
+    selected a subset of decks (``clm slides normalize --only`` / ``--exclude``
+    / ``--shipping-only``) normalizes exactly that set without a second walk.
+    """
     combined = NormalizationResult()
 
     for sf in slide_files:

--- a/src/clm/slides/refusal_report.py
+++ b/src/clm/slides/refusal_report.py
@@ -1,0 +1,245 @@
+"""Build an authoring worklist from ``assign-ids`` refusals (gap #5).
+
+``clm slides assign-ids`` already reports each refused ``file:line`` and,
+for soft refusals, a proposed slug. But to actually *author* a good
+``slide_id`` by hand — which is the only way to clear a **hard** refusal —
+you need each cell's body and the surrounding slide context (the nearest
+preceding ``slide_id`` and heading so you know *where* in the deck you
+are). Course conversions extracted that with throwaway scripts; this
+module makes it a first-class report.
+
+The worklist is a post-processing layer over :class:`AssignResult`: the
+engine stays unchanged and emits cheap ``Refusal`` records (``file:line``
+plus reason/proposal). Only when context is requested do we re-read the
+affected files — a small subset — and pull each refused cell's marker,
+body, and preceding anchors back out. This mirrors how
+:mod:`clm.slides.validation_summary` layers on top of the validator.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.slides.assign_ids import Refusal
+from clm.slides.headingless import extract_heading
+from clm.slides.raw_cells import RawCell, split_cells
+from clm.slides.slug import strip_preserve_marker
+
+__all__ = [
+    "RefusalContext",
+    "RefusalEntry",
+    "RefusalWorklist",
+    "build_refusal_worklist",
+    "render_worklist",
+    "worklist_to_dict",
+]
+
+
+@dataclass
+class RefusalContext:
+    """Authoring context for one refused cell, recovered from its file."""
+
+    marker: str  # the cell header line, verbatim
+    cell_type: str  # "markdown" / "code" / "j2"
+    lang: str | None
+    body: str  # the cell body, verbatim (trailing blank lines stripped)
+    preceding_slide_id: str | None  # nearest preceding bare slide_id
+    preceding_heading: str | None  # nearest preceding markdown heading text
+
+
+@dataclass
+class RefusalEntry:
+    """One refusal, optionally enriched with :class:`RefusalContext`."""
+
+    file: str
+    line: int
+    severity: str  # "soft" / "hard"
+    reason: str
+    proposed_slug: str | None = None
+    proposed_title: str | None = None
+    context: RefusalContext | None = None
+
+
+@dataclass
+class RefusalWorklist:
+    """The hand-authoring worklist: every refusal, hard ones first."""
+
+    entries: list[RefusalEntry] = field(default_factory=list)
+
+    @property
+    def hard(self) -> list[RefusalEntry]:
+        return [e for e in self.entries if e.severity == "hard"]
+
+    @property
+    def soft(self) -> list[RefusalEntry]:
+        return [e for e in self.entries if e.severity == "soft"]
+
+
+def _strip_trailing_blank(body: str) -> str:
+    lines = body.split("\n")
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines)
+
+
+def _preceding_anchors(cells: list[RawCell], idx: int) -> tuple[str | None, str | None]:
+    """Nearest preceding ``slide_id`` and heading for the cell at ``idx``.
+
+    The two anchors are found independently — the closest preceding cell
+    that carries a ``slide_id`` and the closest preceding cell whose body
+    has a markdown heading need not be the same cell. We stop as soon as
+    both are known.
+    """
+    found_id: str | None = None
+    found_heading: str | None = None
+    for j in range(idx - 1, -1, -1):
+        cell = cells[j]
+        if found_id is None and cell.metadata.slide_id:
+            found_id = strip_preserve_marker(cell.metadata.slide_id)
+        if found_heading is None:
+            heading = extract_heading(cell.body)
+            if heading:
+                found_heading = heading
+        if found_id is not None and found_heading is not None:
+            break
+    return found_id, found_heading
+
+
+def _context_for_file(refusals: list[Refusal], text: str) -> dict[int, RefusalContext]:
+    """Map each refused line in one file to its recovered context."""
+    _, cells = split_cells(text)
+    by_line: dict[int, int] = {cell.line_number: i for i, cell in enumerate(cells)}
+    out: dict[int, RefusalContext] = {}
+    for refusal in refusals:
+        idx = by_line.get(refusal.line)
+        if idx is None:
+            continue
+        cell = cells[idx]
+        slide_id, heading = _preceding_anchors(cells, idx)
+        out[refusal.line] = RefusalContext(
+            marker=cell.header,
+            cell_type=cell.metadata.cell_type,
+            lang=cell.metadata.lang,
+            body=_strip_trailing_blank(cell.body),
+            preceding_slide_id=slide_id,
+            preceding_heading=heading,
+        )
+    return out
+
+
+def build_refusal_worklist(
+    refusals: list[Refusal], *, with_context: bool = False
+) -> RefusalWorklist:
+    """Turn engine ``Refusal`` records into an authoring worklist.
+
+    With ``with_context`` the affected files are re-read once each and every
+    refused cell is enriched with its marker, body, and preceding
+    ``slide_id``/heading anchors. Without it the worklist carries only the
+    cheap ``file:line``/reason/proposal data already in ``refusals`` (no
+    file reads). Hard refusals sort before soft ones; within a severity the
+    original ``(file, line)`` order is preserved.
+    """
+    context_by_file: dict[str, dict[int, RefusalContext]] = {}
+    if with_context:
+        grouped: dict[str, list[Refusal]] = defaultdict(list)
+        for refusal in refusals:
+            grouped[refusal.file].append(refusal)
+        for file_str, file_refusals in grouped.items():
+            try:
+                text = Path(file_str).read_text(encoding="utf-8")
+            except OSError:
+                continue
+            context_by_file[file_str] = _context_for_file(file_refusals, text)
+
+    entries = [
+        RefusalEntry(
+            file=refusal.file,
+            line=refusal.line,
+            severity=refusal.severity,
+            reason=refusal.reason,
+            proposed_slug=refusal.proposed_slug,
+            proposed_title=refusal.proposed_title,
+            context=context_by_file.get(refusal.file, {}).get(refusal.line),
+        )
+        for refusal in refusals
+    ]
+    # Hard first, then soft; stable within each severity.
+    entries.sort(key=lambda e: 0 if e.severity == "hard" else 1)
+    return RefusalWorklist(entries=entries)
+
+
+def _render_entry(entry: RefusalEntry) -> list[str]:
+    out = [f"─── {entry.file}:{entry.line}  [{entry.severity}]"]
+    out.append(f"    reason: {entry.reason}")
+    if entry.proposed_slug or entry.proposed_title:
+        bits = []
+        if entry.proposed_title:
+            bits.append(f'title="{entry.proposed_title}"')
+        if entry.proposed_slug:
+            bits.append(f'proposed slide_id="{entry.proposed_slug}"')
+        out.append("    " + ", ".join(bits))
+    ctx = entry.context
+    if ctx is not None:
+        anchor_bits = []
+        if ctx.preceding_slide_id:
+            anchor_bits.append(f'after slide_id="{ctx.preceding_slide_id}"')
+        if ctx.preceding_heading:
+            anchor_bits.append(f'heading "{ctx.preceding_heading}"')
+        if anchor_bits:
+            out.append("    " + " / ".join(anchor_bits))
+        else:
+            out.append("    (no preceding slide_id/heading — start of deck)")
+        out.append(f"    | {ctx.marker}")
+        for line in ctx.body.split("\n"):
+            out.append(f"    | {line}")
+    return out
+
+
+def render_worklist(worklist: RefusalWorklist) -> str:
+    """Human-readable worklist; hard refusals first, then soft."""
+    if not worklist.entries:
+        return "No refusals — every slide either has or was assigned an id."
+    lines: list[str] = []
+    for entry in worklist.entries:
+        lines.extend(_render_entry(entry))
+        lines.append("")
+    lines.append(
+        f"{len(worklist.hard)} hard refusal(s) (need a hand-authored slide_id), "
+        f"{len(worklist.soft)} soft refusal(s)."
+    )
+    return "\n".join(lines)
+
+
+def worklist_to_dict(worklist: RefusalWorklist) -> dict:
+    """JSON-serializable worklist."""
+
+    def ctx_dict(ctx: RefusalContext | None) -> dict | None:
+        if ctx is None:
+            return None
+        return {
+            "marker": ctx.marker,
+            "cell_type": ctx.cell_type,
+            "lang": ctx.lang,
+            "body": ctx.body,
+            "preceding_slide_id": ctx.preceding_slide_id,
+            "preceding_heading": ctx.preceding_heading,
+        }
+
+    return {
+        "hard_refusals": len(worklist.hard),
+        "soft_refusals": len(worklist.soft),
+        "refusals": [
+            {
+                "file": e.file,
+                "line": e.line,
+                "severity": e.severity,
+                "reason": e.reason,
+                "proposed_slug": e.proposed_slug,
+                "proposed_title": e.proposed_title,
+                "context": ctx_dict(e.context),
+            }
+            for e in worklist.entries
+        ],
+    }

--- a/src/clm/slides/slug_quality.py
+++ b/src/clm/slides/slug_quality.py
@@ -1,0 +1,277 @@
+"""Flag low-quality ``slide_id`` slugs for review (gap #6).
+
+Bulk minting with ``assign-ids --accept-content-derived`` can produce
+thousands of ids, most fine but a minority low-information: single generic
+tokens (``data`` / ``true`` / ``value``), very short code-identifier-shaped
+slugs (``cp`` / ``df`` / ``os``), or slugs that hit the 30-char cap and lost
+their trailing words. Scanning all 3,000 by hand to find those is the chore
+this module removes: it classifies each slug by cheap, source-independent
+heuristics so the author reviews only the flagged minority.
+
+The heuristics judge the slug *string* — they do not re-run extraction or
+need the cell. A flag is a "worth a look", not a verdict: ``introduction``
+is a single token and perfectly good, so :data:`SlugIssue.SINGLE_TOKEN` is
+``low`` severity. The high-confidence signals are the very-short and generic
+ones. ``title`` (the reserved id for ``header()`` macro slides) is never
+flagged.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.slides.pairing import TITLE_SLIDE_ID
+from clm.slides.raw_cells import split_cells
+from clm.slides.slug import MAX_SLUG_LENGTH, strip_preserve_marker
+
+__all__ = [
+    "ISSUE_SEVERITY",
+    "SEVERITY_ORDER",
+    "SlugFinding",
+    "SlugIssue",
+    "SlugReport",
+    "classify_slug",
+    "render_report",
+    "report_to_dict",
+    "scan_slug_quality",
+]
+
+# A single token at or below this length reads as an abbreviation / code
+# identifier (``cp``, ``df``, ``os``, ``np``) rather than a descriptive title.
+VERY_SHORT_MAX = 3
+
+# A slug this close to the 30-char cap was almost certainly trimmed: the
+# slugifier drops trailing words (or hard-truncates a long first token) only
+# when the joined form would exceed MAX_SLUG_LENGTH, so trailing context was
+# likely lost.
+TRUNCATION_THRESHOLD = MAX_SLUG_LENGTH - 2  # 28
+
+# Single-token slugs that carry no topical information. Deliberately curated
+# and conservative — these are flagged ``high`` because a lone one of them is
+# almost never the title an author would choose.
+GENERIC_WORDS = frozenset(
+    {
+        "data",
+        "value",
+        "values",
+        "true",
+        "false",
+        "none",
+        "null",
+        "foo",
+        "bar",
+        "baz",
+        "tmp",
+        "temp",
+        "output",
+        "input",
+        "result",
+        "results",
+        "code",
+        "example",
+        "examples",
+        "demo",
+        "test",
+        "todo",
+        "stuff",
+        "thing",
+        "things",
+        "item",
+        "items",
+        "misc",
+        "other",
+        "untitled",
+    }
+)
+
+
+class SlugIssue(enum.Enum):
+    """A reviewable quality signal on a slug."""
+
+    VERY_SHORT = "very_short"
+    GENERIC = "generic"
+    POSSIBLY_TRUNCATED = "possibly_truncated"
+    SINGLE_TOKEN = "single_token"
+
+
+ISSUE_SEVERITY: dict[SlugIssue, str] = {
+    SlugIssue.VERY_SHORT: "high",
+    SlugIssue.GENERIC: "high",
+    SlugIssue.POSSIBLY_TRUNCATED: "medium",
+    SlugIssue.SINGLE_TOKEN: "low",
+}
+
+SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+def classify_slug(slide_id: str) -> list[SlugIssue]:
+    """Return the quality issues a slug exhibits (empty == looks fine).
+
+    Heuristics on the bare (preserve-marker-stripped) slug:
+
+    - length ``>= TRUNCATION_THRESHOLD`` → ``POSSIBLY_TRUNCATED``;
+    - exactly one token of length ``<= VERY_SHORT_MAX`` → ``VERY_SHORT``;
+    - exactly one token in :data:`GENERIC_WORDS` → ``GENERIC``;
+    - any other single-token slug → ``SINGLE_TOKEN`` (informational).
+
+    The reserved ``title`` id and the empty string are never flagged.
+    """
+    bare = strip_preserve_marker(slide_id)
+    if not bare or bare == TITLE_SLIDE_ID:
+        return []
+
+    issues: list[SlugIssue] = []
+    if len(bare) >= TRUNCATION_THRESHOLD:
+        issues.append(SlugIssue.POSSIBLY_TRUNCATED)
+
+    tokens = bare.split("-")
+    if len(tokens) == 1:
+        tok = tokens[0]
+        if len(tok) <= VERY_SHORT_MAX:
+            issues.append(SlugIssue.VERY_SHORT)
+        elif tok in GENERIC_WORDS:
+            issues.append(SlugIssue.GENERIC)
+        else:
+            issues.append(SlugIssue.SINGLE_TOKEN)
+
+    return issues
+
+
+@dataclass
+class SlugFinding:
+    """One slide_id flagged for review."""
+
+    file: str
+    line: int
+    slide_id: str
+    issues: list[SlugIssue]
+
+    @property
+    def severity(self) -> str:
+        """The worst (highest-confidence) severity among this slug's issues."""
+        return min(
+            (ISSUE_SEVERITY[i] for i in self.issues),
+            key=lambda s: SEVERITY_ORDER[s],
+            default="low",
+        )
+
+
+@dataclass
+class SlugReport:
+    """Outcome of scanning a deck set for low-quality slugs."""
+
+    findings: list[SlugFinding] = field(default_factory=list)
+    total_ids: int = 0
+    files_scanned: int = 0
+
+    @property
+    def by_issue(self) -> dict[SlugIssue, int]:
+        counts: dict[SlugIssue, int] = defaultdict(int)
+        for finding in self.findings:
+            for issue in finding.issues:
+                counts[issue] += 1
+        return dict(counts)
+
+    @property
+    def by_severity(self) -> dict[str, int]:
+        counts: dict[str, int] = defaultdict(int)
+        for finding in self.findings:
+            counts[finding.severity] += 1
+        return dict(counts)
+
+    def at_or_above(self, min_severity: str) -> list[SlugFinding]:
+        ceiling = SEVERITY_ORDER[min_severity]
+        return [f for f in self.findings if SEVERITY_ORDER[f.severity] <= ceiling]
+
+
+def scan_slug_quality(files: list[Path]) -> SlugReport:
+    """Classify every slide_id on the given decks; collect the flagged ones.
+
+    Only slide/subslide *start* cells are inspected — narrative cells inherit
+    their slide's id, so counting them would double-report. Within one file a
+    given bare id is reported once (at its first occurrence), so a bilingual
+    deck's DE/EN twin cells (which share an id) yield a single finding.
+    """
+    report = SlugReport()
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        report.files_scanned += 1
+        _, cells = split_cells(text)
+        file_str = str(path)
+        seen_in_file: set[str] = set()
+        for cell in cells:
+            if not cell.metadata.is_slide_start:
+                continue
+            raw = cell.metadata.slide_id
+            if not raw:
+                continue
+            bare = strip_preserve_marker(raw)
+            if bare in seen_in_file:
+                continue
+            seen_in_file.add(bare)
+            report.total_ids += 1
+            issues = classify_slug(raw)
+            if issues:
+                report.findings.append(
+                    SlugFinding(
+                        file=file_str,
+                        line=cell.line_number,
+                        slide_id=bare,
+                        issues=issues,
+                    )
+                )
+    return report
+
+
+def render_report(report: SlugReport, *, min_severity: str = "low") -> str:
+    """Human-readable slug-quality report at or above ``min_severity``."""
+    shown = report.at_or_above(min_severity)
+    shown.sort(key=lambda f: (SEVERITY_ORDER[f.severity], f.file, f.line))
+
+    if not report.findings:
+        return f"Scanned {report.total_ids} slide_id(s) in {report.files_scanned} file(s) — all look fine."
+
+    lines: list[str] = []
+    for finding in shown:
+        tags = ", ".join(i.value for i in finding.issues)
+        lines.append(
+            f"[{finding.severity:<6}] {finding.file}:{finding.line} "
+            f'slide_id="{finding.slide_id}" — {tags}'
+        )
+    lines.append("")
+    sev = report.by_severity
+    lines.append(
+        f"Scanned {report.total_ids} slide_id(s) in {report.files_scanned} file(s): "
+        f"{len(report.findings)} flagged "
+        f"({sev.get('high', 0)} high, {sev.get('medium', 0)} medium, {sev.get('low', 0)} low)."
+    )
+    if min_severity != "low" and len(shown) != len(report.findings):
+        lines.append(f"Showing {len(shown)} at severity >= {min_severity}.")
+    return "\n".join(lines)
+
+
+def report_to_dict(report: SlugReport) -> dict:
+    """JSON-serializable slug-quality report."""
+    return {
+        "total_ids": report.total_ids,
+        "files_scanned": report.files_scanned,
+        "flagged": len(report.findings),
+        "by_severity": report.by_severity,
+        "by_issue": {issue.value: count for issue, count in report.by_issue.items()},
+        "findings": [
+            {
+                "file": f.file,
+                "line": f.line,
+                "slide_id": f.slide_id,
+                "severity": f.severity,
+                "issues": [i.value for i in f.issues],
+            }
+            for f in report.findings
+        ],
+    }

--- a/src/clm/slides/validation_summary.py
+++ b/src/clm/slides/validation_summary.py
@@ -1,0 +1,166 @@
+"""Category rollup for slide-validation findings (gap #2, ``--summary``).
+
+A corpus validate can emit thousands of findings; a flat list is unreadable.
+This module rolls findings up into a compact triage table so an author can see
+"what kinds of problems, how many, and which decks are worst" at a glance.
+
+Two axes, both derived from :class:`clm.slides.validator.Finding`:
+
+- **category × severity** — the validator's own ``category`` field
+  (``format`` / ``pairing`` / ``tags``) crossed with severity. This is exact
+  and always correct.
+- **kind** — a finer bucket (missing-slide_id, adjacency, count-mismatch, …)
+  derived from the message text via :func:`classify_kind`. This is a *display
+  heuristic* over message signatures, with an ``other`` fallback so nothing is
+  dropped or miscounted away; treat the category×severity axis as authoritative.
+
+Plus a **per-file** breakdown (decks with the most findings), since "which decks
+need work" is the question a conversion gate actually asks.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from clm.slides.validator import Finding
+
+
+# Ordered (kind, predicate-substring) rules. First match wins, so more specific
+# signatures come before broader ones. Substrings are matched case-insensitively
+# against the finding message. Kept deliberately small and explicit — see the
+# module docstring on why this is a supplementary heuristic, not the source of
+# truth.
+_KIND_RULES: list[tuple[str, tuple[str, ...]]] = [
+    ("missing-slide_id", ("missing slide_id",)),
+    ("slide_id-slug", ("not a valid kebab-case",)),
+    ("slide_id-mismatch", ("slide_id",)),  # remaining slide_id findings (parity/order)
+    ("adjacency", ("adjacent", "intervening", "not adjacent")),
+    ("count-mismatch", ("count", "number of cells", "mismatched cell")),
+    ("start-completed", ("'start'", "'completed'", "start tag", "completed tag")),
+    ("malformed-marker", ("malformed", "does not start with")),
+    ("unexpected-tag", ("unrecognized tag", "is not expected on")),
+    ("shared-cell", ("shared cell", "diverge")),
+    ("voiceover", ("voiceover", "for_slide")),
+]
+
+
+def classify_kind(message: str) -> str:
+    """Bucket a finding *message* into a coarse kind (heuristic; see module doc)."""
+    lowered = message.lower()
+    for kind, needles in _KIND_RULES:
+        if any(n in lowered for n in needles):
+            return kind
+    return "other"
+
+
+@dataclass
+class FileRollup:
+    """Per-file finding counts."""
+
+    file: str
+    errors: int = 0
+    warnings: int = 0
+    info: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.errors + self.warnings + self.info
+
+
+@dataclass
+class ValidationSummary:
+    """A rolled-up view of a flat finding list."""
+
+    total: int = 0
+    by_severity: Counter = field(default_factory=Counter)
+    by_category_severity: dict[str, Counter] = field(default_factory=dict)
+    by_kind: Counter = field(default_factory=Counter)
+    by_file: list[FileRollup] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "total": self.total,
+            "by_severity": dict(self.by_severity),
+            "by_category_severity": {
+                cat: dict(counts) for cat, counts in self.by_category_severity.items()
+            },
+            "by_kind": dict(self.by_kind),
+            "by_file": [
+                {
+                    "file": fr.file,
+                    "errors": fr.errors,
+                    "warnings": fr.warnings,
+                    "info": fr.info,
+                    "total": fr.total,
+                }
+                for fr in self.by_file
+            ],
+        }
+
+
+def summarize_findings(findings: list[Finding]) -> ValidationSummary:
+    """Roll *findings* up by severity, category, kind, and file."""
+    summary = ValidationSummary(total=len(findings))
+    files: dict[str, FileRollup] = {}
+
+    for f in findings:
+        summary.by_severity[f.severity] += 1
+        summary.by_category_severity.setdefault(f.category, Counter())[f.severity] += 1
+        summary.by_kind[classify_kind(f.message)] += 1
+
+        rollup = files.setdefault(f.file or "<unknown>", FileRollup(file=f.file or "<unknown>"))
+        if f.severity == "error":
+            rollup.errors += 1
+        elif f.severity == "warning":
+            rollup.warnings += 1
+        else:
+            rollup.info += 1
+
+    # Worst decks first: errors, then warnings, then total, then path for stability.
+    summary.by_file = sorted(
+        files.values(),
+        key=lambda fr: (-fr.errors, -fr.warnings, -fr.total, fr.file),
+    )
+    return summary
+
+
+def render_summary(summary: ValidationSummary, *, top_files: int = 20) -> list[str]:
+    """Render *summary* as human-readable lines (no trailing newlines)."""
+    lines: list[str] = []
+    sev = summary.by_severity
+    lines.append(
+        f"{summary.total} finding(s): "
+        f"{sev.get('error', 0)} error(s), "
+        f"{sev.get('warning', 0)} warning(s), "
+        f"{sev.get('info', 0)} info"
+    )
+
+    if summary.total == 0:
+        return lines
+
+    lines.append("")
+    lines.append("By category:")
+    for category in sorted(summary.by_category_severity):
+        counts = summary.by_category_severity[category]
+        detail = ", ".join(f"{n} {s}" for s, n in sorted(counts.items()))
+        lines.append(f"  {category}: {detail}")
+
+    lines.append("")
+    lines.append("By kind:")
+    for kind, n in summary.by_kind.most_common():
+        lines.append(f"  {kind}: {n}")
+
+    shown = summary.by_file[:top_files]
+    lines.append("")
+    label = f"Top {len(shown)} deck(s) by finding count:"
+    lines.append(label)
+    for fr in shown:
+        lines.append(f"  {fr.file}: {fr.errors} error(s), {fr.warnings} warning(s)")
+    remaining = len(summary.by_file) - len(shown)
+    if remaining > 0:
+        lines.append(f"  … and {remaining} more deck(s) with findings")
+
+    return lines

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -1667,7 +1667,27 @@ def validate_directory(
             ``None`` runs the default bundle, which excludes the opt-in
             ``voiceover`` coverage check (issue #176).
     """
-    slide_files = find_slide_files_recursive(path)
+    return validate_files(find_slide_files_recursive(path), checks=checks)
+
+
+def validate_files(
+    slide_files: list[Path],
+    checks: list[str] | None = None,
+) -> ValidationResult:
+    """Validate an explicit list of slide files (same logic as a directory walk).
+
+    Factored out of :func:`validate_directory` so callers that have already
+    computed a file set — e.g. ``clm validate --shipping-only``, which filters a
+    directory down to the decks reachable from course specs — get identical
+    per-file checks *and* the once-per-pair split-pair parity, without a second
+    filesystem walk.
+
+    Args:
+        slide_files: The slide files to validate.
+        checks: Which checks to run (passed to :func:`validate_file`).
+            ``None`` runs the default bundle, which excludes the opt-in
+            ``voiceover`` coverage check (issue #176).
+    """
     all_findings: list[Finding] = []
     combined_review = ReviewMaterial() if (not checks or set(checks) & ALL_REVIEW_CHECKS) else None
 

--- a/tests/cli/test_assign_ids_refusals.py
+++ b/tests/cli/test_assign_ids_refusals.py
@@ -1,0 +1,100 @@
+"""Tests for ``clm slides assign-ids --report-refusals [--context]`` (gap #5)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+DECK = (
+    '# %% [markdown] lang="en" tags=["slide"]\n'
+    "# ## Introduction\n"
+    "\n"
+    '# %% [markdown] lang="en" tags=["slide"]\n'
+    '# <img src="img/diagram.png">\n'
+)
+
+
+def _deck(tmp_path: Path) -> Path:
+    f = tmp_path / "slides_x.py"
+    f.write_text(DECK, encoding="utf-8")
+    return f
+
+
+def test_report_refusals_lists_hard(tmp_path):
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--report-refusals"])
+    assert r.exit_code == 2  # hard refusal present
+    assert "[hard]" in r.output
+    assert "1 hard refusal(s)" in r.output
+    # Without --context, no cell body is shown.
+    assert "img/diagram.png" not in r.output
+
+
+def test_report_refusals_does_not_write(tmp_path):
+    f = _deck(tmp_path)
+    before = f.read_text(encoding="utf-8")
+    CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--report-refusals", "--report-only"])
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_context_implies_report_refusals_and_shows_body(tmp_path):
+    f = _deck(tmp_path)
+    # --context alone (no explicit --report-refusals) still produces the worklist.
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--context", "--report-only"])
+    assert "[hard]" in r.output
+    assert "img/diagram.png" in r.output
+    assert 'heading "Introduction"' in r.output
+
+
+def test_report_refusals_json(tmp_path):
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["slides", "assign-ids", str(f), "--context", "--json", "--report-only"]
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert data["hard_refusals"] == 1
+    ctx = data["refusals"][0]["context"]
+    assert ctx["preceding_heading"] == "Introduction"
+    assert "diagram.png" in ctx["body"]
+
+
+def test_clean_deck_reports_no_refusals(tmp_path):
+    f = tmp_path / "slides_ok.py"
+    f.write_text(
+        '# %% [markdown] lang="en" tags=["slide"]\n# ## Introduction\n',
+        encoding="utf-8",
+    )
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--report-refusals"])
+    assert r.exit_code == 0
+    assert "No refusals" in r.output
+
+
+def test_report_refusals_directory_scope(tmp_path):
+    # The worklist reflects scoping: --only bilingual drops the split half.
+    s = tmp_path / "slides" / "topic_010_a"
+    s.mkdir(parents=True)
+    (s / "slides_bi.py").write_text(DECK, encoding="utf-8")
+    half = '# %% [markdown] lang="de" tags=["slide"]\n# <img src="img/de.png">\n'
+    (s / "slides_y.de.py").write_text(half, encoding="utf-8")
+    (s / "slides_y.en.py").write_text(
+        '# %% [markdown] lang="en" tags=["slide"]\n# <img src="img/en.png">\n',
+        encoding="utf-8",
+    )
+    r = CliRunner().invoke(
+        cli,
+        [
+            "slides",
+            "assign-ids",
+            str(tmp_path / "slides"),
+            "--report-refusals",
+            "--report-only",
+            "--only",
+            "bilingual",
+        ],
+    )
+    assert "slides_bi.py" in r.output
+    assert "slides_y.de.py" not in r.output

--- a/tests/cli/test_course_gate.py
+++ b/tests/cli/test_course_gate.py
@@ -1,0 +1,140 @@
+"""Tests for ``clm course gate``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+HEADING_PAIR = (
+    '# %% [markdown] lang="de" tags=["slide"]\n# ## Einfuehrung\n\n'
+    '# %% [markdown] lang="en" tags=["slide"]\n# ## Introduction\n'
+)
+NON_EXTRACTABLE = '# %% [markdown] lang="de" tags=["slide"]\n#\n'
+
+
+def _write_spec(tmp_path: Path, sections_xml: str) -> Path:
+    spec_file = tmp_path / "course-specs" / "test.xml"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>Test</de><en>Test</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          {sections_xml}
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _deck(tmp_path: Path, topic: str, name: str, content: str) -> Path:
+    d = tmp_path / "slides" / "module_100_x" / topic
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _section(name: str, *topics: str) -> str:
+    t = "".join(f"<topic>{x}</topic>" for x in topics)
+    return f"<section><name><de>{name}</de><en>{name}</en></name><topics>{t}</topics></section>"
+
+
+class TestCourseGateCommand:
+    def test_dry_run_mechanical_is_clean_exit0(self, tmp_path):
+        _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+        spec = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(cli, ["course", "gate", str(spec), "--data-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "MECHANICALLY CLEAN" in result.output
+        assert "slide_ids: 2" in result.output
+
+    def test_needs_author_exit1(self, tmp_path):
+        _deck(tmp_path, "topic_010_intro", "slides_bad.py", NON_EXTRACTABLE)
+        spec = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(cli, ["course", "gate", str(spec), "--data-dir", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "NEEDS AUTHOR" in result.output
+        assert "slide_id_hard_refusal" in result.output
+
+    def test_apply_writes(self, tmp_path):
+        p = _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+        spec = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["course", "gate", str(spec), "--data-dir", str(tmp_path), "--apply"]
+        )
+
+        assert result.exit_code == 0
+        assert 'slide_id="' in p.read_text(encoding="utf-8")
+        assert "Residual after apply" in result.output
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        p = _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+        spec = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+        before = p.read_text(encoding="utf-8")
+
+        CliRunner().invoke(cli, ["course", "gate", str(spec), "--data-dir", str(tmp_path)])
+
+        assert p.read_text(encoding="utf-8") == before
+
+    def test_json_output(self, tmp_path):
+        _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+        spec = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["course", "gate", str(spec), "--data-dir", str(tmp_path), "--json"]
+        )
+
+        data = json.loads(result.output[result.output.index("{") : result.output.rindex("}") + 1])
+        assert data["deck_count"] == 1
+        assert data["mechanical"]["by_operation"]["slide_ids"] == 2
+        assert data["is_clean"] is True
+
+    def test_directory_target(self, tmp_path):
+        _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+
+        result = CliRunner().invoke(cli, ["course", "gate", str(tmp_path / "slides")])
+
+        assert result.exit_code == 0
+        assert "Scope: 1 deck" in result.output
+
+    def test_operations_filter(self, tmp_path):
+        # Only tag_migration requested → the id-less pair is NOT minted.
+        _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+        spec = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "course",
+                "gate",
+                str(spec),
+                "--data-dir",
+                str(tmp_path),
+                "--operations",
+                "tag_migration",
+            ],
+        )
+
+        assert "slide_ids:" not in result.output
+
+    def test_bad_operation_errors(self, tmp_path):
+        _deck(tmp_path, "topic_010_intro", "slides_intro.py", HEADING_PAIR)
+        result = CliRunner().invoke(
+            cli, ["course", "gate", str(tmp_path / "slides"), "--operations", "nope"]
+        )
+        assert result.exit_code != 0
+        assert "Unknown operation" in result.output

--- a/tests/cli/test_coverage_report.py
+++ b/tests/cli/test_coverage_report.py
@@ -1,0 +1,119 @@
+"""Tests for ``clm slides coverage-report`` (gap #8)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+
+def _bi(de: int, en: int) -> str:
+    cells = [f'# %% [markdown] lang="de" tags=["slide"]\n# ## De {i}\n' for i in range(de)]
+    cells += [f'# %% [markdown] lang="en" tags=["slide"]\n# ## En {i}\n' for i in range(en)]
+    return "\n".join(cells)
+
+
+def _tree(tmp_path: Path) -> Path:
+    s = tmp_path / "slides" / "module_100_x"
+    t1 = s / "topic_010_a"
+    t1.mkdir(parents=True)
+    (t1 / "slides_bal.py").write_text(_bi(2, 2), encoding="utf-8")
+    (t1 / "slides_imb.py").write_text(_bi(2, 1), encoding="utf-8")
+    t2 = s / "topic_020_b"
+    t2.mkdir(parents=True)
+    (t2 / "slides_de.de.py").write_text(_bi(1, 0), encoding="utf-8")
+    arch = s / "_archive"
+    arch.mkdir(parents=True)
+    (arch / "slides_old.py").write_text(_bi(1, 0), encoding="utf-8")
+    return tmp_path / "slides"
+
+
+def _spec(tmp_path: Path, *topics: str) -> Path:
+    t = "".join(f"<topic>{x}</topic>" for x in topics)
+    spec = tmp_path / "course-specs" / "c.xml"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        dedent(f"""\
+        <course><name><de>C</de><en>C</en></name><prog-lang>python</prog-lang>
+        <description><de></de><en></en></description><certificate><de></de><en></en></certificate>
+        <sections><section><name><de>S</de><en>S</en></name>
+        <topics>{t}</topics></section></sections></course>
+        """),
+        encoding="utf-8",
+    )
+    return spec
+
+
+def test_directory_report(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "coverage-report", str(slides)])
+    assert r.exit_code == 0
+    assert "slides_imb.py" in r.output  # imbalanced bilingual
+    assert "slides_de.de.py" in r.output  # de-only split half
+    assert "slides_bal.py" not in r.output  # balanced not listed
+
+
+def test_json_by_status(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "coverage-report", str(slides), "--json"])
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert data["by_status"]["de_only"] >= 1
+    assert data["by_status"]["imbalanced"] >= 1
+
+
+def test_status_filter(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["slides", "coverage-report", str(slides), "--status", "de_only", "--json"]
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert {d["status"] for d in data["decks"]} == {"de_only"}
+
+
+def test_exclude_archive(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["slides", "coverage-report", str(slides), "--exclude", "_archive", "--json"]
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    names = {Path(d["label"]).name for d in data["decks"]}
+    assert "slides_old.py" not in names
+
+
+def test_shipping_only(tmp_path):
+    slides = _tree(tmp_path)
+    _spec(tmp_path, "a")  # only topic_010_a ships
+    r = CliRunner().invoke(
+        cli, ["slides", "coverage-report", str(slides), "--shipping-only", "--json"]
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    names = {Path(d["label"]).name for d in data["decks"]}
+    assert names == {"slides_bal.py", "slides_imb.py"}
+
+
+def test_spec_path(tmp_path):
+    _tree(tmp_path)
+    spec = _spec(tmp_path, "a")
+    r = CliRunner().invoke(cli, ["slides", "coverage-report", str(spec)])
+    assert r.exit_code == 0
+    assert "slides_imb.py" in r.output
+
+
+def test_scope_on_spec_errors(tmp_path):
+    _tree(tmp_path)
+    spec = _spec(tmp_path, "a")
+    r = CliRunner().invoke(cli, ["slides", "coverage-report", str(spec), "--exclude", "_archive"])
+    assert r.exit_code != 0
+    assert "directory" in r.output
+
+
+def test_all_balanced_message(tmp_path):
+    s = tmp_path / "slides" / "topic_010_a"
+    s.mkdir(parents=True)
+    (s / "slides_ok.py").write_text(_bi(2, 2), encoding="utf-8")
+    r = CliRunner().invoke(cli, ["slides", "coverage-report", str(tmp_path / "slides")])
+    assert "balanced" in r.output

--- a/tests/cli/test_deck_scope_cli.py
+++ b/tests/cli/test_deck_scope_cli.py
@@ -1,0 +1,187 @@
+"""Tests for the deck-scoping flags on ``assign-ids`` and ``normalize`` (gap #4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+BI = (
+    '# %% [markdown] lang="de" tags=["slide"]\n# ## Einfuehrung\n\n'
+    '# %% [markdown] lang="en" tags=["slide"]\n# ## Introduction\n'
+)
+HALF_DE = '# %% [markdown] lang="de" tags=["slide"]\n# ## Einfuehrung\n'
+HALF_EN = '# %% [markdown] lang="en" tags=["slide"]\n# ## Introduction\n'
+
+
+def _tree(tmp_path: Path) -> Path:
+    """A slides tree with a bilingual deck, a split pair, and an archived deck."""
+    s = tmp_path / "slides" / "module_100_x"
+    (s / "topic_010_a").mkdir(parents=True)
+    (s / "topic_010_a" / "slides_bi.py").write_text(BI, encoding="utf-8")
+    (s / "topic_020_b").mkdir(parents=True)
+    (s / "topic_020_b" / "slides_x.de.py").write_text(HALF_DE, encoding="utf-8")
+    (s / "topic_020_b" / "slides_x.en.py").write_text(HALF_EN, encoding="utf-8")
+    (s / "_archive" / "topic_900_old").mkdir(parents=True)
+    (s / "_archive" / "topic_900_old" / "slides_old.py").write_text(BI, encoding="utf-8")
+    return tmp_path / "slides"
+
+
+def _spec(tmp_path: Path, *topics: str) -> Path:
+    t = "".join(f"<topic>{x}</topic>" for x in topics)
+    spec = tmp_path / "course-specs" / "c.xml"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>C</de><en>C</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          <sections><section><name><de>S</de><en>S</en></name>
+          <topics>{t}</topics></section></sections>
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _ids_in(path: Path) -> int:
+    return path.read_text(encoding="utf-8").count("slide_id=")
+
+
+class TestAssignIdsScope:
+    def test_only_bilingual_excludes_splits(self, tmp_path):
+        slides = _tree(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "slides",
+                "assign-ids",
+                str(slides),
+                "--accept-content-derived",
+                "--only",
+                "bilingual",
+            ],
+        )
+        assert result.exit_code == 0
+        # Bilingual + archived bilingual minted; split halves untouched.
+        assert _ids_in(slides / "module_100_x" / "topic_010_a" / "slides_bi.py") == 2
+        assert _ids_in(slides / "module_100_x" / "topic_020_b" / "slides_x.de.py") == 0
+
+    def test_exclude_archive(self, tmp_path):
+        slides = _tree(tmp_path)
+        CliRunner().invoke(
+            cli,
+            [
+                "slides",
+                "assign-ids",
+                str(slides),
+                "--accept-content-derived",
+                "--only",
+                "bilingual",
+                "--exclude",
+                "_archive",
+            ],
+        )
+        assert _ids_in(slides / "module_100_x" / "topic_010_a" / "slides_bi.py") == 2
+        assert (
+            _ids_in(slides / "module_100_x" / "_archive" / "topic_900_old" / "slides_old.py") == 0
+        )
+
+    def test_only_split_touches_pair_only(self, tmp_path):
+        slides = _tree(tmp_path)
+        CliRunner().invoke(
+            cli,
+            ["slides", "assign-ids", str(slides), "--accept-content-derived", "--only", "split"],
+        )
+        assert _ids_in(slides / "module_100_x" / "topic_020_b" / "slides_x.de.py") >= 1
+        assert _ids_in(slides / "module_100_x" / "topic_010_a" / "slides_bi.py") == 0
+
+    def test_shipping_only(self, tmp_path):
+        slides = _tree(tmp_path)
+        _spec(tmp_path, "a")  # only topic_010_a ("a") ships
+        CliRunner().invoke(
+            cli,
+            ["slides", "assign-ids", str(slides), "--accept-content-derived", "--shipping-only"],
+        )
+        assert _ids_in(slides / "module_100_x" / "topic_010_a" / "slides_bi.py") == 2
+        # topic_020_b and _archive are not in the spec → untouched.
+        assert _ids_in(slides / "module_100_x" / "topic_020_b" / "slides_x.de.py") == 0
+        assert (
+            _ids_in(slides / "module_100_x" / "_archive" / "topic_900_old" / "slides_old.py") == 0
+        )
+
+    def test_scope_on_single_file_errors(self, tmp_path):
+        slides = _tree(tmp_path)
+        f = slides / "module_100_x" / "topic_010_a" / "slides_bi.py"
+        result = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--only", "bilingual"])
+        assert result.exit_code != 0
+        assert "apply to a directory" in result.output
+
+    def test_report_only_json_respects_scope(self, tmp_path):
+        slides = _tree(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "slides",
+                "assign-ids",
+                str(slides),
+                "--accept-content-derived",
+                "--report-only",
+                "--only",
+                "bilingual",
+                "--exclude",
+                "_archive",
+                "--json",
+            ],
+        )
+        data = json.loads(result.output[result.output.index("{") : result.output.rindex("}") + 1])
+        assert data["files_visited"] == 1
+
+
+class TestNormalizeScope:
+    def test_only_bilingual_dry_run(self, tmp_path):
+        slides = _tree(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "slides",
+                "normalize",
+                str(slides),
+                "--operations",
+                "slide_ids",
+                "--dry-run",
+                "--only",
+                "bilingual",
+                "--exclude",
+                "_archive",
+                "--json",
+            ],
+        )
+        data = json.loads(result.output[result.output.index("{") : result.output.rindex("}") + 1])
+        # Only the single bilingual deck's cells are in scope.
+        files = {c["file"] for c in data["changes"]}
+        assert all("slides_bi.py" in f for f in files)
+
+    def test_shipping_only_applies(self, tmp_path):
+        slides = _tree(tmp_path)
+        _spec(tmp_path, "a")
+        CliRunner().invoke(
+            cli,
+            ["slides", "normalize", str(slides), "--operations", "slide_ids", "--shipping-only"],
+        )
+        assert _ids_in(slides / "module_100_x" / "topic_010_a" / "slides_bi.py") == 2
+        assert _ids_in(slides / "module_100_x" / "topic_020_b" / "slides_x.de.py") == 0
+
+    def test_scope_on_spec_errors(self, tmp_path):
+        _tree(tmp_path)
+        spec = _spec(tmp_path, "a")
+        result = CliRunner().invoke(cli, ["slides", "normalize", str(spec), "--only", "bilingual"])
+        assert result.exit_code != 0
+        assert "apply to a directory" in result.output

--- a/tests/cli/test_slug_report.py
+++ b/tests/cli/test_slug_report.py
@@ -1,0 +1,118 @@
+"""Tests for ``clm slides slug-report`` (gap #6)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+
+def _deck(*slide_ids: str) -> str:
+    cells = [
+        f'# %% [markdown] lang="en" tags=["slide"] slide_id="{sid}"\n# ## Heading {i}\n'
+        for i, sid in enumerate(slide_ids)
+    ]
+    return "\n".join(cells)
+
+
+def _tree(tmp_path: Path) -> Path:
+    s = tmp_path / "slides" / "module_100_x" / "topic_010_a"
+    s.mkdir(parents=True)
+    (s / "slides_bi.py").write_text(_deck("introduction-to-x", "df", "data"), encoding="utf-8")
+    arch = tmp_path / "slides" / "module_100_x" / "_archive"
+    arch.mkdir(parents=True)
+    (arch / "slides_old.py").write_text(_deck("cp"), encoding="utf-8")
+    return tmp_path / "slides"
+
+
+def _spec(tmp_path: Path, *topics: str) -> Path:
+    t = "".join(f"<topic>{x}</topic>" for x in topics)
+    spec = tmp_path / "course-specs" / "c.xml"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>C</de><en>C</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          <sections><section><name><de>S</de><en>S</en></name>
+          <topics>{t}</topics></section></sections>
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec
+
+
+def test_directory_scan_flags(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(slides)])
+    assert r.exit_code == 0
+    assert 'slide_id="df"' in r.output
+    assert 'slide_id="data"' in r.output
+    # The clean multi-token id is not flagged.
+    assert 'slide_id="introduction-to-x"' not in r.output
+
+
+def test_min_severity_high(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(slides), "--min-severity", "high"])
+    assert 'slide_id="df"' in r.output  # very_short = high
+    # introduction-to-x isn't flagged at all; a low single_token would be hidden.
+
+
+def test_json_output(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(slides), "--json"])
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert data["by_issue"]["very_short"] >= 1
+    assert data["by_issue"]["generic"] >= 1
+
+
+def test_exclude_archive(tmp_path):
+    slides = _tree(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["slides", "slug-report", str(slides), "--exclude", "_archive", "--json"]
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    files = {Path(f["file"]).name for f in data["findings"]}
+    assert "slides_old.py" not in files  # the archived "cp" deck was excluded
+    assert "slides_bi.py" in files
+
+
+def test_shipping_only(tmp_path):
+    slides = _tree(tmp_path)
+    _spec(tmp_path, "a")  # only topic_010_a ships
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(slides), "--shipping-only", "--json"])
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    files = {Path(f["file"]).name for f in data["findings"]}
+    assert files == {"slides_bi.py"}  # the archived deck does not ship
+
+
+def test_spec_path_resolves_decks(tmp_path):
+    _tree(tmp_path)
+    spec = _spec(tmp_path, "a")
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(spec)])
+    assert r.exit_code == 0
+    assert 'slide_id="df"' in r.output
+
+
+def test_scope_on_spec_errors(tmp_path):
+    _tree(tmp_path)
+    spec = _spec(tmp_path, "a")
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(spec), "--exclude", "_archive"])
+    assert r.exit_code != 0
+    assert "directory" in r.output
+
+
+def test_clean_tree_message(tmp_path):
+    s = tmp_path / "slides" / "topic_010_a"
+    s.mkdir(parents=True)
+    (s / "slides_ok.py").write_text(_deck("introduction-to-functions"), encoding="utf-8")
+    r = CliRunner().invoke(cli, ["slides", "slug-report", str(tmp_path / "slides")])
+    assert "all look fine" in r.output

--- a/tests/cli/test_spec_decks.py
+++ b/tests/cli/test_spec_decks.py
@@ -1,0 +1,211 @@
+"""Tests for ``clm spec decks`` and ``clm slides referenced-by``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+
+def _write_spec(tmp_path: Path, sections_xml: str, name: str = "test.xml") -> Path:
+    spec_file = tmp_path / "course-specs" / name
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>Test</de><en>Test</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          {sections_xml}
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _topic(tmp_path: Path, module: str, topic: str, *decks: str) -> Path:
+    topic_dir = tmp_path / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    for deck in decks:
+        (topic_dir / deck).write_text("# %% [markdown]\n# Hello\n", encoding="utf-8")
+    return topic_dir
+
+
+def _section(name: str, *topics: str, module: str | None = None) -> str:
+    topic_xml = "".join(f"<topic>{t}</topic>" for t in topics)
+    module_attr = f' module="{module}"' if module else ""
+    return (
+        f"<section{module_attr}><name><de>{name}</de><en>{name}</en></name>"
+        f"<topics>{topic_xml}</topics></section>"
+    )
+
+
+def _json_from_output(output: str) -> dict:
+    start = output.index("{")
+    end = output.rindex("}") + 1
+    return json.loads(output[start:end])
+
+
+class TestSpecDecksCommand:
+    def test_lists_all_decks_in_topic_dir(self, tmp_path):
+        _topic(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_props",
+            "slides_properties.py",
+            "slides_property_setters.py",
+        )
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'props')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["spec", "decks", str(spec_file), "--data-dir", str(tmp_path)]
+        )
+
+        assert result.exit_code == 0
+        assert "slides_properties.py" in result.output
+        assert "slides_property_setters.py" in result.output
+
+    def test_json_output(self, tmp_path):
+        _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["spec", "decks", str(spec_file), "--data-dir", str(tmp_path), "--json"]
+        )
+
+        assert result.exit_code == 0
+        data = _json_from_output(result.output)
+        assert data["deck_count"] == 1
+        assert data["lang"] == "both"
+        assert any("slides_intro.py" in d for d in data["decks"])
+
+    def test_lang_filter_excludes_other_split_half(self, tmp_path):
+        _topic(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_intro",
+            "slides_intro.de.py",
+            "slides_intro.en.py",
+            "slides_bilingual.py",
+        )
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli,
+            ["spec", "decks", str(spec_file), "--data-dir", str(tmp_path), "--lang", "de"],
+        )
+
+        assert result.exit_code == 0
+        assert "slides_intro.de.py" in result.output
+        assert "slides_intro.en.py" not in result.output
+        # Bilingual decks serve both languages, so they survive a --lang filter.
+        assert "slides_bilingual.py" in result.output
+
+    def test_unresolved_topic_warns(self, tmp_path):
+        _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro', 'ghost')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["spec", "decks", str(spec_file), "--data-dir", str(tmp_path)]
+        )
+
+        assert result.exit_code == 0
+        # stderr is captured separately on Click 8.1 and merged on 8.2+; check both.
+        combined = result.output + (result.stderr if result.stderr_bytes else "")
+        assert "ghost" in combined
+        assert "slides_intro.py" in result.output
+
+    def test_all_specs_annotates_each_deck(self, tmp_path):
+        _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        _topic(tmp_path, "module_100_basics", "topic_020_extra", "slides_extra.py")
+        _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>", name="a.xml")
+        _write_spec(
+            tmp_path,
+            f"<sections>{_section('S', 'intro', 'extra')}</sections>",
+            name="b.xml",
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "spec",
+                "decks",
+                "--all-specs",
+                str(tmp_path / "course-specs"),
+                "--data-dir",
+                str(tmp_path),
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = _json_from_output(result.output)
+        by_name = {Path(d["path"]).name: d["specs"] for d in data["decks"]}
+        assert by_name["slides_intro.py"] == ["a.xml", "b.xml"]
+        assert by_name["slides_extra.py"] == ["b.xml"]
+
+    def test_requires_spec_or_all_specs(self, tmp_path):
+        result = CliRunner().invoke(cli, ["spec", "decks"])
+        assert result.exit_code != 0
+        assert "SPEC_FILE or --all-specs" in result.output
+
+    def test_rejects_both_spec_and_all_specs(self, tmp_path):
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S')}</sections>")
+        result = CliRunner().invoke(
+            cli,
+            ["spec", "decks", str(spec_file), "--all-specs", str(tmp_path / "course-specs")],
+        )
+        assert result.exit_code != 0
+        assert "not both" in result.output
+
+
+class TestReferencedByCommand:
+    def test_finds_referencing_spec(self, tmp_path):
+        topic_dir = _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        deck = topic_dir / "slides_intro.py"
+        _write_spec(tmp_path, f"<sections>{_section('Intro', 'intro')}</sections>")
+
+        result = CliRunner().invoke(cli, ["slides", "referenced-by", str(deck)])
+
+        assert result.exit_code == 0
+        assert "test.xml" in result.output
+        assert "intro" in result.output
+
+    def test_unreferenced_deck(self, tmp_path):
+        topic_dir = _topic(tmp_path, "module_100_basics", "topic_010_orphan", "slides_orphan.py")
+        deck = topic_dir / "slides_orphan.py"
+        _write_spec(tmp_path, f"<sections>{_section('S')}</sections>")
+
+        result = CliRunner().invoke(cli, ["slides", "referenced-by", str(deck)])
+
+        assert result.exit_code == 0
+        assert "unreferenced" in result.output
+
+    def test_json_output(self, tmp_path):
+        topic_dir = _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        deck = topic_dir / "slides_intro.py"
+        _write_spec(tmp_path, f"<sections>{_section('Intro', 'intro')}</sections>")
+
+        result = CliRunner().invoke(cli, ["slides", "referenced-by", str(deck), "--json"])
+
+        assert result.exit_code == 0
+        data = _json_from_output(result.output)
+        assert data["referenced"] is True
+        assert data["references"][0]["topic_id"] == "intro"
+
+    def test_missing_specs_dir_errors(self, tmp_path):
+        topic_dir = _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        deck = topic_dir / "slides_intro.py"
+        # No course-specs/ directory created.
+
+        result = CliRunner().invoke(cli, ["slides", "referenced-by", str(deck)])
+
+        assert result.exit_code != 0
+        assert "Specs directory not found" in result.output

--- a/tests/cli/test_spec_orphans.py
+++ b/tests/cli/test_spec_orphans.py
@@ -1,0 +1,137 @@
+"""Tests for ``clm spec orphans`` (gap #7)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+DECK = '# %% [markdown] lang="en" tags=["slide"]\n# ## Intro\n'
+
+
+def _course(tmp_path: Path) -> Path:
+    """A course with one shipping deck and three orphans; return the course root."""
+    slides = tmp_path / "slides" / "module_100_x"
+    ref = slides / "topic_0000_a"
+    ref.mkdir(parents=True)
+    (ref / "slides_a.py").write_text(DECK, encoding="utf-8")
+    orph = slides / "topic_900_b"
+    orph.mkdir(parents=True)
+    (orph / "slides_b_old.py").write_text(DECK, encoding="utf-8")
+    (orph / "slides_b_part1.py").write_text(DECK, encoding="utf-8")
+    (orph / "slides_b_misc.py").write_text(DECK, encoding="utf-8")
+    ck = ref / ".ipynb_checkpoints"
+    ck.mkdir()
+    (ck / "slides_a-checkpoint.py").write_text(DECK, encoding="utf-8")
+
+    specs = tmp_path / "course-specs"
+    specs.mkdir()
+    (specs / "c.xml").write_text(
+        dedent("""\
+        <course><name><de>C</de><en>C</en></name><prog-lang>python</prog-lang>
+        <description><de></de><en></en></description><certificate><de></de><en></en></certificate>
+        <sections><section><name><de>S</de><en>S</en></name>
+        <topics><topic>a</topic></topics></section></sections></course>
+        """),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_lists_orphans_grouped(tmp_path):
+    _course(tmp_path)
+    r = CliRunner().invoke(cli, ["spec", "orphans", str(tmp_path / "course-specs")])
+    assert r.exit_code == 0
+    assert "slides_b_old.py" in r.output
+    assert "slides_b_part1.py" in r.output
+    assert "slides_b_misc.py" in r.output
+    # The shipping deck is not listed.
+    assert "slides_a.py" not in r.output
+    # The checkpoint dir is surfaced as cruft.
+    assert ".ipynb_checkpoints" in r.output
+
+
+def test_kind_filter(tmp_path):
+    _course(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["spec", "orphans", str(tmp_path / "course-specs"), "--kind", "superseded", "--json"]
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    kinds = {o["kind"] for o in data["orphans"]}
+    assert kinds == {"superseded"}
+
+
+def test_json_shape(tmp_path):
+    _course(tmp_path)
+    r = CliRunner().invoke(cli, ["spec", "orphans", str(tmp_path / "course-specs"), "--json"])
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert data["orphan_count"] == 3
+    assert data["by_kind"] == {"superseded": 1, "alternate": 1, "unknown": 1}
+    assert len(data["checkpoints"]) == 1
+
+
+def test_clean_checkpoints_removes(tmp_path):
+    _course(tmp_path)
+    ck = tmp_path / "slides" / "module_100_x" / "topic_0000_a" / ".ipynb_checkpoints"
+    assert ck.exists()
+    r = CliRunner().invoke(
+        cli, ["spec", "orphans", str(tmp_path / "course-specs"), "--clean-checkpoints"]
+    )
+    assert "Removed 1" in r.output
+    assert not ck.exists()
+
+
+def test_clean_checkpoints_json_records_removed(tmp_path):
+    _course(tmp_path)
+    r = CliRunner().invoke(
+        cli,
+        ["spec", "orphans", str(tmp_path / "course-specs"), "--clean-checkpoints", "--json"],
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert len(data["checkpoints_removed"]) == 1
+
+
+def test_slides_dir_override(tmp_path):
+    _course(tmp_path)
+    # Move specs somewhere whose parent has no slides/ — must use --slides-dir.
+    far = tmp_path / "elsewhere" / "specs"
+    far.mkdir(parents=True)
+    (far / "c.xml").write_text(
+        (tmp_path / "course-specs" / "c.xml").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    r = CliRunner().invoke(
+        cli,
+        ["spec", "orphans", str(far), "--slides-dir", str(tmp_path / "slides"), "--json"],
+    )
+    data = json.loads(r.output[r.output.index("{") : r.output.rindex("}") + 1])
+    assert data["orphan_count"] == 3
+
+
+def test_missing_slides_dir_errors(tmp_path):
+    specs = tmp_path / "course-specs"
+    specs.mkdir()
+    (specs / "c.xml").write_text(
+        dedent("""\
+        <course><name><de>C</de><en>C</en></name><prog-lang>python</prog-lang>
+        <description><de></de><en></en></description><certificate><de></de><en></en></certificate>
+        <sections><section><name><de>S</de><en>S</en></name>
+        <topics><topic>a</topic></topics></section></sections></course>
+        """),
+        encoding="utf-8",
+    )
+    r = CliRunner().invoke(cli, ["spec", "orphans", str(specs)])
+    assert r.exit_code != 0
+    assert "Slides directory not found" in r.output
+
+
+def test_no_specs_errors(tmp_path):
+    empty = tmp_path / "course-specs"
+    empty.mkdir()
+    (tmp_path / "slides").mkdir()
+    r = CliRunner().invoke(cli, ["spec", "orphans", str(empty)])
+    assert r.exit_code != 0
+    assert "No *.xml specs" in r.output

--- a/tests/cli/test_validate_deep.py
+++ b/tests/cli/test_validate_deep.py
@@ -1,0 +1,178 @@
+"""Tests for ``clm validate`` deep / summary / shipping-only modes (gap #2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+CLEAN_DECK = dedent(
+    """\
+    # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+    # ## Titel
+
+    # %% [markdown] lang="en" tags=["slide"] slide_id="title"
+    # ## Title
+    """
+)
+
+# Missing slide_id on the slide cells — a *content* error (since 1.8) that
+# structure-only spec validation does not catch.
+MISSING_ID_DECK = dedent(
+    """\
+    # %% [markdown] lang="de" tags=["slide"]
+    # ## Titel
+
+    # %% [markdown] lang="en" tags=["slide"]
+    # ## Title
+    """
+)
+
+
+def _write_spec(tmp_path: Path, sections_xml: str, name: str = "test.xml") -> Path:
+    spec_file = tmp_path / "course-specs" / name
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>Test</de><en>Test</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          {sections_xml}
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _deck(tmp_path: Path, module: str, topic: str, name: str, content: str) -> Path:
+    topic_dir = tmp_path / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    p = topic_dir / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _section(name: str, *topics: str) -> str:
+    topic_xml = "".join(f"<topic>{t}</topic>" for t in topics)
+    return f"<section><name><de>{name}</de><en>{name}</en></name><topics>{topic_xml}</topics></section>"
+
+
+def _json(output: str) -> dict:
+    return json.loads(output[output.index("{") : output.rindex("}") + 1])
+
+
+class TestDeep:
+    def test_structure_ok_but_deck_content_error(self, tmp_path):
+        # Spec structure is fine (topic resolves); the deck has a content error.
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", MISSING_ID_DECK)
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        runner = CliRunner()
+        shallow = runner.invoke(cli, ["validate", str(spec_file), "--data-dir", str(tmp_path)])
+        deep = runner.invoke(
+            cli, ["validate", str(spec_file), "--data-dir", str(tmp_path), "--deep"]
+        )
+
+        # Structure-only passes; deep catches the missing slide_id and fails.
+        assert shallow.exit_code == 0
+        assert deep.exit_code == 1
+        assert "slide_id" in deep.output
+
+    def test_deep_clean_passes(self, tmp_path):
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", CLEAN_DECK)
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["validate", str(spec_file), "--data-dir", str(tmp_path), "--deep"]
+        )
+
+        assert result.exit_code == 0
+        assert "Spec structure: OK" in result.output
+
+    def test_deep_json_has_spec_and_slides(self, tmp_path):
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", MISSING_ID_DECK)
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli,
+            ["validate", str(spec_file), "--data-dir", str(tmp_path), "--deep", "--json"],
+        )
+
+        data = _json(result.output)
+        assert data["kind"] == "deep"
+        assert "spec" in data and "slides" in data
+        assert data["slides"]["findings"]
+
+    def test_deep_on_slides_path_errors(self, tmp_path):
+        p = _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", CLEAN_DECK)
+        result = CliRunner().invoke(cli, ["validate", str(p), "--deep"])
+        assert result.exit_code != 0
+        assert "--deep applies to a spec" in result.output
+
+
+class TestSummary:
+    def test_summary_on_spec_implies_deep(self, tmp_path):
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", MISSING_ID_DECK)
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["validate", str(spec_file), "--data-dir", str(tmp_path), "--summary"]
+        )
+
+        assert "By category:" in result.output
+        assert "By kind:" in result.output
+        assert result.exit_code == 1  # the missing-id error still fails
+
+    def test_summary_json(self, tmp_path):
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", MISSING_ID_DECK)
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli,
+            ["validate", str(spec_file), "--data-dir", str(tmp_path), "--summary", "--json"],
+        )
+        data = _json(result.output)
+        assert "summary" in data
+        assert data["summary"]["total"] >= 1
+
+
+class TestShippingOnly:
+    def test_skips_unreferenced_decks(self, tmp_path):
+        # Referenced clean deck + an UNreferenced deck with a content error.
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", CLEAN_DECK)
+        _deck(tmp_path, "module_100_basics", "topic_900_archive", "slides_old.py", MISSING_ID_DECK)
+        _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        slides_dir = tmp_path / "slides"
+        runner = CliRunner()
+        full = runner.invoke(cli, ["validate", str(slides_dir)])
+        shipped = runner.invoke(cli, ["validate", str(slides_dir), "--shipping-only"])
+
+        # The whole-tree walk sees the archived deck's error; shipping-only skips it.
+        assert full.exit_code == 1
+        assert shipped.exit_code == 0
+        assert "OK" in shipped.output
+
+    def test_shipping_only_requires_directory(self, tmp_path):
+        p = _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", CLEAN_DECK)
+        _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+        result = CliRunner().invoke(cli, ["validate", str(p), "--shipping-only"])
+        assert result.exit_code != 0
+
+    def test_shipping_only_explicit_specs_dir(self, tmp_path):
+        _deck(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py", CLEAN_DECK)
+        _deck(tmp_path, "module_100_basics", "topic_900_archive", "slides_old.py", MISSING_ID_DECK)
+        specs = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>").parent
+
+        result = CliRunner().invoke(
+            cli,
+            ["validate", str(tmp_path / "slides"), "--shipping-only", "--specs-dir", str(specs)],
+        )
+        assert result.exit_code == 0

--- a/tests/core/test_spec_decks.py
+++ b/tests/core/test_spec_decks.py
@@ -1,0 +1,170 @@
+"""Tests for :mod:`clm.core.spec_decks` (spec → deck resolution)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from clm.core.course_spec import CourseSpec
+from clm.core.spec_decks import (
+    find_deck_references,
+    resolve_spec_decks,
+)
+
+
+def _write_spec(tmp_path: Path, sections_xml: str, name: str = "test.xml") -> Path:
+    spec_file = tmp_path / "course-specs" / name
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>Test</de><en>Test</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          {sections_xml}
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _topic(tmp_path: Path, module: str, topic: str, *decks: str) -> Path:
+    topic_dir = tmp_path / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    for deck in decks:
+        (topic_dir / deck).write_text("# %% [markdown]\n# Hello\n", encoding="utf-8")
+    return topic_dir
+
+
+@pytest.fixture()
+def slides_dir(tmp_path: Path) -> Path:
+    return tmp_path / "slides"
+
+
+class TestResolveSpecDecks:
+    def test_topic_pulls_in_every_deck_in_its_directory(self, tmp_path, slides_dir):
+        # The whole point of gap #1: one topic dir → multiple decks.
+        _topic(
+            tmp_path,
+            "module_100_basics",
+            "topic_010_props",
+            "slides_properties.py",
+            "slides_property_setters.py",
+        )
+        spec = CourseSpec.from_file(
+            _write_spec(
+                tmp_path,
+                "<sections><section><name><de>S</de><en>S</en></name>"
+                "<topics><topic>props</topic></topics></section></sections>",
+            )
+        )
+
+        resolution = resolve_spec_decks(spec, slides_dir)
+
+        names = sorted(d.name for d in resolution.deck_files)
+        assert names == ["slides_properties.py", "slides_property_setters.py"]
+        assert resolution.unresolved == []
+
+    def test_unresolved_topic_is_reported_not_dropped(self, tmp_path, slides_dir):
+        _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        spec = CourseSpec.from_file(
+            _write_spec(
+                tmp_path,
+                "<sections><section><name><de>S</de><en>S</en></name>"
+                "<topics><topic>intro</topic><topic>ghost</topic></topics>"
+                "</section></sections>",
+            )
+        )
+
+        resolution = resolve_spec_decks(spec, slides_dir)
+
+        assert [t.topic_id for t in resolution.unresolved] == ["ghost"]
+        assert len(resolution.deck_files) == 1
+
+    def test_unbound_duplicate_is_first_occurrence_wins(self, tmp_path, slides_dir):
+        # Same topic id in two modules, unbound reference → build picks the
+        # first (sorted) module and records the other as shadowed.
+        _topic(tmp_path, "module_100_a", "topic_010_intro", "slides_a.py")
+        _topic(tmp_path, "module_200_b", "topic_010_intro", "slides_b.py")
+        spec = CourseSpec.from_file(
+            _write_spec(
+                tmp_path,
+                "<sections><section><name><de>S</de><en>S</en></name>"
+                "<topics><topic>intro</topic></topics></section></sections>",
+            )
+        )
+
+        resolution = resolve_spec_decks(spec, slides_dir)
+
+        assert [d.name for d in resolution.deck_files] == ["slides_a.py"]
+        topic = resolution.topics[0]
+        assert topic.resolved_module == "module_100_a"
+        assert [m.module for m in topic.shadowed] == ["module_200_b"]
+
+    def test_module_bound_reference_picks_that_module(self, tmp_path, slides_dir):
+        _topic(tmp_path, "module_100_a", "topic_010_intro", "slides_a.py")
+        _topic(tmp_path, "module_200_b", "topic_010_intro", "slides_b.py")
+        spec = CourseSpec.from_file(
+            _write_spec(
+                tmp_path,
+                '<sections><section module="module_200_b">'
+                "<name><de>S</de><en>S</en></name>"
+                "<topics><topic>intro</topic></topics></section></sections>",
+            )
+        )
+
+        resolution = resolve_spec_decks(spec, slides_dir)
+
+        assert [d.name for d in resolution.deck_files] == ["slides_b.py"]
+        assert resolution.topics[0].resolved_module == "module_200_b"
+
+    def test_prebuilt_topic_map_is_reused(self, tmp_path, slides_dir):
+        from clm.core.topic_resolver import build_topic_map
+
+        _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        spec = CourseSpec.from_file(
+            _write_spec(
+                tmp_path,
+                "<sections><section><name><de>S</de><en>S</en></name>"
+                "<topics><topic>intro</topic></topics></section></sections>",
+            )
+        )
+        topic_map = build_topic_map(slides_dir)
+
+        resolution = resolve_spec_decks(spec, slides_dir, topic_map=topic_map)
+
+        assert [d.name for d in resolution.deck_files] == ["slides_intro.py"]
+
+
+class TestFindDeckReferences:
+    def test_reverse_lookup_finds_referencing_spec(self, tmp_path, slides_dir):
+        topic_dir = _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        deck = topic_dir / "slides_intro.py"
+        spec_file = _write_spec(
+            tmp_path,
+            "<sections><section><name><de>S</de><en>S</en></name>"
+            "<topics><topic>intro</topic></topics></section></sections>",
+        )
+
+        refs = find_deck_references(deck, [spec_file], slides_dir)
+
+        assert len(refs) == 1
+        assert refs[0].topic_id == "intro"
+        assert refs[0].spec_path == spec_file
+
+    def test_unreferenced_deck_returns_empty(self, tmp_path, slides_dir):
+        topic_dir = _topic(tmp_path, "module_100_basics", "topic_010_orphan", "slides_orphan.py")
+        deck = topic_dir / "slides_orphan.py"
+        spec_file = _write_spec(
+            tmp_path,
+            "<sections><section><name><de>S</de><en>S</en></name>"
+            "<topics></topics></section></sections>",
+        )
+
+        refs = find_deck_references(deck, [spec_file], slides_dir)
+
+        assert refs == []

--- a/tests/core/test_spec_orphans.py
+++ b/tests/core/test_spec_orphans.py
@@ -1,0 +1,162 @@
+"""Tests for orphan detection and classification (gap #7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from clm.core.spec_orphans import (
+    OrphanKind,
+    classify_orphan,
+    find_checkpoint_dirs,
+    find_orphans,
+    render_report,
+    report_to_dict,
+)
+
+DECK = '# %% [markdown] lang="en" tags=["slide"]\n# ## Intro\n'
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "name,kind,reason_sub",
+        [
+            ("slides_x_old.py", OrphanKind.SUPERSEDED, "_old"),
+            ("slides_x_old2.py", OrphanKind.SUPERSEDED, "_old"),
+            ("slides_x_bak.py", OrphanKind.SUPERSEDED, "bak"),
+            ("slides_x_backup.py", OrphanKind.SUPERSEDED, "backup"),
+            ("slides_x_orig.py", OrphanKind.SUPERSEDED, "orig"),
+            ("slides_x_deprecated.py", OrphanKind.SUPERSEDED, "deprecated"),
+            ("slides_x_v1.py", OrphanKind.SUPERSEDED, "version"),
+            ("slides_x_2.py", OrphanKind.SUPERSEDED, "numeric"),
+            ("slides_x_part1.py", OrphanKind.ALTERNATE, "part"),
+            ("slides_x_part5.py", OrphanKind.ALTERNATE, "part"),
+            ("slides_x_short.py", OrphanKind.ALTERNATE, "short"),
+            ("slides_x_long.py", OrphanKind.ALTERNATE, "long"),
+            ("slides_x.py", OrphanKind.UNKNOWN, "no recognizable"),
+            ("slides_observer_advanced.py", OrphanKind.UNKNOWN, "no recognizable"),
+        ],
+    )
+    def test_cases(self, name, kind, reason_sub):
+        k, reason = classify_orphan(Path(name))
+        assert k == kind
+        assert reason_sub in reason
+
+    def test_alternate_beats_numeric_for_partn(self):
+        # _part2 ends in a digit but must classify as alternate, not numeric dup.
+        k, _ = classify_orphan(Path("slides_topic_part2.py"))
+        assert k == OrphanKind.ALTERNATE
+
+    def test_lang_tag_stripped_before_marker(self):
+        k, _ = classify_orphan(Path("slides_x_old.de.py"))
+        assert k == OrphanKind.SUPERSEDED
+        k2, _ = classify_orphan(Path("slides_x_part1.en.py"))
+        assert k2 == OrphanKind.ALTERNATE
+
+
+def _course(tmp_path: Path, referenced: list[str], orphan_decks: dict[str, list[str]]) -> Path:
+    """Build a course; return the course-specs dir.
+
+    ``referenced`` is the topic ids the single spec pulls in. ``orphan_decks``
+    maps a topic-dir id -> deck filenames that no spec references.
+    """
+    slides = tmp_path / "slides" / "module_100_x"
+    for i, tid in enumerate(referenced):
+        d = slides / f"topic_{i:03d}0_{tid}"
+        d.mkdir(parents=True)
+        (d / f"slides_{tid}.py").write_text(DECK, encoding="utf-8")
+    for tid, decks in orphan_decks.items():
+        d = slides / f"topic_900_{tid}"
+        d.mkdir(parents=True)
+        for deck in decks:
+            (d / deck).write_text(DECK, encoding="utf-8")
+
+    specs = tmp_path / "course-specs"
+    specs.mkdir(parents=True, exist_ok=True)
+    topics = "".join(f"<topic>{t}</topic>" for t in referenced)
+    (specs / "c.xml").write_text(
+        dedent(f"""\
+        <course><name><de>C</de><en>C</en></name><prog-lang>python</prog-lang>
+        <description><de></de><en></en></description><certificate><de></de><en></en></certificate>
+        <sections><section><name><de>S</de><en>S</en></name>
+        <topics>{topics}</topics></section></sections></course>
+        """),
+        encoding="utf-8",
+    )
+    return specs
+
+
+class TestFindOrphans:
+    def test_referenced_decks_are_not_orphans(self, tmp_path):
+        specs = _course(tmp_path, ["a"], {"b": ["slides_b_old.py"]})
+        slides_dir = tmp_path / "slides"
+        report = find_orphans(sorted(specs.glob("*.xml")), slides_dir)
+        paths = {p.name for p in (o.path for o in report.orphans)}
+        assert "slides_a.py" not in paths
+        assert "slides_b_old.py" in paths
+        assert report.shipping_count == 1
+
+    def test_grouping_by_kind(self, tmp_path):
+        specs = _course(
+            tmp_path,
+            ["a"],
+            {"b": ["slides_b_old.py", "slides_b_part1.py", "slides_b_misc.py"]},
+        )
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        by_kind = report.by_kind
+        assert len(by_kind[OrphanKind.SUPERSEDED]) == 1
+        assert len(by_kind[OrphanKind.ALTERNATE]) == 1
+        assert len(by_kind[OrphanKind.UNKNOWN]) == 1
+
+    def test_checkpoints_excluded_from_decks_and_reported(self, tmp_path):
+        specs = _course(tmp_path, ["a"], {})
+        ck = tmp_path / "slides" / "module_100_x" / "topic_0000_a" / ".ipynb_checkpoints"
+        ck.mkdir(parents=True)
+        (ck / "slides_a-checkpoint.py").write_text(DECK, encoding="utf-8")
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        # The checkpoint copy is not a deck and not an orphan.
+        assert all(".ipynb_checkpoints" not in p.parts for p in (o.path for o in report.orphans))
+        assert len(report.checkpoints) == 1
+
+    def test_non_py_orphan_detected(self, tmp_path):
+        # A .cpp orphan must be found — the report walk is extension-complete.
+        specs = _course(tmp_path, ["a"], {})
+        d = tmp_path / "slides" / "module_100_x" / "topic_900_c"
+        d.mkdir(parents=True)
+        (d / "slides_c_old.cpp").write_text("// %%\n", encoding="utf-8")
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        names = {p.name for p in (o.path for o in report.orphans)}
+        assert "slides_c_old.cpp" in names
+
+    def test_find_checkpoint_dirs(self, tmp_path):
+        slides = tmp_path / "slides"
+        (slides / "a" / ".ipynb_checkpoints").mkdir(parents=True)
+        (slides / "b" / ".ipynb_checkpoints").mkdir(parents=True)
+        found = find_checkpoint_dirs(slides)
+        assert len(found) == 2
+
+
+class TestRender:
+    def test_clean_course_message(self, tmp_path):
+        specs = _course(tmp_path, ["a"], {})
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        out = render_report(report, tmp_path / "slides")
+        assert "No orphans" in out
+
+    def test_render_groups_and_summarizes(self, tmp_path):
+        specs = _course(tmp_path, ["a"], {"b": ["slides_b_old.py", "slides_b_part1.py"]})
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        out = render_report(report, tmp_path / "slides")
+        assert "superseded" in out
+        assert "alternate" in out
+        assert "slides_b_old.py" in out
+
+    def test_to_dict_shape(self, tmp_path):
+        specs = _course(tmp_path, ["a"], {"b": ["slides_b_old.py"]})
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        d = report_to_dict(report)
+        assert d["orphan_count"] == 1
+        assert d["by_kind"]["superseded"] == 1
+        assert d["orphans"][0]["kind"] == "superseded"

--- a/tests/slides/test_course_gate.py
+++ b/tests/slides/test_course_gate.py
@@ -1,0 +1,94 @@
+"""Tests for :mod:`clm.slides.course_gate`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.slides.course_gate import run_course_gate, scope_decks
+
+# A balanced DE/EN pair with headings but no slide_id → content-derived mint
+# (mechanical, no author work).
+HEADING_PAIR = (
+    '# %% [markdown] lang="de" tags=["slide"]\n# ## Einfuehrung\n\n'
+    '# %% [markdown] lang="en" tags=["slide"]\n# ## Introduction\n'
+)
+
+# A single non-extractable DE slide → hard refusal (needs author).
+NON_EXTRACTABLE = '# %% [markdown] lang="de" tags=["slide"]\n#\n'
+
+# alt-after-start → a tag_migration mechanical change.
+ALT_AFTER_START = (
+    '# %% [markdown] lang="de" tags=["slide", "start"] slide_id="s"\n# ## A\n\n'
+    '# %% [markdown] lang="de" tags=["alt"] slide_id="s"\n# ## B\n'
+)
+
+
+def _deck(
+    tmp_path: Path,
+    name: str,
+    content: str,
+    *,
+    module: str = "module_100_x",
+    topic: str = "topic_010_y",
+) -> Path:
+    d = tmp_path / "slides" / module / topic
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestRunCourseGate:
+    def test_mechanical_only_no_author(self, tmp_path):
+        _deck(tmp_path, "slides_intro.py", HEADING_PAIR)
+        report = run_course_gate(tmp_path / "slides", tmp_path / "slides")
+
+        assert report.deck_count == 1
+        assert report.changes_by_operation.get("slide_ids", 0) == 2
+        assert report.needs_author == []
+        assert report.residual is None  # dry-run
+        assert report.is_clean is True
+
+    def test_hard_refusal_needs_author(self, tmp_path):
+        _deck(tmp_path, "slides_bad.py", NON_EXTRACTABLE)
+        report = run_course_gate(tmp_path / "slides", tmp_path / "slides")
+
+        issues = {ri.issue for ri in report.needs_author}
+        assert "slide_id_hard_refusal" in issues
+        assert report.is_clean is False
+
+    def test_tag_migration_change(self, tmp_path):
+        _deck(tmp_path, "slides_tags.py", ALT_AFTER_START)
+        report = run_course_gate(tmp_path / "slides", tmp_path / "slides")
+
+        assert report.changes_by_operation.get("tag_migration", 0) == 1
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        p = _deck(tmp_path, "slides_intro.py", HEADING_PAIR)
+        before = p.read_text(encoding="utf-8")
+
+        run_course_gate(tmp_path / "slides", tmp_path / "slides", apply=False)
+
+        assert p.read_text(encoding="utf-8") == before
+
+    def test_apply_writes_and_clears(self, tmp_path):
+        p = _deck(tmp_path, "slides_intro.py", HEADING_PAIR)
+        report = run_course_gate(tmp_path / "slides", tmp_path / "slides", apply=True)
+
+        assert 'slide_id="' in p.read_text(encoding="utf-8")
+        assert report.residual is not None
+        assert report.residual.by_severity.get("error", 0) == 0
+        assert report.is_clean is True
+
+    def test_invalid_operation_raises(self, tmp_path):
+        _deck(tmp_path, "slides_intro.py", HEADING_PAIR)
+        with pytest.raises(ValueError, match="Unknown operation"):
+            run_course_gate(tmp_path / "slides", tmp_path / "slides", operations=["bogus"])
+
+    def test_scope_decks_directory(self, tmp_path):
+        _deck(tmp_path, "slides_a.py", HEADING_PAIR)
+        _deck(tmp_path, "slides_b.py", HEADING_PAIR, topic="topic_020_z")
+        decks = scope_decks(tmp_path / "slides", tmp_path / "slides")
+        assert len(decks) == 2

--- a/tests/slides/test_deck_scope.py
+++ b/tests/slides/test_deck_scope.py
@@ -1,0 +1,74 @@
+"""Tests for :mod:`clm.slides.deck_scope`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.slides.deck_scope import (
+    course_root_for_path,
+    filter_decks,
+)
+
+DECKS = [
+    Path("slides/module_100/topic_010/slides_bi.py"),
+    Path("slides/module_100/topic_020/slides_x.de.py"),
+    Path("slides/module_100/topic_020/slides_x.en.py"),
+    Path("slides/module_100/_archive/topic_900/slides_old.py"),
+]
+
+
+class TestFilterDecks:
+    def test_only_bilingual(self):
+        kept = filter_decks(DECKS, only="bilingual")
+        assert [p.name for p in kept] == ["slides_bi.py", "slides_old.py"]
+
+    def test_only_split(self):
+        kept = filter_decks(DECKS, only="split")
+        assert [p.name for p in kept] == ["slides_x.de.py", "slides_x.en.py"]
+
+    def test_exclude_by_component(self):
+        kept = filter_decks(DECKS, exclude=["_archive"])
+        assert all("_archive" not in p.parts for p in kept)
+        assert len(kept) == 3
+
+    def test_exclude_glob(self):
+        kept = filter_decks(DECKS, exclude=["*.de.py"])
+        assert all(not p.name.endswith(".de.py") for p in kept)
+
+    def test_combined_only_and_exclude(self):
+        kept = filter_decks(DECKS, only="bilingual", exclude=["_archive"])
+        assert [p.name for p in kept] == ["slides_bi.py"]
+
+    def test_shipping_filter(self, tmp_path):
+        a = tmp_path / "a.py"
+        b = tmp_path / "b.py"
+        a.write_text("x", encoding="utf-8")
+        b.write_text("y", encoding="utf-8")
+        kept = filter_decks([a, b], shipping={a.resolve()})
+        assert kept == [a]
+
+    def test_unknown_only_raises(self):
+        with pytest.raises(ValueError, match="Unknown --only"):
+            filter_decks(DECKS, only="bogus")
+
+    def test_no_filters_keeps_all(self):
+        assert filter_decks(DECKS) == DECKS
+
+
+class TestCourseRootForPath:
+    def test_slides_root(self, tmp_path):
+        slides = tmp_path / "slides"
+        slides.mkdir()
+        assert course_root_for_path(slides) == tmp_path.resolve()
+
+    def test_under_slides(self, tmp_path):
+        deep = tmp_path / "slides" / "module_100" / "topic_010"
+        deep.mkdir(parents=True)
+        assert course_root_for_path(deep) == tmp_path.resolve()
+
+    def test_no_slides_ancestor(self, tmp_path):
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        assert course_root_for_path(other) is None

--- a/tests/slides/test_lang_coverage.py
+++ b/tests/slides/test_lang_coverage.py
@@ -1,0 +1,109 @@
+"""Tests for the DE/EN coverage core (gap #8)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.lang_coverage import (
+    CoverageStatus,
+    classify_counts,
+    count_languages,
+    render_report,
+    report_to_dict,
+    scan_coverage,
+)
+
+
+def _bi(de: int, en: int) -> str:
+    cells = []
+    for i in range(de):
+        cells.append(f'# %% [markdown] lang="de" tags=["slide"]\n# ## De {i}\n')
+    for i in range(en):
+        cells.append(f'# %% [markdown] lang="en" tags=["slide"]\n# ## En {i}\n')
+    return "\n".join(cells)
+
+
+class TestCounting:
+    def test_count_languages(self):
+        assert count_languages(_bi(2, 3)) == (2, 3)
+
+    def test_narrative_not_counted(self):
+        text = (
+            '# %% [markdown] lang="en" tags=["slide"]\n# ## Slide\n\n'
+            '# %% [markdown] lang="en" tags=["notes"]\n# notes\n\n'
+            '# %% [markdown] lang="de" tags=["notes"]\n# notizen\n'
+        )
+        # One EN slide; the two notes cells are excluded.
+        assert count_languages(text) == (0, 1)
+
+    def test_classify(self):
+        assert classify_counts(2, 2) == CoverageStatus.BALANCED
+        assert classify_counts(0, 0) == CoverageStatus.BALANCED
+        assert classify_counts(3, 0) == CoverageStatus.DE_ONLY
+        assert classify_counts(0, 3) == CoverageStatus.EN_ONLY
+        assert classify_counts(3, 2) == CoverageStatus.IMBALANCED
+
+
+class TestScan:
+    def test_bilingual_balanced_and_imbalanced(self, tmp_path):
+        (tmp_path / "slides_bal.py").write_text(_bi(2, 2), encoding="utf-8")
+        (tmp_path / "slides_imb.py").write_text(_bi(2, 1), encoding="utf-8")
+        report = scan_coverage(sorted(tmp_path.glob("*.py")))
+        by = {e.label.split("slides_")[1]: e for e in report.entries}
+        assert by["bal.py"].status == CoverageStatus.BALANCED
+        assert by["imb.py"].status == CoverageStatus.IMBALANCED
+        assert by["imb.py"].delta == 1
+        assert by["imb.py"].kind == "bilingual"
+
+    def test_split_pair_scored_together(self, tmp_path):
+        (tmp_path / "slides_p.de.py").write_text(_bi(1, 0), encoding="utf-8")
+        (tmp_path / "slides_p.en.py").write_text(_bi(0, 2), encoding="utf-8")
+        report = scan_coverage(sorted(tmp_path.glob("*.py")))
+        assert len(report.entries) == 1
+        e = report.entries[0]
+        assert e.kind == "split-pair"
+        assert (e.de_cells, e.en_cells) == (1, 2)
+        assert e.status == CoverageStatus.IMBALANCED
+
+    def test_lone_split_half_is_one_language(self, tmp_path):
+        (tmp_path / "slides_lone.de.py").write_text(_bi(2, 0), encoding="utf-8")
+        report = scan_coverage(sorted(tmp_path.glob("*.py")))
+        e = report.entries[0]
+        assert e.kind == "split-half"
+        assert (e.de_cells, e.en_cells) == (2, 0)
+        assert e.status == CoverageStatus.DE_ONLY
+
+    def test_balanced_split_pair(self, tmp_path):
+        (tmp_path / "slides_p.de.py").write_text(_bi(2, 0), encoding="utf-8")
+        (tmp_path / "slides_p.en.py").write_text(_bi(0, 2), encoding="utf-8")
+        report = scan_coverage(sorted(tmp_path.glob("*.py")))
+        assert report.entries[0].status == CoverageStatus.BALANCED
+        assert not report.incomplete
+
+    def test_incomplete_excludes_balanced(self, tmp_path):
+        (tmp_path / "slides_bal.py").write_text(_bi(2, 2), encoding="utf-8")
+        (tmp_path / "slides_de.de.py").write_text(_bi(1, 0), encoding="utf-8")
+        report = scan_coverage(sorted(tmp_path.glob("*.py")))
+        assert [e.kind for e in report.incomplete] == ["split-half"]
+
+
+class TestRender:
+    def test_all_balanced_message(self, tmp_path):
+        (tmp_path / "slides_a.py").write_text(_bi(1, 1), encoding="utf-8")
+        out = render_report(scan_coverage(sorted(tmp_path.glob("*.py"))))
+        assert "balanced" in out
+
+    def test_render_groups(self, tmp_path):
+        (tmp_path / "slides_de.de.py").write_text(_bi(1, 0), encoding="utf-8")
+        (tmp_path / "slides_imb.py").write_text(_bi(2, 1), encoding="utf-8")
+        out = render_report(scan_coverage(sorted(tmp_path.glob("*.py"))), base=tmp_path)
+        assert "needs EN translation" in out
+        assert "imbalanced" in out
+        assert "Δ1" in out
+
+    def test_to_dict(self, tmp_path):
+        (tmp_path / "slides_de.de.py").write_text(_bi(1, 0), encoding="utf-8")
+        d = report_to_dict(scan_coverage(sorted(tmp_path.glob("*.py"))))
+        assert d["total"] == 1
+        assert d["by_status"]["de_only"] == 1
+        assert d["decks"][0]["status"] == "de_only"

--- a/tests/slides/test_refusal_report.py
+++ b/tests/slides/test_refusal_report.py
@@ -1,0 +1,141 @@
+"""Tests for the assign-ids refusal worklist (gap #5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.assign_ids import AssignOptions, Refusal, assign_ids_in_file
+from clm.slides.refusal_report import (
+    build_refusal_worklist,
+    render_worklist,
+    worklist_to_dict,
+)
+
+# A deck with: a headed slide, a hard-refusal slide (img, no alt), and a
+# soft-refusal slide (bullet content but no heading).
+DECK = (
+    '# %% [markdown] lang="en" tags=["slide"]\n'
+    "# ## Introduction\n"
+    "#\n"
+    "# Welcome.\n"
+    "\n"
+    '# %% [markdown] lang="en" tags=["slide"]\n'
+    '# <img src="img/diagram.png">\n'
+    "\n"
+    '# %% [markdown] lang="en" tags=["slide"]\n'
+    "# - first bullet here\n"
+    "# - second bullet\n"
+)
+
+
+def _write(tmp_path: Path, text: str = DECK) -> Path:
+    f = tmp_path / "slides_x.py"
+    f.write_text(text, encoding="utf-8")
+    return f
+
+
+class TestBuildWorklist:
+    def test_hard_and_soft_collected(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        wl = build_refusal_worklist(result.refusals)
+        assert len(wl.hard) == 1
+        assert len(wl.soft) == 1
+        # Hard sorts before soft.
+        assert wl.entries[0].severity == "hard"
+        assert wl.entries[1].severity == "soft"
+
+    def test_no_context_means_no_file_read(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        # Delete the file: build without context must not need it.
+        f.unlink()
+        wl = build_refusal_worklist(result.refusals, with_context=False)
+        assert all(e.context is None for e in wl.entries)
+
+    def test_context_recovers_marker_body_anchors(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        wl = build_refusal_worklist(result.refusals, with_context=True)
+        hard = wl.hard[0]
+        assert hard.context is not None
+        assert hard.context.marker.startswith("# %% [markdown]")
+        assert "img/diagram.png" in hard.context.body
+        assert hard.context.preceding_heading == "Introduction"
+        assert hard.context.cell_type == "markdown"
+        assert hard.context.lang == "en"
+
+    def test_soft_refusal_keeps_proposal(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        wl = build_refusal_worklist(result.refusals, with_context=True)
+        soft = wl.soft[0]
+        assert soft.proposed_slug  # bullet-derived slug
+        assert soft.context is not None
+        assert "first bullet" in soft.context.body
+
+    def test_preceding_slide_id_after_write(self, tmp_path):
+        # When ids are actually written, the hard refusal's preceding anchor
+        # picks up the real slide_id minted on the headed slide.
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(accept_content_derived=True))
+        wl = build_refusal_worklist(result.refusals, with_context=True)
+        hard = wl.hard[0]
+        assert hard.context is not None
+        assert hard.context.preceding_slide_id == "introduction"
+
+    def test_missing_file_degrades_gracefully(self, tmp_path):
+        refusals = [Refusal(file=str(tmp_path / "gone.py"), line=3, severity="hard", reason="x")]
+        wl = build_refusal_worklist(refusals, with_context=True)
+        assert wl.entries[0].context is None
+
+    def test_start_of_deck_has_no_anchors(self, tmp_path):
+        text = '# %% [markdown] lang="en" tags=["slide"]\n# <img src="x.png">\n'
+        f = _write(tmp_path, text)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        wl = build_refusal_worklist(result.refusals, with_context=True)
+        ctx = wl.hard[0].context
+        assert ctx is not None
+        assert ctx.preceding_slide_id is None
+        assert ctx.preceding_heading is None
+
+
+class TestRender:
+    def test_empty_worklist_message(self):
+        out = render_worklist(build_refusal_worklist([]))
+        assert "No refusals" in out
+
+    def test_render_includes_body_and_anchor(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        out = render_worklist(build_refusal_worklist(result.refusals, with_context=True))
+        assert "[hard]" in out
+        assert 'heading "Introduction"' in out
+        assert "img/diagram.png" in out
+        assert "1 hard refusal(s)" in out
+
+    def test_render_without_context_is_compact(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        out = render_worklist(build_refusal_worklist(result.refusals))
+        assert "[hard]" in out
+        # No body lines piped in without context.
+        assert "img/diagram.png" not in out
+
+
+class TestToDict:
+    def test_dict_shape(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        d = worklist_to_dict(build_refusal_worklist(result.refusals, with_context=True))
+        assert d["hard_refusals"] == 1
+        assert d["soft_refusals"] == 1
+        assert len(d["refusals"]) == 2
+        hard = next(r for r in d["refusals"] if r["severity"] == "hard")
+        assert hard["context"]["preceding_heading"] == "Introduction"
+
+    def test_dict_no_context_is_null(self, tmp_path):
+        f = _write(tmp_path)
+        result = assign_ids_in_file(f, AssignOptions(report_only=True))
+        d = worklist_to_dict(build_refusal_worklist(result.refusals))
+        assert all(r["context"] is None for r in d["refusals"])

--- a/tests/slides/test_slug_quality.py
+++ b/tests/slides/test_slug_quality.py
@@ -1,0 +1,150 @@
+"""Tests for the slug-quality classifier and scanner (gap #6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.slides.slug_quality import (
+    SlugIssue,
+    classify_slug,
+    render_report,
+    report_to_dict,
+    scan_slug_quality,
+)
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "slug,expected",
+        [
+            ("cp", [SlugIssue.VERY_SHORT]),
+            ("df", [SlugIssue.VERY_SHORT]),
+            ("x", [SlugIssue.VERY_SHORT]),
+            ("os", [SlugIssue.VERY_SHORT]),
+            ("data", [SlugIssue.GENERIC]),
+            ("true", [SlugIssue.GENERIC]),
+            ("value", [SlugIssue.GENERIC]),
+            ("introduction", [SlugIssue.SINGLE_TOKEN]),
+            ("functions", [SlugIssue.SINGLE_TOKEN]),
+        ],
+    )
+    def test_single_token_cases(self, slug, expected):
+        assert classify_slug(slug) == expected
+
+    def test_multi_token_clean(self):
+        assert classify_slug("introduction-to-functions") == []
+        assert classify_slug("step-2") == []
+        assert classify_slug("python-3") == []
+
+    def test_truncation_flag(self):
+        # 30 chars, at the cap.
+        slug = "my-great-slide-about-functions"
+        assert len(slug) == 30
+        assert SlugIssue.POSSIBLY_TRUNCATED in classify_slug(slug)
+
+    def test_short_multi_token_not_truncated(self):
+        assert classify_slug("a-b-c") == []  # 5 chars, multi-token, fine
+
+    def test_title_and_empty_never_flagged(self):
+        assert classify_slug("title") == []
+        assert classify_slug("") == []
+
+    def test_preserve_marker_stripped(self):
+        assert classify_slug("!data") == [SlugIssue.GENERIC]
+        assert classify_slug("!introduction-to-functions") == []
+
+
+def _deck(slide_ids: list[str]) -> str:
+    cells = []
+    for i, sid in enumerate(slide_ids):
+        cells.append(
+            f'# %% [markdown] lang="en" tags=["slide"] slide_id="{sid}"\n# ## Heading {i}\n'
+        )
+    return "\n".join(cells)
+
+
+class TestScan:
+    def test_collects_only_flagged(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["introduction-to-x", "df", "data"]), encoding="utf-8")
+        report = scan_slug_quality([f])
+        assert report.total_ids == 3
+        flagged = {finding.slide_id for finding in report.findings}
+        assert flagged == {"df", "data"}  # the clean multi-token id is not flagged
+
+    def test_narrative_cells_not_double_counted(self, tmp_path):
+        text = (
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="df"\n# ## Heading\n\n'
+            '# %% [markdown] lang="en" tags=["notes"] slide_id="df"\n# speaker notes\n'
+        )
+        f = tmp_path / "slides_x.py"
+        f.write_text(text, encoding="utf-8")
+        report = scan_slug_quality([f])
+        # The notes cell inherits "df" but must not be scanned/counted again.
+        assert report.total_ids == 1
+        assert len(report.findings) == 1
+
+    def test_bilingual_twin_reported_once(self, tmp_path):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="df"\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="df"\n# ## Title\n'
+        )
+        f = tmp_path / "slides_x.py"
+        f.write_text(text, encoding="utf-8")
+        report = scan_slug_quality([f])
+        assert report.total_ids == 1
+        assert len(report.findings) == 1
+
+    def test_missing_file_skipped(self, tmp_path):
+        report = scan_slug_quality([tmp_path / "gone.py"])
+        assert report.files_scanned == 0
+        assert report.total_ids == 0
+
+    def test_by_severity_and_issue(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["df", "data", "introduction"]), encoding="utf-8")
+        report = scan_slug_quality([f])
+        assert report.by_severity == {"high": 2, "low": 1}
+        assert report.by_issue[SlugIssue.VERY_SHORT] == 1
+        assert report.by_issue[SlugIssue.GENERIC] == 1
+
+    def test_at_or_above(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["df", "introduction"]), encoding="utf-8")
+        report = scan_slug_quality([f])
+        high = report.at_or_above("high")
+        assert [f.slide_id for f in high] == ["df"]
+        assert len(report.at_or_above("low")) == 2
+
+
+class TestRender:
+    def test_clean_message(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["introduction-to-functions"]), encoding="utf-8")
+        out = render_report(scan_slug_quality([f]))
+        assert "all look fine" in out
+
+    def test_render_lists_and_summarizes(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["df", "data", "introduction"]), encoding="utf-8")
+        out = render_report(scan_slug_quality([f]))
+        assert 'slide_id="df"' in out
+        assert "very_short" in out
+        assert "3 flagged" in out
+
+    def test_min_severity_filters_render(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["df", "introduction"]), encoding="utf-8")
+        out = render_report(scan_slug_quality([f]), min_severity="high")
+        assert 'slide_id="df"' in out
+        assert 'slide_id="introduction"' not in out
+
+    def test_to_dict_shape(self, tmp_path):
+        f = tmp_path / "slides_x.py"
+        f.write_text(_deck(["df", "introduction"]), encoding="utf-8")
+        d = report_to_dict(scan_slug_quality([f]))
+        assert d["total_ids"] == 2
+        assert d["flagged"] == 2
+        assert d["by_issue"]["very_short"] == 1

--- a/tests/slides/test_validation_summary.py
+++ b/tests/slides/test_validation_summary.py
@@ -1,0 +1,88 @@
+"""Tests for :mod:`clm.slides.validation_summary`."""
+
+from __future__ import annotations
+
+from clm.slides.validation_summary import (
+    classify_kind,
+    render_summary,
+    summarize_findings,
+)
+from clm.slides.validator import Finding
+
+
+def _f(severity: str, category: str, file: str, message: str, line: int = 1) -> Finding:
+    return Finding(severity=severity, category=category, file=file, line=line, message=message)
+
+
+class TestClassifyKind:
+    def test_missing_slide_id(self):
+        assert classify_kind("slide/subslide cell missing slide_id") == "missing-slide_id"
+
+    def test_slug(self):
+        assert (
+            classify_kind("slide_id 'Foo' is not a valid kebab-case ASCII slug") == "slide_id-slug"
+        )
+
+    def test_malformed_marker(self):
+        assert classify_kind("Cell header does not start with '# %%'") == "malformed-marker"
+
+    def test_start_completed(self):
+        assert (
+            classify_kind("'completed' tag without a preceding 'start' cell") == "start-completed"
+        )
+
+    def test_unknown_falls_back_to_other(self):
+        assert classify_kind("something entirely novel") == "other"
+
+
+class TestSummarizeFindings:
+    def test_counts_by_severity_and_category(self):
+        findings = [
+            _f("error", "format", "a.py", "Cell header does not start with '# %%'"),
+            _f("error", "tags", "a.py", "Unrecognized tag 'x'"),
+            _f("warning", "pairing", "b.py", "slide_id mismatch across pair"),
+        ]
+        s = summarize_findings(findings)
+
+        assert s.total == 3
+        assert s.by_severity["error"] == 2
+        assert s.by_severity["warning"] == 1
+        assert s.by_category_severity["format"]["error"] == 1
+        assert s.by_category_severity["pairing"]["warning"] == 1
+
+    def test_per_file_sorted_worst_first(self):
+        findings = [
+            _f("warning", "tags", "low.py", "x"),
+            _f("error", "format", "high.py", "Cell header does not start with '# %%'"),
+            _f("error", "tags", "high.py", "Unrecognized tag 'y'"),
+        ]
+        s = summarize_findings(findings)
+
+        assert s.by_file[0].file == "high.py"
+        assert s.by_file[0].errors == 2
+        assert s.by_file[1].file == "low.py"
+
+    def test_to_dict_roundtrips_structure(self):
+        s = summarize_findings([_f("error", "format", "a.py", "missing slide_id")])
+        d = s.to_dict()
+        assert d["total"] == 1
+        assert d["by_kind"]["missing-slide_id"] == 1
+        assert d["by_file"][0]["file"] == "a.py"
+
+    def test_empty(self):
+        s = summarize_findings([])
+        assert s.total == 0
+        assert s.by_file == []
+
+
+class TestRenderSummary:
+    def test_empty_is_single_line(self):
+        lines = render_summary(summarize_findings([]))
+        assert len(lines) == 1
+        assert "0 finding" in lines[0]
+
+    def test_truncates_file_list(self):
+        findings = [_f("error", "format", f"deck_{i}.py", "missing slide_id") for i in range(25)]
+        lines = render_summary(summarize_findings(findings), top_files=10)
+        text = "\n".join(lines)
+        assert "and 15 more deck(s)" in text


### PR DESCRIPTION
@
## Summary

Turns the course-conversion tooling gaps into first-class `clm` commands,
starting from the prioritized gaps doc. Each gap recurs on every course
conversion / corpus-wide validator bump and was previously reimplemented as a
throwaway script.

### Contents

1. **`docs/claude/course-conversion-tooling-gaps.md`** — the 9 prioritized gaps.
2. **`docs/claude/course-conversion-tooling-handover.md`** — running handover:
   verified codebase anchors + per-tool plan + progress log.
3. **Tool #1 — spec→deck resolution (the highest-value gap):**
   - `clm.core.spec_decks` (`resolve_spec_decks` / `find_deck_references`) — the
     single source of truth, mirroring the build exactly: a `<topic>` resolves to
     a topic *directory* and **every** `slides_*.py` in it is a deck. Module
     bindings resolve in-module; unbound duplicate IDs are first-occurrence-wins
     with shadowed matches surfaced in `--json`. A deck-filename-stem heuristic
     silently misses decks — the mistake that motivated this.
   - `clm spec decks <spec.xml>` (new `spec` group): `--lang de|en|both`,
     `--all-specs DIR` (union shipping set annotated per spec), `--json`.
   - `clm slides referenced-by <deck.py>` — reverse lookup (or `unreferenced`).

### Verification

- 18 new tests (`tests/core/test_spec_decks.py`, `tests/cli/test_spec_decks.py`).
- ruff + mypy clean; pre-push fast suite passed.
- Smoke-tested on the CSharpCourses corpus: 64-deck spec resolved with no false
  misses, `--all-specs` correctly annotated decks shared across two specs, reverse
  lookup found both referencing specs.
- `clm info commands` topic + CHANGELOG updated.

Tools #2–#9 (deep/scoped validation, course-gate orchestrator, mint scoping, …)
follow on this branch in priority order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@