### PR TITLE
fix(notebook): write output with LF newlines on all platforms

### DIFF
--- a/src/clm/workers/notebook/notebook_worker.py
+++ b/src/clm/workers/notebook/notebook_worker.py
@@ -251,7 +251,13 @@ class NotebookWorker(Worker):
 
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            with open(output_path, "w", encoding="utf-8") as f:
+            # newline="\n" is required: without it, Python's text-mode
+            # universal-newline translation rewrites every "\n" to os.linesep
+            # (CRLF) on Windows Direct workers, while Docker/Linux workers emit
+            # LF. That platform split produces spurious CRLF in built output
+            # (noisy diffs, "CRLF will be replaced by LF" warnings). Pinning
+            # LF keeps output byte-identical across platforms.
+            with open(output_path, "w", encoding="utf-8", newline="\n") as f:
                 f.write(result)
 
             logger.info(f"Notebook written to {output_path}")

--- a/tests/workers/notebook/test_notebook_worker.py
+++ b/tests/workers/notebook/test_notebook_worker.py
@@ -461,6 +461,64 @@ class TestNotebookWorkerProcessJob:
                 assert output_file.read_text() == result_content
 
     @pytest.mark.asyncio
+    async def test_process_job_async_writes_lf_line_endings(self, worker_id, db_path, tmp_path):
+        """Output must be written with LF line endings on every platform.
+
+        Regression test: the writer used ``open(path, "w")`` (text mode)
+        without ``newline=``, so Python's universal-newline translation
+        rewrote every ``\\n`` to ``os.linesep`` — i.e. CRLF on Windows
+        Direct workers, while Docker/Linux workers emitted LF. That platform
+        split produced spurious CRLF in built course output (noisy diffs,
+        "CRLF will be replaced by LF" warnings). Pinning ``newline="\\n"``
+        keeps output byte-identical regardless of the host OS, so we assert
+        on the raw bytes rather than the (translation-hiding) text read.
+        """
+        from clm.workers.notebook.notebook_worker import NotebookWorker
+
+        input_file = tmp_path / "notebook.ipynb"
+        input_file.write_text('{"cells": [], "metadata": {}, "nbformat": 4}')
+
+        output_file = tmp_path / "output" / "notebook.py"
+
+        job = Job(
+            id=1,
+            job_type="notebook",
+            input_file=str(input_file),
+            output_file=str(output_file),
+            content_hash="test-hash",
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "notebook",
+            },
+            status="processing",
+            created_at=datetime.now(),
+        )
+
+        worker = NotebookWorker(worker_id, db_path)
+        # Multi-line, LF-only content as produced by jupytext/nbconvert.
+        result_content = "# %%\nprint('line one')\nprint('line two')\n"
+
+        with patch("clm.workers.notebook.notebook_worker.create_output_spec") as mock_create_spec:
+            mock_spec = MagicMock()
+            mock_create_spec.return_value = mock_spec
+
+            with patch("clm.workers.notebook.notebook_worker.NotebookProcessor") as MockProcessor:
+                mock_processor = MagicMock()
+                mock_processor.process_notebook = AsyncMock(return_value=result_content)
+                MockProcessor.return_value = mock_processor
+
+                await worker._process_job_async(job)
+
+        # Inspect raw bytes: text-mode reads would hide CRLF via universal
+        # newline translation, so we must read in binary.
+        raw = output_file.read_bytes()
+        assert b"\r\n" not in raw, "output contains CRLF — newline translation regressed"
+        assert b"\r" not in raw, "output contains a stray CR byte"
+        assert raw == result_content.encode("utf-8")
+
+    @pytest.mark.asyncio
     async def test_process_job_async_adds_to_cache(self, worker_id, db_path, tmp_path):
         """Should add result to cache after processing."""
         from clm.workers.notebook.notebook_worker import NotebookWorker


### PR DESCRIPTION
## Problem

Running `clm build` on Windows produced output files with **CRLF** line endings. In course repos (e.g. `output/shared/machine-learning-azav-de`) this showed up as a trailing `^M` on most changed lines in `git diff`, plus "CRLF will be replaced by LF" warnings on `git add`.

## Root cause

Every notebook-worker output — executed `.ipynb`, jupytext `.py`, and the HTML body — is written through a single line in `notebook_worker.py`:

```python
with open(output_path, "w", encoding="utf-8") as f:
    f.write(result)
```

Text mode **without** `newline=` triggers Python's universal-newline translation, which rewrites every `\n` to `os.linesep`. On Windows Direct workers that's CRLF; Docker/Linux workers emit LF. The `result` string is built with `\n` (jupytext/nbconvert), so the line endings depended entirely on the host OS.

Target repos declare `* text=auto eol=lf` and normalize CRLF→LF on commit, so the committed blob stayed LF — but the working tree carried real CRLF, producing noisy diffs, git warnings, and churn on every Windows build.

## Fix

Pin `newline="\n"` on the write so output is byte-identical regardless of host OS. This matches the convention already used elsewhere in the codebase (e.g. `http_replay_cassette._atomic_write_text`, the trace writers). `write_other_files_sync` already uses `write_bytes`, so it was unaffected.

## Test

Adds `test_process_job_async_writes_lf_line_endings`, which drives `_process_job_async` with multi-line LF content and asserts the **raw bytes** on disk contain no CR (reading in binary, since a text-mode read would hide CRLF via the same translation). Verified it fails without the fix:

```
AssertionError: output contains CRLF — newline translation regressed
assert b'\r\n' not in b"# %%\r\nprint('line one')\r\nprint('line two')\r\n"
```

Full `test_notebook_worker.py` (36 tests) passes; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
