### PR TITLE
fix(voiceover): preserve exact voiceover position for title greetings (#246) and mid-group j2 cells (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A title-slide greeting voiceover now keeps its exact position across
+  `clm voiceover extract` → build / `inline` (#246).** Follow-up to #242, which
+  fixed the title greeting being *dropped*; this fixes it being *reordered*.
+  `extract` stamped the title voiceover with `for_slide="title"` but **no
+  `vo_anchor`** (its backward predecessor-walk skips the slide_id-less j2 title
+  macro), so on merge the greeting was appended at the **end** of the title
+  slide's cell group. When the greeting was authored *before* the title slide's
+  trailing `keep`/code cells, the built notebook therefore moved it after those
+  cells — content-preserving but not byte-identical to the inline build.
+  `extract` now records a title-macro anchor (`vo_anchor="tm:title#0"`) for a
+  title greeting with no content predecessor, and the merge / `inline` resolve it
+  to the title macro cell, restoring the greeting immediately after the title
+  slide. A greeting authored *after* a title-slide content cell anchors to that
+  cell as usual (`fp:`), and legacy companions with no `vo_anchor` keep the
+  previous group-end placement, so already-built decks are unaffected.
+
 ## [1.8.3] - 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **A voiceover authored after a mid-slide-group j2 cell now keeps its exact
+  position across `clm voiceover extract` → build / `inline` (#247).** A j2
+  macro cell (header `# {{ … }}` / `# j2 …` — e.g. an inline widget) embedded
+  between a slide's content and a following voiceover was an invisible anchor
+  barrier: `extract`'s predecessor-walk skipped j2 cells, so the voiceover was
+  anchored to the content cell *above* the macro and the build merge / `inline`
+  re-inserted it *before* the macro — content-preserving but not byte-identical,
+  and reported clean (no relocation, nothing unmatched). A mid-group j2 cell is
+  now an eligible positional anchor, matched by its body fingerprint (stable
+  because the companion merge runs *before* j2 expansion), so the voiceover
+  returns to its authored slot after the macro. The title-slide macro keeps its
+  dedicated `tm:title#0` anchor (#246), and legacy companions with no
+  `vo_anchor` are unaffected.
 - **A title-slide greeting voiceover now keeps its exact position across
   `clm voiceover extract` → build / `inline` (#246).** Follow-up to #242, which
   fixed the title greeting being *dropped*; this fixes it being *reordered*.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1688,7 +1688,12 @@ carries no `slide_id` of its own — is anchored by the conventional
 build merge and `clm voiceover inline` anchor it back to the title slide, so a
 title greeting round-trips and builds in companion form exactly as it does
 inline. Companions extracted before the fix (which carried `slide_id="title"`
-with no `for_slide`) still merge — no re-extract needed.
+with no `for_slide`) still merge — no re-extract needed. Since CLM {version}
+(#246), the greeting's **exact position** within the opening segment is also
+preserved: a greeting authored *before* the title slide's trailing `keep`/code
+cells gets a title-macro `vo_anchor` (`tm:title#0`) so the merge restores it
+right after the title slide rather than at the end of the title group. Legacy
+companions with no `vo_anchor` keep the group-end placement.
 
 **Paired extract (auto-pairing), since CLM {version}.** When `FILE` is a split
 half (`<deck>.de.py` / `<deck>.en.py`) whose twin exists on disk, both

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1723,6 +1723,13 @@ slide group. It is body-only and occurrence-qualified, so editing a
 sibling cell's tags, inserting unrelated slides, or the build's blank-line
 cleanup between extract and inline does not move the voiceover.
 
+Since CLM {version} (#247), a j2 macro cell embedded *mid* slide-group — an
+inline widget, say — is also an eligible anchor. A voiceover authored after
+such a cell anchors to it (by body fingerprint, which is stable because the
+companion merge runs *before* j2 expansion) and is restored to its slot
+*after* the macro, rather than being hoisted in front of it. The title-slide
+macro keeps its dedicated `tm:title#0` anchor (#246).
+
 Since CLM {version}, extract **refuses to overwrite an existing companion**
 unless `--force` is given (it raises rather than writing, leaving both files
 untouched). The companion is *rebuilt* from the slide's current voiceover

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -344,11 +344,25 @@ def _ensure_slide_ids(cells: list[_RawCell], path: Path, text: str) -> int:
 # ordinal — ``id:<sid>#<n>`` / ``fp:<hash>#<n>`` — meaning "the n-th cell
 # in the group matching this token". Resolution is always scoped to the
 # owning slide group; it never searches across groups.
+#
+# A third kind ``tm:title#0`` (the title-macro anchor) addresses the
+# macro-generated title slide directly. That slide is a j2 ``header`` macro
+# cell carrying no slide_id, so it can be neither ``id:``- nor ``fp:``-anchored
+# (j2 cells are excluded from anchor candidates). A title greeting authored
+# *before* the title slide's trailing continuation cells therefore has no
+# content predecessor; ``tm:title#0`` records "right after the title macro" so
+# the merge restores it at the start of the title group rather than the end
+# (#246). ``occ`` is always 0 — a deck has exactly one title macro.
 # ---------------------------------------------------------------------------
 
 _FOR_SLIDE_RE = re.compile(r'\s*for_slide="[^"]*"')
 _VO_ANCHOR_RE = re.compile(r'\s*vo_anchor="[^"]*"')
 _VO_ANCHOR_VALUE_RE = re.compile(r'vo_anchor="([^"]*)"')
+
+# The title-macro anchor (#246): kind ``tm`` resolves to the j2 title macro
+# cell itself rather than a content cell within a slide group.
+_TITLE_MACRO_KIND = "tm"
+_TITLE_MACRO_ANCHOR = f"{_TITLE_MACRO_KIND}:{TITLE_SLIDE_ID}#0"
 
 
 def _body_fingerprint(cell: _RawCell) -> str:
@@ -600,11 +614,26 @@ def _plan_extraction(
         if slide_id:
             pred_idx = _find_predecessor_index(cells, idx, vo_lang)
             bounds = _slide_group_bounds(cells, slide_id, vo_lang, id_map)
-            anchor = (
-                _anchor_token(cells, pred_idx, bounds, vo_lang)
-                if pred_idx is not None and bounds is not None
-                else None
-            )
+            # The predecessor must lie *within* the owning slide group for its
+            # anchor to resolve there at merge time. For non-title slides this
+            # always holds (the slide-start cell is itself an eligible
+            # predecessor). For the title slide the group starts at the j2 macro,
+            # which the predecessor walk skips over — so the walk can escape
+            # *upward* past the macro onto a cell authored before it (e.g. a
+            # top-of-deck import). Such a predecessor is out of group; anchoring
+            # to it would silently misplace the greeting at the group end on
+            # merge (#246). Fall back to the title-macro anchor instead.
+            anchor: str | None
+            if pred_idx is not None and bounds is not None and bounds[0] <= pred_idx < bounds[1]:
+                anchor = _anchor_token(cells, pred_idx, bounds, vo_lang)
+            elif slide_id == TITLE_SLIDE_ID and bounds is not None:
+                # The title greeting has no in-group content predecessor: its
+                # only predecessor is the slide_id-less j2 title macro (or a cell
+                # above it). Record a title-macro anchor so the merge restores it
+                # at the *start* of the title group rather than the end (#246).
+                anchor = _TITLE_MACRO_ANCHOR
+            else:
+                anchor = None
             new_header = _build_voiceover_header(vo_cell, slide_id, anchor)
             vo_cell.lines[0] = new_header
             vo_cell.metadata = parse_cell_header(new_header)
@@ -967,11 +996,24 @@ def _is_title_intent(for_slide: str | None, slide_id: str | None) -> bool:
     return for_slide is None and slide_id == TITLE_SLIDE_ID
 
 
+def _find_title_macro_index(cells: list[_RawCell]) -> int | None:
+    """Index of the j2 ``header`` title-macro cell, or ``None`` if absent.
+
+    The macro-generated title slide carries no ``slide_id``, so it never appears
+    in ``id_map``; this is how the title group is located instead (#242, #246).
+    A deck has at most one title macro, so the first match is returned.
+    """
+    for i, cell in enumerate(cells):
+        if is_title_macro_cell(cell):
+            return i
+    return None
+
+
 def _find_title_insertion_point(
     cells: list[_RawCell],
     vo_lang: str | None,
 ) -> int | None:
-    """Find where to insert a title-greeting voiceover.
+    """Find where to insert an *anchorless* title-greeting voiceover.
 
     The macro-generated title slide is the j2 ``header`` macro cell, which
     carries no ``slide_id`` — so :func:`_find_insertion_point` cannot resolve
@@ -979,17 +1021,18 @@ def _find_title_insertion_point(
     and walks forward over its (id-less, non-slide-start) continuation cells —
     mirroring the group-end logic of :func:`_find_insertion_point` — so the
     voiceover lands at the end of the title slide group, just before the first
-    real slide. That matches where an inline title greeting sits.
+    real slide.
+
+    This is the *fallback* for a title companion with no ``vo_anchor`` (legacy
+    pre-#242/#246 extracts, hand-authored cells). A freshly-extracted title
+    greeting now carries a ``tm:`` anchor recording its exact authored position
+    and is restored via :func:`_match_anchor`, so it never reaches here (#246).
 
     Returns the insert-after index, or ``None`` when the deck has no title
     macro (e.g. a mis-authored ``slide_id="title"`` with no header macro), in
     which case the caller reports the cell unmatched rather than guessing.
     """
-    start: int | None = None
-    for i, cell in enumerate(cells):
-        if is_title_macro_cell(cell):
-            start = i
-            break
+    start = _find_title_macro_index(cells)
     if start is None:
         return None
 
@@ -1034,6 +1077,11 @@ def _slide_group_bounds(
     """
     indices = id_map.get(for_slide)
     if not indices:
+        # The macro-generated title slide carries no slide_id, so it never
+        # appears in id_map. Resolve its group via the title macro cell so a
+        # title voiceover's anchor can be scoped to the title group (#246).
+        if for_slide == TITLE_SLIDE_ID:
+            return _title_group_bounds(cells, vo_lang)
         return None
 
     start: int | None = None
@@ -1045,6 +1093,35 @@ def _slide_group_bounds(
             start = idx
     if start is None:
         start = indices[0]
+
+    end = len(cells)
+    for i in range(start + 1, len(cells)):
+        meta = cells[i].metadata
+        if not meta.is_slide_start:
+            continue
+        if vo_lang is not None and meta.lang is not None and meta.lang != vo_lang:
+            continue
+        end = i
+        break
+    return start, end
+
+
+def _title_group_bounds(
+    cells: list[_RawCell],
+    vo_lang: str | None,
+) -> tuple[int, int] | None:
+    """Return ``(start, end)`` bounds of the macro-generated title slide group.
+
+    ``start`` is the j2 title macro cell; ``end`` is the index of the next
+    slide-start after it (exclusive, language-aware), or ``len(cells)``. The
+    title slide has no ``slide_id``, so this is the title analogue of the
+    ``id_map`` lookup in :func:`_slide_group_bounds`, used to scope a title
+    voiceover's anchor to the title group (#246). Returns ``None`` when the deck
+    has no title macro.
+    """
+    start = _find_title_macro_index(cells)
+    if start is None:
+        return None
 
     end = len(cells)
     for i in range(start + 1, len(cells)):
@@ -1100,8 +1177,17 @@ def _match_anchor(
     foreign slide that happens to share a body fingerprint. The whole-file
     best-effort is used only for an anchor with no ``for_slide`` at all
     (hand-authored companions).
+
+    The title-macro anchor (``tm:``, #246) is resolved directly to the j2 title
+    macro cell, independent of ``id_map`` / group bounds — the title slide has
+    no ``slide_id`` to scope by, and a title greeting recorded with this anchor
+    sits immediately after the macro. Returns ``None`` (caller falls back) when
+    the deck no longer has a title macro.
     """
     kind, value, occ = _split_anchor(anchor)
+
+    if kind == _TITLE_MACRO_KIND:
+        return _find_title_macro_index(cells)
 
     if for_slide:
         bounds = _slide_group_bounds(cells, for_slide, vo_lang, id_map)

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -373,8 +373,20 @@ def _body_fingerprint(cell: _RawCell) -> str:
     cleanup that ``extract`` applies to the whole slide text *after* the
     anchor is recorded. Trailing whitespace is stripped and the cell type
     is folded in to avoid markdown/code collisions.
+
+    A j2 cell carries its entire content on its header line ``lines[0]`` (the
+    ``# {{ ... }}`` / ``# j2 ...`` macro call); its ``lines[1:]`` are only
+    inter-cell blanks. So for a j2 cell the header *is* the body and must be
+    hashed — otherwise every j2 cell collapses to the same empty fingerprint
+    and two different macros become indistinguishable, leaving the occurrence
+    ordinal as the only (brittle) discriminator (#247). This is safe because
+    the companion merge runs host-side on the raw slide text *before* j2
+    expansion, so the macro call is byte-identical at extract and at merge
+    time. Content cells keep hashing only ``lines[1:]`` so a header-only edit
+    (e.g. adding a tag) never moves their voiceover.
     """
-    body_lines = [ln.rstrip() for ln in cell.lines[1:]]
+    src = cell.lines if cell.metadata.is_j2 else cell.lines[1:]
+    body_lines = [ln.rstrip() for ln in src]
     body_lines = [ln for ln in body_lines if ln]
     norm = "\n".join(body_lines)
     payload = f"{cell.metadata.cell_type}\x00{norm}"
@@ -398,15 +410,21 @@ def _anchor_candidates(
 ) -> list[int]:
     """Indices within ``bounds`` matching an anchor ``(kind, value)``.
 
-    Returned in document order. Narrative/j2 cells and cells of a
-    conflicting language are excluded so the occurrence ordinal counts the
-    same content cells at extract time and at inline time.
+    Returned in document order. Narrative cells (other voiceover/notes
+    cells) and cells of a conflicting language are excluded so the
+    occurrence ordinal counts the same cells at extract time and at inline
+    time. A j2 cell *is* eligible: a voiceover authored after a mid-group j2
+    cell (e.g. an inline widget macro) anchors to it via an ``fp:`` body
+    fingerprint, and the host-side merge runs *before* j2 expansion so that
+    fingerprint is stable (#247). The title macro never resolves here — it
+    carries the dedicated ``tm:`` anchor (#246), matched separately — so its
+    presence among the candidates is harmless.
     """
     lo, hi = bounds
     out: list[int] = []
     for i in range(lo, hi):
         meta = cells[i].metadata
-        if meta.is_narrative or meta.is_j2:
+        if meta.is_narrative:
             continue
         if vo_lang and meta.lang and meta.lang != vo_lang:
             continue
@@ -429,7 +447,15 @@ def _anchor_token(
     predecessor's position among same-token candidates in that group, so a
     voiceover after the second of two identical cells resolves back to the
     second, not the first.
+
+    The j2 title macro is anchored with its dedicated, content-independent
+    ``tm:`` token (#246) rather than a fingerprint of its ``header(...)`` call,
+    so a title greeting sitting directly under the macro restores to the start
+    of the title group regardless of the title text. Every *other* j2 cell (an
+    inline widget macro, say) gets an ordinary ``fp:`` anchor (#247).
     """
+    if is_title_macro_cell(cells[pred_idx]):
+        return _TITLE_MACRO_ANCHOR
     kind, value = _anchor_key(cells[pred_idx])
     candidates = _anchor_candidates(cells, bounds, kind, value, vo_lang)
     occ = candidates.index(pred_idx) if pred_idx in candidates else 0
@@ -458,16 +484,21 @@ def _find_predecessor_index(
     voiceover_idx: int,
     vo_lang: str | None,
 ) -> int | None:
-    """Index of the content cell immediately preceding a voiceover cell.
+    """Index of the cell immediately preceding a voiceover cell.
 
-    Walks backward over j2 and narrative cells (other voiceover/notes
-    cells) and over cells of a conflicting language, returning the first
-    real content cell. Returns ``None`` if the voiceover has no content
-    cell above it.
+    Walks backward over narrative cells (other voiceover/notes cells) and
+    over cells of a conflicting language, returning the first cell that can
+    serve as a positional anchor. A j2 cell *is* eligible: a voiceover
+    authored after a mid-group j2 macro must anchor to it, not skip over it
+    onto the content cell above — otherwise the merge re-inserts the
+    voiceover *before* the j2 and the round-trip is not byte-identical
+    (#247). The title macro is one such j2 cell and is given the dedicated
+    ``tm:`` anchor by :func:`_anchor_token` (#246). Returns ``None`` if the
+    voiceover has no eligible cell above it.
     """
     for i in range(voiceover_idx - 1, -1, -1):
         meta = cells[i].metadata
-        if meta.is_j2 or meta.is_narrative:
+        if meta.is_narrative:
             continue
         if meta.lang is not None and vo_lang is not None and meta.lang != vo_lang:
             continue
@@ -959,15 +990,17 @@ def _find_insertion_point(
         best = indices[-1]
 
     # Walk forward from `best` to skip any non-voiceover continuation cells
-    # that belong to the same slide group (e.g., code cells after a slide)
+    # that belong to the same slide group (e.g., code cells after a slide).
+    # A mid-group j2 cell (an inline widget macro) is also a continuation: it
+    # carries no slide_id and is not a slide-start, so the group only ends at
+    # the next slide-start. Breaking at it would strand a group-end fallback
+    # before the j2 instead of after it (#247).
     insert_after = best
     for i in range(best + 1, len(cells)):
         cell = cells[i]
         if cell.metadata.is_narrative:
             break
         if cell.metadata.is_slide_start:
-            break
-        if cell.metadata.is_j2:
             break
         # If this cell has a different slide_id, stop
         if cell.metadata.slide_id and cell.metadata.slide_id != slide_id:
@@ -1043,14 +1076,16 @@ def _find_title_insertion_point(
             break
         if meta.is_slide_start:
             break
-        if meta.is_j2:
-            break
         # A continuation cell carrying its own slide_id belongs to a later
         # slide group (the title group has none of its own), so stop.
         if meta.slide_id:
             break
         if vo_lang and meta.lang and meta.lang != vo_lang:
             break
+        # A mid-title-group j2 cell (e.g. a widget on the title slide) is a
+        # continuation, not a boundary: walk over it so an anchorless title
+        # greeting still lands at the true group end rather than before it
+        # (#247).
         insert_after = i
 
     return insert_after

--- a/tests/slides/test_voiceover_tools.py
+++ b/tests/slides/test_voiceover_tools.py
@@ -2271,3 +2271,268 @@ class TestAnchorAmbiguityAndScoping:
         out, res = _round_trip(tmp_path, deck)
         assert res.relocated_cells == 0
         _assert_order(out, "b = 2", "VO after the multi-blank cell.", "trailing = 99")
+
+
+# ---------------------------------------------------------------------------
+# #247 — a j2 cell embedded mid-slide-group is no longer an invisible anchor
+# barrier. A voiceover authored after such a cell (e.g. an inline widget macro)
+# must anchor *to* the j2 cell, so extract/merge/inline restore its exact
+# position instead of re-inserting it before the j2.
+# ---------------------------------------------------------------------------
+
+
+def _anchor_for_body(comp: Path, needle: str) -> str | None:
+    """The ``vo_anchor`` token of the companion cell whose body contains ``needle``."""
+    for cell in parse_cells(comp.read_text(encoding="utf-8")):
+        if needle in cell.content:
+            m = re.search(r'vo_anchor="([^"]*)"', cell.header)
+            return m.group(1) if m else None
+    return None
+
+
+# A real j2 cell header must start with ``# {{ `` or ``# j2 ``; ``widget(...)``
+# stands in for any inline macro a deck might embed between content and its
+# voiceover.
+J2_MID_GROUP_DECK = """\
+# %% [markdown] lang="de" tags=["slide"] slide_id="real"
+# ## Real
+
+# {{ widget("demo") }}
+
+# %% [markdown] lang="de" tags=["voiceover"] slide_id="real"
+# VO after the widget.
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="next"
+# ## Next
+"""
+
+
+class TestMidGroupJ2Anchor:
+    """#247 — mid-group j2 cells are anchorable predecessors / insert targets."""
+
+    def test_extract_anchors_voiceover_to_mid_group_j2(self, tmp_path: Path):
+        """The recorded anchor is an ``fp:`` of the j2 cell, not the content
+        cell above it. The old predecessor walk skipped the j2 and mis-anchored
+        to the heading, so the merge hoisted the voiceover above the j2."""
+        f = tmp_path / "slides_w.py"
+        f.write_text(J2_MID_GROUP_DECK, encoding="utf-8", newline="\n")
+
+        extract_voiceover(f)
+
+        anchor = _anchor_for_body(companion_path(f), "VO after the widget.")
+        assert anchor is not None and anchor.startswith("fp:")
+
+    def test_merge_keeps_voiceover_after_mid_group_j2(self, tmp_path: Path):
+        """The build path (merge) restores the voiceover after the j2 widget,
+        byte-identically, with no anchor leak."""
+        f = tmp_path / "slides_w.py"
+        f.write_text(J2_MID_GROUP_DECK, encoding="utf-8", newline="\n")
+        extract_voiceover(f)
+
+        merged, unmatched = merge_voiceover_text(
+            f.read_text(encoding="utf-8"), companion_path(f).read_text(encoding="utf-8")
+        )
+
+        assert unmatched == []
+        assert "vo_anchor" not in merged
+        _assert_order(merged, "## Real", 'widget("demo")', "VO after the widget.", "## Next")
+        assert _strip_for_slide(merged).strip() == J2_MID_GROUP_DECK.strip()
+
+    def test_inline_round_trip_with_mid_group_j2_byte_identical(self, tmp_path: Path):
+        """extract -> inline restores the deck exactly (the voiceover already
+        carries its slide_id, so extract adds nothing) and reports no
+        relocation."""
+        f = tmp_path / "slides_w.py"
+        f.write_text(J2_MID_GROUP_DECK, encoding="utf-8", newline="\n")
+
+        extract_voiceover(f)
+        res = inline_voiceover(f)
+
+        assert res.relocated_cells == 0
+        assert res.unmatched_cells == 0
+        assert res.companion_deleted
+        assert f.read_text(encoding="utf-8") == J2_MID_GROUP_DECK
+
+    def test_voiceovers_around_mid_group_j2_keep_order(self, tmp_path: Path):
+        """``content / VO_A / j2 widget / VO_B``: VO_A anchors to the heading,
+        VO_B to the widget, so both keep their slots across the round-trip."""
+        deck = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## Slide\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO before the widget.\n\n'
+            '# {{ widget("demo") }}\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO after the widget.\n\n'
+            '# %% tags=["keep"]\nx = 1\n'
+        )
+        out, res = _round_trip(tmp_path, deck)
+
+        assert res.relocated_cells == 0
+        _assert_order(
+            out,
+            "## Slide",
+            "VO before the widget.",
+            'widget("demo")',
+            "VO after the widget.",
+            "x = 1",
+        )
+
+    def test_duplicate_mid_group_j2_occ_disambiguates(self, tmp_path: Path):
+        """Two identical j2 widgets in one group: a VO after the second anchors
+        to the second via the occurrence ordinal, not the first — proving the
+        ordinal counts j2 cells consistently at extract and merge time."""
+        deck = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## Slide\n\n'
+            '# {{ widget("x") }}\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO after the FIRST widget.\n\n'
+            '# {{ widget("x") }}\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n# VO after the SECOND widget.\n'
+        )
+        out, res = _round_trip(tmp_path, deck)
+
+        assert res.relocated_cells == 0
+        w1 = out.index('widget("x")')
+        w2 = out.index('widget("x")', w1 + 1)
+        v1 = out.index("VO after the FIRST widget.")
+        v2 = out.index("VO after the SECOND widget.")
+        assert w1 < v1 < w2 < v2
+
+    def test_legacy_anchorless_voiceover_lands_after_mid_group_j2(self):
+        """A *legacy* companion (``for_slide``, no ``vo_anchor``) for a slide
+        with a mid-group j2 now lands at the true group end — after the j2 —
+        rather than being stranded before it. The group-end fallback no longer
+        breaks on a j2 continuation cell (#247)."""
+        slide = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="real"\n# ## Real\n\n'
+            '# {{ widget("demo") }}\n\n'
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="next"\n# ## Next\n'
+        )
+        legacy = '# %% [markdown] lang="de" tags=["voiceover"] for_slide="real"\n# Legacy VO.\n'
+
+        merged, unmatched = merge_voiceover_text(slide, legacy)
+
+        assert unmatched == []
+        _assert_order(merged, "## Real", 'widget("demo")', "Legacy VO.", "## Next")
+
+    def test_title_greeting_under_macro_still_uses_tm_anchor(self, tmp_path: Path):
+        """The j2 title macro is now an eligible predecessor (it is a j2 cell),
+        yet it keeps its dedicated ``tm:`` anchor — not an ``fp:`` of the
+        ``header()`` call — so the #246 title behaviour is preserved. This guards
+        the interaction between the #247 j2-aware walk and the #246 macro anchor.
+        """
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(TITLE_BEFORE_KEEP_EN, encoding="utf-8")
+
+        extract_voiceover(slide, force=True)
+
+        comp = slide.with_name("voiceover_015.en.py")
+        assert _vo_anchor_of(comp) == "tm:title#0"
+
+    def test_title_slide_widget_after_macro_anchors_via_fp(self, tmp_path: Path):
+        """A j2 widget on the title slide (after the header macro) followed by a
+        greeting: the greeting anchors to the *widget* via ``fp:`` (the widget is
+        not the title macro) and round-trips — exercising the now-j2-aware title
+        group bounds and candidate set."""
+        deck = """\
+# j2 from 'macros.j2' import header_en
+# {{ header_en("T") }}
+
+# {{ widget("demo") }}
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="title"
+# - Greeting after widget.
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="real"
+# - Real
+"""
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(deck, encoding="utf-8")
+
+        extract_voiceover(slide, force=True)
+        comp = slide.with_name("voiceover_015.en.py")
+        anchor = _vo_anchor_of(comp)
+        assert anchor is not None and anchor.startswith("fp:")
+
+        merged, unmatched = merge_voiceover_text(
+            slide.read_text(encoding="utf-8"), comp.read_text(encoding="utf-8")
+        )
+        assert unmatched == []
+        _assert_order(
+            merged,
+            'header_en("T")',
+            'widget("demo")',
+            "Greeting after widget.",
+            "- Real",
+        )
+        assert _strip_for_slide(merged).strip() == deck.strip()
+
+    def test_inserting_different_j2_above_anchor_does_not_misplace(self, tmp_path: Path):
+        """A j2 anchor must track its *specific* macro across edits, not degrade
+        to 'the N-th j2 cell'. Inserting an unrelated j2 cell above the anchored
+        widget between extract and the build merge must not hoist the voiceover
+        in front of its true predecessor — the fingerprint folds in the j2
+        header so distinct macros get distinct anchors (#247)."""
+        deck = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## S\n\n'
+            '# {{ realwidget("anchor") }}\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="s"\n# VO for the REAL widget.\n\n'
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="next"\n# ## Next\n'
+        )
+        f = tmp_path / "slides_e.py"
+        f.write_text(deck, encoding="utf-8", newline="\n")
+        extract_voiceover(f)
+        comp = companion_path(f).read_text(encoding="utf-8")
+
+        # Author inserts an unrelated j2 widget ABOVE the anchored one.
+        edited = f.read_text(encoding="utf-8").replace(
+            '# {{ realwidget("anchor") }}',
+            '# {{ newwidget("inserted") }}\n\n# {{ realwidget("anchor") }}',
+        )
+        merged, unmatched = merge_voiceover_text(edited, comp)
+
+        assert unmatched == []
+        # The voiceover stays after its OWN widget, not the freshly-inserted one.
+        _assert_order(
+            merged,
+            'newwidget("inserted")',
+            'realwidget("anchor")',
+            "VO for the REAL widget.",
+            "## Next",
+        )
+
+    def test_reordering_distinct_j2_widgets_does_not_swap_narration(self, tmp_path: Path):
+        """Two distinct widgets, each with its own voiceover: swapping the
+        widgets between extract and inline moves each narration WITH its widget
+        rather than leaving them pinned by ordinal. Guards the shared-fingerprint
+        defect the #247 review caught (all j2 cells once hashed identically)."""
+        deck = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="s"\n# ## S\n\n'
+            '# {{ widget("alpha") }}\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="s"\n# VO for ALPHA.\n\n'
+            '# {{ widget("beta") }}\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="s"\n# VO for BETA.\n'
+        )
+        f = tmp_path / "slides_r.py"
+        f.write_text(deck, encoding="utf-8", newline="\n")
+        extract_voiceover(f)
+
+        # Swap the two widgets in the (voiceover-stripped) slide file.
+        sentinel = "@@SWAP@@"
+        t = f.read_text(encoding="utf-8")
+        t = (
+            t.replace('# {{ widget("alpha") }}', sentinel)
+            .replace('# {{ widget("beta") }}', '# {{ widget("alpha") }}')
+            .replace(sentinel, '# {{ widget("beta") }}')
+        )
+        f.write_text(t, encoding="utf-8", newline="\n")
+
+        res = inline_voiceover(f)
+        out = f.read_text(encoding="utf-8")
+
+        assert res.unmatched_cells == 0
+        # Each narration tracks its widget across the swap (not swapped by ordinal).
+        _assert_order(
+            out,
+            'widget("beta")',
+            "VO for BETA.",
+            'widget("alpha")',
+            "VO for ALPHA.",
+        )

--- a/tests/slides/test_voiceover_tools.py
+++ b/tests/slides/test_voiceover_tools.py
@@ -899,10 +899,57 @@ TITLE_SLIDE_BILINGUAL = """\
 """
 
 
+# #246 — a title greeting authored *before* the title slide's trailing
+# ``keep``/code cells. The greeting's only predecessor is the slide_id-less j2
+# title macro, so it must be anchored to the macro (``tm:``) and restored at the
+# *start* of the title group, not dumped at the end.
+TITLE_BEFORE_KEEP_EN = """\
+# j2 from 'macros.j2' import header_en
+# {{ header_en("LangChain Tracing with LangSmith") }}
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="title"
+# - Welcome back!
+
+# %% tags=["keep"]
+import os
+
+# %% tags=["keep"]
+from langchain_core.messages import HumanMessage
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="what-is-langsmith"
+# - What Is LangSmith?
+"""
+
+# The same deck but with the greeting authored *after* a trailing ``keep`` cell:
+# its predecessor is a real content cell, so a normal ``fp:`` anchor restores it.
+TITLE_AFTER_KEEP_EN = """\
+# j2 from 'macros.j2' import header_en
+# {{ header_en("LangChain Tracing with LangSmith") }}
+
+# %% tags=["keep"]
+import os
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="title"
+# - Welcome back!
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="what-is-langsmith"
+# - What Is LangSmith?
+"""
+
+
 def _strip_for_slide(text: str) -> str:
     """Drop the ``for_slide`` attribute — the build worker strips it from output,
     so this is how we compare extract+merge against the inline-authored source."""
     return re.sub(r'\s*for_slide="[^"]*"', "", text)
+
+
+def _vo_anchor_of(comp: Path) -> str | None:
+    """The ``vo_anchor`` token on the companion's title voiceover cell, if any."""
+    for cell in parse_cells(comp.read_text(encoding="utf-8")):
+        if cell.metadata.is_narrative and cell.metadata.for_slide == "title":
+            m = re.search(r'vo_anchor="([^"]*)"', cell.header)
+            return m.group(1) if m else None
+    return None
 
 
 class TestTitleGreetingVoiceover:
@@ -1062,6 +1109,141 @@ agenda = 1
         assert unmatched == []
         assert merged.index("agenda = 1") < merged.index("Greeting.")
         assert merged.index("Greeting.") < merged.index("first-real-slide")
+
+    # -- #246: title greeting authored before trailing keep cells ----------
+
+    def test_extract_title_before_keep_emits_macro_anchor(self, tmp_path: Path):
+        """A title greeting with no content predecessor (authored before the
+        title slide's keep cells) is stamped with the ``tm:`` title-macro anchor
+        so the merge can restore its position rather than appending at the end of
+        the title group (#246)."""
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(TITLE_BEFORE_KEEP_EN, encoding="utf-8")
+
+        extract_voiceover(slide, force=True)
+
+        comp = slide.with_name("voiceover_015.en.py")
+        assert _vo_anchor_of(comp) == "tm:title#0"
+
+    def test_extract_then_merge_title_before_keep_byte_identical(self, tmp_path: Path):
+        """#246 acceptance (build path): extract + the build merge restore the
+        greeting to its authored slot — immediately after the title slide and
+        *before* the trailing keep cells — byte-identically."""
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(TITLE_BEFORE_KEEP_EN, encoding="utf-8")
+        extract_voiceover(slide, force=True)
+        comp = slide.with_name("voiceover_015.en.py")
+
+        merged, unmatched = merge_voiceover_text(
+            slide.read_text(encoding="utf-8"), comp.read_text(encoding="utf-8")
+        )
+
+        assert unmatched == []
+        # Greeting immediately after the title slide, before the keep cells.
+        assert merged.index("Welcome back") < merged.index("import os")
+        assert _strip_for_slide(merged).strip() == TITLE_BEFORE_KEEP_EN.strip()
+
+    def test_extract_then_inline_title_before_keep_byte_identical(self, tmp_path: Path):
+        """#246 acceptance (inline path): extract then inline restores the deck
+        exactly, with the greeting back before the keep cells and no relocation
+        reported."""
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(TITLE_BEFORE_KEEP_EN, encoding="utf-8")
+
+        extract_voiceover(slide, force=True)
+        result = inline_voiceover(slide)
+
+        assert result.unmatched_cells == 0
+        assert result.relocated_cells == 0
+        assert result.companion_deleted
+        assert slide.read_text(encoding="utf-8").strip() == TITLE_BEFORE_KEEP_EN.strip()
+
+    def test_extract_title_after_keep_roundtrips_via_fp_anchor(self, tmp_path: Path):
+        """A greeting authored *after* a keep cell has a real content predecessor,
+        so it gets an ``fp:`` anchor (not ``tm:``) and still round-trips exactly —
+        the title-group bounds now resolve for the slide_id-less title slide."""
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(TITLE_AFTER_KEEP_EN, encoding="utf-8")
+
+        extract_voiceover(slide, force=True)
+        comp = slide.with_name("voiceover_015.en.py")
+        anchor = _vo_anchor_of(comp)
+        assert anchor is not None and anchor.startswith("fp:")
+
+        merged, unmatched = merge_voiceover_text(
+            slide.read_text(encoding="utf-8"), comp.read_text(encoding="utf-8")
+        )
+        assert unmatched == []
+        assert merged.index("import os") < merged.index("Welcome back")
+        assert _strip_for_slide(merged).strip() == TITLE_AFTER_KEEP_EN.strip()
+
+    def test_legacy_anchorless_title_before_keep_unchanged(self):
+        """A *legacy* companion (``for_slide="title"`` with no ``vo_anchor``) keeps
+        the documented group-end fallback even when the title slide has trailing
+        cells — the #246 fix only affects freshly-extracted, anchored companions,
+        so already-built decks are unaffected."""
+        slide = """\
+# j2 from 'macros.j2' import header_en
+# {{ header_en("T") }}
+
+# %% tags=["keep"]
+import os
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="real"
+# - Real
+"""
+        legacy = '# %% [markdown] lang="en" tags=["voiceover"] for_slide="title"\n# - Greeting.\n'
+        merged, unmatched = merge_voiceover_text(slide, legacy)
+
+        assert unmatched == []
+        # No anchor to honour → falls back to the end of the title group.
+        assert merged.index("import os") < merged.index("Greeting.")
+        assert merged.index("Greeting.") < merged.index("real")
+
+    def test_extract_title_with_cell_before_macro_uses_macro_anchor(self, tmp_path: Path):
+        """A content cell authored *before* the j2 title macro (e.g. a top-of-deck
+        import) is out of the title group. The predecessor walk skips the macro
+        and would otherwise land on that out-of-group cell, producing an ``fp:``
+        anchor that silently can't resolve within the title bounds at merge —
+        dumping the greeting at the group end. The title greeting must instead get
+        the ``tm:`` macro anchor and round-trip byte-identically (#246 regression
+        of the fix itself)."""
+        deck = """\
+# %% tags=["keep"]
+import preamble
+
+# j2 from 'macros.j2' import header_en
+# {{ header_en("Title") }}
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="title"
+# - Welcome!
+
+# %% tags=["keep"]
+import os
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="what-is-langsmith"
+# - What Is LangSmith?
+"""
+        slide = tmp_path / "slides_015.en.py"
+        slide.write_text(deck, encoding="utf-8")
+
+        extract_voiceover(slide, force=True)
+        comp = slide.with_name("voiceover_015.en.py")
+        assert _vo_anchor_of(comp) == "tm:title#0"
+
+        merged, unmatched = merge_voiceover_text(
+            slide.read_text(encoding="utf-8"), comp.read_text(encoding="utf-8")
+        )
+        assert unmatched == []
+        # Greeting after the macro, before the *in-group* trailing keep cell.
+        assert merged.index("Welcome!") < merged.index("import os")
+        assert _strip_for_slide(merged).strip() == deck.strip()
+
+        # And the inline round-trip restores it exactly, no relocation.
+        result = inline_voiceover(slide)
+        assert result.relocated_cells == 0
+        assert result.unmatched_cells == 0
+        assert slide.read_text(encoding="utf-8").strip() == deck.strip()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two stacked fixes to the voiceover positional-anchor machinery (`vo_anchor`, #199). Both close their own issue; #247 builds on #246's `tm:` anchor, so they ship together. Neither was on `master`.

## #246 — title-slide greeting reordered after `extract`
`extract` stamped a title greeting with `for_slide="title"` but **no `vo_anchor`** (the predecessor-walk skips the slide_id-less j2 title macro), so on merge the greeting was appended at the **end** of the title group. A greeting authored *before* the title slide's trailing `keep`/code cells therefore moved after them — content-preserving but not byte-identical to the inline build.

Fix: a third anchor kind `tm:title#0` records the title-macro position directly; merge/`inline` resolve it to the macro cell, restoring the greeting immediately after the title slide. A greeting authored *after* a title-slide content cell anchors to that cell (`fp:`) as before; legacy anchorless companions keep the group-end fallback.

## #247 — a mid-slide-group j2 cell was an invisible anchor barrier
A j2 cell embedded mid-group (e.g. an inline `# {{ widget(...) }}` macro) was skipped by `extract`'s backward walk and broke the forward insert-scans, so a voiceover authored *after* it anchored to the content cell *above* it and merge/`inline` re-inserted it *before* the j2 — reordered, reported clean (`relocated=0`, `unmatched=[]`).

Fix: mid-group j2 cells are now eligible positional anchors (`_find_predecessor_index`, `_find_insertion_point`, `_find_title_insertion_point` no longer skip/break on `is_j2`; `_anchor_candidates` includes them). The title macro keeps its dedicated `tm:title#0` anchor; every other j2 cell gets an ordinary `fp:` anchor.

### Fingerprint landmine (found by adversarial review)
`_body_fingerprint` hashed only `cell.lines[1:]`, but a j2 cell's whole content is its header line `lines[0]` — so **every** j2 cell hashed to the same value, making a j2 `fp:` anchor positional-only and silently misplacing a voiceover when an unrelated j2 cell was inserted/reordered in the group between extract and merge. Fixed by hashing `cell.lines` (header included) for j2 cells, while content cells keep hashing `lines[1:]` (header-only edits like adding a tag still never move their voiceover). Stable because the host-side companion merge runs *before* j2 expansion.

## Testing & review
- New regression tests: `TestTitleGreetingVoiceover` (#246) and `TestMidGroupJ2Anchor` (#247, incl. two edit-survival cases — insert-a-different-j2 and reorder-distinct-widgets).
- **1402 passed, 2 skipped** across `tests/slides/` + `tests/notebooks/`; ruff + mypy clean; pre-push fast suite green.
- Two-round adversarial multi-agent review: round 1 found and verified the fingerprint bug (fixed); round 2 came back dry.
- `CHANGELOG.md` and the `vo_anchor` info topic (`commands.md`) updated.

Closes #246
Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)