### PR TITLE
refactor(sync): unify both baselines into one BaselineBundle representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm slides sync`'s baseline plumbing is unified, and the deterministic
+  id-migration now also runs on a committed (git-HEAD) baseline** (issue #289
+  P1). Both baseline sources now produce one representation (`BaselineBundle`,
+  the membership-widened watermark shape — git HEAD is re-derived through the
+  exact chokepoints a watermark recording uses) consumed by a single code path
+  for every baseline aspect: the keyed diff, the neutral / id-less / header
+  drift detectors, tag mirroring, and the apply engine's anchor-reuse and
+  id-migration passes (which now read the same rows the classifier diffed
+  against, carried on the plan). This deletes the per-aspect parallel git-HEAD
+  derivations whose coverage gaps produced the #269 silent drops and the #289
+  git-HEAD tag drop — the two sources can no longer diverge in coverage by
+  construction. User-visible improvement: the `def-my-fun` drifted-id
+  migration (and the opt-in `--llm-recover` tier) previously read only the
+  watermark, so on the *first* sync of a committed pair a split id'd cell was
+  not re-united with its construct; it now migrates identically on both
+  baselines.
 - **`clm slides sync` no longer silently drops a one-sided tag-only edit**
   (issue #289, found by the sync architecture review in
   `docs/claude/sync-engine-architecture-assessment.md`). Three tag-channel

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -63,7 +63,6 @@ from clm.slides.sync_plan import (
     Proposal,
     SyncPlan,
     TagHold,
-    _git_head_text,
     ordered_sync_cells,
     watermark_rows,
     watermark_tag_map,
@@ -372,11 +371,9 @@ def apply_plan(
     # cell, the slide_id is left on the wrong half. Move it back onto the cell whose
     # construct it names BEFORE the structural pass propagates, so the corrected ids
     # ride along to the twin.
-    _migrate_drifted_ids(
-        plan, de_state, en_state, watermark_cache, result, recoverer, alignment_cache
-    )
+    _migrate_drifted_ids(plan, de_state, en_state, result, recoverer, alignment_cache)
 
-    baseline_anchors = _baseline_anchor_hashes(watermark_cache, plan)
+    baseline_anchors = _baseline_anchor_hashes(plan)
     apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
 
     # Place a newly-added slide group at its source position. The per-cell add path
@@ -2306,50 +2303,29 @@ def _anchor_map_from_rows(rows: list[tuple[str | None, str | None, str]]) -> dic
     }
 
 
-def _baseline_anchor_hashes(
-    cache: SyncWatermarkCache | None,
-    plan: SyncPlan,
-) -> dict[str, dict[str, str]]:
+def _baseline_anchor_hashes(plan: SyncPlan) -> dict[str, dict[str, str]]:
     """Per-language ``{anchor: content_hash}`` of the last-synced state.
 
     The structural pass uses it to tell an UNCHANGED id-less localized code cell
     (anchor present with the same hash) from an edited one — so the former is reused
     verbatim and the latter is re-translated (Issue #190 item 3 / §8), and the same
     drift signal lets a group with an otherwise-unchanged ``("L", kind)`` signature
-    rebuild (Issue #269). Built from whichever baseline the plan resolved:
-
-    - ``watermark`` — the widened watermark rows (every non-j2 cell);
-    - ``git-head`` — the committed (HEAD) decks, parsed the same way, so the
-      cold-start (first) sync gets the same drift detection instead of an empty map
-      that would silently drop an id-less-localized body edit (Issue #269).
-
-    Empty for a baseline of ``none`` (true cold start) — the structural pass then
-    translates as before.
+    rebuild (Issue #269). Read straight off the plan's resolved
+    :class:`~clm.slides.sync_plan.BaselineBundle` (#289 P1) — watermark or
+    git-HEAD, the same rows the classifier diffed against, so plan and apply
+    agree by construction (this replaces a per-source re-derivation whose
+    git-HEAD branch keyed anchors over a *different* cell population than the
+    watermark branch). Empty for a baseline of ``none`` (true cold start) — the
+    structural pass then translates as before.
     """
     out: dict[str, dict[str, str]] = {"de": {}, "en": {}}
-    if plan.baseline_source == "watermark" and cache is not None:
-        for lang in ("de", "en"):
-            rows = cache.get_deck(str(plan.de_path), str(plan.en_path), lang)
-            out[lang] = _anchor_map_from_rows(
-                [(sid, construct, chash) for (_p, sid, _r, chash, construct) in rows]
-            )
-    elif plan.baseline_source == "git-head":
-        for lang, path in (("de", plan.de_path), ("en", plan.en_path)):
-            text = _git_head_text(path)
-            if text is None:
-                continue
-            cells = parse_cells(text, comment_token_for_path(path))
-            out[lang] = _anchor_map_from_rows(
-                [
-                    (
-                        c.metadata.slide_id,
-                        construct_of(c.metadata, c.content),
-                        cell_content_hash(c.content),
-                    )
-                    for c in cells
-                    if not c.metadata.is_j2
-                ]
-            )
+    bundle = plan.baseline_bundle
+    if bundle is None:
+        return out
+    for lang in ("de", "en"):
+        out[lang] = _anchor_map_from_rows(
+            [(sid, construct, chash) for (_p, sid, _r, chash, construct) in bundle.rows[lang]]
+        )
     return out
 
 
@@ -2361,22 +2337,24 @@ def _effective_direction(plan: SyncPlan) -> str | None:
     return plan.anchor_direction
 
 
-def _baseline_shared(
-    cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
-) -> tuple[dict[str, str], set[str]]:
+def _baseline_shared(plan: SyncPlan) -> tuple[dict[str, str], set[str]]:
     """Baseline ``{slide_id: construct}`` and the set of content hashes, ``shared`` only.
 
     The §9 migration only touches language-neutral code cells, which live in the
     ``shared`` partition — so the baseline is read from there alone (a slide_id
     reused across partitions must not borrow another partition's construct). The
     content-hash set lets the migration tell a genuine split-product (a *new* cell)
-    from a pre-existing cell that merely shares a construct name.
+    from a pre-existing cell that merely shares a construct name. Read from the
+    plan's :class:`~clm.slides.sync_plan.BaselineBundle` (#289 P1) — so the
+    migration now also runs on a committed (git-HEAD) baseline, where it was
+    previously inert (the cache had no pair to read).
     """
     constructs: dict[str, str] = {}
     hashes: set[str] = set()
-    if cache is None:
+    bundle = plan.baseline_bundle
+    if bundle is None:
         return constructs, hashes
-    for _pos, sid, _role, chash, construct in cache.get_deck(str(de_path), str(en_path), "shared"):
+    for _pos, sid, _role, chash, construct in bundle.rows["shared"]:
         hashes.add(chash)
         if sid is not None and construct is not None:
             constructs.setdefault(sid, construct)
@@ -2387,7 +2365,6 @@ def _migrate_drifted_ids(
     plan: SyncPlan,
     de_state: FileState,
     en_state: FileState,
-    cache: SyncWatermarkCache | None,
     result: ApplyResult,
     recoverer: AlignmentRecoverer | None = None,
     alignment_cache: SyncAlignmentCache | None = None,
@@ -2432,20 +2409,18 @@ def _migrate_drifted_ids(
     if _effective_direction(plan) is None:
         return
     before = result.applied_migrate
-    baseline_constructs, baseline_hashes = _baseline_shared(cache, plan.de_path, plan.en_path)
+    baseline_constructs, baseline_hashes = _baseline_shared(plan)
     if baseline_constructs:
         _migrate_one_deck(de_state, baseline_constructs, baseline_hashes, result)
         _migrate_one_deck(en_state, baseline_constructs, baseline_hashes, result)
-    loc_constructs, loc_de_hashes, loc_en_hashes = _baseline_localized(
-        cache, plan.de_path, plan.en_path
-    )
+    loc_constructs, loc_de_hashes, loc_en_hashes = _baseline_localized(plan)
     if loc_constructs:
         _migrate_localized_paired(
             de_state, en_state, loc_constructs, loc_de_hashes, loc_en_hashes, result
         )
     if recoverer is not None and baseline_constructs and result.applied_migrate == before:
         _recover_drifted_ids(
-            plan, de_state, en_state, cache, baseline_constructs, recoverer, alignment_cache, result
+            plan, de_state, en_state, baseline_constructs, recoverer, alignment_cache, result
         )
 
 
@@ -2503,9 +2478,7 @@ def _migrate_one_deck(
         idless_by_construct.pop(base_construct, None)  # at most one migration per construct
 
 
-def _baseline_localized(
-    cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
-) -> tuple[dict[str, str], set[str], set[str]]:
+def _baseline_localized(plan: SyncPlan) -> tuple[dict[str, str], set[str], set[str]]:
     """Baseline ``{slide_id: construct}`` for localized id'd code, + per-deck hashes.
 
     Localized cells live in the ``de``/``en`` partitions (not ``shared``): an id'd
@@ -2514,18 +2487,21 @@ def _baseline_localized(
     agree — it is read from the ``de`` partition. The per-deck content-hash sets
     (every recorded row of each deck) let the paired migration tell a genuine
     split-product (a *new* cell) from a pre-existing one (each deck checked against
-    its own baseline, since localized bodies differ across decks).
+    its own baseline, since localized bodies differ across decks). Read from the
+    plan's :class:`~clm.slides.sync_plan.BaselineBundle` (#289 P1), so it works on
+    a committed (git-HEAD) baseline too.
     """
     constructs: dict[str, str] = {}
     de_hashes: set[str] = set()
     en_hashes: set[str] = set()
-    if cache is None:
+    bundle = plan.baseline_bundle
+    if bundle is None:
         return constructs, de_hashes, en_hashes
-    for _pos, sid, role, chash, construct in cache.get_deck(str(de_path), str(en_path), "de"):
+    for _pos, sid, role, chash, construct in bundle.rows["de"]:
         de_hashes.add(chash)
         if role == CODE_ROLE and sid is not None and construct is not None:
             constructs.setdefault(sid, construct)
-    for _pos, _sid, _role, chash, _construct in cache.get_deck(str(de_path), str(en_path), "en"):
+    for _pos, _sid, _role, chash, _construct in bundle.rows["en"]:
         en_hashes.add(chash)
     return constructs, de_hashes, en_hashes
 
@@ -2645,22 +2621,20 @@ def _region_of(cells: list[RawCell]) -> list[RegionCell]:
     ]
 
 
-def _shared_region(
-    cache: SyncWatermarkCache | None, de_path: Path, en_path: Path
-) -> list[RegionCell]:
-    """The baseline neutral-**code** region from the watermark ``shared`` partition.
+def _shared_region(plan: SyncPlan) -> list[RegionCell]:
+    """The baseline neutral-**code** region from the bundle's ``shared`` partition.
 
     Filters the membership-widened ``shared`` rows to the ``neutral-code`` role so
     the base region covers exactly the cells :func:`_neutral_code_cells` yields live
-    (neutral markdown is excluded). Position order is preserved.
+    (neutral markdown is excluded). Position order is preserved. Read from the
+    plan's :class:`~clm.slides.sync_plan.BaselineBundle` (#289 P1).
     """
-    if cache is None:
+    bundle = plan.baseline_bundle
+    if bundle is None:
         return []
     return [
         RegionCell(slide_id=sid, construct=construct, content_hash=chash)
-        for (_pos, sid, role, chash, construct) in cache.get_deck(
-            str(de_path), str(en_path), "shared"
-        )
+        for (_pos, sid, role, chash, construct) in bundle.rows["shared"]
         if role == NEUTRAL_CODE_ROLE
     ]
 
@@ -2684,7 +2658,6 @@ def _recover_drifted_ids(
     plan: SyncPlan,
     de_state: FileState,
     en_state: FileState,
-    cache: SyncWatermarkCache | None,
     baseline_constructs: dict[str, str],
     recoverer: AlignmentRecoverer,
     alignment_cache: SyncAlignmentCache | None,
@@ -2716,7 +2689,7 @@ def _recover_drifted_ids(
         return
     if not _has_drifted_id(baseline_constructs, current_region):
         return  # nothing genuinely drifted -> do not spend the LLM
-    base_region = _shared_region(cache, plan.de_path, plan.en_path)
+    base_region = _shared_region(plan)
     if not base_region:
         return
     # Only escalate when there is a genuine realignment target: a *new* id-less

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -236,6 +236,35 @@ class PlanIssue:
     tag_hold: TagHold | None = None
 
 
+#: One membership-widened watermark row: (position, slide_id, role, content_hash, construct).
+_WatermarkRow = tuple[int, str | None, str, str, str | None]
+
+
+@dataclass(frozen=True)
+class BaselineBundle:
+    """The single baseline representation every consumer reads (#289 P1).
+
+    Both baseline sources produce this one membership-widened shape — the
+    watermark cache by reading its stored partitions
+    (:func:`_bundle_from_watermark`), git HEAD by re-deriving the *same* rows
+    from the committed text via :func:`watermark_rows` /
+    :func:`watermark_tag_map` (:func:`_bundle_from_git_head`). Every baseline
+    consumer — the keyed diff, the shared / id-less / header drift detectors,
+    Tier C retag, and the apply-side anchor / id-migration passes (via
+    ``SyncPlan.baseline_bundle``) — reads from here, so the two sources can
+    never again diverge in *coverage*: the per-aspect parallel git-HEAD
+    plumbing this replaces is how #269 (git path missing the shared/id-less/
+    header baselines), #225/#226 (git-gate predicates), and the #289 git-HEAD
+    tag drop shipped. ``source`` is provenance, not plumbing — the #225/#226
+    committed-pair semantics still key on it.
+    """
+
+    source: str  # "watermark" | "git-head"
+    rows: dict[str, list[_WatermarkRow]]  # partitions "de" | "en" | "shared"
+    tags: dict[str, dict[int, frozenset[str]]]  # partitions "de" | "en" | "shared"
+    header_hashes: dict[str, list[str]]  # "de" | "en" (ordered j2 header hashes)
+
+
 @dataclass
 class SyncPlan:
     """The full result of classifying one split pair against its baseline."""
@@ -257,6 +286,10 @@ class SyncPlan:
     # them post-pass to fail-safe on any id-less drift that was not propagated.
     idless_baseline_de: list[str] | None = None
     idless_baseline_en: list[str] | None = None
+    # The resolved baseline itself (#289 P1), carried so the apply engine reads
+    # the SAME rows the classifier diffed against (anchor reuse, id-migration)
+    # instead of re-deriving them — plan and apply agree by construction.
+    baseline_bundle: BaselineBundle | None = None
 
     @property
     def has_baseline(self) -> bool:
@@ -619,14 +652,6 @@ def _idless_localized_baseline_from_rows(
     ]
 
 
-def _idless_localized_baseline_from_git_head(path: Path, lang: str) -> list[str] | None:
-    """git-HEAD counterpart of :func:`_idless_localized_baseline_from_rows`, or ``None``."""
-    text = _git_head_text(path)
-    if text is None:
-        return None
-    return _idless_localized_hashes(parse_cells(text, comment_token_for_path(path)), lang)
-
-
 def _classify_idless_localized_drift(
     plan: SyncPlan,
     de_cells: list[Cell],
@@ -969,60 +994,70 @@ def _git_head_text(path: Path) -> str | None:
     return completed.stdout
 
 
-def _baseline_from_git_head(path: Path) -> list[BaselineCell] | None:
-    """Derive a baseline from the committed (HEAD) version of ``path``.
+def _bundle_from_watermark(
+    cache: SyncWatermarkCache, de_path: Path, en_path: Path
+) -> BaselineBundle | None:
+    """The pair's recorded watermark as a :class:`BaselineBundle`, or ``None``.
 
-    Returns ``None`` when git is unavailable, the file is untracked, or the
-    deck's language cannot be inferred from its name. An empty list means the
-    file existed at HEAD but had no sync-relevant cells.
+    A straight read of the partitions :func:`clm.slides.sync_apply._record_watermark`
+    stores. ``None`` when the pair has no watermark (the caller then falls back to
+    git HEAD). A pre-#198 watermark simply yields empty tag maps (direction
+    degrades to undeterminable); a pre-#269 one yields empty header partitions
+    (both halves read as drifted → no false one-sided alert).
     """
-    lang = _lang_for_path(path)
-    if lang is None:
+    if not cache.has_pair(str(de_path), str(en_path)):
         return None
-    text = _git_head_text(path)
-    if text is None:
-        return None
-    cells = parse_cells(text, comment_token_for_path(path))
-    return [
-        BaselineCell(
-            position=c.position,
-            slide_id=c.slide_id,
-            role=c.role,
-            content_hash=c.content_hash,
-            tags=c.tags,
-        )
-        for c in ordered_sync_cells(cells, lang)
-    ]
+    de, en = str(de_path), str(en_path)
+    return BaselineBundle(
+        source="watermark",
+        rows={
+            "de": cache.get_deck(de, en, "de"),
+            "en": cache.get_deck(de, en, "en"),
+            "shared": cache.get_deck(de, en, "shared"),
+        },
+        tags={
+            "de": cache.get_deck_tags(de, en, "de"),
+            "en": cache.get_deck_tags(de, en, "en"),
+            "shared": cache.get_deck_tags(de, en, "shared"),
+        },
+        header_hashes={
+            "de": [chash for (_p, _s, _r, chash, _c) in cache.get_deck(de, en, "de-header")],
+            "en": [chash for (_p, _s, _r, chash, _c) in cache.get_deck(de, en, "en-header")],
+        },
+    )
 
 
-def _shared_baseline_from_git_head(path: Path) -> list[str] | None:
-    """Ordered language-neutral (``shared``) cell hashes from HEAD:``path``, or ``None``.
+def _bundle_from_git_head(de_path: Path, en_path: Path) -> BaselineBundle | None:
+    """The committed (HEAD) pair re-derived as a :class:`BaselineBundle`, or ``None``.
 
-    The git-HEAD counterpart of the watermark's ``shared`` partition: neutral
-    cells are byte-identical across the two halves (the ``unify`` invariant), so
-    either committed half yields the same sequence. Returns ``None`` when the
-    committed text is unavailable — :func:`align_anchored` then degrades to "no
-    shared baseline" exactly as it does for a pre-#190 watermark. Without this,
-    the git-HEAD (cold-start / first-sync) path could not detect a one-sided
-    edit, add, or removal of a neutral cell, silently dropping it (Issue #269).
+    Derives **exactly** the rows a watermark recording of the HEAD text would
+    store — the same :func:`watermark_rows` / :func:`watermark_tag_map` /
+    :func:`_header_hashes` chokepoints ``_record_watermark`` uses — so every
+    consumer downstream is source-agnostic by construction. The ``shared``
+    partition is taken from the DE half (neutral cells are byte-identical across
+    the halves — the ``unify`` invariant — exactly as ``_record_watermark``
+    records it). ``None`` when git/the committed text is unavailable or a deck's
+    language cannot be inferred from its name (the caller then runs with no
+    baseline).
     """
-    text = _git_head_text(path)
-    if text is None:
+    if _lang_for_path(de_path) is None or _lang_for_path(en_path) is None:
         return None
-    return _shared_hashes(parse_cells(text, comment_token_for_path(path)))
-
-
-def _header_baseline_from_git_head(path: Path) -> list[str] | None:
-    """git-HEAD counterpart of the watermark ``de-header`` / ``en-header`` partition.
-
-    Ordered j2 header hashes from the committed half (Issue #269), or ``None`` when
-    the committed text is unavailable. Used so the cold-start (first) sync can detect
-    a one-sided header edit even before a watermark exists.
-    """
-    text = _git_head_text(path)
-    if text is None:
+    de_text = _git_head_text(de_path)
+    en_text = _git_head_text(en_path)
+    if de_text is None or en_text is None:
         return None
-    return _header_hashes(parse_cells(text, comment_token_for_path(path)))
+    de_head = parse_cells(de_text, comment_token_for_path(de_path))
+    en_head = parse_cells(en_text, comment_token_for_path(en_path))
+    de_rows = watermark_rows(de_head)
+    en_rows = watermark_rows(en_head)
+    de_tags = watermark_tag_map(de_head)
+    en_tags = watermark_tag_map(en_head)
+    return BaselineBundle(
+        source="git-head",
+        rows={"de": de_rows["de"], "en": en_rows["en"], "shared": de_rows["shared"]},
+        tags={"de": de_tags["de"], "en": en_tags["en"], "shared": de_tags["shared"]},
+        header_hashes={"de": _header_hashes(de_head), "en": _header_hashes(en_head)},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2285,56 +2320,38 @@ def build_sync_plan(
     en_header_baseline: list[str] | None = None
     source = "none"
 
-    if watermark_cache is not None and watermark_cache.has_pair(str(de_path), str(en_path)):
-        de_rows = watermark_cache.get_deck(str(de_path), str(en_path), "de")
-        en_rows = watermark_cache.get_deck(str(de_path), str(en_path), "en")
-        de_baseline = _baseline_from_watermark(
-            de_rows, watermark_cache.get_deck_tags(str(de_path), str(en_path), "de")
-        )
-        en_baseline = _baseline_from_watermark(
-            en_rows, watermark_cache.get_deck_tags(str(de_path), str(en_path), "en")
-        )
+    # Resolve the baseline into the ONE representation every consumer reads
+    # (#289 P1): the watermark when recorded, else git HEAD re-derived into the
+    # identical membership-widened shape. Each per-baseline aspect below — the
+    # keyed diff, the neutral/id-less/header drift sequences, Tier C retag, and
+    # the apply-side passes (via plan.baseline_bundle) — is derived from the
+    # bundle by ONE code path, so the two sources cannot diverge in coverage
+    # (the parallel per-aspect git-HEAD plumbing this replaces is how the #269
+    # baseline gaps and the #289 git-HEAD tag drop shipped).
+    bundle: BaselineBundle | None = None
+    if watermark_cache is not None:
+        bundle = _bundle_from_watermark(watermark_cache, de_path, en_path)
+    if (
+        bundle is None
+        and allow_git_fallback
+        and not _pair_is_unbootstrapped(de_current, en_current)
+    ):
+        bundle = _bundle_from_git_head(de_path, en_path)
+
+    if bundle is not None:
+        source = bundle.source
+        de_baseline = _baseline_from_watermark(bundle.rows["de"], bundle.tags["de"])
+        en_baseline = _baseline_from_watermark(bundle.rows["en"], bundle.tags["en"])
         # Ordered content hashes of the baseline's neutral cells (position order),
         # matching _shared_hashes — see align_anchored for why this is a sequence,
         # not an anchor map.
         baseline_shared = [
-            chash
-            for (_pos, _sid, _role, chash, _construct) in watermark_cache.get_deck(
-                str(de_path), str(en_path), "shared"
-            )
+            chash for (_pos, _sid, _role, chash, _construct) in bundle.rows["shared"]
         ]
-        de_idless_baseline = _idless_localized_baseline_from_rows(de_rows)
-        en_idless_baseline = _idless_localized_baseline_from_rows(en_rows)
-        de_header_baseline = [
-            chash
-            for (_p, _sid, _r, chash, _c) in watermark_cache.get_deck(
-                str(de_path), str(en_path), "de-header"
-            )
-        ]
-        en_header_baseline = [
-            chash
-            for (_p, _sid, _r, chash, _c) in watermark_cache.get_deck(
-                str(de_path), str(en_path), "en-header"
-            )
-        ]
-        source = "watermark"
-    elif allow_git_fallback and not _pair_is_unbootstrapped(de_current, en_current):
-        gb_de = _baseline_from_git_head(de_path)
-        gb_en = _baseline_from_git_head(en_path)
-        if gb_de is not None and gb_en is not None:
-            de_baseline, en_baseline = gb_de, gb_en
-            # Issue #269: derive the ``shared`` (language-neutral) baseline from the
-            # committed half too, so the ``align_anchored`` gate below fires on the
-            # cold-start (first) sync — without it a one-sided edit/add/remove of a
-            # neutral cell is invisible and silently dropped while the run reports
-            # "decks already consistent". Neutral cells are byte-identical across
-            # halves (the unify invariant), so either half yields the same sequence.
-            baseline_shared = _shared_baseline_from_git_head(de_path)
-            de_idless_baseline = _idless_localized_baseline_from_git_head(de_path, "de")
-            en_idless_baseline = _idless_localized_baseline_from_git_head(en_path, "en")
-            de_header_baseline = _header_baseline_from_git_head(de_path)
-            en_header_baseline = _header_baseline_from_git_head(en_path)
-            source = "git-head"
+        de_idless_baseline = _idless_localized_baseline_from_rows(bundle.rows["de"])
+        en_idless_baseline = _idless_localized_baseline_from_rows(bundle.rows["en"])
+        de_header_baseline = bundle.header_hashes["de"]
+        en_header_baseline = bundle.header_hashes["en"]
 
     plan = classify_changes(
         de_current,
@@ -2348,9 +2365,12 @@ def build_sync_plan(
     )
     # Carry the id-less localized baselines onto the plan so the structural pass
     # (hash-anchored drift detection) and the apply-time fail-safe can reach them
-    # without re-deriving the baseline (Issue #269).
+    # without re-deriving the baseline (Issue #269) — and the whole bundle, so the
+    # apply engine's anchor-reuse / id-migration passes read the SAME baseline the
+    # classifier diffed against (#289 P1).
     plan.idless_baseline_de = de_idless_baseline
     plan.idless_baseline_en = en_idless_baseline
+    plan.baseline_bundle = bundle
 
     # Item-2 (Phase 3a): detect a language-neutral code-only change the keyed
     # classifier cannot see, and hand its direction to the structural pass. Only
@@ -2440,40 +2460,19 @@ def build_sync_plan(
     # Tier C (Issue #198 / #190 item 3): mirror a tag-only edit on an id-less
     # localized cell — the per-cell engine cannot key it (no slide_id) and the
     # body-hash classifier is blind to a tag change. Baseline rows + tags come
-    # from the watermark, or (#289) are re-derived from the committed git-HEAD
-    # text — the same membership-widened shape via watermark_rows/watermark_tag_map
-    # — so the first sync of a committed pair mirrors the edit too. Appends
-    # id-less ``retag`` proposals, then re-sorts to interleave with the keyed plan.
-    retag_baseline: (
-        tuple[
-            list[tuple[int, str | None, str, str, str | None]],
-            list[tuple[int, str | None, str, str, str | None]],
-            dict[int, frozenset[str]],
-            dict[int, frozenset[str]],
-        ]
-        | None
-    ) = None
-    if source == "watermark" and watermark_cache is not None:
-        retag_baseline = (
-            watermark_cache.get_deck(str(de_path), str(en_path), "de"),
-            watermark_cache.get_deck(str(de_path), str(en_path), "en"),
-            watermark_cache.get_deck_tags(str(de_path), str(en_path), "de"),
-            watermark_cache.get_deck_tags(str(de_path), str(en_path), "en"),
+    # straight off the bundle (#289: both sources, so the first sync of a
+    # committed pair mirrors the edit too). Appends id-less ``retag`` proposals,
+    # then re-sorts so they interleave with the keyed plan.
+    if bundle is not None:
+        _classify_localized_idless_retags(
+            de_cells,
+            en_cells,
+            bundle.rows["de"],
+            bundle.rows["en"],
+            bundle.tags["de"],
+            bundle.tags["en"],
+            plan,
         )
-    elif source == "git-head":
-        de_head_text = _git_head_text(de_path)
-        en_head_text = _git_head_text(en_path)
-        if de_head_text is not None and en_head_text is not None:
-            de_head = parse_cells(de_head_text, comment_token_for_path(de_path))
-            en_head = parse_cells(en_head_text, comment_token_for_path(en_path))
-            retag_baseline = (
-                watermark_rows(de_head)["de"],
-                watermark_rows(en_head)["en"],
-                watermark_tag_map(de_head)["de"],
-                watermark_tag_map(en_head)["en"],
-            )
-    if retag_baseline is not None:
-        _classify_localized_idless_retags(de_cells, en_cells, *retag_baseline, plan)
         plan.proposals.sort(key=_proposal_sort_key)
 
     # Phase 3 (#216 §12): a cold-start refusal becomes a `pending` bootstrap

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -358,6 +358,68 @@ def test_phase4_def_my_fun_id_migration(tmp_path: Path):
         assert "import time" in by_id["import-time"].content  # orphan got a content slug
 
 
+def test_phase4_id_migration_works_on_git_head_baseline(tmp_path: Path):
+    """The §9 def-my-fun migration on a COMMITTED pair's first sync (#289 P1).
+
+    Pre-P1 the migration read its baseline straight from the watermark cache, so
+    on a git-HEAD baseline (a committed, never-synced pair) it was silently inert
+    — the drifted id surfaced as churn instead of one targeted header write. The
+    unified :class:`BaselineBundle` feeds it the same ``shared`` constructs from
+    the committed text, so the first sync migrates the id exactly like a
+    watermark run.
+    """
+    import shutil
+    import subprocess
+
+    import pytest
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    de = _slide("de", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    en = _slide("en", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    for args in (
+        ("init", "-q"),
+        ("config", "user.email", "t@example.com"),
+        ("config", "user.name", "Test"),
+        ("add", "-A"),
+        ("-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline"),
+    ):
+        subprocess.run(["git", *args], cwd=str(tmp_path), check=True, capture_output=True)
+
+    de_path.write_text(
+        _slide("de", "s", "# ## S")
+        + _code_idd_neutral("def-my-fun", "import time")  # id left on the import half
+        + _code_shared('def my_fun():\n    time.sleep(1)\n    print("foo")'),  # id-less def
+        encoding="utf-8",
+    )
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")  # fresh — no pair recorded
+    translator = CountingTranslator()
+    judge = CountingJudge()
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        assert plan.baseline_source == "git-head"
+        result = apply_plan(plan, judge=judge, translator=translator, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 1
+    assert translator.calls == []  # deterministic, no LLM
+    for path in (de_path, en_path):  # corrected ids on BOTH decks (neutral -> symmetric)
+        by_id = {
+            c.metadata.slide_id: c
+            for c in parse_cells(path.read_text(encoding="utf-8"))
+            if c.metadata.slide_id
+        }
+        assert "def my_fun" in by_id["def-my-fun"].content
+        assert "time.sleep(1)" in by_id["def-my-fun"].content
+        assert "import time" in by_id["import-time"].content
+
+
 def test_phase4_no_migration_without_matching_idless_cell(tmp_path: Path):
     # The id drifted (def -> import on the SAME cell) but there is NO id-less cell
     # carrying the old construct (no split — a genuine replacement). The migration


### PR DESCRIPTION
## What

The **P1 recommendation** of the sync architecture review (#288), second item of the #289 series (after #290): collapse the git-HEAD baseline's parallel per-aspect plumbing into the single representation the watermark already uses.

## Why

#269 (git path missing the shared/id-less/header baselines), #225/#226 (git-gate predicates), and #289's git-HEAD tag drop all shared one structural cause: **the two baseline sources were parallel implementations that could silently diverge in coverage.** Each new baseline aspect had to be wired twice; forgetting the git-HEAD twin produced a silent drop on exactly the most common real run (the first sync of a committed pair).

## How

- **One representation:** `BaselineBundle` — the membership-widened watermark shape (rows + tags per partition, header hashes per half).
- **Two constructors:** `_bundle_from_watermark` (reads the stored partitions) and `_bundle_from_git_head` (re-derives the *same* rows from the committed text through the exact chokepoints `_record_watermark` uses: `watermark_rows` / `watermark_tag_map` / `_header_hashes`).
- **One consumption path:** keyed diff, `baseline_shared`, id-less + header drift sequences, and Tier C retag all derive from the bundle; a new baseline aspect is automatically present for both sources.
- **Plan and apply agree by construction:** the bundle rides on `SyncPlan.baseline_bundle`, so the apply engine's anchor-reuse and id-migration passes read the same rows the classifier diffed against instead of re-deriving them.
- **Deleted:** `_baseline_from_git_head`, `_shared_baseline_from_git_head`, `_idless_localized_baseline_from_git_head`, `_header_baseline_from_git_head`, and `_baseline_anchor_hashes`' git-HEAD branch (which keyed anchors over a *different* cell population than the watermark branch — the last latent source-divergence).
- **Unchanged:** `baseline_source` stays as a provenance label — the #225 (`_pair_is_unbootstrapped`) and #226 (`_refuse_idcarrying_mismatched`) committed-pair semantics still key on it.

## Behavior change (intended, tested)

`_baseline_shared` / `_baseline_localized` / `_shared_region` now read the bundle instead of the watermark cache, so the **deterministic def-my-fun id-migration (and the opt-in `--llm-recover` tier) now also runs on a committed (git-HEAD) baseline**, where it was silently inert — the first sync of a committed pair previously left a split id'd cell un-migrated. New regression test: `test_phase4_id_migration_works_on_git_head_baseline`.

Everything else is behavior parity: the full slides suite (1517 tests) passes unchanged and all 13 coverage-matrix probes (`scripts/sync_matrix_probes.py`) report identical verdicts before/after.

## Testing

- Full `tests/slides/` suite green; fast suite green on the pre-push hook; ruff + mypy clean.
- Probe smoke run identical to #290's post-fix state (P1 PROPAGATED, P5/P9 ALERTED + wm-held).

Part of #289 (assessment §5 P1). Net: −203/+253 lines, with the plumbing now impossible to fork per source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
