### PR TITLE
feat(export): add `outline --weekdays` and flatten subsections by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`clm export outline --weekdays [never|always]`** controls whether a
+  section's `<subsection>` weekday/name groupings are rendered as bold labels
+  in the Markdown outline. The default is `never`: every section's decks are
+  flattened into plain bullets, so weeks read uniformly whether or not they
+  declare subsections (previously, weeks that declared subsections rendered
+  weekday groups while weeks that did not — and disabled weeks under
+  `--include-disabled=merge`, which ignored subsections entirely — rendered
+  flat, an inconsistent mix). Pass `--weekdays always` to group decks under
+  their weekday/name label in every week, disabled weeks included. The JSON
+  format is unaffected — it always carries the grouping as a structured
+  `subsections` array.
+
 ### Changed
 
 - **The course-document commands `outline`, `schedule`, and `summarize` moved

--- a/src/clm/cli/commands/outline.py
+++ b/src/clm/cli/commands/outline.py
@@ -176,16 +176,20 @@ def _render_section_subsections(
     language: str,
     *,
     mark_disabled: bool = True,
+    show_weekdays: bool = False,
 ) -> list[str]:
     """Render the bullet lines for a section that uses subsections.
 
     Bare topics (under *no* declared subsection) are listed first as flat
-    bullets; each visible subsection then renders as a bold-label bullet with
-    its decks indented beneath it. Disabled subsections get a ``(disabled)``
-    marker unless ``mark_disabled`` is False (``--include-disabled=merge``, which
-    folds disabled content into the normal flow). ``candidates`` is the full
-    declared subsection set (visible or not) so a topic under a hidden
-    subsection is not mistaken for a bare topic.
+    bullets. With ``show_weekdays`` each visible subsection then renders as a
+    bold-label bullet (its weekday/name) with its decks indented beneath it;
+    without it (the default) the subsection grouping is dropped and its decks
+    are emitted as flat bullets in document order — so the outline reads the
+    same whether or not a section happens to declare ``<subsection>`` groups.
+    Disabled subsections get a ``(disabled)`` marker unless ``mark_disabled`` is
+    False (``--include-disabled=merge``, which folds disabled content into the
+    normal flow). ``candidates`` is the full declared subsection set (visible or
+    not) so a topic under a hidden subsection is not mistaken for a bare topic.
     """
     resolved_titles = {topic.id: _topic_deck_titles(topic, language) for topic in section.topics}
     subsection_topic_ids = {t.id for sub in candidates for t in sub.topics}
