### PR TITLE
fix(export): filter split-language decks; add --include-disabled=merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `-L/--language` is the canonical spelling everywhere (`schedule` keeps
   `--lang` as an alias). The MCP `course_outline` tool is unchanged (it still
   shows optional content). See `clm info migration`.
+- **`--include-disabled` now takes an optional value** on all three `clm export`
+  commands: a bare `--include-disabled` (or `=marked`) keeps the previous
+  behaviour (disabled content tagged `(disabled)`, disabled whole sections
+  listed after the enabled ones in `outline`/`summary`), while
+  `--include-disabled=merge` folds disabled content into the normal course flow
+  — in declared order, with no marker — so a roadmap spec reads like a finished
+  course. Structured outputs (`outline --format json`, `schedule --format csv`)
+  keep the disabled state recorded even under `=merge`.
 
 ### Fixed
 
+- **`clm export` commands no longer emit both languages of a split deck.**
+  When a topic ships split `slides_x.de.py` + `slides_x.en.py` companions, a
+  `-L de` outline/summary listed *both* the German and the English title (and
+  the JSON `slides` array carried both), because the section-flat, JSON-slide,
+  summary, and disabled-topic enumerations skipped the `output_language_filter`
+  the subsection path already applied. All enumerations now filter split
+  companions to the requested language (via `output_language_filter` for the
+  built course and the `.de`/`.en` filename suffix for disabled topics read
+  from disk), so a split pair contributes a single entry — matching the build's
+  per-language routing. Bilingual decks are unaffected.
 - **The mitmproxy transport now records and replays a per-request response
   *sequence*** instead of collapsing a repeated request to its first response.
   A non-deterministic endpoint (a temperature>0 LLM, or OpenRouter routing the

--- a/docs/claude/design/export-command-group.md
+++ b/docs/claude/design/export-command-group.md
@@ -113,9 +113,65 @@ cli.add_command(export_group)
 The flat `cli.add_command(outline/schedule/summarize)` registrations are
 removed.
 
+## Follow-up (2026-06-09): split-language filtering + `--include-disabled=merge`
+
+Two issues surfaced once the group shipped against a real split-language course
+(`machine-learning-azav`):
+
+### 1. Both languages leaked for split decks (bug)
+
+A split topic ships `slides_x.de.py` + `slides_x.en.py`; each companion carries
+the requested `-L` language's title in *both* `Text` slots and an
+`output_language_filter` of its own language. The subsection path already
+filtered on that (`_topic_deck_titles` / `_topic_decks`), but four other
+enumerations did not, so `-L de` emitted both the German and English title:
+
+- **Family A — resolved `NotebookFile`** (filter on `output_language_filter`):
+  `outline.generate_outline` flat else-branch, `outline.generate_outline_json`
+  topic-slides, `outline._subsections_json` enabled-subsection slides,
+  `summary.build_sections_data`.
+- **Family B — on-disk paths** (filter on the `.de`/`.en` filename suffix):
+  `_export_shared.disabled_topic_files`, the single chokepoint for every
+  disabled-topic read across all three commands.
+
+Fix: two shared predicates in `_export_shared.py` —
+`notebook_in_language(notebook, language)` and `path_in_language(path,
+language)` (the latter built on `split_lang_suffix`) — applied at every
+enumeration. `disabled_topic_files` gained a required `language` parameter.
+Known limitation: a topic that ships *both* a bilingual file and split
+companions still lists both (family dedup is the build's `slide_family_key`
+concern, out of scope here).
+
+### 2. `--include-disabled=merge`
+
+`--include-disabled` became an *optional-value* option (the only one in the
+CLI): omitted ⇒ excluded; bare / `=marked` ⇒ the original "tagged + appended"
+behaviour; `=merge` ⇒ disabled content folded into the **normal declared
+order** with **no `(disabled)` marker**, so a roadmap spec reads like a finished
+course.
+
+- Threading: the option dest is `disabled_mode: str | None`; each handler calls
+  `resolve_disabled_mode()` → `(include_disabled, merge_disabled)` bools. The
+  generators keep plain-`bool` signatures and gained a defaulted
+  `merge_disabled` — so the MCP `course_outline` caller and the direct-generator
+  tests are unaffected.
+- outline/summary needed real **declared-order interleaving** (a `built_section_map`
+  keyed by `section_match_key` lets the merge path walk the full `keep_disabled`
+  section list and recover each enabled section's built object). schedule already
+  numbered disabled weeks in declared position, so merge is render-only there
+  (`render_markdown(mark_disabled=…)`); the schedule data flags stay truthful so
+  the CSV `disabled` column is unaffected.
+- Structured outputs keep the disabled bit as **metadata** under `=merge`
+  (`outline --format json` `"disabled": true`, `schedule --format csv` `disabled`
+  column); merge changes only the human-readable placement and marker.
+- Click caveat: a bare `--include-disabled` immediately before the `SPEC_FILE`
+  positional is consumed as the value — documented; use `=VALUE` and keep the
+  spec first.
+
 ## Out of scope
 
 - Folding `clm slides slug-report` / `coverage-report` into `export` (they are
   slide-corpus reports, already grouped under `slides`).
 - Subsection-level optional filtering inside `summary` (see limitation above).
 - Any change to build behavior.
+- Deduping a bilingual file against its own split companions in document views.

--- a/docs/user-guide/spec-file-reference.md
+++ b/docs/user-guide/spec-file-reference.md
@@ -298,8 +298,10 @@ Example of a roadmap section deferred until its topics exist:
 Building such a spec (`clm build course.xml`) silently skips the
 disabled section and all its unresolved topic references. Use
 `clm export outline course.xml --include-disabled` to see the full roadmap
-including disabled sections, and `clm validate course.xml
---include-disabled` to validate disabled sections' topics with a
+with disabled sections tagged `(disabled)` (or
+`clm export outline course.xml --include-disabled=merge` to fold them into the
+normal course flow with no marker, in declared order), and `clm validate
+course.xml --include-disabled` to validate disabled sections' topics with a
 `(disabled)` suffix on each finding.
 
 #### `<topic>`

--- a/src/clm/cli/commands/_export_shared.py
+++ b/src/clm/cli/commands/_export_shared.py
@@ -12,18 +12,20 @@ commands — they never change the build, only what appears in the document.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 import click
 
 from clm.core.utils.notebook_utils import find_notebook_titles
-from clm.infrastructure.utils.path_utils import is_slides_file
+from clm.infrastructure.utils.path_utils import is_slides_file, split_lang_suffix
 
 if TYPE_CHECKING:
     from clm.core.course import Course
+    from clm.core.course_files.notebook_file import NotebookFile
     from clm.core.course_spec import SectionSpec, SubsectionSpec, TopicSpec
+    from clm.core.section import Section
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -84,14 +86,29 @@ def output_options(func: F) -> F:
 
 
 def selection_options(func: F) -> F:
-    """``--include-optional`` and ``--include-disabled`` selection gates."""
+    """``--include-optional`` and ``--include-disabled`` selection gates.
+
+    ``--include-disabled`` is an *optional-value* option (the only one in the
+    CLI): omitted it excludes disabled content; a bare ``--include-disabled``
+    (or ``=marked``) includes it tagged ``(disabled)``; ``=merge`` folds it into
+    the normal course flow with no marker. Use the ``=VALUE`` form to be
+    unambiguous — a bare flag placed *immediately before* the ``SPEC_FILE``
+    positional would consume it as the value (Click optional-value behaviour),
+    so keep the spec file first.
+    """
     func = click.option(
         "--include-disabled",
-        "include_disabled",
-        is_flag=True,
-        default=False,
-        help='Include sections/subsections marked enabled="false", tagged with a '
-        "(disabled) marker. Off by default.",
+        "disabled_mode",
+        is_flag=False,
+        flag_value="marked",
+        default=None,
+        type=click.Choice(["marked", "merge"], case_sensitive=False),
+        metavar="[marked|merge]",
+        help='Include sections/subsections marked enabled="false". Bare (or '
+        "=marked): tagged with a (disabled) marker (disabled whole sections "
+        "after the enabled ones in outline/summary). =merge: folded into the "
+        "normal course flow, in declared order, with no marker. Omitted: "
+        "disabled content is excluded (default).",
     )(func)
     func = click.option(
         "--include-optional",
@@ -103,6 +120,21 @@ def selection_options(func: F) -> F:
         "--include-disabled is given as well.",
     )(func)
     return func
+
+
+def resolve_disabled_mode(disabled_mode: str | None) -> tuple[bool, bool]:
+    """Translate the ``--include-disabled`` value into two booleans.
+
+    Returns ``(include_disabled, merge_disabled)``:
+
+    * ``None``      -> ``(False, False)`` — disabled content excluded (default).
+    * ``"marked"``  -> ``(True, False)``  — included with a ``(disabled)`` marker.
+    * ``"merge"``   -> ``(True, True)``   — folded into the normal flow, no marker.
+
+    The export command handlers call this once and thread the two booleans into
+    the generators, which keep their plain-``bool`` signatures.
+    """
+    return (disabled_mode is not None, disabled_mode == "merge")
 
 
 def check_exclusive_output(output_file: Path | None, output_dir: Path | None) -> None:
@@ -143,9 +175,59 @@ def subsection_visible(
 
 
 # ---------------------------------------------------------------------------
+# Per-language filtering (split .de/.en companions)
+# ---------------------------------------------------------------------------
+def notebook_in_language(notebook: NotebookFile, language: str) -> bool:
+    """Whether a resolved ``NotebookFile`` belongs in a *language*'s document.
+
+    A bilingual file (``output_language_filter is None``) belongs to every
+    language; a split ``.de``/``.en`` companion only to its own. This is the
+    predicate every "resolved course" enumeration must apply so a split pair
+    contributes a single entry, matching the build's per-language routing.
+    """
+    flt = notebook.output_language_filter
+    return flt is None or flt == language
+
+
+def path_in_language(path: Path, language: str) -> bool:
+    """The filesystem twin of :func:`notebook_in_language`.
+
+    Used where slide files are read straight from disk (disabled topics, which
+    are not part of the built course). A bilingual ``slides_x.py`` matches every
+    language; a split ``slides_x.de.py`` / ``slides_x.en.py`` only its own.
+    """
+    lang = split_lang_suffix(path)
+    return lang is None or lang == language
+
+
+# ---------------------------------------------------------------------------
+# Declared-order section walk (used by --include-disabled=merge)
+# ---------------------------------------------------------------------------
+def iter_declared_sections(
+    course: Course, full_sections: list[SectionSpec]
+) -> Iterator[tuple[SectionSpec, tuple[Section, SectionSpec] | None]]:
+    """Walk the full declared section list in document order for merge mode.
+
+    Yields ``(full_spec, built)`` where *built* is the ``(Section,
+    SectionSpec)`` pair from the enabled-parse course for an enabled section, or
+    ``None`` for a disabled one. Enabled sections are matched to the built
+    course **positionally** — ``course.sections`` is the enabled subset of
+    *full_sections* in the same document order — so this is robust to duplicate,
+    id-less section names. (A name/id-keyed map would collapse two same-named
+    id-less sections onto one built object; the positional walk does not.)
+    """
+    built_iter = iter(zip(course.sections, course.spec.sections, strict=False))
+    for full_spec in full_sections:
+        if full_spec.enabled:
+            yield full_spec, next(built_iter, None)
+        else:
+            yield full_spec, None
+
+
+# ---------------------------------------------------------------------------
 # Disabled-topic resolution (filesystem fallback)
 # ---------------------------------------------------------------------------
-def disabled_topic_files(course: Course, topic_spec: TopicSpec) -> list[Path] | None:
+def disabled_topic_files(course: Course, topic_spec: TopicSpec, language: str) -> list[Path] | None:
     """Return the slide-file paths of a topic, resolved from the filesystem.
 
     Used to surface topics that are *not* part of the built course (disabled
@@ -153,6 +235,11 @@ def disabled_topic_files(course: Course, topic_spec: TopicSpec) -> list[Path] | 
     filesystem-wide topic map. Returns ``None`` when the id cannot be resolved
     (so callers can fall back to a ``<topic_id>`` display); an empty list when
     the topic resolves but contains no slide files.
+
+    Split ``.de``/``.en`` companions are filtered to *language* via
+    :func:`path_in_language` so a split pair contributes one file — the same
+    per-language routing the built course applies, kept consistent for the
+    not-built (disabled) topics read straight from disk.
     """
     topic_path = course._topic_path_map.get(topic_spec.id)
     if topic_path is None:
@@ -160,11 +247,11 @@ def disabled_topic_files(course: Course, topic_spec: TopicSpec) -> list[Path] | 
 
     slide_paths: list[Path] = []
     if topic_path.is_file():
-        if is_slides_file(topic_path):
+        if is_slides_file(topic_path) and path_in_language(topic_path, language):
             slide_paths.append(topic_path)
     elif topic_path.is_dir():
         for child in sorted(topic_path.iterdir()):
-            if child.is_file() and is_slides_file(child):
+            if child.is_file() and is_slides_file(child) and path_in_language(child, language):
                 slide_paths.append(child)
     return slide_paths
 
@@ -177,7 +264,7 @@ def disabled_topic_slides(
     Reads the H1 header from each slide file the same way :class:`NotebookFile`
     does. Returns ``None``/``[]`` following :func:`disabled_topic_files`.
     """
-    slide_paths = disabled_topic_files(course, topic_spec)
+    slide_paths = disabled_topic_files(course, topic_spec, language)
     if slide_paths is None:
         return None
 

--- a/src/clm/cli/commands/outline.py
+++ b/src/clm/cli/commands/outline.py
@@ -12,8 +12,11 @@ import click
 
 from clm.cli.commands._export_shared import (
     check_exclusive_output,
+    iter_declared_sections,
     language_option,
+    notebook_in_language,
     output_options,
+    resolve_disabled_mode,
     section_visible,
     selection_options,
     spec_argument,
@@ -45,10 +48,7 @@ def _topic_deck_titles(topic, language: str) -> list[str]:
     """
     titles: list[str] = []
     for notebook in topic.notebooks:
-        if (
-            notebook.output_language_filter is not None
-            and notebook.output_language_filter != language
-        ):
+        if not notebook_in_language(notebook, language):
             continue
         try:
             title = notebook.title[language]
@@ -174,14 +174,18 @@ def _render_section_subsections(
     candidates: list[SubsectionSpec],
     course: Course,
     language: str,
+    *,
+    mark_disabled: bool = True,
 ) -> list[str]:
     """Render the bullet lines for a section that uses subsections.
 
     Bare topics (under *no* declared subsection) are listed first as flat
     bullets; each visible subsection then renders as a bold-label bullet with
     its decks indented beneath it. Disabled subsections get a ``(disabled)``
-    marker. ``candidates`` is the full declared subsection set (visible or not)
-    so a topic under a hidden subsection is not mistaken for a bare topic.
+    marker unless ``mark_disabled`` is False (``--include-disabled=merge``, which
+    folds disabled content into the normal flow). ``candidates`` is the full
+    declared subsection set (visible or not) so a topic under a hidden
+    subsection is not mistaken for a bare topic.
     """
     resolved_titles = {topic.id: _topic_deck_titles(topic, language) for topic in section.topics}
     subsection_topic_ids = {t.id for sub in candidates for t in sub.topics}
@@ -195,7 +199,7 @@ def _render_section_subsections(
             lines.append(f"- {title}")
 
     for subsection in subsections:
-        marker = "" if subsection.enabled else " (disabled)"
+        marker = "" if (subsection.enabled or not mark_disabled) else " (disabled)"
         label = subsection_label(subsection, language) or "(unnamed)"
         lines.append(f"- **{label}**{marker}")
         for title in _subsection_deck_titles(subsection, course, language, resolved_titles):
@@ -222,7 +226,7 @@ def _subsections_json(
             "slides": [
                 {"file": f.path.name, "title": f.title[language]}
                 for f in topic.files
-                if isinstance(f, NotebookFile)
+                if isinstance(f, NotebookFile) and notebook_in_language(f, language)
             ],
         }
 
@@ -257,6 +261,79 @@ def _subsections_json(
     return result
 
 
+def _render_enabled_section_block(
+    section: Section,
+    section_spec: SectionSpec,
+    course: Course,
+    language: str,
+    *,
+    sections_only: bool,
+    full_sections: list[SectionSpec] | None,
+    include_disabled: bool,
+    include_optional: bool,
+    mark_disabled: bool,
+) -> list[str]:
+    """Markdown lines for one enabled section (heading, body, trailing blank).
+
+    ``mark_disabled`` controls whether disabled *subsections* nested in this
+    section keep their ``(disabled)`` marker (True, default/marked mode) or are
+    folded in silently (False, ``--include-disabled=merge``).
+    """
+    lines = [f"## {section.name[language]}", ""]
+    if sections_only:
+        return lines
+    candidates = _candidate_subsections(section_spec, full_sections, include_disabled)
+    subsections = _subsections_to_render(candidates, include_disabled, include_optional)
+    if candidates:
+        lines.extend(
+            _render_section_subsections(
+                section, subsections, candidates, course, language, mark_disabled=mark_disabled
+            )
+        )
+    else:
+        # Flat rendering for sections without subsections; split .de/.en
+        # companions are filtered to the requested language.
+        for notebook in section.notebooks:
+            if isinstance(notebook, NotebookFile) and notebook_in_language(notebook, language):
+                lines.append(f"- {notebook.title[language]}")
+    lines.append("")
+    return lines
+
+
+def _render_disabled_section_block(
+    section_spec: SectionSpec,
+    course: Course,
+    language: str,
+    *,
+    sections_only: bool,
+    mark_disabled: bool,
+) -> list[str]:
+    """Markdown lines for one disabled whole section, read from the filesystem.
+
+    With ``mark_disabled`` the heading and every bullet carry a ``(disabled)``
+    marker; ``--include-disabled=merge`` passes False so the section reads like
+    any enabled one.
+    """
+    marker = " (disabled)" if mark_disabled else ""
+    lines = [f"## {section_spec.name[language]}{marker}", ""]
+    if sections_only:
+        return lines
+    if not section_spec.topics:
+        lines.append("- (no topics declared)")
+        lines.append("")
+        return lines
+    for topic_spec in section_spec.topics:
+        slides = _disabled_topic_slides(course, topic_spec, language)
+        if not slides:
+            # Topic missing on disk, or resolved with no slide files: show its id.
+            lines.append(f"- {topic_spec.id}{marker}")
+        else:
+            for _file_name, title in slides:
+                lines.append(f"- {title}{marker}")
+    lines.append("")
+    return lines
+
+
 def generate_outline(
     course: Course,
     language: str,
@@ -266,6 +343,7 @@ def generate_outline(
     full_sections: list[SectionSpec] | None = None,
     include_disabled: bool = False,
     include_optional: bool = False,
+    merge_disabled: bool = False,
 ) -> str:
     """Generate a Markdown outline for a course.
 
@@ -284,61 +362,154 @@ def generate_outline(
     Returns:
         Markdown string with the course outline
     """
-    lines = []
+    # Course title as H1.
+    lines = [f"# {course.name[language]}", ""]
 
-    # Course title as H1
-    lines.append(f"# {course.name[language]}")
-    lines.append("")
+    if merge_disabled and full_sections is not None:
+        # Fold disabled whole sections into declared order, with no markers.
+        for full_spec, built in iter_declared_sections(course, full_sections):
+            if full_spec.optional and not include_optional:
+                continue
+            if full_spec.enabled:
+                if built is None:
+                    continue
+                section, section_spec = built
+                lines.extend(
+                    _render_enabled_section_block(
+                        section,
+                        section_spec,
+                        course,
+                        language,
+                        sections_only=sections_only,
+                        full_sections=full_sections,
+                        include_disabled=include_disabled,
+                        include_optional=include_optional,
+                        mark_disabled=False,
+                    )
+                )
+            else:
+                lines.extend(
+                    _render_disabled_section_block(
+                        full_spec,
+                        course,
+                        language,
+                        sections_only=sections_only,
+                        mark_disabled=False,
+                    )
+                )
+        return "\n".join(lines)
 
+    # Default / marked mode: enabled sections in order, then disabled whole
+    # sections appended at the end with a (disabled) marker.
     # course.sections aligns 1:1 with course.spec.sections (no section
     # selection is applied in the outline path, and the spec was parsed
     # enabled-only). The spec side carries the retained subsection grouping.
     for section, section_spec in zip(course.sections, course.spec.sections, strict=True):
         if not section_visible(section_spec, include_optional=include_optional):
             continue
-        lines.append(f"## {section.name[language]}")
-        lines.append("")
-        if sections_only:
-            continue
-        candidates = _candidate_subsections(section_spec, full_sections, include_disabled)
-        subsections = _subsections_to_render(candidates, include_disabled, include_optional)
-        if candidates:
-            lines.extend(
-                _render_section_subsections(section, subsections, candidates, course, language)
+        lines.extend(
+            _render_enabled_section_block(
+                section,
+                section_spec,
+                course,
+                language,
+                sections_only=sections_only,
+                full_sections=full_sections,
+                include_disabled=include_disabled,
+                include_optional=include_optional,
+                mark_disabled=True,
             )
-        else:
-            # Unchanged flat rendering for sections without subsections.
-            for notebook in section.notebooks:
-                if isinstance(notebook, NotebookFile):
-                    title = notebook.title[language]
-                    lines.append(f"- {title}")
-        lines.append("")
+        )
 
     for section_spec in disabled_sections or []:
         if section_spec.optional and not include_optional:
             continue
-        lines.append(f"## {section_spec.name[language]} (disabled)")
-        lines.append("")
-        if sections_only:
-            continue
-        if not section_spec.topics:
-            lines.append("- (no topics declared)")
-            lines.append("")
-            continue
-        for topic_spec in section_spec.topics:
-            slides = _disabled_topic_slides(course, topic_spec, language)
-            if slides is None:
-                # Topic does not exist on disk — fall back to topic id.
-                lines.append(f"- {topic_spec.id} (disabled)")
-            elif not slides:
-                # Topic resolved but has no slide files.
-                lines.append(f"- {topic_spec.id} (disabled)")
-            else:
-                for _file_name, title in slides:
-                    lines.append(f"- {title} (disabled)")
-        lines.append("")
+        lines.extend(
+            _render_disabled_section_block(
+                section_spec,
+                course,
+                language,
+                sections_only=sections_only,
+                mark_disabled=True,
+            )
+        )
 
     return "\n".join(lines)
+
+
+def _enabled_section_json(
+    section: Section,
+    section_spec: SectionSpec,
+    course: Course,
+    language: str,
+    *,
+    number: int,
+    sections_only: bool,
+    full_sections: list[SectionSpec] | None,
+    include_disabled: bool,
+    include_optional: bool,
+) -> dict:
+    """JSON entry for one enabled section.
+
+    Split ``.de``/``.en`` companions are filtered to *language* so a split pair
+    contributes one slide entry.
+    """
+    entry: dict = {"number": number, "name": section.name[language], "disabled": False}
+    if section.id is not None:
+        entry["id"] = section.id
+    if not sections_only:
+        candidates = _candidate_subsections(section_spec, full_sections, include_disabled)
+        subsections = _subsections_to_render(candidates, include_disabled, include_optional)
+        visible_topic_ids = _visible_topic_ids(section, candidates, subsections)
+        topics: list[dict] = []
+        for topic in section.topics:
+            if topic.id not in visible_topic_ids:
+                continue
+            slides = [
+                {"file": f.path.name, "title": f.title[language]}
+                for f in topic.files
+                if isinstance(f, NotebookFile) and notebook_in_language(f, language)
+            ]
+            topics.append({"topic_id": topic.id, "directory": str(topic.path), "slides": slides})
+        entry["topics"] = topics
+        if candidates:
+            entry["subsections"] = _subsections_json(section, subsections, course, language)
+    return entry
+
+
+def _disabled_section_json(
+    section_spec: SectionSpec,
+    course: Course,
+    language: str,
+    *,
+    number: int,
+    sections_only: bool,
+) -> dict:
+    """JSON entry for one disabled whole section, read from the filesystem.
+
+    The ``"disabled"`` field stays ``True`` even under ``merge`` — it is
+    structured metadata, not a visible marker — while ``merge`` changes only the
+    section's *placement* (declared order rather than appended at the end).
+    """
+    entry: dict = {"number": number, "name": section_spec.name[language], "disabled": True}
+    if section_spec.id is not None:
+        entry["id"] = section_spec.id
+    if not sections_only:
+        topics: list[dict] = []
+        for topic_spec in section_spec.topics:
+            slides_data = _disabled_topic_slides(course, topic_spec, language)
+            topic_path = course._topic_path_map.get(topic_spec.id)
+            topics.append(
+                {
+                    "topic_id": topic_spec.id,
+                    "directory": str(topic_path) if topic_path is not None else None,
+                    "slides": [
+                        {"file": fname, "title": title} for fname, title in (slides_data or [])
+                    ],
+                }
+            )
+        entry["topics"] = topics
+    return entry
 
 
 def generate_outline_json(
@@ -350,6 +521,7 @@ def generate_outline_json(
     full_sections: list[SectionSpec] | None = None,
     include_disabled: bool = False,
     include_optional: bool = False,
+    merge_disabled: bool = False,
 ) -> dict:
     """Generate a structured JSON outline for a course.
 
@@ -368,71 +540,75 @@ def generate_outline_json(
         Dict with the course outline in structured form.
     """
     sections: list[dict] = []
+
+    if merge_disabled and full_sections is not None:
+        # Fold disabled whole sections into declared order (placement only; the
+        # per-entry "disabled" flag stays truthful).
+        for full_spec, built in iter_declared_sections(course, full_sections):
+            if full_spec.optional and not include_optional:
+                continue
+            if full_spec.enabled:
+                if built is None:
+                    continue
+                section, section_spec = built
+                sections.append(
+                    _enabled_section_json(
+                        section,
+                        section_spec,
+                        course,
+                        language,
+                        number=len(sections) + 1,
+                        sections_only=sections_only,
+                        full_sections=full_sections,
+                        include_disabled=include_disabled,
+                        include_optional=include_optional,
+                    )
+                )
+            else:
+                sections.append(
+                    _disabled_section_json(
+                        full_spec,
+                        course,
+                        language,
+                        number=len(sections) + 1,
+                        sections_only=sections_only,
+                    )
+                )
+        return {
+            "course_name": course.name[language],
+            "language": language,
+            "sections": sections,
+        }
+
     for section, section_spec in zip(course.sections, course.spec.sections, strict=True):
         if not section_visible(section_spec, include_optional=include_optional):
             continue
-        entry: dict = {
-            "number": len(sections) + 1,
-            "name": section.name[language],
-            "disabled": False,
-        }
-        if section.id is not None:
-            entry["id"] = section.id
-        if not sections_only:
-            candidates = _candidate_subsections(section_spec, full_sections, include_disabled)
-            subsections = _subsections_to_render(candidates, include_disabled, include_optional)
-            visible_topic_ids = _visible_topic_ids(section, candidates, subsections)
-            topics: list[dict] = []
-            for topic in section.topics:
-                if topic.id not in visible_topic_ids:
-                    continue
-                slides: list[dict] = []
-                for f in topic.files:
-                    if isinstance(f, NotebookFile):
-                        slides.append(
-                            {
-                                "file": f.path.name,
-                                "title": f.title[language],
-                            }
-                        )
-                topics.append(
-                    {
-                        "topic_id": topic.id,
-                        "directory": str(topic.path),
-                        "slides": slides,
-                    }
-                )
-            entry["topics"] = topics
-            if candidates:
-                entry["subsections"] = _subsections_json(section, subsections, course, language)
-        sections.append(entry)
+        sections.append(
+            _enabled_section_json(
+                section,
+                section_spec,
+                course,
+                language,
+                number=len(sections) + 1,
+                sections_only=sections_only,
+                full_sections=full_sections,
+                include_disabled=include_disabled,
+                include_optional=include_optional,
+            )
+        )
 
     for section_spec in disabled_sections or []:
         if section_spec.optional and not include_optional:
             continue
-        entry = {
-            "number": len(sections) + 1,
-            "name": section_spec.name[language],
-            "disabled": True,
-        }
-        if section_spec.id is not None:
-            entry["id"] = section_spec.id
-        if not sections_only:
-            topics = []
-            for t in section_spec.topics:
-                slides_data = _disabled_topic_slides(course, t, language)
-                topic_path = course._topic_path_map.get(t.id)
-                topics.append(
-                    {
-                        "topic_id": t.id,
-                        "directory": str(topic_path) if topic_path is not None else None,
-                        "slides": [
-                            {"file": fname, "title": title} for fname, title in (slides_data or [])
-                        ],
-                    }
-                )
-            entry["topics"] = topics
-        sections.append(entry)
+        sections.append(
+            _disabled_section_json(
+                section_spec,
+                course,
+                language,
+                number=len(sections) + 1,
+                sections_only=sections_only,
+            )
+        )
 
     return {
         "course_name": course.name[language],
@@ -492,7 +668,7 @@ def outline(
     language: str | None,
     output_format: str,
     include_optional: bool,
-    include_disabled: bool,
+    disabled_mode: str | None,
     sections_only: bool,
 ):
     """Generate an outline of a course in Markdown or JSON format.
@@ -509,9 +685,13 @@ def outline(
         clm export outline course.xml -d ./docs        # Both languages to directory
         clm export outline course.xml --sections-only  # Section headings only
         clm export outline course.xml --include-optional  # Keep optional modules
+        clm export outline course.xml --include-disabled         # Roadmap, tagged
+        clm export outline course.xml --include-disabled=merge   # Roadmap, in flow
     """
     # Validate mutually exclusive options
     check_exclusive_output(output_file, output_dir)
+
+    include_disabled, merge_disabled = resolve_disabled_mode(disabled_mode)
 
     # Load course specification.
     # The main spec always drops disabled sections; if --include-disabled is
@@ -567,6 +747,7 @@ def outline(
                     full_sections=full_sections,
                     include_disabled=include_disabled,
                     include_optional=include_optional,
+                    merge_disabled=merge_disabled,
                 ),
                 indent=2,
             )
@@ -578,6 +759,7 @@ def outline(
             full_sections=full_sections,
             include_disabled=include_disabled,
             include_optional=include_optional,
+            merge_disabled=merge_disabled,
         )
 
     # Determine languages to generate

--- a/src/clm/cli/commands/schedule.py
+++ b/src/clm/cli/commands/schedule.py
@@ -27,7 +27,9 @@ from clm.cli.commands._export_shared import (
     check_exclusive_output,
     disabled_topic_slides,
     language_option,
+    notebook_in_language,
     output_options,
+    resolve_disabled_mode,
     section_visible,
     selection_options,
     spec_argument,
@@ -125,10 +127,7 @@ def _topic_decks(topic, language: str) -> list[ScheduleDeck]:
     """
     decks: list[ScheduleDeck] = []
     for notebook in topic.notebooks:
-        if (
-            notebook.output_language_filter is not None
-            and notebook.output_language_filter != language
-        ):
+        if not notebook_in_language(notebook, language):
             continue
         try:
             title = notebook.title[language]
@@ -323,11 +322,17 @@ def render_markdown(
     language: str,
     *,
     no_topic: bool = False,
+    mark_disabled: bool = True,
 ) -> str:
     """Render the schedule as Markdown: one table per week.
 
     With ``no_topic`` the Topic column is dropped, leaving just Day and
     Video (slides) — the columns a certification authority needs.
+
+    With ``mark_disabled`` False (``--include-disabled=merge``) the ``(disabled)``
+    tags are suppressed so disabled weeks/days read like enabled ones; the weeks
+    already appear in declared order. The schedule data (and the CSV ``disabled``
+    column) keep their truthful flags regardless.
     """
     day_h, video_h, topic_h = _MD_HEADERS[language]
     empty_cell = "—"
@@ -335,7 +340,7 @@ def render_markdown(
     lines: list[str] = [f"# {course_title}", ""]
 
     for week in weeks:
-        week_title = week.title + (disabled_tag if week.disabled else "")
+        week_title = week.title + (disabled_tag if (week.disabled and mark_disabled) else "")
         lines.append(f"## {week_title}")
         lines.append("")
         if not week.days:
@@ -352,8 +357,11 @@ def render_markdown(
             lines.append("|------|------|------|")
         for day in week.days:
             # Mark a disabled subsection inside an otherwise-enabled week; if the
-            # whole week is disabled the heading already carries the tag.
-            label_text = day.label + (disabled_tag if day.disabled and not week.disabled else "")
+            # whole week is disabled the heading already carries the tag. Merge
+            # mode (mark_disabled False) suppresses the tag entirely.
+            label_text = day.label + (
+                disabled_tag if (day.disabled and not week.disabled and mark_disabled) else ""
+            )
             day_label = _md_cell(label_text)
             if not day.decks:
                 if no_topic:
@@ -447,7 +455,7 @@ def schedule(
     output_dir: Path | None,
     no_topic: bool,
     include_optional: bool,
-    include_disabled: bool,
+    disabled_mode: str | None,
     data_dir: Path | None,
 ):
     """Export a day-of-week deck listing for certification.
@@ -462,12 +470,16 @@ def schedule(
         clm export schedule course.xml -f csv           # CSV (one row per deck)
         clm export schedule course.xml --no-topic       # Day + video/slides only
         clm export schedule course.xml --include-optional   # Add optional modules
+        clm export schedule course.xml --include-disabled        # Disabled days, tagged
+        clm export schedule course.xml --include-disabled=merge  # Disabled days, in flow
         clm export schedule course.xml -o schedule.md   # Write to a file
         clm export schedule course.xml -d ./docs        # Write into a directory
     """
     language = language.lower()
     output_format = output_format.lower()
     check_exclusive_output(output_file, output_dir)
+
+    include_disabled, merge_disabled = resolve_disabled_mode(disabled_mode)
 
     try:
         spec = CourseSpec.from_file(spec_file)
@@ -510,7 +522,13 @@ def schedule(
     if output_format == "csv":
         content = render_csv(weeks, no_topic=no_topic, include_disabled=include_disabled)
     else:
-        content = render_markdown(course.name[language], weeks, language, no_topic=no_topic)
+        content = render_markdown(
+            course.name[language],
+            weeks,
+            language,
+            no_topic=no_topic,
+            mark_disabled=not merge_disabled,
+        )
 
     if output_dir is not None:
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/clm/cli/commands/summarize.py
+++ b/src/clm/cli/commands/summarize.py
@@ -33,8 +33,11 @@ from rich.progress import (
 from clm.cli.commands._export_shared import (
     check_exclusive_output,
     disabled_topic_files,
+    iter_declared_sections,
     language_option,
+    notebook_in_language,
     output_options,
+    resolve_disabled_mode,
     section_visible,
     selection_options,
     spec_argument,
@@ -344,13 +347,27 @@ def _disk_notebooks(
     """Resolve a (disabled) section's slide files from the filesystem."""
     notebooks: list[_DiskNotebook] = []
     for topic_spec in section_spec.topics:
-        for path in disabled_topic_files(course, topic_spec) or []:
+        for path in disabled_topic_files(course, topic_spec, language) or []:
             try:
                 title = find_notebook_titles(path.read_text(encoding="utf-8"), default=path.stem)
             except (OSError, ValueError):
                 title = Text(de=path.stem, en=path.stem)
             notebooks.append(_DiskNotebook(path=path, title=title))
     return notebooks
+
+
+def _enabled_section_notebooks(section, language: str) -> list:
+    """Built-course notebooks for an enabled section, filtered to *language*.
+
+    Split ``.de``/``.en`` companions are filtered by ``output_language_filter``
+    so a split pair is summarized once (under the requested language) rather
+    than producing a duplicate entry for the other language's companion.
+    """
+    return [
+        f
+        for f in section.files
+        if isinstance(f, NotebookFile) and notebook_in_language(f, language)
+    ]
 
 
 def build_sections_data(
@@ -360,21 +377,45 @@ def build_sections_data(
     include_optional: bool,
     include_disabled: bool,
     full_sections: list[SectionSpec] | None,
+    merge_disabled: bool = False,
 ) -> list[SectionData]:
     """Build the (heading, notebooks, disabled) list the generator iterates.
 
     Optional whole sections are dropped unless ``include_optional``. Note this
     gates optional *sections* only — ``summary`` flattens a section to its
     notebooks and cannot filter optional *subsections* within an included
-    section. Disabled sections are appended (read from disk) when
-    ``include_disabled`` and *full_sections* are supplied.
+    section.
+
+    Disabled sections (read from disk) are surfaced when ``include_disabled``
+    and *full_sections* are supplied: in the default/marked mode they are
+    appended after the enabled sections with their ``disabled`` flag set (so the
+    heading gets a ``(disabled)`` marker); with ``merge_disabled`` they are
+    interleaved in declared order and reported as not-disabled, so they read
+    like any enabled section.
     """
-    data: list[SectionData] = []
+    if merge_disabled and full_sections is not None:
+        data: list[SectionData] = []
+        for full_spec, built in iter_declared_sections(course, full_sections):
+            if full_spec.optional and not include_optional:
+                continue
+            if full_spec.enabled:
+                if built is None:
+                    continue
+                section, _section_spec = built
+                data.append(
+                    (section.name[language], _enabled_section_notebooks(section, language), False)
+                )
+            else:
+                data.append(
+                    (full_spec.name[language], _disk_notebooks(course, full_spec, language), False)
+                )
+        return data
+
+    data = []
     for section, section_spec in zip(course.sections, course.spec.sections, strict=True):
         if not section_visible(section_spec, include_optional=include_optional):
             continue
-        notebooks = [f for f in section.files if isinstance(f, NotebookFile)]
-        data.append((section.name[language], notebooks, False))
+        data.append((section.name[language], _enabled_section_notebooks(section, language), False))
 
     if include_disabled and full_sections is not None:
         for section_spec in full_sections:
@@ -668,7 +709,7 @@ def summary(
     output_file: Path | None,
     output_dir: Path | None,
     include_optional: bool,
-    include_disabled: bool,
+    disabled_mode: str | None,
     model: str | None,
     api_base: str | None,
     style: str,
@@ -691,8 +732,11 @@ def summary(
         clm export summary course.xml --audience trainer -o summary.md
         clm export summary course.xml --audience client -d ./docs
         clm export summary course.xml --audience trainer --model openai/gpt-4o
+        clm export summary course.xml --audience client --include-disabled=merge
     """
     check_exclusive_output(output_file, output_dir)
+
+    include_disabled, merge_disabled = resolve_disabled_mode(disabled_mode)
 
     # Load config for LLM settings
     from clm.infrastructure.config import get_config
@@ -742,6 +786,7 @@ def summary(
         include_optional=include_optional,
         include_disabled=include_disabled,
         full_sections=full_sections,
+        merge_disabled=merge_disabled,
     )
 
     # Progress goes to stderr so it doesn't mix with markdown output on stdout

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -390,11 +390,23 @@ All three share a common option vocabulary:
 | `-o, --output FILE` | Write to FILE (mutually exclusive with `-d`). |
 | `-d, --output-dir DIR` | Write to DIR with auto-generated filenames (mutually exclusive with `-o`). |
 | `--include-optional` | Include modules marked `optional="true"` (on a `<section>` or `<subsection>`). Off by default. |
-| `--include-disabled` | Include sections/subsections marked `enabled="false"`, tagged `(disabled)`. Off by default. |
+| `--include-disabled[=marked\|merge]` | Include sections/subsections marked `enabled="false"`. Off by default (excluded). A bare `--include-disabled` (or `=marked`) tags them `(disabled)` — disabled whole sections are listed after the enabled ones in `outline`/`summary`. `=merge` folds them into the normal course flow, in declared order, with no marker. |
 
 `optional="true"` and `enabled="false"` are **presentation-only** for these
 commands — they never change the build, only what appears in the document. An
 element that is both optional and disabled needs **both** flags to appear.
+
+Because `--include-disabled` takes an optional value, give the value with `=`
+(e.g. `--include-disabled=merge`) and keep `SPEC_FILE` first — a bare
+`--include-disabled` placed immediately before the spec path would be parsed as
+its value. In the structured outputs (`outline --format json`, `schedule
+--format csv`) the disabled state stays recorded (`"disabled": true` /
+`disabled` column) even under `=merge`; merge only changes the human-readable
+placement and marker.
+
+Split-language decks (`slides_x.de.py` + `slides_x.en.py`) are filtered to the
+requested `-L` language across all three commands, so a split pair contributes a
+single entry — the same per-language routing the build applies.
 
 #### `clm export outline`
 
@@ -416,8 +428,10 @@ group: a bold weekday/label bullet with the subsection's decks nested beneath
 it, after any bare (unscheduled) topics. Hiding an optional/disabled subsection
 also hides its topics (they are not demoted to bare bullets). `--include-disabled`
 surfaces disabled subsections (and disabled sections) with a `(disabled)`
-marker, reading their decks from disk. The JSON format adds a `subsections`
-array to each section that uses them (alongside the flat `topics` list).
+marker, reading their decks from disk and appending disabled whole sections
+after the enabled ones; `--include-disabled=merge` instead interleaves them in
+declared order with no marker. The JSON format adds a `subsections` array to
+each section that uses them (alongside the flat `topics` list).
 
 Examples:
 
@@ -427,7 +441,8 @@ clm export outline course.xml -L de
 clm export outline course.xml -d ./docs
 clm export outline course.xml --format json
 clm export outline course.xml --include-optional
-clm export outline course.xml --include-disabled
+clm export outline course.xml --include-disabled          # roadmap weeks, tagged + appended
+clm export outline course.xml --include-disabled=merge     # roadmap weeks folded into the flow
 clm export outline course.xml --sections-only
 ```
 
@@ -450,7 +465,7 @@ clm export schedule [OPTIONS] SPEC_FILE
 | `-o, --output FILE` / `-d, --output-dir DIR` | Write to FILE / to a directory (filename `<course>-schedule-<lang>.<ext>`). |
 | `--no-topic` | Omit the Topic column, leaving just day and video/slides — the columns a certification authority needs (applies to both `md` and `csv`). |
 | `--include-optional` | Include modules marked `optional="true"` (on a `<section>` or `<subsection>`). |
-| `--include-disabled` | Surface disabled subsections/sections (read from disk), tagged `(disabled)`; the CSV gains a trailing `disabled` column. |
+| `--include-disabled[=marked\|merge]` | Surface disabled subsections/sections (read from disk). Bare/`=marked`: tagged `(disabled)`. `=merge`: no tag (weeks already appear in declared order). The CSV gains a trailing `disabled` column whenever disabled content is included (truthful even under `=merge`). |
 | `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the spec location. |
 
 Each listing is **single-language** — run once per language to produce both.
@@ -485,6 +500,7 @@ clm export schedule course.xml -f csv           # CSV (one row per deck)
 clm export schedule course.xml --no-topic       # Day + video/slides only (cert authority)
 clm export schedule course.xml --include-optional   # Add optional modules
 clm export schedule course.xml --include-disabled   # Show disabled days, tagged
+clm export schedule course.xml --include-disabled=merge   # Show disabled days, no tag
 clm export schedule course.xml -o schedule.md   # Write to a file
 clm export schedule course.xml -d ./docs        # Write into a directory
 ```
@@ -2435,7 +2451,7 @@ clm export summary [OPTIONS] SPEC_FILE
 | `-L, --language [de\|en]` | Language for the summary structure (default: `en`) |
 | `-o, --output FILE` / `-d, --output-dir DIR` | Shared output options (see `clm export`). |
 | `--include-optional` | Include optional **whole sections** (gates sections only — a summary flattens each section to its notebooks and cannot drop optional *subsections*). |
-| `--include-disabled` | Summarize disabled whole sections too (read from disk), tagged `(disabled)`. |
+| `--include-disabled[=marked\|merge]` | Summarize disabled whole sections too (read from disk). Bare/`=marked`: heading tagged `(disabled)`, appended after the enabled sections. `=merge`: interleaved in declared order with no marker. |
 | `--model TEXT` | LLM model identifier |
 | `--api-base TEXT` | Custom API base URL |
 | `--no-cache` | Skip cache, re-generate all summaries |
@@ -2450,6 +2466,7 @@ clm export summary course.xml --audience trainer -o summary.md
 clm export summary course.xml --audience client -d ./docs
 clm export summary course.xml --audience trainer --model openai/gpt-4o
 clm export summary course.xml --audience client --style bullets
+clm export summary course.xml --audience client --include-disabled=merge
 ```
 
 ### `clm voiceover`

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -26,7 +26,13 @@ The three commands also gained a **consistent option vocabulary**:
   you pass the flag. (The MCP `course_outline` tool is unchanged — it still
   shows optional content.)
 - `--include-disabled` (now on all three) — include `enabled="false"`
-  sections/subsections, tagged `(disabled)`.
+  sections/subsections. It takes an **optional value**: a bare
+  `--include-disabled` (or `=marked`) tags them `(disabled)` (disabled whole
+  sections listed after the enabled ones in `outline`/`summary`), while
+  `--include-disabled=merge` folds them into the normal course flow, in
+  declared order, with no marker. Give the value with `=` and keep `SPEC_FILE`
+  first, since a bare flag placed immediately before the spec path would be
+  read as its value.
 - `clm export schedule` gained `-d/--output-dir`; `-L/--language` is the
   canonical spelling everywhere (`schedule` keeps `--lang` as an alias).
 

--- a/tests/cli/test_export_language_and_merge.py
+++ b/tests/cli/test_export_language_and_merge.py
@@ -1,0 +1,518 @@
+"""Per-language filtering and ``--include-disabled=merge`` for ``clm export``.
+
+Two behaviours that the rest of the export tests do not cover because the
+shared ``tests/test-data`` slides are not split-language decks:
+
+1. **Bilingual split fix.** A split topic ships ``slides_x.de.py`` +
+   ``slides_x.en.py``; under ``-L de`` only the ``.de`` half must appear. This
+   regressed in every "resolved course" enumeration that skipped
+   ``output_language_filter`` (outline flat sections + JSON slides, summary) and
+   in the filesystem read for disabled topics (``disabled_topic_files``). The
+   fixtures here build real split decks on disk so the filter is exercised
+   end-to-end.
+
+2. **``--include-disabled=merge``.** Bare ``--include-disabled`` keeps the
+   legacy "marked" behaviour (a ``(disabled)`` marker; disabled whole sections
+   appended after the enabled ones for outline/summary). ``=merge`` folds
+   disabled content into the normal declared order with no marker.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands._export_shared import resolve_disabled_mode
+from clm.cli.main import cli
+
+
+# ---------------------------------------------------------------------------
+# On-disk course builders
+# ---------------------------------------------------------------------------
+def _split_topic(slides_root: Path, module: str, num: int, topic_id: str, de: str, en: str) -> None:
+    """Write a split ``.de.py`` / ``.en.py`` deck pair for *topic_id*."""
+    topic_dir = slides_root / module / f"topic_{num}_{topic_id}"
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    # A markdown cell gives `clm export summary` (client audience) extractable
+    # content so the deck shows up in the dry-run listing.
+    (topic_dir / f"slides_{topic_id}.de.py").write_text(
+        f"# j2 from 'macros.j2' import header_de\n# {{{{ header_de(\"{de}\") }}}}\n\n"
+        "# %% [markdown]\n# Intro.\n\n# %%\nprint(1)\n",
+        encoding="utf-8",
+    )
+    (topic_dir / f"slides_{topic_id}.en.py").write_text(
+        f"# j2 from 'macros.j2' import header_en\n# {{{{ header_en(\"{en}\") }}}}\n\n"
+        "# %% [markdown]\n# Intro.\n\n# %%\nprint(1)\n",
+        encoding="utf-8",
+    )
+
+
+def _bilingual_topic(
+    slides_root: Path, module: str, num: int, topic_id: str, de: str, en: str
+) -> None:
+    """Write a single bilingual ``slides_x.py`` deck (no language suffix)."""
+    topic_dir = slides_root / module / f"topic_{num}_{topic_id}"
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    (topic_dir / f"slides_{topic_id}.py").write_text(
+        f'# j2 from \'macros.j2\' import header\n# {{{{ header("{de}", "{en}") }}}}\n\n'
+        "# %% [markdown]\n# Intro.\n\n# %%\nprint(1)\n",
+        encoding="utf-8",
+    )
+
+
+def _write_spec(tmp_path: Path, body: str) -> Path:
+    spec_file = tmp_path / "course-specs" / "spec.xml"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(
+            f"""\
+            <course>
+              <name><de>Kurs</de><en>Course</en></name>
+              <prog-lang>python</prog-lang>
+              <description><de>.</de><en>.</en></description>
+              <certificate><de>.</de><en>.</en></certificate>
+              <sections>
+            {body}
+              </sections>
+            </course>
+            """
+        ),
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+@pytest.fixture
+def flat_split_course(tmp_path: Path) -> Path:
+    """Three flat (no-subsection) sections; the middle one disabled.
+
+    Declared order Alpha, Bravo (disabled), Charlie lets us distinguish marked
+    (disabled appended last) from merge (declared order). Alpha mixes a split
+    topic (``foo``) with a bilingual one (``qux``) to prove bilingual decks
+    survive the language filter.
+    """
+    slides = tmp_path / "slides"
+    _split_topic(slides, "module_010_a", 100, "foo", "Foo DE", "Foo EN")
+    _bilingual_topic(slides, "module_010_a", 110, "qux", "Qux DE", "Qux EN")
+    _split_topic(slides, "module_020_b", 100, "bar", "Bar DE", "Bar EN")
+    _split_topic(slides, "module_030_c", 100, "baz", "Baz DE", "Baz EN")
+    return _write_spec(
+        tmp_path,
+        """\
+        <section id="alpha"><name><de>Alpha</de><en>Alpha</en></name>
+          <topics><topic>foo</topic><topic>qux</topic></topics>
+        </section>
+        <section id="bravo" enabled="false"><name><de>Bravo</de><en>Bravo</en></name>
+          <topics><topic>bar</topic></topics>
+        </section>
+        <section id="charlie"><name><de>Charlie</de><en>Charlie</en></name>
+          <topics><topic>baz</topic></topics>
+        </section>""",
+    )
+
+
+@pytest.fixture
+def subsection_split_course(tmp_path: Path) -> Path:
+    """One week with an enabled and a disabled weekday subsection of split decks."""
+    slides = tmp_path / "slides"
+    _split_topic(slides, "module_010_a", 100, "foo", "Foo DE", "Foo EN")
+    _split_topic(slides, "module_010_a", 110, "bar", "Bar DE", "Bar EN")
+    return _write_spec(
+        tmp_path,
+        """\
+        <section><name><de>Woche 1</de><en>Week 1</en></name>
+          <topics>
+            <subsection weekday="mon"><topic>foo</topic></subsection>
+            <subsection weekday="tue" enabled="false"><topic>bar</topic></subsection>
+          </topics>
+        </section>""",
+    )
+
+
+def _run(*args: str) -> object:
+    return CliRunner().invoke(cli, list(args))
+
+
+# ---------------------------------------------------------------------------
+# resolve_disabled_mode unit
+# ---------------------------------------------------------------------------
+class TestResolveDisabledMode:
+    def test_none_excludes(self):
+        assert resolve_disabled_mode(None) == (False, False)
+
+    def test_marked(self):
+        assert resolve_disabled_mode("marked") == (True, False)
+
+    def test_merge(self):
+        assert resolve_disabled_mode("merge") == (True, True)
+
+
+# ---------------------------------------------------------------------------
+# Bilingual split fix — outline
+# ---------------------------------------------------------------------------
+class TestOutlineSplitLanguage:
+    def test_markdown_de_shows_only_de_half(self, flat_split_course):
+        result = _run("export", "outline", str(flat_split_course), "-L", "de")
+        assert result.exit_code == 0, result.output
+        assert "- Foo DE" in result.output
+        assert "- Baz DE" in result.output
+        assert "- Qux DE" in result.output  # bilingual deck survives
+        # The English split companions must NOT leak in.
+        assert "Foo EN" not in result.output
+        assert "Baz EN" not in result.output
+        assert "Qux EN" not in result.output
+        # Exactly one bullet per split deck.
+        assert result.output.count("- Foo DE") == 1
+
+    def test_markdown_en_shows_only_en_half(self, flat_split_course):
+        result = _run("export", "outline", str(flat_split_course), "-L", "en")
+        assert result.exit_code == 0, result.output
+        assert "- Foo EN" in result.output
+        assert "- Baz EN" in result.output
+        assert "- Qux EN" in result.output
+        assert "Foo DE" not in result.output
+        assert "Baz DE" not in result.output
+
+    def test_json_de_one_slide_per_split_topic(self, flat_split_course):
+        result = _run("export", "outline", str(flat_split_course), "-L", "de", "-f", "json")
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        alpha = next(s for s in data["sections"] if s["name"] == "Alpha")
+        foo = next(t for t in alpha["topics"] if t["topic_id"] == "foo")
+        titles = [s["title"] for s in foo["slides"]]
+        assert titles == ["Foo DE"]
+
+
+# ---------------------------------------------------------------------------
+# Bilingual split fix — summary
+# ---------------------------------------------------------------------------
+class TestSummarySplitLanguage:
+    def test_dry_run_de_no_english_companion(self, flat_split_course):
+        result = _run(
+            "export",
+            "summary",
+            str(flat_split_course),
+            "--audience",
+            "client",
+            "--dry-run",
+            "-L",
+            "de",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Foo DE" in result.output
+        assert "Baz DE" in result.output
+        assert "Foo EN" not in result.output
+        assert "Baz EN" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Bilingual split fix — schedule (enabled + disabled subsections, Family B)
+# ---------------------------------------------------------------------------
+class TestScheduleSplitLanguage:
+    def test_enabled_subsection_de_single_language(self, subsection_split_course):
+        result = _run("export", "schedule", str(subsection_split_course), "-L", "de")
+        assert result.exit_code == 0, result.output
+        assert "Foo DE" in result.output
+        assert "Foo EN" not in result.output
+
+    def test_disabled_subsection_de_single_language(self, subsection_split_course):
+        result = _run(
+            "export", "schedule", str(subsection_split_course), "-L", "de", "--include-disabled"
+        )
+        assert result.exit_code == 0, result.output
+        # Disabled day surfaced from disk, single language, label tagged.
+        assert "Bar DE" in result.output
+        assert "Bar EN" not in result.output
+        assert "(disabled)" in result.output
+
+    def test_merge_drops_disabled_tag(self, subsection_split_course):
+        result = _run(
+            "export",
+            "schedule",
+            str(subsection_split_course),
+            "-L",
+            "de",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Bar DE" in result.output
+        assert "(disabled)" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --include-disabled value modes — outline markdown
+# ---------------------------------------------------------------------------
+class TestOutlineDisabledModes:
+    def test_default_excludes_disabled(self, flat_split_course):
+        result = _run("export", "outline", str(flat_split_course), "-L", "en")
+        assert result.exit_code == 0, result.output
+        assert "Bravo" not in result.output
+
+    def test_bare_flag_is_marked_and_appended(self, flat_split_course):
+        """Legacy bare --include-disabled: marker + disabled section last."""
+        result = _run("export", "outline", str(flat_split_course), "-L", "en", "--include-disabled")
+        assert result.exit_code == 0, result.output
+        assert "## Bravo (disabled)" in result.output
+        # Bravo (disabled) is appended after the enabled Charlie.
+        assert result.output.index("## Charlie") < result.output.index("## Bravo (disabled)")
+        # Disabled topic read from disk, single language.
+        assert "- Bar EN (disabled)" in result.output
+        assert "Bar DE" not in result.output
+
+    def test_marked_explicit_value(self, flat_split_course):
+        result = _run(
+            "export", "outline", str(flat_split_course), "-L", "en", "--include-disabled=marked"
+        )
+        assert result.exit_code == 0, result.output
+        assert "## Bravo (disabled)" in result.output
+
+    def test_merge_interleaves_in_declared_order_without_marker(self, flat_split_course):
+        result = _run(
+            "export", "outline", str(flat_split_course), "-L", "en", "--include-disabled=merge"
+        )
+        assert result.exit_code == 0, result.output
+        assert "(disabled)" not in result.output
+        assert "## Bravo" in result.output
+        # Declared order Alpha, Bravo, Charlie.
+        assert (
+            result.output.index("## Alpha")
+            < result.output.index("## Bravo")
+            < result.output.index("## Charlie")
+        )
+
+    def test_merge_disabled_topic_single_language(self, flat_split_course):
+        result = _run(
+            "export", "outline", str(flat_split_course), "-L", "de", "--include-disabled=merge"
+        )
+        assert result.exit_code == 0, result.output
+        assert "- Bar DE" in result.output
+        assert "Bar EN" not in result.output
+
+    def test_bogus_value_rejected(self, flat_split_course):
+        result = _run("export", "outline", str(flat_split_course), "--include-disabled=bogus")
+        assert result.exit_code != 0
+        assert "not one of" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# --include-disabled value modes — outline JSON
+# ---------------------------------------------------------------------------
+class TestOutlineJsonDisabledModes:
+    def test_marked_appends_disabled_entry(self, flat_split_course):
+        result = _run(
+            "export",
+            "outline",
+            str(flat_split_course),
+            "-L",
+            "en",
+            "-f",
+            "json",
+            "--include-disabled",
+        )
+        assert result.exit_code == 0, result.output
+        names = [s["name"] for s in json.loads(result.output)["sections"]]
+        assert names == ["Alpha", "Charlie", "Bravo"]
+
+    def test_merge_interleaves_keeps_disabled_flag(self, flat_split_course):
+        result = _run(
+            "export",
+            "outline",
+            str(flat_split_course),
+            "-L",
+            "en",
+            "-f",
+            "json",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        sections = json.loads(result.output)["sections"]
+        assert [s["name"] for s in sections] == ["Alpha", "Bravo", "Charlie"]
+        assert [s["number"] for s in sections] == [1, 2, 3]
+        bravo = next(s for s in sections if s["name"] == "Bravo")
+        # JSON keeps the disabled bit as metadata; merge changes only placement.
+        assert bravo["disabled"] is True
+        enabled = next(s for s in sections if s["name"] == "Alpha")
+        assert enabled["disabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# --include-disabled value modes — summary
+# ---------------------------------------------------------------------------
+class TestSummaryDisabledModes:
+    def _headings(self, output: str) -> list[str]:
+        return [line for line in output.splitlines() if line.startswith("## ")]
+
+    def test_marked_appends_disabled_heading(self, flat_split_course):
+        result = _run(
+            "export",
+            "summary",
+            str(flat_split_course),
+            "--audience",
+            "client",
+            "--dry-run",
+            "-L",
+            "en",
+            "--include-disabled",
+        )
+        assert result.exit_code == 0, result.output
+        assert "## Bravo (disabled)" in result.output
+        assert self._headings(result.output) == ["## Alpha", "## Charlie", "## Bravo (disabled)"]
+
+    def test_merge_interleaves_without_marker(self, flat_split_course):
+        result = _run(
+            "export",
+            "summary",
+            str(flat_split_course),
+            "--audience",
+            "client",
+            "--dry-run",
+            "-L",
+            "en",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        assert "(disabled)" not in result.output
+        assert self._headings(result.output) == ["## Alpha", "## Bravo", "## Charlie"]
+
+
+# ---------------------------------------------------------------------------
+# Merge robustness: duplicate, id-less section names
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def dup_name_course(tmp_path: Path) -> Path:
+    """Two enabled sections share a name and have no id, with a disabled one
+    between them. A name/id-keyed merge map would collapse the two onto one
+    built section; the positional walk must keep each section's own content.
+    """
+    slides = tmp_path / "slides"
+    _split_topic(slides, "module_010_a", 100, "foo", "Foo DE", "Foo EN")
+    _split_topic(slides, "module_020_b", 100, "bar", "Bar DE", "Bar EN")
+    _split_topic(slides, "module_030_c", 100, "baz", "Baz DE", "Baz EN")
+    return _write_spec(
+        tmp_path,
+        """\
+        <section><name><de>Dup</de><en>Dup</en></name>
+          <topics><topic>foo</topic></topics>
+        </section>
+        <section enabled="false"><name><de>Mid</de><en>Mid</en></name>
+          <topics><topic>bar</topic></topics>
+        </section>
+        <section><name><de>Dup</de><en>Dup</en></name>
+          <topics><topic>baz</topic></topics>
+        </section>""",
+    )
+
+
+class TestMergeDuplicateSectionNames:
+    def test_merge_keeps_each_section_content(self, dup_name_course):
+        result = _run(
+            "export", "outline", str(dup_name_course), "-L", "en", "--include-disabled=merge"
+        )
+        assert result.exit_code == 0, result.output
+        # Each enabled section renders its OWN topic exactly once (a keyed map
+        # would have collapsed the two "Dup" sections onto the last one).
+        assert result.output.count("- Foo EN") == 1
+        assert result.output.count("- Baz EN") == 1
+        assert "- Bar EN" in result.output  # disabled middle section, folded in
+        assert "(disabled)" not in result.output
+
+    def test_marked_keeps_each_section_content(self, dup_name_course):
+        result = _run("export", "outline", str(dup_name_course), "-L", "en", "--include-disabled")
+        assert result.exit_code == 0, result.output
+        assert result.output.count("- Foo EN") == 1
+        assert result.output.count("- Baz EN") == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-product edges flagged by review
+# ---------------------------------------------------------------------------
+class TestOutlineJsonMergeLanguage:
+    def test_merge_de_disabled_section_slides_single_language(self, flat_split_course):
+        result = _run(
+            "export",
+            "outline",
+            str(flat_split_course),
+            "-L",
+            "de",
+            "-f",
+            "json",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        bravo = next(s for s in json.loads(result.output)["sections"] if s["name"] == "Bravo")
+        titles = [s["title"] for t in bravo["topics"] for s in t["slides"]]
+        assert titles == ["Bar DE"]
+
+
+class TestOutlineDisabledSubsectionMerge:
+    def test_markdown_disabled_subsection_unmarked_single_language(self, subsection_split_course):
+        result = _run(
+            "export",
+            "outline",
+            str(subsection_split_course),
+            "-L",
+            "de",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        assert "(disabled)" not in result.output
+        assert "**Dienstag**" in result.output  # disabled tue subsection still rendered
+        assert "- Bar DE" in result.output
+        assert "Bar EN" not in result.output
+
+    def test_markdown_disabled_subsection_marked_by_default(self, subsection_split_course):
+        result = _run(
+            "export", "outline", str(subsection_split_course), "-L", "de", "--include-disabled"
+        )
+        assert result.exit_code == 0, result.output
+        assert "**Dienstag** (disabled)" in result.output
+
+    def test_json_disabled_subsection_merge_keeps_enabled_flag(self, subsection_split_course):
+        result = _run(
+            "export",
+            "outline",
+            str(subsection_split_course),
+            "-L",
+            "de",
+            "-f",
+            "json",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        week = json.loads(result.output)["sections"][0]
+        tue = next(ss for ss in week["subsections"] if ss["label"] == "Dienstag")
+        assert tue["enabled"] is False  # structured flag stays truthful
+        titles = [s["title"] for t in tue["topics"] for s in t["slides"]]
+        assert titles == ["Bar DE"]
+
+
+class TestScheduleCsvModes:
+    def test_csv_de_split_single_row(self, subsection_split_course):
+        result = _run("export", "schedule", str(subsection_split_course), "-L", "de", "-f", "csv")
+        assert result.exit_code == 0, result.output
+        assert "Foo DE" in result.output
+        assert "Foo EN" not in result.output
+        assert result.output.count("Foo DE") == 1
+
+    def test_csv_merge_keeps_truthful_disabled_column(self, subsection_split_course):
+        result = _run(
+            "export",
+            "schedule",
+            str(subsection_split_course),
+            "-L",
+            "de",
+            "-f",
+            "csv",
+            "--include-disabled=merge",
+        )
+        assert result.exit_code == 0, result.output
+        # Structured CSV keeps the disabled column + truthful flag under merge;
+        # only the human-readable Markdown tag is suppressed.
+        assert result.output.splitlines()[0].endswith(",disabled")
+        assert ",true" in result.output  # the disabled tue deck row
+        assert "Bar DE" in result.output
+        assert "Bar EN" not in result.output


### PR DESCRIPTION
## Summary

Two changes to the `clm export` group, prompted by running it against a real split-language course (`machine-learning-azav`):

### 1. Bug fix — split decks no longer print both languages

`clm export outline … --language=de` listed **both** the German and English title of every split deck (`Präsenz - Kursübersicht` *and* `Classroom - Course Overview`). A split topic ships `slides_x.de.py` + `slides_x.en.py` companions, each with its own `output_language_filter`; the `<subsection>` path filtered on it, but several other enumerations did not.

**Scope of the bug (it was not just `outline`):**

- **Family A** — resolved-`NotebookFile` paths missing the `output_language_filter` guard: `outline` flat-section markdown, `outline` JSON topic-slides, `outline`'s enabled-subsection JSON builder, and **`clm export summary`** (it summarized both companions).
- **Family B** — disabled-topic filesystem reads (`disabled_topic_files`) missing the `.de`/`.en` suffix guard: the shared chokepoint behind the `--include-disabled` paths of **all three** commands.
- `clm export schedule`'s main path was already correct.

Fixed at every site via two shared predicates — `notebook_in_language` (resolved file) and `path_in_language` (on-disk path, built on `split_lang_suffix`). `disabled_topic_files` gained a required `language` parameter. Verified on the real AZAV spec: `-L de` lists 124 German slide entries with **0** English leakage; bilingual decks still appear in both languages.

### 2. Feature — `--include-disabled=merge`

`--include-disabled` is now an optional-value option on all three export commands:

| Form | Behaviour |
|---|---|
| *(omitted)* | disabled content excluded (default, unchanged) |
| `--include-disabled` / `=marked` | included, tagged `(disabled)`; disabled whole sections appended after the enabled ones in outline/summary (unchanged) |
| `--include-disabled=merge` | folded into the normal **declared order, no marker** — a roadmap spec reads like a finished course |

The value resolves to two bools via `resolve_disabled_mode`; the generators keep plain-`bool` signatures plus a defaulted `merge_disabled`, so the MCP `course_outline` caller and direct-generator tests are untouched. Merge interleaving walks the full declared section list and matches enabled sections to the built course **positionally** (`iter_declared_sections`) — robust to duplicate, id-less section names. Structured outputs (`outline --format json` `"disabled"` field, `schedule --format csv` `disabled` column) keep the disabled bit as metadata under `=merge`; merge changes only the human-readable placement/marker.

## Compatibility note

Because `--include-disabled` now takes a value, a **bare** `--include-disabled` placed *immediately before* the `SPEC_FILE` positional (`clm export outline --include-disabled course.xml`) is parsed as `course.xml` being the value and errors. Put the spec first (as in all examples), or use `--include-disabled=merge`/`=marked`. This is inherent to the optional-value form and is documented in `--help` and `clm info migration`. Default/marked **output** is byte-identical to before.

## Tests & docs

- New `tests/cli/test_export_language_and_merge.py` (split-deck fixtures): per-language filtering and all three disabled modes across outline (md+json), schedule (md+csv), and summary — including a duplicate-id-less-name regression test for the positional merge walk.
- All 1481 CLI tests pass; ruff + mypy clean.
- Docs: `commands.md` / `migration.md` info topics, design doc, `CHANGELOG`, spec-file reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
