### PR TITLE
fix(sync): never silently drop a tag-only edit; mirror id-less retags on git-HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm slides sync` no longer silently drops a one-sided tag-only edit**
+  (issue #289, found by the sync architecture review in
+  `docs/claude/sync-engine-architecture-assessment.md`). Three tag-channel
+  gaps — all of which previously reported *"decks already consistent"* and
+  advanced the watermark over the divergence, permanently hiding it from
+  later syncs — are closed:
+  - a tag-only edit on an **id-less localized** cell is now **mirrored** on a
+    committed (git-HEAD) baseline too, not only against a watermark: the
+    Tier C retag classifier re-derives the baseline rows + tag sets from the
+    committed text, so the first sync of a freshly-split committed pair
+    carries a `keep`/`alt` tag change across;
+  - a tag-only edit on a **language-neutral (shared)** cell — whose tags must
+    match across the halves, since a neutral cell is shared verbatim header
+    included — now **errors** (the body-hash detectors are blind to it, and
+    sync has no neutral-retag mirror yet): the watermark holds and nothing is
+    written. A combined body+tag edit still propagates both via the structural
+    rebuild's verbatim header copy, with no false alert. The post-apply
+    shared-cell parity fail-safe also compares tag sets now;
+  - a tag-only edit on an id-less localized cell **while the other half
+    reorders slide groups** (issue #285) now **errors** instead of vanishing:
+    positional tag mirroring is unsound across a reorder, so the drift is
+    detected order-blind (hash-keyed against each half's own baseline) and the
+    watermark holds.
+  A new channel-coverage meta-test pins the class: every channel the sync
+  watermark records (body hash, tags, header, order, identity, construct — per
+  partition) must name a live detector or fail-safe, so a future recorded
+  channel can no longer ship unconsumed the way shared-partition tags did.
 - **`clm slides sync` no longer errors when a new slide group is inserted next
   to a language-neutral cell.** Adding a new id'd slide (a localized markdown
   cell + its following language-neutral code cells) right after a neutral cell —

--- a/scripts/sync_matrix_probes.py
+++ b/scripts/sync_matrix_probes.py
@@ -9,9 +9,11 @@ and reports:
   ALERTED     - errors/deferred/issue-error raised, watermark held
   SILENT-DROP - plan.is_noop, no alert, change not propagated (the forbidden state)
 
-As of master ``fab89615``, P1 / P5 / P9 are the three live SILENT-DROP cells (all
-tag-channel); promote each into ``tests/slides/`` as an expected-alert regression
-test once the channel-generic tag-parity fail-safe (assessment §5 P0) lands.
+On master ``fab89615`` (pre-#289), P1 / P5 / P9 were the three live SILENT-DROP
+cells (all tag-channel). The #289 fix closed them — P1 now PROPAGATES (Tier C on
+the git-HEAD baseline), P5 / P9 ALERT with the watermark held — and promoted the
+probes into ``tests/slides/test_sync_tag_drift.py``; this script remains the
+quick whole-matrix smoke run.
 
 Run: ``uv run python scripts/sync_matrix_probes.py``
 """

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1438,6 +1438,18 @@ surfaced as a `conflict`: both decks are left untouched and it is listed
 in the summary. Resolve it with `--interactive` (`[d]e-wins` /
 `[e]n-wins`) or by editing one side and re-running.
 
+**Tag-only edits (since CLM {version}).** Tags are language-independent, so a
+synced pair carries identical tag sets per cell. A one-sided tag-only edit
+(e.g. adding `keep`/`alt`) on an id'd cell, or on an **id-less localized**
+cell, is **mirrored** to the twin — on both the watermark and the committed
+(git-HEAD) baseline. Two tag shapes sync cannot mirror are **errored, never
+silently dropped** (the watermark holds and nothing is written): a tag edit
+on a **language-neutral** cell (shared verbatim across the halves — apply the
+tag change to both halves yourself, the bodies stay untouched), and an
+id-less tag edit made **while the other half reorders slide groups**
+(positional mirroring is unsound across a reorder — sync the reorder first,
+then re-run).
+
 **Two LLMs.** Edits are reconciled by a judge whose backend you pick
 with `--provider`: **`openrouter`** (the default — Claude Sonnet via
 OpenRouter, fast) or **`local`** (the Ollama daemon — offline but

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -691,6 +691,39 @@ def _flag_shared_cell_divergence(
             "not propagated; re-run sync (a watermark now exists) or resolve the "
             "divergence manually"
         )
+        return
+    # Issue #289: the bodies agree, but a neutral cell is shared verbatim
+    # INCLUDING its header — so the tag sets must match too. The body hash is
+    # blind to a tag-only change, which let a one-sided tag edit slip every body
+    # detector; this is the post-apply net behind the plan-time
+    # ``_classify_neutral_tag_drift`` detector. Positional zip is sound here:
+    # the pass was otherwise clean, so the orders are reconciled (and the hash
+    # sequences just compared equal).
+    de_tags = _shared_cell_tag_sets(de_state)
+    en_tags = _shared_cell_tag_sets(en_state)
+    for i, (dt, et) in enumerate(zip(de_tags, en_tags, strict=True)):
+        if dt != et:
+            result.errors.append(
+                "language-neutral (shared) cell tags differ between de and en after "
+                f"sync (cell {de[i][1]!r}: de={sorted(dt)}, en={sorted(et)}); a "
+                "tag-only change was not propagated — apply it to both halves or "
+                "resolve manually"
+            )
+            return
+
+
+def _shared_cell_tag_sets(state: FileState) -> list[frozenset[str]]:
+    """Ordered tag sets of a deck's language-neutral cells (Issue #289).
+
+    Partitioned exactly like :func:`_shared_cell_hashes` /
+    :func:`_shared_cell_descriptors` (the parity invariant), so index *i* names the
+    same cell in all three views.
+    """
+    return [
+        frozenset(cell.metadata.tags)
+        for cell in state.cells
+        if not cell.metadata.is_j2 and cell.metadata.lang not in ("de", "en")
+    ]
 
 
 def _idless_localized_group_kinds(state: FileState) -> list[tuple[int, str]]:

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -1907,9 +1907,10 @@ def _retag_idless(
 def _classify_localized_idless_retags(
     de_cells: list[Cell],
     en_cells: list[Cell],
-    watermark_cache: SyncWatermarkCache,
-    de_path: Path,
-    en_path: Path,
+    de_rows: list[tuple[int, str | None, str, str, str | None]],
+    en_rows: list[tuple[int, str | None, str, str, str | None]],
+    de_base_tags: dict[int, frozenset[str]],
+    en_base_tags: dict[int, frozenset[str]],
     plan: SyncPlan,
 ) -> None:
     """Mirror a tag-only edit on an **id-less localized** cell across the halves.
@@ -1921,16 +1922,23 @@ def _classify_localized_idless_retags(
     to :func:`_maybe_retag`. This pass gives those cells a cross-language identity
     by **position** in their language's cell stream (the #190 item-3 identity,
     already recorded in the membership-widened watermark) and applies the same
-    one-sided-drift rule (:func:`_retag_direction`) against the watermark's recorded
+    one-sided-drift rule (:func:`_retag_direction`) against the baseline's recorded
     tag set, emitting an id-less ``retag`` the apply targets by position.
+
+    ``de_rows``/``en_rows`` and ``de_base_tags``/``en_base_tags`` are the
+    membership-widened baseline rows + per-position tag sets, from **either**
+    baseline source: the watermark, or — Issue #289 — re-derived from the committed
+    git-HEAD text via :func:`watermark_rows` / :func:`watermark_tag_map`, so the
+    first sync of a committed pair mirrors an id-less tag edit instead of silently
+    dropping it (the pre-#289 ``source == "watermark"`` gate). A pre-#198 watermark
+    row simply has no recorded tag set, so direction degrades to undeterminable.
 
     Conservative by construction — any doubt declines either the whole pass or the
     individual cell rather than risk mirroring a tag onto the wrong cell:
 
-    - **watermark baseline only** (the caller gates on ``source == "watermark"``):
-      the git-HEAD baseline records no tags for id-less cells, so direction would
-      be undeterminable;
-    - **no ``move``**: a reorder invalidates positional pairing;
+    - **no ``move``**: a reorder invalidates positional pairing — but a tag drift
+      under a move is *alerted* (:func:`_alert_idless_tag_drift_under_move`, #285)
+      rather than silently skipped;
     - **structural alignment**: each language's localized stream must have the same
       length as the other *and* as its own baseline (so position *i* still names the
       same cell), and every positionally-paired cell must be a true twin
@@ -1956,11 +1964,16 @@ def _classify_localized_idless_retags(
     ``_maybe_retag`` ``both`` path and the reorder/ambiguity warnings; see #198.)
     """
     if plan.count("move") > 0:
-        return  # a reorder this pass — positional pairing is unsound
+        # A reorder this pass — positional pairing is unsound, so the mirror is
+        # declined. But declining silently was Issue #285: a one-sided tag-only
+        # edit was dropped while the move applied and the watermark advanced over
+        # the loss. Detect the drift order-blind (hash-keyed) and alert instead.
+        _alert_idless_tag_drift_under_move(
+            plan, de_cells, en_cells, de_rows, en_rows, de_base_tags, en_base_tags
+        )
+        return
     de_loc = _localized_lang_cells(de_cells, "de")
     en_loc = _localized_lang_cells(en_cells, "en")
-    de_rows = watermark_cache.get_deck(str(de_path), str(en_path), "de")
-    en_rows = watermark_cache.get_deck(str(de_path), str(en_path), "en")
     if not (len(de_loc) == len(en_loc) == len(de_rows) == len(en_rows)):
         return  # structural drift — positions unreliable; validator flags asymmetry
     if not _streams_aligned(de_loc, en_loc):
@@ -1981,8 +1994,6 @@ def _classify_localized_idless_retags(
     en_cur_counts = Counter(en_cur_hash)
     de_base_counts = Counter(de_base_hash.values())
     en_base_counts = Counter(en_base_hash.values())
-    de_base_tags = watermark_cache.get_deck_tags(str(de_path), str(en_path), "de")
-    en_base_tags = watermark_cache.get_deck_tags(str(de_path), str(en_path), "en")
     for i, (de_cell, en_cell) in enumerate(zip(de_loc, en_loc, strict=True)):
         # Only the id-less localized cells; id-carrying twins ride the per-cell path.
         if role_of(de_cell.metadata) is not None or role_of(en_cell.metadata) is not None:
@@ -2020,6 +2031,155 @@ def _classify_localized_idless_retags(
                     tag_hold=TagHold(position=i),
                 )
             )
+
+
+def _alert_idless_tag_drift_under_move(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    de_rows: list[tuple[int, str | None, str, str, str | None]],
+    en_rows: list[tuple[int, str | None, str, str, str | None]],
+    de_base_tags: dict[int, frozenset[str]],
+    en_base_tags: dict[int, frozenset[str]],
+) -> None:
+    """Alert on an id-less localized tag drift Tier C declined under a move (#285/#289).
+
+    Positional mirroring is unsound across a reorder, so Tier C bails — but a
+    one-sided tag-only edit must not then vanish while the move applies and the
+    watermark advances over the loss (the #285 silent drop). Detection is
+    **hash-keyed**, so it is reorder-invariant: each half's id-less localized
+    cells whose body is *unchanged* (its hash present in that half's own baseline,
+    unique on both sides — the recurring non-unique-anchor guard) are compared by
+    tag set against the baseline's recorded tags at that hash. A drift on either
+    half is something this pass cannot mirror → error, so the watermark holds and
+    the buffered flush writes nothing. A changed-body cell is skipped — body drift
+    under a move is the #282 detector's domain. Degrades silently when the
+    baseline recorded no tags (a pre-#198 watermark). One clear error per pass.
+    """
+    if plan.has_errors:
+        return
+    sides = (
+        ("de", de_cells, de_rows, de_base_tags),
+        ("en", en_cells, en_rows, en_base_tags),
+    )
+    for lang, cells, rows, base_tags in sides:
+        idless_rows = [
+            (pos, chash)
+            for (pos, _sid, role, chash, _construct) in rows
+            if role in (LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE)
+        ]
+        base_counts = Counter(chash for _pos, chash in idless_rows)
+        base_map = {
+            chash: base_tags.get(pos) for pos, chash in idless_rows if base_counts[chash] == 1
+        }
+        current = [
+            c
+            for c in cells
+            if not c.metadata.is_j2 and c.metadata.lang == lang and role_of(c.metadata) is None
+        ]
+        cur_counts = Counter(cell_content_hash(c.content) for c in current)
+        for cell in current:
+            chash = cell_content_hash(cell.content)
+            if cur_counts[chash] != 1:
+                continue  # duplicated body — cannot anchor; validator flags asymmetry
+            recorded = base_map.get(chash)
+            if recorded is None:
+                continue  # body changed/new (#282's domain) or no recorded tags
+            if frozenset(cell.metadata.tags) != recorded:
+                plan.issues.append(
+                    PlanIssue(
+                        severity="error",
+                        slide_id=None,
+                        reason=f"tags changed on an id-less localized {lang} cell while "
+                        "slide groups were reordered; tag mirroring is positional and "
+                        "unsound across a reorder (#285) — apply the tag change on both "
+                        "halves (or sync the reorder first), then re-run",
+                    )
+                )
+                return
+
+
+def _cell_first_line(body: str, limit: int = 48) -> str:
+    """A short locatable excerpt of a cell body (its first non-blank line)."""
+    for raw in body.split("\n"):
+        line = raw.strip()
+        if line.startswith("# "):
+            line = line[2:].strip()
+        elif line.startswith("// "):
+            line = line[3:].strip()
+        if line and line not in ("#", "//"):
+            return line[:limit] + ("…" if len(line) > limit else "")
+    return "(empty cell)"
+
+
+def _grouped_neutral_tagged(
+    cells: list[Cell],
+) -> dict[str | None, list[tuple[str, frozenset[str], str]]]:
+    """``group_slide_id -> ordered [(content_hash, tags, body)]`` of its neutral cells.
+
+    The tag-carrying sibling of :func:`_grouped_neutral_map` (same group-keyed,
+    reorder-invariant association, same ``shared`` predicate); the body rides along
+    only so an alert can name the cell.
+    """
+    out: dict[str | None, list[tuple[str, frozenset[str], str]]] = {}
+    group_sid: str | None = None
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_slide_start:
+            group_sid = meta.slide_id
+        if meta.is_j2 or meta.lang in ("de", "en"):
+            continue
+        out.setdefault(group_sid, []).append(
+            (cell_content_hash(cell.content), frozenset(meta.tags), cell.content)
+        )
+    return out
+
+
+def _classify_neutral_tag_drift(plan: SyncPlan, de_cells: list[Cell], en_cells: list[Cell]) -> None:
+    """Alert on a tag-only divergence of a language-neutral shared cell (Issue #289).
+
+    A neutral cell is shared **verbatim** across the split halves — header
+    included — so its tag set must match across de and en. Every body-channel
+    detector hashes ``Cell.content`` (body only), so a one-sided tag-only edit was
+    invisible: the run reported "decks already consistent" and the watermark
+    advanced over the divergence (the #289 P9 silent drop; the watermark even
+    records shared-partition tags, but nothing consumed them).
+
+    Scoped to **equal-body groups**: a group whose neutral *hash sequence* differs
+    across the halves is skipped entirely — body drift is owned by
+    :func:`align_anchored` + the structural pass, whose region rebuild copies the
+    source cell verbatim *including its header*, so a combined body+tag edit
+    propagates there and must not be double-alerted here. Only when the bodies
+    fully agree and the tags do not is the divergence un-propagatable by any
+    existing path → error, watermark held, nothing written. Group-keyed like
+    :func:`_grouped_neutral_map`, so a one-sided group reorder cannot mis-pair the
+    comparison. Baseline-free by design (like the post-apply parity fail-safe): a
+    standing tag asymmetry is a unify-invariant violation the run must not call
+    "consistent", whoever caused it.
+    """
+    if plan.has_errors:
+        return
+    de_map = _grouped_neutral_tagged(de_cells)
+    en_map = _grouped_neutral_tagged(en_cells)
+    for key in sorted(de_map.keys() | en_map.keys(), key=lambda k: (k is None, k or "")):
+        de_list = de_map.get(key, [])
+        en_list = en_map.get(key, [])
+        if [h for h, _t, _b in de_list] != [h for h, _t, _b in en_list]:
+            continue  # body drift in this group — the body machinery owns it
+        for (_h, de_tags, body), (_h2, en_tags, _b2) in zip(de_list, en_list, strict=True):
+            if de_tags != en_tags:
+                plan.issues.append(
+                    PlanIssue(
+                        severity="error",
+                        slide_id=None,
+                        reason="tags on a language-neutral (shared) cell differ between "
+                        f"the halves (cell {_cell_first_line(body)!r}: "
+                        f"de={sorted(de_tags)}, en={sorted(en_tags)}); sync does not "
+                        "mirror neutral-cell tag edits — apply the tag change to both "
+                        "halves, then re-run",
+                    )
+                )
+                return
 
 
 _KIND_ORDER = {
@@ -2268,15 +2428,52 @@ def build_sync_plan(
         plan, de_cells, en_cells, baseline_shared, de_idless_baseline, en_idless_baseline
     )
 
+    # Issue #289: a language-neutral cell is shared verbatim INCLUDING its header,
+    # but every body-channel detector hashes the body only — so a one-sided
+    # tag-only edit on a neutral cell was silently dropped (and baselined) while
+    # the run reported "consistent". Alert on an equal-body / unequal-tags neutral
+    # pair; a body-differing group is left to the body machinery, whose verbatim
+    # region rebuild carries the header (and so the tags) across.
+    if plan.has_baseline:
+        _classify_neutral_tag_drift(plan, de_cells, en_cells)
+
     # Tier C (Issue #198 / #190 item 3): mirror a tag-only edit on an id-less
     # localized cell — the per-cell engine cannot key it (no slide_id) and the
-    # body-hash classifier is blind to a tag change. Only against a real watermark
-    # baseline (the git-HEAD baseline records no id-less tags). Appends id-less
-    # ``retag`` proposals, then re-sorts so they interleave with the keyed plan.
+    # body-hash classifier is blind to a tag change. Baseline rows + tags come
+    # from the watermark, or (#289) are re-derived from the committed git-HEAD
+    # text — the same membership-widened shape via watermark_rows/watermark_tag_map
+    # — so the first sync of a committed pair mirrors the edit too. Appends
+    # id-less ``retag`` proposals, then re-sorts to interleave with the keyed plan.
+    retag_baseline: (
+        tuple[
+            list[tuple[int, str | None, str, str, str | None]],
+            list[tuple[int, str | None, str, str, str | None]],
+            dict[int, frozenset[str]],
+            dict[int, frozenset[str]],
+        ]
+        | None
+    ) = None
     if source == "watermark" and watermark_cache is not None:
-        _classify_localized_idless_retags(
-            de_cells, en_cells, watermark_cache, de_path, en_path, plan
+        retag_baseline = (
+            watermark_cache.get_deck(str(de_path), str(en_path), "de"),
+            watermark_cache.get_deck(str(de_path), str(en_path), "en"),
+            watermark_cache.get_deck_tags(str(de_path), str(en_path), "de"),
+            watermark_cache.get_deck_tags(str(de_path), str(en_path), "en"),
         )
+    elif source == "git-head":
+        de_head_text = _git_head_text(de_path)
+        en_head_text = _git_head_text(en_path)
+        if de_head_text is not None and en_head_text is not None:
+            de_head = parse_cells(de_head_text, comment_token_for_path(de_path))
+            en_head = parse_cells(en_head_text, comment_token_for_path(en_path))
+            retag_baseline = (
+                watermark_rows(de_head)["de"],
+                watermark_rows(en_head)["en"],
+                watermark_tag_map(de_head)["de"],
+                watermark_tag_map(en_head)["en"],
+            )
+    if retag_baseline is not None:
+        _classify_localized_idless_retags(de_cells, en_cells, *retag_baseline, plan)
         plan.proposals.sort(key=_proposal_sort_key)
 
     # Phase 3 (#216 §12): a cold-start refusal becomes a `pending` bootstrap

--- a/tests/slides/test_sync_tag_drift.py
+++ b/tests/slides/test_sync_tag_drift.py
@@ -1,0 +1,427 @@
+"""Regression tests for Issue #289 — tag-channel propagate-or-alert.
+
+The 2026-06-09 architecture review (``docs/claude/sync-engine-architecture-assessment.md``
+§2.1, probes in ``scripts/sync_matrix_probes.py``) found three silent drops, all in
+the **tag metadata channel** — the one channel the body-hash detectors are blind to:
+
+- a one-sided tag-only edit on an **id-less localized** cell under a **git-HEAD**
+  baseline (Tier C was gated ``source == "watermark"``) — now **mirrored** (P1);
+- a one-sided tag-only edit on a **language-neutral shared** cell, under either
+  baseline (recorded by the watermark, read by nothing) — now **alerted** (P9);
+- a tag-only id-less retag under a concurrent group reorder (#285) — was dropped
+  *and* the watermark advanced over the loss — now **alerted, watermark held** (P5).
+
+This file also promotes the review's clean probes (id-less localized remove,
+intra-group neutral reorder, id-less localized add × git-HEAD) into committed
+tests, and pins the **channel-coverage meta-test**: every channel the watermark
+records must name a live detector or fail-safe, so the next recorded channel
+cannot ship uncovered.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import clm.slides.sync_apply as sync_apply_mod
+import clm.slides.sync_plan as sync_plan_mod
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.slides.sync_apply import _record_watermark, apply_plan
+from clm.slides.sync_plan import build_sync_plan
+from clm.slides.sync_translate import StaticSlideTranslator
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+
+
+# ---------------------------------------------------------------------------
+# Harness (the test_sync_issue_269 pattern: baseline -> one-sided edit -> sync)
+# ---------------------------------------------------------------------------
+
+
+def _title(lang: str, sid: str = "title", txt: str = "T") -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n# # {txt}\n'
+
+
+def _slide(lang: str, sid: str, txt: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n# # {txt}\n'
+
+
+def _ncode(body: str, tags: str = '["keep"]') -> str:
+    return f"# %% tags={tags}\n{body}\n"
+
+
+def _idless_code(lang: str, body: str, tags: str | None = None) -> str:
+    t = f" tags={tags}" if tags else ""
+    return f'# %% lang="{lang}"{t}\n{body}\n'
+
+
+def _idless_md(lang: str, body: str, tags: str | None = None) -> str:
+    t = f" tags={tags}" if tags else ""
+    return f'# %% [markdown] lang="{lang}"{t}\n{body}\n'
+
+
+def _deck(*parts: str) -> str:
+    return "\n".join(parts)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _sync(
+    tmp: Path,
+    baseline: str,
+    de0: str,
+    en0: str,
+    de1: str,
+    en1: str,
+    *,
+    mapping: dict[str, str] | None = None,
+):
+    db = tmp / "clm-llm.sqlite"
+    de_path, en_path = tmp / "deck.de.py", tmp / "deck.en.py"
+    de_path.write_text(de0, encoding="utf-8")
+    en_path.write_text(en0, encoding="utf-8")
+    if baseline == "git-head":
+        _git(tmp, "init", "-q")
+        _git(tmp, "config", "user.email", "t@example.com")
+        _git(tmp, "config", "user.name", "Test")
+        _git(tmp, "add", "-A")
+        _git(tmp, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+    else:
+        wm = SyncWatermarkCache(db)
+        _record_watermark(wm, de_path, en_path)
+        wm.close()
+    de_path.write_text(de1, encoding="utf-8")
+    en_path.write_text(en1, encoding="utf-8")
+    translator = StaticSlideTranslator(mapping=mapping or {}, default="<<XL>>")
+    wm = SyncWatermarkCache(db)
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
+        result = apply_plan(plan, judge=None, translator=translator, watermark_cache=wm)
+    finally:
+        wm.close()
+    return plan, result, de_path.read_text(encoding="utf-8"), en_path.read_text(encoding="utf-8")
+
+
+def _alerted(plan, result) -> bool:
+    return (
+        plan.has_errors
+        or result.has_errors
+        or result.deferred > 0
+        or any(i.severity == "error" for i in plan.issues)
+    )
+
+
+def _falsely_consistent(plan, result, propagated: bool) -> bool:
+    """The forbidden state: reported consistent while a change was NOT handled."""
+    return plan.is_noop and not propagated and not _alerted(plan, result)
+
+
+BASELINES = ["git-head", "watermark"]
+
+
+# ---------------------------------------------------------------------------
+# Id-less localized retag — now mirrored under BOTH baselines (#289 P1)
+# ---------------------------------------------------------------------------
+
+
+class TestIdlessRetagBothBaselines:
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_idless_code_tag_add_is_mirrored(self, tmp_path: Path, baseline: str):
+        de = _deck(_title("de"), _idless_code("de", 'print("hallo")'))
+        en = _deck(_title("en"), _idless_code("en", 'print("hello")'))
+        en1 = _deck(_title("en"), _idless_code("en", 'print("hello")', tags='["keep"]'))
+        plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+        assert '# %% lang="de" tags=["keep"]' in de_after  # mirrored onto the DE twin
+        assert result.applied_retag == 1
+        assert result.watermark_recorded
+        assert not _falsely_consistent(plan, result, True)
+
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_idless_markdown_tag_add_is_mirrored(self, tmp_path: Path, baseline: str):
+        de = _deck(_title("de"), _idless_md("de", "# Hinweis"))
+        en = _deck(_title("en"), _idless_md("en", "# Note"))
+        de1 = _deck(_title("de"), _idless_md("de", "# Hinweis", tags='["alt"]'))
+        plan, result, _, en_after = _sync(tmp_path, baseline, de, en, de1, en)
+        assert '# %% [markdown] lang="en" tags=["alt"]' in en_after
+        assert result.applied_retag == 1
+        assert not _falsely_consistent(plan, result, True)
+
+
+# ---------------------------------------------------------------------------
+# Neutral shared cell, tag-only edit — alerted, never dropped (#289 P9)
+# ---------------------------------------------------------------------------
+
+
+class TestNeutralTagDrift:
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_one_sided_neutral_tag_edit_alerts(self, tmp_path: Path, baseline: str):
+        de = _deck(_title("de"), _ncode("import os"))
+        en = _deck(_title("en"), _ncode("import os"))
+        en1 = _deck(_title("en"), _ncode("import os", tags='["keep", "alt"]'))
+        plan, result, de_after, en_after = _sync(tmp_path, baseline, de, en, de, en1)
+        assert _alerted(plan, result)
+        assert not _falsely_consistent(plan, result, False)
+        assert result.watermark_recorded is False  # never baseline the divergence
+        assert '"alt"' not in de_after  # nothing written (buffered flush held)
+        assert '"alt"' in en_after  # the author's own edit is intact
+
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_both_sides_updated_identically_is_clean(self, tmp_path: Path, baseline: str):
+        de = _deck(_title("de"), _ncode("import os"))
+        en = _deck(_title("en"), _ncode("import os"))
+        de1 = _deck(_title("de"), _ncode("import os", tags='["keep", "alt"]'))
+        en1 = _deck(_title("en"), _ncode("import os", tags='["keep", "alt"]'))
+        plan, result, _, _ = _sync(tmp_path, baseline, de, en, de1, en1)
+        assert not _alerted(plan, result)
+        assert plan.is_noop
+
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_body_plus_tag_edit_propagates_both_no_false_alert(self, tmp_path: Path, baseline: str):
+        """A combined body+tag edit rides the structural rebuild (header copied
+        verbatim), so the tag-drift detector must NOT fire on it."""
+        de = _deck(_title("de"), _ncode("import os"))
+        en = _deck(_title("en"), _ncode("import os"))
+        en1 = _deck(_title("en"), _ncode("import os  # EDIT", tags='["keep", "alt"]'))
+        plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+        assert "import os  # EDIT" in de_after  # body propagated
+        assert '"alt"' in de_after  # tags rode along on the verbatim header copy
+        assert not _alerted(plan, result)
+        assert result.watermark_recorded
+
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_neutral_tag_drift_alert_is_reorder_invariant(self, tmp_path: Path, baseline: str):
+        """A one-sided group reorder + an opposite-half neutral tag edit must alert
+        (group-keyed comparison), not mis-pair or drop."""
+        de0 = _deck(_slide("de", "a", "A"), _ncode("import os"), _slide("de", "b", "B"))
+        en0 = _deck(_slide("en", "a", "A"), _ncode("import os"), _slide("en", "b", "B"))
+        # DE: tag-only edit on its neutral cell. EN: reorders the groups.
+        de1 = _deck(
+            _slide("de", "a", "A"),
+            _ncode("import os", tags='["keep", "alt"]'),
+            _slide("de", "b", "B"),
+        )
+        en1 = _deck(_slide("en", "b", "B"), _slide("en", "a", "A"), _ncode("import os"))
+        plan, result, _, en_after = _sync(tmp_path, baseline, de0, en0, de1, en1)
+        assert _alerted(plan, result)
+        assert result.watermark_recorded is False
+        assert '"alt"' not in en_after  # nothing silently healed over
+
+
+# ---------------------------------------------------------------------------
+# Id-less retag under a concurrent move — alerted, watermark held (#285)
+# ---------------------------------------------------------------------------
+
+
+class TestIdlessRetagUnderMove:
+    def test_target_half_tag_edit_under_move_alerts(self, tmp_path: Path):
+        de0 = _deck(
+            _slide("de", "a", "A"), _idless_code("de", 'print("hallo")'), _slide("de", "b", "B")
+        )
+        en0 = _deck(
+            _slide("en", "a", "A"), _idless_code("en", 'print("hello")'), _slide("en", "b", "B")
+        )
+        # DE: tag-only edit on its id-less cell. EN: reorders the groups.
+        de1 = _deck(
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("hallo")', tags='["keep"]'),
+            _slide("de", "b", "B"),
+        )
+        en1 = _deck(
+            _slide("en", "b", "B"), _slide("en", "a", "A"), _idless_code("en", 'print("hello")')
+        )
+        plan, result, de_after, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en1)
+        assert _alerted(plan, result)
+        assert result.watermark_recorded is False  # pre-#289 this ADVANCED over the drop
+        assert '# %% lang="en" tags=["keep"]' not in en_after  # not mis-mirrored
+        assert 'tags=["keep"]' in de_after  # the author's own edit intact
+
+    def test_source_half_tag_edit_under_own_move_alerts(self, tmp_path: Path):
+        """The reordering half tag-edits its own id-less cell — equally
+        un-mirrorable (Tier C declined), so it must alert, not vanish."""
+        de0 = _deck(
+            _slide("de", "a", "A"), _idless_code("de", 'print("hallo")'), _slide("de", "b", "B")
+        )
+        en0 = _deck(
+            _slide("en", "a", "A"), _idless_code("en", 'print("hello")'), _slide("en", "b", "B")
+        )
+        de1 = _deck(
+            _slide("de", "b", "B"),
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("hallo")', tags='["keep"]'),
+        )
+        plan, result, _, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en0)
+        assert _alerted(plan, result)
+        assert result.watermark_recorded is False
+        assert 'tags=["keep"]' not in en_after
+
+
+# ---------------------------------------------------------------------------
+# Promoted clean probes (review §2.1 P3 / P4 / P6 — previously uncovered cells)
+# ---------------------------------------------------------------------------
+
+
+class TestPromotedCleanProbes:
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_idless_localized_remove_propagates(self, tmp_path: Path, baseline: str):
+        de = _deck(_title("de"), _idless_code("de", 'print("hallo")'), _ncode("import os"))
+        en = _deck(_title("en"), _idless_code("en", 'print("hello")'), _ncode("import os"))
+        en1 = _deck(_title("en"), _ncode("import os"))
+        plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+        assert "hallo" not in de_after  # the removal mirrored to DE
+        assert not _falsely_consistent(plan, result, True)
+
+    @pytest.mark.parametrize("baseline", BASELINES)
+    def test_intra_group_neutral_reorder_propagates(self, tmp_path: Path, baseline: str):
+        de = _deck(_title("de"), _ncode("import os"), _ncode("import sys"))
+        en = _deck(_title("en"), _ncode("import os"), _ncode("import sys"))
+        en1 = _deck(_title("en"), _ncode("import sys"), _ncode("import os"))
+        plan, result, de_after, _ = _sync(tmp_path, baseline, de, en, de, en1)
+        assert de_after.find("import sys") < de_after.find("import os")
+        assert not _falsely_consistent(plan, result, True)
+
+    def test_idless_localized_add_propagates_git_head(self, tmp_path: Path):
+        de = _deck(_title("de"), _ncode("import os"))
+        en = _deck(_title("en"), _ncode("import os"))
+        en1 = _deck(_title("en"), _ncode("import os"), _idless_code("en", 'print("new")'))
+        plan, result, de_after, _ = _sync(
+            tmp_path, "git-head", de, en, de, en1, mapping={'print("new")': 'print("neu")'}
+        )
+        assert "neu" in de_after
+        assert not _falsely_consistent(plan, result, True)
+
+
+# ---------------------------------------------------------------------------
+# Channel-coverage meta-test (#289): no recorded channel without a named check
+# ---------------------------------------------------------------------------
+
+# Every (partition, field) the watermark records, mapped to the functions that
+# keep its propagate-or-alert invariant. Adding a partition or widening the row
+# tuple in ``_record_watermark`` fails this test until the new channel is
+# registered here WITH a live detector or fail-safe — the #289 class closer
+# (the P9 drop was exactly a recorded-but-unconsumed channel: shared tags).
+_ROW_FIELDS = ("position", "slide_id", "role", "content_hash", "construct")
+
+CHANNEL_COVERAGE: dict[tuple[str, str], list[tuple[object, str]]] = {
+    # body hashes: the keyed diff + the anchor passes + the post-apply parity nets
+    ("de", "content_hash"): [
+        (sync_plan_mod, "classify_changes"),
+        (sync_plan_mod, "_classify_idless_localized_drift"),
+        (sync_apply_mod, "_flag_idless_localized_divergence"),
+    ],
+    ("en", "content_hash"): [
+        (sync_plan_mod, "classify_changes"),
+        (sync_plan_mod, "_classify_idless_localized_drift"),
+        (sync_apply_mod, "_flag_idless_localized_divergence"),
+    ],
+    ("shared", "content_hash"): [
+        (sync_plan_mod, "align_anchored"),
+        (sync_apply_mod, "_flag_shared_cell_divergence"),
+    ],
+    # order: move detection + the structural/order fail-safes
+    ("de", "position"): [(sync_plan_mod, "_moved_keys")],
+    ("en", "position"): [(sync_plan_mod, "_moved_keys")],
+    ("shared", "position"): [
+        (sync_plan_mod, "align_anchored"),
+        (sync_apply_mod, "_flag_shared_cell_divergence"),
+    ],
+    # identity
+    ("de", "slide_id"): [(sync_plan_mod, "classify_changes")],
+    ("en", "slide_id"): [(sync_plan_mod, "classify_changes")],
+    ("shared", "slide_id"): [(sync_apply_mod, "_migrate_drifted_ids")],
+    ("de", "role"): [(sync_plan_mod, "classify_changes")],
+    ("en", "role"): [(sync_plan_mod, "classify_changes")],
+    ("shared", "role"): [(sync_apply_mod, "_shared_region")],
+    # construct anchors (id-migration + verbatim reuse)
+    ("de", "construct"): [(sync_apply_mod, "_baseline_anchor_hashes")],
+    ("en", "construct"): [(sync_apply_mod, "_baseline_anchor_hashes")],
+    ("shared", "construct"): [(sync_apply_mod, "_migrate_drifted_ids")],
+    # tags (#198 / #289): keyed retag, Tier C (+ its under-move alert), neutral drift
+    ("de", "tags"): [
+        (sync_plan_mod, "_maybe_retag"),
+        (sync_plan_mod, "_classify_localized_idless_retags"),
+        (sync_plan_mod, "_alert_idless_tag_drift_under_move"),
+    ],
+    ("en", "tags"): [
+        (sync_plan_mod, "_maybe_retag"),
+        (sync_plan_mod, "_classify_localized_idless_retags"),
+        (sync_plan_mod, "_alert_idless_tag_drift_under_move"),
+    ],
+    ("shared", "tags"): [
+        (sync_plan_mod, "_classify_neutral_tag_drift"),
+        (sync_apply_mod, "_flag_shared_cell_divergence"),
+    ],
+    # j2 deck headers (#269): alert-only by design
+    ("de-header", "content_hash"): [(sync_plan_mod, "_classify_header_drift")],
+    ("en-header", "content_hash"): [(sync_plan_mod, "_classify_header_drift")],
+    ("de-header", "position"): [(sync_plan_mod, "_classify_header_drift")],
+    ("en-header", "position"): [(sync_plan_mod, "_classify_header_drift")],
+    ("de-header", "slide_id"): [(sync_plan_mod, "_classify_header_drift")],
+    ("en-header", "slide_id"): [(sync_plan_mod, "_classify_header_drift")],
+    ("de-header", "role"): [(sync_plan_mod, "_classify_header_drift")],
+    ("en-header", "role"): [(sync_plan_mod, "_classify_header_drift")],
+    ("de-header", "construct"): [(sync_plan_mod, "_classify_header_drift")],
+    ("en-header", "construct"): [(sync_plan_mod, "_classify_header_drift")],
+}
+
+
+class _RecordingCache:
+    """Captures exactly which channels ``_record_watermark`` writes."""
+
+    def __init__(self) -> None:
+        self.channels: set[tuple[str, str]] = set()
+
+    def put_deck(self, *, de_path, en_path, lang, cells, tags=None):  # noqa: ANN001
+        for row in cells:
+            assert len(row) == len(_ROW_FIELDS), (
+                "watermark row widened — register the new field's detector/fail-safe "
+                "in CHANNEL_COVERAGE (test_sync_tag_drift.py) before recording it"
+            )
+            for field in _ROW_FIELDS:
+                self.channels.add((lang, field))
+        if tags is not None:
+            self.channels.add((lang, "tags"))
+
+
+class TestChannelCoverage:
+    def test_every_recorded_channel_has_a_named_check(self, tmp_path: Path):
+        de_path = tmp_path / "deck.de.py"
+        en_path = tmp_path / "deck.en.py"
+        # One cell of every class, so every partition records rows.
+        de_path.write_text(
+            _deck(
+                '# j2 from \'macros.j2\' import header_de\n# {{ header_de("T", "01") }}\n',
+                _title("de"),
+                _ncode("import os"),
+                _idless_code("de", 'print("hallo")', tags='["keep"]'),
+            ),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _deck(
+                '# j2 from \'macros.j2\' import header_en\n# {{ header_en("T", "01") }}\n',
+                _title("en"),
+                _ncode("import os"),
+                _idless_code("en", 'print("hello")', tags='["keep"]'),
+            ),
+            encoding="utf-8",
+        )
+        cache = _RecordingCache()
+        _record_watermark(cache, de_path, en_path)  # type: ignore[arg-type]
+
+        unregistered = sorted(cache.channels - set(CHANNEL_COVERAGE))
+        assert not unregistered, (
+            f"watermark records channel(s) {unregistered} with no registered "
+            "detector/fail-safe — a recorded-but-unconsumed channel is exactly how "
+            "the #289 tag drops shipped; add the covering check, then register it"
+        )
+        for channel in cache.channels:
+            for module, name in CHANNEL_COVERAGE[channel]:
+                assert hasattr(module, name), (
+                    f"channel {channel} names {name}, which no longer exists — "
+                    "update CHANNEL_COVERAGE to the function that now owns it"
+                )


### PR DESCRIPTION
## What

Closes #289 — the P0 recommendation of the sync architecture review (#288). Closes the three tag-channel silent drops the review found on master `fab89615`, **as a class**, not just as instances. Relates to #285 (converted from silent drop to alert — do not auto-close; full mirroring under a reorder remains open there).

## The three fixes

| Cell (review probe) | Before | After |
|---|---|---|
| tag-only edit × id-less localized × **git-HEAD** baseline (P1) | silent drop + **watermark advanced over the loss** | **MIRRORED** — Tier C (`_classify_localized_idless_retags`) now takes baseline rows + tag sets from either source; for git-HEAD they are re-derived from the committed text via `watermark_rows`/`watermark_tag_map` |
| tag-only edit × **neutral shared** cell × both baselines (P9) | silent drop + watermark advanced (`watermark_tag_map` recorded shared-partition tags; **nothing ever read them**) | **ALERTED**, watermark held — new `_classify_neutral_tag_drift`: group-keyed (reorder-invariant), scoped to **equal-body** groups so a combined body+tag edit still propagates both via the structural rebuild's verbatim header copy (no false alert). The post-apply shared-cell parity fail-safe compares tag sets too |
| id-less tag-only retag under a concurrent group reorder (#285, P5) | silent drop + watermark advanced (worse than filed) | **ALERTED**, watermark held — new `_alert_idless_tag_drift_under_move`: hash-keyed (order-blind) per-half compare vs its own baseline, fires only on unchanged-body cells (changed bodies stay #282's domain) |

## The class closer

`TestChannelCoverage` (in the new `tests/slides/test_sync_tag_drift.py`): captures exactly which channels `_record_watermark` writes (partition × field, row-tuple arity included) and asserts each names a **live** detector or fail-safe in a coverage registry. A future recorded-but-unconsumed channel — exactly how the shared-tags drop shipped — now fails the suite until it is covered.

## Also in this PR

- The review's probes promoted to committed regression tests (both baselines parametrized): the three fixed cells, plus the previously **uncovered** clean cells — id-less localized remove, intra-group neutral reorder, id-less localized add × git-HEAD.
- Probe smoke run (`uv run python scripts/sync_matrix_probes.py`): P1 PROPAGATED, P5/P9 ALERTED + wm-held, all other cells unchanged.
- Info topic (`clm info commands`, sync section): new "Tag-only edits" paragraph; CHANGELOG entry; probe-script docstring refreshed.

## Testing

- `tests/slides/` full suite: **1494 → 1514 passed** (20 new), 2 skipped; zero regressions from the new detectors.
- Fast suite green on the pre-push hook; ruff + mypy clean.
- **Watch item:** the corpus no-op harness (PythonCourses, not present locally) — a pair with a *standing* neutral-cell tag asymmetry would flip from no-op to error under the new detector. Such a state is a unify-invariant violation (the pair would not round-trip), so none are expected in a valid corpus, but the next corpus run will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
