### PR TITLE
refactor(sync): materialize structural-pass translations into the shared 2b cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm slides sync`'s structural pass no longer calls the translator inside
+  its region rebuild** (issue #289 P2, completing the resolve-then-apply
+  redesign's last deferred follow-up). The translations a rebuild needs are
+  pre-resolved into the run's shared outcome cache (the same cache the add
+  walks use, so a deferred add's outcome is already there when the rebuild
+  reaches for the cell); the rebuild itself is mechanical, with the documented
+  inline fallback for a cache miss. Unchanged id-less cells stay on the
+  verbatim-reuse path (never translated). Behavior-preserving — the full
+  slides suite is green unchanged. The opt-in `--llm-recover` tier remains
+  inline **by decision** (it fires only when the deterministic id-migration is
+  stuck, which cannot be known before execute without simulating that tier;
+  it is already cached, validated, and safe-aborting) — recorded in
+  `docs/claude/design/sync-plan-resolve-apply.md`.
 - **`clm slides sync`'s baseline plumbing is unified, and the deterministic
   id-migration now also runs on a committed (git-HEAD) baseline** (issue #289
   P1). Both baseline sources now produce one representation (`BaselineBundle`,

--- a/docs/claude/design/sync-plan-resolve-apply.md
+++ b/docs/claude/design/sync-plan-resolve-apply.md
@@ -9,10 +9,22 @@ apply divergence** it exposed.
 
 **Status:** design accepted (2 forks settled — see §3); implementation phased
 (§10). **Phase 1 DONE** (the `refuse` disposition + both-directions guard moved to
-the resolver; all 5 parity/doubling xfails flipped — §9). **Phase 2 DONE (scoped):**
-the edit and add paths are materialize-then-execute (the model calls moved to 2b;
-execute writes mechanically). The id-migration recoverer and the `sync_code`
-structural translate remain inline as **explicitly-deferred follow-ups** (§10).
+the resolver; all 5 parity/doubling xfails flipped — §9). **Phase 2 DONE, follow-ups
+resolved 2026-06-10 (#289 P2):** the edit, add, **and structural** paths are
+materialize-then-execute — `_materialize_structural` pre-resolves the changed
+id-less localized cells into the run's **shared** `TranslationOutcome` cache (now
+defined in `sync_code`, consumed by both the add walks and the region rebuild, so
+a deferred add's outcome is already cached when the rebuild reaches for the cell);
+the rebuild reads cache-first with the documented inline fallback for a miss (a
+reuse-eligible cell whose target twin turns out absent/ambiguous). The
+**id-migration recoverer stays inline by decision, not omission**: it only fires
+when the deterministic migration tier is stuck, which is knowable before execute
+only by simulating that tier on copied states — a new lock-step contract (the
+simulation must track the real migration forever) bought for zero behavioral gain,
+since the recoverer is already opt-in, fingerprint-cached, hard-validated
+(`validate_alignment`), and safe-aborts to a deferral that holds the watermark.
+Materializing it would also force the LLM spend on passes the deterministic tier
+goes on to handle. Recorded as the accepted end-state of Phase 2.
 **Phase 3.1 (id-less cold-pair minting) DONE** — `build_sync_plan` emits a `pending`
 mint candidate, `apply_plan` verifies via the new `CorrespondenceVerifier` and mints
 via `assign_ids_in_split_pair`; `--verify-cold-pairs` default-on with a provider.
@@ -22,9 +34,9 @@ run right after the mint pass and mutually exclusive with it); `apply_plan` veri
 the same way and stamps the id'd half's *existing* ids onto the id-less twin
 (`_apply_cold_adopt` / `_adopt_ids_in_split_pair` — an explicit per-cell header stamp,
 **not** `assign_ids_in_split_pair`, which cannot pair an id-less cell with an id'd
-one). Mismatched-id and mixed-authority stay `refuse`. The whole #216 cluster is now
-resolved end-to-end; the only remaining items are the Phase-2 deferred follow-ups
-(the id-migration recoverer + `sync_code` structural translate).
+one). Mismatched-id and mixed-authority stay `refuse`. The whole #216 cluster is
+resolved end-to-end, and the Phase-2 follow-ups are closed (structural translate
+materialized; recoverer inline-by-decision — see the Phase 2 status above).
 
 ---
 
@@ -244,10 +256,14 @@ test: judge called once, in materialize). The add path materializes via
 source-cell id; the two add walks read the cache through `_translate`, with a
 model fallback for a cache miss that never fires because the materialize walks
 enumerate a **superset** of what execute translates (boundary test: translator
-called once per cell). Behavior-preserving (1106 sync tests green). **Deferred
-follow-ups (call models inline still):** the id-migration recoverer and the
-`sync_code` structural translate; and a single bundled `MaterializedPlan` object
-(the two materialize seams suffice, and the add seam is ordering-sensitive).
+called once per cell). Behavior-preserving (1106 sync tests green). **Follow-ups
+resolved 2026-06-10 (#289 P2):** the `sync_code` structural translate is
+materialized (`_materialize_structural` → the shared `TranslationOutcome` cache,
+inline fallback retained); the id-migration recoverer is **inline by decision**
+(see the Status block at the top — predicting its stuck-gate requires simulating
+the deterministic tier, a lock-step contract for zero behavioral gain); a bundled
+`MaterializedPlan` object stays rejected (the materialize seams suffice, and the
+add seam is ordering-sensitive).
 
 **Phase 3 — Cold-start minting + correspondence gate. [3.1 (id-less) DONE; 3.2
 (half-id'd) DONE — see §12].** `build_sync_plan` emits a `pending` mint candidate for

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -56,7 +56,7 @@ from clm.infrastructure.llm.ollama_client import OllamaError
 from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cell_header, parse_cells
 from clm.slides.raw_cells import RawCell
 from clm.slides.slug import resolve_collision, slugify
-from clm.slides.sync_code import apply_code_structure
+from clm.slides.sync_code import TranslationOutcome, apply_code_structure
 from clm.slides.sync_plan import (
     MEMBERSHIP_ROLES,
     NEUTRAL_CODE_ROLE,
@@ -89,6 +89,7 @@ from clm.slides.sync_translate import TranslationError
 from clm.slides.sync_writeback import (
     CODE_ROLE,
     FileState,
+    anchor_of,
     build_twin_cell,
     cell_content_hash,
     construct_of,
@@ -194,21 +195,6 @@ class _EditOutcome:
 
     verdict: str  # "update" | "in_sync" | "blocked"
     proposed_text: str | None = None
-    error: str | None = None
-
-
-@dataclass
-class _TransOutcome:
-    """The materialized translation of one add/rename source cell (#216 2b).
-
-    Computed by :func:`_materialize_idcarrying` / :func:`_materialize_idless` so the
-    add execute walks call no translator: ``body`` is the translated counterpart, or
-    ``error`` is the deferral message to record (the translation raised). Exactly one
-    is set. Keyed by ``id(cell)`` of the source cell (stable: both decks load once
-    and the walks hold the same cell objects).
-    """
-
-    body: str | None = None
     error: str | None = None
 
 
@@ -349,12 +335,18 @@ def apply_plan(
             _note_deferred(deferred_keys, proposal)
         # "add" / "rename" are handled by _apply_adds below (always applied).
 
+    # The run's shared translation-outcome cache (#216 2b / #289 P2), keyed by
+    # source-cell id: the add materializers fill it for the add walks, the
+    # structural materializer below adds the changed id-less localized cells, and
+    # both execute passes read it — one model-call site per cell for the run.
+    translations: dict[int, TranslationOutcome] = {}
+
     # Adds run before moves so a freshly-inserted slide takes part in any
     # reorder. Adds are sticky via the stamped id (a re-run no longer sees an
     # id-less cell), so unlike moves they apply even on a *deferred* (non-clean)
     # pass — but, like every cell, the stamped id only reaches disk on an
     # error-free pass (the end-of-pass flush is gated on no errors).
-    _apply_adds(de_state, en_state, result, plan, translator)
+    _apply_adds(de_state, en_state, result, plan, translator, translations)
 
     # Moves are applied last, and only if the rest of the pass is clean (so the
     # watermark will advance and the reorder stays idempotent).
@@ -373,8 +365,16 @@ def apply_plan(
     # ride along to the twin.
     _migrate_drifted_ids(plan, de_state, en_state, result, recoverer, alignment_cache)
 
+    # Stage 2b for the structural pass (#289 P2): pre-resolve every translation
+    # the region rebuild will need into the shared cache, so the rebuild itself
+    # is mechanical. Runs after the id-migration (a freshly-stamped id moves a
+    # cell out of the id-less set, so enumerating here matches the rebuild
+    # exactly) and before any structural mutation.
     baseline_anchors = _baseline_anchor_hashes(plan)
-    apply_code_structure(plan, de_state, en_state, translator, result, baseline_anchors)
+    _materialize_structural(plan, de_state, en_state, translator, baseline_anchors, translations)
+    apply_code_structure(
+        plan, de_state, en_state, translator, result, baseline_anchors, translations
+    )
 
     # Place a newly-added slide group at its source position. The per-cell add path
     # anchors a new group beside the nearest neighbour it can name by (slide_id,
@@ -1554,6 +1554,7 @@ def _apply_adds(
     result: ApplyResult,
     plan: SyncPlan,
     translator: SlideTranslator | None,
+    translations: dict[int, TranslationOutcome],
 ) -> None:
     """Translate and insert counterparts for new and copy-pasted cells.
 
@@ -1590,15 +1591,17 @@ def _apply_adds(
         return
 
     # Stage 2b for the add path (#216 resolve-then-apply): every translation is
-    # materialized into ``translations`` (keyed by source-cell id) just before the
-    # execute walk that consumes it, the only place the add path calls the
-    # translator. The walks below mint ids (deterministic) and insert twins,
-    # reading the cache; the ``translator`` they still receive is only a safety
-    # fallback for a cache miss (the materialize walks are built to enumerate a
-    # superset of what the execute walks translate, so a miss never happens). The
-    # materialize calls sit right before their walks so cell identity — and the
-    # post-id-carrying state the id-less walk reads — match exactly.
-    translations: dict[int, _TransOutcome] = {}
+    # materialized into ``translations`` — the run's SHARED outcome cache, keyed
+    # by source-cell id (#289 P2: the structural pass later reads the same cache,
+    # so a deferred add's outcome is already there when a rebuild reaches for the
+    # cell) — just before the execute walk that consumes it, the only place the
+    # add path calls the translator. The walks below mint ids (deterministic) and
+    # insert twins, reading the cache; the ``translator`` they still receive is
+    # only a safety fallback for a cache miss (the materialize walks are built to
+    # enumerate a superset of what the execute walks translate, so a miss never
+    # happens). The materialize calls sit right before their walks so cell
+    # identity — and the post-id-carrying state the id-less walk reads — match
+    # exactly.
 
     # id-carrying adds: a new cell (slide / subslide / narrative / aux markdown /
     # localized code) already minted with a slide_id on one side only — e.g. a
@@ -1657,7 +1660,7 @@ def _cache_translation(
     target_lang: str,
     role: str,
     translator: SlideTranslator,
-    cache: dict[int, _TransOutcome],
+    cache: dict[int, TranslationOutcome],
 ) -> None:
     """Translate one add source cell into ``cache`` (no ``result`` accounting here).
 
@@ -1673,9 +1676,9 @@ def _cache_translation(
             target_lang=target_lang,
             role=role,
         )
-        cache[id(cell)] = _TransOutcome(body=body)
+        cache[id(cell)] = TranslationOutcome(body=body)
     except TranslationError as exc:
-        cache[id(cell)] = _TransOutcome(error=f"{role}: translation failed: {exc}")
+        cache[id(cell)] = TranslationOutcome(error=f"{role}: translation failed: {exc}")
 
 
 def _materialize_idcarrying(
@@ -1684,7 +1687,7 @@ def _materialize_idcarrying(
     target_lang: str,
     add_keys: set[tuple[str | None, str]],
     translator: SlideTranslator,
-    cache: dict[int, _TransOutcome],
+    cache: dict[int, TranslationOutcome],
 ) -> None:
     """Pre-translate every id-carrying add cell (those :func:`_add_idcarrying_one_direction` translates)."""
     for cell in list(source_state.cells):
@@ -1703,7 +1706,7 @@ def _materialize_idless(
     target_lang: str,
     copy_slide_ids: set[int],
     translator: SlideTranslator,
-    cache: dict[int, _TransOutcome],
+    cache: dict[int, TranslationOutcome],
 ) -> None:
     """Pre-translate every cell :func:`_add_one_direction` will translate.
 
@@ -1740,6 +1743,53 @@ def _materialize_idless(
         _cache_translation(cell, source_lang, target_lang, role, translator, cache)
 
 
+def _materialize_structural(
+    plan: SyncPlan,
+    de_state: FileState,
+    en_state: FileState,
+    translator: SlideTranslator | None,
+    baseline_anchors: dict[str, dict[str, str]],
+    translations: dict[int, TranslationOutcome],
+) -> None:
+    """Pre-translate the structural pass's changed id-less localized cells (#289 P2).
+
+    Stage 2b for the structural path: enumerates the id-less localized source
+    cells :func:`clm.slides.sync_code._rebuild_region` translates — those whose
+    content anchor is **not** recorded unchanged in the baseline (an unchanged
+    cell is reuse-spliced verbatim, Issue #190 item 3, and must not be translated
+    here either) — and resolves each through the run's shared outcome cache. The
+    execute pass then reads the cache; a miss (a reuse-eligible cell whose target
+    twin turns out absent or ambiguous mid-rebuild) falls back to translating
+    inline, the same documented safety net the add path carries. Keyed-cell
+    fallback translations need no enumeration here: a deferred add's source cell
+    already sits in the shared cache from the add materializers.
+
+    Skipped without a baseline (``plan.baseline_bundle`` ``None``): a no-baseline
+    run has no reuse path, so the rebuild translates every id-less cell of a
+    rebuilding region — but only of *rebuilding* regions, which cannot be
+    enumerated without replaying the rebuild decisions; the inline path keeps
+    that rare cold shape exactly as it was.
+    """
+    if translator is None or plan.baseline_bundle is None:
+        return
+    direction = _effective_direction(plan)
+    if direction is None:
+        return
+    if direction == "en->de":
+        source_state, source_lang, target_lang = en_state, "en", "de"
+    else:
+        source_state, source_lang, target_lang = de_state, "de", "en"
+    src_anchors = baseline_anchors.get(source_lang, {})
+    for cell in list(source_state.cells):
+        meta = cell.metadata
+        if meta.is_j2 or meta.lang != source_lang or role_of(meta) is not None:
+            continue
+        if src_anchors.get(anchor_of(meta, cell.body)) == cell_content_hash(cell.body):
+            continue  # unchanged since baseline → spliced verbatim, never translated
+        kind = CODE_ROLE if meta.cell_type == "code" else "markdown"
+        _cache_translation(cell, source_lang, target_lang, kind, translator, translations)
+
+
 def _add_idcarrying_one_direction(
     source_state: FileState,
     target_state: FileState,
@@ -1748,7 +1798,7 @@ def _add_idcarrying_one_direction(
     add_keys: set[tuple[str | None, str]],
     translator: SlideTranslator,
     result: ApplyResult,
-    translations: dict[int, _TransOutcome],
+    translations: dict[int, TranslationOutcome],
 ) -> None:
     """Insert the twin of each id-carrying new cell, under the same id, at anchor.
 
@@ -1831,7 +1881,7 @@ def _add_one_direction(
     used_ids: set[str],
     result: ApplyResult,
     copy_slide_ids: set[int],
-    translations: dict[int, _TransOutcome],
+    translations: dict[int, TranslationOutcome],
 ) -> None:
     """Walk the source deck, minting ids for new and copy-pasted slides.
 
@@ -1915,7 +1965,7 @@ def _translate(
     translator: SlideTranslator,
     role: str,
     result: ApplyResult,
-    translations: dict[int, _TransOutcome],
+    translations: dict[int, TranslationOutcome],
 ) -> str | None:
     """Return the materialized translation of a cell, recording a deferral on failure.
 

--- a/src/clm/slides/sync_code.py
+++ b/src/clm/slides/sync_code.py
@@ -39,6 +39,7 @@ this structural step.
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from clm.slides.raw_cells import RawCell
@@ -57,7 +58,27 @@ if TYPE_CHECKING:
     from clm.slides.sync_plan import SyncPlan
     from clm.slides.sync_translate import SlideTranslator
 
-__all__ = ["apply_code_structure"]
+__all__ = ["TranslationOutcome", "apply_code_structure"]
+
+
+@dataclass
+class TranslationOutcome:
+    """The materialized translation of one source cell (#216 2b / #289 P2).
+
+    ``body`` is the translated counterpart, or ``error`` is the deferral message
+    to record (the translation raised). Exactly one is set. Keyed by ``id(cell)``
+    of the source cell (stable: both decks load once and every walk holds the
+    same cell objects). One shared cache serves the add walks
+    (:func:`clm.slides.sync_apply._materialize_idcarrying` /
+    ``_materialize_idless``) AND the structural pass
+    (``_materialize_structural``), so e.g. a deferred add's source cell already
+    carries its outcome when the structural rebuild reaches for it. Defined here
+    (the lowest consumer) because :mod:`clm.slides.sync_apply` imports this
+    module.
+    """
+
+    body: str | None = None
+    error: str | None = None
 
 
 def apply_code_structure(
@@ -67,6 +88,7 @@ def apply_code_structure(
     translator: SlideTranslator | None,
     result: ApplyResult,
     baseline_anchors: dict[str, dict[str, str]] | None = None,
+    translations: dict[int, TranslationOutcome] | None = None,
 ) -> None:
     """Propagate language-neutral / id-less-localized cells and fix group order.
 
@@ -79,6 +101,13 @@ def apply_code_structure(
     localized code cell is **unchanged** (its source-side anchor is in the
     baseline with the same content hash), the existing target twin is spliced
     verbatim instead of re-translated — Issue #190 item 3 (§8).
+
+    ``translations`` is the shared pre-materialized translation cache (#289 P2,
+    stage 2b): the rebuild reads each needed translation from it by source-cell
+    id, so the common path calls no model inside the execute walk. A miss —
+    e.g. a reuse-eligible cell whose target twin turned out absent/ambiguous —
+    falls back to translating inline, the same documented safety net as the add
+    path.
     """
     direction = _single_direction(plan)
     if direction is None:
@@ -137,6 +166,7 @@ def apply_code_structure(
             translator,
             result,
             src_anchors,
+            translations,
         )
         if rebuilt is None:
             # A translation needed for the rebuild failed (no translator, or it
@@ -318,6 +348,7 @@ def _rebuild_region(
     translator: SlideTranslator | None,
     result: ApplyResult,
     src_anchors: dict[str, str] | None = None,
+    translations: dict[int, TranslationOutcome] | None = None,
 ) -> list[RawCell] | None:
     """Rebuild a target region to mirror the source region's cell order.
 
@@ -364,9 +395,12 @@ def _rebuild_region(
                 out.append(twin)
             else:
                 # The per-cell pass should have placed this twin (add/edit). If it
-                # is missing (e.g. translation deferred), translate as a fallback;
+                # is missing (e.g. translation deferred), translate as a fallback —
+                # the shared cache already carries a deferred add's outcome — and
                 # on failure, abort the whole region rather than drop the cell.
-                body = _translate(cell, source_lang, target_lang, role, translator, result)
+                body = _translate(
+                    cell, source_lang, target_lang, role, translator, result, translations
+                )
                 if body is None:
                     return None
                 out.append(build_twin_cell(cell, target_lang, body))
@@ -381,7 +415,9 @@ def _rebuild_region(
                 out.append(reused)
                 continue
             kind = CODE_ROLE if meta.cell_type == "code" else "markdown"
-            body = _translate(cell, source_lang, target_lang, kind, translator, result)
+            body = _translate(
+                cell, source_lang, target_lang, kind, translator, result, translations
+            )
             if body is None:
                 return None
             out.append(build_twin_cell(cell, target_lang, body))
@@ -434,8 +470,23 @@ def _translate(
     role: str,
     translator: SlideTranslator | None,
     result: ApplyResult,
+    translations: dict[int, TranslationOutcome] | None = None,
 ) -> str | None:
-    """Translate a cell body for the structural pass, recording failures."""
+    """Resolve a cell's translation for the structural pass, recording failures.
+
+    Reads the pre-materialized outcome from the shared ``translations`` cache
+    first (#289 P2 — the model call happened in stage 2b); a miss falls back to
+    translating inline, the documented safety net for a cell the materializer
+    could not foresee needing (e.g. a reuse-eligible cell whose target twin
+    turned out absent or ambiguous).
+    """
+    cached = translations.get(id(cell)) if translations is not None else None
+    if cached is not None:
+        if cached.error is not None:
+            result.deferred += 1
+            result.errors.append(f"code-structure: {cached.error}")
+            return None
+        return cached.body
     if translator is None:
         result.deferred += 1
         result.errors.append(f"code-structure: no translator for a {role} cell")


### PR DESCRIPTION
## What

The **P2 recommendation** of the sync architecture review (#288), third and final structural item of the #289 series (after #290 and #296): complete the resolve-then-apply redesign's deferred Phase-2 follow-ups. One is implemented, the other is **closed as inline-by-decision** with the rationale recorded in the design doc.

## Implemented: structural translate → stage 2b

- `TranslationOutcome` (was `sync_apply._TransOutcome`) moves to `sync_code` (the lowest consumer); **one shared per-run outcome cache** now serves the add walks *and* the structural region rebuild, hoisted into `apply_plan`.
- New `_materialize_structural`: pre-resolves exactly the id-less localized source cells the rebuild translates — those whose content anchor is **not** recorded unchanged in the baseline. Unchanged cells stay on the item-3 verbatim-reuse path and are never translated (no wasted LLM spend). Runs after the deterministic id-migration (a freshly-stamped id moves a cell out of the id-less set, so the enumeration matches the rebuild exactly) and before any structural mutation.
- `sync_code._translate` reads the cache first; a miss (a reuse-eligible cell whose target twin turns out absent or ambiguous mid-rebuild — e.g. translated call-name anchors) falls back inline, the same documented safety net the add path carries. The existing rebuild-failure test exercises precisely this fallback.
- **Shared-cache payoff:** a deferred add's source cell is already cached when the rebuild's missing-twin fallback reaches for it — the two paths can no longer translate the same cell twice.

## Declined: materializing the `--llm-recover` tier

The recoverer fires only when the deterministic id-migration is stuck — knowable before execute only by **simulating that tier on copied states**, a new lock-step implicit contract (the simulation must track the real migration forever) bought for zero behavioral gain: the recoverer is already opt-in, fingerprint-cached, hard-validated (`validate_alignment` never drops a worn id), and safe-aborts to a watermark-holding deferral. Materializing it would also force LLM spend on passes the deterministic tier goes on to handle. Recorded as Phase 2's accepted end state in `docs/claude/design/sync-plan-resolve-apply.md` (status block + §10).

## Testing

Behavior-preserving: full `tests/slides/` suite green unchanged (1518 tests); all 13 matrix probes (`scripts/sync_matrix_probes.py`) identical. The existing counting-translator tests pin one-call-per-cell (a double materialize+execute call would fail them); fast suite green on the pre-push hook; ruff + mypy clean.

Part of #289 (assessment §5 P2). With this, the #289 series' structural work is complete; remaining from the assessment are P4 test-debt items (non-Python engine test, corpus mutation oracle) and the optional P3 (stored base bodies for 3-up conflict UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
