### PR TITLE
Cohort viewing calendar: project schedule onto per-cohort real dates (#283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Cohort viewing calendars (`clm export calendar`, `clm calendar check` /
+  `status`)** project a course's schedule onto one cohort's real calendar dates
+  (issue #283). Where `clm export schedule` is course-relative ("Week 3,
+  Tuesday"), a *calendar* maps the same ordered day-buckets onto actual dates
+  for a cohort, absorbing that cohort's holidays, delayed start, multi-week
+  breaks, and catch-up days. The trainer maintains only the deltas in a small
+  hand-edited `release/<channel>.calendar.toml` (start/end, weekly teaching
+  pattern, single-or-interval holidays, and ordered `merge`/`split`/`insert`/
+  `pin` adjustments) beside the channel's release ledger; the per-video dates
+  are computed. A holiday removes a teaching date so later content slides
+  automatically; `pin`s anchor a day to a date and segment the timeline, and an
+  over-full segment is reported with the exact "merge ≥ N buckets" deficit
+  rather than silently redistributed. `clm export calendar` renders Markdown,
+  CSV, or a subscribable `.ics` feed (stable event UIDs, so a re-export updates
+  events in place); `clm calendar check` validates a calendar (date-free,
+  non-zero exit on errors); `clm calendar status [--as-of DATE]` shows where a
+  cohort is today, its plan coordinate, and the drift in days versus the ideal
+  plan. See `clm info commands`.
 - **`clm export outline --weekdays [never|always]`** controls whether a
   section's `<subsection>` weekday/name groupings are rendered as bold labels
   in the Markdown outline. The default is `never`: every section's decks are

--- a/docs/claude/design/cohort-viewing-calendar.md
+++ b/docs/claude/design/cohort-viewing-calendar.md
@@ -150,35 +150,56 @@ can be overridden per cohort.
 ## 6. The cohort calendar file
 
 One small, hand-editable file per channel, living beside the channel's ledger
-(`release/jan.txt` → `release/jan.calendar.yaml`). It is **not** part of the
+(`release/jan.txt` → `release/jan.calendar.toml`). It is **not** part of the
 spec XML — the spec stays diff-clean while this file absorbs the per-cohort
-churn, exactly mirroring the ledger philosophy. YAML, because the content is a
-few scalars plus two lists and it produces clean per-deviation diffs.
+churn, exactly mirroring the ledger philosophy. **TOML**, because it is the
+project's existing config idiom (`[tool.clm]`), parses with the stdlib
+`tomllib` (no new dependency — a value the ledger module shares), has **native
+date literals** (so `start`/`holidays`/`pin` dates become `datetime.date`
+directly), and produces clean per-deviation diffs. The file is only ever *read*
+programmatically (it is hand-edited; there is no `calendar add` writer), so
+`tomllib`'s read-only nature is no limitation.
 
-```yaml
+```toml
 # Cohort "jan" of ml-course — viewing calendar
-start: 2026-03-02              # first teaching date (a Monday)
-end:   2026-06-30              # last allowable teaching date; enforced by `check`
-pattern: [mon, tue, wed]       # optional; defaults to weekdays used in the spec
+start = 2026-03-02              # first teaching date (a Monday)
+end   = 2026-06-30              # last allowable teaching date; enforced by `check`
+pattern = ["mon", "tue", "wed"] # optional; defaults to weekdays used in the spec
 
-holidays:
-  - 2026-04-06                                   # single day (Easter Monday)
-  - 2026-05-01                                   # single day (Labour Day)
-  - {from: 2026-07-20, to: 2026-08-02, label: "Summer break"}   # inclusive interval
+holidays = [
+  2026-04-06,                                            # single day (Easter Monday)
+  2026-05-01,                                            # single day (Labour Day)
+  {from = 2026-07-20, to = 2026-08-02, label = "Summer break"},  # inclusive interval
+]
 
-adjustments:                   # ordered; the only thing the trainer routinely touches
-  - {merge: 2026-03-18, count: 2}                       # catch-up: 2 buckets on one date
-  - {split: variables_intro, dates: [2026-03-25, 2026-03-26]}   # slow down one bucket
-  - {insert: 2026-03-30, label: "Review & Q&A"}         # teaching date, no new video
-  - {pin: control_flow, date: 2026-04-09}               # anchor a bucket to a date
+# adjustments are an ordered array-of-tables — the only thing the trainer
+# routinely touches. Order is the file order of the [[adjustments]] blocks.
+[[adjustments]]
+merge = 2026-03-18              # catch-up: collapse `count` buckets onto one date
+count = 2
+
+[[adjustments]]
+split = "variables_intro"       # slow down one bucket across several dates
+dates = [2026-03-25, 2026-03-26]
+
+[[adjustments]]
+insert = 2026-03-30             # a teaching date carrying no new video
+label = "Review & Q&A"
+
+[[adjustments]]
+pin  = "control_flow"           # anchor a bucket to an exact date
+date = 2026-04-09
 ```
+
+Each `[[adjustments]]` table is identified by which of `merge` / `split` /
+`insert` / `pin` key it carries (exactly one is required per table).
 
 ### 6.1 Holidays
 
 Each entry is either:
 
 - a **single date**: `2026-04-06`, or
-- an **interval**: `{from: <date>, to: <date>, label?: <text>}`, **inclusive**
+- an **interval**: `{from = <date>, to = <date>, label = <text>?}`, **inclusive**
   on both ends. Intervals exist specifically for multi-day closures such as a
   two-week break — far less cumbersome than listing fourteen dates.
 
@@ -189,16 +210,18 @@ falling on a non-teaching weekday is a harmless no-op, and `check` notes it).
 
 An ordered list of perturbations applied to the default 1:1 zip, in sequence.
 
-| Form | Meaning |
+Each is a `[[adjustments]]` table carrying exactly one of these keys:
+
+| Keys | Meaning |
 |---|---|
-| `{merge: <date>, count: N}` | The next `N` buckets all land on `<date>` (collapse to one date). Catch-up. Pulls all subsequent buckets earlier. |
-| `{split: <bucket-ref>, dates: [<date>, ...]}` | The referenced bucket is spread across the listed dates. Decks may be distributed across the dates (optional per-date deck lists in a later iteration); by default the bucket's decks are shown on the first date and the rest are "continue". Pushes subsequent buckets later. |
-| `{insert: <date>, label: <text>}` | A teaching date carrying no new video (review, exam, guest session). Consumes a date; pushes subsequent buckets later. |
-| `{pin: <bucket-ref>, date: <date>}` | Anchor: the referenced bucket lands on exactly `<date>`. See §6.3. |
+| `merge = <date>`, `count = N` | The next `N` buckets all land on `<date>` (collapse to one date). Catch-up. Pulls all subsequent buckets earlier. |
+| `split = <bucket-ref>`, `dates = [<date>, ...]` | The referenced bucket is spread across the listed dates. Decks may be distributed across the dates (optional per-date deck lists in a later iteration); by default the bucket's decks are shown on the first date and the rest are "continue". Pushes subsequent buckets later. |
+| `insert = <date>`, `label = <text>` | A teaching date carrying no new video (review, exam, guest session). Consumes a date; pushes subsequent buckets later. |
+| `pin = <bucket-ref>`, `date = <date>` | Anchor: the referenced bucket lands on exactly `<date>`. See §6.3. |
 
 **Bucket references** (`<bucket-ref>`) are **topic or deck ids**, not week/weekday
 coordinates. Topic ids are the stable identifiers already used by the ledger;
-week/weekday coordinates shift whenever the spec is edited. `pin: control_flow`
+week/weekday coordinates shift whenever the spec is edited. `pin = "control_flow"`
 means "the bucket containing the deck/topic `control_flow`". If a ref is
 ambiguous or missing, `check` errors (§8).
 
@@ -268,21 +291,32 @@ The cohort started a day late, so the real teaching dates are **Tue, Wed, Thu,
 Fri** (4 dates). The trainer wants Monday's content to begin Tuesday but still
 finish the week on Friday:
 
-```yaml
-adjustments:
-  - {pin: M1, date: 2026-03-03}   # B_Mon starts Tue
-  - {pin: F2, date: 2026-03-06}   # B_Fri lands Fri
+```toml
+[[adjustments]]
+pin  = "M1"        # B_Mon starts Tue
+date = 2026-03-03
+
+[[adjustments]]
+pin  = "F2"        # B_Fri lands Fri
+date = 2026-03-06
 ```
 
 Segment Tue–Fri now holds 5 buckets in 4 dates → `calendar check` errors:
 `merge ≥ 1 bucket`. The trainer picks where to double up (say, the two lightest
 adjacent days, Tue + Wed):
 
-```yaml
-adjustments:
-  - {pin: M1, date: 2026-03-03}
-  - {pin: F2, date: 2026-03-06}
-  - {merge: 2026-03-04, count: 2}   # B_Tue + B_Wed share Wednesday
+```toml
+[[adjustments]]
+pin  = "M1"
+date = 2026-03-03
+
+[[adjustments]]
+pin  = "F2"
+date = 2026-03-06
+
+[[adjustments]]
+merge = 2026-03-04   # B_Tue + B_Wed share Wednesday
+count = 2
 ```
 
 Result — predictable, and only the day the trainer chose is doubled:
@@ -389,12 +423,12 @@ class Bucket:
     weekday_label: str          # plan-relative label
 
 @define
-class CohortCalendarConfig:     # parsed from release/<channel>.calendar.yaml
+class CohortCalendarConfig:     # parsed from release/<channel>.calendar.toml
     start: date
     end: date | None
     pattern: tuple[str, ...]    # weekday tokens; empty → derive from spec
-    holidays: list[Holiday]     # Holiday = single date | inclusive interval
-    adjustments: list[Adjustment]
+    holidays: tuple[Holiday, ...]   # Holiday = single date | inclusive interval
+    adjustments: tuple[Adjustment, ...]   # Merge | Split | Insert | Pin, in file order
 
 @define
 class Assignment:               # one calendar row
@@ -418,17 +452,20 @@ Course planned as 12 weeks × Mon/Tue/Wed. This cohort started a few days late a
 hit two single-day public holidays plus a two-week break, and is now ~1 week
 behind. The trainer wants to recover one day.
 
-```yaml
-# release/spring.calendar.yaml
-start: 2026-03-04        # started Wed, not Mon — two slots simply don't exist
-end:   2026-06-17
-pattern: [mon, tue, wed]
-holidays:
-  - 2026-04-06                                   # Easter Monday
-  - 2026-05-01                                   # Labour Day
-  - {from: 2026-05-18, to: 2026-05-29, label: "Two-week break"}
-adjustments:
-  - {merge: 2026-06-09, count: 2}                # double up one day to recover
+```toml
+# release/spring.calendar.toml
+start = 2026-03-04        # started Wed, not Mon — two slots simply don't exist
+end   = 2026-06-17
+pattern = ["mon", "tue", "wed"]
+holidays = [
+  2026-04-06,                                    # Easter Monday
+  2026-05-01,                                    # Labour Day
+  {from = 2026-05-18, to = 2026-05-29, label = "Two-week break"},
+]
+
+[[adjustments]]
+merge = 2026-06-09        # double up one day to recover
+count = 2
 ```
 
 - The late start, two holidays, and the break all drop teaching dates; content
@@ -436,7 +473,7 @@ adjustments:
 - `calendar check` confirms the 12 weeks of buckets still fit before
   `2026-06-17` *given* the one `merge`; without it, `check` would report the
   deficit ("merge ≥ 1 bucket to finish by Jun 17").
-- `export calendar spring.calendar.yaml -f ics` gives students a feed that, after
+- `export calendar spring.calendar.toml -f ics` gives students a feed that, after
   the next push, shows the recovered day and the shifted dates with no duplicate
   events.
 
@@ -456,7 +493,7 @@ and what-if previews).
 
 1. **Content sequence** — refactor `export schedule` to expose ordered `Bucket`s
    (incl. `span`); no behavior change to `schedule`.
-2. **Config + parse** — `release/<channel>.calendar.yaml` schema, loader,
+2. **Config + parse** — `release/<channel>.calendar.toml` schema, loader,
    `Holiday` interval support, defaulted `pattern`.
 3. **Projection engine** — date generation, pin segmentation, adjustments; pure
    and unit-tested.

