### PR TITLE
fix(sync): mirror an id-less tag-only edit across a group reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`clm slides sync` now mirrors a tag-only edit on an id-less localized cell
+  across a concurrent slide-group reorder** (issue #285). Live positional
+  pairing is unsound under a reorder, so the Tier C retag mirror used to
+  decline — silently before #289, with an error after #290. The baseline
+  provides a sound, reorder-invariant join instead: the drifted cell is found
+  by unique body hash against its own baseline (a tag-only edit never changes
+  the body), its baseline *position* indexes the twin (the two localized
+  streams are positional twins at the last sync, verified on the recorded
+  rows), and the twin's baseline hash locates it in the current, reordered
+  stream. The tag mirrors and the reorder applies in the same clean pass.
+  Anything the route cannot anchor still **errors** rather than guessing or
+  dropping: byte-identical duplicate bodies (detected via per-group tag
+  multisets — previously these slipped silently to the validator even in the
+  alert path), tags drifted on both twins, misaligned baseline streams, or a
+  pass that also adds/removes cells (a remove would shift the positions the
+  retag applier targets — sync in two steps).
 - **`clm slides sync`'s structural pass no longer calls the translator inside
   its region rebuild** (issue #289 P2, completing the resolve-then-apply
   redesign's last deferred follow-up). The translations a rebuild needs are

--- a/scripts/sync_matrix_probes.py
+++ b/scripts/sync_matrix_probes.py
@@ -10,10 +10,12 @@ and reports:
   SILENT-DROP - plan.is_noop, no alert, change not propagated (the forbidden state)
 
 On master ``fab89615`` (pre-#289), P1 / P5 / P9 were the three live SILENT-DROP
-cells (all tag-channel). The #289 fix closed them — P1 now PROPAGATES (Tier C on
-the git-HEAD baseline), P5 / P9 ALERT with the watermark held — and promoted the
-probes into ``tests/slides/test_sync_tag_drift.py``; this script remains the
-quick whole-matrix smoke run.
+cells (all tag-channel). The #289 fix closed them — P1 PROPAGATES (Tier C on the
+git-HEAD baseline), P9 ALERTS with the watermark held, and P5 (#285), first
+alerted by #290, now PROPAGATES too (the tag is mirrored across the reorder via
+its baseline twin). The probes are promoted into
+``tests/slides/test_sync_tag_drift.py``; this script remains the quick
+whole-matrix smoke run.
 
 Run: ``uv run python scripts/sync_matrix_probes.py``
 """

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1442,13 +1442,16 @@ in the summary. Resolve it with `--interactive` (`[d]e-wins` /
 synced pair carries identical tag sets per cell. A one-sided tag-only edit
 (e.g. adding `keep`/`alt`) on an id'd cell, or on an **id-less localized**
 cell, is **mirrored** to the twin — on both the watermark and the committed
-(git-HEAD) baseline. Two tag shapes sync cannot mirror are **errored, never
-silently dropped** (the watermark holds and nothing is written): a tag edit
-on a **language-neutral** cell (shared verbatim across the halves — apply the
-tag change to both halves yourself, the bodies stay untouched), and an
-id-less tag edit made **while the other half reorders slide groups**
-(positional mirroring is unsound across a reorder — sync the reorder first,
-then re-run).
+(git-HEAD) baseline, and **also across a concurrent slide-group reorder**
+(the twin is located reorder-invariantly via the baseline, by body hash).
+Tag shapes sync cannot mirror are **errored, never silently dropped** (the
+watermark holds and nothing is written): a tag edit on a **language-neutral**
+cell (shared verbatim across the halves — apply the tag change to both halves
+yourself, the bodies stay untouched), a tag edit among **byte-identical
+duplicate** id-less cells (nothing can anchor which twin to retag), tags
+changed on **both** twins, and an under-reorder tag edit coinciding with
+other structural changes (add/remove) in the same pass — sync those in two
+steps.
 
 **Two LLMs.** Edits are reconciled by a judge whose backend you pick
 with `--provider`: **`openrouter`** (the default — Claude Sonnet via

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -1971,9 +1971,9 @@ def _classify_localized_idless_retags(
     Conservative by construction — any doubt declines either the whole pass or the
     individual cell rather than risk mirroring a tag onto the wrong cell:
 
-    - **no ``move``**: a reorder invalidates positional pairing — but a tag drift
-      under a move is *alerted* (:func:`_alert_idless_tag_drift_under_move`, #285)
-      rather than silently skipped;
+    - **no ``move``**: a reorder invalidates LIVE positional pairing — a tag drift
+      under a move is mirrored via the reorder-invariant baseline-twin route, or
+      alerted (:func:`_classify_idless_retags_under_move`, #285) — never skipped;
     - **structural alignment**: each language's localized stream must have the same
       length as the other *and* as its own baseline (so position *i* still names the
       same cell), and every positionally-paired cell must be a true twin
@@ -1999,11 +1999,10 @@ def _classify_localized_idless_retags(
     ``_maybe_retag`` ``both`` path and the reorder/ambiguity warnings; see #198.)
     """
     if plan.count("move") > 0:
-        # A reorder this pass — positional pairing is unsound, so the mirror is
-        # declined. But declining silently was Issue #285: a one-sided tag-only
-        # edit was dropped while the move applied and the watermark advanced over
-        # the loss. Detect the drift order-blind (hash-keyed) and alert instead.
-        _alert_idless_tag_drift_under_move(
+        # A reorder this pass — CURRENT-position pairing is unsound. Mirror via
+        # the reorder-invariant hash/baseline-position route instead (#285); a
+        # drift that route cannot mirror safely is alerted, never dropped.
+        _classify_idless_retags_under_move(
             plan, de_cells, en_cells, de_rows, en_rows, de_base_tags, en_base_tags
         )
         return
@@ -2068,7 +2067,16 @@ def _classify_localized_idless_retags(
             )
 
 
-def _alert_idless_tag_drift_under_move(
+# Proposal kinds that make the under-move tag mirror unsafe: any of these can
+# reshape a localized stream between plan time and the retag's apply step (a
+# remove shifts the current positions the id-less retag applier targets), so a
+# pass carrying one keeps the conservative alert instead of mirroring.
+_MOVE_RETAG_BLOCKERS = frozenset(
+    {"add", "remove", "rename", "conflict", "refuse", "mint", "adopt", "reconcile"}
+)
+
+
+def _classify_idless_retags_under_move(
     plan: SyncPlan,
     de_cells: list[Cell],
     en_cells: list[Cell],
@@ -2077,61 +2085,171 @@ def _alert_idless_tag_drift_under_move(
     de_base_tags: dict[int, frozenset[str]],
     en_base_tags: dict[int, frozenset[str]],
 ) -> None:
-    """Alert on an id-less localized tag drift Tier C declined under a move (#285/#289).
+    """Mirror a tag-only id-less edit across a group reorder, or alert (#285).
 
-    Positional mirroring is unsound across a reorder, so Tier C bails — but a
-    one-sided tag-only edit must not then vanish while the move applies and the
-    watermark advances over the loss (the #285 silent drop). Detection is
-    **hash-keyed**, so it is reorder-invariant: each half's id-less localized
-    cells whose body is *unchanged* (its hash present in that half's own baseline,
-    unique on both sides — the recurring non-unique-anchor guard) are compared by
-    tag set against the baseline's recorded tags at that hash. A drift on either
-    half is something this pass cannot mirror → error, so the watermark holds and
-    the buffered flush writes nothing. A changed-body cell is skipped — body drift
-    under a move is the #282 detector's domain. Degrades silently when the
-    baseline recorded no tags (a pre-#198 watermark). One clear error per pass.
+    Tier C's live positional pairing is unsound under a move, but the **baseline**
+    still provides a sound, reorder-invariant join:
+
+    1. the drifted cell is located in its own half by **unique body hash**
+       against its own baseline (a tag-only edit never changes the body);
+    2. its **baseline position** indexes the twin: at the last sync the two
+       localized streams were positional twins (the invariant the no-move path
+       asserts live; verified here on the recorded rows), so the same position
+       in the *other* half's baseline names the twin's body hash;
+    3. that hash locates the twin in the other half's **current** (reordered)
+       stream — hash-keyed, so the reorder cannot mis-pair it.
+
+    Every lookup carries the recurring non-unique-anchor guard (the hash must be
+    unique in baseline AND current, on the half where it is used). Anything the
+    route cannot mirror — a duplicated body, a twin whose own body changed, tags
+    drifted on *both* twins, misaligned baseline streams, or a pass that also
+    carries a stream-reshaping proposal (:data:`_MOVE_RETAG_BLOCKERS` — a remove
+    would shift the current positions the retag applier targets) — is **alerted**
+    (error, watermark held, nothing written), never silently dropped: the pre-#289
+    behavior was the #285 silent drop, the #290 fix alerted, this mirrors.
     """
     if plan.has_errors:
         return
-    sides = (
+    localized = (LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE)
+    mirror_ok = not any(p.kind in _MOVE_RETAG_BLOCKERS for p in plan.proposals)
+    # The cross-half join key is the BASELINE position — sound only if the
+    # recorded streams are positional twins (same length, localized rows of the
+    # same kind facing each other).
+    aligned = len(de_rows) == len(en_rows) and all(
+        (de_row[2] in localized) == (en_row[2] in localized)
+        and (de_row[2] == en_row[2] if de_row[2] in localized else True)
+        for de_row, en_row in zip(de_rows, en_rows, strict=True)
+    )
+
+    def _index_half(lang: str, cells: list[Cell], rows, base_tags):
+        """Per half: baseline pos→hash (+uniqueness) and unique-hash→current cell."""
+        idless_rows = [(pos, chash) for (pos, _sid, role, chash, _c) in rows if role in localized]
+        base_counts = Counter(chash for _pos, chash in idless_rows)
+        hash_by_pos = dict(idless_rows)
+        stream = [c for c in cells if not c.metadata.is_j2 and c.metadata.lang == lang]
+        cur_counts = Counter(
+            cell_content_hash(c.content) for c in stream if role_of(c.metadata) is None
+        )
+        cell_by_hash: dict[str, tuple[int, Cell]] = {}
+        for idx, c in enumerate(stream):
+            if role_of(c.metadata) is not None:
+                continue
+            chash = cell_content_hash(c.content)
+            if cur_counts[chash] == 1 and base_counts.get(chash, 0) <= 1:
+                cell_by_hash[chash] = (idx, c)
+        return base_counts, hash_by_pos, base_tags, cell_by_hash
+
+    halves = {
+        "de": _index_half("de", de_cells, de_rows, de_base_tags),
+        "en": _index_half("en", en_cells, en_rows, en_base_tags),
+    }
+
+    def _locate(lang: str, pos: int):
+        """``(drifted, tags_now, stream_idx, cell)`` at baseline ``pos``, or ``None``.
+
+        ``None`` when the cell cannot be soundly located there: no recorded
+        hash/tags at ``pos``, a non-unique body (baseline or current), or the
+        body itself changed (the cell's hash no longer occurs — #282's domain).
+        """
+        base_counts, hash_by_pos, base_tags, cell_by_hash = halves[lang]
+        chash = hash_by_pos.get(pos)
+        recorded = base_tags.get(pos)
+        if chash is None or recorded is None or base_counts[chash] != 1:
+            return None
+        entry = cell_by_hash.get(chash)
+        if entry is None:
+            return None
+        idx, cell = entry
+        now = frozenset(cell.metadata.tags)
+        return (now != recorded, now, idx, cell)
+
+    def _alert(reason: str) -> None:
+        plan.issues.append(PlanIssue(severity="error", slide_id=None, reason=reason))
+
+    # Duplicate-bodied cells defeat the hash anchor, so a tag drift among them
+    # cannot be attributed to a cell — but it can still be DETECTED: for a hash
+    # whose multiplicity is unchanged, the multiset of tag sets across the
+    # duplicates must match the baseline's. A pure swap of identical cells keeps
+    # the multiset (no false positive); a tag edit changes it → alert (the
+    # pre-#285 paths skipped these silently, deferring to the validator). A
+    # multiplicity change is a body add/remove — the body channel's domain.
+    for lang, cells, rows, base_tags in (
         ("de", de_cells, de_rows, de_base_tags),
         ("en", en_cells, en_rows, en_base_tags),
-    )
-    for lang, cells, rows, base_tags in sides:
-        idless_rows = [
-            (pos, chash)
-            for (pos, _sid, role, chash, _construct) in rows
-            if role in (LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE)
-        ]
-        base_counts = Counter(chash for _pos, chash in idless_rows)
-        base_map = {
-            chash: base_tags.get(pos) for pos, chash in idless_rows if base_counts[chash] == 1
-        }
-        current = [
-            c
-            for c in cells
-            if not c.metadata.is_j2 and c.metadata.lang == lang and role_of(c.metadata) is None
-        ]
-        cur_counts = Counter(cell_content_hash(c.content) for c in current)
-        for cell in current:
-            chash = cell_content_hash(cell.content)
-            if cur_counts[chash] != 1:
-                continue  # duplicated body — cannot anchor; validator flags asymmetry
-            recorded = base_map.get(chash)
-            if recorded is None:
-                continue  # body changed/new (#282's domain) or no recorded tags
-            if frozenset(cell.metadata.tags) != recorded:
-                plan.issues.append(
-                    PlanIssue(
-                        severity="error",
-                        slide_id=None,
-                        reason=f"tags changed on an id-less localized {lang} cell while "
-                        "slide groups were reordered; tag mirroring is positional and "
-                        "unsound across a reorder (#285) — apply the tag change on both "
-                        "halves (or sync the reorder first), then re-run",
-                    )
+    ):
+        base_groups: dict[str, list[frozenset[str] | None]] = {}
+        for pos, _sid, role, chash, _c in rows:
+            if role in localized:
+                base_groups.setdefault(chash, []).append(base_tags.get(pos))
+        cur_groups: dict[str, list[frozenset[str]]] = {}
+        for c in cells:
+            if not c.metadata.is_j2 and c.metadata.lang == lang and role_of(c.metadata) is None:
+                cur_groups.setdefault(cell_content_hash(c.content), []).append(
+                    frozenset(c.metadata.tags)
+                )
+        for chash, base_tag_sets in base_groups.items():
+            if len(base_tag_sets) < 2 or any(t is None for t in base_tag_sets):
+                continue  # unique (the positional route's job) or pre-#198 rows
+            now_tag_sets = cur_groups.get(chash, [])
+            if len(now_tag_sets) != len(base_tag_sets):
+                continue  # a duplicate was added/removed — body channel's domain
+            if Counter(now_tag_sets) != Counter(base_tag_sets):
+                _alert(
+                    f"tags changed on duplicate-bodied id-less localized {lang} cells "
+                    "while slide groups were reordered; identical bodies cannot anchor "
+                    "a tag mirror (#285) — apply the tag change on both halves, then "
+                    "re-run"
                 )
                 return
+
+    positions = sorted(
+        {pos for (pos, _s, role, _h, _c) in de_rows if role in localized}
+        | {pos for (pos, _s, role, _h, _c) in en_rows if role in localized}
+    )
+    for pos in positions:
+        de_loc = _locate("de", pos)
+        en_loc = _locate("en", pos)
+        de_drift = de_loc is not None and de_loc[0]
+        en_drift = en_loc is not None and en_loc[0]
+        if not de_drift and not en_drift:
+            continue
+        if de_drift and en_drift:
+            _alert(
+                f"tags of the id-less localized twin pair at baseline position {pos} "
+                "changed on both decks while slide groups were reordered; "
+                "reconcile the tags manually, then re-run"
+            )
+            return
+        source_lang = "de" if de_drift else "en"
+        target_lang = "en" if de_drift else "de"
+        source = de_loc if de_drift else en_loc
+        target = en_loc if de_drift else de_loc
+        assert source is not None
+        if not (mirror_ok and aligned) or target is None:
+            _alert(
+                f"tags changed on an id-less localized {source_lang} cell while slide "
+                "groups were reordered, and the twin cannot be safely located "
+                "(#285) — apply the tag change on both halves (or sync the reorder "
+                "first), then re-run"
+            )
+            return
+        _drifted, tags_now, source_idx, source_cell = source
+        _t_drifted, _t_tags, target_idx, _target_cell = target
+        kind_label = "code" if source_cell.metadata.cell_type == "code" else "markdown"
+        plan.proposals.append(
+            Proposal(
+                kind="retag",
+                role=kind_label,
+                direction=f"{source_lang}->{target_lang}",
+                slide_id=None,
+                reason=f"tags changed on {source_lang.upper()} ({sorted(tags_now)}) — "
+                "id-less localized cell, mirrored across a group reorder via its "
+                "baseline twin (#285)",
+                source_position=source_idx,
+                target_position=target_idx,
+                tags=tuple(source_cell.metadata.tags),
+            )
+        )
 
 
 def _cell_first_line(body: str, limit: int = 48) -> str:

--- a/tests/slides/test_sync_tag_drift.py
+++ b/tests/slides/test_sync_tag_drift.py
@@ -63,6 +63,10 @@ def _idless_md(lang: str, body: str, tags: str | None = None) -> str:
     return f'# %% [markdown] lang="{lang}"{t}\n{body}\n'
 
 
+def _vo(lang: str, sid: str, body: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n{body}\n'
+
+
 def _deck(*parts: str) -> str:
     return "\n".join(parts)
 
@@ -213,12 +217,15 @@ class TestNeutralTagDrift:
 
 
 # ---------------------------------------------------------------------------
-# Id-less retag under a concurrent move — alerted, watermark held (#285)
+# Id-less retag under a concurrent move — MIRRORED via the baseline twin (#285)
 # ---------------------------------------------------------------------------
 
 
 class TestIdlessRetagUnderMove:
-    def test_target_half_tag_edit_under_move_alerts(self, tmp_path: Path):
+    def test_target_half_tag_edit_under_move_is_mirrored(self, tmp_path: Path):
+        """#285 closed: pre-#289 this silently dropped (and baselined the loss);
+        #290 alerted; the baseline-twin route now MIRRORS the tag across the
+        reorder — both changes land, clean pass, watermark advances."""
         de0 = _deck(
             _slide("de", "a", "A"), _idless_code("de", 'print("hallo")'), _slide("de", "b", "B")
         )
@@ -235,14 +242,18 @@ class TestIdlessRetagUnderMove:
             _slide("en", "b", "B"), _slide("en", "a", "A"), _idless_code("en", 'print("hello")')
         )
         plan, result, de_after, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en1)
-        assert _alerted(plan, result)
-        assert result.watermark_recorded is False  # pre-#289 this ADVANCED over the drop
-        assert '# %% lang="en" tags=["keep"]' not in en_after  # not mis-mirrored
+        assert not _alerted(plan, result)
+        assert result.applied_retag == 1
+        assert '# %% lang="en" tags=["keep"]' in en_after  # tag mirrored onto the EN twin
         assert 'tags=["keep"]' in de_after  # the author's own edit intact
+        assert result.applied_move >= 1  # the reorder applied too
+        assert de_after.index('slide_id="b"') < de_after.index('slide_id="a"')  # mirrored to DE
+        assert result.watermark_recorded
+        assert not _falsely_consistent(plan, result, True)
 
-    def test_source_half_tag_edit_under_own_move_alerts(self, tmp_path: Path):
-        """The reordering half tag-edits its own id-less cell — equally
-        un-mirrorable (Tier C declined), so it must alert, not vanish."""
+    def test_source_half_tag_edit_under_own_move_is_mirrored(self, tmp_path: Path):
+        """The reordering half tag-edits its own id-less cell — same route, the
+        twin is located on the unreordered half."""
         de0 = _deck(
             _slide("de", "a", "A"), _idless_code("de", 'print("hallo")'), _slide("de", "b", "B")
         )
@@ -255,6 +266,92 @@ class TestIdlessRetagUnderMove:
             _idless_code("de", 'print("hallo")', tags='["keep"]'),
         )
         plan, result, _, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en0)
+        assert not _alerted(plan, result)
+        assert result.applied_retag == 1
+        assert '# %% lang="en" tags=["keep"]' in en_after
+        assert result.watermark_recorded
+
+    def test_duplicate_body_under_move_alerts(self, tmp_path: Path):
+        """Two byte-identical id-less cells defeat the hash anchor — the mirror
+        declines and ALERTS (never guesses a twin, never drops)."""
+        de0 = _deck(
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("x")'),
+            _slide("de", "b", "B"),
+            _idless_code("de", 'print("x")'),
+        )
+        en0 = _deck(
+            _slide("en", "a", "A"),
+            _idless_code("en", 'print("x")'),
+            _slide("en", "b", "B"),
+            _idless_code("en", 'print("x")'),
+        )
+        de1 = _deck(
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("x")', tags='["keep"]'),
+            _slide("de", "b", "B"),
+            _idless_code("de", 'print("x")'),
+        )
+        en1 = _deck(
+            _slide("en", "b", "B"),
+            _idless_code("en", 'print("x")'),
+            _slide("en", "a", "A"),
+            _idless_code("en", 'print("x")'),
+        )
+        plan, result, _, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en1)
+        assert _alerted(plan, result)
+        assert result.watermark_recorded is False
+        assert 'tags=["keep"]' not in en_after
+
+    def test_both_sided_tag_drift_under_move_alerts(self, tmp_path: Path):
+        """Both twins' tags drifted — a conflict no direction can resolve."""
+        de0 = _deck(
+            _slide("de", "a", "A"), _idless_code("de", 'print("hallo")'), _slide("de", "b", "B")
+        )
+        en0 = _deck(
+            _slide("en", "a", "A"), _idless_code("en", 'print("hello")'), _slide("en", "b", "B")
+        )
+        de1 = _deck(
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("hallo")', tags='["keep"]'),
+            _slide("de", "b", "B"),
+        )
+        en1 = _deck(
+            _slide("en", "b", "B"),
+            _slide("en", "a", "A"),
+            _idless_code("en", 'print("hello")', tags='["alt"]'),
+        )
+        plan, result, de_after, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en1)
+        assert _alerted(plan, result)
+        assert result.watermark_recorded is False
+        assert '"alt"' not in de_after and '"keep"' not in en_after  # neither overwritten
+
+    def test_move_with_concurrent_remove_alerts_not_mirrors(self, tmp_path: Path):
+        """A coexisting remove reshapes the stream the retag applier targets —
+        the mirror declines to today's alert rather than retag a shifted cell."""
+        de0 = _deck(
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("hallo")'),
+            _slide("de", "b", "B"),
+            _vo("de", "b", "# N"),
+        )
+        en0 = _deck(
+            _slide("en", "a", "A"),
+            _idless_code("en", 'print("hello")'),
+            _slide("en", "b", "B"),
+            _vo("en", "b", "# N"),
+        )
+        # DE: tag edit. EN: reorders groups AND removes the voiceover companion.
+        de1 = _deck(
+            _slide("de", "a", "A"),
+            _idless_code("de", 'print("hallo")', tags='["keep"]'),
+            _slide("de", "b", "B"),
+            _vo("de", "b", "# N"),
+        )
+        en1 = _deck(
+            _slide("en", "b", "B"), _slide("en", "a", "A"), _idless_code("en", 'print("hello")')
+        )
+        plan, result, _, en_after = _sync(tmp_path, "watermark", de0, en0, de1, en1)
         assert _alerted(plan, result)
         assert result.watermark_recorded is False
         assert 'tags=["keep"]' not in en_after
@@ -344,12 +441,12 @@ CHANNEL_COVERAGE: dict[tuple[str, str], list[tuple[object, str]]] = {
     ("de", "tags"): [
         (sync_plan_mod, "_maybe_retag"),
         (sync_plan_mod, "_classify_localized_idless_retags"),
-        (sync_plan_mod, "_alert_idless_tag_drift_under_move"),
+        (sync_plan_mod, "_classify_idless_retags_under_move"),
     ],
     ("en", "tags"): [
         (sync_plan_mod, "_maybe_retag"),
         (sync_plan_mod, "_classify_localized_idless_retags"),
-        (sync_plan_mod, "_alert_idless_tag_drift_under_move"),
+        (sync_plan_mod, "_classify_idless_retags_under_move"),
     ],
     ("shared", "tags"): [
         (sync_plan_mod, "_classify_neutral_tag_drift"),


### PR DESCRIPTION
## What

Closes #285 — the last open item from the sync architecture review (#288/#289). A tag-only edit on an id-less localized cell made while the other half reorders slide groups is now **mirrored**, not just alerted: pre-#289 it silently dropped (and the watermark advanced over the loss), #290 converted it to an error, this PR completes it to a propagation. Matrix probe P5 graduates `ALERTED → PROPAGATED`.

## How — the reorder-invariant baseline-twin join

Live positional pairing is unsound under a move (why Tier C declined), but the **baseline** still provides a sound join:

1. the drifted cell is located in its own half by **unique body hash** against its own baseline — a tag-only edit never changes the body;
2. its **baseline position** indexes the twin: at the last sync the two localized streams were positional twins (verified on the recorded rows — length and per-position kind);
3. the twin's baseline hash locates it in the other half's **current, reordered** stream — hash-keyed, so the reorder cannot mis-pair it.

Every lookup carries the engine's recurring non-unique-anchor guard. The proposal lands as an ordinary id-less `retag` with current stream indices; the applier runs before moves in the pipeline, so the targeted positions are stable, and the tag mirror plus the reorder apply in one clean pass (watermark advances).

## What still errors — never guesses, never drops

- **Byte-identical duplicate bodies**: nothing can anchor *which* twin to retag — but the drift is now still **detected** via per-duplicate-group tag multisets (a pure swap of identical cells keeps the multiset; a tag edit changes it). The expected-alert test for this exposed that even #290's alert path skipped duplicates silently, deferring to the validator — closed here.
- Tags drifted on **both** twins (a conflict no direction resolves).
- Misaligned baseline streams (a committed pair that was never positionally twinned).
- A pass that also **adds/removes** cells (`_MOVE_RETAG_BLOCKERS`): a remove shifts the current positions the retag applier targets — sync in two steps.

## Testing

- `TestIdlessRetagUnderMove` grows from 2 expect-alert tests to 5: both mirror directions (tag edit on the reordering half and on the unreordered half) + the three residual alerts (duplicate bodies, both-sided drift, coexisting remove).
- The channel-coverage meta-test failed on the renamed symbol until the registry was updated — exactly its designed tripwire behavior.
- Full `tests/slides/` suite: 1539 passed; corpus mutation oracle green against the local corpus; all 13 matrix probes correct (P5 now PROPAGATED, wm-advanced); fast suite green on the pre-push hook; ruff + mypy clean.
- Info topic (`clm info commands` sync section) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
