### PR TITLE
feat(slides): validate + normalize cell spacing (blank lines, markdown lead)

### DIFF
--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -602,10 +602,20 @@ either a `workshop` tag or a slide-start cell whose `slide_id` begins with
 |---------|----------|-------|
 | markdown `# Workshop …` heading with no workshop scope covering it | `warning` | Heading match is case-sensitive, tolerant of `#`-count and whitespace (`^#+\s*Workshop\b`). Continuation headings (e.g. `## Workshop (Continued)`) inside an already-open scope are *not* flagged. Suggested fix: add a `workshop` tag or a `workshop-…` slide_id. |
 
+Since CLM {version}, the `format` check group also enforces **cell spacing**
+(both `warning`s — non-breaking; `clm slides normalize` auto-fixes them):
+
+| Finding | Severity | Notes |
+|---------|----------|-------|
+| cell is not separated from the previous cell by a blank line | `warning` | A blank line is required before every cell **except a j2 cell** — the title-header block (`# j2 … import header` immediately followed by `# {{ header(…) }}`) is tight-coupled and exempt. Cells run together are valid percent-format but render and diff poorly. Fix with `clm slides normalize`. |
+| markdown cell body does not start with a blank comment line (`#`) | `warning` | A markdown cell should open `# %% [markdown]` / `#` / `# <content>`; the leading `#` is what makes content that starts with a bullet (or heading) render correctly. j2 cells (the title macro) are exempt; empty-body cells are skipped. Fix with `clm slides normalize`. |
+
 Quick mode (`--quick`) runs the slide_id checks because they walk cells
 linearly and don't false-positive on in-progress edits. The workshop-scope
 check runs in quick mode too. The DE/EN count/tag-mismatch checks remain
-excluded from quick mode.
+excluded from quick mode, as do the cell-spacing checks above (they would
+fire on an in-progress markdown cell before the author has typed the
+leading `#`).
 
 Examples:
 
@@ -620,7 +630,14 @@ clm validate slides/module_010/topic_100_intro/ --quick
 *Removed in CLM 1.8: the flat alias `clm normalize-slides` no longer exists — use this group-qualified form.*
 
 Normalize slide files by applying mechanical fixes: tag migration (`alt`→`completed`),
-workshop tag insertion, DE/EN interleaving, and slide ID auto-generation.
+workshop tag insertion, DE/EN interleaving, slide ID auto-generation, and — since
+CLM {version} — **cell spacing** (`cell_spacing`).
+
+The `cell_spacing` operation fixes the two formatting issues the `format`
+validator now warns about: it inserts a blank line before every cell that lacks
+one (except the tight-coupled j2 title-header block), and prepends a blank
+comment line (`#`) to any markdown cell whose body starts directly with content.
+It runs by default (part of `all`) and is idempotent.
 
 ```
 clm slides normalize [OPTIONS] PATH
@@ -628,7 +645,7 @@ clm slides normalize [OPTIONS] PATH
 
 | Option | Description |
 |--------|-------------|
-| `--operations TEXT` | Comma-separated operations: `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `all` (default: `all`) |
+| `--operations TEXT` | Comma-separated operations: `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
 | `--dry-run` | Preview changes without modifying files |
 | `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--json` | Output as JSON |
@@ -641,6 +658,8 @@ clm slides normalize slides/module_010/topic_100_intro/slides_intro.py
 clm slides normalize slides/module_010/ --dry-run
 clm slides normalize slides/module_010/ --operations tag_migration
 clm slides normalize slides/module_010/ --operations slide_ids --json
+# Fix only cell spacing (blank line between cells + markdown leading `#`).
+clm slides normalize slides/module_010/ --operations cell_spacing
 # Pre-conversion: canonicalize start/completed order so the split round-trips exactly
 clm slides normalize slides/module_010/topic_100_intro/ --operations interleaving --canonicalize-start-completed
 ```

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -127,6 +127,30 @@ A generated deck is valid for all the split-pair tooling immediately — it pass
 `clm validate slides <dir> --fail-on warning` (slide_id set/order parity,
 shared-cell byte parity, pairing adjacency, companion `for_slide` parity).
 
+## Cell-spacing checks + `cell_spacing` normalize ({version} — additive)
+
+`clm validate` (the `format` group) now surfaces two `warning`s, and
+`clm slides normalize` gains a `cell_spacing` operation that fixes them:
+
+- **A cell must be separated from the previous cell by a blank line** — except a
+  j2 cell, since the title-header block (`# j2 … import header` immediately
+  followed by `# {{ header(…) }}`) is tight-coupled by design.
+- **A markdown cell body must start with a blank comment line (`#`)** — so
+  content that opens with a bullet or heading renders correctly.
+
+**Non-breaking but newly visible.** Both are `warning`s, so the default
+error-gate and existing CI are unaffected — but `clm validate --fail-on warning`
+(the pre-commit gate) will now flag pre-existing slides that lack a blank lead or
+run cells together. Fix a whole course in one pass:
+
+```bash
+clm slides normalize slides/                       # fixes spacing with the other ops
+clm slides normalize slides/ --operations cell_spacing   # spacing only
+```
+
+`cell_spacing` runs by default (part of `all`), is idempotent, and preserves the
+split/unify round-trip. No code or spec changes are required in course repos.
+
 ## Breaking changes in CLM 1.8
 
 CLM 1.8 retires the Phase 0 deprecation period. It carries **intentional

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -104,7 +104,9 @@ class NormalizationResult:
 # Operations
 # ---------------------------------------------------------------------------
 
