### PR TITLE
Release 1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-06-06
+
 ### Fixed
 
 - **A title-slide greeting voiceover now survives `clm voiceover extract` (#242).**
@@ -22,6 +24,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   fix merge without a re-extract. Adding `slide_id` to the macros (the issue's
   alternative) is neither necessary nor sufficient — the merge runs before j2
   expansion and the worker strips `slide_id`/`for_slide` from output.
+- **`load_worker_config` no longer poisons the global config singleton (#223).**
+  Applying CLI `--workers` overrides mutated `get_config().worker_management` —
+  a process-global singleton — in place, so a build/test that resolved to Docker
+  mode permanently flipped `default_execution_mode` to `"docker"` for every later
+  call in the process; a subsequent override-free build then built a Docker
+  executor with no image and raised `ValueError: Docker execution mode requires
+  'image'`. Order-dependent under `pytest-xdist`, so it surfaced as a rare CI
+  flake. The loader now deep-copies (`model_copy(deep=True)`) before applying
+  overrides, so each call is self-contained and the shared default can't be
+  poisoned.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Draw.io diagrams) into multiple output formats (HTML slides, executed
 notebooks, extracted code) for multiple audiences (students, solutions,
 speaker notes).
 
-**Version**: 1.8.2 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.8.3 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hoelzl/clm/actions/workflows/ci.yml/badge.svg)](https://github.com/hoelzl/clm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hoelzl/clm/branch/master/graph/badge.svg)](https://codecov.io/gh/hoelzl/clm)
 
-**Version**: 1.8.2 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.8.3 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 CLM is a course content processing system that converts educational materials (Jupyter notebooks, PlantUML diagrams, Draw.io diagrams) into multiple output formats.
 

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -50,7 +50,7 @@ On Windows (PowerShell):
 ### PlantUML Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.8.2`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.8.3`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -73,7 +73,7 @@ docker build -f docker/plantuml/Dockerfile -t docker.io/mhoelzl/clm-plantuml-con
 ### Draw.io Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-drawio-converter:1.8.2`
+- `docker.io/mhoelzl/clm-drawio-converter:1.8.3`
 - `docker.io/mhoelzl/clm-drawio-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -107,7 +107,7 @@ The notebook processor has **two variants** to support different use cases:
 **Best for:** Courses without deep learning, or running on Apple Silicon Macs.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.8.2-lite`
+- `docker.io/mhoelzl/clm-notebook-processor:1.8.3-lite`
 - `docker.io/mhoelzl/clm-notebook-processor:lite`
 
 **Base Image:** `python:3.11-slim` (multi-arch: amd64, arm64)
@@ -139,8 +139,8 @@ docker build -f docker/notebook/Dockerfile \
 **Best for:** Deep learning courses, CUDA-accelerated processing.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.8.2` (default)
-- `docker.io/mhoelzl/clm-notebook-processor:1.8.2-full`
+- `docker.io/mhoelzl/clm-notebook-processor:1.8.3` (default)
+- `docker.io/mhoelzl/clm-notebook-processor:1.8.3-full`
 - `docker.io/mhoelzl/clm-notebook-processor:latest`
 - `docker.io/mhoelzl/clm-notebook-processor:full`
 
@@ -172,7 +172,7 @@ docker build -f docker/notebook/Dockerfile -t docker.io/mhoelzl/clm-notebook-pro
 - .NET SDK 10.0 (C# and F# kernels)
 - Deno (TypeScript/JavaScript kernel)
 - Java JDK (Java kernel)
-- IJava 1.8.2 (Java Jupyter kernel)
+- IJava 1.8.3 (Java Jupyter kernel)
 - micromamba + xeus-cpp (C++ kernel)
 
 **Jupyter Kernels:**
@@ -223,12 +223,12 @@ The build scripts automatically set these arguments.
 All images use the Hub namespace (`docker.io/mhoelzl/clm-*`) for consistency:
 
 **PlantUML/DrawIO:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.8.2`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.8.3`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Notebook (with variants):**
-- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.8.2`, `:full`, `:1.8.2-full`
-- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.8.2-lite`
+- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.8.3`, `:full`, `:1.8.3-full`
+- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.8.3-lite`
 
 ### BuildKit Cache Mounts
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,6 +1,6 @@
 # CLM Architecture
 
-This document describes the current architecture of the CLM system (v1.8.2).
+This document describes the current architecture of the CLM system (v1.8.3).
 
 ## Overview
 
@@ -42,7 +42,7 @@ CLM is a course content processing system that converts educational materials (J
                          │
 ┌────────────────────────▼──────────────────────────────────┐
 │          clm.workers (Worker Implementations)              │
-│                                (v1.8.2)             │
+│                                (v1.8.3)             │
 │  ├── notebook/ (NotebookWorker, templates, processors)    │
 │  ├── plantuml/ (PlantUmlWorker, converter)                │
 │  └── drawio/ (DrawioWorker, converter)                    │
@@ -211,7 +211,7 @@ class Worker(ABC):
 
 ### Layer 3: Workers (Worker Implementations)
 
-**Purpose**: Concrete worker implementations for different file types (v1.8.2)
+**Purpose**: Concrete worker implementations for different file types (v1.8.3)
 
 Workers are now integrated into the main `clm` package under `clm.workers/`. Previously they were separate packages in the `services/` directory.
 
@@ -566,7 +566,7 @@ CLM has evolved significantly:
 - No message broker required
 - Reduced from 8 Docker services to 3
 
-**v0.6.2 → v1.8.2** (2025): Integrated workers
+**v0.6.2 → v1.8.3** (2025): Integrated workers
 - Workers integrated into main package (`clm.workers`)
 - Optional dependencies for each worker
 - Four-layer architecture (core, infrastructure, workers, cli)
@@ -1190,4 +1190,4 @@ Potential improvements (not currently planned):
 ---
 
 **Last Updated**: 2026-02-13
-**Version**: 1.8.2
+**Version**: 1.8.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-academy-lecture-manager"
-version = "1.8.2"
+version = "1.8.3"
 description = "Coding-Academy Lecture Manager - A course content processing system"
 authors = [
     {name = "Dr. Matthias Hölzl", email = "tc@xantira.com"},
@@ -404,7 +404,7 @@ ignore = [
 known-first-party = ["clm"]
 
 [tool.bumpversion]
-current_version = "1.8.2"
+current_version = "1.8.3"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/src/clm/__version__.py
+++ b/src/clm/__version__.py
@@ -1,3 +1,3 @@
 """Version information for CLM."""
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1009,7 +1009,7 @@ def _is_cpp_image_available() -> bool:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.8.2-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.8.3-full",
         ]:
             try:
                 client.images.get(tag)
@@ -1030,7 +1030,7 @@ def _get_full_image_name() -> str | None:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.8.2-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.8.3-full",
         ]:
             try:
                 client.images.get(tag)

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "coding-academy-lecture-manager"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Patch release **1.8.3**.

### Added
- `clm slides sync` reconciles a committed mismatched-id twin instead of only refusing it (#228, strategy B).

### Fixed
- Title-slide greeting voiceover survives `clm voiceover extract` (#242).
- `load_worker_config` no longer poisons the global config singleton (#223) — fixes an order-dependent CI flake.

Merge with a **merge commit** so the `Bump version: 1.8.2 → 1.8.3` commit is preserved and the release workflow auto-tags + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)