### PR TITLE
fix: slug collision length cap (#233) + voiceover test cache isolation (#235)

### DIFF
--- a/changelog.d/233-slug-collision-cap.fixed.md
+++ b/changelog.d/233-slug-collision-cap.fixed.md
@@ -1,0 +1,4 @@
+- `clm slides assign-ids` no longer mints collision-suffixed slide ids that
+  exceed the 30-character slug cap (and that `clm slides validate` then
+  rejected) — the base slug is trimmed at a word boundary before the `-N`
+  dedup suffix is appended (#233).

--- a/changelog.d/235-voiceover-test-cache-isolation.fixed.md
+++ b/changelog.d/235-voiceover-test-cache-isolation.fixed.md
@@ -1,0 +1,4 @@
+- The voiceover transcribe CLI tests no longer leak a
+  `.clm/voiceover-cache/transcripts/` directory into the working directory
+  `pytest` was invoked from — they now isolate the transcript cache under
+  `tmp_path` via `--cache-root` (#235).

--- a/src/clm/slides/slug.py
+++ b/src/clm/slides/slug.py
@@ -186,16 +186,23 @@ def is_valid_slug(slide_id: str, *, max_length: int = MAX_SLUG_LENGTH) -> bool:
     return bool(re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", bare))
 
 
-def resolve_collision(base: str, used: Iterable[str]) -> str:
+def resolve_collision(base: str, used: Iterable[str], *, max_length: int = MAX_SLUG_LENGTH) -> str:
     """Append ``-2``/``-3``/... until the slug is unique within ``used``.
 
     Comparisons are done on the bare (marker-stripped) form so that
-    ``!intro`` and ``intro`` correctly count as a collision.
+    ``!intro`` and ``intro`` correctly count as a collision. The suffixed
+    result always fits within ``max_length`` — the base is trimmed at a
+    word boundary if needed so that minted ids never fail
+    :func:`is_valid_slug` (issue #233).
     """
     used_bare = {strip_preserve_marker(s) for s in used}
     if base not in used_bare:
         return base
     n = 2
-    while f"{base}-{n}" in used_bare:
+    while True:
+        suffix = f"-{n}"
+        head = "-".join(_truncate_to_cap(base.split("-"), max_length - len(suffix)))
+        candidate = f"{head}{suffix}"
+        if candidate not in used_bare:
+            return candidate
         n += 1
-    return f"{base}-{n}"

--- a/tests/cli/test_voiceover_command.py
+++ b/tests/cli/test_voiceover_command.py
@@ -345,7 +345,7 @@ class TestTranscribeCommand:
         runner = CliRunner()
         result = runner.invoke(
             voiceover_group,
-            ["transcribe", str(video), "--lang", "de"],
+            ["--cache-root", str(tmp_path / "cache"), "transcribe", str(video), "--lang", "de"],
         )
 
         assert result.exit_code == 0, result.output
@@ -367,7 +367,14 @@ class TestTranscribeCommand:
         runner = CliRunner()
         result = runner.invoke(
             voiceover_group,
-            ["transcribe", str(video), "-o", str(out_file)],
+            [
+                "--cache-root",
+                str(tmp_path / "cache"),
+                "transcribe",
+                str(video),
+                "-o",
+                str(out_file),
+            ],
         )
 
         assert result.exit_code == 0, result.output

--- a/tests/slides/test_slug.py
+++ b/tests/slides/test_slug.py
@@ -141,3 +141,33 @@ class TestResolveCollision:
     def test_preserve_marker_collides(self):
         # !foo and foo are the same identifier — collision must trigger.
         assert resolve_collision("foo", ["!foo"]) == "foo-2"
+
+    def test_suffix_never_exceeds_length_cap(self):
+        # Issue #233: a 28-char base + "-2" used to mint a 31-char id that
+        # is_valid_slug then rejected. The base must be trimmed at a word
+        # boundary so the suffixed result stays within the cap.
+        base = "load-data-from-database-using"
+        assert len(base) >= MAX_SLUG_LENGTH - 2
+        result = resolve_collision(base, [base])
+        assert result == "load-data-from-database-2"
+        assert is_valid_slug(result)
+
+    def test_suffix_at_exact_cap_is_kept(self):
+        # Base short enough that base + "-2" fits exactly: no trimming.
+        base = "a" * (MAX_SLUG_LENGTH - 2)
+        result = resolve_collision(base, [base])
+        assert result == f"{base}-2"
+        assert is_valid_slug(result)
+
+    def test_trimmed_candidate_collisions_keep_counting(self):
+        base = "load-data-from-database-using"
+        used = [base, "load-data-from-database-2"]
+        result = resolve_collision(base, used)
+        assert result == "load-data-from-database-3"
+        assert is_valid_slug(result)
+
+    def test_single_long_token_is_hard_truncated(self):
+        base = "x" * MAX_SLUG_LENGTH
+        result = resolve_collision(base, [base])
+        assert result == "x" * (MAX_SLUG_LENGTH - 2) + "-2"
+        assert is_valid_slug(result)


### PR DESCRIPTION
## Summary

Two small, independent bug fixes found while triaging the C++-conversion issue batch.

### Slug collision cap (#233, item 5)

`resolve_collision` appended the `-N` dedup suffix without re-checking the 30-char slug cap, so `assign-ids` could mint an id (e.g. `load-data-from-database-using-2`, 31 chars) that `clm slides validate` then rejected as "not a valid kebab-case ASCII slug". The base slug is now trimmed at a word boundary before the suffix is appended, so minted ids always satisfy `is_valid_slug`. This resolves item 5 of #233 (the latent self-inconsistency bug); the other items are addressed separately.

### Voiceover test cwd pollution (#235)

The two `clm voiceover transcribe` CLI tests invoked the command without cache isolation, so the transcript cache fell back to `Path.cwd()` and leaked a `.clm/voiceover-cache/transcripts/` directory into whatever repo `pytest` was run from. They now pass `--cache-root <tmp_path>/cache`, matching the `--no-cache` isolation the detect/identify tests already use.

Closes #235.

## Test plan

- New `TestResolveCollision` cases: cap-exceeding base is trimmed at a word boundary, exact-cap fit untouched, trimmed-candidate collisions keep counting, single long token hard-truncated.
- Existing slug + voiceover CLI suites pass; verified no `.clm/` directory appears in the repo root after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
