### PR TITLE
feat(slides): clm slides translate — full-deck cold-start translation (#232)

### DIFF
--- a/docs/claude/slides-translate-bootstrap-handover-archive.md
+++ b/docs/claude/slides-translate-bootstrap-handover-archive.md
@@ -1,7 +1,23 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-06-05 -->
+
+# Handover Archive: Full-deck translation — `clm slides translate` (deck bootstrap)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete. **There is no
+> active handover document.** It must **not** be used with `/resume-feature`,
+> `/implement-next-phase`, or similar commands that expect an active work plan.
+>
+> Feature shipped via **PR #234** (Issue #232); all 5 phases merged onto branch
+> `claude/slides-translate-bootstrap`. If you need to resume related work, start a
+> fresh handover.
+
+---
+
 # Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
 
-**Status:** ✅ **FEATURE COMPLETE — all 5 phases DONE.** Phase 1 = pure engine `translate_deck.py`. Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion in lockstep. Phase 4 = the `clm slides translate` (+ `bootstrap` alias) CLI command + `TranslationCache`/`CachingSlideTranslator`. Phase 5 = info-topic docs (`commands.md` + `migration.md`) + the validate acceptance gate. All green; lint/format/mypy clean; fast suite green. **No phases remain — this handover is ready to retire** (`docs/claude/.../-archive`). The only optional follow-ups are in §8.
-**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, `28511cb2` Phase 4, Phase 5 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
+**Status:** ✅ **FEATURE COMPLETE — all 5 phases DONE.** Phase 1 = pure engine `translate_deck.py`. Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion in lockstep. Phase 4 = the `clm slides translate` (+ `bootstrap` alias) CLI command + `TranslationCache`/`CachingSlideTranslator`. Phase 5 = info-topic docs (`commands.md` + `migration.md`) + the validate acceptance gate. All green; lint/format/mypy clean; fast suite green. Shipped via **PR #234**.
+**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, `28511cb2` Phase 4, `23ed7b87` Phase 5).
 **Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
 **Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
 **Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
@@ -18,7 +34,7 @@ This feature adds **`clm slides translate SOURCE`** (alias `bootstrap`): a one-s
 
 **Why it matters:** authoring a bilingual deck currently means hand-writing both halves or hand-copying+translating cell by cell. This automates the cold-start translation while keeping the result immediately valid for the split-pair tooling (`sync`, `unify`, validators).
 
-**Issues/PRs:** tracking issue **#232** (https://github.com/hoelzl/clm/issues/232). (Loosely adjacent to the #158 1.8 gate, but independent of it.)
+**Issues/PRs:** tracking issue **#232** (https://github.com/hoelzl/clm/issues/232); shipped in **PR #234**.
 
 ---
 
@@ -43,18 +59,18 @@ No new mechanism needed:
 - A cell with **no `lang` attribute** is *neutral/shared* → copied **byte-for-byte** into both halves, **never translated** (this is how code cells behave idiomatically).
 - A cell **with a `lang` tag** is *localized* → translated. `role == "code"` selects `_CODE_SYSTEM_PROMPT` (localizes **only** human-facing string literals + comments, keeps identifiers/keywords byte-identical); markdown/narrative roles select `_SYSTEM_PROMPT`.
 
-The gate is the existing `role_of` (`src/clm/slides/sync_writeback.py:66`) / `_membership_role` (`src/clm/slides/sync_plan.py`). **The bootstrap engine MUST reuse this gate, not re-implement it** — translating a neutral/shared cell breaks the `unify` round-trip (`UnifyError`) and trips `validator._check_shared_cell_parity`.
+The gate is the existing `role_of` (`src/clm/slides/sync_writeback.py:66`) / `_membership_role` (`src/clm/slides/sync_plan.py`). **The bootstrap engine MUST reuse this gate, not re-implement it** — translating a neutral/shared cell breaks the `unify` round-trip (`UnifyError`) and trips `validator._check_shared_cell_parity`. *(See the Phase 1 discovery: the implemented gate is actually `metadata.lang`, which subsumes this — `role_of` is `None` for an id-less localized code cell that must still translate.)*
 
 ### D4 — Output shape: split sibling `.en.py` *(user-confirmed)*
 `translate slides_x.de.py` writes the sibling split half `slides_x.en.py`. Matches `sync`, the validator, and `assign_ids_in_split_pair` directly. If the author wants a bilingual file, they run `clm slides unify` afterward. (Rejected: emit a unified bilingual `.py` — needs an extra split before feeding split-pair tooling, second code path.)
 
 ### D5 — Voiceover companion translated in lockstep *(user-confirmed)*
-If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preserving `for_slide` / `vo_anchor`) and write `voiceover_<name>.<tgt>.py`, placed via `effective_write_layout`. Skipping it would ship the new deck with source-language narration. Note `derive_split_twin` returns `None` for `voiceover_*`, so the companion is handled explicitly, not as a deck half.
+If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preserving `for_slide` / `vo_anchor`) and write `voiceover_<name>.<tgt>.py`, placed in the source companion's directory (sibling or `voiceover/` subdir). Skipping it would ship the new deck with source-language narration. Note `derive_split_twin` returns `None` for `voiceover_*`, so the companion is handled explicitly, not as a deck half.
 
