### PR TITLE
fix(errors): classify pool-shutdown orphans as infrastructure, not user

### DIFF
--- a/src/clm/cli/error_categorizer.py
+++ b/src/clm/cli/error_categorizer.py
@@ -41,6 +41,35 @@ class ErrorCategorizer:
         # Try to parse structured error if it's JSON
         error_info = ErrorCategorizer._parse_error_message(error_message)
 
+        # Pool-shutdown orphans are infrastructure errors, never the input
+        # file's fault. The sentinel is stamped on any job that was still in
+        # flight when the worker pool stopped (build interrupted or shutdown
+        # race), regardless of job type, so this check is centralized here
+        # ahead of the per-type categorizers. Classifying it as ``user`` (the
+        # drawio/notebook default) would (a) wrongly blame the file and (b)
+        # persist it to ``processing_issues``, where it would replay on every
+        # subsequent cached build until the cache is wiped.
+        from clm.infrastructure.database.job_queue import JobQueue
+
+        orphan_sentinel = JobQueue.ORPHAN_ERROR_MESSAGE
+        if orphan_sentinel in (error_message or "") or orphan_sentinel in str(
+            error_info.get("error_message", "")
+        ):
+            return BuildError(
+                error_type="infrastructure",
+                category="orphaned_job",
+                severity="error",
+                file_path=input_file,
+                message=error_message,
+                actionable_guidance=(
+                    "The worker was stopped before it finished this job (build "
+                    "interrupted or worker-pool shutdown race), so the job never "
+                    "completed. Re-run the build; the input file is not at fault."
+                ),
+                job_id=job_id,
+                correlation_id=correlation_id,
+            )
+
         # Delegate to specific categorizer based on job type
         if job_type == "notebook":
             return ErrorCategorizer._categorize_notebook_error(

--- a/tests/cli/test_error_categorizer.py
+++ b/tests/cli/test_error_categorizer.py
@@ -126,6 +126,67 @@ class TestDrawioErrorCategorization:
         )
 
 
+class TestOrphanedJobCategorization:
+    """Tests for pool-shutdown orphan categorization.
+
+    A job that is still in flight when the worker pool stops is stamped with
+    ``JobQueue.ORPHAN_ERROR_MESSAGE``. This is an infrastructure error (build
+    interrupted / shutdown race), never the input file's fault, and must not
+    be classified as a ``user`` error for any job type -- otherwise it would
+    blame the file and get persisted to ``processing_issues``, replaying on
+    every cached build.
+    """
+
+    def test_drawio_orphan_is_infrastructure_not_user(self):
+        """An orphaned drawio job must not be blamed on the diagram."""
+        from clm.infrastructure.database.job_queue import JobQueue
+
+        error = ErrorCategorizer.categorize_job_error(
+            job_type="drawio",
+            input_file="vector-difference.drawio",
+            error_message=JobQueue.ORPHAN_ERROR_MESSAGE,
+            job_payload={},
+            job_id=81111,
+        )
+
+        assert error.error_type == "infrastructure"
+        assert error.category == "orphaned_job"
+        # Must NOT carry the "check your diagram" user-error guidance.
+        assert "drawio diagram" not in error.actionable_guidance.lower()
+        assert "re-run" in error.actionable_guidance.lower()
+        assert error.job_id == 81111
+
+    def test_notebook_orphan_is_infrastructure_not_user(self):
+        """The same shutdown race orphans notebook jobs too (e.g. #81175)."""
+        from clm.infrastructure.database.job_queue import JobQueue
+
+        error = ErrorCategorizer.categorize_job_error(
+            job_type="notebook",
+            input_file="slides_010_simple_agent.de.py",
+            error_message=JobQueue.ORPHAN_ERROR_MESSAGE,
+            job_payload={},
+        )
+
+        assert error.error_type == "infrastructure"
+        assert error.category == "orphaned_job"
+
+    def test_orphan_sentinel_embedded_in_structured_error(self):
+        """Sentinel wrapped in a JSON error payload is still detected."""
+        import json
+
+        from clm.infrastructure.database.job_queue import JobQueue
+
+        error = ErrorCategorizer.categorize_job_error(
+            job_type="drawio",
+            input_file="test.drawio",
+            error_message=json.dumps({"error_message": JobQueue.ORPHAN_ERROR_MESSAGE}),
+            job_payload={},
+        )
+
+        assert error.error_type == "infrastructure"
+        assert error.category == "orphaned_job"
+
+
 class TestNotebookErrorCategorization:
     """Tests for notebook error categorization."""
 


### PR DESCRIPTION
## Problem

A drawio diagram (`vector-difference.drawio`) was reported as a **`[User Error]` — "Check your DrawIO diagram for errors"** on *every* build of the ML-AZAV course, always citing the same stale `Job ID: #81111`. The diagram is valid (renders to a correct PNG in ~2s).

### Root cause

1. A one-off **worker-pool shutdown race** left drawio job #81111 in flight when the pool stopped; it was stamped with `JobQueue.ORPHAN_ERROR_MESSAGE` (`"worker died mid-job (orphaned at pool shutdown)"`).
2. `ErrorCategorizer._categorize_drawio_error` matched none of its specific patterns (missing-exe, missing-input, V8-crash) and **fell through to the default `error_type="user"`** with "Check your DrawIO diagram for errors."
3. Because it was labeled `user`, `SqliteBackend` **persisted it** to `processing_issues` (configuration/infrastructure errors are intentionally *not* cached; only user errors are).
4. The diagram's content hash never changes and a successful re-render doesn't clear stored issues, so `_report_cached_issues` **replayed** the stale error on every subsequent cached build.

The persisted-error replay is working as designed (it's what keeps genuine content bugs visible across cached builds). The only defect is an **infrastructure error mislabeled as a user error**, which let it into the replay store.

## Fix

Centralize an orphan-sentinel check in `categorize_job_error`, *before* the per-job-type dispatch, returning an `infrastructure` / `orphaned_job` error with re-run guidance. Infrastructure errors are not cached, so this both removes the false diagram-blame and keeps the transient error out of the replay store. Central placement also covers notebook/plantuml orphans from the same race (e.g. notebook job #81175, observed alongside #81111).

## Tests

Adds `TestOrphanedJobCategorization`:
- drawio orphan → infrastructure, not user, no "diagram" blame
- notebook orphan → infrastructure
- sentinel embedded in a structured JSON error payload → still detected

`tests/cli/test_error_categorizer.py` 18 passed; `tests/cli/test_error_reporting_integration.py` 3 passed. Pre-commit (ruff lint/format, mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)