### PR TITLE
feat(notebook): resolve Jinja {% include %} against topic siblings

### DIFF
--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -77,6 +77,42 @@ clm build course.xml --only-sections w03,w04 -w
 clm build course.xml --only-sections "Week 03"
 ```
 
+#### Jinja `{% include %}` in slide source
+
+Before a notebook is converted, its source is expanded as a Jinja
+template (this is what makes the `# {{ header(…) }}` title macro work).
+Two loaders back `{% include %}`, searched in this order:
+
+1. The bundled per-language template directory inside the `clm` package
+   (`src/clm/workers/notebook/templates_<prog_lang>/`) — the source of
+   `macros.j2` and friends.
+2. The notebook's own **topic siblings** — any non-image file sitting
+   next to the slide file in its topic directory (since CLM {version}).
+
+So a deck can render a sibling file verbatim, e.g. show a C++ header
+that lives beside it:
+
+````text
+// ```cpp
+// {% include "add.h" %}
+// ```
+````
+
+Resolution notes:
+
+- The include target is the sibling's path **relative to the topic
+  directory** (forward slashes), matching how the file is shipped to
+  the worker — the same set of files an `<include>` splices in are
+  also includable this way.
+- The bundled package directory is searched **first**, so a sibling can
+  never shadow a bundled template: a sibling named `macros.j2` is
+  ignored in favor of the shipped macros. Siblings only supply names the
+  package does not already provide.
+- Binary siblings (anything that is not valid UTF-8) are skipped — they
+  cannot be Jinja templates.
+- An include with no matching bundled template and no matching sibling
+  still fails the build with `TemplateNotFound`, as before.
+
 #### Iterating on a single section
 
 `--only-sections` is a dev-time iteration flag for large courses. It

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -16,7 +16,14 @@ from typing import TYPE_CHECKING, cast
 import jupytext.config as jupytext_config  # type: ignore[import-untyped]
 import psutil  # type: ignore[import-untyped]
 import traitlets.log
-from jinja2 import Environment, PackageLoader, StrictUndefined
+from jinja2 import (
+    ChoiceLoader,
+    DictLoader,
+    Environment,
+    FileSystemLoader,
+    PackageLoader,
+    StrictUndefined,
+)
 from jupyter_client.manager import AsyncKernelManager
 from jupytext import jupytext
 from nbconvert import HTMLExporter
@@ -1367,7 +1374,7 @@ class NotebookProcessor:
 
         # Normal processing path
         expanded_nb = await self.load_and_expand_jinja_template(
-            payload.data, payload.input_file_name, cid
+            payload.data, payload.input_file_name, cid, payload, source_dir
         )
         processed_nb = await self.process_notebook_for_spec(expanded_nb, payload)
         result = await self.create_contents(processed_nb, payload, source_dir=source_dir)
@@ -1490,10 +1497,15 @@ class NotebookProcessor:
         return filtered_nb
 
     async def load_and_expand_jinja_template(
-        self, notebook_text: str, notebook_file: str, cid
+        self,
+        notebook_text: str,
+        notebook_file: str,
+        cid,
+        payload: NotebookPayload | None = None,
+        source_dir: Path | None = None,
     ) -> str:
         logger.debug(f"{cid}:Loading and expanding Jinja template")
