### PR TITLE
feat(slides sync): wire --glossary into the incremental new-slide path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`clm slides sync` honors the translation glossary on the new-slide path**
+  (follow-up to PR #264). The `--glossary` translation conventions — a style note
+  plus a term glossary appended to the translation prompt — were wired into
+  `clm slides translate` / `bootstrap` but not into the incremental `clm slides
+  sync` add path, so a brand-new slide translated *during a sync* ignored the
+  course's conventions. `sync` now resolves a glossary too. Because sync is
+  **bidirectional** (a new EN slide flows to DE and a new DE slide flows to EN in
+  the same pass), it resolves the conventions **per target language**: a new EN
+  slide translated to DE uses the **DE** glossary, a new DE slide translated to EN
+  uses the **EN** glossary. Each is auto-discovered as `clm-glossary.<lang>.md`
+  walking up from the deck, or supplied explicitly with `--glossary-de` /
+  `--glossary-en`; a language with no glossary translates with no conventions, as
+  before. Batch (`DIR`) runs resolve one glossary from the directory root (the
+  translator is shared across the sweep). The glossary-discovery helpers are now
+  shared by both commands (`clm.slides.glossary`).
+
+### Fixed
+
+- **`clm slides translate`'s delegated-sync path now selects the glossary
+  per-language too.** When the twin already exists, `translate` degrades to the
+  bidirectional sync engine; it previously applied the single target-language
+  glossary to *both* add directions, so a reverse-direction new slide got the
+  wrong-language conventions. It now resolves a per-language map there (parity with
+  `clm slides sync`); the cold-start bootstrap path is single-direction and
+  unchanged.
+- **The dedicated deck-title translation prompt no longer strips terminal
+  punctuation.** The `title` role prompt (PR #264) told the model to drop trailing
+  punctuation, which silently mangled a legitimately punctuated title (e.g.
+  `header_de("Was ist neu?")` → "What's New?"). It now preserves the source title's
+  terminal `?`/`!` (while still forbidding the stray leading `# ` / quotes that were
+  the actual bug being fixed).
+
 ## [1.9.2] - 2026-06-08
 
 ### Added

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -67,6 +67,7 @@ from clm.infrastructure.llm.openrouter_client import (
     OpenRouterSyncJudge,
     has_openrouter_api_key,
 )
+from clm.slides.glossary import GLOSSARY_STEM, resolve_guidance_by_lang
 from clm.slides.pairing import (
     derive_split_pair_from_stem,
     derive_split_twin,
@@ -121,6 +122,34 @@ def _resolve_prog_lang(path: Path) -> str:
         return path_to_prog_lang(target)
     except (KeyError, ValueError):
         return "python"
+
+
+def _resolve_sync_guidance(
+    source_dir: Path,
+    glossary_de: Path | None,
+    glossary_en: Path | None,
+    *,
+    as_json: bool,
+) -> dict[str, str]:
+    """Resolve the per-target-language translation conventions for the add path.
+
+    ``sync`` is bidirectional — a brand-new EN slide is translated to DE (using the
+    DE conventions) and a brand-new DE slide to EN (using the EN conventions) in the
+    same pass — so a glossary is resolved **per target language**: an explicit
+    ``--glossary-de`` / ``--glossary-en``, else an auto-discovered
+    ``clm-glossary.<lang>.md`` walking up from ``source_dir`` (a deck's directory,
+    or the batch root). Returns the ``{target_lang: conventions_text}`` map the
+    :class:`OpenRouterSlideTranslator` selects from; echoes which file supplied each
+    (unless ``--json``). A language with no glossary is simply absent — that
+    direction translates with no conventions, exactly as before this option.
+    """
+    guidance, used = resolve_guidance_by_lang(
+        source_dir, explicit={"de": glossary_de, "en": glossary_en}
+    )
+    if not as_json:
+        for lang in sorted(used):
+            click.echo(f"Using glossary ({lang}): {used[lang]}", err=True)
+    return guidance
 
 
 def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
@@ -307,6 +336,26 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
     ),
 )
 @click.option(
+    "--glossary-de",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Translation conventions (Markdown: a style note + term glossary) for "
+        "German targets — a brand-new EN slide translated to DE on the add path. "
+        f"Default: auto-discover '{GLOSSARY_STEM}.de.md' walking up from the deck."
+    ),
+)
+@click.option(
+    "--glossary-en",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Translation conventions (Markdown: a style note + term glossary) for "
+        "English targets — a brand-new DE slide translated to EN on the add path. "
+        f"Default: auto-discover '{GLOSSARY_STEM}.en.md' walking up from the deck."
+    ),
+)
+@click.option(
     "--llm-recover",
     is_flag=True,
     default=False,
@@ -391,6 +440,8 @@ def slides_sync_cmd(
     ollama_url: str | None,
     llm_timeout: float | None,
     translation_model: str,
+    glossary_de: Path | None,
+    glossary_en: Path | None,
     llm_recover: bool,
     recovery_model: str,
     verify_cold_pairs: bool | None,
@@ -474,6 +525,16 @@ def slides_sync_cmd(
                 "--dry-run / --explain over the directory."
             )
         batch_mode = "explain" if explain else ("dry-run" if dry_run else "apply")
+        # One glossary resolution for the whole sweep (the translator is shared across
+        # pairs), discovered from the batch root. Only an apply sweep translates, so a
+        # dry-run / explain sweep neither reads a glossary nor echoes a "Using glossary"
+        # line. A glossary buried below the root, beside a single deck, is not found by
+        # this root-level walk — pass it explicitly, or sync that deck on its own.
+        batch_guidance = (
+            _resolve_sync_guidance(de_path, glossary_de, glossary_en, as_json=as_json)
+            if batch_mode == "apply"
+            else {}
+        )
         _run_batch(
             de_path,
             mode=batch_mode,
@@ -485,7 +546,9 @@ def slides_sync_cmd(
             provider_available=provider_available,
             make_judge=lambda: _resolve_judge(provider, llm_model, ollama_url, llm_timeout),
             make_translator=lambda: OpenRouterSlideTranslator(
-                model=translation_model, prog_lang=_resolve_prog_lang(de_path)
+                model=translation_model,
+                prog_lang=_resolve_prog_lang(de_path),
+                guidance_by_lang=batch_guidance,
             ),
             make_recoverer=lambda: _resolve_recoverer(llm_recover, recovery_model),
             make_verifier=lambda: _resolve_verifier(verify_enabled),
@@ -520,6 +583,15 @@ def slides_sync_cmd(
 
         load_env_files(de_path.parent, en_path.parent)
 
+    # Resolve per-target-language translation conventions (style + glossary) for the
+    # bidirectional add path. Only the writing modes build a translator, so dry-run /
+    # explain resolve nothing (and echo no "Using glossary" line).
+    guidance_by_lang: dict[str, str] = {}
+    if not dry_run and not explain:
+        guidance_by_lang = _resolve_sync_guidance(
+            de_path.parent, glossary_de, glossary_en, as_json=as_json
+        )
+
     watermark_cache: SyncWatermarkCache | None = None
     alignment_cache: SyncAlignmentCache | None = None
     correspondence_cache: SyncCorrespondenceCache | None = None
@@ -553,7 +625,9 @@ def slides_sync_cmd(
             mode = "interactive"
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(
-                model=translation_model, prog_lang=_resolve_prog_lang(de_path)
+                model=translation_model,
+                prog_lang=_resolve_prog_lang(de_path),
+                guidance_by_lang=guidance_by_lang,
             )
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
             verifier = _resolve_verifier(verify_enabled)
@@ -575,7 +649,9 @@ def slides_sync_cmd(
             mode = "apply"
             judge = _resolve_judge(provider, llm_model, ollama_url, llm_timeout)
             translator = OpenRouterSlideTranslator(
-                model=translation_model, prog_lang=_resolve_prog_lang(de_path)
+                model=translation_model,
+                prog_lang=_resolve_prog_lang(de_path),
+                guidance_by_lang=guidance_by_lang,
             )
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
             verifier = _resolve_verifier(verify_enabled)

--- a/src/clm/cli/commands/slides_translate.py
+++ b/src/clm/cli/commands/slides_translate.py
@@ -47,6 +47,7 @@ from clm.infrastructure.llm.openrouter_client import (
     has_openrouter_api_key,
 )
 from clm.infrastructure.utils.path_utils import path_to_prog_lang
+from clm.slides.glossary import GLOSSARY_STEM, resolve_guidance, resolve_guidance_by_lang
 from clm.slides.sync_translate import (
     DEFAULT_TRANSLATION_MODEL,
     CachingSlideTranslator,
@@ -70,6 +71,7 @@ def _make_translator(
     translation_cache: TranslationCache | None,
     prog_lang: str = "python",
     guidance: str = "",
+    guidance_by_lang: dict[str, str] | None = None,
 ) -> SlideTranslator:
     """The OpenRouter slide translator, cache-wrapped unless ``--no-cache``.
 
@@ -77,44 +79,20 @@ def _make_translator(
     translator, exactly as the sync CLI tests patch ``OpenRouterSlideTranslator``.
     ``prog_lang`` makes the prompt name the deck's language + comment token;
     ``guidance`` carries optional target-language conventions (style + glossary)
-    appended to the system prompt and folded into the cache key.
+    for the **single-direction** bootstrap path; ``guidance_by_lang`` carries
+    **per-language** conventions for the delegated-sync path (bidirectional, like
+    ``clm slides sync``). Either is appended to the system prompt and folded into
+    the cache key.
     """
     inner = OpenRouterSlideTranslator(
-        model=translation_model, prog_lang=prog_lang, guidance=guidance
+        model=translation_model,
+        prog_lang=prog_lang,
+        guidance=guidance,
+        guidance_by_lang=guidance_by_lang or {},
     )
     if translation_cache is None:
         return inner
     return CachingSlideTranslator(inner=inner, cache=translation_cache)
-
-
-# Auto-discovered glossary filename, parameterized by target language, e.g.
-# ``clm-glossary.de.md``. The first such file found walking up from the deck's
-# directory supplies translation conventions for that target language.
-_GLOSSARY_STEM = "clm-glossary"
-
-
-def _discover_glossary(start: Path, target_lang: str) -> Path | None:
-    """First ``clm-glossary.<target_lang>.md`` found walking up from ``start``.
-
-    Mirrors the ``.env`` auto-load: the course repo keeps the (domain-specific,
-    human-edited) glossary near its slides and clm finds it without a flag.
-    """
-    name = f"{_GLOSSARY_STEM}.{target_lang}.md"
-    for directory in [start, *start.parents]:
-        candidate = directory / name
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def _resolve_guidance(
-    glossary: Path | None, source_dir: Path, target_lang: str
-) -> tuple[str, Path | None]:
-    """Return ``(guidance_text, path)``: explicit ``--glossary`` wins, else auto-discover."""
-    path = glossary if glossary is not None else _discover_glossary(source_dir, target_lang)
-    if path is None:
-        return "", None
-    return path.read_text(encoding="utf-8").strip(), path
 
 
 @click.command("translate")
@@ -185,7 +163,7 @@ def _resolve_guidance(
     help=(
         "Translation conventions file (Markdown: a style note + term glossary) "
         "appended to the translation prompt. Default: auto-discover "
-        f"'{_GLOSSARY_STEM}.<target-lang>.md' walking up from SOURCE's directory."
+        f"'{GLOSSARY_STEM}.<target-lang>.md' walking up from SOURCE's directory."
     ),
 )
 @click.option(
@@ -272,16 +250,36 @@ def slides_translate_cmd(
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
         translation_cache = TranslationCache(cache_root / CACHE_DB_NAME)
 
-    # Resolve translation conventions (style + glossary) for the target language:
-    # an explicit --glossary, else an auto-discovered clm-glossary.<lang>.md.
-    guidance, glossary_path = _resolve_guidance(glossary, source.parent, paths.target_lang)
-    if glossary_path is not None and not as_json:
-        click.echo(f"Using glossary: {glossary_path}", err=True)
+    # Resolve translation conventions (style + glossary). The bootstrap path is
+    # single-direction (source -> target), so the target-language glossary applies
+    # (an explicit --glossary, else an auto-discovered clm-glossary.<target>.md). The
+    # delegated-sync path (twin present) translates brand-new slides in BOTH
+    # directions — exactly like `clm slides sync` — so it resolves a per-language map
+    # there, so a reverse-direction add gets ITS language's conventions rather than
+    # the target's (parity with sync; --glossary still pins the target language).
+    guidance = ""
+    guidance_by_lang: dict[str, str] = {}
+    if will_sync:
+        guidance_by_lang, used = resolve_guidance_by_lang(
+            source.parent,
+            explicit={paths.target_lang: glossary, paths.source_lang: None},
+        )
+        if not as_json:
+            for lang in sorted(used):
+                click.echo(f"Using glossary ({lang}): {used[lang]}", err=True)
+    else:
+        guidance, glossary_path = resolve_guidance(glossary, source.parent, paths.target_lang)
+        if glossary_path is not None and not as_json:
+            click.echo(f"Using glossary: {glossary_path}", err=True)
 
     result: BootstrapResult
     try:
         translator = _make_translator(
-            translation_model, translation_cache, path_to_prog_lang(source), guidance
+            translation_model,
+            translation_cache,
+            path_to_prog_lang(source),
+            guidance,
+            guidance_by_lang,
         )
         # A judge is only consulted on the delegated-sync path (twin present).
         judge = _resolve_judge(provider, llm_model, None, None) if will_sync else None

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1320,6 +1320,19 @@ written into the file, so a deck stays id-light yet syncs precisely:
 Use `--explain` to see the anchor-level view (per-cell anchor + drift, the
 propagation direction, drifted ids) for any pair.
 
+**Translation conventions (glossary).** A brand-new slide on the add path is
+translated by the same model `clm slides translate` uses, and it honors the same
+**glossary** — a Markdown style note + term glossary appended to the translation
+prompt (keep "Dictionary", address the reader with "Sie"). Because sync is
+**bidirectional**, the glossary is resolved **per target language**: a new EN
+slide translated to DE uses the **DE** conventions and a new DE slide translated
+to EN uses the **EN** conventions. Each is auto-discovered as
+`clm-glossary.<lang>.md` walking up from the deck (a `clm-glossary.de.md` next to
+your slides is found automatically), or supplied explicitly with `--glossary-de` /
+`--glossary-en`. A language with no glossary simply translates with no conventions
+(unchanged from before). In **batch (`DIR`) mode** the translator is shared across
+the sweep, so the glossary is resolved once from the directory root.
+
 ```
 clm slides sync [OPTIONS] DE_PATH [EN_PATH]
 clm slides sync [OPTIONS] DIR          # batch: sync every pair under DIR
@@ -1335,6 +1348,8 @@ clm slides sync [OPTIONS] DIR          # batch: sync every pair under DIR
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (only used with `--provider local`; default: `$OLLAMA_URL` or `http://localhost:11434`). |
 | `--llm-timeout SECONDS` | Per-call timeout for the edit judge. Provider-aware default: 120s for `openrouter` (fast hosted model), 300s for `local` (a large local reasoning model can spend minutes "thinking"). |
 | `--translation-model TEXT` | OpenRouter model used to translate brand-new slides for the add path (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`; adds defer when absent. |
+| `--glossary-de PATH` | Translation conventions (Markdown: a style note + term glossary) for **German** targets — a brand-new EN slide translated to DE on the add path. Default: auto-discover `clm-glossary.de.md` walking up from the deck. |
+| `--glossary-en PATH` | Translation conventions for **English** targets — a brand-new DE slide translated to EN on the add path. Default: auto-discover `clm-glossary.en.md` walking up from the deck. |
 | `--verify-cold-pairs` / `--no-verify-cold-pairs` | **Bootstrap and reconcile split-pair `slide_id`s, gated by a cheap correspondence check (default on when an OpenRouter/OpenAI key is set).** A never-id'd cold pair is **minted** a shared id per slide; a half-id'd pair's id-less half **adopts** the id'd half's ids; a committed pair sharing some ids but giving one slide a *divergent* id on each half is **reconciled** — `sync` rewrites the divergent id so both halves share one (EN-authority), surfaced as a `reconcile` proposal (#228). Each is applied only after a cheap LLM (Haiku, via OpenRouter) confirms the two halves actually correspond. With `--no-verify-cold-pairs` (or no key) such a pair is **refused** instead — sync one direction at a time, or run `clm slides assign-ids`. |
 | `--llm-recover` | **Opt into the bounded-LLM recovery tier (default off).** When the deterministic id-migration is stuck on an *ambiguous* drifted `slide_id` (a function renamed while a cell was split, an unresolvable tie), ask Claude (Opus, via OpenRouter) for a **validated, body-free** id↔cell alignment. Without this flag such a region is left untouched and re-surfaces next run. The model only ever sees content anchors (construct + hash + id), never cell source, and its map is validated (it can never drop a stable `slide_id`) before any header is written. Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`. |
 | `--recovery-model TEXT` | OpenRouter model for `--llm-recover` alignment (default: `anthropic/claude-opus-4`). |
@@ -1474,10 +1489,10 @@ clm slides bootstrap [OPTIONS] SOURCE   # alias
 | `--dry-run` | Preview only: show the target path and how many cells would be translated vs copied (and the companion), and write nothing. Uses no LLM and no API key. |
 | `--force` | Overwrite an existing twin (and its companion) by re-bootstrapping. Without it, an existing twin degrades to an incremental sync. |
 | `--translation-model TEXT` | OpenRouter model used to translate the deck (default: `anthropic/claude-sonnet-4-6`). Needs `$OPENROUTER_API_KEY` / `$OPENAI_API_KEY`. |
+| `--glossary PATH` | Translation conventions file (Markdown: a style note + term glossary) appended to the translation prompt. Default: auto-discover `clm-glossary.<target-lang>.md` walking up from SOURCE's directory. |
 | `--provider [openrouter\|local]` | Edit-judge backend for the *delegated-sync* path (when the twin already exists); unused on the bootstrap path. Overridable with `$CLM_SYNC_PROVIDER`. |
 | `--llm-model TEXT` | Model for the delegated-sync edit judge (default `anthropic/claude-sonnet-4-6` for openrouter). |
 | `--cache-dir PATH` | Directory holding the translation + watermark caches. Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<cwd>/.clm-cache/`. |
-| `--glossary PATH` | Translation conventions file (Markdown: a style note + term glossary) appended to the translation prompt. Default: auto-discover `clm-glossary.<target-lang>.md` walking up from SOURCE's directory (like `.env`). |
 | `--no-cache` | Do not read or write the translation / watermark caches. |
 | `--no-env-file` | Do not auto-load a `.env` file. |
 | `--json` | Emit a JSON report instead of human-readable lines. |

--- a/src/clm/slides/glossary.py
+++ b/src/clm/slides/glossary.py
@@ -1,0 +1,110 @@
+"""Translation-conventions (glossary) discovery — shared by translate & sync.
+
+A course pins target-language conventions — a short style note plus a term
+glossary — in a Markdown file named ``clm-glossary.<target-lang>.md`` kept near
+its slides. The text is appended verbatim to the new-slide translation prompt so
+register (formal "Sie" vs. "du") and term handling (keep "Dictionary", translate
+"Schleife") stay consistent across a deck. clm stays domain-agnostic: it only
+*locates and reads* the file — the course repo supplies the content (see
+``clm slides translate --glossary`` and ``clm slides sync --glossary-de/-en``).
+
+Discovery mirrors the ``.env`` auto-load: walk up from the deck's directory and
+take the first match. ``clm slides translate`` resolves **one** target language
+(it has a single direction); ``clm slides sync`` is **bidirectional** — a new DE
+slide flows to EN and a new EN slide flows to DE in the same pass — so it
+resolves a glossary per target language with :func:`resolve_guidance_by_lang`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = [
+    "GLOSSARY_STEM",
+    "discover_glossary",
+    "glossary_name",
+    "read_guidance",
+    "resolve_guidance",
+    "resolve_guidance_by_lang",
+]
+
+# Auto-discovered glossary filename, parameterized by target language, e.g.
+# ``clm-glossary.de.md``. The first such file found walking up from the deck's
+# directory supplies translation conventions for that target language.
+GLOSSARY_STEM = "clm-glossary"
+
+
+def glossary_name(target_lang: str) -> str:
+    """The conventions filename for translations INTO ``target_lang``."""
+    return f"{GLOSSARY_STEM}.{target_lang}.md"
+
+
+def discover_glossary(start: Path, target_lang: str) -> Path | None:
+    """First ``clm-glossary.<target_lang>.md`` found walking up from ``start``.
+
+    ``start`` may be a deck file's directory or a directory itself; both it and
+    each of its parents are checked, nearest first. Mirrors the ``.env``
+    auto-load: the course repo keeps the (domain-specific, human-edited) glossary
+    near its slides and clm finds it without a flag.
+    """
+    name = glossary_name(target_lang)
+    for directory in [start, *start.parents]:
+        candidate = directory / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def read_guidance(path: Path) -> str:
+    """Read a glossary file's text, trimmed of surrounding whitespace."""
+    return path.read_text(encoding="utf-8").strip()
+
+
+def resolve_guidance(
+    glossary: Path | None, source_dir: Path, target_lang: str
+) -> tuple[str, Path | None]:
+    """Resolve conventions for a **single** target language (translate/bootstrap).
+
+    Returns ``(guidance_text, path)``: an explicit ``--glossary`` path wins, else
+    the auto-discovered ``clm-glossary.<target_lang>.md``. ``("", None)`` when no
+    file is found **or** the found file is empty/whitespace-only — an empty glossary
+    contributes nothing, so it is reported as absent (no path), matching
+    :func:`resolve_guidance_by_lang` and so the caller emits no misleading
+    "using glossary" message for a file that adds no conventions.
+    """
+    path = glossary if glossary is not None else discover_glossary(source_dir, target_lang)
+    if path is None:
+        return "", None
+    text = read_guidance(path)
+    if not text:
+        return "", None  # an empty glossary file is treated as no glossary
+    return text, path
+
+
+def resolve_guidance_by_lang(
+    source_dir: Path,
+    *,
+    explicit: dict[str, Path | None],
+) -> tuple[dict[str, str], dict[str, Path]]:
+    """Resolve conventions per target language for a **bidirectional** sync.
+
+    ``explicit`` maps each target language (``"de"`` / ``"en"``) to an explicit
+    ``--glossary-<lang>`` path, or ``None`` to auto-discover that language's
+    ``clm-glossary.<lang>.md`` walking up from ``source_dir``. Returns
+    ``(guidance_by_lang, used_paths)``: the non-empty conventions text keyed by
+    target language, and the file that supplied each (for an informational
+    message). A language with no explicit path and no discovered (or empty) file
+    is simply absent from both maps — its direction translates with no glossary.
+    """
+    guidance: dict[str, str] = {}
+    used: dict[str, Path] = {}
+    for lang, path in explicit.items():
+        resolved = path if path is not None else discover_glossary(source_dir, lang)
+        if resolved is None:
+            continue
+        text = read_guidance(resolved)
+        if not text:
+            continue  # an empty glossary file is treated as no glossary
+        guidance[lang] = text
+        used[lang] = resolved
+    return guidance, used

--- a/src/clm/slides/sync_translate.py
+++ b/src/clm/slides/sync_translate.py
@@ -128,20 +128,91 @@ class OpenRouterSlideTranslator:
     # repo supplies the text (see ``clm slides translate --glossary``). When set, it
     # is folded into ``prompt_version`` so a different glossary keys a different cache
     # entry and editing the glossary invalidates by cache miss.
+    #
+    # ``guidance`` applies to a translation in **any** direction — the one-direction
+    # ``translate`` / ``bootstrap`` case, which resolves a single target glossary.
+    # ``guidance_by_lang`` (target_lang → conventions) is the **bidirectional**
+    # ``sync`` case: a new DE slide is translated to EN with the EN conventions and a
+    # new EN slide to DE with the DE conventions, in one pass. The two are
+    # alternatives — when ``guidance_by_lang`` is non-empty it wins per target and
+    # ``guidance`` is ignored; see :meth:`_guidance_for`.
     guidance: str = ""
+    guidance_by_lang: dict[str, str] = field(default_factory=dict)
     # Derived in ``__post_init__`` from the base version + a guidance fingerprint.
     # ``init=False`` so it is never passed in; the cache wrapper reads it.
     prompt_version: str = field(init=False, default=_BASE_PROMPT_VERSION)
 
     def __post_init__(self) -> None:
+        self.prompt_version = self._compute_prompt_version()
+
+    def _compute_prompt_version(self) -> str:
+        """The cache key version: ``translate-v1`` plus a guidance fingerprint.
+
+        Two DISTINCT namespaces, so a single-string guidance and a per-language map
+        can never share a key whatever their text:
+
+        - per-language ``guidance_by_lang`` (bidirectional sync) → ``v1:gm<fp>`` over
+          the whole cleaned map, ordered by language. It takes precedence when it has
+          content, matching :meth:`_guidance_for`.
+        - single-direction ``guidance`` (translate/bootstrap) → ``v1:g<sha(text)>``,
+          the ORIGINAL shape, so an existing ``translate`` cache stays valid.
+        - neither → bare ``v1`` (no glossary, no flag-day invalidation).
+
+        The map is fingerprinted WHOLE (not per target), so the key is computed once
+        at construction. ``clm slides sync`` runs this translator **uncached**, so the
+        map key is inert there today; only the cached ``translate`` delegated-sync
+        path keys on it, where editing one language's glossary also re-translates the
+        other direction's adds (a cheap over-invalidation — incremental syncs add few
+        slides). A future cached standalone sync wanting to avoid that would need a
+        per-target signature (a ``prompt_version`` that varies per call).
+        """
+        cleaned = {k: v.strip() for k, v in self.guidance_by_lang.items() if v.strip()}
+        if cleaned:
+            # \x1e/\x1f are record/unit separators; the "gm" namespace keeps a
+            # one-entry map (encoded "lang\x1etext") from ever colliding with a
+            # single-string guidance of that exact text.
+            joined = "\x1f".join(f"{k}\x1e{cleaned[k]}" for k in sorted(cleaned))
+            fp = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:12]
+            return f"{_BASE_PROMPT_VERSION}:gm{fp}"
         guidance = self.guidance.strip()
         if guidance:
             fp = hashlib.sha256(guidance.encode("utf-8")).hexdigest()[:12]
-            self.prompt_version = f"{_BASE_PROMPT_VERSION}:g{fp}"
-        else:
-            # No guidance → byte-identical to the original v1 prompt, so keep the
-            # v1 key: no flag-day invalidation for callers that pass no glossary.
-            self.prompt_version = _BASE_PROMPT_VERSION
+            return f"{_BASE_PROMPT_VERSION}:g{fp}"
+        return _BASE_PROMPT_VERSION
+
+    def _guidance_for(self, target_lang: str) -> str:
+        """The conventions text to append for a translation INTO ``target_lang``.
+
+        Per-language ``guidance_by_lang`` (bidirectional sync) wins when it has any
+        content; otherwise the single ``guidance`` string (one-direction
+        translate/bootstrap) applies regardless of direction. Whitespace-only is
+        treated as none, so an empty/absent glossary appends nothing.
+        """
+        if self.guidance_by_lang and any(v.strip() for v in self.guidance_by_lang.values()):
+            return self.guidance_by_lang.get(target_lang, "").strip()
+        return self.guidance.strip()
+
+    def _system_message(self, role: str, source_lang: str, target_lang: str) -> str:
+        """Assemble the system prompt for a cell ``role`` and direction.
+
+        The role-specific base prompt with the language/comment-token descriptors
+        filled in, then the caller-supplied conventions for ``target_lang``
+        appended AFTER ``.format()`` so any braces in the glossary (JSON, f-strings,
+        code) are never read as format fields. A pure, network-free seam so the
+        prompt assembly (incl. glossary selection) is unit-testable.
+        """
+        comment_prefix, prog_lang_name = _prog_lang_descriptors(self.prog_lang)
+        system = _system_prompt_for(role).format(
+            source_lang=_LANG_NAMES.get(source_lang, source_lang),
+            target_lang=_LANG_NAMES.get(target_lang, target_lang),
+            role=role,
+            comment_prefix=comment_prefix,
+            prog_lang_name=prog_lang_name,
+        )
+        guidance = self._guidance_for(target_lang)
+        if guidance:
+            system = f"{system}\n\n{guidance}"
+        return system
 
     def _client(self):  # pragma: no cover - thin network adapter
         # Shared with the edit judge so key/base resolution stays in one place.
@@ -157,19 +228,7 @@ class OpenRouterSlideTranslator:
         target_lang: str,
         role: str,
     ) -> str:  # pragma: no cover - exercised via mocked client / integration
-        comment_prefix, prog_lang_name = _prog_lang_descriptors(self.prog_lang)
-        system = _system_prompt_for(role).format(
-            source_lang=_LANG_NAMES.get(source_lang, source_lang),
-            target_lang=_LANG_NAMES.get(target_lang, target_lang),
-            role=role,
-            comment_prefix=comment_prefix,
-            prog_lang_name=prog_lang_name,
-        )
-        # Append the caller-supplied conventions AFTER .format() so any braces in
-        # the glossary (JSON, f-strings, code) are never read as format fields.
-        guidance = self.guidance.strip()
-        if guidance:
-            system = f"{system}\n\n{guidance}"
+        system = self._system_message(role, source_lang, target_lang)
 
         def _create():
             return self._client().chat.completions.create(
@@ -238,8 +297,9 @@ _TITLE_SYSTEM_PROMPT = (
     "You translate a single slide-deck title from {source_lang} to {target_lang} for a "
     "{prog_lang_name} programming course. Return ONLY the translated title as a short "
     "plain phrase: no Markdown, no leading '{comment_prefix}' or other comment prefix, "
-    "no surrounding quotes, no trailing punctuation, and no commentary. Keep code "
-    "identifiers, library names, and product names unchanged."
+    "no surrounding quotes, and no commentary. Preserve the title's own terminal "
+    "punctuation — keep a trailing '?' or '!' if the source title has one (but do not "
+    "add any). Keep code identifiers, library names, and product names unchanged."
 )
 
 

--- a/tests/cli/test_slides_sync.py
+++ b/tests/cli/test_slides_sync.py
@@ -333,6 +333,317 @@ class TestApply:
 
 
 # ---------------------------------------------------------------------------
+# Glossary (translation conventions) wiring into the bidirectional add path
+# ---------------------------------------------------------------------------
+
+
+def _capture_translator(monkeypatch) -> dict:
+    """Patch the translator factory to capture its construction kwargs.
+
+    Proves the glossary the CLI resolved is actually handed to the translator that
+    drives new-slide translation (the prompt assembly itself is unit-tested in
+    tests/slides/test_sync_translate_prompts.py). Returns a dict the test inspects
+    after the run.
+    """
+    from clm.cli.commands import slides_sync as cmd
+    from clm.slides.sync_translate import StaticSlideTranslator
+
+    captured: dict = {}
+
+    def fake(**kwargs):
+        captured.update(kwargs)
+        return StaticSlideTranslator(default="# ## Translated\n#\n# - point")
+
+    monkeypatch.setattr(cmd, "OpenRouterSlideTranslator", fake)
+    return captured
+
+
+class TestGlossary:
+    """`clm slides sync` resolves per-target-language conventions for the add path:
+    explicit `--glossary-de` / `--glossary-en`, else an auto-discovered
+    `clm-glossary.<lang>.md`. The resolved map reaches the translator; dry-run /
+    explain (no translator) resolve nothing.
+    """
+
+    def test_auto_discovers_de_glossary_next_to_deck(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / "clm-glossary.de.md").write_text("Address with 'Sie'.\n", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {"de": "Address with 'Sie'."}
+        assert "Using glossary (de):" in (result.stderr or "")
+
+    def test_auto_discovers_both_languages(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / "clm-glossary.de.md").write_text("Sie", encoding="utf-8")
+        (tmp_path / "clm-glossary.en.md").write_text("formal", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {"de": "Sie", "en": "formal"}
+
+    def test_explicit_flag_overrides_and_supplies(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        # A discoverable DE glossary, plus an EN one supplied explicitly by path.
+        (tmp_path / "clm-glossary.de.md").write_text("auto-de", encoding="utf-8")
+        explicit_en = tmp_path / "my-en-conventions.md"
+        explicit_en.write_text("explicit-en", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [
+                str(de_path),
+                str(en_path),
+                "--glossary-en",
+                str(explicit_en),
+                "--cache-dir",
+                str(cache_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {"de": "auto-de", "en": "explicit-en"}
+
+    def test_no_glossary_passes_empty_map(self, cli_runner: CliRunner, tmp_path: Path, monkeypatch):
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {}
+        assert "Using glossary" not in (result.stderr or "")
+
+    def test_dry_run_resolves_no_glossary(self, cli_runner: CliRunner, tmp_path: Path, monkeypatch):
+        # Dry-run builds no translator, so it must not echo a "Using glossary" line
+        # (and must not need a key) even when a glossary is present on disk.
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / "clm-glossary.de.md").write_text("Sie", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--dry-run", "--cache-dir", str(cache_dir)],
+        )
+
+        assert result.exit_code == 1, _combined(result)  # an edit is pending
+        assert captured == {}  # no translator constructed on a dry-run
+        assert "Using glossary" not in _combined(result)
+
+    def test_missing_explicit_glossary_is_usage_error(self, cli_runner: CliRunner, tmp_path: Path):
+        de_path, en_path = _write_pair(tmp_path, _DE_BASE, _EN_BASE)
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--glossary-de", str(tmp_path / "nope.md"), "--no-cache"],
+        )
+        assert result.exit_code == 2  # click.Path(exists=True)
+
+    def test_no_glossary_under_interactive(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # The interactive constructor is a separate call site; prove guidance_by_lang
+        # reaches it too (a discoverable DE glossary, applied via the 'a' decision).
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / "clm-glossary.de.md").write_text("Sie", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd,
+            [str(de_path), str(en_path), "--interactive", "--cache-dir", str(cache_dir)],
+            input="a\n",
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {"de": "Sie"}
+
+    def test_empty_glossary_file_is_no_glossary(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # A whitespace-only glossary file contributes nothing: empty map, no echo.
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        de_path, en_path, cache_dir = _edit_scenario(tmp_path)
+        (tmp_path / "clm-glossary.de.md").write_text("   \n\n", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {}
+        assert "Using glossary" not in (result.stderr or "")
+
+    def test_glossary_reaches_translator_in_batch_apply(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # The shared batch translator is built once from the root-level glossary.
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        captured = _capture_translator(monkeypatch)
+        root = tmp_path / "decks"
+        root.mkdir()
+        cache_dir = tmp_path / "cache"
+        a_de, a_en = _write_pair(root, _DE_EDITED, _EN_BASE, stem="apis")
+        _seed_watermark(
+            cache_dir, a_de.resolve(), a_en.resolve(), de_text=_DE_BASE, en_text=_EN_BASE
+        )
+        (root / "clm-glossary.de.md").write_text("Sie", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(root), "--yes", "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        assert captured["guidance_by_lang"] == {"de": "Sie"}
+
+
+def _recording_translator(monkeypatch, sink: list) -> None:
+    """Patch the translator with a REAL OpenRouterSlideTranslator whose network
+    client is faked to record the assembled system prompt and echo the source body.
+
+    Unlike ``_capture_translator`` (which records only construction kwargs), this
+    drives the genuine ``_system_message`` / ``_guidance_for`` selection on an actual
+    ``translate()`` call, so a test can prove the per-target glossary text reaches the
+    prompt end-to-end through the engine on a real add.
+    """
+    from types import SimpleNamespace
+
+    from clm.cli.commands import slides_sync as cmd
+    from clm.slides.sync_translate import OpenRouterSlideTranslator
+
+    def factory(**kwargs):
+        translator = OpenRouterSlideTranslator(**kwargs)
+
+        def fake_client():
+            def create(*, model, messages, temperature, max_tokens):
+                sink.append({"system": messages[0]["content"], "user": messages[1]["content"]})
+                # Echo the source body as the "translation" — structurally valid.
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(message=SimpleNamespace(content=messages[1]["content"]))
+                    ]
+                )
+
+            return SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+        translator._client = fake_client
+        return translator
+
+    monkeypatch.setattr(cmd, "OpenRouterSlideTranslator", factory)
+
+
+class TestGlossaryReachesPrompt:
+    """End-to-end: a new-slide ADD during sync drives the real translator, and the
+    per-target glossary text lands in the assembled system prompt — the bidirectional
+    behavior the docs advertise, proven through the engine (not just construction).
+    """
+
+    def _baseline_with_new_slide(self, tmp_path: Path, *, side: str):
+        """Watermark-baselined id'd pair, then append ONE id-less slide on ``side``.
+
+        A new DE slide flows DE->EN (target en); a new EN slide flows EN->DE
+        (target de). Returns ``(de_path, en_path, cache_dir)``.
+        """
+        cache_dir = tmp_path / "cache"
+        de_base = _cell("de", "a", "# ## A")
+        en_base = _cell("en", "a", "# ## A")
+        de_path, en_path = _write_pair(tmp_path, de_base, en_base, stem="gloss")
+        _seed_watermark(
+            cache_dir, de_path.resolve(), en_path.resolve(), de_text=de_base, en_text=en_base
+        )
+        if side == "de":
+            de_path.write_text(de_base + _idless_slide("de", "# ## Neu"), encoding="utf-8")
+        else:
+            en_path.write_text(en_base + _idless_slide("en", "# ## New"), encoding="utf-8")
+        return de_path, en_path, cache_dir
+
+    def test_de_to_en_add_uses_en_glossary(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # A brand-new DE slide is translated INTO English → the EN glossary applies.
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        sink: list = []
+        _recording_translator(monkeypatch, sink)
+        de_path, en_path, cache_dir = self._baseline_with_new_slide(tmp_path, side="de")
+        (tmp_path / "clm-glossary.en.md").write_text("EN-CONVENTIONS-XYZ", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        systems = [r["system"] for r in sink]
+        assert systems, "the add must have driven at least one translate() call"
+        # The English glossary reached the prompt; it is a translation INTO English.
+        assert any("EN-CONVENTIONS-XYZ" in s for s in systems)
+        assert any("to English" in s for s in systems)
+
+    def test_en_to_de_add_uses_de_glossary(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # The reverse direction: a brand-new EN slide is translated INTO German → the
+        # DE glossary applies (the asymmetry a single-glossary design would get wrong).
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        sink: list = []
+        _recording_translator(monkeypatch, sink)
+        de_path, en_path, cache_dir = self._baseline_with_new_slide(tmp_path, side="en")
+        (tmp_path / "clm-glossary.de.md").write_text("DE-CONVENTIONS-ABC", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        systems = [r["system"] for r in sink]
+        assert systems, "the add must have driven at least one translate() call"
+        assert any("DE-CONVENTIONS-ABC" in s for s in systems)
+        assert any("to German" in s for s in systems)
+
+    def test_de_to_en_add_does_not_leak_de_glossary(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # Both glossaries present: a DE->EN add must use ONLY the EN one (no leak).
+        _stub_judge(monkeypatch, _EN_PROPOSAL)
+        sink: list = []
+        _recording_translator(monkeypatch, sink)
+        de_path, en_path, cache_dir = self._baseline_with_new_slide(tmp_path, side="de")
+        (tmp_path / "clm-glossary.en.md").write_text("EN-ONLY", encoding="utf-8")
+        (tmp_path / "clm-glossary.de.md").write_text("DE-ONLY", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_cmd, [str(de_path), str(en_path), "--cache-dir", str(cache_dir)]
+        )
+
+        assert result.exit_code == 0, _combined(result)
+        systems = [r["system"] for r in sink]
+        assert any("EN-ONLY" in s for s in systems)
+        # The German conventions must NOT appear in an English-target prompt.
+        assert all("DE-ONLY" not in s for s in systems)
+
+
+# ---------------------------------------------------------------------------
 # Interactive
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_slides_translate.py
+++ b/tests/cli/test_slides_translate.py
@@ -76,6 +76,25 @@ def _patch_translator(monkeypatch, translator) -> None:
     monkeypatch.setattr(cmd, "_make_translator", lambda *_a, **_k: translator)
 
 
+def _capture_translator_args(monkeypatch, translator) -> dict:
+    """Patch ``_make_translator`` to record the resolved guidance it is handed.
+
+    The command calls ``_make_translator(model, cache, prog_lang, guidance,
+    guidance_by_lang)`` positionally, so the fake captures both the single-string
+    ``guidance`` (bootstrap path) and the per-language ``guidance_by_lang``
+    (delegated-sync path) and returns a working static ``translator``.
+    """
+    captured: dict = {}
+
+    def fake(model, cache, prog_lang="python", guidance="", guidance_by_lang=None):
+        captured["guidance"] = guidance
+        captured["guidance_by_lang"] = guidance_by_lang
+        return translator
+
+    monkeypatch.setattr(cmd, "_make_translator", fake)
+    return captured
+
+
 def _patch_key(monkeypatch, present: bool = True) -> None:
     monkeypatch.setattr(cmd, "has_openrouter_api_key", lambda *_a, **_k: present)
 
@@ -248,6 +267,102 @@ class TestErrors:
             slides_translate_cmd, [str(tmp_path / "nope.de.py"), *_common(tmp_path)]
         )
         assert result.exit_code == 2  # click.Path(exists=True)
+
+
+# ---------------------------------------------------------------------------
+# --glossary (translation conventions) — original PR #264 feature + parity
+# ---------------------------------------------------------------------------
+
+
+class TestGlossary:
+    """CLI-level coverage for `--glossary` (the original PR #264 surface shipped
+    with only prompt_version unit tests) and the delegated-sync per-language parity.
+    """
+
+    def test_bootstrap_auto_discovers_target_glossary(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        captured = _capture_translator_args(monkeypatch, _mirror_translator(de, en))
+        # source is .de → target en → clm-glossary.en.md is discovered.
+        (tmp_path / "clm-glossary.en.md").write_text("Use formal English.", encoding="utf-8")
+
+        result = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert captured["guidance"] == "Use formal English."  # single-direction bootstrap
+        assert not captured["guidance_by_lang"]  # None or {} — bootstrap is one-way
+        assert "Using glossary:" in (result.stderr or "")
+
+    def test_explicit_glossary_wins_over_autodiscovery(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        captured = _capture_translator_args(monkeypatch, _mirror_translator(de, en))
+        (tmp_path / "clm-glossary.en.md").write_text("auto", encoding="utf-8")
+        explicit = _write(tmp_path / "custom.md", "explicit conventions")
+
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(de_path), "--glossary", str(explicit), *_common(tmp_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["guidance"] == "explicit conventions"
+
+    def test_json_suppresses_using_glossary_message(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        _capture_translator_args(monkeypatch, _mirror_translator(de, en))
+        (tmp_path / "clm-glossary.en.md").write_text("conv", encoding="utf-8")
+
+        result = cli_runner.invoke(
+            slides_translate_cmd, [str(de_path), "--json", *_common(tmp_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using glossary" not in (result.output + (result.stderr or ""))
+
+    def test_no_glossary_passes_empty_guidance(self, cli_runner, tmp_path, monkeypatch):
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _patch_key(monkeypatch)
+        captured = _capture_translator_args(monkeypatch, _mirror_translator(de, en))
+
+        result = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert captured["guidance"] == ""
+        assert "Using glossary" not in (result.stderr or "")
+
+    def test_delegated_sync_resolves_per_language_map(self, cli_runner, tmp_path, monkeypatch):
+        # When the twin already exists, translate degrades to the bidirectional sync
+        # engine — so it must resolve a PER-LANGUAGE map (not the single target
+        # glossary), or a reverse-direction add would get the wrong-language conventions.
+        from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
+
+        de, en = _split(_DECK)
+        de_path = _write(tmp_path / "slides_x.de.py", de)
+        _write(tmp_path / "slides_x.en.py", en)  # twin present → delegated sync
+        _patch_key(monkeypatch)
+        captured = _capture_translator_args(monkeypatch, _mirror_translator(de, en))
+        monkeypatch.setattr(
+            cmd,
+            "_resolve_judge",
+            lambda *_a, **_k: StaticSyncJudge(
+                default_proposal=SyncProposal(verdict="in_sync", proposed_text="")
+            ),
+        )
+        (tmp_path / "clm-glossary.de.md").write_text("DE conventions", encoding="utf-8")
+        (tmp_path / "clm-glossary.en.md").write_text("EN conventions", encoding="utf-8")
+
+        result = cli_runner.invoke(slides_translate_cmd, [str(de_path), *_common(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "incremental sync" in result.output  # delegated, not bootstrapped
+        # Per-language map (both directions), and the single guidance is NOT used.
+        assert captured["guidance"] == ""
+        assert captured["guidance_by_lang"] == {"de": "DE conventions", "en": "EN conventions"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slides/test_glossary.py
+++ b/tests/slides/test_glossary.py
@@ -1,0 +1,124 @@
+"""Unit tests for the shared glossary-discovery helpers (translate + sync).
+
+The discovery walk and per-language resolution are pure filesystem logic, so
+they are exercised directly here without a CLI runner or an LLM. The CLI wiring
+that *uses* them lives in ``tests/cli/test_slides_translate.py`` (single target)
+and ``tests/cli/test_slides_sync.py`` (bidirectional).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.glossary import (
+    GLOSSARY_STEM,
+    discover_glossary,
+    glossary_name,
+    resolve_guidance,
+    resolve_guidance_by_lang,
+)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Name + discovery walk
+# ---------------------------------------------------------------------------
+
+
+def test_glossary_name_is_lang_parameterized() -> None:
+    assert glossary_name("de") == f"{GLOSSARY_STEM}.de.md"
+    assert glossary_name("en") == f"{GLOSSARY_STEM}.en.md"
+
+
+def test_discover_finds_in_start_dir(tmp_path: Path) -> None:
+    g = _write(tmp_path / "clm-glossary.de.md", "Sie")
+    assert discover_glossary(tmp_path, "de") == g
+
+
+def test_discover_walks_up_nearest_first(tmp_path: Path) -> None:
+    # A glossary at the root AND one nearer the deck: the nearer one wins.
+    _write(tmp_path / "clm-glossary.de.md", "root")
+    deck_dir = tmp_path / "slides" / "topic"
+    nearer = _write(deck_dir / "clm-glossary.de.md", "nearer")
+    assert discover_glossary(deck_dir, "de") == nearer
+
+
+def test_discover_returns_none_when_absent(tmp_path: Path) -> None:
+    assert discover_glossary(tmp_path, "de") is None
+
+
+def test_discover_is_language_specific(tmp_path: Path) -> None:
+    _write(tmp_path / "clm-glossary.de.md", "Sie")
+    assert discover_glossary(tmp_path, "en") is None  # only .de present
+
+
+# ---------------------------------------------------------------------------
+# Single-target resolution (translate / bootstrap)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_guidance_explicit_wins(tmp_path: Path) -> None:
+    _write(tmp_path / "clm-glossary.de.md", "auto")
+    explicit = _write(tmp_path / "custom.md", "explicit conventions")
+    text, path = resolve_guidance(explicit, tmp_path, "de")
+    assert text == "explicit conventions"
+    assert path == explicit  # the explicit path bypasses discovery
+
+
+def test_resolve_guidance_auto_discovers(tmp_path: Path) -> None:
+    g = _write(tmp_path / "clm-glossary.de.md", "  Address with 'Sie'.\n")
+    text, path = resolve_guidance(None, tmp_path, "de")
+    assert text == "Address with 'Sie'."  # trimmed
+    assert path == g
+
+
+def test_resolve_guidance_none_found(tmp_path: Path) -> None:
+    assert resolve_guidance(None, tmp_path, "de") == ("", None)
+
+
+# ---------------------------------------------------------------------------
+# Bidirectional resolution (sync)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_by_lang_auto_discovers_both(tmp_path: Path) -> None:
+    de = _write(tmp_path / "clm-glossary.de.md", "Sie")
+    en = _write(tmp_path / "clm-glossary.en.md", "formal")
+    guidance, used = resolve_guidance_by_lang(tmp_path, explicit={"de": None, "en": None})
+    assert guidance == {"de": "Sie", "en": "formal"}
+    assert used == {"de": de, "en": en}
+
+
+def test_resolve_by_lang_asymmetric_only_de(tmp_path: Path) -> None:
+    # The common course shape: only a DE glossary exists. EN is simply absent —
+    # a DE->EN add translates with no conventions.
+    de = _write(tmp_path / "clm-glossary.de.md", "Sie")
+    guidance, used = resolve_guidance_by_lang(tmp_path, explicit={"de": None, "en": None})
+    assert guidance == {"de": "Sie"}
+    assert used == {"de": de}
+    assert "en" not in guidance
+
+
+def test_resolve_by_lang_explicit_overrides_one_side(tmp_path: Path) -> None:
+    _write(tmp_path / "clm-glossary.de.md", "auto-de")
+    explicit_en = _write(tmp_path / "my-en.md", "explicit-en")
+    guidance, used = resolve_guidance_by_lang(tmp_path, explicit={"de": None, "en": explicit_en})
+    assert guidance == {"de": "auto-de", "en": "explicit-en"}
+    assert used["en"] == explicit_en
+
+
+def test_resolve_by_lang_empty_file_is_no_glossary(tmp_path: Path) -> None:
+    # A whitespace-only glossary file appends nothing and is reported as absent.
+    _write(tmp_path / "clm-glossary.de.md", "   \n\n")
+    guidance, used = resolve_guidance_by_lang(tmp_path, explicit={"de": None, "en": None})
+    assert guidance == {}
+    assert used == {}
+
+
+def test_resolve_by_lang_none_found(tmp_path: Path) -> None:
+    assert resolve_guidance_by_lang(tmp_path, explicit={"de": None, "en": None}) == ({}, {})

--- a/tests/slides/test_sync_translate_prompts.py
+++ b/tests/slides/test_sync_translate_prompts.py
@@ -119,3 +119,114 @@ def test_guidance_folds_into_prompt_version() -> None:
     assert OpenRouterSlideTranslator(guidance="Use 'du'.").prompt_version != g.prompt_version
     # Whitespace-only guidance is treated as none.
     assert OpenRouterSlideTranslator(guidance="   \n").prompt_version == "translate-v1"
+
+
+# --- per-language guidance (the bidirectional sync add path) ----------------
+
+
+def test_guidance_by_lang_selects_per_target() -> None:
+    # sync is bidirectional: a DE target gets the DE conventions, an EN target the
+    # EN conventions, from one translator instance.
+    t = OpenRouterSlideTranslator(guidance_by_lang={"de": "Sie", "en": "formal English"})
+    assert t._guidance_for("de") == "Sie"
+    assert t._guidance_for("en") == "formal English"
+
+
+def test_guidance_by_lang_absent_language_appends_nothing() -> None:
+    # The common course shape: only a DE glossary. A DE->EN add (target en) has no
+    # conventions; an EN->DE add (target de) uses the DE conventions.
+    t = OpenRouterSlideTranslator(guidance_by_lang={"de": "Sie"})
+    assert t._guidance_for("de") == "Sie"
+    assert t._guidance_for("en") == ""
+
+
+def test_guidance_by_lang_wins_over_single_guidance() -> None:
+    # The two are alternatives; when guidance_by_lang has content it takes precedence
+    # per target and the single string is ignored.
+    t = OpenRouterSlideTranslator(guidance="single", guidance_by_lang={"de": "per-de"})
+    assert t._guidance_for("de") == "per-de"
+    assert t._guidance_for("en") == ""  # not "single"
+
+
+def test_empty_guidance_by_lang_falls_back_to_single() -> None:
+    # An all-empty map is treated as no map, so the single guidance still applies.
+    t = OpenRouterSlideTranslator(guidance="single", guidance_by_lang={"de": "  \n"})
+    assert t._guidance_for("de") == "single"
+    assert t._guidance_for("en") == "single"
+
+
+def test_guidance_by_lang_folds_into_prompt_version() -> None:
+    base = OpenRouterSlideTranslator()
+    g = OpenRouterSlideTranslator(guidance_by_lang={"de": "Sie", "en": "formal"})
+    assert g.prompt_version.startswith("translate-v1:g")
+    assert g.prompt_version != base.prompt_version
+    # Stable per content, order-independent (sorted by language).
+    assert (
+        OpenRouterSlideTranslator(guidance_by_lang={"en": "formal", "de": "Sie"}).prompt_version
+        == g.prompt_version
+    )
+    # Editing either side invalidates by cache miss.
+    assert (
+        OpenRouterSlideTranslator(guidance_by_lang={"de": "du", "en": "formal"}).prompt_version
+        != g.prompt_version
+    )
+    # All-empty map → bare v1 key (no flag-day invalidation).
+    assert OpenRouterSlideTranslator(guidance_by_lang={"de": "  "}).prompt_version == "translate-v1"
+
+
+def test_single_guidance_prompt_version_unchanged_by_new_field() -> None:
+    # Regression: adding guidance_by_lang must not change the single-guidance cache
+    # key shape (an existing translate cache stays valid).
+    import hashlib
+
+    text = "Address the reader with 'Sie'."
+    fp = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    assert OpenRouterSlideTranslator(guidance=text).prompt_version == f"translate-v1:g{fp}"
+
+
+def test_single_string_and_map_signatures_do_not_collide() -> None:
+    # Distinct cache-key namespaces (:g for single-string, :gm for the map) mean a
+    # single-string guidance and a per-language map NEVER share a key — even this
+    # adversarial input, where the one-entry map encodes to exactly the single string
+    # ("de\x1eSie") and so produces the same sha, must still key different entries.
+    single = OpenRouterSlideTranslator(guidance="de\x1eSie")
+    mapped = OpenRouterSlideTranslator(guidance_by_lang={"de": "Sie"})
+    assert single.prompt_version != mapped.prompt_version
+    assert single.prompt_version.startswith("translate-v1:g")
+    assert mapped.prompt_version.startswith("translate-v1:gm")
+
+
+# --- the system-prompt assembly seam (base + selected guidance) -------------
+
+
+def test_system_message_appends_selected_guidance() -> None:
+    t = OpenRouterSlideTranslator(guidance_by_lang={"de": "GLOSSARY-DE", "en": "GLOSSARY-EN"})
+    # EN->DE add: the DE conventions are appended; the EN ones are not.
+    de_msg = t._system_message("slide", "en", "de")
+    assert de_msg.endswith("\n\nGLOSSARY-DE")
+    assert "GLOSSARY-EN" not in de_msg
+    # DE->EN add: the EN conventions.
+    en_msg = t._system_message("slide", "de", "en")
+    assert en_msg.endswith("\n\nGLOSSARY-EN")
+
+
+def test_system_message_no_guidance_is_bare_prompt() -> None:
+    t = OpenRouterSlideTranslator()
+    msg = t._system_message("slide", "de", "en")
+    # With no glossary the message is EXACTLY the formatted base prompt — no appended
+    # "\n\n<guidance>" block. The equality check fully proves that.
+    assert msg == _SYSTEM_PROMPT.format(
+        source_lang="German",
+        target_lang="English",
+        role="slide",
+        comment_prefix="# ",
+        prog_lang_name="Python",
+    )
+
+
+def test_system_message_brace_safe_guidance() -> None:
+    # A glossary with JSON / f-string braces must be appended verbatim, never read
+    # as a .format() field (it is concatenated AFTER formatting).
+    t = OpenRouterSlideTranslator(guidance_by_lang={"de": 'keep {"role": "system"} literal'})
+    msg = t._system_message("slide", "en", "de")
+    assert msg.endswith('keep {"role": "system"} literal')


### PR DESCRIPTION
## Summary

`clm slides translate`/`bootstrap` gained a `--glossary` translation-conventions file in #264 (a style note + term glossary appended to the LLM translation prompt), but it was **never wired into `clm slides sync`** — so a brand-new slide translated *during a sync* ignored the course's conventions. This PR closes that gap.

Because sync is **bidirectional** (a new EN slide flows to DE and a new DE slide flows to EN in one pass), the glossary is resolved **per target language**:

- a new EN slide translated to DE uses the **DE** glossary;
- a new DE slide translated to EN uses the **EN** glossary.

Each is auto-discovered as `clm-glossary.<lang>.md` walking up from the deck (like `.env`), or supplied explicitly via `--glossary-de` / `--glossary-en`. A language with no glossary translates with no conventions, exactly as before. Batch (`DIR`) runs resolve one glossary from the directory root (the translator is shared across the sweep).

## Changes

- **New `clm.slides.glossary`** module factors out discovery/resolution, shared by both commands (`discover_glossary`, `resolve_guidance`, `resolve_guidance_by_lang`).
- **`OpenRouterSlideTranslator`** gains `guidance_by_lang` (target_lang → text), selected per call in a new testable `_system_message()` seam. The single-string `guidance` cache key stays **byte-identical** (`:g<sha>`, no flag-day invalidation for existing `translate` users); the per-language map uses a distinct `:gm<sha>` namespace so the two can never collide.
- **`slides_sync.py`** adds `--glossary-de` / `--glossary-en` + auto-discovery, wired into all three translator constructions (batch / interactive / apply); resolution is skipped on `--dry-run` / `--explain`.
- **`slides_translate.py`** refactored to import the shared helpers (behavior-preserving).

## Follow-ups from an adversarial review (covering #264 too)

A multi-agent review with per-finding verification surfaced no blockers/majors; the substantive items are addressed here:

- **Original-feature bug:** `clm slides translate`'s delegated-sync path applied one target's glossary to *both* add directions. It now resolves a per-language map there (parity with sync); the cold-start bootstrap path stays single-direction (cache key unchanged).
- **Original-feature bug:** the `title`-role prompt told the model to strip terminal punctuation, mangling `header_de("Was ist neu?")` → "What's New". It now preserves the source title's `?`/`!`.
- An empty/whitespace-only glossary file is uniformly treated as "no glossary".
- `clm info commands` now documents `--glossary` (translate) and `--glossary-de`/`--glossary-en` (sync) — #264 left the topic stale (per the repo's Info Topics Maintenance Rule).

## Tests

- New `tests/slides/test_glossary.py` (discovery/resolution).
- Extended translator-prompt unit tests: per-language selection, `_system_message`, and a `:g`/`:gm` namespace non-collision regression (which caught — and drove the fix for — a single-entry-map collision).
- CLI wiring tests for sync **and** end-to-end tests proving the per-target glossary text reaches the real `translate()` prompt in each direction (EN→DE add uses DE glossary, DE→EN uses EN, no cross-leak).
- CLI `--glossary` tests for `translate` (the original feature shipped with only prompt_version unit tests).

Full fast suite green locally: **7182 passed, 3 skipped, 1 xfailed**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