@@ -200,10 +204,15 @@ def _render_section_subsections(
 
     for subsection in subsections:
         marker = "" if (subsection.enabled or not mark_disabled) else " (disabled)"
-        label = subsection_label(subsection, language) or "(unnamed)"
-        lines.append(f"- **{label}**{marker}")
-        for title in _subsection_deck_titles(subsection, course, language, resolved_titles):
-            lines.append(f"  - {title}{marker}")
+        titles = _subsection_deck_titles(subsection, course, language, resolved_titles)
+        if show_weekdays:
+            label = subsection_label(subsection, language) or "(unnamed)"
+            lines.append(f"- **{label}**{marker}")
+            for title in titles:
+                lines.append(f"  - {title}{marker}")
+        else:
+            for title in titles:
+                lines.append(f"- {title}{marker}")
     return lines
 
 
@@ -272,12 +281,15 @@ def _render_enabled_section_block(
     include_disabled: bool,
     include_optional: bool,
     mark_disabled: bool,
+    show_weekdays: bool,
 ) -> list[str]:
     """Markdown lines for one enabled section (heading, body, trailing blank).
 
     ``mark_disabled`` controls whether disabled *subsections* nested in this
     section keep their ``(disabled)`` marker (True, default/marked mode) or are
-    folded in silently (False, ``--include-disabled=merge``).
+    folded in silently (False, ``--include-disabled=merge``). ``show_weekdays``
+    controls whether ``<subsection>`` weekday/name groupings are rendered as
+    bold labels or flattened into plain bullets.
     """
     lines = [f"## {section.name[language]}", ""]
     if sections_only:
@@ -287,7 +299,13 @@ def _render_enabled_section_block(
     if candidates:
         lines.extend(
             _render_section_subsections(
-                section, subsections, candidates, course, language, mark_disabled=mark_disabled
+                section,
+                subsections,
+                candidates,
+                course,
+                language,
+                mark_disabled=mark_disabled,
+                show_weekdays=show_weekdays,
             )
         )
     else:
@@ -300,6 +318,50 @@ def _render_enabled_section_block(
     return lines
 
 
+def _disabled_topic_titles(course: Course, topic_spec, language: str) -> list[str]:
+    """Deck titles for one *disabled* topic, read from disk (id fallback).
+
+    Returns the topic id (as a single-element list) when the topic has no
+    resolvable slide files, so a planned-but-absent topic still appears.
+    """
+    slides = _disabled_topic_slides(course, topic_spec, language)
+    if not slides:
+        return [topic_spec.id]
+    return [title for _file_name, title in slides]
+
+
+def _render_disabled_section_subsections(
+    section_spec: SectionSpec,
+    course: Course,
+    language: str,
+    marker: str,
+) -> list[str]:
+    """Render a disabled whole section's bullets with its ``<subsection>`` groups.
+
+    Used by ``--weekdays always`` so disabled weeks show the same weekday/name
+    grouping as enabled ones. All decks are read from the filesystem (disabled
+    topics are not part of the built course). Bare topics (under no subsection)
+    are listed first; each subsection then renders as a bold-label bullet with
+    its decks indented beneath it. Every line carries the section's ``marker``
+    (the whole section is disabled); the subsection's own ``enabled`` flag adds
+    no extra marker beyond that.
+    """
+    subsection_topic_ids = {t.id for sub in section_spec.subsections for t in sub.topics}
+    lines: list[str] = []
+    for topic_spec in section_spec.topics:
+        if topic_spec.id in subsection_topic_ids:
+            continue
+        for title in _disabled_topic_titles(course, topic_spec, language):
+            lines.append(f"- {title}{marker}")
+    for subsection in section_spec.subsections:
+        label = subsection_label(subsection, language) or "(unnamed)"
+        lines.append(f"- **{label}**{marker}")
+        for topic_spec in subsection.topics:
+            for title in _disabled_topic_titles(course, topic_spec, language):
+                lines.append(f"  - {title}{marker}")
+    return lines
+
+
 def _render_disabled_section_block(
     section_spec: SectionSpec,
     course: Course,
@@ -307,29 +369,31 @@ def _render_disabled_section_block(
     *,
     sections_only: bool,
     mark_disabled: bool,
+    show_weekdays: bool,
 ) -> list[str]:
     """Markdown lines for one disabled whole section, read from the filesystem.
 
     With ``mark_disabled`` the heading and every bullet carry a ``(disabled)``
     marker; ``--include-disabled=merge`` passes False so the section reads like
-    any enabled one.
+    any enabled one. With ``show_weekdays`` and a section that declares
+    ``<subsection>`` groups, the decks render grouped under bold weekday/name
+    labels (mirroring enabled sections); otherwise they are flat bullets.
     """
     marker = " (disabled)" if mark_disabled else ""
     lines = [f"## {section_spec.name[language]}{marker}", ""]
     if sections_only:
+        return lines
+    if show_weekdays and section_spec.subsections:
+        lines.extend(_render_disabled_section_subsections(section_spec, course, language, marker))
+        lines.append("")
         return lines
     if not section_spec.topics:
         lines.append("- (no topics declared)")
         lines.append("")
         return lines
     for topic_spec in section_spec.topics:
-        slides = _disabled_topic_slides(course, topic_spec, language)
-        if not slides:
-            # Topic missing on disk, or resolved with no slide files: show its id.
-            lines.append(f"- {topic_spec.id}{marker}")
-        else:
-            for _file_name, title in slides:
-                lines.append(f"- {title}{marker}")
+        for title in _disabled_topic_titles(course, topic_spec, language):
+            lines.append(f"- {title}{marker}")
     lines.append("")
     return lines
 
@@ -344,6 +408,7 @@ def generate_outline(
     include_disabled: bool = False,
     include_optional: bool = False,
     merge_disabled: bool = False,
+    show_weekdays: bool = False,
 ) -> str:
     """Generate a Markdown outline for a course.
 
@@ -358,6 +423,11 @@ def generate_outline(
             bullet points).
         include_optional: When False (default), sections/subsections marked
             ``optional="true"`` are omitted.
+        show_weekdays: When True, ``<subsection>`` weekday/name groupings are
+            rendered as bold labels with their decks indented beneath. When
+            False (default), the grouping is dropped and every deck is a flat
+            bullet, so the outline reads uniformly regardless of which sections
+            declare subsections.
 
     Returns:
         Markdown string with the course outline
@@ -385,6 +455,7 @@ def generate_outline(
                         include_disabled=include_disabled,
                         include_optional=include_optional,
                         mark_disabled=False,
+                        show_weekdays=show_weekdays,
                     )
                 )
             else:
@@ -395,6 +466,7 @@ def generate_outline(
                         language,
                         sections_only=sections_only,
                         mark_disabled=False,
+                        show_weekdays=show_weekdays,
                     )
                 )
         return "\n".join(lines)
@@ -418,6 +490,7 @@ def generate_outline(
                 include_disabled=include_disabled,
                 include_optional=include_optional,
                 mark_disabled=True,
+                show_weekdays=show_weekdays,
             )
         )
 
@@ -431,6 +504,7 @@ def generate_outline(
                 language,
                 sections_only=sections_only,
                 mark_disabled=True,
+                show_weekdays=show_weekdays,
             )
         )
 
@@ -661,6 +735,18 @@ def titles_are_identical(course: Course) -> bool:
     default=False,
     help="Emit only section headings, omitting the topic/slide entries within each section.",
 )
+@click.option(
+    "--weekdays",
+    "weekdays_mode",
+    type=click.Choice(["never", "always"], case_sensitive=False),
+    default="never",
+    show_default=True,
+    help="Show the <subsection> weekday/name groupings as bold labels. "
+    "never (default): flatten every section's decks into plain bullets, so "
+    "weeks read uniformly whether or not they declare subsections. always: "
+    "group decks under their weekday/name label in every week. Markdown only; "
+    "JSON always carries the grouping as structured data.",
+)
 def outline(
     spec_file: Path,
     output_file: Path | None,
@@ -670,6 +756,7 @@ def outline(
     include_optional: bool,
     disabled_mode: str | None,
     sections_only: bool,
+    weekdays_mode: str,
 ):
     """Generate an outline of a course in Markdown or JSON format.
 
@@ -684,6 +771,7 @@ def outline(
         clm export outline course.xml -o out.md        # Write to file
         clm export outline course.xml -d ./docs        # Both languages to directory
         clm export outline course.xml --sections-only  # Section headings only
+        clm export outline course.xml --weekdays always # Group decks by weekday
         clm export outline course.xml --include-optional  # Keep optional modules
         clm export outline course.xml --include-disabled         # Roadmap, tagged
         clm export outline course.xml --include-disabled=merge   # Roadmap, in flow
@@ -692,6 +780,7 @@ def outline(
     check_exclusive_output(output_file, output_dir)
 
     include_disabled, merge_disabled = resolve_disabled_mode(disabled_mode)
+    show_weekdays = weekdays_mode.lower() == "always"
 
     # Load course specification.
     # The main spec always drops disabled sections; if --include-disabled is
@@ -760,6 +849,7 @@ def outline(
             include_disabled=include_disabled,
             include_optional=include_optional,
             merge_disabled=merge_disabled,
+            show_weekdays=show_weekdays,
         )
 
     # Determine languages to generate

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -421,17 +421,23 @@ clm export outline [OPTIONS] SPEC_FILE
 | `-o/-d/-L/--include-optional/--include-disabled` | Shared options (see `clm export` above; `-L` defaults to `en` for stdout/`-o`, both languages for `-d`). |
 | `--format [markdown\|json]` | Output format (default: markdown). |
 | `--sections-only` | Emit only section headings, omitting per-topic/slide entries within each section. |
+| `--weekdays [never\|always]` | Show the `<subsection>` weekday/name groupings as bold labels (Markdown only). `never` (default): flatten every section's decks into plain bullets, so weeks read uniformly whether or not they declare subsections. `always`: group decks under their weekday/name label in every week (including disabled weeks under `--include-disabled`). |
 
-When a section uses the optional `<subsection>` layer (see
-`clm info spec-files`), the outline renders each subsection as an indented
-group: a bold weekday/label bullet with the subsection's decks nested beneath
-it, after any bare (unscheduled) topics. Hiding an optional/disabled subsection
-also hides its topics (they are not demoted to bare bullets). `--include-disabled`
+A section may use the optional `<subsection>` layer (see `clm info spec-files`)
+to group its decks under a weekday or label (`<section>` = week,
+`<subsection>` = day). By default (`--weekdays never`) the outline ignores that
+grouping and lists every deck as a flat bullet, so a section reads the same
+whether or not it declares subsections. Pass `--weekdays always` to render each
+subsection as an indented group instead: a bold weekday/label bullet with the
+subsection's decks nested beneath it, after any bare (unscheduled) topics.
+Hiding an optional/disabled subsection always hides its topics (they are not
+demoted to bare bullets), regardless of `--weekdays`. `--include-disabled`
 surfaces disabled subsections (and disabled sections) with a `(disabled)`
 marker, reading their decks from disk and appending disabled whole sections
 after the enabled ones; `--include-disabled=merge` instead interleaves them in
-declared order with no marker. The JSON format adds a `subsections` array to
-each section that uses them (alongside the flat `topics` list).
+declared order with no marker. The JSON format always adds a `subsections`
+array to each section that uses them (alongside the flat `topics` list) — it
+carries the grouping as structured data and is unaffected by `--weekdays`.
 
 Examples:
 
@@ -440,6 +446,7 @@ clm export outline course.xml
 clm export outline course.xml -L de
 clm export outline course.xml -d ./docs
 clm export outline course.xml --format json
+clm export outline course.xml --weekdays always           # group decks by weekday/label
 clm export outline course.xml --include-optional
 clm export outline course.xml --include-disabled          # roadmap weeks, tagged + appended
 clm export outline course.xml --include-disabled=merge     # roadmap weeks folded into the flow

--- a/tests/cli/test_export_language_and_merge.py
+++ b/tests/cli/test_export_language_and_merge.py
@@ -457,6 +457,8 @@ class TestOutlineDisabledSubsectionMerge:
             "-L",
             "de",
             "--include-disabled=merge",
+            "--weekdays",
+            "always",
         )
         assert result.exit_code == 0, result.output
         assert "(disabled)" not in result.output
@@ -466,7 +468,14 @@ class TestOutlineDisabledSubsectionMerge:
 
     def test_markdown_disabled_subsection_marked_by_default(self, subsection_split_course):
         result = _run(
-            "export", "outline", str(subsection_split_course), "-L", "de", "--include-disabled"
+            "export",
+            "outline",
+            str(subsection_split_course),
+            "-L",
+            "de",
+            "--include-disabled",
+            "--weekdays",
+            "always",
         )
         assert result.exit_code == 0, result.output
         assert "**Dienstag** (disabled)" in result.output

--- a/tests/cli/test_outline.py
+++ b/tests/cli/test_outline.py
@@ -704,7 +704,9 @@ class TestOutlineIncludeOptional:
 
     def test_optional_hidden_by_default_no_bare_leak(self):
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "outline", str(OPTIONAL_SPEC_PATH), "-L", "en"])
+        result = runner.invoke(
+            cli, ["export", "outline", str(OPTIONAL_SPEC_PATH), "-L", "en", "--weekdays", "always"]
+        )
         assert result.exit_code == 0, result.output
         assert "**Monday, Tuesday**" in result.output
         # Optional Wednesday subsection, its topic, and optional Week 2 are gone.
@@ -715,7 +717,17 @@ class TestOutlineIncludeOptional:
     def test_include_optional_shows_modules(self):
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["export", "outline", str(OPTIONAL_SPEC_PATH), "-L", "en", "--include-optional"]
+            cli,
+            [
+                "export",
+                "outline",
+                str(OPTIONAL_SPEC_PATH),
+                "-L",
+                "en",
+                "--include-optional",
+                "--weekdays",
+                "always",
+            ],
         )
         assert result.exit_code == 0, result.output
         assert "**Wednesday**" in result.output

--- a/tests/cli/test_outline_subsections.py
+++ b/tests/cli/test_outline_subsections.py
@@ -32,7 +32,7 @@ def plain_course() -> Course:
 
 class TestMarkdownSubsections:
     def test_subsections_render_as_bold_groups(self, course):
-        out = generate_outline(course, "en")
+        out = generate_outline(course, "en", show_weekdays=True)
         assert "## Week 1" in out
         assert "- **Monday**" in out
         assert "  - Some Topic from Test 1" in out
@@ -41,7 +41,7 @@ class TestMarkdownSubsections:
         assert "  - Was this really ML?" in out
 
     def test_bare_topic_rendered_before_subsection(self, course):
-        out = generate_outline(course, "en")
+        out = generate_outline(course, "en", show_weekdays=True)
         # Week 2 has a bare topic then a wed subsection.
         week2 = out.split("## Week 2", 1)[1]
         assert "- Another Topic from Test 1" in week2
@@ -49,7 +49,7 @@ class TestMarkdownSubsections:
         assert week2.index("Another Topic from Test 1") < week2.index("**Wednesday**")
 
     def test_german_weekday_labels(self, course):
-        out = generate_outline(course, "de")
+        out = generate_outline(course, "de", show_weekdays=True)
         assert "- **Montag**" in out
         assert "- **Dienstag — Recht**" in out
 
@@ -58,6 +58,36 @@ class TestMarkdownSubsections:
         out = generate_outline(plain_course, "en")
         assert "- Some Topic from Test 1" in out
         assert "**" not in out
+
+
+class TestMarkdownWeekdaysDefault:
+    """``show_weekdays`` defaults to False: subsection groupings are flattened.
+
+    The decks still appear (in document order) but without the bold weekday
+    label or indentation, so a spec reads the same whether or not it happens to
+    declare ``<subsection>`` groups (the reported inconsistency)."""
+
+    def test_default_flattens_subsections(self, course):
+        out = generate_outline(course, "en")
+        assert "## Week 1" in out
+        # No bold weekday labels anywhere.
+        assert "**" not in out
+        # ...but every deck is still listed as a flat bullet.
+        assert "- Some Topic from Test 1" in out
+        assert "- A Topic from Test 2" in out
+        assert "- Was this really ML?" in out
+
+    def test_bare_topic_still_first_when_flattened(self, course):
+        out = generate_outline(course, "en")
+        week2 = out.split("## Week 2", 1)[1]
+        assert "- Another Topic from Test 1" in week2
+
+    def test_flat_default_matches_plain_spec_shape(self, course, plain_course):
+        """Flattened subsection output uses the same bullet shape as a plain spec."""
+        sub_out = generate_outline(course, "en")
+        plain_out = generate_outline(plain_course, "en")
+        for line in (*sub_out.splitlines(), *plain_out.splitlines()):
+            assert not line.startswith("  - ")  # no indented deck lines in either
 
 
 class TestJsonSubsections:
@@ -102,14 +132,16 @@ class TestDisabledSubsectionInEnabledSection:
 
     def test_default_hides_disabled_subsection(self):
         course, _full = self._course_and_full()
-        out = generate_outline(course, "en")
+        out = generate_outline(course, "en", show_weekdays=True)
         assert "- **Monday**" in out
         assert "Tuesday" not in out
         assert "(disabled)" not in out
 
     def test_include_disabled_shows_disabled_subsection(self):
         course, full = self._course_and_full()
-        out = generate_outline(course, "en", full_sections=full.sections, include_disabled=True)
+        out = generate_outline(
+            course, "en", full_sections=full.sections, include_disabled=True, show_weekdays=True
+        )
         assert "- **Monday**" in out
         assert "- **Tuesday** (disabled)" in out
         # Its deck title is resolved from the filesystem fallback.
@@ -127,7 +159,15 @@ class TestDisabledSubsectionInEnabledSection:
     def test_cli_include_disabled(self):
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["export", "outline", str(DISABLED_SUB_SPEC_PATH), "--include-disabled"]
+            cli,
+            [
+                "export",
+                "outline",
+                str(DISABLED_SUB_SPEC_PATH),
+                "--include-disabled",
+                "--weekdays",
+                "always",
+            ],
         )
         assert result.exit_code == 0, result.output
         assert "- **Tuesday** (disabled)" in result.output
@@ -136,9 +176,17 @@ class TestDisabledSubsectionInEnabledSection:
 class TestOutlineCliSubsections:
     def test_cli_markdown(self):
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "outline", str(SPEC_PATH)])
+        result = runner.invoke(cli, ["export", "outline", str(SPEC_PATH), "--weekdays", "always"])
         assert result.exit_code == 0, result.output
         assert "- **Monday**" in result.output
