### PR TITLE
build(deps): add deepagents + psycopg to the ml extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ml = [
     "scikit-learn>=1.5.1",
     "skorch>=1.0.2",
     "sqlalchemy>=2.0.32",
+    "psycopg[binary]>=3.2",  # PostgreSQL driver for the Docker/Postgres deployment decks
     # Visualization
     "matplotlib>=3.9.2",
     "seaborn>=0.13.2",
@@ -125,6 +126,7 @@ ml = [
     "langchain-openrouter",
     "langchain-text-splitters",
     "langgraph>=1.1.2",
+    "deepagents>=0.6.0",  # AI-Agents-II deck (create_deep_agent on LangGraph)
     "qdrant-client>=1.13.0",
     "langchain-qdrant",
     "fastembed>=0.6.0",


### PR DESCRIPTION
Week 16 (AI Agents II) uses `deepagents` (`create_deep_agent`); Week 19 Docker/Postgres decks use `psycopg`. Adds both to the `[ml]` optional-extra (aggregated by `[all]`) so courses on `coding-academy-lecture-manager[all]` get them on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)