### PR TITLE
fix(http-replay): sequence-aware mitmproxy record/replay for non-deterministic responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The mitmproxy transport now records and replays a per-request response
+  *sequence*** instead of collapsing a repeated request to its first response.
+  A non-deterministic endpoint (a temperature>0 LLM, or OpenRouter routing the
+  same request to different providers) answers an identical request differently
+  on successive calls; when a *later* request embeds an earlier response (e.g.
+  `summarize | translate`, where `translate` carries the generated summary), the
+  old first-seen-wins dedup dropped every response after the first, so the
+  downstream request matched nothing on replay and failed with `clm_replay_miss`.
+  Recording now keys dedup on `(request, response)` so distinct responses to the
+  same request are kept in order, and replay serves them in recorded order via a
+  per-request cursor — sticking on the last match once exhausted, so a genuinely
+  repeatable request never misses and a single-entry cassette still serves
+  repeatably (unchanged). The host-side fold gained `preserve_sequence=True`
+  (mitmproxy only; the vcrpy path keeps the deduped fold). Decks affected before
+  this fix: `chains_and_lcel/slides_020`, `prompt_templates/slides_010`,
+  `langgraph_intro/slides_010`.
+
 ## [1.10.0] - 2026-06-08
 
 ### Changed

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -486,6 +486,13 @@ class Course(NotebookMixin):
                     CassettePaths(canonical=canonical, staging=synthetic),
                     sweep_orphans=False,
                     overwrite_existing=overwrite_existing,
+                    # The mitmproxy transport records a per-request response
+                    # *sequence* (a non-deterministic endpoint answers an
+                    # identical request differently on successive calls); fold it
+                    # order-preserving so a downstream request that embedded the
+                    # later response still replay-matches. The vcrpy path keeps
+                    # the deduped fold (preserve_sequence defaults to False).
+                    preserve_sequence=True,
                 )
             except Exception as exc:  # noqa: BLE001 — never mask the build result
                 logger.warning(

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -157,6 +157,7 @@ class _Target:
         "recorded",
         "to_write",
         "seen",
+        "served",
     )
 
     def __init__(self, canonical: Path, write_path: Path, *, is_staging: bool) -> None:
@@ -181,9 +182,19 @@ class _Target:
         # cassette (seeded existing entries + new) so the in-place rewrite
         # preserves prior recordings.
         self.to_write: list[tuple] = []
-        # Fingerprints already recorded this build (dedup; mirrors the host
-        # merge's ``_dedup_key`` so the addon and merge agree).
-        self.seen: set[tuple[str, str, bytes]] = set()
+        # Sequence-aware dedup key: ``fingerprint(request) + (response_fp,)``.
+        # Same request + same response collapses; same request + a *different*
+        # response (non-deterministic endpoint) is kept as a separate ordered
+        # interaction so a downstream request embedding the later response still
+        # replay-matches. The host-side mitmproxy merge preserves the same
+        # ordering (``preserve_sequence=True``).
+        self.seen: set[tuple] = set()
+        # Replay cursor: indices of ``recorded`` already served this build.
+        # Repeated identical requests are served in recorded order (R1, R2, …);
+        # once a request's recordings are exhausted the *last* match is served
+        # again, so a genuinely repeatable request never misses and a
+        # single-entry cassette stays byte-for-byte replay-compatible.
+        self.served: set[int] = set()
 
 
 class ClmReplayAddon:
@@ -364,12 +375,13 @@ class ClmReplayAddon:
         serve, record, _overwrite = self._modes_for(target.cassette_existed)
 
         if serve:
-            for rec_request, rec_response in target.recorded:
-                if cf.requests_match(filtered, rec_request):
-                    flow.response = self._build_reply(rec_response)
-                    flow.metadata[_FLOW_SERVED_KEY] = True
-                    self._trace_request(flow, tag, "served")
-                    return
+            chosen = self._select_serve_index(target.recorded, filtered, target.served)
+            if chosen is not None:
+                target.served.add(chosen)
+                flow.response = self._build_reply(target.recorded[chosen][1])
+                flow.metadata[_FLOW_SERVED_KEY] = True
+                self._trace_request(flow, tag, "served")
+                return
 
         if not record:
             # Strict replay (``replay``, or ``once`` with an existing cassette):
