### PR TITLE
feat(slides translate): glossary guidance + dedicated title prompt

### DIFF
--- a/src/clm/cli/commands/slides_translate.py
+++ b/src/clm/cli/commands/slides_translate.py
@@ -69,17 +69,52 @@ def _make_translator(
     translation_model: str,
     translation_cache: TranslationCache | None,
     prog_lang: str = "python",
+    guidance: str = "",
 ) -> SlideTranslator:
     """The OpenRouter slide translator, cache-wrapped unless ``--no-cache``.
 
     Factored out (and module-level) so tests can monkeypatch it with a static
     translator, exactly as the sync CLI tests patch ``OpenRouterSlideTranslator``.
-    ``prog_lang`` makes the prompt name the deck's language + comment token.
+    ``prog_lang`` makes the prompt name the deck's language + comment token;
+    ``guidance`` carries optional target-language conventions (style + glossary)
+    appended to the system prompt and folded into the cache key.
     """
-    inner = OpenRouterSlideTranslator(model=translation_model, prog_lang=prog_lang)
+    inner = OpenRouterSlideTranslator(
+        model=translation_model, prog_lang=prog_lang, guidance=guidance
+    )
     if translation_cache is None:
         return inner
     return CachingSlideTranslator(inner=inner, cache=translation_cache)
+
+
+# Auto-discovered glossary filename, parameterized by target language, e.g.
+# ``clm-glossary.de.md``. The first such file found walking up from the deck's
+# directory supplies translation conventions for that target language.
+_GLOSSARY_STEM = "clm-glossary"
+
+
+def _discover_glossary(start: Path, target_lang: str) -> Path | None:
+    """First ``clm-glossary.<target_lang>.md`` found walking up from ``start``.
+
+    Mirrors the ``.env`` auto-load: the course repo keeps the (domain-specific,
+    human-edited) glossary near its slides and clm finds it without a flag.
+    """
+    name = f"{_GLOSSARY_STEM}.{target_lang}.md"
+    for directory in [start, *start.parents]:
+        candidate = directory / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _resolve_guidance(
+    glossary: Path | None, source_dir: Path, target_lang: str
+) -> tuple[str, Path | None]:
+    """Return ``(guidance_text, path)``: explicit ``--glossary`` wins, else auto-discover."""
+    path = glossary if glossary is not None else _discover_glossary(source_dir, target_lang)
+    if path is None:
+        return "", None
+    return path.read_text(encoding="utf-8").strip(), path
 
 
 @click.command("translate")
