### PR TITLE
fix(release): keep .git out of the provenance manifest and release sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Provenance manifest no longer records `.git` (and other never-copied
+  paths) from output trees (issue #302).** The manifest's dir-group walk now
+  applies the same ignore filter as the build's dir-group copy, so a `.git`
+  left inside an output target (e.g. by `clm git init`) no longer enters the
+  skeleton as 1000+ topic-less entries that `clm release sync` would then
+  copy into a cohort repo — for a language-scoped channel landing at the repo
+  root and clobbering the destination's real `.git`. As defense in depth,
+  `clm release sync` now refuses to copy any manifest path containing a
+  `.git`/`.svn`/`.hg` segment (with a warning), so a polluted manifest from
+  an older build can never overwrite a destination repo's VCS metadata.
+
 ## [1.11.0] - 2026-06-10
 
 ### Added

--- a/src/clm/core/provenance_manifest.py
+++ b/src/clm/core/provenance_manifest.py
@@ -45,6 +45,7 @@ from clm.core.image_registry import get_relative_img_path
 from clm.infrastructure.utils.path_utils import (
     ext_for,
     is_ignored_file_for_output,
+    is_ignored_path_in_output_tree,
     output_path_for,
     output_specs,
 )
@@ -208,6 +209,13 @@ def _enumerate_dir_group_outputs(
     and record the files actually found on disk; placements the build did not
     produce simply have no directory. Ownership comes from the recorded
     ``DirGroup.spec`` (``None``/``None`` for a global ``<dir-groups>`` entry).
+
+    The walk applies the same ignore filter as the build's dir-group copy
+    (:func:`is_ignored_path_in_output_tree`): the copy never produces files
+    under ``.git``/IDE/cache directories, so anything found there — e.g. the
+    ``.git`` that ``clm git init`` creates inside an output target — is not a
+    build output and must not enter the manifest (issue #302), where the
+    release sync would promote it into cohort repos.
     """
     for dir_group in course.dir_groups:
         spec = dir_group.spec
@@ -221,17 +229,20 @@ def _enumerate_dir_group_outputs(
                     if not out_dir.is_dir():
                         continue
                     for path in sorted(out_dir.rglob("*")):
-                        if path.is_file():
-                            yield (
-                                path,
-                                {
-                                    "section_id": section_id,
-                                    "topic_id": topic_id,
-                                    "kind": None,
-                                    "format": "dir-group",
-                                    "language": lang,
-                                },
-                            )
+                        if not path.is_file():
+                            continue
+                        if is_ignored_path_in_output_tree(path.relative_to(out_dir)):
+                            continue
+                        yield (
+                            path,
+                            {
+                                "section_id": section_id,
+                                "topic_id": topic_id,
+                                "kind": None,
+                                "format": "dir-group",
+                                "language": lang,
+                            },
+                        )
 
 
 def _hash_file(path: Path) -> str:

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -328,6 +328,28 @@ def is_ignored_file_for_output(file_path: Path) -> bool:
     return False
 
 
+def is_ignored_path_in_output_tree(rel_path: Path) -> bool:
+    """Return True if a path *found inside* an output tree cannot be a build output.
+
+    Mirrors the dir-group copy filter (``shutil.ignore_patterns(*SKIP_DIRS_FOR_OUTPUT,
+    *SKIP_DIRS_PATTERNS, *SKIP_OUTPUT_FILE_GLOBS)`` in
+    ``LocalOpsBackend.copy_dir_group_files``): the build never copies VCS/IDE/cache
+    directories or output-suppressed files, so anything found beneath them was put
+    there by something else — e.g. the ``.git`` that ``clm git init`` creates inside
+    an output target (issue #302) — and must not be recorded as build provenance.
+
+    Unlike :func:`is_ignored_file_for_output` (which classifies *source* files and
+    also applies course-scan suffix rules), this checks every segment of the
+    output-relative path **including the final name**, so a worktree-style ``.git``
+    *file* is rejected too, and deliberately does not reject suffixes like ``.bin``
+    that the dir-group copy does ship.
+    """
+    if is_ignored_dir_for_output(rel_path):
+        return True
+    name = rel_path.name
+    return any(pattern.match(name) for pattern in SKIP_OUTPUT_FILE_PATTERNS)
+
+
 def simplify_ordered_name(name: str, prefix: str | None = None) -> str:
     name = name.rsplit(".", maxsplit=1)[0]
     parts = name.split("_")

--- a/src/clm/release/sync.py
+++ b/src/clm/release/sync.py
@@ -14,7 +14,11 @@ index. The rules (issue #208):
 
 Promotion copies bytes verbatim from the source tree; it never rebuilds or
 re-executes anything, and — because the manifest lists only topic output files —
-it never copies ``.clm-*`` build sidecars into the destination.
+it never copies ``.clm-*`` build sidecars into the destination. As defense in
+depth it also refuses any manifest entry under a VCS metadata directory
+(``.git``/``.svn``/``.hg``): a polluted manifest from an older build that
+walked a stray ``.git`` into the skeleton (issue #302) must never overwrite
+the destination repo's own ``.git``.
 """
 
 from __future__ import annotations
@@ -22,7 +26,7 @@ from __future__ import annotations
 import logging
 import shutil
 from collections.abc import Iterable
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from attrs import frozen
@@ -189,10 +193,25 @@ def apply_sync(
     )
 
 
+# Never promote VCS metadata, no matter what the manifest claims (issue #302):
+# copying e.g. ``.git/index`` into the destination working tree would corrupt
+# the cohort repo the sync is populating.
+_VCS_DIR_NAMES = frozenset({".git", ".svn", ".hg"})
+
+
+def _is_vcs_path(rel: str) -> bool:
+    return any(part in _VCS_DIR_NAMES for part in PurePosixPath(rel).parts)
+
+
 def _copy_files(files: list[dict[str, Any]], source_root: Path, dest_root: Path) -> int:
     copied = 0
+    refused_vcs = 0
     for entry in files:
         rel = entry["path"]
+        if _is_vcs_path(rel):
+            refused_vcs += 1
+            logger.debug("release sync: refusing VCS metadata path from manifest: %s", rel)
+            continue
         src = source_root / rel
         if not src.is_file():
             logger.warning("release sync: source file missing, skipping: %s", src)
@@ -201,4 +220,11 @@ def _copy_files(files: list[dict[str, Any]], source_root: Path, dest_root: Path)
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         copied += 1
+    if refused_vcs:
+        logger.warning(
+            "release sync: refused to copy %d VCS metadata file(s) (.git/.svn/.hg) "
+            "listed in the source manifest — the manifest is polluted (issue #302); "
+            "rebuild the source target to clean it",
+            refused_vcs,
+        )
     return copied

--- a/tests/core/test_provenance_manifest.py
+++ b/tests/core/test_provenance_manifest.py
@@ -305,6 +305,35 @@ def test_manifest_records_dir_group_outputs_with_ownership(tmp_path):
     assert entry["content_hash"].startswith("sha256:")
 
 
+def test_dir_group_walk_ignores_vcs_and_output_suppressed_files(tmp_path):
+    """A ``.git`` inside a dir-group output dir (e.g. left by ``clm git init``
+    on the target) must not enter the manifest — the release sync would
+    otherwise promote stale ``.git/*`` into cohort repos (issue #302)."""
+    course = _course_from_test_spec_1(tmp_path / "out")
+    target = course.output_targets[0]
+
+    owned = [dg for dg in course.dir_groups if dg.spec is not None and dg.spec.topic_id]
+    dir_group = owned[0]
+    out_dirs = dir_group.output_dirs(
+        False, "de", target.output_root, skip_toplevel=target.is_explicit
+    )
+    placed_dir = out_dirs[0]
+    git_dir = placed_dir / ".git"
+    (git_dir / "refs" / "heads").mkdir(parents=True, exist_ok=True)
+    (git_dir / "index").write_bytes(b"DIRC")
+    (git_dir / "refs" / "heads" / "master").write_text("0" * 40, encoding="utf-8")
+    (placed_dir / "slides_x.http-cassette.yaml").write_text("interactions: []", encoding="utf-8")
+    (placed_dir / "example.txt").write_text("hi", encoding="utf-8")
+
+    manifest = build_provenance_manifest(
+        course, target, source_commit=None, source_dirty=None, built_at=BUILT_AT
+    )
+    paths = [f["path"] for f in manifest["files"] if f["format"] == "dir-group"]
+    assert any(p.endswith("example.txt") for p in paths)
+    assert not any(".git/" in p for p in paths)
+    assert not any(p.endswith(".http-cassette.yaml") for p in paths)
+
+
 # ---------------------------------------------------------------------------
 # topic_digest_from_files / manifest_topic_digest (issue #208 step 5 join key)
 # ---------------------------------------------------------------------------

--- a/tests/infrastructure/utils/path_utils_test.py
+++ b/tests/infrastructure/utils/path_utils_test.py
@@ -20,6 +20,7 @@ from clm.infrastructure.utils.path_utils import (
     is_ignored_dir_for_output,
     is_ignored_file_for_course,
     is_ignored_file_for_output,
+    is_ignored_path_in_output_tree,
     is_slides_file,
     output_path_for,
     output_specs,
@@ -458,6 +459,35 @@ class TestSidecarSubdirSkips:
         cassette = nested / "slides_010v.http-cassette.yaml"
         cassette.write_text("interactions: []")
         assert is_ignored_file_for_output(cassette)
+
+
+class TestIsIgnoredPathInOutputTree:
+    """The output-tree walk filter (issue #302) mirrors the dir-group copy ignore."""
+
+    def test_rejects_files_under_a_git_dir(self):
+        assert is_ignored_path_in_output_tree(Path(".git/COMMIT_EDITMSG"))
+        assert is_ignored_path_in_output_tree(Path(".git/refs/heads/master"))
+        assert is_ignored_path_in_output_tree(Path("nested/.git/index"))
+
+    def test_rejects_a_worktree_style_git_file(self):
+        # In a linked worktree ``.git`` is a *file*; the final segment counts.
+        assert is_ignored_path_in_output_tree(Path(".git"))
+
+    def test_rejects_other_vcs_and_cache_dirs(self):
+        assert is_ignored_path_in_output_tree(Path(".idea/workspace.xml"))
+        assert is_ignored_path_in_output_tree(Path("examples/__pycache__/mod.pyc"))
+
+    def test_rejects_output_suppressed_file_names(self):
+        assert is_ignored_path_in_output_tree(Path("topic/slides_010v.http-cassette.yaml"))
+        assert is_ignored_path_in_output_tree(Path("topic/voiceover_slides_010.py"))
+
+    def test_keeps_ordinary_skeleton_files(self):
+        assert not is_ignored_path_in_output_tree(Path("README.md"))
+        assert not is_ignored_path_in_output_tree(Path(".gitignore"))
+        assert not is_ignored_path_in_output_tree(Path("setup/uv.lock"))
+        # Suffix rules from course scanning do NOT apply: the dir-group copy
+        # ships e.g. ``.bin`` data files, so the manifest must record them.
+        assert not is_ignored_path_in_output_tree(Path("data/model.bin"))
 
 
 class TestOutputFilePatterns:

--- a/tests/release/test_sync.py
+++ b/tests/release/test_sync.py
@@ -192,6 +192,56 @@ def test_released_but_unbuilt_topic_is_not_frozen(tmp_path):
     assert not frozen.is_frozen("ghost")
 
 
+def test_sync_refuses_vcs_paths_from_a_polluted_manifest(tmp_path, caplog):
+    """Defense in depth (issue #302): a manifest from an older build that
+    walked a stray ``.git`` into the skeleton must never overwrite the
+    destination repo's own ``.git``."""
+    manifest = _manifest()
+    manifest["files"] += [
+        {
+            "path": ".git/index",
+            "topic_id": None,
+            "section_id": None,
+            "kind": None,
+            "format": "dir-group",
+            "language": "de",
+            "content_hash": "sha256:ddd",
+        },
+        {
+            "path": "Sec/.svn/entries",
+            "topic_id": "intro",
+            "section_id": "w01",
+            "kind": None,
+            "format": "dir-group",
+            "language": "en",
+            "content_hash": "sha256:eee",
+        },
+    ]
+    source = _materialize_source(tmp_path, manifest)
+    dest = tmp_path / "jan"
+    (dest / ".git").mkdir(parents=True)
+    (dest / ".git" / "index").write_bytes(b"REAL")
+    frozen = FrozenManifest(channel="jan")
+
+    plan = plan_sync(manifest=manifest, ledger_released=["intro"], frozen=frozen)
+    result = apply_sync(
+        plan=plan,
+        manifest=manifest,
+        source_root=source,
+        dest_root=dest,
+        frozen=frozen,
+        copied_at="t1",
+    )
+
+    # The legitimate skeleton + topic files were copied; the VCS entries were not.
+    assert (dest / INTRO_PATH).is_file()
+    assert (dest / SKELETON_PATH).is_file()
+    assert not (dest / "Sec" / ".svn").exists()
+    assert (dest / ".git" / "index").read_bytes() == b"REAL"
+    assert result.files_copied == 2
+    assert "refused to copy 1 VCS metadata file" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # Failed topics in a partial manifest (issue #295)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes both root causes of #302: a stray `.git` inside a release source-target's output (e.g. created there by `clm git init`) was walked into the provenance manifest as 1000+ topic-less skeleton entries, which `clm release sync` then copied into cohort repos — for a language-scoped channel (#293) landing at the destination repo root and clobbering its real `.git`.

## Changes

1. **Root cause — manifest walk filter.** The dir-group walk in `provenance_manifest.py` now applies the same ignore filter as the build's dir-group copy, via the new `is_ignored_path_in_output_tree()` in `path_utils.py` (mirrors the `shutil.ignore_patterns(*SKIP_DIRS_FOR_OUTPUT, *SKIP_DIRS_PATTERNS, *SKIP_OUTPUT_FILE_GLOBS)` call in `LocalOpsBackend.copy_dir_group_files`). Files the build can never have produced — VCS/IDE/cache directories, output-suppressed names like cassettes and voiceover companions — no longer enter the manifest. The check covers every relative segment **including the final name** (so a worktree-style `.git` *file* is caught too) and deliberately skips course-scan suffix rules, so `.bin` data the dir-group copy legitimately ships stays recorded.

2. **Defense in depth — sync refusal.** `release/sync.py::_copy_files` refuses any manifest path containing a `.git`/`.svn`/`.hg` segment and logs a summary warning pointing at the polluted manifest, so even a manifest from an older build can never overwrite a destination repo's VCS metadata.

## Tests

- Unit tests for `is_ignored_path_in_output_tree` (`.git` dir/file, IDE/cache dirs, suppressed names, and the kept `.bin`/`.gitignore`/`README.md` cases).
- Manifest test: a `.git` tree + cassette placed inside a dir-group output dir stay out of the manifest while a sibling legitimate file is recorded.
- Sync test: a polluted manifest with `.git/index` and `Sec/.svn/entries` entries copies only the legitimate files and leaves the destination's real `.git/index` byte-identical.
- Full fast suite green (7516 passed), ruff/mypy clean; CHANGELOG updated under Unreleased.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
