### PR TITLE
Bump version: 1.9.0 → 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Notebook-worker output is now written with LF newlines on every platform**
+  (PR #260). All notebook-worker outputs (executed `.ipynb`, jupytext `.py`, and
+  the HTML body) go through one `open(..., "w")` write that, lacking a `newline=`
+  argument, let Python's universal-newline translation rewrite every `\n` to
+  `os.linesep` — CRLF on Windows Direct workers, LF on Docker/Linux. So a Windows
+  `clm build` produced CRLF working-tree files, yielding trailing-`^M` diffs and
+  "CRLF will be replaced by LF" warnings in course repos that normalize to
+  `eol=lf`. The write now pins `newline="\n"`, matching the convention used
+  elsewhere in the codebase, so output is byte-identical regardless of host OS.
 - **Pool-shutdown orphan jobs are no longer mis-blamed on the user** (PR #259).
   A worker-pool shutdown race could leave a valid job (e.g. a drawio diagram)
   stamped with the orphan sentinel; the drawio categorizer matched none of its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-06-07
+
 ### Added
 
 - **Day-of-week scheduling: `<subsection>` spec layer + `clm schedule`**
@@ -48,6 +50,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   so the builds become byte-identical and the code is finally executed as code
   rather than rendered as markdown text. It runs first among the normalize passes,
   is idempotent, and is a no-op on a conforming deck.
+- **Jinja `{% include %}` in slide source now resolves against the topic's own
+  siblings** (PR #258). A deck that does `{% include "add.h" %}` to show a file
+  sitting next to it previously failed with `TemplateNotFound`, because the Jinja
+  environment only loaded the bundled `templates_<prog_lang>/` package. The loader
+  is now a `ChoiceLoader`: the bundled package is tried **first** (so `macros.j2`
+  and friends can never be shadowed by a same-named sibling), then the notebook's
+  topic siblings as a fallback — a `FileSystemLoader` on `source_dir` in Docker
+  source-mount mode and/or a `DictLoader` decoded from `payload.other_files` in
+  direct mode (non-UTF-8 siblings are skipped). When a deck has no siblings the
+  plain package loader is used unchanged, so existing courses are unaffected. See
+  the new "Jinja `{% include %}` in slide source" section under `clm build` in
+  `clm info commands`.
 
 ### Changed
 
@@ -71,6 +85,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   tag on the server after the CI-green gate; dropping the local tag removes a
   must-never-push footgun and the post-release tag-reconciliation step. Release
   procedure docs updated accordingly.
+
+### Fixed
+
+- **Pool-shutdown orphan jobs are no longer mis-blamed on the user** (PR #259).
+  A worker-pool shutdown race could leave a valid job (e.g. a drawio diagram)
+  stamped with the orphan sentinel; the drawio categorizer matched none of its
+  specific patterns and fell through to `error_type="user"` ("Check your DrawIO
+  diagram for errors"). Because user errors are persisted to `processing_issues`
+  (and the content hash never changes), the stale error was then **replayed on
+  every subsequent cached build**. `categorize_job_error` now checks for the
+  orphan sentinel *before* the per-job-type dispatch and returns an
+  `infrastructure` / `orphaned_job` error with re-run guidance — infrastructure
+  errors are not cached, so the transient failure stays out of the replay store
+  and the false diagram-blame disappears. The central placement also covers
+  notebook and plantuml orphans from the same race.
 
 ## [1.9.0] - 2026-06-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Draw.io diagrams) into multiple output formats (HTML slides, executed
 notebooks, extracted code) for multiple audiences (students, solutions,
 speaker notes).
 
-**Version**: 1.9.0 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.9.1 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hoelzl/clm/actions/workflows/ci.yml/badge.svg)](https://github.com/hoelzl/clm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hoelzl/clm/branch/master/graph/badge.svg)](https://codecov.io/gh/hoelzl/clm)
 
-**Version**: 1.9.0 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.9.1 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 CLM is a course content processing system that converts educational materials (Jupyter notebooks, PlantUML diagrams, Draw.io diagrams) into multiple output formats.
 

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -50,7 +50,7 @@ On Windows (PowerShell):
 ### PlantUML Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.9.0`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.9.1`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -73,7 +73,7 @@ docker build -f docker/plantuml/Dockerfile -t docker.io/mhoelzl/clm-plantuml-con
 ### Draw.io Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-drawio-converter:1.9.0`
+- `docker.io/mhoelzl/clm-drawio-converter:1.9.1`
 - `docker.io/mhoelzl/clm-drawio-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -107,7 +107,7 @@ The notebook processor has **two variants** to support different use cases:
 **Best for:** Courses without deep learning, or running on Apple Silicon Macs.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.9.0-lite`
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.1-lite`
 - `docker.io/mhoelzl/clm-notebook-processor:lite`
 
 **Base Image:** `python:3.11-slim` (multi-arch: amd64, arm64)
@@ -139,8 +139,8 @@ docker build -f docker/notebook/Dockerfile \
 **Best for:** Deep learning courses, CUDA-accelerated processing.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.9.0` (default)
-- `docker.io/mhoelzl/clm-notebook-processor:1.9.0-full`
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.1` (default)
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.1-full`
 - `docker.io/mhoelzl/clm-notebook-processor:latest`
 - `docker.io/mhoelzl/clm-notebook-processor:full`
 
@@ -172,7 +172,7 @@ docker build -f docker/notebook/Dockerfile -t docker.io/mhoelzl/clm-notebook-pro
 - .NET SDK 10.0 (C# and F# kernels)
 - Deno (TypeScript/JavaScript kernel)
 - Java JDK (Java kernel)
-- IJava 1.9.0 (Java Jupyter kernel)
+- IJava 1.9.1 (Java Jupyter kernel)
 - micromamba + xeus-cpp (C++ kernel)
 
 **Jupyter Kernels:**
@@ -223,12 +223,12 @@ The build scripts automatically set these arguments.
 All images use the Hub namespace (`docker.io/mhoelzl/clm-*`) for consistency:
 
 **PlantUML/DrawIO:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.9.0`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.9.1`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Notebook (with variants):**
-- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.9.0`, `:full`, `:1.9.0-full`
-- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.9.0-lite`
+- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.9.1`, `:full`, `:1.9.1-full`
+- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.9.1-lite`
 
 ### BuildKit Cache Mounts
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,6 +1,6 @@
 # CLM Architecture
 
-This document describes the current architecture of the CLM system (v1.9.0).
+This document describes the current architecture of the CLM system (v1.9.1).
 
 ## Overview
 
@@ -42,7 +42,7 @@ CLM is a course content processing system that converts educational materials (J
                          │
 ┌────────────────────────▼──────────────────────────────────┐
 │          clm.workers (Worker Implementations)              │
-│                                (v1.9.0)             │
+│                                (v1.9.1)             │
 │  ├── notebook/ (NotebookWorker, templates, processors)    │
 │  ├── plantuml/ (PlantUmlWorker, converter)                │
 │  └── drawio/ (DrawioWorker, converter)                    │
@@ -211,7 +211,7 @@ class Worker(ABC):
 
 ### Layer 3: Workers (Worker Implementations)
 
-**Purpose**: Concrete worker implementations for different file types (v1.9.0)
+**Purpose**: Concrete worker implementations for different file types (v1.9.1)
 
 Workers are now integrated into the main `clm` package under `clm.workers/`. Previously they were separate packages in the `services/` directory.
 
@@ -566,7 +566,7 @@ CLM has evolved significantly:
 - No message broker required
 - Reduced from 8 Docker services to 3
 
-**v0.6.2 → v1.9.0** (2025): Integrated workers
+**v0.6.2 → v1.9.1** (2025): Integrated workers
 - Workers integrated into main package (`clm.workers`)
 - Optional dependencies for each worker
 - Four-layer architecture (core, infrastructure, workers, cli)
@@ -1190,4 +1190,4 @@ Potential improvements (not currently planned):
 ---
 
 **Last Updated**: 2026-02-13
-**Version**: 1.9.0
+**Version**: 1.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-academy-lecture-manager"
-version = "1.9.0"
+version = "1.9.1"
 description = "Coding-Academy Lecture Manager - A course content processing system"
 authors = [
     {name = "Dr. Matthias Hölzl", email = "tc@xantira.com"},
@@ -404,7 +404,7 @@ ignore = [
 known-first-party = ["clm"]
 
 [tool.bumpversion]
-current_version = "1.9.0"
+current_version = "1.9.1"
 commit = true
 # No local tag: the Release workflow (.github/workflows/release.yml) creates the
 # authoritative vX.Y.Z tag on the server *after* the CI-green gate, so a red

--- a/src/clm/__version__.py
+++ b/src/clm/__version__.py
@@ -1,3 +1,3 @@
 """Version information for CLM."""
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1009,7 +1009,7 @@ def _is_cpp_image_available() -> bool:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.9.0-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.9.1-full",
         ]:
             try:
                 client.images.get(tag)
@@ -1030,7 +1030,7 @@ def _get_full_image_name() -> str | None:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.9.0-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.9.1-full",
         ]:
             try:
                 client.images.get(tag)

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "coding-academy-lecture-manager"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Cuts the **1.9.1** patch release. All changes since v1.9.0 are additive features and fixes (no breaking changes).

## CHANGELOG `[1.9.1]`

### Added
- `<subsection weekday=…>` spec layer + `clm schedule` day-of-week export (#261)
- `clm slides assign-ids --accept-code-derived` opt-in slug fallback (#251)
- `clm slides normalize` `preamble_code` operation (#253)
- Jinja `{% include %}` resolves against topic siblings (#258)

### Changed
- `clm validate` / `clm slides split` warn about preamble code (#253)
- CI/release workflows on Node.js 24 actions + grouped Dependabot (#254)
- `bump-my-version` no longer creates a local `vX.Y.Z` tag

### Fixed
- Notebook-worker output written with LF newlines on every platform (#260)
- Pool-shutdown orphan jobs classified as infrastructure, not user (#259)

## Release mechanics
- Docs/CHANGELOG updated first, then `bump-my-version bump patch` (1.9.0 → 1.9.1 across 8 files).
- Local gate green: `pytest -m "not docker"` → **7289 passed, 13 skipped, 1 xfailed**.
- **Merge with a merge commit** (not squash/rebase) so the `Bump version …` commit lands on `master` and triggers `release.yml`, which gates on CI green, then publishes to PyPI (OIDC) and creates the GitHub Release from the `## [1.9.1]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
