### PR TITLE
fix(slides): wrap preamble code so split builds match bilingual (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   minting funnels never start emitting opaque code-line slugs); the conversion
   pipeline passes both. Genuinely empty / pure-punctuation / magic-only cells
   still refuse. (#251)
+- **`clm slides normalize` gains a `preamble_code` operation** (default-on) that
+  fixes issue #253: executable code between the `# {{ header(…) }}` macro call and
+  the first `# %%` cell has no cell marker, so jupytext folds it into the header
+  cell — and, at build time, into the **title markdown**. In the bilingual
+  `header(de, en)` macro that code rides the EN title (silently dropped from a DE
+  build); in a split `.de.py` half it rides the DE title (kept), so the bilingual
+  and split builds diverge on the DE side and the conversion is not
+  render-neutral. The new op moves the code into its own shared `# %%` code cell —
+  included identically in every build and copied verbatim to both split halves —
+  so the builds become byte-identical and the code is finally executed as code
+  rather than rendered as markdown text. It runs first among the normalize passes,
+  is idempotent, and is a no-op on a conforming deck.
 
 ### Changed
 
+- **`clm validate` (`format` group) and `clm slides split` now warn about
+  preamble code** (issue #253). `validate` emits a `warning`-severity finding and
+  `split` prints a non-fatal `warning:` to stderr (it never rewrites the source,
+  so the byte-identical round-trip is preserved). Both point at `clm slides
+  normalize` for the fix. Top-of-file code *before* the `# j2` import line (a true
+  file preamble, e.g. a leading `import os`) is already render-neutral and is not
+  flagged.
 - **CI/release workflows upgraded to Node.js 24-based actions.** GitHub is
   forcing JavaScript actions onto Node.js 24 (Node.js 20 is deprecated and
   removed from runners in September 2026). `actions/checkout`, `setup-python`,

--- a/src/clm/cli/commands/normalize_slides.py
+++ b/src/clm/cli/commands/normalize_slides.py
@@ -106,10 +106,12 @@ def normalize_slides_cmd(
 
     \b
     Operations:
+        preamble_code   Wrap code that precedes the first cell into its own cell
         tag_migration   Rename alt->completed after start cells
         workshop_tags   Add workshop tag to workshop heading cells
         interleaving    Normalize DE/EN cell ordering
         slide_ids       Auto-generate slide_id metadata for cells
+        cell_spacing    Normalize blank-line separation between cells
         all             All of the above (default)
 
     \b

--- a/src/clm/cli/commands/split.py
+++ b/src/clm/cli/commands/split.py
@@ -76,6 +76,8 @@ def split_cmd(source: Path, force: bool, report_only: bool, as_json: bool) -> No
 
 
 def _print_human(result: SplitResult, *, report_only: bool) -> None:
+    for warning in result.warnings:
+        click.echo(f"warning: {warning}", err=True)
     prefix = "[report-only] " if report_only else ""
     verb = "would write" if report_only else "wrote"
     paths = [result.de_path, result.en_path]
@@ -96,5 +98,6 @@ def _to_dict(result: SplitResult, *, report_only: bool) -> dict[str, object]:
         "source_companion": result.source_companion,
         "de_companion": result.de_companion,
         "en_companion": result.en_companion,
+        "warnings": result.warnings,
         "report_only": report_only,
     }

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -781,6 +781,7 @@ Since CLM {version}, the `format` check group also enforces **cell spacing**
 |---------|----------|-------|
 | cell is not separated from the previous cell by a blank line | `warning` | A blank line is required before every cell **except a j2 cell** — the title-header block (`# j2 … import header` immediately followed by `# {{ header(…) }}`) is tight-coupled and exempt. Cells run together are valid percent-format but render and diff poorly. Fix with `clm slides normalize`. |
 | markdown cell body does not start with a blank comment line (`#`) | `warning` | A markdown cell should open `# %% [markdown]` / `#` / `# <content>`; the leading `#` is what makes content that starts with a bullet (or heading) render correctly. j2 cells (the title macro) are exempt; empty-body cells are skipped. Fix with `clm slides normalize`. |
+| executable code appears before the first `%% ` cell marker (issue #253) | `warning` | (since CLM {version}) Code between the `# {{ header(…) }}` macro call and the first `# %%` cell has no cell marker, so jupytext folds it into the header cell. At build time it lands in the **title markdown** — silently dropped from a DE build (it rides the EN title in the bilingual macro) yet kept in the split DE half, so the bilingual and split builds diverge. A `warning`, not an `error`: the source still round-trips through `split`/`unify`. Fix with `clm slides normalize` (the `preamble_code` op wraps it in its own `# %%` cell). |
 
 Quick mode (`--quick`) runs the slide_id checks because they walk cells
 linearly and don't false-positive on in-progress edits. The workshop-scope
@@ -802,8 +803,9 @@ clm validate slides/module_010/topic_100_intro/ --quick
 *Removed in CLM 1.8: the flat alias `clm normalize-slides` no longer exists — use this group-qualified form.*
 
 Normalize slide files by applying mechanical fixes: tag migration (`alt`→`completed`),
-workshop tag insertion, DE/EN interleaving, slide ID auto-generation, and — since
-CLM {version} — **cell spacing** (`cell_spacing`).
+workshop tag insertion, DE/EN interleaving, slide ID auto-generation, **cell spacing**
+(`cell_spacing`), and — since CLM {version} — **preamble-code wrapping**
+(`preamble_code`).
 
 The `cell_spacing` operation fixes the two formatting issues the `format`
 validator now warns about: it inserts a blank line before every cell that lacks
@@ -811,13 +813,24 @@ one (except the tight-coupled j2 title-header block), and prepends a blank
 comment line (`#`) to any markdown cell whose body starts directly with content.
 It runs by default (part of `all`) and is idempotent.
 
+The `preamble_code` operation (since CLM {version}) fixes issue #253: code that
+sits between the `# {{ header(…) }}` macro call and the first `# %%` cell has no
+cell marker of its own, so jupytext folds it into the header cell and — at build
+time — into the **title markdown**, where it diverges between bilingual and split
+builds. The op moves that code into its own `# %%` code cell (a shared,
+language-neutral cell included in every build and copied verbatim to both split
+halves), making the conversion render-neutral and finally executing the code as
+code rather than rendering it as markdown text. It runs **first** (before the
+other passes), is default-on (part of `all`), idempotent, and a strict no-op on
+a conforming deck.
+
 ```
 clm slides normalize [OPTIONS] PATH
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--operations TEXT` | Comma-separated operations: `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
+| `--operations TEXT` | Comma-separated operations: `preamble_code`, `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
 | `--dry-run` | Preview changes without modifying files |
 | `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--json` | Output as JSON |
@@ -841,6 +854,8 @@ clm slides normalize slides/module_010/ --operations tag_migration
 clm slides normalize slides/module_010/ --operations slide_ids --json
 # Fix only cell spacing (blank line between cells + markdown leading `#`).
 clm slides normalize slides/module_010/ --operations cell_spacing
+# Fix only preamble code (wrap code before the first cell into its own `# %%` cell)
+clm slides normalize slides/module_010/ --operations preamble_code
 # Pre-conversion: canonicalize start/completed order so the split round-trips exactly
 clm slides normalize slides/module_010/topic_100_intro/ --operations interleaving --canonicalize-start-completed
 # Scope: mint ids on bilingual decks only, skipping an _archive/ dir
@@ -1507,6 +1522,15 @@ by matching id. Since CLM {version} the parser recognises the deck's
 own comment token (`# %%` for Python/Rust, `// %%` for C#/C++/Java/TS),
 so split/unify and the rest of the authoring tooling work on every
 supported prog_lang — the token is derived from the file extension.
+
+**Preamble code (issue #253).** Since CLM {version}, `split` emits a `warning:`
+(to stderr; does not fail) when SOURCE has executable code between the
+`# {{ header(…) }}` macro call and the first `# %%` cell. The split itself stays
+byte-identical (the code is copied to both halves), but such code folds into the
+**title markdown** at build time and is **not render-neutral** between the
+bilingual and split forms. `split` never rewrites the source — run
+`clm slides normalize` (the `preamble_code` op) first to wrap the code in its own
+`# %%` cell, then re-split.
 
 **Voiceover companion.** If SOURCE has a sibling voiceover companion
 (`slides_<name>.py` → `voiceover_<name>.<ext>`), `split` splits it in

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -196,6 +196,49 @@ clm slides normalize slides/ --operations cell_spacing   # spacing only
 `cell_spacing` runs by default (part of `all`), is idempotent, and preserves the
 split/unify round-trip. No code or spec changes are required in course repos.
 
+## Preamble-code wrapping: `preamble_code` (issue #253, {version} — additive)
+
+A deck may carry **preamble code** — an executable line between the
+`# {{ header(…) }}` macro call and the first `# %%` cell, e.g.:
+
+```python
+# j2 from 'macros.j2' import header
+# {{ header("Regeln für Typen", "Rules for Types") }}
+from typing import Iterable          # <- preamble code, no cell marker
+# %% [markdown] lang="de" ...
+```
+
+Because `# {{ ` is itself a cell boundary, that code becomes the **body** of the
+header cell, and jupytext folds it into the **title markdown** at build time. In
+the bilingual `header(de, en)` macro the code rides the EN title (so it is
+silently dropped from a DE build); in a split `.de.py` half it rides the DE title
+(so it is kept). The two builds therefore **diverge on the DE side** — the
+bilingual→split conversion is not render-neutral. The split *source* still
+round-trips byte-identically; the divergence is build-side only.
+
+CLM {version} addresses this three ways:
+
+- **`clm validate`** (the `format` group) emits a `warning` pointing at the code.
+- **`clm slides split`** prints a `warning:` (to stderr; non-fatal) and never
+  rewrites the source.
+- **`clm slides normalize`** gains a `preamble_code` operation that moves the
+  code into its own `# %%` code cell — a shared, language-neutral cell that every
+  build includes identically and `split` copies verbatim to both halves. After
+  the fix the import is finally executed **as code** (not rendered as markdown
+  text), and the bilingual and split builds are byte-identical.
+
+```bash
+clm slides normalize slides/                          # fixes it with the other ops
+clm slides normalize slides/ --operations preamble_code   # this fix only
+```
+
+**Non-breaking.** The validate finding is a `warning` (the default error-gate and
+CI are unaffected). `preamble_code` runs first among the normalize ops, is
+default-on (part of `all`), idempotent, and a strict no-op on a conforming deck.
+**Note:** top-of-file code *before* the `# j2` import line (a true file preamble,
+e.g. a leading `import os`) lands in the split's shared preamble and is already
+render-neutral — it is **not** flagged.
+
 ## Breaking changes in CLM 1.8
 
 CLM 1.8 retires the Phase 0 deprecation period. It carries **intentional

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -105,8 +105,52 @@ class NormalizationResult:
 # ---------------------------------------------------------------------------
 
 ALL_OPERATIONS = frozenset(
-    {"tag_migration", "workshop_tags", "interleaving", "slide_ids", "cell_spacing"}
+    {
+        "preamble_code",
+        "tag_migration",
+        "workshop_tags",
+        "interleaving",
+        "slide_ids",
+        "cell_spacing",
+    }
 )
+
+
+# ---------------------------------------------------------------------------
+# Preamble code: wrap bare code folded into a header cell into its own cell
+# ---------------------------------------------------------------------------
+
+
+def _apply_preamble_code(
+    cells: list[_RawCell], file_path: str, comment_token: str = "#"
+) -> list[Change]:
+    """Move code folded into a leading j2 (header) cell into its own ``%% `` cell.
+
+    Code between the ``# {{ header(...) }}`` macro call and the first ``%% ``
+    cell has no cell marker, so jupytext folds it into the header cell and the
+    title markdown — silently dropped from a DE build yet kept in the split DE
+    half, so bilingual and split builds diverge (issue #253). Re-homing it in a
+    shared ``%% `` code cell makes every build include it identically (and run
+    it as code). Mutates ``cells`` in place; idempotent on a conforming deck.
+    Runs before the other passes so they see the canonical cell structure;
+    inter-cell spacing is finalized later by ``cell_spacing``.
+    """
+    from clm.slides.preamble_code import wrap_preamble_code
+
+    changes: list[Change] = []
+    for finding in wrap_preamble_code(cells, comment_token):
+        changes.append(
+            Change(
+                file=file_path,
+                operation="preamble_code",
+                line=finding.first_code_line,
+                description=(
+                    "Wrapped code that preceded the first cell marker into a "
+                    f"`{comment_token} %%` code cell"
+                ),
+            )
+        )
+    return changes
 
 
 # ---------------------------------------------------------------------------
@@ -751,7 +795,12 @@ def normalize_file(
     all_changes: list[Change] = []
     all_review: list[ReviewItem] = []
 
-    # Apply operations in deterministic order
+    # Apply operations in deterministic order. Preamble-code wrapping runs first
+    # so every later pass (interleaving, slide_ids, cell_spacing) sees the
+    # canonical cell structure with the code in its own cell.
+    if "preamble_code" in op_set:
+        all_changes.extend(_apply_preamble_code(cells, file_str, comment_token))
+
     if "tag_migration" in op_set:
         all_changes.extend(_apply_tag_migration(cells, file_str))
 

--- a/src/clm/slides/preamble_code.py
+++ b/src/clm/slides/preamble_code.py
@@ -1,0 +1,143 @@
+"""Detect (and re-home) "preamble code" folded into a j2 header cell.
+
+**The problem (issue #253).** jupytext's ``py:percent`` reader folds any code
+that has no preceding ``# %%`` marker into the *preceding* cell. When such code
+sits between the ``# {{ header(...) }}`` macro call and the first real ``# %%``
+cell, it becomes the **body** of the j2 header cell::
+
+    # j2 from 'macros.j2' import header
+    # {{ header("Regeln für Typen", "Rules for Types") }}
+    from typing import Iterable          # <- folded into the header cell's body
+    # %% [markdown] lang="de" ...
+
+Because ``# {{ `` and ``# j2 `` are themselves cell boundaries, this code is
+**never** part of the :func:`clm.slides.raw_cells.split_cells` preamble string —
+it lives in ``RawCell.lines[1:]`` of the trailing j2 cell.
+
+At build time the header macro expands to the title slide(s), and the trailing
+code is folded into the *title markdown*. In the **bilingual** ``header(de, en)``
+form the macro's last cell is the EN title, so the code attaches to EN and is
+silently dropped from a DE build. In the **split** form ``header_de`` emits only
+a DE cell, so the same code attaches to DE and survives. The two builds therefore
+diverge on the DE side — the conversion is not render-neutral.
+
+**The fix.** Move the code into its own ``# %%`` code cell. A code cell carries
+no ``lang``, so it is included verbatim in every build and ``split`` copies it
+identically to both halves — bilingual and split builds become byte-identical
+(and the code is finally executed as code rather than rendered as markdown text).
+
+This module is the single source of truth used by the validator (warning),
+``clm slides split`` (warning), and ``clm slides normalize`` (auto-fix).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from clm.notebooks.slide_parser import parse_cell_header
+from clm.slides.raw_cells import RawCell
+
+
+@dataclass(frozen=True)
+class PreambleCodeFinding:
+    """One j2 cell whose body carries executable preamble code."""
+
+    cell_index: int
+    """Index of the offending j2 cell in the ``cells`` list."""
+    header_line: int
+    """1-based line number of that j2 cell's header (the macro/import line)."""
+    first_code_line: int
+    """1-based absolute line number of the first offending code line."""
+    code_lines: list[str]
+    """The non-blank, non-comment body lines, verbatim and in order."""
+
+
+def _is_code_line(line: str, comment_token: str) -> bool:
+    """True iff ``line`` is executable code (non-blank and not a comment)."""
+    return bool(line.strip()) and not line.lstrip().startswith(comment_token)
+
+
+def _code_body_indices(body: list[str], comment_token: str) -> list[int]:
+    return [i for i, line in enumerate(body) if _is_code_line(line, comment_token)]
+
+
+def find_preamble_code(cells: list[RawCell], comment_token: str = "#") -> list[PreambleCodeFinding]:
+    """Return findings for code folded into a *leading* j2 cell body.
+
+    Only the run of j2 cells at the top of the file (the ``import`` directive
+    and the ``# {{ header(...) }}`` macro call) is inspected; iteration stops at
+    the first non-j2 cell. A body line counts as code iff it is non-blank and
+    does not start with ``comment_token`` (``"#"`` for python/rust, ``"//"`` for
+    cpp/csharp/java/typescript). Blank and comment lines are ignored, so a
+    normal markdown body — whose ``#``-prefixed lines look like comments — never
+    matches (and markdown cells are not j2 anyway).
+    """
+    findings: list[PreambleCodeFinding] = []
+    for idx, cell in enumerate(cells):
+        if not cell.metadata.is_j2:
+            break
+        body = cell.lines[1:]
+        code_idx = _code_body_indices(body, comment_token)
+        if code_idx:
+            findings.append(
+                PreambleCodeFinding(
+                    cell_index=idx,
+                    header_line=cell.line_number,
+                    first_code_line=cell.line_number + 1 + code_idx[0],
+                    code_lines=[body[i] for i in code_idx],
+                )
+            )
+    return findings
+
+
+def wrap_preamble_code(cells: list[RawCell], comment_token: str = "#") -> list[PreambleCodeFinding]:
+    """Re-home preamble code into ``# %%`` code cells, mutating ``cells`` in place.
+
+    For each leading j2 cell whose body carries code, the body from the first
+    code line onward (preserving any interleaved comments) is moved into a new
+    shared ``# %%`` code cell inserted directly after that j2 cell. Lines that
+    preceded the code — comments and blank lines alike — stay on the j2 cell
+    verbatim, so no authored content is lost. Only the *trailing* blank lines of
+    the moved run are dropped (they are pure separators, re-added by the
+    ``cell_spacing`` normalizer pass that runs afterwards).
+
+    The new cell carries no ``lang`` (it is a shared cell), so the bilingual
+    ``split`` copies it verbatim to both halves and the round trip stays
+    byte-identical.
+
+    Returns the findings (one per rewritten j2 cell), with line numbers relative
+    to the pre-mutation file. Idempotent: a conforming deck is a no-op.
+    """
+    marker = f"{comment_token} %%"
+    wrapped: list[PreambleCodeFinding] = []
+    i = 0
+    while i < len(cells) and cells[i].metadata.is_j2:
+        cell = cells[i]
+        body = cell.lines[1:]
+        code_idx = _code_body_indices(body, comment_token)
+        if code_idx:
+            first = code_idx[0]
+            head = body[:first]  # kept verbatim on the j2 cell — no content loss
+            moved = body[first:]
+            while moved and not moved[-1].strip():
+                moved.pop()
+            wrapped.append(
+                PreambleCodeFinding(
+                    cell_index=i,
+                    header_line=cell.line_number,
+                    first_code_line=cell.line_number + 1 + first,
+                    code_lines=[line for line in moved if _is_code_line(line, comment_token)],
+                )
+            )
+            cell.lines = [cell.lines[0], *head]
+            cells.insert(
+                i + 1,
+                RawCell(
+                    lines=[marker, *moved],
+                    line_number=cell.line_number + 1 + first,
+                    metadata=parse_cell_header(marker, comment_token),
+                ),
+            )
+            i += 1  # skip the cell we just inserted (it is non-j2)
+        i += 1
+    return wrapped

--- a/src/clm/slides/split.py
+++ b/src/clm/slides/split.py
@@ -111,6 +111,7 @@ class SplitResult:
     source_companion: str | None = None
     de_companion: str | None = None
     en_companion: str | None = None
+    warnings: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -361,6 +362,8 @@ def split_in_file(
     text = source.read_text(encoding="utf-8")
     de_text, en_text = split_text(text, comment_token)
 
+    warnings = _preamble_code_warnings(text, source, comment_token)
+
     companion = _plan_companion_split(source, de_path, en_path, comment_token)
 
     overwrote: list[str] = []
@@ -396,7 +399,33 @@ def split_in_file(
         source_companion=str(companion.source) if companion is not None else None,
         de_companion=str(companion.de_path) if companion is not None else None,
         en_companion=str(companion.en_path) if companion is not None else None,
+        warnings=warnings,
     )
+
+
+def _preamble_code_warnings(text: str, source: Path, comment_token: str = "#") -> list[str]:
+    """Warn (without rewriting) when ``text`` has code folded into a header cell.
+
+    Such code (between the ``{{ header(...) }}`` macro and the first ``%% `` cell)
+    is preserved byte-identically by the split — the round trip still holds — but
+    at build time it folds into the title markdown and is NOT render-neutral
+    between the bilingual and split forms (issue #253). We never mutate the source
+    here (that would break ``unify(split(x)) == x``); we only point the user at
+    ``clm slides normalize``, which moves the code into its own ``%% `` cell.
+    """
+    from clm.slides.preamble_code import find_preamble_code
+
+    _preamble, cells = split_cells(text, comment_token)
+    warnings: list[str] = []
+    for finding in find_preamble_code(cells, comment_token):
+        warnings.append(
+            f"{source}:{finding.first_code_line}: executable code before the first "
+            f"`%% ` cell is folded into the header cell and will be dropped or "
+            f"mis-rendered, so the split is not render-neutral with the bilingual "
+            f"build (issue #253). Run `clm slides normalize` to wrap it in a code "
+            f"cell, then re-split."
+        )
+    return warnings
 
 
 def _split_target(source: Path, lang: str) -> Path:

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -260,6 +260,44 @@ def _check_markdown_blank_lead(raw_cells: list[RawCell], file_path: str) -> list
     return findings
 
 
+def _check_preamble_code(
+    raw_cells: list[RawCell], file_path: str, comment_token: str = "#"
+) -> list[Finding]:
+    """Warn when executable code is folded into a leading j2 (header) cell body.
+
+    Code that sits between the ``# {{ header(...) }}`` macro call and the first
+    ``%% `` cell has no cell marker of its own, so jupytext folds it into the
+    header cell. At build time it lands in the title markdown — silently dropped
+    from a DE build (it rides the EN title in the bilingual macro) yet kept in
+    the split DE half, so bilingual and split builds diverge (issue #253). A
+    *warning*, not an error: the source still round-trips through split/unify,
+    and escalating it would block the 1.8 validator gate. Operates on
+    :class:`RawCell` because the parsed ``Cell`` model discards the j2 cell body.
+    """
+    from clm.slides.preamble_code import find_preamble_code
+
+    findings: list[Finding] = []
+    for finding in find_preamble_code(raw_cells, comment_token):
+        findings.append(
+            Finding(
+                severity="warning",
+                category="format",
+                file=file_path,
+                line=finding.first_code_line,
+                message=(
+                    "executable code appears before the first `%% ` cell marker; "
+                    "it is folded into the header cell and is silently dropped or "
+                    "mis-rendered across bilingual and split builds (issue #253)"
+                ),
+                suggestion=(
+                    "Move the code into its own `%% ` code cell "
+                    "(`clm slides normalize` fixes this automatically)."
+                ),
+            )
+        )
+    return findings
+
+
 def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
     """Check tag validity, unclosed start/completed pairs, and orphan end-workshop tags."""
     findings: list[Finding] = []
@@ -1661,6 +1699,7 @@ def validate_file(
         _, raw_cells = split_raw_cells(text, comment_token)
         findings.extend(_check_cell_separation(raw_cells, file_str))
         findings.extend(_check_markdown_blank_lead(raw_cells, file_str))
+        findings.extend(_check_preamble_code(raw_cells, file_str, comment_token))
     if "tags" in check_set:
         findings.extend(_check_tags(cells, file_str))
     if "pairing" in check_set:

--- a/tests/cli/test_normalize_slides.py
+++ b/tests/cli/test_normalize_slides.py
@@ -61,6 +61,37 @@ class TestNormalizeSlidesCmd:
         assert data["status"] == "applied"
         assert len(data["changes"]) == 1
 
+    def test_preamble_code_operation(self, tmp_path):
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("Regeln", "Rules") }}\n'
+            "from typing import Iterable\n\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n#\n# ## A\n'
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(path), "--operations", "preamble_code"])
+        assert result.exit_code == 0
+        assert "preamble_code" in result.output
+        assert "# %%\nfrom typing import Iterable" in path.read_text(encoding="utf-8")
+
+    def test_preamble_code_dry_run_reports_without_writing(self, tmp_path):
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("Regeln", "Rules") }}\n'
+            "from typing import Iterable\n\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n#\n# ## A\n'
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        runner = CliRunner()
+        result = runner.invoke(
+            normalize_slides_cmd, [str(path), "--operations", "preamble_code", "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert "[DRY RUN]" in result.output
+        assert "preamble_code" in result.output
+        assert path.read_text(encoding="utf-8") == text
+
     def test_review_items_exit_2(self, tmp_path):
         # Count mismatch produces review items → exit 2 when no other changes
         text = (

--- a/tests/cli/test_validate_slides.py
+++ b/tests/cli/test_validate_slides.py
@@ -59,6 +59,33 @@ class TestValidateSlidesCommand:
         assert result.exit_code == 1
         assert "ERROR" in result.output
 
+    def test_preamble_code_warning_exit_zero(self, tmp_path):
+        # A deck with code folded into the header cell (issue #253) warns but,
+        # with the default --fail-on, still exits 0 (gate-safety). The DE/EN
+        # pair keeps the pairing check clean so only the warning is present.
+        p = _write_slide(
+            tmp_path,
+            "slides_preamble.py",
+            """\
+            # j2 from 'macros.j2' import header
+            # {{ header("Regeln", "Rules") }}
+            from typing import Iterable
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="gh"
+            #
+            # ## Hinweise
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="gh"
+            #
+            # ## Hints
+            """,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p)])
+        assert result.exit_code == 0
+        assert "WARN" in result.output
+        assert "#253" in result.output
+
     def test_json_output(self, tmp_path):
         p = _write_slide(
             tmp_path,

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -967,6 +967,108 @@ class TestSlideIds:
 # ---------------------------------------------------------------------------
 
 
+_DECK_WITH_PREAMBLE = (
+    "# j2 from 'macros.j2' import header\n"
+    '# {{ header("Regeln für Typen", "Rules for Types") }}\n'
+    "from typing import Iterable\n"
+    "\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+    "#\n# ## Hinweise\n"
+)
+
+
+class TestPreambleCode:
+    def test_wraps_preamble_code(self, tmp_path):
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        result = normalize_file(path, operations=["preamble_code", "cell_spacing"])
+        assert result.files_modified == 1
+        out = path.read_text(encoding="utf-8")
+        # The import is now its own bare code cell, no longer on the header cell.
+        assert "}}\nfrom typing" not in out
+        assert "# %%\nfrom typing import Iterable" in out
+
+    def test_change_recorded(self, tmp_path):
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        result = normalize_file(path, operations=["preamble_code"])
+        ops = [c for c in result.changes if c.operation == "preamble_code"]
+        assert len(ops) == 1
+        assert ops[0].line == 3
+
+    def test_runs_by_default(self, tmp_path):
+        assert "preamble_code" in ALL_OPERATIONS
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        normalize_file(path)  # no operations => all, including preamble_code
+        out = path.read_text(encoding="utf-8")
+        assert "# %%\nfrom typing import Iterable" in out
+
+    def test_idempotent(self, tmp_path):
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        normalize_file(path)
+        first = path.read_text(encoding="utf-8")
+        result = normalize_file(path)
+        assert [c for c in result.changes if c.operation == "preamble_code"] == []
+        assert path.read_text(encoding="utf-8") == first
+
+    def test_no_code_no_change(self, tmp_path):
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("DE", "EN") }}\n\n'
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n#\n# ## A\n'
+        )
+        path = _write_slide(tmp_path / "slides_x.py", text)
+        result = normalize_file(path, operations=["preamble_code"])
+        assert [c for c in result.changes if c.operation == "preamble_code"] == []
+        assert result.files_modified == 0
+
+    def test_round_trip_preserved(self, tmp_path):
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        normalize_file(path)
+        out = path.read_text(encoding="utf-8")
+        preamble, cells = _split_raw_cells(out)
+        assert _reconstruct(preamble, cells) == out
+
+    def test_normalized_split_round_trips_and_is_render_neutral(self, tmp_path):
+        """After normalize, the bilingual deck and its split halves agree.
+
+        The wrapped code cell is shared (no lang), so split copies it verbatim
+        to both halves and unify reproduces the normalized text byte-for-byte —
+        the conversion is finally render-neutral (issue #253).
+        """
+        from clm.slides.split import split_text, unify_texts
+
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        normalize_file(path)
+        normalized = path.read_text(encoding="utf-8")
+        de_text, en_text = split_text(normalized)
+        assert unify_texts(de_text, en_text) == normalized
+        # The import survives as a shared code cell in BOTH halves.
+        assert "# %%\nfrom typing import Iterable" in de_text
+        assert "# %%\nfrom typing import Iterable" in en_text
+
+    def test_clike_wraps_with_slash_marker(self, tmp_path):
+        text = (
+            "// j2 from 'macros.j2' import header\n"
+            '// {{ header("DE", "EN") }}\n'
+            "using System;\n\n"
+            '// %% [markdown] lang="de" tags=["slide"] slide_id="a"\n//\n// ## A\n'
+        )
+        path = _write_slide(tmp_path / "slides_x.cs", text)
+        normalize_file(path, operations=["preamble_code", "cell_spacing"])
+        out = path.read_text(encoding="utf-8")
+        assert "// %%\nusing System;" in out
+
+    def test_resolves_validator_warning(self, tmp_path):
+        from clm.slides.validator import validate_file
+
+        path = _write_slide(tmp_path / "slides_x.py", _DECK_WITH_PREAMBLE)
+        before = [f for f in validate_file(path, checks=["format"]).findings if "#253" in f.message]
+        assert before  # the preamble-code warning is present
+        normalize_file(path)
+        after = [f for f in validate_file(path, checks=["format"]).findings if "#253" in f.message]
+        assert after == []
+
+
 class TestCellSpacing:
     def test_inserts_blank_between_cells(self, tmp_path):
         text = '# %% [markdown] lang="de"\n#\n# ## A\n# %% [markdown] lang="de"\n#\n# ## B\n'

--- a/tests/slides/test_preamble_code.py
+++ b/tests/slides/test_preamble_code.py
@@ -1,0 +1,259 @@
+"""Tests for :mod:`clm.slides.preamble_code` (issue #253).
+
+Preamble code — executable code folded into a leading j2 header cell body
+because it sits between the ``# {{ header(...) }}`` macro call and the first
+``# %%`` cell — is detected by :func:`find_preamble_code` and re-homed into its
+own ``# %%`` code cell by :func:`wrap_preamble_code`.
+"""
+
+from __future__ import annotations
+
+from clm.slides.preamble_code import find_preamble_code, wrap_preamble_code
+from clm.slides.raw_cells import reconstruct, split_cells
+
+# The exact issue-#253 shape: code between the header macro and the first cell.
+_DECK_WITH_PREAMBLE = (
+    "# j2 from 'macros.j2' import header\n"
+    '# {{ header("Regeln für Typen", "Rules for Types") }}\n'
+    "from typing import Iterable\n"
+    "\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+    "# DE content\n"
+)
+
+# The conforming form: code already in its own cell.
+_DECK_CLEAN = (
+    "# j2 from 'macros.j2' import header\n"
+    '# {{ header("Regeln für Typen", "Rules for Types") }}\n'
+    "\n"
+    "# %%\n"
+    "from typing import Iterable\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+    "# DE content\n"
+)
+
+# Top-of-file code (before the j2 import) lands in the split_cells preamble
+# string, copied identically to both halves — render-neutral, NOT flagged.
+_DECK_TOP_PREAMBLE = (
+    "import os\n"
+    "\n"
+    "# j2 from 'macros.j2' import header\n"
+    '# {{ header("DE", "EN") }}\n'
+    "\n"
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+    "# DE content\n"
+)
+
+
+class TestFindPreambleCode:
+    def test_detects_code_in_header_macro_body(self):
+        _, cells = split_cells(_DECK_WITH_PREAMBLE)
+        findings = find_preamble_code(cells)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.first_code_line == 3
+        assert f.code_lines == ["from typing import Iterable"]
+
+    def test_no_finding_when_code_in_own_cell(self):
+        _, cells = split_cells(_DECK_CLEAN)
+        assert find_preamble_code(cells) == []
+
+    def test_no_finding_for_top_of_file_preamble(self):
+        # `import os` before the j2 import is in the split_cells preamble
+        # string, not a j2 cell body — render-neutral, must not be flagged.
+        _, cells = split_cells(_DECK_TOP_PREAMBLE)
+        assert find_preamble_code(cells) == []
+
+    def test_ignores_blank_and_comment_body_lines(self):
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("DE", "EN") }}\n'
+            "# just a trailing comment\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+        )
+        _, cells = split_cells(text)
+        assert find_preamble_code(cells) == []
+
+    def test_detects_code_in_import_cell(self):
+        # Code folded into the import directive's cell (before the macro call).
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            "bad_code()\n"
+            '# {{ header("DE", "EN") }}\n'
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+        )
+        _, cells = split_cells(text)
+        findings = find_preamble_code(cells)
+        assert len(findings) == 1
+        assert findings[0].code_lines == ["bad_code()"]
+
+    def test_clike_comment_token(self):
+        text = (
+            "// j2 from 'macros.j2' import header\n"
+            '// {{ header("DE", "EN") }}\n'
+            "using System;\n"
+            "\n"
+            '// %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "// DE content\n"
+        )
+        _, cells = split_cells(text, comment_token="//")
+        findings = find_preamble_code(cells, comment_token="//")
+        assert len(findings) == 1
+        assert findings[0].code_lines == ["using System;"]
+
+    def test_detects_code_in_split_header_de_body(self):
+        # An already-split .de.py half edited to add preamble code: header_de is
+        # still a j2 cell, so the same detection applies.
+        text = (
+            "# j2 from 'macros.j2' import header_de\n"
+            '# {{ header_de("Regeln für Typen") }}\n'
+            "from typing import Iterable\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+        )
+        _, cells = split_cells(text)
+        findings = find_preamble_code(cells)
+        assert len(findings) == 1
+        assert findings[0].code_lines == ["from typing import Iterable"]
+
+    def test_detects_code_in_split_header_en_body(self):
+        text = (
+            "# j2 from 'macros.j2' import header_en\n"
+            '# {{ header_en("Rules for Types") }}\n'
+            "from typing import Iterable\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="gh"\n'
+            "# EN content\n"
+        )
+        _, cells = split_cells(text)
+        findings = find_preamble_code(cells)
+        assert len(findings) == 1
+        assert findings[0].code_lines == ["from typing import Iterable"]
+
+    def test_comment_before_code_reports_code_line(self):
+        # A comment line precedes the code in the j2 body: the reported line must
+        # be the CODE line, not the comment.
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("DE", "EN") }}\n'
+            "# explanatory comment\n"
+            "from typing import Iterable\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+        )
+        _, cells = split_cells(text)
+        findings = find_preamble_code(cells)
+        assert len(findings) == 1
+        assert findings[0].first_code_line == 4  # the import, not the comment at L3
+        assert findings[0].code_lines == ["from typing import Iterable"]
+
+    def test_only_leading_j2_cells_scanned(self):
+        # A mid-file `# %%` code cell with code is NOT preamble code.
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("DE", "EN") }}\n'
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+            "\n"
+            "# %%\n"
+            "y = 2\n"
+        )
+        _, cells = split_cells(text)
+        assert find_preamble_code(cells) == []
+
+
+class TestWrapPreambleCode:
+    def test_moves_code_into_own_cell(self):
+        _, cells = split_cells(_DECK_WITH_PREAMBLE)
+        wrapped = wrap_preamble_code(cells)
+        assert len(wrapped) == 1
+        out = reconstruct("", cells)
+        # The header cell no longer carries the import …
+        assert "}}\nfrom typing" not in out
+        # … and a new bare `# %%` code cell now holds it.
+        assert "# %%\nfrom typing import Iterable" in out
+
+    def test_no_content_lost(self):
+        _, cells = split_cells(_DECK_WITH_PREAMBLE)
+        wrap_preamble_code(cells)
+        out = reconstruct("", cells)
+        assert "from typing import Iterable" in out
+        assert "Regeln für Typen" in out
+        assert "DE content" in out
+
+    def test_idempotent(self):
+        _, cells = split_cells(_DECK_WITH_PREAMBLE)
+        wrap_preamble_code(cells)
+        out = reconstruct("", cells)
+        _, cells2 = split_cells(out)
+        assert wrap_preamble_code(cells2) == []
+
+    def test_noop_on_clean_deck(self):
+        _, cells = split_cells(_DECK_CLEAN)
+        assert wrap_preamble_code(cells) == []
+
+    def test_wraps_split_header_de(self):
+        text = (
+            "# j2 from 'macros.j2' import header_de\n"
+            '# {{ header_de("Regeln für Typen") }}\n'
+            "from typing import Iterable\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+        )
+        _, cells = split_cells(text)
+        wrapped = wrap_preamble_code(cells)
+        assert len(wrapped) == 1
+        out = reconstruct("", cells)
+        assert "# %%\nfrom typing import Iterable" in out
+        assert "}}\nfrom typing" not in out
+
+    def test_comment_before_code_preserved_on_j2_cell(self):
+        # The leading comment stays on the j2 cell; the code moves; the new
+        # cell's line_number reflects the actual code line (review finding #1).
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("DE", "EN") }}\n'
+            "# explanatory comment\n"
+            "from typing import Iterable\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "# DE content\n"
+        )
+        _, cells = split_cells(text)
+        wrap_preamble_code(cells)
+        # j2 macro cell keeps the comment; new code cell carries the import.
+        macro_cell = cells[1]
+        assert "# explanatory comment" in macro_cell.lines
+        new_cell = cells[2]
+        assert new_cell.lines[0] == "# %%"
+        assert new_cell.lines[1] == "from typing import Iterable"
+        # line_number points at the real code line (L4), not header+1 (L3).
+        assert new_cell.line_number == 4
+        # No content lost.
+        out = reconstruct("", cells)
+        assert "# explanatory comment" in out
+        assert "from typing import Iterable" in out
+
+    def test_clike_uses_slash_marker(self):
+        text = (
+            "// j2 from 'macros.j2' import header\n"
+            '// {{ header("DE", "EN") }}\n'
+            "using System;\n"
+            "\n"
+            '// %% [markdown] lang="de" tags=["slide"] slide_id="gh"\n'
+            "// DE content\n"
+        )
+        _, cells = split_cells(text, comment_token="//")
+        wrap_preamble_code(cells, comment_token="//")
+        out = reconstruct("", cells)
+        assert "// %%\nusing System;" in out

