### PR TITLE
Bump version: 1.10.0 → 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-10
+
 ### Added
 
 - **Multiple release streams per cohort (issue #291).** A course can declare
@@ -78,6 +80,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   their weekday/name label in every week, disabled weeks included. The JSON
   format is unaffected — it always carries the grouping as a structured
   `subsections` array.
+- **Two new `clm slides sync` test oracles** close the architecture review's
+  remaining coverage gaps (issue #289 P4): `tests/slides/test_sync_non_python.py`
+  drives the engine end-to-end on a C# (`//`-token) split pair for the first
+  time — neutral verbatim copy, id-less re-translation, add-with-insert (the
+  built twin must carry the `// %%` header family), tag mirroring, and the
+  neutral tag-drift alert, on both baselines — and
+  `tests/slides/test_sync_corpus_mutation.py` (slow/integration, corpus-gated
+  like the no-op backstop) is the corpus' first **positive propagation
+  oracle**: scripted one-sided mutations of real PythonCourses decks per
+  change-type (neutral edit/add, id-less localized edit, companion remove,
+  tag-only retag, judge-reconciled edit), asserting each is propagated to the
+  other half or alerted — never silently dropped — on pairs selected per
+  target cell class and verified post-sync-clean.
 
 ### Changed
 
@@ -101,22 +116,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   — in declared order, with no marker — so a roadmap spec reads like a finished
   course. Structured outputs (`outline --format json`, `schedule --format csv`)
   keep the disabled state recorded even under `=merge`.
-
-### Added
-
-- **Two new `clm slides sync` test oracles** close the architecture review's
-  remaining coverage gaps (issue #289 P4): `tests/slides/test_sync_non_python.py`
-  drives the engine end-to-end on a C# (`//`-token) split pair for the first
-  time — neutral verbatim copy, id-less re-translation, add-with-insert (the
-  built twin must carry the `// %%` header family), tag mirroring, and the
-  neutral tag-drift alert, on both baselines — and
-  `tests/slides/test_sync_corpus_mutation.py` (slow/integration, corpus-gated
-  like the no-op backstop) is the corpus' first **positive propagation
-  oracle**: scripted one-sided mutations of real PythonCourses decks per
-  change-type (neutral edit/add, id-less localized edit, companion remove,
-  tag-only retag, judge-reconciled edit), asserting each is propagated to the
-  other half or alerted — never silently dropped — on pairs selected per
-  target cell class and verified post-sync-clean.
+- **`clm export outline` / `clm export summary` now filter split-companion decks
+  to the requested language.** When a topic ships split `slides_x.de.py` +
+  `slides_x.en.py` companions, a `-L de` outline/summary listed *both* the
+  German and the English title (and the JSON `slides` array carried both),
+  because the section-flat, JSON-slide, summary, and disabled-topic enumerations
+  skipped the `output_language_filter` the subsection path already applied. All
+  enumerations now filter split companions to the requested language (via
+  `output_language_filter` for the built course and the `.de`/`.en` filename
+  suffix for disabled topics read from disk), so a split pair contributes a
+  single entry — matching the build's per-language routing. Bilingual decks are
+  unaffected.
+- **`clm slides sync` parity errors now name the diverging cells**, instead of a
+  generic "a change to a shared cell was not propagated". The shared-cell error
+  lists the cell text present on one half but missing on the other (or the first
+  out-of-order cell), and the id-less-localized error points at the slide group
+  and cell kind — so the divergence can be located without a manual diff.
+- **`clm slides sync` shows progress while it runs.** A directory (batch) sweep
+  prints a `[i/N] <deck> …` header per pair, and a writing run prints a short
+  stderr tick per LLM call (`· reconciling …` / `· translating …`) so a long
+  sync is visibly alive. Progress goes to stderr and is suppressed under
+  `--json` (stdout stays pure JSON).
+- **The mitmproxy transport now records and replays a per-request response
+  *sequence*** instead of collapsing a repeated request to its first response.
+  A non-deterministic endpoint (a temperature>0 LLM, or OpenRouter routing the
+  same request to different providers) answers an identical request differently
+  on successive calls; when a *later* request embeds an earlier response (e.g.
+  `summarize | translate`, where `translate` carries the generated summary), the
+  old first-seen-wins dedup dropped every response after the first, so the
+  downstream request matched nothing on replay and failed with `clm_replay_miss`.
+  Recording now keys dedup on `(request, response)` so distinct responses to the
+  same request are kept in order, and replay serves them in recorded order via a
+  per-request cursor — sticking on the last match once exhausted, so a genuinely
+  repeatable request never misses and a single-entry cassette still serves
+  repeatably (unchanged). The host-side fold gained `preserve_sequence=True`
+  (mitmproxy only; the vcrpy path keeps the deduped fold). Decks affected before
+  this fix: `chains_and_lcel/slides_020`, `prompt_templates/slides_010`,
+  `langgraph_intro/slides_010`.
 
 ### Fixed
 
@@ -223,46 +259,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   alongside a reorder still merges cleanly (the halves agree, so nothing is lost).
   Reconcile a genuine conflict by hand (apply the reorder and the edit on the same
   half, or sync them in separate steps) and re-run.
-
-### Changed
-
-- **`clm slides sync` parity errors now name the diverging cells**, instead of a
-  generic "a change to a shared cell was not propagated". The shared-cell error
-  lists the cell text present on one half but missing on the other (or the first
-  out-of-order cell), and the id-less-localized error points at the slide group
-  and cell kind — so the divergence can be located without a manual diff.
-- **`clm slides sync` shows progress while it runs.** A directory (batch) sweep
-  prints a `[i/N] <deck> …` header per pair, and a writing run prints a short
-  stderr tick per LLM call (`· reconciling …` / `· translating …`) so a long
-  sync is visibly alive. Progress goes to stderr and is suppressed under
-  `--json` (stdout stays pure JSON).
-
-
-  When a topic ships split `slides_x.de.py` + `slides_x.en.py` companions, a
-  `-L de` outline/summary listed *both* the German and the English title (and
-  the JSON `slides` array carried both), because the section-flat, JSON-slide,
-  summary, and disabled-topic enumerations skipped the `output_language_filter`
-  the subsection path already applied. All enumerations now filter split
-  companions to the requested language (via `output_language_filter` for the
-  built course and the `.de`/`.en` filename suffix for disabled topics read
-  from disk), so a split pair contributes a single entry — matching the build's
-  per-language routing. Bilingual decks are unaffected.
-- **The mitmproxy transport now records and replays a per-request response
-  *sequence*** instead of collapsing a repeated request to its first response.
-  A non-deterministic endpoint (a temperature>0 LLM, or OpenRouter routing the
-  same request to different providers) answers an identical request differently
-  on successive calls; when a *later* request embeds an earlier response (e.g.
-  `summarize | translate`, where `translate` carries the generated summary), the
-  old first-seen-wins dedup dropped every response after the first, so the
-  downstream request matched nothing on replay and failed with `clm_replay_miss`.
-  Recording now keys dedup on `(request, response)` so distinct responses to the
-  same request are kept in order, and replay serves them in recorded order via a
-  per-request cursor — sticking on the last match once exhausted, so a genuinely
-  repeatable request never misses and a single-entry cassette still serves
-  repeatably (unchanged). The host-side fold gained `preserve_sequence=True`
-  (mitmproxy only; the vcrpy path keeps the deduped fold). Decks affected before
-  this fix: `chains_and_lcel/slides_020`, `prompt_templates/slides_010`,
-  `langgraph_intro/slides_010`.
 
 ## [1.10.0] - 2026-06-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Draw.io diagrams) into multiple output formats (HTML slides, executed
 notebooks, extracted code) for multiple audiences (students, solutions,
 speaker notes).
 
-**Version**: 1.10.0 | **License**: MIT | **Python**: 3.12, 3.13, 3.14
+**Version**: 1.11.0 | **License**: MIT | **Python**: 3.12, 3.13, 3.14
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hoelzl/clm/actions/workflows/ci.yml/badge.svg)](https://github.com/hoelzl/clm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hoelzl/clm/branch/master/graph/badge.svg)](https://codecov.io/gh/hoelzl/clm)
 
-**Version**: 1.10.0 | **License**: MIT | **Python**: 3.12, 3.13, 3.14
+**Version**: 1.11.0 | **License**: MIT | **Python**: 3.12, 3.13, 3.14
 
 CLM is a course content processing system that converts educational materials (Jupyter notebooks, PlantUML diagrams, Draw.io diagrams) into multiple output formats.
 

--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -50,7 +50,7 @@ On Windows (PowerShell):
 ### PlantUML Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.10.0`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.11.0`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Base Image:** `python:3.12-slim`
@@ -73,7 +73,7 @@ docker build -f docker/plantuml/Dockerfile -t docker.io/mhoelzl/clm-plantuml-con
 ### Draw.io Converter
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-drawio-converter:1.10.0`
+- `docker.io/mhoelzl/clm-drawio-converter:1.11.0`
 - `docker.io/mhoelzl/clm-drawio-converter:latest`
 
 **Base Image:** `python:3.12-slim`
@@ -107,7 +107,7 @@ The notebook processor has **two variants** to support different use cases:
 **Best for:** Courses without deep learning, or running on Apple Silicon Macs.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.10.0-lite`
+- `docker.io/mhoelzl/clm-notebook-processor:1.11.0-lite`
 - `docker.io/mhoelzl/clm-notebook-processor:lite`
 
 **Base Image:** `python:3.12-slim` (multi-arch: amd64, arm64)
@@ -139,8 +139,8 @@ docker build -f docker/notebook/Dockerfile \
 **Best for:** Deep learning courses, CUDA-accelerated processing.
 
 **Image Tags:**
-- `docker.io/mhoelzl/clm-notebook-processor:1.10.0` (default)
-- `docker.io/mhoelzl/clm-notebook-processor:1.10.0-full`
+- `docker.io/mhoelzl/clm-notebook-processor:1.11.0` (default)
+- `docker.io/mhoelzl/clm-notebook-processor:1.11.0-full`
 - `docker.io/mhoelzl/clm-notebook-processor:latest`
 - `docker.io/mhoelzl/clm-notebook-processor:full`
 
@@ -172,7 +172,7 @@ docker build -f docker/notebook/Dockerfile -t docker.io/mhoelzl/clm-notebook-pro
 - .NET SDK 10.0 (C# and F# kernels)
 - Deno (TypeScript/JavaScript kernel)
 - Java JDK (Java kernel)
-- IJava 1.10.0 (Java Jupyter kernel)
+- IJava 1.11.0 (Java Jupyter kernel)
 - micromamba + xeus-cpp (C++ kernel)
 
 **Jupyter Kernels:**
@@ -223,12 +223,12 @@ The build scripts automatically set these arguments.
 All images use the Hub namespace (`docker.io/mhoelzl/clm-*`) for consistency:
 
 **PlantUML/DrawIO:**
-- `docker.io/mhoelzl/clm-plantuml-converter:1.10.0`
+- `docker.io/mhoelzl/clm-plantuml-converter:1.11.0`
 - `docker.io/mhoelzl/clm-plantuml-converter:latest`
 
 **Notebook (with variants):**
-- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.10.0`, `:full`, `:1.10.0-full`
-- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.10.0-lite`
+- **Full (default):** `docker.io/mhoelzl/clm-notebook-processor:latest`, `:1.11.0`, `:full`, `:1.11.0-full`
+- **Lite:** `docker.io/mhoelzl/clm-notebook-processor:lite`, `:1.11.0-lite`
 
 ### BuildKit Cache Mounts
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,6 +1,6 @@
 # CLM Architecture
 
-This document describes the current architecture of the CLM system (v1.10.0).
+This document describes the current architecture of the CLM system (v1.11.0).
 
 ## Overview
 
@@ -42,7 +42,7 @@ CLM is a course content processing system that converts educational materials (J
                          │
 ┌────────────────────────▼──────────────────────────────────┐
 │          clm.workers (Worker Implementations)              │
-│                                (v1.10.0)             │
+│                                (v1.11.0)             │
 │  ├── notebook/ (NotebookWorker, templates, processors)    │
 │  ├── plantuml/ (PlantUmlWorker, converter)                │
 │  └── drawio/ (DrawioWorker, converter)                    │
@@ -211,7 +211,7 @@ class Worker(ABC):
 
 ### Layer 3: Workers (Worker Implementations)
 
-**Purpose**: Concrete worker implementations for different file types (v1.10.0)
+**Purpose**: Concrete worker implementations for different file types (v1.11.0)
 
 Workers are now integrated into the main `clm` package under `clm.workers/`. Previously they were separate packages in the `services/` directory.
 
@@ -566,7 +566,7 @@ CLM has evolved significantly:
 - No message broker required
 - Reduced from 8 Docker services to 3
 
-**v0.6.2 → v1.10.0** (2025): Integrated workers
+**v0.6.2 → v1.11.0** (2025): Integrated workers
 - Workers integrated into main package (`clm.workers`)
 - Optional dependencies for each worker
 - Four-layer architecture (core, infrastructure, workers, cli)
@@ -1190,4 +1190,4 @@ Potential improvements (not currently planned):
 ---
 
 **Last Updated**: 2026-02-13
-**Version**: 1.10.0
+**Version**: 1.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-academy-lecture-manager"
-version = "1.10.0"
+version = "1.11.0"
 description = "Coding-Academy Lecture Manager - A course content processing system"
 authors = [
     {name = "Dr. Matthias Hölzl", email = "tc@xantira.com"},
@@ -416,7 +416,7 @@ ignore = [
 known-first-party = ["clm"]
 
 [tool.bumpversion]
-current_version = "1.10.0"
+current_version = "1.11.0"
 commit = true
 # No local tag: the Release workflow (.github/workflows/release.yml) creates the
 # authoritative vX.Y.Z tag on the server *after* the CI-green gate, so a red

--- a/src/clm/__version__.py
+++ b/src/clm/__version__.py
@@ -1,3 +1,3 @@
 """Version information for CLM."""
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -1009,7 +1009,7 @@ def _is_cpp_image_available() -> bool:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.10.0-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.11.0-full",
         ]:
             try:
                 client.images.get(tag)
@@ -1030,7 +1030,7 @@ def _get_full_image_name() -> str | None:
         # Try to find the full image with C++ support
         for tag in [
             "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.10.0-full",
+            "docker.io/mhoelzl/clm-notebook-processor:1.11.0-full",
         ]:
             try:
                 client.images.get(tag)

--- a/uv.lock
+++ b/uv.lock
@@ -966,7 +966,7 @@ wheels = [
 
 [[package]]
 name = "coding-academy-lecture-manager"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- Reorganise the `[Unreleased]` CHANGELOG section into a clean `[1.11.0]` entry: merged duplicate `### Added` / `### Changed` blocks, gave the orphaned split-companion-filter paragraph a proper bullet heading, and moved the mitmproxy sequence item into `### Changed`.
- Bump version 1.10.0 → 1.11.0 via `bump-my-version bump minor`.

## What's in this release (since 1.10.0)

**Added** — multiple release streams per cohort (#291), language-scoped release channels (#293), declarative GitLab access-group shares + `clm release provision` (#294), `clm git` skips release build-source targets (#292), partial manifests so a failing deck no longer blocks all releases (#295), cohort viewing calendars (`clm export calendar` / `clm calendar check` / `clm calendar status`, #283), `clm export outline --weekdays`, two new `clm slides sync` test oracles (#289 P4).

**Changed** — `clm outline`/`schedule`/`summarize` removed and replaced by `clm export outline`/`schedule`/`summary` (breaking, no alias); `--include-disabled` gains optional `=merge` value; `clm export outline`/`summary` filter split companions to the requested `-L` language; `clm slides sync` parity errors now name the diverging cells; sync progress output; mitmproxy per-request response sequence (#275).

**Fixed** — six `clm slides sync` correctness fixes: tag-only edit mirrored across group reorder (#285), structural pass no longer calls translator in rebuild (#289 P2), baseline plumbing unified (#289 P1), three tag-channel silent-drop gaps closed (#289/#290), slide-group-order reconciled after structural pass, edit+reorder conflict errors correctly (#282).

## Test plan

- [x] `pytest -m "not docker"` — 7659 passed, 13 skipped, 1 xfailed (12 min)
- [ ] CI must be green before merge — merge with a **merge commit** (not squash/rebase) to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)