### PR TITLE
feat(schedule): --no-topic / --include-optional, multi-weekday subsections, workday-coverage check

### DIFF
--- a/src/clm/cli/commands/outline.py
+++ b/src/clm/cli/commands/outline.py
@@ -231,9 +231,13 @@ def _subsections_json(
                 )
         result.append(
             {
+                # `weekday` is the first token (back-compat); `weekdays` is the
+                # full ordered list for multi-day subsections.
                 "weekday": subsection.weekday,
+                "weekdays": list(subsection.weekdays),
                 "label": subsection_label(subsection, language),
                 "enabled": subsection.enabled,
+                "optional": subsection.optional,
                 "topics": topics_out,
             }
         )

--- a/src/clm/cli/commands/schedule.py
+++ b/src/clm/cli/commands/schedule.py
@@ -63,9 +63,14 @@ class ScheduleDeck:
 class ScheduleDay:
     """One day (``<subsection>``) of a week, with its decks in order."""
 
-    weekday: str | None  # language-neutral token, or None for a thematic group
+    weekdays: list[str]  # language-neutral tokens; empty for a thematic group
     label: str  # localized display label
     decks: list[ScheduleDeck] = field(default_factory=list)
+
+    @property
+    def weekday(self) -> str | None:
+        """The first weekday token, or ``None`` — convenience for single-day callers."""
+        return self.weekdays[0] if self.weekdays else None
 
 
 @dataclass
@@ -80,13 +85,15 @@ class ScheduleWeek:
 def subsection_label(subsection: SubsectionSpec, language: str) -> str:
     """Resolve a subsection's display label for *language*.
 
-    A ``<name>`` override wins; otherwise the weekday token is localized via
-    :data:`WEEKDAY_LABELS`; otherwise (neither set) the label is empty.
+    A ``<name>`` override wins; otherwise the weekday token(s) are localized
+    via :data:`WEEKDAY_LABELS` and joined with ", " (so a multi-day
+    subsection reads "Monday, Tuesday, Wednesday"); otherwise (neither set)
+    the label is empty.
     """
     if subsection.name is not None:
         return subsection.name[language]
-    if subsection.weekday is not None:
-        return WEEKDAY_LABELS[subsection.weekday][language]
+    if subsection.weekdays:
+        return ", ".join(WEEKDAY_LABELS[wd][language] for wd in subsection.weekdays)
     return ""
 
 
@@ -120,12 +127,19 @@ def _topic_decks(topic, language: str) -> list[ScheduleDeck]:
     return decks
 
 
-def build_schedule(course: Course, language: str) -> list[ScheduleWeek]:
+def build_schedule(
+    course: Course, language: str, *, include_optional: bool = False
+) -> list[ScheduleWeek]:
     """Build the day-of-week schedule from a resolved *course*.
 
     Walks each section's retained ``<subsection>`` structure and maps every
     subsection topic to its resolved decks. Sections (weeks) are numbered
     1-based in declared order; only enabled subsections are listed.
+
+    Optional modules (``optional="true"`` on a ``<section>`` or
+    ``<subsection>``) are omitted unless ``include_optional`` is set. Skipped
+    optional weeks keep their declared number (so an excluded optional Week 3
+    leaves Weeks 1, 2, 4, … rather than renumbering).
     """
     weeks: list[ScheduleWeek] = []
     # course.sections aligns 1:1 with course.spec.sections (no section
@@ -133,6 +147,9 @@ def build_schedule(course: Course, language: str) -> list[ScheduleWeek]:
     for number, (section, section_spec) in enumerate(
         zip(course.sections, course.spec.sections, strict=True), start=1
     ):
+        if section_spec.optional and not include_optional:
+            continue
+
         topic_decks: dict[str, list[ScheduleDeck]] = {}
         for topic in section.topics:
             topic_decks[topic.id] = _topic_decks(topic, language)
@@ -141,12 +158,14 @@ def build_schedule(course: Course, language: str) -> list[ScheduleWeek]:
         for subsection in section_spec.subsections:
             if not subsection.enabled:
                 continue