+
+    def test_cli_weekdays_default_is_flat(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export", "outline", str(SPEC_PATH)])
+        assert result.exit_code == 0, result.output
+        # Default (never): no bold weekday labels, decks listed flat.
+        assert "**" not in result.output
+        assert "- Some Topic from Test 1" in result.output
 
     def test_cli_json(self):
         runner = CliRunner()


### PR DESCRIPTION
## Problem

`clm export outline` rendered a section's `<subsection weekday="…">` groups as bold weekday labels **only** for weeks that happened to declare them, leaving every other week as flat bullets — an inconsistent mix. Concretely, in the AZAV ML spec:

- Weeks 1–7 (no subsections) → flat bullets
- Week 8 (enabled, declares `mon`/`thu`) → bold **Montag**/**Donnerstag** labels
- Weeks 9+ (disabled, declare mon–fri, folded in via `--include-disabled=merge`) → flat, because the disabled-section renderer ignored subsections entirely

There was no option controlling this; the weekday grouping just leaked through wherever it was declared on an enabled section.

## Fix

Add `clm export outline --weekdays [never|always]`, default **`never`**:

- **`never`** (default): flatten every section's decks into plain bullets in document order, so weeks read uniformly regardless of whether they declare subsections.
- **`always`**: group decks under their bold weekday/name label in **every** week, including disabled weeks — the disabled whole-section renderer now honors its `<subsection>` layer too (previously it didn't, which was the source of the inconsistency).

JSON output is unaffected: it always carries the grouping as a structured `subsections` array (data, not presentation).

Per the original request, the `incomplete` mode was intentionally **not** implemented — the spec doesn't record a week's intended teaching days, so any definition of "incomplete" would have been arbitrary.

## Verified against the real AZAV spec

- Default `never`: week 8 renders flat, identical in shape to all other weeks.
- `--weekdays always`: week 8 and the formerly-flat disabled week 9 both show weekday labels.

## Also

- Updated the `commands` info topic and CHANGELOG.
- Moved the existing grouped-rendering tests to `--weekdays always` / `show_weekdays=True` (the bold label was incidental to what they verified) and added coverage for the new flat default. Full fast suite green (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