-ALL_OPERATIONS = frozenset({"tag_migration", "workshop_tags", "interleaving", "slide_ids"})
+ALL_OPERATIONS = frozenset(
+    {"tag_migration", "workshop_tags", "interleaving", "slide_ids", "cell_spacing"}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -634,6 +636,72 @@ def _apply_slide_ids(
 
 
 # ---------------------------------------------------------------------------
+# Cell spacing: blank line between cells + markdown leading blank comment
+# ---------------------------------------------------------------------------
+
+
+def _apply_cell_spacing(cells: list[_RawCell], file_path: str) -> list[Change]:
+    """Normalize inter-cell and intra-cell whitespace (two mechanical fixes).
+
+    The counterparts of the validator's ``cell-separation`` and
+    ``markdown-blank-lead`` warnings:
+
+    1. A non-j2 cell must be preceded by a blank line — represented as a trailing
+       empty body line on the *previous* cell. j2 cells (the tight-coupled title
+       header block ``# j2 import`` → ``# {{ header }}``) are exempt.
+    2. A non-j2 markdown cell's body must start with a blank comment line (``#``),
+       so content that opens with a bullet or heading renders correctly.
+
+    Mutates ``cells`` in place. Idempotent: a conforming deck yields no changes.
+    """
+    changes: list[Change] = []
+
+    # Fix 1 — markdown leading blank comment. Done first; it only touches the
+    # FRONT of a cell's body, so it never interferes with the trailing-blank pass.
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.cell_type != "markdown":
+            continue
+        body = cell.lines[1:]
+        if not body:
+            continue
+        first = body[0]
+        if first.strip() == "#":
+            continue  # already a blank comment
+        if first.strip() == "":
+            # A bare blank line where the `#` belongs — promote it to the comment.
+            cell.lines[1] = "#"
+        else:
+            cell.lines.insert(1, "#")
+        changes.append(
+            Change(
+                file=file_path,
+                operation="cell_spacing",
+                line=cell.line_number,
+                description="Added leading blank comment line (`#`) to markdown cell",
+            )
+        )
+
+    # Fix 2 — blank-line separation before each non-j2 cell.
+    for prev, cur in zip(cells, cells[1:], strict=False):
+        if cur.metadata.is_j2:
+            continue
+        if len(prev.lines) > 1 and prev.lines[-1].strip() == "":
+            continue  # already separated
+        prev.lines.append("")
+        changes.append(
+            Change(
+                file=file_path,
+                operation="cell_spacing",
+                line=cur.line_number,
+                description="Added blank line before cell",
+            )
+        )
+
+    return changes
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -697,6 +765,11 @@ def normalize_file(
         slide_id_changes, slide_id_reviews = _apply_slide_ids(cells, path, assign_options)
         all_changes.extend(slide_id_changes)
         all_review.extend(slide_id_reviews)
+
+    # Cell spacing runs last, on the final cell order (after any interleaving
+    # reorder), so blank-line separation reflects the cells' final adjacency.
+    if "cell_spacing" in op_set:
+        all_changes.extend(_apply_cell_spacing(cells, file_str))
 
     modified = False
     if all_changes and not dry_run:

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -28,6 +28,7 @@ from clm.slides.pairing import (
     is_title_macro_cell,
     split_twin_pair,
 )
+from clm.slides.raw_cells import RawCell
 from clm.slides.raw_cells import split_cells as split_raw_cells
 from clm.slides.slug import (
     MAX_SLUG_LENGTH,
@@ -179,6 +180,82 @@ def _check_format(cells: list[Cell], file_path: str) -> list[Finding]:
                     )
                 )
 
+    return findings
+
+
+def _ends_with_blank_line(cell: RawCell) -> bool:
+    """True iff ``cell``'s body ends with at least one blank line.
+
+    Inter-cell separation is stored as trailing empty body lines on the *preceding*
+    cell (``reconstruct`` joins cells with a single ``\\n``), so a preceding cell
+    that ends with a blank line is what puts a blank line before the next cell.
+    """
+    return len(cell.lines) > 1 and cell.lines[-1].strip() == ""
+
+
+def _is_blank_comment(line: str) -> bool:
+    """True iff ``line`` is a markdown blank-comment line (just ``#``)."""
+    return line.strip() == "#"
+
+
+def _check_cell_separation(raw_cells: list[RawCell], file_path: str) -> list[Finding]:
+    """Warn when a cell is not separated from the previous one by a blank line.
+
+    A blank line is required before every cell **except a j2 cell** — the canonical
+    title-header block writes ``# j2 ... import header`` immediately followed by
+    ``# {{ header(...) }}`` with no blank between the two directives, so j2 cells
+    tight-couple and are exempt. Cells run together are valid percent-format but
+    render and diff poorly. Operates on :class:`RawCell` because the parsed ``Cell``
+    model strips inter-cell whitespace.
+    """
+    findings: list[Finding] = []
+    for prev, cur in zip(raw_cells, raw_cells[1:], strict=False):
+        if cur.metadata.is_j2:
+            continue
+        if not _ends_with_blank_line(prev):
+            findings.append(
+                Finding(
+                    severity="warning",
+                    category="format",
+                    file=file_path,
+                    line=cur.line_number,
+                    message="cell is not separated from the previous cell by a blank line",
+                    suggestion="Insert a blank line between cells (`clm slides normalize` fixes this).",
+                )
+            )
+    return findings
+
+
+def _check_markdown_blank_lead(raw_cells: list[RawCell], file_path: str) -> list[Finding]:
+    """Warn when a markdown cell body does not start with a blank comment line.
+
+    A markdown cell should open with a ``#`` line before its content
+    (``# %% [markdown]`` / ``#`` / ``# <content>``). The leading ``#`` is what makes
+    content that starts with a bullet or heading render correctly. j2 cells (the
+    title macro) are exempt and empty-body cells are skipped.
+    """
+    findings: list[Finding] = []
+    for cell in raw_cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.cell_type != "markdown":
+            continue
+        body = cell.lines[1:]
+        if not body:
+            continue
+        if not _is_blank_comment(body[0]):
+            findings.append(
+                Finding(
+                    severity="warning",
+                    category="format",
+                    file=file_path,
+                    line=cell.line_number,
+                    message="markdown cell body does not start with a blank comment line (`#`)",
+                    suggestion=(
+                        "Begin the markdown cell with a `#` line "
+                        "(`clm slides normalize` fixes this)."
+                    ),
+                )
+            )
     return findings
 
 
@@ -1566,6 +1643,11 @@ def validate_file(
 
     if "format" in check_set:
         findings.extend(_check_format(cells, file_str))
+        # Cell spacing runs on the raw (whitespace-preserving) cells, since the
+        # parsed Cell model strips the blank lines these checks inspect.
+        _, raw_cells = split_raw_cells(text)
+        findings.extend(_check_cell_separation(raw_cells, file_str))
+        findings.extend(_check_markdown_blank_lead(raw_cells, file_str))
     if "tags" in check_set:
         findings.extend(_check_tags(cells, file_str))
     if "pairing" in check_set:

--- a/tests/cli/test_validate_deep.py
+++ b/tests/cli/test_validate_deep.py
@@ -13,9 +13,11 @@ from clm.cli.main import cli
 CLEAN_DECK = dedent(
     """\
     # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+    #
     # ## Titel
 
     # %% [markdown] lang="en" tags=["slide"] slide_id="title"
+    #
     # ## Title
     """
 )

--- a/tests/cli/test_validate_slides.py
+++ b/tests/cli/test_validate_slides.py
@@ -25,9 +25,11 @@ class TestValidateSlidesCommand:
             "slides_ok.py",
             """\
             # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+            #
             # ## Titel
 
             # %% [markdown] lang="en" tags=["slide"] slide_id="title"
+            #
             # ## Title
 
             # %% tags=["keep"]
@@ -63,9 +65,11 @@ class TestValidateSlidesCommand:
             "slides_ok.py",
             """\
             # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+            #
             # ## Titel
 
             # %% [markdown] lang="en" tags=["slide"] slide_id="title"
+            #
             # ## Title
             """,
         )
@@ -152,8 +156,8 @@ class TestValidateSlidesCommand:
         topic_dir = tmp_path / "topic_010_intro"
         topic_dir.mkdir()
         (topic_dir / "slides_intro.py").write_text(
-            '# %% [markdown] lang="de" tags=["slide"] slide_id="title"\n# ## Titel\n'
-            '# %% [markdown] lang="en" tags=["slide"] slide_id="title"\n# ## Title\n',
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="title"\n#\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="title"\n#\n# ## Title\n',
             encoding="utf-8",
         )
 
@@ -170,8 +174,8 @@ class TestValidateSlidesCommand:
         t1 = m1 / "topic_010_intro"
         t1.mkdir(parents=True)
         (t1 / "slides_intro.py").write_text(
-            '# %% [markdown] lang="de" tags=["slide"] slide_id="title"\n# ## Titel\n'
-            '# %% [markdown] lang="en" tags=["slide"] slide_id="title"\n# ## Title\n',
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="title"\n#\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="title"\n#\n# ## Title\n',
             encoding="utf-8",
         )
 
@@ -253,9 +257,11 @@ class TestValidateSlidesCommand:
             "slides_ok.py",
             """\
             # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+            #
             # ## Titel
 
             # %% [markdown] lang="en" tags=["slide"] slide_id="title"
+            #
             # ## Title
             """,
         )

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -962,5 +962,97 @@ class TestSlideIds:
         assert 'slide_id="wichtige-methoden"' in new_text
 
 
+# ---------------------------------------------------------------------------
+# Cell spacing (blank line between cells; markdown leading blank comment)
+# ---------------------------------------------------------------------------
+
+
+class TestCellSpacing:
+    def test_inserts_blank_between_cells(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n#\n# ## A\n# %% [markdown] lang="de"\n#\n# ## B\n'
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        result = normalize_file(path, operations=["cell_spacing"])
+        assert result.files_modified == 1
+        out = path.read_text(encoding="utf-8")
+        assert "# ## A\n\n# %% [markdown]" in out
+
+    def test_inserts_markdown_lead(self, tmp_path):
+        text = '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n# - Bullet\n'
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        normalize_file(path, operations=["cell_spacing"])
+        out = path.read_text(encoding="utf-8")
+        assert out.startswith(
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n#\n# - Bullet'
+        )
+
+    def test_bare_blank_promoted_to_comment(self, tmp_path):
+        # A bare empty first line (not a `#` comment) becomes the blank comment.
+        text = '# %% [markdown] lang="de"\n\n# ## A\n'
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        normalize_file(path, operations=["cell_spacing"])
+        assert path.read_text(encoding="utf-8") == '# %% [markdown] lang="de"\n#\n# ## A\n'
+
+    def test_j2_header_block_not_separated(self, tmp_path):
+        text = (
+            "# j2 from 'm' import header\n"
+            '# {{ header_de("T") }}\n\n'
+            '# %% [markdown] lang="de"\n#\n# ## A\n'
+        )
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        result = normalize_file(path, operations=["cell_spacing"])
+        out = path.read_text(encoding="utf-8")
+        # No blank inserted between the j2 import and the header macro.
+        assert "import header\n# {{ header_de" in out
+        assert result.files_modified == 0  # already conforming
+
+    def test_idempotent(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n# ## A\n# %%\nx = 1\n'
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        normalize_file(path, operations=["cell_spacing"])
+        first = path.read_text(encoding="utf-8")
+        result = normalize_file(path, operations=["cell_spacing"])
+        assert result.files_modified == 0
+        assert path.read_text(encoding="utf-8") == first
+
+    def test_round_trip_preserved(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n# ## A\n# %%\nx = 1\n'
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        normalize_file(path, operations=["cell_spacing"])
+        out = path.read_text(encoding="utf-8")
+        preamble, cells = _split_raw_cells(out)
+        assert _reconstruct(preamble, cells) == out
+
+    def test_runs_by_default(self, tmp_path):
+        assert "cell_spacing" in ALL_OPERATIONS
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n# ## A\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="a"\n# ## B\n'
+        )
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        normalize_file(path)  # no operations => all, including cell_spacing
+        out = path.read_text(encoding="utf-8")
+        assert "#\n# ## A" in out
+        assert "#\n# ## B" in out
+
+    def test_resolves_validator_warnings(self, tmp_path):
+        from clm.slides.validator import validate_file
+
+        text = '# %% [markdown] lang="de" slide_id="a"\n# ## A\n# %%\nx = 1\n'
+        path = _write_slide(tmp_path / "slides_x.de.py", text)
+        before = [
+            f
+            for f in validate_file(path, checks=["format"]).findings
+            if "blank line" in f.message or "blank comment" in f.message
+        ]
+        assert before  # spacing warnings present
+        normalize_file(path, operations=["cell_spacing"])
+        after = [
+            f
+            for f in validate_file(path, checks=["format"]).findings
+            if "blank line" in f.message or "blank comment" in f.message
+        ]
+        assert after == []
+
+
 # Import needed for TestResultStatus
 from clm.slides.normalizer import Change, ReviewItem  # noqa: E402

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -39,9 +39,11 @@ class TestCheckFormat:
             "slides_ok.py",
             """\
             # %% [markdown] lang="de" tags=["slide"]
+            #
             # ## Titel
 
             # %% [markdown] lang="en" tags=["slide"]
+            #
             # ## Title
 
             # %% tags=["keep"]
@@ -57,6 +59,7 @@ class TestCheckFormat:
             "slides_bad_tags.py",
             """\
             # %% [markdown] tags=broken
+            #
             # ## Bad
             """,
         )
@@ -71,6 +74,7 @@ class TestCheckFormat:
             "slides_bad_lang.py",
             """\
             # %% [markdown] lang=de tags=["slide"]
+            #
             # ## Bad
             """,
         )
@@ -88,9 +92,11 @@ class TestCheckFormat:
             # {{ header("T", "T") }}
 
             # %% [markdown] lang="de" tags=["slide"]
+            #
             # ## Titel
 
             # %% [markdown] lang="en" tags=["slide"]
+            #
             # ## Title
             """,
         )
@@ -2714,13 +2720,13 @@ class TestValidateDirectory:
         topic_dir = tmp_path / "topic_010_intro"
         topic_dir.mkdir()
         (topic_dir / "slides_intro.py").write_text(
-            '# %% [markdown] lang="de" tags=["slide"] slide_id="title"\n# ## Titel\n'
-            '# %% [markdown] lang="en" tags=["slide"] slide_id="title"\n# ## Title\n',
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="title"\n#\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="title"\n#\n# ## Title\n',
             encoding="utf-8",
         )
         (topic_dir / "slides_extra.py").write_text(
-            '# %% [markdown] lang="de" tags=["slide"] slide_id="more"\n# ## Mehr\n'
-            '# %% [markdown] lang="en" tags=["slide"] slide_id="more"\n# ## More\n',
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="more"\n#\n# ## Mehr\n\n'
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="more"\n#\n# ## More\n',
             encoding="utf-8",
         )
         # Non-slide file should be ignored
@@ -2785,8 +2791,8 @@ class TestValidateCourse:
         t1 = m1 / "topic_010_intro"
         t1.mkdir(parents=True)
         (t1 / "slides_intro.py").write_text(
-            '# %% [markdown] lang="de" tags=["slide"]\n# ## Titel\n'
-            '# %% [markdown] lang="en" tags=["slide"]\n# ## Title\n',
+            '# %% [markdown] lang="de" tags=["slide"]\n#\n# ## Titel\n\n'
+            '# %% [markdown] lang="en" tags=["slide"]\n#\n# ## Title\n',
             encoding="utf-8",
         )
 
@@ -2931,3 +2937,77 @@ def test_companion_location_ambiguity_is_flagged(tmp_path):
     ]
     assert len(ambiguity) == 1
     assert ambiguity[0].category == "pairing"
+
+
+# ---------------------------------------------------------------------------
+# Cell spacing checks (blank line between cells; markdown leading blank comment)
+# ---------------------------------------------------------------------------
+
+_J2_HEADER = "# j2 from 'macros.j2' import header\n# {{ header_de(\"Titel\") }}\n"
+
+
+def _write_raw(tmp_path: Path, content: str, name: str = "slides_x.de.py") -> Path:
+    """Write byte-exact content (no dedent — these tests are whitespace-sensitive)."""
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8", newline="\n")
+    return p
+
+
+def _separation(result: ValidationResult) -> list[Finding]:
+    return [f for f in result.findings if "separated from the previous" in f.message]
+
+
+def _lead(result: ValidationResult) -> list[Finding]:
+    return [f for f in result.findings if "blank comment" in f.message]
+
+
+class TestCellSeparationCheck:
+    def test_missing_blank_between_cells_warns(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n#\n# ## A\n# %% [markdown] lang="de"\n#\n# ## B\n'
+        seps = _separation(validate_file(_write_raw(tmp_path, text), checks=["format"]))
+        assert len(seps) == 1
+        assert seps[0].severity == "warning"
+        assert seps[0].category == "format"
+
+    def test_blank_present_no_warning(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n#\n# ## A\n\n# %% [markdown] lang="de"\n#\n# ## B\n'
+        assert _separation(validate_file(_write_raw(tmp_path, text), checks=["format"])) == []
+
+    def test_j2_header_block_exempt(self, tmp_path):
+        # The `# j2 import` -> `# {{ header }}` adjacency carries no blank by design.
+        text = _J2_HEADER + '\n# %% [markdown] lang="de"\n#\n# ## A\n'
+        assert _separation(validate_file(_write_raw(tmp_path, text), checks=["format"])) == []
+
+    def test_code_cell_separation_enforced(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n#\n# ## A\n# %%\nx = 1\n'
+        assert len(_separation(validate_file(_write_raw(tmp_path, text), checks=["format"]))) == 1
+
+    def test_content_cell_after_macro_without_blank_warns(self, tmp_path):
+        # The header macro (j2) is exempt as a *target*, but a content cell right
+        # after it with no blank IS flagged (the macro must end with a blank).
+        text = _J2_HEADER + '# %% [markdown] lang="de"\n#\n# ## A\n'
+        assert len(_separation(validate_file(_write_raw(tmp_path, text), checks=["format"]))) == 1
+
+
+class TestMarkdownBlankLeadCheck:
+    def test_missing_lead_warns(self, tmp_path):
+        text = '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n# - Bullet\n'
+        leads = _lead(validate_file(_write_raw(tmp_path, text), checks=["format"]))
+        assert len(leads) == 1
+        assert leads[0].severity == "warning"
+
+    def test_lead_present_no_warning(self, tmp_path):
+        text = '# %% [markdown] lang="de"\n#\n# - Bullet\n'
+        assert _lead(validate_file(_write_raw(tmp_path, text), checks=["format"])) == []
+
+    def test_code_cell_not_subject(self, tmp_path):
+        text = '# %% lang="de"\nx = 1\n'
+        assert _lead(validate_file(_write_raw(tmp_path, text), checks=["format"])) == []
+
+    def test_j2_macro_not_subject(self, tmp_path):
+        assert _lead(validate_file(_write_raw(tmp_path, _J2_HEADER), checks=["format"])) == []
+
+    def test_runs_under_default_checks(self, tmp_path):
+        # No explicit --checks: the format bundle (and thus these) run by default.
+        text = '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n# - Bullet\n'
+        assert len(_lead(validate_file(_write_raw(tmp_path, text)))) == 1


### PR DESCRIPTION
## Summary

Teaches `clm validate` to detect — and `clm slides normalize` to fix — two percent-format slide spacing issues that were previously unenforced:

1. **Cells run together with no blank line between them.** Valid percent-format, but renders and diffs poorly.
2. **A markdown cell whose body starts directly with content** (e.g. a bullet) instead of a blank comment line `#`, which renders incorrectly.

## Validator (`format` group, both `warning`)

- **`_check_cell_separation`** — a blank line is required before every cell **except a j2 cell**. The canonical title-header block (`# j2 … import header` immediately followed by `# {{ header(…) }}`) is tight-coupled by design, so j2 cells are exempt.
- **`_check_markdown_blank_lead`** — a non-j2 markdown cell's body must start with a `#` line, so content opening with a bullet/heading renders correctly.

Both operate on `RawCell` (the parsed `Cell` model strips the inter-cell whitespace they inspect). They run in the default `format` bundle — so plain `clm validate` and the `--fail-on warning` pre-commit gate catch them — but **not** in `--quick` mode, which would fire on in-progress edits (consistent with how the DE/EN count/tag-mismatch checks are already excluded from quick mode).

## Normalizer (`cell_spacing` operation)

A new `cell_spacing` operation fixes both: it inserts a blank line before a non-j2 cell that lacks one, and prepends `#` to a markdown cell missing the lead (a bare empty first line is promoted to the comment). It is registered in `ALL_OPERATIONS` so it **runs by default**, is **idempotent**, and **preserves the split/unify round-trip**. It runs last, on the final cell order (after any interleaving reorder).

## Behavior change to be aware of

Both checks are **`warning`** severity, so the default error-gate and existing CI are unaffected. But under `--fail-on warning` (the pre-commit gate), course repos will now surface these on pre-existing slides until `clm slides normalize slides/` is run. That is the intended "discovery + fix" — non-breaking, fixable in one pass.

Several pre-existing terse test fixtures asserted a clean validate but lacked the blank lead / separation; they were updated to conform (the warnings they now surface are correct).

## Testing

18 new tests (`tests/slides/test_validator.py`, `tests/slides/test_normalizer.py`) plus updated CLI fixtures (`tests/cli/test_validate_slides.py`):

- separation flagged / not-flagged; j2 header block exempt; code cells subject to separation but not the markdown-lead check.
- normalize fixes both, is idempotent, preserves the round-trip, runs by default, and resolves the validator warnings.

Full fast suite green (6682 passed); lint/format/mypy clean.

## Docs

Per CLAUDE.md's Info Topics rule: `commands.md` (a `format` findings table + the `cell_spacing` operation/example) and `migration.md` (an additive entry — non-breaking but newly visible under `--fail-on warning`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