@@ -144,6 +179,16 @@ def _make_translator(
     ),
 )
 @click.option(
+    "--glossary",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Translation conventions file (Markdown: a style note + term glossary) "
+        "appended to the translation prompt. Default: auto-discover "
+        f"'{_GLOSSARY_STEM}.<target-lang>.md' walking up from SOURCE's directory."
+    ),
+)
+@click.option(
     "--no-cache", is_flag=True, help="Do not read or write the translation/watermark caches."
 )
 @click.option(
@@ -166,6 +211,7 @@ def slides_translate_cmd(
     provider: str,
     llm_model: str | None,
     cache_dir: Path | None,
+    glossary: Path | None,
     no_cache: bool,
     no_env_file: bool,
     as_json: bool,
@@ -226,10 +272,16 @@ def slides_translate_cmd(
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
         translation_cache = TranslationCache(cache_root / CACHE_DB_NAME)
 
+    # Resolve translation conventions (style + glossary) for the target language:
+    # an explicit --glossary, else an auto-discovered clm-glossary.<lang>.md.
+    guidance, glossary_path = _resolve_guidance(glossary, source.parent, paths.target_lang)
+    if glossary_path is not None and not as_json:
+        click.echo(f"Using glossary: {glossary_path}", err=True)
+
     result: BootstrapResult
     try:
         translator = _make_translator(
-            translation_model, translation_cache, path_to_prog_lang(source)
+            translation_model, translation_cache, path_to_prog_lang(source), guidance
         )
         # A judge is only consulted on the delegated-sync path (twin present).
         judge = _resolve_judge(provider, llm_model, None, None) if will_sync else None

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -41,6 +41,11 @@ __all__ = [
 # Claude Sonnet via OpenRouter — the voiceover propagate path's precedent.
 DEFAULT_TRANSLATION_MODEL = "anthropic/claude-sonnet-4-6"
 
+# Base cache/prompt version. A guidance glossary folds a fingerprint onto this
+# (see ``OpenRouterSlideTranslator.__post_init__``); the bare value is kept when
+# no glossary is supplied so the existing Python cache stays valid.
+_BASE_PROMPT_VERSION = "translate-v1"
+
 
 class TranslationError(Exception):
     """A new-slide translation could not be produced."""
@@ -113,11 +118,30 @@ class OpenRouterSlideTranslator:
     api_key: str | None = None
     temperature: float = 0.2
     max_tokens: int = 4096
-    prompt_version: str = "translate-v1"
     # The deck's programming language (e.g. "python", "csharp", "cpp"). Drives the
     # comment prefix and language name named in the prompt, so a //-deck is told to
     # preserve "// " prefixes and a C# code cell is translated as C#, not Python.
     prog_lang: str = "python"
+    # Optional target-language conventions (a style note + glossary), rendered as
+    # prompt text by the caller and appended verbatim to the system prompt. clm
+    # stays domain-agnostic: it knows nothing of "Sie" or "Dictionary" — the course
+    # repo supplies the text (see ``clm slides translate --glossary``). When set, it
+    # is folded into ``prompt_version`` so a different glossary keys a different cache
+    # entry and editing the glossary invalidates by cache miss.
+    guidance: str = ""
+    # Derived in ``__post_init__`` from the base version + a guidance fingerprint.
+    # ``init=False`` so it is never passed in; the cache wrapper reads it.
+    prompt_version: str = field(init=False, default=_BASE_PROMPT_VERSION)
+
+    def __post_init__(self) -> None:
+        guidance = self.guidance.strip()
+        if guidance:
+            fp = hashlib.sha256(guidance.encode("utf-8")).hexdigest()[:12]
+            self.prompt_version = f"{_BASE_PROMPT_VERSION}:g{fp}"
+        else:
+            # No guidance → byte-identical to the original v1 prompt, so keep the
+            # v1 key: no flag-day invalidation for callers that pass no glossary.
+            self.prompt_version = _BASE_PROMPT_VERSION
 
     def _client(self):  # pragma: no cover - thin network adapter
         # Shared with the edit judge so key/base resolution stays in one place.
@@ -141,6 +165,11 @@ class OpenRouterSlideTranslator:
             comment_prefix=comment_prefix,
             prog_lang_name=prog_lang_name,
         )
+        # Append the caller-supplied conventions AFTER .format() so any braces in
+        # the glossary (JSON, f-strings, code) are never read as format fields.
+        guidance = self.guidance.strip()
+        if guidance:
+            system = f"{system}\n\n{guidance}"
 
         def _create():
             return self._client().chat.completions.create(
@@ -199,9 +228,33 @@ _CODE_SYSTEM_PROMPT = (
 )
 
 
+# The deck title is the bare string argument of the ``header_<lang>("…")`` macro —
+# NOT a percent-format cell body. Running it through ``_SYSTEM_PROMPT`` (which
+# announces "every line is prefixed with '# '") makes the model hallucinate a
+# leading "# " and treat the title as a directive to preserve, so it comes back
+# untranslated and prefixed (e.g. ``header_de("# Your First Web Service")``). A
+# dedicated title prompt fixes both: plain phrase in, plain translated phrase out.
+_TITLE_SYSTEM_PROMPT = (
+    "You translate a single slide-deck title from {source_lang} to {target_lang} for a "
+    "{prog_lang_name} programming course. Return ONLY the translated title as a short "
+    "plain phrase: no Markdown, no leading '{comment_prefix}' or other comment prefix, "
+    "no surrounding quotes, no trailing punctuation, and no commentary. Keep code "
+    "identifiers, library names, and product names unchanged."
+)
+
+
 def _system_prompt_for(role: str) -> str:
-    """Pick the system prompt for a cell ``role`` (code cells are not Markdown)."""
-    return _CODE_SYSTEM_PROMPT if role == "code" else _SYSTEM_PROMPT
+    """Pick the system prompt for a cell ``role``.
+
+    Code cells get the identifier-preserving code prompt; the ``"title"`` pseudo-role
+    (the ``header_<lang>`` macro argument) gets the bare-phrase title prompt; all other
+    roles use the Markdown prose prompt.
+    """
+    if role == "code":
+        return _CODE_SYSTEM_PROMPT
+    if role == "title":
+        return _TITLE_SYSTEM_PROMPT
+    return _SYSTEM_PROMPT
 
 
 def _prog_lang_descriptors(prog_lang: str) -> tuple[str, str]:

--- a/src/clm/slides/translate_deck.py
+++ b/src/clm/slides/translate_deck.py
@@ -246,11 +246,14 @@ def _rewrite_header_macro(
     translated_title = title
     if title.strip():
         try:
+            # role="title": a dedicated bare-phrase prompt. Using "markdown" here
+            # makes the model add a stray "# " and skip translation (the title is
+            # not a percent-format cell body). See sync_translate._TITLE_SYSTEM_PROMPT.
             translated_title = translator.translate(
                 source_body=title,
                 source_lang=source_lang,
                 target_lang=target_lang,
-                role="markdown",
+                role="title",
             ).strip()
         except TranslationError as exc:
             raise TranslateDeckError(

--- a/tests/slides/test_sync_translate_prompts.py
+++ b/tests/slides/test_sync_translate_prompts.py
@@ -12,7 +12,10 @@ import pytest
 from clm.slides.sync_translate import (
     _CODE_SYSTEM_PROMPT,
     _SYSTEM_PROMPT,
+    _TITLE_SYSTEM_PROMPT,
+    OpenRouterSlideTranslator,
     _prog_lang_descriptors,
+    _system_prompt_for,
 )
 
 
@@ -73,3 +76,46 @@ def test_python_prompt_unchanged() -> None:
         prog_lang_name=name,
     )
     assert "'# '" in prompt  # regression: Python decks still told the # prefix
+
+
+# --- title role (the header_<lang> macro argument) -------------------------
+
+
+def test_title_role_selects_title_prompt() -> None:
+    assert _system_prompt_for("title") is _TITLE_SYSTEM_PROMPT
+    assert _system_prompt_for("code") is _CODE_SYSTEM_PROMPT
+    assert _system_prompt_for("slide") is _SYSTEM_PROMPT
+
+
+def test_title_prompt_forbids_prefix_and_quotes() -> None:
+    prompt = _TITLE_SYSTEM_PROMPT.format(
+        source_lang="English",
+        target_lang="German",
+        role="title",
+        comment_prefix="# ",
+        prog_lang_name="Python",
+    )
+    assert "no Markdown" in prompt
+    assert "no surrounding quotes" in prompt
+    assert "comment prefix" in prompt  # the leading-'# ' leak guard
+
+
+# --- guidance (glossary) folds into the cache key --------------------------
+
+
+def test_guidance_folds_into_prompt_version() -> None:
+    base = OpenRouterSlideTranslator()
+    assert base.prompt_version == "translate-v1"  # no glossary → v1 key, no flag-day
+
+    g = OpenRouterSlideTranslator(guidance="Address the reader with 'Sie'.")
+    assert g.prompt_version.startswith("translate-v1:g")
+    assert g.prompt_version != base.prompt_version
+
+    # Same guidance → same version (a stable, reusable cache key).
+    assert OpenRouterSlideTranslator(guidance="Address the reader with 'Sie'.").prompt_version == (
+        g.prompt_version
+    )
+    # Different guidance → different version (editing the glossary invalidates).
+    assert OpenRouterSlideTranslator(guidance="Use 'du'.").prompt_version != g.prompt_version
+    # Whitespace-only guidance is treated as none.
+    assert OpenRouterSlideTranslator(guidance="   \n").prompt_version == "translate-v1"

--- a/tests/slides/test_translate_deck.py
+++ b/tests/slides/test_translate_deck.py
@@ -98,6 +98,25 @@ def _reverse_translator(de_text: str, en_text: str) -> StaticSlideTranslator:
     return StaticSlideTranslator(mapping=mapping)
 
 
+class _RoleRecorder:
+    """A translator that records each ``(source_body, role)`` and echoes the body.
+
+    Echoing the source body unchanged keeps the generated pair structurally valid
+    (it round-trips), so the engine runs to completion and we can inspect which
+    ``role`` each cell — especially the header title — was translated under.
+    """
+
+    prompt_version = "rec"
+    prog_lang = "python"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.calls.append((source_body, role))
+        return source_body
+
+
 def _split(text: str) -> tuple[str, str]:
     de, en = split_text(text)
     # Sanity: the fixture itself round-trips, so any later inequality is the
@@ -219,6 +238,19 @@ class TestTranslateDeckText:
         _assert_valid_pair(de, result.target_text)
         assert result.header_translated is False
         assert "Alone" in result.target_text
+
+    def test_header_title_uses_title_role(self):
+        # The header title must be translated via the dedicated "title" role, not
+        # the markdown prose role — otherwise the model adds a stray "# " prefix
+        # and leaves the title untranslated. See sync_translate._TITLE_SYSTEM_PROMPT.
+        text = HEADER_PREAMBLE + _slide_pair("intro", "Einleitung", "Introduction")
+        de, _en = _split(text)
+        rec = _RoleRecorder()
+        translate_deck_text(de, source_lang="de", target_lang="en", translator=rec)
+        roles_by_body = dict(rec.calls)
+        assert roles_by_body["Titel DE"] == "title"
+        # A slide body still goes through a prose role, never "title".
+        assert all(role != "title" for body, role in rec.calls if body != "Titel DE")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an optional **translation glossary** to `clm slides translate` / `bootstrap`
and fixes a **deck-title translation bug**. Motivated by the first production use of
the cold-start translation path (a German bootstrap of ~18 Python-course decks),
where two systematic quality problems surfaced.

### 1. Glossary guidance
`OpenRouterSlideTranslator` gains a `guidance` field whose text is appended to the
translation system prompt (after `.format()`, so braces in the glossary are safe).
The CLI resolves it from `--glossary PATH` or by auto-discovering
`clm-glossary.<target-lang>.md` walking up from the deck (like `.env`). clm stays
domain-agnostic — the course repo owns the conventions (register, term
keep/translate rules, orthography). The guidance text is fingerprinted into
`prompt_version`, so a different glossary keys a different cache entry and editing
the glossary invalidates by cache miss; decks translated **without** a glossary keep
the bare `translate-v1` key (no flag-day invalidation).

### 2. Title-role fix
The `header_<lang>("...")` title was translated through the **markdown prose** prompt,
which announces "every line is prefixed with `# `". The model therefore added a stray
`# ` and left the title in the source language, e.g. `header_de("# Your First Web
Service")`. A dedicated `"title"` role/prompt translates the bare phrase and forbids
any prefix or quotes.

## Tests
- title-role prompt selection + content (no-prefix/no-quotes guard)
- guidance folds into `prompt_version` (stable per text, distinct per text, absent when empty)
- deck engine routes the header title through `role="title"`
- All 78 `-k translate` tests pass; ruff + mypy clean.

## Notes
- Scoped to the cold-start `translate`/`bootstrap` path; wiring the glossary into the
  incremental `sync` new-slide path is a sensible follow-up.
- A previous-cells-context + provider-prompt-caching idea was considered for cross-cell
  consistency but proved unnecessary — the glossary + register instruction achieved it.
