### PR TITLE
feat(run): spec-defined task sequences via `clm run` (`<tasks>` block)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`clm run` — spec-defined task sequences.** A new `<tasks>` block in the
+  course spec declares named sequences of clm commands (e.g. a `pre-release`
+  task that regenerates calendar/outline exports and then builds, so the
+  output never ships stale files). `clm run pre-release course.xml` executes
+  the steps in order; `clm run course.xml` lists the spec's tasks; `--dry-run`
+  previews the resolved commands. Steps are clm commands only (no shell — that
+  is what makes tasks portable across machines), support a `{spec}`
+  placeholder, run as subprocesses in the same Python environment, and are all
+  validated (placeholders + command existence) before the first one executes.
+  The first failing step aborts the task with its exit code. `clm validate`
+  checks declared tasks too. `python -m clm` now works (new module entry
+  point). See `clm info spec-files` / `clm info commands` and
+  `docs/user-guide/tasks.md`.
 - **`clm calendar push` — mirror a cohort's viewing calendar into Google
   Calendar.** Students subscribe to one shared Google calendar and pushed
   schedule changes propagate within minutes (no `.ics` hosting, no feed-refresh

--- a/docs/claude/design/spec-task-runner.md
+++ b/docs/claude/design/spec-task-runner.md
@@ -1,0 +1,220 @@
+# Spec-Defined Task Runner (`clm run`)
+
+**Status**: Implemented (branch `claude/spec-task-runner`)
+**Date**: 2026-06-10
+
+## Motivation
+
+Course maintainers run the same course-specific sequence of clm commands at
+certain points in the workflow. The motivating case: before releasing, the
+calendar and outline exports must be regenerated whenever the course spec has
+changed, and this must happen **before** the `clm build` step that copies
+those files into the output directory. Forgetting a step ships stale
+calendar/outline files.
+
+A shell script could automate this, but:
+
+- scripts are **machine-specific** (shell, paths, PATH setup), while the
+  commands are **course-specific**;
+- every step is a clm command anyway, so the course spec — already the
+  canonical home for course-specific configuration — can carry the sequence
+  portably.
+
+So: declare named task sequences in the course spec, run them with a single
+command. The trainer iterates with `clm build` (possibly `--watch`), and when
+ready to release types:
+
+```
+clm run pre-release course.xml
+```
+
+and every export/build step runs in order with the correct arguments.
+
+This is deliberately a **task runner**, not a hook system: nothing fires
+implicitly inside other commands. `clm build` stays exactly as fast and
+predictable as today; the sequence runs only when explicitly requested.
+
+## Spec format
+
+A new optional top-level `<tasks>` element in the course spec XML:
+
+```xml
+<course>
+  ...
+  <tasks>
+    <task name="pre-release" description="Regenerate exports, then build">
+      <step>export calendar {spec} --channel jan -f ics -o release/jan.ics</step>
+      <step>export outline {spec} -o outline/</step>
+      <step>build {spec} --provenance-manifest</step>
+    </task>
+    <task name="check">
+      <step>validate {spec}</step>
+      <step>calendar check {spec} --channel jan</step>
+    </task>
+  </tasks>
+</course>
+```
+
+- `<task name="...">` — required, unique within the spec. Optional
+  `description` attribute shown by the task listing.
+- `<step>` — text content is one clm command line **without the leading
+  `clm`**. Steps run in document order.
+
+### Placeholders
+
+Step text supports placeholder substitution before tokenization:
+
+| Placeholder | Expands to |
+|---|---|
+| `{spec}` | Absolute path of the spec file passed to `clm run` |
+
+An explicit placeholder is used instead of auto-injecting the spec path
+because commands take `SPEC_FILE` at different positions and some steps may
+not need it at all (`clm workers status`, …). Explicit text in the spec is
+exactly what would be typed at the prompt — no hidden rewriting.
+
+Unknown `{...}` placeholders are a hard error at resolution time (catches
+typos before anything runs). Literal braces, should they ever be needed, are
+written `{{` / `}}`.
+
+Future placeholders (not v1): `{course-root}` (spec's parent directory), and
+user parameters such as `{channel}` supplied via
+`clm run pre-release --param channel=jan` — deferred until a concrete need
+appears.
+
+### Path style inside steps
+
+Steps are tokenized with `shlex.split(..., posix=True)`, where backslash is
+an escape character. Paths inside steps must therefore use **forward
+slashes** (`-o release/jan.ics`), which clm accepts on all platforms and
+which keeps specs portable. Quoting (`"a path/with spaces.md"`) works as in
+a POSIX shell. This is documented in the spec-files info topic.
+
+## CLI
+
+New top-level command (no existing `run` command or alias conflicts):
+
+```
+clm run TASK SPEC_FILE [--dry-run]
+clm run SPEC_FILE            # lists available tasks (TASK omitted)
+clm run --list SPEC_FILE     # explicit spelling of the same
+```
+
+Both positionals are declared `required=False`; the command resolves them at
+runtime: with two arguments it runs the task; with one argument that is an
+existing file it lists that spec's tasks (name, description, step count);
+anything else is a usage error. This keeps the natural word order
+(`clm run pre-release course.xml`) while making listing cheap to discover.
+
+Behavior while running:
+
+- Before any step executes, **all** steps are resolved and validated
+  (placeholders substituted, tokenized, first token(s) checked against the
+  Click command tree). A typo in step 3 fails fast, not after 10 minutes of
+  build in step 1.
+- Each step is echoed as `[i/N] clm <resolved command>` before running, with
+  stdout/stderr passed straight through (live build progress).
+- The first non-zero exit aborts the task; `clm run` reports which step
+  failed and exits with that step's exit code.
+- `--dry-run` prints the fully resolved command lines and runs nothing.
+
+## Execution model
+
+Each step runs as a **subprocess**: `[sys.executable, "-m", "clm", *tokens]`.
+
+Why subprocess rather than invoking the Click commands in-process:
+
+- **Fidelity**: a step behaves exactly as if typed at the prompt — same
+  argument parsing, same exit codes, same logging setup.
+- **Isolation**: clm commands mutate global state (logging configuration,
+  worker pools, job-queue connections). Running `build` after `export`
+  in one process risks cross-contamination that subprocesses rule out.
+- **Cost is irrelevant**: ~1 s of interpreter startup per step is noise next
+  to export/build runtimes.
+
+`sys.executable -m clm` (not a PATH lookup of `clm`) guarantees the steps use
+the same interpreter and venv as the parent `clm run` — significant in this
+repo, where each worktree has its own venv. This requires a new two-line
+`src/clm/__main__.py`:
+
+```python
+from clm.cli.main import cli
+
+cli()
+```
+
+Steps inherit the parent's working directory and environment, so relative
+output paths in steps (`-o outline/`) resolve exactly as they would
+interactively.
+
+## Constraints and safety
+
+- **clm commands only.** The runner prepends the interpreter; there is no
+  shell, so steps cannot smuggle in arbitrary programs, pipes, or
+  redirection. This is a feature: it is what makes tasks portable across
+  machines/OSes, and it keeps "commands embedded in a data file" from
+  becoming an arbitrary-code-execution channel that surprises anyone opening
+  a course repo. An escape hatch for external commands is deliberately out
+  of scope; if a real need appears it gets its own opt-in design (explicit
+  `<step shell="...">` plus a consent story), not a quiet extension.
+- **No nesting in v1.** `run` is rejected as a step verb, so tasks cannot
+  invoke tasks (no cycle handling needed). If composition is wanted later,
+  the cleaner form is `<step task="other-task"/>` expanded inline at
+  resolution time with cycle detection.
+- Validation of the first token(s) against the actual Click command tree
+  (`clm.cli.main.cli`) means renamed/removed commands are caught at
+  resolution time with a clear message, version-accurately.
+
+## Implementation sketch
+
+1. **Spec parsing** (`src/clm/core/course_spec.py`):
+   - `@frozen class TaskSpec`: `name: str`, `description: str = ""`,
+     `steps: tuple[str, ...]`.
+   - `CourseSpec.tasks: tuple[TaskSpec, ...]` parsed from
+     `root.find("tasks")` in `from_file()`. Parse-time errors: duplicate
+     task names, empty `name`, task with no steps, empty step text.
+2. **`src/clm/__main__.py`** — module entry point (above).
+3. **CLI command** (`src/clm/cli/commands/run.py`):
+   - Resolution: placeholder substitution → `shlex.split(posix=True)` →
+     first-token validation against the command tree (walk `cli.commands`
+     through groups for multi-word verbs like `export calendar`).
+   - Execution loop with echo, pass-through output, abort-on-failure.
+   - Registered in `main.py`: `cli.add_command(run_cmd, name="run")`.
+4. **Tests**:
+   - `tests/core/`: `<tasks>` parsing (happy path, duplicates, empty task,
+     missing name).
+   - `tests/cli/`: resolution + validation + `--dry-run` + listing via
+     `CliRunner` (mind the Click 8.1/8.2 ctor compat pattern); failure
+     propagation with a monkeypatched subprocess runner; one cheap
+     end-to-end run of a trivial real step (e.g. `info commands`) to prove
+     the `-m clm` re-invocation works.
+5. **Docs** (mandatory per the info-topics rule):
+   - `src/clm/cli/info_topics/spec-files.md`: `<tasks>`/`<task>`/`<step>`
+     element, placeholder table, forward-slash rule.
+   - `src/clm/cli/info_topics/commands.md`: `clm run`.
+   - User guide: short "Task sequences" section (likely a new
+     `docs/user-guide/tasks.md` linked from the docs map), cross-referenced
+     from `solution-release.md`'s workflow steps.
+   - `CHANGELOG.md`.
+
+## Out of scope (v1)
+
+- Arbitrary/external (non-clm) commands — see Constraints.
+- Task nesting / composition.
+- Parallel steps, conditionals, per-step environment variables.
+- `--watch` integration (the iterate loop stays plain `clm build --watch`;
+  `clm run` is the explicit "I'm ready" action).
+- `--keep-going` (continue past failures).
+
+## Resolved questions (2026-06-10)
+
+1. **Command name**: `clm run`. Listing is the only other task-specific
+   action and the no-task form covers it; easy to regroup later if the task
+   system grows.
+2. **Listing UX**: a single existing-file argument lists that spec's tasks;
+   `--list` is the explicit spelling.
+3. **`clm validate` integration**: yes — the spec validator resolves every
+   step (structure, placeholders, command-tree existence), the same checks
+   `clm run` performs before executing. Structural rules live in
+   `CourseSpec.validate_tasks()` (also part of `CourseSpec.validate()`, so
+   build/export commands reject a malformed `<tasks>` block too).

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -30,6 +30,7 @@ CLM (Coding-Academy Lecture Manager) is a course content processing system that 
 - **[Recording Management](recordings.md)** - Process and track video recordings
 - **[Voiceover Synchronization](voiceover.md)** - Transcribe videos and sync with slides
 - **[Solution Release](solution-release.md)** - Release solutions to student cohorts one topic at a time (frozen per cohort)
+- **[Task Sequences](tasks.md)** - Declare named clm-command sequences in the spec and run them with `clm run` (e.g. a `pre-release` routine)
 - **[HTTP Replay](http-replay.md)** - Deterministic builds for notebooks that call live HTTP services
 - **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
 

--- a/docs/user-guide/solution-release.md
+++ b/docs/user-guide/solution-release.md
@@ -68,6 +68,11 @@ clm build course.xml        # writes .clm-manifest.json under each output root
 `--only-sections`, and errored builds — so build the *whole* solutions target
 when you intend to release from it.)
 
+If this build is preceded by the same routine every time (regenerating
+calendar/outline exports so the build copies current files), declare the
+sequence as a `<tasks>` entry in the spec and run it with one command —
+see [Task Sequences](tasks.md).
+
 ## 3. Create each cohort repo (once)
 
 ```bash

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -1,0 +1,71 @@
+# Task Sequences (`clm run`)
+
+Course maintenance often involves the same sequence of clm commands, run in
+the same order, with the same arguments — for example regenerating calendar
+and outline exports **before** the build that copies them into the output
+directory. Forgetting one step ships stale files.
+
+The `<tasks>` block in the course spec captures such sequences once, next to
+the course they belong to, and `clm run` executes them with a single command.
+Because tasks live in the spec (not in a shell script), they are versioned
+with the course and work identically on every machine and operating system.
+
+## Declaring tasks
+
+Add a `<tasks>` block to the course spec:
+
+```xml
+<course>
+    ...
+    <tasks>
+        <task name="pre-release" description="Regenerate exports, then build">
+            <step>export calendar {spec} --channel jan -f ics -o release/jan.ics</step>
+            <step>export outline {spec} -o outline/</step>
+            <step>build {spec} --provenance-manifest</step>
+        </task>
+        <task name="check">
+            <step>validate {spec}</step>
+            <step>calendar check {spec} --channel jan</step>
+        </task>
+    </tasks>
+</course>
+```
+
+Each `<step>` is one clm command line without the leading `clm` — exactly
+what you would type at the prompt. `{spec}` expands to the absolute path of
+the spec file passed to `clm run`. See `clm info spec-files` for the full
+element reference (placeholders, quoting, path rules).
+
+## Running tasks
+
+```bash
+# Iterate while authoring...
+clm build course.xml --watch
+
+# ...then run the whole pre-release sequence in one shot:
+clm run pre-release course.xml
+
+# What tasks does this course define?
+clm run course.xml
+
+# What exactly would run?
+clm run pre-release course.xml --dry-run
+```
+
+Steps run in order; each is echoed as `[i/N] clm <command>` before it
+executes. The first failing step aborts the task, and its exit code becomes
+clm's exit code. All steps are validated (placeholders, command existence)
+before the first one runs, so a typo in a late step fails immediately instead
+of after a long build.
+
+## Design constraints (and why)
+
+- **clm commands only.** Steps run without a shell — no pipes, redirection,
+  or external programs. This is what makes tasks portable; machine-specific
+  automation belongs in a script outside the spec.
+- **Forward slashes in paths.** Steps are parsed with POSIX quoting rules;
+  clm accepts forward-slash paths on every platform, including Windows.
+- **No task nesting.** A step cannot invoke `clm run`.
+
+`clm validate course.xml` checks every declared task, so broken tasks surface
+during normal validation rather than on release day.

--- a/src/clm/__main__.py
+++ b/src/clm/__main__.py
@@ -1,0 +1,11 @@
+"""Module entry point so ``python -m clm`` works.
+
+``clm run`` re-invokes the CLI through ``sys.executable -m clm`` (not a
+PATH lookup of ``clm``) so task steps are guaranteed to use the same
+interpreter and virtual environment as the parent process.
+"""
+
+from clm.cli.main import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/clm/cli/commands/run.py
+++ b/src/clm/cli/commands/run.py
@@ -1,0 +1,171 @@
+"""``clm run`` — execute a named task sequence declared in the course spec.
+
+A ``<tasks>`` block in the spec declares named sequences of clm commands
+(see ``clm info spec-files``). The trainer iterates with ``clm build``
+(possibly ``--watch``) and, when ready, runs e.g. ``clm run pre-release
+course.xml`` to execute every step — calendar/outline exports, the final
+build — in order with the correct arguments.
+
+Every step runs as a subprocess (``sys.executable -m clm …``) so it behaves
+exactly as if typed at the prompt, in the same venv as the parent, with no
+global state shared between steps. All steps are resolved and validated
+against the Click command tree *before* the first one runs, so a typo in
+step 3 fails fast instead of after a long build in step 1.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from clm.core.course_spec import CourseSpec, CourseSpecError, TaskSpec
+from clm.core.tasks import TaskStepError, resolve_step
+
+
+def unknown_cli_command_error(tokens: list[str]) -> str | None:
+    """Check that *tokens* starts with a real clm (sub)command.
+
+    Walks the Click command tree group by group until a terminal command is
+    reached; the remaining tokens are that command's arguments and are not
+    validated here (only the command itself can parse them). Returns an
+    error message, or None when the command resolves.
+    """
+    # Imported lazily: this module is itself part of the CLI, and the spec
+    # validator calls this function from outside the command tree.
+    from clm.cli.main import cli
+
+    current: click.Command = cli
+    path = "clm"
+    i = 0
+    while isinstance(current, click.Group):
+        if i >= len(tokens) or tokens[i].startswith("-"):
+            subcommands = ", ".join(sorted(current.commands))
+            return f"'{path}' needs a subcommand (one of: {subcommands})"
+        name = tokens[i]
+        subcommand = current.commands.get(name)
+        if subcommand is None:
+            subcommands = ", ".join(sorted(current.commands))
+            return f"'{path} {name}' is not a clm command (available: {subcommands})"
+        current = subcommand
+        path = f"{path} {name}"
+        i += 1
+    return None
+
+
+def _resolve_task_steps(task: TaskSpec, spec_file: Path) -> list[list[str]]:
+    """Resolve and validate every step of *task*; raise on the first problem."""
+    resolved: list[list[str]] = []
+    for i, step in enumerate(task.steps, start=1):
+        try:
+            tokens = resolve_step(step, spec_path=spec_file)
+        except TaskStepError as e:
+            raise click.ClickException(f"Task '{task.name}', step {i}: {e}") from None
+        error = unknown_cli_command_error(tokens)
+        if error:
+            raise click.ClickException(f"Task '{task.name}', step {i}: {error}")
+        resolved.append(tokens)
+    return resolved
+
+
+def _load_spec(spec_file: Path) -> CourseSpec:
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as e:
+        raise click.ClickException(str(e)) from None
+    errors = spec.validate_tasks()
+    if errors:
+        details = "\n".join(f"  - {error}" for error in errors)
+        raise click.ClickException(f"Invalid <tasks> block in {spec_file}:\n{details}")
+    return spec
+
+
+def _list_tasks(spec: CourseSpec, spec_file: Path) -> None:
+    if not spec.tasks:
+        click.echo(f"No <tasks> defined in {spec_file}.")
+        return
+    click.echo(f"Tasks in {spec_file}:")
+    for task in spec.tasks:
+        n = len(task.steps)
+        suffix = f" — {task.description}" if task.description else ""
+        click.echo(f"  {task.name}{suffix} ({n} step{'s' if n != 1 else ''})")
+        for step in task.steps:
+            click.echo(f"    clm {step}")
+
+
+@click.command("run")
+@click.argument("task_name", metavar="[TASK]", required=False)
+@click.argument(
+    "spec_file",
+    metavar="[SPEC_FILE]",
+    required=False,
+    type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--list",
+    "list_tasks",
+    is_flag=True,
+    help="List the spec's tasks instead of running one (same as omitting TASK).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print the fully resolved commands without executing anything.",
+)
+def run_cmd(task_name: str | None, spec_file: Path | None, list_tasks: bool, dry_run: bool) -> None:
+    """Run a named task sequence declared in the course spec.
+
+    Tasks are sequences of clm commands declared in a <tasks> block of the
+    spec file (see `clm info spec-files`). Steps run in order; the first
+    failing step aborts the task and its exit code becomes clm's exit code.
+
+    \b
+    Examples:
+        clm run pre-release course.xml            # run task 'pre-release'
+        clm run course.xml                        # list available tasks
+        clm run pre-release course.xml --dry-run  # show resolved commands
+    """
+    # `clm run course.xml` — a single argument naming an existing file is the
+    # spec, and listing is implied.
+    if spec_file is None and task_name is not None and Path(task_name).is_file():
+        spec_file = Path(task_name)
+        task_name = None
+    if spec_file is None:
+        raise click.UsageError(
+            "Missing spec file. Usage: clm run TASK SPEC_FILE (or clm run SPEC_FILE to list tasks)."
+        )
+    if not spec_file.is_file():
+        raise click.UsageError(f"Spec file not found: {spec_file}")
+
+    spec = _load_spec(spec_file)
+
+    if task_name is None or list_tasks:
+        _list_tasks(spec, spec_file)
+        return
+
+    task = spec.task(task_name)
+    if task is None:
+        available = ", ".join(t.name for t in spec.tasks) or "none defined"
+        raise click.ClickException(
+            f"No task named {task_name!r} in {spec_file} (available: {available})."
+        )
+
+    resolved = _resolve_task_steps(task, spec_file)
+
+    total = len(resolved)
+    for i, tokens in enumerate(resolved, start=1):
+        command_line = f"clm {shlex.join(tokens)}"
+        click.echo(f"[{i}/{total}] {command_line}")
+        if dry_run:
+            continue
+        returncode = subprocess.run([sys.executable, "-m", "clm", *tokens]).returncode
+        if returncode != 0:
+            click.echo(
+                f"Task '{task.name}' aborted: step {i}/{total} failed with "
+                f"exit code {returncode} ({command_line}).",
+                err=True,
+            )
+            raise SystemExit(returncode)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -375,6 +375,45 @@ List output targets defined in a course spec file.
 clm targets SPEC_FILE
 ```
 
+### `clm run` (CLM {version}+)
+
+Run a named task sequence declared in the spec's `<tasks>` block (see
+`clm info spec-files`). Tasks automate course-specific routines — e.g. a
+`pre-release` task that regenerates calendar/outline exports and then builds,
+so nothing is forgotten when promoting materials.
+
+```
+clm run TASK SPEC_FILE [OPTIONS]   # run a task
+clm run SPEC_FILE                  # list the spec's tasks
+```
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Print the fully resolved commands without executing anything. |
+| `--list` | List the spec's tasks instead of running one (same as omitting TASK). |
+
+Behavior:
+
+- All steps are resolved and validated (placeholders, command existence)
+  **before** the first one runs — a typo in step 3 fails fast, not after a
+  long build in step 1.
+- Each step is echoed as `[i/N] clm <command>` and runs as a subprocess with
+  the same Python interpreter and environment as the parent `clm`, inheriting
+  the current working directory.
+- The first failing step aborts the task; its exit code becomes clm's exit
+  code.
+
+```bash
+# Iterate while authoring...
+clm build course.xml --watch
+
+# ...then run the whole pre-release sequence in one shot:
+clm run pre-release course.xml
+
+# Preview what would run:
+clm run pre-release course.xml --dry-run
+```
+
 ### `clm export`
 
 Group for the **course-document exports** — commands that turn a course spec

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -747,6 +747,52 @@ course-level settings, copy the full block into the target.
 an effective `<jupyterlite>` block at either level; otherwise the build fails
 with a pointer to this topic.
 