-### D6 — Smaller decisions (defaults; not re-litigated unless the user objects)
+### D6 — Smaller decisions (defaults)
 - **Direction:** inferred from the source half's `.de`/`.en` tag (`.de.py` → produces `.en`), with an optional **`--to en|de`** override for safety when a source mixes/omits lang tags.
 - **ID authority:** EN-authority `de_id == en_id` via `assign_ids_in_split_pair`, run over the freshly-written pair. If the source half is itself **id-less**, mint at bootstrap so the pair is **never born id-less** (an id-less/half-id'd pair would otherwise force a downstream cold-mint/adopt round needing the correspondence verifier + key).
-- **Performance:** synchronous per-cell loop to start (consistent with the apply engine), backed by a new `TranslationCache` (shared `clm-llm.sqlite` shape) so re-runs/tests are cheap. Async fan-out (`client.py` `_get_semaphore` pattern, default `max_concurrent=5`) is a later optimization only if real decks are too slow.
+- **Performance:** synchronous per-cell loop, backed by a `TranslationCache` (shared `clm-llm.sqlite` shape) so re-runs/tests are cheap. Async fan-out (`client.py` `_get_semaphore` pattern, default `max_concurrent=5`) is a later optimization only if real decks are too slow.
 - **`--force`:** overwrite an existing **non-empty** twin; without it, an existing twin → delegate to sync (per D2), never silent overwrite.
 - **Bilingual-stem source:** if `SOURCE` is a bilingual deck (no `.de`/`.en` tag) rather than a single half, reject with a hint to run `clm slides split` first (keep the contract explicit).
 
@@ -74,7 +90,6 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - Header grammar is **reused** from `split.py` (`_HEADER_DE_RE`/`_HEADER_EN_RE` + import REs), not re-implemented.
 - **Safety guard:** before returning, the engine self-checks `split(unify(de, en)) == (de, en)` (ordering the two halves by language — `unify_texts` takes `(de, en)` positionally) and raises `TranslateDeckError` rather than emit a structurally-malformed pair. All-or-nothing — never half-writes; on a per-cell `TranslationError` it raises naming the slide.
 - **Tests:** `tests/slides/test_translate_deck.py` (17, all green) — round-trip + content on every shape (slide / voiceover / localized-code / id-less-code / shared / no-header / reverse-direction), byte-exact on trailing-symmetric decks, and the error paths.
-- **Two deliberate deviations from the original phase plan** (see §8): (1) `TranslationCache` moved to **Phase 4** — a caching translator *wrapper* at the integration layer keeps Phase 1 pure/offline; (2) `slide_id` minting moved to **Phase 2** — the engine carries through whatever ids the source has (via `swap_lang`); minting a never-id'd source happens at the file/orchestration layer.
 
 ### Phase 2 — Idempotency + sync convergence + watermark — [DONE]
 **Accomplished:** the D2 dispatch and the "next sync is a no-op" seal, in `src/clm/slides/translate_bootstrap.py`.
@@ -83,7 +98,7 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - `bootstrap_deck(...)`: the dispatch. **Twin present** (and not `--force`) → `_delegate_to_sync` = `build_sync_plan` + `apply_plan` mirroring `slides_sync_cmd`. **Twin absent / empty / `--force`** → `_bootstrap_new_twin`: `translate_deck_text` → `write_text(newline="\n")` → `assign_ids_in_split_pair(de, en, AssignOptions(accept_content_derived=True))` (EN-authority parity; mints onto **both** halves if the source was id-less; `force=False` preserves any author id) → `_record_watermark`.
 - Pure orchestration over **injected** deps (translator/judge/recoverer/verifier/caches) — builds no LLM client, loads no `.env`, closes no cache (the CLI owns those). Offline-testable through the `SlideTranslator`/`SyncJudge` protocols.
 - **Result:** `BootstrapResult` (`action` = `"bootstrapped"`/`"synced"`, `deck`/`assign` or `plan`/`apply_result`, `ids_assigned`, `watermark_recorded`).
-- **Acceptance — met:** `translate` twice → second run is a `sync` no-op (`action=="synced"`, `proposals==[]`, no errors, deck not doubled), proven for **both** an id'd and an **id-less** source (the latter rewrites both halves on run 1, so it exercises the post-mint watermark). Round-trip + parity hold on the written files, including a **trailing-asymmetric** deck (ends on a slide pair). 19 tests in `tests/slides/test_translate_bootstrap.py`.
+- **Acceptance — met:** `translate` twice → second run is a `sync` no-op (`action=="synced"`, `proposals==[]`, no errors, deck not doubled), proven for **both** an id'd and an **id-less** source (the latter rewrites both halves on run 1, so it exercises the post-mint watermark). Round-trip + parity hold on the written files, including a **trailing-asymmetric** deck (ends on a slide pair). 19 tests added (28 total after Phase 3) in `tests/slides/test_translate_bootstrap.py`.
 
 ### Phase 3 — Voiceover companion in lockstep — [DONE]
 **Accomplished:** D5, inside `translate_bootstrap.py`.
@@ -96,9 +111,6 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **Deferred:** full companion *sync* (reconciling an already-present companion when the deck twin exists) is out of scope — the bootstrap creates it once; later deck syncs leave it alone. Also not special-cased: a companion whose `for_slide` references an **id-less** deck (a malformed input — `extract` requires deck ids; the bootstrap mint with `force=False` preserves existing ids, so a real companion's `for_slide` stays valid).
 
 ### Phase 4 — CLI command `clm slides translate` (+ `bootstrap` alias) — [DONE]
-**Accomplishes:** user-facing surface.
-
-**Done as built:**
 - **`src/clm/cli/commands/slides_translate.py`** — the Click command wrapping `bootstrap_deck`. Options: `--to en|de`, `--dry-run` (side-effect-free preview: counts translatable-vs-copied + target + companion, **no LLM/key**, exit 0), `--json`, `--force`, `--translation-model`, `--provider` (judge backend for the delegated-sync path only), `--llm-model`, `--cache-dir`, `--no-cache`, `--no-env-file`. It calls `derive_bootstrap_paths` first (pure) to decide bootstrap-vs-sync **before** building any client, builds the translator always and the judge (via reused `slides_sync._resolve_judge`) only on the sync path. Recoverer/verifier are intentionally **off** (a bootstrap-created pair is already id'd+watermarked; advanced id-migration lives on `clm slides sync`).
 - **No key → exit 1, write nothing** — but only on the **bootstrap** path (a whole untranslated deck is useless). The delegated-sync path degrades like `clm slides sync` (adds defer). `_make_translator` is a module-level factory so tests patch it with a static translator; `has_openrouter_api_key` is imported into the module namespace and patched in tests.
 - **`TranslationCache`** in `src/clm/infrastructure/llm/cache.py` (table `translations`, PK `(content_hash, prompt_version, source_lang, target_lang, role)`, get/put/invalidate/close; only successful results) + **`CachingSlideTranslator`** in `sync_translate.py` wrapping a `SlideTranslator`, `prompt_version` computed in `__post_init__` (a settable field, **not** a property — a read-only property fails the Protocol's settable `prompt_version: str` under mypy) with the model folded in so two models never share an entry.
@@ -107,8 +119,6 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **Acceptance — met:** `CliRunner` tests (11) — absent-twin bootstrap (exit 0, twin == split's EN), no-key exit 1 + nothing written, `--dry-run` no-write + `--json` shape, `--to` reverse direction, present-twin → incremental-sync no-op (not doubled), `--force` overwrite, bilingual-stem/missing-source exit 2, and the `bootstrap` alias via the `slides` group. Plus 13 cache/caching-translator unit tests in `tests/infrastructure/llm/test_translation_cache.py`.
 
 ### Phase 5 — Docs & acceptance gate — [DONE]
-**Accomplished:** the CLAUDE.md Info Topics Maintenance Rule + end-to-end validation.
-
 - Added a `### clm slides translate` section to `src/clm/cli/info_topics/commands.md` (option table, exit codes, examples, the `bootstrap` alias, the lang-tag rule, companion lockstep, dispatch/idempotency), with `{version}` placeholders. Also updated the `### clm slides sync` cross-reference ("sync never invents a translated half") to point at `clm slides translate` for the cold start.
 - Added a `## Bootstrap a second language: clm slides translate ({version} — additive)` entry to `migration.md` (the `translate` → `sync` → `unify` workflow; additive, no break).
 - **MCP: intentionally skipped** — the MCP surface wraps read/analysis library functions (`suggest_sync`, `validate`, `normalize`); the writing+LLM `slides_sync` is **not** exposed there, so `slides_translate` is out of scope by the same rationale (not an omission).
@@ -116,98 +126,76 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 ---
 
-## 4. Current Status
+## 4. Final Status (at retirement)
 
-- **Completed:** design + **all 5 phases**. `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, `28511cb2` Phase 4, Phase 5 commit follows (docs + acceptance gate). Lint/format/mypy clean; fast suite green. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master, pushed. The three user-facing forks are settled (D1, D4, D5).
-- **In progress:** none — feature complete.
-- **Blockers / open questions:** none. The `--to` question is resolved: `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source* (a tag-less single half is rejected with a "run split first" hint), and `--to` is an optional override.
-- **Tests:** all phases covered (see §7). Counts: 17 (`test_translate_deck`) + 28 (`test_translate_bootstrap`) + 13 (`test_translation_cache`) + 12 (`test_slides_translate`, incl. the acceptance gate).
-- **Remaining:** open a PR to `master`, then **retire this handover** (→ `-archive`). No code work left.
+- **Completed:** design + **all 5 phases**. `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, `28511cb2` Phase 4, `23ed7b87` Phase 5. Lint/format/mypy clean; fast suite green (6664 passing). Issue **#232**; shipped via **PR #234**.
+- **Tests (70 total):** 17 (`test_translate_deck`) + 28 (`test_translate_bootstrap`) + 13 (`test_translation_cache`) + 12 (`test_slides_translate`, incl. the acceptance gate).
+- **The `--to` question** is resolved: `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source* (a tag-less single half is rejected with a "run split first" hint), and `--to` is an optional override.
 
 ---
 
-## 5. Next Steps
+## 5. Optional Future Work (not required)
 
-**All 5 phases are DONE — no implementation work remains.** The only follow-ups are process:
-1. **Open a PR** from `claude/slides-translate-bootstrap` → `master` (link #232). The branch is pushed and the pre-push gate (ruff, format, mypy, fast suite) passes.
-2. **Retire this handover** — rename to `docs/claude/slides-translate-bootstrap-handover-archive.md` (the `retire-handover` skill), since the feature is shipped.
-3. **Optional future work** (not required): async fan-out of the per-cell translate loop (`client.py` `_get_semaphore`, default `max_concurrent=5`) if real decks are slow; full companion *sync* (reconciling an already-present companion on the sync-delegation path); a `--to` requirement when a source genuinely has no lang tags (currently inferred from the filename tag).
-
-**The feature is usable today:** `clm slides translate slides_x.de.py`. Single entry point `bootstrap_deck(...) -> BootstrapResult` in `src/clm/slides/translate_bootstrap.py`; CLI in `src/clm/cli/commands/slides_translate.py`.
-
-**Setup:** worktree venv must be synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (memory `feedback-worktree-venv-sync`). Run tests with `uv run python -m pytest …` (system Python has no pytest).
-
-**Gotchas to watch (these silently corrupt the pair):**
-- **Phase 1 already handles** the translate-vs-copy gate (`metadata.lang`, *not* `role_of` — a localized id-less code cell is `role_of()==None` but must translate), the header-macro/import rewrite (reused `split.py` regexes), and the `split(unify(de,en))==(de,en)` validity guard. Don't re-implement these in Phase 2.
-- Emitting the twin id-less → forces a downstream cold-mint/adopt round (needs verifier + key). Mint ids at bootstrap via `assign_ids_in_split_pair`.
-- Missing watermark seal → the next `sync` re-diffs and may re-propose. The `_record_watermark` call is load-bearing for D2.
-- Program extension may be `.cpp`/`.java` etc.; the `.de`/`.en` tag sits immediately before the final extension. Use `split_lang_tag` (prefix-agnostic) for naming — don't assume `.py`.
-- Line endings: write with `newline="\n"`; never line-string surgery — use `raw_cells` / `FileState`.
+- Async fan-out of the per-cell translate loop (`client.py` `_get_semaphore`, default `max_concurrent=5`) if real decks are slow.
+- Full companion *sync* (reconciling an already-present companion on the sync-delegation path).
+- A `--to` requirement when a source genuinely has no lang tags (currently inferred from the filename tag).
 
 ---
 
 ## 6. Key Files & Architecture
 
 ### New files
-- **`src/clm/slides/translate_deck.py` — DONE (Phase 1).** The pure, offline bootstrap engine: `translate_deck_text(source_text, *, source_lang, target_lang, translator) -> TranslateDeckResult`. Parses a source half, classifies cells by `metadata.lang`, translates localized ones (code via `CODE_ROLE`), copies neutral ones verbatim, rewrites the header macro/import (reusing `split.py` regexes), self-checks the split/unify round-trip, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable. **Also reusable for the Phase 3 voiceover companion** — companions are just lang-tagged cells with no header macro, which this engine already handles.
-- **`tests/slides/test_translate_deck.py` — DONE (17 tests).**
-- **`src/clm/slides/translate_bootstrap.py` — DONE (Phases 2 + 3).** File/orchestration layer: `derive_bootstrap_paths` (direction + existence-agnostic twin path + rejections), `bootstrap_deck` (the D2 dispatch), `_bootstrap_new_twin` (translate deck + companion → write both → `assign_ids_in_split_pair` → `_record_watermark`), `_translate_companion` (Phase 3 — `resolve_companion` + `companion_name`, all-or-nothing, skip/force), `_delegate_to_sync` (mirror of `slides_sync_cmd`). Injected deps only (no client/`.env`/cache-close). Public surface: `bootstrap_deck`, `derive_bootstrap_paths`, `BootstrapResult`, `CompanionResult`, `BootstrapPaths`, `TranslateBootstrapError`. **This is the single entry point the Phase 4 CLI calls.**
-- **`tests/slides/test_translate_bootstrap.py` — DONE (28 tests, incl. 9 companion).**
-- **`src/clm/cli/commands/slides_translate.py` — DONE (Phase 4).** The `clm slides translate` (+ `bootstrap`) Click command over `bootstrap_deck`; `_make_translator` factory (patchable), `derive_bootstrap_paths`-first dispatch, `--dry-run` preview, `--json`, exit-code matrix.
-- **`TranslationCache` (`src/clm/infrastructure/llm/cache.py`) + `CachingSlideTranslator` (`src/clm/slides/sync_translate.py`) — DONE (Phase 4).** Persistent per-cell translation cache + a `SlideTranslator`-protocol wrapper (model-folded version; `prompt_version` is a computed field, not a property).
-- **`tests/cli/test_slides_translate.py` — DONE (11 tests).** **`tests/infrastructure/llm/test_translation_cache.py` — DONE (13 tests).**
+- **`src/clm/slides/translate_deck.py` (Phase 1).** The pure, offline bootstrap engine: `translate_deck_text(source_text, *, source_lang, target_lang, translator) -> TranslateDeckResult`. Parses a source half, classifies cells by `metadata.lang`, translates localized ones (code via `CODE_ROLE`), copies neutral ones verbatim, rewrites the header macro/import (reusing `split.py` regexes), self-checks the split/unify round-trip, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable.
+- **`src/clm/slides/translate_bootstrap.py` (Phases 2 + 3).** File/orchestration layer: `derive_bootstrap_paths` (direction + existence-agnostic twin path + rejections), `bootstrap_deck` (the D2 dispatch), `_bootstrap_new_twin` (translate deck + companion → write both → `assign_ids_in_split_pair` → `_record_watermark`), `_translate_companion` (`resolve_companion` + `companion_name`, all-or-nothing, skip/force), `_delegate_to_sync` (mirror of `slides_sync_cmd`). Public surface: `bootstrap_deck`, `derive_bootstrap_paths`, `BootstrapResult`, `CompanionResult`, `BootstrapPaths`, `TranslateBootstrapError`.
+- **`src/clm/cli/commands/slides_translate.py` (Phase 4).** The `clm slides translate` (+ `bootstrap`) Click command; `_make_translator` factory (patchable), `derive_bootstrap_paths`-first dispatch, `--dry-run` preview, `--json`, exit-code matrix.
+- **`TranslationCache` (`src/clm/infrastructure/llm/cache.py`) + `CachingSlideTranslator` (`src/clm/slides/sync_translate.py`) (Phase 4).**
+- Tests: `tests/slides/test_translate_deck.py` (17), `tests/slides/test_translate_bootstrap.py` (28), `tests/infrastructure/llm/test_translation_cache.py` (13), `tests/cli/test_slides_translate.py` (12).
 
 ### Modified files
-- `src/clm/cli/main.py` — registers `translate` + `bootstrap` under `slides_group` (~line 167). **DONE.**
-- `src/clm/cli/info_topics/commands.md` — `### clm slides translate` section + updated the sync cross-reference. **DONE (Phase 5).**
-- `src/clm/cli/info_topics/migration.md` — `## Bootstrap a second language` entry. **DONE (Phase 5).**
+- `src/clm/cli/main.py` — registers `translate` + `bootstrap` under `slides_group` (~line 167).
+- `src/clm/cli/info_topics/commands.md` — `### clm slides translate` section + sync cross-reference.
+- `src/clm/cli/info_topics/migration.md` — `## Bootstrap a second language` entry.
 
-### Reuse surface (verified at these paths/lines)
+### Reuse surface (verified at these paths/lines at time of writing)
 | Symbol | Location | Role |
 |---|---|---|
 | `SlideTranslator` (Protocol) / `OpenRouterSlideTranslator` / `StaticSlideTranslator` | `src/clm/slides/sync_translate.py:45 / :96 / :69` | per-cell translator; `translate(*, source_body, source_lang, target_lang, role) -> str`. `StaticSlideTranslator` = deterministic test fake. |
 | `_system_prompt_for` / `_CODE_SYSTEM_PROMPT` / `DEFAULT_TRANSLATION_MODEL` | `sync_translate.py:188 / :174 / :37` | role→prompt selection; code prompt keeps identifiers byte-identical; model `anthropic/claude-sonnet-4-6`. |
 | `role_of` | `src/clm/slides/sync_writeback.py:66` | the translate-vs-copy gate (keyed on `lang` presence + cell_type). |
 | `swap_lang` / `build_twin_cell` | `sync_writeback.py:228 / :241` | lossless twin-cell construction. |
-| `FileState` | `sync_writeback.py` | batched, header/padding-preserving deck writer. |
 | `split_cells` / `reconstruct` | `src/clm/slides/raw_cells.py:53 / :95` | byte-faithful parse→write foundation. |
 | `assign_ids_in_split_pair` | `src/clm/slides/assign_ids.py:823` | EN-authority shared-id minting (`de_id==en_id`) with round-trip guard. |
 | header-macro regexes + `split_text` / `unify_texts` | `src/clm/slides/split.py` | `header_de`↔`header_en` swap; the round-trip invariant to assert. |
 | `derive_split_twin` / `split_lang_tag` / `order_split_pair` | `src/clm/slides/pairing.py:210 / :158 / :189` | target-path derivation + twin-missing detection. |
 | `build_sync_plan` / `apply_plan` | `src/clm/slides/sync_plan.py:1664` / `sync_apply.py:208` | delegated to when the twin already exists (D2). |
 | `_record_watermark` / `SyncWatermarkCache` | `sync_apply.py:2172` / `src/clm/infrastructure/llm/cache.py:652` | idempotency seal. |
-| `has_openrouter_api_key` / `build_openrouter_client` | `src/clm/infrastructure/llm/openrouter_client.py:71` | provider/key wiring. |
+| `resolve_companion` / `companion_name` | `src/clm/slides/voiceover_tools.py:233 / :181` | companion resolution + naming (D5). |
+| `has_openrouter_api_key` / `build_openrouter_client` | `src/clm/infrastructure/llm/openrouter_client.py:71 / :81` | provider/key wiring. |
 | `load_env_files` | `src/clm/cli/env_loading.py:45` | `.env` walk-up (respect `--no-env-file`). |
-| `call_with_retries` | `src/clm/infrastructure/llm/retry.py` | bounded backoff; re-raises on exhaustion (never silently drops a cell). |
-| `effective_write_layout` | `src/clm/slides/sidecar_layout.py` | voiceover companion placement (D5). |
-| `_resolve_single_path` (the guard we sit beside) | `src/clm/cli/commands/slides_sync.py:148` | the current refusal to invent a missing twin — reference, not modified. |
 
 ### How it connects
-`slides_translate.py` (CLI) → resolves source + twin via `pairing` → **twin present**: `build_sync_plan`+`apply_plan` (existing sync) — **twin absent**: `translate_deck.py` (new engine, drives `SlideTranslator`) → `assign_ids_in_split_pair` → `_record_watermark`. Companion handled in lockstep. Validation gate is `clm validate slides`.
+`slides_translate.py` (CLI) → resolves source + twin via `derive_bootstrap_paths` → **twin present**: `build_sync_plan`+`apply_plan` (existing sync) — **twin absent**: `translate_deck.py` (new engine, drives `SlideTranslator`) → `assign_ids_in_split_pair` → `_record_watermark`. Companion handled in lockstep. Validation gate is `clm validate slides`.
 
 ---
 
 ## 7. Testing Approach
 
-- **Unit (primary, offline):** drive everything through the `SlideTranslator` **Protocol** with `StaticSlideTranslator` — **no network, no vcrpy cassette** (this is a host-side path, unlike in-kernel build LLM traffic). The whole sync stack is tested this way; follow it.
-- **Phase 1 invariants — DONE (17 tests, all green):** the primary assertion is `split(unify(de, en)) == (de, en)` (`_assert_valid_pair`) plus content checks (right language survives, shared cells present, header swapped). Byte-exact `== other_half` is asserted only on *trailing-symmetric* decks (header-only or shared-cell-terminated) — see the trailing-blank note in §8. The strongest cases use a `_mirror_translator` built from the canonical split halves so a correct engine regenerates the other side's content exactly.
-- **Phase 2:** run `translate` twice → second run = `sync` no-op (assert no doubling, watermark recorded, subsequent `sync` clean). Present-twin delegation path exercised.
-- **Phase 3:** companion translated, `for_slide`/`vo_anchor` preserved, parity validator passes.
-- **Phase 4:** `CliRunner` for absent/present twin, `--dry-run` writes nothing, `--json` envelope shape, no-key degradation (exit 1 + warning, no crash), `--force` overwrite, exit-code matrix. Note the Click 8.1-vs-8.2 `CliRunner` compat pattern (memory `feedback-click-82-clirunner-compat`).
-- **Acceptance:** generated deck passes `clm validate slides <dir> --fail-on warning`.
-- **Run:** `pytest tests/slides/test_translate_deck.py tests/cli/test_slides_translate.py` during dev; full fast suite `pytest` before push (pre-push hook, ~72s). The commit hook can flake on unrelated recordings polling under xdist contention — if so, `PYTEST_XDIST_AUTO_NUM_WORKERS=4 git commit` (memory `project-topic-sidecar-subdirs`).
+- **Unit (primary, offline):** drive everything through the `SlideTranslator` **Protocol** with `StaticSlideTranslator` — **no network, no vcrpy cassette** (this is a host-side path, unlike in-kernel build LLM traffic). The whole sync stack is tested this way.
+- **Engine invariants (17 tests):** the primary assertion is `split(unify(de, en)) == (de, en)` (`_assert_valid_pair`) plus content checks. Byte-exact `== other_half` is asserted only on *trailing-symmetric* decks (header-only or shared-cell-terminated). The strongest cases use a `_mirror_translator` built from the canonical split halves so a correct engine regenerates the other side's content exactly.
+- **Bootstrap (28 tests):** run `translate` twice → second run = `sync` no-op (assert no doubling, watermark recorded). Companion translated, `for_slide`/`vo_anchor` preserved.
+- **CLI (12 tests):** `CliRunner` for absent/present twin, `--dry-run` writes nothing, `--json` shape, no-key degradation (exit 1, nothing written), `--force`, exit-code matrix, and the acceptance gate (`clm validate <dir> --fail-on warning` passes). Note the Click 8.1-vs-8.2 `CliRunner` compat pattern (memory `feedback-click-82-clirunner-compat`).
+- **Run:** full fast suite `pytest` before push (pre-push hook, ~72s). The commit hook can flake on unrelated recordings polling under xdist contention — if so, `PYTEST_XDIST_AUTO_NUM_WORKERS=4 git commit`.
 
 ---
 
-## 8. Session Notes
+## 8. Session Notes / Discoveries
 
-- The user is the project author and explicitly chose the **separate-command** surface, **split-sibling** output, and **lockstep voiceover** when asked. Don't re-open these without cause.
-- The "code is translated iff it has a lang tag" requirement was the user's own framing — and it happens to be exactly the existing `role_of` / no-lang-is-shared model. Lean on that; don't invent a parallel marker.
-- Grounding for this design came from a multi-agent read of the sync engine, slide format, pairing/cold-start machinery, LLM infra, and CLI surface. The reuse table in §6 was re-verified against the live tree (symbol names + line numbers) before writing this doc.
-- CLAUDE.md hard rules in play: type hints on public APIs; `attrs @define` internal / Pydantic at boundaries; `logging.getLogger(__name__)` never `print()`; Python over bash for any tooling; **update info topics** when CLI behavior changes (Phase 5 is not optional). Commits that fail a hook didn't happen — fix, re-stage, new commit (never `--amend` a rejected commit).
+- The user is the project author and explicitly chose the **separate-command** surface, **split-sibling** output, and **lockstep voiceover** when asked.
+- The "code is translated iff it has a lang tag" requirement was the user's own framing — and it happens to be exactly the existing `role_of` / no-lang-is-shared model. No parallel marker invented.
 
-### Phase 1 discoveries (read before Phase 2)
-- **The translate-vs-copy gate is `metadata.lang`, NOT `role_of`.** The original plan said "gate on `role_of(meta) is None`", but `role_of` returns `None` for a localized id-less code cell (`# %% lang="de"` with no `slide_id`) — which *must* be translated. So: `lang == source_lang` → translate; `lang is None` → copy verbatim. `role_of`/`cell_type` only select the prompt (`CODE_ROLE` → code prompt). This is encoded in `_translation_role` and the main loop.
-- **`split` produces trailing-blank-asymmetric halves.** The cell that ends the bilingual source carries an extra EOF blank line that, after `split`, lands on **only one** half. So a generated half (the engine mirrors the *source* half's per-cell trailing blanks) does **not** in general byte-match the other half of an arbitrary bilingual deck — and that is correct: when bootstrapping there is no pre-existing other half to match. The honest invariant is the round-trip, not byte-equality. Byte-exact tests therefore use decks that end on a shared cell (symmetric) or are header-only. Phase 2 writes these halves to disk as-is; don't try to "fix" the asymmetry.
+### Phase 1 discoveries (load-bearing)
+- **The translate-vs-copy gate is `metadata.lang`, NOT `role_of`.** The original plan said "gate on `role_of(meta) is None`", but `role_of` returns `None` for a localized id-less code cell (`# %% lang="de"` with no `slide_id`) — which *must* be translated. So: `lang == source_lang` → translate; `lang is None` → copy verbatim. `role_of`/`cell_type` only select the prompt (`CODE_ROLE` → code prompt). Encoded in `_translation_role` and the main loop.
+- **`split` produces trailing-blank-asymmetric halves.** The cell that ends the bilingual source carries an extra EOF blank line that, after `split`, lands on **only one** half. So a generated half (the engine mirrors the *source* half's per-cell trailing blanks) does **not** in general byte-match the other half of an arbitrary bilingual deck — and that is correct: when bootstrapping there is no pre-existing other half to match. The honest invariant is the round-trip, not byte-equality. Byte-exact tests therefore use decks that end on a shared cell (symmetric) or are header-only.
 - **The round-trip guard verifies split-*validity*, not translation *fidelity*.** A translator that injects a *valid* `lang="en"` cell boundary produces an extra-but-valid cell that still round-trips (guard won't flag it); only a structurally-breaking injection (e.g. a no-lang cell appearing in one half) trips it. Fidelity is the LLM's job / a later verify pass, not the engine's.
-- **The engine reuses `split.py`'s private header regexes** (`_HEADER_DE_RE` etc.) via `from clm.slides import split`. Deliberate (the handover's "don't duplicate the header grammar" rule). If a reviewer prefers, promote them to public names in `split.py` — but do not fork copies.
+- **The engine reuses `split.py`'s private header regexes** (`_HEADER_DE_RE` etc.) via `from clm.slides import split`. Deliberate (the "don't duplicate the header grammar" rule).
+- **`CachingSlideTranslator.prompt_version` must be a settable field, not a property** — a read-only `@property` fails the `SlideTranslator` Protocol's settable `prompt_version: str` under mypy. Computed in `__post_init__`, model folded in.

--- a/docs/claude/slides-translate-bootstrap-handover.md
+++ b/docs/claude/slides-translate-bootstrap-handover.md
@@ -1,7 +1,7 @@
 # Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
 
-**Status:** **Phases 1–3 DONE.** Phase 1 = pure engine `translate_deck.py` (17 tests). Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion translated in lockstep (now **28 tests** in `test_translate_bootstrap.py`). All green; lint/format/mypy clean; full slides suite (1176) + fast suite green. **Phase 4 (the `clm slides translate` CLI command) is next.**
-**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, Phase 3 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
+**Status:** **Phases 1–4 DONE.** Phase 1 = pure engine `translate_deck.py`. Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion in lockstep. Phase 4 = the `clm slides translate` (+ `bootstrap` alias) CLI command + `TranslationCache`/`CachingSlideTranslator`. All green; lint/format/mypy clean; fast suite green. **Phase 5 (info-topic docs + acceptance gate) is next** — and is required by CLAUDE.md's Info Topics rule since a new CLI command landed.
+**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, Phase 4 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
 **Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
 **Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
 **Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
@@ -95,16 +95,16 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **Acceptance — met:** companion translated alongside the deck; `for_slide` + `vo_anchor` preserved; companion pair round-trips; subdir layout preserved; existing target skipped; `--force` regenerates; re-run via sync leaves it untouched; translation failure writes nothing. 9 companion tests (28 total in `tests/slides/test_translate_bootstrap.py`).
 - **Deferred:** full companion *sync* (reconciling an already-present companion when the deck twin exists) is out of scope — the bootstrap creates it once; later deck syncs leave it alone. Also not special-cased: a companion whose `for_slide` references an **id-less** deck (a malformed input — `extract` requires deck ids; the bootstrap mint with `force=False` preserves existing ids, so a real companion's `for_slide` stays valid).
 
-### Phase 4 — CLI command `clm slides translate` (+ `bootstrap` alias) — [TODO]
+### Phase 4 — CLI command `clm slides translate` (+ `bootstrap` alias) — [DONE]
 **Accomplishes:** user-facing surface.
 
-- New module `src/clm/cli/commands/slides_translate.py`; clone the option skeleton from `slides_sync.py` and the simple-mutation skeleton from `split.py`:
-  - `--to en|de`, `--dry-run` / `--explain` (side-effect-free: parse + classify + count translatable vs copied + show target path + id plan; skip LLM/.env where possible), `--json` (`_to_dict`: `cells_translated`, `cells_copied`, `target_path`, `ids_minted`, `deferred`), `--force`, `--provider` (env `CLM_SYNC_PROVIDER`), `--translation-model`, `--cache-dir` (env `CLM_CACHE_DIR`), `--no-cache`, `--no-env-file`.
-- Reuse `has_openrouter_api_key` (`openrouter_client.py:71`), `build_openrouter_client`, `load_env_files` (`env_loading.py:45`), `resolve_cache_dir`. No key → **exit 1, write nothing** (a whole deck of untranslated placeholders is not useful — unlike sync's per-cell defer); the engine is all-or-nothing. On `TranslationError` it already raises (never half-writes).
-- **`TranslationCache` lands here (moved from Phase 1):** add a `TranslationCache` to `src/clm/infrastructure/llm/cache.py` (one table in `clm-llm.sqlite`; key = content-hash + **model-folded** `prompt_version`; cache only successful results) and expose it as a `CachingSlideTranslator` that *wraps* a `SlideTranslator` and is passed into `translate_deck_text`. The engine stays cache-agnostic (depends only on the protocol), so this is purely additive.
-- Register in `src/clm/cli/main.py` (~line 168): `slides_group.add_command(translate_cmd, name="translate")` and a second registration for `bootstrap`. Use the try/except optional-import pattern (main.py ~112-130) if LLM deps may be absent.
-- Exit codes: `0` wrote/clean, `1` some cells deferred (no key) / needs review, `2` hard error (twin exists without `--force`, engine down, bilingual-stem source).
-- **Acceptance:** `CliRunner` tests for absent-twin bootstrap, present-twin delegation, `--dry-run` no-write, `--json` shape, no-key degradation, `--force` overwrite, exit codes.
+**Done as built:**
+- **`src/clm/cli/commands/slides_translate.py`** — the Click command wrapping `bootstrap_deck`. Options: `--to en|de`, `--dry-run` (side-effect-free preview: counts translatable-vs-copied + target + companion, **no LLM/key**, exit 0), `--json`, `--force`, `--translation-model`, `--provider` (judge backend for the delegated-sync path only), `--llm-model`, `--cache-dir`, `--no-cache`, `--no-env-file`. It calls `derive_bootstrap_paths` first (pure) to decide bootstrap-vs-sync **before** building any client, builds the translator always and the judge (via reused `slides_sync._resolve_judge`) only on the sync path. Recoverer/verifier are intentionally **off** (a bootstrap-created pair is already id'd+watermarked; advanced id-migration lives on `clm slides sync`).
+- **No key → exit 1, write nothing** — but only on the **bootstrap** path (a whole untranslated deck is useless). The delegated-sync path degrades like `clm slides sync` (adds defer). `_make_translator` is a module-level factory so tests patch it with a static translator; `has_openrouter_api_key` is imported into the module namespace and patched in tests.
+- **`TranslationCache`** in `src/clm/infrastructure/llm/cache.py` (table `translations`, PK `(content_hash, prompt_version, source_lang, target_lang, role)`, get/put/invalidate/close; only successful results) + **`CachingSlideTranslator`** in `sync_translate.py` wrapping a `SlideTranslator`, `prompt_version` computed in `__post_init__` (a settable field, **not** a property — a read-only property fails the Protocol's settable `prompt_version: str` under mypy) with the model folded in so two models never share an entry.
+- Registered in `src/clm/cli/main.py` (~line 167) under `slides_group` for both `translate` and `bootstrap` (same command object, two names — Click handles this; no optional-import guard needed, the deps are core).
+- Exit codes: `0` wrote/clean, `1` delegated-sync deferred / no key, `2` hard error (bad source → `UsageError`; `TranslateDeckError` mid-bootstrap → caught, exit 2, nothing written).
+- **Acceptance — met:** `CliRunner` tests (11) — absent-twin bootstrap (exit 0, twin == split's EN), no-key exit 1 + nothing written, `--dry-run` no-write + `--json` shape, `--to` reverse direction, present-twin → incremental-sync no-op (not doubled), `--force` overwrite, bilingual-stem/missing-source exit 2, and the `bootstrap` alias via the `slides` group. Plus 13 cache/caching-translator unit tests in `tests/infrastructure/llm/test_translation_cache.py`.
 
 ### Phase 5 — Docs & acceptance gate — [TODO]
 **Accomplishes:** the CLAUDE.md Info Topics Maintenance Rule + end-to-end validation.
@@ -118,26 +118,22 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 ## 4. Current Status
 
-- **Completed:** design + **Phase 1** (`translate_deck.py`, `cf1c8e06`) + **Phase 2** (`translate_bootstrap.py`, `29947b88`) + **Phase 3** (companion-in-lockstep, in `translate_bootstrap.py`). Lint/format/mypy clean; full `tests/slides` (1176) + fast suite green; 28 tests in `test_translate_bootstrap.py`. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master. The three user-facing forks are settled (D1, D4, D5).
-- **In progress:** none — Phase 4 (CLI) not started.
-- **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. Confirm at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently: infer from filename, `--to` optional override — note `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source*, so a tag-less single half is already rejected with a "run split first" hint).
-- **Tests:** Phases 1–3 fully covered (see §7). Phases 4–5 pending.
+- **Completed:** design + **Phase 1** (`translate_deck.py`, `cf1c8e06`) + **Phase 2** (`translate_bootstrap.py`, `29947b88`) + **Phase 3** (companion, `c9199c8a`) + **Phase 4** (CLI `slides_translate.py` + `TranslationCache`/`CachingSlideTranslator`). Lint/format/mypy clean; fast suite green. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master. The three user-facing forks are settled (D1, D4, D5).
+- **In progress:** none — Phase 5 (docs) not started.
+- **Blockers / open questions:** none blocking. The `--to` question is resolved: `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source* (a tag-less single half is rejected with a "run split first" hint), and `--to` is an optional override.
+- **Tests:** Phases 1–4 fully covered (see §7). Phase 5 pending.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 4 — the `clm slides translate` CLI command (+ `bootstrap` alias).** The engine (Phase 1), the dispatch (Phase 2) and the companion (Phase 3) are all in `clm.slides`; Phase 4 is the user-facing Click surface over `bootstrap_deck`. The full plan is in **§3 Phase 4** — the short version:
-1. New module `src/clm/cli/commands/slides_translate.py`. Clone the option skeleton from `slides_sync.py` (`--provider`, `--translation-model`, `--cache-dir`, `--no-cache`, `--no-env-file`) and add `--to en|de`, `--dry-run`/`--explain` (side-effect-free: call `derive_bootstrap_paths` + parse + count translatable-vs-copied + show target path + id/companion plan; build **no** LLM client), `--json` (`_to_dict`), `--force`.
-2. Decide bootstrap-vs-sync **before** building any client by calling `derive_bootstrap_paths` (it's pure) — then build the translator (`OpenRouterSlideTranslator`) always, and the judge/recoverer/verifier/caches only on the sync path (twin present). Wire exactly as `slides_sync_cmd` does (env load via `load_env_files` unless `--no-env-file`; `resolve_cache_dir`; close caches in a `finally`).
-3. **No key → exit 1, write nothing** (the engine is all-or-nothing; unlike sync's per-cell defer, a whole deck of placeholders is useless). Reuse `has_openrouter_api_key`.
-4. **`TranslationCache` lands here (moved from Phase 1):** add it to `src/clm/infrastructure/llm/cache.py` and expose a `CachingSlideTranslator` that *wraps* a `SlideTranslator` and is passed into `bootstrap_deck` — the engine stays cache-agnostic, so it's purely additive.
-5. Register in `src/clm/cli/main.py` (~line 168) under `slides_group` for both `translate` and `bootstrap`; optional-import guard if LLM deps may be absent.
-6. Exit codes: `0` wrote/clean, `1` review/no-key, `2` hard error.
+**Start Phase 5 — info-topic docs + acceptance gate (the final phase).** A new CLI command landed, so CLAUDE.md's **Info Topics Maintenance Rule (CRITICAL)** now requires updating the version-accurate docs downstream agents read. Plan:
+1. Add a `### clm slides translate` section to `src/clm/cli/info_topics/commands.md`, modeled on the existing `### clm slides sync` block (option table, exit codes `0/1/2`, examples — `clm slides translate slides_x.de.py`, `--to`, `--dry-run`, `--force`). Use `{version}` placeholders — never hardcode versions. Mention the `bootstrap` alias and that code is translated iff a cell carries a `lang` tag.
+2. Add a `migration.md` entry: the "bootstrap a second language" workflow (`translate` once → then `sync` forever; run `unify` for a bilingual file).
+3. (Optional) If the MCP server exposes slide tools, add a `slides_translate` tool + a parity entry — check `src/clm/mcp/` first; skip if not a natural fit.
+4. **Acceptance gate:** generate a deck via the CLI (offline, with a static translator in a test, or by hand) and confirm it passes `clm validate slides <dir> --fail-on warning` (slide_id set+order parity, shared-cell byte parity, pairing adjacency, companion `for_slide` parity). A round-trip test feeding a real bilingual fixture through split → translate-one-half → validate is the strongest end-to-end check.
 
-**Acceptance:** `CliRunner` tests for absent-twin bootstrap, present-twin delegation, `--dry-run` no-write, `--json` shape, no-key degradation, `--force`, exit-code matrix. Mind the Click 8.1-vs-8.2 `CliRunner` compat pattern (memory `feedback-click-82-clirunner-compat`).
-
-**Phases 1–3 are DONE.** `bootstrap_deck(source_path, *, target_lang=None, translator, judge=None, watermark_cache=None, recoverer=None, alignment_cache=None, verifier=None, correspondence_cache=None, provider_available=False, force=False) -> BootstrapResult` is the single entry point the CLI calls. It already does the twin dispatch, EN-authority mint, watermark seal, and companion-in-lockstep; the `translate`-twice no-op is proven (id'd, id-less, asymmetric) and nothing half-writes.
+**Phases 1–4 are DONE.** The feature is fully usable from the CLI today (`clm slides translate slides_x.de.py`); Phase 5 is documentation + the validation gate, not new behavior. The single entry point is `bootstrap_deck(source_path, *, target_lang=None, translator, judge=None, watermark_cache=None, recoverer=None, alignment_cache=None, verifier=None, correspondence_cache=None, provider_available=False, force=False) -> BootstrapResult`; the CLI is `src/clm/cli/commands/slides_translate.py`.
 
 **Setup:** worktree venv must be synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (memory `feedback-worktree-venv-sync`). Run tests with `uv run python -m pytest …` (system Python has no pytest).
 
@@ -157,9 +153,9 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **`tests/slides/test_translate_deck.py` — DONE (17 tests).**
 - **`src/clm/slides/translate_bootstrap.py` — DONE (Phases 2 + 3).** File/orchestration layer: `derive_bootstrap_paths` (direction + existence-agnostic twin path + rejections), `bootstrap_deck` (the D2 dispatch), `_bootstrap_new_twin` (translate deck + companion → write both → `assign_ids_in_split_pair` → `_record_watermark`), `_translate_companion` (Phase 3 — `resolve_companion` + `companion_name`, all-or-nothing, skip/force), `_delegate_to_sync` (mirror of `slides_sync_cmd`). Injected deps only (no client/`.env`/cache-close). Public surface: `bootstrap_deck`, `derive_bootstrap_paths`, `BootstrapResult`, `CompanionResult`, `BootstrapPaths`, `TranslateBootstrapError`. **This is the single entry point the Phase 4 CLI calls.**
 - **`tests/slides/test_translate_bootstrap.py` — DONE (28 tests, incl. 9 companion).**
-- `src/clm/cli/commands/slides_translate.py` — the `clm slides translate` Click command (Phase 4).
-- `TranslationCache` + `CachingSlideTranslator` in `src/clm/infrastructure/llm/cache.py` / `sync_translate.py` (Phase 4 — moved from Phase 1).
-- Tests: `tests/cli/test_slides_translate.py` (CLI), companion/idempotency tests (Phases 2–4).
+- **`src/clm/cli/commands/slides_translate.py` — DONE (Phase 4).** The `clm slides translate` (+ `bootstrap`) Click command over `bootstrap_deck`; `_make_translator` factory (patchable), `derive_bootstrap_paths`-first dispatch, `--dry-run` preview, `--json`, exit-code matrix.
+- **`TranslationCache` (`src/clm/infrastructure/llm/cache.py`) + `CachingSlideTranslator` (`src/clm/slides/sync_translate.py`) — DONE (Phase 4).** Persistent per-cell translation cache + a `SlideTranslator`-protocol wrapper (model-folded version; `prompt_version` is a computed field, not a property).
+- **`tests/cli/test_slides_translate.py` — DONE (11 tests).** **`tests/infrastructure/llm/test_translation_cache.py` — DONE (13 tests).**
 
 ### Modified files
 - `src/clm/cli/main.py` — register `translate` + `bootstrap` under `slides_group` (~line 168).

--- a/docs/claude/slides-translate-bootstrap-handover.md
+++ b/docs/claude/slides-translate-bootstrap-handover.md
@@ -1,0 +1,194 @@
+# Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
+
+**Status:** design accepted (user-confirmed forks below); **no code written yet** — Phase 1 is next.
+**Recommended branch:** `claude/slides-translate-bootstrap` off `master` (this feature builds on the now-merged sync core; do **not** branch off `claude/issue-226-partial-overlap-mismatch`).
+**Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
+**Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
+**Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
+
+> One-line orientation: this is **orchestration over existing primitives**, not new machinery. The translator, role-aware prompts, id parity, lossless cell round-trip, and a test fake all already exist. The new code is (a) a pure bootstrap engine that loops the existing per-cell translator over a whole source half, (b) a thin CLI command, and (c) a "twin already exists → just run sync" delegation that makes re-runs converge to incremental sync.
+
+---
+
+## 1. Feature Overview
+
+When an author writes a slide deck in a **single language** (e.g. only `slides_x.de.py`), there is currently **no tool to generate the other-language half**. `clm slides sync` deliberately refuses: `_resolve_single_path` (`src/clm/cli/commands/slides_sync.py:148`) raises `UsageError("no EN twin found ... rather than invent a full translated half")`. Sync only fills **per-cell** gaps inside an **already-existing** pair.
+
+This feature adds **`clm slides translate SOURCE`** (alias `bootstrap`): a one-shot, one-directional, full-deck translation that synthesizes the missing-language split half. Code is mostly **not** translated — controlled by the existing lang-tag mechanism (see Design Decision D3). After the twin exists, the command **delegates to `sync`**, so the author has a single lifecycle: `translate` once → `sync` forever after.
+
+**Why it matters:** authoring a bilingual deck currently means hand-writing both halves or hand-copying+translating cell by cell. This automates the cold-start translation while keeping the result immediately valid for the split-pair tooling (`sync`, `unify`, validators).
+
+**Issues/PRs:** tracking issue **#232** (https://github.com/hoelzl/clm/issues/232). (Loosely adjacent to the #158 1.8 gate, but independent of it.)
+
+---
+
+## 2. Design Decisions
+
+### D1 — Separate command, NOT a mode of `sync` *(user-confirmed)*
+`clm slides translate` is a new sibling command that **reuses sync's engine**, rather than a `--bootstrap` flag on `sync`.
+
+- **Why:** `sync` is a *reconciler of an existing pair* (per-cell drift, conflict isolation, watermarks, refuse-on-ambiguity); bootstrap is the opposite shape (one source, no twin, no baseline, all adds one direction, no conflicts). Folding in would mean **relaxing the exact `_resolve_single_path` guard** the recent #216/#225/#226 hardening erected, on the most safety-critical module. CLM convention is also one-verb-per-command (`split`/`unify`, `extract`/`inline` are siblings, never `--mode` flags).
+- **Footgun avoided:** if `sync` silently translated a whole deck whenever a twin was missing, a mistyped path would kick off an expensive surprise LLM run. A named command makes the intent explicit.
+- **Rejected alternative:** `sync --bootstrap`. Honors "always the same tool" literally but threads a not-yet-existent-file case through baseline resolution and the `_refuse_*_both_directions` guards — high blast radius for the same outcome.
+
+### D2 — Idempotency by delegation *(core safety property)*
+The command's central dispatch:
+- **Twin absent** → run the bootstrap engine (Phase 1).
+- **Twin present** → do **not** bootstrap; delegate straight to `build_sync_plan` + `apply_plan` exactly as `slides_sync_cmd` does.
+
+Re-running therefore **converges to plain `sync` by construction** — never re-translates the whole deck, never doubles. After a bootstrap write, **record the watermark** so the very next `sync` is a clean no-op.
+
+### D3 — Lang tags already control code-vs-prose translation *(user's instinct, confirmed by the code)*
+No new mechanism needed:
+- A cell with **no `lang` attribute** is *neutral/shared* → copied **byte-for-byte** into both halves, **never translated** (this is how code cells behave idiomatically).
+- A cell **with a `lang` tag** is *localized* → translated. `role == "code"` selects `_CODE_SYSTEM_PROMPT` (localizes **only** human-facing string literals + comments, keeps identifiers/keywords byte-identical); markdown/narrative roles select `_SYSTEM_PROMPT`.
+
+The gate is the existing `role_of` (`src/clm/slides/sync_writeback.py:66`) / `_membership_role` (`src/clm/slides/sync_plan.py`). **The bootstrap engine MUST reuse this gate, not re-implement it** — translating a neutral/shared cell breaks the `unify` round-trip (`UnifyError`) and trips `validator._check_shared_cell_parity`.
+
+### D4 — Output shape: split sibling `.en.py` *(user-confirmed)*
+`translate slides_x.de.py` writes the sibling split half `slides_x.en.py`. Matches `sync`, the validator, and `assign_ids_in_split_pair` directly. If the author wants a bilingual file, they run `clm slides unify` afterward. (Rejected: emit a unified bilingual `.py` — needs an extra split before feeding split-pair tooling, second code path.)
+
+### D5 — Voiceover companion translated in lockstep *(user-confirmed)*
+If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preserving `for_slide` / `vo_anchor`) and write `voiceover_<name>.<tgt>.py`, placed via `effective_write_layout`. Skipping it would ship the new deck with source-language narration. Note `derive_split_twin` returns `None` for `voiceover_*`, so the companion is handled explicitly, not as a deck half.
+
+### D6 — Smaller decisions (defaults; not re-litigated unless the user objects)
+- **Direction:** inferred from the source half's `.de`/`.en` tag (`.de.py` → produces `.en`), with an optional **`--to en|de`** override for safety when a source mixes/omits lang tags.
+- **ID authority:** EN-authority `de_id == en_id` via `assign_ids_in_split_pair`, run over the freshly-written pair. If the source half is itself **id-less**, mint at bootstrap so the pair is **never born id-less** (an id-less/half-id'd pair would otherwise force a downstream cold-mint/adopt round needing the correspondence verifier + key).
+- **Performance:** synchronous per-cell loop to start (consistent with the apply engine), backed by a new `TranslationCache` (shared `clm-llm.sqlite` shape) so re-runs/tests are cheap. Async fan-out (`client.py` `_get_semaphore` pattern, default `max_concurrent=5`) is a later optimization only if real decks are too slow.
+- **`--force`:** overwrite an existing **non-empty** twin; without it, an existing twin → delegate to sync (per D2), never silent overwrite.
+- **Bilingual-stem source:** if `SOURCE` is a bilingual deck (no `.de`/`.en` tag) rather than a single half, reject with a hint to run `clm slides split` first (keep the contract explicit).
+
+---
+
+## 3. Phase Breakdown
+
+### Phase 1 — Core bootstrap engine `src/clm/slides/translate_deck.py` (pure, offline) — [TODO] ← NEXT
+**Accomplishes:** turn one source half's text into the translated target half's text, deterministically and without network.
+
+- Parse the source with `raw_cells.split_cells` (`src/clm/slides/raw_cells.py:53`) — **byte-faithful**. Never use `slide_parser.parse_cells` (lossy; read-only analysis only).
+- For each `RawCell`, classify with `role_of` (`sync_writeback.py:66`) / `_membership_role` (`sync_plan.py`):
+  - neutral / no-`lang` (incl. idiomatic code) → **copy verbatim** into the target half.
+  - localized → translate via the `SlideTranslator` protocol (`sync_translate.py:45`), `role` selecting code-vs-markdown prompt.
+- Title slide is a **j2 header macro**, not a normal cell: swap `header_de("…")` ↔ `header_en("…")` **and** the `import header_de`/`import header_en` line **structurally** using `split.py`'s header regexes — translate only the title string argument. Running the macro through the cell translator corrupts it.
+- Build twins with `build_twin_cell` (`sync_writeback.py:241`) / `swap_lang` (`sync_writeback.py:228`) — preserves `slide_id` + tags + cell-type, swaps `lang`. Order cells so the translated twin sits adjacent to its source under the same id (so `unify` can interleave).
+- Stamp the source half's `slide_id`s onto the twins (carried through `swap_lang`).
+- New `TranslationCache` in `src/clm/infrastructure/llm/cache.py` (one table in the shared `clm-llm.sqlite`; key = content-hash + **model-folded** `prompt_version`; cache only successful results — safe-abort caches nothing).
+- **Acceptance:** given a source half + a `StaticSlideTranslator`, produce the target text such that `split(unify(de, en)) == (de, en)` and `unify(de, en)` round-trips. Neutral cells byte-identical across halves. Unit tests only, no network.
+
+### Phase 2 — Idempotency + sync convergence + watermark — [TODO]
+**Accomplishes:** the D2 dispatch and the "next sync is a no-op" seal.
+
+- Resolve source + derive twin with `derive_split_twin` (`pairing.py:210`) / `split_lang_tag` (`pairing.py:158`).
+- **Twin present** → delegate to `build_sync_plan` (`sync_plan.py:1664`) + `apply_plan` (`sync_apply.py:208`) (mirror `slides_sync_cmd`'s wiring). **Twin absent** → Phase 1 bootstrap, then:
+  - run `assign_ids_in_split_pair` (`assign_ids.py:823`, `AssignOptions(accept_content_derived=True)`) for EN-authority parity (re-slugs from EN headings; writes the **source** half back too if ids changed — keep parity).
+  - record the watermark via `_record_watermark` (`sync_apply.py:2172`) + `SyncWatermarkCache` (`cache.py:652`).
+- **Acceptance:** `translate` twice → the second run is a `sync` no-op; deck is not doubled; a subsequent `clm slides sync` reports clean. Round-trip + parity assertions hold on the written files.
+
+### Phase 3 — Voiceover companion in lockstep — [TODO]
+**Accomplishes:** D5.
+
+- Detect `voiceover_<name>.<src>.py`; translate localized cells preserving `for_slide` / `vo_anchor`; write `voiceover_<name>.<tgt>.py` via `effective_write_layout` (`src/clm/slides/sidecar_layout.py`).
+- **Acceptance:** companion `for_slide` parity holds against the translated deck (`validator._check_split_companion_for_slide_parity`); narration cells are translated, anchors preserved.
+
+### Phase 4 — CLI command `clm slides translate` (+ `bootstrap` alias) — [TODO]
+**Accomplishes:** user-facing surface.
+
+- New module `src/clm/cli/commands/slides_translate.py`; clone the option skeleton from `slides_sync.py` and the simple-mutation skeleton from `split.py`:
+  - `--to en|de`, `--dry-run` / `--explain` (side-effect-free: parse + classify + count translatable vs copied + show target path + id plan; skip LLM/.env where possible), `--json` (`_to_dict`: `cells_translated`, `cells_copied`, `target_path`, `ids_minted`, `deferred`), `--force`, `--provider` (env `CLM_SYNC_PROVIDER`), `--translation-model`, `--cache-dir` (env `CLM_CACHE_DIR`), `--no-cache`, `--no-env-file`.
+- Reuse `has_openrouter_api_key` (`openrouter_client.py:71`), `build_openrouter_client`, `load_env_files` (`env_loading.py:45`), `resolve_cache_dir`. No key → **warn + degrade** (defer localized cells or exit 1), never crash. On `TranslationError`, defer-and-report (the never-drop-content discipline at `sync_apply.py` `_translate`).
+- Register in `src/clm/cli/main.py` (~line 168): `slides_group.add_command(translate_cmd, name="translate")` and a second registration for `bootstrap`. Use the try/except optional-import pattern (main.py ~112-130) if LLM deps may be absent.
+- Exit codes: `0` wrote/clean, `1` some cells deferred (no key) / needs review, `2` hard error (twin exists without `--force`, engine down, bilingual-stem source).
+- **Acceptance:** `CliRunner` tests for absent-twin bootstrap, present-twin delegation, `--dry-run` no-write, `--json` shape, no-key degradation, `--force` overwrite, exit codes.
+
+### Phase 5 — Docs & acceptance gate — [TODO]
+**Accomplishes:** the CLAUDE.md Info Topics Maintenance Rule + end-to-end validation.
+
+- Add a `### clm slides translate` section to `src/clm/cli/info_topics/commands.md`, modeled on the existing `### clm slides sync` block (option table + exit codes + examples). Use `{version}` placeholders — never hardcode versions.
+- Add a `migration.md` entry: the "bootstrap a second language" workflow (`translate` → then `sync`).
+- If exposed via MCP, add a `slides_translate` tool + a migration parity entry.
+- **Acceptance gate:** a generated deck passes `clm validate slides <dir> --fail-on warning` (slide_id set+order parity, shared-cell byte parity, pairing adjacency, companion `for_slide` parity).
+
+---
+
+## 4. Current Status
+
+- **Completed:** design only. The three user-facing forks are settled (D1, D4, D5). The reuse surface is verified against the live tree (all symbols in §6 exist at the cited paths/lines as of this writing).
+- **In progress:** none — implementation not started.
+- **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. One thing to confirm with the user at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently planned as: infer from filename, `--to` optional override).
+- **Tests:** none yet. Strategy in §7.
+
+---
+
+## 5. Next Steps
+
+**Start Phase 1.** Prerequisites/setup:
+1. From this worktree, create the branch: `git fetch origin && git switch -C claude/slides-translate-bootstrap origin/master`.
+2. Ensure the worktree venv is synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (see memory `feedback-worktree-venv-sync`).
+3. Read `src/clm/slides/sync_translate.py` (the translator + both prompts), `src/clm/slides/sync_writeback.py` (`role_of`, `swap_lang`, `build_twin_cell`, `FileState`), `src/clm/slides/split.py` (header-macro regexes + the `unify`/`split` round-trip invariant), and `src/clm/slides/sync_apply.py` `_add_one_direction` / `_translate` (the existing per-cell translate+mint+insert pattern to mirror).
+
+**Gotchas to watch (these silently corrupt the pair):**
+- Translating a neutral/shared cell → `UnifyError` + `_check_shared_cell_parity` failure. Gate strictly on `role_of(meta) is None` / `meta.lang is None`.
+- Running the header macro through the cell translator, or forgetting the `import header_de`→`import header_en` line swap → broken title slide + split↔bilingual round-trip. Reuse `split.py`'s regexes.
+- Emitting the twin id-less → forces a downstream cold-mint/adopt round (needs verifier + key). Mint ids at bootstrap.
+- Missing watermark seal → the next `sync` re-diffs and may re-propose. The `_record_watermark` call is load-bearing for D2.
+- Program extension may be `.cpp`/`.java` etc.; the `.de`/`.en` tag sits immediately before the final extension. Use `split_lang_tag` (prefix-agnostic) for naming — don't assume `.py`.
+- Line endings: write with `newline="\n"`; never line-string surgery — use `raw_cells` / `FileState`.
+
+---
+
+## 6. Key Files & Architecture
+
+### New files
+- `src/clm/slides/translate_deck.py` — the pure bootstrap engine (Phase 1). Parses a source half, classifies cells, translates localized ones, copies neutral ones verbatim, swaps the header macro, builds twins, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable.
+- `src/clm/cli/commands/slides_translate.py` — the `clm slides translate` Click command (Phase 4).
+- `TranslationCache` class added to `src/clm/infrastructure/llm/cache.py` (Phase 1).
+- Tests: `tests/slides/test_translate_deck.py` (engine), `tests/cli/test_slides_translate.py` (CLI), companion/idempotency tests.
+
+### Modified files
+- `src/clm/cli/main.py` — register `translate` + `bootstrap` under `slides_group` (~line 168).
+- `src/clm/cli/info_topics/commands.md` — `### clm slides translate` section (Phase 5).
+- `src/clm/cli/info_topics/migration.md` — bootstrap-a-second-language workflow entry (Phase 5).
+
+### Reuse surface (verified at these paths/lines)
+| Symbol | Location | Role |
+|---|---|---|
+| `SlideTranslator` (Protocol) / `OpenRouterSlideTranslator` / `StaticSlideTranslator` | `src/clm/slides/sync_translate.py:45 / :96 / :69` | per-cell translator; `translate(*, source_body, source_lang, target_lang, role) -> str`. `StaticSlideTranslator` = deterministic test fake. |
+| `_system_prompt_for` / `_CODE_SYSTEM_PROMPT` / `DEFAULT_TRANSLATION_MODEL` | `sync_translate.py:188 / :174 / :37` | role→prompt selection; code prompt keeps identifiers byte-identical; model `anthropic/claude-sonnet-4-6`. |
+| `role_of` | `src/clm/slides/sync_writeback.py:66` | the translate-vs-copy gate (keyed on `lang` presence + cell_type). |
+| `swap_lang` / `build_twin_cell` | `sync_writeback.py:228 / :241` | lossless twin-cell construction. |
+| `FileState` | `sync_writeback.py` | batched, header/padding-preserving deck writer. |
+| `split_cells` / `reconstruct` | `src/clm/slides/raw_cells.py:53 / :95` | byte-faithful parse→write foundation. |
+| `assign_ids_in_split_pair` | `src/clm/slides/assign_ids.py:823` | EN-authority shared-id minting (`de_id==en_id`) with round-trip guard. |
+| header-macro regexes + `split_text` / `unify_texts` | `src/clm/slides/split.py` | `header_de`↔`header_en` swap; the round-trip invariant to assert. |
+| `derive_split_twin` / `split_lang_tag` / `order_split_pair` | `src/clm/slides/pairing.py:210 / :158 / :189` | target-path derivation + twin-missing detection. |
+| `build_sync_plan` / `apply_plan` | `src/clm/slides/sync_plan.py:1664` / `sync_apply.py:208` | delegated to when the twin already exists (D2). |
+| `_record_watermark` / `SyncWatermarkCache` | `sync_apply.py:2172` / `src/clm/infrastructure/llm/cache.py:652` | idempotency seal. |
+| `has_openrouter_api_key` / `build_openrouter_client` | `src/clm/infrastructure/llm/openrouter_client.py:71` | provider/key wiring. |
+| `load_env_files` | `src/clm/cli/env_loading.py:45` | `.env` walk-up (respect `--no-env-file`). |
+| `call_with_retries` | `src/clm/infrastructure/llm/retry.py` | bounded backoff; re-raises on exhaustion (never silently drops a cell). |
+| `effective_write_layout` | `src/clm/slides/sidecar_layout.py` | voiceover companion placement (D5). |
+| `_resolve_single_path` (the guard we sit beside) | `src/clm/cli/commands/slides_sync.py:148` | the current refusal to invent a missing twin — reference, not modified. |
+
+### How it connects
+`slides_translate.py` (CLI) → resolves source + twin via `pairing` → **twin present**: `build_sync_plan`+`apply_plan` (existing sync) — **twin absent**: `translate_deck.py` (new engine, drives `SlideTranslator`) → `assign_ids_in_split_pair` → `_record_watermark`. Companion handled in lockstep. Validation gate is `clm validate slides`.
+
+---
+
+## 7. Testing Approach
+
+- **Unit (primary, offline):** drive everything through the `SlideTranslator` **Protocol** with `StaticSlideTranslator` — **no network, no vcrpy cassette** (this is a host-side path, unlike in-kernel build LLM traffic). The whole sync stack is tested this way; follow it.
+- **Phase 1 invariants to assert:** neutral cells byte-identical across halves; `split(unify(de,en)) == (de,en)`; localized markdown translated, code identifiers untouched (only string/comment payload changes under the static fake); header macro swapped (`header_de`→`header_en` + import line) with title arg translated; ids carried onto twins.
+- **Phase 2:** run `translate` twice → second run = `sync` no-op (assert no doubling, watermark recorded, subsequent `sync` clean). Present-twin delegation path exercised.
+- **Phase 3:** companion translated, `for_slide`/`vo_anchor` preserved, parity validator passes.
+- **Phase 4:** `CliRunner` for absent/present twin, `--dry-run` writes nothing, `--json` envelope shape, no-key degradation (exit 1 + warning, no crash), `--force` overwrite, exit-code matrix. Note the Click 8.1-vs-8.2 `CliRunner` compat pattern (memory `feedback-click-82-clirunner-compat`).
+- **Acceptance:** generated deck passes `clm validate slides <dir> --fail-on warning`.
+- **Run:** `pytest tests/slides/test_translate_deck.py tests/cli/test_slides_translate.py` during dev; full fast suite `pytest` before push (pre-push hook, ~72s). The commit hook can flake on unrelated recordings polling under xdist contention — if so, `PYTEST_XDIST_AUTO_NUM_WORKERS=4 git commit` (memory `project-topic-sidecar-subdirs`).
+
+---
+
+## 8. Session Notes
+
+- The user is the project author and explicitly chose the **separate-command** surface, **split-sibling** output, and **lockstep voiceover** when asked. Don't re-open these without cause.
+- The "code is translated iff it has a lang tag" requirement was the user's own framing — and it happens to be exactly the existing `role_of` / no-lang-is-shared model. Lean on that; don't invent a parallel marker.
+- Grounding for this design came from a multi-agent read of the sync engine, slide format, pairing/cold-start machinery, LLM infra, and CLI surface. The reuse table in §6 was re-verified against the live tree (symbol names + line numbers) before writing this doc.
+- CLAUDE.md hard rules in play: type hints on public APIs; `attrs @define` internal / Pydantic at boundaries; `logging.getLogger(__name__)` never `print()`; Python over bash for any tooling; **update info topics** when CLI behavior changes (Phase 5 is not optional). Commits that fail a hook didn't happen — fix, re-stage, new commit (never `--amend` a rejected commit).

--- a/docs/claude/slides-translate-bootstrap-handover.md
+++ b/docs/claude/slides-translate-bootstrap-handover.md
@@ -1,7 +1,7 @@
 # Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
 
-**Status:** **Phase 1 + Phase 2 DONE.** Phase 1 = pure engine `src/clm/slides/translate_deck.py` (17 tests). Phase 2 = file/orchestration layer `src/clm/slides/translate_bootstrap.py` (19 tests) — the D2 dispatch (twin absent→bootstrap+mint+watermark; twin present→delegate to sync), all green; lint/format/mypy clean; full slides suite (1165) green. **Phase 3 (voiceover companion in lockstep) is next.**
-**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, Phase 2 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
+**Status:** **Phases 1–3 DONE.** Phase 1 = pure engine `translate_deck.py` (17 tests). Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion translated in lockstep (now **28 tests** in `test_translate_bootstrap.py`). All green; lint/format/mypy clean; full slides suite (1176) + fast suite green. **Phase 4 (the `clm slides translate` CLI command) is next.**
+**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, Phase 3 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
 **Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
 **Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
 **Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
@@ -85,11 +85,15 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **Result:** `BootstrapResult` (`action` = `"bootstrapped"`/`"synced"`, `deck`/`assign` or `plan`/`apply_result`, `ids_assigned`, `watermark_recorded`).
 - **Acceptance — met:** `translate` twice → second run is a `sync` no-op (`action=="synced"`, `proposals==[]`, no errors, deck not doubled), proven for **both** an id'd and an **id-less** source (the latter rewrites both halves on run 1, so it exercises the post-mint watermark). Round-trip + parity hold on the written files, including a **trailing-asymmetric** deck (ends on a slide pair). 19 tests in `tests/slides/test_translate_bootstrap.py`.
 
-### Phase 3 — Voiceover companion in lockstep — [TODO]
-**Accomplishes:** D5.
+### Phase 3 — Voiceover companion in lockstep — [DONE]
+**Accomplished:** D5, inside `translate_bootstrap.py`.
 
-- Detect `voiceover_<name>.<src>.py`; translate localized cells preserving `for_slide` / `vo_anchor`; write `voiceover_<name>.<tgt>.py` via `effective_write_layout` (`src/clm/slides/sidecar_layout.py`).
-- **Acceptance:** companion `for_slide` parity holds against the translated deck (`validator._check_split_companion_for_slide_parity`); narration cells are translated, anchors preserved.
+- `_translate_companion(paths, translator, force)`: on the **bootstrap** path only, `resolve_companion(source_path)` finds the source half's companion (sibling **or** `voiceover/` subdir). The target is `companion_name(twin_path)` placed in the **source companion's directory** (foldered stays foldered) — mirroring `split._plan_companion_split`. It is translated by the **same** `translate_deck_text` (a companion is just `lang`-tagged narrative cells, no header macro), so `build_twin_cell` preserves `for_slide` / `vo_anchor` / `slide_id` / `tags` verbatim (only `lang` + body change).
+- **All-or-nothing:** both the deck and the companion are translated *before any write*, so a companion translation failure aborts the whole bootstrap with nothing on disk (test asserts this).
+- **Idempotency:** an existing non-empty target companion is `"skipped"` (never doubled) unless `--force`. The **sync-delegation** path does not touch the companion (`result.companion is None`), so a re-run can't double it.
+- **Result:** `BootstrapResult.companion: CompanionResult | None` (`action` = `"translated"`/`"skipped"`, `source`, `target`, `translation`).
+- **Acceptance — met:** companion translated alongside the deck; `for_slide` + `vo_anchor` preserved; companion pair round-trips; subdir layout preserved; existing target skipped; `--force` regenerates; re-run via sync leaves it untouched; translation failure writes nothing. 9 companion tests (28 total in `tests/slides/test_translate_bootstrap.py`).
+- **Deferred:** full companion *sync* (reconciling an already-present companion when the deck twin exists) is out of scope — the bootstrap creates it once; later deck syncs leave it alone. Also not special-cased: a companion whose `for_slide` references an **id-less** deck (a malformed input — `extract` requires deck ids; the bootstrap mint with `force=False` preserves existing ids, so a real companion's `for_slide` stays valid).
 
 ### Phase 4 — CLI command `clm slides translate` (+ `bootstrap` alias) — [TODO]
 **Accomplishes:** user-facing surface.
@@ -114,24 +118,26 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 ## 4. Current Status
 
-- **Completed:** design + **Phase 1** (pure engine `translate_deck.py` + 17 tests, `cf1c8e06`) + **Phase 2** (orchestration `translate_bootstrap.py` + 19 tests). Both lint/format/mypy clean; full `tests/slides` suite (1165) green. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master. The three user-facing forks are settled (D1, D4, D5).
-- **In progress:** none — Phase 3 not started.
+- **Completed:** design + **Phase 1** (`translate_deck.py`, `cf1c8e06`) + **Phase 2** (`translate_bootstrap.py`, `29947b88`) + **Phase 3** (companion-in-lockstep, in `translate_bootstrap.py`). Lint/format/mypy clean; full `tests/slides` (1176) + fast suite green; 28 tests in `test_translate_bootstrap.py`. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master. The three user-facing forks are settled (D1, D4, D5).
+- **In progress:** none — Phase 4 (CLI) not started.
 - **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. Confirm at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently: infer from filename, `--to` optional override — note `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source*, so a tag-less single half is already rejected with a "run split first" hint).
-- **Tests:** Phases 1–2 fully covered (see §7). Phases 3–5 pending.
+- **Tests:** Phases 1–3 fully covered (see §7). Phases 4–5 pending.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 3 — voiceover companion in lockstep (D5).** The deck-half engine (`translate_deck_text`) already translates lang-tagged narrative cells and copies neutral ones, and `bootstrap_deck` is the orchestration seam to hook into. A voiceover companion (`voiceover_<name>.<src>.py`) is *just* lang-tagged cells with no header macro, which `translate_deck_text` handles as-is. Plan:
-1. In `bootstrap_deck` (twin-**absent** path), after writing the deck twin, detect the source companion next to the source half. Companion naming is `voiceover_*` and it carries the same `.de`/`.en` tag; resolve its placement with `effective_write_layout` (`src/clm/slides/sidecar_layout.py`) — it may live as a sibling or under a `voiceover/` subdir (topic-sidecar-subdirs, PR #218). Reuse the resolver (`resolve_companion`) rather than re-deriving the path.
-2. Translate the companion's text with `translate_deck_text` (same translator) and write `voiceover_<name>.<tgt>.py` via the layout. **Preserve `for_slide` / `vo_anchor`** — these are cell metadata the engine copies verbatim (they are not `lang`-gated), so they should survive untouched; add a test asserting it.
-3. `derive_bootstrap_paths` currently **rejects** a `voiceover_*` *source* (a companion is never a standalone translate target). Keep that — the companion is found and translated *from the deck*, not passed directly.
-4. **Idempotency:** a companion already present must not be re-translated/doubled. Mirror the deck dispatch — if the target companion exists, skip (or, later, sync it). For Phase 3, skip-with-note is acceptable; full companion-sync can defer.
+**Start Phase 4 — the `clm slides translate` CLI command (+ `bootstrap` alias).** The engine (Phase 1), the dispatch (Phase 2) and the companion (Phase 3) are all in `clm.slides`; Phase 4 is the user-facing Click surface over `bootstrap_deck`. The full plan is in **§3 Phase 4** — the short version:
+1. New module `src/clm/cli/commands/slides_translate.py`. Clone the option skeleton from `slides_sync.py` (`--provider`, `--translation-model`, `--cache-dir`, `--no-cache`, `--no-env-file`) and add `--to en|de`, `--dry-run`/`--explain` (side-effect-free: call `derive_bootstrap_paths` + parse + count translatable-vs-copied + show target path + id/companion plan; build **no** LLM client), `--json` (`_to_dict`), `--force`.
+2. Decide bootstrap-vs-sync **before** building any client by calling `derive_bootstrap_paths` (it's pure) — then build the translator (`OpenRouterSlideTranslator`) always, and the judge/recoverer/verifier/caches only on the sync path (twin present). Wire exactly as `slides_sync_cmd` does (env load via `load_env_files` unless `--no-env-file`; `resolve_cache_dir`; close caches in a `finally`).
+3. **No key → exit 1, write nothing** (the engine is all-or-nothing; unlike sync's per-cell defer, a whole deck of placeholders is useless). Reuse `has_openrouter_api_key`.
+4. **`TranslationCache` lands here (moved from Phase 1):** add it to `src/clm/infrastructure/llm/cache.py` and expose a `CachingSlideTranslator` that *wraps* a `SlideTranslator` and is passed into `bootstrap_deck` — the engine stays cache-agnostic, so it's purely additive.
+5. Register in `src/clm/cli/main.py` (~line 168) under `slides_group` for both `translate` and `bootstrap`; optional-import guard if LLM deps may be absent.
+6. Exit codes: `0` wrote/clean, `1` review/no-key, `2` hard error.
 
-**Acceptance:** companion `for_slide` parity holds against the translated deck (`validator._check_split_companion_for_slide_parity`); narration cells are translated; `vo_anchor` preserved; re-running does not double the companion. Add tests to `tests/slides/test_translate_bootstrap.py` (or a new `test_*` file) driven by `StaticSlideTranslator`.
+**Acceptance:** `CliRunner` tests for absent-twin bootstrap, present-twin delegation, `--dry-run` no-write, `--json` shape, no-key degradation, `--force`, exit-code matrix. Mind the Click 8.1-vs-8.2 `CliRunner` compat pattern (memory `feedback-click-82-clirunner-compat`).
 
-**Phase 2 is DONE** (`translate_bootstrap.py`): the twin dispatch, EN-authority minting and watermark seal are in place and the `translate`-twice no-op is proven (incl. id-less + asymmetric decks). Engine-level round-trip is guaranteed by Phase 1; Phase 2 additionally proves the on-disk pair round-trips and is idempotent.
+**Phases 1–3 are DONE.** `bootstrap_deck(source_path, *, target_lang=None, translator, judge=None, watermark_cache=None, recoverer=None, alignment_cache=None, verifier=None, correspondence_cache=None, provider_available=False, force=False) -> BootstrapResult` is the single entry point the CLI calls. It already does the twin dispatch, EN-authority mint, watermark seal, and companion-in-lockstep; the `translate`-twice no-op is proven (id'd, id-less, asymmetric) and nothing half-writes.
 
 **Setup:** worktree venv must be synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (memory `feedback-worktree-venv-sync`). Run tests with `uv run python -m pytest …` (system Python has no pytest).
 
@@ -149,8 +155,8 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 ### New files
 - **`src/clm/slides/translate_deck.py` — DONE (Phase 1).** The pure, offline bootstrap engine: `translate_deck_text(source_text, *, source_lang, target_lang, translator) -> TranslateDeckResult`. Parses a source half, classifies cells by `metadata.lang`, translates localized ones (code via `CODE_ROLE`), copies neutral ones verbatim, rewrites the header macro/import (reusing `split.py` regexes), self-checks the split/unify round-trip, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable. **Also reusable for the Phase 3 voiceover companion** — companions are just lang-tagged cells with no header macro, which this engine already handles.
 - **`tests/slides/test_translate_deck.py` — DONE (17 tests).**
-- **`src/clm/slides/translate_bootstrap.py` — DONE (Phase 2).** File/orchestration layer: `derive_bootstrap_paths` (direction + existence-agnostic twin path + rejections), `bootstrap_deck` (the D2 dispatch), `_bootstrap_new_twin` (translate→write→`assign_ids_in_split_pair`→`_record_watermark`), `_delegate_to_sync` (mirror of `slides_sync_cmd`). Injected deps only (no client/`.env`/cache-close). `BootstrapResult`/`BootstrapPaths`/`TranslateBootstrapError` are the public surface. **This is the seam Phase 3's voiceover companion hooks into.**
-- **`tests/slides/test_translate_bootstrap.py` — DONE (19 tests).**
+- **`src/clm/slides/translate_bootstrap.py` — DONE (Phases 2 + 3).** File/orchestration layer: `derive_bootstrap_paths` (direction + existence-agnostic twin path + rejections), `bootstrap_deck` (the D2 dispatch), `_bootstrap_new_twin` (translate deck + companion → write both → `assign_ids_in_split_pair` → `_record_watermark`), `_translate_companion` (Phase 3 — `resolve_companion` + `companion_name`, all-or-nothing, skip/force), `_delegate_to_sync` (mirror of `slides_sync_cmd`). Injected deps only (no client/`.env`/cache-close). Public surface: `bootstrap_deck`, `derive_bootstrap_paths`, `BootstrapResult`, `CompanionResult`, `BootstrapPaths`, `TranslateBootstrapError`. **This is the single entry point the Phase 4 CLI calls.**
+- **`tests/slides/test_translate_bootstrap.py` — DONE (28 tests, incl. 9 companion).**
 - `src/clm/cli/commands/slides_translate.py` — the `clm slides translate` Click command (Phase 4).
 - `TranslationCache` + `CachingSlideTranslator` in `src/clm/infrastructure/llm/cache.py` / `sync_translate.py` (Phase 4 — moved from Phase 1).
 - Tests: `tests/cli/test_slides_translate.py` (CLI), companion/idempotency tests (Phases 2–4).

--- a/docs/claude/slides-translate-bootstrap-handover.md
+++ b/docs/claude/slides-translate-bootstrap-handover.md
@@ -1,7 +1,7 @@
 # Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
 
-**Status:** design accepted (user-confirmed forks below); **no code written yet** — Phase 1 is next.
-**Recommended branch:** `claude/slides-translate-bootstrap` off `master` (this feature builds on the now-merged sync core; do **not** branch off `claude/issue-226-partial-overlap-mismatch`).
+**Status:** **Phase 1 DONE** (`src/clm/slides/translate_deck.py` + 17 tests, all green; lint/format/mypy clean). Phase 2 (idempotency + sync delegation + watermark) is next.
+**Branch:** `claude/slides-translate-bootstrap` off `master` (commit `fdf7772` handover, Phase 1 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
 **Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
 **Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
 **Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
@@ -62,18 +62,19 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 ## 3. Phase Breakdown
 
-### Phase 1 — Core bootstrap engine `src/clm/slides/translate_deck.py` (pure, offline) — [TODO] ← NEXT
-**Accomplishes:** turn one source half's text into the translated target half's text, deterministically and without network.
+### Phase 1 — Core bootstrap engine `src/clm/slides/translate_deck.py` (pure, offline) — [DONE]
+**Accomplished:** `translate_deck_text(source_text, *, source_lang, target_lang, translator) -> TranslateDeckResult` turns one source half's text into the translated target half's text, deterministically and without network. Public API: `translate_deck_text`, `TranslateDeckError`, `TranslateDeckResult` (`.target_text`, `.cells`, `.translated_count`, `.copied_count`, `.header_translated`).
 
-- Parse the source with `raw_cells.split_cells` (`src/clm/slides/raw_cells.py:53`) — **byte-faithful**. Never use `slide_parser.parse_cells` (lossy; read-only analysis only).
-- For each `RawCell`, classify with `role_of` (`sync_writeback.py:66`) / `_membership_role` (`sync_plan.py`):
-  - neutral / no-`lang` (incl. idiomatic code) → **copy verbatim** into the target half.
-  - localized → translate via the `SlideTranslator` protocol (`sync_translate.py:45`), `role` selecting code-vs-markdown prompt.
-- Title slide is a **j2 header macro**, not a normal cell: swap `header_de("…")` ↔ `header_en("…")` **and** the `import header_de`/`import header_en` line **structurally** using `split.py`'s header regexes — translate only the title string argument. Running the macro through the cell translator corrupts it.
-- Build twins with `build_twin_cell` (`sync_writeback.py:241`) / `swap_lang` (`sync_writeback.py:228`) — preserves `slide_id` + tags + cell-type, swaps `lang`. Order cells so the translated twin sits adjacent to its source under the same id (so `unify` can interleave).
-- Stamp the source half's `slide_id`s onto the twins (carried through `swap_lang`).
-- New `TranslationCache` in `src/clm/infrastructure/llm/cache.py` (one table in the shared `clm-llm.sqlite`; key = content-hash + **model-folded** `prompt_version`; cache only successful results — safe-abort caches nothing).
-- **Acceptance:** given a source half + a `StaticSlideTranslator`, produce the target text such that `split(unify(de, en)) == (de, en)` and `unify(de, en)` round-trips. Neutral cells byte-identical across halves. Unit tests only, no network.
+- Parses the source with `raw_cells.split_cells` (byte-faithful). Per cell:
+  - **header macro** (`header_<src>`) → rewrite to `header_<tgt>` + translate only the title string;
+  - **header import** (`from … import header_<src>`) → rewrite to `header_<tgt>`;
+  - **localized** (`metadata.lang == source_lang`) → translate via the `SlideTranslator` protocol and `build_twin_cell`, re-appending the source cell's trailing-blank count to preserve spacing;
+  - **everything else** (no-lang shared cells incl. code, non-header j2) → copy verbatim.
+- **Key correction vs. the original plan:** the translate-vs-copy gate is **`metadata.lang`**, NOT `role_of`. A localized *id-less* code cell has `role_of() is None` yet carries `lang` and must be translated. `role_of`/`cell_type` only pick the prompt (`CODE_ROLE` → code prompt).
+- Header grammar is **reused** from `split.py` (`_HEADER_DE_RE`/`_HEADER_EN_RE` + import REs), not re-implemented.
+- **Safety guard:** before returning, the engine self-checks `split(unify(de, en)) == (de, en)` (ordering the two halves by language — `unify_texts` takes `(de, en)` positionally) and raises `TranslateDeckError` rather than emit a structurally-malformed pair. All-or-nothing — never half-writes; on a per-cell `TranslationError` it raises naming the slide.
+- **Tests:** `tests/slides/test_translate_deck.py` (17, all green) — round-trip + content on every shape (slide / voiceover / localized-code / id-less-code / shared / no-header / reverse-direction), byte-exact on trailing-symmetric decks, and the error paths.
+- **Two deliberate deviations from the original phase plan** (see §8): (1) `TranslationCache` moved to **Phase 4** — a caching translator *wrapper* at the integration layer keeps Phase 1 pure/offline; (2) `slide_id` minting moved to **Phase 2** — the engine carries through whatever ids the source has (via `swap_lang`); minting a never-id'd source happens at the file/orchestration layer.
 
 ### Phase 2 — Idempotency + sync convergence + watermark — [TODO]
 **Accomplishes:** the D2 dispatch and the "next sync is a no-op" seal.
@@ -95,7 +96,8 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 - New module `src/clm/cli/commands/slides_translate.py`; clone the option skeleton from `slides_sync.py` and the simple-mutation skeleton from `split.py`:
   - `--to en|de`, `--dry-run` / `--explain` (side-effect-free: parse + classify + count translatable vs copied + show target path + id plan; skip LLM/.env where possible), `--json` (`_to_dict`: `cells_translated`, `cells_copied`, `target_path`, `ids_minted`, `deferred`), `--force`, `--provider` (env `CLM_SYNC_PROVIDER`), `--translation-model`, `--cache-dir` (env `CLM_CACHE_DIR`), `--no-cache`, `--no-env-file`.
-- Reuse `has_openrouter_api_key` (`openrouter_client.py:71`), `build_openrouter_client`, `load_env_files` (`env_loading.py:45`), `resolve_cache_dir`. No key → **warn + degrade** (defer localized cells or exit 1), never crash. On `TranslationError`, defer-and-report (the never-drop-content discipline at `sync_apply.py` `_translate`).
+- Reuse `has_openrouter_api_key` (`openrouter_client.py:71`), `build_openrouter_client`, `load_env_files` (`env_loading.py:45`), `resolve_cache_dir`. No key → **exit 1, write nothing** (a whole deck of untranslated placeholders is not useful — unlike sync's per-cell defer); the engine is all-or-nothing. On `TranslationError` it already raises (never half-writes).
+- **`TranslationCache` lands here (moved from Phase 1):** add a `TranslationCache` to `src/clm/infrastructure/llm/cache.py` (one table in `clm-llm.sqlite`; key = content-hash + **model-folded** `prompt_version`; cache only successful results) and expose it as a `CachingSlideTranslator` that *wraps* a `SlideTranslator` and is passed into `translate_deck_text`. The engine stays cache-agnostic (depends only on the protocol), so this is purely additive.
 - Register in `src/clm/cli/main.py` (~line 168): `slides_group.add_command(translate_cmd, name="translate")` and a second registration for `bootstrap`. Use the try/except optional-import pattern (main.py ~112-130) if LLM deps may be absent.
 - Exit codes: `0` wrote/clean, `1` some cells deferred (no key) / needs review, `2` hard error (twin exists without `--force`, engine down, bilingual-stem source).
 - **Acceptance:** `CliRunner` tests for absent-twin bootstrap, present-twin delegation, `--dry-run` no-write, `--json` shape, no-key degradation, `--force` overwrite, exit codes.
@@ -112,24 +114,29 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 ## 4. Current Status
 
-- **Completed:** design only. The three user-facing forks are settled (D1, D4, D5). The reuse surface is verified against the live tree (all symbols in §6 exist at the cited paths/lines as of this writing).
-- **In progress:** none — implementation not started.
-- **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. One thing to confirm with the user at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently planned as: infer from filename, `--to` optional override).
-- **Tests:** none yet. Strategy in §7.
+- **Completed:** design + **Phase 1** (pure engine `src/clm/slides/translate_deck.py` + `tests/slides/test_translate_deck.py`, 17 tests green, lint/format/mypy clean). Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master; handover committed `fdf7772`, Phase 1 commit follows. The three user-facing forks are settled (D1, D4, D5).
+- **In progress:** none — Phase 2 not started.
+- **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. Confirm at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently planned as: infer from filename, `--to` optional override).
+- **Tests:** Phase 1 fully covered (see §7). Phases 2–5 pending.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 1.** Prerequisites/setup:
-1. From this worktree, create the branch: `git fetch origin && git switch -C claude/slides-translate-bootstrap origin/master`.
-2. Ensure the worktree venv is synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (see memory `feedback-worktree-venv-sync`).
-3. Read `src/clm/slides/sync_translate.py` (the translator + both prompts), `src/clm/slides/sync_writeback.py` (`role_of`, `swap_lang`, `build_twin_cell`, `FileState`), `src/clm/slides/split.py` (header-macro regexes + the `unify`/`split` round-trip invariant), and `src/clm/slides/sync_apply.py` `_add_one_direction` / `_translate` (the existing per-cell translate+mint+insert pattern to mirror).
+**Start Phase 2 — idempotency + sync delegation + watermark + id minting.** This is the file/orchestration layer that wraps the Phase 1 pure engine. Build a function (e.g. `clm/slides/translate_bootstrap.py`) that:
+1. Resolves the source half and derives the twin path with `derive_split_twin` (`pairing.py:210`) / `split_lang_tag` (`pairing.py:158`).
+2. **Dispatch:** twin **present** → do not bootstrap; delegate to `build_sync_plan` (`sync_plan.py:1664`) + `apply_plan` (`sync_apply.py:208`) exactly as `slides_sync_cmd` wires them (degrade to incremental sync). Twin **absent** → run Phase 1 `translate_deck_text`, write both halves, then:
+   - run `assign_ids_in_split_pair` (`assign_ids.py:823`, `AssignOptions(accept_content_derived=True)`) over the freshly-written pair so it carries EN-authority `de_id==en_id` (writes the source half back too if ids changed — keep parity). If the source was id-less this is where ids are minted, so the pair is never born id-less.
+   - record the watermark via `_record_watermark` (`sync_apply.py:2172`) + `SyncWatermarkCache` (`cache.py:652`) so the next `clm slides sync` is a clean no-op.
+3. Writes via `FileState`/`atomic_write_all` with `newline="\n"`.
+
+**Acceptance:** `translate` twice → the second run is a sync no-op; deck not doubled; a subsequent `clm slides sync` reports clean. Round-trip + parity hold on the written files. (Engine-level round-trip is already guaranteed by Phase 1.)
+
+**Setup:** worktree venv must be synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (memory `feedback-worktree-venv-sync`). Run tests with `uv run python -m pytest …` (system Python has no pytest).
 
 **Gotchas to watch (these silently corrupt the pair):**
-- Translating a neutral/shared cell → `UnifyError` + `_check_shared_cell_parity` failure. Gate strictly on `role_of(meta) is None` / `meta.lang is None`.
-- Running the header macro through the cell translator, or forgetting the `import header_de`→`import header_en` line swap → broken title slide + split↔bilingual round-trip. Reuse `split.py`'s regexes.
-- Emitting the twin id-less → forces a downstream cold-mint/adopt round (needs verifier + key). Mint ids at bootstrap.
+- **Phase 1 already handles** the translate-vs-copy gate (`metadata.lang`, *not* `role_of` — a localized id-less code cell is `role_of()==None` but must translate), the header-macro/import rewrite (reused `split.py` regexes), and the `split(unify(de,en))==(de,en)` validity guard. Don't re-implement these in Phase 2.
+- Emitting the twin id-less → forces a downstream cold-mint/adopt round (needs verifier + key). Mint ids at bootstrap via `assign_ids_in_split_pair`.
 - Missing watermark seal → the next `sync` re-diffs and may re-propose. The `_record_watermark` call is load-bearing for D2.
 - Program extension may be `.cpp`/`.java` etc.; the `.de`/`.en` tag sits immediately before the final extension. Use `split_lang_tag` (prefix-agnostic) for naming — don't assume `.py`.
 - Line endings: write with `newline="\n"`; never line-string surgery — use `raw_cells` / `FileState`.
@@ -139,10 +146,12 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 ## 6. Key Files & Architecture
 
 ### New files
-- `src/clm/slides/translate_deck.py` — the pure bootstrap engine (Phase 1). Parses a source half, classifies cells, translates localized ones, copies neutral ones verbatim, swaps the header macro, builds twins, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable.
+- **`src/clm/slides/translate_deck.py` — DONE (Phase 1).** The pure, offline bootstrap engine: `translate_deck_text(source_text, *, source_lang, target_lang, translator) -> TranslateDeckResult`. Parses a source half, classifies cells by `metadata.lang`, translates localized ones (code via `CODE_ROLE`), copies neutral ones verbatim, rewrites the header macro/import (reusing `split.py` regexes), self-checks the split/unify round-trip, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable. **Also reusable for the Phase 3 voiceover companion** — companions are just lang-tagged cells with no header macro, which this engine already handles.
+- **`tests/slides/test_translate_deck.py` — DONE (17 tests).**
+- `src/clm/slides/translate_bootstrap.py` — file/orchestration layer (Phase 2): dispatch, id minting, watermark.
 - `src/clm/cli/commands/slides_translate.py` — the `clm slides translate` Click command (Phase 4).
-- `TranslationCache` class added to `src/clm/infrastructure/llm/cache.py` (Phase 1).
-- Tests: `tests/slides/test_translate_deck.py` (engine), `tests/cli/test_slides_translate.py` (CLI), companion/idempotency tests.
+- `TranslationCache` + `CachingSlideTranslator` in `src/clm/infrastructure/llm/cache.py` / `sync_translate.py` (Phase 4 — moved from Phase 1).
+- Tests: `tests/cli/test_slides_translate.py` (CLI), companion/idempotency tests (Phases 2–4).
 
 ### Modified files
 - `src/clm/cli/main.py` — register `translate` + `bootstrap` under `slides_group` (~line 168).
@@ -177,7 +186,7 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 ## 7. Testing Approach
 
 - **Unit (primary, offline):** drive everything through the `SlideTranslator` **Protocol** with `StaticSlideTranslator` — **no network, no vcrpy cassette** (this is a host-side path, unlike in-kernel build LLM traffic). The whole sync stack is tested this way; follow it.
-- **Phase 1 invariants to assert:** neutral cells byte-identical across halves; `split(unify(de,en)) == (de,en)`; localized markdown translated, code identifiers untouched (only string/comment payload changes under the static fake); header macro swapped (`header_de`→`header_en` + import line) with title arg translated; ids carried onto twins.
+- **Phase 1 invariants — DONE (17 tests, all green):** the primary assertion is `split(unify(de, en)) == (de, en)` (`_assert_valid_pair`) plus content checks (right language survives, shared cells present, header swapped). Byte-exact `== other_half` is asserted only on *trailing-symmetric* decks (header-only or shared-cell-terminated) — see the trailing-blank note in §8. The strongest cases use a `_mirror_translator` built from the canonical split halves so a correct engine regenerates the other side's content exactly.
 - **Phase 2:** run `translate` twice → second run = `sync` no-op (assert no doubling, watermark recorded, subsequent `sync` clean). Present-twin delegation path exercised.
 - **Phase 3:** companion translated, `for_slide`/`vo_anchor` preserved, parity validator passes.
 - **Phase 4:** `CliRunner` for absent/present twin, `--dry-run` writes nothing, `--json` envelope shape, no-key degradation (exit 1 + warning, no crash), `--force` overwrite, exit-code matrix. Note the Click 8.1-vs-8.2 `CliRunner` compat pattern (memory `feedback-click-82-clirunner-compat`).
@@ -192,3 +201,9 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - The "code is translated iff it has a lang tag" requirement was the user's own framing — and it happens to be exactly the existing `role_of` / no-lang-is-shared model. Lean on that; don't invent a parallel marker.
 - Grounding for this design came from a multi-agent read of the sync engine, slide format, pairing/cold-start machinery, LLM infra, and CLI surface. The reuse table in §6 was re-verified against the live tree (symbol names + line numbers) before writing this doc.
 - CLAUDE.md hard rules in play: type hints on public APIs; `attrs @define` internal / Pydantic at boundaries; `logging.getLogger(__name__)` never `print()`; Python over bash for any tooling; **update info topics** when CLI behavior changes (Phase 5 is not optional). Commits that fail a hook didn't happen — fix, re-stage, new commit (never `--amend` a rejected commit).
+
+### Phase 1 discoveries (read before Phase 2)
+- **The translate-vs-copy gate is `metadata.lang`, NOT `role_of`.** The original plan said "gate on `role_of(meta) is None`", but `role_of` returns `None` for a localized id-less code cell (`# %% lang="de"` with no `slide_id`) — which *must* be translated. So: `lang == source_lang` → translate; `lang is None` → copy verbatim. `role_of`/`cell_type` only select the prompt (`CODE_ROLE` → code prompt). This is encoded in `_translation_role` and the main loop.
+- **`split` produces trailing-blank-asymmetric halves.** The cell that ends the bilingual source carries an extra EOF blank line that, after `split`, lands on **only one** half. So a generated half (the engine mirrors the *source* half's per-cell trailing blanks) does **not** in general byte-match the other half of an arbitrary bilingual deck — and that is correct: when bootstrapping there is no pre-existing other half to match. The honest invariant is the round-trip, not byte-equality. Byte-exact tests therefore use decks that end on a shared cell (symmetric) or are header-only. Phase 2 writes these halves to disk as-is; don't try to "fix" the asymmetry.
+- **The round-trip guard verifies split-*validity*, not translation *fidelity*.** A translator that injects a *valid* `lang="en"` cell boundary produces an extra-but-valid cell that still round-trips (guard won't flag it); only a structurally-breaking injection (e.g. a no-lang cell appearing in one half) trips it. Fidelity is the LLM's job / a later verify pass, not the engine's.
+- **The engine reuses `split.py`'s private header regexes** (`_HEADER_DE_RE` etc.) via `from clm.slides import split`. Deliberate (the handover's "don't duplicate the header grammar" rule). If a reviewer prefers, promote them to public names in `split.py` — but do not fork copies.

--- a/docs/claude/slides-translate-bootstrap-handover.md
+++ b/docs/claude/slides-translate-bootstrap-handover.md
@@ -1,7 +1,7 @@
 # Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
 
-**Status:** **Phases 1–4 DONE.** Phase 1 = pure engine `translate_deck.py`. Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion in lockstep. Phase 4 = the `clm slides translate` (+ `bootstrap` alias) CLI command + `TranslationCache`/`CachingSlideTranslator`. All green; lint/format/mypy clean; fast suite green. **Phase 5 (info-topic docs + acceptance gate) is next** — and is required by CLAUDE.md's Info Topics rule since a new CLI command landed.
-**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, Phase 4 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
+**Status:** ✅ **FEATURE COMPLETE — all 5 phases DONE.** Phase 1 = pure engine `translate_deck.py`. Phase 2 = orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark). Phase 3 = voiceover companion in lockstep. Phase 4 = the `clm slides translate` (+ `bootstrap` alias) CLI command + `TranslationCache`/`CachingSlideTranslator`. Phase 5 = info-topic docs (`commands.md` + `migration.md`) + the validate acceptance gate. All green; lint/format/mypy clean; fast suite green. **No phases remain — this handover is ready to retire** (`docs/claude/.../-archive`). The only optional follow-ups are in §8.
+**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, `28511cb2` Phase 4, Phase 5 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
 **Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
 **Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
 **Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
@@ -106,34 +106,34 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - Exit codes: `0` wrote/clean, `1` delegated-sync deferred / no key, `2` hard error (bad source → `UsageError`; `TranslateDeckError` mid-bootstrap → caught, exit 2, nothing written).
 - **Acceptance — met:** `CliRunner` tests (11) — absent-twin bootstrap (exit 0, twin == split's EN), no-key exit 1 + nothing written, `--dry-run` no-write + `--json` shape, `--to` reverse direction, present-twin → incremental-sync no-op (not doubled), `--force` overwrite, bilingual-stem/missing-source exit 2, and the `bootstrap` alias via the `slides` group. Plus 13 cache/caching-translator unit tests in `tests/infrastructure/llm/test_translation_cache.py`.
 
-### Phase 5 — Docs & acceptance gate — [TODO]
-**Accomplishes:** the CLAUDE.md Info Topics Maintenance Rule + end-to-end validation.
+### Phase 5 — Docs & acceptance gate — [DONE]
+**Accomplished:** the CLAUDE.md Info Topics Maintenance Rule + end-to-end validation.
 
-- Add a `### clm slides translate` section to `src/clm/cli/info_topics/commands.md`, modeled on the existing `### clm slides sync` block (option table + exit codes + examples). Use `{version}` placeholders — never hardcode versions.
-- Add a `migration.md` entry: the "bootstrap a second language" workflow (`translate` → then `sync`).
-- If exposed via MCP, add a `slides_translate` tool + a migration parity entry.
-- **Acceptance gate:** a generated deck passes `clm validate slides <dir> --fail-on warning` (slide_id set+order parity, shared-cell byte parity, pairing adjacency, companion `for_slide` parity).
+- Added a `### clm slides translate` section to `src/clm/cli/info_topics/commands.md` (option table, exit codes, examples, the `bootstrap` alias, the lang-tag rule, companion lockstep, dispatch/idempotency), with `{version}` placeholders. Also updated the `### clm slides sync` cross-reference ("sync never invents a translated half") to point at `clm slides translate` for the cold start.
+- Added a `## Bootstrap a second language: clm slides translate ({version} — additive)` entry to `migration.md` (the `translate` → `sync` → `unify` workflow; additive, no break).
+- **MCP: intentionally skipped** — the MCP surface wraps read/analysis library functions (`suggest_sync`, `validate`, `normalize`); the writing+LLM `slides_sync` is **not** exposed there, so `slides_translate` is out of scope by the same rationale (not an omission).
+- **Acceptance gate — met:** `test_generated_deck_passes_validate_fail_on_warning` bootstraps a deck through the **real CLI** and asserts `clm validate <dir> --fail-on warning` exits 0 (slide_id set/order parity, shared-cell byte parity, pairing adjacency, companion `for_slide` parity all hold on the generated pair).
 
 ---
 
 ## 4. Current Status
 
-- **Completed:** design + **Phase 1** (`translate_deck.py`, `cf1c8e06`) + **Phase 2** (`translate_bootstrap.py`, `29947b88`) + **Phase 3** (companion, `c9199c8a`) + **Phase 4** (CLI `slides_translate.py` + `TranslationCache`/`CachingSlideTranslator`). Lint/format/mypy clean; fast suite green. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master. The three user-facing forks are settled (D1, D4, D5).
-- **In progress:** none — Phase 5 (docs) not started.
-- **Blockers / open questions:** none blocking. The `--to` question is resolved: `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source* (a tag-less single half is rejected with a "run split first" hint), and `--to` is an optional override.
-- **Tests:** Phases 1–4 fully covered (see §7). Phase 5 pending.
+- **Completed:** design + **all 5 phases**. `cf1c8e06` Phase 1, `29947b88` Phase 2, `c9199c8a` Phase 3, `28511cb2` Phase 4, Phase 5 commit follows (docs + acceptance gate). Lint/format/mypy clean; fast suite green. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master, pushed. The three user-facing forks are settled (D1, D4, D5).
+- **In progress:** none — feature complete.
+- **Blockers / open questions:** none. The `--to` question is resolved: `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source* (a tag-less single half is rejected with a "run split first" hint), and `--to` is an optional override.
+- **Tests:** all phases covered (see §7). Counts: 17 (`test_translate_deck`) + 28 (`test_translate_bootstrap`) + 13 (`test_translation_cache`) + 12 (`test_slides_translate`, incl. the acceptance gate).
+- **Remaining:** open a PR to `master`, then **retire this handover** (→ `-archive`). No code work left.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 5 — info-topic docs + acceptance gate (the final phase).** A new CLI command landed, so CLAUDE.md's **Info Topics Maintenance Rule (CRITICAL)** now requires updating the version-accurate docs downstream agents read. Plan:
-1. Add a `### clm slides translate` section to `src/clm/cli/info_topics/commands.md`, modeled on the existing `### clm slides sync` block (option table, exit codes `0/1/2`, examples — `clm slides translate slides_x.de.py`, `--to`, `--dry-run`, `--force`). Use `{version}` placeholders — never hardcode versions. Mention the `bootstrap` alias and that code is translated iff a cell carries a `lang` tag.
-2. Add a `migration.md` entry: the "bootstrap a second language" workflow (`translate` once → then `sync` forever; run `unify` for a bilingual file).
-3. (Optional) If the MCP server exposes slide tools, add a `slides_translate` tool + a parity entry — check `src/clm/mcp/` first; skip if not a natural fit.
-4. **Acceptance gate:** generate a deck via the CLI (offline, with a static translator in a test, or by hand) and confirm it passes `clm validate slides <dir> --fail-on warning` (slide_id set+order parity, shared-cell byte parity, pairing adjacency, companion `for_slide` parity). A round-trip test feeding a real bilingual fixture through split → translate-one-half → validate is the strongest end-to-end check.
+**All 5 phases are DONE — no implementation work remains.** The only follow-ups are process:
+1. **Open a PR** from `claude/slides-translate-bootstrap` → `master` (link #232). The branch is pushed and the pre-push gate (ruff, format, mypy, fast suite) passes.
+2. **Retire this handover** — rename to `docs/claude/slides-translate-bootstrap-handover-archive.md` (the `retire-handover` skill), since the feature is shipped.
+3. **Optional future work** (not required): async fan-out of the per-cell translate loop (`client.py` `_get_semaphore`, default `max_concurrent=5`) if real decks are slow; full companion *sync* (reconciling an already-present companion on the sync-delegation path); a `--to` requirement when a source genuinely has no lang tags (currently inferred from the filename tag).
 
-**Phases 1–4 are DONE.** The feature is fully usable from the CLI today (`clm slides translate slides_x.de.py`); Phase 5 is documentation + the validation gate, not new behavior. The single entry point is `bootstrap_deck(source_path, *, target_lang=None, translator, judge=None, watermark_cache=None, recoverer=None, alignment_cache=None, verifier=None, correspondence_cache=None, provider_available=False, force=False) -> BootstrapResult`; the CLI is `src/clm/cli/commands/slides_translate.py`.
+**The feature is usable today:** `clm slides translate slides_x.de.py`. Single entry point `bootstrap_deck(...) -> BootstrapResult` in `src/clm/slides/translate_bootstrap.py`; CLI in `src/clm/cli/commands/slides_translate.py`.
 
 **Setup:** worktree venv must be synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (memory `feedback-worktree-venv-sync`). Run tests with `uv run python -m pytest …` (system Python has no pytest).
 
@@ -158,9 +158,9 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **`tests/cli/test_slides_translate.py` — DONE (11 tests).** **`tests/infrastructure/llm/test_translation_cache.py` — DONE (13 tests).**
 
 ### Modified files
-- `src/clm/cli/main.py` — register `translate` + `bootstrap` under `slides_group` (~line 168).
-- `src/clm/cli/info_topics/commands.md` — `### clm slides translate` section (Phase 5).
-- `src/clm/cli/info_topics/migration.md` — bootstrap-a-second-language workflow entry (Phase 5).
+- `src/clm/cli/main.py` — registers `translate` + `bootstrap` under `slides_group` (~line 167). **DONE.**
+- `src/clm/cli/info_topics/commands.md` — `### clm slides translate` section + updated the sync cross-reference. **DONE (Phase 5).**
+- `src/clm/cli/info_topics/migration.md` — `## Bootstrap a second language` entry. **DONE (Phase 5).**
 
 ### Reuse surface (verified at these paths/lines)
 | Symbol | Location | Role |

--- a/docs/claude/slides-translate-bootstrap-handover.md
+++ b/docs/claude/slides-translate-bootstrap-handover.md
@@ -1,7 +1,7 @@
 # Handover: Full-deck translation — `clm slides translate` (deck bootstrap)
 
-**Status:** **Phase 1 DONE** (`src/clm/slides/translate_deck.py` + 17 tests, all green; lint/format/mypy clean). Phase 2 (idempotency + sync delegation + watermark) is next.
-**Branch:** `claude/slides-translate-bootstrap` off `master` (commit `fdf7772` handover, Phase 1 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
+**Status:** **Phase 1 + Phase 2 DONE.** Phase 1 = pure engine `src/clm/slides/translate_deck.py` (17 tests). Phase 2 = file/orchestration layer `src/clm/slides/translate_bootstrap.py` (19 tests) — the D2 dispatch (twin absent→bootstrap+mint+watermark; twin present→delegate to sync), all green; lint/format/mypy clean; full slides suite (1165) green. **Phase 3 (voiceover companion in lockstep) is next.**
+**Branch:** `claude/slides-translate-bootstrap` off `master` (`fdf7772` handover, `cf1c8e06` Phase 1, Phase 2 commit follows). Do **not** branch off `claude/issue-226-partial-overlap-mismatch`.
 **Builds on (all merged to master):** the resolve-then-apply sync engine (#166/#190/#216), cold-start mint/adopt (#216), committed un-bootstrapped pairs (#225), partial-overlap mismatch (#226).
 **Related design notes:** `docs/claude/design/single-language-authoring-sync.md`, `docs/claude/design/sync-plan-resolve-apply.md`.
 **Sibling handover:** `docs/claude/sync-plan-resolve-apply-handover.md` (the engine this feature reuses).
@@ -76,14 +76,14 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 - **Tests:** `tests/slides/test_translate_deck.py` (17, all green) — round-trip + content on every shape (slide / voiceover / localized-code / id-less-code / shared / no-header / reverse-direction), byte-exact on trailing-symmetric decks, and the error paths.
 - **Two deliberate deviations from the original phase plan** (see §8): (1) `TranslationCache` moved to **Phase 4** — a caching translator *wrapper* at the integration layer keeps Phase 1 pure/offline; (2) `slide_id` minting moved to **Phase 2** — the engine carries through whatever ids the source has (via `swap_lang`); minting a never-id'd source happens at the file/orchestration layer.
 
-### Phase 2 — Idempotency + sync convergence + watermark — [TODO]
-**Accomplishes:** the D2 dispatch and the "next sync is a no-op" seal.
+### Phase 2 — Idempotency + sync convergence + watermark — [DONE]
+**Accomplished:** the D2 dispatch and the "next sync is a no-op" seal, in `src/clm/slides/translate_bootstrap.py`.
 
-- Resolve source + derive twin with `derive_split_twin` (`pairing.py:210`) / `split_lang_tag` (`pairing.py:158`).
-- **Twin present** → delegate to `build_sync_plan` (`sync_plan.py:1664`) + `apply_plan` (`sync_apply.py:208`) (mirror `slides_sync_cmd`'s wiring). **Twin absent** → Phase 1 bootstrap, then:
-  - run `assign_ids_in_split_pair` (`assign_ids.py:823`, `AssignOptions(accept_content_derived=True)`) for EN-authority parity (re-slugs from EN headings; writes the **source** half back too if ids changed — keep parity).
-  - record the watermark via `_record_watermark` (`sync_apply.py:2172`) + `SyncWatermarkCache` (`cache.py:652`).
-- **Acceptance:** `translate` twice → the second run is a `sync` no-op; deck is not doubled; a subsequent `clm slides sync` reports clean. Round-trip + parity assertions hold on the written files.
+- `derive_bootstrap_paths(source_path, target_lang=None) -> BootstrapPaths`: resolves direction (`split_lang_tag`, with a `--to` override), derives the twin path **existence-agnostically** (`_twin_path` swaps the second-to-last dotted segment — `derive_split_twin` could not be reused because it returns `None` when the twin is *absent*, which is exactly the bootstrap case), and resolves all paths so the watermark key matches a later `clm slides sync`. Rejects a bilingual stem (no tag), a `voiceover_*` source, and a contradictory/unsupported `--to`. `twin_exists` folds in **non-emptiness** (an empty twin is treated as absent).
+- `bootstrap_deck(...)`: the dispatch. **Twin present** (and not `--force`) → `_delegate_to_sync` = `build_sync_plan` + `apply_plan` mirroring `slides_sync_cmd`. **Twin absent / empty / `--force`** → `_bootstrap_new_twin`: `translate_deck_text` → `write_text(newline="\n")` → `assign_ids_in_split_pair(de, en, AssignOptions(accept_content_derived=True))` (EN-authority parity; mints onto **both** halves if the source was id-less; `force=False` preserves any author id) → `_record_watermark`.
+- Pure orchestration over **injected** deps (translator/judge/recoverer/verifier/caches) — builds no LLM client, loads no `.env`, closes no cache (the CLI owns those). Offline-testable through the `SlideTranslator`/`SyncJudge` protocols.
+- **Result:** `BootstrapResult` (`action` = `"bootstrapped"`/`"synced"`, `deck`/`assign` or `plan`/`apply_result`, `ids_assigned`, `watermark_recorded`).
+- **Acceptance — met:** `translate` twice → second run is a `sync` no-op (`action=="synced"`, `proposals==[]`, no errors, deck not doubled), proven for **both** an id'd and an **id-less** source (the latter rewrites both halves on run 1, so it exercises the post-mint watermark). Round-trip + parity hold on the written files, including a **trailing-asymmetric** deck (ends on a slide pair). 19 tests in `tests/slides/test_translate_bootstrap.py`.
 
 ### Phase 3 — Voiceover companion in lockstep — [TODO]
 **Accomplishes:** D5.
@@ -114,23 +114,24 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 
 ## 4. Current Status
 
-- **Completed:** design + **Phase 1** (pure engine `src/clm/slides/translate_deck.py` + `tests/slides/test_translate_deck.py`, 17 tests green, lint/format/mypy clean). Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master; handover committed `fdf7772`, Phase 1 commit follows. The three user-facing forks are settled (D1, D4, D5).
-- **In progress:** none — Phase 2 not started.
-- **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. Confirm at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently planned as: infer from filename, `--to` optional override).
-- **Tests:** Phase 1 fully covered (see §7). Phases 2–5 pending.
+- **Completed:** design + **Phase 1** (pure engine `translate_deck.py` + 17 tests, `cf1c8e06`) + **Phase 2** (orchestration `translate_bootstrap.py` + 19 tests). Both lint/format/mypy clean; full `tests/slides` suite (1165) green. Issue **#232** filed. Branch `claude/slides-translate-bootstrap` off master. The three user-facing forks are settled (D1, D4, D5).
+- **In progress:** none — Phase 3 not started.
+- **Blockers / open questions:** none blocking. D6 defaults stand unless the user objects. Confirm at Phase 4: whether `--to` should be required when the source half has **no** lang tags at all (currently: infer from filename, `--to` optional override — note `derive_bootstrap_paths` requires a `.de`/`.en` tag on the *source*, so a tag-less single half is already rejected with a "run split first" hint).
+- **Tests:** Phases 1–2 fully covered (see §7). Phases 3–5 pending.
 
 ---
 
 ## 5. Next Steps
 
-**Start Phase 2 — idempotency + sync delegation + watermark + id minting.** This is the file/orchestration layer that wraps the Phase 1 pure engine. Build a function (e.g. `clm/slides/translate_bootstrap.py`) that:
-1. Resolves the source half and derives the twin path with `derive_split_twin` (`pairing.py:210`) / `split_lang_tag` (`pairing.py:158`).
-2. **Dispatch:** twin **present** → do not bootstrap; delegate to `build_sync_plan` (`sync_plan.py:1664`) + `apply_plan` (`sync_apply.py:208`) exactly as `slides_sync_cmd` wires them (degrade to incremental sync). Twin **absent** → run Phase 1 `translate_deck_text`, write both halves, then:
-   - run `assign_ids_in_split_pair` (`assign_ids.py:823`, `AssignOptions(accept_content_derived=True)`) over the freshly-written pair so it carries EN-authority `de_id==en_id` (writes the source half back too if ids changed — keep parity). If the source was id-less this is where ids are minted, so the pair is never born id-less.
-   - record the watermark via `_record_watermark` (`sync_apply.py:2172`) + `SyncWatermarkCache` (`cache.py:652`) so the next `clm slides sync` is a clean no-op.
-3. Writes via `FileState`/`atomic_write_all` with `newline="\n"`.
+**Start Phase 3 — voiceover companion in lockstep (D5).** The deck-half engine (`translate_deck_text`) already translates lang-tagged narrative cells and copies neutral ones, and `bootstrap_deck` is the orchestration seam to hook into. A voiceover companion (`voiceover_<name>.<src>.py`) is *just* lang-tagged cells with no header macro, which `translate_deck_text` handles as-is. Plan:
+1. In `bootstrap_deck` (twin-**absent** path), after writing the deck twin, detect the source companion next to the source half. Companion naming is `voiceover_*` and it carries the same `.de`/`.en` tag; resolve its placement with `effective_write_layout` (`src/clm/slides/sidecar_layout.py`) — it may live as a sibling or under a `voiceover/` subdir (topic-sidecar-subdirs, PR #218). Reuse the resolver (`resolve_companion`) rather than re-deriving the path.
+2. Translate the companion's text with `translate_deck_text` (same translator) and write `voiceover_<name>.<tgt>.py` via the layout. **Preserve `for_slide` / `vo_anchor`** — these are cell metadata the engine copies verbatim (they are not `lang`-gated), so they should survive untouched; add a test asserting it.
+3. `derive_bootstrap_paths` currently **rejects** a `voiceover_*` *source* (a companion is never a standalone translate target). Keep that — the companion is found and translated *from the deck*, not passed directly.
+4. **Idempotency:** a companion already present must not be re-translated/doubled. Mirror the deck dispatch — if the target companion exists, skip (or, later, sync it). For Phase 3, skip-with-note is acceptable; full companion-sync can defer.
 
-**Acceptance:** `translate` twice → the second run is a sync no-op; deck not doubled; a subsequent `clm slides sync` reports clean. Round-trip + parity hold on the written files. (Engine-level round-trip is already guaranteed by Phase 1.)
+**Acceptance:** companion `for_slide` parity holds against the translated deck (`validator._check_split_companion_for_slide_parity`); narration cells are translated; `vo_anchor` preserved; re-running does not double the companion. Add tests to `tests/slides/test_translate_bootstrap.py` (or a new `test_*` file) driven by `StaticSlideTranslator`.
+
+**Phase 2 is DONE** (`translate_bootstrap.py`): the twin dispatch, EN-authority minting and watermark seal are in place and the `translate`-twice no-op is proven (incl. id-less + asymmetric decks). Engine-level round-trip is guaranteed by Phase 1; Phase 2 additionally proves the on-disk pair round-trips and is idempotent.
 
 **Setup:** worktree venv must be synced (`uv sync --extra all`) — a repo-root `.venv` silently resolves `clm` to the main repo (memory `feedback-worktree-venv-sync`). Run tests with `uv run python -m pytest …` (system Python has no pytest).
 
@@ -148,7 +149,8 @@ If `voiceover_<name>.<src>.py` exists, translate its localized cells too (preser
 ### New files
 - **`src/clm/slides/translate_deck.py` — DONE (Phase 1).** The pure, offline bootstrap engine: `translate_deck_text(source_text, *, source_lang, target_lang, translator) -> TranslateDeckResult`. Parses a source half, classifies cells by `metadata.lang`, translates localized ones (code via `CODE_ROLE`), copies neutral ones verbatim, rewrites the header macro/import (reusing `split.py` regexes), self-checks the split/unify round-trip, returns target text. Protocol-driven (`SlideTranslator`) so it's offline-testable. **Also reusable for the Phase 3 voiceover companion** — companions are just lang-tagged cells with no header macro, which this engine already handles.
 - **`tests/slides/test_translate_deck.py` — DONE (17 tests).**
-- `src/clm/slides/translate_bootstrap.py` — file/orchestration layer (Phase 2): dispatch, id minting, watermark.
+- **`src/clm/slides/translate_bootstrap.py` — DONE (Phase 2).** File/orchestration layer: `derive_bootstrap_paths` (direction + existence-agnostic twin path + rejections), `bootstrap_deck` (the D2 dispatch), `_bootstrap_new_twin` (translate→write→`assign_ids_in_split_pair`→`_record_watermark`), `_delegate_to_sync` (mirror of `slides_sync_cmd`). Injected deps only (no client/`.env`/cache-close). `BootstrapResult`/`BootstrapPaths`/`TranslateBootstrapError` are the public surface. **This is the seam Phase 3's voiceover companion hooks into.**
+- **`tests/slides/test_translate_bootstrap.py` — DONE (19 tests).**
 - `src/clm/cli/commands/slides_translate.py` — the `clm slides translate` Click command (Phase 4).
 - `TranslationCache` + `CachingSlideTranslator` in `src/clm/infrastructure/llm/cache.py` / `sync_translate.py` (Phase 4 — moved from Phase 1).
 - Tests: `tests/cli/test_slides_translate.py` (CLI), companion/idempotency tests (Phases 2–4).

--- a/src/clm/cli/commands/slides_translate.py
+++ b/src/clm/cli/commands/slides_translate.py
@@ -1,0 +1,403 @@
+"""``clm slides translate`` (alias ``bootstrap``) — full-deck cold-start translation.
+
+Issue #232. When an author writes a deck in a **single** language (only
+``slides_x.de.py``), this command synthesizes the other-language split half as a
+complete translation of the whole deck — the cold start that ``clm slides sync``
+deliberately refuses to perform (``sync`` only fills per-cell gaps inside an
+*already-existing* pair).
+
+Code is mostly **not** translated: a cell with no ``lang`` attribute is shared
+and copied byte-for-byte into both halves; only ``lang``-tagged cells are
+translated (code cells through the identifier-preserving code prompt). The
+voiceover companion is translated in lockstep. Freshly-bootstrapped pairs are
+minted with EN-authority shared ``slide_id``\\ s and the sync watermark is
+recorded, so the next ``clm slides translate`` (or ``clm slides sync``) is a
+clean incremental no-op rather than a re-translation.
+
+Dispatch (design decision D2): when the twin is **absent** the deck is
+bootstrapped; when it is **present** the command degrades to incremental
+``sync`` (``build_sync_plan`` + ``apply_plan``), so re-running converges and
+never doubles the deck.
+
+Exit codes:
+
+- ``0`` — wrote the new half (or the delegated sync was clean)
+- ``1`` — needs review (a delegated sync deferred something), or no API key
+- ``2`` — a hard error (a bad source path, or the engine could not translate)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from clm.cli.commands.slides_sync import CACHE_DB_NAME, _resolve_judge
+from clm.infrastructure.llm.cache import (
+    SyncWatermarkCache,
+    TranslationCache,
+    resolve_cache_dir,
+)
+from clm.infrastructure.llm.openrouter_client import (
+    DEFAULT_SYNC_JUDGE_MODEL,
+    has_openrouter_api_key,
+)
+from clm.slides.sync_translate import (
+    DEFAULT_TRANSLATION_MODEL,
+    CachingSlideTranslator,
+    OpenRouterSlideTranslator,
+)
+from clm.slides.translate_bootstrap import (
+    BootstrapResult,
+    TranslateBootstrapError,
+    bootstrap_deck,
+    derive_bootstrap_paths,
+)
+from clm.slides.translate_deck import TranslateDeckError
+
+if TYPE_CHECKING:
+    from clm.slides.sync_translate import SlideTranslator
+    from clm.slides.translate_bootstrap import BootstrapPaths
+
+
+def _make_translator(
+    translation_model: str, translation_cache: TranslationCache | None
+) -> SlideTranslator:
+    """The OpenRouter slide translator, cache-wrapped unless ``--no-cache``.
+
+    Factored out (and module-level) so tests can monkeypatch it with a static
+    translator, exactly as the sync CLI tests patch ``OpenRouterSlideTranslator``.
+    """
+    inner = OpenRouterSlideTranslator(model=translation_model)
+    if translation_cache is None:
+        return inner
+    return CachingSlideTranslator(inner=inner, cache=translation_cache)
+
+
+@click.command("translate")
+@click.argument("source", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--to",
+    "to_lang",
+    type=click.Choice(["en", "de"]),
+    default=None,
+    help=(
+        "Target language. Default: the opposite of SOURCE's .de/.en tag "
+        "(slides_x.de.py → en). Override when a source mixes/omits lang tags."
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help=(
+        "Preview only: show the target path and how many cells would be "
+        "translated vs copied, and write nothing. Uses no LLM and no API key."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Overwrite an existing twin (and its companion) by re-bootstrapping. "
+        "Without it, an existing twin degrades to an incremental sync instead."
+    ),
+)
+@click.option(
+    "--translation-model",
+    default=DEFAULT_TRANSLATION_MODEL,
+    show_default=True,
+    help="OpenRouter model used to translate the deck. Needs $OPENROUTER_API_KEY (or $OPENAI_API_KEY).",
+)
+@click.option(
+    "--provider",
+    type=click.Choice(["openrouter", "local"]),
+    default=lambda: os.environ.get("CLM_SYNC_PROVIDER") or "openrouter",
+    show_default="openrouter (or $CLM_SYNC_PROVIDER)",
+    help=(
+        "Edit-reconciliation judge backend for the delegated-sync path (when the "
+        "twin already exists): 'openrouter' (default) or 'local' (Ollama). Unused "
+        "on the bootstrap path."
+    ),
+)
+@click.option(
+    "--llm-model",
+    default=None,
+    help=f"Model for the delegated-sync edit judge (default '{DEFAULT_SYNC_JUDGE_MODEL}' for openrouter).",
+)
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Directory holding the translation + watermark caches (default: "
+        "--cache-dir > $CLM_CACHE_DIR > tool.clm.cache_dir > <cwd>/.clm-cache/)."
+    ),
+)
+@click.option(
+    "--no-cache", is_flag=True, help="Do not read or write the translation/watermark caches."
+)
+@click.option(
+    "--no-env-file",
+    is_flag=True,
+    default=False,
+    help=(
+        "Do not auto-load a .env file. By default the command walks up from "
+        "SOURCE's directory and loads the first .env found, so a project "
+        "$OPENROUTER_API_KEY / $OPENAI_API_KEY is available to the translator."
+    ),
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def slides_translate_cmd(
+    source: Path,
+    to_lang: str | None,
+    dry_run: bool,
+    force: bool,
+    translation_model: str,
+    provider: str,
+    llm_model: str | None,
+    cache_dir: Path | None,
+    no_cache: bool,
+    no_env_file: bool,
+    as_json: bool,
+) -> None:
+    """Translate a single-language deck SOURCE into its other-language split half.
+
+    SOURCE is one half of a split deck (``slides_x.de.py`` or ``slides_x.en.py``).
+    The matching ``slides_x.en.py`` / ``slides_x.de.py`` is synthesized as a full
+    translation; a voiceover companion is translated in lockstep. Run
+    ``clm slides unify`` afterward for a bilingual file, or just keep editing the
+    halves and ``clm slides sync`` them.
+
+    \b
+    Behavior:
+      * Twin absent → bootstrap: translate the whole deck, copy shared (no-lang)
+        cells verbatim, mint EN-authority shared slide_ids, and record the sync
+        watermark. Re-running is then a clean incremental sync.
+      * Twin present → delegate to incremental sync (never re-translates the deck).
+      * --dry-run previews the plan and writes nothing.
+    """
+    # Resolve direction + twin path up front (pure, no LLM) so we know whether
+    # this is a bootstrap or a sync before building any client. A bad source
+    # (bilingual stem, voiceover companion, contradictory --to) errors here.
+    try:
+        paths = derive_bootstrap_paths(source, to_lang)
+    except TranslateBootstrapError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    if dry_run:
+        _emit_dry_run(paths, as_json=as_json)
+        sys.exit(0)
+
+    will_sync = paths.twin_exists and not force
+
+    # Load the project .env so a key kept only in .env is found before the key
+    # check (the usual course-repo layout). Skipped with --no-env-file.
+    if not no_env_file:
+        from clm.cli.env_loading import load_env_files
+
+        load_env_files(paths.source_path.parent, paths.twin_path.parent)
+
+    # The bootstrap path translates the WHOLE deck, so without a key it would
+    # produce nothing useful — fail fast and write nothing (unlike sync's
+    # per-cell defer). The delegated-sync path degrades like `clm slides sync`.
+    if not will_sync and not has_openrouter_api_key():
+        click.echo(
+            "error: OPENROUTER_API_KEY (or OPENAI_API_KEY) is not set; cannot "
+            "translate the deck. Set a key (or keep it in a .env next to the deck) "
+            "and re-run.",
+            err=True,
+        )
+        sys.exit(1)
+
+    watermark_cache: SyncWatermarkCache | None = None
+    translation_cache: TranslationCache | None = None
+    if not no_cache:
+        cache_root = resolve_cache_dir(cli_override=cache_dir)
+        watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
+        translation_cache = TranslationCache(cache_root / CACHE_DB_NAME)
+
+    result: BootstrapResult
+    try:
+        translator = _make_translator(translation_model, translation_cache)
+        # A judge is only consulted on the delegated-sync path (twin present).
+        judge = _resolve_judge(provider, llm_model, None, None) if will_sync else None
+        result = bootstrap_deck(
+            source,
+            target_lang=to_lang,
+            translator=translator,
+            judge=judge,
+            watermark_cache=watermark_cache,
+            force=force,
+        )
+    except TranslateDeckError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+    finally:
+        if watermark_cache is not None:
+            watermark_cache.close()
+        if translation_cache is not None:
+            translation_cache.close()
+
+    exit_code = _exit_code(result)
+    if as_json:
+        click.echo(json.dumps(_to_dict(result, exit_code), indent=2))
+    else:
+        _print_human(result)
+    sys.exit(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+def _exit_code(result: BootstrapResult) -> int:
+    """0 wrote/clean, 1 review (a delegated sync deferred), 2 sync error."""
+    if result.action == "bootstrapped":
+        return 0  # the engine is all-or-nothing; reaching here means it wrote.
+    apply_result = result.apply_result
+    if apply_result is None:
+        return 0
+    if apply_result.has_errors or (result.plan is not None and result.plan.has_errors):
+        return 2
+    if apply_result.deferred > 0:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Dry-run (side-effect-free preview)
+# ---------------------------------------------------------------------------
+
+
+def _count_cells(text: str) -> tuple[int, int]:
+    """(translatable, copied): lang-tagged cells vs language-neutral/shared cells."""
+    from clm.slides.raw_cells import split_cells
+
+    _, cells = split_cells(text)
+    translatable = sum(1 for c in cells if c.metadata.lang is not None)
+    copied = len(cells) - translatable
+    return translatable, copied
+
+
+def _companion_preview(paths: BootstrapPaths) -> str | None:
+    """The target companion name a bootstrap would write, if a source companion
+    exists (read-only — used by --dry-run)."""
+    from clm.slides.voiceover_tools import companion_name, resolve_companion
+
+    source_companion = resolve_companion(paths.source_path)
+    if source_companion is None:
+        return None
+    return (source_companion.parent / companion_name(paths.twin_path)).name
+
+
+def _emit_dry_run(paths: BootstrapPaths, *, as_json: bool) -> None:
+    action = "sync" if paths.twin_exists else "bootstrap"
+    translatable, copied = _count_cells(paths.source_path.read_text(encoding="utf-8"))
+    companion = _companion_preview(paths)
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "mode": "dry-run",
+                    "action": action,
+                    "source": str(paths.source_path),
+                    "target": str(paths.twin_path),
+                    "source_lang": paths.source_lang,
+                    "target_lang": paths.target_lang,
+                    "cells_translatable": translatable,
+                    "cells_copied": copied,
+                    "companion": companion,
+                    "twin_exists": paths.twin_exists,
+                },
+                indent=2,
+            )
+        )
+        return
+    if action == "sync":
+        click.echo(
+            f"{paths.twin_path.name} already exists — `clm slides translate` would run "
+            f"an incremental sync (use `clm slides sync --dry-run` for the per-cell plan)."
+        )
+        return
+    click.echo(
+        f"Would bootstrap {paths.twin_path.name} from {paths.source_path.name} "
+        f"({paths.source_lang}→{paths.target_lang}): "
+        f"{translatable} cell(s) to translate, {copied} copied verbatim."
+    )
+    if companion is not None:
+        click.echo(f"Would translate voiceover companion → {companion}.")
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def _print_human(result: BootstrapResult) -> None:
+    if result.action == "synced":
+        apply_result = result.apply_result
+        assert apply_result is not None
+        click.echo(
+            f"{result.twin_path.name} already existed — ran incremental sync: "
+            f"{apply_result.applied} applied, {apply_result.deferred} deferred, "
+            f"{len(apply_result.errors)} error(s)."
+        )
+        for err in apply_result.errors:
+            click.echo(f"  error: {err}")
+        if apply_result.applied > 0:
+            click.echo("Review the propagated changes with `git diff` before committing.")
+        return
+
+    deck = result.deck
+    assert deck is not None
+    parts = [f"{deck.translated_count} translated", f"{deck.copied_count} copied"]
+    if result.ids_assigned:
+        parts.append(f"{result.ids_assigned} slide_id(s) minted")
+    click.echo(f"Bootstrapped {result.twin_path.name} ({', '.join(parts)}).")
+    if result.companion is not None:
+        if result.companion.action == "translated":
+            click.echo(f"Translated voiceover companion → {result.companion.target.name}.")
+        else:
+            click.echo(
+                f"Left existing voiceover companion {result.companion.target.name} untouched "
+                f"(use --force to regenerate)."
+            )
+    click.echo("Review the new half with `git diff` before committing.")
+
+
+def _to_dict(result: BootstrapResult, exit_code: int) -> dict:
+    companion: dict | None = None
+    if result.companion is not None:
+        companion = {
+            "action": result.companion.action,
+            "source": str(result.companion.source),
+            "target": str(result.companion.target),
+        }
+    out: dict = {
+        "action": result.action,
+        "source": str(result.source_path),
+        "target": str(result.twin_path),
+        "source_lang": result.source_lang,
+        "target_lang": result.target_lang,
+        "companion": companion,
+        "watermark_recorded": result.watermark_recorded,
+        "exit_code": exit_code,
+    }
+    if result.deck is not None:
+        out["cells_translated"] = result.deck.translated_count
+        out["cells_copied"] = result.deck.copied_count
+        out["ids_assigned"] = result.ids_assigned
+    if result.apply_result is not None:
+        out["sync"] = {
+            "applied": result.apply_result.applied,
+            "deferred": result.apply_result.deferred,
+            "errors": list(result.apply_result.errors),
+        }
+    return out

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -765,8 +765,10 @@ syncs the pair. You may also pass the **bilingual deck stem** (`slides_x.py`, no
 `.de`/`.en` tag) when it still exists on disk, and both halves are derived. The
 derivation is prefix-agnostic (so `apis.de.py` works) and the resolved pair is
 still run through the pairing guard above. A missing twin is a clear usage error
-(exit 2) — sync never invents a translated half; run `clm slides split` first.
-The two-path form is unchanged.
+(exit 2) — sync never invents a translated half. To create a missing
+other-language half from scratch, use **`clm slides translate`** (below); to split
+an existing bilingual deck into halves, run `clm slides split` first. The two-path
+form is unchanged.
 
 **Batch mode (since CLM {version}).** `DE_PATH` may also be a **directory** —
 every `.de`/`.en` deck pair under the tree is synced in one pass. Enumeration is
@@ -956,6 +958,102 @@ clm slides sync intro.de.py intro.en.py --dry-run --json
 
 # Stateless run: ignore/leave the watermark, baseline off git HEAD.
 clm slides sync intro.de.py intro.en.py --no-cache
+```
+
+### `clm slides translate`
+
+*Added in CLM {version}. Alias: `clm slides bootstrap`.*
+
+Cold-start translation of a **single-language** deck into its other-language
+split half. When an author has written only `slides_x.de.py`, this synthesizes
+`slides_x.en.py` (and vice-versa) as a complete translation of the whole deck —
+the one thing `clm slides sync` deliberately refuses to do (sync only fills
+per-cell gaps inside an *already-existing* pair). After the twin exists, keep the
+two halves in step with `clm slides sync`; run `clm slides unify` for a single
+bilingual file.
+
+**Code is mostly not translated — the `lang` tag decides.** A cell with **no**
+`lang` attribute is *shared* and copied **byte-for-byte** into both halves; only
+**`lang`-tagged** cells are translated. Idiomatic code carries no `lang` tag, so
+it is copied verbatim; a code cell whose string literals / comments are shown to
+the learner carries `lang=` and is translated through a prompt that keeps every
+identifier byte-identical. This is the same model `clm slides sync` and the
+validator already use — there is no new marker.
+
+**Dispatch (idempotent by design).** If the other-language half is **absent**,
+the deck is bootstrapped: the whole deck is translated, shared cells copied,
+EN-authority shared `slide_id`s minted onto **both** halves, and the sync
+watermark recorded. If the twin is **already present**, the command degrades to
+an incremental `clm slides sync` (it never re-translates the whole deck). So
+running `clm slides translate` twice is safe — the second run is a clean sync
+no-op and the deck is never doubled. Use `--force` to re-bootstrap over an
+existing twin.
+
+**Direction** is inferred from the source half's `.de` / `.en` tag (`.de.py` →
+produces `.en`). Override with `--to en|de`. The source **must** be one split
+half: a bilingual deck stem (no tag) is rejected with a hint to run
+`clm slides split` first.
+
+**Voiceover companion in lockstep.** If the source half has a `voiceover_*`
+companion, it is translated alongside the deck into the matching
+`voiceover_*.<lang>.py` (in the same `voiceover/` subdir or sibling location),
+preserving each cell's `for_slide` / `vo_anchor` anchors. An existing target
+companion is left untouched unless `--force`.
+
+**Key and `.env`.** Translation needs `$OPENROUTER_API_KEY` (or
+`$OPENAI_API_KEY`); the command walks up from the deck and loads the first `.env`
+it finds (skip with `--no-env-file`). On the **bootstrap** path a missing key is
+a hard stop — the command exits `1` and writes nothing (a whole untranslated deck
+is useless), unlike sync's per-cell defer. `--dry-run` uses no key and no LLM.
+
+```
+clm slides translate [OPTIONS] SOURCE
+clm slides bootstrap [OPTIONS] SOURCE   # alias
+```
+
+| Option | Description |
+|--------|-------------|
+| `--to [en\|de]` | Target language. Default: the opposite of SOURCE's `.de`/`.en` tag. Override when a source mixes/omits `lang` tags. |
+| `--dry-run` | Preview only: show the target path and how many cells would be translated vs copied (and the companion), and write nothing. Uses no LLM and no API key. |
+| `--force` | Overwrite an existing twin (and its companion) by re-bootstrapping. Without it, an existing twin degrades to an incremental sync. |
+| `--translation-model TEXT` | OpenRouter model used to translate the deck (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`. |
+| `--provider [openrouter\|local]` | Edit-judge backend for the *delegated-sync* path (when the twin already exists); unused on the bootstrap path. Overridable with `$CLM_SYNC_PROVIDER`. |
+| `--llm-model TEXT` | Model for the delegated-sync edit judge (default `anthropic/claude-sonnet-4-6` for openrouter). |
+| `--cache-dir PATH` | Directory holding the translation + watermark caches. Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<cwd>/.clm-cache/`. |
+| `--no-cache` | Do not read or write the translation / watermark caches. |
+| `--no-env-file` | Do not auto-load a `.env` file. |
+| `--json` | Emit a JSON report instead of human-readable lines. |
+
+Exit codes: `0` wrote the new half (or the delegated sync was clean), `1` the
+delegated sync left something for review **or** no API key was available on the
+bootstrap path (nothing written), `2` a hard error (the source is not a single
+split half, or the deck could not be translated — nothing is written).
+
+The `--json` report carries `action` (`bootstrapped` / `synced`), `source`,
+`target`, `source_lang`, `target_lang`, the `companion` (`action`, `source`,
+`target`) or `null`, `watermark_recorded`, and — for a bootstrap —
+`cells_translated`, `cells_copied`, `ids_assigned`. `--dry-run --json` carries
+`mode: "dry-run"`, the `action` that *would* run, and `cells_translatable` /
+`cells_copied` counts.
+
+Examples:
+
+```bash
+# Author wrote only slides_x.de.py — create the English half.
+clm slides translate slides/topic/slides_x.de.py
+
+# Preview without translating (no key needed).
+clm slides translate slides/topic/slides_x.de.py --dry-run
+
+# Force the direction (e.g. a source that mixes/omits lang tags).
+clm slides translate slides/topic/slides_x.de.py --to en
+
+# Re-bootstrap over an existing (e.g. stale) twin.
+clm slides translate slides/topic/slides_x.de.py --force
+
+# After bootstrapping, keep the halves in step, or merge to a bilingual file.
+clm slides sync slides/topic/slides_x.de.py
+clm slides unify slides/topic/slides_x.de.py
 ```
 
 ### `clm slides coverage`

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -84,6 +84,49 @@ This default is write-time only and never changes build output. Precedence for a
 new companion: explicit `--layout` flag → an existing `voiceover/` directory →
 the course default → `sibling`.
 
+## Bootstrap a second language: `clm slides translate` ({version} — additive)
+
+New command **`clm slides translate SOURCE`** (alias `clm slides bootstrap`)
+generates the missing-language split half of a single-language deck as a full
+translation. This is the cold start `clm slides sync` deliberately refuses to
+perform — sync only fills per-cell gaps inside an *already-existing* pair, and a
+missing twin is a usage error there.
+
+**Nothing changes for existing course repos** — this is a new command, no
+behavior change to `build`, `sync`, `split`, or `unify`. Adopt it when starting a
+new deck in one language:
+
+```bash
+# 1. You wrote only slides_x.de.py. Create the English half.
+clm slides translate slides/topic/slides_x.de.py
+
+# 2. From here on, keep the two halves in step with the usual tool.
+clm slides sync slides/topic/slides_x.de.py
+
+# 3. (Optional) merge to a single bilingual file for editing.
+clm slides unify slides/topic/slides_x.de.py
+```
+
+What it does (see `clm info commands` → *`clm slides translate`* for the full
+reference):
+
+- Code is translated **iff** a cell carries a `lang` tag — the existing
+  no-`lang`-is-shared model, no new marker. Shared (no-`lang`) cells, including
+  idiomatic code, are copied byte-for-byte into both halves.
+- The voiceover companion (`voiceover_*`) is translated in lockstep, preserving
+  `for_slide` / `vo_anchor`.
+- EN-authority shared `slide_id`s are minted onto both halves and the sync
+  watermark is recorded, so the **next** `translate` or `sync` is a clean no-op —
+  re-running never doubles the deck (a present twin degrades to incremental sync;
+  `--force` re-bootstraps).
+- Needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`); reads a project `.env`. With
+  no key the bootstrap exits `1` and writes nothing. `--dry-run` previews with no
+  key and no LLM.
+
+A generated deck is valid for all the split-pair tooling immediately — it passes
+`clm validate slides <dir> --fail-on warning` (slide_id set/order parity,
+shared-cell byte parity, pairing adjacency, companion `for_slide` parity).
+
 ## Breaking changes in CLM 1.8
 
 CLM 1.8 retires the Phase 0 deprecation period. It carries **intentional

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -93,6 +93,7 @@ from clm.cli.commands.release import release_group  # noqa: E402
 from clm.cli.commands.resolve_topic import resolve_topic_cmd  # noqa: E402
 from clm.cli.commands.search_slides import search_slides_cmd  # noqa: E402
 from clm.cli.commands.slides_sync import slides_sync_cmd  # noqa: E402
+from clm.cli.commands.slides_translate import slides_translate_cmd  # noqa: E402
 from clm.cli.commands.split import split_cmd  # noqa: E402
 from clm.cli.commands.status import status  # noqa: E402
 from clm.cli.commands.suggest_sync import suggest_sync_cmd  # noqa: E402
@@ -165,6 +166,9 @@ slides_group.add_command(unify_cmd, name="unify")
 slides_group.add_command(language_view_cmd, name="language-view")
 slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
 slides_group.add_command(slides_sync_cmd, name="sync")
+slides_group.add_command(slides_translate_cmd, name="translate")
+# `bootstrap` is an alias for the cold-start direction of the same command.
+slides_group.add_command(slides_translate_cmd, name="bootstrap")
 slides_group.add_command(search_slides_cmd, name="search")
 slides_group.add_command(tidy_cmd, name="tidy")
 cli.add_command(slides_group)

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -168,6 +168,89 @@ class TitleSuggestionCache:
         self._conn.close()
 
 
+class TranslationCache:
+    """Cache translated cell bodies for ``clm slides translate`` (Issue #232).
+
+    Keyed by ``(content_hash, prompt_version, source_lang, target_lang, role)``:
+    the source body's hash plus everything that changes the *output* — the
+    translator's prompt version (model-folded by the caller, so two models never
+    share an entry), the direction, and the role (markdown vs the
+    identifier-preserving code prompt). Bootstrapping a whole deck is the same
+    per-cell translation a later sync would do, so a shared cache makes re-runs
+    and tests cheap. Only **successful** translations are stored.
+
+    Shares the consuming repo's ``clm-llm.sqlite`` cache file with the other LLM
+    caches but lives in its own table.
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._conn = sqlite3.connect(str(db_path))
+        self._migrate()
+
+    def _migrate(self) -> None:
+        cursor = self._conn.execute("PRAGMA table_info(translations)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if not columns:
+            self._conn.execute(
+                """CREATE TABLE translations (
+                    content_hash   TEXT NOT NULL,
+                    prompt_version TEXT NOT NULL,
+                    source_lang    TEXT NOT NULL,
+                    target_lang    TEXT NOT NULL,
+                    role           TEXT NOT NULL,
+                    translation    TEXT NOT NULL,
+                    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (content_hash, prompt_version, source_lang, target_lang, role)
+                )"""
+            )
+            self._conn.commit()
+
+    def get(
+        self,
+        content_hash: str,
+        prompt_version: str,
+        source_lang: str,
+        target_lang: str,
+        role: str,
+    ) -> str | None:
+        row = self._conn.execute(
+            "SELECT translation FROM translations WHERE content_hash=? AND prompt_version=? "
+            "AND source_lang=? AND target_lang=? AND role=?",
+            (content_hash, prompt_version, source_lang, target_lang, role),
+        ).fetchone()
+        return row[0] if row else None
+
+    def put(
+        self,
+        content_hash: str,
+        prompt_version: str,
+        source_lang: str,
+        target_lang: str,
+        role: str,
+        translation: str,
+    ) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO translations
+               (content_hash, prompt_version, source_lang, target_lang, role, translation)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (content_hash, prompt_version, source_lang, target_lang, role, translation),
+        )
+        self._conn.commit()
+
+    def invalidate_prompt_version(self, prompt_version: str) -> int:
+        """Delete entries whose prompt version no longer matches."""
+        cursor = self._conn.execute(
+            "DELETE FROM translations WHERE prompt_version!=?",
+            (prompt_version,),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def close(self) -> None:
+        self._conn.close()
+
+
 class CoverageCache:
     """Cache LLM voiceover-coverage verdicts.
 

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -17,16 +17,21 @@ it with :class:`StaticSlideTranslator` and never touch the network.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from clm.infrastructure.llm.retry import call_with_retries
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import TranslationCache
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "DEFAULT_TRANSLATION_MODEL",
+    "CachingSlideTranslator",
     "OpenRouterSlideTranslator",
     "SlideTranslator",
     "StaticSlideTranslator",
@@ -188,3 +193,55 @@ _CODE_SYSTEM_PROMPT = (
 def _system_prompt_for(role: str) -> str:
     """Pick the system prompt for a cell ``role`` (code cells are not Markdown)."""
     return _CODE_SYSTEM_PROMPT if role == "code" else _SYSTEM_PROMPT
+
+
+@dataclass
+class CachingSlideTranslator:
+    """Wrap a :class:`SlideTranslator` with a persistent :class:`TranslationCache`.
+
+    Satisfies the ``SlideTranslator`` protocol itself, so it is a drop-in for the
+    engine: a cache hit skips the network, a miss calls ``inner`` and stores the
+    successful result. The cache key folds the wrapped translator's ``model`` (if
+    any) into ``prompt_version`` so two models — or a future prompt revision —
+    never share an entry. Used by ``clm slides translate`` so a re-run (or a
+    bootstrap of a deck that shares cells with a previously translated one) is
+    cheap; the engine stays cache-agnostic (it depends only on the protocol).
+    """
+
+    inner: SlideTranslator
+    cache: TranslationCache
+    # A settable attribute (not a property) so this satisfies the SlideTranslator
+    # protocol's ``prompt_version: str``. Folds the wrapped model into the version
+    # so a model switch invalidates by cache miss rather than returning the other
+    # model's translation. Computed once at construction.
+    prompt_version: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        model = getattr(self.inner, "model", "")
+        self.prompt_version = (
+            f"{self.inner.prompt_version}:{model}" if model else self.inner.prompt_version
+        )
+
+    def translate(
+        self,
+        *,
+        source_body: str,
+        source_lang: str,
+        target_lang: str,
+        role: str,
+    ) -> str:
+        content_hash = hashlib.sha256(source_body.encode("utf-8")).hexdigest()
+        version = self.prompt_version
+        hit = self.cache.get(content_hash, version, source_lang, target_lang, role)
+        if hit is not None:
+            return hit
+        result = self.inner.translate(
+            source_body=source_body,
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=role,
+        )
+        # Only successful results reach here (inner raises TranslationError on
+        # failure), so the cache never stores a bad translation.
+        self.cache.put(content_hash, version, source_lang, target_lang, role, result)
+        return result

--- a/src/clm/slides/translate_bootstrap.py
+++ b/src/clm/slides/translate_bootstrap.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "BootstrapPaths",
     "BootstrapResult",
+    "CompanionResult",
     "TranslateBootstrapError",
     "bootstrap_deck",
     "derive_bootstrap_paths",
@@ -100,6 +101,26 @@ class BootstrapPaths:
     twin_exists: bool
 
 
+CompanionAction = Literal["translated", "skipped"]
+
+
+@dataclass(frozen=True)
+class CompanionResult:
+    """How the source half's voiceover companion was handled (design decision D5).
+
+    ``action`` is ``"translated"`` when a new ``voiceover_<name>.<tgt>.py`` was
+    synthesized in lockstep with the deck, or ``"skipped"`` when one already
+    existed (left untouched, never doubled). ``translation`` carries the engine
+    result for a translated companion (``None`` for a skip). ``source`` /
+    ``target`` are the companion halves.
+    """
+
+    source: Path
+    target: Path
+    action: CompanionAction
+    translation: TranslateDeckResult | None = None
+
+
 @dataclass
 class BootstrapResult:
     """Outcome of one :func:`bootstrap_deck` call.
@@ -107,7 +128,9 @@ class BootstrapResult:
     ``action`` is ``"bootstrapped"`` when a new half was synthesized or
     ``"synced"`` when an existing twin routed the call to the incremental sync
     engine. The per-path detail (``deck`` / ``assign`` for a bootstrap;
-    ``plan`` / ``apply_result`` for a sync) is whichever path ran.
+    ``plan`` / ``apply_result`` for a sync) is whichever path ran. ``companion``
+    records the voiceover companion translated alongside a bootstrap (``None``
+    when the source has no companion, or on the sync path).
     """
 
     action: BootstrapAction
@@ -122,6 +145,7 @@ class BootstrapResult:
     plan: SyncPlan | None = None
     apply_result: ApplyResult | None = None
     watermark_recorded: bool = False
+    companion: CompanionResult | None = None
 
     @property
     def ids_assigned(self) -> int:
@@ -246,7 +270,9 @@ def bootstrap_deck(
             provider_available=provider_available,
         )
 
-    return _bootstrap_new_twin(paths, translator=translator, watermark_cache=watermark_cache)
+    return _bootstrap_new_twin(
+        paths, translator=translator, watermark_cache=watermark_cache, force=force
+    )
 
 
 def _bootstrap_new_twin(
@@ -254,14 +280,17 @@ def _bootstrap_new_twin(
     *,
     translator: SlideTranslator,
     watermark_cache: SyncWatermarkCache | None,
+    force: bool,
 ) -> BootstrapResult:
-    """Synthesize, write and seal the missing-language half.
+    """Synthesize, write and seal the missing-language half (and its companion).
 
-    Order matters: translate (the engine self-checks the split/unify round-trip,
-    so a malformed half never reaches disk) → write the twin → mint EN-authority
-    shared ids across **both** halves (also fills the source half if it was
-    id-less, so the pair is never born id-less) → record the watermark from the
-    final, id'd files so the next ``sync`` is a clean no-op.
+    Order matters: translate the deck **and** the voiceover companion *up front*
+    (the engine self-checks each pair's split/unify round-trip, and nothing is on
+    disk yet, so a translation failure leaves no half-written deck) → write the
+    deck twin → write the companion twin → mint EN-authority shared ids across
+    **both** deck halves (also fills the source half if it was id-less, so the
+    pair is never born id-less) → record the watermark from the final, id'd files
+    so the next ``sync`` is a clean no-op.
     """
     source_text = paths.source_path.read_text(encoding="utf-8")
     deck = translate_deck_text(
@@ -270,9 +299,18 @@ def _bootstrap_new_twin(
         target_lang=paths.target_lang,
         translator=translator,
     )
+    # Translate the companion in lockstep (D5) BEFORE any write, so a companion
+    # failure aborts the whole bootstrap instead of leaving a deck with no
+    # narration twin. Returns None when the source half has no companion.
+    companion = _translate_companion(paths, translator=translator, force=force)
+
     # newline="\n": never let the platform inject CRLF (the split-pair tooling and
     # the round-trip invariant assume LF), matching assign_ids' own write.
     paths.twin_path.write_text(deck.target_text, encoding="utf-8", newline="\n")
+    if companion is not None and companion.translation is not None:
+        companion.target.write_text(
+            companion.translation.target_text, encoding="utf-8", newline="\n"
+        )
 
     # EN-authority shared-id parity (de_id == en_id) over the freshly written pair.
     # accept_content_derived=True so a heading-less slide still mints from its
@@ -313,6 +351,51 @@ def _bootstrap_new_twin(
         deck=deck,
         assign=assign,
         watermark_recorded=watermark_recorded,
+        companion=companion,
+    )
+
+
+def _translate_companion(
+    paths: BootstrapPaths,
+    *,
+    translator: SlideTranslator,
+    force: bool,
+) -> CompanionResult | None:
+    """Plan the voiceover companion's translation in lockstep with the deck (D5).
+
+    Returns ``None`` when the source half has no voiceover companion. Otherwise
+    the target companion is ``voiceover_<name>.<tgt>.py`` placed in the **same
+    directory** the source companion lives in (so a foldered ``voiceover/`` topic
+    stays foldered) — mirroring ``split``'s ``_plan_companion_split``. An existing
+    non-empty target is left untouched (``"skipped"``) unless ``force``, so a
+    re-run never doubles the narration. Translation happens here (raising before
+    any write on failure); the **caller** performs the write.
+
+    A companion is just ``lang``-tagged narrative cells with no header macro, so
+    :func:`translate_deck_text` handles it directly — translating each localized
+    cell while ``build_twin_cell`` preserves ``for_slide`` / ``vo_anchor`` /
+    ``slide_id`` / ``tags`` verbatim (only ``lang`` and the body change), which is
+    exactly the companion ``for_slide`` parity the validator checks.
+    """
+    # Deferred import: a deck with no companion never pulls in the voiceover layer.
+    from clm.slides.voiceover_tools import companion_name, resolve_companion
+
+    source_companion = resolve_companion(paths.source_path)
+    if source_companion is None:
+        return None
+    # Keep the target in the source companion's directory (sibling or voiceover/
+    # subdir), named for the deck twin — voiceover_<name>.<tgt>.py.
+    target = source_companion.parent / companion_name(paths.twin_path)
+    if target.exists() and target.stat().st_size > 0 and not force:
+        return CompanionResult(source=source_companion, target=target, action="skipped")
+    translation = translate_deck_text(
+        source_companion.read_text(encoding="utf-8"),
+        source_lang=paths.source_lang,
+        target_lang=paths.target_lang,
+        translator=translator,
+    )
+    return CompanionResult(
+        source=source_companion, target=target, action="translated", translation=translation
     )
 
 

--- a/src/clm/slides/translate_bootstrap.py
+++ b/src/clm/slides/translate_bootstrap.py
@@ -1,0 +1,365 @@
+"""File/orchestration layer for ``clm slides translate`` (deck bootstrap).
+
+Phase 2 of Issue #232. Wraps the pure Phase 1 engine
+(:func:`clm.slides.translate_deck.translate_deck_text`) with the side-effecting
+work it deliberately avoids — disk resolution, the *idempotency dispatch*, id
+minting and the watermark seal — so that running ``translate`` over a
+single-language deck produces a valid split pair *and* every subsequent run
+degrades to a plain incremental ``sync`` instead of re-translating (or doubling)
+the deck.
+
+The central safety property (design decision D2) is **idempotency by
+delegation**:
+
+* **twin absent** (or empty, or ``--force``) → run the bootstrap engine, write
+  the new half, mint EN-authority shared ``slide_id``\\ s across the freshly
+  written pair (:func:`~clm.slides.assign_ids.assign_ids_in_split_pair`), and
+  record the structural watermark so the next ``sync`` is a clean no-op;
+* **twin present** → do **not** bootstrap; delegate straight to
+  :func:`~clm.slides.sync_plan.build_sync_plan` +
+  :func:`~clm.slides.sync_apply.apply_plan`, exactly as ``clm slides sync``
+  wires them. Re-running therefore converges to incremental sync by
+  construction — it never re-translates the whole deck and never doubles it.
+
+This module is pure orchestration over injected dependencies (the translator,
+edit judge, recoverer, verifier and caches) — it neither builds an LLM client
+nor loads ``.env``; the CLI (Phase 4) owns provider/key wiring and the cache
+lifecycle. That keeps the whole dispatch offline-testable through the
+``SlideTranslator`` / ``SyncJudge`` protocols.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from clm.slides.assign_ids import AssignOptions, AssignResult, assign_ids_in_split_pair
+from clm.slides.pairing import split_lang_tag
+from clm.slides.sync_apply import ApplyResult, _record_watermark, apply_plan
+from clm.slides.sync_plan import SyncPlan, build_sync_plan
+from clm.slides.translate_deck import TranslateDeckResult, translate_deck_text
+
+if TYPE_CHECKING:
+    from clm.infrastructure.llm.cache import (
+        SyncAlignmentCache,
+        SyncCorrespondenceCache,
+        SyncWatermarkCache,
+    )
+    from clm.infrastructure.llm.ollama_client import SyncJudge
+    from clm.slides.sync_recover import AlignmentRecoverer, CorrespondenceVerifier
+    from clm.slides.sync_translate import SlideTranslator
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BootstrapPaths",
+    "BootstrapResult",
+    "TranslateBootstrapError",
+    "bootstrap_deck",
+    "derive_bootstrap_paths",
+]
+
+_SUPPORTED_LANGS = ("de", "en")
+
+BootstrapAction = Literal["bootstrapped", "synced"]
+
+
+class TranslateBootstrapError(Exception):
+    """Raised when a deck cannot be resolved for bootstrapping.
+
+    Covers a source that is not a single split half — a bilingual deck stem
+    (run ``clm slides split`` first), a voiceover companion (translated with its
+    deck, not on its own), or an unsupported / contradictory ``--to`` target.
+    Translation failures inside the engine surface as
+    :class:`~clm.slides.translate_deck.TranslateDeckError`.
+    """
+
+
+@dataclass(frozen=True)
+class BootstrapPaths:
+    """The resolved direction and file paths for one bootstrap.
+
+    ``source_path`` / ``twin_path`` are the half the author wrote and the half
+    we will produce; ``de_path`` / ``en_path`` are the same two files ordered by
+    language (the order :func:`assign_ids_in_split_pair`, the watermark and the
+    sync engine all expect). All three are absolute, resolved paths so the
+    watermark key matches a later ``clm slides sync`` over the same deck.
+    ``twin_exists`` is true only when the twin file is present **and non-empty**
+    — an empty twin is treated as absent so a stray ``touch`` does not route a
+    fresh deck through sync.
+    """
+
+    source_path: Path
+    twin_path: Path
+    de_path: Path
+    en_path: Path
+    source_lang: str
+    target_lang: str
+    twin_exists: bool
+
+
+@dataclass
+class BootstrapResult:
+    """Outcome of one :func:`bootstrap_deck` call.
+
+    ``action`` is ``"bootstrapped"`` when a new half was synthesized or
+    ``"synced"`` when an existing twin routed the call to the incremental sync
+    engine. The per-path detail (``deck`` / ``assign`` for a bootstrap;
+    ``plan`` / ``apply_result`` for a sync) is whichever path ran.
+    """
+
+    action: BootstrapAction
+    source_path: Path
+    twin_path: Path
+    de_path: Path
+    en_path: Path
+    source_lang: str
+    target_lang: str
+    deck: TranslateDeckResult | None = None
+    assign: AssignResult | None = None
+    plan: SyncPlan | None = None
+    apply_result: ApplyResult | None = None
+    watermark_recorded: bool = False
+
+    @property
+    def ids_assigned(self) -> int:
+        """How many ``slide_id``\\ s the EN-authority mint stamped (0 when the
+        source was already fully id'd, or when delegating to sync)."""
+        return len(self.assign.assignments) if self.assign is not None else 0
+
+
+def _twin_path(source_path: Path, target_lang: str) -> Path:
+    """The sibling split half's path for ``target_lang`` — existence-agnostic.
+
+    Unlike :func:`~clm.slides.pairing.derive_split_twin` (which returns the twin
+    only if it is already on disk), this derives the path the twin *would* have
+    so the bootstrap can create it. The ``.de`` / ``.en`` tag sits immediately
+    before the final extension (``split_lang_tag`` guarantees the
+    ``<stem>.<lang>.<ext>`` shape), so swapping the second-to-last dotted segment
+    is prefix- and extension-agnostic (``apis.de.cpp`` → ``apis.en.cpp``).
+    """
+    parts = source_path.name.split(".")
+    parts[-2] = target_lang
+    return source_path.with_name(".".join(parts))
+
+
+def derive_bootstrap_paths(source_path: Path, target_lang: str | None = None) -> BootstrapPaths:
+    """Resolve direction + twin path for ``source_path`` (writes nothing).
+
+    Exposed so the CLI can decide *before* building any LLM client whether a run
+    will bootstrap or delegate to sync. ``target_lang`` overrides the inferred
+    direction (``--to``); when ``None`` it is the opposite of the source half's
+    ``.de`` / ``.en`` tag. Raises :class:`TranslateBootstrapError` for a source
+    that is not a single split half or a contradictory target.
+    """
+    if source_path.name.startswith("voiceover_"):
+        raise TranslateBootstrapError(
+            f"{source_path.name} is a voiceover companion, not a deck half; "
+            "its narration is translated together with the deck it belongs to "
+            "(run `clm slides translate` on the deck itself)."
+        )
+    source_lang = split_lang_tag(source_path)
+    if source_lang is None:
+        raise TranslateBootstrapError(
+            f"{source_path.name} carries no .de/.en language tag, so there is no "
+            "single source half to translate from. If it is a bilingual deck, run "
+            "`clm slides split` first, then translate one of the halves."
+        )
+    if target_lang is None:
+        target_lang = "en" if source_lang == "de" else "de"
+    if target_lang not in _SUPPORTED_LANGS:
+        raise TranslateBootstrapError(
+            f"unsupported target language {target_lang!r}; supported languages are "
+            f"{_SUPPORTED_LANGS}."
+        )
+    if target_lang == source_lang:
+        raise TranslateBootstrapError(
+            f"source half is already .{source_lang} and --to {target_lang} asks for "
+            "the same language; pass the other language (or omit --to to infer it)."
+        )
+
+    # Resolve so the watermark key (keyed by the (de_path, en_path) strings) is
+    # the same form `clm slides sync` records — otherwise a later sync would miss
+    # this run's watermark and re-baseline off git HEAD. resolve() is happy with a
+    # not-yet-existent twin (strict=False).
+    source_path = source_path.resolve()
+    twin_path = _twin_path(source_path, target_lang).resolve()
+    de_path, en_path = (source_path, twin_path) if source_lang == "de" else (twin_path, source_path)
+    twin_exists = twin_path.exists() and twin_path.stat().st_size > 0
+    return BootstrapPaths(
+        source_path=source_path,
+        twin_path=twin_path,
+        de_path=de_path,
+        en_path=en_path,
+        source_lang=source_lang,
+        target_lang=target_lang,
+        twin_exists=twin_exists,
+    )
+
+
+def bootstrap_deck(
+    source_path: Path,
+    *,
+    target_lang: str | None = None,
+    translator: SlideTranslator,
+    judge: SyncJudge | None = None,
+    watermark_cache: SyncWatermarkCache | None = None,
+    recoverer: AlignmentRecoverer | None = None,
+    alignment_cache: SyncAlignmentCache | None = None,
+    verifier: CorrespondenceVerifier | None = None,
+    correspondence_cache: SyncCorrespondenceCache | None = None,
+    provider_available: bool = False,
+    force: bool = False,
+) -> BootstrapResult:
+    """Bootstrap the other-language half of ``source_path`` — or sync if it exists.
+
+    The dispatch (design decision D2): when the twin is **absent** (or empty, or
+    ``force``) synthesize it with the Phase 1 engine, mint EN-authority shared
+    ids over the new pair, and record the watermark; when the twin is **present**
+    delegate to the incremental sync engine. The caller owns the cache lifecycle
+    (open / close) exactly as ``clm slides sync`` does — this function never
+    closes a cache it was handed.
+
+    ``translator`` drives both the whole-deck bootstrap and sync's new-slide
+    path; ``judge`` (plus the optional recoverer / verifier / caches) is only
+    consulted on the sync-delegation path. Raises
+    :class:`TranslateBootstrapError` for an unbootstrappable source and
+    :class:`~clm.slides.translate_deck.TranslateDeckError` if the engine cannot
+    produce a valid half.
+    """
+    paths = derive_bootstrap_paths(source_path, target_lang)
+
+    if paths.twin_exists and not force:
+        # Twin already on disk → this is no longer a cold start. Converge to plain
+        # incremental sync rather than re-translate (and never double the deck).
+        return _delegate_to_sync(
+            paths,
+            judge=judge,
+            translator=translator,
+            watermark_cache=watermark_cache,
+            recoverer=recoverer,
+            alignment_cache=alignment_cache,
+            verifier=verifier,
+            correspondence_cache=correspondence_cache,
+            provider_available=provider_available,
+        )
+
+    return _bootstrap_new_twin(paths, translator=translator, watermark_cache=watermark_cache)
+
+
+def _bootstrap_new_twin(
+    paths: BootstrapPaths,
+    *,
+    translator: SlideTranslator,
+    watermark_cache: SyncWatermarkCache | None,
+) -> BootstrapResult:
+    """Synthesize, write and seal the missing-language half.
+
+    Order matters: translate (the engine self-checks the split/unify round-trip,
+    so a malformed half never reaches disk) → write the twin → mint EN-authority
+    shared ids across **both** halves (also fills the source half if it was
+    id-less, so the pair is never born id-less) → record the watermark from the
+    final, id'd files so the next ``sync`` is a clean no-op.
+    """
+    source_text = paths.source_path.read_text(encoding="utf-8")
+    deck = translate_deck_text(
+        source_text,
+        source_lang=paths.source_lang,
+        target_lang=paths.target_lang,
+        translator=translator,
+    )
+    # newline="\n": never let the platform inject CRLF (the split-pair tooling and
+    # the round-trip invariant assume LF), matching assign_ids' own write.
+    paths.twin_path.write_text(deck.target_text, encoding="utf-8", newline="\n")
+
+    # EN-authority shared-id parity (de_id == en_id) over the freshly written pair.
+    # accept_content_derived=True so a heading-less slide still mints from its
+    # content slug instead of refusing (a bootstrap should leave no id-less cell).
+    # force=False so any id the author already wrote is preserved, not re-slugged.
+    # The engine's round-trip guard already proved the pair is unifiable, so this
+    # never returns None in practice; treat a defensive None as "ids unchanged".
+    assign = assign_ids_in_split_pair(
+        paths.de_path, paths.en_path, AssignOptions(accept_content_derived=True)
+    )
+    if assign is None:
+        # Unreachable given the engine's round-trip guard (it proved the exact
+        # pair now on disk is unifiable). Surface it if it ever fires in the field
+        # rather than silently shipping an id-less pair.
+        logger.warning(
+            "id minting skipped for %s / %s: pair was not unifiable despite the "
+            "engine round-trip guard — the bootstrapped pair may be id-less",
+            paths.de_path,
+            paths.en_path,
+        )
+
+    watermark_recorded = False
+    if watermark_cache is not None:
+        # Record both decks' post-mint state as the sync baseline — load-bearing
+        # for D2 (without it the next `sync` re-diffs off git HEAD and may
+        # re-propose). Reads the files back from disk, so it sees the id'd halves.
+        _record_watermark(watermark_cache, paths.de_path, paths.en_path)
+        watermark_recorded = True
+
+    return BootstrapResult(
+        action="bootstrapped",
+        source_path=paths.source_path,
+        twin_path=paths.twin_path,
+        de_path=paths.de_path,
+        en_path=paths.en_path,
+        source_lang=paths.source_lang,
+        target_lang=paths.target_lang,
+        deck=deck,
+        assign=assign,
+        watermark_recorded=watermark_recorded,
+    )
+
+
+def _delegate_to_sync(
+    paths: BootstrapPaths,
+    *,
+    judge: SyncJudge | None,
+    translator: SlideTranslator,
+    watermark_cache: SyncWatermarkCache | None,
+    recoverer: AlignmentRecoverer | None,
+    alignment_cache: SyncAlignmentCache | None,
+    verifier: CorrespondenceVerifier | None,
+    correspondence_cache: SyncCorrespondenceCache | None,
+    provider_available: bool,
+) -> BootstrapResult:
+    """Route a present-twin run through the incremental sync engine.
+
+    Mirrors the apply branch of ``slides_sync_cmd`` so a second ``translate`` (or
+    a ``translate`` of a deck whose twin already exists) behaves identically to
+    ``clm slides sync`` — incremental, watermark-driven, never re-translating the
+    whole deck.
+    """
+    plan = build_sync_plan(
+        paths.de_path,
+        paths.en_path,
+        watermark_cache=watermark_cache,
+        provider_available=provider_available,
+    )
+    apply_result = apply_plan(
+        plan,
+        judge=judge,
+        translator=translator,
+        watermark_cache=watermark_cache,
+        recoverer=recoverer,
+        alignment_cache=alignment_cache,
+        verifier=verifier,
+        correspondence_cache=correspondence_cache,
+    )
+    return BootstrapResult(
+        action="synced",
+        source_path=paths.source_path,
+        twin_path=paths.twin_path,
+        de_path=paths.de_path,
+        en_path=paths.en_path,
+        source_lang=paths.source_lang,
+        target_lang=paths.target_lang,
+        plan=plan,
+        apply_result=apply_result,
+        watermark_recorded=apply_result.watermark_recorded,
+    )

--- a/src/clm/slides/translate_deck.py
+++ b/src/clm/slides/translate_deck.py
@@ -1,0 +1,333 @@
+"""Full-deck translation engine: synthesize the other-language split half.
+
+Phase 1 of the ``clm slides translate`` feature (Issue #232). Pure, offline and
+Protocol-driven: given the *text* of a single-language split half (e.g. a
+``slides_x.de.py``), :func:`translate_deck_text` produces the text of the other
+half (``slides_x.en.py``) by
+
+* translating every **localized** cell — one carrying a ``lang=`` attribute —
+  via the :class:`~clm.slides.sync_translate.SlideTranslator` protocol (code
+  cells through the code prompt, which keeps identifiers byte-identical;
+  markdown through the prose prompt);
+* copying every **language-neutral / shared** cell — no ``lang`` attribute,
+  including idiomatic code — *verbatim*; and
+* rewriting the j2 title macro structurally (``header_de`` ↔ ``header_en`` plus
+  its ``import`` directive) while translating only the title string.
+
+The translate-vs-copy decision keys on ``metadata.lang`` — **not** on
+:func:`~clm.slides.sync_writeback.role_of`, which returns ``None`` for a
+localized but id-less code cell even though that cell must still be translated.
+``role_of`` / the cell type only select which translation prompt is used.
+
+Before returning, the generated half is validated against the canonical
+split/unify round-trip (``split(unify(de, en)) == (de, en)``) — the same
+invariant :mod:`clm.slides.split` rests on — so a malformed twin can never
+reach disk. The engine is all-or-nothing: it returns a complete target text or
+raises :class:`TranslateDeckError`; it never half-writes.
+
+This module touches neither the network nor the filesystem. File resolution,
+provider/key wiring, id minting, the watermark seal, the voiceover companion
+and result caching are later phases.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+
+from clm.notebooks.slide_parser import CellMetadata
+from clm.slides import split
+from clm.slides.raw_cells import RawCell, reconstruct, split_cells
+from clm.slides.sync_translate import SlideTranslator, TranslationError
+from clm.slides.sync_writeback import CODE_ROLE, build_twin_cell, role_of
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CellTranslation",
+    "TranslateDeckError",
+    "TranslateDeckResult",
+    "translate_deck_text",
+]
+
+# Only de/en are modelled: the title macro (``header_de`` / ``header_en``) and
+# the whole split/unify machinery are de/en specific.
+_SUPPORTED_LANGS = ("de", "en")
+
+# The canonical per-language header grammar lives in :mod:`clm.slides.split`;
+# reuse it rather than duplicating the regexes (divergent copies are the
+# documented landmine — see the feature handover §5).
+_HEADER_MACRO_RE = {"de": split._HEADER_DE_RE, "en": split._HEADER_EN_RE}
+_HEADER_IMPORT_RE = {"de": split._HEADER_DE_IMPORT_RE, "en": split._HEADER_EN_IMPORT_RE}
+
+
+CellKind = Literal["translated", "copied", "header", "import"]
+
+
+class TranslateDeckError(Exception):
+    """Raised when the other-language half cannot be produced.
+
+    Covers an unsupported language, a translation failure on a specific cell,
+    and a generated pair that fails the split/unify round-trip — i.e. anything
+    that would otherwise put a malformed or incomplete twin on disk.
+    """
+
+
+@dataclass(frozen=True)
+class CellTranslation:
+    """How one source cell was mapped into the target half (for reporting)."""
+
+    index: int  # position of the cell in the source half (0-based)
+    kind: CellKind
+    role: str | None  # the translation role for ``translated`` cells, else None
+    slide_id: str | None
+    lang: str | None
+
+
+@dataclass
+class TranslateDeckResult:
+    """Outcome of one :func:`translate_deck_text` call."""
+
+    target_text: str
+    cells: list[CellTranslation] = field(default_factory=list)
+
+    @property
+    def translated_count(self) -> int:
+        """Localized body cells whose content was sent through the translator."""
+        return sum(1 for c in self.cells if c.kind == "translated")
+
+    @property
+    def copied_count(self) -> int:
+        """Shared / language-neutral cells copied verbatim."""
+        return sum(1 for c in self.cells if c.kind == "copied")
+
+    @property
+    def header_translated(self) -> bool:
+        """Whether a title header macro was rewritten (and its title translated)."""
+        return any(c.kind == "header" for c in self.cells)
+
+
+def translate_deck_text(
+    source_text: str,
+    *,
+    source_lang: str,
+    target_lang: str,
+    translator: SlideTranslator,
+) -> TranslateDeckResult:
+    """Translate a single-language split half into its other-language twin.
+
+    ``source_text`` is the verbatim content of a ``*.<source_lang>.py`` split
+    half. Returns the text of the matching ``*.<target_lang>.py`` half plus a
+    per-cell report. Raises :class:`TranslateDeckError` if a cell cannot be
+    translated or the generated pair does not round-trip.
+    """
+    if source_lang not in _SUPPORTED_LANGS or target_lang not in _SUPPORTED_LANGS:
+        raise TranslateDeckError(
+            f"unsupported language pair {source_lang!r}->{target_lang!r}; "
+            f"supported languages are {_SUPPORTED_LANGS}"
+        )
+    if source_lang == target_lang:
+        raise TranslateDeckError(f"source and target language are both {source_lang!r}")
+
+    preamble, source_cells = split_cells(source_text)
+
+    target_cells: list[RawCell] = []
+    report: list[CellTranslation] = []
+
+    for index, cell in enumerate(source_cells):
+        meta = cell.metadata
+
+        # 1. The title macro: rewrite header_<src> -> header_<tgt>, translating
+        #    only the title argument. Structural — never run through the cell
+        #    body translator.
+        if meta.is_j2 and _HEADER_MACRO_RE[source_lang].search(cell.header):
+            target_cells.append(_rewrite_header_macro(cell, source_lang, target_lang, translator))
+            report.append(CellTranslation(index, "header", None, meta.slide_id, meta.lang))
+            continue
+
+        # 2. The header import directive: from ... import header_<src> -> header_<tgt>.
+        if meta.is_j2 and _HEADER_IMPORT_RE[source_lang].match(cell.header):
+            target_cells.append(_rewrite_header_import(cell, target_lang))
+            report.append(CellTranslation(index, "import", None, meta.slide_id, meta.lang))
+            continue
+
+        # 3. A localized cell (carries lang=) — translate its body and swap the
+        #    language. Gate on lang, NOT role_of: a localized id-less code cell
+        #    has role_of() == None but must still be translated.
+        if meta.lang == source_lang:
+            role = _translation_role(meta)
+            target_cells.append(
+                _translate_localized_cell(cell, source_lang, target_lang, role, translator)
+            )
+            report.append(CellTranslation(index, "translated", role, meta.slide_id, meta.lang))
+            continue
+
+        # 4. Everything else — language-neutral / shared cells (no lang),
+        #    non-header j2 directives, and defensively any stray foreign-language
+        #    cell — is copied verbatim. Shared cells MUST stay byte-identical
+        #    across the two halves or unify/validation breaks.
+        target_cells.append(_clone_cell(cell))
+        report.append(CellTranslation(index, "copied", None, meta.slide_id, meta.lang))
+
+    target_text = reconstruct(preamble, target_cells)
+    _assert_round_trips(source_text, target_text, source_lang)
+    return TranslateDeckResult(target_text=target_text, cells=report)
+
+
+def _translation_role(meta: CellMetadata) -> str:
+    """Pick the translator ``role`` for a localized cell.
+
+    ``CODE_ROLE`` for any code cell (selects the identifier-preserving code
+    prompt), otherwise the cell's narrative role (``slide`` / ``notes`` / …) or
+    ``"markdown"`` — mirroring how :mod:`clm.slides.sync_apply` calls the
+    translator. Only ``"code"`` changes the prompt; the rest is cosmetic prompt
+    text.
+    """
+    if meta.cell_type == "code":
+        return CODE_ROLE
+    return role_of(meta) or "markdown"
+
+
+def _translate_localized_cell(
+    cell: RawCell,
+    source_lang: str,
+    target_lang: str,
+    role: str,
+    translator: SlideTranslator,
+) -> RawCell:
+    """Build the target-language twin of a localized ``cell``.
+
+    Translates the body, swaps the language attribute, and re-appends the
+    source cell's trailing blank lines so the target half keeps the same
+    inter-cell spacing.
+    """
+    source_body = cell.body.rstrip("\n")
+    try:
+        translated = translator.translate(
+            source_body=source_body,
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=role,
+        )
+    except TranslationError as exc:
+        sid = cell.metadata.slide_id or "<no id>"
+        raise TranslateDeckError(
+            f"could not translate cell {sid!r} (line {cell.line_number}): {exc}"
+        ) from exc
+
+    twin = build_twin_cell(cell, target_lang, translated)
+    blanks = _trailing_blanks(cell)
+    if blanks:
+        twin.lines = [*twin.lines, *([""] * blanks)]
+    return twin
+
+
+def _rewrite_header_macro(
+    cell: RawCell,
+    source_lang: str,
+    target_lang: str,
+    translator: SlideTranslator,
+) -> RawCell:
+    """Rewrite a ``header_<src>("Title")`` macro to ``header_<tgt>("…")``.
+
+    The title is natural language, so it is translated; everything else on the
+    header line (the ``# `` prefix, any surrounding text) is preserved by
+    substituting only the matched macro span.
+    """
+    header_line = cell.header
+    match = _HEADER_MACRO_RE[source_lang].search(header_line)
+    assert match is not None  # caller guarantees a match
+    title = match.group(2)
+
+    translated_title = title
+    if title.strip():
+        try:
+            translated_title = translator.translate(
+                source_body=title,
+                source_lang=source_lang,
+                target_lang=target_lang,
+                role="markdown",
+            ).strip()
+        except TranslationError as exc:
+            raise TranslateDeckError(
+                f"could not translate the deck title {title!r} (line {cell.line_number}): {exc}"
+            ) from exc
+
+    target_macro = f"header_{target_lang}"
+    new_header = _HEADER_MACRO_RE[source_lang].sub(
+        lambda _m: f'{{{{ {target_macro}("{translated_title}") }}}}',
+        header_line,
+    )
+    return RawCell(
+        lines=[new_header, *cell.lines[1:]],
+        line_number=cell.line_number,
+        metadata=cell.metadata,
+    )
+
+
+def _rewrite_header_import(cell: RawCell, target_lang: str) -> RawCell:
+    """Rewrite ``from … import header_<src>`` to ``… import header_<tgt>``."""
+    source_lang = "de" if target_lang == "en" else "en"
+    target_macro = f"header_{target_lang}"
+    new_header = _HEADER_IMPORT_RE[source_lang].sub(
+        lambda m: f"{m.group(1)}{target_macro}",
+        cell.header,
+    )
+    return RawCell(
+        lines=[new_header, *cell.lines[1:]],
+        line_number=cell.line_number,
+        metadata=cell.metadata,
+    )
+
+
+def _clone_cell(cell: RawCell) -> RawCell:
+    """A verbatim copy of ``cell`` (independent ``lines`` list)."""
+    return RawCell(
+        lines=list(cell.lines),
+        line_number=cell.line_number,
+        metadata=cell.metadata,
+    )
+
+
+def _trailing_blanks(cell: RawCell) -> int:
+    """Count the blank body lines at the end of ``cell`` (separator padding)."""
+    n = 0
+    for line in reversed(cell.lines[1:]):
+        if line == "":
+            n += 1
+        else:
+            break
+    return n
+
+
+def _assert_round_trips(source_text: str, target_text: str, source_lang: str) -> None:
+    """Guard that the generated (source, target) pair is a valid split twin.
+
+    Re-unifies the two halves and splits them back; the result must reproduce
+    both inputs byte-for-byte. This is the canonical split/unify invariant the
+    rest of the slide tooling depends on, so passing it means the generated half
+    pairs cleanly, keeps shared cells byte-identical, and carries matching
+    slide_ids in order. Any failure raises :class:`TranslateDeckError` so a
+    malformed half is never written.
+
+    ``unify_texts`` takes ``(de, en)`` positionally, so order the two halves by
+    language rather than by source/target (else an ``en->de`` run would feed the
+    halves in the wrong slots).
+    """
+    if source_lang == "de":
+        de_text, en_text = source_text, target_text
+    else:
+        de_text, en_text = target_text, source_text
+    try:
+        unified = split.unify_texts(de_text, en_text)
+        de_back, en_back = split.split_text(unified)
+    except (split.UnifyError, split.SplitError) as exc:
+        raise TranslateDeckError(
+            f"generated translation does not form a valid split pair: {exc}"
+        ) from exc
+    if (de_back, en_back) != (de_text, en_text):
+        raise TranslateDeckError(
+            "generated translation failed the split/unify round-trip; the source "
+            "deck may use non-canonical formatting — try `clm slides normalize` first"
+        )

--- a/tests/cli/test_slides_translate.py
+++ b/tests/cli/test_slides_translate.py
@@ -266,3 +266,30 @@ def test_bootstrap_alias_is_registered(cli_runner, tmp_path, monkeypatch):
     result = cli_runner.invoke(cli, ["slides", "bootstrap", str(de_path), *_common(tmp_path)])
     assert result.exit_code == 0, result.output
     assert (tmp_path / "slides_x.en.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 acceptance gate: a generated deck passes the pre-commit validator
+# ---------------------------------------------------------------------------
+
+
+def test_generated_deck_passes_validate_fail_on_warning(cli_runner, tmp_path, monkeypatch):
+    """End-to-end: bootstrap a deck via the CLI, then `clm validate ... --fail-on
+    warning` (the pre-commit gate) must pass — slide_id set/order parity,
+    shared-cell byte parity, pairing adjacency, companion for_slide parity."""
+    from clm.cli.main import cli
+
+    de, en = _split(_DECK)
+    topic = tmp_path / "slides" / "module_010" / "topic_100_intro"
+    topic.mkdir(parents=True)
+    de_path = _write(topic / "slides_intro.de.py", de)
+    _patch_key(monkeypatch)
+    _patch_translator(monkeypatch, _mirror_translator(de, en))
+
+    boot = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+    assert boot.exit_code == 0, boot.output
+    assert (topic / "slides_intro.en.py").exists()
+
+    # The generated pair is immediately valid for the split-pair tooling.
+    val = cli_runner.invoke(cli, ["validate", str(topic), "--fail-on", "warning"])
+    assert val.exit_code == 0, val.output

--- a/tests/cli/test_slides_translate.py
+++ b/tests/cli/test_slides_translate.py
@@ -1,0 +1,268 @@
+"""CLI tests for ``clm slides translate`` (alias ``bootstrap``) — Issue #232, Phase 4.
+
+The command wraps the bootstrap engine. These tests drive the Click surface with
+the translator factory and judge patched to static fakes, so they exercise flag
+parsing, the bootstrap-vs-sync dispatch, file writes and exit codes without a
+live LLM or an API key.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands import slides_translate as cmd
+from clm.cli.commands.slides_translate import slides_translate_cmd
+from clm.slides.raw_cells import split_cells
+from clm.slides.split import split_text, unify_texts
+from clm.slides.sync_translate import StaticSlideTranslator
+
+
+@pytest.fixture
+def cli_runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+HEADER_PREAMBLE = (
+    '# j2 from \'macros.j2\' import header\n# {{ header("Titel DE", "Title EN") }}\n\n'
+)
+TITLES = {"Titel DE": "Title EN"}
+
+
+def _slide_pair(slug: str, de_title: str, en_title: str) -> str:
+    return (
+        f'# %% [markdown] lang="de" tags=["slide"] slide_id="{slug}"\n'
+        f"#\n# ## {de_title}\n#\n# - DE Bullet\n\n"
+        f'# %% [markdown] lang="en" tags=["slide"] slide_id="{slug}"\n'
+        f"#\n# ## {en_title}\n#\n# - EN Bullet\n\n"
+    )
+
+
+def _shared_code(name: str = "end") -> str:
+    return f'# %% tags=["keep"]\n{name} = 1\n\n'
+
+
+_DECK = HEADER_PREAMBLE + _slide_pair("intro", "Einleitung", "Introduction") + _shared_code("end")
+
+
+def _localized_bodies(text: str) -> list[str]:
+    _, cells = split_cells(text)
+    return [c.body.rstrip("\n") for c in cells if c.metadata.lang is not None]
+
+
+def _mirror_translator(de: str, en: str) -> StaticSlideTranslator:
+    mapping = dict(zip(_localized_bodies(de), _localized_bodies(en)))
+    mapping.update(TITLES)
+    return StaticSlideTranslator(mapping=mapping)
+
+
+def _split(text: str) -> tuple[str, str]:
+    de, en = split_text(text)
+    assert unify_texts(de, en) == text
+    return de, en
+
+
+def _patch_translator(monkeypatch, translator) -> None:
+    monkeypatch.setattr(cmd, "_make_translator", lambda *_a, **_k: translator)
+
+
+def _patch_key(monkeypatch, present: bool = True) -> None:
+    monkeypatch.setattr(cmd, "has_openrouter_api_key", lambda *_a, **_k: present)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8", newline="\n")
+    return path
+
+
+def _common(tmp_path: Path) -> list[str]:
+    """Flags every writing test wants: own cache dir, no .env walk."""
+    return ["--no-env-file", "--cache-dir", str(tmp_path / "cache")]
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap path
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrap:
+    def test_writes_twin_exit_0(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        _patch_translator(monkeypatch, _mirror_translator(de, en))
+
+        result = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        twin = tmp_path / "slides_x.en.py"
+        assert twin.exists()
+        assert twin.read_text(encoding="utf-8") == en
+        assert "Bootstrapped slides_x.en.py" in result.output
+
+    def test_no_key_exits_1_writes_nothing(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch, present=False)
+        _patch_translator(monkeypatch, _mirror_translator(de, en))
+
+        result = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+
+        assert result.exit_code == 1
+        assert not (tmp_path / "slides_x.en.py").exists()
+
+    def test_json_output(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        _patch_translator(monkeypatch, _mirror_translator(de, en))
+
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(de_path), "--json", *_common(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["action"] == "bootstrapped"
+        assert payload["target"].endswith("slides_x.en.py")
+        assert payload["cells_translated"] == 1
+        assert payload["source_lang"] == "de" and payload["target_lang"] == "en"
+
+    def test_to_override_reverse_direction(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        en_path = _write(tmp_path / "slides_x.en.py", en)
+        rev = dict(zip(_localized_bodies(en), _localized_bodies(de)))
+        rev["Title EN"] = "Titel DE"
+        _patch_key(monkeypatch)
+        _patch_translator(monkeypatch, StaticSlideTranslator(mapping=rev))
+
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(en_path), "--to", "de", *_common(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "slides_x.de.py").read_text(encoding="utf-8") == de
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_writes_nothing_no_key_needed(self, cli_runner, tmp_path, monkeypatch):
+        de, _ = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        # No key, no translator patch — dry-run must not touch either.
+        _patch_key(monkeypatch, present=False)
+
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(de_path), "--dry-run", "--no-env-file"]
+        )
+        assert result.exit_code == 0, result.output
+        assert not (tmp_path / "slides_x.en.py").exists()
+        assert "Would bootstrap slides_x.en.py" in result.output
+
+    def test_json(self, cli_runner, tmp_path, monkeypatch):
+        de, _ = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(de_path), "--dry-run", "--json", "--no-env-file"]
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["mode"] == "dry-run"
+        assert payload["action"] == "bootstrap"
+        assert payload["cells_translatable"] == 1
+        assert payload["cells_copied"] >= 1  # header + shared code
+
+
+# ---------------------------------------------------------------------------
+# Present-twin → sync delegation
+# ---------------------------------------------------------------------------
+
+
+class TestSyncDelegation:
+    def test_second_run_delegates_to_sync(self, cli_runner, tmp_path, monkeypatch):
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        _patch_translator(monkeypatch, _mirror_translator(de, en))
+        monkeypatch.setattr(
+            cmd,
+            "_resolve_judge",
+            lambda *_a, **_k: StaticSyncJudge(
+                default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+            ),
+        )
+
+        first = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+        assert first.exit_code == 0, first.output
+        twin = tmp_path / "slides_x.en.py"
+        before = twin.read_text(encoding="utf-8")
+
+        second = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+        assert second.exit_code == 0, second.output
+        assert "incremental sync" in second.output
+        assert twin.read_text(encoding="utf-8") == before  # not doubled
+
+    def test_force_overwrites_existing_twin(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _write(tmp_path / "slides_x.en.py", '# %% [markdown] lang="en"\n#\n# stale\n\n')
+        _patch_key(monkeypatch)
+        _patch_translator(monkeypatch, _mirror_translator(de, en))
+
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(de_path), "--force", *_common(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "stale" not in (tmp_path / "slides_x.en.py").read_text(encoding="utf-8")
+        assert "Bootstrapped" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Errors / rejection
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_bilingual_stem_is_usage_error(self, cli_runner, tmp_path, monkeypatch):
+        # No .de/.en tag on the source -> UsageError (exit 2).
+        src = _write(tmp_path / "slides_x.py", _DECK)
+        result = cli_runner.invoke(slides_translate_cmd, [str(src), *_common(tmp_path)])
+        assert result.exit_code == 2
+
+    def test_missing_source_is_error(self, cli_runner, tmp_path):
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(tmp_path / "nope.de.py"), *_common(tmp_path)]
+        )
+        assert result.exit_code == 2  # click.Path(exists=True)
+
+
+# ---------------------------------------------------------------------------
+# bootstrap alias (via the slides group)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_alias_is_registered(cli_runner, tmp_path, monkeypatch):
+    from clm.cli.main import cli
+
+    de, en = _split(_DECK)
+    de_path = _write(tmp_path / "slides_x.de.py", de)
+    _patch_key(monkeypatch)
+    _patch_translator(monkeypatch, _mirror_translator(de, en))
+
+    result = cli_runner.invoke(cli, ["slides", "bootstrap", str(de_path), *_common(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "slides_x.en.py").exists()

--- a/tests/infrastructure/llm/test_translation_cache.py
+++ b/tests/infrastructure/llm/test_translation_cache.py
@@ -1,0 +1,149 @@
+"""Tests for :class:`clm.infrastructure.llm.cache.TranslationCache` and the
+:class:`clm.slides.sync_translate.CachingSlideTranslator` wrapper (Issue #232)."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import TranslationCache
+from clm.slides.sync_translate import CachingSlideTranslator, TranslationError
+
+
+@pytest.fixture
+def cache(tmp_path: Path):
+    c = TranslationCache(tmp_path / "clm-llm.sqlite")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+class TestTranslationCache:
+    def test_round_trip(self, cache):
+        cache.put("h1", "v1", "de", "en", "markdown", "Hello")
+        assert cache.get("h1", "v1", "de", "en", "markdown") == "Hello"
+
+    def test_miss(self, cache):
+        assert cache.get("nope", "v1", "de", "en", "markdown") is None
+
+    def test_overwrite_same_key(self, cache):
+        cache.put("h1", "v1", "de", "en", "markdown", "First")
+        cache.put("h1", "v1", "de", "en", "markdown", "Second")
+        assert cache.get("h1", "v1", "de", "en", "markdown") == "Second"
+
+    def test_direction_in_key(self, cache):
+        cache.put("h1", "v1", "de", "en", "markdown", "to-en")
+        cache.put("h1", "v1", "en", "de", "markdown", "to-de")
+        assert cache.get("h1", "v1", "de", "en", "markdown") == "to-en"
+        assert cache.get("h1", "v1", "en", "de", "markdown") == "to-de"
+
+    def test_role_in_key(self, cache):
+        cache.put("h1", "v1", "de", "en", "markdown", "prose")
+        cache.put("h1", "v1", "de", "en", "code", "code")
+        assert cache.get("h1", "v1", "de", "en", "markdown") == "prose"
+        assert cache.get("h1", "v1", "de", "en", "code") == "code"
+
+    def test_prompt_version_in_key(self, cache):
+        cache.put("h1", "v1", "de", "en", "markdown", "old")
+        cache.put("h1", "v2", "de", "en", "markdown", "new")
+        assert cache.get("h1", "v1", "de", "en", "markdown") == "old"
+        assert cache.get("h1", "v2", "de", "en", "markdown") == "new"
+
+    def test_invalidate_prompt_version(self, cache):
+        cache.put("h1", "v1", "de", "en", "markdown", "a")
+        cache.put("h2", "v1", "de", "en", "markdown", "b")
+        cache.put("h3", "v2", "de", "en", "markdown", "c")
+        assert cache.invalidate_prompt_version("v2") == 2
+        assert cache.get("h1", "v1", "de", "en", "markdown") is None
+        assert cache.get("h3", "v2", "de", "en", "markdown") == "c"
+
+    def test_survives_close_and_reopen(self, tmp_path: Path):
+        path = tmp_path / "clm-llm.sqlite"
+        first = TranslationCache(path)
+        first.put("h1", "v1", "de", "en", "markdown", "Persisted")
+        first.close()
+        second = TranslationCache(path)
+        try:
+            assert second.get("h1", "v1", "de", "en", "markdown") == "Persisted"
+        finally:
+            second.close()
+
+
+@dataclass
+class _CountingTranslator:
+    """A SlideTranslator that records every call and maps body -> result."""
+
+    mapping: dict[str, str] = field(default_factory=dict)
+    model: str = "test-model"
+    prompt_version: str = "pv1"
+    calls: list[str] = field(default_factory=list)
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.calls.append(source_body)
+        if source_body in self.mapping:
+            return self.mapping[source_body]
+        raise TranslationError(f"no mapping for {source_body!r}")
+
+
+class TestCachingSlideTranslator:
+    def test_first_call_misses_then_caches(self, cache):
+        inner = _CountingTranslator(mapping={"Hallo": "Hello"})
+        wrapped = CachingSlideTranslator(inner=inner, cache=cache)
+        out = wrapped.translate(
+            source_body="Hallo", source_lang="de", target_lang="en", role="markdown"
+        )
+        assert out == "Hello"
+        # Second call with the same inputs is served from the cache (inner not hit).
+        out2 = wrapped.translate(
+            source_body="Hallo", source_lang="de", target_lang="en", role="markdown"
+        )
+        assert out2 == "Hello"
+        assert inner.calls == ["Hallo"]  # inner called exactly once
+
+    def test_cache_persists_across_wrapper_instances(self, cache):
+        inner1 = _CountingTranslator(mapping={"Hallo": "Hello"})
+        CachingSlideTranslator(inner=inner1, cache=cache).translate(
+            source_body="Hallo", source_lang="de", target_lang="en", role="markdown"
+        )
+        # A fresh wrapper over a fresh inner reuses the cached entry.
+        inner2 = _CountingTranslator(mapping={})  # would raise if consulted
+        out = CachingSlideTranslator(inner=inner2, cache=cache).translate(
+            source_body="Hallo", source_lang="de", target_lang="en", role="markdown"
+        )
+        assert out == "Hello"
+        assert inner2.calls == []
+
+    def test_failure_is_not_cached(self, cache):
+        inner = _CountingTranslator(mapping={})
+        wrapped = CachingSlideTranslator(inner=inner, cache=cache)
+        with pytest.raises(TranslationError):
+            wrapped.translate(source_body="x", source_lang="de", target_lang="en", role="markdown")
+        # Nothing stored: hash of "x" must not be present.
+        h = hashlib.sha256(b"x").hexdigest()
+        assert cache.get(h, wrapped.prompt_version, "de", "en", "markdown") is None
+
+    def test_model_folded_into_version(self, cache):
+        # Two models with the same base prompt_version must not share an entry.
+        a = CachingSlideTranslator(
+            inner=_CountingTranslator(mapping={"k": "A"}, model="m-a"), cache=cache
+        )
+        b = CachingSlideTranslator(
+            inner=_CountingTranslator(mapping={"k": "B"}, model="m-b"), cache=cache
+        )
+        assert (
+            a.translate(source_body="k", source_lang="de", target_lang="en", role="markdown") == "A"
+        )
+        assert (
+            b.translate(source_body="k", source_lang="de", target_lang="en", role="markdown") == "B"
+        )
+        assert a.prompt_version != b.prompt_version
+
+    def test_satisfies_protocol(self, cache):
+        from clm.slides.sync_translate import SlideTranslator
+
+        wrapped = CachingSlideTranslator(inner=_CountingTranslator(), cache=cache)
+        assert isinstance(wrapped, SlideTranslator)

--- a/tests/slides/test_translate_bootstrap.py
+++ b/tests/slides/test_translate_bootstrap.py
@@ -26,6 +26,7 @@ from clm.slides.split import split_text, unify_texts
 from clm.slides.sync_translate import StaticSlideTranslator
 from clm.slides.translate_bootstrap import (
     BootstrapResult,
+    CompanionResult,
     TranslateBootstrapError,
     bootstrap_deck,
     derive_bootstrap_paths,
@@ -121,6 +122,31 @@ _DECK_ASYMMETRIC = (
     + _slide_pair("intro", "Einleitung", "Introduction")
     + _slide_pair("more", "Mehr", "More")
 )
+
+
+def _companion_pair(slide_id: str) -> str:
+    """A bilingual voiceover companion: a lang-tagged narrative cell per side,
+    carrying for_slide + vo_anchor (the metadata that must survive translation)."""
+    return (
+        f'# %% [markdown] lang="de" tags=["voiceover"] for_slide="{slide_id}" '
+        f'vo_anchor="id:{slide_id}"\n#\n# Voiceover DE für {slide_id}\n\n'
+        f'# %% [markdown] lang="en" tags=["voiceover"] for_slide="{slide_id}" '
+        f'vo_anchor="id:{slide_id}"\n#\n# Voiceover EN for {slide_id}\n\n'
+    )
+
+
+_COMPANION = _companion_pair("intro")
+
+
+def _combined_translator(
+    de_deck: str, en_deck: str, de_comp: str, en_comp: str
+) -> StaticSlideTranslator:
+    """One translator covering BOTH the deck and the companion bodies (a single
+    translator drives both translations in :func:`bootstrap_deck`)."""
+    mapping = dict(zip(_localized_bodies(de_deck), _localized_bodies(en_deck)))
+    mapping.update(dict(zip(_localized_bodies(de_comp), _localized_bodies(en_comp))))
+    mapping.update(TITLES)
+    return StaticSlideTranslator(mapping=mapping)
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +437,132 @@ class TestResolution:
         # An empty twin must not route to sync; it is bootstrapped over.
         assert result.action == "bootstrapped"
         assert (tmp_path / "slides_x.en.py").read_text(encoding="utf-8") == en
+
+
+# ---------------------------------------------------------------------------
+# D5: voiceover companion translated in lockstep
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceoverCompanion:
+    def _setup(self, tmp_path: Path, *, comp_dir: Path | None = None):
+        """Write a deck source half + its bilingual-split DE companion; return
+        (de_path, target_companion_path, combined_translator)."""
+        de_deck, en_deck = _split(_DECK)
+        de_comp, en_comp = _split(_COMPANION)
+        de_path = _write(tmp_path / "slides_x.de.py", de_deck)
+        loc = comp_dir if comp_dir is not None else tmp_path
+        loc.mkdir(parents=True, exist_ok=True)
+        _write(loc / "voiceover_x.de.py", de_comp)
+        translator = _combined_translator(de_deck, en_deck, de_comp, en_comp)
+        return de_path, loc / "voiceover_x.en.py", translator
+
+    def test_companion_translated_alongside_deck(self, tmp_path: Path):
+        de_path, target, translator = self._setup(tmp_path)
+        result = bootstrap_deck(de_path, translator=translator)
+
+        assert result.action == "bootstrapped"
+        assert isinstance(result.companion, CompanionResult)
+        assert result.companion.action == "translated"
+        assert result.companion.target == target
+        assert target.exists()
+        text = target.read_text(encoding="utf-8")
+        assert "Voiceover EN for intro" in text
+        assert "Voiceover DE" not in text
+
+    def test_for_slide_and_vo_anchor_preserved(self, tmp_path: Path):
+        de_path, target, translator = self._setup(tmp_path)
+        bootstrap_deck(de_path, translator=translator)
+        text = target.read_text(encoding="utf-8")
+        # Anchoring metadata rides through untouched (build_twin_cell only swaps
+        # lang + body); this is the companion for_slide parity the validator wants.
+        assert 'for_slide="intro"' in text
+        assert 'vo_anchor="id:intro"' in text
+        assert 'lang="en"' in text and 'lang="de"' not in text
+
+    def test_companion_pair_round_trips(self, tmp_path: Path):
+        de_path, target, translator = self._setup(tmp_path)
+        bootstrap_deck(de_path, translator=translator)
+        de_comp = (tmp_path / "voiceover_x.de.py").read_text(encoding="utf-8")
+        en_comp = target.read_text(encoding="utf-8")
+        assert split_text(unify_texts(de_comp, en_comp)) == (de_comp, en_comp)
+
+    def test_no_companion_is_a_noop(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)  # no companion file
+        result = bootstrap_deck(de_path, translator=_mirror_translator(de, en))
+        assert result.action == "bootstrapped"
+        assert result.companion is None
+
+    def test_existing_companion_is_skipped_not_doubled(self, tmp_path: Path):
+        # Deck twin absent (so we bootstrap) but the target companion already
+        # exists -> leave it untouched rather than overwrite/double.
+        de_path, target, translator = self._setup(tmp_path)
+        _write(target, '# %% [markdown] lang="en"\n#\n# hand-written EN\n\n')
+        result = bootstrap_deck(de_path, translator=translator)
+        assert result.action == "bootstrapped"
+        assert result.companion is not None and result.companion.action == "skipped"
+        assert "hand-written EN" in target.read_text(encoding="utf-8")
+
+    def test_force_regenerates_companion(self, tmp_path: Path):
+        de_path, target, translator = self._setup(tmp_path)
+        bootstrap_deck(de_path, translator=translator)  # creates the deck twin + companion
+        _write(target, "stale")  # corrupt the target companion
+        # Deck twin now exists, so only --force re-runs the bootstrap (deck + companion).
+        result = bootstrap_deck(de_path, translator=translator, force=True)
+        assert result.action == "bootstrapped"
+        assert result.companion is not None and result.companion.action == "translated"
+        assert "stale" not in target.read_text(encoding="utf-8")
+        assert "Voiceover EN for intro" in target.read_text(encoding="utf-8")
+
+    def test_companion_subdir_layout_is_preserved(self, tmp_path: Path):
+        # Source companion under voiceover/ -> target lands in voiceover/ too,
+        # never as a stray sibling (foldered topic stays foldered).
+        vo_dir = tmp_path / "voiceover"
+        de_path, target, translator = self._setup(tmp_path, comp_dir=vo_dir)
+        result = bootstrap_deck(de_path, translator=translator)
+        assert result.companion is not None and result.companion.action == "translated"
+        assert (vo_dir / "voiceover_x.en.py").exists()
+        assert not (tmp_path / "voiceover_x.en.py").exists()
+
+    def test_rerun_via_sync_does_not_touch_companion(self, tmp_path: Path):
+        # First run bootstraps deck + companion; second run sees the deck twin and
+        # delegates to sync, which must not re-translate or double the companion.
+        de_path, target, translator = self._setup(tmp_path)
+        cache = _cache(tmp_path)
+        try:
+            bootstrap_deck(de_path, translator=translator, watermark_cache=cache)
+            comp_after_first = target.read_text(encoding="utf-8")
+            second = bootstrap_deck(
+                de_path,
+                translator=translator,
+                judge=StaticSyncJudge(
+                    default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+                ),
+                watermark_cache=cache,
+            )
+        finally:
+            cache.close()
+        assert second.action == "synced"
+        assert second.companion is None  # sync path owns no companion lifecycle
+        assert target.read_text(encoding="utf-8") == comp_after_first  # not doubled
+
+    def test_companion_translation_failure_aborts_before_any_write(self, tmp_path: Path):
+        # A translator that handles the deck but not the companion body must fail
+        # the whole bootstrap with nothing written (all-or-nothing across both).
+        de_deck, en_deck = _split(_DECK)
+        de_comp, _ = _split(_COMPANION)
+        de_path = _write(tmp_path / "slides_x.de.py", de_deck)
+        _write(tmp_path / "voiceover_x.de.py", de_comp)
+        # Deck-only translator: no mapping for the companion body -> raises.
+        deck_only = _mirror_translator(de_deck, en_deck)
+        from clm.slides.translate_deck import TranslateDeckError
+
+        with pytest.raises(TranslateDeckError):
+            bootstrap_deck(de_path, translator=deck_only)
+        # Neither the deck twin nor the companion twin reached disk.
+        assert not (tmp_path / "slides_x.en.py").exists()
+        assert not (tmp_path / "voiceover_x.en.py").exists()
 
 
 def test_result_type_is_exported():

--- a/tests/slides/test_translate_bootstrap.py
+++ b/tests/slides/test_translate_bootstrap.py
@@ -1,0 +1,418 @@
+"""Tests for :mod:`clm.slides.translate_bootstrap` — the file/orchestration layer.
+
+Phase 2 of ``clm slides translate`` (Issue #232). Where Phase 1
+(:mod:`clm.slides.translate_deck`) is the pure, offline engine, this layer adds
+the side effects: resolving the twin path, the *idempotency dispatch* (twin
+absent → bootstrap; twin present → delegate to the incremental sync engine),
+EN-authority id minting, and the watermark seal that makes the next ``sync`` a
+clean no-op.
+
+The load-bearing properties under test are D2 (re-running converges to sync and
+never doubles the deck) and the parity invariants (the written pair round-trips
+and carries matching ``slide_id``\\ s). Everything is offline — driven through
+the ``SlideTranslator`` / ``SyncJudge`` protocols with the static fakes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+from clm.slides.raw_cells import split_cells
+from clm.slides.split import split_text, unify_texts
+from clm.slides.sync_translate import StaticSlideTranslator
+from clm.slides.translate_bootstrap import (
+    BootstrapResult,
+    TranslateBootstrapError,
+    bootstrap_deck,
+    derive_bootstrap_paths,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / building blocks (shared with tests/slides/test_translate_deck.py)
+# ---------------------------------------------------------------------------
+
+HEADER_PREAMBLE = (
+    '# j2 from \'macros.j2\' import header\n# {{ header("Titel DE", "Title EN") }}\n\n'
+)
+TITLES = {"Titel DE": "Title EN"}
+
+
+def _slide_pair(slug: str, de_title: str, en_title: str) -> str:
+    return (
+        f'# %% [markdown] lang="de" tags=["slide"] slide_id="{slug}"\n'
+        f"#\n# ## {de_title}\n#\n# - DE Bullet\n\n"
+        f'# %% [markdown] lang="en" tags=["slide"] slide_id="{slug}"\n'
+        f"#\n# ## {en_title}\n#\n# - EN Bullet\n\n"
+    )
+
+
+def _idless_slide_pair(de_title: str, en_title: str) -> str:
+    """A slide pair with NO slide_id — minting fodder for the bootstrap."""
+    return (
+        f'# %% [markdown] lang="de" tags=["slide"]\n'
+        f"#\n# ## {de_title}\n#\n# - DE Bullet\n\n"
+        f'# %% [markdown] lang="en" tags=["slide"]\n'
+        f"#\n# ## {en_title}\n#\n# - EN Bullet\n\n"
+    )
+
+
+def _shared_code(name: str = "end") -> str:
+    return f'# %% tags=["keep"]\n{name} = 1\n\n'
+
+
+def _localized_bodies(text: str) -> list[str]:
+    _, cells = split_cells(text)
+    return [c.body.rstrip("\n") for c in cells if c.metadata.lang is not None]
+
+
+def _mirror_translator(de_text: str, en_text: str) -> StaticSlideTranslator:
+    """DE-body/title -> EN twin, built straight from the canonical split halves."""
+    mapping = dict(zip(_localized_bodies(de_text), _localized_bodies(en_text)))
+    mapping.update(TITLES)
+    return StaticSlideTranslator(mapping=mapping)
+
+
+def _reverse_translator(de_text: str, en_text: str) -> StaticSlideTranslator:
+    mapping = dict(zip(_localized_bodies(en_text), _localized_bodies(de_text)))
+    mapping["Title EN"] = "Titel DE"
+    return StaticSlideTranslator(mapping=mapping)
+
+
+def _split(text: str) -> tuple[str, str]:
+    de, en = split_text(text)
+    assert unify_texts(de, en) == text  # the fixture itself round-trips
+    return de, en
+
+
+def _slide_ids(text: str) -> list[str | None]:
+    _, cells = split_cells(text)
+    return [c.metadata.slide_id for c in cells if c.metadata.is_slide_start]
+
+
+def _cell_count(text: str) -> int:
+    _, cells = split_cells(text)
+    return len(cells)
+
+
+def _cache(tmp_path: Path) -> SyncWatermarkCache:
+    return SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8", newline="\n")
+    return path
+
+
+# A trailing-symmetric deck (ends on a shared cell) so the generated EN half
+# byte-matches split's EN half exactly — see test_translate_deck §ByteExact.
+_DECK = HEADER_PREAMBLE + _slide_pair("intro", "Einleitung", "Introduction") + _shared_code("end")
+_IDLESS_DECK = (
+    HEADER_PREAMBLE + _idless_slide_pair("Einleitung", "Introduction") + _shared_code("end")
+)
+# A deck that ends on a slide *pair* (no shared terminator) is trailing-blank
+# *asymmetric* after split — exercises the harder path through assign_ids +
+# watermark, where the generated half does not byte-match a hypothetical other.
+_DECK_ASYMMETRIC = (
+    HEADER_PREAMBLE
+    + _slide_pair("intro", "Einleitung", "Introduction")
+    + _slide_pair("more", "Mehr", "More")
+)
+
+
+# ---------------------------------------------------------------------------
+# Absent twin -> bootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapWritesTwin:
+    def test_writes_valid_round_tripping_pair(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        cache = _cache(tmp_path)
+        try:
+            result = bootstrap_deck(
+                de_path, translator=_mirror_translator(de, en), watermark_cache=cache
+            )
+        finally:
+            cache.close()
+
+        assert result.action == "bootstrapped"
+        twin = tmp_path / "slides_x.en.py"
+        assert twin.exists()
+        twin_text = twin.read_text(encoding="utf-8")
+        # Trailing-symmetric deck: the new half equals split's EN half exactly.
+        assert twin_text == en
+        # ... and the on-disk pair round-trips like any real split pair.
+        de_text = de_path.read_text(encoding="utf-8")
+        assert split_text(unify_texts(de_text, twin_text)) == (de_text, twin_text)
+        assert result.watermark_recorded is True
+
+    def test_records_watermark_for_the_pair(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        cache = _cache(tmp_path)
+        try:
+            result = bootstrap_deck(
+                de_path, translator=_mirror_translator(de, en), watermark_cache=cache
+            )
+            assert cache.has_pair(str(result.de_path), str(result.en_path))
+        finally:
+            cache.close()
+
+    def test_no_cache_skips_watermark_but_still_writes(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        result = bootstrap_deck(de_path, translator=_mirror_translator(de, en))
+        assert result.action == "bootstrapped"
+        assert result.watermark_recorded is False
+        assert (tmp_path / "slides_x.en.py").read_text(encoding="utf-8") == en
+
+    def test_asymmetric_deck_round_trips_and_is_idempotent(self, tmp_path: Path):
+        # A deck ending on a slide pair is trailing-blank asymmetric after split:
+        # the generated half does not byte-match a hypothetical other half, but it
+        # must still form a valid, idempotent pair on disk.
+        de, en = _split(_DECK_ASYMMETRIC)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        twin = tmp_path / "slides_x.en.py"
+        cache = _cache(tmp_path)
+        try:
+            first = bootstrap_deck(
+                de_path, translator=_mirror_translator(de, en), watermark_cache=cache
+            )
+            de_text = de_path.read_text(encoding="utf-8")
+            en_text = twin.read_text(encoding="utf-8")
+            # The written pair round-trips like any real split pair.
+            assert split_text(unify_texts(de_text, en_text)) == (de_text, en_text)
+            second = bootstrap_deck(
+                de_path,
+                translator=_mirror_translator(de, en),
+                judge=StaticSyncJudge(
+                    default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+                ),
+                watermark_cache=cache,
+            )
+        finally:
+            cache.close()
+        assert first.action == "bootstrapped"
+        assert second.action == "synced"
+        assert second.plan is not None and second.plan.proposals == []
+        assert twin.read_text(encoding="utf-8") == en_text  # not doubled
+
+    def test_reverse_direction_en_source_writes_de(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        en_path = _write(tmp_path / "slides_x.en.py", en)
+        result = bootstrap_deck(en_path, translator=_reverse_translator(de, en))
+        assert result.action == "bootstrapped"
+        assert result.source_lang == "en"
+        assert result.target_lang == "de"
+        twin = tmp_path / "slides_x.de.py"
+        twin_text = twin.read_text(encoding="utf-8")
+        assert twin_text == de
+        assert split_text(unify_texts(twin_text, en)) == (twin_text, en)
+
+
+# ---------------------------------------------------------------------------
+# ID minting / preservation
+# ---------------------------------------------------------------------------
+
+
+class TestIdParity:
+    def test_idless_source_mints_matching_ids_on_both_halves(self, tmp_path: Path):
+        de, en = _split(_IDLESS_DECK)
+        assert _slide_ids(de) == [None]  # the fixture really is id-less
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        result = bootstrap_deck(de_path, translator=_mirror_translator(de, en))
+
+        de_ids = _slide_ids(de_path.read_text(encoding="utf-8"))
+        en_ids = _slide_ids((tmp_path / "slides_x.en.py").read_text(encoding="utf-8"))
+        # EN-authority slug "introduction" minted onto BOTH halves, in parity.
+        assert de_ids == en_ids == ["introduction"]
+        assert result.ids_assigned > 0
+
+    def test_existing_ids_are_preserved_not_reslugged(self, tmp_path: Path):
+        # The author's id differs from the content-derived slug; minting must
+        # not overwrite it (force=False -> existing id wins).
+        deck = (
+            HEADER_PREAMBLE
+            + _slide_pair("custom-intro", "Einleitung", "Introduction")
+            + _shared_code("end")
+        )
+        de, en = _split(deck)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        bootstrap_deck(de_path, translator=_mirror_translator(de, en))
+
+        assert _slide_ids(de_path.read_text(encoding="utf-8")) == ["custom-intro"]
+        assert _slide_ids((tmp_path / "slides_x.en.py").read_text(encoding="utf-8")) == [
+            "custom-intro"
+        ]
+
+    def test_idless_source_twice_is_a_sync_noop(self, tmp_path: Path):
+        # The interesting idempotency case: minting rewrites BOTH halves on the
+        # first run, so the watermark must capture the post-mint state for the
+        # second run to see no change (not re-mint, not double).
+        de, en = _split(_IDLESS_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        twin = tmp_path / "slides_x.en.py"
+        cache = _cache(tmp_path)
+        try:
+            bootstrap_deck(de_path, translator=_mirror_translator(de, en), watermark_cache=cache)
+            de_after = de_path.read_text(encoding="utf-8")
+            en_after = twin.read_text(encoding="utf-8")
+            second = bootstrap_deck(
+                de_path,
+                translator=_mirror_translator(de, en),
+                judge=StaticSyncJudge(
+                    default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+                ),
+                watermark_cache=cache,
+            )
+        finally:
+            cache.close()
+        assert second.action == "synced"
+        assert second.apply_result is not None and not second.apply_result.has_errors
+        assert second.plan is not None and second.plan.proposals == []
+        # Both halves untouched by the second run (no re-mint, no doubling).
+        assert de_path.read_text(encoding="utf-8") == de_after
+        assert twin.read_text(encoding="utf-8") == en_after
+
+
+# ---------------------------------------------------------------------------
+# D2: idempotency by delegation — the central safety property
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyByDelegation:
+    def test_translate_twice_is_a_sync_noop(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        twin = tmp_path / "slides_x.en.py"
+        cache = _cache(tmp_path)
+        try:
+            first = bootstrap_deck(
+                de_path, translator=_mirror_translator(de, en), watermark_cache=cache
+            )
+            assert first.action == "bootstrapped"
+            after_first = twin.read_text(encoding="utf-8")
+            cells_after_first = _cell_count(after_first)
+
+            # Second run: twin now exists -> must degrade to incremental sync,
+            # not re-translate. With the watermark recorded, sync sees no change.
+            second = bootstrap_deck(
+                de_path,
+                translator=_mirror_translator(de, en),
+                judge=StaticSyncJudge(
+                    default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+                ),
+                watermark_cache=cache,
+            )
+        finally:
+            cache.close()
+
+        assert second.action == "synced"
+        assert second.apply_result is not None
+        assert not second.apply_result.has_errors
+        assert second.apply_result.deferred == 0
+        assert second.apply_result.applied == 0  # nothing to do
+        assert second.plan is not None and second.plan.proposals == []
+        # The deck was not doubled or otherwise rewritten.
+        after_second = twin.read_text(encoding="utf-8")
+        assert after_second == after_first
+        assert _cell_count(after_second) == cells_after_first
+
+    def test_present_twin_in_sync_delegates_without_doubling(self, tmp_path: Path):
+        # Both halves already on disk, in parity, no prior watermark: a translate
+        # must route through sync and report clean rather than re-bootstrap.
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _write(tmp_path / "slides_x.en.py", en)
+        cache = _cache(tmp_path)
+        try:
+            result = bootstrap_deck(
+                de_path,
+                translator=_mirror_translator(de, en),
+                judge=StaticSyncJudge(
+                    default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+                ),
+                watermark_cache=cache,
+            )
+        finally:
+            cache.close()
+        assert result.action == "synced"
+        assert result.apply_result is not None
+        assert not result.apply_result.has_errors
+        assert (tmp_path / "slides_x.en.py").read_text(encoding="utf-8") == en
+
+
+# ---------------------------------------------------------------------------
+# --force
+# ---------------------------------------------------------------------------
+
+
+class TestForce:
+    def test_force_overwrites_an_existing_twin(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        twin = _write(tmp_path / "slides_x.en.py", '# %% [markdown] lang="en"\n#\n# stale\n\n')
+        result = bootstrap_deck(de_path, translator=_mirror_translator(de, en), force=True)
+        assert result.action == "bootstrapped"
+        # The stale hand-written twin is gone, replaced by the synthesized half.
+        assert "stale" not in twin.read_text(encoding="utf-8")
+        assert twin.read_text(encoding="utf-8") == en
+
+
+# ---------------------------------------------------------------------------
+# Path resolution / rejection
+# ---------------------------------------------------------------------------
+
+
+class TestResolution:
+    def test_rejects_bilingual_stem(self, tmp_path: Path):
+        with pytest.raises(TranslateBootstrapError, match="no .de/.en language tag"):
+            derive_bootstrap_paths(tmp_path / "slides_x.py")
+
+    def test_rejects_voiceover_companion(self, tmp_path: Path):
+        with pytest.raises(TranslateBootstrapError, match="voiceover companion"):
+            derive_bootstrap_paths(tmp_path / "voiceover_x.de.py")
+
+    def test_to_override_same_language_rejected(self, tmp_path: Path):
+        with pytest.raises(TranslateBootstrapError, match="same language"):
+            derive_bootstrap_paths(tmp_path / "slides_x.de.py", target_lang="de")
+
+    def test_to_override_unsupported_language_rejected(self, tmp_path: Path):
+        with pytest.raises(TranslateBootstrapError, match="unsupported target"):
+            derive_bootstrap_paths(tmp_path / "slides_x.de.py", target_lang="fr")
+
+    def test_derives_twin_path_and_direction(self, tmp_path: Path):
+        de_path = _write(tmp_path / "slides_x.de.py", _split(_DECK)[0])
+        paths = derive_bootstrap_paths(de_path)
+        assert paths.source_lang == "de"
+        assert paths.target_lang == "en"
+        assert paths.twin_path.name == "slides_x.en.py"
+        assert paths.de_path == paths.source_path
+        assert paths.en_path == paths.twin_path
+        assert paths.twin_exists is False
+
+    def test_prefix_and_extension_agnostic_twin(self, tmp_path: Path):
+        # No slides_ prefix, non-.py extension: the .de/.en tag still drives it.
+        src = tmp_path / "apis.de.cpp"
+        _write(src, "")
+        paths = derive_bootstrap_paths(src)
+        assert paths.twin_path.name == "apis.en.cpp"
+
+    def test_empty_twin_is_treated_as_absent(self, tmp_path: Path):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _write(tmp_path / "slides_x.en.py", "")  # stray empty file
+        result = bootstrap_deck(de_path, translator=_mirror_translator(de, en))
+        # An empty twin must not route to sync; it is bootstrapped over.
+        assert result.action == "bootstrapped"
+        assert (tmp_path / "slides_x.en.py").read_text(encoding="utf-8") == en
+
+
+def test_result_type_is_exported():
+    # Cheap guard that the public surface stays importable from one place.
+    assert BootstrapResult.__module__ == "clm.slides.translate_bootstrap"

--- a/tests/slides/test_translate_deck.py
+++ b/tests/slides/test_translate_deck.py
@@ -1,0 +1,326 @@
+"""Tests for :mod:`clm.slides.translate_deck` — full-deck translation engine.
+
+The engine synthesizes the other-language split half of a single-language deck
+(Issue #232, Phase 1). The load-bearing correctness invariant is that the
+generated ``(de, en)`` pair round-trips through the canonical split/unify
+machinery — ``split(unify(de, en)) == (de, en)`` — i.e. the new half pairs
+cleanly, keeps shared cells byte-identical and carries matching slide_ids in
+order. On top of that we check the *content* (the right language survives in
+each half) and pin exact byte output on decks whose structure is naturally
+trailing-symmetric (header-only or shared-cell-terminated).
+
+Note: split itself produces trailing-blank-*asymmetric* halves — the cell that
+ends the bilingual source carries an extra EOF blank that lands on only one
+side. So a generated half (which mirrors the *source* half's spacing) does not
+in general byte-match the other half of an arbitrary bilingual deck; it is its
+own self-consistent, round-tripping file. That is correct: when bootstrapping
+there is no pre-existing other half to match.
+
+Everything is offline: the engine depends only on the ``SlideTranslator``
+protocol, driven here by ``StaticSlideTranslator``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides.raw_cells import split_cells
+from clm.slides.split import split_text, unify_texts
+from clm.slides.sync_translate import StaticSlideTranslator, TranslationError
+from clm.slides.translate_deck import (
+    TranslateDeckError,
+    translate_deck_text,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / building blocks (mirroring tests/slides/test_split.py)
+# ---------------------------------------------------------------------------
+
+
+HEADER_PREAMBLE = (
+    '# j2 from \'macros.j2\' import header\n# {{ header("Titel DE", "Title EN") }}\n\n'
+)
+TITLES = {"Titel DE": "Title EN"}
+
+
+def _slide_pair(slug: str, de_title: str, en_title: str) -> str:
+    return (
+        f'# %% [markdown] lang="de" tags=["slide"] slide_id="{slug}"\n'
+        f"#\n# ## {de_title}\n#\n# - DE Bullet\n\n"
+        f'# %% [markdown] lang="en" tags=["slide"] slide_id="{slug}"\n'
+        f"#\n# ## {en_title}\n#\n# - EN Bullet\n\n"
+    )
+
+
+def _voiceover_pair(slug: str) -> str:
+    return (
+        f'# %% [markdown] lang="de" tags=["voiceover"] slide_id="{slug}"\n'
+        f"#\n# Voiceover DE für {slug}\n\n"
+        f'# %% [markdown] lang="en" tags=["voiceover"] slide_id="{slug}"\n'
+        f"#\n# Voiceover EN for {slug}\n\n"
+    )
+
+
+def _localized_code_pair(slug: str, de: str, en: str) -> str:
+    return f'# %% lang="de" slide_id="{slug}"\n{de}\n\n# %% lang="en" slide_id="{slug}"\n{en}\n\n'
+
+
+def _idless_code_pair(de: str, en: str) -> str:
+    """A localized code pair with NO slide_id (the role_of-is-None case)."""
+    return f'# %% lang="de"\n{de}\n\n# %% lang="en"\n{en}\n\n'
+
+
+def _shared_code(name: str = "x") -> str:
+    return f'# %% tags=["keep"]\n{name} = 1\n\n'
+
+
+def _localized_bodies(text: str) -> list[str]:
+    """The ``rstrip``-ed bodies of the lang-tagged cells, in order."""
+    _, cells = split_cells(text)
+    return [c.body.rstrip("\n") for c in cells if c.metadata.lang is not None]
+
+
+def _mirror_translator(de_text: str, en_text: str) -> StaticSlideTranslator:
+    """A translator that turns each DE localized body/title into its EN twin.
+
+    Built straight from the canonical split halves, so feeding it the DE half
+    regenerates the EN content exactly.
+    """
+    mapping = dict(zip(_localized_bodies(de_text), _localized_bodies(en_text)))
+    mapping.update(TITLES)
+    return StaticSlideTranslator(mapping=mapping)
+
+
+def _reverse_translator(de_text: str, en_text: str) -> StaticSlideTranslator:
+    """The EN -> DE mirror (for testing the reverse direction)."""
+    mapping = dict(zip(_localized_bodies(en_text), _localized_bodies(de_text)))
+    mapping["Title EN"] = "Titel DE"
+    return StaticSlideTranslator(mapping=mapping)
+
+
+def _split(text: str) -> tuple[str, str]:
+    de, en = split_text(text)
+    # Sanity: the fixture itself round-trips, so any later inequality is the
+    # engine's doing, not a malformed fixture.
+    assert unify_texts(de, en) == text
+    return de, en
+
+
+def _assert_valid_pair(de_text: str, en_text: str) -> None:
+    """The generated pair must round-trip like any real split pair."""
+    assert split_text(unify_texts(de_text, en_text)) == (de_text, en_text)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — a valid, correctly-translated other half
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateDeckText:
+    def test_single_slide_pair(self):
+        text = HEADER_PREAMBLE + _slide_pair("intro", "Einleitung", "Introduction")
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert "Introduction" in result.target_text
+        assert "Einleitung" not in result.target_text
+        assert 'header_en("Title EN")' in result.target_text
+        assert "header_de" not in result.target_text
+        assert result.translated_count == 1
+
+    def test_reverse_direction_en_to_de(self):
+        text = HEADER_PREAMBLE + _slide_pair("intro", "Einleitung", "Introduction")
+        de, en = _split(text)
+        result = translate_deck_text(
+            en, source_lang="en", target_lang="de", translator=_reverse_translator(de, en)
+        )
+        # Generated half is the DE side; it must pair with the EN source.
+        _assert_valid_pair(result.target_text, en)
+        assert "Einleitung" in result.target_text
+        assert "Introduction" not in result.target_text
+        assert "header_en" not in result.target_text
+
+    def test_shared_code_is_copied_not_translated(self):
+        text = HEADER_PREAMBLE + _shared_code("x") + _slide_pair("a", "Eins", "One")
+        de, en = _split(text)
+        # The mirror translator has NO mapping for "x = 1"; if the engine tried
+        # to translate the shared cell, StaticSlideTranslator would raise.
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert "x = 1" in result.target_text
+        assert result.copied_count == 1  # the shared code cell
+
+    def test_localized_code_pair_with_id(self):
+        text = HEADER_PREAMBLE + _localized_code_pair("c1", 'print("Hallo")', 'print("Hello")')
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert 'print("Hello")' in result.target_text
+        assert 'print("Hallo")' not in result.target_text
+        assert result.translated_count == 1
+
+    def test_idless_localized_code_is_translated(self):
+        # role_of() is None for a localized id-less code cell, but it carries
+        # lang= and so MUST be translated — the gate is lang, not role_of.
+        text = HEADER_PREAMBLE + _idless_code_pair('greet("Welt")', 'greet("World")')
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert 'greet("World")' in result.target_text
+        assert 'greet("Welt")' not in result.target_text
+        assert result.translated_count == 1
+
+    def test_voiceover_cells_are_translated(self):
+        text = HEADER_PREAMBLE + _slide_pair("a", "Eins", "One") + _voiceover_pair("a")
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert "Voiceover EN for a" in result.target_text
+        assert "Voiceover DE" not in result.target_text
+
+    def test_mixed_multi_shape_deck(self):
+        text = (
+            HEADER_PREAMBLE
+            + _shared_code("setup")
+            + _slide_pair("a", "Eins", "One")
+            + _localized_code_pair("c1", 'print("Hallo")', 'print("Hello")')
+            + _idless_code_pair("y = 2  # zwei", "y = 2  # two")
+            + _slide_pair("b", "Zwei", "Two")
+            + _voiceover_pair("b")
+        )
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert result.translated_count == 5  # 2 slides + 2 code + 1 voiceover
+        assert result.copied_count == 1  # shared setup code
+        assert result.header_translated is True
+        assert "Einleitung" not in result.target_text  # nothing German left in slides
+
+    def test_deck_without_header_macro(self):
+        # A plain single-language deck that never adopted the bilingual header
+        # convention still translates; there is simply no header to rewrite.
+        text = _slide_pair("only", "Allein", "Alone")
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        _assert_valid_pair(de, result.target_text)
+        assert result.header_translated is False
+        assert "Alone" in result.target_text
+
+
+# ---------------------------------------------------------------------------
+# Exact byte output — on trailing-symmetric decks the generated half equals
+# what split would have produced for the other side.
+# ---------------------------------------------------------------------------
+
+
+class TestByteExactOutput:
+    def test_header_only(self):
+        de, en = _split(HEADER_PREAMBLE)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        assert result.target_text == en
+        assert result.header_translated is True
+
+    def test_empty_title_is_not_translated(self):
+        text = '# j2 from \'macros.j2\' import header\n# {{ header("", "") }}\n\n'
+        de, en = _split(text)
+        # An empty title must not be sent to the translator (no mapping for "").
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=StaticSlideTranslator()
+        )
+        assert result.target_text == en
+
+    def test_slide_then_shared_terminator(self):
+        # Ending on a shared cell makes the two halves trailing-symmetric, so
+        # the generated EN half byte-matches split's EN half exactly.
+        text = (
+            HEADER_PREAMBLE
+            + _slide_pair("intro", "Einleitung", "Introduction")
+            + _shared_code("end")
+        )
+        de, en = _split(text)
+        result = translate_deck_text(
+            de, source_lang="de", target_lang="en", translator=_mirror_translator(de, en)
+        )
+        assert result.target_text == en
+
+    def test_reverse_byte_exact(self):
+        text = (
+            HEADER_PREAMBLE
+            + _slide_pair("intro", "Einleitung", "Introduction")
+            + _shared_code("end")
+        )
+        de, en = _split(text)
+        result = translate_deck_text(
+            en, source_lang="en", target_lang="de", translator=_reverse_translator(de, en)
+        )
+        assert result.target_text == de
+
+
+# ---------------------------------------------------------------------------
+# Error paths — never write a malformed or incomplete half
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_unsupported_language(self):
+        with pytest.raises(TranslateDeckError, match="unsupported language"):
+            translate_deck_text(
+                HEADER_PREAMBLE,
+                source_lang="de",
+                target_lang="fr",
+                translator=StaticSlideTranslator(default="x"),
+            )
+
+    def test_same_language(self):
+        with pytest.raises(TranslateDeckError, match="both"):
+            translate_deck_text(
+                HEADER_PREAMBLE,
+                source_lang="de",
+                target_lang="de",
+                translator=StaticSlideTranslator(default="x"),
+            )
+
+    def test_translation_failure_surfaces_cell(self):
+        text = HEADER_PREAMBLE + _slide_pair("intro", "Einleitung", "Introduction")
+        de, _ = _split(text)
+        # A translator that can do the title but not the slide body must fail
+        # loudly, naming the offending slide, and never half-write.
+        translator = StaticSlideTranslator(mapping=TITLES)
+        with pytest.raises(TranslateDeckError, match="intro"):
+            translate_deck_text(de, source_lang="de", target_lang="en", translator=translator)
+
+    def test_translation_failure_is_raised_not_swallowed(self):
+        text = _slide_pair("only", "Allein", "Alone")
+        de, _ = _split(text)
+        with pytest.raises(TranslateDeckError):
+            translate_deck_text(
+                de, source_lang="de", target_lang="en", translator=StaticSlideTranslator()
+            )
+
+    def test_round_trip_guard_rejects_structural_corruption(self):
+        # A translation that injects a *no-lang* cell boundary appears in only
+        # one half, so the pair no longer aligns; the split/unify validity guard
+        # must catch it rather than write a corrupt deck. (A guard on validity,
+        # not on translation fidelity — an injected valid lang="en" cell would
+        # round-trip and is out of scope.)
+        text = _slide_pair("only", "Allein", "Alone")
+        de, _ = _split(text)
+        rogue = StaticSlideTranslator(default="# %%\n_INJECTED_ = 1")
+        with pytest.raises(TranslateDeckError, match="split"):
+            translate_deck_text(de, source_lang="de", target_lang="en", translator=rogue)


### PR DESCRIPTION
## Summary

Adds **`clm slides translate SOURCE`** (alias `clm slides bootstrap`): when an author writes a deck in a single language (only `slides_x.de.py`), generate the other-language split half as a complete translation of the whole deck. This is the cold start `clm slides sync` deliberately refuses to perform — sync only fills per-cell gaps inside an *already-existing* pair.

Closes #232.

## Behavior

- **Code is mostly not translated — the `lang` tag decides.** A cell with no `lang` attribute is *shared* and copied byte-for-byte into both halves; only `lang`-tagged cells are translated (code cells through the identifier-preserving code prompt). No new marker — the existing `role_of` / no-`lang`-is-shared model.
- **Voiceover companion translated in lockstep**, preserving `for_slide` / `vo_anchor`, placed in the same `voiceover/` subdir or sibling location as the source companion.
- **Idempotent by design (D2):** twin absent → bootstrap (translate whole deck, copy shared cells, mint EN-authority shared `slide_id`s onto both halves, record the sync watermark); twin present → degrade to incremental `clm slides sync`. So re-running converges to a clean sync no-op and never doubles the deck. `--force` re-bootstraps.
- Emits the **split sibling** (`slides_x.de.py` → `slides_x.en.py`); run `clm slides unify` afterward for a bilingual file.
- Needs `$OPENROUTER_API_KEY` (or `$OPENAI_API_KEY`); reads a project `.env`. No key on the bootstrap path → exit 1, writes nothing. `--dry-run` previews with no key/LLM.

## Design

A **separate command that reuses sync's engine** (not a `sync --bootstrap` flag): the operations differ in shape (synthesize-missing vs reconcile-existing), and folding in would relax the recently-hardened `_resolve_single_path` guard. Pure orchestration over existing primitives — `OpenRouterSlideTranslator`, `build_twin_cell`/`swap_lang`, `assign_ids_in_split_pair`, the watermark seal, `resolve_companion`/`companion_name`.

## Phases (all 5 shipped)

1. `cf1c8e06` — pure offline engine `translate_deck.py`
2. `29947b88` — orchestration `translate_bootstrap.py` (D2 dispatch + mint + watermark)
3. `c9199c8a` — voiceover companion in lockstep
4. `28511cb2` — CLI command (+ `bootstrap` alias) + `TranslationCache` / `CachingSlideTranslator`
5. `23ed7b87` — info-topic docs (`commands.md` + `migration.md`) + validate acceptance gate

## Testing

70 feature tests, all offline (driven through the `SlideTranslator` / `SyncJudge` protocols, no network):

- `tests/slides/test_translate_deck.py` (17) — the engine on every cell shape, both directions, byte-exact output, error paths.
- `tests/slides/test_translate_bootstrap.py` (28) — the dispatch, id minting/preservation, the `translate`-twice sync no-op (proven for id'd, id-less, and trailing-asymmetric decks), and the companion-in-lockstep path.
- `tests/infrastructure/llm/test_translation_cache.py` (13) — the cache + caching translator.
- `tests/cli/test_slides_translate.py` (12) — the CLI surface, including the **acceptance gate**: a CLI-generated deck passes `clm validate <dir> --fail-on warning`.

Lint/format/mypy clean; full fast suite green throughout (6664 passing).

## Docs

Per CLAUDE.md's Info Topics rule: a `### clm slides translate` section in `commands.md` and a `## Bootstrap a second language` entry in `migration.md`. The `clm slides sync` cross-reference now points at `translate` for the cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