+            if subsection.optional and not include_optional:
+                continue
             decks: list[ScheduleDeck] = []
             for topic_spec in subsection.topics:
                 decks.extend(topic_decks.get(topic_spec.id, []))
             days.append(
                 ScheduleDay(
-                    weekday=subsection.weekday,
+                    weekdays=list(subsection.weekdays),
                     label=subsection_label(subsection, language),
                     decks=decks,
                 )
@@ -161,8 +180,18 @@ def _md_cell(text: str) -> str:
     return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ").strip()
 
 
-def render_markdown(course_title: str, weeks: list[ScheduleWeek], language: str) -> str:
-    """Render the schedule as Markdown: one table per week."""
+def render_markdown(
+    course_title: str,
+    weeks: list[ScheduleWeek],
+    language: str,
+    *,
+    no_topic: bool = False,
+) -> str:
+    """Render the schedule as Markdown: one table per week.
+
+    With ``no_topic`` the Topic column is dropped, leaving just Day and
+    Video (slides) — the columns a certification authority needs.
+    """
     day_h, video_h, topic_h = _MD_HEADERS[language]
     empty_cell = "—"
     lines: list[str] = [f"# {course_title}", ""]
@@ -176,41 +205,57 @@ def render_markdown(course_title: str, weeks: list[ScheduleWeek], language: str)
             lines.append("")
             continue
 
-        lines.append(f"| {day_h} | {video_h} | {topic_h} |")
-        lines.append("|------|------|------|")
+        if no_topic:
+            lines.append(f"| {day_h} | {video_h} |")
+            lines.append("|------|------|")
+        else:
+            lines.append(f"| {day_h} | {video_h} | {topic_h} |")
+            lines.append("|------|------|------|")
         for day in week.days:
             day_label = _md_cell(day.label)
             if not day.decks:
-                lines.append(f"| {day_label} | {empty_cell} | {empty_cell} |")
+                if no_topic:
+                    lines.append(f"| {day_label} | {empty_cell} |")
+                else:
+                    lines.append(f"| {day_label} | {empty_cell} | {empty_cell} |")
                 continue
             for index, deck in enumerate(day.decks):
                 first = _md_cell(day.label) if index == 0 else ""
-                lines.append(
-                    f"| {first} | {_md_cell(deck.video_title)} | {_md_cell(deck.topic_id)} |"
-                )
+                video = _md_cell(deck.video_title)
+                if no_topic:
+                    lines.append(f"| {first} | {video} |")
+                else:
+                    lines.append(f"| {first} | {video} | {_md_cell(deck.topic_id)} |")
         lines.append("")
 
     return "\n".join(lines).rstrip("\n") + "\n"
 
 
-def render_csv(weeks: list[ScheduleWeek]) -> str:
-    """Render the schedule as CSV: one row per deck."""
+def render_csv(weeks: list[ScheduleWeek], *, no_topic: bool = False) -> str:
+    """Render the schedule as CSV: one row per deck.
+
+    A multi-day subsection joins its weekday tokens with "," in the
+    ``weekday`` field (the cell is quoted by the CSV writer). With
+    ``no_topic`` the ``topic`` column is dropped.
+    """
+    fields = [f for f in _CSV_FIELDS if not (no_topic and f == "topic")]
     buffer = io.StringIO()
     writer = csv.writer(buffer, lineterminator="\n")
-    writer.writerow(_CSV_FIELDS)
+    writer.writerow(fields)
     for week in weeks:
         for day in week.days:
+            weekday_cell = ",".join(day.weekdays)
             for deck in day.decks:
-                writer.writerow(
-                    [
-                        week.number,
-                        week.title,
-                        day.weekday or "",
-                        deck.video_title,
-                        deck.topic_id,
-                        deck.deck_file,
-                    ]
-                )
+                row = [
+                    week.number,
+                    week.title,
+                    weekday_cell,
+                    deck.video_title,
+                ]
+                if not no_topic:
+                    row.append(deck.topic_id)
+                row.append(deck.deck_file)
+                writer.writerow(row)
     return buffer.getvalue()
 
 
@@ -245,6 +290,21 @@ def render_csv(weeks: list[ScheduleWeek]) -> str:
     help="Write output to FILE instead of stdout.",
 )
 @click.option(
+    "--no-topic",
+    "no_topic",
+    is_flag=True,
+    help="Omit the Topic column, leaving just day and video/slides "
+    "(the columns a certification authority needs).",
+)
+@click.option(
+    "--include-optional",
+    "include_optional",
+    is_flag=True,
+    help='Include modules marked optional="true" (on a <section> or '
+    "<subsection>). Off by default; optional modules that are also "
+    'disabled (enabled="false") are never listed, flag or not.',
+)
+@click.option(
     "--data-dir",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Course data directory (contains slides/). Default: inferred from spec location.",
@@ -254,6 +314,8 @@ def schedule(
     language: str,
     output_format: str,
     output_file: Path | None,
+    no_topic: bool,
+    include_optional: bool,
     data_dir: Path | None,
 ):
     """Export a day-of-week deck listing for certification.
@@ -266,6 +328,8 @@ def schedule(
         clm schedule course.xml                  # German Markdown to stdout
         clm schedule course.xml -L en            # English listing
         clm schedule course.xml -f csv           # CSV (one row per deck)
+        clm schedule course.xml --no-topic       # Day + video/slides only
+        clm schedule course.xml --include-optional   # Add optional modules
         clm schedule course.xml -o schedule.md   # Write to a file
     """
     language = language.lower()
@@ -285,7 +349,7 @@ def schedule(
 
     course = Course.from_spec(spec, course_root, output_root=None)
 
-    weeks = build_schedule(course, language)
+    weeks = build_schedule(course, language, include_optional=include_optional)
 
     if not any(week.days for week in weeks):
         click.echo(
@@ -296,9 +360,9 @@ def schedule(
         )
 
     if output_format == "csv":
-        content = render_csv(weeks)
+        content = render_csv(weeks, no_topic=no_topic)
     else:
-        content = render_markdown(course.name[language], weeks, language)
+        content = render_markdown(course.name[language], weeks, language, no_topic=no_topic)
 
     if output_file is not None:
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/clm/cli/commands/validate.py
+++ b/src/clm/cli/commands/validate.py
@@ -111,6 +111,15 @@ def _slides_dir_for_spec(data_dir: Path | None, spec_file: Path) -> Path:
     help=('Spec-only: validate sections marked enabled="false". Not valid with --kind=slides.'),
 )
 @click.option(
+    "--check-workdays",
+    is_flag=True,
+    help=(
+        "Spec-only: warn ('missing_workday') when a section that uses the "
+        "day-of-week <subsection> layer leaves a Mon–Fri workday uncovered. "
+        "Off by default. Not valid with --kind=slides."
+    ),
+)
+@click.option(
     "--fail-on",
     type=click.Choice(["error", "warning"], case_sensitive=False),
     default=None,
@@ -162,6 +171,7 @@ def validate_cmd(
     checks: str | None,
     quick: bool,
     include_disabled: bool,
+    check_workdays: bool,
     fail_on: str | None,
     deep: bool,
     summary: bool,
@@ -196,12 +206,15 @@ def validate_cmd(
             checks=checks,
             quick=quick,
             include_disabled=include_disabled,
+            check_workdays=check_workdays,
             fail_on=fail_on,
             deep=deep,
             summary=summary,
             shipping_only=shipping_only,
         )
     else:  # slides
+        if check_workdays:
+            raise click.UsageError("--check-workdays is spec-only; not valid with --kind=slides.")
         _validate_slides_path(
             ctx,
             path,
@@ -227,6 +240,7 @@ def _validate_spec_path(
     checks: str | None,
     quick: bool,
     include_disabled: bool,
+    check_workdays: bool,
     fail_on: str | None,
     deep: bool,
     summary: bool,
@@ -257,6 +271,7 @@ def _validate_spec_path(
             data_dir=data_dir,
             as_json=as_json,
             include_disabled=include_disabled,
+            check_workdays=check_workdays,
         )
         return
 
@@ -266,6 +281,7 @@ def _validate_spec_path(
         as_json=as_json,
         checks=checks,
         include_disabled=include_disabled,
+        check_workdays=check_workdays,
         fail_on=fail_on,
         summary=summary,
     )
@@ -278,6 +294,7 @@ def _run_deep_spec(
     as_json: bool,
     checks: str | None,
     include_disabled: bool,
+    check_workdays: bool,
     fail_on: str | None,
     summary: bool,
 ) -> None:
@@ -290,7 +307,12 @@ def _run_deep_spec(
     check_list = _parse_checks(checks)
 
     try:
-        spec_result = validate_spec(spec_file, slides_dir, include_disabled=include_disabled)
+        spec_result = validate_spec(
+            spec_file,
+            slides_dir,
+            include_disabled=include_disabled,
+            check_workdays=check_workdays,
+        )
     except CourseSpecError as e:
         raise click.ClickException(str(e)) from None
 

--- a/src/clm/cli/commands/validate_spec.py
+++ b/src/clm/cli/commands/validate_spec.py
@@ -30,11 +30,19 @@ from clm.slides.spec_validator import validate_spec
     "from a disabled section has '(disabled)' appended to its message so you "
     "can distinguish roadmap content from active content.",
 )
+@click.option(
+    "--check-workdays",
+    is_flag=True,
+    default=False,
+    help="Warn ('missing_workday') when a section that uses the day-of-week "
+    "<subsection> layer leaves a Mon–Fri workday uncovered. Off by default.",
+)
 def validate_spec_cmd(
     spec_file: Path,
     data_dir: Path | None,
     as_json: bool,
     include_disabled: bool,
+    check_workdays: bool,
 ):
     """Validate a course specification XML file.
 
@@ -51,7 +59,12 @@ def validate_spec_cmd(
     slides_dir = _resolve_slides_dir(data_dir, spec_file)
 
     try:
-        result = validate_spec(spec_file, slides_dir, include_disabled=include_disabled)
+        result = validate_spec(
+            spec_file,
+            slides_dir,
+            include_disabled=include_disabled,
+            check_workdays=check_workdays,
+        )
     except CourseSpecError as e:
         raise click.ClickException(str(e)) from None
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -428,6 +428,8 @@ clm schedule [OPTIONS] SPEC_FILE
 | `-L, --language`, `--lang [de\|en]` | Language for deck titles/labels (default: `de`). Titles come from the matching-language `header`/`header_de`/`header_en` macro. |
 | `-f, --format [md\|csv]` | Output format (default: `md`). |
 | `-o, --output FILE` | Write to FILE instead of stdout. |
+| `--no-topic` | Omit the Topic column, leaving just day and video/slides — the columns a certification authority needs (applies to both `md` and `csv`). |
+| `--include-optional` | Include modules marked `optional="true"` (on a `<section>` or `<subsection>`). Off by default; optional modules that are also `enabled="false"` are never listed, flag or not. |
 | `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the spec location. |
 
 Each listing is **single-language** — run once per language to produce both.
@@ -435,14 +437,21 @@ Deck order within a (week, day) is topic document order, then `slides_NNN_`
 order within each topic, matching the build.
 
 - **`--format md`** (default): one Markdown table per week, columns
-  weekday / video (deck title) / topic. The weekday label appears on the first
-  deck row of each day. Days are fixed-length by definition, so there are no
-  durations/minutes. Empty days render a placeholder row.
+  weekday / video (deck title) / topic (the Topic column is dropped with
+  `--no-topic`). The weekday label appears on the first deck row of each day.
+  Days are fixed-length by definition, so there are no durations/minutes. Empty
+  days render a placeholder row. A subsection that spans several days
+  (`weekday="mon,tue"`) renders a single joined label.
 - **`--format csv`**: one row per deck, with header
-  `week,week_title,weekday,video_title,topic,deck_file`.
+  `week,week_title,weekday,video_title,topic,deck_file` (`topic` dropped with
+  `--no-topic`). A multi-day subsection joins its tokens in the `weekday` cell
+  (`mon,tue`, quoted by the CSV writer).
 
-Only enabled subsections are listed. Bare topics that sit under no subsection
-do not appear in the listing (`clm validate` reports them as an info finding).
+Only enabled subsections are listed; optional ones require `--include-optional`.
+An excluded optional `<section>` keeps its declared week number (so omitting an
+optional Week 3 leaves Weeks 1, 2, 4, … rather than renumbering). Bare topics
+that sit under no subsection do not appear in the listing (`clm validate`
+reports them as an info finding).
 
 Examples:
 
@@ -450,6 +459,8 @@ Examples:
 clm schedule course.xml                  # German Markdown to stdout
 clm schedule course.xml -L en            # English listing
 clm schedule course.xml -f csv           # CSV (one row per deck)
+clm schedule course.xml --no-topic       # Day + video/slides only (cert authority)
+clm schedule course.xml --include-optional   # Add optional modules
 clm schedule course.xml -o schedule.md   # Write to a file
 ```
 
@@ -684,6 +695,7 @@ that referenced dir-group paths exist.
 | `--data-dir DIR` | Course data directory (contains slides/) |
 | `--json` | Output as JSON |
 | `--include-disabled` | Also validate sections marked `enabled="false"`; each finding from a disabled section has `(disabled)` appended to its message (default: disabled sections are skipped) |
+| `--check-workdays` | Warn (`missing_workday`) when a section that uses the day-of-week `<subsection>` layer leaves a Mon–Fri workday uncovered. Off by default (most courses do not fill all five days). Spec-only. |
 | `--deep` | After structure validation, run the full slide validator on **every deck the spec pulls in** (its shipping set) and report both. Exits non-zero on a structure error or a deck-content error (`--fail-on` governs the deck-content threshold). Resolves decks with the same build-faithful semantics as `clm spec decks`. |
 | `--summary` | Roll the deck-content findings up into a category/kind histogram with per-deck counts instead of a flat list (intended for corpus-scale validates that emit thousands of findings). On a spec, `--summary` implies `--deep`. |
 | `--checks LIST`, `--fail-on [error\|warning]` | Slides-validator options (see slides mode); valid on a spec only together with `--deep`, where they apply to the deck-content pass. |

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -101,6 +101,7 @@ Optional `<section>` attributes:
 | `enabled` | `"true"` (default) or `"false"`, case-insensitive. A disabled section is dropped from the parsed spec entirely, so `clm build`, `clm outline`, `clm validate`, and all MCP tools ignore it without needing code changes. Disabled sections may omit `<topics>` or reference topic IDs that do not yet exist — they are never built or validated, which lets a full roadmap spec live as a single file instead of carrying a separate `-build.xml` subset. |
 | `id` | Optional stable identifier for the section (e.g. `id="w03"`). Recommended for courses that are frequently filtered, because IDs are stable under reordering and renaming. |
 | `module` | Optional module-directory binding (e.g. `module="module_545_ml_azav_cohort_2026_04"`). When set, every `<topic>` inside this section resolves only against that module — duplicate topic IDs in other modules are ignored. This is the supported mechanism for cohort archives or course variants that share topic IDs with the live module. The value is the literal directory name under `slides/`. Per-topic `module=` (see below) overrides the section default for individual topics. |
+| `optional` | `"true"` or `"false"` (default `false`). Marks a whole week an **optional module**: excluded from `clm schedule` / `clm outline` listings unless `--include-optional` is passed. Presentation-only — it never affects the build. Same semantics as `optional` on `<subsection>` (see below); `optional` + `enabled="false"` is never listed. An excluded optional section keeps its declared week number in `clm schedule`. |
 
 Example of a roadmap section deferred until its topics exist:
 
@@ -216,6 +217,12 @@ may appear under `<topics>`, in any order.
             <name><de>Dienstag — Recht</de><en>Tuesday — Law</en></name>
             <topic>llm_ethics_azav</topic>   <!-- all its decks land on Tue -->
         </subsection>
+        <subsection weekday="wed,thu">   <!-- one block spanning two days -->
+            <topic>deep_learning_intro</topic>
+        </subsection>
+        <subsection weekday="fri" optional="true">   <!-- excluded unless --include-optional -->
+            <topic>bonus_capstone</topic>
+        </subsection>
     </topics>
 </section>
 ```
@@ -236,8 +243,9 @@ Optional `<subsection>` attributes:
 
 | Attribute | Description |
 |-----------|-------------|
-| `weekday` | Optional, language-neutral token from `{mon, tue, wed, thu, fri, sat, sun}` (case-insensitive), localized at render time. `sat`/`sun` are valid; AZAV uses Mon–Fri only. A closed enum lets the validator check ordering/uniqueness. Omit it for a generic thematic group that carries only a `<name>`. |
+| `weekday` | Optional, one or more language-neutral tokens from `{mon, tue, wed, thu, fri, sat, sun}` (case-insensitive), localized at render time. A single token (`weekday="mon"`) or a comma-separated list (`weekday="mon,tue,wed"`) so **one subsection can span several days**; a multi-day subsection renders as a joined label ("Monday, Tuesday, Wednesday"). `sat`/`sun` are valid; AZAV uses Mon–Fri only. A closed enum lets the validator check ordering/uniqueness/coverage. Omit it for a generic thematic group that carries only a `<name>`. |
 | `enabled` | `"true"` (default) or `"false"`. A disabled subsection is dropped entirely from the build — topics and all — exactly like a disabled `<section>`. It is retained only by tooling parsed with `--include-disabled`. |
+| `optional` | `"true"` or `"false"` (default `false`). An **optional module**: excluded from `clm schedule` / `clm outline` listings unless `--include-optional` is passed. Presentation-only — it never affects the build (the topics still flatten in). `optional` + `enabled="false"` is never listed, flag or not (disabled wins). The same `optional` attribute is also accepted on `<section>` to mark a whole week optional. |
 
 A `<subsection>` may also carry an optional `<name>` (`<de>`/`<en>`) label
 override; when omitted, the displayed label is derived from `weekday`. A
@@ -248,7 +256,10 @@ attributes).
 `clm validate` adds four advisory subsection checks (none is an error):
 duplicate weekday within a section, weekdays out of Mon→Sun order, an empty
 day (a subsection with no topics or whose topics resolve to zero decks), and
-(info) bare topics mixed with subsections (they appear under no day).
+(info) bare topics mixed with subsections (they appear under no day). A fifth
+**opt-in** check, `clm validate --check-workdays`, warns (`missing_workday`)
+when a section that uses the day-of-week layer leaves a Mon–Fri workday
+uncovered.
 
 ### `<author>` (Optional)
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -219,6 +219,11 @@ class TopicSpec:
 WEEKDAY_ORDER: tuple[str, ...] = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
 VALID_WEEKDAYS: frozenset[str] = frozenset(WEEKDAY_ORDER)
 
+# The workdays a Mon–Fri course is expected to fill. Used by the opt-in
+# ``clm validate --check-workdays`` coverage check, which warns when a section
+# that uses the day-of-week subsection layer leaves one of these uncovered.
+REQUIRED_WORKDAYS: tuple[str, ...] = ("mon", "tue", "wed", "thu", "fri")
+
 
 @frozen
 class SubsectionSpec:
@@ -242,23 +247,38 @@ class SubsectionSpec:
             that also appear in the parent :attr:`SectionSpec.topics` flat
             list. A *disabled* subsection's topics are held only here — they
             are deliberately kept out of the flat build list (see ``enabled``).
-        weekday: A language-neutral weekday token from :data:`VALID_WEEKDAYS`
-            (``"mon"``..``"sun"``), or ``None`` for a generic thematic group
-            that carries only a ``<name>``.
+        weekdays: Zero or more language-neutral weekday tokens from
+            :data:`VALID_WEEKDAYS` (``"mon"``..``"sun"``), in declared order.
+            A single ``<subsection weekday="mon,tue,wed">`` spans several
+            days; an empty tuple is a generic thematic group that carries
+            only a ``<name>``. The :attr:`weekday` property returns the first
+            token (or ``None``) for callers that only handle a single day.
         name: Optional bilingual label override. When ``None``, consumers
-            derive the displayed label from ``weekday``.
+            derive the displayed label from ``weekdays``.
         enabled: Mirrors ``<section enabled=...>``. A disabled subsection is
             dropped entirely from the build — its topics never enter the flat
             :attr:`SectionSpec.topics` list (the build path), regardless of
             ``keep_disabled``. With ``keep_disabled=True`` the wrapper is still
             retained in :attr:`SectionSpec.subsections` so tooling
             (``clm outline --include-disabled``) can surface it.
+        optional: An optional module that is excluded from ``clm schedule`` /
+            ``clm outline`` listings unless ``--include-optional`` is passed.
+            Presentation-only: it never affects the build (the topics still
+            flatten into :attr:`SectionSpec.topics` like any enabled
+            subsection). An ``optional`` *and* disabled subsection is dropped
+            entirely (``enabled`` wins) — it is never listed, flag or not.
     """
 
     topics: list[TopicSpec] = Factory(list)
-    weekday: str | None = None
+    weekdays: tuple[str, ...] = ()
     name: Text | None = None
     enabled: bool = True
+    optional: bool = False
+
+    @property
+    def weekday(self) -> str | None:
+        """The first weekday token, or ``None`` — convenience for single-day callers."""
+        return self.weekdays[0] if self.weekdays else None
 
 
 @frozen
@@ -286,6 +306,12 @@ class SectionSpec:
     # disabled subsections appear here only when parsed with
     # ``keep_disabled=True``.
     subsections: list[SubsectionSpec] = Factory(list)
+    # An optional module (whole week). Excluded from ``clm schedule`` /
+    # ``clm outline`` listings unless ``--include-optional`` is passed.
+    # Presentation-only, exactly like :attr:`SubsectionSpec.optional`: it
+    # never gates the build. An ``optional`` *and* disabled section is still
+    # dropped at parse time (``enabled`` wins) and is never listed.
+    optional: bool = False
 
     def module_for(self, topic_spec: TopicSpec) -> str | None:
         """Effective module binding for *topic_spec* under this section.
@@ -443,6 +469,36 @@ def _parse_enabled_attr(value: str | None, *, label: str) -> bool:
         f"Invalid value for 'enabled' attribute on {label}: {value!r}. "
         f"Expected 'true' or 'false' (case-insensitive)."
     )
+
+
+def _parse_weekdays_attr(value: str | None, *, section_label: str) -> tuple[str, ...]:
+    """Parse a ``<subsection>`` ``weekday`` attribute into ordered tokens.
+
+    Accepts a single token (``"mon"``) or a comma-separated list
+    (``"mon,tue,wed"``), so one ``<subsection>`` can span several days
+    (issue #261 follow-up). Each token is normalized to lowercase and
+    validated against the closed :data:`VALID_WEEKDAYS` enum; an unknown
+    token is a hard :class:`CourseSpecError`. Returns an empty tuple when the
+    attribute is absent or blank (a thematic group carrying only a
+    ``<name>``). Duplicate tokens collapse, preserving first-occurrence
+    order.
+    """
+    if value is None:
+        return ()
+    result: list[str] = []
+    for raw in value.split(","):
+        token = raw.strip().lower()
+        if not token:
+            continue
+        if token not in VALID_WEEKDAYS:
+            raise CourseSpecError(
+                f"Invalid weekday {raw.strip()!r} on a <subsection> in "
+                f"{section_label}. Expected one of {list(WEEKDAY_ORDER)} "
+                f"(language-neutral, lowercase), optionally comma-separated."
+            )
+        if token not in result:
+            result.append(token)
+    return tuple(result)
 
 
 @frozen
@@ -1205,8 +1261,9 @@ class CourseSpec:
         Returns ``None`` when the subsection is disabled and
         ``keep_disabled`` is False, so the caller drops it entirely
         (topics and all) — mirroring how a disabled ``<section>`` is
-        dropped. ``weekday`` is validated against the closed
-        :data:`VALID_WEEKDAYS` enum; an unknown token is a hard error.
+        dropped. ``weekday`` accepts a single token or a comma-separated
+        list, each validated against the closed :data:`VALID_WEEKDAYS`
+        enum; an unknown token is a hard error.
         """
         enabled = _parse_enabled_attr(
             sub_elem.attrib.get("enabled"), label=f"subsection in {section_label}"
@@ -1214,18 +1271,8 @@ class CourseSpec:
         if not enabled and not keep_disabled:
             return None
 
-        weekday_raw = sub_elem.attrib.get("weekday")
-        weekday: str | None = None
-        if weekday_raw is not None:
-            normalized = weekday_raw.strip().lower()
-            if normalized:
-                if normalized not in VALID_WEEKDAYS:
-                    raise CourseSpecError(
-                        f"Invalid weekday {weekday_raw!r} on a <subsection> in "
-                        f"{section_label}. Expected one of "
-                        f"{list(WEEKDAY_ORDER)} (language-neutral, lowercase)."
-                    )
-                weekday = normalized
+        weekdays = _parse_weekdays_attr(sub_elem.attrib.get("weekday"), section_label=section_label)
+        optional = _parse_bool_attr(sub_elem.attrib.get("optional"), attr_name="optional")
 
         name_elem = sub_elem.find("name")
         name: Text | None = None
@@ -1240,7 +1287,13 @@ class CourseSpec:
             CourseSpec._parse_topic_element(topic_elem, section_label=section_label)
             for topic_elem in sub_elem.findall("topic")
         ]
-        return SubsectionSpec(topics=topics, weekday=weekday, name=name, enabled=enabled)
+        return SubsectionSpec(
+            topics=topics,
+            weekdays=weekdays,
+            name=name,
+            enabled=enabled,
+            optional=optional,
+        )
 
     @staticmethod
     def _iter_topic_elements(
@@ -1297,6 +1350,9 @@ class CourseSpec:
             section_module = section_elem.attrib.get("module") or None
             section_http_replay = _parse_bool_attr(
                 section_elem.attrib.get("http-replay"), attr_name="http-replay"
+            )
+            section_optional = _parse_bool_attr(
+                section_elem.attrib.get("optional"), attr_name="optional"
             )
 
             if not enabled and not keep_disabled:
@@ -1364,6 +1420,7 @@ class CourseSpec:
                     includes=section_includes,
                     http_replay=section_http_replay,
                     subsections=subsections,
+                    optional=section_optional,
                 )
             )
         return sections

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -14,7 +14,13 @@ from pathlib import Path
 
 import tomllib
 
-from clm.core.course_spec import WEEKDAY_ORDER, CourseSpec, IncludeSpec, SectionSpec
+from clm.core.course_spec import (
+    REQUIRED_WORKDAYS,
+    WEEKDAY_ORDER,
+    CourseSpec,
+    IncludeSpec,
+    SectionSpec,
+)
 from clm.core.include_ledger import LEDGER_NAME, Ledger
 from clm.core.topic_resolver import (
     TopicMatch,
@@ -60,6 +66,7 @@ def validate_spec(
     slides_dir: Path,
     *,
     include_disabled: bool = False,
+    check_workdays: bool = False,
 ) -> SpecValidationResult:
     """Validate a course spec XML file for consistency.
 
@@ -82,6 +89,11 @@ def validate_spec(
             False (disabled sections are dropped at parse time and
             therefore invisible to validation, which is the desired
             behavior for the fast build path).
+        check_workdays: If True, add the opt-in ``missing_workday`` check —
+            for every section that uses the day-of-week subsection layer,
+            warn when a Mon–Fri workday (:data:`REQUIRED_WORKDAYS`) is left
+            uncovered. Off by default (most courses do not fill all five
+            days). See ``clm validate --check-workdays``.
 
     Returns:
         A :class:`SpecValidationResult` with all findings.
@@ -254,6 +266,7 @@ def validate_spec(
         topic_map=topic_map,
         findings=findings,
         suffix=_suffix,
+        check_workdays=check_workdays,
     )
 
     # Dir-group path checks
@@ -300,10 +313,11 @@ def _validate_subsections(
     topic_map: dict[str, list[TopicMatch]],
     findings: list[SpecFinding],
     suffix: Callable[[bool, str], str],
+    check_workdays: bool = False,
 ) -> None:
     """Emit findings for ``<subsection>`` day-of-week groupings (issue #261).
 
-    Four checks, per the design:
+    Four default checks, per the design:
 
     1. ``duplicate_weekday`` (warning) — the same weekday token appears on
        more than one subsection within a single section.
@@ -314,9 +328,15 @@ def _validate_subsections(
     4. ``unscheduled_topics`` (info) — a section mixes bare ``<topic>``s
        (which appear under no day) with ``<subsection>``s.
 
-    Only enabled subsections are checked for 1–3 (a disabled subsection is
-    roadmap content, like a disabled section). All checks are
-    informational/advisory: none is an error.
+    Plus one opt-in check, gated on *check_workdays*:
+
+    5. ``missing_workday`` (warning) — a section that uses the day-of-week
+       layer leaves a Mon–Fri workday uncovered.
+
+    A subsection may span several days (``weekday="mon,tue"``); every check
+    operates on the flattened weekday tokens. Only enabled subsections are
+    checked (a disabled subsection is roadmap content, like a disabled
+    section). All checks are informational/advisory: none is an error.
     """
     for section in spec.sections:
         section_name = section.name.en or section.name.de
@@ -331,7 +351,9 @@ def _validate_subsections(
             continue
 
         # --- Checks 1 & 2: weekday duplicates and ordering ---
-        weekdays = [sub.weekday for sub in enabled_subs if sub.weekday is not None]
+        # Flatten across subsections AND across each subsection's own tokens
+        # so a multi-day subsection participates in both checks.
+        weekdays = [wd for sub in enabled_subs for wd in sub.weekdays]
 
         seen: set[str] = set()
         reported_dup: set[str] = set()
@@ -385,7 +407,11 @@ def _validate_subsections(
 
         # --- Check 3: empty days ---
         for sub in enabled_subs:
-            label = sub.weekday or (sub.name.en or sub.name.de if sub.name else "") or "(unnamed)"
+            label = (
+                ",".join(sub.weekdays)
+                or (sub.name.en or sub.name.de if sub.name else "")
+                or "(unnamed)"
+            )
             if not sub.topics:
                 findings.append(
                     SpecFinding(
@@ -451,6 +477,35 @@ def _validate_subsections(
                     ),
                 )
             )
+
+        # --- Check 5 (opt-in): workday coverage ---
+        # Only sections that actually use the day-of-week layer (at least one
+        # enabled subsection carrying a weekday) are held to full Mon–Fri
+        # coverage; purely thematic, name-only subsections are exempt.
+        if check_workdays:
+            weekday_subs = [sub for sub in enabled_subs if sub.weekdays]
+            if weekday_subs:
+                covered = {wd for sub in weekday_subs for wd in sub.weekdays}
+                missing = [wd for wd in REQUIRED_WORKDAYS if wd not in covered]
+                if missing:
+                    listed = ", ".join(missing)
+                    findings.append(
+                        SpecFinding(
+                            severity="warning",
+                            type="missing_workday",
+                            section=section_name,
+                            message=suffix(
+                                section_disabled,
+                                f"Section '{section_name}' has no subsection for "
+                                f"workday(s): {listed}.",
+                            ),
+                            suggestion=(
+                                'Add a <subsection weekday="..."> for each missing '
+                                "workday, or omit --check-workdays if partial weeks "
+                                "are intended."
+                            ),
+                        )
+                    )
 
 
 @dataclass

--- a/tests/cli/test_schedule.py
+++ b/tests/cli/test_schedule.py
@@ -31,14 +31,19 @@ def course() -> Course:
 
 class TestSubsectionLabel:
     def test_name_override_wins(self):
-        sub = SubsectionSpec(weekday="tue", name=Text(de="Recht", en="Law"))
+        sub = SubsectionSpec(weekdays=("tue",), name=Text(de="Recht", en="Law"))
         assert subsection_label(sub, "de") == "Recht"
         assert subsection_label(sub, "en") == "Law"
 
     def test_weekday_localized_when_no_name(self):
-        sub = SubsectionSpec(weekday="mon")
+        sub = SubsectionSpec(weekdays=("mon",))
         assert subsection_label(sub, "de") == "Montag"
         assert subsection_label(sub, "en") == "Monday"
+
+    def test_multiple_weekdays_join_localized_labels(self):
+        sub = SubsectionSpec(weekdays=("mon", "tue", "wed"))
+        assert subsection_label(sub, "en") == "Monday, Tuesday, Wednesday"
+        assert subsection_label(sub, "de") == "Montag, Dienstag, Mittwoch"
 
     def test_empty_when_neither(self):
         sub = SubsectionSpec()
@@ -95,7 +100,7 @@ class TestRenderMarkdown:
                 title="Week 1",
                 days=[
                     ScheduleDay(
-                        weekday="mon",
+                        weekdays=["mon"],
                         label="Monday",
                         decks=[
                             ScheduleDeck("Intro", "intro", "slides_010_intro"),
@@ -123,7 +128,7 @@ class TestRenderMarkdown:
             ScheduleWeek(
                 number=1,
                 title="W1",
-                days=[ScheduleDay(weekday="mon", label="Monday", decks=[])],
+                days=[ScheduleDay(weekdays=["mon"], label="Monday", decks=[])],
             )
         ]
         out = render_markdown("C", weeks, "en")
@@ -136,7 +141,7 @@ class TestRenderMarkdown:
                 title="W1",
                 days=[
                     ScheduleDay(
-                        weekday="mon",
+                        weekdays=["mon"],
                         label="Monday",
                         decks=[ScheduleDeck("A | B", "t", "f")],
                     )
@@ -145,6 +150,29 @@ class TestRenderMarkdown:
         ]
         out = render_markdown("C", weeks, "en")
         assert r"A \| B" in out
+
+    def test_no_topic_drops_topic_column(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="Week 1",
+                days=[
+                    ScheduleDay(
+                        weekdays=["mon"],
+                        label="Monday",
+                        decks=[ScheduleDeck("Intro", "intro", "slides_010_intro")],
+                    ),
+                    ScheduleDay(weekdays=["tue"], label="Tuesday", decks=[]),
+                ],
+            )
+        ]
+        out = render_markdown("My Course", weeks, "en", no_topic=True)
+        # Two-column header, no Topic.
+        assert "| Day | Video (slides) |" in out
+        assert "Topic" not in out
+        assert "| Monday | Intro |" in out
+        # Empty day still renders a single placeholder column.
+        assert "| Tuesday | — |" in out
 
 
 class TestRenderCsv:
@@ -155,7 +183,7 @@ class TestRenderCsv:
                 title="Week 1",
                 days=[
                     ScheduleDay(
-                        weekday="mon",
+                        weekdays=["mon"],
                         label="Monday",
                         decks=[ScheduleDeck("Intro", "intro", "slides_010_intro")],
                     )
@@ -174,7 +202,7 @@ class TestRenderCsv:
                 title="Einführung, LLMs",
                 days=[
                     ScheduleDay(
-                        weekday="mon",
+                        weekdays=["mon"],
                         label="Montag",
                         decks=[ScheduleDeck("A, B", "t", "f")],
                     )
@@ -184,6 +212,43 @@ class TestRenderCsv:
         out = render_csv(weeks)
         assert '"Einführung, LLMs"' in out
         assert '"A, B"' in out
+
+    def test_no_topic_drops_topic_field(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="Week 1",
+                days=[
+                    ScheduleDay(
+                        weekdays=["mon"],
+                        label="Monday",
+                        decks=[ScheduleDeck("Intro", "intro", "slides_010_intro")],
+                    )
+                ],
+            )
+        ]
+        out = render_csv(weeks, no_topic=True)
+        lines = out.strip().splitlines()
+        assert lines[0] == "week,week_title,weekday,video_title,deck_file"
+        assert lines[1] == "1,Week 1,mon,Intro,slides_010_intro"
+
+    def test_multi_weekday_joined_in_cell(self):
+        weeks = [
+            ScheduleWeek(
+                number=1,
+                title="Week 1",
+                days=[
+                    ScheduleDay(
+                        weekdays=["mon", "tue"],
+                        label="Monday, Tuesday",
+                        decks=[ScheduleDeck("Intro", "intro", "slides_010_intro")],
+                    )
+                ],
+            )
+        ]
+        out = render_csv(weeks)
+        # The comma-joined token set is quoted by the CSV writer.
+        assert '"mon,tue"' in out
 
 
 class TestScheduleCli:
@@ -238,3 +303,57 @@ class TestScheduleCli:
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
         assert "schedule" in result.output
+
+    def test_no_topic_flag_markdown(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(SPEC_PATH), "-L", "en", "--no-topic"])
+        assert result.exit_code == 0, result.output
+        assert "| Day | Video (slides) |" in result.output
+        # The Topic *column* (header and topic-id cells) is gone; deck titles
+        # that merely contain the word "Topic" are unaffected.
+        assert "| Topic |" not in result.output
+        assert "some_topic_from_test_1" not in result.output
+
+    def test_no_topic_flag_csv(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["schedule", str(SPEC_PATH), "-f", "csv", "-L", "en", "--no-topic"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "week,week_title,weekday,video_title,deck_file" in result.output
+        assert "topic" not in result.output.splitlines()[0]
+
+
+OPTIONAL_SPEC_PATH = Path("tests/test-data/course-specs/subsection-optional-spec.xml")
+
+
+class TestScheduleOptional:
+    def test_optional_excluded_by_default(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(OPTIONAL_SPEC_PATH), "-L", "en"])
+        assert result.exit_code == 0, result.output
+        # The multi-day subsection localizes to a joined label.
+        assert "| Monday, Tuesday |" in result.output
+        # Optional Week 2 (whole section) and the optional Wednesday subsection
+        # are both omitted without the flag.
+        assert "## Week 2" not in result.output
+        assert "Wednesday" not in result.output
+
+    def test_include_optional_adds_modules(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["schedule", str(OPTIONAL_SPEC_PATH), "-L", "en", "--include-optional"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "## Week 2" in result.output
+        assert "| Wednesday |" in result.output
+        assert "| Thursday |" in result.output
+
+    def test_excluded_optional_section_keeps_week_numbering(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", str(OPTIONAL_SPEC_PATH), "-f", "csv", "-L", "en"])
+        assert result.exit_code == 0, result.output
+        # Week 1 is present; the optional Week 2 leaves no week-2 rows.
+        assert ",mon,tue," not in result.output  # weekday cell is the joined token set
+        assert '"mon,tue"' in result.output
+        assert "2,Week 2," not in result.output

--- a/tests/cli/test_validate_spec.py
+++ b/tests/cli/test_validate_spec.py
@@ -244,3 +244,53 @@ class TestValidateSpecIncludeDisabled:
         assert len(unresolved) == 1
         assert unresolved[0]["topic_id"] == "not_yet_implemented"
         assert "(disabled)" in unresolved[0]["message"]
+
+
+class TestCheckWorkdays:
+    def test_check_workdays_off_by_default(self, tmp_path):
+        _make_topic(tmp_path, "module_100_basics", "topic_010_intro")
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <subsection weekday="mon"><topic>intro</topic></subsection>
+              </topics>
+            </section></sections>""",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(spec_file), "--data-dir", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "missing_workday" not in result.output
+        assert "workday" not in result.output.lower()
+
+    def test_check_workdays_warns(self, tmp_path):
+        _make_topic(tmp_path, "module_100_basics", "topic_010_intro")
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics>
+                <subsection weekday="mon"><topic>intro</topic></subsection>
+              </topics>
+            </section></sections>""",
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["validate", str(spec_file), "--data-dir", str(tmp_path), "--check-workdays", "--json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        missing = [f for f in data["findings"] if f["type"] == "missing_workday"]
+        assert len(missing) == 1
+        assert "tue" in missing[0]["message"]
+
+    def test_check_workdays_rejected_for_slides(self, tmp_path):
+        (tmp_path / "slides").mkdir(parents=True)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(tmp_path / "slides"), "--check-workdays"])
+        assert result.exit_code != 0
+        assert "spec-only" in result.output.lower()

--- a/tests/core/test_subsection_spec.py
+++ b/tests/core/test_subsection_spec.py
@@ -35,9 +35,11 @@ def _spec_xml(topics_block: str) -> str:
 def test_subsection_defaults():
     sub = SubsectionSpec()
     assert sub.topics == []
+    assert sub.weekdays == ()
     assert sub.weekday is None
     assert sub.name is None
     assert sub.enabled is True
+    assert sub.optional is False
 
 
 def test_subsection_topics_flatten_into_topics_list():
@@ -262,6 +264,78 @@ def test_invalid_weekday_rejected():
     xml = _spec_xml('<subsection weekday="monday"><topic>t</topic></subsection>')
     with pytest.raises(CourseSpecError, match="Invalid weekday"):
         CourseSpec.from_file(io.StringIO(xml))
+
+
+def test_multiple_weekdays_parsed_in_order():
+    xml = _spec_xml('<subsection weekday="mon,tue,wed"><topic>t</topic></subsection>')
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    sub = spec.sections[0].subsections[0]
+    assert sub.weekdays == ("mon", "tue", "wed")
+    # The back-compat single-day property returns the first token.
+    assert sub.weekday == "mon"
+
+
+def test_multiple_weekdays_whitespace_and_case_tolerant():
+    xml = _spec_xml('<subsection weekday=" MON , Tue ,wed"><topic>t</topic></subsection>')
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.sections[0].subsections[0].weekdays == ("mon", "tue", "wed")
+
+
+def test_duplicate_weekday_within_attr_collapsed():
+    xml = _spec_xml('<subsection weekday="mon,mon,tue"><topic>t</topic></subsection>')
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.sections[0].subsections[0].weekdays == ("mon", "tue")
+
+
+def test_invalid_weekday_in_list_rejected():
+    xml = _spec_xml('<subsection weekday="mon,funday"><topic>t</topic></subsection>')
+    with pytest.raises(CourseSpecError, match="Invalid weekday"):
+        CourseSpec.from_file(io.StringIO(xml))
+
+
+def test_empty_weekday_attr_is_no_days():
+    xml = _spec_xml(
+        '<subsection weekday=""><name><de>x</de><en>x</en></name><topic>t</topic></subsection>'
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    sub = spec.sections[0].subsections[0]
+    assert sub.weekdays == ()
+    assert sub.weekday is None
+
+
+def test_subsection_optional_attribute_parsed():
+    xml = _spec_xml(
+        """
+        <subsection weekday="mon"><topic>a</topic></subsection>
+        <subsection weekday="tue" optional="true"><topic>b</topic></subsection>
+        """
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    subs = spec.sections[0].subsections
+    assert [s.optional for s in subs] == [False, True]
+    # optional is presentation-only: both topics still flatten into the build.
+    assert [t.id for t in spec.sections[0].topics] == ["a", "b"]
+
+
+def test_section_optional_attribute_parsed():
+    xml = """
+    <course>
+        <name><de>K</de><en>C</en></name>
+        <prog-lang>python</prog-lang>
+        <description><de>d</de><en>d</en></description>
+        <certificate><de>c</de><en>c</en></certificate>
+        <sections>
+            <section optional="true">
+                <name><de>W1</de><en>W1</en></name>
+                <topics><topic>a</topic></topics>
+            </section>
+        </sections>
+    </course>
+    """
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.sections[0].optional is True
+    # Default is False.
+    assert SubsectionSpec().optional is False
 
 
 def test_invalid_subsection_enabled_value_rejected():

--- a/tests/slides/test_spec_validator_subsections.py
+++ b/tests/slides/test_spec_validator_subsections.py
@@ -229,3 +229,89 @@ class TestDisabledSubsectionNotChecked:
         )
         result = validate_spec(spec, tmp_path / "slides")
         assert "duplicate_weekday" not in _types(result)
+
+
+class TestMultipleWeekdays:
+    def test_multi_weekday_subsection_counts_each_day(self, tmp_path):
+        """A ``weekday="tue,mon"`` subsection is flattened, so the out-of-order
+        pair (tue before mon) is still flagged."""
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="tue,mon"><topic>a</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "weekday_out_of_order" in _types(result)
+
+    def test_duplicate_across_multi_weekday_subsections(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        _make_topic(tmp_path, "module_100", "topic_020_b")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon,tue"><topic>a</topic></subsection>
+            <subsection weekday="tue,wed"><topic>b</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        dups = [f for f in result.findings if f.type == "duplicate_weekday"]
+        assert len(dups) == 1
+        assert "tue" in dups[0].message
+
+
+class TestWorkdayCoverage:
+    def test_missing_workday_off_by_default(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="mon"><topic>a</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides")
+        assert "missing_workday" not in _types(result)
+
+    def test_missing_workday_warns_when_enabled(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="mon"><topic>a</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides", check_workdays=True)
+        missing = [f for f in result.findings if f.type == "missing_workday"]
+        assert len(missing) == 1
+        assert missing[0].severity == "warning"
+        for day in ("tue", "wed", "thu", "fri"):
+            assert day in missing[0].message
+
+    def test_full_week_passes(self, tmp_path):
+        for letter in "abcde":
+            _make_topic(tmp_path, "module_100", f"topic_0{ord(letter)}_{letter}")
+        spec = _write_spec(
+            tmp_path,
+            """\
+            <subsection weekday="mon"><topic>a</topic></subsection>
+            <subsection weekday="tue"><topic>b</topic></subsection>
+            <subsection weekday="wed"><topic>c</topic></subsection>
+            <subsection weekday="thu"><topic>d</topic></subsection>
+            <subsection weekday="fri"><topic>e</topic></subsection>""",
+        )
+        result = validate_spec(spec, tmp_path / "slides", check_workdays=True)
+        assert "missing_workday" not in _types(result)
+
+    def test_one_multi_weekday_subsection_can_cover_the_week(self, tmp_path):
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(
+            tmp_path,
+            '<subsection weekday="mon,tue,wed,thu,fri"><topic>a</topic></subsection>',
+        )
+        result = validate_spec(spec, tmp_path / "slides", check_workdays=True)
+        assert "missing_workday" not in _types(result)
+
+    def test_thematic_only_section_exempt(self, tmp_path):
+        """A section whose subsections carry no weekday (thematic grouping)
+        is not held to workday coverage."""
+        _make_topic(tmp_path, "module_100", "topic_010_a")
+        spec = _write_spec(
+            tmp_path,
+            "<subsection><name><de>Thema</de><en>Theme</en></name><topic>a</topic></subsection>",
+        )
+        result = validate_spec(spec, tmp_path / "slides", check_workdays=True)
+        assert "missing_workday" not in _types(result)

--- a/tests/test-data/course-specs/subsection-optional-spec.xml
+++ b/tests/test-data/course-specs/subsection-optional-spec.xml
@@ -1,0 +1,42 @@
+<course>
+    <name>
+        <de>Mein Kurs</de>
+        <en>My Course</en>
+    </name>
+    <prog-lang>python</prog-lang>
+    <description>
+        <de>Ein Kurs über ein Thema</de>
+        <en>A course about a topic</en>
+    </description>
+    <certificate>
+        <de>...</de>
+        <en>...</en>
+    </certificate>
+    <sections>
+        <section>
+            <name>
+                <de>Woche 1</de>
+                <en>Week 1</en>
+            </name>
+            <topics>
+                <subsection weekday="mon,tue">
+                    <topic>some_topic_from_test_1</topic>
+                </subsection>
+                <subsection weekday="wed" optional="true">
+                    <topic>a_topic_from_test_2</topic>
+                </subsection>
+            </topics>
+        </section>
+        <section optional="true">
+            <name>
+                <de>Woche 2</de>
+                <en>Week 2</en>
+            </name>
+            <topics>
+                <subsection weekday="thu">
+                    <topic>simple_notebook</topic>
+                </subsection>
+            </topics>
+        </section>
+    </sections>
+</course>


### PR DESCRIPTION
## Summary

Extends `clm schedule` and the `<subsection>` day-of-week layer (issue #261) with four certification-oriented features.

### 1. `clm schedule --no-topic`
Drops the Topic column (Markdown) / `topic` field (CSV), leaving just **day** and **video/slides** — the columns a certification authority needs. Applies to both formats.

### 2. `optional` modules + `clm schedule --include-optional`
New `optional="true"` attribute on **both** `<section>` and `<subsection>`. Optional modules are excluded from `clm schedule` / `clm outline` listings unless `--include-optional` is passed.

- **Presentation-only** — never affects the build (topics still flatten into the build list, byte-identical).
- `optional` + `enabled="false"` is **never** listed, flag or not (disabled wins).
- An excluded optional `<section>` keeps its **declared week number** (omitting optional Week 3 leaves Weeks 1, 2, 4, …).

### 3. Multi-day subsections — `weekday="mon,tue,wed"`
One `<subsection>` can now span several days. `SubsectionSpec` stores `weekdays: tuple[str, ...]` (with a back-compat `weekday` first-token property). Labels join localized day names ("Monday, Tuesday, Wednesday"); CSV joins the tokens in the `weekday` cell (`"mon,tue"`, quoted by the writer); all validator checks flatten across the list.

### 4. `clm validate --check-workdays` (opt-in)
Warns (`missing_workday`) when a section that uses the day-of-week layer leaves a **Mon–Fri** workday uncovered. Off by default (most courses don't fill all five days); only fires for sections that actually use weekday subsections (thematic name-only groups are exempt).

## Docs
Updated the info topics per the maintenance rule:
- `spec-files.md`: multi-weekday syntax, `optional` on `<section>`/`<subsection>`, the fifth opt-in validator check.
- `commands.md`: `clm schedule --no-topic`/`--include-optional`, `clm validate --check-workdays`.

## Tests
- New fixture `tests/test-data/course-specs/subsection-optional-spec.xml`.
- Extended parse, schedule-render, validator, and CLI tests (multi-weekday parsing, optional gating, week-number stability, `--no-topic` in both formats, `missing_workday` on/off/coverage).
- Full **fast suite green** (7191 passed); ruff + mypy clean; pre-push gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