+### `<tasks>` (CLM {version}+)
+
+Named sequences of clm commands, executed in order by `clm run <task> <spec>`.
+Use this for course-specific routines that must not be forgotten — e.g.
+regenerating calendar and outline exports **before** the build that copies
+them into the output directory:
+
+```xml
+<tasks>
+    <task name="pre-release" description="Regenerate exports, then build">
+        <step>export calendar {spec} --channel jan -f ics -o release/jan.ics</step>
+        <step>export outline {spec} -o outline/</step>
+        <step>build {spec} --provenance-manifest</step>
+    </task>
+</tasks>
+```
+
+- **`<task name="...">`** — required, unique within the spec. The optional
+  `description` attribute is shown by `clm run <spec>` (task listing).
+- **`<step>`** — one clm command line **without** the leading `clm`. Steps run
+  in declaration order; the first failing step aborts the task and its exit
+  code becomes clm's exit code.
+
+**Placeholders** (substituted before execution; unknown placeholders are an
+error):
+
+| Placeholder | Expands to |
+|---|---|
+| `{spec}` | Absolute path of the spec file passed to `clm run` |
+
+Literal braces are written `{{` / `}}`.
+
+**Rules**:
+
+- Steps must be clm commands — there is no shell, so pipes, redirection, and
+  external programs are not available. This keeps tasks portable across
+  machines and operating systems.
+- Paths inside steps must use **forward slashes** (`-o release/jan.ics`);
+  quoting works as in a POSIX shell (`-o "out dir/"`). clm accepts
+  forward-slash paths on every platform, including Windows.
+- A step must not invoke `clm run` (tasks cannot invoke other tasks).
+
+`clm validate <spec>` checks every task: structure (unique names, non-empty
+steps), placeholders, and that each step names a real clm command in the
+current CLM version.
+
 ## Complete Example
 
 ```xml

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -97,6 +97,7 @@ from clm.cli.commands.normalize_slides import normalize_slides_cmd  # noqa: E402
 from clm.cli.commands.outline import outline  # noqa: E402
 from clm.cli.commands.release import release_group  # noqa: E402
 from clm.cli.commands.resolve_topic import resolve_topic_cmd  # noqa: E402
+from clm.cli.commands.run import run_cmd  # noqa: E402
 from clm.cli.commands.schedule import schedule  # noqa: E402
 from clm.cli.commands.search_slides import search_slides_cmd  # noqa: E402
 from clm.cli.commands.slides_sync import slides_sync_cmd  # noqa: E402
@@ -155,6 +156,7 @@ cli.add_command(delete_database)
 cli.add_command(status)
 cli.add_command(monitor)
 cli.add_command(info)
+cli.add_command(run_cmd, name="run")
 cli.add_command(sync_includes_cmd)
 cli.add_command(serve)
 cli.add_command(completion_cmd)

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -1278,6 +1278,29 @@ class ReleaseChannelsSpec:
         return None
 
 
+@frozen
+class TaskSpec:
+    """One named ``<task>`` from the spec's ``<tasks>`` block (``clm run``).
+
+    Each ``<step>`` child holds one clm command line **without** the leading
+    ``clm`` (e.g. ``export calendar {spec} --channel jan``). Steps run in
+    declaration order; resolution rules (placeholders, tokenization) live in
+    :mod:`clm.core.tasks`.
+    """
+
+    name: str
+    description: str = ""
+    steps: tuple[str, ...] = ()
+
+    @classmethod
+    def from_element(cls, element: ETree.Element) -> "TaskSpec":
+        return cls(
+            name=element.get("name", ""),
+            description=element.get("description", ""),
+            steps=tuple((step.text or "").strip() for step in element.findall("step")),
+        )
+
+
 def release_channel_ref(block: ReleaseChannelsSpec, channel: ReleaseChannelSpec) -> str:
     """The canonical CLI address of *channel*: ``stream/channel`` or bare name.
 
@@ -1302,6 +1325,8 @@ class CourseSpec:
     # One entry per <release-channels> block (a release *stream*, issue #291).
     # Empty list = the solution-release feature is dormant.
     release_channel_blocks: list[ReleaseChannelsSpec] = field(factory=list)
+    # Named clm-command sequences for `clm run` (empty = feature dormant).
+    tasks: list[TaskSpec] = field(factory=list)
     image_options: ImageOptionsSpec = field(factory=ImageOptionsSpec)
     jupyterlite: JupyterLiteConfig | None = None
     author: str = "Dr. Matthias Hölzl"
@@ -1713,6 +1738,27 @@ class CourseSpec:
         """
         return [ReleaseChannelsSpec.from_element(elem) for elem in root.findall("release-channels")]
 
+    @staticmethod
+    def parse_tasks(root: ETree.Element) -> "list[TaskSpec]":
+        """Parse the optional ``<tasks>`` element (``clm run``).
+
+        Returns an empty list when no element is present — the task-runner
+        feature is then dormant. Naming/step rules are enforced by
+        :meth:`validate_tasks`, not here, so a malformed spec can still be
+        loaded for inspection.
+        """
+        container = root.find("tasks")
+        if container is None:
+            return []
+        return [TaskSpec.from_element(elem) for elem in container.findall("task")]
+
+    def task(self, name: str) -> "TaskSpec | None":
+        """Look up a ``<task>`` by name (None when absent)."""
+        for task in self.tasks:
+            if task.name == name:
+                return task
+        return None
+
     def iter_release_channels(
         self,
     ) -> "Iterator[tuple[ReleaseChannelsSpec, ReleaseChannelSpec]]":
@@ -2024,7 +2070,38 @@ class CourseSpec:
                     )
 
         errors.extend(self._validate_release_channels(target_names))
+        errors.extend(self.validate_tasks())
 
+        return errors
+
+    def validate_tasks(self) -> list[str]:
+        """Validate the ``<tasks>`` block structurally (``clm run``).
+
+        Structural rules only — placeholder and command-existence checks need
+        step resolution and the CLI command tree, so they live in
+        :mod:`clm.core.tasks` / the ``clm run`` command and are surfaced by
+        ``clm validate``. Public so the spec validator can reuse the checks
+        without running full-spec validation.
+        """
+        errors: list[str] = []
+        task_names: set[str] = set()
+        for task in self.tasks:
+            label = f"<task name={task.name!r}>" if task.name else "<task>"
+            if not task.name:
+                errors.append("Every <task> needs a name attribute.")
+            elif task.name in task_names:
+                errors.append(f"Duplicate task name: {task.name!r}")
+            task_names.add(task.name)
+
+            if not task.steps:
+                errors.append(f"{label} has no <step> elements.")
+            for i, step in enumerate(task.steps, start=1):
+                if not step:
+                    errors.append(f"{label}: step {i} is empty.")
+                elif step.split()[0] == "run":
+                    errors.append(
+                        f"{label}: step {i} invokes 'clm run' — tasks cannot invoke other tasks."
+                    )
         return errors
 
     def _validate_release_channels(self, target_names: set[str]) -> list[str]:
@@ -2227,6 +2304,7 @@ class CourseSpec:
             dictionaries=cls.parse_dir_groups(root, keep_disabled=keep_disabled),
             output_targets=cls.parse_output_targets(root),
             release_channel_blocks=cls.parse_release_channels(root),
+            tasks=cls.parse_tasks(root),
             image_options=ImageOptionsSpec.from_element(root.find("image-options")),
             jupyterlite=JupyterLiteConfig.from_element(root.find("jupyterlite")),
             author=author,

--- a/src/clm/core/tasks.py
+++ b/src/clm/core/tasks.py
@@ -1,0 +1,85 @@
+"""Resolution of ``<task>`` steps from the course spec (``clm run``).
+
+A step is one clm command line without the leading ``clm`` (e.g.
+``export calendar {spec} --channel jan``). Resolution turns the step text
+into an argv token list in two stages:
+
+1. Tokenize with POSIX ``shlex`` rules — quoting works as in a POSIX
+   shell, and **paths inside steps must use forward slashes** (backslash
+   is the shlex escape character). This keeps specs portable; clm accepts
+   forward-slash paths on every platform.
+2. Substitute ``{placeholder}`` tokens *inside each token*. Substituting
+   after tokenization means substituted values (e.g. a Windows spec path
+   containing backslashes or spaces) are never re-parsed by shlex.
+
+Unknown placeholders are a hard error so typos surface before anything
+runs. Literal braces are written ``{{`` / ``}}``.
+
+This module is CLI-free on purpose: the spec validator
+(:mod:`clm.slides.spec_validator`) uses it to check ``<tasks>`` blocks
+without importing the Click command tree.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+#: Placeholders available in task steps, with a short description each
+#: (used in error messages and documentation).
+KNOWN_PLACEHOLDERS: dict[str, str] = {
+    "spec": "absolute path of the spec file passed to `clm run`",
+}
+
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
+# Sentinels for the ``{{`` / ``}}`` escapes; chr(0) cannot appear in XML text.
+_OPEN_SENTINEL = "\x00<"
+_CLOSE_SENTINEL = "\x00>"
+
+
+class TaskStepError(Exception):
+    """A task step cannot be resolved (bad placeholder, unparseable text)."""
+
+
+def substitute_placeholders(token: str, values: dict[str, str]) -> str:
+    """Replace ``{name}`` placeholders in *token* with their values.
+
+    Raises:
+        TaskStepError: For a placeholder not present in *values*.
+    """
+    masked = token.replace("{{", _OPEN_SENTINEL).replace("}}", _CLOSE_SENTINEL)
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in values:
+            known = ", ".join(f"{{{p}}}" for p in sorted(values))
+            raise TaskStepError(f"unknown placeholder {{{name}}} (known placeholders: {known})")
+        return values[name]
+
+    substituted = _PLACEHOLDER_RE.sub(_replace, masked)
+    return substituted.replace(_OPEN_SENTINEL, "{").replace(_CLOSE_SENTINEL, "}")
+
+
+def resolve_step(step: str, *, spec_path: Path) -> list[str]:
+    """Resolve one step's text into the argv tokens to pass after ``clm``.
+
+    Args:
+        step: The step text from the spec (without the leading ``clm``).
+        spec_path: The spec file the task was loaded from; expands ``{spec}``.
+
+    Raises:
+        TaskStepError: For empty steps, unbalanced quotes, or unknown
+            placeholders.
+    """
+    if not step.strip():
+        raise TaskStepError("step is empty")
+    try:
+        tokens = shlex.split(step, posix=True)
+    except ValueError as e:
+        raise TaskStepError(f"cannot parse step: {e}") from None
+    if not tokens:
+        raise TaskStepError("step is empty")
+
+    values = {"spec": str(spec_path.resolve())}
+    return [substitute_placeholders(token, values) for token in tokens]

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -300,11 +300,65 @@ def validate_spec(
         suffix=_suffix,
     )
 
+    # ``<tasks>`` block (``clm run``): structure plus full step resolution
+    # (placeholders + command existence), so a broken task surfaces here
+    # instead of on release day.
+    _validate_tasks(spec=spec, course_spec_path=course_spec_path, findings=findings)
+
     return SpecValidationResult(
         course_spec=str(course_spec_path),
         topics_total=topics_total,
         findings=findings,
     )
+
+
+def _validate_tasks(
+    *,
+    spec: CourseSpec,
+    course_spec_path: Path,
+    findings: list[SpecFinding],
+) -> None:
+    """Validate the ``<tasks>`` block (``clm run``).
+
+    Structural rules are shared with :meth:`CourseSpec.validate_tasks`; on
+    top of those, every step is resolved (placeholder substitution +
+    tokenization, :mod:`clm.core.tasks`) and its command checked against the
+    actual Click command tree — the same checks ``clm run`` performs before
+    executing anything.
+    """
+    from clm.core.tasks import TaskStepError, resolve_step
+
+    for message in spec.validate_tasks():
+        findings.append(SpecFinding(severity="error", type="invalid_task", message=message))
+
+    # The CLI import is deferred so this module stays importable without
+    # pulling in the whole command tree (e.g. from the MCP server).
+    from clm.cli.commands.run import unknown_cli_command_error
+
+    for task in spec.tasks:
+        for i, step in enumerate(task.steps, start=1):
+            if not step:
+                continue  # already reported by validate_tasks()
+            try:
+                tokens = resolve_step(step, spec_path=course_spec_path)
+            except TaskStepError as e:
+                findings.append(
+                    SpecFinding(
+                        severity="error",
+                        type="invalid_task_step",
+                        message=f"Task '{task.name}', step {i}: {e}",
+                    )
+                )
+                continue
+            error = unknown_cli_command_error(tokens)
+            if error:
+                findings.append(
+                    SpecFinding(
+                        severity="error",
+                        type="unknown_task_command",
+                        message=f"Task '{task.name}', step {i}: {error}",
+                    )
+                )
 
 
 def _validate_subsections(

--- a/tests/cli/test_run_cmd.py
+++ b/tests/cli/test_run_cmd.py
@@ -1,0 +1,263 @@
+"""Tests for ``clm run`` — spec-defined task sequences."""
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.run import run_cmd, unknown_cli_command_error
+
+try:
+    _RUNNER = CliRunner(mix_stderr=False)  # Click < 8.2
+except TypeError:
+    _RUNNER = CliRunner()  # Click >= 8.2 (stderr always separate)
+
+
+def _out(result) -> str:
+    """stdout + stderr, robust across Click 8.1/8.2 stderr handling."""
+    return (result.output or "") + (result.stderr or "")
+
+
+SPEC_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <tasks>
+    <task name="pre-release" description="Exports, then build">
+      <step>export outline {spec} -o outline/</step>
+      <step>build {spec}</step>
+    </task>
+    <task name="single">
+      <step>info commands</step>
+    </task>
+  </tasks>
+</course>
+"""
+
+
+@pytest.fixture
+def spec_file(tmp_path: Path) -> Path:
+    path = tmp_path / "course.xml"
+    path.write_text(SPEC_XML, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def recorded_runs(monkeypatch):
+    """Replace the step subprocess with a recorder returning exit code 0."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("clm.cli.commands.run.subprocess.run", fake_run)
+    return calls
+
+
+def _write_spec(tmp_path: Path, tasks_block: str) -> Path:
+    xml = SPEC_XML.replace(
+        SPEC_XML[SPEC_XML.index("<tasks>") : SPEC_XML.index("</tasks>") + len("</tasks>")],
+        tasks_block,
+    )
+    path = tmp_path / "course.xml"
+    path.write_text(xml, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Listing and argument dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_single_file_argument_lists_tasks(spec_file: Path):
+    result = _RUNNER.invoke(run_cmd, [str(spec_file)])
+    assert result.exit_code == 0
+    assert "pre-release" in _out(result)
+    assert "Exports, then build" in _out(result)
+    assert "(2 steps)" in _out(result)
+    assert "clm build {spec}" in _out(result)
+
+
+def test_list_flag_lists_tasks(spec_file: Path):
+    result = _RUNNER.invoke(run_cmd, ["--list", str(spec_file)])
+    assert result.exit_code == 0
+    assert "single" in _out(result)
+
+
+def test_no_arguments_is_a_usage_error():
+    result = _RUNNER.invoke(run_cmd, [])
+    assert result.exit_code == 2
+    assert "Missing spec file" in _out(result)
+
+
+def test_missing_spec_file_is_a_usage_error(tmp_path: Path):
+    result = _RUNNER.invoke(run_cmd, ["pre-release", str(tmp_path / "nope.xml")])
+    assert result.exit_code == 2
+    assert "not found" in _out(result)
+
+
+def test_unknown_task_reports_available_tasks(spec_file: Path):
+    result = _RUNNER.invoke(run_cmd, ["nope", str(spec_file)])
+    assert result.exit_code == 1
+    assert "No task named 'nope'" in _out(result)
+    assert "pre-release" in _out(result)
+
+
+def test_spec_without_tasks_lists_nothing(tmp_path: Path):
+    spec = _write_spec(tmp_path, "")
+    result = _RUNNER.invoke(run_cmd, [str(spec)])
+    assert result.exit_code == 0
+    assert "No <tasks> defined" in _out(result)
+
+
+# ---------------------------------------------------------------------------
+# Resolution and validation (nothing executed)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_resolved_commands_without_executing(spec_file: Path, recorded_runs: list):
+    result = _RUNNER.invoke(run_cmd, ["pre-release", str(spec_file), "--dry-run"])
+    assert result.exit_code == 0
+    assert "[1/2] clm export outline" in _out(result)
+    assert "[2/2] clm build" in _out(result)
+    assert str(spec_file.resolve()) in _out(result)
+    assert recorded_runs == []
+
+
+def test_unknown_command_in_any_step_fails_before_executing(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(
+        tmp_path,
+        """<tasks>
+      <task name="bad">
+        <step>info commands</step>
+        <step>frobnicate {spec}</step>
+      </task>
+    </tasks>""",
+    )
+    result = _RUNNER.invoke(run_cmd, ["bad", str(spec)])
+    assert result.exit_code == 1
+    assert "step 2" in _out(result)
+    assert "frobnicate" in _out(result)
+    assert recorded_runs == []
+
+
+def test_group_without_subcommand_is_an_error(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(
+        tmp_path,
+        '<tasks><task name="bad"><step>export --help</step></task></tasks>',
+    )
+    result = _RUNNER.invoke(run_cmd, ["bad", str(spec)])
+    assert result.exit_code == 1
+    assert "needs a subcommand" in _out(result)
+    assert recorded_runs == []
+
+
+def test_unknown_placeholder_fails_before_executing(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(
+        tmp_path,
+        '<tasks><task name="bad"><step>build {sepc}</step></task></tasks>',
+    )
+    result = _RUNNER.invoke(run_cmd, ["bad", str(spec)])
+    assert result.exit_code == 1
+    assert "unknown placeholder {sepc}" in _out(result)
+    assert recorded_runs == []
+
+
+def test_structurally_invalid_tasks_block_is_an_error(tmp_path: Path):
+    spec = _write_spec(
+        tmp_path,
+        """<tasks>
+      <task name="a"><step>build {spec}</step></task>
+      <task name="a"><step>validate {spec}</step></task>
+    </tasks>""",
+    )
+    result = _RUNNER.invoke(run_cmd, [str(spec)])
+    assert result.exit_code == 1
+    assert "Duplicate task name" in _out(result)
+
+
+def test_task_nesting_is_rejected(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(
+        tmp_path,
+        '<tasks><task name="a"><step>run b {spec}</step></task></tasks>',
+    )
+    result = _RUNNER.invoke(run_cmd, ["a", str(spec)])
+    assert result.exit_code == 1
+    assert "cannot invoke other tasks" in _out(result)
+    assert recorded_runs == []
+
+
+def test_unknown_cli_command_error_resolves_real_commands():
+    assert unknown_cli_command_error(["build", "spec.xml"]) is None
+    assert unknown_cli_command_error(["export", "calendar", "spec.xml"]) is None
+    error = unknown_cli_command_error(["export", "nope"])
+    assert error is not None and "not a clm command" in error
+    error = unknown_cli_command_error(["export"])
+    assert error is not None and "needs a subcommand" in error
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def test_steps_run_in_order_via_module_invocation(spec_file: Path, recorded_runs: list):
+    result = _RUNNER.invoke(run_cmd, ["pre-release", str(spec_file)])
+    assert result.exit_code == 0
+    assert len(recorded_runs) == 2
+    spec_abs = str(spec_file.resolve())
+    assert recorded_runs[0] == [
+        sys.executable,
+        "-m",
+        "clm",
+        "export",
+        "outline",
+        spec_abs,
+        "-o",
+        "outline/",
+    ]
+    assert recorded_runs[1] == [sys.executable, "-m", "clm", "build", spec_abs]
+
+
+def test_first_failing_step_aborts_with_its_exit_code(spec_file: Path, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return SimpleNamespace(returncode=0 if len(calls) == 1 else 3)
+
+    monkeypatch.setattr("clm.cli.commands.run.subprocess.run", fake_run)
+    result = _RUNNER.invoke(run_cmd, ["pre-release", str(spec_file)])
+    assert result.exit_code == 3
+    assert len(calls) == 2  # step 2 failed; nothing ran after it
+    assert "step 2/2 failed with exit code 3" in _out(result)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (real subprocess)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_run_executes_a_real_step_end_to_end(spec_file: Path):
+    result = subprocess.run(
+        [sys.executable, "-m", "clm", "run", "single", str(spec_file)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "[1/1] clm info commands" in result.stdout
+    # The step's own output (the commands info topic) reached the console.
+    assert "clm" in result.stdout

--- a/tests/core/test_task_specs.py
+++ b/tests/core/test_task_specs.py
@@ -1,0 +1,170 @@
+"""Tests for ``<tasks>`` spec parsing and step resolution (``clm run``)."""
+
+import io
+from pathlib import Path
+
+import pytest
+
+from clm.core.course_spec import CourseSpec
+from clm.core.tasks import TaskStepError, resolve_step, substitute_placeholders
+
+
+def _spec(tasks_block: str) -> CourseSpec:
+    xml = f"""
+    <course>
+      <name><de>T</de><en>T</en></name>
+      <prog-lang>python</prog-lang>
+      <sections>
+        <section>
+          <name><de>S</de><en>S</en></name>
+          <topics><topic>intro</topic></topics>
+        </section>
+      </sections>
+      {tasks_block}
+    </course>
+    """
+    return CourseSpec.from_file(io.StringIO(xml))
+
+
+PRE_RELEASE = """
+<tasks>
+  <task name="pre-release" description="Exports, then build">
+    <step>export calendar {spec} --channel jan -f ics -o release/jan.ics</step>
+    <step>build {spec}</step>
+  </task>
+  <task name="check">
+    <step>validate {spec}</step>
+  </task>
+</tasks>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_absent_tasks_is_empty_list():
+    assert _spec("").tasks == []
+
+
+def test_parses_tasks_in_order_with_steps_and_description():
+    tasks = _spec(PRE_RELEASE).tasks
+    assert [t.name for t in tasks] == ["pre-release", "check"]
+
+    pre = tasks[0]
+    assert pre.description == "Exports, then build"
+    assert pre.steps == (
+        "export calendar {spec} --channel jan -f ics -o release/jan.ics",
+        "build {spec}",
+    )
+    assert tasks[1].description == ""
+    assert tasks[1].steps == ("validate {spec}",)
+
+
+def test_task_lookup_by_name():
+    spec = _spec(PRE_RELEASE)
+    task = spec.task("check")
+    assert task is not None
+    assert task.steps == ("validate {spec}",)
+    assert spec.task("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Structural validation
+# ---------------------------------------------------------------------------
+
+
+def test_valid_tasks_produce_no_errors():
+    assert _spec(PRE_RELEASE).validate_tasks() == []
+
+
+def test_duplicate_task_name_is_an_error():
+    block = """
+    <tasks>
+      <task name="a"><step>build {spec}</step></task>
+      <task name="a"><step>validate {spec}</step></task>
+    </tasks>
+    """
+    errors = _spec(block).validate_tasks()
+    assert any("Duplicate task name: 'a'" in e for e in errors)
+
+
+def test_missing_task_name_is_an_error():
+    errors = _spec("<tasks><task><step>build {spec}</step></task></tasks>").validate_tasks()
+    assert any("needs a name attribute" in e for e in errors)
+
+
+def test_task_without_steps_is_an_error():
+    errors = _spec('<tasks><task name="empty"/></tasks>').validate_tasks()
+    assert any("no <step> elements" in e for e in errors)
+
+
+def test_empty_step_is_an_error():
+    errors = _spec('<tasks><task name="a"><step>  </step></task></tasks>').validate_tasks()
+    assert any("step 1 is empty" in e for e in errors)
+
+
+def test_step_invoking_clm_run_is_an_error():
+    block = """
+    <tasks>
+      <task name="a"><step>run other {spec}</step></task>
+    </tasks>
+    """
+    errors = _spec(block).validate_tasks()
+    assert any("cannot invoke other tasks" in e for e in errors)
+
+
+def test_spec_validate_includes_task_errors():
+    block = '<tasks><task name="empty"/></tasks>'
+    assert any("no <step> elements" in e for e in _spec(block).validate())
+
+
+# ---------------------------------------------------------------------------
+# Step resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_step_tokenizes_and_substitutes_spec(tmp_path: Path):
+    spec_path = tmp_path / "course.xml"
+    tokens = resolve_step("export calendar {spec} --channel jan", spec_path=spec_path)
+    assert tokens == ["export", "calendar", str(spec_path.resolve()), "--channel", "jan"]
+
+
+def test_spec_path_with_spaces_and_backslashes_stays_one_token(tmp_path: Path):
+    # Substitution happens after tokenization, so a substituted path is never
+    # re-parsed by shlex — spaces and (Windows) backslashes survive intact.
+    spec_path = tmp_path / "my courses" / "course.xml"
+    tokens = resolve_step("build {spec}", spec_path=spec_path)
+    assert tokens == ["build", str(spec_path.resolve())]
+
+
+def test_placeholder_embedded_in_a_larger_token(tmp_path: Path):
+    spec_path = tmp_path / "course.xml"
+    tokens = resolve_step("build --spec={spec}", spec_path=spec_path)
+    assert tokens == ["build", f"--spec={spec_path.resolve()}"]
+
+
+def test_quoted_argument_with_spaces(tmp_path: Path):
+    tokens = resolve_step('export outline {spec} -o "out dir/"', spec_path=tmp_path / "c.xml")
+    assert tokens[-1] == "out dir/"
+
+
+def test_unknown_placeholder_is_an_error(tmp_path: Path):
+    with pytest.raises(TaskStepError, match=r"unknown placeholder \{specc\}"):
+        resolve_step("build {specc}", spec_path=tmp_path / "c.xml")
+
+
+def test_empty_step_raises(tmp_path: Path):
+    with pytest.raises(TaskStepError, match="empty"):
+        resolve_step("   ", spec_path=tmp_path / "c.xml")
+
+
+def test_unbalanced_quote_raises(tmp_path: Path):
+    with pytest.raises(TaskStepError, match="cannot parse step"):
+        resolve_step('build "unclosed', spec_path=tmp_path / "c.xml")
+
+
+def test_escaped_braces_become_literal_braces():
+    assert substitute_placeholders("a{{b}}c", {"spec": "X"}) == "a{b}c"
+    assert substitute_placeholders("{spec}{{spec}}", {"spec": "X"}) == "X{spec}"

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -1172,3 +1172,52 @@ class TestCrossReferences:
 
         result = validate_spec(spec_file, tmp_path / "slides")
         assert [f for f in result.findings if f.type.startswith("cross_reference")] == []
+
+
+class TestValidateTasks:
+    """``<tasks>`` findings (``clm run``): structure + step resolution."""
+
+    SECTIONS = """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>"""
+
+    def _validate(self, tmp_path: Path, tasks_xml: str) -> SpecValidationResult:
+        _make_topic(tmp_path, "module_100_basics", "topic_010_intro")
+        spec_file = _write_spec(tmp_path, self.SECTIONS, tasks_xml)
+        return validate_spec(spec_file, tmp_path / "slides")
+
+    def test_clean_tasks_produce_no_findings(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            """<tasks>
+              <task name="pre-release">
+                <step>export outline {spec} -o outline/</step>
+                <step>build {spec}</step>
+              </task>
+            </tasks>""",
+        )
+        assert result.findings == []
+
+    def test_structural_error_is_reported(self, tmp_path):
+        result = self._validate(tmp_path, '<tasks><task name="empty"/></tasks>')
+        assert any(f.type == "invalid_task" for f in result.errors)
+
+    def test_unknown_command_is_reported(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            '<tasks><task name="bad"><step>frobnicate {spec}</step></task></tasks>',
+        )
+        errors = [f for f in result.errors if f.type == "unknown_task_command"]
+        assert len(errors) == 1
+        assert "frobnicate" in errors[0].message
+
+    def test_unknown_placeholder_is_reported(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            '<tasks><task name="bad"><step>build {sepc}</step></task></tasks>',
+        )
+        errors = [f for f in result.errors if f.type == "invalid_task_step"]
+        assert len(errors) == 1
+        assert "{sepc}" in errors[0].message


### PR DESCRIPTION
## Summary

Course-specific pre-build routines (regenerate calendar/outline exports, *then* build so the output ships current files) previously relied on the trainer remembering every step. A shell script would be machine-specific while the commands are course-specific and clm-only — so the course spec now carries them.

A new optional `<tasks>` block declares named sequences of clm commands:

```xml
<tasks>
  <task name="pre-release" description="Regenerate exports, then build">
    <step>export calendar {spec} --channel jan -f ics -o release/jan.ics</step>
    <step>export outline {spec} -o outline/</step>
    <step>build {spec} --provenance-manifest</step>
  </task>
