### PR TITLE
fix(workers): copy-on-write in load_worker_config to stop config singleton leak (#223)

### DIFF
--- a/src/clm/infrastructure/workers/config_loader.py
+++ b/src/clm/infrastructure/workers/config_loader.py
@@ -50,8 +50,16 @@ def load_worker_config(cli_overrides: dict[str, Any] | None = None) -> WorkersMa
     """
     cli_overrides = cli_overrides or {}
 
-    # Load base config from files + env (handled by ClmConfig)
-    config = get_config().worker_management
+    # Load base config from files + env (handled by ClmConfig).
+    #
+    # Deep-copy off the shared singleton: ``get_config()`` returns a
+    # process-global instance, and the CLI-override application below mutates
+    # the config (and its nested per-type models) in place. Operating on the
+    # live singleton would let a per-invocation override (e.g. ``--workers
+    # docker``) leak into every later ``load_worker_config`` call that does not
+    # override the same field, poisoning the default execution mode for the
+    # rest of the process. A copy makes each call self-contained. See #223.
+    config = get_config().worker_management.model_copy(deep=True)
 
     # Apply CLI overrides to global settings
     # Support both CLI-style ("workers") and config-style ("default_execution_mode")

--- a/tests/infrastructure/workers/test_config_loader.py
+++ b/tests/infrastructure/workers/test_config_loader.py
@@ -31,6 +31,13 @@ def mock_base_config():
         type_config.count = 1
         setattr(config, worker_type, type_config)
 
+    # ``load_worker_config`` deep-copies off the singleton before applying
+    # overrides (the #223 copy-on-write). These override-logic tests assert on
+    # (and ``is``-compare against) the object they passed in, so make the mock's
+    # copy a no-op that returns itself. Isolation/COW itself is covered by
+    # ``TestLoadWorkerConfigDoesNotPoisonSingleton`` against a real config.
+    config.model_copy.return_value = config
+
     return config
 
 
@@ -389,3 +396,52 @@ class TestLogging:
         with caplog.at_level(logging.INFO, logger="clm.infrastructure.workers.config_loader"):
             load_worker_config(cli_overrides={"max_workers": 4})
         assert "max_workers_cap" in caplog.text
+
+
+class TestLoadWorkerConfigDoesNotPoisonSingleton:
+    """Regression tests for #223: per-invocation overrides must not leak onto
+    the process-global config singleton.
+
+    These drive a *real* ``WorkersManagementConfig`` (not a MagicMock) so the
+    copy-on-write in ``load_worker_config`` is exercised for real, including the
+    nested per-type models.
+    """
+
+    @pytest.fixture
+    def real_singleton(self):
+        """Patch ``get_config`` to return a real, default config singleton."""
+        from clm.infrastructure.config import ClmConfig
+
+        singleton = ClmConfig()
+        with patch("clm.infrastructure.workers.config_loader.get_config", return_value=singleton):
+            yield singleton
+
+    def test_workers_override_does_not_leak_to_singleton(self, real_singleton):
+        """A ``--workers docker`` override on one call must not flip the
+        singleton's default for the next override-free call."""
+        assert real_singleton.worker_management.default_execution_mode == "direct"
+
+        overridden = load_worker_config(cli_overrides={"workers": "docker"})
+        assert overridden.default_execution_mode == "docker"
+
+        # The singleton is untouched: a later override-free load still defaults
+        # to direct (this is the exact flake from #223 — Docker mode leaking
+        # into a build that never asked for it).
+        assert real_singleton.worker_management.default_execution_mode == "direct"
+        default = load_worker_config()
+        assert default.default_execution_mode == "direct"
+
+    def test_nested_per_type_override_does_not_leak(self, real_singleton):
+        """Deep-copy guard: a per-type count / image override must not mutate
+        the singleton's nested ``WorkerTypeConfig`` instances."""
+        baseline_count = real_singleton.worker_management.notebook.count
+
+        load_worker_config(cli_overrides={"notebook_workers": 7, "notebook_image": "lite"})
+
+        assert real_singleton.worker_management.notebook.count == baseline_count
+        assert real_singleton.worker_management.notebook.image is None
+
+    def test_returned_config_is_a_distinct_copy(self, real_singleton):
+        """Each call returns its own object, not the shared singleton's."""
+        result = load_worker_config()
+        assert result is not real_singleton.worker_management


### PR DESCRIPTION
## Problem

`load_worker_config` mutated `get_config().worker_management` — a **process-global singleton** — in place when applying CLI overrides:

```python
config = get_config().worker_management            # shared singleton
if cli_overrides.get("workers"):
    config.default_execution_mode = cli_overrides["workers"]   # ← poisons it process-wide
```

So a build/test that resolved to **Docker** mode permanently flipped `default_execution_mode` to `"docker"` on the shared instance. A later build that did **not** override `--workers` then inherited `"docker"`, constructed a Docker `WorkerExecutor` with no image, and raised:

```
ValueError: Docker execution mode requires 'image' to be specified
```

This is **order-dependent** under `pytest-xdist`, which is why it surfaced as a rare CI flake (`tests/snapshot/test_manifest_suppressed.py` on Python 3.11, PR #222).

## Fix

Deep-copy the singleton's `worker_management` before applying overrides:

```python
config = get_config().worker_management.model_copy(deep=True)
```

A **deep** copy is required — the loader also mutates nested `WorkerTypeConfig` models (`notebook.image`, per-type `count`). Each call is now self-contained; the shared default can no longer be poisoned. This is the issue's principled **option 1** ("copy-on-write in the loader" — a config loader should not mutate global state as a side effect).

Single production caller is `build.py`, which always uses the returned object — nothing relied on the side-effecting mutation (that reliance *was* the bug).

## Tests

- New `TestLoadWorkerConfigDoesNotPoisonSingleton` drives a **real** `WorkersManagementConfig` and asserts a `docker` override on one call does not flip the singleton (or its nested per-type models) for the next override-free call. **Verified it fails without the fix** (3 failed → 3 passed once `model_copy(deep=True)` is restored).
- Existing MagicMock-based override-logic tests get a no-op `model_copy` so their identity (`is`) assertions still hold.

## Verification

- `tests/infrastructure/workers/` + `tests/snapshot/test_manifest_suppressed.py` → **349 passed**
- ruff + mypy clean; pre-commit + pre-push (fast suite) hooks passed

## Notes

- The `--workers direct` band-aid in `test_manifest_suppressed.py` (#224) is now redundant but harmless; left as defense-in-depth.
- The issue's option 2 (autouse `_config` reset fixture) is unnecessary now that the root cause is gone, so it is intentionally not added.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)