### PR TITLE
Release 1.9.0: multi-language slide authoring tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-06-06
+
+### Added
+
+- **The slide authoring tooling now works on C#/C++/Java/TypeScript decks, not
+  just Python.** CLM's *build* has long been multi-language, but the authoring
+  tooling — `slides split` / `unify`, `sync`, `voiceover extract` / `inline`,
+  `assign-ids`, `normalize`, `validate`, `coverage` / `lang-coverage` /
+  `language-view`, deck discovery, and `translate` / `bootstrap` — hardcoded the
+  Python `#` comment token and `.py` extension. The deck's comment token (`//`
+  for the c-family, `#` for Python) and extension are now threaded through every
+  authoring consumer, resolved per file from the extension via
+  `comment_token_for_path()`. The `//`-family languages (C#, C++, Java,
+  TypeScript) get the same split/sync/voiceover authoring workflow Python already
+  had, including `.de`/`.en` split companions that preserve the deck extension
+  (`*.de.cs`, `*.en.cpp`). The default everywhere stays `#`, so **Python output
+  is byte-identical**. This completes the multi-language authoring migration whose
+  structural prerequisite (the header-line-less title convention) shipped in
+  1.8.4. Investigation + validation:
+  `docs/claude/multi-language-authoring-tooling-investigation.md` §10.
+
+### Changed
+
+- **`sync translate` prompts are now language-aware.** A code cell in a `//`-deck
+  is translated as that language (e.g. C# is translated as C#, not "runnable
+  Python"), and the model is instructed to preserve `// ` comment prefixes. The
+  programming language folds into the translation-cache key for non-Python decks,
+  so cached Python translations are unaffected.
+- **`--help` text and `clm info` topics use a language-neutral `<ext>`
+  placeholder** instead of implying `.py`-only, and two now-inaccurate
+  "Python-only" claims in the info topics were corrected.
+
+### Fixed
+
+- **The build no longer silently drops voiceover on `//`-family decks.** The
+  host-side voiceover companion merge and the authoring `voiceover` writers were
+  Python-token-only, so a `voiceover_*.cs` / `*.cpp` companion was never merged
+  into the built notebook. The merge, the companion writers, and `extract` /
+  `inline` are now token-aware, and the `SKIP_OUTPUT` globs were broadened so
+  `voiceover_*.{cs,cpp,java,ts}` companions never leak into output.
+- **`assign-ids` / `normalize` / `validate` now discover `.cs` / `.cpp` / `.java`
+  / `.ts` decks.** Deck discovery (`rglob` + `is_slides_file`) and `validate`
+  kind-inference were Python-extension-only; the `//`-family decks are now found
+  and dispatched.
+- **Comment-prefix stripping removes the literal prefix, not a character set.**
+  `_strip_comment_prefix` previously used `lstrip("// ")`, which strips *any*
+  leading `/` or space — turning `// /usr/bin` into `usr/bin` and collapsing a C#
+  `///` doc comment. It now strips the exact `// ` prefix once.
+
 ## [1.8.4] - 2026-06-06
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Draw.io diagrams) into multiple output formats (HTML slides, executed
 notebooks, extracted code) for multiple audiences (students, solutions,
 speaker notes).
 
