### PR TITLE
feat(spec): day-of-week scheduling — <subsection> layer + clm schedule (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Day-of-week scheduling: `<subsection>` spec layer + `clm schedule`**
+  (issue #261). A `<section>`'s `<topics>` may now group `<topic>`s into
+  optional `<subsection weekday="mon">…</subsection>` elements (`<section>` =
+  week, `<subsection>` = day) with an optional `<name>` label override and
+  `enabled="false"`. The layer is purely additive: `clm build` flattens
+  subsections away, so a spec with subsections builds **byte-identically** to
+  the same spec with the wrappers removed — no output-dir or topic-resolution
+  changes. A new top-level **`clm schedule`** command exports the certification
+  day-listing from the resolved course in Markdown (one table per week:
+  weekday / video / topic) or CSV (one row per deck), single-language via
+  `--lang` (default `de`). `clm outline` renders subsections indented under
+  their section (with `--include-disabled` surfacing disabled ones), and
+  `clm validate` adds four advisory subsection checks (duplicate weekday,
+  out-of-order weekdays, empty day, and bare-topics-mixed-with-subsections).
+  See `clm info spec-files` and `clm info commands`.
 - **`clm slides assign-ids --accept-code-derived`** — a deterministic, opt-in
   fallback that mints a `slide_id` for bare-expression code subslides the AST
   extractors can't name (`(1 + 1j) * (1 + 1j)` → `1-1j-1-1j`, `letters[0:3]` →

--- a/src/clm/cli/commands/outline.py
+++ b/src/clm/cli/commands/outline.py
@@ -10,10 +10,18 @@ from pathlib import Path
 
 import click
 
+from clm.cli.commands.schedule import subsection_label
 from clm.core.course import Course
 from clm.core.course_files.notebook_file import NotebookFile
 from clm.core.course_paths import resolve_course_paths
-from clm.core.course_spec import CourseSpec, CourseSpecError, SectionSpec, TopicSpec
+from clm.core.course_spec import (
+    CourseSpec,
+    CourseSpecError,
+    SectionSpec,
+    SubsectionSpec,
+    TopicSpec,
+)
+from clm.core.section import Section
 from clm.core.utils.notebook_utils import find_notebook_titles
 from clm.core.utils.text_utils import sanitize_file_name
 from clm.infrastructure.utils.path_utils import is_slides_file
@@ -54,12 +62,192 @@ def _disabled_topic_slides(
     return results
 
 
+def _topic_deck_titles(topic, language: str) -> list[str]:
+    """Return the deck titles of one resolved topic for *language*.
+
+    Split ``.de.py`` / ``.en.py`` companions are filtered to the requested
+    language so a split pair contributes one title, matching the build's
+    per-language routing.
+    """
+    titles: list[str] = []
+    for notebook in topic.notebooks:
+        if (
+            notebook.output_language_filter is not None
+            and notebook.output_language_filter != language
+        ):
+            continue
+        try:
+            title = notebook.title[language]
+        except (KeyError, AttributeError, TypeError):
+            title = notebook.path.stem
+        titles.append(title or notebook.path.stem)
+    return titles
+
+
+def _match_full_section(
+    section_spec: SectionSpec, full_sections: list[SectionSpec]
+) -> SectionSpec | None:
+    """Find *section_spec* in *full_sections* (parsed with ``keep_disabled``).
+
+    Matches by ``id`` first, then by exact bilingual name. Returns ``None``
+    when no counterpart is found, or when the name match is ambiguous (more
+    than one same-named, id-less section) — better to skip disabled-subsection
+    recovery than to attach the wrong section's subsections. Used so an enabled
+    section can recover its *disabled* subsections (which the enabled-only
+    parse dropped).
+    """
+    if section_spec.id is not None:
+        for candidate in full_sections:
+            if candidate.id == section_spec.id:
+                return candidate
+    name_matches = [
+        c
+        for c in full_sections
+        if c.name.de == section_spec.name.de and c.name.en == section_spec.name.en
+    ]
+    if len(name_matches) == 1:
+        return name_matches[0]
+    return None
+
+
+def _subsections_to_render(
+    section_spec: SectionSpec,
+    full_sections: list[SectionSpec] | None,
+    include_disabled: bool,
+) -> list[SubsectionSpec]:
+    """Return the subsections to render for a section.
+
+    Normally the section's own (enabled-only) subsections; when
+    ``include_disabled`` is set and the full (``keep_disabled``) sections
+    are available, the matching full section's subsections — which also
+    carry the disabled ones.
+    """
+    if include_disabled and full_sections is not None:
+        full = _match_full_section(section_spec, full_sections)
+        if full is not None:
+            return full.subsections
+    return section_spec.subsections
+
+
+def _subsection_deck_titles(
+    subsection: SubsectionSpec,
+    course: Course,
+    language: str,
+    resolved_titles: dict[str, list[str]],
+) -> list[str]:
+    """Resolve a subsection's deck titles, in document order.
+
+    Enabled subsections read from *resolved_titles* (the section's resolved
+    decks). Disabled subsections fall back to a filesystem read via
+    :func:`_disabled_topic_slides`, because their topics are not part of the
+    built course; a topic that is not (yet) on disk falls back to its id so
+    planned topics stay visible, matching the disabled whole-section path.
+    """
+    titles: list[str] = []
+    if subsection.enabled:
+        for topic_spec in subsection.topics:
+            titles.extend(resolved_titles.get(topic_spec.id, []))
+        return titles
+    for topic_spec in subsection.topics:
+        slides = _disabled_topic_slides(course, topic_spec, language)
+        if slides:
+            titles.extend(title for _file_name, title in slides)
+        else:
+            titles.append(topic_spec.id)
+    return titles
+
+
+def _render_section_subsections(
+    section: Section,
+    subsections: list[SubsectionSpec],
+    course: Course,
+    language: str,
+) -> list[str]:
+    """Render the bullet lines for a section that uses subsections.
+
+    Bare topics (not under any subsection) are listed first as flat
+    bullets; each subsection then renders as a bold-label bullet with its
+    decks indented beneath it. Disabled subsections get a ``(disabled)``
+    marker.
+    """
+    resolved_titles = {topic.id: _topic_deck_titles(topic, language) for topic in section.topics}
+    subsection_topic_ids = {t.id for sub in subsections for t in sub.topics}
+
+    lines: list[str] = []
+    # Bare topics first, in section (document) order.
+    for topic in section.topics:
+        if topic.id in subsection_topic_ids:
+            continue
+        for title in resolved_titles.get(topic.id, []):
+            lines.append(f"- {title}")
+
+    for subsection in subsections:
+        marker = "" if subsection.enabled else " (disabled)"
+        label = subsection_label(subsection, language) or "(unnamed)"
+        lines.append(f"- **{label}**{marker}")
+        for title in _subsection_deck_titles(subsection, course, language, resolved_titles):
+            lines.append(f"  - {title}{marker}")
+    return lines
+
+
+def _subsections_json(
+    section: Section,
+    subsections: list[SubsectionSpec],
+    course: Course,
+    language: str,
+) -> list[dict]:
+    """Build the JSON ``subsections`` list for a section.
+
+    Enabled subsection topics reuse the section's resolved decks; disabled
+    (or otherwise unresolved) topics fall back to a filesystem read so the
+    structure is still populated under ``--include-disabled``.
+    """
+    resolved: dict[str, dict] = {}
+    for topic in section.topics:
+        resolved[topic.id] = {
+            "directory": str(topic.path),
+            "slides": [
+                {"file": f.path.name, "title": f.title[language]}
+                for f in topic.files
+                if isinstance(f, NotebookFile)
+            ],
+        }
+
+    result: list[dict] = []
+    for subsection in subsections:
+        topics_out: list[dict] = []
+        for topic_spec in subsection.topics:
+            if subsection.enabled and topic_spec.id in resolved:
+                topics_out.append({"topic_id": topic_spec.id, **resolved[topic_spec.id]})
+            else:
+                topic_path = course._topic_path_map.get(topic_spec.id)
+                slides_data = _disabled_topic_slides(course, topic_spec, language) or []
+                topics_out.append(
+                    {
+                        "topic_id": topic_spec.id,
+                        "directory": str(topic_path) if topic_path is not None else None,
+                        "slides": [{"file": fname, "title": title} for fname, title in slides_data],
+                    }
+                )
+        result.append(
+            {
+                "weekday": subsection.weekday,
+                "label": subsection_label(subsection, language),
+                "enabled": subsection.enabled,
+                "topics": topics_out,
+            }
+        )
+    return result
+
+
 def generate_outline(
     course: Course,
     language: str,
     *,
     disabled_sections: list[SectionSpec] | None = None,
     sections_only: bool = False,
+    full_sections: list[SectionSpec] | None = None,
+    include_disabled: bool = False,
 ) -> str:
     """Generate a Markdown outline for a course.
 
@@ -82,15 +270,24 @@ def generate_outline(
     lines.append(f"# {course.name[language]}")
     lines.append("")
 
-    for section in course.sections:
+    # course.sections aligns 1:1 with course.spec.sections (no section
+    # selection is applied in the outline path, and the spec was parsed
+    # enabled-only). The spec side carries the retained subsection grouping.
+    for section, section_spec in zip(course.sections, course.spec.sections, strict=True):
         lines.append(f"## {section.name[language]}")
         lines.append("")
-        if not sections_only:
+        if sections_only:
+            continue
+        subsections = _subsections_to_render(section_spec, full_sections, include_disabled)
+        if subsections:
+            lines.extend(_render_section_subsections(section, subsections, course, language))
+        else:
+            # Unchanged flat rendering for sections without subsections.
             for notebook in section.notebooks:
                 if isinstance(notebook, NotebookFile):
                     title = notebook.title[language]
                     lines.append(f"- {title}")
-            lines.append("")
+        lines.append("")
 
     for section_spec in disabled_sections or []:
         lines.append(f"## {section_spec.name[language]} (disabled)")
@@ -123,6 +320,8 @@ def generate_outline_json(
     *,
     disabled_sections: list[SectionSpec] | None = None,
     sections_only: bool = False,
+    full_sections: list[SectionSpec] | None = None,
+    include_disabled: bool = False,
 ) -> dict:
     """Generate a structured JSON outline for a course.
 
@@ -139,7 +338,7 @@ def generate_outline_json(
         Dict with the course outline in structured form.
     """
     sections: list[dict] = []
-    for section in course.sections:
+    for section, section_spec in zip(course.sections, course.spec.sections, strict=True):
         entry: dict = {
             "number": len(sections) + 1,
             "name": section.name[language],
@@ -167,6 +366,9 @@ def generate_outline_json(
                     }
                 )
             entry["topics"] = topics
+            subsections = _subsections_to_render(section_spec, full_sections, include_disabled)
+            if subsections:
+                entry["subsections"] = _subsections_json(section, subsections, course, language)
         sections.append(entry)
 
     for section_spec in disabled_sections or []:
@@ -307,12 +509,17 @@ def outline(
         raise click.ClickException(f"Failed to parse spec file: {e}") from None
 
     disabled_sections: list[SectionSpec] = []
+    full_sections: list[SectionSpec] | None = None
     if include_disabled:
         try:
             full_spec = CourseSpec.from_file(spec_file, keep_disabled=True)
         except CourseSpecError as e:
             raise click.ClickException(f"Failed to parse spec file: {e}") from None
         disabled_sections = [s for s in full_spec.sections if not s.enabled]
+        # Retained so enabled sections can also surface their *disabled*
+        # subsections (issue #261). Disabled whole sections are rendered
+        # separately via ``disabled_sections``.
+        full_sections = full_spec.sections
 
     # Validate spec
     validation_errors = spec.validate()
@@ -341,6 +548,8 @@ def outline(
                     lang,
                     disabled_sections=disabled_sections,
                     sections_only=sections_only,
+                    full_sections=full_sections,
+                    include_disabled=include_disabled,
                 ),
                 indent=2,
             )
@@ -349,6 +558,8 @@ def outline(
             lang,
             disabled_sections=disabled_sections,
             sections_only=sections_only,
+            full_sections=full_sections,
+            include_disabled=include_disabled,
         )
 
     # Determine languages to generate

--- a/src/clm/cli/commands/schedule.py
+++ b/src/clm/cli/commands/schedule.py
@@ -1,0 +1,308 @@
+"""``clm schedule`` — export a day-of-week deck listing (issue #261).
+
+AZAV (and similar) certification requires a listing of which weekday each
+video (slide deck) is presented, per week. The course spec expresses this
+with an optional ``<subsection weekday="...">`` layer inside each
+``<section>`` (``<section>`` = week, ``<subsection>`` = day; see
+``clm info spec-files``). This command resolves the spec against the
+filesystem decks and emits the certification listing in Markdown (default)
+or CSV.
+
+Each listing is single-language (``--lang``, default German): deck titles
+come from the language-appropriate ``header_*`` macro. Deck order within a
+(week, day) is topic document order, then ``slides_NNN_`` order within each
+topic — the same order the build uses.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import click
+
+from clm.core.course import Course
+from clm.core.course_paths import resolve_course_paths
+from clm.core.course_spec import CourseSpec, CourseSpecError, SubsectionSpec
+from clm.core.utils.text_utils import Text
+
+# Localized weekday labels for the language-neutral tokens in
+# ``clm.core.course_spec.VALID_WEEKDAYS``. Presentation only — the spec and
+# validator deal in the tokens; only rendering resolves them to words.
+WEEKDAY_LABELS: dict[str, Text] = {
+    "mon": Text(de="Montag", en="Monday"),
+    "tue": Text(de="Dienstag", en="Tuesday"),
+    "wed": Text(de="Mittwoch", en="Wednesday"),
+    "thu": Text(de="Donnerstag", en="Thursday"),
+    "fri": Text(de="Freitag", en="Friday"),
+    "sat": Text(de="Samstag", en="Saturday"),
+    "sun": Text(de="Sonntag", en="Sunday"),
+}
+
+# Localized Markdown table headers, per language.
+_MD_HEADERS: dict[str, tuple[str, str, str]] = {
+    "de": ("Tag", "Video (Foliensatz)", "Topic"),
+    "en": ("Day", "Video (slides)", "Topic"),
+}
+
+_CSV_FIELDS = ["week", "week_title", "weekday", "video_title", "topic", "deck_file"]
+
+
+@dataclass
+class ScheduleDeck:
+    """A single video (slide deck) within a scheduled day."""
+
+    video_title: str
+    topic_id: str
+    deck_file: str  # source stem, e.g. "slides_010_introduction_ml_course_azav"
+
+
+@dataclass
+class ScheduleDay:
+    """One day (``<subsection>``) of a week, with its decks in order."""
+
+    weekday: str | None  # language-neutral token, or None for a thematic group
+    label: str  # localized display label
+    decks: list[ScheduleDeck] = field(default_factory=list)
+
+
+@dataclass
+class ScheduleWeek:
+    """One week (``<section>``) with its scheduled days."""
+
+    number: int
+    title: str
+    days: list[ScheduleDay] = field(default_factory=list)
+
+
+def subsection_label(subsection: SubsectionSpec, language: str) -> str:
+    """Resolve a subsection's display label for *language*.
+
+    A ``<name>`` override wins; otherwise the weekday token is localized via
+    :data:`WEEKDAY_LABELS`; otherwise (neither set) the label is empty.
+    """
+    if subsection.name is not None:
+        return subsection.name[language]
+    if subsection.weekday is not None:
+        return WEEKDAY_LABELS[subsection.weekday][language]
+    return ""
+
+
+def _topic_decks(topic, language: str) -> list[ScheduleDeck]:
+    """Return the decks of one resolved topic for *language*, in build order.
+
+    Split ``.de.py`` / ``.en.py`` companions are filtered to the requested
+    language so a split pair is listed once (and with the correct title),
+    mirroring the build's per-language routing.
+    """
+    decks: list[ScheduleDeck] = []
+    for notebook in topic.notebooks:
+        if (
+            notebook.output_language_filter is not None
+            and notebook.output_language_filter != language
+        ):
+            continue
+        try:
+            title = notebook.title[language]
+        except (KeyError, AttributeError, TypeError):
+            title = notebook.path.stem
+        if not title:
+            title = notebook.path.stem
+        decks.append(
+            ScheduleDeck(
+                video_title=title,
+                topic_id=topic.id,
+                deck_file=notebook.path.stem,
+            )
+        )
+    return decks
+
+
+def build_schedule(course: Course, language: str) -> list[ScheduleWeek]:
+    """Build the day-of-week schedule from a resolved *course*.
+
+    Walks each section's retained ``<subsection>`` structure and maps every
+    subsection topic to its resolved decks. Sections (weeks) are numbered
+    1-based in declared order; only enabled subsections are listed.
+    """
+    weeks: list[ScheduleWeek] = []
+    # course.sections aligns 1:1 with course.spec.sections (no section
+    # selection is applied here, and the spec is parsed enabled-only).
+    for number, (section, section_spec) in enumerate(
+        zip(course.sections, course.spec.sections, strict=True), start=1
+    ):
+        topic_decks: dict[str, list[ScheduleDeck]] = {}
+        for topic in section.topics:
+            topic_decks[topic.id] = _topic_decks(topic, language)
+
+        days: list[ScheduleDay] = []
+        for subsection in section_spec.subsections:
+            if not subsection.enabled:
+                continue
+            decks: list[ScheduleDeck] = []
+            for topic_spec in subsection.topics:
+                decks.extend(topic_decks.get(topic_spec.id, []))
+            days.append(
+                ScheduleDay(
+                    weekday=subsection.weekday,
+                    label=subsection_label(subsection, language),
+                    decks=decks,
+                )
+            )
+
+        weeks.append(ScheduleWeek(number=number, title=section.name[language], days=days))
+    return weeks
+
+
+def _md_cell(text: str) -> str:
+    """Escape a value for a Markdown table cell."""
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def render_markdown(course_title: str, weeks: list[ScheduleWeek], language: str) -> str:
+    """Render the schedule as Markdown: one table per week."""
+    day_h, video_h, topic_h = _MD_HEADERS[language]
+    empty_cell = "—"
+    lines: list[str] = [f"# {course_title}", ""]
+
+    for week in weeks:
+        lines.append(f"## {week.title}")
+        lines.append("")
+        if not week.days:
+            note = "_Keine Tage geplant._" if language == "de" else "_No days scheduled._"
+            lines.append(note)
+            lines.append("")
+            continue
+
+        lines.append(f"| {day_h} | {video_h} | {topic_h} |")
+        lines.append("|------|------|------|")
+        for day in week.days:
+            day_label = _md_cell(day.label)
+            if not day.decks:
+                lines.append(f"| {day_label} | {empty_cell} | {empty_cell} |")
+                continue
+            for index, deck in enumerate(day.decks):
+                first = _md_cell(day.label) if index == 0 else ""
+                lines.append(
+                    f"| {first} | {_md_cell(deck.video_title)} | {_md_cell(deck.topic_id)} |"
+                )
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def render_csv(weeks: list[ScheduleWeek]) -> str:
+    """Render the schedule as CSV: one row per deck."""
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(_CSV_FIELDS)
+    for week in weeks:
+        for day in week.days:
+            for deck in day.decks:
+                writer.writerow(
+                    [
+                        week.number,
+                        week.title,
+                        day.weekday or "",
+                        deck.video_title,
+                        deck.topic_id,
+                        deck.deck_file,
+                    ]
+                )
+    return buffer.getvalue()
+
+
+@click.command()
+@click.argument(
+    "spec-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "-L",
+    "--language",
+    "--lang",
+    type=click.Choice(["de", "en"], case_sensitive=False),
+    default="de",
+    show_default=True,
+    help="Language for deck titles and labels (titles come from header_de/header_en).",
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["md", "csv"], case_sensitive=False),
+    default="md",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write output to FILE instead of stdout.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Course data directory (contains slides/). Default: inferred from spec location.",
+)
+def schedule(
+    spec_file: Path,
+    language: str,
+    output_format: str,
+    output_file: Path | None,
+    data_dir: Path | None,
+):
+    """Export a day-of-week deck listing for certification.
+
+    Reads the ``<subsection weekday="...">`` layer of a course spec and the
+    decks discovered on disk, then emits one weekday listing per week.
+
+    \b
+    Examples:
+        clm schedule course.xml                  # German Markdown to stdout
+        clm schedule course.xml -L en            # English listing
+        clm schedule course.xml -f csv           # CSV (one row per deck)
+        clm schedule course.xml -o schedule.md   # Write to a file
+    """
+    language = language.lower()
+    output_format = output_format.lower()
+
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as e:
+        raise click.ClickException(f"Failed to parse spec file: {e}") from None
+
+    validation_errors = spec.validate()
+    if validation_errors:
+        error_msg = "\n".join(f"  - {e}" for e in validation_errors)
+        raise click.ClickException(f"Spec validation failed:\n{error_msg}")
+
+    course_root, _ = resolve_course_paths(spec_file, data_dir=data_dir)
+
+    course = Course.from_spec(spec, course_root, output_root=None)
+
+    weeks = build_schedule(course, language)
+
+    if not any(week.days for week in weeks):
+        click.echo(
+            "Warning: this spec defines no <subsection> days; the schedule is "
+            'empty. Add <subsection weekday="..."> groups to schedule decks. '
+            "See 'clm info spec-files'.",
+            err=True,
+        )
+
+    if output_format == "csv":
+        content = render_csv(weeks)
+    else:
+        content = render_markdown(course.name[language], weeks, language)
+
+    if output_file is not None:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(content, encoding="utf-8")
+        click.echo(f"Written: {output_file}")
+    else:
+        click.echo(content, nl=False)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -392,6 +392,14 @@ clm outline [OPTIONS] SPEC_FILE
 | `--include-disabled` | Include sections marked `enabled="false"` with a `(disabled)` marker (default: omitted). Topics that resolve to slide files on disk show the H1 header (each slide rendered as its own bullet); unresolvable topics fall back to the topic id |
 | `--sections-only` | Emit only section headings, omitting per-topic/slide entries within each section |
 
+When a section uses the optional `<subsection>` layer (see
+`clm info spec-files`), the outline renders each subsection as an indented
+group: a bold weekday/label bullet with the subsection's decks nested beneath
+it, after any bare (unscheduled) topics. `--include-disabled` additionally
+surfaces disabled subsections (and disabled sections) with a `(disabled)`
+marker. The JSON format adds a `subsections` array to each section that uses
+them (alongside the existing flat `topics` list).
+
 Examples:
 
 ```bash
@@ -401,6 +409,48 @@ clm outline course.xml -d ./docs
 clm outline course.xml --format json
 clm outline course.xml --include-disabled
 clm outline course.xml --sections-only
+```
+
+### `clm schedule`
+
+Export a **day-of-week deck listing** for certification (e.g. AZAV requires a
+listing of which weekday each video/slide deck is presented, per week). The
+listing is built from the spec's optional `<subsection weekday="...">` layer
+(`<section>` = week, `<subsection>` = day; see `clm info spec-files`) resolved
+against the decks discovered on disk.
+
+```
+clm schedule [OPTIONS] SPEC_FILE
+```
+
+| Option | Description |
+|--------|-------------|
+| `-L, --language`, `--lang [de\|en]` | Language for deck titles/labels (default: `de`). Titles come from the matching-language `header`/`header_de`/`header_en` macro. |
+| `-f, --format [md\|csv]` | Output format (default: `md`). |
+| `-o, --output FILE` | Write to FILE instead of stdout. |
+| `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the spec location. |
+
+Each listing is **single-language** — run once per language to produce both.
+Deck order within a (week, day) is topic document order, then `slides_NNN_`
+order within each topic, matching the build.
+
+- **`--format md`** (default): one Markdown table per week, columns
+  weekday / video (deck title) / topic. The weekday label appears on the first
+  deck row of each day. Days are fixed-length by definition, so there are no
+  durations/minutes. Empty days render a placeholder row.
+- **`--format csv`**: one row per deck, with header
+  `week,week_title,weekday,video_title,topic,deck_file`.
+
+Only enabled subsections are listed. Bare topics that sit under no subsection
+do not appear in the listing (`clm validate` reports them as an info finding).
+
+Examples:
+
+```bash
+clm schedule course.xml                  # German Markdown to stdout
+clm schedule course.xml -L en            # English listing
+clm schedule course.xml -f csv           # CSV (one row per deck)
+clm schedule course.xml -o schedule.md   # Write to a file
 ```
 
 ### `clm topic resolve`

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -47,6 +47,22 @@ pin — a reformatted deck requires CLM {version}):**
 
 Python (`#`) decks are unchanged.
 
+## Day-of-week scheduling: `<subsection>` + `clm schedule` (issue #261, {version} — additive)
+
+CLM {version} adds an optional `<subsection>` layer inside a `<section>`'s
+`<topics>` to express day-of-week scheduling for certification listings
+(`<section>` = week, `<subsection>` = day), plus a new `clm schedule` command
+that exports the weekday deck listing in Markdown or CSV. See
+`clm info spec-files` for the `<subsection>` grammar and `clm info commands`
+for `clm schedule`.
+
+**Nothing changes for existing specs.** The feature is entirely opt-in: a spec
+that declares no `<subsection>` parses and builds exactly as before. `clm build`
+flattens subsections away, so a spec with subsections builds **byte-identically**
+to the same spec with the wrappers removed — there is no migration step. To
+adopt it, wrap a section's `<topic>`s in `<subsection weekday="mon">…` groups
+and run `clm schedule course.xml`.
+
 ## Per-topic solution release (issue #208, {version} — additive)
 
 CLM {version} adds **per-topic solution release**: hand a student cohort a

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -196,6 +196,60 @@ will silently end up with an empty topic ID. CLM rejects this case with a
 clear error. Specifying the ID via both the `id=` attribute *and* text
 content is also a hard error — pick one form per topic.
 
+#### `<subsection>` — day-of-week / thematic grouping (Optional)
+
+A `<section>`'s `<topics>` may group its `<topic>`s into optional
+`<subsection>` elements. The intended use is **day-of-week scheduling** for
+certification listings (e.g. AZAV): a `<section>` is one week, and each
+`<subsection>` is one day. `<subsection>`s, bare `<topic>`s, or a mix of both
+may appear under `<topics>`, in any order.
+
+```xml
+<section module="module_550_ml_azav">
+    <name><de>Woche 01: …</de><en>Week 01: …</en></name>
+    <topics>
+        <subsection weekday="mon">
+            <topic>introduction_ml_course_azav</topic>
+            <topic>what_are_llms</topic>
+        </subsection>
+        <subsection weekday="tue">
+            <name><de>Dienstag — Recht</de><en>Tuesday — Law</en></name>
+            <topic>llm_ethics_azav</topic>   <!-- all its decks land on Tue -->
+        </subsection>
+    </topics>
+</section>
+```
+
+**The layer is purely additive.** `clm build` **flattens** subsections away:
+it collects the contained `<topic>`s in document order and ignores the
+wrapper, so a spec with subsections builds **byte-identically** to the same
+spec with the `<subsection>` wrappers removed. Subsections have **no** effect
+on output directories or topic→directory resolution. The grouping is retained
+only for `clm outline` (renders subsections indented) and `clm schedule`
+(exports the weekday deck listing).
+
+**Granularity is topic-level**: a subsection holds whole topics, and a
+multi-deck topic's decks all land on its day. To split one topic's decks
+across days, split the topic directory — there is no per-deck day override.
+
+Optional `<subsection>` attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `weekday` | Optional, language-neutral token from `{mon, tue, wed, thu, fri, sat, sun}` (case-insensitive), localized at render time. `sat`/`sun` are valid; AZAV uses Mon–Fri only. A closed enum lets the validator check ordering/uniqueness. Omit it for a generic thematic group that carries only a `<name>`. |
+| `enabled` | `"true"` (default) or `"false"`. A disabled subsection is dropped entirely from the build — topics and all — exactly like a disabled `<section>`. It is retained only by tooling parsed with `--include-disabled`. |
+
+A `<subsection>` may also carry an optional `<name>` (`<de>`/`<en>`) label
+override; when omitted, the displayed label is derived from `weekday`. A
+`<subsection>` contains one or more `<topic>` elements using the **same topic
+grammar** as a bare `<topic>` (ids, `<include>`/`<dir-group>` children,
+attributes).
+
+`clm validate` adds four advisory subsection checks (none is an error):
+duplicate weekday within a section, weekdays out of Mon→Sun order, an empty
+day (a subsection with no topics or whose topics resolve to zero decks), and
+(info) bare topics mixed with subsections (they appear under no day).
+
 ### `<author>` (Optional)
 
 Author name displayed in notebook slide headers. Defaults to `Dr. Matthias Hölzl`.

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -95,6 +95,7 @@ from clm.cli.commands.normalize_slides import normalize_slides_cmd  # noqa: E402
 from clm.cli.commands.outline import outline  # noqa: E402
 from clm.cli.commands.release import release_group  # noqa: E402
 from clm.cli.commands.resolve_topic import resolve_topic_cmd  # noqa: E402
+from clm.cli.commands.schedule import schedule  # noqa: E402
 from clm.cli.commands.search_slides import search_slides_cmd  # noqa: E402
 from clm.cli.commands.slides_sync import slides_sync_cmd  # noqa: E402
 from clm.cli.commands.slides_translate import slides_translate_cmd  # noqa: E402
@@ -148,6 +149,7 @@ from clm.cli.commands.jupyterlite import jupyterlite_group  # noqa: E402
 cli.add_command(build)
 cli.add_command(list_targets, name="targets")
 cli.add_command(outline)
+cli.add_command(schedule)
 cli.add_command(validate_cmd)
 cli.add_command(delete_database)
 cli.add_command(status)

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -210,6 +210,57 @@ class TopicSpec:
     includes: list[IncludeSpec] = Factory(list)
 
 
+# Weekday tokens for ``<subsection weekday="...">`` (issue #261). A closed,
+# language-neutral enum so the validator can check ordering/uniqueness; the
+# tokens are localized only at render time (see
+# ``clm.cli.commands.schedule.WEEKDAY_LABELS``). ``sat``/``sun`` are valid
+# (some industry courses run on Saturday); AZAV uses Mon–Fri only. The tuple
+# defines the canonical week order used for the out-of-order check.
+WEEKDAY_ORDER: tuple[str, ...] = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+VALID_WEEKDAYS: frozenset[str] = frozenset(WEEKDAY_ORDER)
+
+
+@frozen
+class SubsectionSpec:
+    """An optional ``<subsection>`` grouping inside a ``<section>``'s ``<topics>``.
+
+    Groups one or more ``<topic>`` elements under an optional weekday and/or
+    label. It expresses day-of-week scheduling for certification listings
+    (issue #261): ``<section>`` = week, ``<subsection>`` = day.
+
+    The layer is **purely additive**: :meth:`CourseSpec.parse_sections`
+    flattens the topics of *enabled* subsections into the parent
+    :attr:`SectionSpec.topics` list (in document order) so the build path
+    never sees the wrapper. A spec with subsections therefore builds
+    byte-identically to the same spec with the ``<subsection>`` wrappers
+    removed. The grouping is retained here only for outline/schedule output
+    and validation.
+
+    Attributes:
+        topics: The contained topics, in document order. For an *enabled*
+            subsection these are the very same :class:`TopicSpec` objects
+            that also appear in the parent :attr:`SectionSpec.topics` flat
+            list. A *disabled* subsection's topics are held only here — they
+            are deliberately kept out of the flat build list (see ``enabled``).
+        weekday: A language-neutral weekday token from :data:`VALID_WEEKDAYS`
+            (``"mon"``..``"sun"``), or ``None`` for a generic thematic group
+            that carries only a ``<name>``.
+        name: Optional bilingual label override. When ``None``, consumers
+            derive the displayed label from ``weekday``.
+        enabled: Mirrors ``<section enabled=...>``. A disabled subsection is
+            dropped entirely from the build — its topics never enter the flat
+            :attr:`SectionSpec.topics` list (the build path), regardless of
+            ``keep_disabled``. With ``keep_disabled=True`` the wrapper is still
+            retained in :attr:`SectionSpec.subsections` so tooling
+            (``clm outline --include-disabled``) can surface it.
+    """
+
+    topics: list[TopicSpec] = Factory(list)
+    weekday: str | None = None
+    name: Text | None = None
+    enabled: bool = True
+
+
 @frozen
 class SectionSpec:
     name: Text
@@ -227,6 +278,14 @@ class SectionSpec:
     # that do not themselves carry an explicit ``http-replay`` attribute.
     # Per-topic ``http-replay="yes"``/``"no"`` overrides this default.
     http_replay: bool = False
+    # Optional ``<subsection>`` groupings (issue #261). The contained topics
+    # are *also* present in ``topics`` (flattened); this list retains the
+    # day-of-week / thematic grouping for ``clm outline`` and
+    # ``clm schedule``. Empty for sections that use only bare ``<topic>``s.
+    # Honors ``keep_disabled`` the same way ``CourseSpec.sections`` does:
+    # disabled subsections appear here only when parsed with
+    # ``keep_disabled=True``.
+    subsections: list[SubsectionSpec] = Factory(list)
 
     def module_for(self, topic_spec: TopicSpec) -> str | None:
         """Effective module binding for *topic_spec* under this section.
@@ -361,6 +420,28 @@ def _parse_disable_attr(value: str | None, *, attr_name: str) -> bool:
     raise CourseSpecError(
         f"Invalid value for {attr_name!r} attribute: {value!r}. "
         f"Expected 'true'/'yes'/'1' or 'false'/'no'/'0' (case-insensitive)."
+    )
+
+
+def _parse_enabled_attr(value: str | None, *, label: str) -> bool:
+    """Parse an ``enabled`` attribute (default-on, strict true/false).
+
+    Shared by ``<section>`` and ``<subsection>`` parsing. Returns True when
+    the attribute is absent or ``"true"`` and False for ``"false"``
+    (case-insensitive). Any other value is a hard :class:`CourseSpecError`.
+    ``label`` identifies the element in the error message (e.g.
+    ``"section 'Week 1'"``).
+    """
+    if value is None:
+        return True
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise CourseSpecError(
+        f"Invalid value for 'enabled' attribute on {label}: {value!r}. "
+        f"Expected 'true' or 'false' (case-insensitive)."
     )
 
 
@@ -1055,6 +1136,144 @@ class CourseSpec:
         )
 
     @staticmethod
+    def _parse_topic_element(topic_elem: ETree.Element, *, section_label: str) -> TopicSpec:
+        """Parse a single ``<topic>`` element into a :class:`TopicSpec`.
+
+        Shared by both the bare ``<topic>`` path and the ``<subsection>``
+        path so the topic grammar (id forms, ``<include>`` children,
+        attributes) is identical wherever a ``<topic>`` appears.
+        """
+        topic_id_attr = (topic_elem.attrib.get("id") or "").strip()
+        topic_id_text = (topic_elem.text or "").strip()
+        has_child_elements = len(topic_elem) > 0
+
+        if topic_id_attr and topic_id_text:
+            raise CourseSpecError(
+                f"Topic ID specified twice in {section_label}: "
+                f"both as id={topic_id_attr!r} attribute and as "
+                f"text content {topic_id_text!r}. Use only one "
+                f"form per topic. Prefer the id= attribute when "
+                f"the topic carries <include> or other child "
+                f"elements."
+            )
+
+        topic_id = topic_id_attr or topic_id_text
+
+        if has_child_elements and not topic_id:
+            raise CourseSpecError(
+                f"<topic> in {section_label} has child elements "
+                f"but no ID. When a <topic> contains <include> "
+                f"or other child elements, its ID must be set "
+                f'via the id= attribute (e.g. <topic id="my_topic">). '
+                f"The text-content form (<topic>my_topic</topic>) "
+                f"is unsafe with children: XML parsers assign "
+                f"text appearing after a child element to that "
+                f"child's tail rather than to the topic, which "
+                f"silently empties the topic ID."
+            )
+
+        topic_label = (
+            f"topic '{topic_id}' in {section_label}" if topic_id else f"<topic> in {section_label}"
+        )
+        topic_includes = _parse_includes(topic_elem, element_label=topic_label)
+        return TopicSpec(
+            id=topic_id,
+            skip_html=bool(topic_elem.attrib.get("html")),
+            skip_evaluation=_parse_disable_attr(
+                topic_elem.attrib.get("evaluate"), attr_name="evaluate"
+            ),
+            skip_errors=_parse_bool_attr(
+                topic_elem.attrib.get("skip-errors"),
+                attr_name="skip-errors",
+            ),
+            http_replay=_parse_optional_bool_attr(
+                topic_elem.attrib.get("http-replay"),
+                attr_name="http-replay",
+            ),
+            author=topic_elem.attrib.get("author", ""),
+            prog_lang=topic_elem.attrib.get("prog-lang", ""),
+            module=topic_elem.attrib.get("module") or None,
+            includes=topic_includes,
+        )
+
+    @staticmethod
+    def _parse_subsection_element(
+        sub_elem: ETree.Element, *, section_label: str, keep_disabled: bool
+    ) -> SubsectionSpec | None:
+        """Parse a ``<subsection>`` child of ``<topics>`` (issue #261).
+
+        Returns ``None`` when the subsection is disabled and
+        ``keep_disabled`` is False, so the caller drops it entirely
+        (topics and all) — mirroring how a disabled ``<section>`` is
+        dropped. ``weekday`` is validated against the closed
+        :data:`VALID_WEEKDAYS` enum; an unknown token is a hard error.
+        """
+        enabled = _parse_enabled_attr(
+            sub_elem.attrib.get("enabled"), label=f"subsection in {section_label}"
+        )
+        if not enabled and not keep_disabled:
+            return None
+
+        weekday_raw = sub_elem.attrib.get("weekday")
+        weekday: str | None = None
+        if weekday_raw is not None:
+            normalized = weekday_raw.strip().lower()
+            if normalized:
+                if normalized not in VALID_WEEKDAYS:
+                    raise CourseSpecError(
+                        f"Invalid weekday {weekday_raw!r} on a <subsection> in "
+                        f"{section_label}. Expected one of "
+                        f"{list(WEEKDAY_ORDER)} (language-neutral, lowercase)."
+                    )
+                weekday = normalized
+
+        name_elem = sub_elem.find("name")
+        name: Text | None = None
+        if name_elem is not None:
+            de = name_elem.findtext("de") or ""
+            en = name_elem.findtext("en") or ""
+            # An all-empty <name> reads as "absent" so the weekday fallback
+            # still fires; otherwise an empty override would blank the label.
+            name = Text(de=de, en=en) if (de or en) else None
+
+        topics = [
+            CourseSpec._parse_topic_element(topic_elem, section_label=section_label)
+            for topic_elem in sub_elem.findall("topic")
+        ]
+        return SubsectionSpec(topics=topics, weekday=weekday, name=name, enabled=enabled)
+
+    @staticmethod
+    def _iter_topic_elements(
+        section_elem: ETree.Element, *, keep_disabled: bool
+    ) -> "list[ETree.Element]":
+        """Yield every ``<topic>`` element of a section in document order.
+
+        Descends into ``<subsection>`` wrappers (issue #261), skipping
+        disabled subsections unless ``keep_disabled`` is set — the same
+        drop-entirely rule applied to disabled sections. Used by
+        :meth:`parse_dir_groups` so topic-scoped ``<dir-group>`` elements
+        nested inside subsections are still collected.
+        """
+        topics_elem = section_elem.find("topics")
+        if topics_elem is None:
+            return []
+        result: list[ETree.Element] = []
+        for child in topics_elem:
+            if child.tag == "topic":
+                result.append(child)
+            elif child.tag == "subsection":
+                # Loose, non-raising check (mirrors the section-level skip in
+                # parse_dir_groups): malformed ``enabled`` values are validated
+                # authoritatively by parse_sections, which runs first on the
+                # from_file path. Re-raising here would only hurt standalone
+                # callers with a less section-qualified message.
+                disabled = (child.attrib.get("enabled") or "").strip().lower() == "false"
+                if disabled and not keep_disabled:
+                    continue
+                result.extend(child.findall("topic"))
+        return result
+
+    @staticmethod
     def parse_sections(root: ETree.Element, *, keep_disabled: bool = False) -> list[SectionSpec]:
         """Parse <section> elements from a course spec root.
 
@@ -1070,21 +1289,9 @@ class CourseSpec:
         for i, section_elem in enumerate(root.findall("sections/section"), start=1):
             name = parse_multilang(root, f"sections/section[{i}]/name")
 
-            enabled_attr = section_elem.attrib.get("enabled")
-            if enabled_attr is None:
-                enabled = True
-            else:
-                normalized = enabled_attr.strip().lower()
-                if normalized == "true":
-                    enabled = True
-                elif normalized == "false":
-                    enabled = False
-                else:
-                    raise CourseSpecError(
-                        f"Invalid value for 'enabled' attribute on section "
-                        f"'{name.en}': {enabled_attr!r}. "
-                        f"Expected 'true' or 'false' (case-insensitive)."
-                    )
+            enabled = _parse_enabled_attr(
+                section_elem.attrib.get("enabled"), label=f"section '{name.en}'"
+            )
 
             section_id = section_elem.attrib.get("id") or None
             section_module = section_elem.attrib.get("module") or None
@@ -1104,68 +1311,49 @@ class CourseSpec:
 
             topics_elem = section_elem.find("topics")
             topics: list[TopicSpec] = []
+            subsections: list[SubsectionSpec] = []
             if topics_elem is None:
                 if enabled:
                     logger.warning(f"Malformed section: {name.en} has no topics")
                     continue
             else:
-                for topic_elem in topics_elem.findall("topic"):
-                    topic_id_attr = (topic_elem.attrib.get("id") or "").strip()
-                    topic_id_text = (topic_elem.text or "").strip()
-                    has_child_elements = len(topic_elem) > 0
-
-                    if topic_id_attr and topic_id_text:
-                        raise CourseSpecError(
-                            f"Topic ID specified twice in {section_label}: "
-                            f"both as id={topic_id_attr!r} attribute and as "
-                            f"text content {topic_id_text!r}. Use only one "
-                            f"form per topic. Prefer the id= attribute when "
-                            f"the topic carries <include> or other child "
-                            f"elements."
+                # Walk the direct children of <topics> in document order so
+                # bare <topic>s and <subsection> wrappers can be freely
+                # interleaved. Subsection topics are flattened into the same
+                # `topics` list (the build path), and the grouping is retained
+                # in `subsections` for outline/schedule. Comments and unknown
+                # children are ignored (their .tag is not a plain string).
+                for child in topics_elem:
+                    if child.tag == "topic":
+                        topics.append(
+                            CourseSpec._parse_topic_element(child, section_label=section_label)
                         )
-
-                    topic_id = topic_id_attr or topic_id_text
-
-                    if has_child_elements and not topic_id:
-                        raise CourseSpecError(
-                            f"<topic> in {section_label} has child elements "
-                            f"but no ID. When a <topic> contains <include> "
-                            f"or other child elements, its ID must be set "
-                            f'via the id= attribute (e.g. <topic id="my_topic">). '
-                            f"The text-content form (<topic>my_topic</topic>) "
-                            f"is unsafe with children: XML parsers assign "
-                            f"text appearing after a child element to that "
-                            f"child's tail rather than to the topic, which "
-                            f"silently empties the topic ID."
+                    elif child.tag == "subsection":
+                        subsection = CourseSpec._parse_subsection_element(
+                            child,
+                            section_label=section_label,
+                            keep_disabled=keep_disabled,
                         )
-
-                    topic_label = (
-                        f"topic '{topic_id}' in {section_label}"
-                        if topic_id
-                        else f"<topic> in {section_label}"
-                    )
-                    topic_includes = _parse_includes(topic_elem, element_label=topic_label)
-                    topics.append(
-                        TopicSpec(
-                            id=topic_id,
-                            skip_html=bool(topic_elem.attrib.get("html")),
-                            skip_evaluation=_parse_disable_attr(
-                                topic_elem.attrib.get("evaluate"), attr_name="evaluate"
-                            ),
-                            skip_errors=_parse_bool_attr(
-                                topic_elem.attrib.get("skip-errors"),
-                                attr_name="skip-errors",
-                            ),
-                            http_replay=_parse_optional_bool_attr(
-                                topic_elem.attrib.get("http-replay"),
-                                attr_name="http-replay",
-                            ),
-                            author=topic_elem.attrib.get("author", ""),
-                            prog_lang=topic_elem.attrib.get("prog-lang", ""),
-                            module=topic_elem.attrib.get("module") or None,
-                            includes=topic_includes,
-                        )
-                    )
+                        if subsection is None:
+                            # Disabled subsection, dropped entirely (topics and
+                            # all), exactly like a disabled section.
+                            continue
+                        subsections.append(subsection)
+                        # Only ENABLED subsections contribute to the flat build
+                        # list — ALWAYS, independent of keep_disabled. A disabled
+                        # subsection is retained in `subsections` (so outline
+                        # --include-disabled can still render it) but its topics
+                        # must never reach `topics`: that is the list `clm build`
+                        # flattens, and there is no per-topic enabled gate
+                        # downstream. Disabled *sections* are protected from the
+                        # build by SectionSelection.resolved_indices, but a
+                        # disabled subsection nested in an enabled, selected
+                        # section has no such guard — so the gate must live here
+                        # to keep `clm build --only-sections` (which parses with
+                        # keep_disabled=True) byte-identical and to keep disabled
+                        # decks out of the `clm release` ledger.
+                        if subsection.enabled:
+                            topics.extend(subsection.topics)
             sections.append(
                 SectionSpec(
                     name=name,
@@ -1175,6 +1363,7 @@ class CourseSpec:
                     module=section_module,
                     includes=section_includes,
                     http_replay=section_http_replay,
+                    subsections=subsections,
                 )
             )
         return sections
@@ -1215,7 +1404,13 @@ class CourseSpec:
             ):
                 continue
             section_id = section_elem.attrib.get("id") or None
-            for topic_elem in section_elem.findall("topics/topic"):
+            # Walk topic elements in document order, descending into
+            # <subsection> wrappers (issue #261) so dir-groups nested inside a
+            # subsection's topics are collected too. Disabled subsections are
+            # skipped unless keep_disabled, mirroring the section-level skip.
+            for topic_elem in CourseSpec._iter_topic_elements(
+                section_elem, keep_disabled=keep_disabled
+            ):
                 topic_id = (
                     (topic_elem.attrib.get("id") or "").strip()
                     or (topic_elem.text or "").strip()

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -14,9 +14,14 @@ from pathlib import Path
 
 import tomllib
 
-from clm.core.course_spec import CourseSpec, IncludeSpec, SectionSpec
+from clm.core.course_spec import WEEKDAY_ORDER, CourseSpec, IncludeSpec, SectionSpec
 from clm.core.include_ledger import LEDGER_NAME, Ledger
-from clm.core.topic_resolver import TopicMatch, build_topic_map, matches_for_binding
+from clm.core.topic_resolver import (
+    TopicMatch,
+    build_topic_map,
+    find_slide_files,
+    matches_for_binding,
+)
 
 
 @dataclass
@@ -243,6 +248,14 @@ def validate_spec(
                 )
             )
 
+    # Subsection (day-of-week) checks (issue #261).
+    _validate_subsections(
+        spec=spec,
+        topic_map=topic_map,
+        findings=findings,
+        suffix=_suffix,
+    )
+
     # Dir-group path checks
     course_root = slides_dir.parent
     for dg in spec.dictionaries:
@@ -279,6 +292,165 @@ def validate_spec(
         topics_total=topics_total,
         findings=findings,
     )
+
+
+def _validate_subsections(
+    *,
+    spec: CourseSpec,
+    topic_map: dict[str, list[TopicMatch]],
+    findings: list[SpecFinding],
+    suffix: Callable[[bool, str], str],
+) -> None:
+    """Emit findings for ``<subsection>`` day-of-week groupings (issue #261).
+
+    Four checks, per the design:
+
+    1. ``duplicate_weekday`` (warning) — the same weekday token appears on
+       more than one subsection within a single section.
+    2. ``weekday_out_of_order`` (warning) — weekday tokens within a section
+       are not in canonical Mon→Sun order.
+    3. ``empty_day`` (warning) — a subsection that carries no ``<topic>``,
+       or whose resolvable topics produce zero slide decks.
+    4. ``unscheduled_topics`` (info) — a section mixes bare ``<topic>``s
+       (which appear under no day) with ``<subsection>``s.
+
+    Only enabled subsections are checked for 1–3 (a disabled subsection is
+    roadmap content, like a disabled section). All checks are
+    informational/advisory: none is an error.
+    """
+    for section in spec.sections:
+        section_name = section.name.en or section.name.de
+        section_disabled = not section.enabled
+
+        enabled_subs = [sub for sub in section.subsections if sub.enabled]
+        if not enabled_subs:
+            # No (enabled) subsections — nothing day-related to check.
+            # Check 4 still needs the *structure*; but with no enabled
+            # subsections there is no day to schedule against, so there are
+            # no "unscheduled" topics to report.
+            continue
+
+        # --- Checks 1 & 2: weekday duplicates and ordering ---
+        weekdays = [sub.weekday for sub in enabled_subs if sub.weekday is not None]
+
+        seen: set[str] = set()
+        reported_dup: set[str] = set()
+        for wd in weekdays:
+            if wd in seen and wd not in reported_dup:
+                reported_dup.add(wd)
+                findings.append(
+                    SpecFinding(
+                        severity="warning",
+                        type="duplicate_weekday",
+                        section=section_name,
+                        message=suffix(
+                            section_disabled,
+                            f"Section '{section_name}' assigns weekday "
+                            f"'{wd}' to more than one subsection.",
+                        ),
+                        suggestion=(
+                            "Merge the subsections that share a weekday, or "
+                            "correct the weekday on one of them."
+                        ),
+                    )
+                )
+            seen.add(wd)
+
+        prev_index = -1
+        reported_ooo: set[str] = set()
+        for wd in weekdays:
+            index = WEEKDAY_ORDER.index(wd)
+            # Report each offending weekday once (mirrors the duplicate check),
+            # otherwise a weekday that is both out of order and repeated would
+            # emit one identical finding per occurrence.
+            if index < prev_index and wd not in reported_ooo:
+                reported_ooo.add(wd)
+                findings.append(
+                    SpecFinding(
+                        severity="warning",
+                        type="weekday_out_of_order",
+                        section=section_name,
+                        message=suffix(
+                            section_disabled,
+                            f"Section '{section_name}': weekday '{wd}' appears "
+                            f"out of order (expected Mon→Sun order).",
+                        ),
+                        suggestion=(
+                            "Reorder the <subsection> elements so weekdays run "
+                            "Monday through Sunday."
+                        ),
+                    )
+                )
+            prev_index = max(prev_index, index)
+
+        # --- Check 3: empty days ---
+        for sub in enabled_subs:
+            label = sub.weekday or (sub.name.en or sub.name.de if sub.name else "") or "(unnamed)"
+            if not sub.topics:
+                findings.append(
+                    SpecFinding(
+                        severity="warning",
+                        type="empty_day",
+                        section=section_name,
+                        message=suffix(
+                            section_disabled,
+                            f"Section '{section_name}': subsection '{label}' contains no topics.",
+                        ),
+                    )
+                )
+                continue
+            resolved_any = False
+            deck_count = 0
+            for topic_spec in sub.topics:
+                matches = matches_for_binding(
+                    topic_map, topic_spec.id, section.module_for(topic_spec)
+                )
+                if len(matches) == 1:
+                    resolved_any = True
+                    deck_count += len(find_slide_files(matches[0].path))
+            # Only flag "resolves to zero decks" when at least one topic
+            # actually resolved — otherwise the unresolved_topic errors above
+            # already explain the emptiness and this would be noise.
+            if resolved_any and deck_count == 0:
+                findings.append(
+                    SpecFinding(
+                        severity="warning",
+                        type="empty_day",
+                        section=section_name,
+                        message=suffix(
+                            section_disabled,
+                            f"Section '{section_name}': subsection '{label}' "
+                            f"resolves to zero slide decks.",
+                        ),
+                    )
+                )
+
+        # --- Check 4: bare topics mixed with subsections (info) ---
+        # Key by object identity, not topic id: parse_sections appends the very
+        # same TopicSpec objects into both section.topics and the subsections,
+        # so identity cleanly separates bare topics even when a bare topic
+        # happens to share an id with a subsection topic.
+        subsection_topic_obj_ids = {id(t) for sub in section.subsections for t in sub.topics}
+        bare_ids = [t.id for t in section.topics if id(t) not in subsection_topic_obj_ids]
+        if bare_ids:
+            listed = ", ".join(bare_ids)
+            findings.append(
+                SpecFinding(
+                    severity="info",
+                    type="unscheduled_topics",
+                    section=section_name,
+                    message=suffix(
+                        section_disabled,
+                        f"Section '{section_name}' mixes {len(bare_ids)} bare "
+                        f"topic(s) with subsections; these appear under no "
+                        f"weekday: {listed}.",
+                    ),
+                    suggestion=(
+                        "Move each bare topic into a <subsection> to give it a "
+                        "day, or leave it as a deliberately unscheduled topic."
+                    ),
+                )
+            )
 
 
 @dataclass

--- a/tests/cli/test_outline_subsections.py
+++ b/tests/cli/test_outline_subsections.py
@@ -1,0 +1,153 @@
+"""Outline rendering tests for the ``<subsection>`` layer (issue #261)."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.outline import generate_outline, generate_outline_json
+from clm.cli.main import cli
+from clm.core.course import Course
+from clm.core.course_spec import CourseSpec
+
+SPEC_PATH = Path("tests/test-data/course-specs/subsection-spec.xml")
+# A plain spec with no <subsection> usage — used to assert unchanged behavior.
+PLAIN_SPEC_PATH = Path("tests/test-data/course-specs/test-spec-1.xml")
+# An enabled section containing one enabled and one disabled subsection.
+DISABLED_SUB_SPEC_PATH = Path("tests/test-data/course-specs/subsection-disabled-spec.xml")
+
+
+@pytest.fixture
+def course() -> Course:
+    spec = CourseSpec.from_file(SPEC_PATH)
+    return Course.from_spec(spec, SPEC_PATH.parents[1], output_root=None)
+
+
+@pytest.fixture
+def plain_course() -> Course:
+    spec = CourseSpec.from_file(PLAIN_SPEC_PATH)
+    return Course.from_spec(spec, PLAIN_SPEC_PATH.parents[1], output_root=None)
+
+
+class TestMarkdownSubsections:
+    def test_subsections_render_as_bold_groups(self, course):
+        out = generate_outline(course, "en")
+        assert "## Week 1" in out
+        assert "- **Monday**" in out
+        assert "  - Some Topic from Test 1" in out
+        assert "  - A Topic from Test 2" in out
+        assert "- **Tuesday — Law**" in out
+        assert "  - Was this really ML?" in out
+
+    def test_bare_topic_rendered_before_subsection(self, course):
+        out = generate_outline(course, "en")
+        # Week 2 has a bare topic then a wed subsection.
+        week2 = out.split("## Week 2", 1)[1]
+        assert "- Another Topic from Test 1" in week2
+        assert "- **Wednesday**" in week2
+        assert week2.index("Another Topic from Test 1") < week2.index("**Wednesday**")
+
+    def test_german_weekday_labels(self, course):
+        out = generate_outline(course, "de")
+        assert "- **Montag**" in out
+        assert "- **Dienstag — Recht**" in out
+
+    def test_plain_spec_unchanged(self, plain_course):
+        """A spec without subsections renders flat bullets (no bold groups)."""
+        out = generate_outline(plain_course, "en")
+        assert "- Some Topic from Test 1" in out
+        assert "**" not in out
+
+
+class TestJsonSubsections:
+    def test_json_includes_subsections(self, course):
+        data = generate_outline_json(course, "en")
+        week1 = data["sections"][0]
+        assert "subsections" in week1
+        subs = week1["subsections"]
+        assert [s["weekday"] for s in subs] == ["mon", "tue"]
+        assert subs[0]["label"] == "Monday"
+        assert subs[0]["enabled"] is True
+        assert [t["topic_id"] for t in subs[0]["topics"]] == [
+            "some_topic_from_test_1",
+            "a_topic_from_test_2",
+        ]
+
+    def test_json_topics_list_still_present(self, course):
+        """The flat topics list is preserved alongside subsections (additive)."""
+        data = generate_outline_json(course, "en")
+        week1 = data["sections"][0]
+        assert [t["topic_id"] for t in week1["topics"]] == [
+            "some_topic_from_test_1",
+            "a_topic_from_test_2",
+            "punctuation_test",
+        ]
+
+    def test_json_plain_spec_has_no_subsections_key(self, plain_course):
+        data = generate_outline_json(plain_course, "en")
+        for section in data["sections"]:
+            assert "subsections" not in section
+
+
+class TestDisabledSubsectionInEnabledSection:
+    """--include-disabled surfaces a disabled subsection nested in an enabled
+    section (issue #261 requirement #3)."""
+
+    def _course_and_full(self):
+        spec = CourseSpec.from_file(DISABLED_SUB_SPEC_PATH)
+        full = CourseSpec.from_file(DISABLED_SUB_SPEC_PATH, keep_disabled=True)
+        course = Course.from_spec(spec, DISABLED_SUB_SPEC_PATH.parents[1], output_root=None)
+        return course, full
+
+    def test_default_hides_disabled_subsection(self):
+        course, _full = self._course_and_full()
+        out = generate_outline(course, "en")
+        assert "- **Monday**" in out
+        assert "Tuesday" not in out
+        assert "(disabled)" not in out
+
+    def test_include_disabled_shows_disabled_subsection(self):
+        course, full = self._course_and_full()
+        out = generate_outline(course, "en", full_sections=full.sections, include_disabled=True)
+        assert "- **Monday**" in out
+        assert "- **Tuesday** (disabled)" in out
+        # Its deck title is resolved from the filesystem fallback.
+        assert "Was this really ML? (disabled)" in out
+
+    def test_include_disabled_json(self):
+        course, full = self._course_and_full()
+        data = generate_outline_json(
+            course, "en", full_sections=full.sections, include_disabled=True
+        )
+        subs = data["sections"][0]["subsections"]
+        assert [s["enabled"] for s in subs] == [True, False]
+        assert subs[1]["weekday"] == "tue"
+
+    def test_cli_include_disabled(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["outline", str(DISABLED_SUB_SPEC_PATH), "--include-disabled"])
+        assert result.exit_code == 0, result.output
+        assert "- **Tuesday** (disabled)" in result.output
+
+
+class TestOutlineCliSubsections:
+    def test_cli_markdown(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["outline", str(SPEC_PATH)])
+        assert result.exit_code == 0, result.output
+        assert "- **Monday**" in result.output
+
+    def test_cli_json(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["outline", str(SPEC_PATH), "-f", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["sections"][0]["subsections"][0]["weekday"] == "mon"
+
+    def test_cli_sections_only_omits_subsections(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["outline", str(SPEC_PATH), "--sections-only"])
+        assert result.exit_code == 0, result.output
+        assert "**Monday**" not in result.output
+        assert "## Week 1" in result.output

--- a/tests/cli/test_schedule.py
+++ b/tests/cli/test_schedule.py
@@ -1,0 +1,240 @@
+"""Tests for the ``clm schedule`` command (issue #261)."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.schedule import (
+    WEEKDAY_LABELS,
+    ScheduleDay,
+    ScheduleDeck,
+    ScheduleWeek,
+    build_schedule,
+    render_csv,
+    render_markdown,
+    subsection_label,
+)
+from clm.cli.main import cli
+from clm.core.course import Course
+from clm.core.course_spec import CourseSpec, SubsectionSpec
+from clm.core.utils.text_utils import Text
+
+SPEC_PATH = Path("tests/test-data/course-specs/subsection-spec.xml")
+
+
+@pytest.fixture
+def course() -> Course:
+    spec = CourseSpec.from_file(SPEC_PATH)
+    return Course.from_spec(spec, SPEC_PATH.parents[1], output_root=None)
+
+
+class TestSubsectionLabel:
+    def test_name_override_wins(self):
+        sub = SubsectionSpec(weekday="tue", name=Text(de="Recht", en="Law"))
+        assert subsection_label(sub, "de") == "Recht"
+        assert subsection_label(sub, "en") == "Law"
+
+    def test_weekday_localized_when_no_name(self):
+        sub = SubsectionSpec(weekday="mon")
+        assert subsection_label(sub, "de") == "Montag"
+        assert subsection_label(sub, "en") == "Monday"
+
+    def test_empty_when_neither(self):
+        sub = SubsectionSpec()
+        assert subsection_label(sub, "de") == ""
+
+    def test_all_weekdays_have_labels(self):
+        for token in ("mon", "tue", "wed", "thu", "fri", "sat", "sun"):
+            assert WEEKDAY_LABELS[token]["de"]
+            assert WEEKDAY_LABELS[token]["en"]
+
+
+class TestBuildSchedule:
+    def test_weeks_and_days_structure(self, course):
+        weeks = build_schedule(course, "en")
+        assert [w.number for w in weeks] == [1, 2]
+        assert weeks[0].title == "Week 1"
+        assert [d.weekday for d in weeks[0].days] == ["mon", "tue"]
+        assert [d.weekday for d in weeks[1].days] == ["wed"]
+
+    def test_deck_order_within_day(self, course):
+        weeks = build_schedule(course, "en")
+        monday = weeks[0].days[0]
+        assert [d.topic_id for d in monday.decks] == [
+            "some_topic_from_test_1",
+            "a_topic_from_test_2",
+        ]
+        assert monday.decks[0].video_title == "Some Topic from Test 1"
+
+    def test_label_uses_name_override(self, course):
+        weeks = build_schedule(course, "en")
+        tuesday = weeks[0].days[1]
+        assert tuesday.label == "Tuesday — Law"
+
+    def test_language_selects_titles(self, course):
+        weeks_de = build_schedule(course, "de")
+        monday = weeks_de[0].days[0]
+        assert monday.decks[0].video_title == "Folien von Test 1"
+        assert monday.label == "Montag"
+
+    def test_bare_topic_not_listed_as_a_day(self, course):
+        # Week 2 has a bare topic (another_topic_from_test_1) + a wed subsection;
+        # the schedule lists only the day, not the bare topic.
+        weeks = build_schedule(course, "en")
+        week2 = weeks[1]
+        all_topics = [deck.topic_id for day in week2.days for deck in day.decks]
+        assert all_topics == ["simple_notebook"]
+
+
+class TestRenderMarkdown:
+    def test_markdown_table_structure(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="Week 1",
+                days=[
+                    ScheduleDay(
+                        weekday="mon",
+                        label="Monday",
+                        decks=[
+                            ScheduleDeck("Intro", "intro", "slides_010_intro"),
+                            ScheduleDeck("More", "more", "slides_020_more"),
+                        ],
+                    ),
+                ],
+            )
+        ]
+        out = render_markdown("My Course", weeks, "en")
+        assert out.startswith("# My Course\n")
+        assert "## Week 1" in out
+        assert "| Day | Video (slides) | Topic |" in out
+        # Label only on the first deck row of the day.
+        assert "| Monday | Intro | intro |" in out
+        assert "|  | More | more |" in out
+
+    def test_markdown_german_headers(self):
+        weeks = [ScheduleWeek(number=1, title="Woche 1", days=[])]
+        out = render_markdown("Kurs", weeks, "de")
+        assert "_Keine Tage geplant._" in out
+
+    def test_markdown_empty_day_renders_placeholder(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="W1",
+                days=[ScheduleDay(weekday="mon", label="Monday", decks=[])],
+            )
+        ]
+        out = render_markdown("C", weeks, "en")
+        assert "| Monday | — | — |" in out
+
+    def test_markdown_escapes_pipe_in_title(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="W1",
+                days=[
+                    ScheduleDay(
+                        weekday="mon",
+                        label="Monday",
+                        decks=[ScheduleDeck("A | B", "t", "f")],
+                    )
+                ],
+            )
+        ]
+        out = render_markdown("C", weeks, "en")
+        assert r"A \| B" in out
+
+
+class TestRenderCsv:
+    def test_csv_header_and_rows(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="Week 1",
+                days=[
+                    ScheduleDay(
+                        weekday="mon",
+                        label="Monday",
+                        decks=[ScheduleDeck("Intro", "intro", "slides_010_intro")],
+                    )
+                ],
+            )
+        ]
+        out = render_csv(weeks)
+        lines = out.strip().splitlines()
+        assert lines[0] == "week,week_title,weekday,video_title,topic,deck_file"
+        assert lines[1] == "1,Week 1,mon,Intro,intro,slides_010_intro"
+
+    def test_csv_quotes_commas(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="Einführung, LLMs",
+                days=[
+                    ScheduleDay(
+                        weekday="mon",
+                        label="Montag",
+                        decks=[ScheduleDeck("A, B", "t", "f")],
+                    )
+                ],
+            )
+        ]
+        out = render_csv(weeks)
+        assert '"Einführung, LLMs"' in out
+        assert '"A, B"' in out
+
+
+class TestScheduleCli:
+    def test_markdown_default_german(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(SPEC_PATH)])
+        assert result.exit_code == 0, result.output
+        assert "# Mein Kurs" in result.output
+        assert "## Woche 1" in result.output
+        assert "| Montag | Folien von Test 1 | some_topic_from_test_1 |" in result.output
+        assert "| Dienstag — Recht |" in result.output
+
+    def test_markdown_english(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(SPEC_PATH), "-L", "en"])
+        assert result.exit_code == 0, result.output
+        assert "# My Course" in result.output
+        assert "| Monday | Some Topic from Test 1 | some_topic_from_test_1 |" in result.output
+
+    def test_csv_format(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(SPEC_PATH), "-f", "csv", "-L", "en"])
+        assert result.exit_code == 0, result.output
+        assert "week,week_title,weekday,video_title,topic,deck_file" in result.output
+        assert "1,Week 1,mon,Some Topic from Test 1,some_topic_from_test_1," in result.output
+        assert "2,Week 2,wed,Simple Notebook,simple_notebook," in result.output
+
+    def test_output_to_file(self, tmp_path):
+        out_file = tmp_path / "schedule.md"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(SPEC_PATH), "-o", str(out_file)])
+        assert result.exit_code == 0, result.output
+        assert out_file.exists()
+        assert "## Woche 1" in out_file.read_text(encoding="utf-8")
+
+    def test_spec_without_subsections_notes_empty(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["schedule", "tests/test-data/course-specs/test-spec-1.xml", "-L", "en"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "No days scheduled." in result.output
+
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "--help"])
+        assert result.exit_code == 0
+        assert "day-of-week" in result.output.lower() or "weekday" in result.output.lower()
+
+    def test_appears_in_main_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "schedule" in result.output

--- a/tests/core/test_subsection_spec.py
+++ b/tests/core/test_subsection_spec.py
@@ -1,0 +1,337 @@
+"""Parsing tests for the optional ``<subsection>`` day-of-week layer (issue #261)."""
+
+import io
+
+import pytest
+
+from clm.core.course_spec import (
+    WEEKDAY_ORDER,
+    CourseSpec,
+    CourseSpecError,
+    SubsectionSpec,
+)
+from clm.core.utils.text_utils import Text
+
+
+def _spec_xml(topics_block: str) -> str:
+    return f"""
+    <course>
+        <name><de>Mein Kurs</de><en>My Course</en></name>
+        <prog-lang>python</prog-lang>
+        <description><de>d</de><en>d</en></description>
+        <certificate><de>c</de><en>c</en></certificate>
+        <sections>
+            <section>
+                <name><de>Woche 1</de><en>Week 1</en></name>
+                <topics>
+{topics_block}
+                </topics>
+            </section>
+        </sections>
+    </course>
+    """
+
+
+def test_subsection_defaults():
+    sub = SubsectionSpec()
+    assert sub.topics == []
+    assert sub.weekday is None
+    assert sub.name is None
+    assert sub.enabled is True
+
+
+def test_subsection_topics_flatten_into_topics_list():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+            <topic>mon_b</topic>
+        </subsection>
+        <subsection weekday="tue">
+            <topic>tue_a</topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert [t.id for t in spec.sections[0].topics] == ["mon_a", "mon_b", "tue_a"]
+
+
+def test_bare_topics_and_subsections_interleave_in_document_order():
+    xml = _spec_xml(
+        """
+        <topic>bare_one</topic>
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+        </subsection>
+        <topic>bare_two</topic>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert [t.id for t in spec.sections[0].topics] == ["bare_one", "mon_a", "bare_two"]
+
+
+def test_byte_identical_flatten_matches_wrapper_removed_spec():
+    """A spec with subsections flattens to the same topic list as the
+    equivalent spec with the <subsection> wrappers removed."""
+    wrapped = _spec_xml(
+        """
+        <topic>bare_one</topic>
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+            <topic>mon_b</topic>
+        </subsection>
+        """
+    )
+    flat = _spec_xml(
+        """
+        <topic>bare_one</topic>
+        <topic>mon_a</topic>
+        <topic>mon_b</topic>
+        """
+    )
+    wrapped_spec = CourseSpec.from_file(io.StringIO(wrapped))
+    flat_spec = CourseSpec.from_file(io.StringIO(flat))
+    assert wrapped_spec.sections[0].topics == flat_spec.sections[0].topics
+
+
+def test_subsection_structure_retained():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+            <topic>mon_b</topic>
+        </subsection>
+        <subsection weekday="tue">
+            <name><de>Dienstag</de><en>Tuesday</en></name>
+            <topic>tue_a</topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    subs = spec.sections[0].subsections
+    assert len(subs) == 2
+    assert subs[0].weekday == "mon"
+    assert subs[0].name is None
+    assert [t.id for t in subs[0].topics] == ["mon_a", "mon_b"]
+    assert subs[1].weekday == "tue"
+    assert subs[1].name == Text(de="Dienstag", en="Tuesday")
+
+
+def test_subsection_topic_objects_shared_with_flat_list():
+    xml = _spec_xml('<subsection weekday="mon"><topic>mon_a</topic></subsection>')
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    section = spec.sections[0]
+    assert section.topics[0] is section.subsections[0].topics[0]
+
+
+def test_no_subsections_means_empty_list():
+    xml = _spec_xml("<topic>only_bare</topic>")
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.sections[0].subsections == []
+    assert [t.id for t in spec.sections[0].topics] == ["only_bare"]
+
+
+def test_disabled_subsection_dropped_by_default():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+        </subsection>
+        <subsection weekday="tue" enabled="false">
+            <topic>tue_disabled</topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    section = spec.sections[0]
+    assert [t.id for t in section.topics] == ["mon_a"]
+    assert [s.weekday for s in section.subsections] == ["mon"]
+
+
+def test_disabled_subsection_retained_with_keep_disabled():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+        </subsection>
+        <subsection weekday="tue" enabled="false">
+            <topic>tue_disabled</topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml), keep_disabled=True)
+    section = spec.sections[0]
+    # The disabled subsection is retained in `subsections` (so tooling can
+    # surface it), but its topics must NOT enter the flat build list — even
+    # under keep_disabled — to preserve build byte-identity (`--only-sections`
+    # parses with keep_disabled=True) and keep disabled decks out of releases.
+    assert [t.id for t in section.topics] == ["mon_a"]
+    assert [(s.weekday, s.enabled) for s in section.subsections] == [
+        ("mon", True),
+        ("tue", False),
+    ]
+
+
+def test_disabled_subsection_topics_never_in_build_list_under_keep_disabled():
+    """Regression for the byte-identity bug: the flattened build list
+    (section.topics / iter_topic_bindings) must exclude disabled-subsection
+    topics regardless of keep_disabled, since the build path has no per-topic
+    enabled gate."""
+    xml = _spec_xml(
+        """
+        <topic>bare</topic>
+        <subsection weekday="mon">
+            <topic>mon_a</topic>
+        </subsection>
+        <subsection weekday="tue" enabled="false">
+            <topic>tue_disabled</topic>
+        </subsection>
+        """
+    )
+    for keep_disabled in (False, True):
+        spec = CourseSpec.from_file(io.StringIO(xml), keep_disabled=keep_disabled)
+        build_topic_ids = [b.topic_id for b in spec.iter_topic_bindings()]
+        assert "tue_disabled" not in build_topic_ids
+        assert build_topic_ids == ["bare", "mon_a"]
+
+
+def test_nested_subsection_topics_are_ignored():
+    """Non-goal: recursive nesting is not supported (one level only). A
+    <subsection> inside a <subsection> contributes no topics."""
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic>outer_topic</topic>
+            <subsection weekday="tue">
+                <topic>inner_topic</topic>
+            </subsection>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    section = spec.sections[0]
+    assert [t.id for t in section.topics] == ["outer_topic"]
+    assert len(section.subsections) == 1
+    assert [t.id for t in section.subsections[0].topics] == ["outer_topic"]
+
+
+def test_empty_name_element_treated_as_absent():
+    """An all-empty <name> must read as 'no override' so the weekday fallback
+    still produces a label."""
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon"><name></name><topic>t</topic></subsection>
+        <subsection weekday="tue"><name><de></de><en></en></name><topic>u</topic></subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    subs = spec.sections[0].subsections
+    assert subs[0].name is None
+    assert subs[1].name is None
+
+
+def test_subsection_without_weekday_uses_name_only():
+    xml = _spec_xml(
+        """
+        <subsection>
+            <name><de>Thema A</de><en>Theme A</en></name>
+            <topic>topic_a</topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    sub = spec.sections[0].subsections[0]
+    assert sub.weekday is None
+    assert sub.name == Text(de="Thema A", en="Theme A")
+
+
+@pytest.mark.parametrize("weekday", list(WEEKDAY_ORDER))
+def test_all_weekday_tokens_accepted(weekday):
+    xml = _spec_xml(f'<subsection weekday="{weekday}"><topic>t</topic></subsection>')
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.sections[0].subsections[0].weekday == weekday
+
+
+def test_weekday_case_insensitive():
+    xml = _spec_xml('<subsection weekday="MON"><topic>t</topic></subsection>')
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.sections[0].subsections[0].weekday == "mon"
+
+
+def test_invalid_weekday_rejected():
+    xml = _spec_xml('<subsection weekday="monday"><topic>t</topic></subsection>')
+    with pytest.raises(CourseSpecError, match="Invalid weekday"):
+        CourseSpec.from_file(io.StringIO(xml))
+
+
+def test_invalid_subsection_enabled_value_rejected():
+    xml = _spec_xml('<subsection enabled="maybe"><topic>t</topic></subsection>')
+    with pytest.raises(CourseSpecError, match="enabled"):
+        CourseSpec.from_file(io.StringIO(xml))
+
+
+def test_subsection_topic_grammar_supports_attributes():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic author="Prof. X" prog-lang="cpp">styled_topic</topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    topic = spec.sections[0].subsections[0].topics[0]
+    assert topic.id == "styled_topic"
+    assert topic.author == "Prof. X"
+    assert topic.prog_lang == "cpp"
+
+
+def test_subsection_topic_with_include_child_captured():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic id="with_include">
+                <include source="examples/foo" as="foo"/>
+            </topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    topic = spec.sections[0].subsections[0].topics[0]
+    assert topic.id == "with_include"
+    assert len(topic.includes) == 1
+
+
+def test_dir_group_nested_in_subsection_is_collected():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon">
+            <topic id="with_dg">
+                <dir-group>
+                    <name>Code</name>
+                    <path>code/dg</path>
+                </dir-group>
+            </topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert [dg.path for dg in spec.dictionaries] == ["code/dg"]
+
+
+def test_dir_group_in_disabled_subsection_dropped_by_default():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon" enabled="false">
+            <topic id="with_dg">
+                <dir-group>
+                    <name>Code</name>
+                    <path>code/dg</path>
+                </dir-group>
+            </topic>
+        </subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.dictionaries == []
+    kept = CourseSpec.from_file(io.StringIO(xml), keep_disabled=True)
+    assert [dg.path for dg in kept.dictionaries] == ["code/dg"]

--- a/tests/slides/test_spec_validator_subsections.py
+++ b/tests/slides/test_spec_validator_subsections.py
@@ -1,0 +1,231 @@
+"""Validator tests for the ``<subsection>`` day-of-week checks (issue #261)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from clm.slides.spec_validator import validate_spec
+
+
+def _write_spec(tmp_path: Path, topics_xml: str) -> Path:
+    spec_file = tmp_path / "course-specs" / "test.xml"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(f"""\
+        <course>
+          <name><de>Test</de><en>Test</en></name>
+          <prog-lang>python</prog-lang>
+          <description><de></de><en></en></description>
+          <certificate><de></de><en></en></certificate>
+          <sections><section>
+            <name><de>Woche 1</de><en>Week 1</en></name>
+            <topics>
+{topics_xml}
+            </topics>
+          </section></sections>
+        </course>
+        """),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _make_topic(tmp_path: Path, module: str, topic: str, *, with_slide: bool = True) -> Path:
+    topic_dir = tmp_path / "slides" / module / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    if with_slide:
+        (topic_dir / "slides_intro.py").write_text("# %% [markdown]\n# Hi\n")
+    return topic_dir
+
+
+def _types(result) -> list[str]:
+    return [f.type for f in result.findings]
+
+
+class TestCleanSubsections:
+    def test_well_formed_subsections_have_no_subsection_findings(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_intro")
+        _make_topic(tmp_path, "module_100", "topic_020_more")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon"><topic>intro</topic></subsection>
+            <subsection weekday="tue"><topic>more</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        subsection_types = {
+            "duplicate_weekday",
+            "weekday_out_of_order",
+            "empty_day",
+            "unscheduled_topics",
+        }
+        assert not (set(_types(result)) & subsection_types)
+
+
+class TestDuplicateWeekday:
+    def test_duplicate_weekday_warns_once(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        _make_topic(tmp_path, "module_100", "topic_020_b")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon"><topic>a</topic></subsection>
+            <subsection weekday="mon"><topic>b</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        dups = [f for f in result.findings if f.type == "duplicate_weekday"]
+        assert len(dups) == 1
+        assert dups[0].severity == "warning"
+        assert "mon" in dups[0].message
+
+
+class TestWeekdayOrdering:
+    def test_out_of_order_weekday_warns(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        _make_topic(tmp_path, "module_100", "topic_020_b")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="tue"><topic>a</topic></subsection>
+            <subsection weekday="mon"><topic>b</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        order = [f for f in result.findings if f.type == "weekday_out_of_order"]
+        assert len(order) == 1
+        assert order[0].severity == "warning"
+
+    def test_out_of_order_repeated_weekday_reported_once(self, tmp_path):
+        """A weekday that is both out of order AND repeated emits a single
+        out-of-order finding, not one per occurrence."""
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        _make_topic(tmp_path, "module_100", "topic_020_b")
+        _make_topic(tmp_path, "module_100", "topic_030_c")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="tue"><topic>a</topic></subsection>
+            <subsection weekday="mon"><topic>b</topic></subsection>
+            <subsection weekday="mon"><topic>c</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        order = [f for f in result.findings if f.type == "weekday_out_of_order"]
+        assert len(order) == 1
+
+    def test_in_order_weekdays_do_not_warn(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        _make_topic(tmp_path, "module_100", "topic_020_b")
+        _make_topic(tmp_path, "module_100", "topic_030_c")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon"><topic>a</topic></subsection>
+            <subsection weekday="wed"><topic>b</topic></subsection>
+            <subsection weekday="fri"><topic>c</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "weekday_out_of_order" not in _types(result)
+
+
+class TestEmptyDay:
+    def test_subsection_without_topics_warns(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon"><topic>a</topic></subsection>
+            <subsection weekday="tue"><name><de>Leer</de><en>Empty</en></name></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        empty = [f for f in result.findings if f.type == "empty_day"]
+        assert len(empty) == 1
+        assert empty[0].severity == "warning"
+
+    def test_subsection_resolving_to_zero_decks_warns(self, tmp_path):
+        # Topic dir exists (resolves) but has no slide files.
+        _make_topic(tmp_path, "module_100", "topic_010_empty", with_slide=False)
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="mon"><topic>empty</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        empty = [f for f in result.findings if f.type == "empty_day"]
+        assert len(empty) == 1
+        assert "zero slide decks" in empty[0].message
+
+    def test_unresolved_topic_does_not_double_report_as_empty_day(self, tmp_path):
+        # No topic dir at all → unresolved_topic error, but NOT empty_day
+        # (the error already explains the emptiness).
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="mon"><topic>missing</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "unresolved_topic" in _types(result)
+        assert "empty_day" not in _types(result)
+
+
+class TestUnscheduledTopics:
+    def test_bare_topic_mixed_with_subsection_is_info(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_bare")
+        _make_topic(tmp_path, "module_100", "topic_020_mon")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <topic>bare</topic>
+            <subsection weekday="mon"><topic>mon</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        info = [f for f in result.findings if f.type == "unscheduled_topics"]
+        assert len(info) == 1
+        assert info[0].severity == "info"
+        assert "bare" in info[0].message
+
+    def test_bare_topic_sharing_id_with_subsection_topic_still_reported(self, tmp_path):
+        """Identity-keyed detection: a genuinely bare topic whose id also
+        appears inside a subsection is still flagged as unscheduled."""
+        _make_topic(tmp_path, "module_100", "topic_010_shared")
+        _make_topic(tmp_path, "module_100", "topic_020_mon")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <topic>shared</topic>
+            <subsection weekday="mon">
+                <topic>shared</topic>
+                <topic>mon</topic>
+            </subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        info = [f for f in result.findings if f.type == "unscheduled_topics"]
+        assert len(info) == 1
+        assert "shared" in info[0].message
+
+    def test_no_unscheduled_when_all_topics_in_subsections(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_mon")
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="mon"><topic>mon</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "unscheduled_topics" not in _types(result)
+
+    def test_no_subsection_checks_when_no_subsections(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(tmp_path, "<topic>a</topic>")
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "unscheduled_topics" not in _types(result)
+
+
+class TestDisabledSubsectionNotChecked:
+    def test_disabled_subsection_excluded_from_checks_by_default(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        # A disabled subsection with a duplicate weekday should be invisible
+        # to the duplicate/order checks by default (it is dropped at parse).
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon"><topic>a</topic></subsection>
+            <subsection weekday="mon" enabled="false"><topic>a</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "duplicate_weekday" not in _types(result)

--- a/tests/test-data/course-specs/subsection-disabled-spec.xml
+++ b/tests/test-data/course-specs/subsection-disabled-spec.xml
@@ -1,0 +1,19 @@
+<course>
+    <name><de>Mein Kurs</de><en>My Course</en></name>
+    <prog-lang>python</prog-lang>
+    <description><de>Ein Kurs</de><en>A course</en></description>
+    <certificate><de>...</de><en>...</en></certificate>
+    <sections>
+        <section>
+            <name><de>Woche 1</de><en>Week 1</en></name>
+            <topics>
+                <subsection weekday="mon">
+                    <topic>some_topic_from_test_1</topic>
+                </subsection>
+                <subsection weekday="tue" enabled="false">
+                    <topic>punctuation_test</topic>
+                </subsection>
+            </topics>
+        </section>
+    </sections>
+</course>

--- a/tests/test-data/course-specs/subsection-spec.xml
+++ b/tests/test-data/course-specs/subsection-spec.xml
@@ -1,0 +1,45 @@
+<course>
+    <name>
+        <de>Mein Kurs</de>
+        <en>My Course</en>
+    </name>
+    <prog-lang>python</prog-lang>
+    <description>
+        <de>Ein Kurs über ein Thema</de>
+        <en>A course about a topic</en>
+    </description>
+    <certificate>
+        <de>...</de>
+        <en>...</en>
+    </certificate>
+    <sections>
+        <section>
+            <name>
+                <de>Woche 1</de>
+                <en>Week 1</en>
+            </name>
+            <topics>
+                <subsection weekday="mon">
+                    <topic>some_topic_from_test_1</topic>
+                    <topic>a_topic_from_test_2</topic>
+                </subsection>
+                <subsection weekday="tue">
+                    <name><de>Dienstag — Recht</de><en>Tuesday — Law</en></name>
+                    <topic>punctuation_test</topic>
+                </subsection>
+            </topics>
+        </section>
+        <section>
+            <name>
+                <de>Woche 2</de>
+                <en>Week 2</en>
+            </name>
+            <topics>
+                <topic>another_topic_from_test_1</topic>
+                <subsection weekday="wed">
+                    <topic>simple_notebook</topic>
+                </subsection>
+            </topics>
+        </section>
+    </sections>
+</course>


### PR DESCRIPTION
## Summary

Implements issue #261: day-of-week scheduling via an optional `<subsection>` spec layer plus a new `clm schedule` export.

A `<section>`'s `<topics>` may now group `<topic>`s into optional `<subsection weekday="mon">…</subsection>` elements (`<section>` = week, `<subsection>` = day), with an optional `<name>` (de/en) label override and `enabled="false"`. Bare `<topic>`s, `<subsection>`s, or a mix may appear, in any order.

The layer is **purely additive**: `clm build` flattens enabled subsections into the existing flat topic list, so a spec with subsections builds **byte-identically** to the same spec with the wrappers removed — no effect on output directories or topic→directory resolution. The grouping is retained only for outline/schedule/validation.

Closes #261.

## What's included

- **`<subsection>` spec layer** (`core/course_spec.py`): `SubsectionSpec`, `SectionSpec.subsections`, a closed `mon`–`sun` weekday enum, document-order parsing of interleaved bare topics and subsections, dir-groups nested in subsections, one level only (no recursive nesting).
- **`clm schedule`** (new top-level command): the certification day-listing in Markdown (one table per week: weekday / video / topic) or CSV (one row per deck), single-language `--lang de|en` (default `de`), `-o`, `--data-dir`.
- **`clm outline`**: renders subsections indented under their section (bold weekday/label + nested decks, bare topics first); `--include-disabled` surfaces disabled subsections; JSON gains an additive `subsections` array.
- **`clm validate`**: four advisory subsection checks — duplicate weekday, out-of-order weekdays, empty day, and (info) bare topics mixed with subsections.
- **Docs**: `spec-files`, `commands`, and `migration` info topics + CHANGELOG.

## Disabled-subsection build semantics

A disabled subsection is dropped entirely from the build — its topics never enter the flat build list, **regardless of `keep_disabled`**. Disabled *sections* are kept out of the build by section selection, but a disabled subsection nested in an enabled, selected section has no such guard, and `clm build --only-sections` parses with `keep_disabled=True`. The gate therefore lives at parse time, which keeps `--only-sections` byte-identical and keeps disabled decks out of the `clm release` ledger. With `keep_disabled=True` the wrapper is still retained in `subsections` so `clm outline --include-disabled` can surface it.

## Example

```xml
<section module="module_550_ml_azav">
    <name><de>Woche 01: …</de><en>Week 01: …</en></name>
    <topics>
        <subsection weekday="mon">
            <topic>introduction_ml_course_azav</topic>
            <topic>what_are_llms</topic>
        </subsection>
        <subsection weekday="tue">
            <name><de>Dienstag — Recht</de><en>Tuesday — Law</en></name>
            <topic>llm_ethics_azav</topic>
        </subsection>
    </topics>
</section>
```

```
clm schedule course.xml            # German Markdown to stdout
clm schedule course.xml -f csv -L en
```

## Testing

- Full fast suite: **7137 passed, 0 failures**; ruff + mypy clean.
- 80+ new tests across `tests/core/test_subsection_spec.py`, `tests/slides/test_spec_validator_subsections.py`, `tests/cli/test_schedule.py`, `tests/cli/test_outline_subsections.py`, plus two committed spec fixtures.
- A 6-dimension adversarial review (each finding independently verified) ran over the change; it caught one real high-severity byte-identity bug (the disabled-subsection build gate above) and eight low-severity issues — all fixed and covered by regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
