### PR TITLE
docs(claude): clarify that `master` belongs to the main repo (worktree rule)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,13 +116,22 @@ Full procedure lives in `docs/developer-guide/releasing.md`. The hard rules:
   `uv run ruff format src/ tests/`.
 - Commits that fail a hook did **not** happen — fix the issue, re-stage, and
   create a **new** commit. Never `--amend` a commit the hook rejected.
-- **Reset a worktree to master** without breaking the main checkout: from inside
-  the worktree run `git fetch origin && git switch -C <worktree-branch>
-  origin/master`. Git won't let the *same* branch be checked out in two worktrees
-  (no config changes this), so do **not** check out the literal `master` in a
-  worktree, and **never** set `core.bare=true` on the main repo to work around it
-  — that strips the main checkout's working tree and is a recurring source of
-  breakage.
+- **`master` belongs to the main repo — a worktree must NEVER switch to it.**
+  The `master` branch is checked out in the main repo (`C:/…/Projects/clm`), and
+  Git forbids the *same* branch being checked out in two worktrees at once (no
+  config changes this). So a worktree never runs `git switch master` /
+  `git checkout master` — that command can only fail or, if forced, corrupt the
+  main checkout. To put a worktree on the latest master **content**, reset the
+  worktree's **own** branch onto `origin/master` instead. From inside the
+  worktree:
+  ```
+  git fetch origin && git switch -C <worktree-branch> origin/master
+  ```
+  This keeps you on your per-worktree branch (e.g. `worktree-<name>`) with
+  master's exact tree — non-destructive when that branch is already merged/behind.
+  To start fresh work, branch off it: `git switch -c claude/issue-NNN-...`.
+  **Never** set `core.bare=true` on the main repo to "free up" `master` — that
+  strips the main checkout's working tree and is a recurring source of breakage.
 
 ## Documentation Map
 
@@ -161,4 +170,4 @@ do not fabricate options.
 
 **Repository**: https://github.com/hoelzl/clm/ | **Issues**: https://github.com/hoelzl/clm/issues
 
-**Last Updated**: 2026-04-11
+**Last Updated**: 2026-06-05


### PR DESCRIPTION
## What

Clarify the worktree/`master` rule in `CLAUDE.md`. The "Reset a worktree to master" guidance already existed, but it **led with the mechanism** ("Git won't let the same branch be checked out in two worktrees") and buried the concrete fact that actually causes the recurring confusion: **`master` is the main repo's checked-out branch, so a worktree can never switch to it.**

## Change

Rewrote the bullet to lead with the rule as a headline, then state the concrete cause → consequence → correct alternative → the `core.bare=true` warning:

- **`master` belongs to the main repo — a worktree must NEVER switch to it.**
- A worktree never runs `git switch master` / `git checkout master` (it can only fail, or corrupt the main checkout if forced).
- To put a worktree on the latest master *content*, reset the worktree's **own** branch: `git fetch origin && git switch -C <worktree-branch> origin/master`.
- Never `core.bare=true` the main repo to "free up" master.

Also bumped "Last Updated".

## Why

This has been a repeated source of breakage — agents try to `git switch master` in a worktree or flip the main repo to bare to work around the failure, stripping the main checkout's working tree. Leading with the plain rule should stop the confusion at the source.

Docs-only; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
