### PR TITLE
feat(slides): generalize authoring tooling to C#/C++/Java/TS (comment-token; Problem A)

### DIFF
--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -101,6 +101,28 @@ if TYPE_CHECKING:
 CACHE_DB_NAME = "clm-llm.sqlite"
 
 
+def _resolve_prog_lang(path: Path) -> str:
+    """The deck's programming language for the translator prompt.
+
+    Resolves from a file's extension, or (batch mode) from the first deck found
+    under a directory. Falls back to ``"python"`` when unresolvable — the prompt
+    descriptors then degrade gracefully.
+    """
+    from clm.core.topic_resolver import find_slide_files_recursive
+    from clm.infrastructure.utils.path_utils import path_to_prog_lang
+
+    try:
+        target = path
+        if path.is_dir():
+            decks = find_slide_files_recursive(path)
+            if not decks:
+                return "python"
+            target = decks[0]
+        return path_to_prog_lang(target)
+    except (KeyError, ValueError):
+        return "python"
+
+
 def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
     """Validate the two positional paths are the DE/EN halves of one split deck,
     auto-correcting a swapped order, and return them as ``(de, en)``.
@@ -462,7 +484,9 @@ def slides_sync_cmd(
             cache_dir=cache_dir,
             provider_available=provider_available,
             make_judge=lambda: _resolve_judge(provider, llm_model, ollama_url, llm_timeout),
-            make_translator=lambda: OpenRouterSlideTranslator(model=translation_model),
+            make_translator=lambda: OpenRouterSlideTranslator(
+                model=translation_model, prog_lang=_resolve_prog_lang(de_path)
+            ),
             make_recoverer=lambda: _resolve_recoverer(llm_recover, recovery_model),
             make_verifier=lambda: _resolve_verifier(verify_enabled),
         )
@@ -528,7 +552,9 @@ def slides_sync_cmd(
         elif interactive:
             mode = "interactive"
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
-            translator = OpenRouterSlideTranslator(model=translation_model)
+            translator = OpenRouterSlideTranslator(
+                model=translation_model, prog_lang=_resolve_prog_lang(de_path)
+            )
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
             verifier = _resolve_verifier(verify_enabled)
             for issue in plan.issues:
@@ -548,7 +574,9 @@ def slides_sync_cmd(
         else:
             mode = "apply"
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
-            translator = OpenRouterSlideTranslator(model=translation_model)
+            translator = OpenRouterSlideTranslator(
+                model=translation_model, prog_lang=_resolve_prog_lang(de_path)
+            )
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
             verifier = _resolve_verifier(verify_enabled)
             apply_result = apply_plan(

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -1,7 +1,7 @@
 """``clm slides sync`` — single-language authoring sync for split decks.
 
 Issue #166. After an author edits **one** half of a split-format deck pair
-(``<deck>.de.py`` / ``<deck>.en.py``, the layout produced by
+(``<deck>.de.<ext>`` / ``<deck>.en.<ext>``, the layout produced by
 ``clm slides split``), this command brings the *other* half into sync in a
 single pass: edits are propagated, brand-new slides are translated and inserted,
 removed slides are dropped, reorders are mirrored, and a shared ``slide_id`` is
@@ -138,14 +138,14 @@ def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
     if de_path == en_path:
         raise click.UsageError(
             f"DE_PATH and EN_PATH are the same file ({de_path}); pass the two "
-            "halves of a split deck — <deck>.de.py and <deck>.en.py."
+            "halves of a split deck — <deck>.de.<ext> and <deck>.en.<ext>."
         )
     de_tag, en_tag = split_lang_tag(de_path), split_lang_tag(en_path)
     if de_tag is None or en_tag is None:
         bad = de_path if de_tag is None else en_path
         raise click.UsageError(
             f"{bad} is not a split-format slide half. `clm slides sync` expects "
-            "two paths named <deck>.de.py and <deck>.en.py "
+            "two paths named <deck>.de.<ext> and <deck>.en.<ext> "
             "(run `clm slides split <deck>.py` to produce them)."
         )
     if de_tag == en_tag:
@@ -169,9 +169,9 @@ def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
 
 def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Path]:
     """Single-path contract: when EN_PATH is omitted, derive the second half from
-    DE_PATH so the author can run ``clm slides sync <deck>.de.py``.
+    DE_PATH so the author can run ``clm slides sync <deck>.de.<ext>``.
 
-    DE_PATH may be **one half** (``<deck>.de.py`` / ``<deck>.en.py``) — the twin
+    DE_PATH may be **one half** (``<deck>.de.<ext>`` / ``<deck>.en.<ext>``) — the twin
     is derived from disk — or a **bilingual deck stem** (``<deck>.py``, no
     ``.de``/``.en`` tag) whose two halves both exist. Derivation is prefix-agnostic
     (so ``apis.de.py`` works) and the resolved pair is still funnelled through
@@ -189,8 +189,8 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
             if de_path.name.startswith("voiceover_"):
                 raise click.UsageError(
                     f"{de_path.name} is a voiceover companion, not a deck half; "
-                    f"`clm slides sync` reconciles slide decks (<deck>.de.py / "
-                    f"<deck>.en.py), not their voiceover companions."
+                    f"`clm slides sync` reconciles slide decks (<deck>.de.<ext> / "
+                    f"<deck>.en.<ext>), not their voiceover companions."
                 )
             other = "EN" if tag == "de" else "DE"
             raise click.UsageError(
@@ -208,7 +208,7 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
         ext = de_path.suffix
         stem = de_path.name[: -len(ext)] if ext else de_path.name
         raise click.UsageError(
-            f"{de_path.name} is neither a split half (<deck>.de.py / <deck>.en.py) "
+            f"{de_path.name} is neither a split half (<deck>.de.<ext> / <deck>.en.<ext>) "
             f"nor a deck stem with both halves present (expected {stem}.de{ext} and "
             f"{stem}.en{ext} on disk). Pass the two halves explicitly."
         )
@@ -403,9 +403,9 @@ def slides_sync_cmd(
     """Bring a split DE/EN deck pair into sync after editing one side.
 
     DE_PATH and EN_PATH are the two halves of a split-format deck
-    (``<deck>.de.py`` and ``<deck>.en.py``). EN_PATH is **optional**: pass just
+    (``<deck>.de.<ext>`` and ``<deck>.en.<ext>``). EN_PATH is **optional**: pass just
     one half (or the bilingual deck stem ``<deck>.py``) and the other half is
-    derived from disk — ``clm slides sync slides_x.de.py`` syncs the pair.
+    derived from disk — ``clm slides sync slides_x.de.<ext>`` syncs the pair.
 
     \b
     DE_PATH may also be a **directory** — batch mode: every ``.de``/``.en`` deck

--- a/src/clm/cli/commands/slides_translate.py
+++ b/src/clm/cli/commands/slides_translate.py
@@ -1,7 +1,7 @@
 """``clm slides translate`` (alias ``bootstrap``) — full-deck cold-start translation.
 
 Issue #232. When an author writes a deck in a **single** language (only
-``slides_x.de.py``), this command synthesizes the other-language split half as a
+``slides_x.de.<ext>``), this command synthesizes the other-language split half as a
 complete translation of the whole deck — the cold start that ``clm slides sync``
 deliberately refuses to perform (``sync`` only fills per-cell gaps inside an
 *already-existing* pair).
@@ -91,7 +91,7 @@ def _make_translator(
     default=None,
     help=(
         "Target language. Default: the opposite of SOURCE's .de/.en tag "
-        "(slides_x.de.py → en). Override when a source mixes/omits lang tags."
+        "(slides_x.de.<ext> → en). Override when a source mixes/omits lang tags."
     ),
 )
 @click.option(
@@ -172,8 +172,8 @@ def slides_translate_cmd(
 ) -> None:
     """Translate a single-language deck SOURCE into its other-language split half.
 
-    SOURCE is one half of a split deck (``slides_x.de.py`` or ``slides_x.en.py``).
-    The matching ``slides_x.en.py`` / ``slides_x.de.py`` is synthesized as a full
+    SOURCE is one half of a split deck (``slides_x.de.<ext>`` or ``slides_x.en.<ext>``).
+    The matching ``slides_x.en.<ext>`` / ``slides_x.de.<ext>`` is synthesized as a full
     translation; a voiceover companion is translated in lockstep. Run
     ``clm slides unify`` afterward for a bilingual file, or just keep editing the
     halves and ``clm slides sync`` them.

--- a/src/clm/cli/commands/slides_translate.py
+++ b/src/clm/cli/commands/slides_translate.py
@@ -46,6 +46,7 @@ from clm.infrastructure.llm.openrouter_client import (
     DEFAULT_SYNC_JUDGE_MODEL,
     has_openrouter_api_key,
 )
