### PR TITLE
fix(sync): alert on a slide-group reorder vs a concurrent neutral/id-less edit (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   now reconciles slide-group **order** against the propagation source after the
   structural pass (committing only a reorder that reproduces the source's group
   and `(slide_id, role)` order exactly), so such an insertion propagates cleanly.
+- **`clm slides sync` no longer silently drops (or destructively overwrites) a
+  one-sided edit made while the other half reorders slide groups.** When one half
+  reordered slide groups (a `move`) while the other half independently edited a
+  language-neutral (no `lang=`) or id-less-localized cell, the two changes flowed
+  in opposite directions. The reorder permutes the source half's neutral/id-less
+  cell *sequence*, which the positional drift detectors misread as a "drift" —
+  masking the target half's edit. The run reported the decks consistent and
+  advanced the watermark while the edit was lost from **both** halves; for two or
+  more reordered neutral cells the positional shift was even misclassified as a
+  same-cell divergence and **auto-healed**, overwriting the edit on disk (Issue
+  #282). Because a group reorder makes positional pairing unsound, sync now
+  **errors** whenever one half reorders slide groups while the other half has any
+  unreconciled neutral / id-less change (an edit, add, remove, or cross-group
+  reassignment), holding the watermark and leaving both halves untouched on disk so
+  the change is preserved. A neutral edit applied **identically** to both halves
+  alongside a reorder still merges cleanly (the halves agree, so nothing is lost).
+  Reconcile a genuine conflict by hand (apply the reorder and the edit on the same
+  half, or sync them in separate steps) and re-run.
 
 ### Changed
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1409,6 +1409,17 @@ written into the file, so a deck stays id-light yet syncs precisely:
   used to land the new group in the wrong inter-group slot on the other half and
   trip the parity fail-safe above; sync now reconciles slide-group **order**
   against the propagation source, so the insertion propagates cleanly.
+- **Reordering groups on one half while editing a neutral / id-less cell on the
+  other is surfaced, not silently dropped (since CLM {version}, Issue #282).** If
+  one half reorders slide groups (a *move*) while the other half independently
+  edits a language-neutral or id-less-localized cell, the two changes flow in
+  opposite directions and a single sync pass cannot apply both. (The reorder
+  shuffles the source half's cell order, which the drift detectors would otherwise
+  mistake for an edit — masking the real one on the other half, and for two or more
+  reordered cells even auto-healing over it on disk.) Sync now **errors** and holds
+  the watermark, leaving both halves untouched on disk, instead of overwriting the
+  edit. Reconcile by hand (apply the edit and the reorder on the same half, or sync
+  them in separate steps) and re-run.
 
 Use `--explain` to see the anchor-level view (per-cell anchor + drift, the
 propagation direction, drifted ids) for any pair.

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -755,6 +755,135 @@ def _keyed_direction(plan: SyncPlan) -> str | None:
     return next(iter(directions)) if len(directions) == 1 else None
 
 
+def _conflicts_with_keyed(plan: SyncPlan, direction: str | None) -> bool:
+    """Whether ``direction`` opposes the plan's single keyed propagation direction.
+
+    ``True`` only when both a keyed direction (a move/edit proposal) and
+    ``direction`` are present and they disagree — the Issue #282 conflict where a
+    structural change flows one way and a language-neutral edit the other. A
+    missing keyed direction (no keyed proposals, or keyed proposals both ways) or
+    a matching one is not a conflict.
+    """
+    if direction is None:
+        return False
+    keyed = _keyed_direction(plan)
+    return keyed is not None and keyed != direction
+
+
+def _grouped_neutral_map(cells: list[Cell]) -> dict[str | None, list[str]]:
+    """Map ``group_slide_id -> ordered list of neutral content hashes in that group``.
+
+    Associates each language-neutral (``shared``) cell with the ``slide_id`` of the
+    slide group it sits in (``None`` for the head, before the first slide). A GROUP
+    reorder moves whole groups as units — it never reorders cells *within* a group nor
+    changes which group a neutral cell belongs to — so comparing two halves' maps with
+    ``==`` is invariant to a one-sided group reorder (dict key order is irrelevant) yet
+    sensitive to (a) a cross-group reassignment (the cell appears under a different
+    key), (b) an intra-group neutral reorder (the per-group list is ordered), and (c)
+    an edit / add / remove (the list contents change). A flat multiset misses (a) and
+    (b); a flat ordered compare is fooled by the group reorder. The ``shared``
+    predicate (non-j2, language-neutral) matches :func:`watermark_rows`.
+    """
+    out: dict[str | None, list[str]] = {}
+    group_sid: str | None = None
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_slide_start:
+            group_sid = meta.slide_id
+        if meta.is_j2 or meta.lang in ("de", "en"):
+            continue
+        out.setdefault(group_sid, []).append(cell_content_hash(cell.content))
+    return out
+
+
+def _classify_move_target_edit_conflict(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    baseline_shared: list[str] | None,
+    de_idless_baseline: list[str] | None,
+    en_idless_baseline: list[str] | None,
+) -> None:
+    """Alert when a one-sided group reorder coincides with an opposite-half edit (Issue #282).
+
+    A single-direction ``move`` proposal means one half reordered its slide GROUPS.
+    A reorder makes positional pairing of language-neutral / id-less-localized cells
+    UNSOUND (the same reason the keyed walk refuses positional pairing under a move,
+    `_maybe_retag`): the structural pass (:func:`apply_code_structure`) rebuilds each
+    group's contents from the reordering (source) half and the per-cell detectors
+    (:func:`align_anchored`, :func:`_classify_idless_localized_drift`) compare the now
+    permuted sequences positionally. So ANY concurrent change the OTHER (target) half
+    made to its own neutral / id-less cells — a body edit, an add/remove, or a
+    cross-group reassignment — is mis-read or shadowed and silently overwritten with
+    the source's version. Observed failure modes (Issue #282 review):
+
+    - the target's edit is dropped and the watermark advances (no issue at all);
+    - the positional collision is mis-classified as a same-cell §7a divergence and
+      *auto-healed*, overwriting the target edit on disk with only a warning;
+    - a cross-group reassignment (content multiset unchanged) is rebuilt away.
+
+    All are #269 cardinal-invariant violations. Rather than chase each positional
+    artifact, detect the precondition directly: the target half (which did NOT
+    reorder — there is a single move direction) changed its neutral or id-less
+    content relative to its OWN baseline. Because the target's group order is
+    unchanged, that comparison is an ordinary positional compare and is itself sound
+    — and it is exhaustive (edit / add / remove / reassignment all perturb the
+    ordered sequence). Raise an error so the watermark holds and the buffered flush
+    writes nothing, leaving both halves intact on disk for manual reconciliation.
+
+    The legitimate same-direction merge — the author edits ONE half (reordering its
+    groups *and* editing its content) while the other half is untouched — never
+    fires: there the target half equals its baseline. A no-op when a per-cell
+    detector already alerted (``plan.has_errors``), for one clear error per scenario.
+    """
+    if plan.has_errors:
+        return
+    move_dirs = {p.direction for p in plan.proposals if p.kind == "move"}
+    if len(move_dirs) != 1:
+        return  # no move, or moves both ways (ambiguous — deferred elsewhere)
+    move_dir = next(iter(move_dirs))
+    # The move flows source->target; only the SOURCE half reordered, so the TARGET
+    # half's group order still matches baseline and an ordered compare is sound.
+    if move_dir == "de->en":
+        tgt_neutral = _shared_hashes(en_cells)
+        tgt_idless, tgt_idless_base = _idless_localized_hashes(en_cells, "en"), en_idless_baseline
+        target = "en"
+    else:
+        tgt_neutral = _shared_hashes(de_cells)
+        tgt_idless, tgt_idless_base = _idless_localized_hashes(de_cells, "de"), de_idless_baseline
+        target = "de"
+
+    # Neutral cells are shared across the halves, so the target's baseline IS
+    # ``baseline_shared``. A difference (ordered) means the target half edited,
+    # added, removed, or re-associated a neutral cell. But that is only a *conflict*
+    # if the two halves actually DISAGREE on per-group neutral content: a neutral
+    # edit applied identically to BOTH halves keeps the ``unify`` invariant (de == en),
+    # so a reorder cannot clobber it — there is nothing one-sided to lose. Gate on a
+    # reorder-invariant per-group comparison (a flat hash multiset is blind to a
+    # cross-group reassignment; a flat ORDERED compare is fooled by the reorder).
+    neutral_conflict = (
+        baseline_shared is not None
+        and tgt_neutral != baseline_shared
+        and _grouped_neutral_map(de_cells) != _grouped_neutral_map(en_cells)
+    )
+    # Id-less localized cells are per-language (translated), so the two halves cannot
+    # be compared directly; a target-side change from its own baseline is treated as a
+    # conflict (the structural pass would re-translate over it). Conservative by design.
+    idless_changed = tgt_idless_base is not None and tgt_idless != tgt_idless_base
+    if neutral_conflict or idless_changed:
+        plan.issues.append(
+            PlanIssue(
+                severity="error",
+                slide_id=None,
+                reason=f"slide groups were reordered {move_dir} but the {target} half also "
+                "changed a language-neutral or id-less-localized cell; a group reorder and a "
+                "concurrent edit on the other half cannot be reconciled in one pass (positional "
+                "pairing is unsound across a reorder) — apply both on the same half, or sync "
+                "them in separate steps, then re-run",
+            )
+        )
+
+
 def _resolve_divergence_winner(plan: SyncPlan, de_path: Path, en_path: Path) -> str | None:
     """Pick the winning direction for a diverged shared cell (§7a), or ``None``.
 
@@ -2067,7 +2196,16 @@ def build_sync_plan(
     # classifier cannot see, and hand its direction to the structural pass. Only
     # against a real (watermark) baseline; the keyed direction, when present,
     # already drives the structural pass, so the anchor direction is a *fallback*.
-    if baseline_shared is not None:
+    #
+    # Skipped when a single-direction group reorder (a ``move``) is present (Issue
+    # #282): a reorder permutes the neutral-cell *sequence*, so ``align_anchored``'s
+    # flat POSITIONAL compare is unsound — it mis-reads the permutation as a drift,
+    # or cross-pairs two independently edited cells into a phantom §7a divergence and
+    # auto-heals (overwriting one half's edit on disk). Under a reorder, neutral
+    # reconciliation is governed instead by the reorder-invariant per-group signature
+    # in :func:`_classify_move_target_edit_conflict` below.
+    single_move = len({p.direction for p in plan.proposals if p.kind == "move"}) == 1
+    if baseline_shared is not None and not single_move:
         alignment = align_anchored(de_cells, en_cells, baseline_shared)
         if alignment.irreconcilable:
             plan.issues.append(
@@ -2081,6 +2219,22 @@ def build_sync_plan(
             )
         elif alignment.diverged:
             _apply_divergence(plan, de_path, en_path, forced=alignment.direction)
+        elif _conflicts_with_keyed(plan, alignment.direction):
+            # Issue #282 (non-move case): the neutral-cell drift flows the OPPOSITE way
+            # to a keyed propagation direction (an add / edit / remove proposal — a
+            # reorder is handled above). The structural pass keys on the keyed direction
+            # (``_single_direction``) and would silently overwrite the neutral edit, so
+            # alert and hold the watermark — as :func:`_classify_idless_localized_drift`
+            # does for the id-less-localized analog.
+            plan.issues.append(
+                PlanIssue(
+                    severity="error",
+                    slide_id=None,
+                    reason=f"a language-neutral cell drifted {alignment.direction} but "
+                    f"other cells drifted {_keyed_direction(plan)}; sync cannot apply "
+                    "both directions at once — resolve manually",
+                )
+            )
         else:
             plan.anchor_direction = alignment.direction
 
@@ -2103,6 +2257,16 @@ def build_sync_plan(
     # no false one-sided alert, and the next clean sync records the headers).
     if de_header_baseline is not None and en_header_baseline is not None:
         _classify_header_drift(plan, de_cells, en_cells, de_header_baseline, en_header_baseline)
+
+    # Issue #282: a one-sided group reorder (a `move`) on one half collides with an
+    # opposite-side neutral / id-less content edit on the other. The positional drift
+    # detectors above mis-read the reorder as a drift (or a §7a divergence), masking
+    # the edit — a silent drop, or a destructive auto-heal for >=2 reordered neutral
+    # cells. Detect it order-blind via multisets and alert. Runs after the per-cell
+    # classifiers so it defers to (and dedups against) any error they already raised.
+    _classify_move_target_edit_conflict(
+        plan, de_cells, en_cells, baseline_shared, de_idless_baseline, en_idless_baseline
+    )
 
     # Tier C (Issue #198 / #190 item 3): mirror a tag-only edit on an id-less
     # localized cell — the per-cell engine cannot key it (no slide_id) and the

--- a/tests/slides/test_sync_issue_269.py
+++ b/tests/slides/test_sync_issue_269.py
@@ -81,6 +81,12 @@ def _sub_code(sid: str, body: str) -> str:
     return f'# %% tags=["subslide"] slide_id="{sid}"\n{body}\n'
 
 
+def _idd_code(lang: str, sid: str, body: str) -> str:
+    """A localized (id'd) code cell — keyed by ``(slide_id, role)`` so an edit to it
+    yields an ``edit``/keyed proposal in the run's direction."""
+    return f'# %% lang="{lang}" tags=["keep"] slide_id="{sid}"\n{body}\n'
+
+
 def _deck(*parts: str) -> str:
     return "\n".join(parts)
 
@@ -662,3 +668,651 @@ def test_new_neutral_code_group_start_alerts_not_silent(tmp_path: Path, baseline
     assert _alerted(plan, result)
     assert not result.watermark_recorded
     assert not _falsely_consistent(plan, result, False)
+
+
+# ---------------------------------------------------------------------------
+# Issue #282 — a one-sided neutral / id-less edit INSIDE a moved slide group.
+# One half reorders groups (a `move`) while the other independently edits a
+# language-neutral cell inside a moved group: the two changes flow OPPOSITE
+# directions. The structural pass keys on the move's direction and would copy
+# the move source's neutral cell over the target's edit — a silent #269 drop.
+# Sync must ALERT (watermark held, edit untouched on disk), never report
+# consistent. The id-less-localized analog already alerted via
+# _classify_idless_localized_drift; the neutral path was the remaining gap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_opposite_neutral_edit_alerts(tmp_path: Path, baseline: str):
+    # DE reorders groups (B before A → a move de->en); EN edits the neutral cell
+    # inside the moved group A (x = 1 → x = 2 → an en->de drift). Opposite
+    # directions: alert, hold the watermark, leave the EN edit on disk.
+    de = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("de", "B", "Beta"),
+    )
+    en = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("en", "B", "Beta"),
+    )
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "B", "Beta"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 1"),
+    )
+    en1 = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("x = 2"),
+        _sub_md("en", "B", "Beta"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert any(p.kind == "move" for p in plan.proposals)  # the reorder WAS detected
+    assert _alerted(plan, result)  # opposite-direction conflict surfaced
+    assert not result.watermark_recorded  # watermark held over the conflict
+    assert not _falsely_consistent(plan, result, False)
+    # The EN edit is NOT silently dropped: nothing was written, so it stays on disk.
+    assert "x = 2" in en_after
+    assert "x = 2" not in de_after  # and was not (wrongly) reverted/auto-applied either
+    # The error explains the reorder-vs-edit conflict so the author can act on it.
+    msg = "\n".join(i.reason for i in plan.issues if i.severity == "error")
+    assert "reorder" in msg
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_opposite_neutral_edit_mirror_direction_alerts(tmp_path: Path, baseline: str):
+    # The mirror of the above: EN reorders (a move en->de); DE edits the neutral cell
+    # (a de->en drift). Same conflict, opposite roles — must alert symmetrically.
+    de = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("de", "B", "Beta"),
+    )
+    en = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("en", "B", "Beta"),
+    )
+    en1 = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "B", "Beta"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("x = 1"),
+    )
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 2"),
+        _sub_md("de", "B", "Beta"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert not _falsely_consistent(plan, result, False)
+    assert "x = 2" in de_after  # the DE edit stays on disk, not dropped
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_opposite_idless_localized_edit_alerts(tmp_path: Path, baseline: str):
+    # The id-less-LOCALIZED sibling of #282 (already covered by
+    # _classify_idless_localized_drift): DE reorders (move de->en) while EN edits an
+    # id-less localized cell inside the moved group (en->de). The family must alert.
+    de = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "A", "Alpha"),
+        _idless_code("de", 'print("Hallo")'),
+        _sub_md("de", "B", "Beta"),
+    )
+    en = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _idless_code("en", 'print("Hello")'),
+        _sub_md("en", "B", "Beta"),
+    )
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "B", "Beta"),
+        _sub_md("de", "A", "Alpha"),
+        _idless_code("de", 'print("Hallo")'),
+    )
+    en1 = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _idless_code("en", 'print("HELLO")'),
+        _sub_md("en", "B", "Beta"),
+    )
+    plan, result, _de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert not _falsely_consistent(plan, result, False)
+    assert "HELLO" in en_after  # the EN edit not silently overwritten
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_same_direction_neutral_edit_merges(tmp_path: Path, baseline: str):
+    # Non-regression: DE both reorders groups AND edits the neutral cell (both de->en).
+    # No conflict — the move applies and the neutral edit propagates to EN. Must NOT
+    # alert (the #282 fix only fires on OPPOSITE directions).
+    de = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("de", "B", "Beta"),
+    )
+    en = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("en", "B", "Beta"),
+    )
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "B", "Beta"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 99"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en)
+    assert not _alerted(plan, result)
+    assert result.watermark_recorded
+    assert _group_ids(en_after) == ["intro", "B", "A"]  # the reorder reached EN
+    assert "x = 99" in en_after  # the neutral edit reached EN too
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_only_no_neutral_edit_applies_cleanly(tmp_path: Path, baseline: str):
+    # Non-regression: a pure one-sided group reorder (no concurrent neutral edit)
+    # still applies cleanly and advances — the #282 guard must not false-alert when
+    # the neutral cells are byte-identical across the halves.
+    de = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("de", "B", "Beta"),
+    )
+    en = _deck(
+        _title("en", "intro"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("x = 1"),
+        _sub_md("en", "B", "Beta"),
+    )
+    de1 = _deck(
+        _title("de", "intro"),
+        _sub_md("de", "B", "Beta"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("x = 1"),
+    )
+    plan, result, _de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en)
+    assert not _alerted(plan, result)
+    assert result.watermark_recorded
+    assert _group_ids(en_after) == ["intro", "B", "A"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #282 (deeper variants found by adversarial review). The single
+# `_conflicts_with_keyed` guard above only catches the move + ONE neutral cell
+# shape, where align_anchored still yields a clean opposing direction. When the
+# move reorders >=2 neutral / id-less cells, the positional drift detectors
+# mis-read the reorder itself as a "drift" — silently dropping the opposite-side
+# edit (id-less / >=2 neutral) or, worse, mis-classifying it as a §7a same-cell
+# divergence and AUTO-HEALING it (overwriting the edit on disk). The order-blind
+# move-target-edit detector must alert in every case and leave the edit on disk.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_reordering_idless_with_opposite_idless_edit_alerts(tmp_path: Path, baseline: str):
+    # DE reorders two groups, each holding an id-less localized cell (so DE's id-less
+    # SEQUENCE permutes with no content change); EN edits one id-less cell. The
+    # both-sides-"drift" branch of _classify_idless_localized_drift used to trust the
+    # move direction and return silently, stranding EN's edit. Must alert; edit kept.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Alpha"),
+        _idless_code("de", "l1_de"),
+        _sub_md("de", "B", "Beta"),
+        _idless_code("de", "l2_de"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Alpha"),
+        _idless_code("en", "l1_en"),
+        _sub_md("en", "B", "Beta"),
+        _idless_code("en", "l2_en"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Beta"),
+        _idless_code("de", "l2_de"),
+        _sub_md("de", "A", "Alpha"),
+        _idless_code("de", "l1_de"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Alpha"),
+        _idless_code("en", "l1X_en"),
+        _sub_md("en", "B", "Beta"),
+        _idless_code("en", "l2_en"),
+    )
+    plan, result, _de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert any(p.kind == "move" for p in plan.proposals)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert not _falsely_consistent(plan, result, False)
+    assert "l1X_en" in en_after  # EN's id-less edit not silently dropped
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_reordering_neutrals_with_opposite_neutral_edit_alerts(tmp_path: Path, baseline: str):
+    # DE reorders two groups each holding a NEUTRAL code cell (DE's neutral SEQUENCE
+    # permutes, content unchanged); EN edits one neutral cell. align_anchored's
+    # positional zip used to mis-read this as a same-cell §7a divergence and
+    # AUTO-HEAL it — overwriting EN's edit on disk (destructive). Must alert AND the
+    # EN edit must remain on disk (nothing written).
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("p = 1"),
+        _sub_md("de", "B", "Beta"),
+        _ncode("q = 2"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("p = 1"),
+        _sub_md("en", "B", "Beta"),
+        _ncode("q = 2"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Beta"),
+        _ncode("q = 2"),
+        _sub_md("de", "A", "Alpha"),
+        _ncode("p = 1"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Alpha"),
+        _ncode("p = 99"),
+        _sub_md("en", "B", "Beta"),
+        _ncode("q = 2"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert "p = 99" in en_after  # the edit survives on disk — NOT auto-healed away
+    assert "p = 99" not in de_after  # and was not (wrongly) written into DE either
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_two_keyed_dirs_and_opposite_idless_edit_alerts(tmp_path: Path, baseline: str):
+    # The two-opposite-keyed-directions variant. DE reorders groups (move de->en)
+    # AND edits a neutral cell (de->en, setting anchor_direction); EN edits an id'd
+    # cell (en->de, making _keyed_direction ambiguous → None) AND an id-less cell
+    # (en->de). With two keyed directions, _conflicts_with_keyed cannot fire and the
+    # id-less both-drifted branch falls back to the (non-None) anchor_direction and
+    # returns silently — stranding EN's id-less edit. The move-target detector keys
+    # on the MOVE direction (not _keyed_direction / established), so it still alerts.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Alpha"),
+        _idless_code("de", "l1_de"),
+        _ncode("n = 1"),
+        _idd_code("de", "C", "c = 1"),
+        _sub_md("de", "B", "Beta"),
+        _idless_code("de", "l2_de"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Alpha"),
+        _idless_code("en", "l1_en"),
+        _ncode("n = 1"),
+        _idd_code("en", "C", "c = 1"),
+        _sub_md("en", "B", "Beta"),
+        _idless_code("en", "l2_en"),
+    )
+    # DE reorders B before A and edits the neutral cell (n=1 -> n=2, de->en).
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Beta"),
+        _idless_code("de", "l2_de"),
+        _sub_md("de", "A", "Alpha"),
+        _idless_code("de", "l1_de"),
+        _ncode("n = 2"),
+        _idd_code("de", "C", "c = 1"),
+    )
+    # EN edits the id'd cell C (c=1 -> c=2, en->de) and its id-less l1 (en->de).
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Alpha"),
+        _idless_code("en", "l1X_en"),
+        _ncode("n = 1"),
+        _idd_code("en", "C", "c = 2"),
+        _sub_md("en", "B", "Beta"),
+        _idless_code("en", "l2_en"),
+    )
+    plan, result, _de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en1, mapping={"c = 2": "c = 2", "n = 2": "n = 2"}
+    )
+    assert any(p.kind == "move" for p in plan.proposals)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert "l1X_en" in en_after  # EN's id-less edit survives, not silently dropped
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_add_keyed_with_opposite_neutral_edit_alerts(tmp_path: Path, baseline: str):
+    # The conflict guard must cover an ADD-keyed direction, not just move — a future
+    # narrowing to move-only would silently reintroduce the drop. DE adds a new slide
+    # (de->en) while EN edits a neutral cell (en->de): opposite directions → alert.
+    de = _deck(_title("de"), _ncode("x = 1"))
+    en = _deck(_title("en"), _ncode("x = 1"))
+    de1 = _deck(_title("de"), _ncode("x = 1"), _sub_md("de", "NEW", "Neu"))
+    en1 = _deck(_title("en"), _ncode("x = 2"))
+    plan, result, _de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en1, mapping={"# ## Neu": "# ## New"}
+    )
+    assert any(p.kind in ("add", "rename") for p in plan.proposals)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert "x = 2" in en_after  # the neutral edit survives
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_edit_keyed_with_opposite_neutral_edit_alerts(tmp_path: Path, baseline: str):
+    # Same, with an EDIT-keyed direction: DE edits an id'd slide body (de->en) while
+    # EN edits a neutral cell (en->de). Opposite directions → alert, edit kept.
+    de = _deck(_title("de", "s1", "T1"), _ncode("x = 1"))
+    en = _deck(_title("en", "s1", "T1"), _ncode("x = 1"))
+    de1 = _deck(_title("de", "s1", "T1 EDIT"), _ncode("x = 1"))
+    en1 = _deck(_title("en", "s1", "T1"), _ncode("x = 2"))
+    plan, result, _de_after, en_after = _sync(
+        tmp_path, baseline, de, en, de1, en1, mapping={"# # T1 EDIT": "# # T1 EDIT EN"}
+    )
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert "x = 2" in en_after
+
+
+# ---------------------------------------------------------------------------
+# Issue #282 — the reordering half may ALSO edit its own content. A group
+# reorder makes positional pairing of neutral / id-less cells unsound, so ANY
+# concurrent change on the OTHER (target) half — a body edit to a DIFFERENT
+# cell, or a cross-group reassignment that leaves the content multiset
+# unchanged — is mis-paired and silently overwritten (a §7a destructive
+# auto-heal, or a watermark-advancing drop). Sync must alert on any target-half
+# neutral/id-less change while one half reorders, and the merge where only the
+# reordering half changed content (target untouched) must still succeed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_source_and_target_neutral_edits_alerts(tmp_path: Path, baseline: str):
+    # DE reorders groups AND edits its own neutral cell p; EN independently edits a
+    # DIFFERENT neutral cell q. The reorder cross-pairs p and q in the positional
+    # §7a check, which used to auto-heal toward DE and DESTROY EN's q edit on disk.
+    # Must alert and leave BOTH edits on disk (nothing written).
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Al"),
+        _ncode("p = 1"),
+        _sub_md("de", "B", "Be"),
+        _ncode("q = 2"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("p = 1"),
+        _sub_md("en", "B", "Be"),
+        _ncode("q = 2"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Be"),
+        _ncode("q = 2"),
+        _sub_md("de", "A", "Al"),
+        _ncode("p = 11"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("p = 1"),
+        _sub_md("en", "B", "Be"),
+        _ncode("q = 22"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert "p = 11" in de_after  # DE's edit untouched
+    assert "q = 22" in en_after  # EN's edit NOT destructively auto-healed away
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_source_and_target_idless_edits_alerts(tmp_path: Path, baseline: str):
+    # DE reorders groups AND edits its own id-less cell l1; EN edits a DIFFERENT
+    # id-less cell l2. The both-drifted id-less branch used to trust the move
+    # direction and return silently, advancing the watermark and stranding EN's
+    # l2 edit. Must alert; EN's edit kept.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Al"),
+        _idless_code("de", "l1_de"),
+        _sub_md("de", "B", "Be"),
+        _idless_code("de", "l2_de"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _idless_code("en", "l1_en"),
+        _sub_md("en", "B", "Be"),
+        _idless_code("en", "l2_en"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Be"),
+        _idless_code("de", "l2_de"),
+        _sub_md("de", "A", "Al"),
+        _idless_code("de", "l1X_de"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _idless_code("en", "l1_en"),
+        _sub_md("en", "B", "Be"),
+        _idless_code("en", "l2X_en"),
+    )
+    plan, result, _de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    assert "l2X_en" in en_after  # EN's id-less edit not silently dropped
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_target_neutral_cross_group_reassign_alerts(tmp_path: Path, baseline: str):
+    # DE reorders groups; EN re-associates its neutral cells across groups (codeA
+    # under B, codeB under A) — a change that leaves the content MULTISET unchanged,
+    # so a Counter-based check is blind to it. The ordered (positional) compare on
+    # the non-reordering target half still detects it. Must alert.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Al"),
+        _ncode("codeA = 1"),
+        _sub_md("de", "B", "Be"),
+        _ncode("codeB = 2"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("codeA = 1"),
+        _sub_md("en", "B", "Be"),
+        _ncode("codeB = 2"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Be"),
+        _ncode("codeB = 2"),
+        _sub_md("de", "A", "Al"),
+        _ncode("codeA = 1"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("codeB = 2"),
+        _sub_md("en", "B", "Be"),
+        _ncode("codeA = 1"),
+    )
+    plan, result, _de_after, _en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_source_edit_only_merges(tmp_path: Path, baseline: str):
+    # The legitimate merge that must NOT alert: the author edits ONE half (DE) —
+    # reordering its groups AND editing its own neutral cell — while the OTHER half
+    # (EN) is untouched. The reorder + edit both flow de->en, so EN receives both.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Al"),
+        _ncode("p = 1"),
+        _sub_md("de", "B", "Be"),
+        _ncode("q = 2"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("p = 1"),
+        _sub_md("en", "B", "Be"),
+        _ncode("q = 2"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Be"),
+        _ncode("q = 2"),
+        _sub_md("de", "A", "Al"),
+        _ncode("p = 11"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en)
+    assert not _alerted(plan, result)
+    assert result.watermark_recorded
+    assert _group_ids(en_after) == ["title", "B", "A"]  # the reorder reached EN
+    assert "p = 11" in en_after  # DE's neutral edit propagated to EN
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_identical_neutral_edit_on_both_halves_merges(tmp_path: Path, baseline: str):
+    # The conflict guard must NOT fire when a neutral edit was applied IDENTICALLY to
+    # both halves (the unify invariant still holds: de == en) while one half reorders.
+    # The halves agree on the cell, so a reorder cannot clobber it — sync must apply
+    # the reorder cleanly. (The guard gates on a reorder-invariant per-group compare of
+    # the two halves, not just target-vs-baseline, precisely to allow this.)
+    de = _deck(_title("de"), _sub_md("de", "A", "Al"), _ncode("x = 1"), _sub_md("de", "B", "Be"))
+    en = _deck(_title("en"), _sub_md("en", "A", "Al"), _ncode("x = 1"), _sub_md("en", "B", "Be"))
+    # DE reorders B before A AND edits x; EN edits x to the SAME value (no reorder).
+    de1 = _deck(_title("de"), _sub_md("de", "B", "Be"), _sub_md("de", "A", "Al"), _ncode("x = 2"))
+    en1 = _deck(_title("en"), _sub_md("en", "A", "Al"), _ncode("x = 2"), _sub_md("en", "B", "Be"))
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert not _alerted(plan, result)
+    assert result.watermark_recorded
+    assert _group_ids(en_after) == ["title", "B", "A"]  # the reorder reached EN
+    assert "x = 2" in en_after and "x = 1" not in en_after  # the shared edit is kept, once
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_target_intra_group_neutral_reorder_alerts(tmp_path: Path, baseline: str):
+    # DE reorders slide GROUPS; EN reorders two neutral cells WITHIN one group. The two
+    # halves' per-group neutral *multisets* are equal, so a Counter-based gate would
+    # miss it and align_anchored's positional §7a check would destructively auto-heal
+    # EN's reorder away. The per-group ORDERED compare (and bypassing align_anchored
+    # under a move) catches it: must alert and keep EN's order on disk.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Al"),
+        _ncode("a1 = 1"),
+        _ncode("a2 = 2"),
+        _sub_md("de", "B", "Be"),
+        _ncode("b1 = 3"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("a1 = 1"),
+        _ncode("a2 = 2"),
+        _sub_md("en", "B", "Be"),
+        _ncode("b1 = 3"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Be"),
+        _ncode("b1 = 3"),
+        _sub_md("de", "A", "Al"),
+        _ncode("a1 = 1"),
+        _ncode("a2 = 2"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("a2 = 2"),
+        _ncode("a1 = 1"),
+        _sub_md("en", "B", "Be"),
+        _ncode("b1 = 3"),
+    )
+    plan, result, _de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert _alerted(plan, result)
+    assert not result.watermark_recorded
+    # EN's one-sided intra-group reorder is preserved on disk (not auto-healed away).
+    assert _neutral_bodies(en_after) == ["a2 = 2", "a1 = 1", "b1 = 3"]
+
+
+@pytest.mark.parametrize("baseline", BASELINES)
+def test_move_with_multiple_identical_neutral_edits_on_both_halves_merges(
+    tmp_path: Path, baseline: str
+):
+    # The >=2-cell analog of the identical-both-halves merge: two neutral cells edited
+    # to the SAME new values on both halves while DE reorders groups. Here de_shared !=
+    # en_shared (the reorder permutes DE's flat sequence), which used to make
+    # align_anchored false-diverge; bypassing it under a move and gating on the
+    # per-group signature lets this merge cleanly with no alert.
+    de = _deck(
+        _title("de"),
+        _sub_md("de", "A", "Al"),
+        _ncode("a = 1"),
+        _sub_md("de", "B", "Be"),
+        _ncode("b = 2"),
+    )
+    en = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("a = 1"),
+        _sub_md("en", "B", "Be"),
+        _ncode("b = 2"),
+    )
+    de1 = _deck(
+        _title("de"),
+        _sub_md("de", "B", "Be"),
+        _ncode("b = 22"),
+        _sub_md("de", "A", "Al"),
+        _ncode("a = 11"),
+    )
+    en1 = _deck(
+        _title("en"),
+        _sub_md("en", "A", "Al"),
+        _ncode("a = 11"),
+        _sub_md("en", "B", "Be"),
+        _ncode("b = 22"),
+    )
+    plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de1, en1)
+    assert not _alerted(plan, result)
+    assert result.watermark_recorded
+    assert _group_ids(en_after) == ["title", "B", "A"]  # the reorder reached EN
+    assert "a = 11" in en_after and "b = 22" in en_after
+    assert _neutral_bodies(en_after) == _neutral_bodies(de_after)


### PR DESCRIPTION
## Summary

Fixes #282. `clm slides sync` **silently dropped** — or, for two or more reordered
neutral cells, **destructively auto-healed over** — a one-sided edit when one half
reordered slide groups (a `move`) while the other half independently changed a
language-neutral or id-less-localized cell. The run reported the decks consistent
and advanced the watermark while the change was lost from **both** halves (a #269
cardinal-invariant violation).

## Root cause

A group reorder **permutes the source half's neutral/id-less cell sequence**, so
every *positional* detector (`align_anchored`, `_classify_idless_localized_drift`,
`apply_code_structure`) misreads it — masking the target half's change, or
cross-pairing two independent edits into a phantom §7a divergence that auto-heals
onto disk with only a warning.

## Fix

Because a group reorder makes positional pairing unsound, sync now treats **any
unreconciled neutral/id-less change on the non-reordering half** as a conflict and
**errors** — holding the watermark and leaving both halves untouched on disk for
manual reconciliation.

- New `_classify_move_target_edit_conflict` (in `sync_plan.py`, wired after
  `_classify_header_drift`): fires only when a single `move` direction exists and the
  *target* (non-reordering) half changed its neutral/id-less content.
- Detection is **reorder-invariant**, not positional: a per-group, order-sensitive
  signature `_grouped_neutral_map` = `{group_slide_id: [ordered content hashes]}`
  (dict-equality ignores group order → reorder-invariant; the per-group list is
  order-sensitive → catches an intra-group reorder; a cell's key changes → catches a
  cross-group reassignment). Id-less cells compare against the half's own baseline.
- Under a single `move`, `align_anchored`'s flat positional neutral analysis is
  **bypassed** — it is the unsound thing; the per-group signature is the sole arbiter.

Legitimate workflows still merge cleanly: editing **one** half while the other is
untouched, and an **identical** neutral edit applied to both halves (the `unify`
invariant holds, so a reorder cannot clobber it).

## Scope

Beyond the originally-reported single-cell case, this covers the id-less, ≥2-cell
(destructive auto-heal), two-opposite-keyed-direction, cross-group-reassignment, and
intra-group-reorder variants — all surfaced and verified by four rounds of adversarial
multi-agent review.

## Testing

- New regression tests in `tests/slides/test_sync_issue_269.py` across **both**
  `git-head` and `watermark` baselines, each asserting the edit survives on disk; the
  silent-drop/destructive cases were confirmed **load-bearing** (they fail when the
  detector is disabled).
- Full slides suite (1486) and fast suite (7290) green; ruff + mypy clean.
- CHANGELOG + `clm info commands` updated.

## Known residual (low, pre-existing — follow-up filed)

A one-sided **tag-only** retag of an id-less cell is dropped under a move
(`_classify_localized_idless_retags` bails on any move; watermark baseline only —
git-HEAD records no id-less tags). Body content is fully covered. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