</tasks>
```

The trainer iterates with `clm build --watch` as usual, then runs the whole sequence in one shot:

```bash
clm run pre-release course.xml            # run task 'pre-release'
clm run course.xml                        # list available tasks
clm run pre-release course.xml --dry-run  # preview resolved commands
```

## Behavior

- **Fail-fast validation**: all steps are resolved (placeholders, tokenization) and checked against the live Click command tree *before* step 1 runs — a typo in step 3 fails immediately, not after a long build.
- **Subprocess per step**: each step runs as `sys.executable -m clm …` (new `clm/__main__.py`), guaranteeing the parent's interpreter/venv and full isolation between steps; output streams through live. Each step is echoed as `[i/N] clm <command>`; the first failure aborts the task with that step's exit code.
- **`{spec}` placeholder** expands to the spec's absolute path. Substitution happens *per token after* POSIX tokenization, so substituted Windows paths (backslashes, spaces) are never re-parsed by shlex. Unknown placeholders are a hard error; literal braces are `{{` / `}}`.
- **clm commands only, no shell, no task nesting** — by design: that is what makes tasks portable across machines, and it keeps the spec (a shared data file) from becoming an arbitrary-command-execution channel.
- **`clm validate` integration**: the spec validator resolves every declared task (structure + placeholders + command existence); `CourseSpec.validate()` rejects malformed `<tasks>` blocks, so build/export commands refuse them too.

## Implementation

- `src/clm/core/course_spec.py` — `TaskSpec`, `parse_tasks`, `task()` lookup, `validate_tasks()`
- `src/clm/core/tasks.py` — CLI-free step resolution (placeholders + tokenization)
- `src/clm/cli/commands/run.py` — the `clm run` command + command-tree walker
- `src/clm/__main__.py` — module entry point so `python -m clm` works
- `src/clm/slides/spec_validator.py` — `<tasks>` findings (`invalid_task`, `invalid_task_step`, `unknown_task_command`)

## Docs

`<tasks>` section in the `spec-files` info topic, `clm run` in the `commands` info topic, new `docs/user-guide/tasks.md`, cross-link from `solution-release.md`, CHANGELOG entry, design doc at `docs/claude/design/spec-task-runner.md`.

## Testing

- `tests/core/test_task_specs.py` — parsing, structural validation, step resolution (incl. Windows-path/space safety, escaped braces, unbalanced quotes)
- `tests/cli/test_run_cmd.py` — listing/dispatch, dry-run, fail-fast validation (nothing executes), ordered execution, exit-code propagation, plus a real-subprocess e2e test of `python -m clm run …`
- `tests/slides/test_spec_validator.py` — `<tasks>` findings via `clm validate`

Full fast suite green locally (7587 passed), ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