--- a/tests/slides/test_split.py
+++ b/tests/slides/test_split.py
@@ -121,6 +121,19 @@ class TestSplitText:
         with pytest.raises(SplitError):
             split_text(text)
 
+    def test_preamble_code_split_still_round_trips(self):
+        # split must NOT rewrite preamble code (issue #253): it only warns at the
+        # CLI/file layer. The byte-identical round trip must still hold.
+        text = (
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("Titel DE", "Title EN") }}\n'
+            "from typing import Iterable\n\n" + _slide_pair("a", "Eins", "One")
+        )
+        de, en = split_text(text)
+        assert "from typing import Iterable" in de
+        assert "from typing import Iterable" in en
+        assert unify_texts(de, en) == text
+
 
 class TestUnifyTexts:
     def test_round_trip_header_only(self):
@@ -284,6 +297,24 @@ class TestSplitInFile:
         assert result.wrote is True
         assert (tmp_path / "deck.de.py").read_text(encoding="utf-8") != "placeholder"
         assert (tmp_path / "deck.de.py").read_text(encoding="utf-8") != ""
+
+    def test_preamble_code_emits_warning(self, tmp_path: Path) -> None:
+        source = tmp_path / "deck.py"
+        source.write_text(
+            "# j2 from 'macros.j2' import header\n"
+            '# {{ header("Titel DE", "Title EN") }}\n'
+            "from typing import Iterable\n\n" + _slide_pair("a", "Eins", "One"),
+            encoding="utf-8",
+        )
+        result = split_in_file(source)
+        assert result.warnings
+        assert any("#253" in w for w in result.warnings)
+
+    def test_no_warning_for_clean_deck(self, tmp_path: Path) -> None:
+        source = tmp_path / "deck.py"
+        source.write_text(HEADER_PREAMBLE + _slide_pair("a", "Eins", "One"), encoding="utf-8")
+        result = split_in_file(source)
+        assert result.warnings == []
 
 
 class TestUnifyInFile:

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -103,6 +103,65 @@ class TestCheckFormat:
         result = validate_file(p, checks=["format"])
         assert result.findings == []
 