--- a/docs/claude/design/cohort-viewing-calendar.md
+++ b/docs/claude/design/cohort-viewing-calendar.md
@@ -1,0 +1,467 @@
+# Cohort Viewing Calendar
+
+**Status**: Design proposal
+**Date**: 2026-06-09
+**Author**: design session (trainer + AI)
+**Tracking issue**: TBD
+
+## 1. Problem
+
+`clm export schedule` produces the *ideal* plan of a course in **course-relative
+time** — "Week 3, Tuesday: watch these decks". That format is right for planning
+the course but wrong for two things students actually need:
+
+1. **Real calendar dates.** Students want "Tuesday, 17 March: watch these two
+   videos", not "Tuesday of Week 3".
+2. **Reality, not the plan.** Real cohorts deviate from the ideal: public
+   holidays, a delayed start, a two-week break, days where many questions ate
+   the time, days where we deliberately double up to catch back up. After a
+   couple of holidays the plan's "Week N" no longer lines up with the real
+   calendar week, and that drift compounds.
+
+We need a per-cohort, student-facing artifact that maps the course's ordered
+content onto **real dates**, and a mechanism for the trainer to keep it
+matching reality **without re-dating the whole course by hand every time
+something slips**.
+
+There can be multiple cohorts of one course, and cohorts of different courses,
+running simultaneously — each with its own dates. The mechanism must support
+that with no shared mutable state between cohorts.
+
+### Non-goals
+
+- **Not** solution-release timing. This artifact answers *"watch what, by
+  when"* only. When students receive solutions stays the separate, manual
+  `clm release week` / `clm release sync` decision (see §9). The two layers may
+  share date math in a future iteration, but this design keeps them
+  independent.
+- **Not** a re-authoring of the course plan. The course-relative `schedule`
+  (weeks, weekday subsections) remains the single source of *content order*,
+  shared by every cohort.
+
+## 2. Terminology
+
+| Term | Meaning | Time model | Scope |
+|---|---|---|---|
+| **schedule** | The course's ordered plan (existing `clm export schedule`): weeks → weekday subsections → decks. | Course-relative (Week N, Montag) | Per course (shared by all cohorts) |
+| **calendar** | The per-cohort projection of that plan onto real dates. *The new artifact.* | Real dates | Per cohort |
+| **assignment** | One row of a calendar: a date (or date span) and the decks/videos due by it. | Real date | — |
+| **bucket** | One unit of the content sequence: the decks of one teaching day, derived from the schedule. | — | — |
+| **channel** | An existing cohort definition (`<release-channels>` / `<channel>`). The calendar attaches to a channel. | — | Per cohort |
+
+We keep `schedule` for the plan and introduce **calendar** for the dated,
+student-facing artifact. Each line of a calendar is an **assignment**.
+
+## 3. Core idea: project, then patch
+
+The naïve implementation — a hand-maintained table of `date → videos` — is
+unmaintainable: one inserted holiday forces re-dating every row below it, so the
+trainer stops updating it. Instead we model the calendar as a **zip of two
+independent sequences**, and the trainer only ever edits the small deltas from
+the ideal:
+
+1. **Content sequence** — the ordered list of *buckets*, derived from
+   `export schedule`. Shared by all cohorts of the course. Deck-granular.
+2. **Date sequence** — the real teaching dates, *generated* per cohort from four
+   small inputs: a start date, a weekly teaching pattern, a holidays list, and
+   an ordered list of adjustments.
+
+```
+calendar = zip(content_sequence, date_sequence)     # default 1 bucket : 1 date
+           then apply adjustments in order
+```
+
+The trainer never writes down the date of a video. Dates are computed. The
+trainer maintains only `holidays` and `adjustments` — typically a handful of
+lines for an entire course.
+
+### Why this absorbs deviation cheaply
+
+- **Holiday / break** → a date (or interval) is removed from the date sequence,
+  so every bucket after it slides one teaching-date later, **automatically, with
+  zero downstream edits**. "Two holidays → two three-day weeks" is two
+  `holidays` entries. A two-week break is one interval entry. The plan's "Week 4"
+  simply lands in real-calendar week 5 or 6 — fine, because week numbers are
+  plan labels, never dates.
+- **Catch-up** → one `merge` adjustment puts two buckets on one date; everything
+  after pulls one teaching-date earlier. One line.
+- **Slow down** → one `split` adjustment spreads one bucket across two dates.
+- **Anchor** → a `pin` nails a specific bucket to a specific date regardless of
+  drift, and *segments* the timeline so an early miscount can't cascade past it
+  (see §6.3).
+
+## 4. The content sequence (from `schedule`)
+
+The content sequence is the existing schedule's day-buckets, in order:
+
+- Walk weeks (sections) in declared order.
+- Within a week, walk subsections in document order.
+- Each subsection yields **one bucket**, carrying that subsection's decks
+  (deck-granular: title + topic id + deck file, exactly what `export schedule`
+  already computes).
+
+### 4.1 Multi-weekday subsections occupy multiple teaching dates
+
+A `<subsection weekday="mon,tue">` **represents two teaching days** and therefore
+**consumes two teaching dates**. We model this with a `span`:
+
+```
+bucket.span = max(1, number of weekday tokens on the subsection)
+```
+
+- `weekday="mon"` → span 1
+- `weekday="mon,tue"` → span 2
+- subsection with no `weekday` (thematic group) → span 1
+
+A bucket with span *N* occupies *N* consecutive teaching dates. The spec does
+**not** record which deck is taught on which of those days, so by default the
+whole bucket's decks form one assignment over the **date span** (e.g.
+"Mon 2 – Tue 3 Mar: watch [decks]"). A trainer who wants to split the decks
+across the individual dates uses an explicit `split` adjustment (§6.2).
+
+Bare topics (a `<topic>` not inside any subsection) are build-only and never
+appear in the schedule, so they never appear in the calendar either —
+consistent with `export schedule`.
+
+## 5. The date sequence (per cohort)
+
+Generated lazily from the cohort calendar file:
+
+```
+start    : first teaching date
+pattern  : which weekdays are teaching days
+holidays : dates / intervals with no teaching
+```
+
+Algorithm:
+
+```
+cursor = start
+repeat:
+    if weekday(cursor) in pattern and cursor not covered by any holiday:
+        yield cursor                      # a teaching date
+    cursor += 1 day
+```
+
+`pattern` defaults to the set of weekdays actually used by the spec's
+subsections (so a Mon/Tue/Wed part-time course needs no explicit pattern). It
+can be overridden per cohort.
+
+## 6. The cohort calendar file
+
+One small, hand-editable file per channel, living beside the channel's ledger
+(`release/jan.txt` → `release/jan.calendar.yaml`). It is **not** part of the
+spec XML — the spec stays diff-clean while this file absorbs the per-cohort
+churn, exactly mirroring the ledger philosophy. YAML, because the content is a
+few scalars plus two lists and it produces clean per-deviation diffs.
+
+```yaml
+# Cohort "jan" of ml-course — viewing calendar
+start: 2026-03-02              # first teaching date (a Monday)
+end:   2026-06-30              # last allowable teaching date; enforced by `check`
+pattern: [mon, tue, wed]       # optional; defaults to weekdays used in the spec
+
+holidays:
+  - 2026-04-06                                   # single day (Easter Monday)
+  - 2026-05-01                                   # single day (Labour Day)
+  - {from: 2026-07-20, to: 2026-08-02, label: "Summer break"}   # inclusive interval
+
+adjustments:                   # ordered; the only thing the trainer routinely touches
+  - {merge: 2026-03-18, count: 2}                       # catch-up: 2 buckets on one date
+  - {split: variables_intro, dates: [2026-03-25, 2026-03-26]}   # slow down one bucket
+  - {insert: 2026-03-30, label: "Review & Q&A"}         # teaching date, no new video
+  - {pin: control_flow, date: 2026-04-09}               # anchor a bucket to a date
+```
+
+### 6.1 Holidays
+
+Each entry is either:
+
+- a **single date**: `2026-04-06`, or
+- an **interval**: `{from: <date>, to: <date>, label?: <text>}`, **inclusive**
+  on both ends. Intervals exist specifically for multi-day closures such as a
+  two-week break — far less cumbersome than listing fourteen dates.
+
+A holiday only removes dates that would otherwise be teaching dates (a holiday
+falling on a non-teaching weekday is a harmless no-op, and `check` notes it).
+
+### 6.2 Adjustments
+
+An ordered list of perturbations applied to the default 1:1 zip, in sequence.
+
+| Form | Meaning |
+|---|---|
+| `{merge: <date>, count: N}` | The next `N` buckets all land on `<date>` (collapse to one date). Catch-up. Pulls all subsequent buckets earlier. |
+| `{split: <bucket-ref>, dates: [<date>, ...]}` | The referenced bucket is spread across the listed dates. Decks may be distributed across the dates (optional per-date deck lists in a later iteration); by default the bucket's decks are shown on the first date and the rest are "continue". Pushes subsequent buckets later. |
+| `{insert: <date>, label: <text>}` | A teaching date carrying no new video (review, exam, guest session). Consumes a date; pushes subsequent buckets later. |
+| `{pin: <bucket-ref>, date: <date>}` | Anchor: the referenced bucket lands on exactly `<date>`. See §6.3. |
+
+**Bucket references** (`<bucket-ref>`) are **topic or deck ids**, not week/weekday
+coordinates. Topic ids are the stable identifiers already used by the ledger;
+week/weekday coordinates shift whenever the spec is edited. `pin: control_flow`
+means "the bucket containing the deck/topic `control_flow`". If a ref is
+ambiguous or missing, `check` errors (§8).
+
+A pin (or `split`) anchors the **whole bucket** that contains the referenced
+deck, not the individual deck. Pinning a bucket's *first* deck and pinning its
+*last* deck are identical operations — both say "this day's content lands on
+this date". Within-day deck position is irrelevant to a pin; the deck id is just
+the stable handle for naming the bucket. To move a single deck off its day and
+leave the rest behind is a different, deliberate operation — a topic-level
+`split` — never an emergent side effect.
+
+### 6.3 Pins segment the timeline
+
+A `pin` is both an **anchor** and a **firewall**. The timeline is divided into
+segments at each pin (and at `start` / `end`). Each segment is projected
+**independently**: the buckets within a segment are zipped, in order, onto the
+segment's teaching dates, applying any `merge`/`split`/`insert` adjustments that
+fall in that segment.
+
+Consequences:
+
+- An early miscount or a forgotten holiday cannot cascade past a pin — only its
+  own segment is affected.
+- The trainer self-corrects mid-course by pinning *the next bucket* to *today*:
+  everything before is history, everything after re-projects from the anchor.
+- A pin is the natural place to record a known fixed event: "after the two-week
+  break we resume with `control_flow` on 2026-08-03".
+
+### 6.3.1 The engine never guesses — fit is the trainer's call
+
+Within a segment, buckets are placed **eagerly from the start anchor**, each
+consuming `span` consecutive teaching dates, in plan order. The bucket carrying
+the *end* pin must land exactly on the end pin's date. Three cases:
+
+- **Exact fit** — buckets consume precisely the segment's teaching dates. Done.
+- **Over-full** — more buckets (×span) than teaching dates between the anchors.
+  The engine does **not** auto-distribute, auto-merge, or reflow at deck
+  granularity (which would silently dissolve a day's editorial grouping).
+  Instead `check` **errors** with the exact deficit (§8) — e.g. *"segment
+  Tue Mar 3 – Fri Mar 6: 5 buckets, 4 teaching dates — merge ≥ 1 bucket"*. The
+  trainer resolves it with an explicit `merge` (or `split` to push past the end
+  pin), **choosing which days combine**. Result: one day's content combines
+  where the trainer decided; every other day stays fixed.
+- **Under-full** — fewer buckets than teaching dates. Buckets pack eagerly from
+  the start anchor, leaving free teaching dates immediately before the end pin.
+  `check` **warns** ("3 free teaching dates in segment …"); the trainer may
+  `insert` a review/Q&A day, `split` a heavy bucket to fill, or leave the slack.
+
+This is a deliberate **no-magic** rule: the bucket (a plan-day's decks) is the
+atomic unit and its internal grouping is the trainer's editorial intent, never
+silently regrouped. Catch-up always reads as an explicit, diff-visible `merge`;
+the calendar stays predictable and reviewable.
+
+### 6.4 Worked pin example (late start, hold the week's end)
+
+Course intends a Mon–Fri week, `Mar 2–6`; five plan-day buckets:
+
+| Bucket | Plan day | Decks |
+|---|---|---|
+| B_Mon | Mon Mar 2 | M1, M2 |
+| B_Tue | Tue Mar 3 | T1 |
+| B_Wed | Wed Mar 4 | W1, W2, W3 |
+| B_Thu | Thu Mar 5 | H1 |
+| B_Fri | Fri Mar 6 | F1, F2 |
+
+The cohort started a day late, so the real teaching dates are **Tue, Wed, Thu,
+Fri** (4 dates). The trainer wants Monday's content to begin Tuesday but still
+finish the week on Friday:
+
+```yaml
+adjustments:
+  - {pin: M1, date: 2026-03-03}   # B_Mon starts Tue
+  - {pin: F2, date: 2026-03-06}   # B_Fri lands Fri
+```
+
+Segment Tue–Fri now holds 5 buckets in 4 dates → `calendar check` errors:
+`merge ≥ 1 bucket`. The trainer picks where to double up (say, the two lightest
+adjacent days, Tue + Wed):
+
+```yaml
+adjustments:
+  - {pin: M1, date: 2026-03-03}
+  - {pin: F2, date: 2026-03-06}
+  - {merge: 2026-03-04, count: 2}   # B_Tue + B_Wed share Wednesday
+```
+
+Result — predictable, and only the day the trainer chose is doubled:
+
+| Date | Bucket(s) | Decks |
+|---|---|---|
+| Tue Mar 3 | B_Mon | M1, M2 |
+| Wed Mar 4 | B_Tue + B_Wed | T1, W1, W2, W3 |
+| Thu Mar 5 | B_Thu | H1 |
+| Fri Mar 6 | B_Fri | F1, F2 |
+
+## 7. CLI surface
+
+```
+clm export calendar <spec> --channel <name> [-f md|csv|ics] [-L de|en] [-o FILE | -d DIR]
+clm calendar status  <spec> --channel <name>
+clm calendar check   <spec> --channel <name>
+```
+
+- **`export calendar`** — render the projected calendar. Mirrors
+  `export schedule` flags (`-L/--lang`, `-f/--format`, `-o/--output`,
+  `-d/--output-dir`). Formats:
+  - `md` / `csv` — trainer-facing views, same column conventions as
+    `export schedule` plus a real-`date` column.
+  - `ics` — the **student-facing payload** (see §8.1).
+- **`calendar status`** — human summary: today's assignment, the next few days,
+  and the **drift** vs the ideal plan ("plan Week 4 Tue → real Wed 6 May; +6
+  teaching dates behind ideal"). The only "now"-relative command: it defaults to
+  the **system date** and accepts **`--as-of DATE`** to override (for tests,
+  dated handouts, and what-if previews). Its main operational value is catching
+  slip: when the calendar's "today" bucket no longer matches where you actually
+  are, that mismatch is the cue to add an adjustment.
+- **`calendar check`** — validation only, non-zero exit on error (§8). Takes
+  **no date**: whether the buckets fit between the anchors and before `end` is a
+  pure function of the config, independent of when it runs. Suitable for a
+  pre-push hook in the course repo.
+
+The calendar attaches to an existing `<channel>`, so multiple cohorts/courses
+are just independent `(spec, channel)` pairs — no shared state.
+
+## 8. Validation (`calendar check`)
+
+Errors (non-zero exit):
+
+- `pin`/`split` bucket-ref is unknown or ambiguous against the spec.
+- A segment is **over-full**: more buckets than available teaching dates between
+  its bounding pins (or before `end`). Reported with the **deficit** —
+  "segment Apr 9 – Jun 30: 22 buckets, 19 teaching dates; merge ≥ 3 buckets".
+  This makes catch-up *quantified*, not eyeballed.
+- The full content sequence does not fit before `end` — reports how many buckets
+  must be merged to finish in time.
+- A `pin` date is not a teaching date (wrong weekday or falls in a holiday).
+- A `pin` date precedes its segment's start, or pins are out of order.
+
+Warnings (exit 0):
+
+- A holiday that falls on a non-teaching weekday (no-op).
+- A pin-bounded segment is **under-full** (fewer buckets than teaching dates):
+  buckets pack from the start anchor, leaving free dates before the end pin —
+  "3 free teaching dates in segment Tue Mar 3 – Fri Mar 6".
+- Calendar runs out of content before `end` (more dates than buckets — usually
+  fine, the course just finishes early).
+
+`check` itself is date-free. A separate, informational "this anchor date is in
+the past" note belongs to `status` (which knows "today"), not to `check`.
+
+### 8.1 `.ics` output
+
+The `.ics` feed is what students subscribe to, so a pushed adjustment re-syncs
+into their own calendar app automatically.
+
+- One **VEVENT per assignment**, as an **all-day event** (`VALUE=DATE`).
+- A span bucket (multi-weekday, §4.1) becomes a single multi-day all-day event
+  (`DTSTART` = first date, `DTEND` = day after last date, per RFC 5545
+  exclusive-end semantics).
+- `SUMMARY` = localized video/deck titles for that assignment (`-L` controls
+  language); `DESCRIPTION` lists deck files / topic ids for traceability.
+- `UID` is stable across re-exports — derived from `(channel, bucket-ref)` —
+  so re-issuing the feed *updates* events in place instead of duplicating them.
+  This is what lets holidays/catch-up edits propagate cleanly to a subscribed
+  student.
+- `insert` entries (review/exam days) become events with no deck list.
+
+## 9. Relationship to release (kept independent)
+
+This design deliberately does **not** drive solution release. Release stays the
+separate, manual ledger-based flow. The two layers share a conceptual spine —
+both are per-channel, both live as small hand-editable files beside each other
+in the course repo — and a future iteration *could* let a dated-release policy
+read the same projection (e.g. "release a topic's solutions *D* teaching-days
+after its viewing date"). The ledger format already anticipates this with its
+`topic_id @ YYYY-MM-DD` comment. For now they are decoupled: the calendar tells
+students what to watch by when; the trainer still decides explicitly when to
+unlock solutions.
+
+## 10. Data model (sketch)
+
+```python
+@define
+class Bucket:
+    decks: list[ScheduleDeck]   # reuse export-schedule's ScheduleDeck
+    span: int                   # consecutive teaching dates this bucket occupies
+    week: int                   # plan-relative, for drift reporting / labels
+    weekday_label: str          # plan-relative label
+
+@define
+class CohortCalendarConfig:     # parsed from release/<channel>.calendar.yaml
+    start: date
+    end: date | None
+    pattern: tuple[str, ...]    # weekday tokens; empty → derive from spec
+    holidays: list[Holiday]     # Holiday = single date | inclusive interval
+    adjustments: list[Adjustment]
+
+@define
+class Assignment:               # one calendar row
+    start_date: date
+    end_date: date              # == start_date unless a span / split
+    decks: list[ScheduleDeck]   # empty for an `insert`
+    label: str | None           # for inserts; else None
+    bucket_ref: str | None      # stable UID seed for .ics
+
+def project(buckets, config) -> list[Assignment]: ...
+```
+
+- The content sequence (`buckets`) comes from refactoring `export schedule`'s
+  builder to expose buckets, so the two commands cannot drift apart.
+- `project` generates teaching dates, segments at pins, zips per segment, and
+  applies in-segment adjustments — pure and unit-testable with no I/O.
+
+## 11. Worked example (the current real cohort)
+
+Course planned as 12 weeks × Mon/Tue/Wed. This cohort started a few days late and
+hit two single-day public holidays plus a two-week break, and is now ~1 week
+behind. The trainer wants to recover one day.
+
+```yaml
+# release/spring.calendar.yaml
+start: 2026-03-04        # started Wed, not Mon — two slots simply don't exist
+end:   2026-06-17
+pattern: [mon, tue, wed]
+holidays:
+  - 2026-04-06                                   # Easter Monday
+  - 2026-05-01                                   # Labour Day
+  - {from: 2026-05-18, to: 2026-05-29, label: "Two-week break"}
+adjustments:
+  - {merge: 2026-06-09, count: 2}                # double up one day to recover
+```
+
+- The late start, two holidays, and the break all drop teaching dates; content
+  slides later automatically.
+- `calendar check` confirms the 12 weeks of buckets still fit before
+  `2026-06-17` *given* the one `merge`; without it, `check` would report the
+  deficit ("merge ≥ 1 bucket to finish by Jun 17").
+- `export calendar spring.calendar.yaml -f ics` gives students a feed that, after
+  the next push, shows the recovered day and the shifted dates with no duplicate
+  events.
+
+## 12. Open questions / future work
+
+- **Per-date deck distribution in `split`** — *deferred.* First iteration shows
+  the bucket's decks on the first date; richer per-date deck lists can come later.
+- **Dated release policy** — the §9 coupling, if pilots want it.
+- **Validation in CI** — wiring `calendar check` into the course repo's hooks.
+
+**Decided:** `check` and `export calendar` are pure functions of the config and
+take no date. `status` is the only "now"-relative command — it defaults to the
+system date and accepts `--as-of DATE` (for deterministic tests, dated handouts,
+and what-if previews).
+
+## 13. Implementation phases (proposed)
+
+1. **Content sequence** — refactor `export schedule` to expose ordered `Bucket`s
+   (incl. `span`); no behavior change to `schedule`.
+2. **Config + parse** — `release/<channel>.calendar.yaml` schema, loader,
+   `Holiday` interval support, defaulted `pattern`.
+3. **Projection engine** — date generation, pin segmentation, adjustments; pure
+   and unit-tested.
+4. **`export calendar`** — `md`/`csv`/`ics` renderers (reuse schedule columns;
+   stable `.ics` UIDs).
+5. **`calendar check` + `calendar status`** — validation and drift reporting.
+6. **Docs** — `clm info` topics (`commands.md`; a calendar section in
+   `spec-files.md` / a new file-format note), user-guide page, CHANGELOG.

--- a/src/clm/cli/commands/calendar.py
+++ b/src/clm/cli/commands/calendar.py
@@ -1,0 +1,181 @@
+"""``clm export calendar`` — a per-cohort viewing calendar on real dates (#283).
+
+Projects the course schedule (the same ordered day-buckets ``export schedule``
+produces) onto one cohort's real calendar dates, using the cohort's hand-edited
+``release/<channel>.calendar.toml``. Emits a trainer-facing Markdown/CSV view or
+the student-facing ``.ics`` feed.
+
+The calendar file is addressed either by ``--channel NAME`` (resolved beside the
+channel's ledger in the spec's ``<release-channels>``) or by an explicit
+``--calendar PATH``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+from clm.cli.commands._export_shared import (
+    check_exclusive_output,
+    language_option,
+    output_options,
+    spec_argument,
+)
+from clm.cli.commands.schedule import build_buckets, build_schedule
+from clm.cohort_calendar.config import CohortCalendarError, load_calendar_config
+from clm.cohort_calendar.projection import project
+from clm.cohort_calendar.render import render_csv, render_ics, render_markdown
+from clm.core.course import Course
+from clm.core.course_paths import resolve_course_paths
+from clm.core.course_spec import CourseSpec, CourseSpecError
+
+logger = logging.getLogger(__name__)
+
+
+def _abs_under(course_root: Path, value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else course_root / path
+
+
+def resolve_calendar_path(spec_file: Path, channel_name: str, explicit: Path | None) -> Path:
+    """Locate a cohort's calendar file: ``--calendar`` wins, else from the channel.
+
+    The conventional path lives beside the channel's ledger, named
+    ``<channel>.calendar.toml`` (e.g. ledger ``release/jan.txt`` →
+    ``release/jan.calendar.toml``).
+    """
+    if explicit is not None:
+        return explicit
+    if not channel_name:
+        raise click.UsageError("Pass --channel NAME or --calendar PATH.")
+    spec = CourseSpec.from_file(spec_file)
+    channels = spec.release_channels
+    if channels is None:
+        raise click.ClickException(
+            f"{spec_file} has no <release-channels> block; pass --calendar PATH "
+            "instead of --channel."
+        )
+    channel = channels.channel(channel_name)
+    if channel is None:
+        available = ", ".join(c.name for c in channels.channels) or "(none defined)"
+        raise click.ClickException(
+            f"Unknown channel {channel_name!r}. Defined channels: {available}."
+        )
+    course_root, _ = resolve_course_paths(spec_file)
+    ledger = _abs_under(course_root, channel.ledger)
+    return ledger.parent / f"{channel_name}.calendar.toml"
+
+
+@click.command("calendar")
+@spec_argument
+@language_option(
+    default="de",
+    aliases=("--lang",),
+    help="Language for deck titles and weekday labels.",
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["md", "csv", "ics"], case_sensitive=False),
+    default="md",
+    show_default=True,
+    help="Output format (ics = subscribable student feed).",
+)
+@click.option(
+    "--channel",
+    default="",
+    help="Cohort channel name; resolves the calendar file beside its ledger.",
+)
+@click.option(
+    "--calendar",
+    "calendar_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Explicit path to the cohort calendar TOML (overrides --channel).",
+)
+@output_options
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Course data directory (contains slides/). Default: inferred from spec.",
+)
+def calendar(
+    spec_file: Path,
+    language: str,
+    output_format: str,
+    channel: str,
+    calendar_path: Path | None,
+    output_file: Path | None,
+    output_dir: Path | None,
+    data_dir: Path | None,
+) -> None:
+    """Project the course schedule onto a cohort's real calendar dates.
+
+    \b
+    Examples:
+        clm export calendar course.xml --channel jan          # German Markdown
+        clm export calendar course.xml --channel jan -f ics   # student .ics feed
+        clm export calendar course.xml --calendar c.toml -L en -f csv
+        clm export calendar course.xml --channel jan -o jan.ics -f ics
+    """
+    language = language.lower()
+    output_format = output_format.lower()
+    check_exclusive_output(output_file, output_dir)
+
+    cal_path = resolve_calendar_path(spec_file, channel, calendar_path)
+    try:
+        config = load_calendar_config(cal_path)
+    except CohortCalendarError as e:
+        raise click.ClickException(f"Failed to load calendar {cal_path}: {e}") from None
+
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as e:
+        raise click.ClickException(f"Failed to parse spec file: {e}") from None
+    validation_errors = spec.validate()
+    if validation_errors:
+        error_msg = "\n".join(f"  - {e}" for e in validation_errors)
+        raise click.ClickException(f"Spec validation failed:\n{error_msg}")
+
+    course_root, _ = resolve_course_paths(spec_file, data_dir=data_dir)
+    course = Course.from_spec(spec, course_root, output_root=None)
+    buckets = build_buckets(build_schedule(course, language))
+
+    proj = project(buckets, config)
+    for diag in proj.diagnostics:
+        click.echo(f"{diag.level}: {diag.message}", err=True)
+    if not proj.ok:
+        raise click.ClickException(
+            "Calendar has errors (see above); fix the calendar file "
+            "(or run `clm calendar check`) before exporting."
+        )
+
+    namespace = channel or cal_path.stem.replace(".calendar", "")
+    if output_format == "csv":
+        content = render_csv(proj, language)
+        ext = "csv"
+    elif output_format == "ics":
+        content = render_ics(course.name[language], proj, namespace=namespace)
+        ext = "ics"
+    else:
+        content = render_markdown(course.name[language], proj, language)
+        ext = "md"
+
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        from clm.core.utils.text_utils import sanitize_file_name
+
+        title = sanitize_file_name(course.name[language])
+        tag = channel or language
+        file_path = output_dir / f"{title}-calendar-{tag}.{ext}"
+        file_path.write_text(content, encoding="utf-8")
+        click.echo(f"Written: {file_path}")
+    elif output_file is not None:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(content, encoding="utf-8")
+        click.echo(f"Written: {output_file}")
+    else:
+        click.echo(content, nl=False)

--- a/src/clm/cli/commands/calendar.py
+++ b/src/clm/cli/commands/calendar.py
@@ -12,6 +12,7 @@ channel's ledger in the spec's ``<release-channels>``) or by an explicit
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from pathlib import Path
 
@@ -23,10 +24,21 @@ from clm.cli.commands._export_shared import (
     output_options,
     spec_argument,
 )
-from clm.cli.commands.schedule import build_buckets, build_schedule
-from clm.cohort_calendar.config import CohortCalendarError, load_calendar_config
+from clm.cli.commands.schedule import Bucket, build_buckets, build_schedule
+from clm.cohort_calendar.config import (
+    CohortCalendarConfig,
+    CohortCalendarError,
+    load_calendar_config,
+)
 from clm.cohort_calendar.projection import project
-from clm.cohort_calendar.render import render_csv, render_ics, render_markdown
+from clm.cohort_calendar.render import (
+    assignment_content,
+    assignment_date_label,
+    render_csv,
+    render_ics,
+    render_markdown,
+)
+from clm.cohort_calendar.status import compute_status
 from clm.core.course import Course
 from clm.core.course_paths import resolve_course_paths
 from clm.core.course_spec import CourseSpec, CourseSpecError
@@ -37,6 +49,53 @@ logger = logging.getLogger(__name__)
 def _abs_under(course_root: Path, value: str) -> Path:
     path = Path(value)
     return path if path.is_absolute() else course_root / path
+
+
+def _channel_options(func):
+    """Shared ``--channel`` / ``--calendar`` / ``--data-dir`` for calendar commands."""
+    func = click.option(
+        "--data-dir",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        help="Course data directory (contains slides/). Default: inferred from spec.",
+    )(func)
+    func = click.option(
+        "--calendar",
+        "calendar_path",
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+        default=None,
+        help="Explicit path to the cohort calendar TOML (overrides --channel).",
+    )(func)
+    func = click.option(
+        "--channel",
+        default="",
+        help="Cohort channel name; resolves the calendar file beside its ledger.",
+    )(func)
+    return func
+
+
+def _load_config(spec_file: Path, channel: str, calendar_path: Path | None) -> CohortCalendarConfig:
+    cal_path = resolve_calendar_path(spec_file, channel, calendar_path)
+    try:
+        return load_calendar_config(cal_path)
+    except CohortCalendarError as e:
+        raise click.ClickException(f"Failed to load calendar {cal_path}: {e}") from None
+
+
+def _resolve_buckets(
+    spec_file: Path, language: str, data_dir: Path | None
+) -> tuple[Course, list[Bucket]]:
+    """Parse + validate the spec, build the course, and flatten the schedule to buckets."""
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as e:
+        raise click.ClickException(f"Failed to parse spec file: {e}") from None
+    validation_errors = spec.validate()
+    if validation_errors:
+        error_msg = "\n".join(f"  - {e}" for e in validation_errors)
+        raise click.ClickException(f"Spec validation failed:\n{error_msg}")
+    course_root, _ = resolve_course_paths(spec_file, data_dir=data_dir)
+    course = Course.from_spec(spec, course_root, output_root=None)
+    return course, build_buckets(build_schedule(course, language))
 
 
 def resolve_calendar_path(spec_file: Path, channel_name: str, explicit: Path | None) -> Path:
@@ -125,24 +184,8 @@ def calendar(
     output_format = output_format.lower()
     check_exclusive_output(output_file, output_dir)
 
-    cal_path = resolve_calendar_path(spec_file, channel, calendar_path)
-    try:
-        config = load_calendar_config(cal_path)
-    except CohortCalendarError as e:
-        raise click.ClickException(f"Failed to load calendar {cal_path}: {e}") from None
-
-    try:
-        spec = CourseSpec.from_file(spec_file)
-    except CourseSpecError as e:
-        raise click.ClickException(f"Failed to parse spec file: {e}") from None
-    validation_errors = spec.validate()
-    if validation_errors:
-        error_msg = "\n".join(f"  - {e}" for e in validation_errors)
-        raise click.ClickException(f"Spec validation failed:\n{error_msg}")
-
-    course_root, _ = resolve_course_paths(spec_file, data_dir=data_dir)
-    course = Course.from_spec(spec, course_root, output_root=None)
-    buckets = build_buckets(build_schedule(course, language))
+    config = _load_config(spec_file, channel, calendar_path)
+    course, buckets = _resolve_buckets(spec_file, language, data_dir)
 
     proj = project(buckets, config)
     for diag in proj.diagnostics:
@@ -153,7 +196,9 @@ def calendar(
             "(or run `clm calendar check`) before exporting."
         )
 
-    namespace = channel or cal_path.stem.replace(".calendar", "")
+    namespace = channel or resolve_calendar_path(spec_file, channel, calendar_path).stem.replace(
+        ".calendar", ""
+    )
     if output_format == "csv":
         content = render_csv(proj, language)
         ext = "csv"
@@ -179,3 +224,118 @@ def calendar(
         click.echo(f"Written: {output_file}")
     else:
         click.echo(content, nl=False)
+
+
+@click.group("calendar")
+def calendar_group() -> None:
+    """Inspect a cohort's viewing calendar: validate it or show today's status (#283)."""
+
+
+@calendar_group.command("check")
+@spec_argument
+@_channel_options
+def check_cmd(
+    spec_file: Path, channel: str, calendar_path: Path | None, data_dir: Path | None
+) -> None:
+    """Validate a cohort calendar against the course schedule.
+
+    Date-free: reports unknown/ambiguous refs, over-full segments (with the
+    exact deficit), end overflow, and warnings (free dates, stray inserts).
+    Exits non-zero if there are errors — suitable for a pre-push hook.
+    """
+    config = _load_config(spec_file, channel, calendar_path)
+    _, buckets = _resolve_buckets(spec_file, "en", data_dir)
+    proj = project(buckets, config)
+
+    for diag in proj.errors:
+        click.echo(f"error: {diag.message}", err=True)
+    for diag in proj.warnings:
+        click.echo(f"warning: {diag.message}", err=True)
+    n_err, n_warn = len(proj.errors), len(proj.warnings)
+    if n_err:
+        click.echo(f"✗ {n_err} error(s), {n_warn} warning(s).", err=True)
+        raise SystemExit(1)
+    click.echo(f"✓ Calendar OK ({n_warn} warning(s)).")
+
+
+def _format_status(report, language: str) -> list[str]:
+    """Human-readable status lines (pure, for testability)."""
+    lines = [f"As of {report.as_of.isoformat()}:", ""]
+    if report.reference is None and not report.finished:
+        lines.append("No assignments in this calendar.")
+        return lines
+
+    if report.finished:
+        lines.append("Course finished — all assignments are in the past.")
+    elif report.not_started:
+        first = report.reference
+        lines.append(
+            f"Course not started. First class "
+            f"{assignment_date_label(first, language)} — {assignment_content(first)}"
+        )
+    elif report.current is not None:
+        a = report.current
+        lines.append(
+            f"Today: {assignment_date_label(a, language)} — "
+            f"{assignment_content(a) or '(no new video)'}"
+        )
+        if a.plan_label:
+            lines.append(f"   plan: {a.plan_label}")
+    else:
+        lines.append("No class today.")
+        if report.reference is not None:
+            n = report.reference
+            lines.append(f"   next: {assignment_date_label(n, language)} — {assignment_content(n)}")
+
+    if report.drift_days is not None:
+        if report.drift_days == 0:
+            lines.append("Drift: on schedule.")
+        elif report.drift_days > 0:
+            lines.append(f"Drift: {report.drift_days} day(s) behind the ideal plan.")
+        else:
+            lines.append(f"Drift: {abs(report.drift_days)} day(s) ahead of the ideal plan.")
+
+    if report.upcoming:
+        lines.append("")
+        lines.append("Upcoming:")
+        for a in report.upcoming:
+            lines.append(
+                f"  {assignment_date_label(a, language)} — "
+                f"{assignment_content(a) or '(no new video)'}"
+            )
+    return lines
+
+
+@calendar_group.command("status")
+@spec_argument
+@language_option(default="de", aliases=("--lang",), help="Language for titles and labels.")
+@_channel_options
+@click.option(
+    "--as-of",
+    "as_of",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    default=None,
+    help="Reference date (default: today). For tests, dated handouts, what-if previews.",
+)
+def status_cmd(
+    spec_file: Path,
+    language: str,
+    channel: str,
+    calendar_path: Path | None,
+    data_dir: Path | None,
+    as_of: dt.datetime | None,
+) -> None:
+    """Show where a cohort is today vs the plan (the only now-relative command)."""
+    language = language.lower()
+    config = _load_config(spec_file, channel, calendar_path)
+    _, buckets = _resolve_buckets(spec_file, language, data_dir)
+    as_of_date = as_of.date() if as_of is not None else dt.date.today()
+
+    report = compute_status(buckets, config, as_of_date)
+    for line in _format_status(report, language):
+        click.echo(line)
+    if report.has_errors:
+        click.echo(
+            "warning: this calendar has projection errors; run `clm calendar check`.",
+            err=True,
+        )

--- a/src/clm/cli/commands/schedule.py
+++ b/src/clm/cli/commands/schedule.py
@@ -124,6 +124,7 @@ class Bucket:
     span: int
     week: int  # plan-relative week number (from the originating ScheduleWeek)
     weekday_label: str  # localized plan-relative label (e.g. "Montag")
+    weekdays: tuple[str, ...] = ()  # language-neutral tokens, e.g. ("mon", "tue")
 
     @property
     def ref_ids(self) -> set[str]:
@@ -368,6 +369,7 @@ def build_buckets(weeks: list[ScheduleWeek]) -> list[Bucket]:
             span=max(1, len(day.weekdays)),
             week=week.number,
             weekday_label=day.label,
+            weekdays=tuple(day.weekdays),
         )
         for week in weeks
         for day in week.days

--- a/src/clm/cli/commands/schedule.py
+++ b/src/clm/cli/commands/schedule.py
@@ -103,6 +103,44 @@ class ScheduleWeek:
     disabled: bool = False
 
 
+@dataclass
+class Bucket:
+    """One teaching unit of the content sequence — a plan-day's decks.
+
+    A :class:`Bucket` is the atomic unit the cohort *calendar* (issue #283)
+    projects onto real dates: each :class:`ScheduleDay` (one ``<subsection>``)
+    becomes one bucket. It is deliberately the same data the certification
+    schedule renders, so the calendar and ``export schedule`` cannot drift apart.
+
+    ``span`` is the number of teaching dates the bucket occupies: the count of
+    weekday tokens on the originating subsection (a ``weekday="mon,tue"``
+    subsection represents — and so consumes — two teaching days), or 1 for a
+    thematic group with no weekday. ``week`` and ``weekday_label`` carry the
+    plan-relative coordinates, used for labelling and drift reporting; they are
+    never used to *place* the bucket (placement is by real date).
+    """
+
+    decks: list[ScheduleDeck]
+    span: int
+    week: int  # plan-relative week number (from the originating ScheduleWeek)
+    weekday_label: str  # localized plan-relative label (e.g. "Montag")
+
+    @property
+    def ref_ids(self) -> set[str]:
+        """Topic ids and deck-file stems in this bucket.
+
+        These are the stable handles a calendar ``pin``/``split`` adjustment
+        uses to name a bucket (see the cohort-viewing-calendar design doc):
+        week/weekday coordinates move when the spec is edited, deck and topic
+        ids do not.
+        """
+        ids: set[str] = set()
+        for deck in self.decks:
+            ids.add(deck.topic_id)
+            ids.add(deck.deck_file)
+        return ids
+
+
 def subsection_label(subsection: SubsectionSpec, language: str) -> str:
     """Resolve a subsection's display label for *language*.
 
@@ -309,6 +347,31 @@ def _build_schedule_with_disabled(
             )
         )
     return weeks
+
+
+def build_buckets(weeks: list[ScheduleWeek]) -> list[Bucket]:
+    """Flatten a schedule into the ordered *content sequence* for a calendar.
+
+    Each :class:`ScheduleDay` (one ``<subsection>``) becomes one :class:`Bucket`,
+    in week-then-document order — the same order the build and ``export schedule``
+    use. A multi-weekday subsection yields a bucket whose ``span`` equals its
+    weekday count, so it consumes that many teaching dates when projected onto a
+    cohort calendar (issue #283).
+
+    Flattening is faithful and policy-free: every day in *weeks* yields a bucket
+    (including empty-deck days). Whether disabled or optional content appears is
+    the caller's choice, made upstream via :func:`build_schedule`'s flags.
+    """
+    return [
+        Bucket(
+            decks=day.decks,
+            span=max(1, len(day.weekdays)),
+            week=week.number,
+            weekday_label=day.label,
+        )
+        for week in weeks
+        for day in week.days
+    ]
 
 
 def _md_cell(text: str) -> str:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -512,6 +512,125 @@ clm export schedule course.xml -o schedule.md   # Write to a file
 clm export schedule course.xml -d ./docs        # Write into a directory
 ```
 
+#### `clm export calendar`
+
+*New in {version}.* Project the course **schedule onto a cohort's real calendar
+dates**. Where `export schedule` is course-relative ("Week 3, Tuesday"), a
+*calendar* maps the same ordered day-buckets onto actual dates for one cohort,
+absorbing that cohort's holidays, delayed start, breaks, and catch-up. The
+trainer maintains only a small hand-edited `release/<channel>.calendar.toml`
+(see **Cohort calendar file** below); the dates are computed.
+
+```
+clm export calendar [OPTIONS] SPEC_FILE
+```
+
+| Option | Description |
+|--------|-------------|
+| `--channel NAME` | Cohort channel; resolves the calendar file as `<channel>.calendar.toml` beside the channel's ledger in `<release-channels>`. |
+| `--calendar PATH` | Explicit calendar TOML (overrides `--channel`). |
+| `-L, --language`, `--lang [de\|en]` | Language for deck titles and weekday labels (default: `de`). |
+| `-f, --format [md\|csv\|ics]` | Output format (default: `md`). `ics` is the subscribable student feed. |
+| `-o, --output FILE` / `-d, --output-dir DIR` | Write to FILE / to a directory (filename `<course>-calendar-<channel-or-lang>.<ext>`). |
+| `--data-dir DIR` | Course data directory. Default: inferred from the spec location. |
+
+- **`md`** — a date-ordered `Date | Content` table; multi-date spans show a date
+  range and `insert` days show their label in italics.
+- **`csv`** — one row per deck:
+  `date,end_date,weekday,kind,label,video_title,topic,deck_file` (`insert` rows
+  carry an empty deck triple).
+- **`ics`** — one all-day `VEVENT` per assignment, spans using the exclusive-end
+  `DTEND` convention, with **stable per-assignment UIDs** so re-exporting an
+  updated calendar *updates* events in a subscribed client rather than
+  duplicating them.
+
+Projection **errors** (over-full segment, unknown pin/split ref, end overflow)
+are printed to stderr and abort the export with a non-zero exit; fix the
+calendar (or run `clm calendar check`) first. Warnings (free dates, stray
+inserts) are printed but do not block.
+
+```bash
+clm export calendar course.xml --channel jan            # German Markdown
+clm export calendar course.xml --channel jan -f ics     # student .ics feed
+clm export calendar course.xml --calendar c.toml -L en -f csv
+clm export calendar course.xml --channel jan -o jan.ics -f ics
+```
+
+##### Cohort calendar file (`release/<channel>.calendar.toml`)
+
+A small, hand-edited TOML file holding only the *deltas* from the ideal plan.
+Lives beside the channel's release ledger; it is **not** part of the spec.
+
+```toml
+start = 2026-03-02              # first teaching date (required)
+end   = 2026-06-30              # last allowable teaching date (optional; checked)
+pattern = ["mon", "tue", "wed"] # teaching weekdays; default = weekdays the spec uses
+
+holidays = [
+  2026-04-06,                                            # a single day
+  {from = 2026-05-18, to = 2026-05-29, label = "Break"}, # an inclusive interval
+]
+
+# Ordered perturbations of the default 1-bucket-per-teaching-date mapping.
+[[adjustments]]
+merge = 2026-06-09   # collapse `count` buckets onto one date (catch up)
+count = 2
+
+[[adjustments]]
+pin  = "control_flow"  # anchor the bucket containing this topic/deck id to a date
+date = 2026-04-09
+
+[[adjustments]]
+insert = 2026-03-30    # a teaching date with no new video
+label  = "Review & Q&A"
+
+[[adjustments]]
+split = "long_topic"   # spread a bucket across several dates (slow down)
+dates = [2026-03-25, 2026-03-26]
+```
+
+A holiday removes a teaching date, so every later bucket slides one date
+later automatically. `pin`/`split` reference a bucket by a **stable topic/deck
+id** it contains (anchoring the whole day, not the single deck). Pins *segment*
+the timeline; when more buckets fall between two pins than there are teaching
+dates, the engine never guesses — `clm calendar check` reports the exact
+deficit and you resolve it with an explicit `merge`.
+
+### `clm calendar`
+
+*New in {version}.* Inspect a cohort's viewing calendar (see
+`clm export calendar` for the file format).
+
+#### `clm calendar check`
+
+**Date-free validation** of a calendar against the course schedule. Reports
+errors — unknown/ambiguous pin/split refs, over-full segments (with the exact
+"merge ≥ N buckets" deficit), content overflowing `end` — and warnings (free
+teaching dates before a pin, `insert`/`merge` dates that are not teaching
+dates). Exits non-zero if there are errors, so it suits a pre-push hook.
+
+```
+clm calendar check [OPTIONS] SPEC_FILE      # --channel/--calendar/--data-dir
+```
+
+#### `clm calendar status`
+
+Show **where a cohort is today** relative to the plan — the only now-relative
+command. Defaults to the system date; pass `--as-of YYYY-MM-DD` for tests, dated
+handouts, or what-if previews. Reports today's assignment (or the next one), its
+plan coordinate (e.g. `W4 Tuesday`), the **drift** in days versus the ideal
+(no-holiday, no-adjustment) calendar, and an upcoming lookahead.
+
+```
+clm calendar status [OPTIONS] SPEC_FILE     # --channel/--calendar/-L/--as-of/--data-dir
+```
+
+```bash
+clm calendar check  course.xml --channel jan
+clm calendar status course.xml --channel jan -L en
+clm calendar status course.xml --channel jan --as-of 2026-05-06
+```
+
 ### `clm topic resolve`
 
 *Removed in CLM 1.8: the flat alias `clm resolve-topic` no longer exists — use this group-qualified form.*

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -79,7 +79,7 @@ from clm.cli.commands.build import (  # noqa: E402
     build,
     list_targets,
 )
-from clm.cli.commands.calendar import calendar  # noqa: E402
+from clm.cli.commands.calendar import calendar, calendar_group  # noqa: E402
 from clm.cli.commands.cassette import cassette_group  # noqa: E402
 from clm.cli.commands.completion import completion_cmd  # noqa: E402
 from clm.cli.commands.config import config  # noqa: E402
@@ -206,6 +206,7 @@ cli.add_command(authoring_group)
 export_group.add_command(outline, name="outline")
 export_group.add_command(schedule, name="schedule")
 export_group.add_command(calendar, name="calendar")
+cli.add_command(calendar_group, name="calendar")
 export_group.add_command(summary, name="summary")
 export_group.add_command(summary, name="summarize")  # noun-vs-verb alias
 cli.add_command(export_group)

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -79,6 +79,7 @@ from clm.cli.commands.build import (  # noqa: E402
     build,
     list_targets,
 )
+from clm.cli.commands.calendar import calendar  # noqa: E402
 from clm.cli.commands.cassette import cassette_group  # noqa: E402
 from clm.cli.commands.completion import completion_cmd  # noqa: E402
 from clm.cli.commands.config import config  # noqa: E402
@@ -204,6 +205,7 @@ cli.add_command(authoring_group)
 # top-level commands (removed; see migration docs).
 export_group.add_command(outline, name="outline")
 export_group.add_command(schedule, name="schedule")
+export_group.add_command(calendar, name="calendar")
 export_group.add_command(summary, name="summary")
 export_group.add_command(summary, name="summarize")  # noun-vs-verb alias
 cli.add_command(export_group)

--- a/src/clm/cohort_calendar/__init__.py
+++ b/src/clm/cohort_calendar/__init__.py
@@ -1,0 +1,43 @@
+"""Cohort viewing calendar (issue #283).
+
+Projects a course's certification *schedule* (the course-relative plan of
+``export schedule``) onto a cohort's real calendar dates. A *calendar* is the
+zip of a shared content sequence (ordered day-buckets — see
+:func:`clm.cli.commands.schedule.build_buckets`) with a per-cohort date
+sequence generated from a small hand-edited ``release/<channel>.calendar.toml``
+file.
+
+This package holds the pure, I/O-light pieces: the config model + loader
+(:mod:`clm.cohort_calendar.config`) and — later — the projection engine. CLI
+wiring lives in :mod:`clm.cli.commands`.
+"""
+
+from __future__ import annotations
+
+from clm.cohort_calendar.config import (
+    Adjustment,
+    CohortCalendarConfig,
+    CohortCalendarError,
+    Holiday,
+    Insert,
+    Merge,
+    Pin,
+    Split,
+    effective_pattern,
+    load_calendar_config,
+    parse_calendar_config,
+)
+
+__all__ = [
+    "Adjustment",
+    "CohortCalendarConfig",
+    "CohortCalendarError",
+    "Holiday",
+    "Insert",
+    "Merge",
+    "Pin",
+    "Split",
+    "effective_pattern",
+    "load_calendar_config",
+    "parse_calendar_config",
+]

--- a/src/clm/cohort_calendar/__init__.py
+++ b/src/clm/cohort_calendar/__init__.py
@@ -27,17 +27,27 @@ from clm.cohort_calendar.config import (
     load_calendar_config,
     parse_calendar_config,
 )
+from clm.cohort_calendar.projection import (
+    Assignment,
+    Diagnostic,
+    Projection,
+    project,
+)
 
 __all__ = [
     "Adjustment",
+    "Assignment",
     "CohortCalendarConfig",
     "CohortCalendarError",
+    "Diagnostic",
     "Holiday",
     "Insert",
     "Merge",
     "Pin",
+    "Projection",
     "Split",
     "effective_pattern",
     "load_calendar_config",
     "parse_calendar_config",
+    "project",
 ]

--- a/src/clm/cohort_calendar/config.py
+++ b/src/clm/cohort_calendar/config.py
@@ -1,0 +1,300 @@
+"""Per-cohort viewing-calendar config: model + TOML loader (issue #283).
+
+A cohort calendar file (``release/<channel>.calendar.toml``) is the small,
+hand-edited set of *deltas* a trainer maintains to map a course's schedule onto
+one cohort's real dates: a ``start`` (and optional ``end``) date, an optional
+weekly teaching ``pattern``, a list of ``holidays`` (single dates or inclusive
+intervals), and an ordered list of ``adjustments`` (merge / split / insert /
+pin). See ``docs/claude/design/cohort-viewing-calendar.md``.
+
+TOML is the project's existing config idiom and parses with the stdlib
+``tomllib`` (no new dependency), with native date literals so dates land as
+:class:`datetime.date` directly. The file is only ever *read* programmatically,
+so ``tomllib``'s read-only nature is no limitation.
+
+This module is pure parsing + structural validation. It does **not** project
+onto dates or check that buckets *fit* between pins / before ``end`` — those are
+the projection engine's job (a later phase), because they need the course's
+content sequence.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import tomllib
+from attrs import frozen
+
+from clm.core.course_spec import VALID_WEEKDAYS, WEEKDAY_ORDER
+
+
+class CohortCalendarError(Exception):
+    """A cohort calendar file is missing, malformed, or structurally invalid."""
+
+
+@frozen
+class Holiday:
+    """A non-teaching span: a single date (``start == end``) or an inclusive interval."""
+
+    start: dt.date
+    end: dt.date
+    label: str | None = None
+
+    def covers(self, day: dt.date) -> bool:
+        """True if *day* falls within this holiday (both ends inclusive)."""
+        return self.start <= day <= self.end
+
+
+@frozen
+class Merge:
+    """Collapse the next ``count`` buckets onto a single ``date`` (catch-up)."""
+
+    date: dt.date
+    count: int
+
+
+@frozen
+class Split:
+    """Spread the bucket named by ``ref`` across ``dates`` (slow down)."""
+
+    ref: str
+    dates: tuple[dt.date, ...]
+
+
+@frozen
+class Insert:
+    """A teaching ``date`` carrying no new video, labelled (review / exam / guest)."""
+
+    date: dt.date
+    label: str
+
+
+@frozen
+class Pin:
+    """Anchor the bucket named by ``ref`` to exactly ``date`` (segments the timeline)."""
+
+    ref: str
+    date: dt.date
+
+
+Adjustment = Merge | Split | Insert | Pin
+
+
+@frozen
+class CohortCalendarConfig:
+    """The parsed, structurally-valid contents of a cohort calendar file.
+
+    ``pattern`` may be empty, meaning "derive from the weekdays the spec
+    actually uses" — resolve it with :func:`effective_pattern`. ``adjustments``
+    preserve file order (the order in which they apply).
+    """
+
+    start: dt.date
+    end: dt.date | None
+    pattern: tuple[str, ...]
+    holidays: tuple[Holiday, ...]
+    adjustments: tuple[Adjustment, ...]
+
+
+# --- internal value coercion -------------------------------------------------
+
+
+def _as_date(value: Any, ctx: str) -> dt.date:
+    """Require a TOML date literal (not a datetime, not a string)."""
+    # datetime is a subclass of date — a TOML datetime literal must be rejected
+    # so dates stay unambiguous (calendars are whole-day granular).
+    if isinstance(value, dt.datetime) or not isinstance(value, dt.date):
+        raise CohortCalendarError(
+            f"{ctx}: expected a date (YYYY-MM-DD), got {value!r}. "
+            "Use a bare TOML date literal, e.g. 2026-03-02."
+        )
+    return value
+
+
+def _as_int(value: Any, ctx: str) -> int:
+    """Require a plain integer (TOML booleans are Python ints — reject them)."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CohortCalendarError(f"{ctx}: expected an integer, got {value!r}.")
+    return value
+
+
+def _as_str(value: Any, ctx: str) -> str:
+    if not isinstance(value, str):
+        raise CohortCalendarError(f"{ctx}: expected a string, got {value!r}.")
+    return value
+
+
+def _reject_unknown_keys(table: dict[str, Any], allowed: set[str], ctx: str) -> None:
+    unknown = sorted(set(table) - allowed)
+    if unknown:
+        raise CohortCalendarError(f"{ctx}: unknown key(s) {unknown}. Allowed: {sorted(allowed)}.")
+
+
+# --- section parsers ---------------------------------------------------------
+
+
+def _parse_pattern(raw: Any) -> tuple[str, ...]:
+    """Validate the weekday ``pattern`` list; canonicalize order, drop duplicates.
+
+    An empty/absent pattern is allowed (caller derives it from the spec).
+    """
+    if not isinstance(raw, list):
+        raise CohortCalendarError(f"pattern: expected a list of weekday tokens, got {raw!r}.")
+    seen: set[str] = set()
+    for entry in raw:
+        token = _as_str(entry, "pattern entry").lower()
+        if token not in VALID_WEEKDAYS:
+            raise CohortCalendarError(
+                f"pattern: unknown weekday {entry!r}. Expected tokens from {list(WEEKDAY_ORDER)}."
+            )
+        seen.add(token)
+    # Canonical Mon..Sun order, regardless of how the file listed them.
+    return tuple(wd for wd in WEEKDAY_ORDER if wd in seen)
+
+
+def _parse_holiday(entry: Any, index: int) -> Holiday:
+    ctx = f"holidays[{index}]"
+    if isinstance(entry, dt.date) and not isinstance(entry, dt.datetime):
+        return Holiday(start=entry, end=entry)
+    if isinstance(entry, dict):
+        _reject_unknown_keys(entry, {"from", "to", "label"}, ctx)
+        if "from" not in entry or "to" not in entry:
+            raise CohortCalendarError(f"{ctx}: an interval needs both 'from' and 'to' dates.")
+        start = _as_date(entry["from"], f"{ctx}.from")
+        end = _as_date(entry["to"], f"{ctx}.to")
+        if end < start:
+            raise CohortCalendarError(f"{ctx}: interval end {end} is before start {start}.")
+        label = _as_str(entry["label"], f"{ctx}.label") if "label" in entry else None
+        return Holiday(start=start, end=end, label=label)
+    raise CohortCalendarError(
+        f"{ctx}: expected a date or an interval table {{from, to, label?}}, got {entry!r}."
+    )
+
+
+# Discriminator key -> the full set of keys that adjustment kind allows.
+_ADJUSTMENT_KEYS: dict[str, set[str]] = {
+    "merge": {"merge", "count"},
+    "split": {"split", "dates"},
+    "insert": {"insert", "label"},
+    "pin": {"pin", "date"},
+}
+
+
+def _parse_adjustment(table: Any, index: int) -> Adjustment:
+    ctx = f"adjustments[{index}]"
+    if not isinstance(table, dict):
+        raise CohortCalendarError(f"{ctx}: expected a table, got {table!r}.")
+    kinds = [k for k in _ADJUSTMENT_KEYS if k in table]
+    if len(kinds) != 1:
+        raise CohortCalendarError(
+            f"{ctx}: a table must carry exactly one of "
+            f"{sorted(_ADJUSTMENT_KEYS)} (found {sorted(kinds)})."
+        )
+    kind = kinds[0]
+    _reject_unknown_keys(table, _ADJUSTMENT_KEYS[kind], ctx)
+
+    if kind == "merge":
+        count = _as_int(table["count"], f"{ctx}.count") if "count" in table else 0
+        if count < 2:
+            raise CohortCalendarError(
+                f"{ctx}: merge needs count >= 2 (merging fewer than two buckets is a no-op)."
+            )
+        return Merge(date=_as_date(table["merge"], f"{ctx}.merge"), count=count)
+
+    if kind == "split":
+        ref = _as_str(table["split"], f"{ctx}.split")
+        if "dates" not in table or not isinstance(table["dates"], list):
+            raise CohortCalendarError(f"{ctx}: split needs a 'dates' list.")
+        dates = tuple(_as_date(d, f"{ctx}.dates[{i}]") for i, d in enumerate(table["dates"]))
+        if len(set(dates)) < 2:
+            raise CohortCalendarError(f"{ctx}: split needs at least two distinct dates.")
+        return Split(ref=ref, dates=tuple(sorted(dates)))
+
+    if kind == "insert":
+        if "label" not in table:
+            raise CohortCalendarError(f"{ctx}: insert needs a 'label'.")
+        return Insert(
+            date=_as_date(table["insert"], f"{ctx}.insert"),
+            label=_as_str(table["label"], f"{ctx}.label"),
+        )
+
+    # pin
+    if "date" not in table:
+        raise CohortCalendarError(f"{ctx}: pin needs a 'date'.")
+    return Pin(ref=_as_str(table["pin"], f"{ctx}.pin"), date=_as_date(table["date"], f"{ctx}.date"))
+
+
+# --- public API --------------------------------------------------------------
+
+_TOP_LEVEL_KEYS = {"start", "end", "pattern", "holidays", "adjustments"}
+
+
+def parse_calendar_config(text: str) -> CohortCalendarConfig:
+    """Parse a cohort calendar from TOML *text*.
+
+    Raises :class:`CohortCalendarError` with a located message on any malformed
+    or invalid entry. Validation is structural only — it does not check that
+    buckets fit between pins or before ``end`` (that needs the content sequence).
+    """
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise CohortCalendarError(f"invalid TOML: {exc}") from exc
+
+    _reject_unknown_keys(data, _TOP_LEVEL_KEYS, "calendar file")
+
+    if "start" not in data:
+        raise CohortCalendarError("missing required 'start' date.")
+    start = _as_date(data["start"], "start")
+
+    end: dt.date | None = None
+    if "end" in data:
+        end = _as_date(data["end"], "end")
+        if end < start:
+            raise CohortCalendarError(f"end {end} is before start {start}.")
+
+    pattern = _parse_pattern(data["pattern"]) if "pattern" in data else ()
+
+    holidays_raw = data.get("holidays", [])
+    if not isinstance(holidays_raw, list):
+        raise CohortCalendarError(f"holidays: expected a list, got {holidays_raw!r}.")
+    holidays = tuple(_parse_holiday(h, i) for i, h in enumerate(holidays_raw))
+
+    adjustments_raw = data.get("adjustments", [])
+    if not isinstance(adjustments_raw, list):
+        raise CohortCalendarError(
+            f"adjustments: expected an array of tables, got {adjustments_raw!r}."
+        )
+    adjustments = tuple(_parse_adjustment(a, i) for i, a in enumerate(adjustments_raw))
+
+    return CohortCalendarConfig(
+        start=start,
+        end=end,
+        pattern=pattern,
+        holidays=holidays,
+        adjustments=adjustments,
+    )
+
+
+def load_calendar_config(path: Path) -> CohortCalendarConfig:
+    """Load and parse a cohort calendar file. A missing file is an error."""
+    if not path.exists():
+        raise CohortCalendarError(f"calendar file not found: {path}")
+    return parse_calendar_config(path.read_text(encoding="utf-8"))
+
+
+def effective_pattern(configured: tuple[str, ...], available: Iterable[str]) -> tuple[str, ...]:
+    """Resolve the teaching-weekday pattern, in canonical Mon..Sun order.
+
+    An explicit *configured* pattern wins. Otherwise the pattern defaults to the
+    weekdays the course schedule actually uses (*available* — typically the union
+    of the buckets' subsection weekdays), so a Mon/Tue/Wed course needs no
+    explicit pattern.
+    """
+    if configured:
+        return configured
+    present = set(available)
+    return tuple(wd for wd in WEEKDAY_ORDER if wd in present)

--- a/src/clm/cohort_calendar/projection.py
+++ b/src/clm/cohort_calendar/projection.py
@@ -1,0 +1,399 @@
+"""Projection engine: map the content sequence onto a cohort's real dates.
+
+Pure, I/O-free, date-deterministic. Given the ordered *buckets* (the content
+sequence from :func:`clm.cli.commands.schedule.build_buckets`) and a
+:class:`~clm.cohort_calendar.config.CohortCalendarConfig`, :func:`project`
+produces the cohort *calendar*: a list of :class:`Assignment` rows plus
+structural :class:`Diagnostic` s.
+
+The model (see ``docs/claude/design/cohort-viewing-calendar.md`` §6):
+
+* Teaching dates are generated from ``start`` + the effective weekday pattern,
+  minus ``holidays`` — so a holiday simply removes a slot and everything after
+  slides one teaching date later, automatically.
+* By default bucket *i* takes the next ``span`` teaching dates (1 : 1 when
+  span is 1). A holiday or earlier adjustment shifts later buckets for free.
+* **Pins** anchor a bucket to an exact date and *segment* the timeline: each
+  segment is fit independently, so an error in one segment can't cascade.
+* **No magic** (§6.3.1): when a pin-bounded segment holds more bucket-dates
+  than it has teaching dates, the engine does **not** redistribute — it emits an
+  *error* naming the exact deficit ("merge ≥ N buckets"). Under-full segments
+  emit a *warning* with the free-date count. Catch-up is always an explicit,
+  diff-visible ``merge``.
+
+Adjustments:
+
+* ``insert`` — a teaching date carrying no video (review / exam); consumes a
+  slot and pushes later buckets back.
+* ``merge`` — collapse ``count`` consecutive buckets onto one date (catch-up).
+  Each merged bucket is treated as a single date.
+* ``split`` — slow a bucket down to occupy ``len(dates)`` teaching dates. Per
+  §6.2 / §12 the per-date deck distribution is deferred: the bucket's decks ride
+  the first date of its run; this phase honours only the *count* of dates.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING
+
+from attrs import frozen
+
+from clm.cohort_calendar.config import (
+    CohortCalendarConfig,
+    Insert,
+    Merge,
+    Pin,
+    Split,
+    effective_pattern,
+)
+from clm.core.course_spec import WEEKDAY_ORDER
+
+if TYPE_CHECKING:
+    from clm.cli.commands.schedule import Bucket, ScheduleDeck
+
+# Generating teaching dates one calendar day at a time needs an upper bound so a
+# misconfigured (e.g. empty) pattern can't loop forever. Six years comfortably
+# covers any real course.
+_SAFETY_DAYS = 366 * 6
+_ONE_DAY = dt.timedelta(days=1)
+
+
+@frozen
+class Assignment:
+    """One calendar row: what to watch (or do) across a contiguous date span."""
+
+    start_date: dt.date
+    end_date: dt.date  # == start_date for a single-date assignment
+    decks: tuple[ScheduleDeck, ...]  # empty for an `insert`
+    label: str | None  # set for inserts; else None
+    kind: str  # "video" | "merged" | "insert"
+    bucket_refs: tuple[str, ...]  # stable id seeds (deck-file stems) for .ics UIDs
+
+
+@frozen
+class Diagnostic:
+    """A structural finding from projection (surfaced by ``calendar check``)."""
+
+    level: str  # "error" | "warning"
+    message: str
+
+
+@frozen
+class Projection:
+    """The projected calendar plus its diagnostics."""
+
+    assignments: tuple[Assignment, ...]
+    diagnostics: tuple[Diagnostic, ...]
+
+    @property
+    def errors(self) -> tuple[Diagnostic, ...]:
+        return tuple(d for d in self.diagnostics if d.level == "error")
+
+    @property
+    def warnings(self) -> tuple[Diagnostic, ...]:
+        return tuple(d for d in self.diagnostics if d.level == "warning")
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _weekday_token(day: dt.date) -> str:
+    return WEEKDAY_ORDER[day.weekday()]
+
+
+class _TeachingDates:
+    """On-demand, memoized stream of real teaching dates from ``start``.
+
+    A teaching date is one whose weekday is in the pattern and which no holiday
+    covers. ``at`` and ``index_on_or_after`` give the segment fitter its date
+    math without materializing years of dates.
+    """
+
+    def __init__(self, start: dt.date, pattern: frozenset[str], holidays) -> None:
+        self._start = start
+        self._pattern = pattern
+        self._holidays = holidays
+        self._dates: list[dt.date] = []
+        self._cursor = start
+        self._exhausted = not pattern  # empty pattern => no teaching dates ever
+
+    def _grow_to(self, index: int) -> None:
+        cap = self._start + dt.timedelta(days=_SAFETY_DAYS)
+        while len(self._dates) <= index and not self._exhausted:
+            if self._cursor > cap:
+                self._exhausted = True
+                break
+            day = self._cursor
+            self._cursor += _ONE_DAY
+            if _weekday_token(day) in self._pattern and not any(
+                h.covers(day) for h in self._holidays
+            ):
+                self._dates.append(day)
+
+    def at(self, index: int) -> dt.date | None:
+        self._grow_to(index)
+        return self._dates[index] if index < len(self._dates) else None
+
+    def index_on_or_after(self, day: dt.date) -> int:
+        """Smallest teaching-date index whose date is >= *day*."""
+        i = 0
+        while True:
+            d = self.at(i)
+            if d is None or d >= day:
+                return i
+            i += 1
+
+    def is_teaching_date(self, day: dt.date) -> bool:
+        return _weekday_token(day) in self._pattern and not any(
+            h.covers(day) for h in self._holidays
+        )
+
+
+def _resolve_ref(ref: str, buckets) -> tuple[int | None, str | None]:
+    """Resolve a pin/split bucket-ref to a unique bucket index."""
+    matches = [i for i, b in enumerate(buckets) if ref in b.ref_ids]
+    if not matches:
+        return None, f"unknown bucket ref {ref!r} (no topic/deck id matches)."
+    if len(matches) > 1:
+        return None, f"ambiguous bucket ref {ref!r} (matches buckets {matches})."
+    return matches[0], None
+
+
+def _bucket_refs(decks: tuple[ScheduleDeck, ...]) -> tuple[str, ...]:
+    return tuple(d.deck_file for d in decks)
+
+
+def project(buckets: list[Bucket], config: CohortCalendarConfig) -> Projection:
+    """Project *buckets* onto real dates per *config*. Pure; never raises."""
+    diagnostics: list[Diagnostic] = []
+    available_weekdays = {wd for b in buckets for wd in b.weekdays}
+    pattern = effective_pattern(config.pattern, available_weekdays)
+    if not pattern:
+        return Projection(
+            (),
+            (
+                Diagnostic(
+                    "error",
+                    "no teaching weekdays: set `pattern` or use weekday subsections.",
+                ),
+            ),
+        )
+    dates = _TeachingDates(config.start, frozenset(pattern), config.holidays)
+
+    # Index date-keyed adjustments and resolve ref-keyed ones to bucket indices.
+    inserts: dict[dt.date, Insert] = {}
+    merges: dict[dt.date, Merge] = {}
+    splits: dict[int, Split] = {}
+    pins: list[tuple[int, Pin]] = []
+    for adj in config.adjustments:
+        if isinstance(adj, Insert):
+            inserts[adj.date] = adj
+            if not dates.is_teaching_date(adj.date):
+                diagnostics.append(
+                    Diagnostic(
+                        "warning",
+                        f"insert date {adj.date} is not a teaching date "
+                        "(wrong weekday or a holiday); it will not appear.",
+                    )
+                )
+        elif isinstance(adj, Merge):
+            merges[adj.date] = adj
+        elif isinstance(adj, Split):
+            idx, err = _resolve_ref(adj.ref, buckets)
+            if err:
+                diagnostics.append(Diagnostic("error", f"split: {err}"))
+            else:
+                splits[idx] = adj  # type: ignore[index]
+        elif isinstance(adj, Pin):
+            idx, err = _resolve_ref(adj.ref, buckets)
+            if err:
+                diagnostics.append(Diagnostic("error", f"pin: {err}"))
+            else:
+                pins.append((idx, adj))  # type: ignore[arg-type]
+
+    pins.sort(key=lambda p: p[0])
+    for (i0, p0), (i1, p1) in zip(pins, pins[1:], strict=False):
+        if i0 == i1:
+            diagnostics.append(
+                Diagnostic("error", f"two pins target the same bucket (index {i0}).")
+            )
+        if p0.date >= p1.date:
+            diagnostics.append(
+                Diagnostic(
+                    "error",
+                    f"pins out of order: bucket {i0} pinned to {p0.date} but later "
+                    f"bucket {i1} pinned to the earlier-or-equal {p1.date}.",
+                )
+            )
+
+    # Build segment boundaries: bucket-index breakpoints at each pin (and 0/end).
+    breakpoints = [0]
+    for idx, _ in pins:
+        if idx != breakpoints[-1]:
+            breakpoints.append(idx)
+    if breakpoints[-1] != len(buckets):
+        breakpoints.append(len(buckets))
+    pin_by_bucket = dict(pins)
+
+    assignments: list[Assignment] = []
+    # `start` may itself be a pin date; otherwise the first bucket lands on the
+    # first teaching date on/after `start` (which is `start` if it is one).
+    for s in range(len(breakpoints) - 1):
+        lo_bucket = breakpoints[s]
+        hi_bucket = breakpoints[s + 1]
+        seg_start = pin_by_bucket[lo_bucket].date if lo_bucket in pin_by_bucket else config.start
+        # The segment ends where the next pin fixes its bucket; the last segment
+        # is open (optionally bounded by `end`).
+        next_is_pin = hi_bucket in pin_by_bucket
+        seg_end_excl = pin_by_bucket[hi_bucket].date if next_is_pin else None
+
+        _project_segment(
+            buckets=buckets,
+            lo=lo_bucket,
+            hi=hi_bucket,
+            seg_start=seg_start,
+            seg_end_excl=seg_end_excl,
+            config=config,
+            dates=dates,
+            inserts=inserts,
+            merges=merges,
+            splits=splits,
+            assignments=assignments,
+            diagnostics=diagnostics,
+            bounded=next_is_pin,
+        )
+
+    return Projection(tuple(assignments), tuple(diagnostics))
+
+
+def _project_segment(
+    *,
+    buckets,
+    lo: int,
+    hi: int,
+    seg_start: dt.date,
+    seg_end_excl: dt.date | None,
+    config: CohortCalendarConfig,
+    dates: _TeachingDates,
+    inserts: dict[dt.date, Insert],
+    merges: dict[dt.date, Merge],
+    splits: dict[int, Split],
+    assignments: list[Assignment],
+    diagnostics: list[Diagnostic],
+    bounded: bool,
+) -> None:
+    """Place buckets [lo, hi) from *seg_start*, emitting assignments + diagnostics."""
+    start_i = dates.index_on_or_after(seg_start)
+
+    # --- Fit accounting (for the no-magic diagnostics) -----------------------
+    # demand = teaching dates the buckets + inserts need; merges reduce it.
+    demand = 0
+    for i in range(lo, hi):
+        demand += len(splits[i].dates) if i in splits else buckets[i].span
+    for m in merges.values():
+        if _in_window(m.date, seg_start, seg_end_excl) and dates.is_teaching_date(m.date):
+            demand -= m.count - 1
+    for ins_date in inserts:
+        if _in_window(ins_date, seg_start, seg_end_excl) and dates.is_teaching_date(ins_date):
+            demand += 1
+
+    if bounded and seg_end_excl is not None:
+        available = dates.index_on_or_after(seg_end_excl) - start_i
+        if demand > available:
+            diagnostics.append(
+                Diagnostic(
+                    "error",
+                    f"segment {seg_start}–{_prev_day(seg_end_excl)}: {hi - lo} buckets "
+                    f"need {demand} teaching dates but only {available} are available — "
+                    f"merge ≥ {demand - available} bucket(s) to fit.",
+                )
+            )
+        elif demand < available:
+            diagnostics.append(
+                Diagnostic(
+                    "warning",
+                    f"segment {seg_start}–{_prev_day(seg_end_excl)}: "
+                    f"{available - demand} free teaching date(s) before the next pin.",
+                )
+            )
+    elif config.end is not None:
+        end_excl = config.end + _ONE_DAY
+        available = dates.index_on_or_after(end_excl) - start_i
+        if demand > available:
+            diagnostics.append(
+                Diagnostic(
+                    "error",
+                    f"content does not fit before end {config.end}: needs {demand} "
+                    f"teaching dates, {available} available — merge ≥ {demand - available} "
+                    "bucket(s).",
+                )
+            )
+
+    _emit_segment(
+        buckets=buckets,
+        lo=lo,
+        hi=hi,
+        start_i=start_i,
+        dates=dates,
+        inserts=inserts,
+        merges=merges,
+        splits=splits,
+        assignments=assignments,
+    )
+
+
+def _in_window(day: dt.date, lo: dt.date, hi_excl: dt.date | None) -> bool:
+    if day < lo:
+        return False
+    return hi_excl is None or day < hi_excl
+
+
+def _prev_day(day: dt.date) -> dt.date:
+    return day - _ONE_DAY
+
+
+def _emit_segment(
+    *,
+    buckets,
+    lo: int,
+    hi: int,
+    start_i: int,
+    dates: _TeachingDates,
+    inserts: dict[dt.date, Insert],
+    merges: dict[dt.date, Merge],
+    splits: dict[int, Split],
+    assignments: list[Assignment],
+) -> None:
+    """Walk teaching dates from *start_i*, placing buckets [lo, hi)."""
+    di = start_i
+    bi = lo
+    while bi < hi:
+        d = dates.at(di)
+        if d is None:
+            break  # ran out of dates (over-full already reported)
+        if d in inserts:
+            ins = inserts[d]
+            assignments.append(
+                Assignment(d, d, (), ins.label, "insert", (f"insert:{d.isoformat()}",))
+            )
+            di += 1
+            continue
+        if d in merges:
+            count = merges[d].count
+            group = list(range(bi, min(bi + count, hi)))
+            decks: tuple[ScheduleDeck, ...] = tuple(
+                deck for gi in group for deck in buckets[gi].decks
+            )
+            assignments.append(Assignment(d, d, decks, None, "merged", _bucket_refs(decks)))
+            di += 1
+            bi = group[-1] + 1
+            continue
+        bucket = buckets[bi]
+        span = len(splits[bi].dates) if bi in splits else bucket.span
+        last = dates.at(di + span - 1) or d
+        decks = tuple(bucket.decks)
+        assignments.append(Assignment(d, last, decks, None, "video", _bucket_refs(decks)))
+        di += span
+        bi += 1

--- a/src/clm/cohort_calendar/projection.py
+++ b/src/clm/cohort_calendar/projection.py
@@ -69,6 +69,7 @@ class Assignment:
     label: str | None  # set for inserts; else None
     kind: str  # "video" | "merged" | "insert"
     bucket_refs: tuple[str, ...]  # stable id seeds (deck-file stems) for .ics UIDs
+    plan_label: str = ""  # plan-relative coordinate, e.g. "W4 Tuesday" (drift/status)
 
 
 @frozen
@@ -163,6 +164,11 @@ def _resolve_ref(ref: str, buckets) -> tuple[int | None, str | None]:
 
 def _bucket_refs(decks: tuple[ScheduleDeck, ...]) -> tuple[str, ...]:
     return tuple(d.deck_file for d in decks)
+
+
+def _plan_label(bucket) -> str:
+    """The bucket's plan-relative coordinate, e.g. 'W4 Tuesday' (or just 'W4')."""
+    return f"W{bucket.week} {bucket.weekday_label}".rstrip()
 
 
 def project(buckets: list[Bucket], config: CohortCalendarConfig) -> Projection:
@@ -386,7 +392,11 @@ def _emit_segment(
             decks: tuple[ScheduleDeck, ...] = tuple(
                 deck for gi in group for deck in buckets[gi].decks
             )
-            assignments.append(Assignment(d, d, decks, None, "merged", _bucket_refs(decks)))
+            assignments.append(
+                Assignment(
+                    d, d, decks, None, "merged", _bucket_refs(decks), _plan_label(buckets[group[0]])
+                )
+            )
             di += 1
             bi = group[-1] + 1
             continue
@@ -394,6 +404,8 @@ def _emit_segment(
         span = len(splits[bi].dates) if bi in splits else bucket.span
         last = dates.at(di + span - 1) or d
         decks = tuple(bucket.decks)
-        assignments.append(Assignment(d, last, decks, None, "video", _bucket_refs(decks)))
+        assignments.append(
+            Assignment(d, last, decks, None, "video", _bucket_refs(decks), _plan_label(bucket))
+        )
         di += span
         bi += 1

--- a/src/clm/cohort_calendar/render.py
+++ b/src/clm/cohort_calendar/render.py
@@ -1,0 +1,150 @@
+"""Render a projected cohort calendar to Markdown / CSV / iCalendar (#283).
+
+Inputs are a :class:`~clm.cohort_calendar.projection.Projection` (the date-keyed
+assignments) plus the course title and language. The Markdown and CSV views are
+for the trainer; the ``.ics`` feed is the student-facing payload — a subscribable
+calendar whose event UIDs are **stable** across re-exports, so a pushed
+adjustment updates events in place instead of duplicating them.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import io
+
+from clm.cli.commands.schedule import WEEKDAY_LABELS
+from clm.cohort_calendar.projection import Assignment, Projection
+from clm.core.course_spec import WEEKDAY_ORDER
+
+_MD_HEADERS = {
+    "de": ("Datum", "Inhalt"),
+    "en": ("Date", "Content"),
+}
+_CSV_FIELDS = [
+    "date",
+    "end_date",
+    "weekday",
+    "kind",
+    "label",
+    "video_title",
+    "topic",
+    "deck_file",
+]
+
+
+def _weekday_token(day: dt.date) -> str:
+    return WEEKDAY_ORDER[day.weekday()]
+
+
+def _fmt_day(day: dt.date, language: str) -> str:
+    """A localized 'Weekday YYYY-MM-DD' label for a single date."""
+    return f"{WEEKDAY_LABELS[_weekday_token(day)][language]} {day.isoformat()}"
+
+
+def _fmt_span(a: Assignment, language: str) -> str:
+    if a.end_date != a.start_date:
+        return f"{_fmt_day(a.start_date, language)} – {_fmt_day(a.end_date, language)}"
+    return _fmt_day(a.start_date, language)
+
+
+def _md_cell(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _content_text(a: Assignment) -> str:
+    """Plain (un-escaped) content of an assignment: titles, or the insert label."""
+    if a.kind == "insert":
+        return a.label or ""
+    return "; ".join(d.video_title for d in a.decks)
+
+
+def render_markdown(course_title: str, projection: Projection, language: str) -> str:
+    """One date-ordered table: ``Date | Content`` (insert rows shown in italics)."""
+    date_h, content_h = _MD_HEADERS[language]
+    title_suffix = "Kalender" if language == "de" else "Calendar"
+    lines = [f"# {course_title} — {title_suffix}", ""]
+    if not projection.assignments:
+        empty = "_Keine Termine._" if language == "de" else "_No dates scheduled._"
+        lines.append(empty)
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"| {date_h} | {content_h} |")
+    lines.append("|------|------|")
+    for a in projection.assignments:
+        date_cell = _md_cell(_fmt_span(a, language))
+        if a.kind == "insert":
+            content = f"_{_md_cell(a.label or '')}_"
+        else:
+            content = _md_cell(_content_text(a))
+        lines.append(f"| {date_cell} | {content} |")
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def render_csv(projection: Projection, language: str) -> str:
+    """One row per deck (insert rows carry an empty deck triple), date-ordered."""
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(_CSV_FIELDS)
+    for a in projection.assignments:
+        weekday = _weekday_token(a.start_date)
+        base = [a.start_date.isoformat(), a.end_date.isoformat(), weekday, a.kind]
+        if a.kind == "insert" or not a.decks:
+            writer.writerow([*base, a.label or "", "", "", ""])
+            continue
+        for deck in a.decks:
+            writer.writerow([*base, "", deck.video_title, deck.topic_id, deck.deck_file])
+    return buffer.getvalue()
+
+
+def _ics_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n")
+
+
+def _ics_uid(a: Assignment, namespace: str) -> str:
+    """A stable UID per assignment so re-exports update rather than duplicate.
+
+    Seeded by the assignment's bucket refs (deck-file stems) for video/merged
+    rows, or the date for an insert — both stable across re-projection of the
+    same content, even as dates shift.
+    """
+    if a.kind == "insert":
+        key = f"insert-{a.start_date.isoformat()}"
+    else:
+        key = "+".join(a.bucket_refs) or a.start_date.isoformat()
+    return f"{namespace}-{key}@clm.cohort-calendar"
+
+
+def render_ics(course_title: str, projection: Projection, *, namespace: str) -> str:
+    """Render an all-day iCalendar feed (RFC 5545, CRLF line endings).
+
+    Each assignment is one all-day VEVENT; a multi-date span uses the
+    exclusive-end ``DTEND`` convention (end date + 1 day). ``DTSTAMP`` is fixed
+    to each event's start date (no wall-clock read) to keep output deterministic.
+    """
+    cal_name = f"{course_title}" + (f" ({namespace})" if namespace else "")
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//CLM//Cohort Viewing Calendar//EN",
+        "CALSCALE:GREGORIAN",
+        f"X-WR-CALNAME:{_ics_escape(cal_name)}",
+    ]
+    for a in projection.assignments:
+        summary = _content_text(a) or (a.label or "")
+        dtend = a.end_date + dt.timedelta(days=1)  # DTEND is exclusive
+        stamp = a.start_date.strftime("%Y%m%dT000000Z")
+        lines += [
+            "BEGIN:VEVENT",
+            f"UID:{_ics_uid(a, namespace)}",
+            f"DTSTAMP:{stamp}",
+            f"DTSTART;VALUE=DATE:{a.start_date.strftime('%Y%m%d')}",
+            f"DTEND;VALUE=DATE:{dtend.strftime('%Y%m%d')}",
+            f"SUMMARY:{_ics_escape(summary)}",
+        ]
+        if a.kind != "insert" and a.decks:
+            topics = ", ".join(d.topic_id for d in a.decks)
+            lines.append(f"DESCRIPTION:{_ics_escape('Topics: ' + topics)}")
+        lines.append("END:VEVENT")
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"

--- a/src/clm/cohort_calendar/render.py
+++ b/src/clm/cohort_calendar/render.py
@@ -59,6 +59,16 @@ def _content_text(a: Assignment) -> str:
     return "; ".join(d.video_title for d in a.decks)
 
 
+def assignment_date_label(a: Assignment, language: str) -> str:
+    """Public: the localized 'Weekday date' (or range) for one assignment."""
+    return _fmt_span(a, language)
+
+
+def assignment_content(a: Assignment) -> str:
+    """Public: an assignment's display content (deck titles, or the insert label)."""
+    return _content_text(a)
+
+
 def render_markdown(course_title: str, projection: Projection, language: str) -> str:
     """One date-ordered table: ``Date | Content`` (insert rows shown in italics)."""
     date_h, content_h = _MD_HEADERS[language]

--- a/src/clm/cohort_calendar/status.py
+++ b/src/clm/cohort_calendar/status.py
@@ -1,0 +1,94 @@
+"""Calendar status: where a cohort is *today* vs the plan (issue #283, phase 5).
+
+The only "now"-relative piece of the feature. :func:`compute_status` is pure —
+it takes the reference date explicitly (the CLI passes the system date, or
+``--as-of``) so it stays deterministic and testable.
+
+Drift is measured against the *ideal* calendar — the same buckets, start, and
+pattern but with **no holidays and no adjustments** — i.e. the as-planned
+schedule. The reference assignment (the one active today, else the next one) is
+matched to its ideal twin by its first bucket ref (a deck-file stem, stable even
+across merges), and the gap in calendar days is the drift.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING
+
+from attrs import frozen
+
+from clm.cohort_calendar.config import CohortCalendarConfig
+from clm.cohort_calendar.projection import Assignment, project
+
+if TYPE_CHECKING:
+    from clm.cli.commands.schedule import Bucket
+
+_DEFAULT_LOOKAHEAD = 5
+
+
+@frozen
+class StatusReport:
+    """A snapshot of a cohort calendar relative to *as_of*."""
+
+    as_of: dt.date
+    current: Assignment | None  # assignment whose span covers as_of, if any
+    upcoming: tuple[Assignment, ...]  # the next assignments strictly after as_of
+    finished: bool  # as_of is past the last assignment
+    not_started: bool  # as_of is before the first assignment
+    drift_days: int | None  # reference vs ideal: +behind / -ahead / 0 on plan
+    reference: Assignment | None  # the assignment drift was measured against
+    has_errors: bool  # the projection itself failed (see `calendar check`)
+
+
+def _ideal(config: CohortCalendarConfig) -> CohortCalendarConfig:
+    """The as-planned config: same start/pattern, no holidays, no adjustments."""
+    return CohortCalendarConfig(
+        start=config.start,
+        end=None,
+        pattern=config.pattern,
+        holidays=(),
+        adjustments=(),
+    )
+
+
+def _match_ideal(reference: Assignment, ideal: tuple[Assignment, ...]) -> Assignment | None:
+    if not reference.bucket_refs:
+        return None
+    key = reference.bucket_refs[0]
+    return next((a for a in ideal if a.bucket_refs and a.bucket_refs[0] == key), None)
+
+
+def compute_status(
+    buckets: list[Bucket],
+    config: CohortCalendarConfig,
+    as_of: dt.date,
+    *,
+    lookahead: int = _DEFAULT_LOOKAHEAD,
+) -> StatusReport:
+    """Build a :class:`StatusReport` for *as_of* against the projected calendar."""
+    actual = project(buckets, config)
+    assignments = actual.assignments
+
+    current = next((a for a in assignments if a.start_date <= as_of <= a.end_date), None)
+    upcoming = tuple(a for a in assignments if a.start_date > as_of)
+    finished = bool(assignments) and as_of > assignments[-1].end_date
+    not_started = bool(assignments) and as_of < assignments[0].start_date
+
+    reference = current or (upcoming[0] if upcoming else None)
+    drift_days: int | None = None
+    if reference is not None:
+        twin = _match_ideal(reference, project(buckets, _ideal(config)).assignments)
+        if twin is not None:
+            drift_days = (reference.start_date - twin.start_date).days
+
+    return StatusReport(
+        as_of=as_of,
+        current=current,
+        upcoming=upcoming[:lookahead],
+        finished=finished,
+        not_started=not_started,
+        drift_days=drift_days,
+        reference=reference,
+        has_errors=not actual.ok,
+    )

--- a/tests/cli/test_calendar.py
+++ b/tests/cli/test_calendar.py
@@ -1,0 +1,112 @@
+"""Tests for the ``clm export calendar`` command (issue #283, phase 4)."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+SPEC_PATH = Path("tests/test-data/course-specs/subsection-spec.xml")
+
+# The fixture spec: Week 1 mon (two decks) + tue (Law), Week 2 wed. Starting on
+# Monday 2 Mar 2026 with the derived mon/tue/wed pattern lands them on the 2nd,
+# 3rd, 4th.
+CAL_OK = "start = 2026-03-02\n"
+CAL_TOO_SHORT = "start = 2026-03-02\nend = 2026-03-02\n"
+
+
+def _write(tmp_path, text) -> Path:
+    p = tmp_path / "jan.calendar.toml"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestExportCalendar:
+    def test_markdown_default(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["export", "calendar", str(SPEC_PATH), "--calendar", str(cal), "-L", "en"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "— Calendar" in result.output
+        assert "Monday 2026-03-02" in result.output
+        assert "Tuesday 2026-03-03" in result.output
+        assert "Wednesday 2026-03-04" in result.output
+        assert "Some Topic from Test 1" in result.output
+        assert "Simple Notebook" in result.output
+
+    def test_csv(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["export", "calendar", str(SPEC_PATH), "--calendar", str(cal), "-L", "en", "-f", "csv"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "date,end_date,weekday,kind,label,video_title,topic,deck_file" in result.output
+        assert (
+            "2026-03-02,2026-03-02,mon,video,,Some Topic from Test 1,some_topic_from_test_1,"
+            in (result.output)
+        )
+
+    def test_ics(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["export", "calendar", str(SPEC_PATH), "--calendar", str(cal), "-L", "en", "-f", "ics"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "BEGIN:VCALENDAR" in result.output
+        assert "DTSTART;VALUE=DATE:20260302" in result.output
+        assert "SUMMARY:Some Topic from Test 1" in result.output
+
+    def test_output_to_file(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        out = tmp_path / "out.ics"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "export",
+                "calendar",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "-f",
+                "ics",
+                "-o",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        assert "BEGIN:VCALENDAR" in out.read_text(encoding="utf-8")
+
+    def test_projection_errors_exit_nonzero(self, tmp_path):
+        cal = _write(tmp_path, CAL_TOO_SHORT)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["export", "calendar", str(SPEC_PATH), "--calendar", str(cal), "-L", "en"]
+        )
+        assert result.exit_code != 0
+        assert "merge" in result.output  # quantified deficit reported to stderr
+
+    def test_channel_without_release_channels_errors(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export", "calendar", str(SPEC_PATH), "--channel", "jan"])
+        assert result.exit_code != 0
+        assert "release-channels" in result.output
+
+    def test_requires_channel_or_calendar(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export", "calendar", str(SPEC_PATH)])
+        assert result.exit_code != 0
+        assert "--channel" in result.output or "--calendar" in result.output
+
+    def test_registered_in_export_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export", "--help"])
+        assert result.exit_code == 0
+        assert "calendar" in result.output

--- a/tests/cli/test_calendar.py
+++ b/tests/cli/test_calendar.py
@@ -110,3 +110,74 @@ class TestExportCalendar:
         result = runner.invoke(cli, ["export", "--help"])
         assert result.exit_code == 0
         assert "calendar" in result.output
+
+
+class TestCalendarGroup:
+    def test_check_ok(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["calendar", "check", str(SPEC_PATH), "--calendar", str(cal)])
+        assert result.exit_code == 0, result.output
+        assert "Calendar OK" in result.output
+
+    def test_check_reports_errors_and_exits_nonzero(self, tmp_path):
+        cal = _write(tmp_path, CAL_TOO_SHORT)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["calendar", "check", str(SPEC_PATH), "--calendar", str(cal)])
+        assert result.exit_code != 0
+        assert "error:" in result.output
+        assert "merge" in result.output
+
+    def test_status_today(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "calendar",
+                "status",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "-L",
+                "en",
+                "--as-of",
+                "2026-03-02",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "As of 2026-03-02:" in result.output
+        assert "Today: Monday 2026-03-02" in result.output
+        assert "Some Topic from Test 1" in result.output
+        assert "Upcoming:" in result.output
+
+    def test_status_no_class_today(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        runner = CliRunner()
+        # Thu 5 Mar: no class (mon/tue/wed); all three are in the past -> finished.
+        result = runner.invoke(
+            cli,
+            [
+                "calendar",
+                "status",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "-L",
+                "en",
+                "--as-of",
+                "2026-03-05",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "finished" in result.output.lower()
+
+    def test_group_registered(self):
+        runner = CliRunner()
+        top = runner.invoke(cli, ["--help"])
+        assert top.exit_code == 0
+        assert "calendar" in top.output
+        grp = runner.invoke(cli, ["calendar", "--help"])
+        assert grp.exit_code == 0
+        assert "check" in grp.output
+        assert "status" in grp.output

--- a/tests/cli/test_schedule.py
+++ b/tests/cli/test_schedule.py
@@ -7,9 +7,11 @@ from click.testing import CliRunner
 
 from clm.cli.commands.schedule import (
     WEEKDAY_LABELS,
+    Bucket,
     ScheduleDay,
     ScheduleDeck,
     ScheduleWeek,
+    build_buckets,
     build_schedule,
     render_csv,
     render_markdown,
@@ -90,6 +92,82 @@ class TestBuildSchedule:
         week2 = weeks[1]
         all_topics = [deck.topic_id for day in week2.days for deck in day.decks]
         assert all_topics == ["simple_notebook"]
+
+
+class TestBuildBuckets:
+    """The content sequence flattener for the cohort calendar (issue #283)."""
+
+    def _week(self, number, days):
+        return ScheduleWeek(number=number, title=f"Week {number}", days=days)
+
+    def test_flattens_days_in_week_then_document_order(self):
+        weeks = [
+            self._week(
+                1,
+                [
+                    ScheduleDay(weekdays=["mon"], label="Monday", decks=[]),
+                    ScheduleDay(weekdays=["tue"], label="Tuesday", decks=[]),
+                ],
+            ),
+            self._week(2, [ScheduleDay(weekdays=["wed"], label="Wednesday", decks=[])]),
+        ]
+        buckets = build_buckets(weeks)
+        assert [(b.week, b.weekday_label) for b in buckets] == [
+            (1, "Monday"),
+            (1, "Tuesday"),
+            (2, "Wednesday"),
+        ]
+
+    def test_span_is_weekday_count(self):
+        weeks = [
+            self._week(
+                1,
+                [
+                    ScheduleDay(weekdays=["mon"], label="Mon", decks=[]),
+                    ScheduleDay(weekdays=["mon", "tue"], label="Mon, Tue", decks=[]),
+                ],
+            )
+        ]
+        spans = [b.span for b in build_buckets(weeks)]
+        assert spans == [1, 2]
+
+    def test_span_defaults_to_one_for_thematic_group(self):
+        # A subsection with no weekday (thematic <name>-only group) still
+        # occupies a single teaching date.
+        weeks = [self._week(1, [ScheduleDay(weekdays=[], label="Intro", decks=[])])]
+        assert build_buckets(weeks)[0].span == 1
+
+    def test_decks_preserved_in_order(self):
+        decks = [
+            ScheduleDeck("Intro", "intro", "slides_010_intro"),
+            ScheduleDeck("More", "more", "slides_020_more"),
+        ]
+        weeks = [self._week(1, [ScheduleDay(weekdays=["mon"], label="Mon", decks=decks)])]
+        bucket = build_buckets(weeks)[0]
+        assert bucket.decks == decks
+
+    def test_empty_day_still_yields_a_bucket(self):
+        weeks = [self._week(1, [ScheduleDay(weekdays=["mon"], label="Mon", decks=[])])]
+        assert len(build_buckets(weeks)) == 1
+
+    def test_ref_ids_includes_topic_and_deck_file(self):
+        bucket = Bucket(
+            decks=[ScheduleDeck("Intro", "intro", "slides_010_intro")],
+            span=1,
+            week=1,
+            weekday_label="Mon",
+        )
+        assert bucket.ref_ids == {"intro", "slides_010_intro"}
+
+    def test_from_real_schedule(self, course):
+        # The fixture spec: Week 1 (mon: two decks, tue: Law), Week 2 (wed).
+        buckets = build_buckets(build_schedule(course, "en"))
+        assert [(b.week, b.span) for b in buckets] == [(1, 1), (1, 1), (2, 1)]
+        assert [d.topic_id for d in buckets[0].decks] == [
+            "some_topic_from_test_1",
+            "a_topic_from_test_2",
+        ]
+        assert "some_topic_from_test_1" in buckets[0].ref_ids
 
 
 class TestRenderMarkdown:

--- a/tests/cli/test_schedule.py
+++ b/tests/cli/test_schedule.py
@@ -128,8 +128,10 @@ class TestBuildBuckets:
                 ],
             )
         ]
-        spans = [b.span for b in build_buckets(weeks)]
-        assert spans == [1, 2]
+        buckets = build_buckets(weeks)
+        assert [b.span for b in buckets] == [1, 2]
+        # The language-neutral weekday tokens are carried for pattern derivation.
+        assert [b.weekdays for b in buckets] == [("mon",), ("mon", "tue")]
 
     def test_span_defaults_to_one_for_thematic_group(self):
         # A subsection with no weekday (thematic <name>-only group) still

--- a/tests/cohort_calendar/test_config.py
+++ b/tests/cohort_calendar/test_config.py
@@ -1,0 +1,218 @@
+"""Tests for the cohort calendar config loader (issue #283, phase 2)."""
+
+import datetime as dt
+
+import pytest
+
+from clm.cohort_calendar.config import (
+    CohortCalendarError,
+    Holiday,
+    Insert,
+    Merge,
+    Pin,
+    Split,
+    effective_pattern,
+    load_calendar_config,
+    parse_calendar_config,
+)
+
+FULL = """
+start = 2026-03-02
+end   = 2026-06-30
+pattern = ["wed", "mon", "tue"]
+
+holidays = [
+  2026-04-06,
+  {from = 2026-07-20, to = 2026-08-02, label = "Summer break"},
+]
+
+[[adjustments]]
+merge = 2026-03-18
+count = 2
+
+[[adjustments]]
+split = "variables_intro"
+dates = [2026-03-26, 2026-03-25]
+
+[[adjustments]]
+insert = 2026-03-30
+label = "Review & Q&A"
+
+[[adjustments]]
+pin  = "control_flow"
+date = 2026-04-09
+"""
+
+
+class TestParseValid:
+    def test_minimal_start_only(self):
+        cfg = parse_calendar_config("start = 2026-03-02")
+        assert cfg.start == dt.date(2026, 3, 2)
+        assert cfg.end is None
+        assert cfg.pattern == ()
+        assert cfg.holidays == ()
+        assert cfg.adjustments == ()
+
+    def test_full_scalars(self):
+        cfg = parse_calendar_config(FULL)
+        assert cfg.start == dt.date(2026, 3, 2)
+        assert cfg.end == dt.date(2026, 6, 30)
+
+    def test_pattern_canonicalized_to_mon_sun_order(self):
+        cfg = parse_calendar_config(FULL)
+        # File listed wed, mon, tue -> stored Mon, Tue, Wed.
+        assert cfg.pattern == ("mon", "tue", "wed")
+
+    def test_pattern_dedupes(self):
+        cfg = parse_calendar_config('start = 2026-03-02\npattern = ["mon", "mon", "tue"]')
+        assert cfg.pattern == ("mon", "tue")
+
+    def test_holidays_single_and_interval(self):
+        cfg = parse_calendar_config(FULL)
+        assert cfg.holidays[0] == Holiday(dt.date(2026, 4, 6), dt.date(2026, 4, 6))
+        assert cfg.holidays[1] == Holiday(dt.date(2026, 7, 20), dt.date(2026, 8, 2), "Summer break")
+
+    def test_adjustments_parsed_in_file_order_with_types(self):
+        cfg = parse_calendar_config(FULL)
+        assert isinstance(cfg.adjustments[0], Merge)
+        assert isinstance(cfg.adjustments[1], Split)
+        assert isinstance(cfg.adjustments[2], Insert)
+        assert isinstance(cfg.adjustments[3], Pin)
+
+    def test_merge_fields(self):
+        cfg = parse_calendar_config(FULL)
+        assert cfg.adjustments[0] == Merge(date=dt.date(2026, 3, 18), count=2)
+
+    def test_split_dates_sorted(self):
+        cfg = parse_calendar_config(FULL)
+        split = cfg.adjustments[1]
+        assert split.ref == "variables_intro"
+        # File listed 26th then 25th; stored chronologically.
+        assert split.dates == (dt.date(2026, 3, 25), dt.date(2026, 3, 26))
+
+    def test_pin_fields(self):
+        cfg = parse_calendar_config(FULL)
+        assert cfg.adjustments[3] == Pin(ref="control_flow", date=dt.date(2026, 4, 9))
+
+
+class TestParseErrors:
+    def test_missing_start(self):
+        with pytest.raises(CohortCalendarError, match="start"):
+            parse_calendar_config("end = 2026-06-30")
+
+    def test_end_before_start(self):
+        with pytest.raises(CohortCalendarError, match="before start"):
+            parse_calendar_config("start = 2026-06-30\nend = 2026-03-02")
+
+    def test_datetime_literal_rejected(self):
+        with pytest.raises(CohortCalendarError, match="expected a date"):
+            parse_calendar_config("start = 2026-03-02T10:00:00")
+
+    def test_string_date_rejected(self):
+        with pytest.raises(CohortCalendarError, match="expected a date"):
+            parse_calendar_config('start = "2026-03-02"')
+
+    def test_unknown_top_level_key(self):
+        with pytest.raises(CohortCalendarError, match="unknown key"):
+            parse_calendar_config("start = 2026-03-02\nbogus = 1")
+
+    def test_invalid_weekday_token(self):
+        with pytest.raises(CohortCalendarError, match="unknown weekday"):
+            parse_calendar_config('start = 2026-03-02\npattern = ["funday"]')
+
+    def test_invalid_toml(self):
+        with pytest.raises(CohortCalendarError, match="invalid TOML"):
+            parse_calendar_config("start = = 1")
+
+    def test_holiday_interval_reversed(self):
+        text = "start = 2026-03-02\nholidays = [{from = 2026-08-02, to = 2026-07-20}]"
+        with pytest.raises(CohortCalendarError, match="before start"):
+            parse_calendar_config(text)
+
+    def test_holiday_interval_missing_to(self):
+        text = "start = 2026-03-02\nholidays = [{from = 2026-07-20}]"
+        with pytest.raises(CohortCalendarError, match="both 'from' and 'to'"):
+            parse_calendar_config(text)
+
+    def test_holiday_unknown_key(self):
+        text = "start = 2026-03-02\nholidays = [{from = 2026-07-20, to = 2026-07-21, oops = 1}]"
+        with pytest.raises(CohortCalendarError, match="unknown key"):
+            parse_calendar_config(text)
+
+    def test_adjustment_no_discriminator(self):
+        text = "start = 2026-03-02\n[[adjustments]]\ncount = 2"
+        with pytest.raises(CohortCalendarError, match="exactly one"):
+            parse_calendar_config(text)
+
+    def test_adjustment_two_discriminators(self):
+        text = "start = 2026-03-02\n[[adjustments]]\nmerge = 2026-03-18\ncount = 2\npin = 'x'\ndate = 2026-03-18"
+        with pytest.raises(CohortCalendarError, match="exactly one"):
+            parse_calendar_config(text)
+
+    def test_merge_count_too_small(self):
+        text = "start = 2026-03-02\n[[adjustments]]\nmerge = 2026-03-18\ncount = 1"
+        with pytest.raises(CohortCalendarError, match="count >= 2"):
+            parse_calendar_config(text)
+
+    def test_merge_missing_count(self):
+        text = "start = 2026-03-02\n[[adjustments]]\nmerge = 2026-03-18"
+        with pytest.raises(CohortCalendarError, match="count >= 2"):
+            parse_calendar_config(text)
+
+    def test_split_needs_two_distinct_dates(self):
+        text = "start = 2026-03-02\n[[adjustments]]\nsplit = 'x'\ndates = [2026-03-25, 2026-03-25]"
+        with pytest.raises(CohortCalendarError, match="two distinct dates"):
+            parse_calendar_config(text)
+
+    def test_insert_missing_label(self):
+        text = "start = 2026-03-02\n[[adjustments]]\ninsert = 2026-03-30"
+        with pytest.raises(CohortCalendarError, match="needs a 'label'"):
+            parse_calendar_config(text)
+
+    def test_pin_missing_date(self):
+        text = "start = 2026-03-02\n[[adjustments]]\npin = 'x'"
+        with pytest.raises(CohortCalendarError, match="needs a 'date'"):
+            parse_calendar_config(text)
+
+    def test_count_bool_rejected(self):
+        text = "start = 2026-03-02\n[[adjustments]]\nmerge = 2026-03-18\ncount = true"
+        with pytest.raises(CohortCalendarError, match="expected an integer"):
+            parse_calendar_config(text)
+
+
+class TestEffectivePattern:
+    def test_configured_wins(self):
+        assert effective_pattern(("mon", "wed"), ["tue", "thu"]) == ("mon", "wed")
+
+    def test_derived_from_available_in_canonical_order(self):
+        assert effective_pattern((), ["fri", "mon", "wed"]) == ("mon", "wed", "fri")
+
+    def test_derived_empty_when_nothing_available(self):
+        assert effective_pattern((), []) == ()
+
+
+class TestHolidayCovers:
+    def test_single_day(self):
+        h = Holiday(dt.date(2026, 4, 6), dt.date(2026, 4, 6))
+        assert h.covers(dt.date(2026, 4, 6))
+        assert not h.covers(dt.date(2026, 4, 7))
+
+    def test_interval_inclusive(self):
+        h = Holiday(dt.date(2026, 7, 20), dt.date(2026, 8, 2))
+        assert h.covers(dt.date(2026, 7, 20))
+        assert h.covers(dt.date(2026, 8, 2))
+        assert h.covers(dt.date(2026, 7, 25))
+        assert not h.covers(dt.date(2026, 8, 3))
+
+
+class TestLoadFromFile:
+    def test_load_roundtrip(self, tmp_path):
+        path = tmp_path / "jan.calendar.toml"
+        path.write_text(FULL, encoding="utf-8")
+        cfg = load_calendar_config(path)
+        assert cfg.start == dt.date(2026, 3, 2)
+        assert len(cfg.adjustments) == 4
+
+    def test_missing_file_errors(self, tmp_path):
+        with pytest.raises(CohortCalendarError, match="not found"):
+            load_calendar_config(tmp_path / "nope.calendar.toml")

--- a/tests/cohort_calendar/test_projection.py
+++ b/tests/cohort_calendar/test_projection.py
@@ -1,0 +1,229 @@
+"""Tests for the cohort calendar projection engine (issue #283, phase 3)."""
+
+import datetime as dt
+
+from clm.cli.commands.schedule import Bucket, ScheduleDeck
+from clm.cohort_calendar.config import CohortCalendarConfig, Holiday, Insert, Merge, Pin, Split
+from clm.cohort_calendar.projection import project
+
+# March 2026: 2nd=Mon, 3rd=Tue, 4th=Wed, 5th=Thu, 6th=Fri, 7-8 weekend, 9th=Mon.
+MON = dt.date(2026, 3, 2)
+
+
+def deck(name: str) -> ScheduleDeck:
+    return ScheduleDeck(video_title=name, topic_id=name, deck_file=f"slides_{name}")
+
+
+def bucket(*deck_names: str, weekdays=("mon",), week=1, label="day") -> Bucket:
+    return Bucket(
+        decks=[deck(n) for n in deck_names],
+        span=max(1, len(weekdays)),
+        week=week,
+        weekday_label=label,
+        weekdays=tuple(weekdays),
+    )
+
+
+def cfg(start=MON, **kw) -> CohortCalendarConfig:
+    return CohortCalendarConfig(
+        start=start,
+        end=kw.get("end"),
+        pattern=kw.get("pattern", ()),
+        holidays=tuple(kw.get("holidays", ())),
+        adjustments=tuple(kw.get("adjustments", ())),
+    )
+
+
+def dates_of(proj):
+    return [(a.start_date, a.kind, tuple(d.topic_id for d in a.decks)) for a in proj.assignments]
+
+
+class TestBasicProjection:
+    def test_one_to_one_consecutive_days(self):
+        buckets = [
+            bucket("A", weekdays=("mon",)),
+            bucket("B", weekdays=("tue",)),
+            bucket("C", weekdays=("wed",)),
+        ]
+        proj = project(buckets, cfg())
+        assert proj.ok
+        assert [a.start_date for a in proj.assignments] == [
+            dt.date(2026, 3, 2),
+            dt.date(2026, 3, 3),
+            dt.date(2026, 3, 4),
+        ]
+
+    def test_holiday_shifts_everything_after(self):
+        # Tue 3 Mar is a holiday -> C slides from Wed 4th to Mon 9th.
+        buckets = [
+            bucket("A", weekdays=("mon",)),
+            bucket("B", weekdays=("tue",)),
+            bucket("C", weekdays=("wed",)),
+        ]
+        proj = project(buckets, cfg(holidays=[Holiday(dt.date(2026, 3, 3), dt.date(2026, 3, 3))]))
+        assert [a.start_date for a in proj.assignments] == [
+            dt.date(2026, 3, 2),  # Mon
+            dt.date(2026, 3, 4),  # Wed (Tue removed)
+            dt.date(2026, 3, 9),  # next Mon
+        ]
+
+    def test_interval_holiday_two_week_break(self):
+        buckets = [bucket("A", weekdays=("mon",)), bucket("B", weekdays=("mon",))]
+        # A on Mon 2 Mar; a two-week break covering the next two Mondays pushes B
+        # to Mon 23 Mar.
+        proj = project(
+            buckets,
+            cfg(
+                pattern=("mon",),
+                holidays=[Holiday(dt.date(2026, 3, 9), dt.date(2026, 3, 22), "Break")],
+            ),
+        )
+        assert [a.start_date for a in proj.assignments] == [
+            dt.date(2026, 3, 2),
+            dt.date(2026, 3, 23),
+        ]
+
+    def test_span_bucket_occupies_two_dates(self):
+        buckets = [bucket("A", "B", weekdays=("mon", "tue")), bucket("C", weekdays=("wed",))]
+        proj = project(buckets, cfg())
+        a0 = proj.assignments[0]
+        assert a0.start_date == dt.date(2026, 3, 2)  # Mon
+        assert a0.end_date == dt.date(2026, 3, 3)  # Tue (span 2)
+        # C follows on Wed, not overlapping the span.
+        assert proj.assignments[1].start_date == dt.date(2026, 3, 4)
+
+    def test_start_on_non_teaching_day_lands_on_next(self):
+        # Start Sunday 1 Mar with a Mon pattern -> first bucket on Mon 2 Mar.
+        buckets = [bucket("A", weekdays=("mon",))]
+        proj = project(buckets, cfg(start=dt.date(2026, 3, 1), pattern=("mon",)))
+        assert proj.assignments[0].start_date == dt.date(2026, 3, 2)
+
+
+class TestEnd:
+    def test_end_overflow_errors_with_deficit(self):
+        # Five Mon/Tue/Wed buckets but end leaves only the first week (3 dates).
+        buckets = [
+            bucket(c, weekdays=(w,)) for c, w in zip("ABCDE", ["mon", "tue", "wed", "mon", "tue"])
+        ]
+        proj = project(buckets, cfg(end=dt.date(2026, 3, 4)))  # Wed 4 Mar
+        assert not proj.ok
+        assert any("merge ≥ 2" in e.message for e in proj.errors)
+
+    def test_fits_before_end(self):
+        buckets = [bucket(c, weekdays=(w,)) for c, w in zip("ABC", ["mon", "tue", "wed"])]
+        proj = project(buckets, cfg(end=dt.date(2026, 3, 6)))
+        assert proj.ok
+
+
+class TestPins:
+    def _week(self):
+        return [
+            bucket("M1", "M2", weekdays=("mon",)),
+            bucket("T1", weekdays=("tue",)),
+            bucket("W1", "W2", "W3", weekdays=("wed",)),
+            bucket("H1", weekdays=("thu",)),
+            bucket("F1", "F2", weekdays=("fri",)),
+        ]
+
+    def test_overfull_segment_errors_with_deficit(self):
+        # The §6.4 scenario WITHOUT the merge: 5 buckets pinned into 4 dates.
+        adj = [Pin("M1", dt.date(2026, 3, 3)), Pin("F2", dt.date(2026, 3, 6))]
+        proj = project(self._week(), cfg(adjustments=adj))
+        assert not proj.ok
+        assert any("merge ≥ 1" in e.message for e in proj.errors)
+
+    def test_worked_example_with_merge_is_exact(self):
+        # §6.4 resolved: pin start to Tue, end to Fri, merge Tue+Wed on Wed.
+        adj = [
+            Pin("M1", dt.date(2026, 3, 3)),
+            Pin("F2", dt.date(2026, 3, 6)),
+            Merge(dt.date(2026, 3, 4), count=2),
+        ]
+        proj = project(self._week(), cfg(adjustments=adj))
+        assert proj.ok, [d.message for d in proj.diagnostics]
+        assert dates_of(proj) == [
+            (dt.date(2026, 3, 3), "video", ("M1", "M2")),
+            (dt.date(2026, 3, 4), "merged", ("T1", "W1", "W2", "W3")),
+            (dt.date(2026, 3, 5), "video", ("H1",)),
+            (dt.date(2026, 3, 6), "video", ("F1", "F2")),
+        ]
+
+    def test_underfull_segment_warns_with_free_dates(self):
+        buckets = [bucket("A", weekdays=("mon",)), bucket("Z", weekdays=("fri",))]
+        adj = [Pin("A", dt.date(2026, 3, 2)), Pin("Z", dt.date(2026, 3, 6))]
+        proj = project(buckets, cfg(pattern=("mon", "tue", "wed", "thu", "fri"), adjustments=adj))
+        assert proj.ok
+        assert any("free teaching date" in w.message for w in proj.warnings)
+
+    def test_pins_out_of_order_error(self):
+        buckets = [bucket("A", weekdays=("mon",)), bucket("B", weekdays=("tue",))]
+        adj = [Pin("A", dt.date(2026, 3, 5)), Pin("B", dt.date(2026, 3, 3))]
+        proj = project(buckets, cfg(pattern=("mon", "tue", "wed", "thu", "fri"), adjustments=adj))
+        assert any("out of order" in e.message for e in proj.errors)
+
+    def test_unknown_pin_ref_error(self):
+        proj = project([bucket("A", weekdays=("mon",))], cfg(adjustments=[Pin("nope", MON)]))
+        assert any("unknown bucket ref" in e.message for e in proj.errors)
+
+    def test_ambiguous_pin_ref_error(self):
+        # Two buckets both contain a deck named "dup".
+        buckets = [bucket("dup", weekdays=("mon",)), bucket("dup", weekdays=("tue",))]
+        proj = project(buckets, cfg(adjustments=[Pin("dup", dt.date(2026, 3, 3))]))
+        assert any("ambiguous" in e.message for e in proj.errors)
+
+
+class TestInsertAndMerge:
+    def test_insert_emits_label_and_shifts(self):
+        buckets = [bucket("A", weekdays=("mon",)), bucket("B", weekdays=("tue",))]
+        adj = [Insert(dt.date(2026, 3, 3), "Review")]  # Tue 3 Mar is a review day
+        proj = project(buckets, cfg(pattern=("mon", "tue", "wed"), adjustments=adj))
+        kinds = dates_of(proj)
+        assert (dt.date(2026, 3, 2), "video", ("A",)) in kinds
+        assert (dt.date(2026, 3, 3), "insert", ()) in kinds
+        # B is pushed past the review day to Wed 4 Mar.
+        assert (dt.date(2026, 3, 4), "video", ("B",)) in kinds
+
+    def test_insert_on_non_teaching_date_warns(self):
+        buckets = [bucket("A", weekdays=("mon",))]
+        adj = [Insert(dt.date(2026, 3, 7), "Sat")]  # Saturday — not in pattern
+        proj = project(buckets, cfg(pattern=("mon",), adjustments=adj))
+        assert any("not a teaching date" in w.message for w in proj.warnings)
+
+    def test_merge_collapses_buckets_onto_one_date(self):
+        buckets = [
+            bucket("A", weekdays=("mon",)),
+            bucket("B", weekdays=("tue",)),
+            bucket("C", weekdays=("wed",)),
+        ]
+        adj = [Merge(dt.date(2026, 3, 3), count=2)]  # B+C share Tue 3 Mar
+        proj = project(buckets, cfg(adjustments=adj))
+        assert dates_of(proj) == [
+            (dt.date(2026, 3, 2), "video", ("A",)),
+            (dt.date(2026, 3, 3), "merged", ("B", "C")),
+        ]
+
+
+class TestSplit:
+    def test_split_slows_bucket_to_two_dates(self):
+        buckets = [bucket("A", weekdays=("mon",)), bucket("B", weekdays=("tue",))]
+        adj = [Split("A", (dt.date(2026, 3, 2), dt.date(2026, 3, 3)))]
+        proj = project(buckets, cfg(pattern=("mon", "tue", "wed"), adjustments=adj))
+        a0 = proj.assignments[0]
+        assert a0.start_date == dt.date(2026, 3, 2)
+        assert a0.end_date == dt.date(2026, 3, 3)  # occupies two dates
+        # B is pushed to Wed.
+        assert proj.assignments[1].start_date == dt.date(2026, 3, 4)
+
+
+class TestDegenerate:
+    def test_no_teaching_weekdays_errors(self):
+        # Bucket has no weekday tokens and no pattern configured.
+        b = Bucket(decks=[deck("A")], span=1, week=1, weekday_label="x", weekdays=())
+        proj = project([b], cfg())
+        assert not proj.ok
+        assert any("no teaching weekdays" in e.message for e in proj.errors)
+
+    def test_empty_buckets_yields_empty_calendar(self):
+        proj = project([], cfg(pattern=("mon",)))
+        assert proj.assignments == ()
+        assert proj.ok

--- a/tests/cohort_calendar/test_render.py
+++ b/tests/cohort_calendar/test_render.py
@@ -1,0 +1,114 @@
+"""Tests for the cohort calendar renderers (issue #283, phase 4)."""
+
+import datetime as dt
+
+from clm.cli.commands.schedule import ScheduleDeck
+from clm.cohort_calendar.projection import Assignment, Projection
+from clm.cohort_calendar.render import render_csv, render_ics, render_markdown
+
+
+def deck(title, topic, file):
+    return ScheduleDeck(video_title=title, topic_id=topic, deck_file=file)
+
+
+def sample() -> Projection:
+    return Projection(
+        assignments=(
+            Assignment(
+                dt.date(2026, 3, 2),
+                dt.date(2026, 3, 2),
+                (deck("Intro", "intro", "slides_010_intro"),),
+                None,
+                "video",
+                ("slides_010_intro",),
+            ),
+            Assignment(
+                dt.date(2026, 3, 3),
+                dt.date(2026, 3, 3),
+                (),
+                "Review & Q&A",
+                "insert",
+                ("insert:2026-03-03",),
+            ),
+            Assignment(
+                dt.date(2026, 3, 4),
+                dt.date(2026, 3, 5),
+                (deck("Spanned", "span", "slides_020_span"),),
+                None,
+                "video",
+                ("slides_020_span",),
+            ),
+        ),
+        diagnostics=(),
+    )
+
+
+class TestMarkdown:
+    def test_header_and_rows(self):
+        out = render_markdown("My Course", sample(), "en")
+        assert out.startswith("# My Course — Calendar\n")
+        assert "| Date | Content |" in out
+        assert "| Monday 2026-03-02 | Intro |" in out
+        # Insert rows render the label in italics, no decks.
+        assert "| Tuesday 2026-03-03 | _Review & Q&A_ |" in out
+
+    def test_span_renders_date_range(self):
+        out = render_markdown("C", sample(), "en")
+        assert "| Wednesday 2026-03-04 – Thursday 2026-03-05 | Spanned |" in out
+
+    def test_german_headers(self):
+        out = render_markdown("Kurs", sample(), "de")
+        assert "# Kurs — Kalender" in out
+        assert "| Datum | Inhalt |" in out
+        assert "| Montag 2026-03-02 | Intro |" in out
+
+    def test_empty(self):
+        out = render_markdown("C", Projection((), ()), "en")
+        assert "_No dates scheduled._" in out
+
+
+class TestCsv:
+    def test_header_and_video_row(self):
+        out = render_csv(sample(), "en")
+        lines = out.strip().splitlines()
+        assert lines[0] == "date,end_date,weekday,kind,label,video_title,topic,deck_file"
+        assert lines[1] == "2026-03-02,2026-03-02,mon,video,,Intro,intro,slides_010_intro"
+
+    def test_insert_row_has_empty_deck_triple(self):
+        out = render_csv(sample(), "en")
+        assert "2026-03-03,2026-03-03,tue,insert,Review & Q&A,,," in out
+
+    def test_span_end_date_column(self):
+        out = render_csv(sample(), "en")
+        assert "2026-03-04,2026-03-05,wed,video,,Spanned,span,slides_020_span" in out
+
+
+class TestIcs:
+    def test_calendar_envelope(self):
+        out = render_ics("My Course", sample(), namespace="jan")
+        assert out.startswith("BEGIN:VCALENDAR\r\n")
+        assert out.rstrip().endswith("END:VCALENDAR")
+        assert "X-WR-CALNAME:My Course (jan)" in out
+
+    def test_all_day_event_with_stable_uid(self):
+        out = render_ics("C", sample(), namespace="jan")
+        assert "DTSTART;VALUE=DATE:20260302" in out
+        assert "SUMMARY:Intro" in out
+        assert "UID:jan-slides_010_intro@clm.cohort-calendar" in out
+
+    def test_span_uses_exclusive_dtend(self):
+        out = render_ics("C", sample(), namespace="jan")
+        # End date 5 Mar -> exclusive DTEND 6 Mar.
+        assert "DTSTART;VALUE=DATE:20260304" in out
+        assert "DTEND;VALUE=DATE:20260306" in out
+
+    def test_insert_event_uses_label_and_date_uid(self):
+        out = render_ics("C", sample(), namespace="jan")
+        assert "SUMMARY:Review & Q&A" in out
+        assert "UID:jan-insert-2026-03-03@clm.cohort-calendar" in out
+
+    def test_crlf_line_endings(self):
+        out = render_ics("C", sample(), namespace="jan")
+        assert "\r\n" in out
+        # No lone LFs.
+        assert "\n" not in out.replace("\r\n", "")

--- a/tests/cohort_calendar/test_status.py
+++ b/tests/cohort_calendar/test_status.py
@@ -1,0 +1,87 @@
+"""Tests for the cohort calendar status engine (issue #283, phase 5)."""
+
+import datetime as dt
+
+from clm.cli.commands.schedule import Bucket, ScheduleDeck
+from clm.cohort_calendar.config import CohortCalendarConfig, Holiday
+from clm.cohort_calendar.status import compute_status
+
+
+def deck(name):
+    return ScheduleDeck(video_title=name, topic_id=name, deck_file=f"slides_{name}")
+
+
+def bucket(name, weekday, week=1):
+    return Bucket(
+        decks=[deck(name)],
+        span=1,
+        week=week,
+        weekday_label=weekday.capitalize(),
+        weekdays=(weekday,),
+    )
+
+
+def cfg(start=dt.date(2026, 3, 2), holidays=()):
+    return CohortCalendarConfig(
+        start=start, end=None, pattern=(), holidays=tuple(holidays), adjustments=()
+    )
+
+
+WEEK = [bucket("A", "mon"), bucket("B", "tue"), bucket("C", "wed")]
+
+
+class TestComputeStatus:
+    def test_today_is_current_and_on_schedule(self):
+        r = compute_status(WEEK, cfg(), dt.date(2026, 3, 2))
+        assert r.current is not None
+        assert r.current.decks[0].topic_id == "A"
+        assert r.drift_days == 0
+
+    def test_no_class_today_points_at_next(self):
+        # Thu 5 Mar is not a teaching day (mon/tue/wed pattern).
+        r = compute_status(WEEK, cfg(), dt.date(2026, 3, 5))
+        assert r.current is None
+        assert r.finished  # all of A/B/C (2,3,4 Mar) are in the past
+        assert not r.upcoming
+
+    def test_midweek_gap_before_finish(self):
+        # With a Tue holiday, C slides to Mon 9 Mar; as-of Thu 5 Mar sees it ahead.
+        r = compute_status(
+            WEEK,
+            cfg(holidays=[Holiday(dt.date(2026, 3, 3), dt.date(2026, 3, 3))]),
+            dt.date(2026, 3, 5),
+        )
+        assert r.current is None
+        assert not r.finished
+        assert r.reference is not None and r.reference.decks[0].topic_id == "C"
+
+    def test_drift_behind_after_holiday(self):
+        # Tue holiday pushes C from ideal Wed 4 Mar to actual Mon 9 Mar = +5 days.
+        r = compute_status(
+            WEEK,
+            cfg(holidays=[Holiday(dt.date(2026, 3, 3), dt.date(2026, 3, 3))]),
+            dt.date(2026, 3, 9),
+        )
+        assert r.current is not None and r.current.decks[0].topic_id == "C"
+        assert r.drift_days == 5
+
+    def test_not_started(self):
+        r = compute_status(WEEK, cfg(start=dt.date(2026, 3, 9)), dt.date(2026, 3, 2))
+        assert r.not_started
+        assert r.current is None
+        assert r.reference is not None and r.reference.decks[0].topic_id == "A"
+
+    def test_finished(self):
+        r = compute_status(WEEK, cfg(), dt.date(2026, 3, 20))
+        assert r.finished
+        assert not r.upcoming
+
+    def test_upcoming_lookahead_limited(self):
+        many = [bucket(c, w, week=1) for c, w in zip("ABCDE", ["mon", "tue", "wed", "mon", "tue"])]
+        r = compute_status(many, cfg(), dt.date(2026, 3, 1), lookahead=2)
+        assert len(r.upcoming) == 2
+
+    def test_projection_errors_flagged(self):
+        bad = [Bucket(decks=[deck("A")], span=1, week=1, weekday_label="x", weekdays=())]
+        r = compute_status(bad, cfg(), dt.date(2026, 3, 2))
+        assert r.has_errors


### PR DESCRIPTION
Closes #283.

Projects a course's **schedule** (course-relative — "Week 3, Tuesday") onto one cohort's **real calendar dates**, absorbing that cohort's holidays, delayed start, multi-week breaks, and catch-up days. Where `clm export schedule` is the as-planned listing, a *calendar* maps the same ordered day-buckets onto actual dates for a cohort.

Full design: `docs/claude/design/cohort-viewing-calendar.md`.

## How it works

A calendar is the *zip* of two sequences:
- a **content sequence** — the ordered day-buckets `export schedule` already produces (shared by all cohorts);
- a per-cohort **date sequence** — generated from a small, hand-edited `release/<channel>.calendar.toml` (TOML, stdlib `tomllib`, beside the channel's release ledger).

The trainer maintains only the *deltas*: `start`/`end`, a weekly teaching `pattern`, `holidays` (single date or `{from, to, label}` interval), and ordered `[[adjustments]]` (`merge` / `split` / `insert` / `pin`). Every per-video date is computed — a holiday just removes a teaching date, so later content slides automatically.

Key decisions (all settled with the maintainer):
- **Pins** anchor a whole bucket (by stable topic/deck id) and *segment* the timeline; each segment is fit independently.
- **No magic** on overflow: a pin-bounded segment with more buckets than teaching dates is an **error** naming the exact deficit (`merge ≥ N buckets`) — never a silent redistribution. Under-full segments warn with the free-date count; `end` overflow is quantified the same way.
- `check` / `export` are **date-free** (pure functions of config); `status` is the only now-relative command (`--as-of`, drift vs the ideal no-holiday/no-adjustment calendar).
- The `.ics` feed uses **stable per-assignment UIDs**, so re-exporting an updated calendar updates events in a subscribed client instead of duplicating them.

## Commands

- `clm export calendar <spec> [--channel NAME | --calendar PATH] -f md|csv|ics` — render the calendar (md/csv for the trainer, ics the subscribable student feed).
- `clm calendar check <spec> …` — date-free validation; non-zero exit on errors (suits a pre-push hook).
- `clm calendar status <spec> … [--as-of YYYY-MM-DD]` — today's assignment, its plan coordinate, and drift in days vs the ideal plan.

## Phases (all done)

1. Expose `Bucket` content sequence from `export schedule` (no behaviour change)
2. `cohort_calendar` config model + TOML loader
3. Projection engine (date generation, pin segmentation, no-magic overflow)
4. md/csv/ics renderers + `clm export calendar`
5. `clm calendar check` + `status`
6. Docs (`clm info commands`, CHANGELOG)

## Tests & checks

New: `tests/cohort_calendar/{test_config,test_projection,test_render,test_status}.py` + `tests/cli/test_calendar.py` (~130 cases incl. the design's worked example end-to-end). Full local suite green (7354 passed); ruff + mypy clean.

Deferred (noted in the design doc §12): `split` per-date deck distribution, optional dated release-coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
