### PR TITLE
fix(sync): place a new slide group added next to a neutral cell; richer errors + progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- **`clm export` commands no longer emit both languages of a split deck.**
+- **`clm slides sync` no longer errors when a new slide group is inserted next
+  to a language-neutral cell.** Adding a new id'd slide (a localized markdown
+  cell + its following language-neutral code cells) right after a neutral cell —
+  e.g. a `slide_id`-carrying code cell with no `lang=` — made sync place the new
+  group in the wrong inter-group position on the other half and then fail with
+  `language-neutral (shared) cells differ …` / `id-less localized cells … placed
+  differently …`, writing nothing. The id-carrying add path anchors a new group
+  only beside cells it can name by `(slide_id, role)`, so a neutral / id-less
+  neighbour was skipped; the structural pass rebuilds each group's *contents* but
+  never reordered *groups*, so the misplacement survived as a parity error. Sync
+  now reconciles slide-group **order** against the propagation source after the
+  structural pass (committing only a reorder that reproduces the source's group
+  and `(slide_id, role)` order exactly), so such an insertion propagates cleanly.
+
+### Changed
+
+- **`clm slides sync` parity errors now name the diverging cells**, instead of a
+  generic "a change to a shared cell was not propagated". The shared-cell error
+  lists the cell text present on one half but missing on the other (or the first
+  out-of-order cell), and the id-less-localized error points at the slide group
+  and cell kind — so the divergence can be located without a manual diff.
+- **`clm slides sync` shows progress while it runs.** A directory (batch) sweep
+  prints a `[i/N] <deck> …` header per pair, and a writing run prints a short
+  stderr tick per LLM call (`· reconciling …` / `· translating …`) so a long
+  sync is visibly alive. Progress goes to stderr and is suppressed under
+  `--json` (stdout stays pure JSON).
+
+
   When a topic ships split `slides_x.de.py` + `slides_x.en.py` companions, a
   `-L de` outline/summary listed *both* the German and the English title (and
   the JSON `slides` array carried both), because the section-flat, JSON-slide,

--- a/src/clm/cli/commands/slides_sync.py
+++ b/src/clm/cli/commands/slides_sync.py
@@ -95,7 +95,7 @@ from clm.slides.sync_translate import DEFAULT_TRANSLATION_MODEL, OpenRouterSlide
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from clm.infrastructure.llm.ollama_client import SyncJudge
+    from clm.infrastructure.llm.ollama_client import SyncJudge, SyncProposal
     from clm.slides.sync_recover import AlignmentRecoverer, CorrespondenceVerifier
     from clm.slides.sync_translate import SlideTranslator
 
@@ -629,14 +629,15 @@ def slides_sync_cmd(
                 prog_lang=_resolve_prog_lang(de_path),
                 guidance_by_lang=guidance_by_lang,
             )
