### PR TITLE
feat(calendar): `clm calendar push` — mirror cohort calendars into Google Calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`clm calendar push` — mirror a cohort's viewing calendar into Google
+  Calendar.** Students subscribe to one shared Google calendar and pushed
+  schedule changes propagate within minutes (no `.ics` hosting, no feed-refresh
+  lag). The push only touches CLM-managed events: each event is tagged (private
+  extended properties) with the cohort namespace and the same stable
+  per-assignment UID the `.ics` export uses, so re-pushing updates events in
+  place, deletes vanished ones, and never disturbs other events in the same
+  calendar. Credentials (`--credentials` / `CLM_GOOGLE_CREDENTIALS`) accept an
+  OAuth "Desktop app" client (one-time browser consent, cached token) or a
+  service-account key, auto-detected; the target comes from `--calendar-id` or
+  a new optional `[google] calendar_id` table in the cohort calendar TOML.
+  `--dry-run` previews the insert/update/delete plan. Requires the new `[gcal]`
+  extra (`google-api-python-client`, `google-auth`, `google-auth-oauthlib`).
+
 ## [1.11.0] - 2026-06-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ pip install -e ".[all]"           # everything (recommended for development)
 
 For the full list of optional extras (`[notebook]`, `[plantuml]`, `[drawio]`,
 `[all-workers]`, `[recordings]`, `[summarize]`, `[voiceover]`, `[slides]`,
-`[mcp]`, `[ml]`, `[dev]`, `[tui]`, `[web]`) see
+`[gcal]`, `[mcp]`, `[ml]`, `[dev]`, `[tui]`, `[web]`) see
 `docs/user-guide/installation.md`.
 
 ## Testing

--- a/docs/claude/design/cohort-viewing-calendar.md
+++ b/docs/claude/design/cohort-viewing-calendar.md
@@ -483,6 +483,12 @@ count = 2
   the bucket's decks on the first date; richer per-date deck lists can come later.
 - **Dated release policy** — the §9 coupling, if pilots want it.
 - **Validation in CI** — wiring `calendar check` into the course repo's hooks.