-**Version**: 1.8.4 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.9.0 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hoelzl/clm/actions/workflows/ci.yml/badge.svg)](https://github.com/hoelzl/clm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hoelzl/clm/branch/master/graph/badge.svg)](https://codecov.io/gh/hoelzl/clm)
 
-**Version**: 1.8.4 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.9.0 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 CLM is a course content processing system that converts educational materials (Jupyter notebooks, PlantUML diagrams, Draw.io diagrams) into multiple output formats.
 

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -50,7 +50,7 @@ On Windows (PowerShell):
 ### PlantUML Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.8.4`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.9.0`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -73,7 +73,7 @@ docker build -f docker/plantuml/Dockerfile -t docker.io/mhoelzl/clm-plantuml-con
 ### Draw.io Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-drawio-converter:1.8.4`
+- `docker.io/mhoelzl/clm-drawio-converter:1.9.0`
 - `docker.io/mhoelzl/clm-drawio-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -107,7 +107,7 @@ The notebook processor has **two variants** to support different use cases:
 **Best for:** Courses without deep learning, or running on Apple Silicon Macs.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.8.4-lite`
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.0-lite`
 - `docker.io/mhoelzl/clm-notebook-processor:lite`
 
 **Base Image:** `python:3.11-slim` (multi-arch: amd64, arm64)
@@ -139,8 +139,8 @@ docker build -f docker/notebook/Dockerfile \
 **Best for:** Deep learning courses, CUDA-accelerated processing.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.8.4` (default)
-- `docker.io/mhoelzl/clm-notebook-processor:1.8.4-full`
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.0` (default)
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.0-full`
 - `docker.io/mhoelzl/clm-notebook-processor:latest`
 - `docker.io/mhoelzl/clm-notebook-processor:full`
 
@@ -172,7 +172,7 @@ docker build -f docker/notebook/Dockerfile -t docker.io/mhoelzl/clm-notebook-pro
 - .NET SDK 10.0 (C# and F# kernels)
 - Deno (TypeScript/JavaScript kernel)
 - Java JDK (Java kernel)
-- IJava 1.8.4 (Java Jupyter kernel)
+- IJava 1.9.0 (Java Jupyter kernel)
 - micromamba + xeus-cpp (C++ kernel)
 
 **Jupyter Kernels:**
@@ -223,12 +223,12 @@ The build scripts automatically set these arguments.
 All images use the Hub namespace (`docker.io/mhoelzl/clm-*`) for consistency:
 
 **PlantUML/DrawIO:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.8.4`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.9.0`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Notebook (with variants):**
-- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.8.4`, `:full`, `:1.8.4-full`
-- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.8.4-lite`
+- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.9.0`, `:full`, `:1.9.0-full`
+- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.9.0-lite`
 
 ### BuildKit Cache Mounts
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,6 +1,6 @@
 # CLM Architecture
 
-This document describes the current architecture of the CLM system (v1.8.4).
+This document describes the current architecture of the CLM system (v1.9.0).
 
 ## Overview
 
@@ -42,7 +42,7 @@ CLM is a course content processing system that converts educational materials (J
                          │
 ┌────────────────────────▼──────────────────────────────────┐
 │          clm.workers (Worker Implementations)              │
-│                                (v1.8.4)             │
+│                                (v1.9.0)             │
 │  ├── notebook/ (NotebookWorker, templates, processors)    │
 │  ├── plantuml/ (PlantUmlWorker, converter)                │
 │  └── drawio/ (DrawioWorker, converter)                    │
@@ -211,7 +211,7 @@ class Worker(ABC):
 
 ### Layer 3: Workers (Worker Implementations)
 
-**Purpose**: Concrete worker implementations for different file types (v1.8.4)
+**Purpose**: Concrete worker implementations for different file types (v1.9.0)
 
 Workers are now integrated into the main `clm` package under `clm.workers/`. Previously they were separate packages in the `services/` directory.
 
@@ -566,7 +566,7 @@ CLM has evolved significantly:
 - No message broker required
 - Reduced from 8 Docker services to 3
 
-**v0.6.2 → v1.8.4** (2025): Integrated workers
+**v0.6.2 → v1.9.0** (2025): Integrated workers
 - Workers integrated into main package (`clm.workers`)
 - Optional dependencies for each worker
 - Four-layer architecture (core, infrastructure, workers, cli)
@@ -1190,4 +1190,4 @@ Potential improvements (not currently planned):
 ---
 
 **Last Updated**: 2026-02-13
-**Version**: 1.8.4
+**Version**: 1.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-academy-lecture-manager"
-version = "1.8.4"
+version = "1.9.0"
 description = "Coding-Academy Lecture Manager - A course content processing system"
 authors = [
     {name = "Dr. Matthias Hölzl", email = "tc@xantira.com"},
@@ -404,7 +404,7 @@ ignore = [
 known-first-party = ["clm"]
 
 [tool.bumpversion]
-current_version = "1.8.4"
+current_version = "1.9.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/src/clm/__version__.py
+++ b/src/clm/__version__.py
@@ -1,3 +1,3 @@
 """Version information for CLM."""
 
-__version__ = "1.8.4"
+__version__ = "1.9.0"

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1009,7 +1009,7 @@ def _is_cpp_image_available() -> bool:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.8.4-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.9.0-full",
         ]:
             try:
                 client.images.get(tag)
@@ -1030,7 +1030,7 @@ def _get_full_image_name() -> str | None:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.8.4-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.9.0-full",
         ]:
             try:
                 client.images.get(tag)

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "coding-academy-lecture-manager"
-version = "1.8.4"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Release CLM 1.9.0

Cuts the **1.9.0** minor release. The headline change is PR #250 — the slide
**authoring tooling** (split / unify, sync, voiceover extract/inline,
assign-ids, normalize, validate, coverage, discovery, translate) is now
generalized from Python-only to the `//`-family languages (C#, C++, Java,
TypeScript) via comment-token threading. The default everywhere stays `#`, so
**Python output is byte-identical**.

This completes the multi-language authoring migration whose structural
prerequisite — the header-line-less title convention — shipped in 1.8.4.

### What's in this PR
- `docs:` 1.9.0 CHANGELOG section (Added / Changed / Fixed) covering the
  comment-token feature, the language-aware `sync translate` prompts, the
  voiceover-drop fix on `//`-decks, discovery of `.cs`/`.cpp`/`.java`/`.ts`
  decks, and the literal comment-prefix-strip fix.
- `Bump version: 1.8.4 → 1.9.0` across the eight tracked files.

Info topics (`commands.md`, `spec-files.md`) were already updated in PR #250's
C-6 phase. No new `migration` section is needed — 1.9.0 is purely additive
(default `#`, Python byte-identical) and its only prerequisite already ships in
1.8.4's documented header-convention migration.

### Pre-release gate
- Full non-Docker suite green locally: **7129 passed, 13 skipped, 1 xfailed**
  (`pytest -m "not docker"`, 198s).

### Release mechanics
Merge this with a **merge commit** (not squash/rebase) so the `Bump version …`
commit lands on `master` intact — that, plus the CI-green gate, triggers
`release.yml` to tag `v1.9.0`, publish to PyPI via OIDC, and create the GitHub
Release from the matching CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