@@ -407,10 +419,6 @@ class ClmReplayAddon:
         if request is None:
             return  # defensive: should have been flagged ignored in request()
 
-        key = cf.fingerprint(request)
-        if key in target.seen:
-            return  # already recorded this build — keep the eager rewrite cheap
-
         response = cf.vcr_response_dict_from_parts(
             flow.response.status_code,
             flow.response.reason,
@@ -418,6 +426,13 @@ class ClmReplayAddon:
             flow.response.raw_content or b"",
             decode_compressed=True,
         )
+        # Sequence-aware key: same request + same response collapses (cheap eager
+        # rewrite), but the same request returning a *different* response is kept
+        # as a new ordered interaction so the replay sequence is complete.
+        key = cf.fingerprint(request) + (cf.response_fingerprint(response),)
+        if key in target.seen:
+            return  # this exact (request, response) already recorded this build
+
         target.recorded.append((request, response))
         target.to_write.append((request, response))
         target.seen.add(key)
@@ -502,7 +517,7 @@ class ClmReplayAddon:
             return
         for request, response in interactions:
             target.recorded.append((request, response))
-            target.seen.add(cf.fingerprint(request))
+            target.seen.add(cf.fingerprint(request) + (cf.response_fingerprint(response),))
             # The catch-all rewrites the whole cassette in place, so it must
             # keep existing entries; tagged staging files hold only this
             # build's new interactions (the host merge folds them into
@@ -618,6 +633,29 @@ class ClmReplayAddon:
             if k.lower() not in _SERVE_DROP_HEADERS
         ]
         return http.Response.make(status_code, content, headers)
+
+    @staticmethod
+    def _select_serve_index(recorded: list, filtered, served: set) -> int | None:
+        """Pick which recorded interaction to serve for ``filtered`` (replay cursor).
+
+        Scans ``recorded`` in order and returns the index of the first
+        not-yet-served interaction whose request matches; once every match has
+        been served, returns the **last** matching index (the repeatable tail);
+        ``None`` when nothing matches. This replays a per-request response
+        *sequence* in recorded order — so a deck that re-issues an identical
+        request whose non-deterministic response feeds a *later* request matches
+        — while a single-entry recording (the overwhelmingly common case) is
+        still served repeatably, byte-for-byte as before this cursor existed.
+        """
+        chosen: int | None = None
+        last_match: int | None = None
+        for i, (rec_request, _rec_response) in enumerate(recorded):
+            if cf.requests_match(filtered, rec_request):
+                last_match = i
+                if i not in served:
+                    chosen = i
+                    break
+        return chosen if chosen is not None else last_match
 
     @staticmethod
     def _is_replay_miss_marker(response: http.Response) -> bool:

--- a/src/clm/infrastructure/http_replay_mitm/cassette_format.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_format.py
@@ -220,6 +220,28 @@ def fingerprint(request: Request) -> tuple[str, str, bytes]:
     )
 
 
