### PR TITLE
docs: agents commit, push, and open PRs autonomously

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,13 @@ Full procedure lives in `docs/developer-guide/releasing.md`. The hard rules:
 ## Git Workflow
 
 - Branch prefix: `claude/` for AI-generated branches.
+- **Commit, push, and open PRs autonomously — do not wait for a go-ahead.**
+  When a task is finished (in particular after a significant chunk of work is
+  committed), push the branch without asking. When a feature or bugfix is
+  complete and you are working in a worktree, create a Pull Request without
+  asking for permission. Asking is only warranted for genuinely destructive
+  operations (force-push to a shared branch, history rewrites) or pushes to
+  `master` itself.
 - **Git hooks**: install with `uv run pre-commit install` (wires up both hook
   types via `default_install_hook_types`). The **pre-commit** hook runs ruff +
   mypy (fast, every commit); the **pre-push** hook runs the fast test suite
@@ -177,4 +184,4 @@ do not fabricate options.
 
 **Repository**: https://github.com/hoelzl/clm/ | **Issues**: https://github.com/hoelzl/clm/issues
 
-**Last Updated**: 2026-06-05
+**Last Updated**: 2026-06-10

--- a/docs/claude/per-topic-solution-release-handover.md
+++ b/docs/claude/per-topic-solution-release-handover.md
@@ -216,7 +216,9 @@ divergence (step 4), recordings (step 5).
 
 - User prefers granular commit history kept (atomic, each green) — do NOT squash
   the branch; choose squash-vs-merge at PR time. Commit at sensible checkpoints
-  without asking; **push needs an explicit request**.
+  without asking. (Historical note: at the time of this handover pushes needed
+  an explicit request; since 2026-06-10 agents push and open PRs autonomously —
+  see CLAUDE.md "Git Workflow".)
 - PlantUML/DrawIo source diagrams emit only a *source-tree* intermediate image;
   their output copy is a separate image `CourseFile` already covered — don't
   double-count or treat them as missing.


### PR DESCRIPTION
## Summary

Codifies the new standing permission for AI agents working in this repo:

- **Push without a go-ahead**: when a task is finished — in particular after a significant chunk of work has been committed — agents push the branch without waiting for permission.
- **Open PRs without asking**: when a feature or bugfix is complete and the work happened in a worktree, agents create the Pull Request directly.
- Asking remains warranted only for genuinely destructive operations (force-push to a shared branch, history rewrites) or pushes to `master` itself.

## Changes

- `CLAUDE.md`: new bullet at the top of the **Git Workflow** section; bumped *Last Updated*.
- `docs/claude/per-topic-solution-release-handover.md`: the old "push needs an explicit request" session note is marked as historical so a future agent reading the handover doesn't follow the outdated rule.

(The corresponding session memory `feedback_commit_without_asking` was updated alongside this PR; it lives outside the repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
