### PR TITLE
fix(slides sync): propagate or alert all one-sided edits (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm slides sync` no longer silently drops one-sided edits to shared /
+  id-less / header cells (Issue #269).** Sync's promise is that editing one half
+  of a split deck carries *all* changes to the other half, and that it never
+  reports "decks already consistent" while a change was in fact dropped. Several
+  classes of edit violated that — each was silently lost, the run reported "0
+  changes — decks already consistent", and the watermark advanced over the
+  divergence (permanently baselining the loss). All are now propagated, or alerted
+  when they cannot be:
+  - **Language-neutral code/markdown cells on the first sync.** The neutral-cell
+    drift diff ran only against a watermark, so the **cold-start (git `HEAD`)
+    baseline** — the first sync of a freshly-split pair — missed a one-sided edit,
+    add, or removal of a shared cell entirely. The git-HEAD baseline now supplies
+    the shared-cell sequence, so cold-start syncs detect and propagate them (and
+    surface a both-sides divergence) exactly like the watermark path.
+  - **Id-less localized cells** (a `lang=` cell with no `slide_id`). A one-sided
+    body edit had no propagation direction, so it was dropped under *both*
+    baselines. A drift detector now feeds the structural pass a direction; both
+    bare statements (hash-anchored) and named constructs (`def`/`class`/`import`)
+    are re-translated onto the twin. A genuine both-sides id-less edit with no other
+    direction is surfaced rather than guessed.
+  - **The j2 deck header.** A one-sided header edit (a retitle, or a should-be-
+    identical neutral arg) was reported "consistent". Sync still does not
+    auto-translate the header, but a one-sided change is now an **error** that holds
+    the watermark and tells you to update the other header (or run `clm slides
+    translate`).
+  - **Honest reporting + fail-safe.** The summary no longer says "0 changes —
+    decks already consistent" on a run that propagated a structural change (it names
+    the direction), the apply outcome counts a new `structural` figure, and a
+    post-apply parity check errors if the two halves' neutral cells still differ —
+    so an un-propagatable shared-cell change can never be silently banked.
 - **`clm slides translate`'s delegated-sync path now selects the glossary
   per-language too.** When the twin already exists, `translate` degrades to the
   bidirectional sync engine; it previously applied the single target-language

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -1137,7 +1137,8 @@ def _outcome_line(result: ApplyResult) -> str:
         f"{result.applied_remove} remove, "
         f"{result.applied_move} move, {result.applied_add} add, "
         f"{result.applied_rename} rename, {result.applied_mint} mint, "
-        f"{result.applied_adopt} adopt, {result.applied_reconcile} reconcile; "
+        f"{result.applied_adopt} adopt, {result.applied_reconcile} reconcile, "
+        f"{result.applied_structural} structural; "
         f"{result.in_sync} already in sync; "
         f"{result.deferred} deferred; {len(result.errors)} error(s); "
         f"watermark {'advanced' if result.watermark_recorded else 'held'}."
@@ -1247,6 +1248,7 @@ def _apply_dict(result: ApplyResult) -> dict:
             "mint": result.applied_mint,
             "adopt": result.applied_adopt,
             "reconcile": result.applied_reconcile,
+            "structural": result.applied_structural,
             "total": result.applied,
         },
         "in_sync": result.in_sync,

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1296,10 +1296,18 @@ structurally, so it is **not** minted a `slide_id`.
 by a **content anchor** (`hand slide_id > construct slug > content hash`), never
 written into the file, so a deck stays id-light yet syncs precisely:
 
-- **Code-only edits propagate.** Editing *only* a language-neutral code cell on
-  one side — no narrative or id change — is now detected (the anchor diff sees
-  which half drifted) and copied verbatim to the twin. Previously such an edit was
-  silently dropped.
+- **Code-only edits propagate — on the first sync too (Issue #269).** Editing
+  *only* a language-neutral code (or markdown) cell on one side — no narrative or id
+  change — is detected (the anchor diff sees which half drifted) and copied verbatim
+  to the twin. This now also fires on the **cold-start (git `HEAD`) baseline** — the
+  first sync of a freshly-split pair, before any watermark exists. Previously the
+  neutral-cell diff ran only against a watermark, so such an edit on a first sync was
+  silently dropped and reported "decks already consistent".
+- **Id-less localized cell edits propagate (Issue #269).** A `lang=` cell with **no**
+  `slide_id` (a one-off demo / output cell) edited on one side is re-translated onto
+  the twin — both bare statements and named constructs (`def` / `class` / `import`),
+  under either baseline. Previously an id-less-localized-only edit had no direction
+  signal and was silently dropped.
 - **Unchanged localized code is never re-translated.** When a slide group is
   rebuilt for a sibling's sake, an unchanged id-less localized code cell is spliced
   verbatim by its anchor instead of being re-translated — no churn, no LLM spend.
@@ -1316,6 +1324,17 @@ written into the file, so a deck stays id-light yet syncs precisely:
 - **Genuinely ambiguous id realignment** (a function renamed *while* a cell was
   split, an unresolvable tie) is left untouched and re-surfaces next run, unless
   you opt in with `--llm-recover` (above).
+- **The deck header is never silently dropped (Issue #269).** Sync does **not**
+  auto-translate the j2 deck header (`{{ header_xx(…) }}`) — it is language-specific
+  and each half keeps its own. But a header edited on **one** half only is now an
+  **error** (the watermark holds, exit 2) telling you to update the other header (or
+  run `clm slides translate`), instead of being reported "consistent". A header
+  updated on **both** halves is accepted.
+- **A shared-cell parity fail-safe guards the invariant (Issue #269).** After an
+  otherwise-clean apply, the language-neutral cells of the two halves must be
+  byte-identical (the `unify` invariant); if any still differ, sync **errors** and
+  holds the watermark rather than report the decks consistent — so an
+  un-propagatable shared-cell change is always surfaced, never silently banked.
 
 Use `--explain` to see the anchor-level view (per-cell anchor + drift, the
 propagation direction, drifted ids) for any pair.

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -831,9 +831,16 @@ class SyncWatermarkCache:
         tag-only edit. A position absent from ``tags`` (or ``tags=None``) stores
         NULL — "tag set unknown" — which the classifier reads as "tag direction
         undeterminable" and skips, so a pre-#198 watermark degrades gracefully.
+
+        ``de-header`` / ``en-header`` (Issue #269) record each half's j2 deck-header
+        cells (excluded from every other partition) so a one-sided header edit —
+        which sync never auto-translates — can be detected and surfaced rather than
+        silently reported as "consistent".
         """
-        if lang not in ("de", "en", "shared"):
-            raise ValueError(f"lang must be 'de', 'en', or 'shared', got {lang!r}")
+        if lang not in ("de", "en", "shared", "de-header", "en-header"):
+            raise ValueError(
+                f"lang must be 'de', 'en', 'shared', 'de-header', or 'en-header', got {lang!r}"
+            )
         tag_for = tags or {}
         with self._conn:  # single transaction (BEGIN/COMMIT or ROLLBACK)
             self._conn.execute(

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -63,6 +63,7 @@ from clm.slides.sync_plan import (
     Proposal,
     SyncPlan,
     TagHold,
+    _git_head_text,
     ordered_sync_cells,
     watermark_rows,
     watermark_tag_map,
@@ -148,6 +149,8 @@ class ApplyResult:
     applied_reconcile: int = (
         0  # a confirmed mismatched-id twin had its divergent id rewritten (#228)
     )
+    applied_structural: int = 0  # slide-group regions the structural pass rebuilt (#269):
+    # propagated language-neutral / id-less-localized cells the per-cell walk cannot reach
     in_sync: int = 0  # an edit the judge decided needed no change
     deferred: int = 0  # conflict (or moves/adds declined this pass)
     watermark_recorded: bool = False
@@ -166,6 +169,7 @@ class ApplyResult:
             + self.applied_mint
             + self.applied_adopt
             + self.applied_reconcile
+            + self.applied_structural
         )
 
     @property
@@ -372,7 +376,7 @@ def apply_plan(
         plan, de_state, en_state, watermark_cache, result, recoverer, alignment_cache
     )
 
-    baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan.de_path, plan.en_path)
+    baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan)
     apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
 
     # Fail-safe: a complete resolution leaves no duplicate id behind. If one
@@ -381,9 +385,15 @@ def apply_plan(
     _flag_residual_duplicates(de_state, "de", result)
     _flag_residual_duplicates(en_state, "en", result)
     # On an otherwise-clean pass both decks must carry the same (slide_id, role)
-    # set; a one-sided orphan is a silent cross-deck divergence.
+    # set; a one-sided orphan is a silent cross-deck divergence. The shared-cell
+    # parity check (Issue #269) is the cardinal-invariant fail-safe: language-neutral
+    # cells must be byte-identical across the halves after a clean apply, so a residual
+    # divergence means a shared-cell change was dropped — error rather than report
+    # "consistent" and advance the watermark over it.
     if not result.errors and result.deferred == 0 and not plan.has_errors:
         _flag_cross_deck_orphans(de_state, en_state, result)
+        _flag_shared_cell_divergence(de_state, en_state, result)
+        _flag_idless_localized_divergence(plan, de_state, en_state, result)
 
     # Buffered temp-swap (Issue #190 item 1): persist both decks atomically, and
     # ONLY when the whole pass is error-free — neither an apply-time error
@@ -554,6 +564,129 @@ def _flag_cross_deck_orphans(de_state: FileState, en_state: FileState, result: A
         result.errors.append(f"slide_id {sid!r}/{role} present on de but missing on en")
     for sid, role in sorted(en_keys - de_keys):
         result.errors.append(f"slide_id {sid!r}/{role} present on en but missing on de")
+
+
+def _shared_cell_hashes(state: FileState) -> list[str]:
+    """Ordered content hashes of a deck's language-neutral (``shared``) cells.
+
+    Partitioned exactly like :func:`clm.slides.sync_plan.watermark_rows` — a non-j2
+    cell whose ``lang`` is neither ``de`` nor ``en`` — so it spans neutral code,
+    neutral markdown, AND a markdown cell that carries a narrative tag but no
+    ``lang`` (the tagged-neutral blind spot). Hashed with the same
+    :func:`cell_content_hash` the rest of the engine uses, so trailing-blank
+    separator differences never register.
+    """
+    return [
+        cell_content_hash(cell.body)
+        for cell in state.cells
+        if not cell.metadata.is_j2 and cell.metadata.lang not in ("de", "en")
+    ]
+
+
+def _flag_shared_cell_divergence(
+    de_state: FileState, en_state: FileState, result: ApplyResult
+) -> None:
+    """Error if the two halves' language-neutral cells are not byte-identical (#269).
+
+    The cardinal-invariant fail-safe. Language-neutral cells are shared verbatim
+    across a split pair (the ``unify`` invariant), so after a clean apply their
+    ordered content hashes MUST match. If they still diverge, a one-sided edit /
+    add / remove of a neutral cell was *not* propagated — the engine must surface
+    that as an error (holding the watermark and writing nothing) rather than let
+    the pass report "decks already consistent". This backstops the neutral-cell
+    propagation paths (``align_anchored`` + the structural pass) for every neutral
+    cell shape, including a tagged-neutral cell the structural pass cannot rebuild.
+
+    Only invoked on an otherwise-clean pass (no prior error / deferral), so a
+    genuine mismatch here is always an un-propagated divergence, never a
+    double-report of an already-alerted problem.
+    """
+    if _shared_cell_hashes(de_state) != _shared_cell_hashes(en_state):
+        result.errors.append(
+            "language-neutral (shared) cells differ between de and en after sync — "
+            "a change to a shared cell was not propagated; re-run sync (a watermark "
+            "now exists) or resolve the divergence manually"
+        )
+
+
+def _idless_localized_group_kinds(state: FileState) -> list[tuple[int, str]]:
+    """Ordered ``(slide-group index, kind)`` of each id-less localized cell — structure only.
+
+    A ``lang=`` cell with no per-cell role (``role_of`` ``None`` — the ``("L", kind)``
+    set). Content- and language-free, so it is comparable **across** the two halves
+    (which hold translations, not identical text). Under the unify/split invariant the
+    halves place their id-less localized cells in the same slide groups in the same
+    order, so a mismatch is a move the structural pass did not mirror (Issue #269).
+    """
+    out: list[tuple[int, str]] = []
+    group = -1
+    for cell in state.cells:
+        meta = cell.metadata
+        if meta.is_slide_start:
+            group += 1
+        if meta.is_j2:
+            continue
+        if meta.lang in ("de", "en") and role_of(meta) is None:
+            out.append((group, "code" if meta.cell_type == "code" else "markdown"))
+    return out
+
+
+def _idless_localized_body_hashes(state: FileState) -> list[str]:
+    """Ordered content hashes of a deck's id-less localized cells (document order)."""
+    return [
+        cell_content_hash(cell.body)
+        for cell in state.cells
+        if not cell.metadata.is_j2
+        and cell.metadata.lang in ("de", "en")
+        and role_of(cell.metadata) is None
+    ]
+
+
+def _flag_idless_localized_divergence(
+    plan: SyncPlan, de_state: FileState, en_state: FileState, result: ApplyResult
+) -> None:
+    """Error on an un-mirrored move/reorder of id-less localized cells (Issue #269).
+
+    The neutral parity fail-safe (:func:`_flag_shared_cell_divergence`) cannot see
+    these cells — they carry a ``lang``, so they are language-specific (translations),
+    not byte-identical across halves. A one-sided **body edit** is handled by the
+    drift detector + structural pass, but a one-sided **move** (across slide groups)
+    or **reorder** (within a group) of an un-id'd cell can slip through: the flat,
+    order-blind machinery may not detect or cannot rebuild it, which would otherwise
+    leave the halves divergent while the run reports "consistent". Two content-free
+    (so false-positive-free) checks restore propagate-or-**alert**:
+
+    1. **Cross-half structure** — the ordered ``(group, kind)`` of id-less localized
+       cells must match across de and en. A cross-group move breaks it.
+    2. **One-sided pure reorder** — a half whose id-less localized cells are a pure
+       reorder of its baseline (same multiset, different order) while the other half is
+       unchanged. A pure reorder involves no translation, so comparing against the
+       baseline cannot false-positive on a re-translated body edit.
+
+    Documented residual: a one-sided reorder of two **same-kind** id-less cells within
+    one group is alerted (check 2), not auto-propagated — give such cells ``slide_id``s
+    for precise sync.
+    """
+    if _idless_localized_group_kinds(de_state) != _idless_localized_group_kinds(en_state):
+        result.errors.append(
+            "id-less localized cells (lang= cells with no slide_id) are placed "
+            "differently across de and en after sync — a move was not propagated; "
+            "give them slide_ids for precise sync, or resolve manually"
+        )
+        return
+    de_base, en_base = plan.idless_baseline_de, plan.idless_baseline_en
+    if de_base is None or en_base is None:
+        return
+    de_now = _idless_localized_body_hashes(de_state)
+    en_now = _idless_localized_body_hashes(en_state)
+    de_reorder = de_now != de_base and Counter(de_now) == Counter(de_base)
+    en_reorder = en_now != en_base and Counter(en_now) == Counter(en_base)
+    if (de_reorder and en_now == en_base) or (en_reorder and de_now == de_base):
+        result.errors.append(
+            "id-less localized cells were reordered on one deck but not the other "
+            "after sync — give them slide_ids so the order can be mirrored, or "
+            "resolve manually"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1956,35 +2089,69 @@ def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
     return index
 
 
+def _anchor_map_from_rows(rows: list[tuple[str | None, str | None, str]]) -> dict[str, str]:
+    """``{anchor: content_hash}`` over ``(slide_id, construct, content_hash)`` rows.
+
+    A construct anchor is only a *name* (``extract_from_code``), so it is not
+    content-unique: two cells sharing it (two ``import os``, two ``def solution``)
+    cannot be told apart by anchor. Admit an anchor to the reuse set only when it
+    occurs exactly once — a non-unique anchor cannot reliably locate a twin, so its
+    cells re-translate (the honest §12 residual) rather than risk a wrong-twin
+    splice (Issue #190 review). Shared by the watermark and git-HEAD baselines.
+    """
+    anchors = [row_anchor(sid, construct, chash) for (sid, construct, chash) in rows]
+    counts = Counter(anchors)
+    return {
+        anchor: chash
+        for anchor, (_sid, _construct, chash) in zip(anchors, rows, strict=True)
+        if counts[anchor] == 1
+    }
+
+
 def _baseline_anchor_hashes(
     cache: SyncWatermarkCache | None,
-    de_path: Path,
-    en_path: Path,
+    plan: SyncPlan,
 ) -> dict[str, dict[str, str]]:
     """Per-language ``{anchor: content_hash}`` of the last-synced state.
 
-    Built from the widened watermark (every non-j2 cell). The structural pass
-    uses it to tell an UNCHANGED id-less localized code cell (anchor present with
-    the same hash) from an edited one, so the former is reused verbatim instead of
-    re-translated (Issue #190 item 3 / §8). Empty when there is no watermark — the
-    structural pass then translates as before.
+    The structural pass uses it to tell an UNCHANGED id-less localized code cell
+    (anchor present with the same hash) from an edited one — so the former is reused
+    verbatim and the latter is re-translated (Issue #190 item 3 / §8), and the same
+    drift signal lets a group with an otherwise-unchanged ``("L", kind)`` signature
+    rebuild (Issue #269). Built from whichever baseline the plan resolved:
+
+    - ``watermark`` — the widened watermark rows (every non-j2 cell);
+    - ``git-head`` — the committed (HEAD) decks, parsed the same way, so the
+      cold-start (first) sync gets the same drift detection instead of an empty map
+      that would silently drop an id-less-localized body edit (Issue #269).
+
+    Empty for a baseline of ``none`` (true cold start) — the structural pass then
+    translates as before.
     """
     out: dict[str, dict[str, str]] = {"de": {}, "en": {}}
-    if cache is None:
-        return out
-    for lang in ("de", "en"):
-        rows = cache.get_deck(str(de_path), str(en_path), lang)
-        anchors = [row_anchor(sid, construct, chash) for (_p, sid, _r, chash, construct) in rows]
-        # A construct anchor is only a *name* (``extract_from_code``), so it is not
-        # content-unique: two cells sharing it (two ``import os``, two
-        # ``def solution``) cannot be told apart by anchor. Admit an anchor to the
-        # reuse set only when it occurs exactly once — a non-unique anchor cannot
-        # reliably locate a twin, so its cells re-translate (the honest §12
-        # residual) rather than risk a wrong-twin splice (Issue #190 review).
-        counts = Counter(anchors)
-        for anchor, (_p, _sid, _r, chash, _c) in zip(anchors, rows, strict=True):
-            if counts[anchor] == 1:
-                out[lang][anchor] = chash
+    if plan.baseline_source == "watermark" and cache is not None:
+        for lang in ("de", "en"):
+            rows = cache.get_deck(str(plan.de_path), str(plan.en_path), lang)
+            out[lang] = _anchor_map_from_rows(
+                [(sid, construct, chash) for (_p, sid, _r, chash, construct) in rows]
+            )
+    elif plan.baseline_source == "git-head":
+        for lang, path in (("de", plan.de_path), ("en", plan.en_path)):
+            text = _git_head_text(path)
+            if text is None:
+                continue
+            cells = parse_cells(text, comment_token_for_path(path))
+            out[lang] = _anchor_map_from_rows(
+                [
+                    (
+                        c.metadata.slide_id,
+                        construct_of(c.metadata, c.content),
+                        cell_content_hash(c.content),
+                    )
+                    for c in cells
+                    if not c.metadata.is_j2
+                ]
+            )
     return out
 
 
@@ -2458,6 +2625,23 @@ def _clear_slide_id(cell: RawCell) -> None:
     cell.metadata = parse_cell_header(header)
 
 
+def _header_rows(cells: list[Cell]) -> list[tuple[int, str | None, str, str, str | None]]:
+    """Watermark rows for a file's j2 deck-header cells (Issue #269).
+
+    ``(position, slide_id=None, role="header", content_hash, construct=None)`` in
+    j2-cell order — the ``de-header`` / ``en-header`` partition the one-sided
+    header-drift check diffs against.
+    """
+    rows: list[tuple[int, str | None, str, str, str | None]] = []
+    pos = 0
+    for cell in cells:
+        if cell.metadata.is_j2:
+            # A j2 directive's macro text is its header line; Cell.content is empty.
+            rows.append((pos, None, "header", cell_content_hash(cell.header), None))
+            pos += 1
+    return rows
+
+
 def _record_watermark(
     cache: SyncWatermarkCache,
     de_path: Path,
@@ -2502,6 +2686,21 @@ def _record_watermark(
         lang="shared",
         cells=de_rows["shared"],
         tags=de_tags["shared"],
+    )
+    # Issue #269: record each half's j2 deck-header cells (excluded from every other
+    # partition) so a later run can detect a one-sided header edit — which sync never
+    # auto-translates — instead of silently reporting the decks consistent.
+    cache.put_deck(
+        de_path=str(de_path),
+        en_path=str(en_path),
+        lang="de-header",
+        cells=_header_rows(de_cells),
+    )
+    cache.put_deck(
+        de_path=str(de_path),
+        en_path=str(en_path),
+        lang="en-header",
+        cells=_header_rows(en_cells),
     )
 
 

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -38,6 +38,7 @@ this structural step.
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import TYPE_CHECKING
 
 from clm.slides.raw_cells import RawCell
@@ -94,6 +95,12 @@ def apply_code_structure(
     else:
         source_state, target_state, source_lang, target_lang = de_state, en_state, "de", "en"
     src_anchors = (baseline_anchors or {}).get(source_lang, {})
+    # Source-language baseline id-less localized hashes as a multiset (Issue #269):
+    # lets a region detect a HASH-anchored id-less body edit — one whose construct
+    # anchor changes with the body, so ``src_anchors`` (keyed by the *current*
+    # anchor) cannot see it — by content membership instead.
+    src_idless = plan.idless_baseline_de if source_lang == "de" else plan.idless_baseline_en
+    src_idless_counts = Counter(src_idless) if src_idless else None
 
     src_head, src_groups = _split_groups(source_state.cells)
     tgt_head, tgt_groups = _split_groups(target_state.cells)
@@ -113,10 +120,11 @@ def apply_code_structure(
         new_cells.extend(region)
         if was_rebuilt:
             rebuilt_ids.update(id(c) for c in region)
+            result.applied_structural += 1  # Issue #269: surface structural propagation
 
     def reconcile(src_region: list[RawCell], tgt_region: list[RawCell]) -> None:
         if _signature(src_region) == _signature(tgt_region) and not _region_has_localized_drift(
-            src_region, src_anchors
+            src_region, src_anchors, src_idless_counts
         ):
             emit(tgt_region, was_rebuilt=False)
             return
@@ -228,40 +236,71 @@ def _signature(cells: list[RawCell]) -> list[tuple]:
         if meta.is_j2:
             sig.append(("J",))
             continue
+        if meta.lang is None:
+            # Language-neutral: shared verbatim across the halves, so its TEXT is
+            # comparable — and it MUST be, even when the cell carries a narrative
+            # tag (``role_of`` set). The per-cell engine never reconciles a no-lang
+            # cell (``ordered_sync_cells`` filters by ``lang``), so the structural
+            # pass owns it; keying it on role alone would discard the body and let a
+            # one-sided body edit to a tagged-neutral cell slip through silently
+            # (Issue #269). Checked before ``role_of`` precisely so a tag cannot
+            # mask the body.
+            sig.append(("S", cell.body))
+            continue
         role = role_of(meta)
         if role is not None:
             sig.append(("R", role))
-        elif meta.lang is None:
-            sig.append(("S", cell.body))
         else:
             sig.append(("L", "code" if meta.cell_type == "code" else "markdown"))
     return sig
 
 
 def _region_has_localized_drift(
-    src_region: list[RawCell], src_anchors: dict[str, str] | None
+    src_region: list[RawCell],
+    src_anchors: dict[str, str] | None,
+    src_idless_counts: Counter[str] | None = None,
 ) -> str | None:
     """Whether the source region holds an id-less localized cell edited since baseline.
 
-    Item-2b (§7b). A localized id-less code cell that changed must be re-translated,
-    but its ``("L", kind)`` signature is unchanged by a body edit, so the group
-    would not otherwise rebuild. Detect the drift via the baseline anchor→hash map
-    (``baseline_anchors`` for the source language): the cell's anchor is recorded
-    but its current content hash differs. Returns the drifted cell's anchor (truthy)
-    or ``None``. ``src_anchors`` is already de-duplicated (the Phase 2 ``Counter``
-    guard), so a non-unique construct anchor is simply absent — that cell does not
-    force a rebuild (the honest §12 residual), never a wrong one.
+    Item-2b (§7b). A localized id-less cell that changed must be re-translated, but
+    its ``("L", kind)`` signature is unchanged by a body edit, so the group would
+    not otherwise rebuild. Two complementary detectors:
+
+    - **construct anchor** (``src_anchors``): a cell whose stable construct anchor
+      (``def foo`` → ``construct:foo``) is recorded in the baseline but whose current
+      content hash differs. ``src_anchors`` is de-duplicated (the Phase 2 ``Counter``
+      guard), so a non-unique construct anchor is simply absent — that cell does not
+      force a rebuild here (it falls to the hash-membership check below);
+    - **hash membership** (``src_idless_counts``, Issue #269): a *hash-anchored*
+      id-less cell (no nameable construct — a bare ``print(...)`` / expression) edits
+      its own anchor, so the construct check above can never see it. Instead compare
+      content membership: a source id-less cell whose body is not covered by the
+      source-language baseline multiset of id-less hashes is new or edited → drift.
+      The multiset is consumed as matched so an unchanged duplicate-bodied sibling
+      still matches while a genuinely new one does not.
+
+    Returns a truthy marker for the first drifted cell, or ``None``.
     """
-    if not src_anchors:
-        return None
-    for cell in src_region:
-        meta = cell.metadata
-        if meta.is_j2 or meta.lang is None or role_of(meta) is not None:
-            continue  # only id-less LOCALIZED cells (role_of None, lang set)
-        anchor = anchor_of(meta, cell.body)
-        baseline_hash = src_anchors.get(anchor)
-        if baseline_hash is not None and baseline_hash != cell_content_hash(cell.body):
-            return anchor
+    if src_anchors:
+        for cell in src_region:
+            meta = cell.metadata
+            if meta.is_j2 or meta.lang is None or role_of(meta) is not None:
+                continue  # only id-less LOCALIZED cells (role_of None, lang set)
+            anchor = anchor_of(meta, cell.body)
+            baseline_hash = src_anchors.get(anchor)
+            if baseline_hash is not None and baseline_hash != cell_content_hash(cell.body):
+                return anchor
+    if src_idless_counts:
+        remaining = Counter(src_idless_counts)
+        for cell in src_region:
+            meta = cell.metadata
+            if meta.is_j2 or meta.lang is None or role_of(meta) is not None:
+                continue
+            chash = cell_content_hash(cell.body)
+            if remaining.get(chash, 0) > 0:
+                remaining[chash] -= 1  # an unchanged baseline cell accounts for this one
+            else:
+                return f"idless-drift:{chash}"  # body not in baseline → new/edited
     return None
 
 
@@ -307,6 +346,15 @@ def _rebuild_region(
             out.append(twin if twin is not None else _copy_cell(cell))
             j2_seen += 1
             continue
+        if meta.lang is None:
+            # Language-neutral: shared verbatim across the halves, whatever its role.
+            # Checked before ``role_of`` so a tagged-neutral cell (``tags=["slide"]``
+            # but no ``lang``) is copied from the source rather than pulled as a
+            # stale ``(slide_id, role)`` twin — the body edit would otherwise be
+            # dropped (Issue #269). Its header is identical on both halves (no lang
+            # to swap), so a verbatim copy carries any tag/body change across.
+            out.append(_copy_cell(cell))
+            continue
         role = role_of(meta)
         if role is not None:
             twin = _find(tgt_cells, meta.slide_id, role)
@@ -322,8 +370,6 @@ def _rebuild_region(
                 if body is None:
                     return None
                 out.append(build_twin_cell(cell, target_lang, body))
-        elif meta.lang is None:
-            out.append(_copy_cell(cell))  # language-neutral: shared verbatim
         elif meta.lang == source_lang:
             # Item-3 reuse (§8): an UNCHANGED id-less localized cell keeps its
             # existing target twin verbatim instead of being re-translated. It is

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -250,6 +250,13 @@ class SyncPlan:
     # keyed classifier found none — the Issue #190 item-2 signal. ``None`` when
     # no non-keyed cell drifted. Consumed by the structural pass (sync_code).
     anchor_direction: str | None = None
+    # Issue #269: per-language ordered content hashes of the baseline's id-less
+    # localized cells (the ("L", kind) set). ``None`` when no baseline was
+    # resolved. The structural pass uses them (as a multiset) to detect a
+    # hash-anchored id-less body edit a construct anchor cannot see, and apply uses
+    # them post-pass to fail-safe on any id-less drift that was not propagated.
+    idless_baseline_de: list[str] | None = None
+    idless_baseline_en: list[str] | None = None
 
     @property
     def has_baseline(self) -> bool:
@@ -329,6 +336,16 @@ class SyncPlan:
                 "baseline=none: no watermark and no git HEAD to diff against — "
                 "cannot detect edits/removes. Pass --source-lang or commit a "
                 "baseline. (id-less adds are still detected.)"
+            )
+        if self.anchor_direction is not None:
+            # A language-neutral / id-less-localized (structural) change carries no
+            # proposal but DID drift one half: the structural pass propagates it this
+            # run, so the headline must not claim "already consistent" (mirrors
+            # ``is_noop``, which already counts ``anchor_direction``). Issue #269.
+            return (
+                f"baseline={self.baseline_source}: language-neutral/structural "
+                f"change propagating {self.anchor_direction} "
+                f"({self.in_sync_count} cell(s) in sync)."
             )
         return (
             f"baseline={self.baseline_source}: 0 changes — decks already "
@@ -460,6 +477,20 @@ def _shared_hashes(cells: list[Cell]) -> list[str]:
     return [chash for (_pos, _sid, _role, chash, _construct) in watermark_rows(cells)["shared"]]
 
 
+def _header_hashes(cells: list[Cell]) -> list[str]:
+    """Ordered content hashes of a file's j2 deck-header cells (Issue #269).
+
+    The deck header (``# j2 … {{ header_xx(…) }}``) is excluded from every sync
+    partition (``watermark_rows`` / ``role_of`` / ``_shared_hashes`` all skip
+    ``is_j2`` cells) and is language-specific, so sync never auto-translates it. To
+    keep the "never report consistent while a change was dropped" invariant, the
+    header is hashed here so a one-sided header edit can be detected and surfaced.
+    A j2 cell's macro text lives in its **header line** (``Cell.content`` is empty
+    for a directive cell), so that is what is hashed.
+    """
+    return [cell_content_hash(c.header) for c in cells if c.metadata.is_j2]
+
+
 @dataclass(frozen=True)
 class AnchorAlignment:
     """How the language-neutral cells drifted, and what the sync should do.
@@ -555,6 +586,150 @@ def align_anchored(
     return AnchorAlignment(direction=None, diverged=True)
 
 
+def _idless_localized_hashes(cells: list[Cell], lang: str) -> list[str]:
+    """Ordered content hashes of the id-less localized cells of ``lang`` (Issue #269).
+
+    The ``("L", kind)`` set the structural pass owns: a ``lang=``-bearing cell with
+    no per-cell role (``role_of`` ``None`` — i.e. no ``slide_id`` and no narrative
+    tag). The keyed walk skips it (no slide_id) and :func:`align_anchored` skips it
+    (not in the ``shared`` partition), so this ordered sequence is what a one-sided
+    drift detector compares — the localized analog of :func:`_shared_hashes`.
+    """
+    return [
+        cell_content_hash(c.content)
+        for c in cells
+        if not c.metadata.is_j2 and c.metadata.lang == lang and role_of(c.metadata) is None
+    ]
+
+
+def _idless_localized_baseline_from_rows(
+    rows: list[tuple[int, str | None, str, str, str | None]],
+) -> list[str]:
+    """Ordered id-less localized baseline hashes from a watermark ``de``/``en`` partition.
+
+    The membership-widened watermark files an id-less localized cell under the
+    synthetic :data:`LOCALIZED_CODE_ROLE` / :data:`LOCALIZED_MARKDOWN_ROLE` role
+    (its ``role_of`` is ``None``); an id-carrying cell keeps a real role. Selecting
+    those two roles reproduces :func:`_idless_localized_hashes` over the baseline.
+    """
+    return [
+        chash
+        for (_pos, _sid, role, chash, _construct) in rows
+        if role in (LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE)
+    ]
+
+
+def _idless_localized_baseline_from_git_head(path: Path, lang: str) -> list[str] | None:
+    """git-HEAD counterpart of :func:`_idless_localized_baseline_from_rows`, or ``None``."""
+    text = _git_head_text(path)
+    if text is None:
+        return None
+    return _idless_localized_hashes(parse_cells(text, comment_token_for_path(path)), lang)
+
+
+def _classify_idless_localized_drift(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    de_baseline: list[str],
+    en_baseline: list[str],
+) -> None:
+    """Feed a direction for a one-sided id-less localized drift, or alert (Issue #269).
+
+    Compares each half's ordered id-less localized hashes against its baseline. A
+    one-sided drift yields a propagation direction handed to the structural pass
+    (which re-translates the changed cell via ``_region_has_localized_drift`` /
+    signature rebuild); a two-sided drift, or one whose direction conflicts with the
+    direction the rest of the pass already established (keyed proposals or the
+    neutral anchor), is irreconcilable and surfaces as an error so the watermark
+    holds and the user is alerted — never a silent drop.
+    """
+    de_drifted = _idless_localized_hashes(de_cells, "de") != de_baseline
+    en_drifted = _idless_localized_hashes(en_cells, "en") != en_baseline
+    if not de_drifted and not en_drifted:
+        return
+    # The direction the rest of the pass already established: a single keyed edit
+    # direction if any, else the neutral anchor.
+    established = _keyed_direction(plan)
+    if established is None:
+        established = plan.anchor_direction
+    if de_drifted and en_drifted:
+        # Both halves' id-less localized streams changed. When a direction is already
+        # established (a keyed edit or the neutral anchor), the existing id-migration
+        # + structural pass resolve these along it — e.g. a localized id'd code cell
+        # split into import+def on BOTH decks, where the new id-less def appears on
+        # each half. Only when there is NO direction signal at all is this a genuine
+        # both-sides edit a single-direction sync cannot reconcile -> alert.
+        if established is None:
+            plan.issues.append(
+                PlanIssue(
+                    severity="error",
+                    slide_id=None,
+                    reason="id-less localized cells (lang= cells with no slide_id) were "
+                    "edited on both decks; sync cannot determine a single direction — "
+                    "resolve manually or assign slide_ids so the cells can be paired",
+                )
+            )
+        return
+    direction = "de->en" if de_drifted else "en->de"
+    # Reconcile with the established direction. A conflict means the author edited
+    # different cell classes in opposite directions — not safely applicable in one
+    # pass, so alert rather than overwrite one side's edit.
+    if established is not None and established != direction:
+        plan.issues.append(
+            PlanIssue(
+                severity="error",
+                slide_id=None,
+                reason=f"an id-less localized cell drifted {direction} but other cells "
+                f"drifted {established}; sync cannot apply both directions at once — "
+                "resolve manually",
+            )
+        )
+        return
+    if plan.anchor_direction is None:
+        plan.anchor_direction = direction
+
+
+def _classify_header_drift(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    de_baseline: list[str],
+    en_baseline: list[str],
+) -> None:
+    """Alert on a one-sided j2 deck-header edit (Issue #269).
+
+    The deck header is language-specific (``header_de`` vs ``header_en``) and is
+    excluded from every sync partition, so sync neither translates nor propagates
+    it — the structural pass deliberately keeps each half's own header. That is
+    correct behavior, but it must NOT be reported as "decks already consistent"
+    when one half's header was edited and the other's was not. Compare each half's
+    header against its baseline: a one-sided drift is an error so the watermark
+    holds, the run exits non-zero, and the user is told to update the other header
+    (or run ``clm slides translate``). A both-sided drift is treated as "both
+    halves were updated" (no alert); neither-side is a no-op.
+
+    An error rather than a warning because (a) sync genuinely cannot resolve it and
+    (b) only an error makes ``is_noop`` False and the summary non-"consistent" — a
+    warning would still report the decks consistent and exit 0.
+    """
+    de_drifted = _header_hashes(de_cells) != de_baseline
+    en_drifted = _header_hashes(en_cells) != en_baseline
+    if de_drifted == en_drifted:
+        return  # neither changed, or both updated — no one-sided header divergence
+    side, other = ("de", "en") if de_drifted else ("en", "de")
+    plan.issues.append(
+        PlanIssue(
+            severity="error",
+            slide_id=None,
+            reason=f"the {side.upper()} deck header changed since the last sync but the "
+            f"{other.upper()} header did not — sync does not auto-translate the deck "
+            f"header; update the {other.upper()} header to match (or run "
+            "`clm slides translate`), then re-run sync",
+        )
+    )
+
+
 # ``CLM_SYNC__SHARED_DIVERGENCE`` (the §7a knob): how to handle a language-neutral
 # cell edited differently on both decks. ``auto-heal`` propagates the winning side
 # with a warning; ``error`` surfaces it and writes nothing.
@@ -642,16 +817,13 @@ def _lang_for_path(path: Path) -> str | None:
     return None
 
 
-def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
-    """Derive a baseline from the committed (HEAD) version of ``path``.
+def _git_head_text(path: Path) -> str | None:
+    """The committed (HEAD) text of ``path``, or ``None`` if unavailable.
 
-    Returns ``None`` when git is unavailable, the file is untracked, or the
-    deck's language cannot be inferred from its name. An empty list means the
-    file existed at HEAD but had no sync-relevant cells.
+    ``None`` when git is unavailable, the file is untracked, or ``git show``
+    fails. Shared by the per-cell baseline (:func:`_baseline_from_git_head`) and
+    the shared/header baselines so they all read the *same* committed snapshot.
     """
-    lang = _lang_for_path(path)
-    if lang is None:
-        return None
     try:
         completed = subprocess.run(
             ["git", "show", f"HEAD:./{path.name}"],
@@ -665,7 +837,23 @@ def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
         return None
     if completed.returncode != 0:
         return None
-    cells = parse_cells(completed.stdout, comment_token_for_path(path))
+    return completed.stdout
+
+
+def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
+    """Derive a baseline from the committed (HEAD) version of ``path``.
+
+    Returns ``None`` when git is unavailable, the file is untracked, or the
+    deck's language cannot be inferred from its name. An empty list means the
+    file existed at HEAD but had no sync-relevant cells.
+    """
+    lang = _lang_for_path(path)
+    if lang is None:
+        return None
+    text = _git_head_text(path)
+    if text is None:
+        return None
+    cells = parse_cells(text, comment_token_for_path(path))
     return [
         BaselineCell(
             position=c.position,
@@ -676,6 +864,36 @@ def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
         )
         for c in ordered_sync_cells(cells, lang)
     ]
+
+
+def _shared_baseline_from_git_head(path: Path) -> list[str] | None:
+    """Ordered language-neutral (``shared``) cell hashes from HEAD:``path``, or ``None``.
+
+    The git-HEAD counterpart of the watermark's ``shared`` partition: neutral
+    cells are byte-identical across the two halves (the ``unify`` invariant), so
+    either committed half yields the same sequence. Returns ``None`` when the
+    committed text is unavailable — :func:`align_anchored` then degrades to "no
+    shared baseline" exactly as it does for a pre-#190 watermark. Without this,
+    the git-HEAD (cold-start / first-sync) path could not detect a one-sided
+    edit, add, or removal of a neutral cell, silently dropping it (Issue #269).
+    """
+    text = _git_head_text(path)
+    if text is None:
+        return None
+    return _shared_hashes(parse_cells(text, comment_token_for_path(path)))
+
+
+def _header_baseline_from_git_head(path: Path) -> list[str] | None:
+    """git-HEAD counterpart of the watermark ``de-header`` / ``en-header`` partition.
+
+    Ordered j2 header hashes from the committed half (Issue #269), or ``None`` when
+    the committed text is unavailable. Used so the cold-start (first) sync can detect
+    a one-sided header edit even before a watermark exists.
+    """
+    text = _git_head_text(path)
+    if text is None:
+        return None
+    return _header_hashes(parse_cells(text, comment_token_for_path(path)))
 
 
 # ---------------------------------------------------------------------------
@@ -1768,16 +1986,24 @@ def build_sync_plan(
     de_baseline: list[BaselineCell] | None = None
     en_baseline: list[BaselineCell] | None = None
     baseline_shared: list[str] | None = None
+    # Issue #269: ordered content hashes of each half's *id-less localized* cells
+    # (the ("L", kind) set the structural pass owns). None when no baseline.
+    de_idless_baseline: list[str] | None = None
+    en_idless_baseline: list[str] | None = None
+    # Issue #269: ordered content hashes of each half's j2 deck-header cells, for the
+    # one-sided header-drift alert. None when no baseline.
+    de_header_baseline: list[str] | None = None
+    en_header_baseline: list[str] | None = None
     source = "none"
 
     if watermark_cache is not None and watermark_cache.has_pair(str(de_path), str(en_path)):
+        de_rows = watermark_cache.get_deck(str(de_path), str(en_path), "de")
+        en_rows = watermark_cache.get_deck(str(de_path), str(en_path), "en")
         de_baseline = _baseline_from_watermark(
-            watermark_cache.get_deck(str(de_path), str(en_path), "de"),
-            watermark_cache.get_deck_tags(str(de_path), str(en_path), "de"),
+            de_rows, watermark_cache.get_deck_tags(str(de_path), str(en_path), "de")
         )
         en_baseline = _baseline_from_watermark(
-            watermark_cache.get_deck(str(de_path), str(en_path), "en"),
-            watermark_cache.get_deck_tags(str(de_path), str(en_path), "en"),
+            en_rows, watermark_cache.get_deck_tags(str(de_path), str(en_path), "en")
         )
         # Ordered content hashes of the baseline's neutral cells (position order),
         # matching _shared_hashes — see align_anchored for why this is a sequence,
@@ -1788,12 +2014,37 @@ def build_sync_plan(
                 str(de_path), str(en_path), "shared"
             )
         ]
+        de_idless_baseline = _idless_localized_baseline_from_rows(de_rows)
+        en_idless_baseline = _idless_localized_baseline_from_rows(en_rows)
+        de_header_baseline = [
+            chash
+            for (_p, _sid, _r, chash, _c) in watermark_cache.get_deck(
+                str(de_path), str(en_path), "de-header"
+            )
+        ]
+        en_header_baseline = [
+            chash
+            for (_p, _sid, _r, chash, _c) in watermark_cache.get_deck(
+                str(de_path), str(en_path), "en-header"
+            )
+        ]
         source = "watermark"
     elif allow_git_fallback and not _pair_is_unbootstrapped(de_current, en_current):
         gb_de = _baseline_from_git_head(de_path)
         gb_en = _baseline_from_git_head(en_path)
         if gb_de is not None and gb_en is not None:
             de_baseline, en_baseline = gb_de, gb_en
+            # Issue #269: derive the ``shared`` (language-neutral) baseline from the
+            # committed half too, so the ``align_anchored`` gate below fires on the
+            # cold-start (first) sync — without it a one-sided edit/add/remove of a
+            # neutral cell is invisible and silently dropped while the run reports
+            # "decks already consistent". Neutral cells are byte-identical across
+            # halves (the unify invariant), so either half yields the same sequence.
+            baseline_shared = _shared_baseline_from_git_head(de_path)
+            de_idless_baseline = _idless_localized_baseline_from_git_head(de_path, "de")
+            en_idless_baseline = _idless_localized_baseline_from_git_head(en_path, "en")
+            de_header_baseline = _header_baseline_from_git_head(de_path)
+            en_header_baseline = _header_baseline_from_git_head(en_path)
             source = "git-head"
 
     plan = classify_changes(
@@ -1806,6 +2057,11 @@ def build_sync_plan(
         baseline_source=source,
         provider_available=provider_available,
     )
+    # Carry the id-less localized baselines onto the plan so the structural pass
+    # (hash-anchored drift detection) and the apply-time fail-safe can reach them
+    # without re-deriving the baseline (Issue #269).
+    plan.idless_baseline_de = de_idless_baseline
+    plan.idless_baseline_en = en_idless_baseline
 
     # Item-2 (Phase 3a): detect a language-neutral code-only change the keyed
     # classifier cannot see, and hand its direction to the structural pass. Only
@@ -1827,6 +2083,26 @@ def build_sync_plan(
             _apply_divergence(plan, de_path, en_path, forced=alignment.direction)
         else:
             plan.anchor_direction = alignment.direction
+
+    # Issue #269: id-less localized cells (a ``lang=`` cell with no ``slide_id`` —
+    # the ("L", kind) set) are reached by neither the keyed walk (no slide_id) nor
+    # ``align_anchored`` (it inspects only the neutral ``shared`` partition). A
+    # one-sided body edit to one therefore has no direction signal, so the structural
+    # pass skips it and the change is dropped while the run reports "consistent".
+    # Detect the drift against the baseline and feed a direction (or alert if it is
+    # two-sided / conflicts with the other cells' direction). Runs on BOTH baselines.
+    if de_idless_baseline is not None and en_idless_baseline is not None:
+        _classify_idless_localized_drift(
+            plan, de_cells, en_cells, de_idless_baseline, en_idless_baseline
+        )
+
+    # Issue #269: the j2 deck header is excluded from every sync partition and is
+    # never auto-translated, so a one-sided header edit must be surfaced rather than
+    # silently reported "consistent". Runs on BOTH baselines (a pre-#269 watermark
+    # recorded no header rows -> empty baseline -> both halves read as "drifted" ->
+    # no false one-sided alert, and the next clean sync records the headers).
+    if de_header_baseline is not None and en_header_baseline is not None:
+        _classify_header_drift(plan, de_cells, en_cells, de_header_baseline, en_header_baseline)
 
     # Tier C (Issue #198 / #190 item 3): mirror a tag-only edit on an id-less
     # localized cell — the per-cell engine cannot key it (no slide_id) and the

--- a/tests/slides/test_sync_issue_269.py
+++ b/tests/slides/test_sync_issue_269.py
@@ -1,0 +1,379 @@
+"""Regression tests for Issue #269 — sync must propagate ALL one-sided edits or alert.
+
+The cardinal invariant under test: when an author edits one half of a split de/en
+deck, ``clm slides sync`` must carry every change to the other half — code cells,
+markdown cells, the deck header, language-neutral OR localized — when it can, and
+**alert** (error / issue, watermark held, ``is_noop`` False) when it cannot. It must
+NEVER report "decks already consistent" / advance the watermark while a real change
+was silently dropped.
+
+Each scenario is exercised under BOTH baseline sources: a committed git-HEAD baseline
+(the cold-start / first sync of a freshly-split pair) and a recorded watermark.
+Before the fix, every "BUG" case below was a silent drop with ``is_noop`` True.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_apply import _record_watermark, apply_plan
+from clm.slides.sync_plan import build_sync_plan
+from clm.slides.sync_translate import StaticSlideTranslator
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+
+
+# ---------------------------------------------------------------------------
+# Cell / deck builders (a valid split pair: neutral cells byte-identical)
+# ---------------------------------------------------------------------------
+
+
+def _title(lang: str, sid: str = "title", txt: str = "T") -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n# # {txt}\n'
+
+
+def _ncode(body: str) -> str:
+    return f'# %% tags=["keep"]\n{body}\n'
+
+
+def _nmd(body: str) -> str:
+    return f'# %% [markdown] tags=["keep"]\n{body}\n'
+
+
+def _nmd_tagged(body: str) -> str:
+    # A neutral markdown cell that ALSO carries a narrative tag but no lang / slide_id
+    # (the tagged-neutral blind spot). An invalid shape for a real split deck, but the
+    # unify invariant does not forbid it, so sync must still alert rather than drop.
+    return f'# %% [markdown] tags=["slide"]\n{body}\n'
+
+
+def _idless_code(lang: str, body: str) -> str:
+    return f'# %% lang="{lang}"\n{body}\n'
+
+
+def _idless_md(lang: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}"\n{body}\n'
+
+
+def _hdr(lang: str, title: str, num: str = "01") -> str:
+    macro = "header_de" if lang == "de" else "header_en"
+    return f'# j2 from \'macros.j2\' import {macro}\n# {{{{ {macro}("{title}", "{num}") }}}}\n'
+
+
+def _deck(*parts: str) -> str:
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Harness: establish a baseline, apply the edit, return (plan, result, files)
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _sync(
+    tmp: Path,
+    baseline: str,
+    de0: str,
+    en0: str,
+    de1: str,
+    en1: str,
+    *,
+    mapping: dict[str, str] | None = None,
+):
+    db = tmp / "clm-llm.sqlite"
+    de_path, en_path = tmp / "deck.de.py", tmp / "deck.en.py"
+    de_path.write_text(de0, encoding="utf-8")
+    en_path.write_text(en0, encoding="utf-8")
+    if baseline == "git-head":
+        _git(tmp, "init", "-q")
+        _git(tmp, "config", "user.email", "t@example.com")
+        _git(tmp, "config", "user.name", "Test")
+        _git(tmp, "add", "-A")
+        _git(tmp, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+    else:
+        wm = SyncWatermarkCache(db)
+        _record_watermark(wm, de_path, en_path)
+        wm.close()
+    de_path.write_text(de1, encoding="utf-8")
+    en_path.write_text(en1, encoding="utf-8")
+    translator = StaticSlideTranslator(mapping=mapping or {}, default="<<XL>>")
+    wm = SyncWatermarkCache(db)
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
+        result = apply_plan(plan, judge=None, translator=translator, watermark_cache=wm)
+    finally:
+        wm.close()
+    return plan, result, de_path.read_text(encoding="utf-8"), en_path.read_text(encoding="utf-8")
+
+
+def _alerted(plan, result) -> bool:
+    return (
+        plan.has_errors
+        or result.has_errors
+        or result.deferred > 0
+        or any(i.severity == "error" for i in plan.issues)
+    )
+
+
+def _falsely_consistent(plan, result, propagated: bool) -> bool:
+    """The forbidden state: reported consistent while a change was NOT handled."""
+    return plan.is_noop and not propagated and not _alerted(plan, result)
+
+
+BASELINES = ["git-head", "watermark"]
+
+
+# ---------------------------------------------------------------------------
+# Propagation cases — sync must carry the edit to the twin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_neutral_code_body_edit_propagates(tmp_path: Path, baseline: str):
+    de = _deck(_title("de"), _ncode("import os"))
+    en = _deck(_title("en"), _ncode("import os"))
+    plan, result, de_after, _ = _sync(
+        tmp_path, baseline, de, en, de, _deck(_title("en"), _ncode("import os  # EDIT"))
+    )
+    assert "import os  # EDIT" in de_after  # propagated to the unedited DE half
+    assert not _falsely_consistent(plan, result, True)
+    assert not plan.is_noop
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_neutral_markdown_body_edit_propagates(tmp_path: Path, baseline: str):
+    de = _deck(_title("de"), _nmd("# shared note"))
+    en = _deck(_title("en"), _nmd("# shared note"))
+    plan, result, de_after, _ = _sync(
+        tmp_path, baseline, de, en, de, _deck(_title("en"), _nmd("# shared note EDIT"))
+    )
+    assert "# shared note EDIT" in de_after
+    assert not _falsely_consistent(plan, result, True)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_neutral_code_add_propagates(tmp_path: Path, baseline: str):
+    de = _deck(_title("de"), _ncode("import os"))
+    en = _deck(_title("en"), _ncode("import os"))
+    en1 = _deck(_title("en"), _ncode("import os"), _ncode("import sys"))
+    plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert "import sys" in de_after  # the new neutral cell copied to DE
+    assert not _falsely_consistent(plan, result, True)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_neutral_code_remove_propagates(tmp_path: Path, baseline: str):
+    de = _deck(_title("de"), _ncode("import os"), _ncode("import sys"))
+    en = _deck(_title("en"), _ncode("import os"), _ncode("import sys"))
+    en1 = _deck(_title("en"), _ncode("import os"))
+    plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert "import sys" not in de_after  # the removal mirrored to DE
+    assert not _falsely_consistent(plan, result, True)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_idless_localized_code_edit_propagates(tmp_path: Path, baseline: str):
+    """A hash-anchored id-less localized code cell (bare statement) — both baselines."""
+    de = _deck(_title("de"), _idless_code("de", 'print("Anzahl", n)'))
+    en = _deck(_title("en"), _idless_code("en", 'print("count", n)'))
+    en1 = _deck(_title("en"), _idless_code("en", 'print("COUNT", n)'))
+    plan, result, de_after, _ = _sync(
+        tmp_path, baseline, de, en, de, en1, mapping={'print("COUNT", n)': 'print("ANZAHL", n)'}
+    )
+    assert "ANZAHL" in de_after  # re-translated into DE
+    assert not _falsely_consistent(plan, result, True)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_idless_localized_construct_edit_propagates(tmp_path: Path, baseline: str):
+    """A construct-anchored id-less localized cell (a def) — both baselines."""
+    de = _deck(_title("de"), _idless_code("de", 'def f():\n    print("Hallo")'))
+    en = _deck(_title("en"), _idless_code("en", 'def f():\n    print("Hello")'))
+    en1 = _deck(_title("en"), _idless_code("en", 'def f():\n    print("Hello there")'))
+    plan, result, de_after, _ = _sync(
+        tmp_path,
+        baseline,
+        de,
+        en,
+        de,
+        en1,
+        mapping={'def f():\n    print("Hello there")': 'def f():\n    print("Hallo dort")'},
+    )
+    assert "Hallo dort" in de_after
+    assert not _falsely_consistent(plan, result, True)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_idless_localized_markdown_edit_propagates(tmp_path: Path, baseline: str):
+    de = _deck(_title("de"), _idless_md("de", "# Notiz"))
+    en = _deck(_title("en"), _idless_md("en", "# Note"))
+    en1 = _deck(_title("en"), _idless_md("en", "# Note expanded"))
+    plan, result, de_after, _ = _sync(
+        tmp_path, baseline, de, en, de, en1, mapping={"# Note expanded": "# Notiz erweitert"}
+    )
+    assert "Notiz erweitert" in de_after
+    assert not _falsely_consistent(plan, result, True)
+
+
+# ---------------------------------------------------------------------------
+# Alert cases — sync cannot resolve, must alert (never silently "consistent")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_header_title_edit_alerts(tmp_path: Path, baseline: str):
+    de = _deck(_hdr("de", "Schluss"), _title("de", "s1", "X"))
+    en = _deck(_hdr("en", "Reason"), _title("en", "s1", "X"))
+    en1 = _deck(_hdr("en", "Advanced Reason"), _title("en", "s1", "X"))
+    plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert _alerted(plan, result)  # header is not auto-translated → alert
+    assert "Advanced Reason" not in de_after  # not pasted verbatim into DE
+    assert not plan.is_noop
+    assert not _falsely_consistent(plan, result, False)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_header_neutral_arg_edit_alerts(tmp_path: Path, baseline: str):
+    # A byte-identical-across-halves header arg ("01") edited on one side: a genuine
+    # divergence in a should-be-identical value. Must alert, never "consistent".
+    de = _deck(_hdr("de", "Schluss", "01"), _title("de", "s1", "X"))
+    en = _deck(_hdr("en", "Reason", "01"), _title("en", "s1", "X"))
+    en1 = _deck(_hdr("en", "Reason", "02"), _title("en", "s1", "X"))
+    plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert _alerted(plan, result)
+    assert not _falsely_consistent(plan, result, False)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_header_updated_both_sides_is_clean(tmp_path: Path, baseline: str):
+    # Both halves' headers updated (the user translated the title too): no alert.
+    de = _deck(_hdr("de", "Schluss"), _title("de", "s1", "X"))
+    en = _deck(_hdr("en", "Reason"), _title("en", "s1", "X"))
+    plan, result, _, _ = _sync(
+        tmp_path,
+        baseline,
+        de,
+        en,
+        _deck(_hdr("de", "Fortgeschritten"), _title("de", "s1", "X")),
+        _deck(_hdr("en", "Advanced"), _title("en", "s1", "X")),
+    )
+    assert not _alerted(plan, result)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_tagged_neutral_md_edit_alerts(tmp_path: Path, baseline: str):
+    # A markdown cell with a narrative tag but no lang/slide_id can't be auto-rebuilt
+    # (its group has no slide_id to match), so the parity fail-safe must alert.
+    de = _deck(_title("de"), _nmd_tagged("# heading"))
+    en = _deck(_title("en"), _nmd_tagged("# heading"))
+    en1 = _deck(_title("en"), _nmd_tagged("# heading EDIT"))
+    plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert _alerted(plan, result)
+    assert not _falsely_consistent(plan, result, False)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_neutral_cell_diverged_both_sides_alerts_or_heals(tmp_path: Path, baseline: str):
+    # Same neutral cell edited differently on both halves (§7a): auto-heal holds the
+    # watermark with a warning (alert), never a silent "consistent" advance.
+    de = _deck(_title("de"), _ncode("x = 1"))
+    en = _deck(_title("en"), _ncode("x = 1"))
+    plan, result, _, _ = _sync(
+        tmp_path,
+        baseline,
+        de,
+        en,
+        _deck(_title("de"), _ncode("x = 11")),
+        _deck(_title("en"), _ncode("x = 99")),
+    )
+    # Either it healed and held the watermark for review, or it surfaced an error;
+    # in all cases the watermark must NOT advance over the unresolved divergence.
+    assert not result.watermark_recorded
+    assert plan.issues  # a §7a warning or error was raised
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_idless_localized_cross_group_move_alerts(tmp_path: Path, baseline: str):
+    # A one-sided cross-group move of an un-id'd localized cell that leaves the flat
+    # hash sequence unchanged is not auto-propagated; the structural id-less parity
+    # fail-safe must alert (watermark held), never report "consistent".
+    de = _deck(_title("de", "s1"), _idless_code("de", 'print("p")'), _title("de", "s2"))
+    en = _deck(_title("en", "s1"), _idless_code("en", 'print("p")'), _title("en", "s2"))
+    en1 = _deck(_title("en", "s1"), _title("en", "s2"), _idless_code("en", 'print("p")'))
+    plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert not _falsely_consistent(plan, result, False)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_idless_localized_same_group_reorder_alerts(tmp_path: Path, baseline: str):
+    # A one-sided reorder of two same-kind un-id'd localized cells within one group
+    # cannot be auto-propagated (structurally indistinguishable across languages) —
+    # the reorder fail-safe must alert and hold the watermark so a later run never
+    # falsely reports "consistent" over the still-divergent order.
+    de = _deck(
+        _title("de", "s1"), _idless_code("de", 'print("a")'), _idless_code("de", 'print("b")')
+    )
+    en = _deck(
+        _title("en", "s1"), _idless_code("en", 'print("a")'), _idless_code("en", 'print("b")')
+    )
+    en1 = _deck(
+        _title("en", "s1"), _idless_code("en", 'print("b")'), _idless_code("en", 'print("a")')
+    )
+    plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_irreconcilable_neutral_cells_alerts(tmp_path: Path, baseline: str):
+    # Different neutral cells edited on each half: no single direction → error.
+    de = _deck(_title("de"), _ncode("a = 1"), _ncode("b = 2"))
+    en = _deck(_title("en"), _ncode("a = 1"), _ncode("b = 2"))
+    plan, result, _, _ = _sync(
+        tmp_path,
+        baseline,
+        de,
+        en,
+        _deck(_title("de"), _ncode("a = 1  # de"), _ncode("b = 2")),
+        _deck(_title("en"), _ncode("a = 1"), _ncode("b = 2  # en")),
+    )
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+
+
+# ---------------------------------------------------------------------------
+# Honest reporting + no-op safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_summary_not_consistent_when_neutral_change_propagates(tmp_path: Path, baseline: str):
+    de = _deck(_title("de"), _ncode("import os"))
+    en = _deck(_title("en"), _ncode("import os"))
+    plan, _result, _, _ = _sync(
+        tmp_path, baseline, de, en, de, _deck(_title("en"), _ncode("import os  # E"))
+    )
+    assert "already" not in plan.summary().lower()  # not "decks already consistent"
+    assert plan.anchor_direction == "en->de"
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_genuine_noop_still_reports_consistent(tmp_path: Path, baseline: str):
+    # A real no-op (no edits) must still report consistent and advance — no false alarms.
+    de = _deck(_title("de"), _ncode("import os"), _idless_code("de", 'print("a")'))
+    en = _deck(_title("en"), _ncode("import os"), _idless_code("en", 'print("a")'))
+    plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en)
+    assert plan.is_noop
+    assert not _alerted(plan, result)
+    assert "consistent" in plan.summary().lower()


### PR DESCRIPTION
## Summary

`clm slides sync` silently dropped several classes of one-sided edit to a split de/en pair — reporting *"0 changes — decks already consistent"* **and advancing the watermark over the divergence** (permanently baselining the loss). Sync's contract is that editing one half carries *all* changes to the other half, and that it must **never** claim the decks agree while a change was dropped. This PR restores that for every cell class: **propagate when possible, alert (error/issue, watermark held) when not.**

Closes #269.

## Root cause

The dominant cause was a single gap: `build_sync_plan` populated the neutral / id-less / header baselines **only on the watermark branch**, so the **git-HEAD fallback** — which is the baseline for the *first sync of any freshly-split pair* (the CLI always passes a watermark cache, so a brand-new pair has none) — was blind to them. Two further gaps were baseline-independent: id-less localized cells had no drift-direction detector, and j2 deck headers were excluded from every diff layer.

## What changed — every one-sided edit now propagates or alerts

| Edit (one-sided) | Before | After |
|---|---|---|
| Neutral code/markdown body edit, add, remove | dropped on cold-start | **propagated** (both baselines) |
| Id-less localized code/markdown (incl. bare `print(...)`) | dropped on **both** baselines | **propagated** (re-translated) |
| Tagged-neutral cell (`tags=["slide"]`, no lang/id) | dropped | propagated / **alerted** via fail-safe |
| Neutral cell diverged on both halves | dropped on cold-start | **auto-heal / alert** (as watermark path) |
| j2 deck header (title or neutral arg) | reported "consistent" | **error** — watermark held, "update the other header / run `translate`" |
| Cross-group move / same-group reorder of un-id'd localized cells | silently dropped | **alerted** (post-apply structural fail-safe) |

Mechanics:
- **git-HEAD baselines** for the shared / id-less-localized / header partitions (`_shared_baseline_from_git_head`, `_idless_localized_baseline_from_git_head`, `_header_baseline_from_git_head`; `_baseline_anchor_hashes` now also builds from HEAD), so `align_anchored` and the structural pass fire on the first sync.
- **`_classify_idless_localized_drift`** feeds the structural pass a direction for a one-sided id-less edit; `_region_has_localized_drift` gained a baseline-**multiset hash-membership** check so hash-anchored bare statements are caught alongside named constructs.
- **`_signature` / `_rebuild_region`** treat any `lang is None` cell as `("S", body)` (body-sensitive) so a narrative-tagged neutral edit rebuilds.
- **j2 headers** recorded in new `de-header`/`en-header` watermark partitions; a one-sided header drift is an error (sync never auto-translates the header).
- **Honest reporting**: `SyncPlan.summary()` names an anchor-only propagation instead of "already consistent"; the apply outcome adds a `structural` count.
- **Fail-safes** (cardinal-invariant backstop, post-apply): `_flag_shared_cell_divergence` (neutral cells must be byte-identical across halves) and `_flag_idless_localized_divergence` (cross-half group/kind structure + one-sided pure-reorder vs baseline). Both content-free → no translation false-positives.

## Documented residual limitation

A one-sided reorder of two **same-kind** id-less localized cells within one slide group is **alerted, not auto-propagated** (they are structurally indistinguishable across languages) — give such cells `slide_id`s for precise sync. Surfaced in the error message and `clm info commands`.

## Testing

- New `tests/slides/test_sync_issue_269.py` — the full matrix (neutral code/markdown, id-less localized code/markdown, header title/neutral-arg, neutral add/remove, divergence, irreconcilable, cross-group move, same-group reorder, summary honesty, genuine no-op) parametrized over **both** the git-HEAD and watermark baselines.
- Full fast suite green; `ruff` + `mypy` clean. The exact issue repro now propagates end-to-end via the CLI.

## How it was found

An 11-agent audit mapped the 14 violation cases; a 7-agent adversarial pass then caught the move/reorder gap, which the structural fail-safe now closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
