### PR TITLE
docs(info): add calendar, slide-format, and releases info topics

### DIFF
--- a/src/clm/cli/commands/info.py
+++ b/src/clm/cli/commands/info.py
@@ -39,6 +39,21 @@ TOPICS: dict[str, TopicInfo] = {
         "JupyterLite output format: opt-in gates and <jupyterlite> config",
         "jupyterlite.md",
     ),
+    "calendar": TopicInfo(
+        "calendar",
+        "Cohort calendar: project course schedule onto real teaching dates",
+        "calendar.md",
+    ),
+    "slide-format": TopicInfo(
+        "slide-format",
+        "Jupytext percent-format: cell markers, tags, slide_id, bilingual/split structure",
+        "slide-format.md",
+    ),
+    "releases": TopicInfo(
+        "releases",
+        "Per-topic solution release: channels, ledger, sync, clm git",
+        "releases.md",
+    ),
 }
 
 
@@ -70,6 +85,9 @@ def info(topic: str | None) -> None:
         clm info spec-files     # Spec file format reference
         clm info commands       # CLI command reference
         clm info migration      # Breaking changes and migration guide
+        clm info calendar       # Cohort calendar reference
+        clm info slide-format   # Slide file format reference
+        clm info releases       # Per-topic solution release reference
     """
     if topic is None:
         click.echo(f"CLM {__version__} — Available documentation topics:\n")

--- a/src/clm/cli/info_topics/calendar.md
+++ b/src/clm/cli/info_topics/calendar.md
@@ -1,0 +1,147 @@
+# CLM {version} — Cohort Calendar Reference
+
+A cohort calendar projects a course's content schedule onto the real teaching
+dates of a specific cohort. Each cohort has its own `.calendar.toml` file that
+records the start date, teaching-day pattern, holidays, and any adjustments.
+
+## Commands
+
+```
+clm export calendar <spec>   # Render the cohort schedule (md/csv/ics)
+clm calendar check  <spec>   # Validate the calendar file; non-zero on errors
+clm calendar status <spec>   # Show today's position vs plan
+```
+
+### Common flags (all three commands)
+
+| Flag | Description |
+|---|---|
+| `--channel NAME` | Cohort channel name; resolves `release/<NAME>.calendar.toml` beside the channel ledger |
+| `--calendar PATH` | Explicit path to the `.calendar.toml` file (overrides `--channel`) |
+| `--data-dir PATH` | Course data directory containing `slides/` (default: auto-detected) |
+
+Exactly one of `--channel` or `--calendar` is required.
+
+### `clm export calendar` flags
+
+| Flag | Description |
+|---|---|
+| `-f md\|csv\|ics` | Output format: Markdown table (default), CSV, or RFC 5545 iCalendar |
+| `-L de\|en` | Language for titles (default: `de`) |
+| `-o FILE` | Write output to a file |
+| `-d DIR` | Write output to a directory |
+
+### `clm calendar status` flags
+
+| Flag | Description |
+|---|---|
+| `-L de\|en` | Language for titles (default: `de`) |
+| `--as-of DATE` | Reference date in YYYY-MM-DD (default: today) |
+
+## Calendar file format
+
+Calendar files live at `release/<channel>.calendar.toml` alongside the channel
+ledger. They are hand-edited TOML; CLM never writes them.
+
+```toml
+# Required: first teaching date
+start = 2026-03-02
+
+# Optional: last allowable teaching date (enforced by check)
+end = 2026-06-30
+
+# Optional: teaching weekdays. Omit to derive from the spec's <subsection weekday> values.
+# Canonicalized to Mon-Sun order; duplicates removed.
+pattern = ["mon", "wed", "fri"]
+
+# Optional: dates excluded from the teaching sequence
+holidays = [
+    2026-04-06,                                          # single date
+    {from = 2026-07-20, to = 2026-08-02, label = "Summer break"},  # inclusive range
+]
+
+# Optional: adjustments (array of tables, applied in file order)
+[[adjustments]]
+merge = 2026-03-18   # collapse the next `count` buckets onto one date (catch-up)
+count = 2
+
+[[adjustments]]
+split = "variables_intro"   # spread one bucket across multiple dates (slow down)
+dates = [2026-03-25, 2026-03-26]
+
+[[adjustments]]
+insert = 2026-03-30  # teaching date with no new video (review, exam, guest)
+label = "Review & Q&A"
+
+[[adjustments]]
+pin = "control_flow"  # anchor: this bucket lands on exactly this date
+date  = 2026-04-09    # also segments the timeline — miscounts can't cascade past a pin
+```
+
+### Weekday tokens
+
+`mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun` (lowercase, three-letter).
+
+### Bucket references (for `pin` and `split`)
+
+A bucket reference is a **topic ID** or **deck-file stem** (e.g.
+`slides_010_introduction_ml`). These are stable identifiers that do not change
+when the spec is reordered; use them instead of week/weekday coordinates.
+Unknown or ambiguous references are reported as errors by `clm calendar check`.
+
+## Projection rules
+
+1. **Teaching dates** are generated from `start` forward on the days in
+   `pattern`, with `holidays` removed.
+2. **Buckets** are the atomic content units from `clm export schedule`; their
+   order is fixed by the spec.
+3. **Pins segment the timeline.** Each pin creates an independent fitting
+   segment; content before the pin fits independently of content after it.
+4. **Adjustments** are applied in file order: inserts add empty dates, merges
+   collapse buckets, splits spread one bucket across multiple dates.
+5. **Over-full segments** (more buckets than teaching dates) are **errors**;
+   `check` exits non-zero with the exact deficit.
+6. **Under-full segments** (free teaching dates) are **warnings**; `check`
+   exits 0.
+
+## Validation (`clm calendar check`)
+
+Errors cause a non-zero exit:
+- Unknown or ambiguous `pin`/`split` bucket reference
+- More buckets than teaching dates in a segment (reports exact deficit)
+- Content extends past `end`
+- Pin date is not a teaching date (wrong weekday or falls in a holiday)
+
+Warnings (exit 0):
+- Holiday falls on a non-teaching weekday (no-op)
+- Segment has more teaching dates than buckets (free dates)
+- Insert date is not a teaching date
+
+## ICS output
+
+Each assignment becomes an all-day VEVENT. UIDs are derived from stable
+bucket-ref seeds so re-exporting the same calendar produces the same UIDs.
+Multi-day assignments (e.g. a bucket spanning Mon–Tue) are emitted as a single
+multi-day event. The `DTSTAMP` is fixed to the start date for determinism.
+
+## Examples
+
+```bash
+# German Markdown to stdout
+clm export calendar course.xml --channel jan
+
+# English iCalendar file for student subscriptions
+clm export calendar course.xml --channel jan -f ics -L en -o jan.ics
+
+# CSV for spreadsheet import
+clm export calendar course.xml --calendar release/jan.calendar.toml -L en -f csv
+
+# Validate before pushing
+clm calendar check course.xml --channel jan
+
+# Show where the cohort is today
+clm calendar status course.xml --channel jan -L en
+
+# Check status as of a specific date
+clm calendar status course.xml --channel jan --as-of 2026-04-15
+```

--- a/src/clm/cli/info_topics/releases.md
+++ b/src/clm/cli/info_topics/releases.md
@@ -1,0 +1,237 @@
+# CLM {version} — Solution Release Reference
+
+The release system lets a trainer publish course solutions to student cohorts
+**one topic at a time**. Each cohort progresses at its own pace; once a topic
+is released to a cohort it is **frozen** — later edits to the course source
+never rewrite what students already received.
+
+## Concepts
+
+| Term | What it is |
+|---|---|
+| **Channel** | One student cohort's git repository, declared in the spec |
+| **Ledger** | Plain-text list of released topic ids for that cohort (`release/<name>.txt`) |
+| **Provenance manifest** | `.clm-manifest.json` — maps every built output file to its source topic; written by `clm build`; never distributed |
+| **Frozen manifest** | `.clm-released.json` — per-cohort freeze record inside the cohort repo; distributed to students |
+
+## Spec configuration
+
+```xml
+<release-channels source-target="solutions" name="materials">
+    <remote-path>cohorts</remote-path>
+    <share-with group="trainers" access="maintainer" />
+
+    <channel name="jan" path="./cohorts/jan" ledger="release/jan.txt">
+        <share-with group="cohort-jan" access="developer" />
+    </channel>
+
+    <channel name="may" path="./cohorts/may" ledger="release/may.txt" lang="de" />
+</release-channels>
+```
+
+| Attribute | Where | Required | Description |
+|---|---|---|---|
+| `source-target` | `<release-channels>` | yes | Name of the `<output-target>` to promote from (typically a `completed`-kind target) |
+| `name` | `<release-channels>` | when multiple blocks | Stream name; channels are addressed as `stream/channel` (e.g. `materials/jan`) |
+| `name` | `<channel>` | yes | Cohort identifier used on the CLI |
+| `path` | `<channel>` | yes | Path to the cohort's git working tree |
+| `ledger` | `<channel>` | yes | Path to the release ledger file |
+| `lang` | `<channel>` | no | Restrict promotion to one language; re-roots files at the language directory |
+| `<share-with group="…" access="…">` | block or channel | no | GitLab group sharing (applied by `clm release provision`) |
+
+The derived remote URL is:
+`{repository-base}/{remote-path}/{project-slug}-{channel}-{stream}[-{lang}]`
+
+## File formats
+
+### Ledger (`release/jan.txt`)
+
+Plain text, one topic id per line. Comments (`#`) and blank lines ignored.
+Cumulative — entries are never removed. Edit by hand or via `clm release add/week`.
+
+```
+# release/jan.txt
+introduction
+variables
+control_flow
+```
+
+### Provenance manifest (`.clm-manifest.json`)
+
+Written by `clm build` into each output target root. Maps output files to topics.
+**Private — never committed or distributed.** `clm git commit/sync` excludes it
+automatically.
+
+```json
+{
+  "version": 1,
+  "spec": "course.xml",
+  "target": "solutions",
+  "source_commit": "abc1234def",
+  "partial": false,
+  "failed_topics": [],
+  "files": [
+    {"path": "Sec_01/01 Introduction.ipynb", "topic_id": "introduction", ...},
+    {"path": "shared/data.csv", "topic_id": null, ...}
+  ]
+}
+```
+
+`topic_id: null` entries are skeleton/global files not owned by any topic.
+`failed_topics` lists topics whose build errored; they are refused by sync until
+the next successful build.
+
+### Frozen manifest (`.clm-released.json`)
+
+Written into the cohort repo by `clm release sync`. Committed and distributed.
+
+```json
+{
+  "version": 1,
+  "channel": "materials/jan",
+  "skeleton_frozen": true,
+  "frozen": {
+    "introduction": {"source_commit": "abc123", "copied_at": "2026-03-10T10:00:00Z", "topic_digest": "sha256:…"},
+    "variables":    {"source_commit": "abc123", "copied_at": "2026-03-17T10:00:00Z", "topic_digest": "sha256:…"}
+  }
+}
+```
+
+Once a `topic_id` appears in `frozen`, subsequent syncs skip it — students keep
+exactly what they were given. Only `--refreeze` overrides this.
+
+## `clm release` commands
+
+### `clm release add`
+
+Append topic ids to a channel's ledger (validates against spec).
+
+```
+clm release add SPEC TOPIC_ID... --channel NAME
+clm release add SPEC TOPIC_ID... --ledger release/jan.txt
+```
+
+### `clm release week`
+
+Release every topic in one or more course sections.
+
+```
+clm release week SPEC SELECTOR... --channel NAME
+```
+
+Selectors: bare index (`1`), `id:SECTION_ID`, `idx:N`, `name:SUBSTRING`.
+Section indices are disabled-inclusive — enabling/disabling sections does not
+renumber the sections that follow.
+
+### `clm release status`
+
+Show released vs pending topics and (with `--channel` or `--dest`) the frozen state.
+
+```
+clm release status SPEC --channel NAME
+```
+
+### `clm release sync`
+
+**Core step.** Promote released-but-not-frozen topics into the cohort repo.
+
+```
+clm release sync SPEC --channel NAME [--dry-run] [--push] [-m MESSAGE]
+clm release sync SPEC --channel NAME --refreeze TOPIC_ID... [--push]
+clm release sync SPEC --channel NAME --refreeze-all [--push]
+```
+
+Sync actions per topic:
+
+| Action | When |
+|---|---|
+| `copy` | Released, not yet frozen → copy files, freeze |
+| `skip-frozen` | Already frozen → skip |
+| `refreeze` | Frozen but in `--refreeze` set → re-copy, update freeze |
+| `skip-failed` | Build errored for this topic → refuse until next clean build |
+
+Skeleton (global files) is copied once on first sync and then frozen.
+`--push` chains `clm git commit` + `clm git push` after promotion.
+
+### `clm release provision`
+
+Share channel repos with GitLab groups (requires `CLM_GITLAB_TOKEN`).
+
+```
+clm release provision SPEC [--channel NAME] [--dry-run]
+```
+
+## `clm git` commands
+
+All `clm git` subcommands operate on output targets by default; add
+`--channel NAME` or `--all-channels` to operate on cohort repos instead.
+`.clm-manifest.json` is always excluded from staging; `.clm-released.json`
+is always included.
+
+| Command | What it does |
+|---|---|
+| `clm git init SPEC [--channel NAME]` | Initialize git repo; clone from remote if it exists |
+| `clm git status SPEC [--channel NAME]` | Branch, remote URL, ahead/behind, changed files |
+| `clm git commit SPEC -m MSG [--channel NAME]` | Stage + commit (excludes manifest) |
+| `clm git push SPEC [--channel NAME]` | Push to configured remote |
+| `clm git sync SPEC -m MSG [--channel NAME]` | Commit + push in one step |
+| `clm git reset SPEC [--channel NAME]` | Hard-reset to remote tracking branch (discards local changes) |
+
+`clm git sync --amend` implies `--force-with-lease` (required for amended commits).
+
+## Standard workflow
+
+```bash
+# 1. Add the week's topics to the ledger
+clm release week course.xml 1 --channel jan
+
+# 2. Preview what will be promoted
+clm release sync course.xml --channel jan --dry-run
+
+# 3. Promote and push to the cohort repo
+clm release sync course.xml --channel jan --push -m "Release Week 1"
+
+# 4. Check status
+clm release status course.xml --channel jan
+```
+
+### Re-releasing a corrected topic
+
+```bash
+# Fix the source and rebuild
+clm build course.xml
+
+# Re-freeze the corrected topic for jan (already received it)
+clm release sync course.xml --channel jan --refreeze functions --push \
+  -m "Fix functions solution"
+
+# Cohorts that haven't received it yet get the fix automatically on next sync
+```
+
+### Recovering when the remote is ahead
+
+```bash
+clm git reset course.xml --channel jan   # discard local changes
+clm build course.xml                      # rebuild (fast via cache)
+clm release sync course.xml --channel jan --push -m "Resync"
+```
+
+### Multiple cohorts, independent schedules
+
+```bash
+clm release add course.xml functions --channel jan
+clm release sync course.xml --channel jan --push -m "jan: release functions"
+
+clm release add course.xml introduction variables --channel may
+clm release sync course.xml --channel may --push -m "may: release week 1"
+```
+
+## Key design properties
+
+- **Cumulative ledger** — entries are never removed; minimal per-release git diff.
+- **Immutable freezing** — frozen topics are never re-propagated without `--refreeze`.
+- **Provenance-driven** — files are promoted via manifest lookup, not path inference.
+- **Idempotent syncs** — re-running sync is safe; frozen topics are skipped.
+- **Manifest exclusion** — `.clm-manifest.json` is never distributed; the frozen manifest `.clm-released.json` is.
+
+See `clm info commands` for the full flag reference.

--- a/src/clm/cli/info_topics/slide-format.md
+++ b/src/clm/cli/info_topics/slide-format.md
@@ -1,0 +1,178 @@
+# CLM {version} — Slide File Format Reference
+
+CLM slide files use the **jupytext percent-format**: plain source files
+(`.py`, `.cs`, `.cpp`, `.java`, `.ts`, …) with cell boundaries marked by a
+comment token + `%%`. The comment token is `#` for Python/Rust/Markdown and
+`//` for C++/C#/Java/TypeScript.
+
+## Cell boundary syntax
+
+```python
+# %%                       # code cell (Python)
+# %% [markdown]            # markdown cell (Python)
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+//  %%                     # code cell (C#/C++/Java/TypeScript)
+// %% [markdown]           # markdown cell
+```
+
+All metadata is **optional and order-independent** on the marker line:
+
+| Attribute | Values | Purpose |
+|---|---|---|
+| `[markdown]` | present/absent | Markdown cell (absent = code cell) |
+| `lang="de"` / `lang="en"` | `de`, `en` | Language filter; omit for shared cells |
+| `tags=["t1", "t2"]` | list of tag names | Presentation and visibility control |
+| `slide_id="slug"` | kebab-case ASCII, ≤ 30 chars | Stable cross-reference key |
+| `for_slide="slug"` | bare slug | Voiceover companion back-reference |
+
+Cells without a `lang` attribute are **shared** — included in every language build.
+
+## Jinja2 (j2) cells
+
+The file opens with a j2 import and a title macro call; these are not `# %%` cells:
+
+```python
+# j2 from 'macros.j2' import header
+# {{ header("Deutsches Thema", "English Topic") }}
+```
+
+`header()` emits two `slide`-tagged markdown cells — one DE, one EN — both
+anchored to `slide_id="title"`. In split-format files the bilingual form is
+replaced by `header_de()` (in `.de.*`) and `header_en()` (in `.en.*`).
+
+## Tag reference
+
+### Slide-structure tags
+
+| Tag | Meaning |
+|---|---|
+| `slide` | Starts a new visual slide; opens a **slide group** |
+| `subslide` | Starts a sub-slide within the current slide |
+| `notes` | Brief speaker hint; attached to preceding slide |
+| `voiceover` | Read-aloud narration script; attached to preceding slide |
+
+### Code-visibility tags
+
+| Tag | Meaning |
+|---|---|
+| `keep` | Visible in all output kinds |
+| `start` | Starter code shown in the code-along output; paired with `completed` |
+| `completed` | Full solution shown in the completed/speaker output |
+
+The `start` / `completed` pair represents the same logical code block in two
+variants. Canonical DE/EN interleaving is:
+```
+[DE start]  [EN start]  [DE completed]  [EN completed]
+```
+The cohesion layout `[DE start]  [DE completed]  [EN start]  [EN completed]`
+is also valid; `clm slides normalize --operations interleaving` converts to canonical.
+
+### Other tags
+
+| Tag | Meaning |
+|---|---|
+| `workshop` | Marks the heading cell that opens a workshop section |
+| `end-workshop` | Marks the first cell after the workshop scope |
+| `answer` | Solution text; cleared in code-along output |
+| `private` | Visible only in trainer/speaker output |
+| `del` | Removed from all outputs |
+| `nodataurl` | Prevents image inlining as data-URL |
+
+## `slide_id` convention
+
+`slide_id` is a **stable, EN-derived, kebab-case slug** that is the cross-language
+join key for sync, voiceover, and split operations.
+
+- Slide and subslide cells carry a `slide_id`; narrative cells inherit it.
+- The **preserve marker** `!` (e.g., `slide_id="!intro"`) prevents auto-regeneration.
+  The `!` is source-level only; all comparisons use the bare form (`intro`).
+- Auto-generate missing ids with `clm slides assign-ids`.
+- Duplicate bare-form ids within a file are an error.
+
+## Bilingual structure
+
+A bilingual file contains interleaved DE and EN cells:
+
+```python
+# j2 from 'macros.j2' import header
+# {{ header("Grundlagen", "Basics") }}
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="variables"
+# ## Variablen
+# Variablen speichern Werte.
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="variables"
+# ## Variables
+# Variables store values.
+
+# %% tags=["keep"]
+name = "Alice"        # shared — identical in both language builds
+
+# %% tags=["start"]
+value =               # shared starter code
+
+# %% tags=["completed"]
+value = 42            # shared completed code
+
+# %% [markdown] lang="de" tags=["voiceover"] slide_id="variables"
+# Erklären Sie Speicherverwaltung.
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="variables"
+# Explain memory management.
+```
+
+Rules:
+- Paired DE/EN slide cells must share the same bare `slide_id`.
+- Shared cells appear in the same position in both language builds.
+- The EN heading is the authority for the slug.
+
+## Split-format (`.de.*` / `.en.*`)
+
+`clm slides split` produces a **split pair** from a bilingual file.
+Each half keeps all shared cells byte-for-byte and only the cells for its language:
+
+```python
+# .de.py
+# j2 from 'macros.j2' import header_de
+# {{ header_de("Grundlagen") }}
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="variables"
+# ## Variablen
+
+# %% tags=["keep"]
+name = "Alice"        # shared — byte-identical to .en.py
+```
+
+```python
+# .en.py
+# j2 from 'macros.j2' import header_en
+# {{ header_en("Basics") }}
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="variables"
+# ## Variables
+
+# %% tags=["keep"]
+name = "Alice"        # shared — byte-identical to .de.py
+```
+
+Invariant: `unify(*split(deck))` reproduces the original bilingual file byte-for-byte.
+The `slide_id` set and order must agree between the two halves — they are the
+cross-language join key. Divergence is detected by `clm validate` (cross-file check).
+
+Voiceover companions (e.g., `voiceover_basics.de.py` / `voiceover_basics.en.py`)
+follow the same pattern; their cells use `for_slide` instead of `slide_id` to
+reference the slide they narrate.
+
+## Validation and normalization
+
+| Command | What it does |
+|---|---|
+| `clm validate <path>` | Check format, pairing, tags, slide_ids |
+| `clm validate <path> --quick` | Fast syntax-only check (pre-save hook) |
+| `clm slides normalize <path>` | Auto-fix spacing, tag migration, interleaving, slide_ids |
+| `clm slides assign-ids <path>` | Mint missing `slide_id` values |
+| `clm slides split <path>` | Convert bilingual → `.de.*` / `.en.*` pair |
+| `clm slides unify <path>` | Merge split pair → bilingual |
+| `clm slides sync <path>` | Propagate edits from one half to the other |
+
+See `clm info commands` for full flag reference.

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -141,4 +141,7 @@ class TestLoadTopicContent:
         assert "commands" in TOPICS
         assert "migration" in TOPICS
         assert "jupyterlite" in TOPICS
-        assert len(TOPICS) == 4
+        assert "calendar" in TOPICS
+        assert "slide-format" in TOPICS
+        assert "releases" in TOPICS
+        assert len(TOPICS) == 7


### PR DESCRIPTION
## Summary

- Adds `clm info calendar` — cohort calendar commands (`export calendar`, `calendar check/status`), `.calendar.toml` format (start/end/pattern/holidays/adjustments), projection rules, ICS UID stability, and examples
- Adds `clm info slide-format` — jupytext percent-format cell marker syntax, all metadata attributes (`lang`, `tags`, `slide_id`, `for_slide`), full tag reference, bilingual DE/EN structure, split-format `.de.*`/`.en.*` pairs, j2 header macro, `!` preserve marker
- Adds `clm info releases` — the four moving parts (channel/ledger/provenance-manifest/frozen-manifest), `<release-channels>` spec config, both JSON file formats, all `clm release` subcommands, all `clm git` subcommands, standard workflow sequences
- Updates `test_topics_registry_complete` to expect 7 topics

## Motivation

Downstream course-repo agents call `clm info <topic>` to understand current CLM behaviour. Three workflows (cohort calendar, slide authoring, per-topic release) had no dedicated topic, leaving agents to mine detail out of the 3 500-line `commands.md`.

## Test plan

- [x] `clm info` lists all seven topics
- [x] `clm info calendar`, `clm info slide-format`, `clm info releases` each render without error
- [x] Pre-commit hooks (ruff + mypy) pass
- [x] Full fast test suite passes (7508 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)