### PR TITLE
feat(release): evergreen files — skeleton files exempt from the freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Evergreen release files — `<evergreen>` patterns and `clm release sync
+  --evergreen`.** Skeleton (global) files matching an evergreen glob pattern
+  are exempt from the release freeze: every sync re-copies a matching file
+  whose built content differs from the cohort's copy — for files that are
+  *meant* to change over a cohort's lifetime (a NEWS file, announcements),
+  which previously froze with the rest of the skeleton after the first sync
+  and could never be updated. Patterns are declared on `<release-channels>`
+  (inherited by every channel; channel-level entries are additive) or passed
+  per-invocation with the repeatable `--evergreen` option, and match
+  destination-relative POSIX paths (re-rooted paths for `lang`-scoped
+  channels). Evergreen is skeleton-only by design: patterns matching
+  topic-owned files are warned about and ignored (topic content still changes
+  only via `--refreeze`), and the comparison is stateless (destination hash
+  vs. manifest hash) so the `.clm-released.json` format is unchanged and
+  re-runs are idempotent.
+
 - **`clm calendar push` — mirror a cohort's viewing calendar into Google
   Calendar.** Students subscribe to one shared Google calendar and pushed
   schedule changes propagate within minutes (no `.ics` hosting, no feed-refresh

--- a/docs/claude/design/release-evergreen-files.md
+++ b/docs/claude/design/release-evergreen-files.md
@@ -1,0 +1,111 @@
+# Evergreen Release Files
+
+**Status**: Implemented
+**Branch**: `claude/release-evergreen-files`
+
+## Problem
+
+`clm release sync` is add-only by design: once content reaches a cohort it is
+frozen and never modified again. The freeze operates at two boundaries
+(`src/clm/release/sync.py`):
+
+1. **Topics** — a topic id recorded in `.clm-released.json` is skipped by later
+   syncs (`skip-frozen`); `--refreeze` is the explicit override.
+2. **Skeleton** — all global files (`topic_id: null` in the provenance
+   manifest: dir-groups, shared data) are copied once on the first sync, then
+   `skeleton_frozen = true` forever. **No override exists.**
+
+Some global files are *meant* to change over the lifetime of a cohort — a NEWS
+file, announcements, a schedule. Today they freeze with the rest of the
+skeleton after the first sync and can never be updated.
+
+## Design: evergreen files
+
+The complement of "frozen": a set of glob patterns naming **skeleton files that
+are never frozen** — every sync re-promotes a matching file when the built
+content differs from what is in the cohort repo.
+
+### Spec syntax
+
+Declared in `<release-channels>`, inherited by every channel (same parse-time
+inheritance as `<share-with>`); channel-level entries are **additive** (union,
+not override — patterns have no identity key):
+
+```xml
+<release-channels source-target="solutions" name="materials">
+    <evergreen>NEWS.md</evergreen>
+    <evergreen>announcements/*</evergreen>
+    <channel name="jan" path="./cohorts/jan" ledger="release/jan.txt">
+        <evergreen>jan-schedule.md</evergreen>
+    </channel>
+</release-channels>
+```
+
+CLI escape hatch on `clm release sync` for explicit-paths mode (which has no
+spec block): `--evergreen PATTERN` (repeatable, additive with the channel's
+patterns).
+
+The name deliberately avoids `refresh` — one typo away from the existing
+`--refreeze`, which does something different. "Evergreen" is the natural
+antonym of the system's freeze metaphor.
+
+### Semantics
+
+- **Skeleton-only.** Patterns match only manifest entries with
+  `topic_id: null`. A pattern that matches a *topic-owned* file is reported
+  (warning pointing at `--refreeze`) and ignored. This keeps every existing
+  invariant intact: `topic_digest` stays truthful for drift detection,
+  `--refreeze` remains the only way topic content changes, and an evergreen
+  pattern can never leak files of an unreleased topic into a cohort.
+- **Matching**: `fnmatch.fnmatchcase` against the manifest-relative POSIX path
+  — the path *as it appears in the cohort repo*. For `lang`-scoped channels
+  that is the path after `restrict_manifest_to_language` re-roots it, so
+  patterns are written dest-relative. `*` crosses `/` (fnmatch semantics), so
+  `NEWS*.md` matches at the root and `*/NEWS.md` matches at any depth.
+- **Copy-on-change, stateless**: an evergreen file plans `refresh` when the
+  destination file is missing or its sha256 differs from the manifest's
+  `content_hash`, else `up-to-date`. The destination *is* the state — no
+  change to the `.clm-released.json` format, no version bump, idempotent
+  re-runs, and `--push` commits nothing when nothing changed. This is sound
+  because promotion copies bytes verbatim: after a copy, dest hash ==
+  manifest hash.
+- **First sync**: the skeleton copy already delivers evergreen files; the
+  evergreen pass only operates once the skeleton is frozen
+  (`plan.copy_skeleton == False`). A skeleton file *added* to the source after
+  the skeleton froze still reaches cohorts if it matches an evergreen pattern
+  (dest missing → refresh); non-evergreen late additions stay frozen out, as
+  before.
+- **Failed builds**: a partial manifest already excludes failed topics' files;
+  skeleton entries have no topic, so an intact skeleton still refreshes during
+  a partial build.
+- **VCS guard**: evergreen reuses the same `.git`/`.svn`/`.hg` refusal as all
+  promotion copies (issue #302), and the scan additionally never plans a VCS
+  path.
+- **No deletions**: removing an evergreen file from the source stops
+  refreshing it but does not delete it from cohorts — sync never deletes.
+
+### Rejected alternatives
+
+- **Recording refreshes in `.clm-released.json`** — a second source of truth
+  plus a format version bump; hashing a handful of small matched dest files
+  per sync is free.
+- **Always-copy instead of copy-on-change** — loses the "refreshed N files"
+  signal and makes every `--push` produce mtime-churn.
+- **Allowing evergreen to match topic files** — breaks the `topic_digest`
+  drift contract and opens the unreleased-topic leak. If a use case emerges
+  it is an explicit v2 with digest-exclusion semantics, not a default.
+
+## Implementation map
+
+| Layer | Change |
+|---|---|
+| `core/course_spec.py` | `evergreen` on `ReleaseChannelSpec`/`ReleaseChannelsSpec`, `<evergreen>` parsing with block→channel inheritance, validation (no empty/backslash patterns) |
+| `core/provenance_manifest.py` | `hash_file` made public (shared by the evergreen scan) |
+| `release/sync.py` | `scan_evergreen(manifest, patterns, dest_root)` → `EvergreenScan` (plans + ignored topic-owned matches); `SyncPlan.evergreen`; `apply_sync` refresh pass (skipped while `copy_skeleton`); `SyncResult.refreshed_files` |
+| `cli/commands/release.py` | `--evergreen` on `sync`, channel pattern resolution, plan display (`refresh`/up-to-date), result + push-message reporting, topic-owned-match warning |
+| Info topics | `releases.md`, `spec-files.md`, `commands.md` |
+
+Tests: `tests/core/test_release_channels_spec.py` (parsing/validation),
+`tests/release/test_sync.py` (scan + apply semantics),
+`tests/release/test_release_cli.py` (end-to-end refresh across syncs,
+explicit-mode flag, lang re-rooting, warnings, dry-run).

--- a/docs/user-guide/solution-release.md
+++ b/docs/user-guide/solution-release.md
@@ -141,6 +141,38 @@ clm release sync course.xml --channel jan --refreeze functions --push -m "Fix fu
 clm release sync course.xml --channel jan --refreeze-all       # re-freeze everything (rare)
 ```
 
+## Evergreen files (e.g. a NEWS file)
+
+Global (skeleton) files — those not owned by any topic, such as shared data or
+dir-group content — are copied once on the first sync and then frozen with the
+rest of the skeleton. Some of them are *meant* to change over a cohort's
+lifetime: a NEWS file, announcements, a schedule. Declare those as
+**evergreen** and every sync re-copies them whenever the built content differs
+from the cohort's copy:
+
+```xml
+<release-channels source-target="solutions">
+    <evergreen>NEWS.md</evergreen>
+    <channel name="jan" path="./solutions/jan" ledger="release/jan.txt">
+        <evergreen>jan-schedule.md</evergreen>   <!-- additive per cohort -->
+    </channel>
+</release-channels>
+```
+
+```bash
+# Edit NEWS.md in the course source, rebuild, sync — the cohort's copy follows.
+clm build course.xml
+clm release sync course.xml --channel jan --push -m "Update NEWS"
+```
+
+Patterns are `fnmatch` globs matched against the path as it appears in the
+cohort repo (POSIX separators; the re-rooted path for `lang`-scoped channels);
+the repeatable `--evergreen PATTERN` option adds patterns per invocation.
+Evergreen is **skeleton-only**: a pattern matching a topic-owned file is
+warned about and ignored — released topic content still changes only via
+`--refreeze`. Syncing never deletes; removing an evergreen file from the
+source just stops refreshing it.
+
 ## How `clm git --channel` differs from ordinary `clm git`
 
 The regular `clm git` subcommands operate on your `<output-targets>` repos.

--- a/docs/user-guide/spec-file-reference.md
+++ b/docs/user-guide/spec-file-reference.md
@@ -965,6 +965,7 @@ the spec stays diff-clean as you release week by week.
 | `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). One repo per cohort; **not** language-scoped. |
 | `ledger` (attr) | `<channel>` | Yes | Path to the cohort's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. |
 | `<remote-path>` | `<channel>` | No | Override the block-level `<remote-path>` for this one cohort. |
+| `<evergreen>` | `<release-channels>` or `<channel>` | No | Glob pattern of **skeleton files exempt from the freeze**: every `clm release sync` re-copies a matching file whose built content differs from the cohort's copy (e.g. a NEWS file). Block-level patterns are inherited by every channel; channel-level patterns are additive. Skeleton-only — patterns matching topic-owned files are warned about and ignored. See the [Solution Release guide](solution-release.md#evergreen-files-eg-a-news-file). |
 
 The remote URL is derived as
 `{repository-base}/{remote-path}/{project-slug}-{name}` (the `<remote-path>`

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -38,7 +38,14 @@ from clm.core.provenance_manifest import (
 )
 from clm.release.frozen_manifest import FROZEN_FILENAME, FrozenManifest
 from clm.release.ledger import Ledger, partition_known
-from clm.release.sync import SyncResult, apply_sync, plan_sync
+from clm.release.sync import (
+    REFRESH,
+    EvergreenScan,
+    SyncResult,
+    apply_sync,
+    plan_sync,
+    scan_evergreen,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +78,8 @@ class _ResolvedChannel:
     # Channel language scope (issue #293). Empty = the channel receives every
     # built language root.
     lang: str = ""
+    # Evergreen glob patterns (block-level inherited + channel additions).
+    evergreen: tuple[str, ...] = ()
 
 
 @click.group("release")
@@ -104,6 +113,7 @@ def _resolve_channel(spec_file: Path, channel_name: str) -> _ResolvedChannel:
         source=source,
         dest=_abs_under(course_root, channel.path),
         lang=channel.lang,
+        evergreen=channel.evergreen,
     )
 
 
@@ -118,6 +128,8 @@ def _default_push_message(channel_name: str, result: SyncResult) -> str:
         parts.append(f"{len(result.copied_topics)} new")
     if result.refrozen_topics:
         parts.append(f"{len(result.refrozen_topics)} refrozen")
+    if result.refreshed_files:
+        parts.append(f"{len(result.refreshed_files)} evergreen")
     # The first sync of a cohort ships the skeleton (dir-group/shared files) even
     # with no topics released yet — don't call that "no topic changes".
     if not parts and result.skeleton_copied:
@@ -475,6 +487,15 @@ def status_cmd(
     "directory (issue #293). Overrides the channel's lang attribute; requires "
     "SPEC_FILE. --source must point at the output-target root.",
 )
+@click.option(
+    "--evergreen",
+    "evergreen_patterns",
+    multiple=True,
+    help="Glob pattern (destination-relative POSIX path) of skeleton files "
+    "kept evergreen: re-copied whenever the built content differs from the "
+    "cohort's copy (e.g. NEWS.md). Repeatable; adds to the channel's "
+    "<evergreen> patterns from the spec.",
+)
 @click.option("--dry-run", is_flag=True, help="Print the plan; copy nothing.")
 @click.option(
     "--push",
@@ -498,6 +519,7 @@ def sync_cmd(
     refreeze_ids: tuple[str, ...],
     refreeze_all: bool,
     language: str | None,
+    evergreen_patterns: tuple[str, ...],
     dry_run: bool,
     push: bool,
     commit_message: str | None,
@@ -513,8 +535,14 @@ def sync_cmd(
     promotes only that language's files, re-rooted so the cohort repo's root
     is the language directory (issue #293). Without either, the destination
     receives every built language root.
+
+    Skeleton files matching an evergreen pattern (the channel's ``<evergreen>``
+    declarations plus any ``--evergreen`` options) are exempt from the
+    skeleton freeze: each sync re-copies a matching file whose built content
+    differs from the cohort's copy.
     """
     channel_lang = ""
+    channel_evergreen: tuple[str, ...] = ()
     if channel:
         if spec_file is None:
             raise click.ClickException("--channel requires the SPEC_FILE argument.")
@@ -526,6 +554,7 @@ def sync_cmd(
         source_path = source_path or resolved.source
         dest_path = dest_path or resolved.dest
         channel_lang = resolved.lang
+        channel_evergreen = resolved.evergreen
 
     if ledger_path is None or source_path is None or dest_path is None:
         raise click.ClickException(
@@ -571,12 +600,32 @@ def sync_cmd(
     frozen_path = dest_path / FROZEN_FILENAME
     frozen = FrozenManifest.load(frozen_path, channel=channel_name)
 
+    # Channel patterns plus CLI additions; the scan runs against the
+    # (possibly language-restricted) manifest, so patterns are matched on
+    # destination-relative paths.
+    patterns = tuple(dict.fromkeys((*channel_evergreen, *evergreen_patterns)))
+    scan = (
+        scan_evergreen(manifest=manifest, patterns=patterns, dest_root=dest_path)
+        if patterns
+        else EvergreenScan()
+    )
+    if scan.topic_owned_matches:
+        click.echo(
+            f"Warning: evergreen pattern(s) matched {len(scan.topic_owned_matches)} "
+            f"topic-owned file(s) — evergreen applies only to global (skeleton) "
+            f"files; use --refreeze to update released topic content: "
+            + ", ".join(scan.topic_owned_matches[:5])
+            + (", …" if len(scan.topic_owned_matches) > 5 else ""),
+            err=True,
+        )
+
     refreeze = set(ledger.released) if refreeze_all else set(refreeze_ids)
     plan = plan_sync(
         manifest=manifest,
         ledger_released=ledger.released,
         frozen=frozen,
         refreeze=refreeze,
+        evergreen=scan.plans,
     )
 
     if manifest.get("partial"):
@@ -594,6 +643,15 @@ def sync_cmd(
         click.echo(
             f"  {topic_plan.action:<11} {topic_plan.topic_id} ({topic_plan.file_count} files)"
         )
+    # On the first sync the skeleton copy delivers evergreen files itself, so
+    # the evergreen lines only appear once the skeleton is frozen.
+    if plan.evergreen and not plan.copy_skeleton:
+        for evergreen_plan in plan.evergreen:
+            if evergreen_plan.action == REFRESH:
+                click.echo(f"  {REFRESH:<11} {evergreen_plan.path} (evergreen)")
+        up_to_date = sum(1 for e in plan.evergreen if e.action != REFRESH)
+        if up_to_date:
+            click.echo(f"  evergreen: {up_to_date} file(s) up-to-date")
 
     if dry_run:
         click.echo("Dry run: nothing copied.")
@@ -616,6 +674,11 @@ def sync_cmd(
         f"{len(result.refrozen_topics)} re-frozen, "
         f"{len(result.skipped_topics)} already frozen (skipped)."
     )
+    if result.refreshed_files:
+        click.echo(
+            f"Evergreen: refreshed {len(result.refreshed_files)} file(s): "
+            + ", ".join(result.refreshed_files)
+        )
     if result.failed_topics:
         click.echo(
             f"Warning: {len(result.failed_topics)} released topic(s) NOT promoted "

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2588,6 +2588,7 @@ Key options for `release sync`:
 | `--language de\|en` | Promote only this language's files, re-rooted at the language directory (issue #293). Overrides the channel's `lang` attribute; requires `SPEC_FILE`; `--source` must point at the output-target root. |
 | `--refreeze TOPIC` | Re-copy and re-freeze an already-frozen topic (e.g. a bug fix). Repeatable. |
 | `--refreeze-all` | Re-copy and re-freeze every released topic. |
+| `--evergreen PATTERN` | Glob pattern (destination-relative POSIX path) of **skeleton files kept evergreen**: re-copied whenever the built content differs from the cohort's copy (e.g. `NEWS.md`). Repeatable; adds to the channel's `<evergreen>` spec patterns. Skeleton-only — a pattern matching topic-owned files is warned about and ignored (use `--refreeze`). |
 | `--push` | After promoting, commit and push the cohort repo (via `clm git`'s commit/push). The repo must already exist — run `clm git init … --channel` once first. |
 | `-m, --message` | Commit message used by `--push` (default: a one-line summary of the sync). |
 | `--dry-run` | Print the promotion plan; copy nothing. |
@@ -2596,6 +2597,14 @@ The source must be built with the provenance manifest (`clm build` writes it by
 default since CLM {version}). Promotion copies bytes by manifest and records each
 topic in the cohort's frozen manifest (`.clm-released.json`); a frozen topic is
 never re-propagated unless you pass `--refreeze`.
+
+**Evergreen files.** Skeleton (global) files matching the channel's
+`<evergreen>` patterns — or `--evergreen` options — are exempt from the
+skeleton freeze: each sync re-copies a matching file whose built content
+differs from the cohort's copy, with no freeze-record bookkeeping (the
+destination's content is the state, so re-runs are idempotent and `--push`
+commits nothing when nothing changed). See `clm info spec-files` for the
+`<evergreen>` element.
 
 **Partial manifests (issue #295).** A whole-course build that errors on some
 topics still writes the manifest for the cleanly-built subset, recording the

--- a/src/clm/cli/info_topics/releases.md
+++ b/src/clm/cli/info_topics/releases.md
@@ -20,6 +20,7 @@ never rewrite what students already received.
 <release-channels source-target="solutions" name="materials">
     <remote-path>cohorts</remote-path>
     <share-with group="trainers" access="maintainer" />
+    <evergreen>NEWS.md</evergreen>
 
     <channel name="jan" path="./cohorts/jan" ledger="release/jan.txt">
         <share-with group="cohort-jan" access="developer" />
@@ -38,6 +39,7 @@ never rewrite what students already received.
 | `ledger` | `<channel>` | yes | Path to the release ledger file |
 | `lang` | `<channel>` | no | Restrict promotion to one language; re-roots files at the language directory |
 | `<share-with group="…" access="…">` | block or channel | no | GitLab group sharing (applied by `clm release provision`) |
+| `<evergreen>` | block or channel | no | Glob pattern of skeleton files exempt from the freeze — re-copied on every sync when the built content changed (e.g. a NEWS file). Block patterns are inherited; channel patterns are additive |
 
 The derived remote URL is:
 `{repository-base}/{remote-path}/{project-slug}-{channel}-{stream}[-{lang}]`
@@ -139,6 +141,7 @@ clm release status SPEC --channel NAME
 clm release sync SPEC --channel NAME [--dry-run] [--push] [-m MESSAGE]
 clm release sync SPEC --channel NAME --refreeze TOPIC_ID... [--push]
 clm release sync SPEC --channel NAME --refreeze-all [--push]
+clm release sync SPEC --channel NAME --evergreen PATTERN [--push]
 ```
 
 Sync actions per topic:
@@ -150,7 +153,14 @@ Sync actions per topic:
 | `refreeze` | Frozen but in `--refreeze` set → re-copy, update freeze |
 | `skip-failed` | Build errored for this topic → refuse until next clean build |
 
-Skeleton (global files) is copied once on first sync and then frozen.
+Skeleton (global files) is copied once on first sync and then frozen —
+**except evergreen files**: skeleton files matching the channel's
+`<evergreen>` patterns (or `--evergreen` options) plan `refresh` whenever the
+built content differs from the cohort's copy, and `up-to-date` otherwise.
+Evergreen is skeleton-only; patterns matching topic-owned files are warned
+about and ignored (topic content changes only via `--refreeze`). The
+comparison is stateless (destination hash vs. manifest hash), so nothing is
+recorded in the frozen manifest and re-runs are idempotent.
 `--push` chains `clm git commit` + `clm git push` after promotion.
 
 ### `clm release provision`
@@ -226,10 +236,21 @@ clm release add course.xml introduction variables --channel may
 clm release sync course.xml --channel may --push -m "may: release week 1"
 ```
 
+### Updating a NEWS file across releases
+
+```bash
+# Spec: <evergreen>NEWS.md</evergreen> inside <release-channels>.
+# Edit the source NEWS file, rebuild, and sync — every cohort's copy follows.
+clm build course.xml
+clm release sync course.xml --channel jan --push -m "Update NEWS"
+```
+
 ## Key design properties
 
 - **Cumulative ledger** — entries are never removed; minimal per-release git diff.
-- **Immutable freezing** — frozen topics are never re-propagated without `--refreeze`.
+- **Immutable freezing** — frozen topics are never re-propagated without `--refreeze`;
+  the only exception is **evergreen** skeleton files (declared via `<evergreen>`),
+  which follow the latest build by design.
 - **Provenance-driven** — files are promoted via manifest lookup, not path inference.
 - **Idempotent syncs** — re-running sync is safe; frozen topics are skipped.
 - **Manifest exclusion** — `.clm-manifest.json` is never distributed; the frozen manifest `.clm-released.json` is.

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -664,12 +664,14 @@ addressing unchanged.
 | `source-target` (attr) | `<release-channels>` | Yes | Name of the `<output-target>` that is this stream's frozen source (e.g. a `completed` target for solutions, a `code-along`/`partial` target for materials). Must name a declared output target. |
 | `<remote-path>` | `<release-channels>` | No | Default remote path (e.g. a GitLab group) for every channel that does not override it. |
 | `<share-with>` | `<release-channels>` | No | Default GitLab group share inherited by every channel (issue #294, see below). |
+| `<evergreen>` | `<release-channels>` | No | Glob pattern of **skeleton files exempt from the freeze**, inherited by every channel (see below). |
 | `name` (attr) | `<channel>` | Yes | Cohort identifier (no `/`). Addresses the channel on the CLI and forms the derived repo name. |
 | `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). One repo per channel; must be unique across **all** streams. |
 | `ledger` (attr) | `<channel>` | Yes | Path to the channel's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. Unique across all streams. |
 | `lang` (attr) | `<channel>` | No | Scope the channel to one language (`de`/`en`, issue #293). `clm release sync` then promotes only that language's files, **re-rooted** so the repo root is the language directory (matching per-language repos like `…-azav-de`), and the derived repo name appends `-{lang}`. **Unset**: the channel receives every built language root. |
 | `<remote-path>` | `<channel>` | No | Override the block-level `<remote-path>` for this one cohort. |
 | `<share-with>` | `<channel>` | No | GitLab group(s) to share the channel repo into (issue #294, see below). |
+| `<evergreen>` | `<channel>` | No | Additional evergreen pattern(s) for this one cohort (additive to the block's). |
 
 The remote URL is derived as
 `{repository-base}/{remote-path}/{project-slug}-{channel}[-{stream}][-{lang}]`
@@ -698,6 +700,37 @@ inherited access level.
 
 The element text is the full group path; `access` is one of `guest`,
 `reporter` (default), `developer`, `maintainer`.
+
+#### `<evergreen>` — skeleton files exempt from the freeze (CLM {version}+)
+
+Global (skeleton) files matching an `<evergreen>` glob pattern are **never
+frozen**: every `clm release sync` re-copies a matching file whose built
+content differs from the cohort's copy. Use this for files that are *meant*
+to change over a cohort's lifetime — a NEWS file, announcements, a schedule —
+which would otherwise freeze with the rest of the skeleton after the first
+sync.
+
+```xml
+<release-channels source-target="solutions">
+    <evergreen>NEWS.md</evergreen>
+    <evergreen>announcements/*</evergreen>
+    <channel name="jan" path="./solutions/jan" ledger="release/jan.txt">
+        <evergreen>jan-schedule.md</evergreen>
+    </channel>
+</release-channels>
+```
+
+Block-level patterns are inherited by every channel; channel-level patterns
+are **additive**. Patterns are `fnmatch` globs matched against the file's
+path **as it appears in the cohort repo** (POSIX separators; for a
+`lang`-scoped channel that is the re-rooted path). `*` crosses `/`, so
+`NEWS*.md` matches at the root and `*/NEWS.md` at any depth.
+
+Evergreen is **skeleton-only by design**: a pattern matching a topic-owned
+file is reported and ignored — released topic content changes only via
+`clm release sync --refreeze`, keeping the per-topic freeze record truthful.
+Sync never deletes: removing an evergreen file from the source stops
+refreshing it but leaves the cohort's copy in place.
 
 #### Provenance and freeze records
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -1194,6 +1194,12 @@ class ReleaseChannelSpec:
     entries (e.g. a trainers group) are inherited by every channel and come
     first; a channel-level entry for the same group overrides the inherited
     access level.
+
+    ``evergreen`` lists glob patterns (matched against destination-relative
+    POSIX paths) of skeleton files that are **never frozen**: ``clm release
+    sync`` re-promotes a matching file whenever the built content differs from
+    the cohort's copy (e.g. a NEWS file). Block-level ``<evergreen>`` entries
+    are inherited by every channel; channel-level entries are additive.
     """
 
     name: str
@@ -1202,6 +1208,7 @@ class ReleaseChannelSpec:
     remote_path: str = ""
     lang: str = ""
     share_with: tuple[ShareWithSpec, ...] = ()
+    evergreen: tuple[str, ...] = ()
 
     @classmethod
     def from_element(
@@ -1210,12 +1217,17 @@ class ReleaseChannelSpec:
         *,
         default_remote_path: str = "",
         default_shares: "tuple[ShareWithSpec, ...]" = (),
+        default_evergreen: "tuple[str, ...]" = (),
     ) -> "ReleaseChannelSpec":
         own_shares = tuple(ShareWithSpec.from_element(sw) for sw in element.findall("share-with"))
         # Inherited entries first; a channel-level entry for the same group
         # replaces the inherited one (its access wins).
         own_groups = {s.group for s in own_shares}
         shares = tuple(s for s in default_shares if s.group not in own_groups) + own_shares
+        own_evergreen = tuple((eg.text or "").strip() for eg in element.findall("evergreen"))
+        # Inherited patterns first, channel additions after; duplicates dropped
+        # (patterns have no identity key, so union — not override — semantics).
+        evergreen = tuple(dict.fromkeys(default_evergreen + own_evergreen))
         return cls(
             name=element.get("name", ""),
             path=element.get("path", ""),
@@ -1223,6 +1235,7 @@ class ReleaseChannelSpec:
             remote_path=(element_text(element, "remote-path") or default_remote_path),
             lang=element.get("lang", ""),
             share_with=shares,
+            evergreen=evergreen,
         )
 
 
@@ -1249,6 +1262,8 @@ class ReleaseChannelsSpec:
     # Stream name. Empty for the single-block (issue #208) layout; required
     # and unique when several <release-channels> blocks are declared.
     name: str = ""
+    # Block-level evergreen patterns, inherited by every channel.
+    evergreen: tuple[str, ...] = ()
 
     @classmethod
     def from_element(cls, element: ETree.Element) -> "ReleaseChannelsSpec":
@@ -1258,9 +1273,14 @@ class ReleaseChannelsSpec:
         default_shares = tuple(
             ShareWithSpec.from_element(sw) for sw in element.findall("share-with")
         )
+        # Block-level <evergreen> patterns likewise apply to every channel.
+        default_evergreen = tuple((eg.text or "").strip() for eg in element.findall("evergreen"))
         channels = [
             ReleaseChannelSpec.from_element(
-                ch, default_remote_path=remote_path, default_shares=default_shares
+                ch,
+                default_remote_path=remote_path,
+                default_shares=default_shares,
+                default_evergreen=default_evergreen,
             )
             for ch in element.findall("channel")
         ]
@@ -1269,6 +1289,7 @@ class ReleaseChannelsSpec:
             channels=channels,
             remote_path=remote_path,
             name=element.get("name", ""),
+            evergreen=default_evergreen,
         )
 
     def channel(self, name: str) -> "ReleaseChannelSpec | None":
@@ -1286,6 +1307,25 @@ def release_channel_ref(block: ReleaseChannelsSpec, channel: ReleaseChannelSpec)
     bare name, so issue-#208 era commands are unchanged.
     """
     return f"{block.name}/{channel.name}" if block.name else channel.name
+
+
+def _validate_evergreen_patterns(patterns: tuple[str, ...], owner_label: str) -> list[str]:
+    """Validation errors for ``<evergreen>`` patterns declared on *owner_label*.
+
+    Patterns are matched against destination-relative POSIX paths by the
+    release sync, so an empty pattern (matches nothing) or a backslash
+    separator (never matches a POSIX path) is a spec mistake, not a no-op.
+    """
+    errors: list[str] = []
+    for pattern in patterns:
+        if not pattern:
+            errors.append(f"{owner_label}: <evergreen> needs a glob pattern as text content.")
+        elif "\\" in pattern:
+            errors.append(
+                f"{owner_label}: evergreen pattern {pattern!r} contains a backslash; "
+                f"patterns match POSIX paths — use '/' as the separator."
+            )
+    return errors
 
 
 @frozen
@@ -2070,6 +2110,8 @@ class CourseSpec:
                     f"name an <output-target>."
                 )
 
+            errors.extend(_validate_evergreen_patterns(block.evergreen, block_label))
+
             channel_names: set[str] = set()
             for channel in block.channels:
                 ref = release_channel_ref(block, channel)
@@ -2118,6 +2160,11 @@ class CourseSpec:
                             f"Channel '{ref}': invalid share-with access "
                             f"{share.access!r}. Valid values: {sorted(VALID_SHARE_ACCESS)}"
                         )
+
+                # Channel-own patterns only — inherited ones were validated at
+                # block level and would otherwise repeat per channel.
+                own_evergreen = tuple(p for p in channel.evergreen if p not in set(block.evergreen))
+                errors.extend(_validate_evergreen_patterns(own_evergreen, f"Channel '{ref}'"))
 
         return errors
 

--- a/src/clm/core/provenance_manifest.py
+++ b/src/clm/core/provenance_manifest.py
@@ -245,7 +245,13 @@ def _enumerate_dir_group_outputs(
                         )
 
 
-def _hash_file(path: Path) -> str:
+def hash_file(path: Path) -> str:
+    """The ``sha256:<hex>`` digest of *path*'s bytes, as recorded in manifests.
+
+    Public because the release sync's evergreen scan compares destination
+    files against manifest ``content_hash`` values, so both sides must use
+    the same digest format.
+    """
     digest = hashlib.sha256()
     with path.open("rb") as fh:
         for chunk in iter(lambda: fh.read(_HASH_CHUNK), b""):
@@ -297,7 +303,7 @@ def build_provenance_manifest(
                 "kind": record["kind"],
                 "format": record["format"],
                 "language": record["language"],
-                "content_hash": _hash_file(out_path),
+                "content_hash": hash_file(out_path),
             }
         )
     files.sort(key=lambda r: r["path"])

--- a/src/clm/release/sync.py
+++ b/src/clm/release/sync.py
@@ -10,7 +10,13 @@ index. The rules (issue #208):
 * a released topic **already frozen** -> skip (students keep what they were
   given) unless it is in *refreeze*;
 * the skeleton (global, topic-less files) is copied once at channel init, then
-  frozen.
+  frozen;
+* **evergreen** skeleton files (glob patterns from ``<evergreen>`` /
+  ``--evergreen``) are exempt from the skeleton freeze: every sync re-copies a
+  matching file whose built content differs from the destination's (e.g. a
+  NEWS file). Evergreen is skeleton-only by design — topic content changes
+  only via *refreeze*, keeping the per-topic ``topic_digest`` truthful and
+  making it impossible for a pattern to leak files of an unreleased topic.
 
 Promotion copies bytes verbatim from the source tree; it never rebuilds or
 re-executes anything, and — because the manifest lists only topic output files —
@@ -26,12 +32,17 @@ from __future__ import annotations
 import logging
 import shutil
 from collections.abc import Iterable
+from fnmatch import fnmatchcase
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 from attrs import frozen
 
-from clm.core.provenance_manifest import manifest_files_by_topic, topic_digest_from_files
+from clm.core.provenance_manifest import (
+    hash_file,
+    manifest_files_by_topic,
+    topic_digest_from_files,
+)
 from clm.release.frozen_manifest import FrozenManifest, FrozenRecord
 
 logger = logging.getLogger(__name__)
@@ -45,6 +56,10 @@ SKIP_FROZEN = "skip-frozen"
 # refused until a build succeeds for it. Never frozen, so it is retried.
 SKIP_FAILED = "skip-failed"
 
+# Evergreen plan actions.
+REFRESH = "refresh"
+UP_TO_DATE = "up-to-date"
+
 
 @frozen
 class TopicPlan:
@@ -54,10 +69,36 @@ class TopicPlan:
 
 
 @frozen
+class EvergreenPlan:
+    """One evergreen skeleton file: re-copy (*refresh*) or already current."""
+
+    path: str
+    action: str
+
+
+@frozen
+class EvergreenScan:
+    """Result of matching evergreen patterns against a source manifest.
+
+    ``topic_owned_matches`` lists paths a pattern matched but that belong to a
+    topic — evergreen is skeleton-only, so they are ignored (the caller warns;
+    topic content changes only via ``--refreeze``).
+    """
+
+    plans: tuple[EvergreenPlan, ...] = ()
+    topic_owned_matches: tuple[str, ...] = ()
+
+    @property
+    def to_refresh(self) -> tuple[EvergreenPlan, ...]:
+        return tuple(p for p in self.plans if p.action == REFRESH)
+
+
+@frozen
 class SyncPlan:
     copy_skeleton: bool
     skeleton_file_count: int
     topics: tuple[TopicPlan, ...]
+    evergreen: tuple[EvergreenPlan, ...] = ()
 
     @property
     def to_copy(self) -> tuple[TopicPlan, ...]:
@@ -82,6 +123,50 @@ class SyncResult:
     # Released topics refused because the source build errored for them
     # (issue #295). Not frozen — they promote once a build succeeds.
     failed_topics: tuple[str, ...] = ()
+    # Evergreen skeleton files re-copied because their built content differed
+    # from the destination's.
+    refreshed_files: tuple[str, ...] = ()
+
+
+def scan_evergreen(
+    *,
+    manifest: dict[str, Any],
+    patterns: Iterable[str],
+    dest_root: Path,
+) -> EvergreenScan:
+    """Match evergreen *patterns* against *manifest* and the destination state.
+
+    Patterns are matched (``fnmatch.fnmatchcase``) against the manifest's
+    destination-relative POSIX paths — for a language-scoped channel that is
+    the path *after* re-rooting, i.e. exactly the path inside the cohort repo.
+
+    A matching **skeleton** entry (``topic_id: null``) plans :data:`REFRESH`
+    when the destination file is missing or its content hash differs from the
+    manifest's ``content_hash``, else :data:`UP_TO_DATE`. The comparison is
+    stateless — the destination *is* the record — which is sound because
+    promotion copies bytes verbatim (after a copy, dest hash == manifest
+    hash). Matching topic-owned entries are collected separately and never
+    planned; VCS metadata paths are refused outright (issue #302).
+    """
+    pattern_list = [p for p in patterns if p]
+    if not pattern_list:
+        return EvergreenScan()
+    plans: list[EvergreenPlan] = []
+    topic_owned: list[str] = []
+    for entry in manifest.get("files", []):
+        rel = entry.get("path", "")
+        if not any(fnmatchcase(rel, pattern) for pattern in pattern_list):
+            continue
+        if _is_vcs_path(rel):
+            logger.debug("evergreen: refusing VCS metadata path: %s", rel)
+            continue
+        if entry.get("topic_id") is not None:
+            topic_owned.append(rel)
+            continue
+        dst = dest_root / rel
+        current = dst.is_file() and hash_file(dst) == entry.get("content_hash")
+        plans.append(EvergreenPlan(rel, UP_TO_DATE if current else REFRESH))
+    return EvergreenScan(plans=tuple(plans), topic_owned_matches=tuple(topic_owned))
 
 
 def plan_sync(
@@ -90,6 +175,7 @@ def plan_sync(
     ledger_released: Iterable[str],
     frozen: FrozenManifest,
     refreeze: Iterable[str] = (),
+    evergreen: Iterable[EvergreenPlan] = (),
 ) -> SyncPlan:
     """Compute what a sync would do, without touching the filesystem.
 
@@ -98,6 +184,9 @@ def plan_sync(
     :data:`SKIP_FAILED` rather than copied — unless it is already frozen and
     not being refrozen, in which case the ordinary :data:`SKIP_FROZEN` applies
     (the cohort already has it; nothing would be copied anyway).
+
+    *evergreen* carries the plans of a prior :func:`scan_evergreen` (which
+    reads the destination, so it stays out of this pure planning step).
     """
     refreeze_set = set(refreeze)
     failed_topics = set(manifest.get("failed_topics", []))
@@ -119,6 +208,7 @@ def plan_sync(
         copy_skeleton=not frozen.skeleton_frozen,
         skeleton_file_count=len(skeleton_files),
         topics=tuple(plans),
+        evergreen=tuple(evergreen),
     )
 
 
@@ -136,6 +226,10 @@ def apply_sync(
     Mutates *frozen* in place (the caller persists it afterward). A topic with
     no files in the source manifest (e.g. released but not yet built) is logged
     and **not** frozen, so it is retried once it is built.
+
+    The evergreen pass runs only once the skeleton is frozen: on the first
+    sync the skeleton copy itself delivers every skeleton file — evergreen
+    ones included — so refreshing then would re-copy bytes just written.
     """
     by_topic = manifest_files_by_topic(manifest)
     source_commit = manifest.get("source_commit")
@@ -144,10 +238,28 @@ def apply_sync(
     refrozen: list[str] = []
     skipped: list[str] = []
     failed: list[str] = []
+    refreshed: list[str] = []
 
     if plan.copy_skeleton:
         files_copied += _copy_files(by_topic.get(None, []), source_root, dest_root)
         frozen.skeleton_frozen = True
+    else:
+        skeleton_by_path = {e["path"]: e for e in by_topic.get(None, [])}
+        for evergreen_plan in plan.evergreen:
+            if evergreen_plan.action != REFRESH:
+                continue
+            entry = skeleton_by_path.get(evergreen_plan.path)
+            if entry is None:
+                # The scan only plans skeleton entries; a miss means the plan
+                # and manifest went out of sync — skip rather than guess.
+                logger.warning(
+                    "evergreen: %r is not a skeleton file in the manifest; skipped",
+                    evergreen_plan.path,
+                )
+                continue
+            if _copy_files([entry], source_root, dest_root):
+                files_copied += 1
+                refreshed.append(evergreen_plan.path)
 
     for topic_plan in plan.topics:
         if topic_plan.action == SKIP_FROZEN:
@@ -190,6 +302,7 @@ def apply_sync(
         skeleton_copied=plan.copy_skeleton,
         files_copied=files_copied,
         failed_topics=tuple(failed),
+        refreshed_files=tuple(refreshed),
     )
 
 

--- a/tests/core/test_release_channels_spec.py
+++ b/tests/core/test_release_channels_spec.py
@@ -214,6 +214,79 @@ class TestChannelRemoteUrl:
         assert plain == "https://gitlab.example.com/ca/ml-jan"
 
 
+class TestEvergreen:
+    """``<evergreen>`` patterns: skeleton files exempt from the freeze."""
+
+    BLOCK = """
+    <release-channels source-target="shared">
+      <evergreen>NEWS.md</evergreen>
+      <evergreen>announcements/*</evergreen>
+      <channel name="jan" path="./solutions/jan" ledger="release/jan.txt">
+        <evergreen>jan-schedule.md</evergreen>
+        <evergreen>NEWS.md</evergreen>
+      </channel>
+      <channel name="may" path="./solutions/may" ledger="release/may.txt"/>
+    </release-channels>
+    """
+
+    def test_block_patterns_inherited_and_channel_additions_unioned(self):
+        block = _spec(self.BLOCK, TWO_STREAM_TARGETS).release_channel_blocks[0]
+        assert block.evergreen == ("NEWS.md", "announcements/*")
+        # Channel-level entries are additive; the duplicate NEWS.md is dropped.
+        assert block.channel("jan").evergreen == (
+            "NEWS.md",
+            "announcements/*",
+            "jan-schedule.md",
+        )
+        # A channel without its own entries inherits the block's.
+        assert block.channel("may").evergreen == ("NEWS.md", "announcements/*")
+
+    def test_absent_evergreen_defaults_empty(self):
+        block = """
+        <release-channels source-target="shared">
+          <channel name="jan" path="./solutions/jan" ledger="release/jan.txt"/>
+        </release-channels>
+        """
+        rc = _spec(block, TWO_STREAM_TARGETS).release_channel_blocks[0]
+        assert rc.evergreen == ()
+        assert rc.channel("jan").evergreen == ()
+
+    def test_valid_evergreen_validates_clean(self):
+        assert _spec(self.BLOCK, TWO_STREAM_TARGETS).validate() == []
+
+    def test_empty_pattern_is_a_validation_error(self):
+        block = """
+        <release-channels source-target="shared">
+          <evergreen></evergreen>
+          <channel name="jan" path="./solutions/jan" ledger="release/jan.txt"/>
+        </release-channels>
+        """
+        errors = _spec(block, TWO_STREAM_TARGETS).validate()
+        assert any("<evergreen> needs a glob pattern" in e for e in errors)
+
+    def test_backslash_pattern_is_a_validation_error(self):
+        block = r"""
+        <release-channels source-target="shared">
+          <channel name="jan" path="./solutions/jan" ledger="release/jan.txt">
+            <evergreen>docs\NEWS.md</evergreen>
+          </channel>
+        </release-channels>
+        """
+        errors = _spec(block, TWO_STREAM_TARGETS).validate()
+        assert any("backslash" in e and "Channel 'jan'" in e for e in errors)
+
+    def test_block_level_error_not_repeated_per_channel(self):
+        block = """
+        <release-channels source-target="shared">
+          <evergreen></evergreen>
+          <channel name="jan" path="./solutions/jan" ledger="release/jan.txt"/>
+          <channel name="may" path="./solutions/may" ledger="release/may.txt"/>
+        </release-channels>
+        """
+        errors = _spec(block, TWO_STREAM_TARGETS).validate()
+        assert sum("<evergreen> needs a glob pattern" in e for e in errors) == 1
+
+
 class TestLanguageScopedChannels:
     """Channel `lang` attribute (issue #293)."""
 

--- a/tests/release/test_release_cli.py
+++ b/tests/release/test_release_cli.py
@@ -1,5 +1,6 @@
 """Tests for the ``clm release`` CLI (issue #208, steps 2 + 3d)."""
 
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -853,6 +854,173 @@ def test_missing_language_root_is_a_clear_error(tmp_path):
     sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-de"])
     assert sync.exit_code != 0
     assert "Language root not found" in sync.output
+
+
+# ---------------------------------------------------------------------------
+# Evergreen skeleton files (never frozen; re-copied when content changes)
+# ---------------------------------------------------------------------------
+
+SPEC_WITH_EVERGREEN = SPEC_WITH_CHANNELS.replace(
+    '<release-channels source-target="src">',
+    '<release-channels source-target="src">\n    <evergreen>NEWS.md</evergreen>',
+)
+
+
+def _sha(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _set_news(root: Path, content: str, *, path: str = "NEWS.md", language: str = "en") -> None:
+    """Write/update a NEWS skeleton file in a built source, with a real hash.
+
+    Evergreen compares the destination's sha256 against the manifest's
+    ``content_hash``, so the entry must carry the true digest of the bytes —
+    unlike the other fixtures' fake hashes.
+    """
+    manifest = json.loads((root / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    manifest["files"] = [e for e in manifest["files"] if e["path"] != path] + [
+        {
+            "path": path,
+            "topic_id": None,
+            "section_id": None,
+            "kind": None,
+            "format": "dir-group",
+            "language": language,
+            "content_hash": _sha(content),
+        }
+    ]
+    (root / MANIFEST_FILENAME).write_text(json.dumps(manifest), encoding="utf-8")
+    target = root / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def test_channel_evergreen_refreshes_news_across_syncs(tmp_path):
+    runner = CliRunner()
+    spec_file = _write_spec(tmp_path, SPEC_WITH_EVERGREEN)
+    source = tmp_path / "output" / "src"
+    _write_source(source)
+    _set_news(source, "news v1")
+
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "jan"])
+    first = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan"])
+    assert first.exit_code == 0, first.output
+    dest = tmp_path / "solutions" / "jan"
+    # First sync ships NEWS with the skeleton; no refresh pass yet.
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "news v1"
+    assert "refresh" not in first.output
+
+    # The course publishes a new NEWS; the next sync refreshes it while the
+    # frozen topic stays untouched.
+    _set_news(source, "news v2")
+    second = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan"])
+    assert second.exit_code == 0, second.output
+    assert "refresh" in second.output
+    assert "NEWS.md" in second.output
+    assert "skip-frozen" in second.output
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "news v2"
+    frozen = FrozenManifest.load(dest / FROZEN_FILENAME, channel="jan")
+    assert frozen.is_frozen("intro")
+    assert frozen.skeleton_frozen is True
+
+    # Unchanged content -> up-to-date, nothing copied.
+    third = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan"])
+    assert third.exit_code == 0, third.output
+    assert "up-to-date" in third.output
+    assert "Evergreen: refreshed" not in third.output
+
+
+def test_evergreen_flag_in_explicit_paths_mode(tmp_path):
+    runner = CliRunner()
+    source = tmp_path / "src"
+    dest = tmp_path / "jan"
+    _write_source(source)
+    _set_news(source, "news v1")
+    ledger = tmp_path / "jan.txt"
+    Ledger(["intro"]).save(ledger)
+    args = ["sync", "--ledger", str(ledger), "--source", str(source), "--dest", str(dest)]
+
+    first = runner.invoke(release_group, [*args, "--evergreen", "NEWS.md"])
+    assert first.exit_code == 0, first.output
+
+    _set_news(source, "news v2")
+    second = runner.invoke(release_group, [*args, "--evergreen", "NEWS.md"])
+    assert second.exit_code == 0, second.output
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "news v2"
+    assert "Evergreen: refreshed 1 file(s): NEWS.md" in second.output
+
+    # Without the flag (and no spec patterns) the file stays frozen.
+    _set_news(source, "news v3")
+    third = runner.invoke(release_group, args)
+    assert third.exit_code == 0, third.output
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "news v2"
+
+
+def test_evergreen_pattern_matching_topic_files_warns_and_ignores(tmp_path):
+    runner = CliRunner()
+    source = tmp_path / "src"
+    dest = tmp_path / "jan"
+    _write_source(source)
+    ledger = tmp_path / "jan.txt"
+    Ledger(["intro"]).save(ledger)
+    args = ["sync", "--ledger", str(ledger), "--source", str(source), "--dest", str(dest)]
+
+    first = runner.invoke(release_group, args)
+    assert first.exit_code == 0, first.output
+
+    # The pattern matches a topic-owned notebook: warned about, never planned.
+    (source / "Sec" / "01 Intro.ipynb").write_text("patched", encoding="utf-8")
+    second = runner.invoke(release_group, [*args, "--evergreen", "Sec/*"])
+    assert second.exit_code == 0, second.output
+    assert "topic-owned" in second.output
+    assert "--refreeze" in second.output
+    assert (dest / "Sec/01 Intro.ipynb").read_text(encoding="utf-8") == "sha256:a"
+
+
+def test_evergreen_dry_run_shows_refresh_and_copies_nothing(tmp_path):
+    runner = CliRunner()
+    source = tmp_path / "src"
+    dest = tmp_path / "jan"
+    _write_source(source)
+    _set_news(source, "news v1")
+    ledger = tmp_path / "jan.txt"
+    Ledger(["intro"]).save(ledger)
+    args = ["sync", "--ledger", str(ledger), "--source", str(source), "--dest", str(dest)]
+
+    first = runner.invoke(release_group, [*args, "--evergreen", "NEWS.md"])
+    assert first.exit_code == 0, first.output
+
+    _set_news(source, "news v2")
+    dry = runner.invoke(release_group, [*args, "--evergreen", "NEWS.md", "--dry-run"])
+    assert dry.exit_code == 0, dry.output
+    assert "refresh" in dry.output
+    assert "NEWS.md" in dry.output
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "news v1"
+
+
+def test_lang_channel_evergreen_matches_rerooted_path(tmp_path):
+    """Patterns are destination-relative: for a lang-scoped channel the NEWS
+    at ``ml-de/NEWS.md`` in the source matches the pattern ``NEWS.md``."""
+    runner = CliRunner()
+    spec = SPEC_LANG_CHANNELS.replace(
+        '<release-channels source-target="src">',
+        '<release-channels source-target="src">\n    <evergreen>NEWS.md</evergreen>',
+    )
+    spec_file = _write_spec(tmp_path, spec)
+    source = tmp_path / "output" / "src"
+    _write_two_language_source(source)
+    _set_news(source, "de news v1", path="ml-de/NEWS.md", language="de")
+
+    runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", "jan-de"])
+    first = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-de"])
+    assert first.exit_code == 0, first.output
+    dest = tmp_path / "solutions" / "jan-de"
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "de news v1"
+
+    _set_news(source, "de news v2", path="ml-de/NEWS.md", language="de")
+    second = runner.invoke(release_group, ["sync", str(spec_file), "--channel", "jan-de"])
+    assert second.exit_code == 0, second.output
+    assert (dest / "NEWS.md").read_text(encoding="utf-8") == "de news v2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/release/test_sync.py
+++ b/tests/release/test_sync.py
@@ -1,7 +1,18 @@
 """Tests for the release sync/promote algorithm (issue #208, step 2)."""
 
+import hashlib
+
 from clm.release.frozen_manifest import FrozenManifest, FrozenRecord
-from clm.release.sync import COPY, REFREEZE, SKIP_FROZEN, apply_sync, plan_sync
+from clm.release.sync import (
+    COPY,
+    REFREEZE,
+    REFRESH,
+    SKIP_FROZEN,
+    UP_TO_DATE,
+    apply_sync,
+    plan_sync,
+    scan_evergreen,
+)
 
 INTRO_PATH = "En/Course/Notebooks/Completed/Sec/01 Intro.ipynb"
 FUNCS_PATH = "En/Course/Notebooks/Completed/Sec/02 Funcs.ipynb"
@@ -240,6 +251,181 @@ def test_sync_refuses_vcs_paths_from_a_polluted_manifest(tmp_path, caplog):
     assert (dest / ".git" / "index").read_bytes() == b"REAL"
     assert result.files_copied == 2
     assert "refused to copy 1 VCS metadata file" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Evergreen skeleton files (never frozen; re-copied when the content changes)
+# ---------------------------------------------------------------------------
+
+NEWS_PATH = "NEWS.md"
+
+
+def _sha(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _evergreen_manifest(news_content: str = "news v1") -> dict:
+    """The standard manifest plus a NEWS skeleton file with a *real* hash.
+
+    Evergreen comparisons hash the destination bytes, so — unlike the other
+    fixtures, where ``content_hash`` is a fake — the NEWS entry's hash must be
+    the true sha256 of its content.
+    """
+    manifest = _manifest()
+    manifest["files"].append(
+        {
+            "path": NEWS_PATH,
+            "topic_id": None,
+            "section_id": None,
+            "kind": None,
+            "format": "dir-group",
+            "language": "en",
+            "content_hash": _sha(news_content),
+        }
+    )
+    return manifest
+
+
+def _materialize_evergreen_source(tmp_path, manifest, news_content: str = "news v1"):
+    source = _materialize_source(tmp_path, manifest)
+    (source / NEWS_PATH).write_text(news_content, encoding="utf-8")
+    return source
+
+
+def test_scan_plans_refresh_when_dest_missing_and_up_to_date_when_current(tmp_path):
+    manifest = _evergreen_manifest("news v1")
+    dest = tmp_path / "jan"
+
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    assert [(p.path, p.action) for p in scan.plans] == [(NEWS_PATH, REFRESH)]
+    assert [p.path for p in scan.to_refresh] == [NEWS_PATH]
+
+    dest.mkdir()
+    (dest / NEWS_PATH).write_text("news v1", encoding="utf-8")
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    assert [(p.path, p.action) for p in scan.plans] == [(NEWS_PATH, UP_TO_DATE)]
+    assert scan.to_refresh == ()
+
+
+def test_scan_reports_topic_owned_matches_and_never_plans_them(tmp_path):
+    manifest = _evergreen_manifest()
+    scan = scan_evergreen(manifest=manifest, patterns=["*"], dest_root=tmp_path / "jan")
+    # Only skeleton entries are planned; topic-owned matches are reported.
+    assert {p.path for p in scan.plans} == {SKELETON_PATH, NEWS_PATH}
+    assert set(scan.topic_owned_matches) == {INTRO_PATH, FUNCS_PATH}
+
+
+def test_scan_refuses_vcs_paths(tmp_path):
+    manifest = _evergreen_manifest()
+    manifest["files"].append({"path": ".git/index", "topic_id": None, "content_hash": "sha256:x"})
+    scan = scan_evergreen(manifest=manifest, patterns=["*"], dest_root=tmp_path / "jan")
+    assert ".git/index" not in {p.path for p in scan.plans}
+
+
+def test_scan_without_patterns_is_empty(tmp_path):
+    scan = scan_evergreen(manifest=_evergreen_manifest(), patterns=[], dest_root=tmp_path / "jan")
+    assert scan.plans == ()
+    assert scan.topic_owned_matches == ()
+
+
+def test_first_sync_delivers_evergreen_via_skeleton_not_the_refresh_pass(tmp_path):
+    manifest = _evergreen_manifest("news v1")
+    source = _materialize_evergreen_source(tmp_path, manifest, "news v1")
+    dest = tmp_path / "jan"
+    frozen = FrozenManifest(channel="jan")
+
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    plan = plan_sync(
+        manifest=manifest, ledger_released=["intro"], frozen=frozen, evergreen=scan.plans
+    )
+    assert plan.copy_skeleton is True
+
+    result = apply_sync(
+        plan=plan,
+        manifest=manifest,
+        source_root=source,
+        dest_root=dest,
+        frozen=frozen,
+        copied_at="t1",
+    )
+    # NEWS arrived with the skeleton; the refresh pass did not run again.
+    assert (dest / NEWS_PATH).read_text(encoding="utf-8") == "news v1"
+    assert result.refreshed_files == ()
+
+
+def test_changed_evergreen_refreshes_after_skeleton_freeze(tmp_path):
+    # First sync freezes topic + skeleton.
+    manifest = _evergreen_manifest("news v1")
+    source = _materialize_evergreen_source(tmp_path, manifest, "news v1")
+    dest = tmp_path / "jan"
+    frozen = FrozenManifest(channel="jan")
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    plan = plan_sync(
+        manifest=manifest, ledger_released=["intro"], frozen=frozen, evergreen=scan.plans
+    )
+    apply_sync(
+        plan=plan,
+        manifest=manifest,
+        source_root=source,
+        dest_root=dest,
+        frozen=frozen,
+        copied_at="t1",
+    )
+    record_before = frozen.frozen["intro"]
+
+    # The source NEWS changes; the next build records the new hash.
+    manifest = _evergreen_manifest("news v2")
+    source = _materialize_evergreen_source(tmp_path, manifest, "news v2")
+
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    plan = plan_sync(
+        manifest=manifest, ledger_released=["intro"], frozen=frozen, evergreen=scan.plans
+    )
+    assert plan.copy_skeleton is False
+    assert plan.topics[0].action == SKIP_FROZEN
+
+    result = apply_sync(
+        plan=plan,
+        manifest=manifest,
+        source_root=source,
+        dest_root=dest,
+        frozen=frozen,
+        copied_at="t2",
+    )
+    assert result.refreshed_files == (NEWS_PATH,)
+    assert result.files_copied == 1
+    assert (dest / NEWS_PATH).read_text(encoding="utf-8") == "news v2"
+    # The freeze record is untouched: evergreen never touches topic state.
+    assert frozen.frozen["intro"] == record_before
+
+    # A third sync with unchanged content is a no-op.
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    assert [(p.path, p.action) for p in scan.plans] == [(NEWS_PATH, UP_TO_DATE)]
+
+
+def test_evergreen_added_after_skeleton_freeze_is_promoted(tmp_path):
+    """A NEWS file that did not exist when the skeleton froze still reaches the
+    cohort once it matches an evergreen pattern (dest missing -> refresh)."""
+    manifest = _evergreen_manifest("late news")
+    source = _materialize_evergreen_source(tmp_path, manifest, "late news")
+    dest = tmp_path / "jan"
+    dest.mkdir()
+    frozen = FrozenManifest(channel="jan", skeleton_frozen=True)
+
+    scan = scan_evergreen(manifest=manifest, patterns=["NEWS.md"], dest_root=dest)
+    plan = plan_sync(manifest=manifest, ledger_released=[], frozen=frozen, evergreen=scan.plans)
+    result = apply_sync(
+        plan=plan,
+        manifest=manifest,
+        source_root=source,
+        dest_root=dest,
+        frozen=frozen,
+        copied_at="t1",
+    )
+    assert result.refreshed_files == (NEWS_PATH,)
+    assert (dest / NEWS_PATH).read_text(encoding="utf-8") == "late news"
+    # The rest of the skeleton stays frozen out, as before.
+    assert not (dest / SKELETON_PATH).exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`clm release sync` is add-only by design: topics freeze per id (with `--refreeze` as the explicit override), and the skeleton — all global, topic-less files — is copied once on the first sync and then frozen with **no** override. Files that are *meant* to change over a cohort's lifetime (a NEWS file, announcements, a schedule) could therefore never be updated after the first sync.

This PR introduces **evergreen files**: skeleton files matching a glob pattern are exempt from the skeleton freeze, and every sync re-copies a matching file whose built content differs from the cohort's copy.

```xml
<release-channels source-target="solutions">
    <evergreen>NEWS.md</evergreen>                  <!-- inherited by every channel -->
    <channel name="jan" path="./solutions/jan" ledger="release/jan.txt">
        <evergreen>jan-schedule.md</evergreen>      <!-- additive per cohort -->
    </channel>
</release-channels>
```

```bash
clm release sync course.xml --channel jan --push          # NEWS.md follows the latest build
clm release sync … --evergreen NEWS.md                    # per-invocation / explicit-paths mode
```

## Design decisions

- **Skeleton-only.** Patterns match only `topic_id: null` manifest entries; a match on a topic-owned file is warned about and ignored (pointing at `--refreeze`). This keeps the per-topic `topic_digest` truthful for drift detection, keeps `--refreeze` the only way released topic content changes, and makes it impossible for a pattern to leak files of an unreleased topic.
- **Stateless copy-on-change.** The scan compares the destination file's sha256 against the manifest's `content_hash` — sound because promotion copies bytes verbatim. No change to the `.clm-released.json` format, idempotent re-runs, empty `--push` diffs when nothing changed.
- **First sync** delivers evergreen files via the normal skeleton copy; the refresh pass operates only once the skeleton is frozen. A NEWS file added *after* the skeleton froze still reaches cohorts (dest missing → refresh).
- **Matching**: fnmatch globs over destination-relative POSIX paths (the re-rooted path for `lang`-scoped channels), validated in the spec (non-empty, no backslashes). All evergreen copies go through the existing issue-#302 VCS-path refusal.
- **No deletions** — consistent with sync never deleting anything.

Plan/`--dry-run` output gains `refresh` / `up-to-date` lines, results report "Evergreen: refreshed N file(s)", and default push messages gain "N evergreen".

Full rationale (including rejected alternatives) in `docs/claude/design/release-evergreen-files.md`.

## Changes

- `core/course_spec.py` — `evergreen` on `ReleaseChannelSpec`/`ReleaseChannelsSpec`, `<evergreen>` parsing with block→channel inheritance, validation.
- `core/provenance_manifest.py` — `hash_file` made public (shared digest format).
- `release/sync.py` — `scan_evergreen` → `EvergreenScan`; `SyncPlan.evergreen`; refresh pass in `apply_sync`; `SyncResult.refreshed_files`.
- `cli/commands/release.py` — `--evergreen` on `sync`, channel pattern resolution, plan/result/push-message reporting, topic-owned-match warning.
- Info topics (`releases`, `spec-files`, `commands`), `docs/user-guide/solution-release.md`, `spec-file-reference.md`, CHANGELOG.

## Testing

- 16 new tests: spec parsing/validation, engine semantics (refresh on change, up-to-date no-op, freeze record untouched, late-added evergreen, VCS refusal, topic-owned reporting), CLI end-to-end (NEWS refresh across three syncs, explicit `--evergreen` mode, lang re-rooting, warning, dry-run).
- Fast suite: 7567 passed locally (one unrelated known-flaky worker test passes in isolation). Ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