+- **Google Calendar push** — *shipped* as `clm calendar push`
+  (`clm.cohort_calendar.google_sync`, `[gcal]` extra): a one-way mirror into a
+  shared Google calendar, diffing against CLM-managed events tagged with the
+  cohort namespace plus the §8.1 stable UIDs (private extended properties), so
+  re-pushes update in place and foreign events are never touched. Target id
+  from `--calendar-id` or the `[google]` table in the calendar TOML.
 
 **Decided:** `check` and `export calendar` are pure functions of the config and
 take no date. `status` is the only "now"-relative command — it defaults to the

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -276,6 +276,25 @@ These help diagnose builds that hang on a single notebook (see issue #143).
 |----------|-------------|---------|
 | `CLM_DATA_DIR` | Default data directory for the MCP server (contains `slides/`, `course-specs/`). Used by `clm mcp` and the `clm.slides` CLI tools when no `--data-dir` is given. | (cwd) |
 
+### Google Calendar Push (`clm calendar push`)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CLM_GOOGLE_CREDENTIALS` | Path to the Google credentials JSON used by `clm calendar push` (same as `--credentials`). Either an OAuth "Desktop app" client — a browser consent flow runs once, then the token is cached in the user config dir (`google-calendar-token.json`) — or a service-account key for a service account the target calendar is shared with ("Make changes to events"). | (unset) |
+
+The target calendar id can be stored per cohort in the calendar TOML instead of
+passing `--calendar-id` on every push:
+
+```toml
+# release/<channel>.calendar.toml
+[google]
+calendar_id = "abc123…@group.calendar.google.com"
+```
+
+One-time Google-side setup: create a Google Cloud project, enable the
+**Google Calendar API**, and create either an OAuth client (type "Desktop app")
+or a service account; download the JSON. Requires the `[gcal]` extra.
+
 ### Recording Management (`clm recordings`)
 
 The recordings module has its own `[recordings]` config section with a nested

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -155,6 +155,11 @@ CLM has several optional dependency groups for different features:
   - MCP server for AI-assisted slide authoring
   - Install: `pip install -e ".[mcp]"`
 
+**Cohort Calendars**:
+- **[gcal]**: google-api-python-client, google-auth, google-auth-oauthlib
+  - Required for: `clm calendar push` (mirror a cohort's viewing calendar into Google Calendar)
+  - Install: `pip install -e ".[gcal]"`
+
 **Output Bundling**:
 - **[jupyterlite]**: jupyterlite-core, jupyterlite-pyodide-kernel, jupyterlite-xeus, jupyter-server
   - Required for: the `jupyterlite` output format (browser-based notebook site bundler)
@@ -172,7 +177,7 @@ CLM has several optional dependency groups for different features:
   - Install: `pip install -e ".[dev]"`
 
 **Everything**:
-- **[all]**: All of the above (all-workers, ml, summarize, voiceover, recordings, slides, mcp, jupyterlite, replay, dev, tui, web)
+- **[all]**: All of the above (all-workers, ml, summarize, voiceover, recordings, slides, gcal, mcp, jupyterlite, replay, dev, tui, web)
   - Required for: Full development and testing
   - Install: `pip install -e ".[all]"`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,12 @@ jupyterlite = [
 slides = [
     "rapidfuzz>=3.0.0",
 ]
+# Google Calendar push for cohort viewing calendars (`clm calendar push`)
+gcal = [
+    "google-api-python-client>=2.100.0",
+    "google-auth>=2.23.0",
+    "google-auth-oauthlib>=1.2.0",
+]
 # HTTP request/response replay for notebooks that call live services
 # (e.g. ``requests``, ``httpx``). Enables offline, deterministic HTML
 # builds when a topic opts in via ``http-replay="yes"`` in the spec.
@@ -255,7 +261,7 @@ web = [
 ]
 # Everything
 all = [
-    "coding-academy-lecture-manager[all-workers,ml,summarize,voiceover,recordings,slides,mcp,jupyterlite,replay,dev,tui,web]",
+    "coding-academy-lecture-manager[all-workers,ml,summarize,voiceover,recordings,slides,gcal,mcp,jupyterlite,replay,dev,tui,web]",
 ]
 
 [project.urls]
@@ -378,6 +384,13 @@ module = [
     "vcr.*",
     "filelock",
     "filelock.*",
+    # The [gcal] extra's packages ship without (complete) type stubs; they are
+    # also only imported lazily inside functions.
+    "googleapiclient",
+    "googleapiclient.*",
+    "google.*",
+    "google_auth_oauthlib",
+    "google_auth_oauthlib.*",
     # mitmproxy runs out-of-process (uv tool install); the addon module is
     # loaded by mitmdump's own interpreter, not clm's venv, so the package is
     # intentionally absent from clm's environment.

--- a/src/clm/cli/commands/calendar.py
+++ b/src/clm/cli/commands/calendar.py
@@ -228,7 +228,7 @@ def calendar(
 
 @click.group("calendar")
 def calendar_group() -> None:
-    """Inspect a cohort's viewing calendar: validate it or show today's status (#283)."""
+    """A cohort's viewing calendar: validate, show today's status, or push to Google (#283)."""
 
 
 @calendar_group.command("check")
@@ -256,6 +256,104 @@ def check_cmd(
         click.echo(f"✗ {n_err} error(s), {n_warn} warning(s).", err=True)
         raise SystemExit(1)
     click.echo(f"✓ Calendar OK ({n_warn} warning(s)).")
+
+
+def _plan_totals(plan, *, prefix: str) -> str:
+    return (
+        f"{prefix}{len(plan.inserts)} insert(s), {len(plan.updates)} update(s), "
+        f"{len(plan.deletes)} delete(s); {plan.unchanged} unchanged."
+    )
+
+
+@calendar_group.command("push")
+@spec_argument
+@language_option(default="de", aliases=("--lang",), help="Language for event titles.")
+@_channel_options
+@click.option(
+    "--calendar-id",
+    default="",
+    help="Google calendar id (overrides [google] calendar_id in the calendar TOML).",
+)
+@click.option(
+    "--credentials",
+    "credentials_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    envvar="CLM_GOOGLE_CREDENTIALS",
+    show_envvar=True,
+    default=None,
+    help="Google credentials JSON: an OAuth 'Desktop app' client or a service-account key.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show the insert/update/delete plan without changing the calendar.",
+)
+def push_cmd(
+    spec_file: Path,
+    language: str,
+    channel: str,
+    calendar_path: Path | None,
+    data_dir: Path | None,
+    calendar_id: str,
+    credentials_path: Path | None,
+    dry_run: bool,
+) -> None:
+    """Mirror a cohort's viewing calendar into a Google calendar.
+
+    Only events tagged as CLM-managed for this cohort are created, updated, or
+    deleted — other events in the same calendar are never touched. Event
+    identity matches the .ics export's stable UIDs, so re-pushing after a
+    schedule change updates events in place instead of duplicating them.
+
+    Requires the [gcal] extra and a Google credentials JSON (--credentials or
+    CLM_GOOGLE_CREDENTIALS): either an OAuth "Desktop app" client (a browser
+    consent flow runs once, then the token is cached) or a service account the
+    target calendar is shared with ("Make changes to events").
+    """
+    from clm.cohort_calendar import google_sync
+
+    language = language.lower()
+    config = _load_config(spec_file, channel, calendar_path)
+    _, buckets = _resolve_buckets(spec_file, language, data_dir)
+    proj = project(buckets, config)
+    for diag in proj.diagnostics:
+        click.echo(f"{diag.level}: {diag.message}", err=True)
+    if not proj.ok:
+        raise click.ClickException(
+            "Calendar has errors (see above); fix the calendar file "
+            "(or run `clm calendar check`) before pushing."
+        )
+
+    target = calendar_id or config.google_calendar_id
+    if not target:
+        raise click.ClickException(
+            "No Google calendar id: pass --calendar-id or set\n"
+            '  [google]\n  calendar_id = "..."\nin the cohort calendar file.'
+        )
+    if credentials_path is None:
+        raise click.ClickException(
+            "No Google credentials: pass --credentials PATH or set CLM_GOOGLE_CREDENTIALS."
+        )
+
+    namespace = channel or resolve_calendar_path(spec_file, channel, calendar_path).stem.replace(
+        ".calendar", ""
+    )
+    desired = google_sync.build_desired_events(proj, namespace=namespace)
+
+    try:
+        creds = google_sync.load_credentials(credentials_path)
+        service = google_sync.build_service(creds)
+        existing = google_sync.fetch_managed_events(service, target, namespace)
+        plan = google_sync.plan_sync(desired, existing)
+        if dry_run:
+            for line in google_sync.describe_plan(plan):
+                click.echo(line)
+            click.echo(_plan_totals(plan, prefix="Dry run — would apply: "))
+            return
+        google_sync.apply_plan(service, target, plan)
+    except google_sync.GoogleSyncError as e:
+        raise click.ClickException(str(e)) from None
+    click.echo(_plan_totals(plan, prefix="Pushed: "))
 
 
 def _format_status(report, language: str) -> list[str]:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -598,8 +598,8 @@ deficit and you resolve it with an explicit `merge`.
 
 ### `clm calendar`
 
-*New in {version}.* Inspect a cohort's viewing calendar (see
-`clm export calendar` for the file format).
+Work with a cohort's viewing calendar: validate it, show today's status, or
+push it to Google Calendar (see `clm export calendar` for the file format).
 
 #### `clm calendar check`
 
@@ -625,10 +625,48 @@ plan coordinate (e.g. `W4 Tuesday`), the **drift** in days versus the ideal
 clm calendar status [OPTIONS] SPEC_FILE     # --channel/--calendar/-L/--as-of/--data-dir
 ```
 
+#### `clm calendar push`
+
+*New in {version}.* **Mirror the cohort's calendar into a Google calendar.**
+Students subscribe to that one shared calendar; unlike a subscribed `.ics`
+URL, pushed changes propagate within minutes. Requires the `[gcal]` extra
+(`pip install "coding-academy-lecture-manager[gcal]"`).
+
+```
+clm calendar push [OPTIONS] SPEC_FILE
+```
+
+| Option | Meaning |
+|---|---|
+| `--channel NAME` / `--calendar PATH` | Locate the cohort calendar TOML (as in `clm export calendar`). |
+| `--calendar-id ID` | Target Google calendar id. Default: `calendar_id` from the TOML's `[google]` table. |
+| `--credentials PATH` | Google credentials JSON (env: `CLM_GOOGLE_CREDENTIALS`). Either an OAuth "Desktop app" client — a browser consent flow runs once, then the token is cached — or a service-account key for a service account the calendar is shared with ("Make changes to events"). |
+| `-L, --language` | Language for event titles (default `de`). |
+| `--dry-run` | Print the insert/update/delete plan; change nothing. |
+| `--data-dir DIR` | Course data directory (as elsewhere). |
+
+The push only ever touches **CLM-managed events**: every event it creates is
+tagged (via private extended properties) with the cohort namespace and the
+same stable per-assignment UID the `.ics` export uses. Re-pushing after a
+schedule change therefore updates events in place, deletes events whose
+assignment disappeared, and never touches other events in the same calendar.
+Events are all-day and marked free (transparent).
+
+The optional `[google]` table in the cohort calendar TOML holds the target:
+
+```toml
+[google]
+calendar_id = "abc123…@group.calendar.google.com"
+```
+
+A projection error (see `clm calendar check`) blocks the push.
+
 ```bash
 clm calendar check  course.xml --channel jan
 clm calendar status course.xml --channel jan -L en
 clm calendar status course.xml --channel jan --as-of 2026-05-06
+clm calendar push   course.xml --channel jan --dry-run
+clm calendar push   course.xml --channel jan --credentials oauth-client.json
 ```
 
 ### `clm topic resolve`

--- a/src/clm/cohort_calendar/config.py
+++ b/src/clm/cohort_calendar/config.py
@@ -90,6 +90,8 @@ class CohortCalendarConfig:
     ``pattern`` may be empty, meaning "derive from the weekdays the spec
     actually uses" — resolve it with :func:`effective_pattern`. ``adjustments``
     preserve file order (the order in which they apply).
+    ``google_calendar_id`` is the optional ``[google] calendar_id`` push target
+    for ``clm calendar push``.
     """
 
     start: dt.date
@@ -97,6 +99,7 @@ class CohortCalendarConfig:
     pattern: tuple[str, ...]
     holidays: tuple[Holiday, ...]
     adjustments: tuple[Adjustment, ...]
+    google_calendar_id: str | None = None
 
 
 # --- internal value coercion -------------------------------------------------
@@ -229,7 +232,20 @@ def _parse_adjustment(table: Any, index: int) -> Adjustment:
 
 # --- public API --------------------------------------------------------------
 
-_TOP_LEVEL_KEYS = {"start", "end", "pattern", "holidays", "adjustments"}
+_TOP_LEVEL_KEYS = {"start", "end", "pattern", "holidays", "adjustments", "google"}
+
+
+def _parse_google(raw: Any) -> str | None:
+    """Parse the optional ``[google]`` table; returns the calendar id (or None)."""
+    if not isinstance(raw, dict):
+        raise CohortCalendarError(f"google: expected a table, got {raw!r}.")
+    _reject_unknown_keys(raw, {"calendar_id"}, "google")
+    if "calendar_id" not in raw:
+        return None
+    calendar_id = _as_str(raw["calendar_id"], "google.calendar_id").strip()
+    if not calendar_id:
+        raise CohortCalendarError("google.calendar_id: must be a non-empty string.")
+    return calendar_id
 
 
 def parse_calendar_config(text: str) -> CohortCalendarConfig:
@@ -270,12 +286,15 @@ def parse_calendar_config(text: str) -> CohortCalendarConfig:
         )
     adjustments = tuple(_parse_adjustment(a, i) for i, a in enumerate(adjustments_raw))
 
+    google_calendar_id = _parse_google(data["google"]) if "google" in data else None
+
     return CohortCalendarConfig(
         start=start,
         end=end,
         pattern=pattern,
         holidays=holidays,
         adjustments=adjustments,
+        google_calendar_id=google_calendar_id,
     )
 
 

--- a/src/clm/cohort_calendar/google_sync.py
+++ b/src/clm/cohort_calendar/google_sync.py
@@ -1,0 +1,270 @@
+"""Push a projected cohort calendar to Google Calendar (``clm calendar push``).
+
+The push is a one-way mirror of a :class:`~clm.cohort_calendar.projection.Projection`
+into a set of **CLM-managed** events. Every event we create carries two private
+extended properties:
+
+* ``clm_managed=<namespace>`` — the cohort (channel) this event belongs to, and
+  the filter used when listing existing events;
+* ``clm_uid=<uid>`` — the same stable per-assignment UID the ``.ics`` export
+  uses (:func:`clm.cohort_calendar.render.assignment_uid`), so re-pushing after
+  a schedule change updates events in place instead of duplicating them.
+
+Sync semantics: desired events are diffed against the managed events already in
+the calendar — new UIDs are inserted, changed ones updated, vanished ones
+deleted. Events *without* the ``clm_managed`` tag (the trainer's own entries in
+the same calendar) are never listed, modified, or deleted.
+
+Two credential types are accepted, auto-detected from the JSON file:
+
+* an OAuth "Desktop app" client (``installed``/``web`` key) — a browser consent
+  flow runs once, then the token is cached under the user config dir;
+* a service-account key (``"type": "service_account"``) — no browser; share the
+  target calendar with the service account's email ("make changes") instead.
+
+All Google-API imports happen inside functions, so this module — and its pure
+planning half — imports and tests without the ``[gcal]`` extra installed.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import platformdirs
+from attrs import frozen
+
+from clm.cohort_calendar.projection import Projection
+from clm.cohort_calendar.render import assignment_content, assignment_uid
+
+logger = logging.getLogger(__name__)
+
+#: Private extended-property keys stamped on every event CLM manages.
+MANAGED_KEY = "clm_managed"
+UID_KEY = "clm_uid"
+
+#: Events-only scope — pushing needs event CRUD, never calendar-list management.
+SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+_INSTALL_HINT = (
+    "Google Calendar push requires the [gcal] extra: "
+    'pip install "coding-academy-lecture-manager[gcal]"'
+)
+
+
+class GoogleSyncError(Exception):
+    """A dependency, credential, or API failure during a Google Calendar push."""
+
+
+# --- pure planning half (no Google imports) -----------------------------------
+
+
+@frozen
+class SyncPlan:
+    """The diff between the desired events and the managed events in the calendar."""
+
+    inserts: tuple[dict[str, Any], ...]
+    updates: tuple[tuple[str, dict[str, Any]], ...]  # (event_id, desired body)
+    deletes: tuple[tuple[str, str], ...]  # (event_id, display label)
+    unchanged: int
+
+    @property
+    def is_noop(self) -> bool:
+        return not (self.inserts or self.updates or self.deletes)
+
+
+def build_desired_events(projection: Projection, *, namespace: str) -> dict[str, dict[str, Any]]:
+    """Map each assignment to a Google event body, keyed by its stable UID.
+
+    Events are all-day (``start.date`` / exclusive ``end.date``, mirroring the
+    ``.ics`` DTEND convention) and marked ``transparent`` so they never block
+    students' free/busy time.
+    """
+    desired: dict[str, dict[str, Any]] = {}
+    for a in projection.assignments:
+        uid = assignment_uid(a, namespace)
+        if uid in desired:
+            logger.warning("duplicate event UID %s; keeping the later assignment.", uid)
+        body: dict[str, Any] = {
+            "summary": assignment_content(a) or (a.label or ""),
+            "start": {"date": a.start_date.isoformat()},
+            "end": {"date": (a.end_date + dt.timedelta(days=1)).isoformat()},
+            "transparency": "transparent",
+            "extendedProperties": {"private": {MANAGED_KEY: namespace, UID_KEY: uid}},
+        }
+        if a.kind != "insert" and a.decks:
+            body["description"] = "Topics: " + ", ".join(d.topic_id for d in a.decks)
+        desired[uid] = body
+    return desired
+
+
+def _event_uid(event: dict[str, Any]) -> str | None:
+    uid = event.get("extendedProperties", {}).get("private", {}).get(UID_KEY)
+    return uid if isinstance(uid, str) else None
+
+
+def _display(event: dict[str, Any]) -> str:
+    date = (event.get("start") or {}).get("date", "")
+    return f"{date}  {event.get('summary', '')}".strip()
+
+
+def _needs_update(existing: dict[str, Any], desired: dict[str, Any]) -> bool:
+    for field in ("start", "end"):
+        if (existing.get(field) or {}).get("date") != desired[field]["date"]:
+            return True
+    for field in ("summary", "description"):
+        if (existing.get(field) or "") != (desired.get(field) or ""):
+            return True
+    return False
+
+
+def plan_sync(desired: dict[str, dict[str, Any]], existing: list[dict[str, Any]]) -> SyncPlan:
+    """Diff *desired* event bodies against the *existing* managed events.
+
+    Managed events whose UID is missing, duplicated, or no longer desired are
+    deleted; the rest are matched by UID and updated only when a compared field
+    (summary, description, dates) differs.
+    """
+    by_uid: dict[str, dict[str, Any]] = {}
+    deletes: list[tuple[str, str]] = []
+    for event in existing:
+        uid = _event_uid(event)
+        if uid and uid in desired and uid not in by_uid:
+            by_uid[uid] = event
+        else:
+            deletes.append((event["id"], _display(event)))
+
+    inserts: list[dict[str, Any]] = []
+    updates: list[tuple[str, dict[str, Any]]] = []
+    unchanged = 0
+    for uid, body in desired.items():
+        matched = by_uid.get(uid)
+        if matched is None:
+            inserts.append(body)
+        elif _needs_update(matched, body):
+            updates.append((matched["id"], body))
+        else:
+            unchanged += 1
+    return SyncPlan(tuple(inserts), tuple(updates), tuple(deletes), unchanged)
+
+
+def describe_plan(plan: SyncPlan) -> list[str]:
+    """Human-readable plan lines: ``+`` insert, ``~`` update, ``-`` delete."""
+    lines = [f"+ {_display(body)}" for body in plan.inserts]
+    lines += [f"~ {_display(body)}" for _id, body in plan.updates]
+    lines += [f"- {label}" for _id, label in plan.deletes]
+    return lines
+
+
+# --- Google API half (lazy imports) --------------------------------------------
+
+
+def _import_gcal(module: str) -> Any:
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise GoogleSyncError(f"{_INSTALL_HINT} (missing {module}).") from exc
+
+
+def default_token_cache() -> Path:
+    """Where the OAuth user token is cached between runs."""
+    return Path(platformdirs.user_config_dir("clm", appauthor=False)) / "google-calendar-token.json"
+
+
+def load_credentials(credentials_path: Path, *, token_cache: Path | None = None) -> Any:
+    """Load Google credentials, auto-detecting the JSON's credential type."""
+    try:
+        data = json.loads(credentials_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GoogleSyncError(f"cannot read credentials {credentials_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GoogleSyncError(f"{credentials_path} does not contain a credentials JSON object.")
+    if data.get("type") == "service_account":
+        service_account = _import_gcal("google.oauth2.service_account")
+        return service_account.Credentials.from_service_account_file(
+            str(credentials_path), scopes=SCOPES
+        )
+    if "installed" in data or "web" in data:
+        return _oauth_user_credentials(credentials_path, token_cache or default_token_cache())
+    raise GoogleSyncError(
+        f"{credentials_path} is neither a service-account key "
+        '("type": "service_account") nor an OAuth client ("installed"/"web").'
+    )
+
+
+def _oauth_user_credentials(client_secrets: Path, token_cache: Path) -> Any:
+    """Cached-token OAuth flow: refresh if possible, else run the browser consent."""
+    oauth2_credentials = _import_gcal("google.oauth2.credentials")
+    flow_module = _import_gcal("google_auth_oauthlib.flow")
+    transport = _import_gcal("google.auth.transport.requests")
+
+    creds = None
+    if token_cache.exists():
+        try:
+            creds = oauth2_credentials.Credentials.from_authorized_user_file(
+                str(token_cache), SCOPES
+            )
+        except ValueError:
+            creds = None  # corrupt/stale cache — fall through to the consent flow
+    if creds is not None and creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(transport.Request())
+        except Exception as exc:
+            logger.info("token refresh failed (%s); re-running the consent flow.", exc)
+            creds = None
+    if creds is None or not creds.valid:
+        flow = flow_module.InstalledAppFlow.from_client_secrets_file(str(client_secrets), SCOPES)
+        logger.info("Opening a browser for Google OAuth consent ...")
+        creds = flow.run_local_server(port=0)
+        token_cache.parent.mkdir(parents=True, exist_ok=True)
+        token_cache.write_text(creds.to_json(), encoding="utf-8")
+        logger.info("OAuth token cached at %s", token_cache)
+    return creds
+
+
+def build_service(credentials: Any) -> Any:
+    """A Google Calendar v3 service client."""
+    discovery = _import_gcal("googleapiclient.discovery")
+    return discovery.build("calendar", "v3", credentials=credentials, cache_discovery=False)
+
+
+def _execute(request: Any) -> Any:
+    try:
+        return request.execute()
+    except GoogleSyncError:
+        raise
+    except Exception as exc:
+        raise GoogleSyncError(f"Google Calendar API request failed: {exc}") from exc
+
+
+def fetch_managed_events(service: Any, calendar_id: str, namespace: str) -> list[dict[str, Any]]:
+    """All non-cancelled events in *calendar_id* that CLM manages for *namespace*."""
+    events: list[dict[str, Any]] = []
+    page_token: str | None = None
+    while True:
+        response = _execute(
+            service.events().list(
+                calendarId=calendar_id,
+                privateExtendedProperty=f"{MANAGED_KEY}={namespace}",
+                maxResults=2500,
+                pageToken=page_token,
+            )
+        )
+        events.extend(response.get("items", []))
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            return events
+
+
+def apply_plan(service: Any, calendar_id: str, plan: SyncPlan) -> None:
+    """Execute a :class:`SyncPlan` against the calendar (inserts, updates, deletes)."""
+    for body in plan.inserts:
+        _execute(service.events().insert(calendarId=calendar_id, body=body))
+    for event_id, body in plan.updates:
+        _execute(service.events().update(calendarId=calendar_id, eventId=event_id, body=body))
+    for event_id, _label in plan.deletes:
+        _execute(service.events().delete(calendarId=calendar_id, eventId=event_id))

--- a/src/clm/cohort_calendar/render.py
+++ b/src/clm/cohort_calendar/render.py
@@ -111,12 +111,14 @@ def _ics_escape(text: str) -> str:
     return text.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n")
 
 
-def _ics_uid(a: Assignment, namespace: str) -> str:
+def assignment_uid(a: Assignment, namespace: str) -> str:
     """A stable UID per assignment so re-exports update rather than duplicate.
 
     Seeded by the assignment's bucket refs (deck-file stems) for video/merged
     rows, or the date for an insert — both stable across re-projection of the
-    same content, even as dates shift.
+    same content, even as dates shift. Shared with the Google Calendar push
+    (:mod:`clm.cohort_calendar.google_sync`) so the ``.ics`` feed and a pushed
+    calendar agree on event identity.
     """
     if a.kind == "insert":
         key = f"insert-{a.start_date.isoformat()}"
@@ -146,7 +148,7 @@ def render_ics(course_title: str, projection: Projection, *, namespace: str) -> 
         stamp = a.start_date.strftime("%Y%m%dT000000Z")
         lines += [
             "BEGIN:VEVENT",
-            f"UID:{_ics_uid(a, namespace)}",
+            f"UID:{assignment_uid(a, namespace)}",
             f"DTSTAMP:{stamp}",
             f"DTSTART;VALUE=DATE:{a.start_date.strftime('%Y%m%d')}",
             f"DTEND;VALUE=DATE:{dtend.strftime('%Y%m%d')}",

--- a/tests/cli/test_calendar.py
+++ b/tests/cli/test_calendar.py
@@ -181,3 +181,185 @@ class TestCalendarGroup:
         assert grp.exit_code == 0
         assert "check" in grp.output
         assert "status" in grp.output
+
+
+class TestCalendarPush:
+    """``clm calendar push`` — Google API boundary mocked at the google_sync seam."""
+
+    CAL_WITH_ID = CAL_OK + '\n[google]\ncalendar_id = "cal-id"\n'
+
+    @staticmethod
+    def _creds(tmp_path) -> Path:
+        # Content is irrelevant: load_credentials is monkeypatched in tests
+        # that get past the option checks; click only verifies existence.
+        p = tmp_path / "creds.json"
+        p.write_text("{}", encoding="utf-8")
+        return p
+
+    @staticmethod
+    def _patch_api(monkeypatch, existing=None):
+        from clm.cohort_calendar import google_sync
+
+        monkeypatch.setattr(google_sync, "load_credentials", lambda path, **kw: object())
+        monkeypatch.setattr(google_sync, "build_service", lambda creds: object())
+        monkeypatch.setattr(
+            google_sync, "fetch_managed_events", lambda service, cal_id, ns: existing or []
+        )
+
+    def test_requires_calendar_id(self, tmp_path):
+        cal = _write(tmp_path, CAL_OK)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "calendar",
+                "push",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "--credentials",
+                str(self._creds(tmp_path)),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--calendar-id" in result.output
+
+    def test_requires_credentials(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLM_GOOGLE_CREDENTIALS", raising=False)
+        cal = _write(tmp_path, self.CAL_WITH_ID)
+        result = CliRunner().invoke(
+            cli, ["calendar", "push", str(SPEC_PATH), "--calendar", str(cal)]
+        )
+        assert result.exit_code != 0
+        assert "CLM_GOOGLE_CREDENTIALS" in result.output
+
+    def test_dry_run_prints_plan_and_changes_nothing(self, tmp_path, monkeypatch):
+        self._patch_api(monkeypatch)
+        from clm.cohort_calendar import google_sync
+
+        def _no_apply(*args, **kwargs):
+            raise AssertionError("apply_plan must not run under --dry-run")
+
+        monkeypatch.setattr(google_sync, "apply_plan", _no_apply)
+        cal = _write(tmp_path, self.CAL_WITH_ID)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "calendar",
+                "push",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "-L",
+                "en",
+                "--credentials",
+                str(self._creds(tmp_path)),
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "+ 2026-03-02" in result.output
+        assert "Some Topic from Test 1" in result.output
+        assert "Dry run" in result.output
+
+    def test_push_applies_plan(self, tmp_path, monkeypatch):
+        self._patch_api(monkeypatch)
+        from clm.cohort_calendar import google_sync
+
+        applied = {}
+        monkeypatch.setattr(
+            google_sync,
+            "apply_plan",
+            lambda service, cal_id, plan: applied.update(calendar_id=cal_id, plan=plan),
+        )
+        cal = _write(tmp_path, self.CAL_WITH_ID)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "calendar",
+                "push",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "-L",
+                "en",
+                "--credentials",
+                str(self._creds(tmp_path)),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert applied["calendar_id"] == "cal-id"
+        assert len(applied["plan"].inserts) == 3
+        assert "Pushed: 3 insert(s)" in result.output
+
+    def test_cli_calendar_id_overrides_toml(self, tmp_path, monkeypatch):
+        self._patch_api(monkeypatch)
+        from clm.cohort_calendar import google_sync
+
+        applied = {}
+        monkeypatch.setattr(
+            google_sync,
+            "apply_plan",
+            lambda service, cal_id, plan: applied.update(calendar_id=cal_id),
+        )
+        cal = _write(tmp_path, self.CAL_WITH_ID)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "calendar",
+                "push",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "--calendar-id",
+                "other-cal",
+                "--credentials",
+                str(self._creds(tmp_path)),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert applied["calendar_id"] == "other-cal"
+
+    def test_google_error_becomes_clean_cli_error(self, tmp_path, monkeypatch):
+        from clm.cohort_calendar import google_sync
+
+        def _boom(path, **kwargs):
+            raise google_sync.GoogleSyncError("Google Calendar push requires the [gcal] extra")
+
+        monkeypatch.setattr(google_sync, "load_credentials", _boom)
+        cal = _write(tmp_path, self.CAL_WITH_ID)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "calendar",
+                "push",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "--credentials",
+                str(self._creds(tmp_path)),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "[gcal]" in result.output
+
+    def test_projection_errors_block_push(self, tmp_path):
+        cal = _write(tmp_path, CAL_TOO_SHORT + '[google]\ncalendar_id = "cal-id"\n')
+        result = CliRunner().invoke(
+            cli,
+            [
+                "calendar",
+                "push",
+                str(SPEC_PATH),
+                "--calendar",
+                str(cal),
+                "--credentials",
+                str(self._creds(tmp_path)),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "errors" in result.output
+
+    def test_push_registered_in_group_help(self):
+        result = CliRunner().invoke(cli, ["calendar", "--help"])
+        assert result.exit_code == 0
+        assert "push" in result.output

--- a/tests/cohort_calendar/test_config.py
+++ b/tests/cohort_calendar/test_config.py
@@ -216,3 +216,31 @@ class TestLoadFromFile:
     def test_missing_file_errors(self, tmp_path):
         with pytest.raises(CohortCalendarError, match="not found"):
             load_calendar_config(tmp_path / "nope.calendar.toml")
+
+
+class TestGoogleTable:
+    def test_absent_means_none(self):
+        cfg = parse_calendar_config("start = 2026-03-02")
+        assert cfg.google_calendar_id is None
+
+    def test_calendar_id_parsed(self):
+        cfg = parse_calendar_config(
+            'start = 2026-03-02\n[google]\ncalendar_id = "abc123@group.calendar.google.com"\n'
+        )
+        assert cfg.google_calendar_id == "abc123@group.calendar.google.com"
+
+    def test_empty_table_means_none(self):
+        cfg = parse_calendar_config("start = 2026-03-02\n[google]\n")
+        assert cfg.google_calendar_id is None
+
+    def test_empty_calendar_id_rejected(self):
+        with pytest.raises(CohortCalendarError, match="non-empty"):
+            parse_calendar_config('start = 2026-03-02\n[google]\ncalendar_id = "  "\n')
+
+    def test_unknown_key_rejected(self):
+        with pytest.raises(CohortCalendarError, match="google: unknown key"):
+            parse_calendar_config('start = 2026-03-02\n[google]\ncalender_id = "typo"\n')
+
+    def test_non_string_calendar_id_rejected(self):
+        with pytest.raises(CohortCalendarError, match="expected a string"):
+            parse_calendar_config("start = 2026-03-02\n[google]\ncalendar_id = 42\n")

--- a/tests/cohort_calendar/test_google_sync.py
+++ b/tests/cohort_calendar/test_google_sync.py
@@ -1,0 +1,280 @@
+"""Tests for the Google Calendar push: planning, formatting, apply (``calendar push``).
+
+Everything here runs without the ``[gcal]`` extra — the planning half is pure,
+and the apply half takes an injected (fake) service object.
+"""
+
+import datetime as dt
+
+import pytest
+
+from clm.cli.commands.schedule import ScheduleDeck
+from clm.cohort_calendar import google_sync as gs
+from clm.cohort_calendar.projection import Assignment, Projection
+
+
+def deck(title, topic, file):
+    return ScheduleDeck(video_title=title, topic_id=topic, deck_file=file)
+
+
+def sample() -> Projection:
+    return Projection(
+        assignments=(
+            Assignment(
+                dt.date(2026, 3, 2),
+                dt.date(2026, 3, 2),
+                (deck("Intro", "intro", "slides_010_intro"),),
+                None,
+                "video",
+                ("slides_010_intro",),
+            ),
+            Assignment(
+                dt.date(2026, 3, 3),
+                dt.date(2026, 3, 3),
+                (),
+                "Review & Q&A",
+                "insert",
+                ("insert:2026-03-03",),
+            ),
+            Assignment(
+                dt.date(2026, 3, 4),
+                dt.date(2026, 3, 5),
+                (deck("Spanned", "span", "slides_020_span"),),
+                None,
+                "video",
+                ("slides_020_span",),
+            ),
+        ),
+        diagnostics=(),
+    )
+
+
+UID_INTRO = "jan-slides_010_intro@clm.cohort-calendar"
+UID_INSERT = "jan-insert-2026-03-03@clm.cohort-calendar"
+UID_SPAN = "jan-slides_020_span@clm.cohort-calendar"
+
+
+def existing_event(
+    uid,
+    *,
+    eid="ev1",
+    summary="Intro",
+    start="2026-03-02",
+    end="2026-03-03",
+    description="Topics: intro",
+):
+    event = {
+        "id": eid,
+        "summary": summary,
+        "start": {"date": start},
+        "end": {"date": end},
+        "extendedProperties": {"private": {gs.MANAGED_KEY: "jan", gs.UID_KEY: uid}},
+    }
+    if description is not None:
+        event["description"] = description
+    return event
+
+
+class TestBuildDesiredEvents:
+    def test_uids_match_the_ics_export(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        assert set(desired) == {UID_INTRO, UID_INSERT, UID_SPAN}
+
+    def test_video_event_body(self):
+        body = gs.build_desired_events(sample(), namespace="jan")[UID_INTRO]
+        assert body["summary"] == "Intro"
+        assert body["start"] == {"date": "2026-03-02"}
+        assert body["end"] == {"date": "2026-03-03"}  # exclusive end, like DTEND
+        assert body["description"] == "Topics: intro"
+        assert body["transparency"] == "transparent"
+        private = body["extendedProperties"]["private"]
+        assert private == {gs.MANAGED_KEY: "jan", gs.UID_KEY: UID_INTRO}
+
+    def test_insert_uses_label_and_has_no_description(self):
+        body = gs.build_desired_events(sample(), namespace="jan")[UID_INSERT]
+        assert body["summary"] == "Review & Q&A"
+        assert "description" not in body
+
+    def test_span_covers_all_dates(self):
+        body = gs.build_desired_events(sample(), namespace="jan")[UID_SPAN]
+        assert body["start"] == {"date": "2026-03-04"}
+        assert body["end"] == {"date": "2026-03-06"}  # 5 Mar inclusive -> 6 Mar exclusive
+
+
+class TestPlanSync:
+    def test_everything_new_inserts_all(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        plan = gs.plan_sync(desired, [])
+        assert len(plan.inserts) == 3
+        assert not plan.updates and not plan.deletes and plan.unchanged == 0
+
+    def test_identical_event_is_unchanged(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        plan = gs.plan_sync(desired, [existing_event(UID_INTRO)])
+        assert len(plan.inserts) == 2
+        assert not plan.updates and not plan.deletes and plan.unchanged == 1
+
+    def test_shifted_date_updates_in_place(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        stale = existing_event(UID_INTRO, start="2026-03-09", end="2026-03-10")
+        plan = gs.plan_sync(desired, [stale])
+        assert [(eid, body["start"]["date"]) for eid, body in plan.updates] == [
+            ("ev1", "2026-03-02")
+        ]
+        assert not plan.deletes
+
+    def test_changed_summary_updates(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        plan = gs.plan_sync(desired, [existing_event(UID_INTRO, summary="Old title")])
+        assert len(plan.updates) == 1
+
+    def test_vanished_uid_is_deleted(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        gone = existing_event("jan-gone@clm.cohort-calendar", eid="ev9", summary="Removed")
+        plan = gs.plan_sync(desired, [gone])
+        assert [eid for eid, _label in plan.deletes] == ["ev9"]
+
+    def test_duplicate_uid_keeps_one_deletes_rest(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        first = existing_event(UID_INTRO, eid="ev1")
+        second = existing_event(UID_INTRO, eid="ev2")
+        plan = gs.plan_sync(desired, [first, second])
+        assert [eid for eid, _label in plan.deletes] == ["ev2"]
+        assert plan.unchanged == 1
+
+    def test_managed_event_without_uid_is_deleted(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        untagged = {"id": "ev3", "summary": "?", "start": {"date": "2026-03-02"}}
+        plan = gs.plan_sync(desired, [untagged])
+        assert [eid for eid, _label in plan.deletes] == ["ev3"]
+
+    def test_describe_plan_lines(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        gone = existing_event("jan-gone@clm.cohort-calendar", eid="ev9", summary="Removed")
+        shifted = existing_event(UID_INTRO, start="2026-03-09", end="2026-03-10")
+        lines = gs.describe_plan(gs.plan_sync(desired, [gone, shifted]))
+        assert "+ 2026-03-03  Review & Q&A" in lines
+        assert "~ 2026-03-02  Intro" in lines
+        assert "- 2026-03-02  Removed" in lines
+
+    def test_noop_plan(self):
+        plan = gs.plan_sync({}, [])
+        assert plan.is_noop
+
+
+# --- fake Google service --------------------------------------------------------
+
+
+class _Request:
+    def __init__(self, result=None, record=None, error=None):
+        self._result = result if result is not None else {}
+        self._record = record
+        self._error = error
+
+    def execute(self):
+        if self._error is not None:
+            raise self._error
+        if self._record is not None:
+            target, item = self._record
+            target.append(item)
+        return self._result
+
+
+class FakeEvents:
+    """Stand-in for ``service.events()`` recording mutations, serving list pages."""
+
+    def __init__(self, pages, *, fail_insert=False):
+        self._pages = pages
+        self._fail_insert = fail_insert
+        self.inserted = []
+        self.updated = []
+        self.deleted = []
+        self.list_calls = []
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        index = 0 if kwargs.get("pageToken") is None else int(kwargs["pageToken"])
+        page = dict(self._pages[index])
+        if index + 1 < len(self._pages):
+            page["nextPageToken"] = str(index + 1)
+        return _Request(page)
+
+    def insert(self, calendarId, body):
+        if self._fail_insert:
+            return _Request(error=RuntimeError("quota exceeded"))
+        return _Request(record=(self.inserted, body))
+
+    def update(self, calendarId, eventId, body):
+        return _Request(record=(self.updated, (eventId, body)))
+
+    def delete(self, calendarId, eventId):
+        return _Request(record=(self.deleted, eventId))
+
+
+class FakeService:
+    def __init__(self, pages=None, **kwargs):
+        self._events = FakeEvents(pages or [{"items": []}], **kwargs)
+
+    def events(self):
+        return self._events
+
+
+class TestFetchManagedEvents:
+    def test_filters_by_managed_tag_and_paginates(self):
+        pages = [
+            {"items": [existing_event(UID_INTRO, eid="ev1")]},
+            {"items": [existing_event(UID_SPAN, eid="ev2")]},
+        ]
+        service = FakeService(pages)
+        events = gs.fetch_managed_events(service, "cal-id", "jan")
+        assert [e["id"] for e in events] == ["ev1", "ev2"]
+        calls = service.events().list_calls
+        assert len(calls) == 2
+        assert all(c["privateExtendedProperty"] == "clm_managed=jan" for c in calls)
+        assert all(c["calendarId"] == "cal-id" for c in calls)
+
+
+class TestApplyPlan:
+    def test_applies_inserts_updates_deletes(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        gone = existing_event("jan-gone@clm.cohort-calendar", eid="ev9")
+        shifted = existing_event(UID_INTRO, eid="ev1", start="2026-03-09", end="2026-03-10")
+        plan = gs.plan_sync(desired, [gone, shifted])
+
+        service = FakeService()
+        gs.apply_plan(service, "cal-id", plan)
+        events = service.events()
+        assert {b["summary"] for b in events.inserted} == {"Review & Q&A", "Spanned"}
+        assert [eid for eid, _b in events.updated] == ["ev1"]
+        assert events.deleted == ["ev9"]
+
+    def test_api_failure_raises_google_sync_error(self):
+        desired = gs.build_desired_events(sample(), namespace="jan")
+        plan = gs.plan_sync(desired, [])
+        service = FakeService(fail_insert=True)
+        with pytest.raises(gs.GoogleSyncError, match="quota exceeded"):
+            gs.apply_plan(service, "cal-id", plan)
+
+
+class TestLoadCredentials:
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(gs.GoogleSyncError, match="cannot read credentials"):
+            gs.load_credentials(tmp_path / "nope.json")
+
+    def test_invalid_json(self, tmp_path):
+        path = tmp_path / "creds.json"
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(gs.GoogleSyncError, match="cannot read credentials"):
+            gs.load_credentials(path)
+
+    def test_non_object_json(self, tmp_path):
+        path = tmp_path / "creds.json"
+        path.write_text("[1, 2]", encoding="utf-8")
+        with pytest.raises(gs.GoogleSyncError, match="credentials JSON object"):
+            gs.load_credentials(path)
+
+    def test_unrecognized_credential_type(self, tmp_path):
+        path = tmp_path / "creds.json"
+        path.write_text('{"foo": "bar"}', encoding="utf-8")
+        with pytest.raises(gs.GoogleSyncError, match="neither a service-account key"):
+            gs.load_credentials(path)

--- a/uv.lock
+++ b/uv.lock
@@ -1002,6 +1002,9 @@ all = [
     { name = "faster-whisper" },
     { name = "filelock" },
     { name = "ftfy" },
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
     { name = "gradio" },
     { name = "hf-xet" },
     { name = "httptools" },
@@ -1116,6 +1119,11 @@ dev = [
 drawio = [
     { name = "aiofiles" },
     { name = "tenacity" },
+]
+gcal = [
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
 ]
 jupyterlite = [
     { name = "jupyter-server" },
@@ -1278,7 +1286,7 @@ requires-dist = [
     { name = "bm25s", extras = ["core"], marker = "extra == 'ml'", specifier = ">=0.3.2.post1" },
     { name = "clean-text", marker = "extra == 'ml'", specifier = ">=0.6.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "coding-academy-lecture-manager", extras = ["all-workers", "ml", "summarize", "voiceover", "recordings", "slides", "mcp", "jupyterlite", "replay", "dev", "tui", "web"], marker = "extra == 'all'" },
+    { name = "coding-academy-lecture-manager", extras = ["all-workers", "ml", "summarize", "voiceover", "recordings", "slides", "gcal", "mcp", "jupyterlite", "replay", "dev", "tui", "web"], marker = "extra == 'all'" },
     { name = "coding-academy-lecture-manager", extras = ["notebook", "plantuml", "drawio"], marker = "extra == 'all-workers'" },
     { name = "coding-academy-lecture-manager", extras = ["slides"], marker = "extra == 'mcp'" },
     { name = "cookiecutter", marker = "extra == 'ml'" },
@@ -1291,6 +1299,9 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'voiceover'", specifier = ">=1.0.0" },
     { name = "filelock", marker = "extra == 'replay'", specifier = ">=3.12.0" },
     { name = "ftfy", marker = "extra == 'ml'", specifier = ">=6.1.1" },
+    { name = "google-api-python-client", marker = "extra == 'gcal'", specifier = ">=2.100.0" },
+    { name = "google-auth", marker = "extra == 'gcal'", specifier = ">=2.23.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'gcal'", specifier = ">=1.2.0" },
     { name = "gradio", marker = "extra == 'ml'", specifier = ">=6.5.1" },
     { name = "hf-xet", marker = "extra == 'ml'", specifier = ">=1.1.10" },
     { name = "httptools", marker = "extra == 'web'", specifier = ">=0.6.2" },
@@ -1406,7 +1417,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'web'", specifier = ">=0.18.0" },
     { name = "wsproto", marker = "extra == 'web'", specifier = ">=1.2.0" },
 ]
-provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summarize", "recordings", "voiceover", "voiceover-cohere", "voiceover-granite", "jupyterlite", "slides", "replay", "mcp", "dev", "tui", "web", "all"]
+provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summarize", "recordings", "voiceover", "voiceover-cohere", "voiceover-granite", "jupyterlite", "slides", "gcal", "replay", "mcp", "dev", "tui", "web", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2446,6 +2457,38 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.197.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/081d66357118bd260f8f182cb1b2dd5bd32ca88e3714d7c93896cab946fc/google_api_python_client-2.197.0.tar.gz", hash = "sha256:32e03977eda4a66eafc6ae58dc9ec46426b6025636d5ef019c5703013eddd4e5", size = 14707398, upload-time = "2026-05-28T20:23:12.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e5/e9cc221fd75230974d4ef45eb72d2261feca3c110d5554215d516bfe6534/google_api_python_client-2.197.0-py3-none-any.whl", hash = "sha256:0f8b89aa75768161dd4f5092d6bcb386c13236b32e0d9a938c02f71342094d14", size = 15287302, upload-time = "2026-05-28T20:23:09.683Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2461,6 +2504,32 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
 ]
 
 [[package]]
@@ -2765,6 +2834,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -5716,6 +5797,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -6899,6 +6992,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/f8/5dc70102e4d337063452c82e1f0d95e39abfe67aa222ed8a5ddeb9df8de8/requests_file-3.0.1.tar.gz", hash = "sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576", size = 6967, upload-time = "2025-10-20T18:56:42.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/d5/de8f089119205a09da657ed4784c584ede8381a0ce6821212a6d4ca47054/requests_file-3.0.1-py2.py3-none-any.whl", hash = "sha256:d0f5eb94353986d998f80ac63c7f146a307728be051d4d1cd390dbdb59c10fa2", size = 4514, upload-time = "2025-10-20T18:56:41.184Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -8278,6 +8384,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `clm calendar push`, a sibling of `calendar check`/`status` that mirrors a cohort's viewing calendar (#283) into a Google calendar. Students subscribe to one shared calendar; pushed schedule changes propagate within minutes, instead of the ~12-24h refresh lag of a subscribed `.ics` URL (which would also need hosting).

## How it works

- **New module `clm.cohort_calendar.google_sync`** — builds desired all-day events from the projection, diffs them against the calendar's existing CLM-managed events, and applies inserts/updates/deletes.
- **Safe by construction**: every event CLM creates carries two private extended properties — the cohort namespace (`clm_managed`, used as the list filter) and a stable per-assignment UID (`clm_uid`). Re-pushing after a holiday/merge/pin change updates events in place, deletes events whose assignment vanished, and never lists, modifies, or deletes events the trainer added by hand.
- **Shared identity with `.ics`**: the UID is the same one `render_ics` emits (`_ics_uid` made public as `assignment_uid`), so the feed and a pushed calendar agree on event identity.
- **Credentials auto-detect** (`--credentials` / `CLM_GOOGLE_CREDENTIALS`): an OAuth "Desktop app" client (one-time browser consent, token cached under the user config dir) or a service-account key the calendar is shared with.
- **Target calendar** from `--calendar-id` or a new optional `[google] calendar_id` table in `release/<channel>.calendar.toml`.
- `--dry-run` prints the `+`/`~`/`-` plan without writing; a projection error blocks the push (same gate as `export calendar`).
- **New `[gcal]` extra** (google-api-python-client, google-auth, google-auth-oauthlib), included in `[all]`. All Google imports are lazy, so core CLM — and the planning tests — run without it.

## Tests

- 35 new tests: pure plan/diff/apply logic against a fake service (`tests/cohort_calendar/test_google_sync.py`), `[google]` table parsing, and CLI tests mocked at the `google_sync` seam (dry-run, apply, `--calendar-id` precedence, credential/calendar-id/projection error paths).
- No live-API or `[gcal]`-dependent tests; full fast suite green locally (7543 passed), ruff + mypy clean.

## Docs

- `clm info commands` topic: new `clm calendar push` section (per the info-topics maintenance rule).
- `docs/user-guide/configuration.md`: `CLM_GOOGLE_CREDENTIALS`, `[google]` table, one-time Google Cloud setup.
- `docs/user-guide/installation.md`: `[gcal]` extra; CHANGELOG entry; design-doc note in `cohort-viewing-calendar.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
