### PR TITLE
release: multi-stream cohort releases, lang-scoped channels, distribute opt-out, GitLab shares, partial manifests (#291-#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Multiple release streams per cohort (issue #291).** A course can declare
+  several `<release-channels>` blocks — one per release *stream*, each fed by
+  its own `source-target` (e.g. `materials` from a `shared` target released
+  before each session, `solutions` from a `completed` target released after
+  the workshop). With more than one block each needs a unique `name`; channels
+  are addressed as `STREAM/CHANNEL` (`--channel materials/2026-04`) across
+  `clm release`, `clm git --channel/--all-channels`, and `clm calendar`, with
+  bare names still accepted when unique. Derived channel repo names gain the
+  stream segment (`{slug}-{channel}-{stream}`); spec validation rejects
+  duplicate stream/channel names and channels sharing a destination or ledger
+  across streams.
+- **Language-scoped release channels (issue #293).** `<channel lang="de">`
+  promotes only that language's files, re-rooted so the cohort repo's root is
+  the language directory — matching per-language distribution repos like
+  `…/machine-learning-azav-de` — and appends `-{lang}` to the derived repo
+  name. `clm release sync --language de|en` overrides per invocation. A
+  channel without `lang` keeps receiving every built language root (now
+  documented as the defined default).
+- **Declarative GitLab access-group shares (issue #294).** `<share-with
+  access="reporter">students/azav-ml/ml-2026-04</share-with>` on a `<channel>`
+  (or on the block, inherited by every channel) declares which GitLab groups a
+  channel repo is shared into; the new `clm release provision` applies the
+  shares via the GitLab API (idempotent, token from
+  `CLM_GITLAB_TOKEN`/`GITLAB_TOKEN`, safe no-op for non-GitLab remotes,
+  `--dry-run` preview). Repo creation itself stays push-to-create/manual.
+- **`clm git` skips release build-source targets (issue #292).** Without
+  `--target`, `clm git init/status/commit/push/sync/reset` no longer creates
+  or manages repos for output targets that only feed a release stream (named
+  as a `<release-channels source-target>`), nor for targets with an explicit
+  `distribute="false"` — those are private build inputs whose content reaches
+  students only through `clm release sync`. An explicit `--target NAME` still
+  selects such a target, and `distribute="true"` restores wholesale
+  distribution for a release source that is also pushed directly.
+- **A failing deck no longer blocks all releases (issue #295).** A
+  whole-course build with topic-attributable errors now writes the provenance
+  manifest for the cleanly-built subset, excluding the failed topics' entries
+  and recording them (`partial: true`, `failed_topics`). `clm release sync`
+  promotes every green topic and refuses the failed ones (`skip-failed`,
+  never frozen, loud warning) until a build succeeds for them. Errors that
+  cannot be attributed to a topic — and timed-out, `--watch`, or
+  `--only-sections` builds — still suppress the manifest entirely.
 - **Cohort viewing calendars (`clm export calendar`, `clm calendar check` /
   `status`)** project a course's schedule onto one cohort's real calendar dates
   (issue #283). Where `clm export schedule` is course-relative ("Week 3,

--- a/docs/claude/design/per-topic-solution-release.md
+++ b/docs/claude/design/per-topic-solution-release.md
@@ -458,3 +458,18 @@ drive straight through). Each step is independently testable and leaves the tree
 4. Payload round-trip guarantee (Issue #17): `src/clm/infrastructure/messaging/base_classes.py`
 5. Git machinery: `src/clm/cli/commands/git_ops.py`, `GitHubSpec.derive_remote_url()` in
    `src/clm/core/course_spec.py`
+
+---
+
+## 11. Post-ship extensions (issues #291–#295, 2026-06)
+
+Adoption by the ML-AZAV course surfaced five usability gaps, fixed in one
+follow-up batch (PR branch `claude/release-streams-291-295`):
+
+| Issue | Extension |
+|---|---|
+| #291 | **Multiple release streams**: several named `<release-channels>` blocks, each with its own `source-target`; channels addressed as `stream/channel` everywhere (`clm release`, `clm git`, `clm calendar`); repo names gain a `-{stream}` segment. Single unnamed block = unchanged #208 behavior. |
+| #292 | `<output-target distribute="false">`, defaulting to `false` for release `source-target`s — `clm git` (without `--target`) no longer turns private build inputs into distributed repos. |
+| #293 | `<channel lang="de">` / `clm release sync --language`: promote one language root, re-rooted at the language dir (`restrict_manifest_to_language`); repo names gain `-{lang}`. Unset = all language roots (documented default). |
+| #294 | `<share-with access="…">group/path</share-with>` + `clm release provision`: GitLab group shares via API (`src/clm/infrastructure/gitlab_api.py`); share-only by design — repo creation stays push-to-create/manual. |
+| #295 | Partial provenance manifests: an errored whole-course build writes the manifest for the built subset when every error attributes to a topic (`_failed_topic_ids` in `build.py`); manifest records `partial`/`failed_topics`; `plan_sync` refuses those topics with `skip-failed` (never frozen). Unattributable/fatal/timed-out → strict skip as before. |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -215,8 +215,9 @@ in bulk.
 |----------|-------------|---------|
 | `CLM_GIT__REMOTE_TEMPLATE` | URL template for git remotes | `{repository_base}/{repo}` |
 | `CLM_GIT__REMOTE_PATH` | Path segment between base URL and repo name (e.g., GitLab group). Per-target `<remote-path>` overrides still win. | (unset) |
+| `CLM_GITLAB_TOKEN` | GitLab API token (`api` scope) used by `clm release provision` to share channel repos into access groups (issue #294). `GITLAB_TOKEN` is accepted as a fallback. | (unset) |
 
-The remote template supports placeholders: `{repository_base}`, `{remote_path}`, `{repo}`, `{slug}`, `{lang}`, `{suffix}`.
+The remote template supports placeholders: `{repository_base}`, `{remote_path}`, `{repo}`, `{slug}`, `{lang}`, `{suffix}` — plus, for release-channel repos, `{stream}` (the release stream name, issue #291).
 This is useful for SSH access with custom host aliases:
 
 ```bash

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -448,27 +448,77 @@ def _should_emit_provenance_manifest(summary: BuildSummary | None, config: Build
     """Whether to write the ``.clm-manifest.json`` after a finished build.
 
     Beyond the resolved request flag (``config.write_provenance_manifest``), the
-    manifest is written only for a **complete, successful, whole-course** build —
-    mirroring the post-build sweep's conservative skips, because the manifest is a
-    full overwrite of the prior index:
+    manifest is written only for a **whole-course** build — mirroring the
+    post-build sweep's conservative skips, because the manifest is a full
+    overwrite of the prior index:
 
     - ``--watch``: long-running rebuilds populate only the changed file.
     - ``--only-sections``: a section selection would overwrite the full manifest
       with a partial index that silently drops every unselected section's
       provenance (the release engine's join key). The sweep skips this mode for
       the same cross-section-damage reason.
-    - errored / timed-out builds: the output tree is incomplete, so the hashed
-      manifest would claim clean provenance over output the build reported broken.
-      (The non-zero exit happens later, in the ``build`` entry point.)
+    - timed-out builds: pending jobs mean an unknown set of topics never ran,
+      so no honest manifest can be written at all.
+
+    A build with **errors** is no longer an outright skip (issue #295): when
+    every error attributes to a topic (see :func:`_failed_topic_ids`), the
+    manifest is written for the cleanly-built subset with the failed topics
+    excluded and recorded — one flaky deck must not block releasing every
+    other topic. (The non-zero exit still happens later, in the ``build``
+    entry point.)
     """
     return (
         summary is not None
         and config.write_provenance_manifest
         and not config.watch
         and config.resolved_section_selection is None
-        and not summary.errors
         and not summary.timed_out
     )
+
+
+def _failed_topic_ids(summary: BuildSummary, course) -> set[str] | None:
+    """Attribute the build's errors to topics, for the partial manifest (#295).
+
+    Returns the set of topic ids owning at least one errored source file —
+    empty when the build was clean. Returns ``None`` when the errors cannot
+    all be pinned to topics, in which case the caller must skip the manifest
+    entirely (the pre-#295 strict behavior), because an unattributable error
+    leaves unknown parts of the output tree suspect:
+
+    - any ``fatal``-severity error (stage-level breakage, e.g. no workers);
+    - an error without a ``file_path``;
+    - a ``file_path`` that matches no course file (e.g. the spec itself).
+    """
+    relevant = [e for e in summary.errors if e.severity in ("error", "fatal")]
+    if not relevant:
+        return set()
+    if any(e.severity == "fatal" for e in relevant):
+        return None
+
+    topic_by_path: dict[str, str] = {}
+    for file in course.files:
+        try:
+            topic_by_path[str(Path(file.path).resolve())] = file.topic.id
+        except OSError:  # pragma: no cover - unresolvable paths are just skipped
+            continue
+
+    failed: set[str] = set()
+    for error in relevant:
+        if not error.file_path:
+            return None
+        try:
+            topic_id = topic_by_path.get(str(Path(error.file_path).resolve()))
+        except OSError:
+            topic_id = None
+        if topic_id is None:
+            logger.info(
+                "Provenance manifest: error on %r is not attributable to a topic; "
+                "falling back to the strict whole-course gate.",
+                error.file_path,
+            )
+            return None
+        failed.add(topic_id)
+    return failed
 
 
 def create_output_formatter(config: BuildConfig) -> OutputFormatter:
@@ -1737,28 +1787,45 @@ async def main_build(
 
     # Provenance manifests: one .clm-manifest.json per output root (issue #208).
     # On by default since step 3d (and suppressed for --snapshot / --verify-against
-    # at the entry point). Only written for a complete, successful, whole-course
-    # build — see _should_emit_provenance_manifest, which mirrors the post-build
-    # sweep's conservative skips. Capturing the source commit and writing the
-    # manifest must never fail an otherwise successful build, so any error here is
-    # logged and swallowed.
-    if _should_emit_provenance_manifest(summary, config):
+    # at the entry point). Only written for a whole-course build — see
+    # _should_emit_provenance_manifest, which mirrors the post-build sweep's
+    # conservative skips. A build with topic-attributable errors writes a
+    # *partial* manifest that excludes and records the failed topics (issue
+    # #295) so unrelated topics stay releasable. Capturing the source commit
+    # and writing the manifest must never fail an otherwise successful build,
+    # so any error here is logged and swallowed.
+    if summary is not None and _should_emit_provenance_manifest(summary, config):
         from datetime import datetime, timezone
 
         from clm.core.git_info import get_git_info
         from clm.core.provenance_manifest import write_provenance_manifests
 
         try:
-            git = get_git_info(course.course_root)
-            written = write_provenance_manifests(
-                course,
-                source_commit=git["commit"],
-                source_dirty=git["dirty"],
-                built_at=datetime.now(timezone.utc).isoformat(),
-                spec_name=config.spec_file.name,
-            )
-            if written:
-                logger.info("Wrote %d provenance manifest(s)", len(written))
+            failed_topics = _failed_topic_ids(summary, course)
+            if failed_topics is None:
+                logger.warning(
+                    "Skipping provenance manifest(s): the build reported errors "
+                    "that cannot be attributed to specific topics."
+                )
+            else:
+                if failed_topics:
+                    logger.warning(
+                        "Writing partial provenance manifest(s): %d failed topic(s) "
+                        "excluded and recorded (%s).",
+                        len(failed_topics),
+                        ", ".join(sorted(failed_topics)),
+                    )
+                git = get_git_info(course.course_root)
+                written = write_provenance_manifests(
+                    course,
+                    source_commit=git["commit"],
+                    source_dirty=git["dirty"],
+                    built_at=datetime.now(timezone.utc).isoformat(),
+                    spec_name=config.spec_file.name,
+                    failed_topics=failed_topics,
+                )
+                if written:
+                    logger.info("Wrote %d provenance manifest(s)", len(written))
         except Exception as e:
             logger.warning("Failed to write provenance manifest(s): %s", e, exc_info=True)
 

--- a/src/clm/cli/commands/calendar.py
+++ b/src/clm/cli/commands/calendar.py
@@ -110,21 +110,21 @@ def resolve_calendar_path(spec_file: Path, channel_name: str, explicit: Path | N
     if not channel_name:
         raise click.UsageError("Pass --channel NAME or --calendar PATH.")
     spec = CourseSpec.from_file(spec_file)
-    channels = spec.release_channels
-    if channels is None:
+    if not spec.release_channel_blocks:
         raise click.ClickException(
             f"{spec_file} has no <release-channels> block; pass --calendar PATH "
             "instead of --channel."
         )
-    channel = channels.channel(channel_name)
-    if channel is None:
-        available = ", ".join(c.name for c in channels.channels) or "(none defined)"
-        raise click.ClickException(
-            f"Unknown channel {channel_name!r}. Defined channels: {available}."
-        )
+    try:
+        _block, channel = spec.resolve_release_channel(channel_name)
+    except CourseSpecError as e:
+        raise click.ClickException(str(e)) from None
     course_root, _ = resolve_course_paths(spec_file)
     ledger = _abs_under(course_root, channel.ledger)
-    return ledger.parent / f"{channel_name}.calendar.toml"
+    # The cohort has one timeline regardless of release stream, so the
+    # calendar file is keyed by the bare channel (cohort) name — the
+    # materials and solutions streams of one cohort share it (#291).
+    return ledger.parent / f"{channel.name}.calendar.toml"
 
 
 @click.command("calendar")

--- a/src/clm/cli/commands/git_ops.py
+++ b/src/clm/cli/commands/git_ops.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import click
 
 from clm.core.course_paths import resolve_course_paths
-from clm.core.course_spec import CourseSpec
+from clm.core.course_spec import CourseSpec, CourseSpecError, release_channel_ref
 from clm.core.provenance_manifest import MANIFEST_FILENAME
 from clm.infrastructure.config import get_config
 
@@ -350,27 +350,34 @@ def find_release_channel_repos(
     spec_file: Path,
     channel_filter: str | None = None,
 ) -> list[OutputRepo]:
-    """Find the per-cohort release-channel repositories for a course (#208).
+    """Find the per-cohort release-channel repositories for a course (#208, #291).
 
     Mirrors :func:`find_output_repos` but enumerates the ``<release-channels>``
-    block instead of ``<output-targets>``. Each channel is a single,
-    non-language-scoped cohort repo whose working tree is the channel ``path``
+    blocks (one per release stream) instead of ``<output-targets>``. Each
+    channel is a single cohort repo whose working tree is the channel ``path``
     (resolved under the course root, identically to ``clm release``). The remote
     URL is best-effort (used only by ``clm git init``); push/commit operate on
     whatever ``origin`` the repo actually has.
 
     Args:
         spec_file: Path to the course spec file.
-        channel_filter: Optional channel name to restrict the result to.
+        channel_filter: Optional channel address (``stream/channel`` or a
+            unique bare channel name) to restrict the result to. Raises
+            :class:`CourseSpecError` when it does not resolve.
 
     Returns:
-        One :class:`OutputRepo` per matching channel (``source="channel"``);
-        empty when the spec declares no ``<release-channels>`` block.
+        One :class:`OutputRepo` per matching channel (``source="channel"``,
+        ``target_name`` = the canonical channel address); empty when the spec
+        declares no ``<release-channels>`` block.
     """
     spec = CourseSpec.from_file(spec_file)
-    channels_spec = spec.release_channels
-    if channels_spec is None:
+    if not spec.release_channel_blocks:
         return []
+
+    if channel_filter:
+        pairs = [spec.resolve_release_channel(channel_filter)]
+    else:
+        pairs = list(spec.iter_release_channels())
 
     course_root, _ = resolve_course_paths(spec_file)
     github_config = spec.github
@@ -379,10 +386,7 @@ def find_release_channel_repos(
     config_remote_path = config.git.remote_path
 
     repos: list[OutputRepo] = []
-    for channel in channels_spec.channels:
-        if channel_filter and channel.name != channel_filter:
-            continue
-
+    for block, channel in pairs:
         path = Path(channel.path)
         if not path.is_absolute():
             path = course_root / path
@@ -393,12 +397,13 @@ def find_release_channel_repos(
             project_slug=spec.project_slug,
             remote_template=remote_template,
             remote_path=effective_remote_path,
+            stream=block.name,
         )
 
         repos.append(
             OutputRepo(
                 path=path,
-                target_name=channel.name,
+                target_name=release_channel_ref(block, channel),
                 language="",
                 remote_url=remote_url,
                 source="channel",
@@ -425,18 +430,16 @@ def _select_repos(
     if channel or all_channels:
         if target:
             raise click.UsageError("--target cannot be combined with --channel/--all-channels.")
-        channels_spec = CourseSpec.from_file(spec_file).release_channels
-        if channels_spec is None or not channels_spec.channels:
+        spec = CourseSpec.from_file(spec_file)
+        if not any(block.channels for block in spec.release_channel_blocks):
             raise click.ClickException(
                 f"{spec_file.name} declares no <release-channels>; "
                 f"--channel/--all-channels is not available for this course."
             )
-        if channel and channels_spec.channel(channel) is None:
-            available = ", ".join(c.name for c in channels_spec.channels)
-            raise click.ClickException(
-                f"Unknown channel {channel!r}. Defined channels: {available}."
-            )
-        return find_release_channel_repos(spec_file, channel or None)
+        try:
+            return find_release_channel_repos(spec_file, channel or None)
+        except CourseSpecError as e:
+            raise click.ClickException(str(e)) from None
     return find_output_repos(spec_file, target)
 
 
@@ -738,17 +741,19 @@ def _init_create_new_repo(repo: OutputRepo, branch: str) -> None:
 # =============================================================================
 
 # Shared options that switch a subcommand from <output-targets> repos to the
-# per-cohort <release-channels> repos (issue #208). Mutually exclusive with
-# --target; see _select_repos.
+# per-cohort <release-channels> repos (issues #208, #291). Mutually exclusive
+# with --target; see _select_repos.
 _channel_option = click.option(
     "--channel",
     default=None,
-    help="Act on the named release-channel (cohort) repo instead of output targets.",
+    help="Act on the named release-channel (cohort) repo instead of output "
+    "targets. Address a channel in a named stream as STREAM/CHANNEL "
+    "(e.g. materials/2026-04); a bare name works when unique.",
 )
 _all_channels_option = click.option(
     "--all-channels",
     is_flag=True,
-    help="Act on every release-channel (cohort) repo instead of output targets.",
+    help="Act on every release-channel (cohort) repo of every stream instead of output targets.",
 )
 
 

--- a/src/clm/cli/commands/git_ops.py
+++ b/src/clm/cli/commands/git_ops.py
@@ -258,6 +258,11 @@ def find_output_repos(
 ) -> list[OutputRepo]:
     """Find all output repositories for a course spec.
 
+    Targets that are not distributed — an explicit ``distribute="false"`` or,
+    by default, a target feeding a release stream (issue #292) — are skipped
+    when enumerating all targets. Naming one explicitly via *target_filter*
+    still selects it: an explicit request wins over the default-safe skip.
+
     Args:
         spec_file: Path to course spec file
         target_filter: Optional target name to filter by
@@ -278,6 +283,13 @@ def find_output_repos(
         # Course has explicit output targets
         for i, target_spec in enumerate(spec.output_targets):
             if target_filter and target_spec.name != target_filter:
+                continue
+            if not target_filter and not spec.is_distributed_target(target_spec):
+                logger.debug(
+                    "Skipping non-distributed output target %r (release build source "
+                    'or distribute="false")',
+                    target_spec.name,
+                )
                 continue
 
             # Resolve path

--- a/src/clm/cli/commands/git_ops.py
+++ b/src/clm/cli/commands/git_ops.py
@@ -34,8 +34,9 @@ class OutputRepo:
     """Represents an output directory that may have a git repository.
 
     ``source`` distinguishes an ``<output-target>`` repo (``"output"``) from a
-    per-cohort release channel repo (``"channel"``, issue #208). Channel repos
-    are not language-scoped, so their ``language`` is the empty string.
+    per-cohort release channel repo (``"channel"``, issue #208). A channel
+    repo's ``language`` is the empty string unless the channel is
+    language-scoped via its ``lang`` attribute (issue #293).
     """
 
     def __init__(
@@ -410,13 +411,17 @@ def find_release_channel_repos(
             remote_template=remote_template,
             remote_path=effective_remote_path,
             stream=block.name,
+            language=channel.lang,
         )
 
         repos.append(
             OutputRepo(
                 path=path,
+                # A language-scoped channel (issue #293) carries its lang so the
+                # display name reads e.g. "materials/2026-04/de"; the repo path
+                # is still the single channel dest (one repo per channel).
                 target_name=release_channel_ref(block, channel),
-                language="",
+                language=channel.lang,
                 remote_url=remote_url,
                 source="channel",
             )

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -25,7 +25,12 @@ from clm.cli.commands.git_ops import (
     find_release_channel_repos,
 )
 from clm.core.course_paths import resolve_course_paths
-from clm.core.course_spec import CourseSpec, CourseSpecError, SectionSpec
+from clm.core.course_spec import (
+    CourseSpec,
+    CourseSpecError,
+    SectionSpec,
+    release_channel_ref,
+)
 from clm.core.provenance_manifest import MANIFEST_FILENAME, load_manifest
 from clm.release.frozen_manifest import FROZEN_FILENAME, FrozenManifest
 from clm.release.ledger import Ledger, partition_known
@@ -39,8 +44,10 @@ _SPEC_ARG = click.argument(
 _CHANNEL_OPT = click.option(
     "--channel",
     default="",
-    help="Channel name; resolves --ledger/--source/--dest from the spec's "
-    "<release-channels>. Explicit paths override resolution.",
+    help="Channel address; resolves --ledger/--source/--dest from the spec's "
+    "<release-channels>. Use STREAM/CHANNEL (e.g. materials/2026-04) when "
+    "several streams are declared; a bare name works when unique. Explicit "
+    "paths override resolution.",
 )
 _LEDGER_OPT = click.option(
     "--ledger",
@@ -70,24 +77,22 @@ def _abs_under(course_root: Path, value: str) -> Path:
 
 
 def _resolve_channel(spec_file: Path, channel_name: str) -> _ResolvedChannel:
+    """Resolve a channel address (``stream/channel`` or unique bare name, #291)."""
     spec = CourseSpec.from_file(spec_file)
-    channels = spec.release_channels
-    if channels is None:
+    if not spec.release_channel_blocks:
         raise click.ClickException(
             f"{spec_file} has no <release-channels> block; pass explicit "
             f"--ledger/--source/--dest instead of --channel."
         )
-    channel = channels.channel(channel_name)
-    if channel is None:
-        available = ", ".join(c.name for c in channels.channels) or "(none defined)"
-        raise click.ClickException(
-            f"Unknown channel {channel_name!r}. Defined channels: {available}."
-        )
+    try:
+        block, channel = spec.resolve_release_channel(channel_name)
+    except CourseSpecError as e:
+        raise click.ClickException(str(e)) from None
     course_root, _ = resolve_course_paths(spec_file)
-    source_target = next((t for t in spec.output_targets if t.name == channels.source_target), None)
+    source_target = next((t for t in spec.output_targets if t.name == block.source_target), None)
     source = _abs_under(course_root, source_target.path) if source_target else None
     return _ResolvedChannel(
-        name=channel_name,
+        name=release_channel_ref(block, channel),
         ledger=_abs_under(course_root, channel.ledger),
         source=source,
         dest=_abs_under(course_root, channel.path),
@@ -396,6 +401,9 @@ def sync_cmd(
         if spec_file is None:
             raise click.ClickException("--channel requires the SPEC_FILE argument.")
         resolved = _resolve_channel(spec_file, channel)
+        # Use the canonical stream/channel address everywhere downstream
+        # (messages, the frozen manifest's channel field, push hints).
+        channel = resolved.name
         ledger_path = ledger_path or resolved.ledger
         source_path = source_path or resolved.source
         dest_path = dest_path or resolved.dest

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -192,6 +192,101 @@ def _push_channel_repo(
         raise SystemExit(1)
 
 
+@release_group.command("provision")
+@_SPEC_ARG
+@click.option(
+    "--channel",
+    default="",
+    help="Provision a single channel (STREAM/CHANNEL or unique bare name). "
+    "Default: every channel that declares <share-with>.",
+)
+@click.option("--dry-run", is_flag=True, help="Show the shares that would be applied.")
+def provision_cmd(spec_file: Path, channel: str, dry_run: bool) -> None:
+    """Share channel repos into their GitLab access groups (issue #294).
+
+    For every selected channel with ``<share-with>`` declarations, performs
+    the GitLab group-share via the REST API (idempotent — an existing share is
+    reported, not an error). The repo itself must already exist on the remote
+    (push it first via ``clm git init/sync --channel``); provisioning only
+    grants group access, replacing the manual per-cohort UI step.
+
+    Requires a GitLab token with ``api`` scope in ``CLM_GITLAB_TOKEN`` (or
+    ``GITLAB_TOKEN``). Channels without a parseable GitLab remote URL are
+    skipped with a note, so the command is a safe no-op for non-GitLab hosts.
+    """
+    from clm.infrastructure.gitlab_api import (
+        GitLabApiError,
+        gitlab_token,
+        parse_gitlab_remote,
+        share_project_with_group,
+    )
+
+    spec = CourseSpec.from_file(spec_file)
+    if not spec.release_channel_blocks:
+        raise click.ClickException(f"{spec_file} has no <release-channels> block.")
+
+    repos = {r.target_name: r for r in find_release_channel_repos(spec_file, channel or None)}
+    if channel:
+        try:
+            pairs = [spec.resolve_release_channel(channel)]
+        except CourseSpecError as e:
+            raise click.ClickException(str(e)) from None
+    else:
+        pairs = list(spec.iter_release_channels())
+
+    work: list[tuple[str, str, str, str, str]] = []  # ref, base, project, group, access
+    for block, ch in pairs:
+        ref = release_channel_ref(block, ch)
+        if not ch.share_with:
+            if channel:
+                click.echo(f"[{ref}] no <share-with> declared — nothing to provision.")
+            continue
+        repo = repos.get(ref)
+        remote = parse_gitlab_remote(repo.remote_url or "") if repo else None
+        if remote is None:
+            click.echo(
+                f"[{ref}] skipped: no GitLab remote URL could be derived "
+                f"(configure <github> repository-base / remote-path)."
+            )
+            continue
+        base_url, project_path = remote
+        for share in ch.share_with:
+            work.append((ref, base_url, project_path, share.group, share.access))
+
+    if not work:
+        click.echo("Nothing to provision.")
+        return
+
+    if dry_run:
+        click.echo("[DRY RUN] Would apply the following group shares:")
+        for ref, base_url, project_path, group, access in work:
+            click.echo(f"  [{ref}] {base_url}/{project_path} -> {group} ({access})")
+        return
+
+    token = gitlab_token()
+    if token is None:
+        raise click.ClickException(
+            "No GitLab token configured. Set CLM_GITLAB_TOKEN (or GITLAB_TOKEN) "
+            "to a token with 'api' scope, or use --dry-run to preview."
+        )
+
+    errors = 0
+    for ref, base_url, project_path, group, access in work:
+        try:
+            status = share_project_with_group(base_url, project_path, group, access, token)
+        except GitLabApiError as e:
+            click.echo(f"[{ref}] ERROR sharing with {group}: {e}", err=True)
+            errors += 1
+            continue
+        if status == "already-shared":
+            click.echo(f"[{ref}] already shared with {group} — unchanged.")
+        else:
+            click.echo(f"[{ref}] shared {project_path} with {group} ({access}).")
+
+    if errors:
+        raise SystemExit(1)
+
+
 @release_group.command("add")
 @_SPEC_ARG
 @click.argument("topic_ids", nargs=-1, required=True)

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -484,6 +484,12 @@ def sync_cmd(
         refreeze=refreeze,
     )
 
+    if manifest.get("partial"):
+        click.echo(
+            "Note: the source build manifest is partial (the build reported "
+            "errors); topics that failed in that build are refused below "
+            "and promote once a build succeeds for them."
+        )
     click.echo(
         f"Channel '{channel_name or '?'}': "
         f"skeleton {'copy' if plan.copy_skeleton else 'frozen'} "
@@ -515,6 +521,13 @@ def sync_cmd(
         f"{len(result.refrozen_topics)} re-frozen, "
         f"{len(result.skipped_topics)} already frozen (skipped)."
     )
+    if result.failed_topics:
+        click.echo(
+            f"Warning: {len(result.failed_topics)} released topic(s) NOT promoted "
+            f"— they failed in the source build: {', '.join(result.failed_topics)}. "
+            f"Rebuild, then re-run sync.",
+            err=True,
+        )
 
     if push:
         _push_channel_repo(

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -31,7 +31,11 @@ from clm.core.course_spec import (
     SectionSpec,
     release_channel_ref,
 )
-from clm.core.provenance_manifest import MANIFEST_FILENAME, load_manifest
+from clm.core.provenance_manifest import (
+    MANIFEST_FILENAME,
+    load_manifest,
+    restrict_manifest_to_language,
+)
 from clm.release.frozen_manifest import FROZEN_FILENAME, FrozenManifest
 from clm.release.ledger import Ledger, partition_known
 from clm.release.sync import SyncResult, apply_sync, plan_sync
@@ -64,6 +68,9 @@ class _ResolvedChannel:
     ledger: Path
     source: Path | None
     dest: Path
+    # Channel language scope (issue #293). Empty = the channel receives every
+    # built language root.
+    lang: str = ""
 
 
 @click.group("release")
@@ -96,6 +103,7 @@ def _resolve_channel(spec_file: Path, channel_name: str) -> _ResolvedChannel:
         ledger=_abs_under(course_root, channel.ledger),
         source=source,
         dest=_abs_under(course_root, channel.path),
+        lang=channel.lang,
     )
 
 
@@ -364,6 +372,14 @@ def status_cmd(
     help="Re-copy and re-freeze these already-frozen topics (e.g. a bug fix).",
 )
 @click.option("--refreeze-all", is_flag=True, help="Re-copy and re-freeze every released topic.")
+@click.option(
+    "--language",
+    type=click.Choice(["de", "en"]),
+    default=None,
+    help="Promote only this language's files, re-rooted at the language "
+    "directory (issue #293). Overrides the channel's lang attribute; requires "
+    "SPEC_FILE. --source must point at the output-target root.",
+)
 @click.option("--dry-run", is_flag=True, help="Print the plan; copy nothing.")
 @click.option(
     "--push",
@@ -386,6 +402,7 @@ def sync_cmd(
     dest_path: Path | None,
     refreeze_ids: tuple[str, ...],
     refreeze_all: bool,
+    language: str | None,
     dry_run: bool,
     push: bool,
     commit_message: str | None,
@@ -396,7 +413,13 @@ def sync_cmd(
     ``SPEC_FILE``'s <release-channels>) or with explicit
     ``--ledger``/``--source``/``--dest`` paths. With ``--push`` the cohort repo
     is committed and pushed afterward, reusing ``clm git``'s machinery.
+
+    A channel with a ``lang`` attribute — or an explicit ``--language`` —
+    promotes only that language's files, re-rooted so the cohort repo's root
+    is the language directory (issue #293). Without either, the destination
+    receives every built language root.
     """
+    channel_lang = ""
     if channel:
         if spec_file is None:
             raise click.ClickException("--channel requires the SPEC_FILE argument.")
@@ -407,6 +430,7 @@ def sync_cmd(
         ledger_path = ledger_path or resolved.ledger
         source_path = source_path or resolved.source
         dest_path = dest_path or resolved.dest
+        channel_lang = resolved.lang
 
     if ledger_path is None or source_path is None or dest_path is None:
         raise click.ClickException(
@@ -422,6 +446,31 @@ def sync_cmd(
             f"`clm build --provenance-manifest` first."
         )
     manifest = load_manifest(manifest_path)
+
+    # Language scoping (issue #293): restrict the manifest to one language and
+    # re-root both it and the copy source at the language directory.
+    effective_lang = language or channel_lang
+    if effective_lang:
+        if spec_file is None:
+            raise click.ClickException(
+                "--language requires the SPEC_FILE argument (it resolves the "
+                "language directory name from the spec)."
+            )
+        lang_dir = str(CourseSpec.from_file(spec_file).output_dir_name[effective_lang])
+        lang_root = source_path / lang_dir
+        if not lang_root.is_dir():
+            raise click.ClickException(
+                f"Language root not found: {lang_root}. Build the source target "
+                f"for language {effective_lang!r} first."
+            )
+        manifest = restrict_manifest_to_language(manifest, effective_lang, lang_dir)
+        if not manifest["files"]:
+            raise click.ClickException(
+                f"The provenance manifest records no {effective_lang!r} files under "
+                f"{lang_dir!r}; nothing could ever be promoted. Was the source "
+                f"built without that language?"
+            )
+        source_path = lang_root
     ledger = Ledger.load(ledger_path)
     channel_name = channel or dest_path.name
     frozen_path = dest_path / FROZEN_FILENAME

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2461,10 +2461,16 @@ Key options for `git commit`, `git push`, and `git sync`:
 | `-m, --message` | commit, sync | Commit message (required unless `--amend`) |
 | `--amend` | commit, sync | Amend previous commit instead of creating new one |
 | `--force-with-lease` | push, sync | Safe force push (implied by `--amend` on sync) |
-| `--target` | all | Filter to specific output target |
-| `--channel NAME` | all | Act on the named release-channel (cohort) repo instead of output targets (issue #208). Mutually exclusive with `--target`. |
-| `--all-channels` | all | Act on every release-channel (cohort) repo instead of output targets. Mutually exclusive with `--target`. |
+| `--target` | all | Filter to specific output target. Also the only way to act on a non-distributed target (see below). |
+| `--channel NAME` | all | Act on the named release-channel (cohort) repo instead of output targets (issues #208, #291). With several release streams, address a channel as `STREAM/CHANNEL` (e.g. `materials/2026-04`); a bare name works when unique. Mutually exclusive with `--target`. |
+| `--all-channels` | all | Act on every release-channel (cohort) repo of every stream instead of output targets. Mutually exclusive with `--target`. |
 | `--dry-run` | all | Show what would be done |
+
+**Non-distributed targets (issue #292).** Without `--target`, `clm git` skips
+any output target with `distribute="false"` — and, by default, any target named
+as a `<release-channels source-target>` (a private build input for `clm
+release`). Pass `--target NAME` explicitly to act on such a target anyway, or
+set `distribute="true"` on it to restore wholesale distribution.
 
 Examples:
 
@@ -2507,9 +2513,15 @@ Per-topic solution release to student cohorts (issue #208). After a topic's
 workshop has been discussed, release that topic's full solution — and only that
 topic's — into a cohort repository, **frozen** so later course edits never change
 what a cohort already received. Channels are declared in the spec's
-`<release-channels>` block (`clm info spec-files`); the volatile per-topic
+`<release-channels>` block(s) (`clm info spec-files`); the volatile per-topic
 release state lives in a plain-text **ledger** (one topic id per line), never in
 the spec.
+
+A course may declare several `<release-channels>` blocks — one per release
+*stream* (issue #291), e.g. `materials` fed by a `shared` target and
+`solutions` fed by a `completed` target. Channels in a named stream are
+addressed as `STREAM/CHANNEL` (e.g. `--channel materials/2026-04`); a bare
+channel name keeps working when it is unique across streams.
 
 | Subcommand | Description |
 |------------|-------------|
@@ -2517,6 +2529,7 @@ the spec.
 | `release week SPEC_FILE SELECTORS… --channel NAME` | Append **every topic in the selected section(s)** to the ledger — a section-scoped `release add`. `SELECTORS` use the `build --only-sections` grammar (`id:`/`idx:`/`name:` prefixes, or a bare 1-based index / name substring). Section indices are disabled-inclusive; a selected-but-`enabled="false"` section is reported and skipped. |
 | `release status SPEC_FILE --channel NAME` | Show released vs pending topics, and (with a resolvable `--dest`/`--channel`) frozen vs awaiting-sync. |
 | `release sync SPEC_FILE --channel NAME` | Promote released-but-not-frozen topics from the built source into the cohort repo and freeze them. |
+| `release provision SPEC_FILE [--channel NAME]` | Apply the spec's `<share-with>` declarations: share each channel repo into its GitLab access group(s) via the API (issue #294). Idempotent; needs `CLM_GITLAB_TOKEN`/`GITLAB_TOKEN` with `api` scope; repos must already exist on the remote. `--dry-run` previews. Channels without a parseable GitLab remote are skipped with a note. |
 
 A channel can be addressed two ways: `--channel NAME` (resolves the ledger, the
 frozen `--source` build root, and the `--dest` cohort repo from the spec's
@@ -2527,10 +2540,11 @@ Key options for `release sync`:
 
 | Option | Description |
 |--------|-------------|
-| `--channel NAME` | Resolve ledger/source/dest from the spec's `<release-channels>`. |
+| `--channel NAME` | Resolve ledger/source/dest from the spec's `<release-channels>` (use `STREAM/CHANNEL` with several streams). |
 | `--ledger PATH` | Channel release ledger (overrides `--channel` resolution). |
 | `--source DIR` | Built frozen-source output root (must contain `.clm-manifest.json`). |
 | `--dest DIR` | Cohort destination repository (created if absent). |
+| `--language de\|en` | Promote only this language's files, re-rooted at the language directory (issue #293). Overrides the channel's `lang` attribute; requires `SPEC_FILE`; `--source` must point at the output-target root. |
 | `--refreeze TOPIC` | Re-copy and re-freeze an already-frozen topic (e.g. a bug fix). Repeatable. |
 | `--refreeze-all` | Re-copy and re-freeze every released topic. |
 | `--push` | After promoting, commit and push the cohort repo (via `clm git`'s commit/push). The repo must already exist — run `clm git init … --channel` once first. |
@@ -2542,6 +2556,14 @@ default since CLM {version}). Promotion copies bytes by manifest and records eac
 topic in the cohort's frozen manifest (`.clm-released.json`); a frozen topic is
 never re-propagated unless you pass `--refreeze`.
 
+**Partial manifests (issue #295).** A whole-course build that errors on some
+topics still writes the manifest for the cleanly-built subset, recording the
+failed topics. `release sync` promotes every green topic and reports the failed
+ones as `skip-failed` (loudly, but exit 0) — they are never frozen, so they
+promote automatically once a build succeeds for them. Builds whose errors
+cannot be attributed to topics (and timed-out or `--only-sections` builds)
+still write no manifest.
+
 Examples:
 
 ```bash
@@ -2552,6 +2574,13 @@ clm release status course.xml --channel jan                # what's released vs 
 clm git init course.xml --channel jan                      # one-time: create the cohort repo
 clm release sync course.xml --channel jan --push -m "Release functions, lists"
 clm release sync course.xml --channel jan --dry-run        # preview promotion
+
+# Two-stream setup (issue #291): materials before the session, solutions after.
+clm release week course.xml idx:3 --channel materials/2026-04
+clm release sync course.xml --channel materials/2026-04 --push
+clm release week course.xml idx:3 --channel solutions/2026-04   # after the workshop
+clm release sync course.xml --channel solutions/2026-04 --push
+clm release provision course.xml                                # apply <share-with> group shares
 ```
 
 ### `clm jobs`
@@ -3402,6 +3431,7 @@ Create and manage ZIP archives of course output.
 | `CLM_DATA_DIR` | Default data directory for MCP server (contains slides/, course-specs/) |
 | `CLM_GIT__REMOTE_TEMPLATE` | Git remote URL template (e.g., `git@github.com-cam:Org/{repo}.git`) |
 | `CLM_GIT__REMOTE_PATH` | Default remote path between base URL and repo name (e.g., GitLab group) |
+| `CLM_GITLAB_TOKEN` | GitLab API token (`api` scope) used by `clm release provision` for group shares; `GITLAB_TOKEN` is accepted as a fallback. |
 | `CLM_LLM__MODEL` | Default LLM model for summarize (default: `anthropic/claude-sonnet-4-6`) |
 | `CLM_LLM__API_KEY` | API key for LLM provider (or use `OPENAI_API_KEY`) |
 | `CLM_LLM__API_BASE` | API base URL (e.g. `https://openrouter.ai/api/v1`) |

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -558,6 +558,7 @@ Define multiple output directories with content filters.
 | Element | Required | Description |
 |---------|----------|-------------|
 | `name` (attr) | Yes | Unique target identifier |
+| `distribute` (attr) | No | `true`/`false`. `false` marks the target as a **private build input** that `clm git` (without `--target`) never turns into a distributed repo. **Default**: `false` for any target named as a `<release-channels source-target>` (its content reaches students only via `clm release sync`), `true` for everything else. An explicit `--target NAME` always wins over the skip. (Issue #292) |
 | `<path>` | Yes | Output directory (relative or absolute) |
 | `<kinds>` | No | Filter by output kind (omit for all) |
 | `<formats>` | No | Filter by output format (omit for all) |
@@ -630,19 +631,75 @@ the spec stays diff-clean as you release week by week.
 </release-channels>
 ```
 
+#### Multiple release streams (issue #291)
+
+A course may declare **several** `<release-channels>` blocks — one per release
+*stream*, each fed by its own `source-target` and gated by its own ledgers.
+The canonical two-stream setup releases **materials** (code-along + partial,
+before each session) and **solutions** (completed, after the workshop) to the
+same cohort on independent schedules:
+
+```xml
+<release-channels name="materials" source-target="shared">
+    <channel name="2026-04" lang="de"
+             path="./release/materials/2026-04"
+             ledger="release/materials-2026-04.txt"/>
+</release-channels>
+<release-channels name="solutions" source-target="completed">
+    <channel name="2026-04" lang="de"
+             path="./release/solutions/2026-04"
+             ledger="release/solutions-2026-04.txt"/>
+</release-channels>
+```
+
+With more than one block, each needs a unique `name` attribute (the stream
+name). Channels are then addressed as `STREAM/CHANNEL` on the CLI — e.g.
+`--channel materials/2026-04` — and a bare channel name keeps working when it
+is unique across streams. A single unnamed block keeps the original issue-#208
+addressing unchanged.
+
 | Attribute / child | On | Required | Description |
 |---|---|----------|-------------|
-| `source-target` (attr) | `<release-channels>` | Yes | Name of the `completed`-kind `<output-target>` that is the frozen source. Topics are promoted out of this target's built tree. |
+| `name` (attr) | `<release-channels>` | With >1 block | Stream name (unique, no `/`). Appears in CLI addresses (`stream/channel`) and the derived repo name. |
+| `source-target` (attr) | `<release-channels>` | Yes | Name of the `<output-target>` that is this stream's frozen source (e.g. a `completed` target for solutions, a `code-along`/`partial` target for materials). Must name a declared output target. |
 | `<remote-path>` | `<release-channels>` | No | Default remote path (e.g. a GitLab group) for every channel that does not override it. |
-| `name` (attr) | `<channel>` | Yes | Cohort identifier. Addresses the channel on the CLI (`--channel jan`) and forms the derived repo name `{project-slug}-{name}`. |
-| `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). One repo per cohort; **not** language-scoped. |
-| `ledger` (attr) | `<channel>` | Yes | Path to the cohort's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. |
+| `<share-with>` | `<release-channels>` | No | Default GitLab group share inherited by every channel (issue #294, see below). |
+| `name` (attr) | `<channel>` | Yes | Cohort identifier (no `/`). Addresses the channel on the CLI and forms the derived repo name. |
+| `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). One repo per channel; must be unique across **all** streams. |
+| `ledger` (attr) | `<channel>` | Yes | Path to the channel's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. Unique across all streams. |
+| `lang` (attr) | `<channel>` | No | Scope the channel to one language (`de`/`en`, issue #293). `clm release sync` then promotes only that language's files, **re-rooted** so the repo root is the language directory (matching per-language repos like `…-azav-de`), and the derived repo name appends `-{lang}`. **Unset**: the channel receives every built language root. |
 | `<remote-path>` | `<channel>` | No | Override the block-level `<remote-path>` for this one cohort. |
+| `<share-with>` | `<channel>` | No | GitLab group(s) to share the channel repo into (issue #294, see below). |
 
-The remote URL is derived as `{repository-base}/{remote-path}/{project-slug}-{name}`
-(the `<remote-path>` segment is omitted when unset) — see `<github>` and
-`<project-slug>` above. Unlike output targets, a channel repo carries no language
-segment: the cohort `name` disambiguates it.
+The remote URL is derived as
+`{repository-base}/{remote-path}/{project-slug}-{channel}[-{stream}][-{lang}]`
+(the `<remote-path>` segment is omitted when unset; the stream/lang segments
+appear only for named streams / language-scoped channels) — see `<github>`
+and `<project-slug>` above.
+
+#### `<share-with>` — cohort access groups (issue #294)
+
+Declare which GitLab access groups a channel repo is shared into, then apply
+the shares with `clm release provision` (requires a `CLM_GITLAB_TOKEN` /
+`GITLAB_TOKEN` with `api` scope; idempotent; the repo must already exist on
+the remote). Block-level entries (e.g. a trainers group) are inherited by
+every channel; a channel-level entry for the same group overrides the
+inherited access level.
+
+```xml
+<release-channels name="solutions" source-target="completed">
+    <share-with access="maintainer">trainers</share-with>
+    <channel name="2026-04" path="./release/solutions/2026-04"
+             ledger="release/solutions-2026-04.txt">
+        <share-with access="reporter">students/azav-ml/ml-2026-04</share-with>
+    </channel>
+</release-channels>
+```
+
+The element text is the full group path; `access` is one of `guest`,
+`reporter` (default), `developer`, `maintainer`.
+
+#### Provenance and freeze records
 
 The build artifact that makes per-topic promotion possible is the **provenance
 manifest** (`.clm-manifest.json`, written by `clm build` — on by default since
@@ -651,8 +708,16 @@ path alone cannot recover. The manifest is private and is automatically excluded
 from every distributed repo by `clm git`. The per-cohort **frozen manifest**
 (`.clm-released.json`) *does* ship in the channel repo — it is the freeze record.
 
-Drive the workflow with `clm release` (add/status/sync) and `clm git --channel`
-(init/commit/push the cohort repos); run `clm info commands` for both.
+Since CLM {version} (issue #295), a whole-course build that errors on some
+topics still writes the manifest for the cleanly-built subset, recording the
+failed topics (`partial: true` + `failed_topics`). `clm release sync` promotes
+every green topic and refuses the failed ones (`skip-failed`, never frozen)
+until a build succeeds for them — one flaky deck no longer blocks all releases.
+
+Drive the workflow with `clm release` (add/week/status/sync/provision) and
+`clm git --channel` (init/commit/push the cohort repos); run
+`clm info commands` for both. Targets that only feed a release stream are
+skipped by `clm git` without `--target` (issue #292, see `distribute` above).
 
 ### `<jupyterlite>`
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -1,5 +1,6 @@
 import io
 import logging
+from collections.abc import Iterator
 from enum import Enum
 from pathlib import Path
 from xml.etree import ElementTree as ETree
@@ -721,25 +722,29 @@ class GitHubSpec:
         project_slug: str | None = None,
         remote_template: str = "",
         remote_path: str = "",
+        stream: str = "",
     ) -> str | None:
-        """Derive the remote URL for a release channel (issue #208).
+        """Derive the remote URL for a release channel (issues #208, #291).
 
-        A cohort channel is *not* language-scoped — one repo serves one cohort
-        — so the repo name is ``{slug}-{channel_name}`` (the cohort name, e.g.
-        ``cohort-jan``, disambiguates it) rather than appending a ``{lang}``
-        segment and a target suffix. Reusing :meth:`derive_remote_url` with an
-        empty language would emit a stray ``--`` in the repo name; this method
-        avoids that while sharing the same base/remote-path/template handling.
+        The repo name is ``{slug}-{channel_name}`` for the single unnamed
+        ``<release-channels>`` block (the cohort name, e.g. ``cohort-jan``,
+        disambiguates it); a named stream appends its name —
+        ``{slug}-{channel_name}-{stream}`` (e.g. ``ml-2026-04-materials``) —
+        so the two streams of one cohort land in distinct repos. Reusing
+        :meth:`derive_remote_url` with an empty language would emit a stray
+        ``--`` in the repo name; this method avoids that while sharing the
+        same base/remote-path/template handling.
 
         The ``{lang}`` and ``{suffix}`` template placeholders are bound to the
-        empty string for channels. Returns ``None`` when git config is not set.
+        empty string for channels; ``{stream}`` carries the stream name (empty
+        for an unnamed block). Returns ``None`` when git config is not set.
         """
         slug = project_slug or self.project_slug
         if not (slug and self.repository_base):
             return None
 
         effective_remote_path = remote_path or self.remote_path
-        repo = f"{slug}-{channel_name}"
+        repo = "-".join(part for part in (slug, channel_name, stream) if part)
         template = remote_template or self.remote_template
         if not template:
             if effective_remote_path:
@@ -753,6 +758,7 @@ class GitHubSpec:
             slug=slug,
             lang="",
             suffix="",
+            stream=stream,
         )
 
 
@@ -1143,16 +1149,27 @@ class ReleaseChannelSpec:
 
 @frozen
 class ReleaseChannelsSpec:
-    """The ``<release-channels>`` block: per-cohort solution-release channels.
+    """One ``<release-channels>`` block: a release *stream* and its channels.
 
-    ``source_target`` names the ``completed``-kind ``<output-target>`` that is
-    the frozen source. ``remote_path`` is the default remote path for channels
-    that do not override it.
+    ``source_target`` names the ``<output-target>`` that is the frozen source
+    of this stream (typically a ``completed``-kind target for solutions, or a
+    ``code-along``/``partial`` target for pre-session materials). ``remote_path``
+    is the default remote path for channels that do not override it.
+
+    A course may declare **several** blocks — one per release stream (issue
+    #291), e.g. ``materials`` fed by a ``shared`` target and ``solutions`` fed
+    by a ``completed`` target. With more than one block each needs a unique
+    ``name`` attribute (the stream name); channels are then addressed as
+    ``<stream>/<channel>`` (or by bare channel name when unambiguous). A single
+    unnamed block keeps the original issue-#208 behavior.
     """
 
     source_target: str
     channels: list[ReleaseChannelSpec] = field(factory=list)
     remote_path: str = ""
+    # Stream name. Empty for the single-block (issue #208) layout; required
+    # and unique when several <release-channels> blocks are declared.
+    name: str = ""
 
     @classmethod
     def from_element(cls, element: ETree.Element) -> "ReleaseChannelsSpec":
@@ -1165,6 +1182,7 @@ class ReleaseChannelsSpec:
             source_target=element.get("source-target", ""),
             channels=channels,
             remote_path=remote_path,
+            name=element.get("name", ""),
         )
 
     def channel(self, name: str) -> "ReleaseChannelSpec | None":
@@ -1172,6 +1190,16 @@ class ReleaseChannelsSpec:
             if channel.name == name:
                 return channel
         return None
+
+
+def release_channel_ref(block: ReleaseChannelsSpec, channel: ReleaseChannelSpec) -> str:
+    """The canonical CLI address of *channel*: ``stream/channel`` or bare name.
+
+    A channel in a named stream is addressed as ``<stream>/<channel>`` (e.g.
+    ``materials/2026-04``); a channel in the single unnamed block keeps its
+    bare name, so issue-#208 era commands are unchanged.
+    """
+    return f"{block.name}/{channel.name}" if block.name else channel.name
 
 
 @frozen
@@ -1185,7 +1213,9 @@ class CourseSpec:
     github: GitHubSpec = field(factory=GitHubSpec)
     dictionaries: list[DirGroupSpec] = field(factory=list)
     output_targets: list[OutputTargetSpec] = field(factory=list)
-    release_channels: "ReleaseChannelsSpec | None" = None
+    # One entry per <release-channels> block (a release *stream*, issue #291).
+    # Empty list = the solution-release feature is dormant.
+    release_channel_blocks: list[ReleaseChannelsSpec] = field(factory=list)
     image_options: ImageOptionsSpec = field(factory=ImageOptionsSpec)
     jupyterlite: JupyterLiteConfig | None = None
     author: str = "Dr. Matthias Hölzl"
@@ -1586,16 +1616,69 @@ class CourseSpec:
         return targets
 
     @staticmethod
-    def parse_release_channels(root: ETree.Element) -> "ReleaseChannelsSpec | None":
-        """Parse the optional <release-channels> element (issue #208).
+    def parse_release_channels(root: ETree.Element) -> "list[ReleaseChannelsSpec]":
+        """Parse every ``<release-channels>`` element (issues #208, #291).
 
-        Returns ``None`` when the element is absent, in which case the solution-
-        release feature is dormant and all other behavior is unchanged.
+        Returns an empty list when no element is present, in which case the
+        solution-release feature is dormant and all other behavior is
+        unchanged. Each block is one release stream; uniqueness/naming rules
+        are enforced by :meth:`validate`, not here, so a malformed spec can
+        still be loaded for inspection.
         """
-        elem = root.find("release-channels")
-        if elem is None:
-            return None
-        return ReleaseChannelsSpec.from_element(elem)
+        return [ReleaseChannelsSpec.from_element(elem) for elem in root.findall("release-channels")]
+
+    def iter_release_channels(
+        self,
+    ) -> "Iterator[tuple[ReleaseChannelsSpec, ReleaseChannelSpec]]":
+        """Yield every ``(stream block, channel)`` pair in declaration order."""
+        for block in self.release_channel_blocks:
+            for channel in block.channels:
+                yield block, channel
+
+    def release_channel_refs(self) -> list[str]:
+        """The canonical CLI addresses of all channels (see :func:`release_channel_ref`)."""
+        return [
+            release_channel_ref(block, channel) for block, channel in self.iter_release_channels()
+        ]
+
+    def resolve_release_channel(self, ref: str) -> "tuple[ReleaseChannelsSpec, ReleaseChannelSpec]":
+        """Resolve a CLI channel reference to its ``(stream block, channel)`` pair.
+
+        *ref* is either ``<stream>/<channel>`` (exact) or a bare channel name,
+        which must be unique across all streams. Raises :class:`CourseSpecError`
+        with the available addresses on an unknown or ambiguous reference —
+        callers (``clm release``, ``clm git``, ``clm calendar``) surface the
+        message verbatim.
+        """
+        if not self.release_channel_blocks:
+            raise CourseSpecError("The spec declares no <release-channels> block.")
+        if "/" in ref:
+            stream, _, channel_name = ref.partition("/")
+            block = next((b for b in self.release_channel_blocks if b.name == stream), None)
+            if block is None:
+                streams = ", ".join(b.name or "(unnamed)" for b in self.release_channel_blocks)
+                raise CourseSpecError(
+                    f"Unknown release stream {stream!r}. Defined streams: {streams}."
+                )
+            channel = block.channel(channel_name)
+            if channel is None:
+                available = ", ".join(release_channel_ref(block, c) for c in block.channels)
+                raise CourseSpecError(
+                    f"Unknown channel {channel_name!r} in stream {stream!r}. "
+                    f"Defined channels: {available or '(none defined)'}."
+                )
+            return block, channel
+
+        matches = [(b, c) for b, c in self.iter_release_channels() if c.name == ref]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            available = ", ".join(self.release_channel_refs()) or "(none defined)"
+            raise CourseSpecError(f"Unknown channel {ref!r}. Defined channels: {available}.")
+        qualified = ", ".join(release_channel_ref(b, c) for b, c in matches)
+        raise CourseSpecError(
+            f"Channel name {ref!r} exists in several streams; use a qualified address: {qualified}."
+        )
 
     def resolve_section_selectors(self, tokens: list[str]) -> SectionSelection:
         """Resolve a list of ``--only-sections`` selector tokens.
@@ -1838,6 +1921,87 @@ class CourseSpec:
                         f"'clm info jupyterlite' for the required fields."
                     )
 
+        errors.extend(self._validate_release_channels(target_names))
+
+        return errors
+
+    def _validate_release_channels(self, target_names: set[str]) -> list[str]:
+        """Validate the ``<release-channels>`` blocks (issues #208, #291).
+
+        Stream naming: with several blocks every block needs a unique,
+        ``/``-free ``name`` (the stream name used in ``stream/channel``
+        addressing). Channels need unique, ``/``-free names within their block,
+        and a channel's destination ``path`` and ``ledger`` must be unique
+        across *all* streams — two streams writing the same destination would
+        fight over one frozen manifest.
+        """
+        errors: list[str] = []
+        blocks = self.release_channel_blocks
+
+        block_names: set[str] = set()
+        dest_paths: dict[str, str] = {}
+        ledgers: dict[str, str] = {}
+        for block in blocks:
+            block_label = (
+                f"<release-channels name={block.name!r}>" if block.name else "<release-channels>"
+            )
+            if len(blocks) > 1 and not block.name:
+                errors.append(
+                    "With several <release-channels> blocks every block needs a "
+                    "unique name attribute (the release stream name)."
+                )
+            if block.name:
+                if "/" in block.name:
+                    errors.append(
+                        f"{block_label}: stream names must not contain '/' "
+                        f"(it separates stream and channel in CLI addresses)."
+                    )
+                if block.name in block_names:
+                    errors.append(f"Duplicate release stream name: {block.name!r}")
+                block_names.add(block.name)
+
+            if not block.source_target:
+                errors.append(f"{block_label} must declare a source-target attribute.")
+            elif self.output_targets and block.source_target not in target_names:
+                errors.append(
+                    f"{block_label}: source-target {block.source_target!r} does not "
+                    f"name an <output-target>."
+                )
+
+            channel_names: set[str] = set()
+            for channel in block.channels:
+                ref = release_channel_ref(block, channel)
+                if not channel.name:
+                    errors.append(f"{block_label}: every <channel> needs a name attribute.")
+                elif "/" in channel.name:
+                    errors.append(
+                        f"{block_label}: channel name {channel.name!r} must not contain '/'."
+                    )
+                elif channel.name in channel_names:
+                    errors.append(f"{block_label}: duplicate channel name {channel.name!r}.")
+                channel_names.add(channel.name)
+
+                if not channel.path:
+                    errors.append(f"Channel '{ref}' needs a path attribute.")
+                elif channel.path in dest_paths:
+                    errors.append(
+                        f"Channels '{dest_paths[channel.path]}' and '{ref}' share the "
+                        f"destination path {channel.path!r}; every channel needs its own "
+                        f"destination repository."
+                    )
+                else:
+                    dest_paths[channel.path] = ref
+
+                if not channel.ledger:
+                    errors.append(f"Channel '{ref}' needs a ledger attribute.")
+                elif channel.ledger in ledgers:
+                    errors.append(
+                        f"Channels '{ledgers[channel.ledger]}' and '{ref}' share the "
+                        f"ledger {channel.ledger!r}; every channel needs its own ledger."
+                    )
+                else:
+                    ledgers[channel.ledger] = ref
+
         return errors
 
     @classmethod
@@ -1945,7 +2109,7 @@ class CourseSpec:
             github=github_spec,
             dictionaries=cls.parse_dir_groups(root, keep_disabled=keep_disabled),
             output_targets=cls.parse_output_targets(root),
-            release_channels=cls.parse_release_channels(root),
+            release_channel_blocks=cls.parse_release_channels(root),
             image_options=ImageOptionsSpec.from_element(root.find("image-options")),
             jupyterlite=JupyterLiteConfig.from_element(root.find("jupyterlite")),
             author=author,

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -723,28 +723,32 @@ class GitHubSpec:
         remote_template: str = "",
         remote_path: str = "",
         stream: str = "",
+        language: str = "",
     ) -> str | None:
-        """Derive the remote URL for a release channel (issues #208, #291).
+        """Derive the remote URL for a release channel (issues #208, #291, #293).
 
         The repo name is ``{slug}-{channel_name}`` for the single unnamed
         ``<release-channels>`` block (the cohort name, e.g. ``cohort-jan``,
         disambiguates it); a named stream appends its name —
         ``{slug}-{channel_name}-{stream}`` (e.g. ``ml-2026-04-materials``) —
-        so the two streams of one cohort land in distinct repos. Reusing
-        :meth:`derive_remote_url` with an empty language would emit a stray
-        ``--`` in the repo name; this method avoids that while sharing the
-        same base/remote-path/template handling.
+        so the two streams of one cohort land in distinct repos, and a
+        language-scoped channel appends its ``lang`` as the final segment
+        (``…-materials-de``), matching the per-language repo convention.
+        Reusing :meth:`derive_remote_url` with an empty language would emit a
+        stray ``--`` in the repo name; this method avoids that while sharing
+        the same base/remote-path/template handling.
 
-        The ``{lang}`` and ``{suffix}`` template placeholders are bound to the
-        empty string for channels; ``{stream}`` carries the stream name (empty
-        for an unnamed block). Returns ``None`` when git config is not set.
+        The ``{suffix}`` template placeholder is bound to the empty string for
+        channels; ``{stream}`` carries the stream name and ``{lang}`` the
+        channel language (each empty when unset). Returns ``None`` when git
+        config is not set.
         """
         slug = project_slug or self.project_slug
         if not (slug and self.repository_base):
             return None
 
         effective_remote_path = remote_path or self.remote_path
-        repo = "-".join(part for part in (slug, channel_name, stream) if part)
+        repo = "-".join(part for part in (slug, channel_name, stream, language) if part)
         template = remote_template or self.remote_template
         if not template:
             if effective_remote_path:
@@ -756,7 +760,7 @@ class GitHubSpec:
             remote_path=effective_remote_path,
             repo=repo,
             slug=slug,
-            lang="",
+            lang=language,
             suffix="",
             stream=stream,
         )
@@ -1152,12 +1156,20 @@ class ReleaseChannelSpec:
     ``ledger`` (in the course source repo). ``remote_path`` overrides the
     parent ``<release-channels>`` default for remote-URL derivation, mirroring
     :class:`OutputTargetSpec.remote_path`.
+
+    ``lang`` (issue #293) scopes the channel to a single language: ``clm
+    release sync`` then promotes only that language's files, re-rooted at the
+    language directory, and the derived repo name gains a ``-{lang}`` suffix —
+    matching the established per-language distribution convention (e.g.
+    ``…/machine-learning-azav-de``). When unset, the channel receives **every**
+    built language root (the pre-#293 behavior).
     """
 
     name: str
     path: str
     ledger: str
     remote_path: str = ""
+    lang: str = ""
 
     @classmethod
     def from_element(
@@ -1168,6 +1180,7 @@ class ReleaseChannelSpec:
             path=element.get("path", ""),
             ledger=element.get("ledger", ""),
             remote_path=(element_text(element, "remote-path") or default_remote_path),
+            lang=element.get("lang", ""),
         )
 
 
@@ -2041,6 +2054,12 @@ class CourseSpec:
                     )
                 else:
                     ledgers[channel.ledger] = ref
+
+                if channel.lang and channel.lang not in VALID_LANGUAGES:
+                    errors.append(
+                        f"Channel '{ref}': invalid lang {channel.lang!r}. "
+                        f"Valid values: {sorted(VALID_LANGUAGES)}"
+                    )
 
         return errors
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -846,6 +846,12 @@ class OutputTargetSpec:
         remote_path: Optional remote path override for this target (e.g., GitLab
             group). When set, overrides the course-level <remote-path> from
             <github> for remote URL construction.
+        distribute_attr: Raw ``distribute`` XML attribute (issue #292).
+            ``"false"`` marks the target as a private build input (e.g. a
+            release-stream source) that ``clm git`` must not turn into a
+            distributed repo; ``""`` means unset — see
+            :meth:`CourseSpec.is_distributed_target` for the effective default,
+            which auto-excludes release ``source-target``\\ s.
     """
 
     name: str
@@ -855,6 +861,14 @@ class OutputTargetSpec:
     languages: list[str] | None = None
     remote_path: str = ""
     jupyterlite: "JupyterLiteConfig | None" = None
+    distribute_attr: str = ""
+
+    @property
+    def distribute(self) -> bool | None:
+        """The parsed ``distribute`` attribute; ``None`` when unset."""
+        if not self.distribute_attr:
+            return None
+        return self.distribute_attr.lower() == "true"
 
     @classmethod
     def from_element(cls, element: ETree.Element) -> "OutputTargetSpec":
@@ -862,6 +876,7 @@ class OutputTargetSpec:
         name = element.get("name", "default")
         path = element_text(element, "path")
         remote_path = element_text(element, "remote-path") or ""
+        distribute_attr = element.get("distribute", "")
 
         # Parse optional filter lists. Normalize deprecated kind aliases here
         # so downstream consumers (output_targets, execution dependencies,
@@ -881,6 +896,7 @@ class OutputTargetSpec:
             languages=languages,
             remote_path=remote_path,
             jupyterlite=jupyterlite,
+            distribute_attr=distribute_attr,
         )
 
     @staticmethod
@@ -935,6 +951,14 @@ class OutputTargetSpec:
                         f"Invalid language '{lang}' in target '{self.name}'. "
                         f"Valid values: {sorted(VALID_LANGUAGES)}"
                     )
+
+        # Validate the distribute attribute (issue #292). A typo like
+        # distribute="flase" must not silently flip distribution behavior.
+        if self.distribute_attr and self.distribute_attr.lower() not in ("true", "false"):
+            errors.append(
+                f"Invalid distribute value {self.distribute_attr!r} in target "
+                f"'{self.name}'. Valid values: true, false"
+            )
 
         return errors
 
@@ -1634,6 +1658,22 @@ class CourseSpec:
         for block in self.release_channel_blocks:
             for channel in block.channels:
                 yield block, channel
+
+    def is_distributed_target(self, target: OutputTargetSpec) -> bool:
+        """Whether ``clm git`` (without ``--target``) manages a repo for *target*.
+
+        An explicit ``distribute`` attribute wins (issue #292). When unset, a
+        target that feeds a release stream (named as some ``<release-channels
+        source-target>``) defaults to **not** distributed — it is a private
+        build input whose content reaches students only through ``clm release
+        sync`` into per-cohort channel repos, so ``clm git init`` must not
+        create a student-facing repo for it. Every other target defaults to
+        distributed (the pre-#292 behavior).
+        """
+        if target.distribute is not None:
+            return target.distribute
+        release_sources = {block.source_target for block in self.release_channel_blocks}
+        return target.name not in release_sources
 
     def release_channel_refs(self) -> list[str]:
         """The canonical CLI addresses of all channels (see :func:`release_channel_ref`)."""

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -1148,6 +1148,31 @@ def _parse_launcher(text: str) -> str:
     return text
 
 
+# GitLab group-share access levels accepted by <share-with access="...">
+# (issue #294). Mapped to GitLab's numeric levels by the provisioning code.
+VALID_SHARE_ACCESS: frozenset[str] = frozenset({"guest", "reporter", "developer", "maintainer"})
+
+
+@frozen
+class ShareWithSpec:
+    """One ``<share-with>`` declaration: share the channel repo into a group.
+
+    ``group`` is the full GitLab group path (e.g.
+    ``students/azav-ml/ml-2026-04``); ``access`` the access level granted
+    (default ``reporter``). Applied by ``clm release provision`` (issue #294).
+    """
+
+    group: str
+    access: str = "reporter"
+
+    @classmethod
+    def from_element(cls, element: ETree.Element) -> "ShareWithSpec":
+        return cls(
+            group=(element.text or "").strip(),
+            access=element.get("access", "reporter"),
+        )
+
+
 @frozen
 class ReleaseChannelSpec:
     """One cohort's solution-release channel (issue #208).
@@ -1163,6 +1188,12 @@ class ReleaseChannelSpec:
     matching the established per-language distribution convention (e.g.
     ``…/machine-learning-azav-de``). When unset, the channel receives **every**
     built language root (the pre-#293 behavior).
+
+    ``share_with`` (issue #294) lists the GitLab groups the channel repo is
+    shared into by ``clm release provision`` — block-level ``<share-with>``
+    entries (e.g. a trainers group) are inherited by every channel and come
+    first; a channel-level entry for the same group overrides the inherited
+    access level.
     """
 
     name: str
@@ -1170,17 +1201,28 @@ class ReleaseChannelSpec:
     ledger: str
     remote_path: str = ""
     lang: str = ""
+    share_with: tuple[ShareWithSpec, ...] = ()
 
     @classmethod
     def from_element(
-        cls, element: ETree.Element, *, default_remote_path: str = ""
+        cls,
+        element: ETree.Element,
+        *,
+        default_remote_path: str = "",
+        default_shares: "tuple[ShareWithSpec, ...]" = (),
     ) -> "ReleaseChannelSpec":
+        own_shares = tuple(ShareWithSpec.from_element(sw) for sw in element.findall("share-with"))
+        # Inherited entries first; a channel-level entry for the same group
+        # replaces the inherited one (its access wins).
+        own_groups = {s.group for s in own_shares}
+        shares = tuple(s for s in default_shares if s.group not in own_groups) + own_shares
         return cls(
             name=element.get("name", ""),
             path=element.get("path", ""),
             ledger=element.get("ledger", ""),
             remote_path=(element_text(element, "remote-path") or default_remote_path),
             lang=element.get("lang", ""),
+            share_with=shares,
         )
 
 
@@ -1211,8 +1253,15 @@ class ReleaseChannelsSpec:
     @classmethod
     def from_element(cls, element: ETree.Element) -> "ReleaseChannelsSpec":
         remote_path = element_text(element, "remote-path") or ""
+        # Block-level <share-with> entries are inherited by every channel
+        # (issue #294) — e.g. one trainers group shared across all cohorts.
+        default_shares = tuple(
+            ShareWithSpec.from_element(sw) for sw in element.findall("share-with")
+        )
         channels = [
-            ReleaseChannelSpec.from_element(ch, default_remote_path=remote_path)
+            ReleaseChannelSpec.from_element(
+                ch, default_remote_path=remote_path, default_shares=default_shares
+            )
             for ch in element.findall("channel")
         ]
         return cls(
@@ -2060,6 +2109,15 @@ class CourseSpec:
                         f"Channel '{ref}': invalid lang {channel.lang!r}. "
                         f"Valid values: {sorted(VALID_LANGUAGES)}"
                     )
+
+                for share in channel.share_with:
+                    if not share.group:
+                        errors.append(f"Channel '{ref}': <share-with> needs a group path.")
+                    if share.access not in VALID_SHARE_ACCESS:
+                        errors.append(
+                            f"Channel '{ref}': invalid share-with access "
+                            f"{share.access!r}. Valid values: {sorted(VALID_SHARE_ACCESS)}"
+                        )
 
         return errors
 

--- a/src/clm/core/provenance_manifest.py
+++ b/src/clm/core/provenance_manifest.py
@@ -250,13 +250,22 @@ def build_provenance_manifest(
     source_dirty: bool | None,
     built_at: str,
     spec_name: str | None = None,
+    failed_topics: frozenset[str] | set[str] | None = None,
 ) -> dict[str, Any]:
     """Build the manifest dict for a single output *target*.
 
     Records only output files that actually exist on disk, hashing each.
     Entries are sorted by path so the manifest is deterministic and diffs
     cleanly across builds.
+
+    *failed_topics* (issue #295) names topics whose build jobs errored. Their
+    entries are **excluded** — the on-disk files may be stale or partially
+    written, so the manifest must not claim clean provenance over them — and
+    the manifest records them under ``failed_topics`` with ``partial: true``
+    so the release engine can refuse exactly those topics while promoting
+    every cleanly-built one.
     """
+    failed = frozenset(failed_topics or ())
     files: list[dict[str, Any]] = []
     seen: set[str] = set()
     for out_path, record in enumerate_expected_outputs(course, target):
@@ -265,6 +274,8 @@ def build_provenance_manifest(
         except ValueError:
             continue
         if rel in seen or not out_path.is_file():
+            continue
+        if record["topic_id"] in failed:
             continue
         seen.add(rel)
         files.append(
@@ -286,6 +297,8 @@ def build_provenance_manifest(
         "source_commit": source_commit,
         "source_dirty": source_dirty,
         "built_at": built_at,
+        "partial": bool(failed),
+        "failed_topics": sorted(failed),
         "files": files,
     }
 
@@ -297,11 +310,13 @@ def write_provenance_manifests(
     source_dirty: bool | None,
     built_at: str,
     spec_name: str | None = None,
+    failed_topics: frozenset[str] | set[str] | None = None,
 ) -> list[Path]:
     """Write one ``.clm-manifest.json`` per built output target.
 
     Targets whose ``output_root`` does not exist (e.g. a target that produced
     nothing) are skipped. Returns the list of manifest paths written.
+    See :func:`build_provenance_manifest` for *failed_topics* (issue #295).
     """
     written: list[Path] = []
     for target in course.output_targets:
@@ -315,6 +330,7 @@ def write_provenance_manifests(
             source_dirty=source_dirty,
             built_at=built_at,
             spec_name=spec_name,
+            failed_topics=failed_topics,
         )
         manifest_path = out_root / MANIFEST_FILENAME
         manifest_path.write_text(

--- a/src/clm/core/provenance_manifest.py
+++ b/src/clm/core/provenance_manifest.py
@@ -377,6 +377,41 @@ def find_course_manifest_path(
     return None
 
 
+def restrict_manifest_to_language(
+    manifest: dict[str, Any], language: str, lang_dir_name: str
+) -> dict[str, Any]:
+    """A copy of *manifest* holding only *language*'s files, re-rooted (issue #293).
+
+    A build manifest lives at the output-target root and spans every built
+    language; a language-scoped release channel promotes one language root
+    into a repo whose *own* root is that language directory (matching the
+    per-language repo convention, e.g. ``…-azav-de``). So this keeps only
+    entries recorded for *language* whose path lies under *lang_dir_name*
+    (the localized course directory, ``CourseSpec.output_dir_name[lang]``)
+    and strips that leading segment. Both conditions must hold: the language
+    field alone could collide when a course names its de/en directories
+    identically, and the path prefix alone is what makes the re-rooting valid.
+
+    The result is what the release engine should treat as "the manifest" —
+    callers pass ``<target root>/<lang_dir_name>`` as the source root so the
+    rewritten relative paths resolve unchanged.
+    """
+    prefix = lang_dir_name.rstrip("/") + "/"
+    files: list[dict[str, Any]] = []
+    for entry in manifest.get("files", []):
+        if entry.get("language") != language:
+            continue
+        path = entry.get("path", "")
+        if not path.startswith(prefix):
+            logger.debug("language restriction: %r is not under %r; skipped", path, lang_dir_name)
+            continue
+        files.append({**entry, "path": path[len(prefix) :]})
+    restricted = dict(manifest)
+    restricted["files"] = files
+    restricted["language"] = language
+    return restricted
+
+
 def manifest_files_by_topic(
     manifest: dict[str, Any],
 ) -> dict[str | None, list[dict[str, Any]]]:

--- a/src/clm/infrastructure/gitlab_api.py
+++ b/src/clm/infrastructure/gitlab_api.py
@@ -1,0 +1,157 @@
+"""Minimal GitLab REST helper for release provisioning (issue #294).
+
+CLM's only remote-API need today is sharing a per-cohort release repo into a
+GitLab access group (``clm release provision``), so this module deliberately
+implements exactly that — no project creation, no general client. Repos are
+still created the established way (push-to-create or the GitLab UI); the
+share is what used to be a manual, per-cohort UI step.
+
+Authentication: a personal/group access token with ``api`` scope, read from
+``CLM_GITLAB_TOKEN`` (preferred) or ``GITLAB_TOKEN``. Calls are made with the
+``PRIVATE-TOKEN`` header against the API host derived from the channel's
+remote URL, so multi-host setups work without configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from urllib.parse import quote
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+TOKEN_ENV_VARS = ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN")
+
+# GitLab numeric access levels for the share endpoint.
+ACCESS_LEVELS = {
+    "guest": 10,
+    "reporter": 20,
+    "developer": 30,
+    "maintainer": 40,
+}
+
+_SSH_REMOTE = re.compile(r"^(?:ssh://)?git@(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$")
+_HTTP_REMOTE = re.compile(r"^(?P<base>https?://[^/]+)/(?P<path>.+?)(?:\.git)?/?$")
+
+
+class GitLabApiError(Exception):
+    """A provisioning API call failed; the message is user-presentable."""
+
+
+def gitlab_token() -> str | None:
+    """The configured GitLab API token, or ``None`` when not set."""
+    for var in TOKEN_ENV_VARS:
+        token = os.environ.get(var, "").strip()
+        if token:
+            return token
+    return None
+
+
+def parse_gitlab_remote(remote_url: str) -> tuple[str, str] | None:
+    """Split a git remote URL into ``(api base URL, project path)``.
+
+    Handles ``https://host/group/sub/repo[.git]`` and
+    ``git@host:group/sub/repo[.git]`` forms; SSH remotes are mapped onto an
+    ``https://host`` API base. Returns ``None`` for anything else (including
+    local paths), which callers treat as "not provisionable".
+    """
+    if not remote_url:
+        return None
+    match = _HTTP_REMOTE.match(remote_url)
+    if match:
+        path = match.group("path")
+        if "/" not in path:
+            return None
+        return match.group("base"), path
+    match = _SSH_REMOTE.match(remote_url)
+    if match:
+        path = match.group("path")
+        if "/" not in path:
+            return None
+        return f"https://{match.group('host')}", path
+    return None
+
+
+def _request(
+    method: str, url: str, token: str, *, data: dict[str, object] | None = None
+) -> httpx.Response:
+    try:
+        response = httpx.request(
+            method,
+            url,
+            headers={"PRIVATE-TOKEN": token},
+            data=data,
+            timeout=30.0,
+        )
+    except httpx.HTTPError as e:
+        raise GitLabApiError(f"GitLab API request failed: {e}") from e
+    return response
+
+
+def _error_detail(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text.strip()[:200]
+    return str(payload.get("message", payload))
+
+
+def share_project_with_group(
+    base_url: str,
+    project_path: str,
+    group_path: str,
+    access: str,
+    token: str,
+) -> str:
+    """Share *project_path* into *group_path* at *access* level.
+
+    Returns ``"shared"`` on success or ``"already-shared"`` when the share
+    already exists (idempotent re-provisioning). Raises :class:`GitLabApiError`
+    with an actionable message on any other failure (unknown group, missing
+    project, insufficient token scope, ...).
+    """
+    level = ACCESS_LEVELS.get(access)
+    if level is None:
+        raise GitLabApiError(
+            f"Unknown access level {access!r}; valid: {', '.join(sorted(ACCESS_LEVELS))}."
+        )
+
+    group_url = f"{base_url}/api/v4/groups/{quote(group_path, safe='')}"
+    group_response = _request("GET", group_url, token)
+    if group_response.status_code == 404:
+        raise GitLabApiError(
+            f"Group {group_path!r} not found on {base_url} (or the token cannot see it)."
+        )
+    if group_response.status_code != 200:
+        raise GitLabApiError(
+            f"Looking up group {group_path!r} failed with HTTP "
+            f"{group_response.status_code}: {_error_detail(group_response)}"
+        )
+    group_id = group_response.json()["id"]
+
+    share_url = f"{base_url}/api/v4/projects/{quote(project_path, safe='')}/share"
+    share_response = _request(
+        "POST", share_url, token, data={"group_id": group_id, "group_access": level}
+    )
+    if share_response.status_code in (200, 201):
+        return "shared"
+    detail = _error_detail(share_response)
+    # GitLab signals an existing share as 409 Conflict; some versions answer
+    # 400 with a "group_id ... already been taken"-style message instead.
+    if share_response.status_code == 409 or (
+        share_response.status_code == 400 and "already" in detail.lower()
+    ):
+        return "already-shared"
+    if share_response.status_code == 404:
+        raise GitLabApiError(
+            f"Project {project_path!r} not found on {base_url}. Create the repo "
+            f"first (push it via `clm git init`/`clm git sync --channel`, or in "
+            f"the GitLab UI), then re-run provision."
+        )
+    raise GitLabApiError(
+        f"Sharing {project_path!r} with {group_path!r} failed with HTTP "
+        f"{share_response.status_code}: {detail}"
+    )

--- a/src/clm/release/sync.py
+++ b/src/clm/release/sync.py
@@ -36,6 +36,10 @@ logger = logging.getLogger(__name__)
 COPY = "copy"
 REFREEZE = "refreeze"
 SKIP_FROZEN = "skip-frozen"
+# The source build errored for this topic (recorded in the manifest's
+# failed_topics, issue #295): its on-disk output is suspect, so promotion is
+# refused until a build succeeds for it. Never frozen, so it is retried.
+SKIP_FAILED = "skip-failed"
 
 
 @frozen
@@ -59,6 +63,10 @@ class SyncPlan:
     def skipped(self) -> tuple[TopicPlan, ...]:
         return tuple(t for t in self.topics if t.action == SKIP_FROZEN)
 
+    @property
+    def failed(self) -> tuple[TopicPlan, ...]:
+        return tuple(t for t in self.topics if t.action == SKIP_FAILED)
+
 
 @frozen
 class SyncResult:
@@ -67,6 +75,9 @@ class SyncResult:
     skipped_topics: tuple[str, ...]
     skeleton_copied: bool
     files_copied: int
+    # Released topics refused because the source build errored for them
+    # (issue #295). Not frozen — they promote once a build succeeds.
+    failed_topics: tuple[str, ...] = ()
 
 
 def plan_sync(
@@ -76,14 +87,24 @@ def plan_sync(
     frozen: FrozenManifest,
     refreeze: Iterable[str] = (),
 ) -> SyncPlan:
-    """Compute what a sync would do, without touching the filesystem."""
+    """Compute what a sync would do, without touching the filesystem.
+
+    A released topic listed in the manifest's ``failed_topics`` (a partial
+    manifest from an errored build, issue #295) is refused with
+    :data:`SKIP_FAILED` rather than copied — unless it is already frozen and
+    not being refrozen, in which case the ordinary :data:`SKIP_FROZEN` applies
+    (the cohort already has it; nothing would be copied anyway).
+    """
     refreeze_set = set(refreeze)
+    failed_topics = set(manifest.get("failed_topics", []))
     by_topic = manifest_files_by_topic(manifest)
     plans: list[TopicPlan] = []
     for topic_id in ledger_released:
         file_count = len(by_topic.get(topic_id, []))
         if frozen.is_frozen(topic_id) and topic_id not in refreeze_set:
             action = SKIP_FROZEN
+        elif topic_id in failed_topics:
+            action = SKIP_FAILED
         elif frozen.is_frozen(topic_id):
             action = REFREEZE
         else:
@@ -118,6 +139,7 @@ def apply_sync(
     copied: list[str] = []
     refrozen: list[str] = []
     skipped: list[str] = []
+    failed: list[str] = []
 
     if plan.copy_skeleton:
         files_copied += _copy_files(by_topic.get(None, []), source_root, dest_root)
@@ -126,6 +148,14 @@ def apply_sync(
     for topic_plan in plan.topics:
         if topic_plan.action == SKIP_FROZEN:
             skipped.append(topic_plan.topic_id)
+            continue
+        if topic_plan.action == SKIP_FAILED:
+            logger.warning(
+                "release sync: topic %r failed in the source build; refusing to "
+                "promote it until a build succeeds (issue #295)",
+                topic_plan.topic_id,
+            )
+            failed.append(topic_plan.topic_id)
             continue
         files = by_topic.get(topic_plan.topic_id, [])
         if not files:
@@ -155,6 +185,7 @@ def apply_sync(
         skipped_topics=tuple(skipped),
         skeleton_copied=plan.copy_skeleton,
         files_copied=files_copied,
+        failed_topics=tuple(failed),
     )
 
 

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -25,6 +25,7 @@ from clm.cli.commands import build as build_module
 from clm.cli.commands.build import (
     BuildConfig,
     _compute_section_dirs_for_cleanup,
+    _failed_topic_ids,
     _find_env_file,
     _report_duplicate_file_warnings,
     _report_image_collisions,
@@ -1550,10 +1551,12 @@ class TestProvenanceManifestWiring:
 
 
 class TestShouldEmitProvenanceManifest:
-    """The post-build write decision: only a complete, successful, whole-course
-    build emits the manifest (it is a full overwrite of the prior index). Guards
-    against silently corrupting the release join key with a partial/incomplete
-    manifest (issue #208 step 3d review)."""
+    """The post-build write decision: only a whole-course build emits the
+    manifest (it is a full overwrite of the prior index). Guards against
+    silently corrupting the release join key with a partial/incomplete
+    manifest (issue #208 step 3d review). Errored builds are no longer an
+    outright skip here — error handling moved to the topic-attribution step
+    (_failed_topic_ids, issue #295)."""
 
     @staticmethod
     def _summary(*, errors=None, timed_out: bool = False):
@@ -1583,13 +1586,72 @@ class TestShouldEmitProvenanceManifest:
         )
         assert _should_emit_provenance_manifest(self._summary(), config) is False
 
-    def test_errored_build_does_not_emit(self) -> None:
+    def test_errored_build_still_reaches_the_attribution_step(self) -> None:
+        # Issue #295: errors alone no longer suppress the manifest; whether it
+        # is written depends on _failed_topic_ids (tested below).
         config = _make_config(write_provenance_manifest=True)
-        assert _should_emit_provenance_manifest(self._summary(errors=["boom"]), config) is False
+        assert _should_emit_provenance_manifest(self._summary(errors=["boom"]), config) is True
 
     def test_timed_out_build_does_not_emit(self) -> None:
         config = _make_config(write_provenance_manifest=True)
         assert _should_emit_provenance_manifest(self._summary(timed_out=True), config) is False
+
+
+class TestFailedTopicIds:
+    """Error→topic attribution for the partial provenance manifest (issue #295)."""
+
+    @staticmethod
+    def _course(tmp_path):
+        intro = tmp_path / "slides" / "intro.py"
+        deep = tmp_path / "slides" / "deep.py"
+        for p in (intro, deep):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# slide", encoding="utf-8")
+        return SimpleNamespace(
+            files=[
+                SimpleNamespace(path=intro, topic=SimpleNamespace(id="intro")),
+                SimpleNamespace(path=deep, topic=SimpleNamespace(id="deep")),
+            ]
+        )
+
+    @staticmethod
+    def _error(file_path: str, severity: str = "error"):
+        return SimpleNamespace(severity=severity, file_path=file_path)
+
+    def test_clean_build_yields_empty_set(self, tmp_path) -> None:
+        summary = SimpleNamespace(errors=[])
+        assert _failed_topic_ids(summary, self._course(tmp_path)) == set()
+
+    def test_errors_map_to_their_topics(self, tmp_path) -> None:
+        course = self._course(tmp_path)
+        summary = SimpleNamespace(errors=[self._error(str(course.files[0].path))])
+        assert _failed_topic_ids(summary, course) == {"intro"}
+
+    def test_warning_severity_is_ignored(self, tmp_path) -> None:
+        course = self._course(tmp_path)
+        summary = SimpleNamespace(
+            errors=[self._error(str(course.files[0].path), severity="warning")]
+        )
+        assert _failed_topic_ids(summary, course) == set()
+
+    def test_fatal_error_is_unattributable(self, tmp_path) -> None:
+        course = self._course(tmp_path)
+        summary = SimpleNamespace(errors=[self._error("", severity="fatal")])
+        assert _failed_topic_ids(summary, course) is None
+
+    def test_error_without_file_path_is_unattributable(self, tmp_path) -> None:
+        summary = SimpleNamespace(errors=[self._error("")])
+        assert _failed_topic_ids(summary, self._course(tmp_path)) is None
+
+    def test_error_on_a_non_course_file_is_unattributable(self, tmp_path) -> None:
+        summary = SimpleNamespace(errors=[self._error(str(tmp_path / "course.xml"))])
+        assert _failed_topic_ids(summary, self._course(tmp_path)) is None
+
+    def test_multiple_errors_on_one_topic_collapse(self, tmp_path) -> None:
+        course = self._course(tmp_path)
+        path = str(course.files[1].path)
+        summary = SimpleNamespace(errors=[self._error(path), self._error(path)])
+        assert _failed_topic_ids(summary, course) == {"deep"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_git_release_channels.py
+++ b/tests/cli/test_git_release_channels.py
@@ -183,6 +183,69 @@ class TestFindReleaseChannelRepos:
         assert repo.path == abs_cohort  # preserved, NOT joined under course_root
 
 
+SPEC_TWO_STREAMS = """<?xml version="1.0"?>
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <project-slug>ml-course</project-slug>
+  <github>
+    <repository-base>https://github.com/Org</repository-base>
+  </github>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <output-targets>
+    <output-target name="shared"><path>./output/shared</path></output-target>
+    <output-target name="completed"><path>./output/completed</path></output-target>
+  </output-targets>
+  <release-channels name="materials" source-target="shared">
+    <channel name="2026-04" path="./release/materials/2026-04" ledger="release/materials-2026-04.txt"/>
+  </release-channels>
+  <release-channels name="solutions" source-target="completed">
+    <channel name="2026-04" path="./release/solutions/2026-04" ledger="release/solutions-2026-04.txt"/>
+    <channel name="2026-10" path="./release/solutions/2026-10" ledger="release/solutions-2026-10.txt"/>
+  </release-channels>
+</course>
+"""
+
+
+class TestMultiStreamChannelRepos:
+    """Several <release-channels> blocks — one per release stream (issue #291)."""
+
+    def test_all_channels_enumerates_every_stream(self, tmp_path: Path):
+        spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+        repos = find_release_channel_repos(spec_file)
+        assert [r.target_name for r in repos] == [
+            "materials/2026-04",
+            "solutions/2026-04",
+            "solutions/2026-10",
+        ]
+
+    def test_qualified_filter_selects_one_stream_channel(self, tmp_path: Path):
+        spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+        repos = find_release_channel_repos(spec_file, "solutions/2026-04")
+        assert [r.path for r in repos] == [tmp_path / "release" / "solutions" / "2026-04"]
+
+    def test_bare_filter_resolves_when_unique(self, tmp_path: Path):
+        spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+        repos = find_release_channel_repos(spec_file, "2026-10")
+        assert [r.target_name for r in repos] == ["solutions/2026-10"]
+
+    def test_ambiguous_bare_filter_is_a_clear_cli_error(self, tmp_path: Path):
+        spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+        with pytest.raises(click.ClickException, match="several streams"):
+            _select_repos(spec_file, target=None, channel="2026-04", all_channels=False)
+
+    def test_remote_urls_carry_the_stream_suffix(self, tmp_path: Path):
+        spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+        by_name = {r.target_name: r.remote_url for r in find_release_channel_repos(spec_file)}
+        assert by_name["materials/2026-04"] == "https://github.com/Org/ml-course-2026-04-materials"
+        assert by_name["solutions/2026-04"] == "https://github.com/Org/ml-course-2026-04-solutions"
+
+
 # ---------------------------------------------------------------------------
 # _select_repos guards
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_git_release_channels.py
+++ b/tests/cli/test_git_release_channels.py
@@ -17,6 +17,7 @@ from click.testing import CliRunner
 from clm.cli.commands.git_ops import (
     OutputRepo,
     _select_repos,
+    find_output_repos,
     find_release_channel_repos,
     git_group,
 )
@@ -272,12 +273,73 @@ class TestSelectReposGuards:
         repos = _select_repos(spec_file, target=None, channel=None, all_channels=True)
         assert {r.target_name for r in repos} == {"jan", "may"}
 
-    def test_default_mode_uses_output_targets(self, tmp_path: Path):
+    def test_default_mode_uses_output_targets_minus_release_sources(self, tmp_path: Path):
         spec_file = _write_spec(tmp_path, SPEC_WITH_CHANNELS)
         repos = _select_repos(spec_file, target=None, channel=None, all_channels=False)
-        # The single completed output target, one repo per language.
-        assert {r.source for r in repos} == {"output"}
-        assert {r.target_name for r in repos} == {"solutions-source"}
+        # The only output target is the release source-target, which is a
+        # private build input — default enumeration skips it (issue #292).
+        assert repos == []
+
+
+# ---------------------------------------------------------------------------
+# distribute="false" / release-source auto-exclusion (issue #292)
+# ---------------------------------------------------------------------------
+
+SPEC_DISTRIBUTE = """<?xml version="1.0"?>
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <project-slug>ml-course</project-slug>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <output-targets>
+    <output-target name="trainer"><path>./output/trainer</path></output-target>
+    <output-target name="shared" distribute="false"><path>./output/shared</path></output-target>
+    <output-target name="completed"><path>./output/completed</path></output-target>
+    <output-target name="legacy" distribute="true"><path>./output/legacy</path></output-target>
+  </output-targets>
+  <release-channels source-target="completed">
+    <channel name="jan" path="./solutions/jan" ledger="release/jan.txt"/>
+  </release-channels>
+</course>
+"""
+
+
+class TestDistributeFlag:
+    def test_default_enumeration_skips_explicit_and_auto_excluded_targets(self, tmp_path: Path):
+        """`shared` opts out via distribute="false"; `completed` is auto-excluded
+        as the release source-target; `legacy` shows distribute="true" overrides
+        the auto-exclusion (here it is not a source-target, so it is moot but
+        harmless)."""
+        spec_file = _write_spec(tmp_path, SPEC_DISTRIBUTE)
+        repos = find_output_repos(spec_file)
+        assert {r.target_name for r in repos} == {"trainer", "legacy"}
+
+    def test_explicit_target_request_wins_over_the_skip(self, tmp_path: Path):
+        spec_file = _write_spec(tmp_path, SPEC_DISTRIBUTE)
+        assert {r.target_name for r in find_output_repos(spec_file, "shared")} == {"shared"}
+        assert {r.target_name for r in find_output_repos(spec_file, "completed")} == {"completed"}
+
+    def test_distribute_true_keeps_a_release_source_distributed(self, tmp_path: Path):
+        body = SPEC_DISTRIBUTE.replace(
+            '<output-target name="completed">',
+            '<output-target name="completed" distribute="true">',
+        )
+        spec_file = _write_spec(tmp_path, body)
+        repos = find_output_repos(spec_file)
+        assert {r.target_name for r in repos} == {"trainer", "completed", "legacy"}
+
+    def test_invalid_distribute_value_is_a_validation_error(self, tmp_path: Path):
+        from clm.core.course_spec import CourseSpec
+
+        body = SPEC_DISTRIBUTE.replace('distribute="false"', 'distribute="flase"')
+        spec_file = _write_spec(tmp_path, body)
+        errors = CourseSpec.from_file(spec_file).validate()
+        assert any("Invalid distribute value" in e for e in errors)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_provenance_manifest.py
+++ b/tests/core/test_provenance_manifest.py
@@ -488,3 +488,51 @@ def test_restrict_does_not_mutate_the_input():
     restrict_manifest_to_language(manifest, "en", "ml-en")
     assert manifest["files"][0]["path"] == "ml-de/Folien/01 Intro.ipynb"
     assert "language" not in manifest
+
+
+# ---------------------------------------------------------------------------
+# Partial manifest for errored builds (issue #295)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_topics_are_excluded_and_recorded(course_1):
+    target = course_1.output_targets[0]
+    expected = list(enumerate_expected_outputs(course_1, target))
+    # Materialize every enumerated output so only the failed-topic filter,
+    # not the existence filter, decides what lands in the manifest.
+    failed_topic = expected[0][1]["topic_id"]
+    for out_path, _record in expected:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text("x", encoding="utf-8")
+
+    manifest = build_provenance_manifest(
+        course_1,
+        target,
+        source_commit="abc",
+        source_dirty=False,
+        built_at=BUILT_AT,
+        spec_name="course.xml",
+        failed_topics={failed_topic},
+    )
+
+    assert manifest["partial"] is True
+    assert manifest["failed_topics"] == [failed_topic]
+    assert all(f["topic_id"] != failed_topic for f in manifest["files"])
+    # The cleanly-built topics are still fully recorded.
+    other_topics = {r["topic_id"] for _p, r in expected} - {failed_topic}
+    recorded = {f["topic_id"] for f in manifest["files"]}
+    assert other_topics <= recorded
+
+
+def test_clean_build_manifest_is_not_partial(course_1):
+    target = course_1.output_targets[0]
+    manifest = build_provenance_manifest(
+        course_1,
+        target,
+        source_commit="abc",
+        source_dirty=False,
+        built_at=BUILT_AT,
+        spec_name="course.xml",
+    )
+    assert manifest["partial"] is False
+    assert manifest["failed_topics"] == []

--- a/tests/core/test_provenance_manifest.py
+++ b/tests/core/test_provenance_manifest.py
@@ -421,3 +421,70 @@ def test_find_manifest_missing_returns_none(tmp_path):
     out = tmp_path / "out"
     out.mkdir()
     assert find_course_manifest_path(output_root=out) is None
+
+
+# ---------------------------------------------------------------------------
+# restrict_manifest_to_language (issue #293)
+# ---------------------------------------------------------------------------
+
+
+def _two_language_manifest() -> dict:
+    return {
+        "version": 1,
+        "target": "shared",
+        "source_commit": "abc",
+        "files": [
+            {
+                "path": "ml-de/Folien/01 Intro.ipynb",
+                "topic_id": "intro",
+                "language": "de",
+                "content_hash": "sha256:a",
+            },
+            {
+                "path": "ml-en/Slides/01 Intro.ipynb",
+                "topic_id": "intro",
+                "language": "en",
+                "content_hash": "sha256:b",
+            },
+            {
+                "path": "ml-de/data/d.csv",
+                "topic_id": None,
+                "language": "de",
+                "content_hash": "sha256:c",
+            },
+        ],
+    }
+
+
+def test_restrict_keeps_only_the_language_and_strips_the_root():
+    from clm.core.provenance_manifest import restrict_manifest_to_language
+
+    restricted = restrict_manifest_to_language(_two_language_manifest(), "de", "ml-de")
+    assert [f["path"] for f in restricted["files"]] == [
+        "Folien/01 Intro.ipynb",
+        "data/d.csv",
+    ]
+    assert restricted["language"] == "de"
+    # Build-level metadata is preserved for freeze records.
+    assert restricted["source_commit"] == "abc"
+
+
+def test_restrict_requires_both_language_and_path_prefix():
+    from clm.core.provenance_manifest import restrict_manifest_to_language
+
+    manifest = _two_language_manifest()
+    # An entry claiming "de" but living outside the de root is dropped.
+    manifest["files"].append(
+        {"path": "stray/x.txt", "topic_id": "intro", "language": "de", "content_hash": "sha256:x"}
+    )
+    restricted = restrict_manifest_to_language(manifest, "de", "ml-de")
+    assert all(not f["path"].startswith("stray") for f in restricted["files"])
+
+
+def test_restrict_does_not_mutate_the_input():
+    from clm.core.provenance_manifest import restrict_manifest_to_language
+
+    manifest = _two_language_manifest()
+    restrict_manifest_to_language(manifest, "en", "ml-en")
+    assert manifest["files"][0]["path"] == "ml-de/Folien/01 Intro.ipynb"
+    assert "language" not in manifest

--- a/tests/core/test_release_channels_spec.py
+++ b/tests/core/test_release_channels_spec.py
@@ -1,11 +1,13 @@
-"""Tests for ``<release-channels>`` spec parsing (issue #208, step 3)."""
+"""Tests for ``<release-channels>`` spec parsing (issues #208, #291)."""
 
 import io
 
-from clm.core.course_spec import CourseSpec
+import pytest
+
+from clm.core.course_spec import CourseSpec, CourseSpecError, release_channel_ref
 
 
-def _spec(release_channels_block: str) -> CourseSpec:
+def _spec(release_channels_block: str, output_targets: str = "") -> CourseSpec:
     xml = f"""
     <course>
       <name><de>T</de><en>T</en></name>
@@ -16,14 +18,33 @@ def _spec(release_channels_block: str) -> CourseSpec:
           <topics><topic>intro</topic></topics>
         </section>
       </sections>
+      {output_targets}
       {release_channels_block}
     </course>
     """
     return CourseSpec.from_file(io.StringIO(xml))
 
 
-def test_absent_release_channels_is_none():
-    assert _spec("").release_channels is None
+TWO_STREAMS = """
+<release-channels name="materials" source-target="shared">
+  <channel name="2026-04" path="./release/materials/2026-04" ledger="release/materials-2026-04.txt"/>
+  <channel name="2026-10" path="./release/materials/2026-10" ledger="release/materials-2026-10.txt"/>
+</release-channels>
+<release-channels name="solutions" source-target="completed">
+  <channel name="2026-04" path="./release/solutions/2026-04" ledger="release/solutions-2026-04.txt"/>
+</release-channels>
+"""
+
+TWO_STREAM_TARGETS = """
+<output-targets>
+  <output-target name="shared"><path>output/shared</path></output-target>
+  <output-target name="completed"><path>output/completed</path></output-target>
+</output-targets>
+"""
+
+
+def test_absent_release_channels_is_empty_list():
+    assert _spec("").release_channel_blocks == []
 
 
 def test_parses_source_target_channels_and_remote_inheritance():
@@ -36,10 +57,12 @@ def test_parses_source_target_channels_and_remote_inheritance():
       </channel>
     </release-channels>
     """
-    rc = _spec(block).release_channels
-    assert rc is not None
+    blocks = _spec(block).release_channel_blocks
+    assert len(blocks) == 1
+    rc = blocks[0]
     assert rc.source_target == "solutions-source"
     assert rc.remote_path == "cohorts"
+    assert rc.name == ""  # single unnamed block: the issue-#208 layout
     assert [c.name for c in rc.channels] == ["cohort-jan", "cohort-may"]
 
     jan = rc.channel("cohort-jan")
@@ -53,3 +76,139 @@ def test_parses_source_target_channels_and_remote_inheritance():
     assert may.remote_path == "special"  # per-channel override
 
     assert rc.channel("missing") is None
+
+
+class TestMultiStream:
+    """Several <release-channels> blocks, one per release stream (issue #291)."""
+
+    def test_parses_multiple_named_blocks(self):
+        spec = _spec(TWO_STREAMS, TWO_STREAM_TARGETS)
+        assert [b.name for b in spec.release_channel_blocks] == ["materials", "solutions"]
+        assert [b.source_target for b in spec.release_channel_blocks] == ["shared", "completed"]
+        assert spec.release_channel_refs() == [
+            "materials/2026-04",
+            "materials/2026-10",
+            "solutions/2026-04",
+        ]
+
+    def test_qualified_ref_resolves_to_its_stream(self):
+        spec = _spec(TWO_STREAMS, TWO_STREAM_TARGETS)
+        block, channel = spec.resolve_release_channel("solutions/2026-04")
+        assert block.name == "solutions"
+        assert channel.path == "./release/solutions/2026-04"
+        assert release_channel_ref(block, channel) == "solutions/2026-04"
+
+    def test_bare_name_resolves_when_unique(self):
+        spec = _spec(TWO_STREAMS, TWO_STREAM_TARGETS)
+        block, channel = spec.resolve_release_channel("2026-10")
+        assert block.name == "materials"
+        assert channel.name == "2026-10"
+
+    def test_bare_name_ambiguous_across_streams(self):
+        spec = _spec(TWO_STREAMS, TWO_STREAM_TARGETS)
+        with pytest.raises(CourseSpecError, match="several streams"):
+            spec.resolve_release_channel("2026-04")
+
+    def test_unknown_stream_and_channel(self):
+        spec = _spec(TWO_STREAMS, TWO_STREAM_TARGETS)
+        with pytest.raises(CourseSpecError, match="Unknown release stream"):
+            spec.resolve_release_channel("nope/2026-04")
+        with pytest.raises(CourseSpecError, match="Unknown channel"):
+            spec.resolve_release_channel("materials/nope")
+        with pytest.raises(CourseSpecError, match="Unknown channel"):
+            spec.resolve_release_channel("nope")
+
+    def test_bare_name_in_single_unnamed_block_keeps_208_addressing(self):
+        block = """
+        <release-channels source-target="shared">
+          <channel name="jan" path="./solutions/jan" ledger="release/jan.txt"/>
+        </release-channels>
+        """
+        spec = _spec(block, TWO_STREAM_TARGETS)
+        b, c = spec.resolve_release_channel("jan")
+        assert release_channel_ref(b, c) == "jan"
+
+
+class TestMultiStreamValidation:
+    def test_two_valid_streams_validate_clean(self):
+        assert _spec(TWO_STREAMS, TWO_STREAM_TARGETS).validate() == []
+
+    def test_multiple_blocks_require_names(self):
+        unnamed = TWO_STREAMS.replace(' name="materials"', "")
+        errors = _spec(unnamed, TWO_STREAM_TARGETS).validate()
+        assert any("unique name attribute" in e for e in errors)
+
+    def test_duplicate_stream_names_rejected(self):
+        dup = TWO_STREAMS.replace('name="solutions"', 'name="materials"')
+        errors = _spec(dup, TWO_STREAM_TARGETS).validate()
+        assert any("Duplicate release stream name" in e for e in errors)
+
+    def test_source_target_must_name_an_output_target(self):
+        errors = _spec(TWO_STREAMS.replace('"completed"', '"nope"'), TWO_STREAM_TARGETS).validate()
+        assert any("does not name an <output-target>" in e for e in errors)
+
+    def test_missing_source_target_rejected(self):
+        block = """
+        <release-channels name="materials">
+          <channel name="jan" path="./a" ledger="l.txt"/>
+        </release-channels>
+        """
+        errors = _spec(block, TWO_STREAM_TARGETS).validate()
+        assert any("source-target" in e for e in errors)
+
+    def test_shared_dest_path_across_streams_rejected(self):
+        shared_path = TWO_STREAMS.replace(
+            "./release/solutions/2026-04", "./release/materials/2026-04"
+        )
+        errors = _spec(shared_path, TWO_STREAM_TARGETS).validate()
+        assert any("share the destination path" in e for e in errors)
+
+    def test_shared_ledger_across_streams_rejected(self):
+        shared_ledger = TWO_STREAMS.replace(
+            "release/solutions-2026-04.txt", "release/materials-2026-04.txt"
+        )
+        errors = _spec(shared_ledger, TWO_STREAM_TARGETS).validate()
+        assert any("share the ledger" in e for e in errors)
+
+    def test_slash_in_names_rejected(self):
+        bad_stream = TWO_STREAMS.replace('name="materials"', 'name="mat/erials"')
+        assert any(
+            "must not contain '/'" in e for e in _spec(bad_stream, TWO_STREAM_TARGETS).validate()
+        )
+        bad_channel = TWO_STREAMS.replace('name="2026-10"', 'name="2026/10"')
+        assert any(
+            "must not contain '/'" in e for e in _spec(bad_channel, TWO_STREAM_TARGETS).validate()
+        )
+
+    def test_duplicate_channel_names_within_block_rejected(self):
+        dup = TWO_STREAMS.replace('name="2026-10"', 'name="2026-04"')
+        errors = _spec(dup, TWO_STREAM_TARGETS).validate()
+        assert any("duplicate channel name" in e for e in errors)
+
+
+class TestChannelRemoteUrl:
+    def test_stream_suffix_disambiguates_per_stream_repos(self):
+        spec = _spec(
+            TWO_STREAMS,
+            TWO_STREAM_TARGETS.replace(
+                "<output-targets>",
+                "<output-targets>",
+            ),
+        )
+        github = spec.github
+        url = github.derive_channel_remote_url("2026-04", project_slug="ml", stream="materials")
+        # No repository_base configured in this spec -> None
+        assert url is None
+
+    def test_stream_and_plain_urls(self):
+        xml_github = """
+        <github><repository-base>https://gitlab.example.com/ca</repository-base></github>
+        <project-slug>ml</project-slug>
+        """
+        spec = _spec(TWO_STREAMS, TWO_STREAM_TARGETS + xml_github)
+        url = spec.github.derive_channel_remote_url(
+            "2026-04", project_slug="ml", stream="materials"
+        )
+        assert url == "https://gitlab.example.com/ca/ml-2026-04-materials"
+        plain = spec.github.derive_channel_remote_url("jan", project_slug="ml")
+        assert plain == "https://gitlab.example.com/ca/ml-jan"

--- a/tests/core/test_release_channels_spec.py
+++ b/tests/core/test_release_channels_spec.py
@@ -212,3 +212,38 @@ class TestChannelRemoteUrl:
         assert url == "https://gitlab.example.com/ca/ml-2026-04-materials"
         plain = spec.github.derive_channel_remote_url("jan", project_slug="ml")
         assert plain == "https://gitlab.example.com/ca/ml-jan"
+
+
+class TestLanguageScopedChannels:
+    """Channel `lang` attribute (issue #293)."""
+
+    LANG_BLOCK = """
+    <release-channels source-target="shared">
+      <channel name="jan-de" lang="de" path="./solutions/jan-de" ledger="release/jan-de.txt"/>
+      <channel name="jan" path="./solutions/jan" ledger="release/jan.txt"/>
+    </release-channels>
+    """
+
+    def test_lang_parses_and_defaults_to_unscoped(self):
+        spec = _spec(self.LANG_BLOCK, TWO_STREAM_TARGETS)
+        block = spec.release_channel_blocks[0]
+        assert block.channel("jan-de").lang == "de"
+        assert block.channel("jan").lang == ""
+
+    def test_invalid_lang_is_a_validation_error(self):
+        bad = self.LANG_BLOCK.replace('lang="de"', 'lang="fr"')
+        errors = _spec(bad, TWO_STREAM_TARGETS).validate()
+        assert any("invalid lang 'fr'" in e for e in errors)
+
+    def test_valid_lang_validates_clean(self):
+        assert _spec(self.LANG_BLOCK, TWO_STREAM_TARGETS).validate() == []
+
+    def test_remote_url_appends_lang_after_stream(self):
+        from clm.core.course_spec import GitHubSpec
+
+        gh = GitHubSpec(project_slug="ml", repository_base="https://gitlab.example.com/ca")
+        url = gh.derive_channel_remote_url("2026-04", stream="materials", language="de")
+        assert url == "https://gitlab.example.com/ca/ml-2026-04-materials-de"
+        # Lang without stream (single unnamed block).
+        url = gh.derive_channel_remote_url("jan", language="en")
+        assert url == "https://gitlab.example.com/ca/ml-jan-en"

--- a/tests/release/test_provision.py
+++ b/tests/release/test_provision.py
@@ -1,0 +1,263 @@
+"""Tests for ``clm release provision`` and the GitLab share helper (issue #294)."""
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.release import release_group
+from clm.core.course_spec import CourseSpec
+from clm.infrastructure import gitlab_api
+from clm.infrastructure.gitlab_api import (
+    GitLabApiError,
+    parse_gitlab_remote,
+    share_project_with_group,
+)
+
+# ---------------------------------------------------------------------------
+# Spec parsing: <share-with>
+# ---------------------------------------------------------------------------
+
+SPEC_WITH_SHARES = """<?xml version="1.0"?>
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <project-slug>ml</project-slug>
+  <github>
+    <repository-base>https://gitlab.example.com/ca</repository-base>
+  </github>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <output-targets>
+    <output-target name="completed"><path>output/completed</path></output-target>
+  </output-targets>
+  <release-channels name="solutions" source-target="completed">
+    <share-with access="maintainer">trainers</share-with>
+    <channel name="2026-04" path="release/2026-04" ledger="release/2026-04.txt">
+      <share-with>students/azav-ml/ml-2026-04</share-with>
+    </channel>
+    <channel name="2026-10" path="release/2026-10" ledger="release/2026-10.txt">
+      <share-with access="guest">trainers</share-with>
+    </channel>
+  </release-channels>
+</course>
+"""
+
+
+def _spec() -> CourseSpec:
+    return CourseSpec.from_file(io.StringIO(SPEC_WITH_SHARES))
+
+
+class TestShareWithParsing:
+    def test_channel_inherits_block_shares_and_adds_its_own(self):
+        block = _spec().release_channel_blocks[0]
+        ch = block.channel("2026-04")
+        assert [(s.group, s.access) for s in ch.share_with] == [
+            ("trainers", "maintainer"),
+            ("students/azav-ml/ml-2026-04", "reporter"),  # default access
+        ]
+
+    def test_channel_level_entry_overrides_inherited_access(self):
+        block = _spec().release_channel_blocks[0]
+        ch = block.channel("2026-10")
+        assert [(s.group, s.access) for s in ch.share_with] == [("trainers", "guest")]
+
+    def test_invalid_access_is_a_validation_error(self):
+        bad = SPEC_WITH_SHARES.replace('access="maintainer"', 'access="owner"')
+        errors = CourseSpec.from_file(io.StringIO(bad)).validate()
+        assert any("invalid share-with access 'owner'" in e for e in errors)
+
+    def test_valid_spec_validates_clean(self):
+        assert _spec().validate() == []
+
+
+# ---------------------------------------------------------------------------
+# parse_gitlab_remote
+# ---------------------------------------------------------------------------
+
+
+class TestParseGitlabRemote:
+    def test_https_with_nested_groups(self):
+        assert parse_gitlab_remote("https://gitlab.example.com/ca/sub/ml-2026-04") == (
+            "https://gitlab.example.com",
+            "ca/sub/ml-2026-04",
+        )
+
+    def test_https_strips_dot_git_and_trailing_slash(self):
+        assert parse_gitlab_remote("https://gitlab.example.com/ca/repo.git/") == (
+            "https://gitlab.example.com",
+            "ca/repo",
+        )
+
+    def test_ssh_form_maps_to_https_api_base(self):
+        assert parse_gitlab_remote("git@gitlab.example.com:ca/repo.git") == (
+            "https://gitlab.example.com",
+            "ca/repo",
+        )
+
+    def test_unparseable_remotes_return_none(self):
+        assert parse_gitlab_remote("") is None
+        assert parse_gitlab_remote("C:/local/path/repo") is None
+        assert parse_gitlab_remote("https://host/repo-without-group") is None
+
+
+# ---------------------------------------------------------------------------
+# share_project_with_group (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _response(status_code: int, payload=None, text: str = "") -> httpx.Response:
+    if payload is not None:
+        return httpx.Response(status_code, json=payload)
+    return httpx.Response(status_code, text=text)
+
+
+class TestShareProjectWithGroup:
+    def _run(self, responses):
+        calls = []
+
+        def fake_request(method, url, **kwargs):
+            calls.append((method, url, kwargs.get("data")))
+            return responses.pop(0)
+
+        with patch.object(gitlab_api.httpx, "request", side_effect=fake_request):
+            result = share_project_with_group(
+                "https://gitlab.example.com",
+                "ca/ml-2026-04",
+                "students/azav-ml/ml-2026-04",
+                "reporter",
+                "tok",
+            )
+        return result, calls
+
+    def test_happy_path_resolves_group_then_shares(self):
+        result, calls = self._run([_response(200, {"id": 42}), _response(201, {})])
+        assert result == "shared"
+        assert calls[0][0] == "GET"
+        assert "groups/students%2Fazav-ml%2Fml-2026-04" in calls[0][1]
+        assert calls[1][0] == "POST"
+        assert "projects/ca%2Fml-2026-04/share" in calls[1][1]
+        assert calls[1][2] == {"group_id": 42, "group_access": 20}
+
+    def test_existing_share_is_idempotent(self):
+        result, _ = self._run(
+            [_response(200, {"id": 42}), _response(409, {"message": "already shared"})]
+        )
+        assert result == "already-shared"
+
+    def test_400_already_taken_is_idempotent_too(self):
+        result, _ = self._run(
+            [
+                _response(200, {"id": 42}),
+                _response(400, {"message": "group_id has already been taken"}),
+            ]
+        )
+        assert result == "already-shared"
+
+    def test_unknown_group_is_actionable(self):
+        with pytest.raises(GitLabApiError, match="not found"):
+            self._run([_response(404, {})])
+
+    def test_missing_project_advises_creating_the_repo(self):
+        with pytest.raises(GitLabApiError, match="Create the repo"):
+            self._run([_response(200, {"id": 42}), _response(404, {})])
+
+
+# ---------------------------------------------------------------------------
+# clm release provision CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_spec(tmp_path: Path) -> Path:
+    specs_dir = tmp_path / "course-specs"
+    specs_dir.mkdir(exist_ok=True)
+    spec_file = specs_dir / "course.xml"
+    spec_file.write_text(SPEC_WITH_SHARES, encoding="utf-8")
+    return spec_file
+
+
+@pytest.fixture(autouse=True)
+def _clean_git_config():
+    """Neutralize user/env git config so remote-URL derivation is deterministic."""
+    from clm.infrastructure.config import GitConfig
+
+    mock_config = MagicMock()
+    mock_config.git = GitConfig()
+    with patch("clm.cli.commands.git_ops.get_config", return_value=mock_config):
+        yield
+
+
+class TestProvisionCli:
+    def test_dry_run_lists_every_share_without_a_token(self, tmp_path, monkeypatch):
+        for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        spec_file = _write_spec(tmp_path)
+        result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        # Inherited trainers share + cohort share for 2026-04; override for 2026-10.
+        assert "ml-2026-04-solutions -> trainers (maintainer)" in result.output
+        assert "-> students/azav-ml/ml-2026-04 (reporter)" in result.output
+        assert "-> trainers (guest)" in result.output
+
+    def test_missing_token_is_a_clear_error(self, tmp_path, monkeypatch):
+        for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        spec_file = _write_spec(tmp_path)
+        result = CliRunner().invoke(release_group, ["provision", str(spec_file)])
+        assert result.exit_code != 0
+        assert "CLM_GITLAB_TOKEN" in result.output
+
+    def test_shares_are_applied_via_the_api(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_GITLAB_TOKEN", "tok")
+        spec_file = _write_spec(tmp_path)
+        with patch(
+            "clm.infrastructure.gitlab_api.share_project_with_group",
+            side_effect=["shared", "already-shared", "shared"],
+        ) as mock_share:
+            result = CliRunner().invoke(release_group, ["provision", str(spec_file)])
+        assert result.exit_code == 0, result.output
+        assert mock_share.call_count == 3
+        # The first share targets the trainers group at maintainer level.
+        args = mock_share.call_args_list[0][0]
+        assert args[0] == "https://gitlab.example.com"
+        assert args[1] == "ca/ml-2026-04-solutions"
+        assert args[2] == "trainers"
+        assert args[3] == "maintainer"
+        assert "already shared" in result.output
+
+    def test_single_channel_without_shares_reports_nothing_to_do(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_GITLAB_TOKEN", "tok")
+        body = (
+            SPEC_WITH_SHARES.replace('<share-with access="maintainer">trainers</share-with>', "")
+            .replace("<share-with>students/azav-ml/ml-2026-04</share-with>", "")
+            .replace('<share-with access="guest">trainers</share-with>', "")
+        )
+        specs_dir = tmp_path / "course-specs"
+        specs_dir.mkdir()
+        spec_file = specs_dir / "course.xml"
+        spec_file.write_text(body, encoding="utf-8")
+        result = CliRunner().invoke(
+            release_group, ["provision", str(spec_file), "--channel", "solutions/2026-04"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "nothing to provision" in result.output.lower()
+
+    def test_api_error_exits_nonzero_but_continues(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLM_GITLAB_TOKEN", "tok")
+        spec_file = _write_spec(tmp_path)
+        with patch(
+            "clm.infrastructure.gitlab_api.share_project_with_group",
+            side_effect=[GitLabApiError("boom"), "shared", "shared"],
+        ) as mock_share:
+            result = CliRunner().invoke(release_group, ["provision", str(spec_file)])
+        assert result.exit_code == 1
+        assert mock_share.call_count == 3  # later shares still attempted
+        assert "ERROR sharing" in result.output

--- a/tests/release/test_release_cli.py
+++ b/tests/release/test_release_cli.py
@@ -204,6 +204,85 @@ def test_channel_resolves_ledger_source_and_dest_from_spec(tmp_path):
     assert frozen.skeleton_frozen is True
 
 
+SPEC_TWO_STREAMS = """
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <output-targets>
+    <output-target name="shared">
+      <path>output/shared</path>
+      <kinds><kind>code-along</kind></kinds>
+    </output-target>
+    <output-target name="completed">
+      <path>output/completed</path>
+      <kinds><kind>completed</kind></kinds>
+    </output-target>
+  </output-targets>
+  <release-channels name="materials" source-target="shared">
+    <channel name="2026-04" path="release/materials/2026-04" ledger="release/materials-2026-04.txt"/>
+  </release-channels>
+  <release-channels name="solutions" source-target="completed">
+    <channel name="2026-04" path="release/solutions/2026-04" ledger="release/solutions-2026-04.txt"/>
+  </release-channels>
+</course>
+""".strip()
+
+
+def test_two_streams_release_independently_from_their_own_sources(tmp_path):
+    """The keystone scenario of issue #291: one cohort, two declarative streams.
+
+    materials/2026-04 promotes from the `shared` build target, solutions/2026-04
+    from the `completed` target, each gated by its own ledger — without ever
+    falling back to explicit --ledger/--source/--dest plumbing.
+    """
+    runner = CliRunner()
+    course_root = tmp_path
+    spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+    _write_source(course_root / "output" / "shared")
+    _write_source(course_root / "output" / "completed")
+
+    # Release the topic on the materials stream only.
+    add = runner.invoke(
+        release_group, ["add", str(spec_file), "intro", "--channel", "materials/2026-04"]
+    )
+    assert add.exit_code == 0, add.output
+    assert Ledger.load(course_root / "release" / "materials-2026-04.txt").released == ["intro"]
+    assert not (course_root / "release" / "solutions-2026-04.txt").exists()
+
+    sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "materials/2026-04"])
+    assert sync.exit_code == 0, sync.output
+    materials_dest = course_root / "release" / "materials" / "2026-04"
+    assert (materials_dest / "Sec/01 Intro.ipynb").is_file()
+    # The other stream's destination is untouched: its ledger is empty.
+    assert not (course_root / "release" / "solutions" / "2026-04" / "Sec").exists()
+
+    # Now release on the solutions stream; it promotes from ITS source target.
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "solutions/2026-04"])
+    sync2 = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "solutions/2026-04"])
+    assert sync2.exit_code == 0, sync2.output
+    solutions_dest = course_root / "release" / "solutions" / "2026-04"
+    assert (solutions_dest / "Sec/01 Intro.ipynb").is_file()
+
+    # Each destination froze under its canonical stream/channel address.
+    frozen = FrozenManifest.load(solutions_dest / FROZEN_FILENAME, channel="?")
+    assert frozen.channel == "solutions/2026-04"
+
+
+def test_ambiguous_bare_channel_is_a_clear_error(tmp_path):
+    runner = CliRunner()
+    spec_file = _write_spec(tmp_path, SPEC_TWO_STREAMS)
+    result = runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "2026-04"])
+    assert result.exit_code != 0
+    assert "several streams" in result.output
+    assert "materials/2026-04" in result.output
+
+
 # ---------------------------------------------------------------------------
 # `clm release week` (follow-up 3) — section-scoped ledger append
 # ---------------------------------------------------------------------------

--- a/tests/release/test_release_cli.py
+++ b/tests/release/test_release_cli.py
@@ -698,3 +698,158 @@ class TestSyncPush:
         assert FROZEN_FILENAME in tracked
         assert _last_subject(dest) == "Release to jan: 1 new"
         assert _git(remote, "log", "-1", "--format=%s").stdout.strip() == "Release to jan: 1 new"
+
+
+# ---------------------------------------------------------------------------
+# Language-scoped channels (issue #293)
+# ---------------------------------------------------------------------------
+
+SPEC_LANG_CHANNELS = """
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <project-slug>ml</project-slug>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <output-targets>
+    <output-target name="src">
+      <path>output/src</path>
+      <kinds><kind>completed</kind></kinds>
+    </output-target>
+  </output-targets>
+  <release-channels source-target="src">
+    <channel name="jan-de" lang="de" path="solutions/jan-de" ledger="release/jan-de.txt"/>
+    <channel name="jan-en" lang="en" path="solutions/jan-en" ledger="release/jan-en.txt"/>
+    <channel name="jan-all" path="solutions/jan-all" ledger="release/jan-all.txt"/>
+  </release-channels>
+</course>
+""".strip()
+
+
+def _write_two_language_source(root: Path) -> None:
+    """A built `src` target with de (ml-de) and en (ml-en) language roots."""
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "version": 1,
+        "source_commit": "abc",
+        "source_dirty": False,
+        "built_at": "t",
+        "target": "src",
+        "files": [
+            {
+                "path": "ml-de/Folien/01 Intro.ipynb",
+                "topic_id": "intro",
+                "section_id": "w01",
+                "kind": "completed",
+                "format": "notebook",
+                "language": "de",
+                "content_hash": "sha256:a",
+            },
+            {
+                "path": "ml-en/Slides/01 Intro.ipynb",
+                "topic_id": "intro",
+                "section_id": "w01",
+                "kind": "completed",
+                "format": "notebook",
+                "language": "en",
+                "content_hash": "sha256:b",
+            },
+        ],
+    }
+    (root / MANIFEST_FILENAME).write_text(json.dumps(manifest), encoding="utf-8")
+    for entry in manifest["files"]:
+        path = root / entry["path"]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(entry["content_hash"], encoding="utf-8")
+
+
+def test_lang_channel_promotes_one_language_rerooted(tmp_path):
+    runner = CliRunner()
+    spec_file = _write_spec(tmp_path, SPEC_LANG_CHANNELS)
+    _write_two_language_source(tmp_path / "output" / "src")
+
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "jan-de"])
+    sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-de"])
+    assert sync.exit_code == 0, sync.output
+
+    dest = tmp_path / "solutions" / "jan-de"
+    # Re-rooted at the language directory: no ml-de/ segment in the repo.
+    assert (dest / "Folien/01 Intro.ipynb").is_file()
+    assert not (dest / "ml-de").exists()
+    # The other language never leaks into the scoped channel.
+    assert not (dest / "Slides").exists()
+    assert not (dest / "ml-en").exists()
+
+
+def test_unscoped_channel_still_receives_every_language_root(tmp_path):
+    runner = CliRunner()
+    spec_file = _write_spec(tmp_path, SPEC_LANG_CHANNELS)
+    _write_two_language_source(tmp_path / "output" / "src")
+
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "jan-all"])
+    sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-all"])
+    assert sync.exit_code == 0, sync.output
+
+    dest = tmp_path / "solutions" / "jan-all"
+    assert (dest / "ml-de/Folien/01 Intro.ipynb").is_file()
+    assert (dest / "ml-en/Slides/01 Intro.ipynb").is_file()
+
+
+def test_language_option_overrides_channel_scope(tmp_path):
+    runner = CliRunner()
+    spec_file = _write_spec(tmp_path, SPEC_LANG_CHANNELS)
+    _write_two_language_source(tmp_path / "output" / "src")
+
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "jan-all"])
+    sync = runner.invoke(
+        release_group,
+        ["sync", str(spec_file), "--channel", "jan-all", "--language", "en"],
+    )
+    assert sync.exit_code == 0, sync.output
+
+    dest = tmp_path / "solutions" / "jan-all"
+    assert (dest / "Slides/01 Intro.ipynb").is_file()
+    assert not (dest / "ml-de").exists()
+
+
+def test_language_without_spec_file_errors(tmp_path):
+    runner = CliRunner()
+    source = tmp_path / "src"
+    _write_source(source)
+    ledger = tmp_path / "jan.txt"
+    Ledger(["intro"]).save(ledger)
+    result = runner.invoke(
+        release_group,
+        [
+            "sync",
+            "--ledger",
+            str(ledger),
+            "--source",
+            str(source),
+            "--dest",
+            str(tmp_path / "dest"),
+            "--language",
+            "de",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "requires the SPEC_FILE" in result.output
+
+
+def test_missing_language_root_is_a_clear_error(tmp_path):
+    runner = CliRunner()
+    spec_file = _write_spec(tmp_path, SPEC_LANG_CHANNELS)
+    source = tmp_path / "output" / "src"
+    _write_two_language_source(source)
+    import shutil
+
+    shutil.rmtree(source / "ml-de")
+
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "jan-de"])
+    sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-de"])
+    assert sync.exit_code != 0
+    assert "Language root not found" in sync.output

--- a/tests/release/test_release_cli.py
+++ b/tests/release/test_release_cli.py
@@ -853,3 +853,38 @@ def test_missing_language_root_is_a_clear_error(tmp_path):
     sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-de"])
     assert sync.exit_code != 0
     assert "Language root not found" in sync.output
+
+
+# ---------------------------------------------------------------------------
+# Partial manifest from an errored build (issue #295)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_promotes_green_topics_and_refuses_failed_ones(tmp_path):
+    runner = CliRunner()
+    source = tmp_path / "src"
+    _write_source(source)
+    # Mark the build partial with a failed topic that is also released.
+    manifest = json.loads((source / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    manifest["partial"] = True
+    manifest["failed_topics"] = ["flaky"]
+    (source / MANIFEST_FILENAME).write_text(json.dumps(manifest), encoding="utf-8")
+
+    ledger = tmp_path / "jan.txt"
+    Ledger(["intro", "flaky"]).save(ledger)
+    dest = tmp_path / "jan"
+
+    result = runner.invoke(
+        release_group,
+        ["sync", "--ledger", str(ledger), "--source", str(source), "--dest", str(dest)],
+    )
+    assert result.exit_code == 0, result.output
+    # The green topic was promoted and frozen...
+    assert (dest / "Sec/01 Intro.ipynb").is_file()
+    frozen = FrozenManifest.load(dest / FROZEN_FILENAME, channel="jan")
+    assert frozen.is_frozen("intro")
+    # ...the failed one was refused, loudly, and stays unfrozen (retried later).
+    assert not frozen.is_frozen("flaky")
+    assert "skip-failed" in result.output
+    assert "NOT promoted" in result.output
+    assert "partial" in result.output

--- a/tests/release/test_sync.py
+++ b/tests/release/test_sync.py
@@ -190,3 +190,81 @@ def test_released_but_unbuilt_topic_is_not_frozen(tmp_path):
     )
     assert result.copied_topics == ()
     assert not frozen.is_frozen("ghost")
+
+
+# ---------------------------------------------------------------------------
+# Failed topics in a partial manifest (issue #295)
+# ---------------------------------------------------------------------------
+
+
+def _partial_manifest() -> dict:
+    return {
+        "source_commit": "abc",
+        "partial": True,
+        "failed_topics": ["flaky"],
+        "files": [
+            {"path": "Sec/01 Good.ipynb", "topic_id": "good", "content_hash": "sha256:a"},
+            # Stale leftovers from a previous build of the failed topic must
+            # not appear in a partial manifest, but even if they did, the plan
+            # gate (not the file list) is what refuses promotion.
+        ],
+    }
+
+
+def test_plan_refuses_released_topics_that_failed_in_the_source_build():
+    plan = plan_sync(
+        manifest=_partial_manifest(),
+        ledger_released=["good", "flaky"],
+        frozen=FrozenManifest(channel="jan"),
+    )
+    actions = {t.topic_id: t.action for t in plan.topics}
+    assert actions == {"good": "copy", "flaky": "skip-failed"}
+    assert [t.topic_id for t in plan.failed] == ["flaky"]
+    assert [t.topic_id for t in plan.to_copy] == ["good"]
+
+
+def test_already_frozen_failed_topic_stays_an_ordinary_frozen_skip():
+    frozen = FrozenManifest(channel="jan")
+    frozen.freeze("flaky", FrozenRecord(source_commit="old", copied_at="t", topic_digest="d"))
+    plan = plan_sync(
+        manifest=_partial_manifest(),
+        ledger_released=["flaky"],
+        frozen=frozen,
+    )
+    assert plan.topics[0].action == "skip-frozen"
+
+
+def test_refreeze_of_a_failed_topic_is_refused():
+    frozen = FrozenManifest(channel="jan")
+    frozen.freeze("flaky", FrozenRecord(source_commit="old", copied_at="t", topic_digest="d"))
+    plan = plan_sync(
+        manifest=_partial_manifest(),
+        ledger_released=["flaky"],
+        frozen=frozen,
+        refreeze={"flaky"},
+    )
+    assert plan.topics[0].action == "skip-failed"
+
+
+def test_apply_skips_failed_topics_without_freezing(tmp_path):
+    source = tmp_path / "src"
+    (source / "Sec").mkdir(parents=True)
+    (source / "Sec" / "01 Good.ipynb").write_text("good", encoding="utf-8")
+    dest = tmp_path / "dest"
+    frozen = FrozenManifest(channel="jan")
+
+    manifest = _partial_manifest()
+    plan = plan_sync(manifest=manifest, ledger_released=["good", "flaky"], frozen=frozen)
+    result = apply_sync(
+        plan=plan,
+        manifest=manifest,
+        source_root=source,
+        dest_root=dest,
+        frozen=frozen,
+        copied_at="2026-06-10T00:00:00Z",
+    )
+
+    assert result.copied_topics == ("good",)
+    assert result.failed_topics == ("flaky",)
+    assert frozen.is_frozen("good")
+    assert not frozen.is_frozen("flaky")


### PR DESCRIPTION
Implements the five usability issues filed while the ML-AZAV 2026-04 cohort adopted the per-topic frozen release feature (#208/PR #219).

Closes #291
Closes #292
Closes #293
Closes #294
Closes #295

## #291 — Multiple release streams per cohort (keystone)

A course can declare several `<release-channels>` blocks, one per release *stream*, each fed by its own `source-target` — e.g. `materials` from a `shared` target released before each session and `solutions` from a `completed` target released after the workshop. With more than one block each needs a unique `name`; channels are then addressed as `STREAM/CHANNEL` (`--channel materials/2026-04`) across `clm release`, `clm git --channel/--all-channels`, and `clm calendar`, with bare names still accepted when unique — a single unnamed block keeps the issue-#208 behavior byte-for-byte.

- `CourseSpec.release_channel_blocks` (list) with `resolve_release_channel` / `iter_release_channels` helpers and a canonical-address helper `release_channel_ref`.
- Validation: unique `/`‑free stream + channel names, `source-target` must name an output target, and two channels may not share a destination path or ledger across streams (they would fight over one frozen manifest).
- Derived repo names gain the stream segment: `{slug}-{channel}-{stream}`; custom remote templates can use a new `{stream}` placeholder.
- The cohort calendar stays keyed by the bare cohort name — one timeline per cohort regardless of stream.

## #292 — `clm git` skips build-source targets

Both shapes from the issue: an explicit `distribute="false"` attribute on `<output-target>` **and** the auto-default — a target named as any stream's `source-target` is non-distributed unless it says `distribute="true"`. `clm git` without `--target` no longer creates/pushes repos for these private build inputs; an explicit `--target NAME` still selects one (explicit wins). A malformed attribute value is a validation error, not a silent flip.

## #293 — Language-scoped channels

`<channel lang="de">` promotes only that language's manifest entries, re-rooted so the cohort repo's root is the language directory itself — matching the existing per-language convention (`shared/machine-learning-azav-de`) — and the derived repo name appends `-{lang}`. The filter requires **both** the entry's recorded language and the language-root path prefix. `clm release sync --language de|en` overrides per invocation. Decision on the default when `lang` is unset: keep copying every built language root (pre-#293 behavior), now documented rather than left undefined.

## #294 — Declarative GitLab group shares

`<share-with access="reporter">students/azav-ml/ml-2026-04</share-with>` on a `<channel>` (or on the block, inherited by every channel; a channel-level entry for the same group overrides the access level). The new `clm release provision` applies the shares via the GitLab REST API: idempotent (existing shares reported, not failed), token from `CLM_GITLAB_TOKEN`/`GITLAB_TOKEN` (`api` scope), API host derived from the channel's remote URL, `--dry-run` preview, and a clean skip for non-GitLab remotes. Scope is deliberately share-only — CLM had no remote-API surface at all, so repo creation stays push-to-create/manual, and a missing project yields an actionable "push the repo first" error.

## #295 — Provenance manifest for the built subset

A whole-course build with errors now writes `.clm-manifest.json` for the cleanly-built subset: each error is attributed to its owning topic via the course-file → topic map, those topics' entries are excluded, and the manifest records them (`partial: true`, `failed_topics`). `plan_sync` refuses released-but-failed topics with a new `skip-failed` action — never frozen, so they promote automatically once a build succeeds — and `clm release sync` warns loudly while still promoting every green topic.

Safety model: if *any* error cannot be pinned to a topic (fatal severity, empty `file_path`, non-course file), the manifest is skipped entirely — exactly the pre-#295 strict behavior. Timed-out, `--watch`, and `--only-sections` builds still never write a manifest. (Merged manifests for `--only-sections` — option 3 in the issue — were deliberately left out: per-manifest `source_commit` would lie about unselected sections' provenance; can be a follow-up.)

## Docs & tests

- `clm info spec-files` / `clm info commands` updated per the info-topics rule; `configuration.md` (new `CLM_GITLAB_TOKEN`, `{stream}` placeholder), CHANGELOG, and a post-ship section in `docs/claude/design/per-topic-solution-release.md`.
- ~60 new tests across spec parsing/validation, channel resolution, `clm git` discovery, release CLI (two-stream end-to-end, lang re-rooting, partial-manifest refusal), sync engine, build attribution, and the mocked GitLab API client. Full fast suite green (7494 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