+    def test_preamble_code_warns(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "slides_preamble.py",
+            """\
+            # j2 from 'macros.j2' import header
+            # {{ header("Regeln", "Rules") }}
+            from typing import Iterable
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="gh"
+            #
+            # ## Hinweise
+            """,
+        )
+        result = validate_file(p, checks=["format"])
+        pc = [f for f in result.findings if "#253" in f.message]
+        assert len(pc) == 1
+        assert pc[0].severity == "warning"
+        assert pc[0].category == "format"
+        assert pc[0].line == 3
+
+    def test_preamble_code_clean_no_finding(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "slides_preamble_ok.py",
+            """\
+            # j2 from 'macros.j2' import header
+            # {{ header("Regeln", "Rules") }}
+
+            # %%
+            from typing import Iterable
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="gh"
+            #
+            # ## Hinweise
+            """,
+        )
+        result = validate_file(p, checks=["format"])
+        assert [f for f in result.findings if "#253" in f.message] == []
+
+    def test_preamble_code_is_never_an_error(self, tmp_path):
+        # Gate-safety: the preamble-code finding must stay a warning so it never
+        # breaks the 1.8 validator gate (which escalates only named checks).
+        p = _write_slide(
+            tmp_path,
+            "slides_preamble_err.py",
+            """\
+            # j2 from 'macros.j2' import header
+            # {{ header("Regeln", "Rules") }}
+            from typing import Iterable
+
+            # %% [markdown] lang="de" tags=["slide"] slide_id="gh"
+            #
+            # ## Hinweise
+            """,
+        )
+        result = validate_file(p, checks=["format"])
+        assert all(f.severity != "error" for f in result.findings)
+
 
 # ---------------------------------------------------------------------------
 # Tag checks


