### PR TITLE
test(api): reclassify flaky real-uvicorn health test as integration + serial

### DIFF
--- a/tests/infrastructure/api/test_server.py
+++ b/tests/infrastructure/api/test_server.py
@@ -316,29 +316,43 @@ class TestGlobalSingleton:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.serial
 class TestRealUvicornStartup:
     """Bind an actual uvicorn server; hit /health; ensure clean shutdown.
 
     This is the one place that exercises the real threading path
-    end-to-end. It's marked ``slow`` so the fast suite skips it.
+    end-to-end — it opens a real socket and runs a real uvicorn server,
+    so it is an *integration* test (excluded from the fast unit suite)
+    rather than a unit test. It is also marked ``serial`` so that under
+    pytest-xdist it is pinned to a single worker instead of racing the
+    rest of the suite for CPU; a starved server thread is slow to bind
+    its port and used to make this test flaky under high worker counts.
     """
 
     def test_real_server_serves_health(self, db_path: Path) -> None:
         port = _free_port()
         server = WorkerApiServer(db_path, host="127.0.0.1", port=port)
 
-        assert server.start(timeout=5.0) is True
+        assert server.start(timeout=10.0) is True
         try:
             # Poll for readiness — uvicorn's port binding happens shortly
-            # after the started event is set.
+            # after the started event is set (``start`` only sleeps 0.1s
+            # before returning), so the first few requests may be refused
+            # or time out while the socket is still coming up. Catch the
+            # whole ``httpx.TransportError`` family — not just
+            # ``ConnectError`` — because under load the connect or read can
+            # exceed the per-request timeout and raise ``ConnectTimeout`` /
+            # ``ReadTimeout`` (subclasses of ``TimeoutException``, *not* of
+            # ``ConnectError``), which must be retried rather than fail the
+            # test. The per-request timeout is generous for the same reason.
             response = None
-            deadline = time.monotonic() + 5.0
+            deadline = time.monotonic() + 10.0
             while time.monotonic() < deadline:
                 try:
-                    response = httpx.get(f"{server.url}/health", timeout=1.0)
+                    response = httpx.get(f"{server.url}/health", timeout=5.0)
                     break
-                except httpx.ConnectError:
+                except httpx.TransportError:
                     time.sleep(0.05)
 
             assert response is not None, "Server did not accept connections"


### PR DESCRIPTION
## Problem

`TestRealUvicornStartup::test_real_server_serves_health` is flaky under high pytest-xdist worker counts. It is the **only** test in the suite that opens a real socket and runs a real uvicorn server end to end — every other server test uses FastAPI's in-process `TestClient` or mocks the `uvicorn` module / `start_worker_api_server`.

It was marked `slow` (so the fast pre-push suite skipped it), but `slow` still runs under the `-m "not docker"` pre-release gate and in CI, where it flakes.

## Root cause

Two compounding issues:

1. **Contention.** `WorkerApiServer.start()` sets its `_started` event *before* uvicorn binds the port and relies on a fixed `time.sleep(0.1)`. Under heavy xdist load the server thread is starved and slow to bind, so the readiness poll has to do real work.
2. **Too-narrow exception + 1s timeout.** The poll caught only `httpx.ConnectError` with a `timeout=1.0`. Under load the connect/read exceeds 1s and raises `httpx.ConnectTimeout` / `ReadTimeout` — subclasses of `httpx.TimeoutException`, **not** `ConnectError` — which escaped the retry loop and failed the test outright.

## Changes

- Reclassify the test: `@pytest.mark.slow` → **`@pytest.mark.integration`** (drops it from the fast unit suite — it isn't a unit test) **+ `@pytest.mark.serial`** so xdist pins it to a single worker instead of racing the rest of the suite for CPU.
- Harden the readiness poll: catch the whole **`httpx.TransportError`** family (connect refusals *and* timeouts), raise the per-request timeout `1.0 → 5.0`, and widen the poll/`start` deadlines `5.0 → 10.0`.

## Verification

- `-m integration -n0`: `1 passed`
- default fast run: `17 passed, 1 deselected` (the real-server test is now correctly excluded)
- pre-push fast suite passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