+            run_judge, run_translator = _wrap_progress(judge, translator, enabled=True)
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
             verifier = _resolve_verifier(verify_enabled)
             for issue in plan.issues:
                 click.echo(_issue_line(issue))
             walk = run_plan_walker(
                 plan,
-                judge=judge,
-                translator=translator,
+                judge=run_judge,
+                translator=run_translator,
                 watermark_cache=watermark_cache,
                 options=WalkerOptions(),
                 recoverer=recoverer,
@@ -653,12 +654,13 @@ def slides_sync_cmd(
                 prog_lang=_resolve_prog_lang(de_path),
                 guidance_by_lang=guidance_by_lang,
             )
+            run_judge, run_translator = _wrap_progress(judge, translator, enabled=not as_json)
             recoverer = _resolve_recoverer(llm_recover, recovery_model)
             verifier = _resolve_verifier(verify_enabled)
             apply_result = apply_plan(
                 plan,
-                judge=judge,
-                translator=translator,
+                judge=run_judge,
+                translator=run_translator,
                 watermark_cache=watermark_cache,
                 recoverer=recoverer,
                 alignment_cache=alignment_cache,
@@ -790,6 +792,9 @@ def _run_batch(
     if writing:
         judge = make_judge()
         translator = make_translator()
+        # Per-LLM-call progress ticks (stderr) so a long writing sweep shows what it
+        # is working on; suppressed under --json (stdout must stay pure JSON).
+        judge, translator = _wrap_progress(judge, translator, enabled=not as_json)
         recoverer = make_recoverer()
         verifier = make_verifier()
         if recoverer is not None and cache_root is not None:
@@ -799,7 +804,11 @@ def _run_batch(
 
     results: list[_PairResult] = []
     try:
-        for de_path, en_path in pairs:
+        for i, (de_path, en_path) in enumerate(pairs, 1):
+            # Progress header (stderr) so a multi-pair sweep shows which pair is in
+            # flight — the per-pair result lines are printed together at the end.
+            if not as_json:
+                click.echo(f"[{i}/{len(pairs)}] {_deck_label(de_path, root)} …", err=True)
             results.append(
                 _sync_one_pair(
                     de_path,
@@ -1079,6 +1088,80 @@ def _resolve_recoverer(llm_recover: bool, recovery_model: str) -> AlignmentRecov
         )
         return None
     return OpenRouterAlignmentRecoverer(model=recovery_model)
+
+
+def _progress_snippet(text: str, limit: int = 44) -> str:
+    """A short, scannable handle for a cell being reconciled / translated."""
+    for raw in text.split("\n"):
+        line = raw.strip()
+        for pre in ("# ", "// "):
+            if line.startswith(pre):
+                line = line[len(pre) :].strip()
+                break
+        if line and line not in ("#", "//"):
+            return line[:limit] + ("…" if len(line) > limit else "")
+    return "a cell"
+
+
+class _ProgressJudge:
+    """A :class:`SyncJudge` wrapper that emits a stderr tick before each LLM call.
+
+    The judge / translator calls are the slow part of a sync (each is a hosted-LLM
+    round-trip), so a tick per call shows the command is alive and what it is
+    working on. Pure pass-through otherwise; ``None`` judges are never wrapped.
+    """
+
+    def __init__(self, inner: SyncJudge, echo: Callable[[str], None]) -> None:
+        self.inner = inner
+        self.echo = echo
+        self.prompt_version = inner.prompt_version  # protocol member (writable)
+
+    def propose(
+        self, source_text: str, target_text: str, *, source_lang: str, target_lang: str
+    ) -> SyncProposal:
+        self.echo(f"  · reconciling {_progress_snippet(source_text)} …")
+        return self.inner.propose(
+            source_text, target_text, source_lang=source_lang, target_lang=target_lang
+        )
+
+
+class _ProgressTranslator:
+    """A :class:`SlideTranslator` wrapper that emits a stderr tick before each call."""
+
+    def __init__(self, inner: SlideTranslator, echo: Callable[[str], None]) -> None:
+        self.inner = inner
+        self.echo = echo
+        self.prompt_version = inner.prompt_version  # protocol member (writable)
+
+    def translate(self, *, source_body: str, source_lang: str, target_lang: str, role: str) -> str:
+        self.echo(f"  · translating {_progress_snippet(source_body)} …")
+        return self.inner.translate(
+            source_body=source_body,
+            source_lang=source_lang,
+            target_lang=target_lang,
+            role=role,
+        )
+
+
+def _wrap_progress(
+    judge: SyncJudge | None, translator: SlideTranslator | None, *, enabled: bool
+) -> tuple[SyncJudge | None, SlideTranslator | None]:
+    """Wrap the judge/translator so each LLM call prints a progress tick to stderr.
+
+    No-op when ``enabled`` is False (e.g. ``--json``, where stderr ticks would not
+    matter and stdout must stay pure JSON) or when the backend is unavailable
+    (``None``). Wrapping is transparent — the wrappers satisfy the same protocols.
+    """
+    if not enabled:
+        return judge, translator
+
+    def echo(msg: str) -> None:
+        click.echo(msg, err=True)
+
+    return (
+        _ProgressJudge(judge, echo) if judge is not None else None,
+        _ProgressTranslator(translator, echo) if translator is not None else None,
+    )
 
 
 def _resolve_verifier(verify_enabled: bool) -> CorrespondenceVerifier | None:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1283,6 +1283,10 @@ run requires **`--yes`** (or an interactive confirm), since it writes to every
 pair at once; `--dry-run` / `--explain` directory runs are unprompted.
 `--interactive` is single-pair only (it walks one pair's proposals) and is
 rejected with a directory. Do **not** pass a second path with a directory.
+Since CLM {version} a sweep prints a `[i/N] <deck> …` **progress header** per
+pair (stderr), and a writing run prints a short stderr tick per LLM call
+(`· reconciling …` / `· translating …`) so a long sync is visibly alive;
+progress is suppressed under `--json`.
 
 **Default behavior changed in CLM {version}: the command now writes to
 the working tree.** A bare `clm slides sync de en` applies the agreed
@@ -1388,6 +1392,16 @@ written into the file, so a deck stays id-light yet syncs precisely:
   byte-identical (the `unify` invariant); if any still differ, sync **errors** and
   holds the watermark rather than report the decks consistent — so an
   un-propagatable shared-cell change is always surfaced, never silently banked.
+  Since CLM {version} the error **names the diverging cell(s)** — the cell text
+  present on one half but missing on the other (or the first out-of-order cell),
+  and for id-less localized cells the slide group and cell kind — so you can
+  locate the divergence without a manual diff.
+- **A new slide group added next to a neutral cell is placed correctly (since CLM
+  {version}).** Inserting a new id'd slide (a localized markdown cell plus its
+  language-neutral code cells) right after a language-neutral or id-less neighbour
+  used to land the new group in the wrong inter-group slot on the other half and
+  trip the parity fail-safe above; sync now reconciles slide-group **order**
+  against the propagation source, so the insertion propagates cleanly.
 
 Use `--explain` to see the anchor-level view (per-cell anchor + drift, the
 propagation direction, drifted ids) for any pair.

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -379,6 +379,15 @@ def apply_plan(
     baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan)
     apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
 
+    # Place a newly-added slide group at its source position. The per-cell add path
+    # anchors a new group beside the nearest neighbour it can name by (slide_id,
+    # role); a language-neutral or id-less neighbour is invisible to that anchor, so
+    # a new group can land in the wrong inter-group slot. The structural pass above
+    # rebuilds each group's CONTENTS but never reorders GROUPS, so reconcile group
+    # order against the source here — otherwise the misplacement survives only to
+    # trip the shared-cell / id-less parity fail-safe below (the reported bug).
+    _reconcile_group_order(plan, de_state, en_state, result)
+
     # Fail-safe: a complete resolution leaves no duplicate id behind. If one
     # survives (a should-not-happen bug), error so the watermark cannot advance
     # over a corrupt state and the situation is surfaced rather than baselined.
@@ -583,6 +592,77 @@ def _shared_cell_hashes(state: FileState) -> list[str]:
     ]
 
 
+def _cell_snippet(body: str, limit: int = 48) -> str:
+    """A short, human-locatable excerpt of a cell body (its first meaningful line).
+
+    Strips a leading line-comment prefix (``# `` / ``// ``) so a markdown cell reads
+    as its heading text, and truncates to ``limit`` so an error line stays scannable.
+    """
+    for raw in body.split("\n"):
+        line = raw.strip()
+        for pre in ("# ", "// "):
+            if line.startswith(pre):
+                line = line[len(pre) :].strip()
+                break
+        else:
+            if line in ("#", "//"):
+                continue
+        if line:
+            return line[:limit] + ("…" if len(line) > limit else "")
+    return "(empty cell)"
+
+
+def _snippet_list(snippets: list[str], limit: int = 3) -> str:
+    """Render up to ``limit`` cell snippets, with a ``(+N more)`` tail if truncated."""
+    shown = ", ".join(repr(s) for s in snippets[:limit])
+    extra = len(snippets) - limit
+    return f"{shown}, … (+{extra} more)" if extra > 0 else shown
+
+
+def _shared_cell_descriptors(state: FileState) -> list[tuple[str, str]]:
+    """``(content_hash, snippet)`` of each language-neutral cell, in document order.
+
+    Partitioned exactly like :func:`_shared_cell_hashes` (the parity invariant), but
+    carries a snippet too so a divergence can name the offending cell(s).
+    """
+    return [
+        (cell_content_hash(cell.body), _cell_snippet(cell.body))
+        for cell in state.cells
+        if not cell.metadata.is_j2 and cell.metadata.lang not in ("de", "en")
+    ]
+
+
+def _describe_shared_divergence(de: list[tuple[str, str]], en: list[tuple[str, str]]) -> str:
+    """Name the language-neutral cells that diverge between the two halves.
+
+    Reports cells present on one half but not the other (an un-propagated add /
+    remove), else — when both halves hold the same cells in a different order — the
+    first positional mismatch. Caps the listed snippets so the message stays short.
+    """
+    de_by_hash = dict(de)
+    en_by_hash = dict(en)
+    cde, cen = Counter(h for h, _ in de), Counter(h for h, _ in en)
+    # ``dict.fromkeys`` de-dups the multiset diff to DISTINCT hashes (preserving
+    # first-seen order), so two byte-identical added cells list one snippet, not the
+    # same text twice.
+    de_only = list(dict.fromkeys((cde - cen).elements()))
+    en_only = list(dict.fromkeys((cen - cde).elements()))
+    parts: list[str] = []
+    if de_only:
+        parts.append("on de but missing on en: " + _snippet_list([de_by_hash[h] for h in de_only]))
+    if en_only:
+        parts.append("on en but missing on de: " + _snippet_list([en_by_hash[h] for h in en_only]))
+    if parts:
+        return "; ".join(parts)
+    for i, (a, b) in enumerate(zip(de, en, strict=False)):
+        if a[0] != b[0]:
+            return (
+                f"the shared cells are in a different order across the halves (first "
+                f"mismatch at shared-cell #{i + 1}: de has {a[1]!r}, en has {b[1]!r})"
+            )
+    return "the shared cells are in a different order across the halves"
+
+
 def _flag_shared_cell_divergence(
     de_state: FileState, en_state: FileState, result: ApplyResult
 ) -> None:
@@ -596,16 +676,20 @@ def _flag_shared_cell_divergence(
     the pass report "decks already consistent". This backstops the neutral-cell
     propagation paths (``align_anchored`` + the structural pass) for every neutral
     cell shape, including a tagged-neutral cell the structural pass cannot rebuild.
+    The message names the offending cell(s) so the author can find the divergence.
 
     Only invoked on an otherwise-clean pass (no prior error / deferral), so a
     genuine mismatch here is always an un-propagated divergence, never a
     double-report of an already-alerted problem.
     """
-    if _shared_cell_hashes(de_state) != _shared_cell_hashes(en_state):
+    de = _shared_cell_descriptors(de_state)
+    en = _shared_cell_descriptors(en_state)
+    if [h for h, _ in de] != [h for h, _ in en]:
         result.errors.append(
             "language-neutral (shared) cells differ between de and en after sync — "
-            "a change to a shared cell was not propagated; re-run sync (a watermark "
-            "now exists) or resolve the divergence manually"
+            f"{_describe_shared_divergence(de, en)}; a change to a shared cell was "
+            "not propagated; re-run sync (a watermark now exists) or resolve the "
+            "divergence manually"
         )
 
 
@@ -642,6 +726,25 @@ def _idless_localized_body_hashes(state: FileState) -> list[str]:
     ]
 
 
+def _describe_idless_divergence(
+    de_kinds: list[tuple[int, str]], en_kinds: list[tuple[int, str]]
+) -> str:
+    """Name the first slide group where the id-less localized cell layout diverges.
+
+    Each entry is ``(slide-group index, kind)``; the divergence is content-free
+    (these cells are language-specific translations), so the most locatable handle
+    is the 1-based slide-group number and the cell kind (code / markdown).
+    """
+    for i in range(max(len(de_kinds), len(en_kinds))):
+        a = de_kinds[i] if i < len(de_kinds) else None
+        b = en_kinds[i] if i < len(en_kinds) else None
+        if a != b:
+            de_desc = f"a {a[1]} cell in slide group {a[0] + 1}" if a is not None else "(none)"
+            en_desc = f"a {b[1]} cell in slide group {b[0] + 1}" if b is not None else "(none)"
+            return f"de has {de_desc} where en has {en_desc}"
+    return "the id-less localized cell layout differs"
+
+
 def _flag_idless_localized_divergence(
     plan: SyncPlan, de_state: FileState, en_state: FileState, result: ApplyResult
 ) -> None:
@@ -667,11 +770,14 @@ def _flag_idless_localized_divergence(
     one group is alerted (check 2), not auto-propagated — give such cells ``slide_id``s
     for precise sync.
     """
-    if _idless_localized_group_kinds(de_state) != _idless_localized_group_kinds(en_state):
+    de_kinds = _idless_localized_group_kinds(de_state)
+    en_kinds = _idless_localized_group_kinds(en_state)
+    if de_kinds != en_kinds:
         result.errors.append(
             "id-less localized cells (lang= cells with no slide_id) are placed "
-            "differently across de and en after sync — a move was not propagated; "
-            "give them slide_ids for precise sync, or resolve manually"
+            f"differently across de and en after sync — {_describe_idless_divergence(de_kinds, en_kinds)}; "
+            "a move was not propagated; give them slide_ids for precise sync, or "
+            "resolve manually"
         )
         return
     de_base, en_base = plan.idless_baseline_de, plan.idless_baseline_en
@@ -682,9 +788,10 @@ def _flag_idless_localized_divergence(
     de_reorder = de_now != de_base and Counter(de_now) == Counter(de_base)
     en_reorder = en_now != en_base and Counter(en_now) == Counter(en_base)
     if (de_reorder and en_now == en_base) or (en_reorder and de_now == de_base):
+        which = "de" if de_reorder else "en"
         result.errors.append(
-            "id-less localized cells were reordered on one deck but not the other "
-            "after sync — give them slide_ids so the order can be mirrored, or "
+            f"id-less localized cells were reordered on the {which} deck but not the "
+            "other after sync — give them slide_ids so the order can be mirrored, or "
             "resolve manually"
         )
 
@@ -1954,6 +2061,64 @@ def _apply_moves(
             "some moves are not expressible by a slide-group reorder "
             "(narrative companion reassigned to a different slide) — deferred"
         )
+
+
+def _reconcile_group_order(
+    plan: SyncPlan, de_state: FileState, en_state: FileState, result: ApplyResult
+) -> None:
+    """Reorder the target deck's slide groups to match the source's group order.
+
+    The per-cell add path (:func:`_add_idcarrying_one_direction` /
+    :func:`_add_one_direction`) anchors a brand-new slide group beside the nearest
+    preceding neighbour it can name by ``(slide_id, role)``. A language-neutral or
+    id-less neighbour is invisible to that anchor, so a new group can be inserted in
+    the wrong inter-group slot — e.g. a new subslide added right after a neutral
+    code cell lands *before* it instead. The structural pass
+    (:func:`apply_code_structure`) rebuilds each group's *contents* from the source
+    but iterates the target's groups in their current order, so it never reorders
+    *groups*; the misplacement would otherwise survive and surface only as the
+    shared-cell / id-less-localized parity error.
+
+    Run after adds + the structural rebuild, against the run's single propagation
+    source (the keyed-proposal direction, else the neutral-cell anchor direction).
+    Only a reorder that reproduces the source's group order **and** its localized
+    ``(slide_id, role)`` order exactly is committed — the same bar
+    :func:`_apply_moves` uses — so a partial or ambiguous reorder is left untouched
+    for the parity fail-safe rather than guessed at. Whole groups move as verbatim
+    units (each group's internal order was already reconciled above), so this only
+    fixes placement, never content.
+
+    Gated on a fully clean pass (:func:`_pass_is_clean`), exactly like
+    :func:`_apply_moves`: a deferred pass still *writes* its applied changes, so
+    without this guard a reorder a user **skipped** in ``--interactive`` (deferred,
+    never added to ``moves``) would be silently re-applied here against the source
+    and persisted — overriding the skip and re-surfacing nothing next run. Holding
+    the reorder for a clean pass keeps the skip honoured; a misplaced new group on
+    a deferred pass simply re-reconciles on the next (clean) run.
+    """
+    if not _pass_is_clean(plan, result):
+        return
+    directions = {p.direction for p in plan.proposals if p.direction in ("de->en", "en->de")}
+    direction = next(iter(directions)) if len(directions) == 1 else plan.anchor_direction
+    if direction is None:
+        return
+    source_state, target_state = (
+        (de_state, en_state) if direction == "de->en" else (en_state, de_state)
+    )
+    reordered = _group_reorder(target_state.cells, _group_order(source_state.cells))
+    if reordered is None:
+        return  # group order already matches the source
+    if _group_order(reordered) != _group_order(source_state.cells) or _sync_key_order(
+        reordered
+    ) != _sync_key_order(source_state.cells):
+        return  # would not fully reconcile — leave the divergence for the fail-safe
+    sep = target_state.separator_blanks()
+    original_last = target_state.cells[-1] if target_state.cells else None
+    target_state.cells = reordered
+    target_state.dirty = True
+    if original_last is not None:
+        target_state.normalize_displaced_last(original_last, sep)
+    result.applied_structural += 1
 
 
 def _group_order(cells: list[RawCell]) -> list[str]:

--- a/tests/slides/test_sync_issue_269.py
+++ b/tests/slides/test_sync_issue_269.py
@@ -22,7 +22,7 @@ import pytest
 
 from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.notebooks.slide_parser import parse_cells
-from clm.slides.sync_apply import _record_watermark, apply_plan
+from clm.slides.sync_apply import DECISION_SKIP, _record_watermark, apply_plan
 from clm.slides.sync_plan import build_sync_plan
 from clm.slides.sync_translate import StaticSlideTranslator
 
@@ -64,6 +64,21 @@ def _idless_md(lang: str, body: str) -> str:
 def _hdr(lang: str, title: str, num: str = "01") -> str:
     macro = "header_de" if lang == "de" else "header_en"
     return f'# j2 from \'macros.j2\' import {macro}\n# {{{{ {macro}("{title}", "{num}") }}}}\n'
+
+
+def _sub_md(lang: str, sid: str, txt: str) -> str:
+    """A localized (id'd) subslide markdown cell — a slide-group start."""
+    return f'# %% [markdown] lang="{lang}" tags=["subslide"] slide_id="{sid}"\n# ## {txt}\n'
+
+
+def _sub_code(sid: str, body: str) -> str:
+    """A language-neutral code cell that is itself a subslide group-start.
+
+    (The shape of ``visualize-chunks-5`` in the reported bug: a neutral code cell
+    carrying a slide_id + ``subslide`` tag — it starts a group but is invisible to
+    the per-cell add path's ``(slide_id, role)`` anchor.)
+    """
+    return f'# %% tags=["subslide"] slide_id="{sid}"\n{body}\n'
 
 
 def _deck(*parts: str) -> str:
@@ -377,3 +392,273 @@ def test_genuine_noop_still_reports_consistent(tmp_path: Path, baseline: str):
     assert plan.is_noop
     assert not _alerted(plan, result)
     assert "consistent" in plan.summary().lower()
+
+
+# ---------------------------------------------------------------------------
+# New-slide-group placement — a new group added after a NEUTRAL / id-less
+# neighbour must land at the source position, not be misplaced and then trip a
+# parity fail-safe. (The reported bug: the id-carrying add anchors only on cells
+# it can name by (slide_id, role), so a neutral/id-less neighbour is skipped and
+# the new group is inserted in the wrong inter-group slot; the structural pass
+# rebuilds group CONTENTS but never reorders GROUPS, so the misplacement survived
+# as a "shared cells differ" / "id-less placed differently" error.)
+# ---------------------------------------------------------------------------
+
+
+def _group_ids(text: str):
+    return [c.slide_id for c in parse_cells(text) if c.metadata.is_slide_start and c.slide_id]
+
+
+def _neutral_bodies(text: str):
+    return [
+        c.content for c in parse_cells(text) if not c.metadata.is_j2 and c.lang not in ("de", "en")
+    ]
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_new_group_after_neutral_idd_neighbour_places_correctly(tmp_path: Path, baseline: str):
+    # The user's exact shape: a new id'd subslide + neutral code cells inserted after
+    # a neutral-code subslide (`visualize-chunks-5`), between two existing groups.
+    de = _deck(
+        _title("de", "intro"),
+        _sub_code("viz-5", "visualize(chunks)"),
+        _title("de", "tokens", "Tokens"),
+    )
+    en = _deck(
+        _title("en", "intro"),
+        _sub_code("viz-5", "visualize(chunks)"),
+        _title("en", "tokens", "Tokens"),
+    )
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_code("viz-5", "visualize(chunks)"),
+        _sub_md("de", "why-empty", "Warum leerer Separator?"),
+        _ncode("a = 1"),
+        _ncode("b = 2"),
+        _title("de", "tokens", "Tokens"),
+    )
+    plan, result, _de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en, mapping={"# ## Warum leerer Separator?": "# ## Why?"}
+    )
+    assert not _alerted(plan, result)  # no parity error — propagated cleanly
+    assert result.watermark_recorded
+    # The new group landed right after viz-5 on EN, not before it.
+    assert _group_ids(en_after) == ["intro", "viz-5", "why-empty", "tokens"]
+    # Neutral cells are byte-identical and in the same order across the halves.
+    assert _neutral_bodies(en_after) == _neutral_bodies(_de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_new_group_after_idless_neutral_neighbour_places_correctly(tmp_path: Path, baseline: str):
+    # New group preceded by an id-LESS neutral code cell (no slide_id to anchor on).
+    de = _deck(_title("de", "intro"), _ncode("import os"), _title("de", "end", "Ende"))
+    en = _deck(_title("en", "intro"), _ncode("import os"), _title("en", "end", "End"))
+    de1 = _deck(
+        _title("de", "intro"),
+        _ncode("import os"),
+        _sub_md("de", "newgrp", "Neu"),
+        _ncode("import sys"),
+        _title("de", "end", "Ende"),
+    )
+    plan, result, de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en, mapping={"# ## Neu": "# ## New"}
+    )
+    assert not _alerted(plan, result)
+    assert _group_ids(en_after) == ["intro", "newgrp", "end"]
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_new_group_after_idless_localized_neighbour_places_correctly(tmp_path: Path, baseline: str):
+    # New group preceded by an id-less LOCALIZED cell (translated body, un-anchorable).
+    de = _deck(_title("de", "intro"), _idless_code("de", 'print("Hallo")'), _title("de", "end"))
+    en = _deck(_title("en", "intro"), _idless_code("en", 'print("Hello")'), _title("en", "end"))
+    de1 = _deck(
+        _title("de", "intro"),
+        _idless_code("de", 'print("Hallo")'),
+        _sub_md("de", "newgrp", "Neu"),
+        _ncode("import sys"),
+        _title("de", "end"),
+    )
+    plan, result, de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en, mapping={"# ## Neu": "# ## New"}
+    )
+    assert not _alerted(plan, result)
+    assert _group_ids(en_after) == ["intro", "newgrp", "end"]
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics — a genuine (unresolvable) divergence must name the offending cell
+# so the author can locate it (the reported "errors don't say which cell" gap).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_shared_cell_divergence_error_names_cells(tmp_path: Path, baseline: str):
+    # A tagged-neutral cell edited on one side can't be auto-rebuilt → parity error.
+    de = _deck(_title("de"), _nmd_tagged("# heading"))
+    en = _deck(_title("en"), _nmd_tagged("# heading"))
+    en1 = _deck(_title("en"), _nmd_tagged("# heading EDIT"))
+    _plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    msg = "\n".join(result.errors)
+    assert "shared" in msg
+    # Names the divergent content rather than a bare "a change was not propagated".
+    assert "heading EDIT" in msg or "heading" in msg
+    assert "missing on" in msg
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_idless_localized_divergence_error_names_group(tmp_path: Path, baseline: str):
+    # A one-sided cross-group move of an id-less localized cell → parity error that
+    # points at the slide group, not a bare "a move was not propagated".
+    de = _deck(_title("de", "s1"), _idless_code("de", 'print("p")'), _title("de", "s2"))
+    en = _deck(_title("en", "s1"), _idless_code("en", 'print("p")'), _title("en", "s2"))
+    en1 = _deck(_title("en", "s1"), _title("en", "s2"), _idless_code("en", 'print("p")'))
+    _plan, result, _, _ = _sync(tmp_path, baseline, de, en, de, en1)
+    msg = "\n".join(result.errors)
+    assert "slide group" in msg
+
+
+def _shared_snippet_count(msg: str) -> int:
+    """How many cell snippets the 'on de but missing on en' clause lists."""
+    if "on de but missing on en: " not in msg:
+        return 0
+    clause = msg.split("on de but missing on en: ", 1)[1].split(";")[0]
+    return clause.count("'") // 2
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_shared_divergence_dedups_identical_cell_snippets(tmp_path: Path, baseline: str):
+    # Two byte-identical neutral cells added on one half must list the snippet ONCE,
+    # not the same text twice (the message names distinct offending cells).
+    de = _deck(_title("de"), _nmd_tagged("# h"))
+    en = _deck(_title("en"), _nmd_tagged("# h"))
+    # Edit the tagged-neutral cell to the SAME new text on... no: force a divergence
+    # where de has two identical neutral cells en lacks. Use neutral code adds on DE
+    # only, paired with a parity-tripping tagged-neutral so the fail-safe fires.
+    de1 = _deck(_title("de"), _nmd_tagged("# h"), _ncode("import sys"), _ncode("import sys"))
+    en1 = _deck(_title("en"), _nmd_tagged("# h EDIT"))
+    _plan, result, _, _ = _sync(tmp_path, baseline, de, en, de1, en1)
+    msg = "\n".join(result.errors)
+    if "import sys" in msg:
+        # the duplicate 'import sys' must appear once, not twice, in the de-only clause
+        assert msg.count("'import sys'") == 1
+
+
+# ---------------------------------------------------------------------------
+# A SKIPPED move (--interactive) must NOT be silently re-applied by the
+# group-order reconciliation. _reconcile_group_order is gated on a fully clean
+# pass exactly like _apply_moves, so a deferred/skipped reorder is honoured.
+# ---------------------------------------------------------------------------
+
+
+def _sync_skipping_moves(tmp: Path, baseline: str, de0: str, en0: str, de1: str, en1: str):
+    """Like ``_sync`` but SKIPS every ``move`` proposal (mimics an interactive skip)."""
+    db = tmp / "clm-llm.sqlite"
+    de_path, en_path = tmp / "deck.de.py", tmp / "deck.en.py"
+    de_path.write_text(de0, encoding="utf-8")
+    en_path.write_text(en0, encoding="utf-8")
+    if baseline == "git-head":
+        _git(tmp, "init", "-q")
+        _git(tmp, "config", "user.email", "t@example.com")
+        _git(tmp, "config", "user.name", "Test")
+        _git(tmp, "add", "-A")
+        _git(tmp, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+    else:
+        wm = SyncWatermarkCache(db)
+        _record_watermark(wm, de_path, en_path)
+        wm.close()
+    de_path.write_text(de1, encoding="utf-8")
+    en_path.write_text(en1, encoding="utf-8")
+    wm = SyncWatermarkCache(db)
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
+        decisions = {id(p): DECISION_SKIP for p in plan.proposals if p.kind == "move"}
+        result = apply_plan(
+            plan,
+            judge=None,
+            translator=StaticSlideTranslator(default="<<XL>>"),
+            watermark_cache=wm,
+            decisions=decisions,
+        )
+    finally:
+        wm.close()
+    return plan, result, en_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_skipped_move_is_not_reapplied_by_group_reorder(tmp_path: Path, baseline: str):
+    # Author swaps two id'd groups on DE; the user SKIPS the move. The reorder must
+    # NOT be re-applied to EN behind the skip (the bug a naive group-order reconcile
+    # introduces: it would re-order EN to match DE and write it, defeating the skip).
+    de = _deck(_title("de", "intro"), _sub_md("de", "A", "Alpha"), _sub_md("de", "B", "Beta"))
+    en = _deck(_title("en", "intro"), _sub_md("en", "A", "Alpha"), _sub_md("en", "B", "Beta"))
+    de1 = _deck(_title("de", "intro"), _sub_md("de", "B", "Beta"), _sub_md("de", "A", "Alpha"))
+    plan, result, en_after = _sync_skipping_moves(tmp_path, baseline, de, en, de1, en)
+    assert any(p.kind == "move" for p in plan.proposals)  # a move WAS detected
+    assert result.deferred >= 1  # and it was deferred (skipped)
+    assert not result.watermark_recorded  # watermark held over the skip
+    # The skip is honoured: EN keeps its original group order, not DE's swap.
+    assert _group_ids(en_after) == ["intro", "A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# Placement edge cases — a new group at the deck START / END must also land right.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_new_group_at_deck_end_places_correctly(tmp_path: Path, baseline: str):
+    de = _deck(_title("de", "intro"), _sub_code("viz", "visualize()"))
+    en = _deck(_title("en", "intro"), _sub_code("viz", "visualize()"))
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_code("viz", "visualize()"),
+        _sub_md("de", "tail", "Schluss"),
+        _ncode("cleanup()"),
+    )
+    plan, result, de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en, mapping={"# ## Schluss": "# ## End"}
+    )
+    assert not _alerted(plan, result)
+    assert _group_ids(en_after) == ["intro", "viz", "tail"]
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_new_group_at_deck_start_places_correctly(tmp_path: Path, baseline: str):
+    de = _deck(_title("de", "intro"), _ncode("body()"))
+    en = _deck(_title("en", "intro"), _ncode("body()"))
+    de1 = _deck(
+        _sub_md("de", "pre", "Vorab"),
+        _ncode("setup()"),
+        _title("de", "intro"),
+        _ncode("body()"),
+    )
+    plan, result, de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en, mapping={"# ## Vorab": "# ## Preamble"}
+    )
+    assert not _alerted(plan, result)
+    assert _group_ids(en_after) == ["pre", "intro"]
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_new_neutral_code_group_start_alerts_not_silent(tmp_path: Path, baseline: str):
+    # Documented limitation: a brand-new group whose START is itself a NEUTRAL code
+    # cell (a slide_id + subslide tag, no lang — the bare 'visualize-chunks-N' shape)
+    # is not auto-propagated, because the add path keys on (slide_id, role) and a
+    # neutral cell has role None. The cardinal #269 invariant must still hold: sync
+    # ALERTS (watermark held), it must NEVER silently report "consistent".
+    de = _deck(_title("de", "intro"), _title("de", "end", "Ende"))
+    en = _deck(_title("en", "intro"), _title("en", "end", "End"))
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_code("viz-new", "visualize(new)"),
+        _title("de", "end", "Ende"),
+    )
+    plan, result, _, _ = _sync(tmp_path, baseline, de, en, de1, en)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert not _falsely_consistent(plan, result, False)


### PR DESCRIPTION
## Problem

`clm slides sync` errored — `language-neutral (shared) cells differ …` /
`id-less localized cells … placed differently …`, writing nothing — when an
author inserted a **new slide group** (an id'd localized markdown cell plus its
language-neutral code cells) right after a language-neutral or id-less neighbour
(e.g. a `slide_id`-carrying code cell with no `lang=`, like `visualize-chunks-5`).

**Root cause:** the id-carrying add path (`_add_idcarrying_one_direction` /
`_add_one_direction`) anchors a new group only beside cells it can name by
`(slide_id, role)`; a neutral / id-less neighbour is `role_of() == None`, so it is
skipped and the new group lands in the wrong inter-group slot on the other half.
The structural pass (`apply_code_structure`) rebuilds each group's *contents* but
iterates the target's groups in their current order — it never reorders *groups* —
so the misplacement survived as a parity error and nothing was written.

Reproduced on the real `module_550_ml_azav/topic_380_text_processing_azav/
slides_020_text_chunking` pair (no watermark → git-HEAD baseline): before this
fix `applied 5, 2 error(s)`; after, `applied 5, 0 errors`, 59 neutral cells
byte-identical across the halves, the new group correctly placed after
`visualize-chunks-5`.

## Fix

Add `_reconcile_group_order` (called after `apply_code_structure` in
`apply_plan`): reorder the target deck's slide groups to match the propagation
source, reusing the same machinery and strict order-equality bar as
`_apply_moves`. **Gated on a fully clean pass** (`_pass_is_clean`) exactly like
`_apply_moves` — a deferred pass still *writes* its applied changes, so without
the guard a reorder a user **skipped** in `--interactive` would be silently
re-applied and persisted. (This hazard was caught by an adversarial review of the
first cut of the fix and is covered by a regression test.)

## Diagnostics (the second half of the report)

- **Parity errors now name the diverging cells**: the cell text present on one
  half but missing on the other (or the first out-of-order cell), and the slide
  group + kind for id-less localized cells — so a divergence can be located
  without a manual diff. Duplicate snippets are de-duped.
- **Progress indicator**: a `[i/N] <deck> …` header per pair in a batch sweep,
  plus a per-LLM-call stderr tick (`· reconciling …` / `· translating …`) so a
  long sync is visibly alive. Progress goes to stderr and is suppressed under
  `--json` (stdout stays pure JSON).

## Tests

20 new regression tests in `tests/slides/test_sync_issue_269.py` (both git-HEAD
and watermark baselines): new-group placement after neutral / id-less neighbours
and at deck start / end; a skipped `--interactive` move is **not** re-applied
(fails without the `_pass_is_clean` gate); the neutral-code-cell group-start
limitation still **alerts** (never silently drops); and the error messages name
cells / groups. Full slides suite green (1456 passed); ruff + format + mypy clean.

## Docs

`CHANGELOG.md` (Fixed + Changed) and the `clm info commands` info topic updated.

## Known limitation / follow-up

A **pre-existing, separate** bug (reproduces with this change reverted) is filed
as a follow-up issue: when one half reorders groups (a `move`) while the other
half independently edits a neutral / id-less cell inside a moved group, that edit
is silently lost (`apply_code_structure` rebuilds the moved group verbatim from
the move source). Not addressed here to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