+def response_fingerprint(response: dict) -> bytes:
+    """Stable fingerprint of a recorded response body (sequence-aware dedup).
+
+    A non-deterministic endpoint (an LLM at temperature > 0, or OpenRouter
+    routing the same request to different providers) returns a *different*
+    response to the **same** request on each call. Sequence-aware recording
+    keeps those distinct responses as separate ordered interactions — so a
+    downstream request that embedded the second response still replay-matches —
+    while a byte-identical re-recording of the same ``(request, response)`` pair
+    still collapses. Pairing ``fingerprint(request)`` with this response
+    fingerprint is the dedup key for that: same request + same response → one
+    entry; same request + different response → two ordered entries.
+    """
+    body = (response or {}).get("body") or {}
+    raw = body.get("string", b"")
+    if isinstance(raw, bytes):
+        return raw
+    if isinstance(raw, bytearray):
+        return bytes(raw)
+    return str(raw).encode("utf-8", errors="replace")
+
+
 def build_request_filter(
     *,
     filter_headers: Iterable[object] = FILTER_HEADERS,

--- a/src/clm/workers/notebook/http_replay_cassette.py
+++ b/src/clm/workers/notebook/http_replay_cassette.py
@@ -121,6 +121,7 @@ def merge_staging_into_canonical(
     *,
     sweep_orphans: bool = False,
     overwrite_existing: bool = False,
+    preserve_sequence: bool = False,
 ) -> int:
     """Merge per-worker staging files into the canonical cassette.
 
@@ -166,6 +167,17 @@ def merge_staging_into_canonical(
             is used, byte-identical to before this parameter existed. This is
             the producer-agnostic fix for the refresh-overwrite gap (issue
             #165 P3) and benefits both the vcrpy and mitmproxy transports.
+        preserve_sequence: Sequence-aware fold for the **mitmproxy** transport
+            only (the in-kernel vcrpy path leaves this ``False``). When ``True``
+            the fold keeps every distinct ``(request, response)`` interaction in
+            recorded order — deduping only an exact ``(request, response)`` pair,
+            never by request alone — so a per-request *response sequence* (the
+            same request answered differently on successive calls by a
+            non-deterministic endpoint) survives into canonical and replays
+            intact. With ``overwrite_existing`` (refresh) the build's staging
+            *is* the complete recording and replaces canonical wholesale;
+            otherwise (new-episodes) the staging sequence is appended after the
+            existing canonical entries.
 
     Returns:
         Number of staging files folded into the canonical (markered
@@ -245,11 +257,69 @@ def merge_staging_into_canonical(
                         f"before merge ({type(exc).__name__}: {exc}); treating as empty."
                     )
 
+            # ``preserve_sequence`` (mitmproxy transport) keeps every distinct
+            # (request, response) interaction in recorded order, deduping only
+            # exact pairs — so a per-request response *sequence* survives.
+            # ``overwrite_existing`` (refresh) then means "this build's staging
+            # is the complete recording" → replace canonical; otherwise append.
+            if preserve_sequence:
+                if overwrite_existing:
+                    merged_requests = []
+                    merged_responses = []
+                    seen_pairs: set = set()
+                else:
+                    merged_requests = list(canonical_requests)
+                    merged_responses = list(canonical_responses)
+                    seen_pairs = {
+                        (_dedup_key(req), _response_body_bytes(resp))
+                        for req, resp in zip(canonical_requests, canonical_responses, strict=False)
+                    }
+                for staging_path in markered:
+                    try:
+                        staging_requests, staging_responses = FilesystemPersister.load_cassette(
+                            staging_path, serializer=yamlserializer
+                        )
+                    except Exception as exc:  # noqa: BLE001 — defensive
+                        logger.warning(
+                            f"Could not load staging cassette '{staging_path}' "
+                            f"({type(exc).__name__}: {exc}); skipping."
+                        )
+                        _trace(
+                            "cassette.merge.decision",
+                            {
+                                "staging": str(staging_path),
+                                "decision": "load_failed",
+                                "exc_type": type(exc).__name__,
+                            },
+                        )
+                        continue
+                    folded_from_this = 0
+                    duplicates_in_this = 0
+                    for request, response in zip(staging_requests, staging_responses, strict=False):
+                        pair_key = (_dedup_key(request), _response_body_bytes(response))
+                        if pair_key in seen_pairs:
+                            duplicates_in_this += 1
+                            continue
+                        merged_requests.append(request)
+                        merged_responses.append(response)
+                        seen_pairs.add(pair_key)
+                        folded_from_this += 1
+                    _trace(
+                        "cassette.merge.decision",
+                        {
+                            "staging": str(staging_path),
+                            "decision": "folded_sequence",
+                            "marker_present": True,
+                            "interactions_loaded": len(staging_requests),
+                            "interactions_folded": folded_from_this,
+                            "interactions_deduped": duplicates_in_this,
+                        },
+                    )
             # ``overwrite_existing`` lets a staging interaction replace a
             # canonical one with the same fingerprint (refresh/``all``); the
             # default first-seen-wins path is kept verbatim so a no-op build's
             # cassette stays byte-identical to before this parameter existed.
-            if overwrite_existing:
+            elif overwrite_existing:
                 # Last-seen within staging wins (a freshly recorded response
                 # supersedes an earlier/seeded one); canonical entries are
                 # replaced in place to keep the diff minimal, and genuinely new
@@ -569,6 +639,24 @@ def _body_to_dedup_bytes(body) -> bytes:
             return bytes(data)
         return str(data).encode("utf-8", errors="replace")
     return repr(body).encode("utf-8", errors="replace")
+
+
+def _response_body_bytes(response) -> bytes:
+    """Coerce a recorded vcr response's body to stable bytes.
+
+    Pairs with :func:`_dedup_key` to form the exact-``(request, response)``
+    dedup key the sequence-preserving mitmproxy merge uses: a response loaded
+    from a cassette is a dict with ``body.string`` (vcrpy's stub format), so two
+    *different* responses to the same request hash differently and are kept as
+    separate ordered interactions, while a byte-identical re-record collapses.
+    """
+    body = (response or {}).get("body") if isinstance(response, dict) else None
+    raw = body.get("string", b"") if isinstance(body, dict) else b""
+    if isinstance(raw, bytes):
+        return raw
+    if isinstance(raw, bytearray):
+        return bytes(raw)
+    return str(raw).encode("utf-8", errors="replace")
 
 
 def _atomic_write_text(target: Path, text: str) -> None:

--- a/tests/infrastructure/test_http_replay_mitm_cassette_format.py
+++ b/tests/infrastructure/test_http_replay_mitm_cassette_format.py
@@ -92,6 +92,66 @@ def test_response_dict_matches_vcrpy():
     assert actual == expected
 
 
+def test_response_fingerprint_distinguishes_distinct_bodies():
+    """The response fingerprint keys sequence-aware dedup: two responses to the
+    same request collapse only when their bodies are identical."""
+    r1 = cf.vcr_response_dict_from_parts(200, "OK", [], b'{"hit":1}')
+    r1_again = cf.vcr_response_dict_from_parts(200, "OK", [], b'{"hit":1}')
+    r2 = cf.vcr_response_dict_from_parts(200, "OK", [], b'{"hit":2}')
+    assert cf.response_fingerprint(r1) == cf.response_fingerprint(r1_again)
+    assert cf.response_fingerprint(r1) != cf.response_fingerprint(r2)
+    # Robust against a missing/oddly-shaped body dict.
+    assert cf.response_fingerprint({}) == b""
+
+
+def test_select_serve_index_replays_response_sequence_then_repeats_last():
+    """The replay cursor serves a per-request response *sequence* in recorded
+    order, then sticks on the last match once exhausted; a single-entry
+    recording stays repeatable; a non-matching request yields no index.
+
+    Imports the addon (which needs ``mitmproxy``); skipped where the proxy
+    package isn't installed, like the integration module.
+    """
+    pytest.importorskip("mitmproxy")
+    from clm.infrastructure.http_replay_mitm.addon import ClmReplayAddon
+
+    def _req(body: bytes):
+        return cf.vcr_request_from_parts(
+            "POST", "https://api/x", [(b"content-type", b"application/json")], body
+        )
+
+    body = b'{"prompt":"same"}'
+    # Two interactions for the SAME request with distinct responses (R1, R2) —
+    # a non-deterministic endpoint answering one prompt two different ways.
+    recorded = [
+        (_req(body), cf.vcr_response_dict_from_parts(200, "OK", [], b"R1")),
+        (_req(body), cf.vcr_response_dict_from_parts(200, "OK", [], b"R2")),
+    ]
+    incoming = _req(body)
+    served: set[int] = set()
+
+    i1 = ClmReplayAddon._select_serve_index(recorded, incoming, served)
+    assert i1 == 0
+    served.add(i1)
+    i2 = ClmReplayAddon._select_serve_index(recorded, incoming, served)
+    assert i2 == 1
+    served.add(i2)
+    # Sequence exhausted → stick on the last matching entry (repeatable tail).
+    assert ClmReplayAddon._select_serve_index(recorded, incoming, served) == 1
+
+    # A request that matches nothing → no index (strict-replay miss upstream).
+    other = _req(b'{"prompt":"different"}')
+    assert ClmReplayAddon._select_serve_index(recorded, other, set()) is None
+
+    # Single-entry recording stays repeatable (backward-compatible).
+    single = [(_req(body), cf.vcr_response_dict_from_parts(200, "OK", [], b"only"))]
+    seen: set[int] = set()
+    first = ClmReplayAddon._select_serve_index(single, incoming, seen)
+    assert first == 0
+    seen.add(first)
+    assert ClmReplayAddon._select_serve_index(single, incoming, seen) == 0
+
+
 def test_serialized_yaml_byte_identical_plain():
     assert _bridge_yaml(_POST_JSON) == _vcrpy_reference_yaml(_POST_JSON)
 

--- a/tests/workers/notebook/test_http_replay_cassette.py
+++ b/tests/workers/notebook/test_http_replay_cassette.py
@@ -213,3 +213,102 @@ class TestMergeOverwriteExisting:
         merged = cf.load_interactions(canonical)
         assert len(merged) == 1
         assert merged[0][1]["body"]["string"] in (b"FRESH_NEW", "FRESH_NEW")
+
+
+class TestMergePreserveSequence:
+    """Sequence-aware fold for the mitmproxy transport (``preserve_sequence``).
+
+    A non-deterministic endpoint answers the *same* request differently on
+    successive calls. The deduped fold (used by vcrpy and the default path)
+    collapses those to one entry, so a downstream request that embedded the
+    second response can no longer replay-match. ``preserve_sequence=True`` keeps
+    every distinct ``(request, response)`` in recorded order — deduping only an
+    exact pair — so the per-request response sequence survives into canonical.
+    """
+
+    @staticmethod
+    def _interaction(cf, method, url, body, resp_body):
+        request = cf.vcr_request_from_parts(method, url, [(b"content-type", b"text/plain")], body)
+        response = cf.vcr_response_dict_from_parts(
+            200, "OK", [(b"content-type", b"text/plain")], resp_body
+        )
+        return request, response
+
+    def _write_canonical_and_markered_staging(self, tmp_path, canonical_pairs, staging_pairs):
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        canonical = tmp_path / "slides.http-cassette.yaml"
+        staging = canonical.parent / f"{canonical.name}.staging-mitm-test"
+        if canonical_pairs:
+            cf.write_cassette(canonical, canonical_pairs)
+        cf.write_cassette(staging, staging_pairs)
+        write_completion_marker(CassettePaths(canonical=canonical, staging=staging))
+        return cf, canonical, staging
+
+    def test_refresh_keeps_distinct_responses_for_same_request_in_order(self, tmp_path):
+        """The fix: same request, two distinct responses → both kept, in order
+        (the default last-seen-wins fold would collapse them to one)."""
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        url = "https://o.ai/v1/c"
+        staging_pairs = [
+            self._interaction(cf, "POST", url, b"same", b"R1"),
+            self._interaction(cf, "POST", url, b"same", b"R2"),
+        ]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, [], staging_pairs
+        )
+
+        merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging),
+            overwrite_existing=True,
+            preserve_sequence=True,
+        )
+        merged = cf.load_interactions(canonical)
+        bodies = [resp["body"]["string"] for _, resp in merged]
+        assert [b if isinstance(b, bytes) else b.encode() for b in bodies] == [b"R1", b"R2"]
+
+    def test_preserve_sequence_collapses_exact_duplicate_pairs(self, tmp_path):
+        """An exact ``(request, response)`` repeat (a byte-identical re-record)
+        still collapses — only *distinct* responses extend the sequence."""
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        url = "https://o.ai/v1/c"
+        staging_pairs = [
+            self._interaction(cf, "POST", url, b"same", b"R1"),
+            self._interaction(cf, "POST", url, b"same", b"R1"),  # exact dup
+            self._interaction(cf, "POST", url, b"same", b"R2"),
+        ]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, [], staging_pairs
+        )
+
+        merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging),
+            overwrite_existing=True,
+            preserve_sequence=True,
+        )
+        merged = cf.load_interactions(canonical)
+        bodies = [resp["body"]["string"] for _, resp in merged]
+        assert [b if isinstance(b, bytes) else b.encode() for b in bodies] == [b"R1", b"R2"]
+
+    def test_new_episodes_appends_sequence_after_canonical(self, tmp_path):
+        """Without ``overwrite_existing`` (new-episodes), canonical entries are
+        kept and the staging sequence is appended, skipping exact pairs already
+        present."""
+        cf = pytest.importorskip("clm.infrastructure.http_replay_mitm.cassette_format")
+        url = "https://o.ai/v1/c"
+        canonical_pairs = [self._interaction(cf, "POST", url, b"same", b"R1")]
+        staging_pairs = [
+            self._interaction(cf, "POST", url, b"same", b"R1"),  # already in canonical
+            self._interaction(cf, "POST", url, b"same", b"R2"),  # new distinct response
+        ]
+        cf, canonical, staging = self._write_canonical_and_markered_staging(
+            tmp_path, canonical_pairs, staging_pairs
+        )
+
+        merge_staging_into_canonical(
+            CassettePaths(canonical=canonical, staging=staging),
+            overwrite_existing=False,
+            preserve_sequence=True,
+        )
+        merged = cf.load_interactions(canonical)
+        bodies = [resp["body"]["string"] for _, resp in merged]
+        assert [b if isinstance(b, bytes) else b.encode() for b in bodies] == [b"R1", b"R2"]


### PR DESCRIPTION
## Problem

Under the mitmproxy transport (default since 1.10.0), a deck that re-issues an **identical** request whose **non-deterministic** response feeds a *later* request fails strict replay with `clm_replay_miss` — on a fully deterministic cell.

Concretely, `chains_and_lcel/slides_020` runs `pipeline_v1 = summarize_chain | to_translate_input | translate_chain`. The `translate` request embeds the LLM-generated *summary*. At temperature>0 (and with OpenRouter routing the same request to different providers — `Alibaba`/`Nebius`/`StreamLake` were observed in one cassette), each `summarize(sample_text)` call returns a different summary. Record deduped the repeated summarize request to its **first** response; replay served that one response forever, so `pipeline_v1`'s translate request (which had embedded a *different* summary at record time) matched nothing.

Same root cause behind `prompt_templates/slides_010` and `langgraph_intro/slides_010` (a ReAct agent whose tool-call loop is driven by LLM responses).

## Fix

Record/replay a per-request **response sequence** instead of collapsing to one:

- **Record** keys dedup on `(request, response)` — distinct responses to the same request are kept as separate ordered interactions; an exact `(request, response)` repeat still collapses.
- **Replay** serves matches in recorded order via a per-request cursor (`_select_serve_index`), sticking on the **last** match once exhausted — so a genuinely repeatable request never misses and a single-entry cassette is still served repeatably (byte-for-byte unchanged for the common case). Serving the recorded responses in order makes a response-driven deck (including agents) follow the exact recorded request path on replay.
- **Merge** gains `preserve_sequence=True`, wired in **only** for the mitmproxy host fold (`Course.merge_mitmproxy_cassette_staging`). The in-kernel **vcrpy** path keeps its deduped fold, so the matcher/filter drift-guard parity is untouched (mitmproxy-only scope, by design).

## Validation

- Deterministic unit tests: replay cursor (`_select_serve_index` — sequence-in-order → stick-on-last → single-entry repeatable → non-match), response fingerprint, and the sequence-preserving merge (distinct-responses-in-order, exact-pair collapse, new-episodes append).
- Full suite green: **7170 passed, 3 skipped, 1 xfailed**.
- End-to-end: re-recorded + strict-replayed the LangChain week of the ML-AZAV course under the patched transport — 0 errors (was failing before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)