+from clm.infrastructure.utils.path_utils import path_to_prog_lang
 from clm.slides.sync_translate import (
     DEFAULT_TRANSLATION_MODEL,
     CachingSlideTranslator,
@@ -65,14 +66,17 @@ if TYPE_CHECKING:
 
 
 def _make_translator(
-    translation_model: str, translation_cache: TranslationCache | None
+    translation_model: str,
+    translation_cache: TranslationCache | None,
+    prog_lang: str = "python",
 ) -> SlideTranslator:
     """The OpenRouter slide translator, cache-wrapped unless ``--no-cache``.
 
     Factored out (and module-level) so tests can monkeypatch it with a static
     translator, exactly as the sync CLI tests patch ``OpenRouterSlideTranslator``.
+    ``prog_lang`` makes the prompt name the deck's language + comment token.
     """
-    inner = OpenRouterSlideTranslator(model=translation_model)
+    inner = OpenRouterSlideTranslator(model=translation_model, prog_lang=prog_lang)
     if translation_cache is None:
         return inner
     return CachingSlideTranslator(inner=inner, cache=translation_cache)
@@ -224,7 +228,9 @@ def slides_translate_cmd(
 
     result: BootstrapResult
     try:
-        translator = _make_translator(translation_model, translation_cache)
+        translator = _make_translator(
+            translation_model, translation_cache, path_to_prog_lang(source)
+        )
         # A judge is only consulted on the delegated-sync path (twin present).
         judge = _resolve_judge(provider, llm_model, None, None) if will_sync else None
         result = bootstrap_deck(

--- a/src/clm/cli/commands/spec_decks.py
+++ b/src/clm/cli/commands/spec_decks.py
@@ -4,7 +4,7 @@ Spec → deck resolution (gap #1). ``spec decks`` answers "which decks does this
 spec build?"; ``referenced-by`` is the reverse lookup. Both delegate to
 :mod:`clm.core.spec_decks`, which mirrors the build's resolution semantics so the
 shipping set is correct (a ``<topic>`` resolves to a directory and CLM builds
-**every** ``slides_*.py`` in it — filename-stem heuristics silently miss decks).
+**every** ``slides_*.<ext>`` in it — filename-stem heuristics silently miss decks).
 """
 
 from __future__ import annotations
@@ -87,7 +87,7 @@ def spec_decks_cmd(
     """List the deck files a course spec pulls in.
 
     Resolution mirrors the build exactly: a ``<topic>`` resolves to a topic
-    *directory* and **every** ``slides_*.py`` in it is a deck (module-bound
+    *directory* and **every** ``slides_*.<ext>`` in it is a deck (module-bound
     references pick their module; unbound duplicates are first-occurrence-wins).
     This is the reliable way to compute a spec's "shipping set" — do not guess
     from deck filenames.

--- a/src/clm/cli/commands/split.py
+++ b/src/clm/cli/commands/split.py
@@ -40,8 +40,8 @@ from clm.slides.split import SplitError, SplitResult, split_in_file
 )
 @click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
 def split_cmd(source: Path, force: bool, report_only: bool, as_json: bool) -> None:
-    """Split a bilingual SOURCE slide file into ``<basename>.de.py`` and
-    ``<basename>.en.py`` companions.
+    """Split a bilingual SOURCE slide file into ``<basename>.de.<ext>`` and
+    ``<basename>.en.<ext>`` companions.
 
     \b
     The split is byte-identical: ``unify`` of the two outputs reproduces
@@ -54,9 +54,9 @@ def split_cmd(source: Path, force: bool, report_only: bool, as_json: bool) -> No
     outputs.
 
     \b
-    If SOURCE has a sibling voiceover companion (``voiceover_<name>.py``),
-    it is split in lockstep into ``voiceover_<name>.de.py`` /
-    ``voiceover_<name>.en.py`` so the narration is never orphaned;
+    If SOURCE has a sibling voiceover companion (``voiceover_<name>.<ext>``),
+    it is split in lockstep into ``voiceover_<name>.de.<ext>`` /
+    ``voiceover_<name>.en.<ext>`` so the narration is never orphaned;
     ``for_slide`` / ``vo_anchor`` are preserved. ``--force`` also covers
     overwriting existing companion halves.
     """

--- a/src/clm/cli/commands/suggest_sync.py
+++ b/src/clm/cli/commands/suggest_sync.py
@@ -37,7 +37,7 @@ def suggest_sync_cmd(
     Read-only, single-FILE, *bilingual* (de/en cells co-located in one .py)
     suggester. It is hidden from the normal command surface and kept for the
     pre-split bilingual format and agent/MCP use. For split-format decks
-    (``<deck>.de.py`` / ``<deck>.en.py``) use ``clm slides sync``, which
+    (``<deck>.de.<ext>`` / ``<deck>.en.<ext>``) use ``clm slides sync``, which
     reconciles the pair and writes the changes.
 
     Detects cells modified in one language without corresponding changes

--- a/src/clm/cli/commands/summarize.py
+++ b/src/clm/cli/commands/summarize.py
@@ -104,8 +104,10 @@ def extract_notebook_content(
 
     if suffix == ".ipynb":
         return _extract_from_ipynb(text, audience, language)
-    elif suffix == ".py":
-        return _extract_from_py(text, audience)
+    elif suffix in (".py", ".cs", ".cpp", ".cxx", ".cc", ".java", ".ts", ".rs"):
+        from clm.notebooks.slide_parser import comment_token_for_path
+
+        return _extract_from_py(text, audience, comment_token_for_path(notebook_path))
     else:
         return None
 
@@ -140,18 +142,19 @@ def _extract_from_ipynb(text: str, audience: str, language: str = "en") -> str:
     return content[:MAX_CONTENT_CHARS]
 
 
-def _extract_from_py(text: str, audience: str) -> str:
-    """Extract content from a jupytext .py file.
+def _extract_from_py(text: str, audience: str, comment_token: str = "#") -> str:
+    """Extract content from a jupytext percent-format slide file.
 
-    Note: .py files have no per-cell language metadata, so no language
-    filtering is applied here.
+    ``comment_token`` is the deck's line-comment token ("#" python/rust, "//"
+    c-family). Note: these files have no per-cell language metadata, so no
+    language filtering is applied here.
     """
     parts = []
     in_markdown = False
     current_block: list[str] = []
 
     for line in text.splitlines():
-        if line.startswith("# %%") or line.startswith("# +"):
+        if line.startswith(comment_token + " %%") or line.startswith(comment_token + " +"):
             # Flush current block
             if current_block:
                 block_text = "\n".join(current_block)
@@ -165,10 +168,10 @@ def _extract_from_py(text: str, audience: str) -> str:
             continue
 
         if in_markdown:
-            # Strip leading "# " from markdown cells
-            if line.startswith("# "):
-                current_block.append(line[2:])
-            elif line == "#":
+            # Strip the leading comment prefix from markdown cells
+            if line.startswith(comment_token + " "):
+                current_block.append(line[len(comment_token) + 1 :])
+            elif line == comment_token:
                 current_block.append("")
             else:
                 current_block.append(line)

--- a/src/clm/cli/commands/unify.py
+++ b/src/clm/cli/commands/unify.py
@@ -1,7 +1,7 @@
 """``clm slides unify`` — Phase 5 of the slide-format-redesign.
 
-The inverse of ``clm slides split``: combines a ``<basename>.de.py`` /
-``<basename>.en.py`` pair into the bilingual ``<basename>.py``. Shared
+The inverse of ``clm slides split``: combines a ``<basename>.de.<ext>`` /
+``<basename>.en.<ext>`` pair into the bilingual ``<basename>.<ext>``. Shared
 cells (no ``lang`` attribute) must be byte-identical between the two
 inputs — divergent shared content is an error that surfaces before any
 file is written.
@@ -33,7 +33,7 @@ from clm.slides.split import UnifyError, UnifyResult, unify_in_file
     default=None,
     help=(
         "Explicit bilingual target path. Defaults to the basename shared by DE_SOURCE "
-        "and EN_SOURCE — e.g. ``foo.de.py`` + ``foo.en.py`` → ``foo.py``."
+        "and EN_SOURCE — e.g. ``foo.de.<ext>`` + ``foo.en.<ext>`` → ``foo.<ext>``."
     ),
 )
 @click.option(
@@ -69,8 +69,8 @@ def unify_cmd(
 
     \b
     If the pair has sibling voiceover companions
-    (``voiceover_<name>.de.py`` / ``voiceover_<name>.en.py``), they are
-    recombined in lockstep into ``voiceover_<name>.py`` — the inverse of
+    (``voiceover_<name>.de.<ext>`` / ``voiceover_<name>.en.<ext>``), they are
+    recombined in lockstep into ``voiceover_<name>.<ext>`` — the inverse of
     ``split``'s companion split. ``--force`` also covers overwriting an
     existing companion target.
     """

--- a/src/clm/cli/commands/validate.py
+++ b/src/clm/cli/commands/validate.py
@@ -48,7 +48,8 @@ def _infer_kind(path: Path) -> str | None:
         suffix = path.suffix.lower()
         if suffix == ".xml":
             return "spec"
-        if suffix == ".py":
+        # Any slide-source extension (#- and //-family), not just .py.
+        if suffix in (".py", ".cs", ".cpp", ".cxx", ".cc", ".java", ".ts", ".rs"):
             return "slides"
         return None
     if path.is_dir():

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -182,7 +182,7 @@ def voiceover_group(ctx, cache_root, no_cache, refresh_cache):
     "companion_flag",
     default=None,
     help="Force companion-file merge on/off. Default: auto-detect based on "
-    "whether a voiceover_*.py companion file exists next to SLIDES.",
+    "whether a voiceover_*.<ext> companion file exists next to SLIDES.",
 )
 @click.option(
     "--propagate-to",

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -1191,10 +1191,17 @@ def _emit_companion_dry_run_diff(
     results: list,
 ):
     """Emit a unified diff scoped to the companion file for dry-run mode."""
+    from clm.notebooks.slide_parser import comment_token_for_path
     from clm.slides.voiceover_tools import render_companion_update
 
     original_text = companion_file.read_text(encoding="utf-8") if companion_file.exists() else ""
-    updated_text = render_companion_update(original_text, merged_by_slide_id, lang, tag=tag)
+    updated_text = render_companion_update(
+        original_text,
+        merged_by_slide_id,
+        lang,
+        tag=tag,
+        comment_token=comment_token_for_path(companion_file),
+    )
 
     _print_diff_and_rewrite_warnings(original_text, updated_text, companion_file.name, results)
 

--- a/src/clm/cli/commands/voiceover_tools.py
+++ b/src/clm/cli/commands/voiceover_tools.py
@@ -75,12 +75,12 @@ def extract_voiceover_cmd(
 ):
     """Extract voiceover cells from a slide file to a companion file.
 
-    Moves voiceover and notes cells to a companion voiceover_*.py file,
+    Moves voiceover and notes cells to a companion voiceover_*.<ext> file,
     linked via slide_id/for_slide metadata.  Content cells without
     slide_id get auto-generated IDs before extraction.  Refuses to
     overwrite an existing companion unless --force is given.
 
-    On a split half (``<deck>.de.py`` / ``<deck>.en.py``) whose twin exists on
+    On a split half (``<deck>.de.<ext>`` / ``<deck>.en.<ext>``) whose twin exists on
     disk, both companions are extracted in one op by default: the two halves are
     first minted with EN-authority slide_ids so the companions' for_slide sets
     agree, then each half is extracted and all writes commit atomically. Pass
@@ -102,8 +102,8 @@ def extract_voiceover_cmd(
     pair = None if single else derive_split_pair(path)
     if both and pair is None:
         raise click.ClickException(
-            f"--both needs a split deck: '{path.name}' has no <deck>.de.py / "
-            f"<deck>.en.py twin on disk."
+            f"--both needs a split deck: '{path.name}' has no <deck>.de.<ext> / "
+            f"<deck>.en.<ext> twin on disk."
         )
 
     # Fold the --layout flag with the course-wide default (CLM_SIDECAR_LAYOUT /
@@ -153,7 +153,7 @@ def inline_voiceover_cmd(
 ):
     """Inline voiceover cells from a companion file back into a slide file.
 
-    Merges voiceover cells from the companion voiceover_*.py file back
+    Merges voiceover cells from the companion voiceover_*.<ext> file back
     into the slide file, matching via for_slide/slide_id metadata.
     Deletes the companion only when every cell is placed; if any cell is
     unmatched (e.g. its owning slide_id was renamed) the companion is kept

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -187,28 +187,28 @@ across the wipe.
 
 #### Split-source build routing
 
-Slide files in split format — `<basename>.de.py` and
-`<basename>.en.py`, produced by `clm slides split` — route directly
-through the per-language pipeline: a `.de.py` file is built only
-for `lang=de` and a `.en.py` file only for `lang=en`. No unify
+Slide files in split format — `<basename>.de.<ext>` and
+`<basename>.en.<ext>`, produced by `clm slides split` — route directly
+through the per-language pipeline: a `.de.<ext>` file is built only
+for `lang=de` and a `.en.<ext>` file only for `lang=en`. No unify
 step, no temporary file. Build output is byte-identical to building
 the bilingual companion (same per-cell `lang` filter, same output
 paths, same section index — split companions are treated as one
 logical slot when numbering notebooks within a section).
 
 The build detects three other shapes per slide family
-(`slides_foo.py`, `slides_foo.de.py`, `slides_foo.en.py` all share
+(`slides_foo.<ext>`, `slides_foo.de.<ext>`, `slides_foo.en.<ext>` all share
 a *family*) and the routing rule is:
 
-- **Bilingual only** (`slides_foo.py`, no companions) — fed to both
+- **Bilingual only** (`slides_foo.<ext>`, no companions) — fed to both
   DE and EN pipelines exactly as before.
-- **Split pair** (`.de.py` + `.en.py`, no bilingual) — each file
+- **Split pair** (`.de.<ext>` + `.en.<ext>`, no bilingual) — each file
   routes to its own per-language pipeline.
 - **Dual-format conflict** (bilingual *and* at least one split
   companion present) — build refuses before any worker runs with
   category `split_slide_dual_format`. Resolve by running
   `clm slides unify` to merge or deleting the bilingual companion.
-- **Half-pair** (only one of `.de.py` / `.en.py`) — build refuses
+- **Half-pair** (only one of `.de.<ext>` / `.en.<ext>`) — build refuses
   before any worker runs with category `split_slide_half_pair`.
   Add the missing companion.
 
@@ -218,10 +218,10 @@ split pair and emits a `pairing` error finding for any divergence —
 the failure mode that silently produces different DE and EN output
 for what was meant to be language-neutral material.
 
-Phase 6 is Python-only today, mirroring Phase 5's scope: the
-sibling `header_de` / `header_en` macros only ship in
-`templates_python/macros.j2`. Phase 8 adds them to the
-cpp/csharp/java/typescript templates.
+The sibling `header_de` / `header_en` macros (the split prerequisite)
+ship in every language template — `templates_python` and the
+cpp/csharp/java/typescript templates — so split decks work across all
+supported prog_langs.
 
 #### Snapshot / verify
 
@@ -320,7 +320,7 @@ diff. If both a cell error and a verify diff are present, the cell
 error wins.
 
 Since CLM {version}, **dropped companion voiceover** is treated the same
-way. When a separated-voiceover companion (`voiceover_*.py`) has a
+way. When a separated-voiceover companion (`voiceover_*.<ext>`) has a
 `for_slide` that matches no `slide_id` in the slide it accompanies, that
 narration is dropped from the built output — usually because a `slide_id`
 was renamed out from under the companion. The build now reports each drop
@@ -403,7 +403,7 @@ clm spec decks [OPTIONS] [SPEC_FILE]
 
 Resolution mirrors the build exactly, which is the point of the command: a
 `<topic>` resolves to a topic **directory** and CLM builds **every**
-`slides_*.py` in it. The directory name often differs from the deck filenames
+`slides_*.<ext>` in it. The directory name often differs from the deck filenames
 (e.g. topic `properties` → `slides_properties.py` **and**
 `slides_property_setters.py`), so a deck-filename-stem heuristic silently misses
 decks. Module-bound `<topic>`/`<section>` references resolve in their module;
@@ -681,7 +681,7 @@ clm sync-includes course-specs/ml-azav.xml --data-dir /path/to/course
 
 ### `clm validate` (slides mode)
 
-`clm validate slides/` (or `clm validate slides_foo.py`) dispatches
+`clm validate slides/` (or `clm validate slides_foo.<ext>`) dispatches
 to slide validation when the argument is a `.py` file or directory.
 
 *Removed in CLM 1.8: the flat alias `clm validate-slides` no longer exists — use this group-qualified form.*
@@ -905,7 +905,7 @@ Special cases:
     stamped on both, deterministic regardless of file order (the same policy
     as a bilingual file). A pair that is not byte-faithfully unifiable
     (divergent shared cells) falls back to the per-file path below.
-  - **Single-file run** (`clm slides assign-ids slides_x.de.py`) — when the
+  - **Single-file run** (`clm slides assign-ids slides_x.de.<ext>`) — when the
     twin exists on disk with a matching slide count, an **id-less** slide
     adopts the twin's `slide_id` for the positionally-corresponding slide
     instead of minting a divergent slug. When both halves are id-less the
@@ -1075,7 +1075,7 @@ clm slides coverage-report slides/ --exclude _archive --shipping-only
 *Added in CLM {version}.*
 
 Single-language authoring sync for split-format decks
-(`<deck>.de.py` / `<deck>.en.py`, the layout produced by
+(`<deck>.de.<ext>` / `<deck>.en.<ext>`, the layout produced by
 `clm slides split`). After an author edits **one** half of a pair, this
 command brings the *other* half into sync in a single pass: edits are
 propagated, brand-new slides are translated and inserted, removed
@@ -1086,14 +1086,14 @@ minted onto both decks as it goes.
 sync checks that `DE_PATH` and `EN_PATH` are the two halves of **one** deck —
 one `.de` half and one `.en` half of the same name (the routing prefix is not
 required, so `apis.de.py` / `apis.en.py` is fine). A **swapped** order
-(`<deck>.en.py` first) is auto-corrected with a note; passing the **same file**
+(`<deck>.en.<ext>` first) is auto-corrected with a note; passing the **same file**
 twice, **two same-language** halves, **two different decks**, or a path that is
 **not a split half** at all (a bilingual or untagged file) is rejected with a
 usage error before any LLM call or write. This closes the #162 footgun where a
 mismatched pair could silently produce a divergent or no-op sync.
 
 **Single-path form (since CLM {version}).** `EN_PATH` is **optional**: pass just
-one half and the twin is derived from disk — `clm slides sync slides_x.de.py`
+one half and the twin is derived from disk — `clm slides sync slides_x.de.<ext>`
 syncs the pair. You may also pass the **bilingual deck stem** (`slides_x.py`, no
 `.de`/`.en` tag) when it still exists on disk, and both halves are derived. The
 derivation is prefix-agnostic (so `apis.de.py` works) and the resolved pair is
@@ -1299,8 +1299,8 @@ clm slides sync intro.de.py intro.en.py --no-cache
 *Added in CLM {version}. Alias: `clm slides bootstrap`.*
 
 Cold-start translation of a **single-language** deck into its other-language
-split half. When an author has written only `slides_x.de.py`, this synthesizes
-`slides_x.en.py` (and vice-versa) as a complete translation of the whole deck —
+split half. When an author has written only `slides_x.de.<ext>`, this synthesizes
+`slides_x.en.<ext>` (and vice-versa) as a complete translation of the whole deck —
 the one thing `clm slides sync` deliberately refuses to do (sync only fills
 per-cell gaps inside an *already-existing* pair). After the twin exists, keep the
 two halves in step with `clm slides sync`; run `clm slides unify` for a single
@@ -1451,8 +1451,8 @@ pair's cache entry — the rest of the deck stays cached.
 
 ### `clm slides split`
 
-Split a bilingual `.py` slide file into `<basename>.de.py` and
-`<basename>.en.py` companions. Cells with `lang="de"` go to the DE
+Split a bilingual `.py` slide file into `<basename>.de.<ext>` and
+`<basename>.en.<ext>` companions. Cells with `lang="de"` go to the DE
 file, `lang="en"` to the EN file, and shared cells (no `lang` — j2
 directives, language-neutral code) are copied verbatim to both. The
 bilingual `# {{ header("DE", "EN") }}` macro call is rewritten into
@@ -1491,12 +1491,14 @@ Round-trip with `clm slides unify` is byte-identical:
 `unify(*split(deck.py)) == deck.py`. Hard prerequisite: every slide
 carries a valid `slide_id` (Phase 3 enforces this with a warning,
 escalating to error in CLM 1.8) — `unify` pairs adjacent DE/EN cells
-by matching id. Currently Python-only: the slide parser recognises
-only `# %%` cell boundaries; non-Python prog_langs are deferred.
+by matching id. Since CLM {version} the parser recognises the deck's
+own comment token (`# %%` for Python/Rust, `// %%` for C#/C++/Java/TS),
+so split/unify and the rest of the authoring tooling work on every
+supported prog_lang — the token is derived from the file extension.
 
 **Voiceover companion.** If SOURCE has a sibling voiceover companion
-(`slides_<name>.py` → `voiceover_<name>.py`), `split` splits it in
-lockstep into `voiceover_<name>.de.py` / `voiceover_<name>.en.py`,
+(`slides_<name>.py` → `voiceover_<name>.<ext>`), `split` splits it in
+lockstep into `voiceover_<name>.de.<ext>` / `voiceover_<name>.en.<ext>`,
 routing each narration cell by its `lang` and preserving `for_slide` /
 `vo_anchor` verbatim. Without this the companion would be orphaned — the
 build would find no companion next to either split half. `--force`
@@ -1507,8 +1509,8 @@ written). Splitting a deck that has no companion creates no
 
 ### `clm slides unify`
 
-The inverse of `clm slides split`. Combine `<basename>.de.py` and
-`<basename>.en.py` into the bilingual `<basename>.py` companion. Pairs
+The inverse of `clm slides split`. Combine `<basename>.de.<ext>` and
+`<basename>.en.<ext>` into the bilingual `<basename>.<ext>` companion. Pairs
 adjacent DE/EN cells by matching `slide_id`, treats shared cells as
 alignment points (must be byte-identical between the two inputs —
 divergent shared content is an error), and rebuilds the bilingual
@@ -1520,7 +1522,7 @@ clm slides unify [OPTIONS] DE_SOURCE EN_SOURCE
 
 | Option | Description |
 |--------|-------------|
-| `--target FILE` | Explicit bilingual target path. Defaults to the basename shared by the two sources (e.g. `foo.de.py` + `foo.en.py` → `foo.py`). |
+| `--target FILE` | Explicit bilingual target path. Defaults to the basename shared by the two sources (e.g. `foo.de.<ext>` + `foo.en.<ext>` → `foo.<ext>`). |
 | `--force` | Overwrite an existing target file if present |
 | `--report-only`, `--dry-run` | Compute the unified text and report what would be written without modifying files |
 | `--json` | Emit a JSON report |
@@ -1540,8 +1542,8 @@ diverges …`. The same divergence is surfaced by
 build-time gate.
 
 **Voiceover companion.** If the pair has voiceover companions
-(`voiceover_<name>.de.py` / `voiceover_<name>.en.py`), `unify` recombines
-them in lockstep into `voiceover_<name>.py` — the inverse of `split`'s
+(`voiceover_<name>.de.<ext>` / `voiceover_<name>.en.<ext>`), `unify` recombines
+them in lockstep into `voiceover_<name>.<ext>` — the inverse of `split`'s
 companion split, byte-identical. The recombined companion is written to the
 **same directory** the split companions lived in (a `voiceover/` subdirectory
 stays foldered; see `clm slides tidy`). `--force` also covers overwriting an
@@ -1551,15 +1553,15 @@ existing companion target.
 
 Relocate a topic's authoring **sidecars** between the flat and foldered
 layouts. Sidecars are the files that are *not* core source and never reach
-output: voiceover companions (`voiceover_*.py`) and HTTP-replay cassettes
+output: voiceover companions (`voiceover_*.<ext>`) and HTTP-replay cassettes
 (`*.http-cassette.yaml`). `tidy` moves them into per-type subdirectories so a
-topic directory holds only the `slides_*.py` sources and genuine output
+topic directory holds only the `slides_*.<ext>` sources and genuine output
 companions (`img/`, `drawio/`):
 
 ```
 topic_070_rag_introduction/
 ├── cassettes/      ← *.http-cassette.yaml      (was: loose in the topic dir)
-├── voiceover/      ← voiceover_*.py            (was: loose in the topic dir)
+├── voiceover/      ← voiceover_*.<ext>         (was: loose in the topic dir)
 ├── drawio/  img/   ← output companions (unchanged)
 └── slides_010_*.de.py  slides_010_*.en.py      ← core sources
 ```
@@ -1644,7 +1646,7 @@ Suggests which cells need translation updates. Does not modify the file.
 > `clm slides --help` (it stays invocable by name and as the `suggest_sync` MCP
 > tool). It is a read-only suggester for the pre-split **bilingual** layout
 > (de/en cells co-located in one `.py`). For split-format decks
-> (`<deck>.de.py` / `<deck>.en.py`) use **`clm slides sync`**, which reconciles
+> (`<deck>.de.<ext>` / `<deck>.en.<ext>`) use **`clm slides sync`**, which reconciles
 > the pair and writes the changes. Two `sync`-named commands on the everyday
 > surface was a source of confusion — `sync` is the canonical funnel.
 
@@ -1669,7 +1671,7 @@ clm slides suggest-sync slides_intro.py --source-language de --json
 *Removed in CLM 1.8: the flat alias `clm extract-voiceover` no longer exists — use this group-qualified form.*
 
 Extract voiceover and notes cells from a slide file to a companion
-`voiceover_*.py` file, linked via `slide_id`/`for_slide` metadata.
+`voiceover_*.<ext>` file, linked via `slide_id`/`for_slide` metadata.
 Content cells without `slide_id` get auto-generated IDs before extraction.
 
 Since CLM {version}, that ID generation is **twin-aware** on a split half
@@ -1696,7 +1698,7 @@ right after the title slide rather than at the end of the title group. Legacy
 companions with no `vo_anchor` keep the group-end placement.
 
 **Paired extract (auto-pairing), since CLM {version}.** When `FILE` is a split
-half (`<deck>.de.py` / `<deck>.en.py`) whose twin exists on disk, both
+half (`<deck>.de.<ext>` / `<deck>.en.<ext>`) whose twin exists on disk, both
 companions are extracted in **one op** by default: the two halves are first
 minted with **EN-authority** `slide_id`s across both at once (the slug comes
 from the EN heading, stamped identically on both halves), then each half is
@@ -1769,7 +1771,7 @@ clm voiceover extract slides_intro.de.py --force
 
 *Removed in CLM 1.8: the flat alias `clm inline-voiceover` no longer exists — use this group-qualified form.*
 
-Inline voiceover cells from a companion `voiceover_*.py` file back into the
+Inline voiceover cells from a companion `voiceover_*.<ext>` file back into the
 slide file. The companion is deleted **only when every cell is placed**.
 
 Since CLM {version}, each voiceover is re-inserted immediately after the
@@ -2304,12 +2306,12 @@ between arguments is preserved.
 | `--model TEXT` | LLM model for merge/polished mode (default: `anthropic/claude-sonnet-4-6` via OpenRouter) |
 | `--transcript PATH` | Skip ASR; load precomputed transcript JSON (single-part only) |
 | `--alignment PATH` | Skip ASR, detection, matching; load precomputed alignment JSON |
-| `--companion/--no-companion` | Force companion-file merge on/off (default: auto-detect based on whether a `voiceover_*.py` companion exists, in a `voiceover/` subdir or next to SLIDES) |
+| `--companion/--no-companion` | Force companion-file merge on/off (default: auto-detect based on whether a `voiceover_*.<ext>` companion exists, in a `voiceover/` subdir or next to SLIDES) |
 | `--layout [subdir\|sibling]` | Where to create a **new** companion: `subdir` (a `voiceover/` folder) or `sibling`. Default: auto-detect an existing `voiceover/` folder, else sibling. Ignored when a companion already exists — it is updated in place. |
 | `--propagate-to [de\|en]` | After merging `--lang`, translate the changes into the given target language and update its voiceover cells |
 
 **Companion-file merge (auto-detected):**
-- If a `voiceover_*.py` companion file (as produced by `clm voiceover extract`)
+- If a `voiceover_*.<ext>` companion file (as produced by `clm voiceover extract`)
   exists next to `SLIDES`, sync reads baseline voiceover from the companion
   (keyed by `for_slide` → `slide_id`) and writes merged output back to the
   companion. The slide file itself is left untouched.

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -647,9 +647,9 @@ layouts). Within it, CLM distinguishes three kinds of file:
 
 | Kind | Examples | Copied to output? |
 |---|---|---|
-| **Core source** | `slides_*.py` (incl. split `slides_*.de.py` / `slides_*.en.py`) | processed into notebooks/HTML |
+| **Core source** | `slides_*.<ext>` (incl. split `slides_*.de.<ext>` / `slides_*.en.<ext>`) | processed into notebooks/HTML |
 | **Output companions** | `img/`, `drawio/`, loose data files | **yes**, verbatim |
-| **Authoring sidecars** | `voiceover_*.py`, `*.http-cassette.yaml` | **no** |
+| **Authoring sidecars** | `voiceover_*.<ext>`, `*.http-cassette.yaml` | **no** |
 
 The authoring sidecars may live either next to the slides (the default) or
 collected into per-type subdirectories so the topic directory stays focused on
@@ -658,7 +658,7 @@ the editable sources:
 ```
 topic_070_rag_introduction/
 ├── cassettes/      # *.http-cassette.yaml      (also accepted: legacy _cassettes/)
-├── voiceover/      # voiceover_*.py
+├── voiceover/      # voiceover_*.<ext>
 ├── drawio/  img/   # output companions (unchanged)
 ├── slides_010_what_is_rag.de.py
 └── slides_010_what_is_rag.en.py

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -333,10 +333,13 @@ class ProcessNotebookOperation(Operation):
         data = self.input_file.path.read_text(encoding="utf-8")
         companion = self.input_file.companion_voiceover_path
         if companion is not None:
+            from clm.notebooks.slide_parser import comment_token_for_path
             from clm.slides.voiceover_tools import merge_voiceover_text
 
             companion_text = companion.read_text(encoding="utf-8")
-            data, unmatched = merge_voiceover_text(data, companion_text)
+            data, unmatched = merge_voiceover_text(
+                data, companion_text, comment_token_for_path(companion)
+            )
             for for_slide_id in unmatched:
                 logger.warning(
                     f"Companion voiceover '{companion.name}': "

--- a/src/clm/core/topic_resolver.py
+++ b/src/clm/core/topic_resolver.py
@@ -274,7 +274,9 @@ def find_slide_files_recursive(path: Path) -> list[Path]:
     if direct:
         return direct
 
-    return sorted(f.resolve() for f in path.rglob("*.py") if is_slides_file(f))
+    # rglob("*") (not "*.py") so the is_slides_file filter — which already accepts
+    # every SUPPORTED_PROG_LANG_EXTENSIONS — finds .cs/.cpp/.java/.ts decks too.
+    return sorted(f.resolve() for f in path.rglob("*") if f.is_file() and is_slides_file(f))
 
 
 def resolve_topic(

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -107,7 +107,9 @@ SKIP_OUTPUT_FILE_PATTERNS = [
     # OUTPUT and (b) the kernel ``other_files`` payload (the raw author file is
     # never read at runtime). ``is_ignored_file_for_output`` governs exactly
     # those two; source mounts do not consult it, so workers still see it.
-    re.compile(r"voiceover_.*\.py$"),
+    # ``.py`` plus the //-family slide extensions (companion_name preserves the
+    # deck's extension), so a ``voiceover_<stem>.cs`` never leaks into output.
+    re.compile(r"voiceover_.*\.(py|cs|cpp|cxx|cc|java|ts|rs)$"),
 ]
 
 # Parallel glob form of ``SKIP_OUTPUT_FILE_PATTERNS`` for consumers that
@@ -117,7 +119,16 @@ SKIP_OUTPUT_FILE_GLOBS = [
     "*.http-cassette.yaml",
     "*.http-cassette.yaml.staging-*",
     "*.http-cassette.yaml.staging-*.completed",
-    "voiceover_*.py",  # separated-voiceover companions — output-suppressed (see above)
+    # separated-voiceover companions — output-suppressed (see above). One glob
+    # per slide extension (globs have no alternation); keep in sync with the regex.
+    "voiceover_*.py",
+    "voiceover_*.cs",
+    "voiceover_*.cpp",
+    "voiceover_*.cxx",
+    "voiceover_*.cc",
+    "voiceover_*.java",
+    "voiceover_*.ts",
+    "voiceover_*.rs",
 ]
 
 PLANTUML_EXTENSIONS = frozenset({".pu", ".puml", ".plantuml"})

--- a/src/clm/notebooks/slide_parser.py
+++ b/src/clm/notebooks/slide_parser.py
@@ -365,12 +365,27 @@ def _is_cell_boundary(line: str, comment_token: str = "#") -> bool:
     )
 
 
+def _strip_comment_prefix(line: str, comment_token: str) -> str:
+    """Remove the leading comment token as a LITERAL prefix, then leading spaces.
+
+    Uses prefix removal, not ``str.lstrip(token + " ")`` — the latter is a
+    *character-set* strip, so for ``token="//"`` it would eat *every* leading
+    slash (the set ``{'/', ' '}``), corrupting content lines like ``// /usr/bin``
+    or C# ``///`` doc comments. For ``token="#"`` this reproduces the previous
+    behaviour: percent-format body lines always carry the comment token at
+    column 0, and the leading-space lstrip matches the old result.
+    """
+    if line.startswith(comment_token):
+        line = line[len(comment_token) :]
+    return line.lstrip(" ")
+
+
 def _strip_markdown(content: str, comment_token: str = "#") -> str:
     """Strip comment prefixes and markdown formatting from a markdown cell."""
     parts = []
     for line in content.split("\n"):
         # Remove the language comment prefix (e.g. "# " or "// ").
-        stripped = line.lstrip(comment_token + " ").rstrip()
+        stripped = _strip_comment_prefix(line, comment_token).rstrip()
         if stripped.startswith("#"):
             # Strip markdown heading markers (always "#", language-independent).
             stripped = stripped.lstrip("# ").strip()
@@ -391,7 +406,7 @@ def _strip_code_comments(content: str, comment_token: str = "#") -> str:
     """Strip comment prefixes from code content."""
     parts = []
     for line in content.split("\n"):
-        stripped = line.lstrip(comment_token + " ").strip()
+        stripped = _strip_comment_prefix(line, comment_token).strip()
         if stripped:
             parts.append(stripped)
     return " ".join(parts)
@@ -402,7 +417,7 @@ def _extract_title(cell: Cell) -> str:
     if cell.cell_type != "markdown":
         return ""
     for line in cell.content.split("\n"):
-        stripped = line.lstrip(cell.comment_token + " ").strip()
+        stripped = _strip_comment_prefix(line, cell.comment_token).strip()
         if stripped.startswith("#"):
             # Markdown heading
             return stripped.lstrip("# ").strip()

--- a/src/clm/notebooks/slide_parser.py
+++ b/src/clm/notebooks/slide_parser.py
@@ -63,6 +63,10 @@ class Cell:
     header: str
     content: str
     metadata: CellMetadata
+    comment_token: str = "#"
+    """Line-comment token of the source language (``"#"`` python/rust, ``"//"``
+    cpp/csharp/java/typescript). Used when stripping the comment prefix from the
+    cell body. Defaults to ``"#"`` for backward compatibility."""
 
     @property
     def cell_type(self) -> str:
@@ -83,8 +87,8 @@ class Cell:
     def text_content(self) -> str:
         """Extract readable text from the cell, stripping comment prefixes and formatting."""
         if self.metadata.cell_type == "markdown":
-            return _strip_markdown(self.content)
-        return _strip_code_comments(self.content)
+            return _strip_markdown(self.content, self.comment_token)
+        return _strip_code_comments(self.content, self.comment_token)
 
 
 @dataclass
@@ -129,17 +133,21 @@ class SlideGroup:
         return len(self.notes_cells) > 0
 
 
-def parse_cell_header(header: str) -> CellMetadata:
+def parse_cell_header(header: str, comment_token: str = "#") -> CellMetadata:
     """Extract metadata from a cell header line.
+
+    ``comment_token`` is the source language's line-comment token (``"#"`` for
+    python/rust, ``"//"`` for cpp/csharp/java/typescript). Only boundary/j2
+    detection depends on it; the ``lang=``/``tags=``/``slide_id=``/``for_slide=``
+    grammar after ``%%`` is comment-token-independent.
 
     Examples::
 
         # %% [markdown] lang="de" tags=["slide"]
-        # %% tags=["keep"]
-        # %%
+        // %% [markdown] lang="de" tags=["slide"]
         # j2 from 'macros.j2' import header
     """
-    is_j2 = header.startswith("# j2 ") or header.startswith("# {{ ")
+    is_j2 = header.startswith(comment_token + " j2 ") or header.startswith(comment_token + " {{ ")
 
     if is_j2:
         return CellMetadata(
@@ -178,8 +186,12 @@ def parse_cell_header(header: str) -> CellMetadata:
     )
 
 
-def parse_cells(text: str) -> list[Cell]:
-    """Parse a percent-format .py file into a list of cells."""
+def parse_cells(text: str, comment_token: str = "#") -> list[Cell]:
+    """Parse a percent-format slide file into a list of cells.
+
+    ``comment_token`` is the source language's line-comment token (``"#"`` python/
+    rust, ``"//"`` cpp/csharp/java/typescript). Defaults to ``"#"``.
+    """
     lines = text.split("\n")
     cells: list[Cell] = []
     current_header: str | None = None
@@ -187,16 +199,17 @@ def parse_cells(text: str) -> list[Cell]:
     current_line_number = 0
 
     for i, line in enumerate(lines, 1):
-        if _is_cell_boundary(line):
+        if _is_cell_boundary(line, comment_token):
             if current_header is not None:
                 content = "\n".join(current_lines).strip()
-                metadata = parse_cell_header(current_header)
+                metadata = parse_cell_header(current_header, comment_token)
                 cells.append(
                     Cell(
                         line_number=current_line_number,
                         header=current_header,
                         content=content,
                         metadata=metadata,
+                        comment_token=comment_token,
                     )
                 )
             current_header = line
@@ -208,13 +221,14 @@ def parse_cells(text: str) -> list[Cell]:
     # Final cell
     if current_header is not None:
         content = "\n".join(current_lines).strip()
-        metadata = parse_cell_header(current_header)
+        metadata = parse_cell_header(current_header, comment_token)
         cells.append(
             Cell(
                 line_number=current_line_number,
                 header=current_header,
                 content=content,
                 metadata=metadata,
+                comment_token=comment_token,
             )
         )
 
@@ -238,9 +252,12 @@ def parse_slides(
 
     Returns:
         Ordered list of SlideGroup objects.
+
+    The line-comment token is resolved from ``path``'s extension, so this works
+    for ``.py``/``.cs``/``.cpp``/``.java``/``.ts`` slide files alike.
     """
     text = path.read_text(encoding="utf-8")
-    cells = parse_cells(text)
+    cells = parse_cells(text, comment_token_for_path(path))
     return group_slides(cells, lang, include_header=include_header)
 
 
@@ -323,19 +340,39 @@ def group_slides(
 # ---------------------------------------------------------------------------
 
 
-def _is_cell_boundary(line: str) -> bool:
-    """Check if a line starts a new cell."""
-    return line.startswith("# %%") or line.startswith("# j2 ") or line.startswith("# {{ ")
+def comment_token_for_path(path: Path) -> str:
+    """Resolve a slide file's line-comment token from its extension.
+
+    ``.py``/``.rs``/``.md`` → ``"#"``; ``.cs``/``.cpp``/``.java``/``.ts`` → ``"//"``.
+    Falls back to ``"#"`` for unknown extensions. Imports are local to avoid a
+    module-load cycle (slide_parser is imported very early).
+    """
+    from clm.infrastructure.utils.path_utils import path_to_prog_lang
+    from clm.workers.notebook.utils.prog_lang_utils import line_comment_for
+
+    try:
+        return line_comment_for(path_to_prog_lang(path))
+    except (KeyError, ValueError):
+        return "#"
 
 
-def _strip_markdown(content: str) -> str:
+def _is_cell_boundary(line: str, comment_token: str = "#") -> bool:
+    """Check if a line starts a new cell (boundary / j2 statement / j2 expression)."""
+    return (
+        line.startswith(comment_token + " %%")
+        or line.startswith(comment_token + " j2 ")
+        or line.startswith(comment_token + " {{ ")
+    )
+
+
+def _strip_markdown(content: str, comment_token: str = "#") -> str:
     """Strip comment prefixes and markdown formatting from a markdown cell."""
     parts = []
     for line in content.split("\n"):
-        # Remove comment prefix
-        stripped = line.lstrip("# ").rstrip()
+        # Remove the language comment prefix (e.g. "# " or "// ").
+        stripped = line.lstrip(comment_token + " ").rstrip()
         if stripped.startswith("#"):
-            # This is still a comment prefix artifact, strip more
+            # Strip markdown heading markers (always "#", language-independent).
             stripped = stripped.lstrip("# ").strip()
         # Remove markdown formatting
         stripped = re.sub(r"[*_`]", "", stripped)
@@ -350,11 +387,11 @@ def _strip_markdown(content: str) -> str:
     return " ".join(parts)
 
 
-def _strip_code_comments(content: str) -> str:
+def _strip_code_comments(content: str, comment_token: str = "#") -> str:
     """Strip comment prefixes from code content."""
     parts = []
     for line in content.split("\n"):
-        stripped = line.lstrip("# ").strip()
+        stripped = line.lstrip(comment_token + " ").strip()
         if stripped:
             parts.append(stripped)
     return " ".join(parts)
@@ -365,7 +402,7 @@ def _extract_title(cell: Cell) -> str:
     if cell.cell_type != "markdown":
         return ""
     for line in cell.content.split("\n"):
-        stripped = line.lstrip("# ").strip()
+        stripped = line.lstrip(cell.comment_token + " ").strip()
         if stripped.startswith("#"):
             # Markdown heading
             return stripped.lstrip("# ").strip()

--- a/src/clm/notebooks/slide_writer.py
+++ b/src/clm/notebooks/slide_writer.py
@@ -14,33 +14,36 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
 
 logger = logging.getLogger(__name__)
 
 
-def format_narrative_cell(text: str, lang: str, *, tag: str = "voiceover") -> str:
+def format_narrative_cell(
+    text: str, lang: str, *, tag: str = "voiceover", comment_token: str = "#"
+) -> str:
     """Format text as a percent-format narrative cell.
 
     Args:
         text: The narrative text (plain text, one thought per line).
         lang: Language code ("de" or "en").
         tag: Cell tag to use ("voiceover" or "notes").
+        comment_token: The deck's line-comment token ("#" python/rust, "//" c-family).
 
     Returns:
         Complete cell text including the header line.
     """
-    header = f'# %% [markdown] lang="{lang}" tags=["{tag}"]'
+    header = f'{comment_token} %% [markdown] lang="{lang}" tags=["{tag}"]'
     lines = text.strip().split("\n")
-    body_lines = ["#"]  # blank comment line after header
+    body_lines = [comment_token]  # blank comment line after header
     for line in lines:
         stripped = line.strip()
         if not stripped:
-            body_lines.append("#")
+            body_lines.append(comment_token)
         elif stripped.startswith("- ") or stripped.startswith("**["):
-            body_lines.append(f"# {stripped}")
+            body_lines.append(f"{comment_token} {stripped}")
         else:
-            body_lines.append(f"# - {stripped}")
+            body_lines.append(f"{comment_token} - {stripped}")
     return header + "\n" + "\n".join(body_lines)
 
 
@@ -54,6 +57,7 @@ def update_narrative(
     lang: str,
     *,
     tag: str = "voiceover",
+    comment_token: str = "#",
 ) -> str:
     """Update or insert narrative cells in a percent-format .py file.
 
@@ -71,7 +75,7 @@ def update_narrative(
     if not notes_map:
         return text
 
-    cells = parse_cells(text)
+    cells = parse_cells(text, comment_token)
     if not cells:
         return text
 
@@ -88,7 +92,9 @@ def update_narrative(
         notes_text = notes_map[slide_idx]
         info = slide_info[slide_idx]
 
-        notes_cell_text = format_narrative_cell(notes_text, lang, tag=tag)
+        notes_cell_text = format_narrative_cell(
+            notes_text, lang, tag=tag, comment_token=comment_token
+        )
 
         if info["existing_notes_lines"]:
             # Replace existing narrative cell
@@ -130,7 +136,9 @@ def write_narrative(
         Path to the written file.
     """
     text = path.read_text(encoding="utf-8")
-    updated = update_narrative(text, notes_map, lang, tag=tag)
+    updated = update_narrative(
+        text, notes_map, lang, tag=tag, comment_token=comment_token_for_path(path)
+    )
 
     dest = output_path or path
     dest.write_text(updated, encoding="utf-8", newline="\n")

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.utils.path_utils import split_lang_suffix
-from clm.notebooks.slide_parser import parse_cell_header
+from clm.notebooks.slide_parser import comment_token_for_path, parse_cell_header
 from clm.slides.code_cell_extract import extract_from_code
 from clm.slides.headingless import (
     Category,
@@ -389,7 +389,7 @@ def assign_ids_for_text(
     ``twin_ids`` is forwarded to :func:`assign_ids_for_cells` (the #162
     defensive split-half id reuse — see its docstring).
     """
-    preamble, cells = _split_cells(text)
+    preamble, cells = _split_cells(text, comment_token_for_path(file_path))
     result = assign_ids_for_cells(cells, file_path, options, twin_ids=twin_ids)
     result.files_visited = 1
 
@@ -794,9 +794,9 @@ def _twin_ids_for(path: Path, text: str) -> list[str | None] | None:
     twin = split_twin(path)
     if twin is None:
         return None
-    _, own_cells = _split_cells(text)
+    _, own_cells = _split_cells(text, comment_token_for_path(path))
     own_ids = _slide_start_ids(own_cells)
-    _, twin_cells = _split_cells(twin.read_text(encoding="utf-8"))
+    _, twin_cells = _split_cells(twin.read_text(encoding="utf-8"), comment_token_for_path(twin))
     twin_ids = _slide_start_ids(twin_cells)
     if len(twin_ids) != len(own_ids):
         return None
@@ -841,10 +841,11 @@ def assign_ids_in_split_pair(
     """
     from clm.slides.split import SplitError, UnifyError, split_text, unify_texts
 
+    comment_token = comment_token_for_path(en_path)
     de_text = de_path.read_text(encoding="utf-8")
     en_text = en_path.read_text(encoding="utf-8")
     try:
-        unified = unify_texts(de_text, en_text)
+        unified = unify_texts(de_text, en_text, comment_token)
         # Proceed only when unify is *byte-faithful*: split(unify(de, en)) == (de, en).
         # ``unify`` is best-effort for solo / misaligned cells, so a structurally
         # divergent pair can unify without raising — but then the assign->split
@@ -852,7 +853,7 @@ def assign_ids_in_split_pair(
         # guarantees that adding ids and splitting back cannot corrupt the files;
         # otherwise fall back to the per-file defensive (the #162 detective then
         # surfaces the residual divergence).
-        rt_de, rt_en = split_text(unified)
+        rt_de, rt_en = split_text(unified, comment_token)
     except (SplitError, UnifyError):
         return None
     if (rt_de, rt_en) != (de_text, en_text):
@@ -865,7 +866,7 @@ def assign_ids_in_split_pair(
         return result
 
     try:
-        de_new, en_new = split_text(unified_new)
+        de_new, en_new = split_text(unified_new, comment_token)
     except SplitError:  # pragma: no cover - unify succeeded, split should too
         return None
 

--- a/src/clm/slides/coverage.py
+++ b/src/clm/slides/coverage.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
 from clm.slides.pairing import TITLE_SLIDE_ID, is_title_macro_cell
 from clm.slides.slug import strip_preserve_marker
 from clm.slides.workshop_scope import find_workshop_ranges, is_in_workshop
@@ -263,8 +263,9 @@ def _synthetic_title_cell(*, line_number: int, lang: str) -> Cell:
 # ---------------------------------------------------------------------------
 
 
-_BULLET_RE = re.compile(r"^#\s+[-*]\s+(?P<text>.+?)\s*$")
-_NUMBERED_RE = re.compile(r"^#\s+\d+\.\s+(?P<text>.+?)\s*$")
+# Anchored on either comment family (``#`` python/rust, ``//`` c-family).
+_BULLET_RE = re.compile(r"^(?:#|//)\s+[-*]\s+(?P<text>.+?)\s*$")
+_NUMBERED_RE = re.compile(r"^(?:#|//)\s+\d+\.\s+(?P<text>.+?)\s*$")
 _EMPHASIS_RE = re.compile(r"\*+([^*]+)\*+")
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
@@ -297,13 +298,15 @@ def _narrative_text(cells: Sequence[Cell], *, max_chars: int = 6000) -> str:
     parts: list[str] = []
     used = 0
     for cell in cells:
+        token = cell.comment_token
         for raw_line in cell.content.splitlines():
             if not raw_line.strip():
                 continue
-            if raw_line.startswith("# "):
-                line = raw_line[2:]
-            elif raw_line.startswith("#"):
-                line = raw_line[1:]
+            # Literal-prefix strip (keeps content slashes for "//" decks).
+            if raw_line.startswith(token + " "):
+                line = raw_line[len(token) + 1 :]
+            elif raw_line.startswith(token):
+                line = raw_line[len(token) :]
             else:
                 line = raw_line
             if not line.strip():
@@ -345,7 +348,7 @@ def check_coverage_for_text(
     Returns a :class:`CoverageResult`. The text is never mutated.
     """
     result = CoverageResult(files_visited=1)
-    cells = parse_cells(text)
+    cells = parse_cells(text, comment_token_for_path(file_path))
     workshop_count: list[int] = [0]
     pairs = build_coverage_pairs(cells, workshop_slide_count=workshop_count)
     result.pairs_in_workshop = workshop_count[0]

--- a/src/clm/slides/headingless.py
+++ b/src/clm/slides/headingless.py
@@ -49,17 +49,21 @@ class Extraction:
     source: str = ""
 
 
-# Markdown heading: ``# ## Title`` (Python comment prefix included).
-_HEADING_RE = re.compile(r"^#\s+(#{1,6})\s+(?P<text>.+?)\s*$")
+# Each matcher anchors on the line-comment prefix of either family — ``#``
+# (python/rust) or ``//`` (cpp/csharp/java/typescript) — since a deck is
+# single-language the alternation never cross-matches.
+#
+# Markdown heading: ``# ## Title`` / ``// ## Title`` (comment prefix included).
+_HEADING_RE = re.compile(r"^(?:#|//)\s+(#{1,6})\s+(?P<text>.+?)\s*$")
 
-# Bullet: ``# - Text`` or ``# * Text`` (Python comment prefix included).
-_BULLET_RE = re.compile(r"^#\s+[-*]\s+(?P<text>.+?)\s*$")
+# Bullet: ``# - Text`` or ``# * Text`` (comment prefix included).
+_BULLET_RE = re.compile(r"^(?:#|//)\s+[-*]\s+(?P<text>.+?)\s*$")
 
 # Numbered list: ``# 1. Text``.
-_NUMBERED_RE = re.compile(r"^#\s+\d+\.\s+(?P<text>.+?)\s*$")
+_NUMBERED_RE = re.compile(r"^(?:#|//)\s+\d+\.\s+(?P<text>.+?)\s*$")
 
 # Bold *line*: a line that is essentially **bold text** with little else.
-_BOLD_LINE_RE = re.compile(r"^#\s+\*\*([^*]+)\*\*\s*$")
+_BOLD_LINE_RE = re.compile(r"^(?:#|//)\s+\*\*([^*]+)\*\*\s*$")
 
 # Image with alt text.
 _IMG_ALT_RE = re.compile(r'<img[^>]*\balt="([^"]+)"', re.IGNORECASE)
@@ -107,10 +111,13 @@ def _extract_first_prose_line(lines: list[str]) -> str | None:
     """
     for line in lines:
         # Skip blank markdown lines and any non-markdown line (e.g. raw
-        # Python statements in a code cell).
-        if not line.startswith("# "):
+        # code statements in a code cell). Recognize either comment family.
+        if line.startswith("# "):
+            content = line[2:]
+        elif line.startswith("// "):
+            content = line[3:]
+        else:
             continue
-        content = line[2:]
         content = _HTML_TAG_RE.sub("", content)
         content = _BOLD_INLINE_RE.sub(r"\1", content)
         content = _ITALIC_INLINE_RE.sub(r"\1", content)
@@ -187,11 +194,15 @@ def cell_text_for_llm(content: str, *, max_chars: int = 1500) -> str:
     for line in _iter_content_lines(content):
         if not line.strip():
             continue
-        # Drop the Python comment prefix on markdown lines.
+        # Drop the comment prefix on markdown lines (either comment family).
         if line.startswith("# "):
             stripped = line[2:]
+        elif line.startswith("// "):
+            stripped = line[3:]
         elif line.startswith("#"):
             stripped = line[1:]
+        elif line.startswith("//"):
+            stripped = line[2:]
         else:
             stripped = line
         if not stripped.strip():

--- a/src/clm/slides/lang_coverage.py
+++ b/src/clm/slides/lang_coverage.py
@@ -25,6 +25,7 @@ import enum
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from clm.notebooks.slide_parser import comment_token_for_path
 from clm.slides.pairing import iter_split_pairs, split_lang_tag
 from clm.slides.raw_cells import split_cells
 
@@ -49,13 +50,14 @@ class CoverageStatus(enum.Enum):
     IMBALANCED = "imbalanced"  # both present, counts differ — alignment fix
 
 
-def count_languages(text: str) -> tuple[int, int]:
+def count_languages(text: str, comment_token: str = "#") -> tuple[int, int]:
     """Return ``(de_cells, en_cells)`` — slide/subslide start cells by language.
 
     Narrative cells and language-neutral cells (``lang`` unset) are not counted.
+    ``comment_token`` is the source language's line-comment token (``"#"`` / ``"//"``).
     """
     de = en = 0
-    _, cells = split_cells(text)
+    _, cells = split_cells(text, comment_token)
     for cell in cells:
         if not cell.metadata.is_slide_start:
             continue
@@ -132,8 +134,8 @@ def scan_coverage(files: list[Path]) -> CoverageReport:
         de_text, en_text = _read(de_path), _read(en_path)
         if de_text is None or en_text is None:
             continue
-        de_cells = count_languages(de_text)[0]
-        en_cells = count_languages(en_text)[1]
+        de_cells = count_languages(de_text, comment_token_for_path(de_path))[0]
+        en_cells = count_languages(en_text, comment_token_for_path(en_path))[1]
         report.entries.append(
             CoverageEntry(
                 label=str(de_path),
@@ -149,7 +151,7 @@ def scan_coverage(files: list[Path]) -> CoverageReport:
         if text is None:
             continue
         tag = split_lang_tag(solo)
-        de_cells, en_cells = count_languages(text)
+        de_cells, en_cells = count_languages(text, comment_token_for_path(solo))
         if tag is None:
             kind = "bilingual"
         else:

--- a/src/clm/slides/language_tools.py
+++ b/src/clm/slides/language_tools.py
@@ -11,7 +11,8 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
+from clm.slides.raw_cells import is_cell_boundary
 
 
 def get_language_view(
@@ -36,12 +37,13 @@ def get_language_view(
     Returns:
         Filtered file content as a string with line-number annotations.
     """
+    comment_token = comment_token_for_path(path)
     text = path.read_text(encoding="utf-8")
     raw_lines = text.split("\n")
-    cells = parse_cells(text)
+    cells = parse_cells(text, comment_token)
 
     kept = _filter_cells(cells, language, include_voiceover, include_notes)
-    return _reconstruct(kept, raw_lines)
+    return _reconstruct(kept, raw_lines, comment_token)
 
 
 def _filter_cells(
@@ -67,8 +69,12 @@ def _filter_cells(
     return result
 
 
-def _reconstruct(cells: list[Cell], raw_lines: list[str]) -> str:
-    """Reconstruct file text from kept cells with line annotations."""
+def _reconstruct(cells: list[Cell], raw_lines: list[str], comment_token: str = "#") -> str:
+    """Reconstruct file text from kept cells with line annotations.
+
+    The ``[original line N]`` annotation uses the deck's own comment token so the
+    single-language view stays a valid comment in the source language.
+    """
     parts: list[str] = []
 
     for cell in cells:
@@ -79,17 +85,17 @@ def _reconstruct(cells: list[Cell], raw_lines: list[str]) -> str:
                 parts.append(cell.content)
             continue
 
-        # Add line-number annotation
-        parts.append(f"# [original line {cell.line_number}]")
+        # Add line-number annotation (as a comment in the source language)
+        parts.append(f"{comment_token} [original line {cell.line_number}]")
 
         # Emit the cell's raw lines from the original file
-        cell_lines = _extract_raw_cell(cell, raw_lines)
+        cell_lines = _extract_raw_cell(cell, raw_lines, comment_token)
         parts.append(cell_lines)
 
     return "\n".join(parts) + "\n" if parts else ""
 
 
-def _extract_raw_cell(cell: Cell, raw_lines: list[str]) -> str:
+def _extract_raw_cell(cell: Cell, raw_lines: list[str], comment_token: str = "#") -> str:
     """Extract the raw text of a cell from the original file lines.
 
     Uses the cell's ``line_number`` (1-based) as start and scans
@@ -99,7 +105,7 @@ def _extract_raw_cell(cell: Cell, raw_lines: list[str]) -> str:
     end = start + 1
     while end < len(raw_lines):
         line = raw_lines[end]
-        if line.startswith("# %%") or line.startswith("# j2 ") or line.startswith("# {{ "):
+        if is_cell_boundary(line, comment_token):
             break
         end += 1
 
@@ -161,11 +167,12 @@ def suggest_sync(
     Returns:
         A :class:`SyncResult` with suggestions for the target language.
     """
+    comment_token = comment_token_for_path(path)
     current_text = path.read_text(encoding="utf-8")
     head_text = _git_head_content(path)
 
-    current_cells = parse_cells(current_text)
-    head_cells = parse_cells(head_text) if head_text is not None else []
+    current_cells = parse_cells(current_text, comment_token)
+    head_cells = parse_cells(head_text, comment_token) if head_text is not None else []
 
     # Separate cells by language
     cur_de = _lang_cells(current_cells, "de")

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -30,7 +30,7 @@ from clm.core.topic_resolver import (
     find_slide_files_recursive,
     matches_for_binding,
 )
-from clm.notebooks.slide_parser import parse_cell_header
+from clm.notebooks.slide_parser import comment_token_for_path, parse_cell_header
 from clm.slides.pairing import build_slide_groups
 from clm.slides.raw_cells import RawCell as _RawCell
 from clm.slides.raw_cells import reconstruct as _reconstruct
@@ -146,7 +146,7 @@ def _apply_tag_migration(cells: list[_RawCell], file_path: str) -> list[Change]:
 # Workshop tags: add 'workshop' to workshop heading cells
 # ---------------------------------------------------------------------------
 
-_WORKSHOP_RE = re.compile(r"^#\s+##\s+(Workshop|Mini-Workshop)\s*:", re.MULTILINE)
+_WORKSHOP_RE = re.compile(r"^(?:#|//)\s+##\s+(Workshop|Mini-Workshop)\s*:", re.MULTILINE)
 
 
 def _apply_workshop_tags(cells: list[_RawCell], file_path: str) -> list[Change]:
@@ -495,11 +495,15 @@ def _check_similarity(de_cell: _RawCell, en_cell: _RawCell) -> list[str]:
 def _heading_level(cell: _RawCell) -> int:
     """Extract the markdown heading level (0 = no heading)."""
     for line in cell.lines[1:]:
-        # Strip Python comment prefix
+        # Strip the comment prefix (either comment family).
         if line.startswith("# "):
             inner = line[2:]
+        elif line.startswith("// "):
+            inner = line[3:]
         elif line.startswith("#"):
             inner = line[1:]
+        elif line.startswith("//"):
+            inner = line[2:]
         else:
             continue
         inner = inner.lstrip()
@@ -518,9 +522,9 @@ def _bullet_count(cell: _RawCell) -> int:
     """Count top-level list items in a markdown cell."""
     count = 0
     for line in cell.lines[1:]:
-        if line.startswith("# - ") or line.startswith("# * "):
+        if line.startswith(("# - ", "# * ", "// - ", "// * ")):
             count += 1
-        elif re.match(r"^# \d+\.\s", line):
+        elif re.match(r"^(?:#|//) \d+\.\s", line):
             count += 1
     return count
 
@@ -640,7 +644,9 @@ def _apply_slide_ids(
 # ---------------------------------------------------------------------------
 
 
-def _apply_cell_spacing(cells: list[_RawCell], file_path: str) -> list[Change]:
+def _apply_cell_spacing(
+    cells: list[_RawCell], file_path: str, comment_token: str = "#"
+) -> list[Change]:
     """Normalize inter-cell and intra-cell whitespace (two mechanical fixes).
 
     The counterparts of the validator's ``cell-separation`` and
@@ -666,19 +672,19 @@ def _apply_cell_spacing(cells: list[_RawCell], file_path: str) -> list[Change]:
         if not body:
             continue
         first = body[0]
-        if first.strip() == "#":
+        if first.strip() == comment_token:
             continue  # already a blank comment
         if first.strip() == "":
-            # A bare blank line where the `#` belongs — promote it to the comment.
-            cell.lines[1] = "#"
+            # A bare blank line where the comment belongs — promote it.
+            cell.lines[1] = comment_token
         else:
-            cell.lines.insert(1, "#")
+            cell.lines.insert(1, comment_token)
         changes.append(
             Change(
                 file=file_path,
                 operation="cell_spacing",
                 line=cell.line_number,
-                description="Added leading blank comment line (`#`) to markdown cell",
+                description=f"Added leading blank comment line (`{comment_token}`) to markdown cell",
             )
         )
 
@@ -738,8 +744,9 @@ def normalize_file(
         op_set = set(ALL_OPERATIONS)
 
     file_str = str(path)
+    comment_token = comment_token_for_path(path)
     text = path.read_text(encoding="utf-8")
-    preamble, cells = _split_raw_cells(text)
+    preamble, cells = _split_raw_cells(text, comment_token)
 
     all_changes: list[Change] = []
     all_review: list[ReviewItem] = []
@@ -769,7 +776,7 @@ def normalize_file(
     # Cell spacing runs last, on the final cell order (after any interleaving
     # reorder), so blank-line separation reflects the cells' final adjacency.
     if "cell_spacing" in op_set:
-        all_changes.extend(_apply_cell_spacing(cells, file_str))
+        all_changes.extend(_apply_cell_spacing(cells, file_str, comment_token))
 
     modified = False
     if all_changes and not dry_run:

--- a/src/clm/slides/raw_cells.py
+++ b/src/clm/slides/raw_cells.py
@@ -21,12 +21,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from clm.notebooks.slide_parser import CellMetadata, parse_cell_header
+from clm.notebooks.slide_parser import CellMetadata, _is_cell_boundary, parse_cell_header
 
 
-def is_cell_boundary(line: str) -> bool:
-    """Return True iff ``line`` opens a new percent-format cell."""
-    return line.startswith("# %%") or line.startswith("# j2 ") or line.startswith("# {{ ")
+def is_cell_boundary(line: str, comment_token: str = "#") -> bool:
+    """Return True iff ``line`` opens a new percent-format cell.
+
+    Delegates to the single canonical predicate in
+    :mod:`clm.notebooks.slide_parser` so the boundary rule can never drift between
+    the two. ``comment_token`` is the source language's line-comment token
+    (``"#"`` python/rust, ``"//"`` cpp/csharp/java/typescript).
+    """
+    return _is_cell_boundary(line, comment_token)
 
 
 @dataclass
@@ -50,12 +56,15 @@ class RawCell:
         return "\n".join(self.lines[1:])
 
 
-def split_cells(text: str) -> tuple[str, list[RawCell]]:
+def split_cells(text: str, comment_token: str = "#") -> tuple[str, list[RawCell]]:
     """Split ``text`` into ``(preamble, cells)`` losslessly.
 
     ``preamble`` contains every line before the first cell boundary. Each
     ``RawCell`` keeps the boundary line and all following lines until the
-    next boundary (or end of file) in ``lines``.
+    next boundary (or end of file) in ``lines``. ``comment_token`` is the source
+    language's line-comment token (``"#"`` / ``"//"``); it affects only boundary
+    detection and j2 classification — the verbatim ``lines`` are untouched, so the
+    round-trip invariant holds for any language.
     """
     lines = text.split("\n")
     cells: list[RawCell] = []
@@ -64,13 +73,13 @@ def split_cells(text: str) -> tuple[str, list[RawCell]]:
     current_line = 0
     in_cell = False
     for i, line in enumerate(lines):
-        if is_cell_boundary(line):
+        if is_cell_boundary(line, comment_token):
             if in_cell:
                 cells.append(
                     RawCell(
                         lines=current,
                         line_number=current_line,
-                        metadata=parse_cell_header(current[0]),
+                        metadata=parse_cell_header(current[0], comment_token),
                     )
                 )
             current = [line]
@@ -86,7 +95,7 @@ def split_cells(text: str) -> tuple[str, list[RawCell]]:
             RawCell(
                 lines=current,
                 line_number=current_line,
-                metadata=parse_cell_header(current[0]),
+                metadata=parse_cell_header(current[0], comment_token),
             )
         )
     return ("\n".join(preamble), cells)

--- a/src/clm/slides/split.py
+++ b/src/clm/slides/split.py
@@ -64,7 +64,11 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from clm.infrastructure.utils.path_utils import atomic_write_all
+from clm.infrastructure.utils.path_utils import (
+    SUPPORTED_PROG_LANG_EXTENSIONS,
+    atomic_write_all,
+)
+from clm.notebooks.slide_parser import comment_token_for_path
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
 
 # ---------------------------------------------------------------------------
@@ -140,9 +144,11 @@ _HEADER_EN_RE = re.compile(r'(\{\{\s*header_en\s*\(\s*")([^"]*)("\s*\)\s*\}\})')
 
 # Exact bare-form import line — anything more elaborate (extra macros, aliases)
 # is treated as a shared j2 directive and copied verbatim to both outputs.
-_HEADER_IMPORT_RE = re.compile(r"^(#\s*j2\s+from\s+\S+\s+import\s+)header\s*$")
-_HEADER_DE_IMPORT_RE = re.compile(r"^(#\s*j2\s+from\s+\S+\s+import\s+)header_de\s*$")
-_HEADER_EN_IMPORT_RE = re.compile(r"^(#\s*j2\s+from\s+\S+\s+import\s+)header_en\s*$")
+# ``(?:#|//)`` matches either comment family; group 1 captures the actual prefix
+# (incl. the source language's token), so the rewrite preserves ``#`` vs ``//``.
+_HEADER_IMPORT_RE = re.compile(r"^((?:#|//)\s*j2\s+from\s+\S+\s+import\s+)header\s*$")
+_HEADER_DE_IMPORT_RE = re.compile(r"^((?:#|//)\s*j2\s+from\s+\S+\s+import\s+)header_de\s*$")
+_HEADER_EN_IMPORT_RE = re.compile(r"^((?:#|//)\s*j2\s+from\s+\S+\s+import\s+)header_en\s*$")
 
 
 def _is_bilingual_header_cell(cell: RawCell) -> bool:
@@ -174,8 +180,12 @@ def _is_header_en_import_cell(cell: RawCell) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def split_text(text: str) -> tuple[str, str]:
+def split_text(text: str, comment_token: str = "#") -> tuple[str, str]:
     """Return ``(de_text, en_text)`` for a bilingual slide-file ``text``.
+
+    ``comment_token`` is the source language's line-comment token (``"#"`` python/
+    rust, ``"//"`` cpp/csharp/java/typescript). The header-macro rewrite is
+    comment-token-agnostic; only cell splitting needs the token.
 
     The split is purely structural — no cell content is reformatted. Cells
     are routed by ``lang`` attribute: ``lang="de"`` → DE only,
@@ -187,7 +197,7 @@ def split_text(text: str) -> tuple[str, str]:
     Raises :class:`SplitError` if the file contains a ``header_de`` or
     ``header_en`` cell, which indicates the input is already split.
     """
-    preamble, cells = split_cells(text)
+    preamble, cells = split_cells(text, comment_token)
 
     de_cells: list[RawCell] = []
     en_cells: list[RawCell] = []
@@ -292,7 +302,9 @@ class _CompanionSplitPlan:
     en_text: str
 
 
-def _plan_companion_split(source: Path, de_path: Path, en_path: Path) -> _CompanionSplitPlan | None:
+def _plan_companion_split(
+    source: Path, de_path: Path, en_path: Path, comment_token: str = "#"
+) -> _CompanionSplitPlan | None:
     """Plan splitting ``source``'s voiceover companion in lockstep with the deck.
 
     Returns ``None`` when ``source`` has no sibling ``voiceover_*.py``.
@@ -314,7 +326,7 @@ def _plan_companion_split(source: Path, de_path: Path, en_path: Path) -> _Compan
     # in (the ``voiceover/`` subdir or the sibling location), so a foldered topic
     # stays foldered across a split.
     comp_dir = companion.parent
-    comp_de_text, comp_en_text = split_text(companion.read_text(encoding="utf-8"))
+    comp_de_text, comp_en_text = split_text(companion.read_text(encoding="utf-8"), comment_token)
     return _CompanionSplitPlan(
         source=companion,
         de_path=comp_dir / companion_name(de_path),
@@ -345,10 +357,11 @@ def split_in_file(
     de_path = _split_target(source, "de")
     en_path = _split_target(source, "en")
 
+    comment_token = comment_token_for_path(source)
     text = source.read_text(encoding="utf-8")
-    de_text, en_text = split_text(text)
+    de_text, en_text = split_text(text, comment_token)
 
-    companion = _plan_companion_split(source, de_path, en_path)
+    companion = _plan_companion_split(source, de_path, en_path, comment_token)
 
     overwrote: list[str] = []
     if de_path.exists():
@@ -387,13 +400,18 @@ def split_in_file(
 
 
 def _split_target(source: Path, lang: str) -> Path:
-    """Return the ``<basename>.<lang>.py`` companion path for ``source``."""
-    if source.suffix != ".py":
-        raise SplitError(f"source must be a .py file: {source}")
-    basename = source.name[: -len(".py")]
+    """Return the ``<basename>.<lang><ext>`` split path for ``source``.
+
+    Works for any supported slide extension (``.py``/``.cs``/``.cpp``/``.java``/
+    ``.ts``), preserving the source's extension.
+    """
+    suffix = source.suffix
+    if suffix not in SUPPORTED_PROG_LANG_EXTENSIONS:
+        raise SplitError(f"source must be a supported slide file: {source}")
+    basename = source.name[: -len(suffix)]
     if basename.endswith(".de") or basename.endswith(".en"):
         raise SplitError(f"source already looks split (ends with .de/.en): {source}")
-    return source.with_name(f"{basename}.{lang}.py")
+    return source.with_name(f"{basename}.{lang}{suffix}")
 
 
 # ---------------------------------------------------------------------------
@@ -401,8 +419,10 @@ def _split_target(source: Path, lang: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def unify_texts(de_text: str, en_text: str) -> str:
+def unify_texts(de_text: str, en_text: str, comment_token: str = "#") -> str:
     """Return the bilingual text reconstructed from ``de_text`` and ``en_text``.
+
+    ``comment_token`` is the source language's line-comment token (``"#"`` / ``"//"``).
 
     Walks both cell lists with parallel cursors and interleaves cells back
     into the canonical bilingual order:
@@ -418,8 +438,8 @@ def unify_texts(de_text: str, en_text: str) -> str:
     Raises :class:`UnifyError` on any structural mismatch (divergent shared
     cell, leftover cells, header mismatch).
     """
-    de_preamble, de_cells = split_cells(de_text)
-    en_preamble, en_cells = split_cells(en_text)
+    de_preamble, de_cells = split_cells(de_text, comment_token)
+    en_preamble, en_cells = split_cells(en_text, comment_token)
 
     if de_preamble != en_preamble:
         raise UnifyError("DE and EN files differ in their preamble (lines before any cell)")
@@ -633,7 +653,7 @@ class _CompanionUnifyPlan:
 
 
 def _plan_companion_unify(
-    de_source: Path, en_source: Path, target: Path
+    de_source: Path, en_source: Path, target: Path, comment_token: str = "#"
 ) -> _CompanionUnifyPlan | None:
     """Plan recombining the split voiceover companions of a ``.de`` / ``.en`` pair.
 
@@ -656,7 +676,9 @@ def _plan_companion_unify(
     present = de_comp if de_comp is not None else en_comp
     assert present is not None
     target_companion = present.parent / companion_name(target)
-    return _CompanionUnifyPlan(target=target_companion, text=unify_texts(de_text, en_text))
+    return _CompanionUnifyPlan(
+        target=target_companion, text=unify_texts(de_text, en_text, comment_token)
+    )
 
 
 def unify_in_file(
@@ -684,11 +706,12 @@ def unify_in_file(
         target = _unify_target(de_source, en_source)
     target = target.resolve()
 
+    comment_token = comment_token_for_path(de_source)
     de_text = de_source.read_text(encoding="utf-8")
     en_text = en_source.read_text(encoding="utf-8")
-    unified = unify_texts(de_text, en_text)
+    unified = unify_texts(de_text, en_text, comment_token)
 
-    companion = _plan_companion_unify(de_source, en_source, target)
+    companion = _plan_companion_unify(de_source, en_source, target, comment_token)
 
     overwrote = target.exists()
     companion_overwrote = companion is not None and companion.target.exists()
@@ -727,10 +750,11 @@ def _unify_target(de_source: Path, en_source: Path) -> Path:
 
 
 def _strip_lang_suffix(path: Path, lang: str) -> Path:
-    if path.suffix != ".py":
-        raise UnifyError(f"source must be a .py file: {path}")
-    stem = path.name[: -len(".py")]
+    ext = path.suffix
+    if ext not in SUPPORTED_PROG_LANG_EXTENSIONS:
+        raise UnifyError(f"source must be a supported slide file: {path}")
+    stem = path.name[: -len(ext)]
     suffix = f".{lang}"
     if not stem.endswith(suffix):
-        raise UnifyError(f"source does not end in {suffix}.py: {path}")
-    return path.with_name(f"{stem[: -len(suffix)]}.py")
+        raise UnifyError(f"source does not end in {suffix}{ext}: {path}")
+    return path.with_name(f"{stem[: -len(suffix)]}{ext}")

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -53,7 +53,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.llm.ollama_client import OllamaError
-from clm.notebooks.slide_parser import Cell, parse_cell_header, parse_cells
+from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cell_header, parse_cells
 from clm.slides.raw_cells import RawCell
 from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_code import apply_code_structure
@@ -845,7 +845,7 @@ def _slide_cells(path: Path, lang: str) -> list[Cell]:
     """The slide/subslide cells of ``lang`` — the units a cold mint stamps an id onto."""
     return [
         c
-        for c in parse_cells(path.read_text(encoding="utf-8"))
+        for c in parse_cells(path.read_text(encoding="utf-8"), comment_token_for_path(path))
         if c.metadata.lang == lang and role_of(c.metadata) in _SLIDE_ROLES
     ]
 
@@ -1688,7 +1688,13 @@ def _place_new_cell(
     """Stamp the source cell's id and insert the translated counterpart."""
     _stamp_slide_id(cell, new_id)
     source_state.dirty = True
-    new_cell = _build_cell(target_lang, cell.metadata.tags, new_id, target_body)
+    new_cell = _build_cell(
+        target_lang,
+        cell.metadata.tags,
+        new_id,
+        target_body,
+        comment_token_for_path(target_state.path),
+    )
     _insert_at_anchor(target_state, anchor, new_cell)
 
 
@@ -1706,10 +1712,16 @@ def _extract_heading(body: str) -> str:
     residual Markdown.
     """
     for raw in body.split("\n"):
+        # Drop the comment prefix as a literal prefix (either comment family),
+        # so a "**bold**" or "/path" lead-in survives.
         if raw.startswith("# "):
             md = raw[2:].strip()
+        elif raw.startswith("// "):
+            md = raw[3:].strip()
         elif raw.startswith("#"):
             md = raw[1:].strip()
+        elif raw.startswith("//"):
+            md = raw[2:].strip()
         else:
             md = raw.strip()
         if not md:
@@ -1730,14 +1742,17 @@ def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
     cell.metadata = parse_cell_header(header)
 
 
-def _build_cell(lang: str, tags: list[str], slide_id: str, body: str) -> RawCell:
+def _build_cell(
+    lang: str, tags: list[str], slide_id: str, body: str, comment_token: str = "#"
+) -> RawCell:
     """Build a fresh markdown RawCell carrying the translated counterpart.
 
     The body is built bare (no leading/trailing blank lines); the insert
     primitive grants the deck's inter-cell separator based on final position.
+    ``comment_token`` is the target deck's line-comment token (``"#"`` / ``"//"``).
     """
     tag_repr = ", ".join(f'"{t}"' for t in tags) if tags else '"slide"'
-    header = f'# %% [markdown] lang="{lang}" tags=[{tag_repr}] slide_id="{slide_id}"'
+    header = f'{comment_token} %% [markdown] lang="{lang}" tags=[{tag_repr}] slide_id="{slide_id}"'
     body_lines = body.split("\n")
     while body_lines and body_lines[0] == "":  # drop a stray leading blank
         body_lines.pop(0)
@@ -1928,7 +1943,7 @@ def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
     walker can render each proposal's current source/target bodies.
     """
     index: dict[tuple[str, str], str] = {}
-    for cell in parse_cells(path.read_text(encoding="utf-8")):
+    for cell in parse_cells(path.read_text(encoding="utf-8"), comment_token_for_path(path)):
         role = role_of(cell.metadata)
         if role is None:
             continue
@@ -2457,8 +2472,8 @@ def _record_watermark(
     (``_baseline_from_watermark`` filters the synthetic membership roles), so this
     does not change its behavior.
     """
-    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
-    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path))
     de_rows = watermark_rows(de_cells)
     en_rows = watermark_rows(en_cells)
     # Issue #198: record each cell's tag set alongside its row so a later run can
@@ -2592,8 +2607,8 @@ def _record_watermark_partial(
     watermark and let the conflict re-surface instead of dropping it.
     """
     parsed = {
-        "de": parse_cells(de_path.read_text(encoding="utf-8")),
-        "en": parse_cells(en_path.read_text(encoding="utf-8")),
+        "de": parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path)),
+        "en": parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path)),
     }
     cells_by_lang = {
         "de": ordered_sync_cells(parsed["de"], "de"),

--- a/src/clm/slides/sync_direction.py
+++ b/src/clm/slides/sync_direction.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
 from clm.slides.sync_writeback import cell_content_hash
 
 if TYPE_CHECKING:
@@ -177,8 +177,8 @@ def _infer_from_snapshot(
         return _SignalResult(verdict="none", side=None, detail="no snapshot rows for this pair")
 
     try:
-        de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
-        en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+        de_cells = parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path))
+        en_cells = parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path))
     except OSError as exc:
         return _SignalResult(
             verdict="none", side=None, detail=f"could not read source files: {exc}"

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
-from clm.notebooks.slide_parser import Cell, CellMetadata, parse_cells
+from clm.notebooks.slide_parser import Cell, CellMetadata, comment_token_for_path, parse_cells
 from clm.slides.sync_writeback import (
     cell_content_hash,
     construct_of,
@@ -633,11 +633,12 @@ def _baseline_from_watermark(
 
 
 def _lang_for_path(path: Path) -> str | None:
-    name = path.name
-    if name.endswith(".de.py"):
-        return "de"
-    if name.endswith(".en.py"):
-        return "en"
+    # The ``.de`` / ``.en`` tag sits before the final extension
+    # (``foo.de.cs`` -> "de"), so this is prefix- and extension-agnostic
+    # across .py/.cs/.cpp/.java/.ts split halves.
+    parts = path.name.split(".")
+    if len(parts) >= 3 and parts[-2] in ("de", "en"):
+        return parts[-2]
     return None
 
 
@@ -664,7 +665,7 @@ def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
         return None
     if completed.returncode != 0:
         return None
-    cells = parse_cells(completed.stdout)
+    cells = parse_cells(completed.stdout, comment_token_for_path(path))
     return [
         BaselineCell(
             position=c.position,
@@ -1759,8 +1760,8 @@ def build_sync_plan(
     actionable plan upgrades to ``reconcile`` candidates (handled in
     :func:`classify_changes`) instead of refusing.
     """
-    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
-    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path))
     de_current = ordered_sync_cells(de_cells, "de")
     en_current = ordered_sync_cells(en_cells, "en")
 
@@ -2200,8 +2201,8 @@ def render_explain(
     lines.append("  legend: = unchanged  ~ edited  + new  - removed")
     lines.append("")
 
-    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
-    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path))
     de_current = watermark_rows(de_cells)
     en_current = watermark_rows(en_cells)
     current_by_partition = {

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -81,6 +81,7 @@ class StaticSlideTranslator:
     default: str | None = None
     mapping: dict[str, str] = field(default_factory=dict)
     prompt_version: str = "static"
+    prog_lang: str = "python"  # protocol-uniformity; StaticSlideTranslator ignores it
 
     def translate(
         self,
@@ -113,6 +114,10 @@ class OpenRouterSlideTranslator:
     temperature: float = 0.2
     max_tokens: int = 4096
     prompt_version: str = "translate-v1"
+    # The deck's programming language (e.g. "python", "csharp", "cpp"). Drives the
+    # comment prefix and language name named in the prompt, so a //-deck is told to
+    # preserve "// " prefixes and a C# code cell is translated as C#, not Python.
+    prog_lang: str = "python"
 
     def _client(self):  # pragma: no cover - thin network adapter
         # Shared with the edit judge so key/base resolution stays in one place.
@@ -128,10 +133,13 @@ class OpenRouterSlideTranslator:
         target_lang: str,
         role: str,
     ) -> str:  # pragma: no cover - exercised via mocked client / integration
+        comment_prefix, prog_lang_name = _prog_lang_descriptors(self.prog_lang)
         system = _system_prompt_for(role).format(
             source_lang=_LANG_NAMES.get(source_lang, source_lang),
             target_lang=_LANG_NAMES.get(target_lang, target_lang),
             role=role,
+            comment_prefix=comment_prefix,
+            prog_lang_name=prog_lang_name,
         )
 
         def _create():
@@ -165,26 +173,27 @@ _LANG_NAMES = {"de": "German", "en": "English"}
 _SYSTEM_PROMPT = (
     "You translate a single slide cell from {source_lang} to {target_lang} for a "
     "programming course. The cell is a {role} cell in Jupyter percent-format: every "
-    "line is prefixed with '# ' and may contain Markdown (headings like '# ## Title', "
-    "bullet lists, inline code). Translate ONLY the natural-language prose. Preserve "
-    "verbatim: the '# ' line prefixes, Markdown structure and heading levels, code "
-    "spans and identifiers, URLs, and slide directives. Do not add, drop, or reorder "
-    "lines. Return only the translated cell body, no commentary, no code fences."
+    "line is prefixed with '{comment_prefix}' and may contain Markdown (headings like "
+    "'{comment_prefix}## Title', bullet lists, inline code). Translate ONLY the "
+    "natural-language prose. Preserve verbatim: the '{comment_prefix}' line prefixes, "
+    "Markdown structure and heading levels, code spans and identifiers, URLs, and slide "
+    "directives. Do not add, drop, or reorder lines. Return only the translated cell "
+    "body, no commentary, no code fences."
 )
 
-# Code cells are NOT comment-prefixed: they are runnable Python. Only the
+# Code cells are NOT comment-prefixed: they are runnable source. Only the
 # human-facing text inside them (string literals shown to the learner, comments)
 # differs across languages; the code itself is language-neutral and must stay
 # byte-identical so the cell still runs and the two decks share one logic.
 _CODE_SYSTEM_PROMPT = (
-    "You localize a single Python code cell of a {source_lang} programming-course "
-    "slide deck into its {target_lang} counterpart. Return runnable Python, NOT "
-    "Markdown. Translate ONLY human-facing natural-language text: the contents of "
-    "string literals that are shown to a learner (e.g. example prompts, questions, "
-    "user-visible messages) and code comments. Keep EVERYTHING else byte-identical: "
-    "all identifiers, function/variable/class names, keywords, imports, attribute "
-    "and method names, dict keys, operators, numbers, structure, indentation, and "
-    "string literals that are technical (model names, URLs, format strings, JSON "
+    "You localize a single {prog_lang_name} code cell of a {source_lang} "
+    "programming-course slide deck into its {target_lang} counterpart. Return runnable "
+    "{prog_lang_name}, NOT Markdown. Translate ONLY human-facing natural-language text: "
+    "the contents of string literals that are shown to a learner (e.g. example prompts, "
+    "questions, user-visible messages) and code comments. Keep EVERYTHING else "
+    "byte-identical: all identifiers, function/variable/class names, keywords, imports, "
+    "attribute and method names, dict keys, operators, numbers, structure, indentation, "
+    "and string literals that are technical (model names, URLs, format strings, JSON "
     'keys like "role"/"content"/"system"/"user"). Do not add, drop, reorder, '
     "or reformat lines. Return only the cell body, no commentary, no code fences."
 )
@@ -193,6 +202,29 @@ _CODE_SYSTEM_PROMPT = (
 def _system_prompt_for(role: str) -> str:
     """Pick the system prompt for a cell ``role`` (code cells are not Markdown)."""
     return _CODE_SYSTEM_PROMPT if role == "code" else _SYSTEM_PROMPT
+
+
+def _prog_lang_descriptors(prog_lang: str) -> tuple[str, str]:
+    """Return ``(comment_prefix, prog_lang_name)`` for prompt templating.
+
+    e.g. ``"python"`` -> ``("# ", "Python")``; ``"csharp"`` -> ``("// ", "C#")``.
+    Falls back to ``("# ", <prog_lang>)`` for an unknown language.
+    """
+    from clm.workers.notebook.utils.prog_lang_utils import language_info, line_comment_for
+
+    try:
+        prefix = line_comment_for(prog_lang) + " "
+    except (KeyError, ValueError):
+        prefix = "# "
+    try:
+        name = str(language_info(prog_lang).get("name", prog_lang))
+    except (KeyError, ValueError):
+        name = prog_lang
+    # language_info names are inconsistently cased ("python"/"C#"/"Java"); title
+    # only the all-lowercase ones so "C#"/"C++" keep their casing.
+    if name.islower():
+        name = name.capitalize()
+    return prefix, name
 
 
 @dataclass
@@ -218,9 +250,12 @@ class CachingSlideTranslator:
 
     def __post_init__(self) -> None:
         model = getattr(self.inner, "model", "")
-        self.prompt_version = (
-            f"{self.inner.prompt_version}:{model}" if model else self.inner.prompt_version
-        )
+        base = f"{self.inner.prompt_version}:{model}" if model else self.inner.prompt_version
+        # Fold the deck's prog_lang into the key so a C# code cell and a Python one
+        # with identical source never share an entry. Keep "python" un-suffixed so
+        # the existing Python cache stays valid (no flag-day invalidation).
+        prog_lang = getattr(self.inner, "prog_lang", "python")
+        self.prompt_version = f"{base}:{prog_lang}" if prog_lang and prog_lang != "python" else base
 
     def translate(
         self,

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from clm.notebooks.slide_parser import CellMetadata, parse_cell_header
+from clm.notebooks.slide_parser import CellMetadata, comment_token_for_path, parse_cell_header
 from clm.slides.code_cell_extract import extract_from_code
 from clm.slides.raw_cells import RawCell, reconstruct, split_cells
 from clm.slides.slug import slugify
@@ -235,7 +235,10 @@ def swap_lang(header: str, lang: str) -> str:
         return _LANG_ATTR_RE.sub(f'lang="{lang}"', header)
     if "[markdown]" in header:
         return header.replace("[markdown]", f'[markdown] lang="{lang}"', 1)
-    return header.replace("# %%", f'# %% lang="{lang}"', 1)
+    # bare "<token> %%" code-cell header — insert lang after the %% marker for
+    # either comment family.
+    marker = "// %%" if header.startswith("// %%") else "# %%"
+    return header.replace(marker, f'{marker} lang="{lang}"', 1)
 
 
 def build_twin_cell(source_cell: RawCell, target_lang: str, target_body: str) -> RawCell:
@@ -314,7 +317,7 @@ class FileState:
     @classmethod
     def load(cls, path: Path) -> FileState:
         text = path.read_text(encoding="utf-8")
-        preamble, cells = split_cells(text)
+        preamble, cells = split_cells(text, comment_token_for_path(path))
         return cls(
             path=path,
             preamble=preamble,

--- a/src/clm/slides/tidy.py
+++ b/src/clm/slides/tidy.py
@@ -39,7 +39,7 @@ from clm.slides.voiceover_tools import COMPANION_SUBDIR
 CASSETTE_SUBDIR = "cassettes"
 CASSETTE_LEGACY_SUBDIR = "_cassettes"
 
-_VOICEOVER_RE = re.compile(r"voiceover_.*\.py$")
+_VOICEOVER_RE = re.compile(r"voiceover_.*\.(py|cs|cpp|cxx|cc|java|ts|rs)$")
 _CASSETTE_RE = re.compile(r".*\.http-cassette\.yaml$")
 _STAGING_RE = re.compile(r".*\.http-cassette\.yaml\.staging-.*$")
 

--- a/src/clm/slides/translate_bootstrap.py
+++ b/src/clm/slides/translate_bootstrap.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from clm.notebooks.slide_parser import comment_token_for_path
 from clm.slides.assign_ids import AssignOptions, AssignResult, assign_ids_in_split_pair
 from clm.slides.pairing import split_lang_tag
 from clm.slides.sync_apply import ApplyResult, _record_watermark, apply_plan
@@ -293,11 +294,13 @@ def _bootstrap_new_twin(
     so the next ``sync`` is a clean no-op.
     """
     source_text = paths.source_path.read_text(encoding="utf-8")
+    comment_token = comment_token_for_path(paths.source_path)
     deck = translate_deck_text(
         source_text,
         source_lang=paths.source_lang,
         target_lang=paths.target_lang,
         translator=translator,
+        comment_token=comment_token,
     )
     # Translate the companion in lockstep (D5) BEFORE any write, so a companion
     # failure aborts the whole bootstrap instead of leaving a deck with no
@@ -393,6 +396,7 @@ def _translate_companion(
         source_lang=paths.source_lang,
         target_lang=paths.target_lang,
         translator=translator,
+        comment_token=comment_token_for_path(paths.source_path),
     )
     return CompanionResult(
         source=source_companion, target=target, action="translated", translation=translation

--- a/src/clm/slides/translate_deck.py
+++ b/src/clm/slides/translate_deck.py
@@ -114,13 +114,16 @@ def translate_deck_text(
     source_lang: str,
     target_lang: str,
     translator: SlideTranslator,
+    comment_token: str = "#",
 ) -> TranslateDeckResult:
     """Translate a single-language split half into its other-language twin.
 
-    ``source_text`` is the verbatim content of a ``*.<source_lang>.py`` split
-    half. Returns the text of the matching ``*.<target_lang>.py`` half plus a
-    per-cell report. Raises :class:`TranslateDeckError` if a cell cannot be
-    translated or the generated pair does not round-trip.
+    ``source_text`` is the verbatim content of a ``*.<source_lang><ext>`` split
+    half. Returns the text of the matching ``*.<target_lang><ext>`` half plus a
+    per-cell report. ``comment_token`` is the source language's line-comment
+    token (``"#"`` python/rust, ``"//"`` cpp/csharp/java/typescript). Raises
+    :class:`TranslateDeckError` if a cell cannot be translated or the generated
+    pair does not round-trip.
     """
     if source_lang not in _SUPPORTED_LANGS or target_lang not in _SUPPORTED_LANGS:
         raise TranslateDeckError(
@@ -130,7 +133,7 @@ def translate_deck_text(
     if source_lang == target_lang:
         raise TranslateDeckError(f"source and target language are both {source_lang!r}")
 
-    preamble, source_cells = split_cells(source_text)
+    preamble, source_cells = split_cells(source_text, comment_token)
 
     target_cells: list[RawCell] = []
     report: list[CellTranslation] = []
@@ -171,7 +174,7 @@ def translate_deck_text(
         report.append(CellTranslation(index, "copied", None, meta.slide_id, meta.lang))
 
     target_text = reconstruct(preamble, target_cells)
-    _assert_round_trips(source_text, target_text, source_lang)
+    _assert_round_trips(source_text, target_text, source_lang, comment_token)
     return TranslateDeckResult(target_text=target_text, cells=report)
 
 
@@ -301,7 +304,9 @@ def _trailing_blanks(cell: RawCell) -> int:
     return n
 
 
-def _assert_round_trips(source_text: str, target_text: str, source_lang: str) -> None:
+def _assert_round_trips(
+    source_text: str, target_text: str, source_lang: str, comment_token: str = "#"
+) -> None:
     """Guard that the generated (source, target) pair is a valid split twin.
 
     Re-unifies the two halves and splits them back; the result must reproduce
@@ -320,8 +325,8 @@ def _assert_round_trips(source_text: str, target_text: str, source_lang: str) ->
     else:
         de_text, en_text = target_text, source_text
     try:
-        unified = split.unify_texts(de_text, en_text)
-        de_back, en_back = split.split_text(unified)
+        unified = split.unify_texts(de_text, en_text, comment_token)
+        de_back, en_back = split.split_text(unified, comment_token)
     except (split.UnifyError, split.SplitError) as exc:
         raise TranslateDeckError(
             f"generated translation does not form a valid split pair: {exc}"

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -21,7 +21,7 @@ from clm.core.topic_resolver import (
     matches_for_binding,
 )
 from clm.infrastructure.utils.path_utils import split_lang_suffix
-from clm.notebooks.slide_parser import Cell, parse_cells
+from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
 from clm.slides.pairing import (
     TITLE_SLIDE_ID,
     build_slide_groups,
@@ -136,16 +136,17 @@ def _check_format(cells: list[Cell], file_path: str) -> list[Finding]:
         if meta.is_j2:
             continue
 
-        # Check that header starts with "# %%"
-        if not header.startswith("# %%"):
+        # Check that header starts with the language's "<token> %%" marker.
+        marker = f"{cell.comment_token} %%"
+        if not header.startswith(marker):
             findings.append(
                 Finding(
                     severity="error",
                     category="format",
                     file=file_path,
                     line=cell.line_number,
-                    message=f"Cell header does not start with '# %%': {header!r}",
-                    suggestion="Cell headers must begin with '# %%'",
+                    message=f"Cell header does not start with {marker!r}: {header!r}",
+                    suggestion=f"Cell headers must begin with {marker!r}",
                 )
             )
             continue
@@ -194,8 +195,8 @@ def _ends_with_blank_line(cell: RawCell) -> bool:
 
 
 def _is_blank_comment(line: str) -> bool:
-    """True iff ``line`` is a markdown blank-comment line (just ``#``)."""
-    return line.strip() == "#"
+    """True iff ``line`` is a markdown blank-comment line (just ``#`` or ``//``)."""
+    return line.strip() in ("#", "//")
 
 
 def _check_cell_separation(raw_cells: list[RawCell], file_path: str) -> list[Finding]:
@@ -413,15 +414,16 @@ def _is_workshop_heading_cell(cell: Cell) -> bool:
     """
     if cell.metadata.cell_type != "markdown":
         return False
+    token = cell.comment_token
     for line in cell.content.split("\n"):
-        if line.startswith("# "):
-            inner = line[2:]
-        elif line.startswith("#"):
-            inner = line[1:]
+        if line.startswith(token + " "):
+            inner = line[len(token) + 1 :]
+        elif line.startswith(token):
+            inner = line[len(token) :]
         else:
             continue
         inner = inner.strip()
-        if inner.startswith("#"):
+        if inner.startswith("#"):  # markdown heading marker (always "#")
             return bool(_WORKSHOP_HEADING_RE.match(inner))
     return False
 
@@ -978,8 +980,8 @@ def _check_shared_cell_parity(de_path: Path, en_path: Path) -> list[Finding]:
 
     de_text = de_path.read_text(encoding="utf-8")
     en_text = en_path.read_text(encoding="utf-8")
-    _, de_cells = split_raw_cells(de_text)
-    _, en_cells = split_raw_cells(en_text)
+    _, de_cells = split_raw_cells(de_text, comment_token_for_path(de_path))
+    _, en_cells = split_raw_cells(en_text, comment_token_for_path(en_path))
 
     de_shared = [c for c in de_cells if _is_shared(c)]
     en_shared = [c for c in en_cells if _is_shared(c)]
@@ -1052,8 +1054,10 @@ def _check_split_tag_parity(de_path: Path, en_path: Path) -> list[Finding]:
     can no longer attribute to one side.
     """
     findings: list[Finding] = []
-    _, de_cells = split_raw_cells(de_path.read_text(encoding="utf-8"))
-    _, en_cells = split_raw_cells(en_path.read_text(encoding="utf-8"))
+    de_token = comment_token_for_path(de_path)
+    en_token = comment_token_for_path(en_path)
+    _, de_cells = split_raw_cells(de_path.read_text(encoding="utf-8"), de_token)
+    _, en_cells = split_raw_cells(en_path.read_text(encoding="utf-8"), en_token)
     de_nonj2 = [c for c in de_cells if not c.metadata.is_j2]
     en_nonj2 = [c for c in en_cells if not c.metadata.is_j2]
     if len(de_nonj2) != len(en_nonj2):
@@ -1112,8 +1116,8 @@ def _check_split_slide_id_parity(de_path: Path, en_path: Path) -> list[Finding]:
     findings: list[Finding] = []
     de_file = str(de_path)
 
-    de_cells = parse_cells(de_path.read_text(encoding="utf-8"))
-    en_cells = parse_cells(en_path.read_text(encoding="utf-8"))
+    de_cells = parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path))
+    en_cells = parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path))
 
     def _ids(cells: list[Cell]) -> list[str]:
         return [
@@ -1248,7 +1252,7 @@ def _check_split_companion_for_slide_parity(de_path: Path, en_path: Path) -> lis
     def _for_slide_set(path: Path) -> set[str]:
         return {
             strip_preserve_marker(c.metadata.for_slide)
-            for c in parse_cells(path.read_text(encoding="utf-8"))
+            for c in parse_cells(path.read_text(encoding="utf-8"), comment_token_for_path(path))
             if c.metadata.for_slide
         }
 
@@ -1386,9 +1390,13 @@ def _extract_code_quality(cells: list[Cell], file_path: str) -> dict:
                 }
             )
 
-        # Detect leading comments in code cells
+        # Detect leading comments in code cells (either comment family)
         lines = content.strip().split("\n")
-        if lines and lines[0].startswith("#") and not lines[0].startswith("# %%"):
+        if (
+            lines
+            and lines[0].startswith(("#", "//"))
+            and not lines[0].startswith(("# %%", "// %%"))
+        ):
             # First line is a comment — may be unnecessary
             preview = "\n".join(lines[:3])
             leading_comments.append(
@@ -1574,11 +1582,15 @@ def _extract_markdown_heading(content: str) -> str:
     (exactly ``# `` or ``#``), then look for the markdown ``#`` heading marker.
     """
     for line in content.split("\n"):
-        # Remove the Python comment prefix
+        # Remove the comment prefix (either comment family)
         if line.startswith("# "):
             inner = line[2:]
+        elif line.startswith("// "):
+            inner = line[3:]
         elif line.startswith("#"):
             inner = line[1:]
+        elif line.startswith("//"):
+            inner = line[2:]
         else:
             continue
         inner = inner.strip()
@@ -1635,9 +1647,10 @@ def validate_file(
     """
     check_set = set(checks) if checks else set(DEFAULT_CHECKS)
     file_str = str(path)
+    comment_token = comment_token_for_path(path)
 
     text = path.read_text(encoding="utf-8")
-    cells = parse_cells(text)
+    cells = parse_cells(text, comment_token)
 
     findings: list[Finding] = []
 
@@ -1645,7 +1658,7 @@ def validate_file(
         findings.extend(_check_format(cells, file_str))
         # Cell spacing runs on the raw (whitespace-preserving) cells, since the
         # parsed Cell model strips the blank lines these checks inspect.
-        _, raw_cells = split_raw_cells(text)
+        _, raw_cells = split_raw_cells(text, comment_token)
         findings.extend(_check_cell_separation(raw_cells, file_str))
         findings.extend(_check_markdown_blank_lead(raw_cells, file_str))
     if "tags" in check_set:
@@ -1717,7 +1730,7 @@ def validate_quick(path: Path) -> ValidationResult:
     """
     file_str = str(path)
     text = path.read_text(encoding="utf-8")
-    cells = parse_cells(text)
+    cells = parse_cells(text, comment_token_for_path(path))
 
     findings: list[Finding] = []
     findings.extend(_check_format(cells, file_str))

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from clm.infrastructure.utils.path_utils import atomic_write_all
-from clm.notebooks.slide_parser import parse_cell_header, parse_cells
+from clm.notebooks.slide_parser import comment_token_for_path, parse_cell_header, parse_cells
 from clm.slides.normalizer import (
     _apply_slide_ids,
     _RawCell,
@@ -575,7 +575,9 @@ def _find_owning_slide_id(cells: list[_RawCell], voiceover_idx: int) -> str | No
 
 def _has_voiceover_cells(path: Path) -> bool:
     """True iff ``path`` contains at least one voiceover/notes cell."""
-    _preamble, cells = _split_raw_cells(path.read_text(encoding="utf-8"))
+    _preamble, cells = _split_raw_cells(
+        path.read_text(encoding="utf-8"), comment_token_for_path(path)
+    )
     return any(_is_voiceover_cell(c) for c in cells)
 
 
@@ -624,7 +626,7 @@ def _plan_extraction(
     )
 
     text = path.read_text(encoding="utf-8")
-    preamble, cells = _split_raw_cells(text)
+    preamble, cells = _split_raw_cells(text, comment_token_for_path(path))
 
     # Check if there are any voiceover cells at all
     vo_indices = [i for i, c in enumerate(cells) if _is_voiceover_cell(c)]
@@ -894,6 +896,7 @@ def extract_voiceover_pair(
 def merge_voiceover_text(
     slide_text: str,
     companion_text: str,
+    comment_token: str = "#",
 ) -> tuple[str, list[str]]:
     """Merge companion voiceover cells into slide text in-memory.
 
@@ -910,8 +913,8 @@ def merge_voiceover_text(
         the companion that could not be matched to a ``slide_id``
         in the slide file.
     """
-    preamble, slide_cells = _split_raw_cells(slide_text)
-    _, companion_cells = _split_raw_cells(companion_text)
+    preamble, slide_cells = _split_raw_cells(slide_text, comment_token)
+    _, companion_cells = _split_raw_cells(companion_text, comment_token)
 
     if not companion_cells:
         return slide_text, []
@@ -1336,8 +1339,9 @@ def inline_voiceover(
     slide_text = path.read_text(encoding="utf-8")
     companion_text = comp.read_text(encoding="utf-8")
 
-    preamble, slide_cells = _split_raw_cells(slide_text)
-    _, companion_cells = _split_raw_cells(companion_text)
+    comment_token = comment_token_for_path(path)
+    preamble, slide_cells = _split_raw_cells(slide_text, comment_token)
+    _, companion_cells = _split_raw_cells(companion_text, comment_token)
 
     if not companion_cells:
         return result
@@ -1464,18 +1468,18 @@ def read_companion_baselines(
     return {sid: "\n".join(parts) for sid, parts in by_id.items()}
 
 
-def _format_companion_cell_body(text: str) -> list[str]:
+def _format_companion_cell_body(text: str, comment_token: str = "#") -> list[str]:
     """Format narrative text as comment-prefixed body lines for a companion cell."""
     lines = text.strip().split("\n")
-    body: list[str] = ["#"]
+    body: list[str] = [comment_token]
     for line in lines:
         stripped = line.strip()
         if not stripped:
-            body.append("#")
+            body.append(comment_token)
         elif stripped.startswith("- ") or stripped.startswith("**["):
-            body.append(f"# {stripped}")
+            body.append(f"{comment_token} {stripped}")
         else:
-            body.append(f"# - {stripped}")
+            body.append(f"{comment_token} - {stripped}")
     return body
 
 
@@ -1485,6 +1489,7 @@ def render_companion_update(
     lang: str,
     *,
     tag: str = "voiceover",
+    comment_token: str = "#",
 ) -> str:
     """Return updated companion file text with ``notes_by_slide_id`` applied.
 
@@ -1497,7 +1502,7 @@ def render_companion_update(
     if not notes_by_slide_id:
         return companion_text
 
-    preamble, cells = _split_raw_cells(companion_text)
+    preamble, cells = _split_raw_cells(companion_text, comment_token)
 
     existing: dict[str, int] = {}
     for i, cell in enumerate(cells):
@@ -1512,12 +1517,14 @@ def render_companion_update(
             existing[meta.for_slide] = i
 
     for slide_id, text in notes_by_slide_id.items():
-        body = _format_companion_cell_body(text)
+        body = _format_companion_cell_body(text, comment_token)
         if slide_id in existing:
             cell = cells[existing[slide_id]]
             cell.lines = [cell.lines[0], *body]
         else:
-            header = f'# %% [markdown] lang="{lang}" tags=["{tag}"] for_slide="{slide_id}"'
+            header = (
+                f'{comment_token} %% [markdown] lang="{lang}" tags=["{tag}"] for_slide="{slide_id}"'
+            )
             new_lines = [header, *body]
             cells.append(
                 _RawCell(
@@ -1555,7 +1562,13 @@ def update_companion_narrative(
         return companion
 
     existing_text = companion.read_text(encoding="utf-8") if companion.exists() else ""
-    new_text = render_companion_update(existing_text, notes_by_slide_id, lang, tag=tag)
+    new_text = render_companion_update(
+        existing_text,
+        notes_by_slide_id,
+        lang,
+        tag=tag,
+        comment_token=comment_token_for_path(companion),
+    )
     # Create the parent on first write so a fresh companion can land in a
     # not-yet-existing ``voiceover/`` subdir (``sync --layout subdir``).
     companion.parent.mkdir(parents=True, exist_ok=True)

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -182,21 +182,23 @@ def companion_name(slide_path: Path) -> str:
     """Return the companion voiceover *filename* for a slide file.
 
     Directory-independent — the name only. Known slide prefixes are replaced
-    with ``voiceover_``; any ``.de`` / ``.en`` language tag is preserved so the
-    two halves of a split deck never collide on one name:
+    with ``voiceover_``; the slide's own extension (``.py``/``.cs``/``.cpp``/
+    ``.java``/``.ts``) is preserved, and any ``.de`` / ``.en`` language tag (part
+    of the stem) is kept so the two halves of a split deck never collide:
 
     ``slides_intro.py`` → ``voiceover_intro.py``
-    ``slides_010_x.de.py`` → ``voiceover_010_x.de.py``
-    ``topic_overview.py`` → ``voiceover_overview.py``
+    ``slides_010_x.de.cs`` → ``voiceover_010_x.de.cs``
+    ``topic_overview.cpp`` → ``voiceover_overview.cpp``
     ``project_setup.py`` → ``voiceover_setup.py``
     """
     stem = slide_path.stem
+    ext = slide_path.suffix
     # Replace known prefixes
     for prefix in ("slides_", "topic_", "project_"):
         if stem.startswith(prefix):
-            return f"voiceover_{stem[len(prefix) :]}.py"
+            return f"voiceover_{stem[len(prefix) :]}{ext}"
     # Fallback: prepend voiceover_
-    return f"voiceover_{stem}.py"
+    return f"voiceover_{stem}{ext}"
 
 
 def companion_path(slide_path: Path) -> Path:

--- a/src/clm/voiceover/backfill.py
+++ b/src/clm/voiceover/backfill.py
@@ -54,7 +54,7 @@ def extract_slide_file_at_rev(slide_path: Path, rev: str, scratch_dir: Path) -> 
         raise FileNotFoundError(f"{slide_path.name} does not exist at revision {rev[:10]}")
     # Use a short SHA suffix so multiple sync-at-rev invocations against
     # the same scratch dir stay distinguishable.
-    out = scratch_dir / f"{slide_path.stem}-at-{rev[:10]}.py"
+    out = scratch_dir / f"{slide_path.stem}-at-{rev[:10]}{slide_path.suffix}"
     out.write_text(content, encoding="utf-8")
     return out
 

--- a/src/clm/workers/notebook/utils/prog_lang_utils.py
+++ b/src/clm/workers/notebook/utils/prog_lang_utils.py
@@ -144,6 +144,17 @@ def jinja_prefix_for(prog_lang: str) -> str:
         raise ValueError(f"Unsupported language: {prog_lang}") from e
 
 
+def line_comment_for(prog_lang: str) -> str:
+    """Return the line-comment token for a language.
+
+    ``"#"`` for python/rust, ``"//"`` for cpp/csharp/java/typescript — the token
+    that precedes ``%%`` / ``j2`` / ``{{`` in that language's percent-format slide
+    files. Derived from the Jinja line-statement prefix (``"# j2"`` / ``"// j2"``)
+    so the two can never drift.
+    """
+    return jinja_prefix_for(prog_lang).split(" ", 1)[0]
+
+
 def jupytext_format_for(prog_lang: str) -> str | dict[str, str]:
     try:
         return cast(str | dict[str, str], config.prog_lang[prog_lang]["jupytext_format"])

--- a/tests/cli/test_discovery_comment_token.py
+++ b/tests/cli/test_discovery_comment_token.py
@@ -1,0 +1,60 @@
+"""Comment-token (``//``-family) coverage for CLI discovery + dispatch.
+
+Problem A Phase 5: recursive slide-file discovery finds .cs/.cpp/… decks (not just
+.py), ``clm validate`` infers "slides" for any slide extension, and ``clm summarize``
+extracts content from //-family decks. (Voiceover/MCP already work via parse_slides,
+which resolves the token from the path.)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.cli.commands.summarize import _extract_from_py
+from clm.cli.commands.validate import _infer_kind
+from clm.core.topic_resolver import find_slide_files_recursive
+
+
+def test_find_slide_files_recursive_finds_clike(tmp_path: Path) -> None:
+    topic = tmp_path / "module_010_intros" / "topic_100_welcome"
+    topic.mkdir(parents=True)
+    cs = topic / "slides_welcome.cs"
+    cs.write_text('// %% [markdown] tags=["slide"]\n// ## Hi\n', encoding="utf-8")
+    cpp = topic / "slides_other.cpp"
+    cpp.write_text('// %% [markdown] tags=["slide"]\n// ## Yo\n', encoding="utf-8")
+    not_a_deck = topic / "helper.cs"  # no slides_/topic_/project_ prefix
+    not_a_deck.write_text("int x = 1;\n", encoding="utf-8")
+
+    found = find_slide_files_recursive(tmp_path)
+    assert cs.resolve() in found
+    assert cpp.resolve() in found
+    assert not_a_deck.resolve() not in found
+
+
+def test_infer_kind_accepts_clike(tmp_path: Path) -> None:
+    # _infer_kind inspects a real path (is_file / suffix), so create the files.
+    for name in ("slides_x.cs", "slides_x.cpp", "slides_x.java", "slides_x.py"):
+        f = tmp_path / name
+        f.write_text("// %%\n", encoding="utf-8")
+        assert _infer_kind(f) == "slides", name
+    (tmp_path / "course.xml").write_text("<course/>", encoding="utf-8")
+    assert _infer_kind(tmp_path / "course.xml") == "spec"
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+    assert _infer_kind(tmp_path / "notes.txt") is None
+
+
+def test_summarize_extract_from_clike() -> None:
+    deck = "\n".join(
+        [
+            '// %% [markdown] tags=["slide"]',
+            "// Hello world",
+            "// %%",
+            "int x = 1;",
+        ]
+    )
+    out = _extract_from_py(deck, "student", "//")
+    assert "Hello world" in out
+    assert "//" not in out  # comment prefix stripped
+    # python regression
+    py = "\n".join(["# %% [markdown]", "# Hi there", "# %%", "x = 1"])
+    assert "Hi there" in _extract_from_py(py, "student", "#")

--- a/tests/notebooks/test_slide_parser_comment_token.py
+++ b/tests/notebooks/test_slide_parser_comment_token.py
@@ -1,0 +1,147 @@
+"""Comment-token (``#`` vs ``//``) parametrization of the slide parsers.
+
+Problem A Phase 1: the shared percent-format parsers
+(:mod:`clm.notebooks.slide_parser`, :mod:`clm.slides.raw_cells`) now take a
+``comment_token`` (default ``"#"``) so they parse C#/C++/Java/TypeScript
+(``//``) decks as well as Python (``#``) ones. The default must reproduce the
+old Python behaviour exactly; the two languages must parse to equivalent cells.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.notebooks.slide_parser import (
+    comment_token_for_path,
+    parse_cell_header,
+    parse_cells,
+    parse_slides,
+)
+from clm.slides.raw_cells import is_cell_boundary, reconstruct, split_cells
+from clm.workers.notebook.utils.prog_lang_utils import line_comment_for
+
+
+def deck(tok: str) -> str:
+    """A structurally identical header-line-less deck for comment token ``tok``."""
+    code = "x = 1" if tok == "#" else "int x = 1;"
+    return "\n".join(
+        [
+            f"{tok} j2 from 'macros.j2' import header",
+            f'{tok} {{{{ header("Titel", "Title") }}}}',
+            "",
+            f'{tok} %% [markdown] lang="de" tags=["slide"]',
+            f"{tok} ## Überschrift",
+            f"{tok}",
+            f"{tok} - Punkt eins",
+            "",
+            f'{tok} %% [markdown] lang="en" tags=["slide"]',
+            f"{tok} ## Heading",
+            "",
+            f'{tok} %% tags=["keep"]',
+            code,
+            "",
+        ]
+    )
+
+
+@pytest.mark.parametrize("tok", ["#", "//"])
+def test_parse_cells_structure(tok: str) -> None:
+    cells = parse_cells(deck(tok), tok)
+    # j2 import, j2 header, de slide, en slide, keep-code  → 5 cells
+    assert len(cells) == 5
+    assert cells[0].metadata.is_j2
+    assert cells[1].metadata.is_j2  # the ``{{ header(...) }}`` call
+    assert cells[2].metadata.cell_type == "markdown"
+    assert cells[2].metadata.lang == "de"
+    assert cells[2].metadata.tags == ["slide"]
+    assert cells[3].metadata.lang == "en"
+    assert cells[4].metadata.cell_type == "code"
+    assert "keep" in cells[4].metadata.tags
+    assert all(c.comment_token == tok for c in cells)
+
+
+def test_text_content_is_token_independent() -> None:
+    py = parse_cells(deck("#"), "#")
+    cs = parse_cells(deck("//"), "//")
+    # The markdown/j2 cells (0-3) carry identical prose in both decks; only the
+    # final code cell differs by design (`x = 1` vs `int x = 1;`).
+    assert [c.text_content() for c in py[:4]] == [c.text_content() for c in cs[:4]]
+    # the de slide reads as plain prose, comment + heading markers stripped
+    assert "Überschrift" in cs[2].text_content()
+    assert "//" not in cs[2].text_content()
+
+
+def test_default_token_matches_explicit_hash() -> None:
+    """Calling the parsers without a token must equal passing ``"#"`` (no regression)."""
+    default = parse_cells(deck("#"))
+    explicit = parse_cells(deck("#"), "#")
+    key = lambda cs: [  # noqa: E731
+        (c.metadata.cell_type, c.metadata.lang, c.metadata.tags, c.metadata.is_j2, c.text_content())
+        for c in cs
+    ]
+    assert key(default) == key(explicit)
+
+
+@pytest.mark.parametrize(
+    "prog_lang,expected",
+    [
+        ("python", "#"),
+        ("rust", "#"),
+        ("csharp", "//"),
+        ("cpp", "//"),
+        ("java", "//"),
+        ("typescript", "//"),
+    ],
+)
+def test_line_comment_for(prog_lang: str, expected: str) -> None:
+    assert line_comment_for(prog_lang) == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("slides_x.py", "#"),
+        ("slides_x.cs", "//"),
+        ("slides_x.cpp", "//"),
+        ("slides_x.java", "//"),
+        ("slides_x.ts", "//"),
+        ("slides_x.rs", "#"),
+        ("slides_x.weird", "#"),  # unknown extension falls back to "#"
+    ],
+)
+def test_comment_token_for_path(name: str, expected: str) -> None:
+    assert comment_token_for_path(Path(name)) == expected
+
+
+def test_parse_cell_header_clike() -> None:
+    m = parse_cell_header('// %% [markdown] lang="de" tags=["slide", "keep"]', "//")
+    assert m.cell_type == "markdown"
+    assert m.lang == "de"
+    assert m.tags == ["slide", "keep"]
+    assert parse_cell_header("// {{ header('a', 'b') }}", "//").is_j2
+    assert parse_cell_header("// j2 from 'macros.j2' import header", "//").is_j2
+    # a "//" header is NOT a boundary/j2 when parsed as Python
+    assert not parse_cell_header("// {{ header('a', 'b') }}", "#").is_j2
+
+
+@pytest.mark.parametrize("tok", ["#", "//"])
+def test_raw_cells_roundtrip_and_boundaries(tok: str) -> None:
+    text = deck(tok)
+    preamble, cells = split_cells(text, tok)
+    assert reconstruct(preamble, cells) == text  # lossless for any language
+    assert len(cells) == 5
+    assert cells[1].metadata.is_j2
+    assert is_cell_boundary(f'{tok} %% [markdown] lang="de"', tok)
+    assert not is_cell_boundary(f'{tok} %% [markdown] lang="de"', "//" if tok == "#" else "#")
+
+
+def test_parse_slides_resolves_token_from_extension(tmp_path: Path) -> None:
+    f = tmp_path / "slides_demo.cs"
+    f.write_text(deck("//"), encoding="utf-8")
+    groups = parse_slides(f, "de")
+    assert any(g.slide_type == "header" for g in groups)
+    titles = [g.title for g in groups]
+    assert "Titel" in titles  # header macro, de side
+    assert "Überschrift" in titles  # the de content slide

--- a/tests/notebooks/test_slide_parser_comment_token.py
+++ b/tests/notebooks/test_slide_parser_comment_token.py
@@ -145,3 +145,25 @@ def test_parse_slides_resolves_token_from_extension(tmp_path: Path) -> None:
     titles = [g.title for g in groups]
     assert "Titel" in titles  # header macro, de side
     assert "Überschrift" in titles  # the de content slide
+
+
+def test_strip_preserves_content_leading_slashes() -> None:
+    """M1 regression: a literal-prefix strip must keep content slashes.
+
+    ``lstrip("// ")`` is a character-set strip that eats every leading slash, so
+    ``// /usr/bin`` would lose its path slash and C# ``///`` would collapse. The
+    parser must remove the comment token as a prefix, not a char set.
+    """
+    text = "\n".join(
+        [
+            '// %% [markdown] lang="de" tags=["slide"]',
+            "// /usr/local/bin is on PATH",
+            "// /// also keeps its slashes",
+        ]
+    )
+    md = parse_cells(text, "//")[0].text_content()
+    assert "/usr/local/bin is on PATH" in md
+    assert "/// also keeps its slashes" in md
+    # the Python analogue is likewise lossless for a path body
+    py = parse_cells('# %% [markdown] lang="de" tags=["slide"]\n# /usr/local/bin', "#")
+    assert "/usr/local/bin" in py[0].text_content()

--- a/tests/slides/test_assign_sync_comment_token.py
+++ b/tests/slides/test_assign_sync_comment_token.py
@@ -1,0 +1,43 @@
+"""Comment-token (``//``-family) coverage for assign-ids + sync writeback.
+
+Problem A Phase 3c: assign-ids mints slide_ids on ``//``-family decks (parse +
+headingless are token-aware), and the sync writeback's ``swap_lang`` inserts a
+``lang=`` attribute on either comment family's bare code-cell header.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.assign_ids import AssignOptions, assign_ids_in_file
+from clm.slides.sync_writeback import swap_lang
+
+
+def test_assign_ids_mints_on_clike_deck(tmp_path: Path) -> None:
+    deck = "\n".join(
+        [
+            '// %% [markdown] lang="de" tags=["slide"]',
+            "//",
+            "// ## Erste Folie",
+            "",
+        ]
+    )
+    f = tmp_path / "slides_demo.de.cs"
+    f.write_text(deck, encoding="utf-8")
+    result = assign_ids_in_file(f, AssignOptions())
+    out = f.read_text(encoding="utf-8")
+    # an id was minted from the "## Erste Folie" heading (headingless saw the //)
+    assert 'slide_id="' in out
+    assert result.assignments
+    # the cell header keeps its // comment token (no corruption)
+    assert out.splitlines()[0].startswith('// %% [markdown] lang="de"')
+
+
+def test_swap_lang_inserts_on_either_family() -> None:
+    assert swap_lang('// %% tags=["keep"]', "de") == '// %% lang="de" tags=["keep"]'
+    # python regression
+    assert swap_lang('# %% tags=["keep"]', "de") == '# %% lang="de" tags=["keep"]'
+    # already-tagged headers just have their lang swapped, both families
+    assert swap_lang('// %% [markdown] lang="en" tags=["slide"]', "de") == (
+        '// %% [markdown] lang="de" tags=["slide"]'
+    )

--- a/tests/slides/test_coverage_langtools_comment_token.py
+++ b/tests/slides/test_coverage_langtools_comment_token.py
@@ -1,0 +1,54 @@
+"""Comment-token (``//``-family) coverage for coverage / lang_coverage / language_tools.
+
+Problem A Phase 3b: the analysis tools (bullet/narrative coverage, DE/EN slide
+counting, single-language view) handle ``//``-family decks. Python (``#``) behaviour
+is unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.coverage import extract_bullets
+from clm.slides.lang_coverage import count_languages
+from clm.slides.language_tools import get_language_view
+
+
+def test_extract_bullets_either_family() -> None:
+    assert extract_bullets("// - First\n// - Second") == ["First", "Second"]
+    assert extract_bullets("// 1. One\n// 2. Two") == ["One", "Two"]
+    assert extract_bullets("# - First") == ["First"]  # python regression
+
+
+def test_count_languages_clike() -> None:
+    deck = "\n".join(
+        [
+            '// %% [markdown] lang="de" tags=["slide"]',
+            "// ## A",
+            '// %% [markdown] lang="en" tags=["slide"]',
+            "// ## A",
+        ]
+    )
+    assert count_languages(deck, "//") == (1, 1)
+    # the wrong token sees zero cells — proves the token is load-bearing
+    assert count_languages(deck, "#") == (0, 0)
+
+
+def test_get_language_view_uses_comment_token(tmp_path: Path) -> None:
+    deck = "\n".join(
+        [
+            '// %% [markdown] lang="de" tags=["slide"]',
+            "// ## Hallo",
+            '// %% [markdown] lang="en" tags=["slide"]',
+            "// ## Hello",
+        ]
+    )
+    f = tmp_path / "slides_x.cs"
+    f.write_text(deck, encoding="utf-8")
+    view = get_language_view(f, "de")
+    # the back-reference annotation must be a // comment (valid in a C# file)
+    assert "// [original line" in view
+    assert "# [original line" not in view
+    # only the de content is kept
+    assert "Hallo" in view
+    assert "Hello" not in view

--- a/tests/slides/test_split_comment_token.py
+++ b/tests/slides/test_split_comment_token.py
@@ -1,0 +1,113 @@
+"""Comment-token (``//``-family) coverage for split / unify / companion naming.
+
+Problem A Phase 2: ``split_text`` / ``unify_texts`` take a ``comment_token``,
+``split_in_file`` / ``unify_in_file`` resolve it from the file extension, the
+header-import rewrite matches either comment family, and ``companion_name``
+preserves the deck's extension. The Python (``#``) behaviour is exercised
+exhaustively by ``test_split.py``; here we prove the ``//`` family works and the
+extension-generic file paths are correct.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.slides.split import (
+    split_in_file,
+    split_text,
+    unify_in_file,
+    unify_texts,
+)
+from clm.slides.voiceover_tools import companion_name
+
+DECK_CS = "\n".join(
+    [
+        "// -*- coding: utf-8 -*-",
+        "// j2 from 'macros.j2' import header",
+        '// {{ header("Titel", "Title") }}',
+        "",
+        '// %% [markdown] lang="de" tags=["slide"] slide_id="intro"',
+        "// ## Überschrift",
+        "",
+        '// %% [markdown] lang="en" tags=["slide"] slide_id="intro"',
+        "// ## Heading",
+        "",
+        '// %% tags=["keep"]',
+        "int x = 1;",
+        "",
+    ]
+)
+
+COMPANION_CS = "\n".join(
+    [
+        '// %% [markdown] lang="de" tags=["voiceover"] for_slide="intro"',
+        "// Sprechertext.",
+        "",
+        '// %% [markdown] lang="en" tags=["voiceover"] for_slide="intro"',
+        "// Speaker text.",
+        "",
+    ]
+)
+
+
+def test_split_rewrites_import_and_macro_with_slashes() -> None:
+    de, en = split_text(DECK_CS, "//")
+    # comment token preserved (// not #), bilingual header → sibling macros
+    assert "// j2 from 'macros.j2' import header_de" in de
+    assert '// {{ header_de("Titel") }}' in de
+    assert "// j2 from 'macros.j2' import header_en" in en
+    assert '// {{ header_en("Title") }}' in en
+    # language routing: de half has no en slide and vice versa
+    assert "Überschrift" in de and "Heading" not in de
+    assert "Heading" in en and "Überschrift" not in en
+    # shared code cell copied to both
+    assert "int x = 1;" in de and "int x = 1;" in en
+
+
+def test_split_unify_roundtrip_clike() -> None:
+    de, en = split_text(DECK_CS, "//")
+    assert unify_texts(de, en, "//") == DECK_CS
+    # the canonical split/unify invariant in both directions
+    assert split_text(unify_texts(de, en, "//"), "//") == (de, en)
+
+
+def test_split_in_file_and_unify_in_file_clike(tmp_path: Path) -> None:
+    src = tmp_path / "slides_demo.cs"
+    src.write_text(DECK_CS, encoding="utf-8")
+    res = split_in_file(src)
+    de_path = tmp_path / "slides_demo.de.cs"
+    en_path = tmp_path / "slides_demo.en.cs"
+    assert Path(res.de_path) == de_path and de_path.exists()
+    assert Path(res.en_path) == en_path and en_path.exists()
+    assert "import header_de" in de_path.read_text(encoding="utf-8")
+    # unify back to a byte-identical bilingual deck
+    rebuilt = tmp_path / "rebuilt.cs"
+    unify_in_file(de_path, en_path, target=rebuilt)
+    assert rebuilt.read_text(encoding="utf-8") == DECK_CS
+
+
+def test_split_in_file_splits_companion_clike(tmp_path: Path) -> None:
+    (tmp_path / "slides_demo.cs").write_text(DECK_CS, encoding="utf-8")
+    (tmp_path / "voiceover_demo.cs").write_text(COMPANION_CS, encoding="utf-8")
+    res = split_in_file(tmp_path / "slides_demo.cs")
+    assert (tmp_path / "voiceover_demo.de.cs").exists()
+    assert (tmp_path / "voiceover_demo.en.cs").exists()
+    assert res.de_companion is not None and res.de_companion.endswith("voiceover_demo.de.cs")
+    assert "Sprechertext." in (tmp_path / "voiceover_demo.de.cs").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("slides_x.cs", "voiceover_x.cs"),
+        ("slides_010_x.de.cpp", "voiceover_010_x.de.cpp"),
+        ("topic_y.java", "voiceover_y.java"),
+        ("project_z.ts", "voiceover_z.ts"),
+        ("slides_x.py", "voiceover_x.py"),  # regression: Python unchanged
+        ("slides_x.de.py", "voiceover_x.de.py"),  # regression: split half
+    ],
+)
+def test_companion_name_preserves_extension(name: str, expected: str) -> None:
+    assert companion_name(Path(name)) == expected

--- a/tests/slides/test_sync_translate_prompts.py
+++ b/tests/slides/test_sync_translate_prompts.py
@@ -1,0 +1,75 @@
+"""Language-aware sync_translate prompts (Problem A Y-5).
+
+The translator prompts must name the deck's actual comment token and programming
+language, so a //-deck is told to preserve "// " prefixes and a C# code cell is
+translated as C#, not "runnable Python".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides.sync_translate import (
+    _CODE_SYSTEM_PROMPT,
+    _SYSTEM_PROMPT,
+    _prog_lang_descriptors,
+)
+
+
+@pytest.mark.parametrize(
+    "prog_lang,prefix,name",
+    [
+        ("python", "# ", "Python"),
+        ("rust", "# ", "Rust"),
+        ("csharp", "// ", "C#"),
+        ("cpp", "// ", "C++"),
+        ("java", "// ", "Java"),
+        ("unknownlang", "# ", "Unknownlang"),  # graceful fallback (token "#", name from the lang)
+    ],
+)
+def test_prog_lang_descriptors(prog_lang: str, prefix: str, name: str) -> None:
+    assert _prog_lang_descriptors(prog_lang) == (prefix, name)
+
+
+def test_typescript_uses_slashes() -> None:
+    prefix, _ = _prog_lang_descriptors("typescript")
+    assert prefix == "// "
+
+
+def test_code_prompt_names_the_language() -> None:
+    prefix, name = _prog_lang_descriptors("csharp")
+    prompt = _CODE_SYSTEM_PROMPT.format(
+        source_lang="German",
+        target_lang="English",
+        role="code",
+        comment_prefix=prefix,
+        prog_lang_name=name,
+    )
+    assert "C# code cell" in prompt
+    assert "runnable C#" in prompt
+    assert "Python" not in prompt  # no Python hardcoding leaks into a C# prompt
+
+
+def test_markdown_prompt_uses_comment_prefix() -> None:
+    prefix, name = _prog_lang_descriptors("cpp")
+    prompt = _SYSTEM_PROMPT.format(
+        source_lang="German",
+        target_lang="English",
+        role="voiceover",
+        comment_prefix=prefix,
+        prog_lang_name=name,
+    )
+    assert "'// '" in prompt  # the model is told the // line prefix
+    assert "'# '" not in prompt  # no stray Python prefix instruction
+
+
+def test_python_prompt_unchanged() -> None:
+    prefix, name = _prog_lang_descriptors("python")
+    prompt = _SYSTEM_PROMPT.format(
+        source_lang="German",
+        target_lang="English",
+        role="voiceover",
+        comment_prefix=prefix,
+        prog_lang_name=name,
+    )
+    assert "'# '" in prompt  # regression: Python decks still told the # prefix

--- a/tests/slides/test_validate_normalize_comment_token.py
+++ b/tests/slides/test_validate_normalize_comment_token.py
@@ -1,0 +1,73 @@
+"""Comment-token (``//``-family) coverage for validate / normalize / headingless.
+
+Problem A Phase 3: the lint/gate/fix tools must accept ``// %%`` headers (no false
+format errors), insert the right blank-comment token when normalizing, and extract
+headings/prose from ``//``-prefixed markdown. Python (``#``) behaviour is unchanged
+(exercised by the existing suites); here we prove the ``//`` family works.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.headingless import Category, classify, extract_heading
+from clm.slides.normalizer import normalize_file
+from clm.slides.validator import validate_file
+
+DECK_CS = "\n".join(
+    [
+        "// -*- coding: utf-8 -*-",
+        "// j2 from 'macros.j2' import header",
+        '// {{ header("Titel", "Title") }}',
+        "",
+        '// %% [markdown] lang="de" tags=["slide"] slide_id="intro"',
+        "//",
+        "// ## Überschrift",
+        "",
+        '// %% [markdown] lang="en" tags=["slide"] slide_id="intro"',
+        "//",
+        "// ## Heading",
+        "",
+    ]
+)
+
+
+def test_validate_accepts_clike_headers(tmp_path: Path) -> None:
+    f = tmp_path / "slides_demo.cs"
+    f.write_text(DECK_CS, encoding="utf-8")
+    result = validate_file(f)
+    # The "// %%" headers must NOT raise the "does not start with ..." format error,
+    # and the "//" blank comments must NOT raise blank-comment warnings (N-2).
+    fmt = [x for x in result.findings if x.category == "format"]
+    assert fmt == [], [f"{x.message}" for x in fmt]
+
+
+def test_normalize_cell_spacing_inserts_comment_token(tmp_path: Path) -> None:
+    deck = "\n".join(
+        [
+            "// j2 from 'macros.j2' import header",
+            '// {{ header("T", "T") }}',
+            "",
+            '// %% [markdown] lang="de" tags=["slide"] slide_id="x"',
+            "// ## Heading",  # missing the leading blank comment
+        ]
+    )
+    f = tmp_path / "slides_x.cs"
+    f.write_text(deck, encoding="utf-8")
+    normalize_file(f, operations=["cell_spacing"])
+    out = f.read_text(encoding="utf-8")
+    # the inserted blank comment is "//" (not a corrupting "#")
+    assert "//\n// ## Heading" in out
+    assert "\n#\n" not in out
+
+
+def test_headingless_extracts_clike() -> None:
+    assert extract_heading("// ## My Title") == "My Title"
+    bullet = classify("// - First bullet")
+    assert bullet.category is Category.EXTRACTABLE
+    assert bullet.text == "First bullet"
+    prose = classify("// Just some prose line")
+    assert prose.text == "Just some prose line"
+    # Python regression
+    assert extract_heading("# ## My Title") == "My Title"
+    assert classify("# - First bullet").text == "First bullet"

--- a/tests/slides/test_voiceover_comment_token.py
+++ b/tests/slides/test_voiceover_comment_token.py
@@ -1,0 +1,63 @@
+"""Comment-token (``//``-family) coverage for voiceover write/merge + suppression.
+
+Problem A Phase 4: the build-time voiceover merge, the companion/narrative writers,
+and the output-suppression patterns all handle ``//``-family (C#/C++/Java/TS) decks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.infrastructure.utils.path_utils import is_ignored_file_for_output
+from clm.notebooks.slide_writer import format_narrative_cell
+from clm.slides.voiceover_tools import merge_voiceover_text, render_companion_update
+
+_SLIDE_CS = "\n".join(
+    [
+        '// %% [markdown] lang="de" tags=["slide"] slide_id="intro"',
+        "// ## Hallo",
+        "",
+    ]
+)
+_COMPANION_CS = "\n".join(
+    [
+        '// %% [markdown] lang="de" tags=["voiceover"] for_slide="intro"',
+        "// Sprechertext.",
+        "",
+    ]
+)
+
+
+def test_merge_voiceover_text_clike() -> None:
+    merged, unmatched = merge_voiceover_text(_SLIDE_CS, _COMPANION_CS, "//")
+    assert unmatched == []
+    assert 'tags=["voiceover"]' in merged
+    assert "Sprechertext." in merged
+    # V-1b: with the wrong token the //-deck parses to zero cells and the
+    # voiceover is silently dropped — proves the token is load-bearing.
+    merged_wrong, _ = merge_voiceover_text(_SLIDE_CS, _COMPANION_CS, "#")
+    assert "Sprechertext." not in merged_wrong
+
+
+def test_format_narrative_cell_clike() -> None:
+    out = format_narrative_cell("Hallo\nWelt", "de", comment_token="//")
+    assert out.startswith('// %% [markdown] lang="de" tags=["voiceover"]')
+    assert "\n// - Hallo" in out
+    # python regression
+    assert format_narrative_cell("Hallo", "de").startswith("# %% [markdown]")
+
+
+def test_render_companion_update_clike() -> None:
+    out = render_companion_update("", {"intro": "Sprechertext"}, "de", comment_token="//")
+    assert '// %% [markdown] lang="de" tags=["voiceover"] for_slide="intro"' in out
+    assert "// - Sprechertext" in out
+
+
+def test_voiceover_companion_output_suppressed() -> None:
+    # D-1: a companion of ANY slide extension is kept out of output, not just .py
+    assert is_ignored_file_for_output(Path("voiceover_intro.cs"))
+    assert is_ignored_file_for_output(Path("voiceover_intro.cpp"))
+    assert is_ignored_file_for_output(Path("voiceover_intro.de.cs"))
+    assert is_ignored_file_for_output(Path("voiceover_intro.py"))  # regression
+    # a normal slide deck must NOT be suppressed
+    assert not is_ignored_file_for_output(Path("slides_intro.cs"))


### PR DESCRIPTION
## Summary

CLM's **build** has long been multi-language, but the recently-built **authoring tooling** (split decks, sync, voiceover extract/inline, assign-ids, normalize, validate, coverage, discovery, translate) hardcoded the Python `#` comment token and `.py` extension. This PR threads the deck's *comment token* and *extension* through every authoring consumer, so the `//`-family languages (C#, C++, Java, TypeScript) get the same split/sync/voiceover workflow Python already had.

The structural prerequisite — making `//`-family decks "header-line-less" so pairing/sync never see an unpaired `lang="de"` title — shipped earlier in **1.8.4** (`header_de`/`header_en` macros added to all four c-family templates, `.c`→`cpp` extension fix, deck-reformat tooling, and the four course repos reformatted). This branch is **Problem A**: the parser/regex/strippers generalization that builds on that.

The default everywhere stays `"#"`, so **Python output is byte-identical** — the token is resolved from the file extension at each `Path` seam via `comment_token_for_path()`.

## What changed (by phase)

- **Phase 1** (`a7859617`) — parser foundation: `prog_lang_utils.line_comment_for`, `Cell.comment_token`, `parse_cells`/`parse_cell_header`/`_is_cell_boundary`/strippers tokenized; `parse_slides` resolves the token from the extension; `raw_cells` delegates to the single canonical boundary check.
- **review fix M1** (`221b4411`) — `_strip_comment_prefix` strips the literal prefix, not a char-set: `lstrip("// ")` would eat every leading `/` (`// /usr/bin` → `usr/bin`, C# `///` collapse). Caught by an adversarial review workflow.
- **Phase 2** (`0971a5a1`) — `split`/`unify` token-aware and extension-generic; header-import regex `(?:#|//)`; companion naming preserves the deck extension; `translate_deck`/`bootstrap` threaded.
- **Phase 3** (`e9087047`, `ece69817`, `6553e811`) — validate / normalize / headingless; coverage / lang-coverage / language-view; assign-ids + the sync engine (plan/apply/writeback/direction).
- **Phase 4** (`00d3d6b9`) — voiceover write/merge (fixes the build merge that silently **dropped** voiceover on `//`-decks), companion writers, extract/inline; `SKIP_OUTPUT` globs broadened so `voiceover_*.{cs,cpp,…}` never leak to output.
- **Phase 5** (`5ba896ba`) — CLI discovery (`rglob` + `is_slides_file`, so `assign-ids`/`normalize`/`validate` find `.cs` decks), `validate` kind-inference, `summarize` dispatch.
- **Y-5** (`c2dce4a3`) — language-aware `sync_translate` prompts: a C# code cell is translated as C# (not "runnable Python") and a `//`-deck is told to preserve `// ` prefixes; prog_lang folds into the translation-cache key (non-python only).
- **C-6** (`93868078`) — docs: generalized `--help`/`clm info` placeholders to `<ext>` and corrected two now-false "Python-only" claims in the info topics.

## Testing

Full fast suite green (6978 passed before C-6); `tests/cli` green (1355 passed); info topics render (14 passed). New `//`-token tests added across parser, split, validate/normalize, coverage/langtools, assign/sync, voiceover, discovery, and sync-translate prompts; `test_header_macros_clike.py` locks the macro change.

Course decks are already reformatted + pushed and the global `clm` is on 1.8.4, so this branch completes the end-to-end `//`-family authoring workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)