### PR TITLE
Release 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-06-08
+
+### Added
+
+- **`clm slides translate` / `bootstrap` glossary guidance (`--glossary`)**
+  (PR #264). The translator now accepts an optional translation conventions file
+  — a Markdown style note plus a term glossary — that is appended to the
+  translation system prompt, so a course can pin a formal register and keep or
+  translate technical terms consistently across a whole deck. Supply it with
+  `--glossary PATH`, or let the command auto-discover `clm-glossary.<target-lang>.md`
+  by walking up from the deck's directory (the same walk-up used for `.env`). The
+  guidance text is folded into the translation cache key (a fingerprint on the
+  `translate-v1` prompt version): a different glossary keys a different cache
+  entry and editing the glossary invalidates affected entries by cache miss,
+  while decks translated without a glossary keep the bare `v1` key (no flag-day
+  invalidation). See `clm info commands`.
+
+### Fixed
+
+- **Deck titles are now translated correctly** (PR #264). The
+  `header_<lang>("…")` deck title was being translated through the markdown-prose
+  prompt, which announces that every line is `#`-prefixed — so the model added a
+  stray `# ` and left the title itself untranslated (e.g.
+  `header_de("# Your First Web Service")`). A dedicated `title` translation role
+  now translates the bare title phrase and forbids any prefix or surrounding
+  quotes.
+
 ## [1.9.1] - 2026-06-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Draw.io diagrams) into multiple output formats (HTML slides, executed
 notebooks, extracted code) for multiple audiences (students, solutions,
 speaker notes).
 
-**Version**: 1.9.1 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.9.2 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hoelzl/clm/actions/workflows/ci.yml/badge.svg)](https://github.com/hoelzl/clm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hoelzl/clm/branch/master/graph/badge.svg)](https://codecov.io/gh/hoelzl/clm)
 
-**Version**: 1.9.1 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
+**Version**: 1.9.2 | **License**: MIT | **Python**: 3.11, 3.12, 3.13, 3.14
 
 CLM is a course content processing system that converts educational materials (Jupyter notebooks, PlantUML diagrams, Draw.io diagrams) into multiple output formats.
 

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -50,7 +50,7 @@ On Windows (PowerShell):
 ### PlantUML Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.9.1`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.9.2`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -73,7 +73,7 @@ docker build -f docker/plantuml/Dockerfile -t docker.io/mhoelzl/clm-plantuml-con
 ### Draw.io Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-drawio-converter:1.9.1`
+- `docker.io/mhoelzl/clm-drawio-converter:1.9.2`
 - `docker.io/mhoelzl/clm-drawio-converter:latest`
 
 **Base Image:** `python:3.11-slim`
@@ -107,7 +107,7 @@ The notebook processor has **two variants** to support different use cases:
 **Best for:** Courses without deep learning, or running on Apple Silicon Macs.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.9.1-lite`
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.2-lite`
 - `docker.io/mhoelzl/clm-notebook-processor:lite`
 
 **Base Image:** `python:3.11-slim` (multi-arch: amd64, arm64)
@@ -139,8 +139,8 @@ docker build -f docker/notebook/Dockerfile \
 **Best for:** Deep learning courses, CUDA-accelerated processing.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.9.1` (default)
-- `docker.io/mhoelzl/clm-notebook-processor:1.9.1-full`
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.2` (default)
+- `docker.io/mhoelzl/clm-notebook-processor:1.9.2-full`
 - `docker.io/mhoelzl/clm-notebook-processor:latest`
 - `docker.io/mhoelzl/clm-notebook-processor:full`
 
@@ -172,7 +172,7 @@ docker build -f docker/notebook/Dockerfile -t docker.io/mhoelzl/clm-notebook-pro
 - .NET SDK 10.0 (C# and F# kernels)
 - Deno (TypeScript/JavaScript kernel)
 - Java JDK (Java kernel)
-- IJava 1.9.1 (Java Jupyter kernel)
+- IJava 1.9.2 (Java Jupyter kernel)
 - micromamba + xeus-cpp (C++ kernel)
 
 **Jupyter Kernels:**
@@ -223,12 +223,12 @@ The build scripts automatically set these arguments.
 All images use the Hub namespace (`docker.io/mhoelzl/clm-*`) for consistency:
 
 **PlantUML/DrawIO:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.9.1`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.9.2`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Notebook (with variants):**
-- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.9.1`, `:full`, `:1.9.1-full`
-- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.9.1-lite`
+- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.9.2`, `:full`, `:1.9.2-full`
+- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.9.2-lite`
 
 ### BuildKit Cache Mounts
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,6 +1,6 @@
 # CLM Architecture
 
-This document describes the current architecture of the CLM system (v1.9.1).
+This document describes the current architecture of the CLM system (v1.9.2).
 
 ## Overview
 
@@ -42,7 +42,7 @@ CLM is a course content processing system that converts educational materials (J
                          │
 ┌────────────────────────▼──────────────────────────────────┐
 │          clm.workers (Worker Implementations)              │
-│                                (v1.9.1)             │
+│                                (v1.9.2)             │
 │  ├── notebook/ (NotebookWorker, templates, processors)    │
 │  ├── plantuml/ (PlantUmlWorker, converter)                │
 │  └── drawio/ (DrawioWorker, converter)                    │
@@ -211,7 +211,7 @@ class Worker(ABC):
 
 ### Layer 3: Workers (Worker Implementations)
 
-**Purpose**: Concrete worker implementations for different file types (v1.9.1)
+**Purpose**: Concrete worker implementations for different file types (v1.9.2)
 
 Workers are now integrated into the main `clm` package under `clm.workers/`. Previously they were separate packages in the `services/` directory.
 
@@ -566,7 +566,7 @@ CLM has evolved significantly:
 - No message broker required
 - Reduced from 8 Docker services to 3
 
-**v0.6.2 → v1.9.1** (2025): Integrated workers
+**v0.6.2 → v1.9.2** (2025): Integrated workers
 - Workers integrated into main package (`clm.workers`)
 - Optional dependencies for each worker
 - Four-layer architecture (core, infrastructure, workers, cli)
@@ -1190,4 +1190,4 @@ Potential improvements (not currently planned):
 ---
 
 **Last Updated**: 2026-02-13
-**Version**: 1.9.1
+**Version**: 1.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-academy-lecture-manager"
-version = "1.9.1"
+version = "1.9.2"
 description = "Coding-Academy Lecture Manager - A course content processing system"
 authors = [
     {name = "Dr. Matthias Hölzl", email = "tc@xantira.com"},
@@ -404,7 +404,7 @@ ignore = [
 known-first-party = ["clm"]
 
 [tool.bumpversion]
-current_version = "1.9.1"
+current_version = "1.9.2"
 commit = true
 # No local tag: the Release workflow (.github/workflows/release.yml) creates the
 # authoritative vX.Y.Z tag on the server *after* the CI-green gate, so a red

--- a/src/clm/__version__.py
+++ b/src/clm/__version__.py
@@ -1,3 +1,3 @@
 """Version information for CLM."""
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1453,6 +1453,16 @@ it finds (skip with `--no-env-file`). On the **bootstrap** path a missing key is
 a hard stop — the command exits `1` and writes nothing (a whole untranslated deck
 is useless), unlike sync's per-cell defer. `--dry-run` uses no key and no LLM.
 
+**Translation conventions (glossary).** Point `--glossary` at a Markdown file (a
+style note plus a term glossary) to pin a target-language register and keep or
+translate technical terms consistently across the deck; the text is appended to
+the translation system prompt. If `--glossary` is omitted, the command
+auto-discovers `clm-glossary.<target-lang>.md` walking up from the deck (the same
+walk-up as `.env`), so a course keeps its glossary next to its slides and needs
+no flag. The guidance is folded into the translation cache key: editing the
+glossary invalidates affected entries by cache miss, while decks translated
+without a glossary keep the bare key (no flag-day invalidation).
+
 ```
 clm slides translate [OPTIONS] SOURCE
 clm slides bootstrap [OPTIONS] SOURCE   # alias
@@ -1467,6 +1477,7 @@ clm slides bootstrap [OPTIONS] SOURCE   # alias
 | `--provider [openrouter\|local]` | Edit-judge backend for the *delegated-sync* path (when the twin already exists); unused on the bootstrap path. Overridable with `$CLM_SYNC_PROVIDER`. |
 | `--llm-model TEXT` | Model for the delegated-sync edit judge (default `anthropic/claude-sonnet-4-6` for openrouter). |
 | `--cache-dir PATH` | Directory holding the translation + watermark caches. Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<cwd>/.clm-cache/`. |
+| `--glossary PATH` | Translation conventions file (Markdown: a style note + term glossary) appended to the translation prompt. Default: auto-discover `clm-glossary.<target-lang>.md` walking up from SOURCE's directory (like `.env`). |
 | `--no-cache` | Do not read or write the translation / watermark caches. |
 | `--no-env-file` | Do not auto-load a `.env` file. |
 | `--json` | Emit a JSON report instead of human-readable lines. |

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1009,7 +1009,7 @@ def _is_cpp_image_available() -> bool:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.9.1-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.9.2-full",
         ]:
             try:
                 client.images.get(tag)
@@ -1030,7 +1030,7 @@ def _get_full_image_name() -> str | None:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.9.1-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.9.2-full",
         ]:
             try:
                 client.images.get(tag)

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "coding-academy-lecture-manager"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Cut the **1.9.2** patch release for the translation enhancements that landed in PR #264.

## What's in 1.9.2

### Added
- **`clm slides translate` / `bootstrap` glossary guidance (`--glossary`)** — an optional translation-conventions file (style note + term glossary) appended to the translation prompt, with auto-discovery of `clm-glossary.<target-lang>.md` (walk-up like `.env`) and cache-key folding so editing the glossary invalidates affected entries by cache miss.

### Fixed
- **Deck titles now translate correctly** — the `header_<lang>("…")` title was routed through the markdown-prose prompt and came out with a stray `# ` and untranslated; a dedicated `title` translation role fixes it.

## Release mechanics
- `CHANGELOG.md` entry added and dated; `clm info commands` (`commands.md`) updated with the `--glossary` option + a "Translation conventions (glossary)" note.
- Version bumped `1.9.1 → 1.9.2` across all 8 configured files (`Bump version …` commit, no local tag — the workflow tags after the CI-green gate).
- Local `pytest -m "not docker"` gate: **7293 passed, 13 skipped, 1 xfailed**.

Merge with a **merge commit** (not squash/rebase) so `.github/workflows/release.yml` recognises the `Bump version …` commit and publishes to PyPI + creates the GitHub Release after CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