### PR DESCRIPTION
Fixes #253.

## Problem

`clm slides split` + build is not render-neutral vs. the bilingual build when a deck has **preamble code** — an executable line between the `# {{ header(...) }}` macro call and the first `# %%` cell:

```python
# j2 from 'macros.j2' import header
# {{ header("Regeln für Typen", "Rules for Types") }}
from typing import Iterable          # <- preamble code, no cell marker
# %% [markdown] lang="de" ...
```

Because `# {{ ` and `# j2 ` are themselves cell boundaries, that code becomes the **body of the header cell** (`RawCell.lines[1:]`) — *not* the file preamble. jupytext folds it into the title markdown at build time. The bilingual `header(de, en)` macro's last cell is the **EN** title, so the code rides EN and is silently dropped from a DE build; a split `header_de` half attaches it to the **DE** title, so it survives. The DE-side build therefore diverges.

## Why the macros can't fix it

A Jinja macro can't know there's trailing code, and "matching the bilingual baseline" would mean replicating its silent import-loss. The whitespace asymmetry between `header_de`/`header_en` (Issue #128) is not the lever here.

## Fix

Move the code into its own `# %%` code cell — a shared, language-neutral cell included identically in every build and copied verbatim to both split halves. Verified that **all four builds (bilingual/split × de/en) become byte-identical**, the import is finally executed *as code* (not rendered as markdown text), the op is idempotent, and `unify(split(x)) == x` still holds.

- **New `clm.slides.preamble_code`** — `find_preamble_code` (detector, scans leading j2-cell bodies) + `wrap_preamble_code` (re-homes the code).
- **`clm validate`** — a `warning`/`format` finding (kept a *warning*, not an error, so the 1.8 validator gate stays green).
- **`clm slides split`** — a non-fatal stderr warning; never rewrites the source, so the byte-identical round-trip is preserved.
- **`clm slides normalize`** — a default-on `preamble_code` op (runs first) that applies the fix.

Top-of-file code *before* the `# j2` line (a true file preamble, e.g. a leading `import os`) lands in the split's shared preamble, is already render-neutral, and is intentionally **not** flagged. (This means the `dynamic_code_execution` deck the issue listed is actually fine and can be un-deferred; only `rules_for_types` needed the fix.)

## Docs & tests

- Updated `info_topics/commands.md`, `info_topics/migration.md`, `CHANGELOG.md`.
- ~35 tests: detector + wrapper (incl. split `.de`/`.en` halves, comment-before-code, `//`-comment languages), the validate/split warnings, the normalize op, idempotency, split round-trip, and end-to-end render-neutrality.

## Verification

- Full fast suite: **7008 passed**; ruff + mypy clean.
- CLI smoke test on the real PythonCourses deck: `validate` warns (exit 0), `split --report-only` warns to stderr, `normalize --dry-run` reports the fix.
- An adversarial multi-agent review surfaced (and this PR fixes) an off-by-N `line_number` on the inserted cell and a blank-line-loss edge case, plus added split-half test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)