### PR TITLE
feat(slides): assign-ids --accept-code-derived — no-refuse id completion for bilingual→split (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`clm slides assign-ids --accept-code-derived`** — a deterministic, opt-in
+  fallback that mints a `slide_id` for bare-expression code subslides the AST
+  extractors can't name (`(1 + 1j) * (1 + 1j)` → `1-1j-1-1j`, `letters[0:3]` →
+  `letters-0-3`), by slugifying the cell's first real code line. Previously
+  these hard-refused, with the non-deterministic LLM (`--llm-suggest`) as the
+  only non-manual escape — so the bilingual→split conversion needed a human to
+  hand-author ids on both split halves. The first-code-line scanner is
+  comment-token-aware, so it also completes non-Python decks
+  (`.cs`/`.cpp`/`.java`/`.ts`), which `ast` can never parse. It is independent
+  of `--accept-content-derived` (separately gated, so the content-derived
+  minting funnels never start emitting opaque code-line slugs); the conversion
+  pipeline passes both. Genuinely empty / pure-punctuation / magic-only cells
+  still refuse. (#251)
+
 ## [1.8.4] - 2026-06-06
 
 ### Changed

--- a/src/clm/cli/commands/assign_ids.py
+++ b/src/clm/cli/commands/assign_ids.py
@@ -59,8 +59,22 @@ CACHE_DB_NAME = "clm-llm.sqlite"
     is_flag=True,
     help=(
         "Bulk-accept content-derived proposals (first bullet, prominent "
-        "bold, image alt) for headingless slides. Hard-refusal cells "
-        "still refuse."
+        "bold, image alt, prose, and the code AST constructs) for "
+        "headingless slides. Bare-expression code cells and hard-refusal "
+        "cells still refuse."
+    ),
+)
+@click.option(
+    "--accept-code-derived",
+    is_flag=True,
+    help=(
+        "Bulk-accept a first-code-line slug for bare-expression code cells "
+        "that have no heading and no extractable construct (e.g. "
+        "`(1 + 1j) * (1 + 1j)` -> `1-1j-1-1j`, `letters[0:3]` -> "
+        "`letters-0-3`). Comment-token-aware, so it works for non-Python "
+        "decks too. Genuinely empty / magic-only cells still refuse. "
+        "Independent of --accept-content-derived; the conversion pipeline "
+        "usually passes both."
     ),
 )
 @click.option(
@@ -161,6 +175,7 @@ def assign_ids_cmd(
     path: Path,
     force: bool,
     accept_content_derived: bool,
+    accept_code_derived: bool,
     llm_suggest: bool,
     report_only: bool,
     llm_model: str,
@@ -194,7 +209,10 @@ def assign_ids_cmd(
       headed       Slug derived from the first markdown heading.
       extractable  Refused by default; --accept-content-derived or
                    --llm-suggest opt into auto-acceptance.
-      no content   Hard refuse; author must write slide_id="..." by hand.
+      code-derived Bare-expression code cells (no heading, no construct);
+                   --accept-code-derived slugs the first code line.
+      no content   Hard refuse; author must write slide_id="..." by hand
+                   (genuinely empty / pure-punctuation / magic-only cells).
 
     \b
     Special cases:
@@ -226,6 +244,7 @@ def assign_ids_cmd(
     options = AssignOptions(
         force=force,
         accept_content_derived=accept_content_derived,
+        accept_code_derived=accept_code_derived,
         llm_suggest=llm_suggest and suggester is not None,
         report_only=report_only,
         llm_suggester=suggester,

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -883,11 +883,20 @@ Three-category policy:
     (transliterated to ASCII).
   **Refused by default**; opt in with `--accept-content-derived` or
   `--llm-suggest`.
+- **code-derived** *(since CLM {version})* — a bare-expression code cell
+  with no heading and none of the AST constructs above (e.g.
+  `(1 + 1j) * (1 + 1j)`, `letters[0:3]`, `a == b`). **Refused by default**;
+  opt in with `--accept-code-derived`, which slugs the cell's first real
+  code line (`letters[0:3]` → `letters-0-3`). The scanner is
+  comment-token-aware, so non-Python decks (`.cs`/`.cpp`/`.java`/`.ts`),
+  which `ast` never parses, are completed too. Independent of
+  `--accept-content-derived` — the bilingual→split conversion typically
+  passes both.
 - **no content** — cell where no extractor produces anything (empty
-  cell, pure `<img>` without alt, unparsable code, magic-only cells).
-  **Hard refuse**; the author has to write `slide_id="…"` by hand,
-  or pass `--llm-suggest` to let the LLM propose a title as a last
-  resort.
+  cell, pure `<img>` without alt, pure-punctuation / `...` code,
+  magic-only cells). **Hard refuse**; the author has to write
+  `slide_id="…"` by hand, or pass `--llm-suggest` to let the LLM propose
+  a title as a last resort.
 
 Special cases:
 
@@ -920,7 +929,8 @@ clm slides assign-ids [OPTIONS] PATH
 | Option | Description |
 |--------|-------------|
 | `--force` | Regenerate ids where the algorithm can produce one. `!`-prefixed ids and cells without a proposal are left untouched. |
-| `--accept-content-derived` | Auto-accept proposals for the extractable category (no LLM). Hard-refusal cells still refuse. |
+| `--accept-content-derived` | Auto-accept proposals for the extractable category (no LLM). Bare-expression code cells and hard-refusal cells still refuse. |
+| `--accept-code-derived` | (since CLM {version}) Auto-accept a first-code-line slug for bare-expression code cells the AST extractors can't name (`(1 + 1j) * (1 + 1j)` → `1-1j-1-1j`, `letters[0:3]` → `letters-0-3`). Comment-token-aware, so it works on non-Python decks (`.cs`/`.cpp`/`.java`/`.ts`). Genuinely empty / pure-punctuation / magic-only cells still refuse. Independent of `--accept-content-derived`. |
 | `--llm-suggest` | Use the local LLM (Ollama, default model `qwen3:30b`) to propose a short title. Fires on both extractable cells (replacing the content-derived title when the LLM returns one) and on hard-refusal cells (last-resort fallback before refusing). Cached per `(content_hash, prompt_version, lang)` in the LLM cache. Falls back silently to refusal when Ollama is unreachable. |
 | `--report-only`, `--dry-run` | List planned assignments and refusals without modifying any file. |
 | `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
@@ -961,6 +971,8 @@ Examples:
 ```bash
 clm slides assign-ids slides/module_010/topic_100/slides_intro.py --report-only
 clm slides assign-ids slides/module_010/ --accept-content-derived
+# Fully automatable bilingual→split prep: also id bare-expression code cells
+clm slides assign-ids slides/module_110_basics/ --accept-content-derived --accept-code-derived
 clm slides assign-ids slides/module_010/topic_100/slides_intro.py --llm-suggest
 clm slides assign-ids slides/module_010/ --force        # regenerate all derivable ids
 # Scope: mint only the bilingual decks, leaving split pairs for `clm slides sync`

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -299,6 +299,35 @@ Voiceover and notes cells inherit the id of the preceding slide
 `clm info commands` → `clm slides assign-ids` for the full flag
 matrix.
 
+## Fully automatable bilingual→split id completion ({version} — additive, issue #251)
+
+Converting a bilingual course module to the split layout is a clean command
+sequence (`assign-ids → split → extract → tidy`) — except `assign-ids` used to
+**hard-refuse** content-less code subslides: a code cell whose first statement is
+a bare expression with no heading and no nameable construct
+(`(1 + 1j) * (1 + 1j)`, `letters[0:3]`, `a == b`). The only non-manual escape
+was the LLM, so a human had to hand-author `slide_id="…"` on **both** split
+halves mid-conversion.
+
+CLM {version} adds the opt-in **`--accept-code-derived`** flag. It slugs each
+such cell's first real code line (`letters[0:3]` → `letters-0-3`), is pair-safe
+(the same id on `.de` / `.en`), stable, and idempotent. The scanner is
+comment-token-aware, so non-Python decks (`.cs`/`.cpp`/`.java`/`.ts`) are
+completed too. Run it alongside `--accept-content-derived` to mint a whole
+module with no human in the loop:
+
+```bash
+clm slides assign-ids slides/module_110_basics/ \
+    --accept-content-derived --accept-code-derived
+```
+
+It is a **separate** flag from `--accept-content-derived` by design: the
+content-derived minting funnels (`clm course gate`, `clm slides sync`,
+`clm slides translate`) keep their current behavior and do not start emitting
+opaque code-line slugs. Genuinely empty / pure-punctuation / magic-only cells
+still refuse — `--report-refusals` then lists only the cells that truly need a
+human.
+
 ## Voiceover extract/inline: data-loss hardening ({version})
 
 CLM {version} closes two ways `clm voiceover extract` / `inline` could lose

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -16,8 +16,11 @@ Rules in one paragraph:
   ``slide_id="title"`` without author input.
 - Headed cells get a slug from the heading. Headingless-but-extractable
   cells are refused by default; ``--accept-content-derived`` or
-  ``--llm-suggest`` opt into auto-acceptance. Hard-refusal cells (no
-  extractable content) always require manual authorship.
+  ``--llm-suggest`` opt into auto-acceptance. A bare-expression code cell
+  (no heading, no extractable construct — e.g. ``(1 + 1j) * (1 + 1j)``)
+  is covered by the opt-in ``--accept-code-derived`` first-code-line
+  fallback (#251). Only genuinely empty / pure-punctuation cells still
+  require manual authorship.
 - Voiceover and notes cells inherit the slide_id of the most recent
   preceding slide/subslide cell (1:N relationship). They are *never*
   written from an extracted heading of their own.
@@ -91,7 +94,12 @@ class AssignedId:
     file: str
     line: int
     slide_id: str
-    source: str  # "heading" / "title-macro" / "voiceover-inherit" / "llm" / "content"
+    # Which strategy produced the id, for the report. One of:
+    # "heading" / "sibling-heading" / "title-macro" / "voiceover-inherit" /
+    # "llm" / "paired" / "twin" / "content:<extractor>" (markdown bullet/bold/
+    # img/prose or the code AST extractors code:class/def/assign/import/call) /
+    # "code:line" (the opt-in first-code-line fallback, #251).
+    source: str
 
 
 @dataclass
@@ -171,6 +179,14 @@ def _write_slide_id(cell: _Cell, slide_id: str) -> None:
 class AssignOptions:
     """Knobs for one assign-ids pass.
 
+    ``accept_content_derived`` bulk-accepts the markdown/AST content
+    extractors (first bullet, bold, img alt, prose, ``code:class``/``def``/
+    ``assign``/``import``/``call``). ``accept_code_derived`` (#251)
+    separately opts into the last-resort first-code-line fallback for bare
+    expression code cells that have no extractable construct; it is a
+    distinct knob so the content-derived funnels never start minting opaque
+    code-line slugs by accident.
+
     ``llm_suggester`` is the mockable :class:`TitleSuggester` from
     :mod:`clm.infrastructure.llm.ollama_client`. Passing ``None`` skips
     LLM use even when ``llm_suggest`` is true (the protocol-level escape
@@ -180,6 +196,7 @@ class AssignOptions:
 
     force: bool = False
     accept_content_derived: bool = False
+    accept_code_derived: bool = False
     llm_suggest: bool = False
     report_only: bool = False
     llm_suggester: TitleSuggester | None = None
@@ -221,17 +238,21 @@ def _proposed_slug_from_extraction(
     return resolve_collision(base, used_ids)
 
 
-def _extract_from_cell(cell: _Cell) -> Extraction:
+def _extract_from_cell(cell: _Cell, comment_token: str, accept_code_derived: bool) -> Extraction:
     """Run the full extractor pipeline on a single cell.
 
     Markdown signals win first via :func:`classify`. When the cell is a
-    code cell and markdown found nothing, the AST extractor in
-    :mod:`clm.slides.code_cell_extract` gets a turn. Falls back to
+    code cell and markdown found nothing, the AST/first-code-line extractor
+    in :mod:`clm.slides.code_cell_extract` gets a turn — ``comment_token``
+    lets its first-code-line fallback recognize comment lines per prog_lang,
+    and ``accept_code_derived`` gates that fallback. Falls back to
     ``NON_EXTRACTABLE`` if neither path produces a proposal.
     """
     extraction = classify(cell.body)
     if extraction.category == Category.NON_EXTRACTABLE and cell.metadata.cell_type == "code":
-        code_extraction = extract_from_code(cell.body)
+        code_extraction = extract_from_code(
+            cell.body, comment_token, accept_code_derived=accept_code_derived
+        )
         if code_extraction is not None:
             return code_extraction
     return extraction
@@ -239,6 +260,13 @@ def _extract_from_cell(cell: _Cell) -> Extraction:
 
 def _content_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# Source labels produced by the opt-in first-code-line fallback (#251), direct
+# and via the DE/EN sibling fallback. Kept bare (not ``content:``-prefixed) so
+# they route through their own ``accept_code_derived`` write-gate clause rather
+# than the ``accept_content_derived`` one the markdown/AST extractors use.
+_CODE_LINE_SOURCES = ("code:line", "sibling-code:line")
 
 
 def assign_ids_for_cells(
@@ -300,6 +328,10 @@ def assign_ids_for_cells(
     # slide/subslide.
     current_slide_id: str | None = None
     file_str = str(file_path)
+    # Line-comment token of the deck's prog_lang ("#" python/rust, "//"
+    # c/c++/c#/java/ts) — needed by the first-code-line fallback so it skips
+    # comments per language. Derived once from the path extension.
+    comment_token = comment_token_for_path(file_path)
     slide_seen = 0  # index among slide/subslide cells (for twin_ids correspondence)
 
     for idx, cell in enumerate(cells):
@@ -352,6 +384,7 @@ def assign_ids_for_cells(
                 group_slug,
                 slug_source_idx=slug_source_idx,
                 alternate_cell=alternate_cell,
+                comment_token=comment_token,
             )
             if new_id is not None:
                 current_slide_id = new_id
@@ -427,6 +460,7 @@ def _handle_slide(
     group_slug: dict[int, str | None],
     slug_source_idx: int,
     alternate_cell: _Cell | None = None,
+    comment_token: str = "#",
 ) -> str | None:
     """Assign or preserve a slide_id on one slide/subslide cell.
 
@@ -487,8 +521,8 @@ def _handle_slide(
 
     # Slug is derived from the slug-source cell (EN sibling, or self).
     # ``_extract_from_cell`` combines the markdown classifier and the
-    # code-cell AST fallback into a single proposal.
-    extraction = _extract_from_cell(slug_source)
+    # code-cell AST/first-code-line fallback into a single proposal.
+    extraction = _extract_from_cell(slug_source, comment_token, options.accept_code_derived)
 
     # Phase 3 fallback: if the EN slug source has nothing to slug from
     # but the DE sibling does, slug from the DE sibling. Transliteration
@@ -498,7 +532,9 @@ def _handle_slide(
     # English titles, and the sibling content is German-side.
     sibling_fallback = False
     if extraction.category == Category.NON_EXTRACTABLE and alternate_cell is not None:
-        alt_extraction = _extract_from_cell(alternate_cell)
+        alt_extraction = _extract_from_cell(
+            alternate_cell, comment_token, options.accept_code_derived
+        )
         if alt_extraction.category != Category.NON_EXTRACTABLE:
             extraction = Extraction(
                 alt_extraction.category,
@@ -536,7 +572,12 @@ def _handle_slide(
         if not proposed_slug:
             proposed_title = extraction.text
             proposed_slug = _proposed_slug_from_extraction(extraction, local_used)
-            source = f"content:{extraction.source}"
+            # The first-code-line fallback keeps a bare label so it gets its
+            # own accept gate; every other content extractor is "content:"-tagged.
+            if extraction.source in _CODE_LINE_SOURCES:
+                source = extraction.source
+            else:
+                source = f"content:{extraction.source}"
 
     else:
         # NON_EXTRACTABLE: Phase 4 last-resort LLM. Without this fallback
@@ -587,22 +628,26 @@ def _handle_slide(
         return proposed_slug
 
     # We have a proposal. Decide whether to write it or refuse.
+    is_code_line = source in _CODE_LINE_SOURCES
     if extraction.category == Category.HEADED:
         write = True
-    elif extraction.category == Category.EXTRACTABLE and (
-        options.accept_content_derived or source == "llm"
-    ):
-        write = True
-    else:
+    elif extraction.category != Category.EXTRACTABLE:
         write = False
+    elif source == "llm":
+        write = True
+    elif is_code_line:
+        write = options.accept_code_derived
+    else:  # content-derived (markdown bullet/bold/img/prose or code AST extractors)
+        write = options.accept_content_derived
 
     if not write:
+        accept_flag = "--accept-code-derived" if is_code_line else "--accept-content-derived"
         result.refusals.append(
             Refusal(
                 file=file_str,
                 line=cell.line_number,
                 severity="soft",
-                reason="headingless slide; pass --accept-content-derived to accept",
+                reason=f"headingless slide; pass {accept_flag} to accept",
                 proposed_slug=proposed_slug,
                 proposed_title=proposed_title,
             )

--- a/src/clm/slides/code_cell_extract.py
+++ b/src/clm/slides/code_cell_extract.py
@@ -1,4 +1,4 @@
-"""AST-based slug extraction for code-typed slide cells.
+"""Slug extraction for code-typed slide cells.
 
 Used by ``clm slides assign-ids`` as a Phase-2 fallback when
 :func:`clm.slides.headingless.classify` returns ``NON_EXTRACTABLE`` on a
@@ -10,24 +10,51 @@ cell whose ``cell_type == "code"``. Walks the top-level statements with
     3. top-level assignment   -> ``<target>``
     4. import / from-import   -> ``import <name> [<name>...]``
     5. expression-stmt call   -> ``<obj> <method>`` (or ``<func>``)
+    6. first code line        -> the raw first non-comment/non-magic line
+                                 (only when ``accept_code_derived`` is set)
 
-Returns ``None`` when the source can't be parsed (shell escapes, magic
-commands, half-finished stubs) or no slug-worthy node is found. The
-caller treats ``None`` as ``NON_EXTRACTABLE`` and falls through to the
-existing refusal / LLM-fallback path.
+Extractors 1-5 are intent-based: they name a salient construct. A bare
+expression statement (``(1 + 1j) * (1 + 1j)``, ``letters[0:3]``,
+``a == b``) has no such construct, so by default it returns ``None`` and
+the caller hard-refuses — the only non-manual escape historically being
+the LLM (#251). Extractor 6 is the **opt-in deterministic fallback** for
+exactly those cells: it slugs the first real code line. It is
+comment-token-aware (:func:`_first_code_line`) so it works across every
+supported prog_lang, not just Python; ``ast`` is Python-only, so for a
+``.cs`` / ``.cpp`` / ``.java`` / ``.ts`` cell the AST extractors never
+fire and extractor 6 is the path that completes the deck.
+
+Returns ``None`` when the source can't be parsed *and* no first-code-line
+fallback applies (shell escapes, magic commands, blank/comment-only
+cells), or no slug-worthy node is found. The caller treats ``None`` as
+``NON_EXTRACTABLE`` and falls through to the existing refusal /
+LLM-fallback path.
 
 Extractor labels (``Extraction.source``) match the precedence order:
 ``code:class``, ``code:def``, ``code:assign``, ``code:import``,
-``code:call``. They surface in the ``assign-ids`` report as
-``content:code:<kind>`` so authors can tell which strategy produced a
-given slug.
+``code:call``, ``code:line``. Labels 1-5 surface in the ``assign-ids``
+report as ``content:code:<kind>`` (gated by ``--accept-content-derived``);
+``code:line`` keeps its bare label and is gated by ``--accept-code-derived``
+so it never silently activates inside the content-derived funnels.
 """
 
 from __future__ import annotations
 
 import ast
+import re
 
 from clm.slides.headingless import Category, Extraction
+
+# Jupyter line magics / shell escapes / help operators — never a slide's
+# identity. Skipping them keeps a magic-only cell (``!pip install …``) a
+# refusal, preserving the pre-1.8 behavior for the ``#``-comment-token
+# languages where these tokens are meaningful (Python/Rust).
+_MAGIC_PREFIXES = ("!", "%", "?")
+
+# A code line must carry at least one ASCII alphanumeric to slugify to
+# anything; a pure-punctuation line (``...``, ``()``, ``_``) slugifies to
+# the empty string and must stay a refusal rather than mint a bogus id.
+_HAS_ALNUM_RE = re.compile(r"[A-Za-z0-9]")
 
 # Cap the number of import names baked into the composite title so a
 # 30-line `from foo import (a, b, c, ...)` block doesn't produce an
@@ -36,28 +63,116 @@ from clm.slides.headingless import Category, Extraction
 _MAX_IMPORT_NAMES = 4
 
 
-def extract_from_code(source: str) -> Extraction | None:
+def extract_from_code(
+    source: str, comment_token: str = "#", *, accept_code_derived: bool = False
+) -> Extraction | None:
     """Return an ``EXTRACTABLE`` proposal derived from code, or ``None``.
 
-    ``source`` should be the raw Python body of a percent-format code
-    cell (no ``# `` prefix). A :class:`SyntaxError` produces ``None`` so
-    one unparsable cell does not abort the larger ``assign-ids`` run.
+    ``source`` is the raw body of a percent-format code cell (no comment
+    prefix). ``comment_token`` is the deck's line-comment token (``"#"``
+    python/rust, ``"//"`` c/c++/c#/java/ts) used only by the
+    ``accept_code_derived`` fallback to recognize comment lines.
+
+    The AST extractors (class/def/assign/import/call) run first when the
+    source parses as Python. A :class:`SyntaxError` (non-Python cell, shell
+    escape, magic, half-finished stub) skips them but is **not** fatal: with
+    ``accept_code_derived`` the comment-token-aware first-code-line fallback
+    still gets a turn, which is what lets a ``.cs`` / ``.ts`` cell — never
+    parseable by :mod:`ast` — be completed. ``None`` is returned only when
+    nothing matched, so the caller hard-refuses as before.
+
+    ``accept_code_derived`` defaults to ``False`` so every existing caller
+    (the content-anchor in :mod:`clm.slides.sync_writeback`, the direct unit
+    tests, the four content-derived funnels) is byte-for-byte unchanged.
     """
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return None
+        tree = None
 
-    for extractor in (
-        _from_class_def,
-        _from_function_def,
-        _from_assignment,
-        _from_import,
-        _from_call,
-    ):
-        result = extractor(tree)
-        if result is not None:
-            return result
+    if tree is not None:
+        for extractor in (
+            _from_class_def,
+            _from_function_def,
+            _from_assignment,
+            _from_import,
+            _from_call,
+        ):
+            result = extractor(tree)
+            if result is not None:
+                return result
+
+    if accept_code_derived:
+        line = _first_code_line(source, comment_token)
+        if line is not None and _HAS_ALNUM_RE.search(line):
+            return Extraction(Category.EXTRACTABLE, line, "code:line")
+
+    return None
+
+
+def _first_code_line(source: str, comment_token: str) -> str | None:
+    """First non-blank, non-comment, non-magic source line, or ``None``.
+
+    Comment-token-aware so it works across every supported prog_lang rather
+    than only Python:
+
+    - ``#``-token languages (Python, Rust): skip ``#`` *and* ``//`` line
+      comments — so a Python ``# comment`` and a Rust ``// comment`` both
+      drop — plus Jupyter line magics / shell escapes (``!pip …``,
+      ``%timeit``). A cell that is only a magic therefore yields ``None``
+      and stays a refusal.
+    - ``//``-token languages (C, C++, C#, Java, TypeScript): skip ``//``
+      line comments.
+
+    ``/* … */`` block comments (including multi-line) are consumed for every
+    language; a line can never validly *start* with ``/*`` in Python, so
+    enabling it there is a harmless no-op while it correctly skips C-family
+    and Rust block comments.
+
+    Returns the first surviving line, or ``None`` when the cell is all
+    blanks / comments / magics. Slugging (and the empty-slug rejection) is
+    the caller's job.
+    """
+    if comment_token == "//":
+        line_comment_prefixes: tuple[str, ...] = ("//",)
+        skip_magics = False
+    else:  # "#" family (Python, Rust)
+        line_comment_prefixes = ("#", "//")
+        skip_magics = True
+
+    in_block = False
+    for raw in source.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+
+        if in_block:
+            close = line.find("*/")
+            if close == -1:
+                continue
+            line = line[close + 2 :].strip()
+            in_block = False
+            if not line:
+                continue
+
+        # Consume any leading inline ``/* … */`` blocks; an unterminated one
+        # opens a multi-line block consumed on subsequent iterations.
+        while line.startswith("/*"):
+            close = line.find("*/", 2)
+            if close == -1:
+                in_block = True
+                line = ""
+                break
+            line = line[close + 2 :].strip()
+        if in_block or not line:
+            continue
+
+        if any(line.startswith(prefix) for prefix in line_comment_prefixes):
+            continue
+        if skip_magics and line[:1] in _MAGIC_PREFIXES:
+            continue
+        return line
+
     return None
 
 

--- a/tests/cli/test_assign_ids_code_derived.py
+++ b/tests/cli/test_assign_ids_code_derived.py
@@ -1,0 +1,92 @@
+"""Tests for ``clm slides assign-ids --accept-code-derived`` (#251).
+
+The first-code-line fallback for bare-expression code cells, exercised through
+the CLI surface: exit codes (0 when it clears the would-be hard refusals, 2
+when a genuinely content-less cell remains), in-file minting, the
+``--accept-content-derived``-alone back-compat guard, and a non-Python deck.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+BARE = '# %% lang="en" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n'
+
+
+def _deck(tmp_path: Path, content: str = BARE, name: str = "slides_code.py") -> Path:
+    f = tmp_path / name
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+def test_bare_expr_hard_refuses_by_default(tmp_path):
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f)])
+    assert r.exit_code == 2
+    assert f.read_text(encoding="utf-8") == BARE
+
+
+def test_accept_code_derived_mints_and_exits_clean(tmp_path):
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--accept-code-derived"])
+    assert r.exit_code == 0
+    assert 'slide_id="1-1j-1-1j"' in f.read_text(encoding="utf-8")
+
+
+def test_accept_content_derived_alone_does_not_mint(tmp_path):
+    # Back-compat guard: the content-derived flag must not start minting
+    # opaque code-line slugs — the bare expression still hard-refuses.
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--accept-content-derived"])
+    assert r.exit_code == 2
+    assert f.read_text(encoding="utf-8") == BARE
+
+
+def test_report_only_with_flag_writes_nothing(tmp_path):
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["slides", "assign-ids", str(f), "--accept-code-derived", "--report-only"]
+    )
+    assert r.exit_code == 0
+    assert f.read_text(encoding="utf-8") == BARE  # unchanged
+    assert "1-1j-1-1j" in r.output  # but the proposed id is reported
+
+
+def test_genuinely_empty_cell_still_exits_2_with_flag(tmp_path):
+    # A bare expression is cleared, but a pure-punctuation cell remains a hard
+    # refusal even with the flag — so the run still exits 2 and reports it.
+    content = (
+        '# %% lang="en" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n'
+        '# %% lang="en" tags=["subslide"]\n...\n'
+    )
+    f = _deck(tmp_path, content)
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--accept-code-derived"])
+    assert r.exit_code == 2
+    # The bare expression was still minted despite the residual hard refusal.
+    assert 'slide_id="1-1j-1-1j"' in f.read_text(encoding="utf-8")
+
+
+def test_report_refusals_shrinks_with_flag(tmp_path):
+    f = _deck(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["slides", "assign-ids", str(f), "--accept-code-derived", "--report-refusals"]
+    )
+    assert r.exit_code == 0
+    assert "No refusals" in r.output
+
+
+def test_non_python_deck_minted_with_flag(tmp_path):
+    cs = '// %% lang="en" tags=["subslide"]\nvar z = (1 + 2) * (3 + 4);\n'
+    f = _deck(tmp_path, cs, name="slides_code.cs")
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--accept-code-derived"])
+    assert r.exit_code == 0
+    assert 'slide_id="var-z-1-2-3-4"' in f.read_text(encoding="utf-8")
+
+
+def test_flag_appears_in_help():
+    r = CliRunner().invoke(cli, ["slides", "assign-ids", "--help"])
+    assert "--accept-code-derived" in r.output

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -711,6 +711,149 @@ class TestCodeCellSlideStart:
         assert result.assignments[0].source == "content:prose"
 
 
+class TestCodeDerivedFallback:
+    """``--accept-code-derived`` first-code-line fallback for bare-expression
+    code cells (#251) — the cells that historically hard-refused with the LLM
+    as the only non-manual escape.
+    """
+
+    BARE = '# %% lang="en" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n'
+
+    def test_default_still_hard_refuses(self):
+        # Unchanged from pre-#251: a bare expression hard-refuses by default.
+        new_text, result = _run(self.BARE)
+        assert result.assignments == []
+        assert result.refusals[0].severity == "hard"
+        assert new_text == self.BARE
+
+    def test_accept_code_derived_mints(self):
+        new_text, result = _run(self.BARE, accept_code_derived=True)
+        assert len(result.assignments) == 1
+        a = result.assignments[0]
+        assert a.slide_id == "1-1j-1-1j"
+        assert a.source == "code:line"
+        assert 'slide_id="1-1j-1-1j"' in new_text
+
+    def test_accept_content_derived_alone_does_not_mint(self):
+        # Critical back-compat: course_gate / sync_apply / translate_bootstrap
+        # pass accept_content_derived=True and must NOT start minting opaque
+        # code-line slugs — that needs the separate accept_code_derived knob.
+        new_text, result = _run(self.BARE, accept_content_derived=True)
+        assert result.assignments == []
+        assert result.refusals[0].severity == "hard"
+        assert new_text == self.BARE
+
+    def test_magic_only_still_hard_refuses_with_flag(self):
+        # The magic is skipped by the scanner, so nothing is extractable.
+        text = '# %% lang="en" tags=["subslide"]\n!pip install requests\n'
+        new_text, result = _run(text, accept_code_derived=True)
+        assert result.assignments == []
+        assert result.refusals[0].severity == "hard"
+
+    def test_punctuation_only_still_hard_refuses_with_flag(self):
+        text = '# %% lang="en" tags=["subslide"]\n...\n'
+        new_text, result = _run(text, accept_code_derived=True)
+        assert result.assignments == []
+        assert result.refusals[0].severity == "hard"
+
+    def test_idempotent_rerun(self):
+        new_text, _ = _run(self.BARE, accept_code_derived=True)
+        new_text2, result2 = _run(new_text, accept_code_derived=True)
+        assert result2.assignments == []
+        assert new_text2 == new_text
+
+    def test_collision_suffix_for_identical_code_lines(self):
+        text = (
+            '# %% lang="en" tags=["subslide"]\nletters[0:3]\n'
+            '# %% lang="en" tags=["subslide"]\nletters[0:3]\n'
+        )
+        new_text, result = _run(text, accept_code_derived=True)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["letters-0-3", "letters-0-3-2"]
+
+    def test_preserve_marker_untouched(self):
+        text = '# %% lang="en" tags=["subslide"] slide_id="!keep"\n(1 + 1j) * (1 + 1j)\n'
+        new_text, result = _run(text, accept_code_derived=True, force=True)
+        assert result.assignments == []
+        assert 'slide_id="!keep"' in new_text
+
+    def test_llm_wins_over_code_derived(self):
+        suggester = StaticTitleSuggester(default="Complex Multiplication")
+        new_text, result = _run(
+            self.BARE,
+            accept_code_derived=True,
+            llm_suggest=True,
+            llm_suggester=suggester,
+        )
+        assert len(result.assignments) == 1
+        a = result.assignments[0]
+        assert a.slide_id == "complex-multiplication"
+        assert a.source == "llm"
+
+    # -- pair-safety across all three id paths --
+
+    def test_pair_safe_bilingual_single_file(self):
+        text = (
+            '# %% lang="de" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n'
+            '# %% lang="en" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n'
+        )
+        new_text, result = _run(text, accept_code_derived=True)
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["1-1j-1-1j", "1-1j-1-1j"]
+        assert {a.source for a in result.assignments} == {"code:line", "paired"}
+
+    def test_pair_safe_split_pair_function(self, tmp_path: Path):
+        de = _write(
+            tmp_path,
+            '# %% lang="de" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n',
+            "deck.de.py",
+        )
+        en = _write(
+            tmp_path,
+            '# %% lang="en" tags=["subslide"]\n(1 + 1j) * (1 + 1j)\n',
+            "deck.en.py",
+        )
+        assign_ids_in_split_pair(de, en, AssignOptions(accept_code_derived=True))
+        assert 'slide_id="1-1j-1-1j"' in de.read_text(encoding="utf-8")
+        assert 'slide_id="1-1j-1-1j"' in en.read_text(encoding="utf-8")
+
+    def test_pair_safe_directory(self, tmp_path: Path):
+        # find_slide_files only discovers slides_*/topic_*/project_* names.
+        _write(tmp_path, '# %% lang="de" tags=["subslide"]\nletters[0:3]\n', "slides_deck.de.py")
+        _write(tmp_path, '# %% lang="en" tags=["subslide"]\nletters[0:3]\n', "slides_deck.en.py")
+        assign_ids_in_directory(tmp_path, AssignOptions(accept_code_derived=True))
+        de_text = (tmp_path / "slides_deck.de.py").read_text(encoding="utf-8")
+        en_text = (tmp_path / "slides_deck.en.py").read_text(encoding="utf-8")
+        assert 'slide_id="letters-0-3"' in de_text
+        assert 'slide_id="letters-0-3"' in en_text
+
+    def test_pair_safe_per_file_twin(self, tmp_path: Path):
+        # EN minted via code-derived, then the id-less DE half adopts the twin
+        # id through the per-file twin path — code-derived ids stay in parity.
+        de = _write(tmp_path, '# %% lang="de" tags=["subslide"]\nletters[0:3]\n', "deck.de.py")
+        en = _write(tmp_path, '# %% lang="en" tags=["subslide"]\nletters[0:3]\n', "deck.en.py")
+        assign_ids_in_file(en, AssignOptions(accept_code_derived=True))
+        assign_ids_in_file(de, AssignOptions(accept_code_derived=True))
+        import re
+
+        de_id = re.search(r'slide_id="([^"]+)"', de.read_text(encoding="utf-8")).group(1)
+        en_id = re.search(r'slide_id="([^"]+)"', en.read_text(encoding="utf-8")).group(1)
+        assert de_id == en_id == "letters-0-3"
+
+    def test_non_python_pair_safe(self):
+        # ast.parse can't parse C#; the comment-token-aware fallback completes
+        # the deck and the EN-authority pair stays in slide_id parity.
+        text = (
+            '// %% lang="de" tags=["subslide"]\nvar z = (1 + 2) * (3 + 4);\n'
+            '// %% lang="en" tags=["subslide"]\nvar z = (1 + 2) * (3 + 4);\n'
+        )
+        new_text, result = assign_ids_for_text(
+            text, Path("deck.cs"), AssignOptions(accept_code_derived=True)
+        )
+        slugs = [a.slide_id for a in result.assignments]
+        assert slugs == ["var-z-1-2-3-4", "var-z-1-2-3-4"]
+
+
 class TestLLMSuggestOnHardRefusal:
     """Phase 4: ``--llm-suggest`` fires on NON_EXTRACTABLE cells as a
     last resort. Without this, the LLM would silently no-op on the

--- a/tests/slides/test_code_cell_extract.py
+++ b/tests/slides/test_code_cell_extract.py
@@ -172,3 +172,101 @@ class TestUnparsable:
 
     def test_magic_in_comment_returns_none(self):
         assert extract_from_code("# !pip install foo\n") is None
+
+
+class TestFirstCodeLineFallback:
+    """The opt-in ``accept_code_derived`` first-code-line fallback (#251).
+
+    For bare-expression code cells the five intent-based extractors can't
+    name — there is no salient construct — the fallback slugs the first real
+    code line. It is comment-token-aware so it works for non-Python decks
+    too, where ``ast.parse`` always fails. Off by default.
+    """
+
+    def test_off_by_default_returns_none(self):
+        # Back-compat: without the flag a bare expression is still None, so
+        # the content-anchor in sync_writeback and the four content-derived
+        # funnels are byte-for-byte unchanged.
+        assert extract_from_code("(1 + 1j) * (1 + 1j)") is None
+
+    def test_binop_expression(self):
+        e = extract_from_code("(1 + 1j) * (1 + 1j)", accept_code_derived=True)
+        assert e is not None
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "code:line"
+        assert e.text == "(1 + 1j) * (1 + 1j)"
+
+    def test_string_concatenation(self):
+        e = extract_from_code('"1" + "2"', accept_code_derived=True)
+        assert e is not None and e.source == "code:line" and e.text == '"1" + "2"'
+
+    def test_subscript_expression(self):
+        e = extract_from_code("letters[0:3]", accept_code_derived=True)
+        assert e is not None and e.text == "letters[0:3]"
+
+    def test_attribute_expression(self):
+        e = extract_from_code("response.choices[0].message.content", accept_code_derived=True)
+        assert e is not None and e.text == "response.choices[0].message.content"
+
+    def test_comparison_expression(self):
+        e = extract_from_code("a == b", accept_code_derived=True)
+        assert e is not None and e.text == "a == b"
+
+    def test_big_int_literal(self):
+        e = extract_from_code(
+            "10000000000000000000000000000000000000000000000000 + 1", accept_code_derived=True
+        )
+        assert e is not None and e.source == "code:line"
+
+    def test_list_literal(self):
+        e = extract_from_code("[1, 2, 3]", accept_code_derived=True)
+        assert e is not None and e.text == "[1, 2, 3]"
+
+    def test_ast_construct_still_wins_over_fallback(self):
+        # A parseable construct keeps its intent-based label even with the
+        # flag on — the fallback is the last extractor.
+        e = extract_from_code("x = 5\n", accept_code_derived=True)
+        assert e is not None and e.source == "code:assign" and e.text == "x"
+
+    def test_skips_leading_comment(self):
+        e = extract_from_code("#setup\n(1 + 1j) * (1 + 1j)\n", accept_code_derived=True)
+        assert e is not None and e.text == "(1 + 1j) * (1 + 1j)"
+
+    def test_comment_only_returns_none(self):
+        assert extract_from_code("# just a comment", "#", accept_code_derived=True) is None
+
+    def test_magic_only_returns_none(self):
+        # The pre-existing "unparsable/magic stays a refusal" contract holds:
+        # the magic line is skipped and nothing else remains.
+        assert extract_from_code("!pip install requests\n", accept_code_derived=True) is None
+
+    def test_punctuation_only_returns_none(self):
+        # No alphanumeric -> no usable slug -> genuinely content-less -> stays
+        # a refusal even with the flag on.
+        assert extract_from_code("...", accept_code_derived=True) is None
+        assert extract_from_code("()", accept_code_derived=True) is None
+        assert extract_from_code("_", accept_code_derived=True) is None
+
+    # -- non-Python: ast.parse always fails; the comment-token-aware scanner
+    #    is the path that completes a .cs / .cpp / .java / .ts deck. --
+
+    def test_non_python_first_line(self):
+        e = extract_from_code("var z = (1 + 2) * (3 + 4);", "//", accept_code_derived=True)
+        assert e is not None and e.source == "code:line"
+        assert e.text == "var z = (1 + 2) * (3 + 4);"
+
+    def test_non_python_skips_line_comment_no_space(self):
+        e = extract_from_code("//note\nDoThing(x);", "//", accept_code_derived=True)
+        assert e is not None and e.text == "DoThing(x);"
+
+    def test_non_python_skips_inline_block_comment(self):
+        e = extract_from_code("/* helper */\nDoThing(x);", "//", accept_code_derived=True)
+        assert e is not None and e.text == "DoThing(x);"
+
+    def test_non_python_skips_multiline_block_comment(self):
+        e = extract_from_code("/*\n multi\n line\n*/\nDoThing(x);", "//", accept_code_derived=True)
+        assert e is not None and e.text == "DoThing(x);"
+
+    def test_non_python_comment_only_returns_none(self):
+        assert extract_from_code("// just a comment", "//", accept_code_derived=True) is None
+        assert extract_from_code("/* block only */", "//", accept_code_derived=True) is None


### PR DESCRIPTION
Implements the **primary fix** of #251: make `slide_id` completion fully automatable for the bilingual→split conversion, so converting a module never requires hand-authoring ids. The **secondary** proposal (split id-guarantee) is deliberately deferred and tracked in #255.

## The gap

`clm slides assign-ids` hard-refused *content-less code subslides* — a code cell whose first statement is a bare expression with no heading and no nameable construct (`(1 + 1j) * (1 + 1j)`, `"1" + "2"`, `letters[0:3]`, `a == b`, `obj.attr = 5`). The five intent-based AST extractors (class/def/assign/import/call) don't fire, so the cell fell to `NON_EXTRACTABLE` where the **only** non-manual escape was the LLM (`--llm-suggest`) — off by default, non-deterministic, needs a reachable Ollama. The result: a human hand-authoring `slide_id="…"` on **both** split halves mid-conversion (the `module_110_basics` repro in #251).

## The fix

A deterministic, **opt-in** `--accept-code-derived` fallback. When the AST extractors find no construct, it slugs the cell's **first real code line** (`letters[0:3]` → `letters-0-3`, `(1 + 1j) * (1 + 1j)` → `1-1j-1-1j`).

Key design decisions (from a multi-agent investigation; see #251):

- **First-code-line, not per-AST-node extraction.** A bare expression has no salient sub-node to name; slugifying the source line is simpler and more correct.
- **Comment-token-aware scanner**, built for every prog_lang from the start: Python/Rust (`#`, Jupyter magics skipped), C-family (`//` line + `/* … */` block comments). Because `ast.parse` is Python-only, this is also what lets **non-Python decks** (`.cs`/`.cpp`/`.java`/`.ts`) be completed — they never parse, but the scanner still finds their first code line.
- **No positional `<deck-stem>-NN` last resort.** Empirically only degenerate punctuation-only / `...` / magic-only cells reach an empty slug, and those *should* stay refusals. Dropping it removes the only index/file-context-dependent (and pair-safety-fragile) surface.
- **Separate flag + source-keyed write-gate.** The new `code:line` source routes through its own `accept_code_derived` gate, so the content-derived minting funnels (`course gate`, `sync`, `translate`, which pass `accept_content_derived=True`) do **not** start emitting opaque code-line slugs. Verified: `--accept-content-derived` alone still hard-refuses a bare expression.
- **Pair-safe / stable / idempotent / `!`-preserve for free** by reusing the existing EN-authority write path (the `group_slug` cache stamps the same id on the `.de`/`.en` twin). Verified across all three id paths (bilingual single-file, `assign_ids_in_split_pair`, per-file twin) and non-Python.

Genuinely empty / pure-punctuation / magic-only cells still hard-refuse (exit 2), so `--report-refusals` shrinks to the cells that truly need a human.

```bash
# Fully automatable module prep — no human in the loop:
clm slides assign-ids slides/module_110_basics/ --accept-content-derived --accept-code-derived
```

## What's in the diff

- **`code_cell_extract.py`** — `_first_code_line` comment-token-aware scanner; `accept_code_derived` param on `extract_from_code`; a `SyntaxError` no longer aborts the fallback (the non-Python path). Default off ⇒ the `sync_writeback` content-anchor and all funnels are byte-for-byte unchanged.
- **`assign_ids.py`** — `AssignOptions.accept_code_derived`; comment-token + flag threaded through `_extract_from_cell`/`_handle_slide`; `code:line` write-gate clause; docstring fixes.
- **`cli/commands/assign_ids.py`** — `--accept-code-derived` option, wired into `AssignOptions`; "code-derived" added to the command's category docstring.
- **Docs** — `info_topics/commands.md` (three-category policy, flag-table row, `module_110_basics` example), `info_topics/migration.md` (additive "Fully automatable bilingual→split id completion" section), `CHANGELOG.md` `[Unreleased]`. Uses `{version}` placeholders.

## Tests

- **40 new tests** — 32 engine (`test_code_cell_extract.py::TestFirstCodeLineFallback`, `test_assign_ids.py::TestCodeDerivedFallback`: per-AST-shape, comment/magic/punctuation handling, non-Python `.cs`, pair-safety across all three id paths, idempotency, collision suffix, `!`-preserve, LLM-beats-code-derived, the `--accept-content-derived`-alone back-compat guard) + 8 CLI (`test_assign_ids_code_derived.py`: exit 0/2, in-file minting, `--report-only`, residual-hard-refusal, non-Python, `--help`).
- **2743 slides + CLI tests pass**, 0 regressions; ruff/format/mypy clean; pre-push fast suite green.

## Deferred

The secondary split id-guarantee (`clm slides split --assign-ids`) is tracked in #255 — the `assign-ids <dir>` → `split` pipeline is already fully scriptable with this PR, so it's belt-and-suspenders. Maintainer can close #251 once satisfied the primary covers the headline goal (#255 tracks the remainder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)