-        jinja_env = self._create_jinja_environment(cid)
+        jinja_env = self._create_jinja_environment(cid, payload, source_dir)
         nb_template = jinja_env.from_string(
             notebook_text,
             globals=self._create_jinja_globals(
@@ -1507,12 +1519,17 @@ class NotebookProcessor:
         logger.debug(f"{cid}:Jinja template expanded for {notebook_file}")
         return cast(str, expanded_nb)
 
-    def _create_jinja_environment(self, cid):
+    def _create_jinja_environment(
+        self,
+        cid,
+        payload: NotebookPayload | None = None,
+        source_dir: Path | None = None,
+    ):
         templates_path = f"{JINJA_TEMPLATES_PREFIX}_{self.output_spec.prog_lang}"
         logger.debug(f"{cid}:Creating Jinja environment with templates from {templates_path}")
         try:
             jinja_env = Environment(
-                loader=PackageLoader("clm.workers.notebook", templates_path),
+                loader=self._create_jinja_loader(cid, templates_path, payload, source_dir),
                 autoescape=False,
                 undefined=StrictUndefined,
                 line_statement_prefix=jinja_prefix_for(self.output_spec.prog_lang),
@@ -1528,6 +1545,70 @@ class NotebookProcessor:
                 f"'{templates_path}': {e}"
             )
             raise
+
+    def _create_jinja_loader(
+        self,
+        cid,
+        templates_path: str,
+        payload: NotebookPayload | None,
+        source_dir: Path | None,
+    ):
+        """Build the Jinja loader used to resolve ``{% include %}`` targets.
+
+        The bundled ``PackageLoader`` (the per-language ``templates_<lang>``
+        directory inside the ``clm`` package, source of ``macros.j2`` etc.)
+        is searched *first*. So that a notebook can ``{% include %}`` a file
+        that sits next to it in its topic (e.g. a ``add.h`` header shown in a
+        slide), the notebook's sibling files are layered *behind* it as a
+        fallback:
+
+        * In Docker source-mount mode the topic directory is on disk, so a
+          ``FileSystemLoader`` pointed at ``source_dir`` exposes the siblings.
+        * Otherwise the siblings travel in ``payload.other_files`` (base64),
+          which CLM already ships for kernel execution; a ``DictLoader`` built
+          from their decoded text makes them includable. Entries that are not
+          valid UTF-8 (e.g. binary assets) are skipped — they cannot be Jinja
+          templates anyway.
+
+        ``ChoiceLoader`` returns the *first* match, so keeping the
+        ``PackageLoader`` ahead of the siblings means a sibling can never
+        shadow a bundled macro file of the same name; it only supplies names
+        the package does not already provide.
+
+        Ordering trade-off (deliberate): if we ever want a course to be able
+        to **override** a bundled template — e.g. ship its own ``macros.j2``
+        next to a slide and have it win over the packaged one — move the
+        sibling loaders *ahead* of ``package_loader`` in this list (siblings
+        first, ``package_loader`` last). That was rejected here because it
+        lets any topic silently redefine the title macro and diverge from the
+        rest of the course; package-first is the safer default. Whoever flips
+        the order must update the "bundled macro not shadowed" test in
+        ``tests/workers/notebook/test_jinja_include_siblings.py`` and the
+        "Jinja ``{% include %}`` in slide source" section in
+        ``src/clm/cli/info_topics/commands.md``.
+        """
+        package_loader = PackageLoader("clm.workers.notebook", templates_path)
+        loaders: list = [package_loader]
+
+        if source_dir is not None:
+            loaders.append(FileSystemLoader(str(source_dir)))
+
+        if payload is not None and payload.other_files:
+            sibling_templates: dict[str, str] = {}
+            for name, encoded in payload.other_files.items():
+                try:
+                    sibling_templates[name] = b64decode(encoded).decode("utf-8")
+                except (ValueError, UnicodeDecodeError):
+                    logger.debug(
+                        f"{cid}:Skipping non-text sibling '{name}' for Jinja include resolution"
+                    )
+            if sibling_templates:
+                loaders.append(DictLoader(sibling_templates))
+
+        if len(loaders) == 1:
+            return package_loader
+
+        return ChoiceLoader(loaders)
 
     @staticmethod
     def _create_jinja_globals(

--- a/tests/workers/notebook/test_jinja_include_siblings.py
+++ b/tests/workers/notebook/test_jinja_include_siblings.py
@@ -1,0 +1,132 @@
+"""Tests for resolving ``{% include %}`` against a notebook's topic siblings.
+
+A slide deck may want to show a file that lives next to it in the topic — e.g.
+a C++ ``add.h`` header rendered inside a fenced code block via
+``{% include "add.h" %}``. Jinja's bundled ``PackageLoader`` only searches the
+per-language ``templates_<lang>`` directory inside the ``clm`` package, so such
+an include used to fail with ``TemplateNotFound``. The processor now searches
+the package loader first and falls back to the notebook's sibling files:
+
+* ``payload.other_files`` (base64) → ``DictLoader`` (direct mode), and
+* ``source_dir`` on disk → ``FileSystemLoader`` (Docker source-mount mode).
+
+The bundled macros must still win on a name clash, and binary siblings must be
+skipped rather than crashing the build.
+"""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+from clm.workers.notebook.notebook_processor import NotebookProcessor
+from clm.workers.notebook.output_spec import SpeakerOutput
+
+ADD_H = "int add(int a, int b);\n"
+
+
+def _make_processor() -> NotebookProcessor:
+    spec = SpeakerOutput(format="notebook", language="en", prog_lang="cpp")
+    proc = NotebookProcessor(spec)
+    proc._author = "Author"
+    proc._organization = "Org"
+    return proc
+
+
+def _payload(data: str, other_files: dict[str, bytes] | None = None) -> NotebookPayload:
+    return NotebookPayload(
+        data=data,
+        input_file="/t/module_110/topic_140/slides_header.cpp",
+        input_file_name="slides_header.cpp",
+        output_file="/t/out.ipynb",
+        kind="speaker",
+        prog_lang="cpp",
+        language="en",
+        format="notebook",
+        correlation_id="cid-include",
+        author="Author",
+        organization="Org",
+        other_files=other_files or {},
+    )
+
+
+async def test_include_resolves_sibling_from_other_files() -> None:
+    data = '// %% [markdown]\n// ```cpp\n// {% include "add.h" %}\n// ```\n'
+    payload = _payload(data, {"add.h": b64encode(ADD_H.encode("utf-8"))})
+    proc = _make_processor()
+
+    expanded = await proc.load_and_expand_jinja_template(
+        payload.data, payload.input_file_name, payload.correlation_id, payload
+    )
+
+    assert "int add(int a, int b);" in expanded
+
+
+async def test_include_resolves_sibling_from_source_dir(tmp_path: Path) -> None:
+    (tmp_path / "add.h").write_text(ADD_H, encoding="utf-8")
+    data = '// %% [markdown]\n// ```cpp\n// {% include "add.h" %}\n// ```\n'
+    payload = _payload(data)
+    proc = _make_processor()
+
+    expanded = await proc.load_and_expand_jinja_template(
+        payload.data,
+        payload.input_file_name,
+        payload.correlation_id,
+        payload,
+        tmp_path,
+    )
+
+    assert "int add(int a, int b);" in expanded
+
+
+async def test_missing_sibling_still_raises() -> None:
+    """No silent pass-through: an include with no matching sibling and no
+    bundled template must still fail loudly."""
+    data = '// %% [markdown]\n// {% include "does_not_exist.h" %}\n'
+    payload = _payload(data)
+    proc = _make_processor()
+
+    with pytest.raises(Exception):  # noqa: B017,PT011 - jinja2.TemplateNotFound
+        await proc.load_and_expand_jinja_template(
+            payload.data, payload.input_file_name, payload.correlation_id, payload
+        )
+
+
+async def test_bundled_macro_not_shadowed_by_sibling() -> None:
+    """A sibling named like a bundled template must not override it: the
+    package loader is searched first, so ``macros.j2`` still resolves to the
+    shipped macros."""
+    sabotage = b64encode(b"SIBLING SABOTAGE")
+    data = "// j2 from 'macros.j2' import header\n// {{ header('Titel', 'Title') }}\n"
+    payload = _payload(data, {"macros.j2": sabotage})
+    proc = _make_processor()
+
+    expanded = await proc.load_and_expand_jinja_template(
+        payload.data, payload.input_file_name, payload.correlation_id, payload
+    )
+
+    assert "SIBLING SABOTAGE" not in expanded
+    assert "Title" in expanded
+
+
+async def test_binary_sibling_is_skipped() -> None:
+    """A non-UTF-8 sibling (e.g. a binary asset) must be skipped, not crash
+    environment construction; text siblings still resolve."""
+    data = '// %% [markdown]\n// {% include "add.h" %}\n'
+    payload = _payload(
+        data,
+        {
+            "logo.bin": b64encode(b"\xff\xfe\x00\x01binary"),
+            "add.h": b64encode(ADD_H.encode("utf-8")),
+        },
+    )
+    proc = _make_processor()
+
+    expanded = await proc.load_and_expand_jinja_template(
+        payload.data, payload.input_file_name, payload.correlation_id, payload
+    )
+
+    assert "int add(int a, int b);" in expanded


### PR DESCRIPTION
## Problem

A slide deck that does `{% include "add.h" %}` to show a sibling file (e.g. `slides/.../topic_140_header/slides_header.cpp` including the `add.h` next to it) fails with `TemplateNotFound`.

Slide source is expanded as a Jinja template before conversion, but `_create_jinja_environment` only wired up a `PackageLoader` pointed at the bundled `templates_<prog_lang>/` directory inside the `clm` package. The notebook's own directory was never on the include search path — so siblings could not be included, even though they are already shipped to the worker (in `payload.other_files`, and on disk under `source_dir` in Docker source-mount mode).

## Fix

`_create_jinja_loader` now returns a `ChoiceLoader`:

1. **`PackageLoader` first** — bundled `macros.j2` etc. can never be shadowed.
2. The notebook's **topic siblings** as a fallback: a `FileSystemLoader` on `source_dir` (Docker source-mount) and/or a `DictLoader` decoded from `other_files` (direct mode). Non-UTF-8 siblings are skipped.

`payload` / `source_dir` are threaded through `process_notebook` → `load_and_expand_jinja_template` → `_create_jinja_environment` as optional args, so existing callers are unaffected. When there are no siblings the plain `PackageLoader` is returned unchanged.

### Ordering trade-off (deliberate)

Package-first means a course cannot override a bundled template from its own directory. That is the safer default (a topic can't silently redefine the title macro and diverge from the rest of the course). A code comment in `_create_jinja_loader` documents exactly how to flip to sibling-override if that is ever wanted, and which test + info topic to update alongside.

## Tests

New `tests/workers/notebook/test_jinja_include_siblings.py` (5 cases):
- sibling resolved from `other_files` (direct mode)
- sibling resolved from `source_dir` (Docker mode)
- missing include still raises `TemplateNotFound`
- bundled `macros.j2` not shadowed by a same-named sibling
- binary (non-UTF-8) sibling skipped, text siblings still resolve

Full notebook-worker suite green (653 passed); ruff + mypy clean.

## Docs

Per the info-topics maintenance rule, adds a "Jinja `{% include %}` in slide source" section to `clm info commands` under `clm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
