### PR TITLE
build(docker): fetch large image inputs at build time instead of git LFS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        lfs: true
+        lfs: false
+
+    # The non-docker test suite needs only the small fixture/template images,
+    # not the docker/ build inputs. Pulling only what we need (and excluding
+    # docker/**) keeps LFS bandwidth down and guards against any large binary
+    # ever re-landing under docker/ silently inflating every CI run.
+    - name: Pull LFS test fixtures (excluding docker build inputs)
+      run: git lfs pull --exclude="docker/**"
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -156,23 +163,13 @@ jobs:
     timeout-minutes: 45
 
     steps:
+    # The notebook/plantuml/drawio build inputs (deno, ijava, drawio .deb) are
+    # now fetched + SHA-256-verified inside the Dockerfiles, so the only LFS
+    # object the image builds need is the small drawio font.
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         lfs: true
-
-    - name: Pull LFS files
-      run: |
-        git lfs pull
-        # Verify LFS files were pulled correctly (should be multi-MB, not ~130 bytes)
-        for f in docker/notebook/*.zip; do
-          size=$(stat -c%s "$f")
-          if [ "$size" -lt 1000000 ]; then
-            echo "Error: LFS file $f not properly pulled (size: $size bytes)"
-            exit 1
-          fi
-          echo "OK: $f is $size bytes"
-        done
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -5,12 +5,15 @@ This document describes how to build Docker images for CLM workers.
 ## Prerequisites
 
 1. **Docker** with BuildKit enabled
-2. **Git LFS** for large binary files
-3. CLM repository cloned with LFS:
+2. **Git LFS** — only needed for the Draw.io image (the small bundled font).
+   The notebook and PlantUML images fetch their build inputs at build time and
+   need no LFS objects. For the Draw.io image:
    ```bash
    git lfs install
    git lfs pull
    ```
+3. **Network access during the build** — the Dockerfiles fetch Deno, IJava, and
+   the Draw.io `.deb` from their pinned upstream releases (SHA-256-verified).
 
 ## Quick Start
 
@@ -248,33 +251,42 @@ RUN --mount=type=cache,target=/opt/conda/pkgs,id=conda-pkgs,sharing=locked \
 
 **Important:** Do not use `--no-cache` with Docker build commands, as this disables cache mounts and makes builds significantly slower.
 
-## Git LFS Files
+## Build inputs (fetched vs vendored)
 
-Several large binary files are stored in Git LFS and must be present before building:
+The large third-party build inputs are **fetched from their pinned upstream
+releases and SHA-256-verified inside the Dockerfiles** rather than vendored in
+git, to keep them out of Git LFS. Bump a version by editing the `ARG …_VERSION`
+/ `ARG …_SHA256` pair in the relevant Dockerfile.
 
-### PlantUML Worker
-- `docker/plantuml/plantuml-1.2024.6.jar` (22MB) - **Committed directly (not LFS)**
+| Worker | Input | Source |
+|--------|-------|--------|
+| Notebook | Deno (`ARG DENO_VERSION`) | fetched from `denoland/deno` releases |
+| Notebook | IJava (`ARG IJAVA_VERSION`) | fetched from `SpencerPark/IJava` releases |
+| Draw.io | Draw.io `.deb` (`ARG DRAWIO_VERSION`) | fetched from `jgraph/drawio-desktop` releases |
+| PlantUML | `plantuml-1.2024.6.jar` (22 MB) | committed directly (not LFS) |
+| Draw.io | `ArchitectsDaughter-Regular.ttf` (~38 KB) | vendored in Git LFS (small) |
 
-### Draw.io Worker
-- `docker/drawio/drawio-amd64-24.7.5.deb` (98MB) - **LFS**
-- `docker/drawio/ArchitectsDaughter-Regular.ttf` (37KB) - **LFS**
-
-### Notebook Worker
-- `docker/notebook/deno-x86_64-unknown-linux-gnu.zip` (~40MB) - **LFS**
-- `docker/notebook/ijava-1.7.0.zip` (~6MB) - **LFS**
-- `docker/notebook/packages-microsoft-prod.deb` (~3KB) - **LFS**
-
-To ensure all LFS files are downloaded:
-
-```bash
-git lfs pull
-```
+Only the small Draw.io font remains in LFS, so a plain `git lfs pull` (or a
+checkout with `lfs: true`) before building the Draw.io image is enough. The
+notebook and PlantUML images need no LFS objects.
 
 ## Troubleshooting
 
-### Build Fails: Missing LFS Files
+### Build Fails: Checksum Mismatch on a Fetched Input
 
-**Error:** `COPY failed: file not found`
+**Error:** `sha256sum: WARNING: 1 computed checksum did NOT match`
+
+**Cause:** the pinned `ARG …_SHA256` no longer matches what the upstream URL
+serves (a re-published asset, or a version bump that updated the URL but not the
+SHA).
+
+**Solution:** download the asset, recompute `sha256sum <file>`, and update the
+matching `ARG …_SHA256` (and `ARG …_VERSION` if you intended a bump) in the
+Dockerfile.
+
+### Build Fails: Missing Draw.io Font
+
+**Error:** `COPY failed: file not found` for `ArchitectsDaughter-Regular.ttf`
 
 **Solution:**
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,20 +8,22 @@ This directory contains Dockerfiles and supporting files for building CLM worker
 - `drawio/` - Draw.io converter worker
 - `notebook/` - Jupyter notebook processor worker
 
-## Git LFS Files
+## Build inputs
 
-Several large binary files are stored in Git LFS:
+Large third-party inputs are **fetched from pinned upstream releases and
+SHA-256-verified at build time** (see the `ARG …_VERSION` / `ARG …_SHA256` pairs
+in the Dockerfiles), so they are no longer vendored in Git LFS:
 
-**DrawIO Worker:**
-- `drawio/drawio-amd64-24.7.5.deb` (98MB) - Draw.io desktop application
-- `drawio/ArchitectsDaughter-Regular.ttf` (37KB) - Font file
+- `notebook/` — Deno runtime, IJava kernel (fetched)
+- `drawio/` — Draw.io desktop `.deb` (fetched)
 
-**Notebook Worker:**
-- `notebook/deno-x86_64-unknown-linux-gnu.zip` (~40MB) - Deno runtime
-- `notebook/ijava-1.3.0.zip` (~6MB) - IJava kernel
-- `notebook/packages-microsoft-prod.deb` (~3KB) - Microsoft package repository config
+Still in-tree:
 
-**Note**: PlantUML JAR (`plantuml/plantuml-1.2024.6.jar`, 22MB) is committed directly (not LFS).
+- `drawio/ArchitectsDaughter-Regular.ttf` (~38 KB) — small font, vendored in Git LFS
+- `plantuml/plantuml-1.2024.6.jar` (22 MB) — committed directly (not LFS)
+
+So only the Draw.io image needs `git lfs pull`; the others need none. See
+`BUILDING.md` for version-bump and checksum-mismatch notes.
 
 ## Building Images
 
@@ -40,8 +42,8 @@ From the repository root:
 ## Requirements
 
 - Docker with BuildKit enabled
-- Git LFS (to checkout large binary files)
-- Repository must be cloned with Git LFS:
+- Network access during the build (Dockerfiles fetch pinned, checksummed inputs)
+- Git LFS only for the Draw.io image (its bundled font):
   ```bash
   git lfs install
   git lfs pull

--- a/docker/drawio/Dockerfile
+++ b/docker/drawio/Dockerfile
@@ -22,20 +22,28 @@ WORKDIR /app
 
 ARG DOCKER_PATH=docker/drawio
 
-# Copy files needed for system install to maximize cache hits
-# The expensive apt/drawio install will only rebuild if these files change
-COPY ${DOCKER_PATH}/drawio-amd64-24.7.5.deb .
+# The font is small (~38 KB) and stays vendored. The Draw.io .deb is fetched
+# from the pinned GitHub release and SHA-256-verified inside the install step
+# below (same pattern as the notebook Dockerfile) rather than vendored as a
+# ~100 MB git LFS object. Bump by checking
+# https://github.com/jgraph/drawio-desktop/releases and updating both below.
 COPY ${DOCKER_PATH}/ArchitectsDaughter-Regular.ttf /usr/local/share/fonts/
+
+ARG DRAWIO_VERSION=24.7.5
+ARG DRAWIO_SHA256=196fd079cf2625be122d2ab94342ddb9547ff500d7398daaf35432aee1674973
 
 # Install system dependencies and drawio
 # Using apt cache mounts to avoid re-downloading packages
 # This is the most expensive step for this service
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    set -eu && \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
     apt-get update && \
     apt-get install -y \
+        ca-certificates \
+        curl \
         dbus \
         dbus-x11 \
         nodejs \
@@ -49,8 +57,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         fonts-liberation \
         fonts-noto \
         fonts-noto-cjk && \
-    apt-get -y -f install ./drawio-amd64-24.7.5.deb && \
-    rm drawio-amd64-24.7.5.deb && \
+    curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+        --output drawio.deb \
+        "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb" && \
+    echo "${DRAWIO_SHA256}  drawio.deb" | sha256sum -c - && \
+    apt-get -y -f install ./drawio.deb && \
+    rm drawio.deb && \
     npm install -g svgo && \
     fc-cache -f -v
 

--- a/docker/drawio/drawio-amd64-24.7.5.deb
+++ b/docker/drawio/drawio-amd64-24.7.5.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:196fd079cf2625be122d2ab94342ddb9547ff500d7398daaf35432aee1674973
-size 98297934

--- a/docker/notebook/Dockerfile
+++ b/docker/notebook/Dockerfile
@@ -108,10 +108,6 @@ FROM base-${VARIANT} AS common
 
 ARG DOCKER_PATH=docker/notebook
 
-# Copy static files needed for installation
-COPY ${DOCKER_PATH}/deno-x86_64-unknown-linux-gnu.zip .
-COPY ${DOCKER_PATH}/ijava-1.3.0.zip .
-
 # Install .NET SDK 10.0 using the official install script
 # Note: .NET 9 has a known issue with dotnet-interactive installation
 # (DotnetToolSettings.xml not found error), fixed in .NET 10
@@ -174,14 +170,34 @@ RUN dotnet tool install -g --no-cache Microsoft.dotnet-interactive && \
     dotnet interactive jupyter install
 
 # Install Deno (TypeScript/JavaScript kernel)
-RUN unzip ./deno-x86_64-unknown-linux-gnu.zip -d deno-bin && \
-    rm ./deno-x86_64-unknown-linux-gnu.zip && \
+# Fetched from the pinned GitHub release and SHA-256-verified rather than
+# vendored in-tree, so the 50 MB archive stays out of git LFS (see the
+# micromamba block above for the same pattern and rationale). Bump by
+# checking https://github.com/denoland/deno/releases and updating both the
+# version tag and SHA below.
+ARG DENO_VERSION=2.1.1
+ARG DENO_SHA256=cbc1b6728040f715e879a3a0c36e462bd09c37b634eb79d04df0bc8bdb07d6c6
+RUN set -eu && \
+    curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+        --output deno.zip \
+        "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" && \
+    echo "${DENO_SHA256}  deno.zip" | sha256sum -c - && \
+    unzip deno.zip -d deno-bin && \
+    rm deno.zip && \
     cp ./deno-bin/deno /usr/local/bin && \
     /usr/local/bin/deno jupyter --unstable --install
 
 # Install IJava (Java kernel)
-RUN unzip ./ijava-1.3.0.zip -d ijava-1.3.0 && \
-    rm ./ijava-1.3.0.zip
+# Same fetch-and-verify approach (was a vendored LFS zip).
+ARG IJAVA_VERSION=1.3.0
+ARG IJAVA_SHA256=484cc62579cb77510b0f0c78283f043794396d8ae9d76a8f2ab5d7368ec246b2
+RUN set -eu && \
+    curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+        --output ijava.zip \
+        "https://github.com/SpencerPark/IJava/releases/download/v${IJAVA_VERSION}/ijava-${IJAVA_VERSION}.zip" && \
+    echo "${IJAVA_SHA256}  ijava.zip" | sha256sum -c - && \
+    unzip ijava.zip -d ijava-1.3.0 && \
+    rm ijava.zip
 WORKDIR /app/ijava-1.3.0
 RUN python3 install.py --sys-prefix
 

--- a/docker/notebook/deno-x86_64-unknown-linux-gnu.zip
+++ b/docker/notebook/deno-x86_64-unknown-linux-gnu.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbc1b6728040f715e879a3a0c36e462bd09c37b634eb79d04df0bc8bdb07d6c6
-size 50072763

--- a/docker/notebook/ijava-1.3.0.zip
+++ b/docker/notebook/ijava-1.3.0.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:484cc62579cb77510b0f0c78283f043794396d8ae9d76a8f2ab5d7368ec246b2
-size 3366077

--- a/docker/notebook/packages-microsoft-prod.deb
+++ b/docker/notebook/packages-microsoft-prod.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8575ebfcbe92bd5161b520dd4664ed436dba25121b95c1bdc4a2bb161474c9d
-size 4308


### PR DESCRIPTION
## Problem

The `docker/` folder vendors three large third-party build inputs as **git LFS** objects:

| File | Size |
|---|---|
| `docker/drawio/drawio-amd64-24.7.5.deb` | 98 MB |
| `docker/notebook/deno-x86_64-unknown-linux-gnu.zip` | 50 MB |
| `docker/notebook/ijava-1.3.0.zip` | 3.4 MB |

Every CI checkout smudges them. Worse, the **`test` matrix job** (3 Python legs, every push + PR) checked them out with `lfs: true` but **uses none of them** — it `wget`s its own PlantUML/DrawIO and runs `-m "not docker"`. So ~450 MB was pulled per run for nothing. That LFS **bandwidth** is the bulk of the repo's ~$10/mo LFS bill, and each version bump adds ~150 MB to LFS **storage** permanently.

## Change (#1 + #2 from the discussion)

**#2 — fetch the inputs at build time** instead of vendoring, using the exact pinned-URL + SHA-256 pattern the notebook Dockerfile already uses for micromamba:

- `docker/notebook/Dockerfile` — deno (**v2.1.1**) and ijava (**v1.3.0**) are now `curl … && sha256sum -c -` from their GitHub releases.
- `docker/drawio/Dockerfile` — the drawio `.deb` (**v24.7.5**) is fetched + verified inside the install step (`curl`/`ca-certificates` added to the apt set).
- Removed the three LFS binaries, plus the **unused orphan** `packages-microsoft-prod.deb` (no Dockerfile references it).
- The small drawio font (~38 KB) stays vendored in LFS.

**#1 — scope the `test` job's LFS pull**: `lfs: false` + `git lfs pull --exclude="docker/**"`. The non-docker suite gets only its small fixture/template images, and a large binary re-landing under `docker/` can never silently re-inflate every run again. The `docker-test` job drops the now-obsolete zip size-verification step and keeps `lfs: true` only for the font.

## How the versions/checksums were pinned

The deno filename carries no version, so each version was recovered by **matching the upstream release asset's exact byte size to the vendored file** (deno → v2.1.1 @ 50,072,763 B, confirmed against its 2024-11-21 build date; ijava and drawio matched exactly too). The `ARG …_SHA256` pins are the authoritative guard — **the `docker-test` CI job builds all three images and is the real validator** (hence opening as draft until it's green).

## Expected impact

- LFS **bandwidth** from these files → ~0 (test job no longer pulls them; image builds fetch from upstream, which is unmetered).
- LFS **storage** stops growing on every version bump.
- CI image-build coverage is unchanged.
- Bonus: fixes a latent drift where the committed deb was drawio 24.7.5 while the `test` job `wget`s 24.7.17.

## Note: optional hardening for later (not in this PR)

If upstream availability/reproducibility ever becomes a concern, **mirror these pinned binaries as GitHub *Release assets* on this repo** and point the Dockerfile `curl`s at those URLs. Release-asset bandwidth is unmetered (unlike LFS), so it keeps the cost win while removing the dependency on third-party release hosting; the SHA-256 pins stay as-is. Costs one asset upload per version bump. Two smaller follow-ups in the same spirit: the ~38 KB drawio font could be inlined as a normal (non-LFS) blob to make `docker/` fully LFS-free, and the existing **historical** LFS blobs still count toward storage until a one-time history rewrite purges them (only worth it if storage, not bandwidth, becomes the dominant cost).

## Caveat

Builds now require **network access at build time** (documented in `docker/BUILDING.md` / `docker/README.md`). The pinned URLs are stable GitHub-release artifacts; deno/drawio/ijava all retain old releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
