### PR TITLE
feat(assign-ids): automate cold-start fixes from #233 (items 1-3)

### DIFF
--- a/changelog.d/233-assign-ids-cold-start-gaps.added.md
+++ b/changelog.d/233-assign-ids-cold-start-gaps.added.md
@@ -1,0 +1,10 @@
+- `clm slides assign-ids` automates three more cold-start fixes (#233):
+  display expressions (`data[:5]`, `result["choices"]`,
+  `response.headers["Content-Type"]`) and `for` loops are now
+  content-derived AST extractions instead of hard refusals; an alt-less
+  `<img src="…">` proposes a slug from the image filename stem
+  (`img-robots-playing-checkers`) instead of hard-refusing (multi-line
+  `<img>` tags no longer leak attribute fragments into prose extraction);
+  and voiceover/notes cells carrying `<deck-stem>-cell-N` conversion
+  placeholder ids are re-pointed to the preceding slide on the normal
+  inherit pass, without `--force`.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1213,7 +1213,14 @@ clm slides normalize slides/ --shipping-only
 Generate stable `slide_id` metadata for slide/subslide cells per the
 EN-derived, kebab-case, ASCII policy. Cells in a DE/EN pair share the
 same id (derived from the EN heading); voiceover/notes cells inherit
-the id of the preceding slide.
+the id of the preceding slide. A voiceover/notes cell that already
+carries a **conversion placeholder** id of the form `<deck-stem>-cell-N`
+(a sequential counter stamped by older conversion tooling, e.g.
+`simple_chatbot-cell-1` inside `slides_030v_simple_chatbot`) is treated
+as id-less and re-pointed to the preceding slide on the normal pass —
+no `--force` needed (since CLM {version}, issue #233). Any other
+existing id still requires `--force` (or the `!` preserve marker to pin
+it permanently).
 
 > **Plumbing (since CLM {version}).** This command is **hidden** from
 > `clm slides --help` and is intended for agents/scripts and one-off id fixes —
@@ -1232,9 +1239,19 @@ Three-category policy:
   - a first bullet, prominent bold line, or `<img alt="…">`,
   - a first non-empty prose line (HTML tags and inline markdown
     stripped, trailing terminal punctuation dropped),
+  - an image without alt text: the **filename stem** of the first
+    `<img src="…">` (since CLM {version}, issue #233) —
+    `<img src="img/robots-playing-checkers.png">` proposes
+    `img-robots-playing-checkers`. Real prose in the same cell wins;
+    multi-line `<img>` tags are recognized too,
   - in a code cell: top-level `class`, `def`, assignment, `import`/
-    `from-import`, or method call (AST-based; precedence in that
-    order),
+    `from-import`, method call, `for`/`async for` loop
+    (`for student in classroom: …` → `for-student-in-classroom`), or a
+    display expression — subscript/attribute/bare name with string keys
+    kept and slices/numeric indexes dropped (`data[:5]` → `data`,
+    `response.headers["Content-Type"]` →
+    `response-headers-content-type`) (AST-based; precedence in that
+    order; loop/display extraction since CLM {version}, issue #233),
   - in a DE/EN pair: when the EN slug source has none of the above
     but the DE sibling does, the slug derives from the DE sibling
     (transliterated to ASCII).
@@ -1242,18 +1259,20 @@ Three-category policy:
   `--llm-suggest`.
 - **code-derived** *(since CLM {version})* — a bare-expression code cell
   with no heading and none of the AST constructs above (e.g.
-  `(1 + 1j) * (1 + 1j)`, `letters[0:3]`, `a == b`). **Refused by default**;
+  `(1 + 1j) * (1 + 1j)`, `a == b`). **Refused by default**;
   opt in with `--accept-code-derived`, which slugs the cell's first real
-  code line (`letters[0:3]` → `letters-0-3`). The scanner is
+  code line (`a == b` → `a-b`). The scanner is
   comment-token-aware, so non-Python decks (`.cs`/`.cpp`/`.java`/`.ts`),
   which `ast` never parses, are completed too. Independent of
   `--accept-content-derived` — the bilingual→split conversion typically
-  passes both.
+  passes both. (Subscript displays like `letters[0:3]` moved **up** to
+  the extractable category in CLM {version}; with only
+  `--accept-code-derived` they now soft-refuse pointing at
+  `--accept-content-derived`.)
 - **no content** — cell where no extractor produces anything (empty
-  cell, pure `<img>` without alt, pure-punctuation / `...` code,
-  magic-only cells). **Hard refuse**; the author has to write
-  `slide_id="…"` by hand, or pass `--llm-suggest` to let the LLM propose
-  a title as a last resort.
+  cell, divider, pure-punctuation / `...` code, magic-only cells).
+  **Hard refuse**; the author has to write `slide_id="…"` by hand, or
+  pass `--llm-suggest` to let the LLM propose a title as a last resort.
 
 Special cases:
 
@@ -1286,8 +1305,8 @@ clm slides assign-ids [OPTIONS] PATH
 | Option | Description |
 |--------|-------------|
 | `--force` | Regenerate ids where the algorithm can produce one. `!`-prefixed ids and cells without a proposal are left untouched. |
-| `--accept-content-derived` | Auto-accept proposals for the extractable category (no LLM). Bare-expression code cells and hard-refusal cells still refuse. |
-| `--accept-code-derived` | (since CLM {version}) Auto-accept a first-code-line slug for bare-expression code cells the AST extractors can't name (`(1 + 1j) * (1 + 1j)` → `1-1j-1-1j`, `letters[0:3]` → `letters-0-3`). Comment-token-aware, so it works on non-Python decks (`.cs`/`.cpp`/`.java`/`.ts`). Genuinely empty / pure-punctuation / magic-only cells still refuse. Independent of `--accept-content-derived`. |
+| `--accept-content-derived` | Auto-accept proposals for the extractable category (no LLM), including image-filename, loop, and display-expression proposals (#233). Bare-expression code cells with no salient name and hard-refusal cells still refuse. |
+| `--accept-code-derived` | (since CLM {version}) Auto-accept a first-code-line slug for bare-expression code cells the AST extractors can't name (`(1 + 1j) * (1 + 1j)` → `1-1j-1-1j`, `a == b` → `a-b`). Comment-token-aware, so it works on non-Python decks (`.cs`/`.cpp`/`.java`/`.ts`). Genuinely empty / pure-punctuation / magic-only cells still refuse. Independent of `--accept-content-derived`. |
 | `--llm-suggest` | Use the local LLM (Ollama, default model `qwen3:30b`) to propose a short title. Fires on both extractable cells (replacing the content-derived title when the LLM returns one) and on hard-refusal cells (last-resort fallback before refusing). Cached per `(content_hash, prompt_version, lang)` in the LLM cache. Falls back silently to refusal when Ollama is unreachable. |
 | `--report-only`, `--dry-run` | List planned assignments and refusals without modifying any file. |
 | `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -96,8 +96,10 @@ class AssignedId:
     slide_id: str
     # Which strategy produced the id, for the report. One of:
     # "heading" / "sibling-heading" / "title-macro" / "voiceover-inherit" /
+    # "voiceover-reinherit" (a <deck-stem>-cell-N placeholder re-pointed, #233) /
     # "llm" / "paired" / "twin" / "content:<extractor>" (markdown bullet/bold/
-    # img/prose or the code AST extractors code:class/def/assign/import/call) /
+    # img_alt/img_src/prose or the code AST extractors
+    # code:class/def/assign/import/call/for/expr) /
     # "code:line" (the opt-in first-code-line fallback, #251).
     source: str
 
@@ -251,7 +253,10 @@ def _extract_from_cell(cell: _Cell, comment_token: str, accept_code_derived: boo
     extraction = classify(cell.body)
     if extraction.category == Category.NON_EXTRACTABLE and cell.metadata.cell_type == "code":
         code_extraction = extract_from_code(
-            cell.body, comment_token, accept_code_derived=accept_code_derived
+            cell.body,
+            comment_token,
+            accept_code_derived=accept_code_derived,
+            display_exprs=True,
         )
         if code_extraction is not None:
             return code_extraction
@@ -397,7 +402,7 @@ def assign_ids_for_cells(
             continue
 
         if role == "narrative":
-            _handle_narrative(cell, current_slide_id, options, file_str, result)
+            _handle_narrative(cell, current_slide_id, options, file_path, file_str, result)
             continue
 
         # role == "skip": unchanged.
@@ -773,10 +778,45 @@ def _try_llm_suggestion(
     return title
 
 
+# Conversion-era placeholder ids stamped on voiceover/notes cells:
+# ``<deck-stem-ish>-cell-<N>`` (e.g. ``simple_chatbot-cell-1`` in deck
+# ``slides_030v_simple_chatbot``). Sequential counters, not slide
+# references — never authoritative (#233).
+_PLACEHOLDER_CELL_RE = re.compile(r"^(?P<prefix>.+)-cell-\d+$")
+
+
+def _normalize_for_stem_match(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def _is_placeholder_narrative_id(existing: str, file_path: Path) -> bool:
+    """Whether ``existing`` is a ``<deck-stem>-cell-N`` conversion placeholder.
+
+    Both conditions must hold: the id matches the ``…-cell-<N>`` shape AND
+    its prefix is the deck's filename stem (or a ``-``-boundary suffix of
+    it, after normalizing ``_``/``-``). A hand-written id that merely ends
+    in a number, or a ``…-cell-N`` id unrelated to this deck's name, is
+    left alone.
+    """
+    m = _PLACEHOLDER_CELL_RE.match(strip_preserve_marker(existing))
+    if m is None:
+        return False
+    prefix = _normalize_for_stem_match(m.group("prefix"))
+    if not prefix:
+        return False
+    stem = file_path.stem
+    for lang_suffix in (".de", ".en"):
+        if stem.endswith(lang_suffix):
+            stem = stem[: -len(lang_suffix)]
+    stem = _normalize_for_stem_match(stem)
+    return stem == prefix or stem.endswith(f"-{prefix}")
+
+
 def _handle_narrative(
     cell: _Cell,
     current_slide_id: str | None,
     options: AssignOptions,
+    file_path: Path,
     file_str: str,
     result: AssignResult,
 ) -> None:
@@ -794,11 +834,15 @@ def _handle_narrative(
 
     bare = current_slide_id
 
-    if existing and not options.force:
-        return
-
     if existing and strip_preserve_marker(existing) == bare:
         return  # idempotent
+
+    # An existing id normally wins without --force — except a
+    # ``<deck-stem>-cell-N`` conversion placeholder, which is never
+    # authoritative and is re-pointed by the normal inherit pass (#233).
+    placeholder = existing is not None and _is_placeholder_narrative_id(existing, file_path)
+    if existing and not options.force and not placeholder:
+        return
 
     if not options.report_only:
         _write_slide_id(cell, bare)
@@ -807,7 +851,7 @@ def _handle_narrative(
             file=file_str,
             line=cell.line_number,
             slide_id=bare,
-            source="voiceover-inherit",
+            source="voiceover-reinherit" if placeholder else "voiceover-inherit",
         )
     )
 

--- a/src/clm/slides/code_cell_extract.py
+++ b/src/clm/slides/code_cell_extract.py
@@ -10,15 +10,26 @@ cell whose ``cell_type == "code"``. Walks the top-level statements with
     3. top-level assignment   -> ``<target>``
     4. import / from-import   -> ``import <name> [<name>...]``
     5. expression-stmt call   -> ``<obj> <method>`` (or ``<func>``)
-    6. first code line        -> the raw first non-comment/non-magic line
+    6. for / async for loop   -> ``for <target> in <iterable>``
+    7. expression-stmt value  -> ``<name> [<key>...]`` (subscript /
+                                 attribute / bare-name display, #233)
+    8. first code line        -> the raw first non-comment/non-magic line
                                  (only when ``accept_code_derived`` is set)
 
-Extractors 1-5 are intent-based: they name a salient construct. A bare
-expression statement (``(1 + 1j) * (1 + 1j)``, ``letters[0:3]``,
-``a == b``) has no such construct, so by default it returns ``None`` and
-the caller hard-refuses — the only non-manual escape historically being
-the LLM (#251). Extractor 6 is the **opt-in deterministic fallback** for
-exactly those cells: it slugs the first real code line. It is
+Extractors 1-7 are intent-based: they name a salient construct.
+Extractors 6-7 (#233) cover the display-style cells common on subslides:
+``data[:5]`` names ``data``, ``response.headers["Content-Type"]`` names
+``response headers Content-Type``, ``for student in classroom: …`` names
+``for student in classroom``. They run only when ``display_exprs`` is
+set: ``assign-ids`` enables it, but the sync content-anchor caller
+(:func:`clm.slides.sync_writeback.construct_of`) must NOT — anchors are
+re-derived against persisted watermark baselines, so widening the
+extractor set there would make unchanged cells' anchors drift. A bare
+expression with no salient name (``(1 + 1j) * (1 + 1j)``, ``a == b``)
+still has no construct, so by default it returns ``None`` and the caller
+hard-refuses — the only non-manual escape historically being the LLM
+(#251). Extractor 8 is the **opt-in deterministic fallback** for exactly
+those cells: it slugs the first real code line. It is
 comment-token-aware (:func:`_first_code_line`) so it works across every
 supported prog_lang, not just Python; ``ast`` is Python-only, so for a
 ``.cs`` / ``.cpp`` / ``.java`` / ``.ts`` cell the AST extractors never
@@ -32,10 +43,11 @@ LLM-fallback path.
 
 Extractor labels (``Extraction.source``) match the precedence order:
 ``code:class``, ``code:def``, ``code:assign``, ``code:import``,
-``code:call``, ``code:line``. Labels 1-5 surface in the ``assign-ids``
-report as ``content:code:<kind>`` (gated by ``--accept-content-derived``);
-``code:line`` keeps its bare label and is gated by ``--accept-code-derived``
-so it never silently activates inside the content-derived funnels.
+``code:call``, ``code:for``, ``code:expr``, ``code:line``. Labels 1-7
+surface in the ``assign-ids`` report as ``content:code:<kind>`` (gated by
+``--accept-content-derived``); ``code:line`` keeps its bare label and is
+gated by ``--accept-code-derived`` so it never silently activates inside
+the content-derived funnels.
 """
 
 from __future__ import annotations
@@ -64,7 +76,11 @@ _MAX_IMPORT_NAMES = 4
 
 
 def extract_from_code(
-    source: str, comment_token: str = "#", *, accept_code_derived: bool = False
+    source: str,
+    comment_token: str = "#",
+    *,
+    accept_code_derived: bool = False,
+    display_exprs: bool = False,
 ) -> Extraction | None:
     """Return an ``EXTRACTABLE`` proposal derived from code, or ``None``.
 
@@ -81,9 +97,13 @@ def extract_from_code(
     parseable by :mod:`ast` — be completed. ``None`` is returned only when
     nothing matched, so the caller hard-refuses as before.
 
-    ``accept_code_derived`` defaults to ``False`` so every existing caller
-    (the content-anchor in :mod:`clm.slides.sync_writeback`, the direct unit
-    tests, the four content-derived funnels) is byte-for-byte unchanged.
+    ``accept_code_derived`` and ``display_exprs`` both default to ``False``
+    so every existing caller (the content-anchor in
+    :mod:`clm.slides.sync_writeback`, the direct unit tests, the four
+    content-derived funnels) is byte-for-byte unchanged. ``display_exprs``
+    (#233) additionally enables the for-loop / display-expression
+    extractors — ``assign-ids`` sets it; the sync content-anchor must not
+    (see the module docstring).
     """
     try:
         tree = ast.parse(source)
@@ -91,13 +111,16 @@ def extract_from_code(
         tree = None
 
     if tree is not None:
-        for extractor in (
+        extractors = [
             _from_class_def,
             _from_function_def,
             _from_assignment,
             _from_import,
             _from_call,
-        ):
+        ]
+        if display_exprs:
+            extractors += [_from_for_loop, _from_expr_value]
+        for extractor in extractors:
             result = extractor(tree)
             if result is not None:
                 return result
@@ -241,6 +264,66 @@ def _from_call(tree: ast.Module) -> Extraction | None:
             name = _call_name(stmt.value.func)
             if name:
                 return Extraction(Category.EXTRACTABLE, name, "code:call")
+    return None
+
+
+def _from_for_loop(tree: ast.Module) -> Extraction | None:
+    """``for student in classroom: …`` -> ``for student in classroom`` (#233)."""
+    for stmt in tree.body:
+        if isinstance(stmt, ast.For | ast.AsyncFor):
+            target = _assignment_target_name(stmt.target)
+            iterable = _value_name(stmt.iter)
+            if target and iterable:
+                return Extraction(Category.EXTRACTABLE, f"for {target} in {iterable}", "code:for")
+            if target:
+                return Extraction(Category.EXTRACTABLE, f"for {target}", "code:for")
+    return None
+
+
+def _from_expr_value(tree: ast.Module) -> Extraction | None:
+    """Bare display expressions: subscript / attribute / name (#233).
+
+    ``data[:5]``                          -> ``data``
+    ``result["choices"]``                 -> ``result choices``
+    ``response.headers["Content-Type"]``  -> ``response headers Content-Type``
+
+    Runs after :func:`_from_call`, so a call expression never lands here.
+    Expressions with no salient head name (arithmetic, comparisons,
+    literals) return ``None`` and keep the hard-refusal behavior.
+    """
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Expr):
+            name = _value_name(stmt.value)
+            if name:
+                return Extraction(Category.EXTRACTABLE, name, "code:expr")
+    return None
+
+
+def _value_name(node: ast.AST) -> str | None:
+    """Render a value expression's salient name as readable text.
+
+    Subscript keys that are string constants are appended
+    (``post["title"]`` -> ``post title``); slices, numeric indexes, and
+    computed keys contribute nothing beyond the base name
+    (``data[:5]`` -> ``data``, ``items[0]`` -> ``items``).
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _value_name(node.value)
+        if prefix:
+            return f"{prefix} {node.attr}"
+        return node.attr
+    if isinstance(node, ast.Subscript):
+        prefix = _value_name(node.value)
+        if prefix is None:
+            return None
+        key = node.slice
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            return f"{prefix} {key.value}"
+        return prefix
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
     return None
 
 

--- a/src/clm/slides/headingless.py
+++ b/src/clm/slides/headingless.py
@@ -9,13 +9,14 @@ Three categories, matching §2.3 of ``handover-slide-format-redesign-clm.md``:
                       assign-ids algorithm handles this directly via
                       :func:`extract_heading`.
 - ``EXTRACTABLE``   — no heading, but a first bullet, a prominent bold
-                      line, or an ``<img alt="...">`` provides enough text
-                      to suggest a slug. The tool refuses by default and
-                      lists the proposal; ``--accept-content-derived``
-                      bulk-accepts.
-- ``NON_EXTRACTABLE`` — pure-image without alt, divider, empty cell, or
-                        anything else that yields no usable text. Hard
-                        refuse — the author has to write the id by hand.
+                      line, an ``<img alt="...">``, or an image filename
+                      (``<img src="...">`` without alt, #233) provides
+                      enough text to suggest a slug. The tool refuses by
+                      default and lists the proposal;
+                      ``--accept-content-derived`` bulk-accepts.
+- ``NON_EXTRACTABLE`` — divider, empty cell, or anything else that yields
+                        no usable text. Hard refuse — the author has to
+                        write the id by hand.
 """
 
 from __future__ import annotations
@@ -40,8 +41,8 @@ class Extraction:
     ``category`` is the classification. ``text`` is the raw extracted
     string (markdown formatting intact — slugification happens later via
     :func:`clm.slides.slug.slugify`). ``source`` identifies *which* extractor
-    matched (``heading``/``bullet``/``bold``/``img_alt``/``prose``) for
-    diagnostics.
+    matched (``heading``/``bullet``/``bold``/``img_alt``/``img_src``/``prose``)
+    for diagnostics.
     """
 
     category: Category
@@ -68,8 +69,20 @@ _BOLD_LINE_RE = re.compile(r"^(?:#|//)\s+\*\*([^*]+)\*\*\s*$")
 # Image with alt text.
 _IMG_ALT_RE = re.compile(r'<img[^>]*\balt="([^"]+)"', re.IGNORECASE)
 
+# Image src attribute — fallback when no alt text exists (#233). Matched
+# per line without requiring a closing ``>``, so a multi-line ``<img``
+# tag (src on the first line, style attributes on later lines) is still
+# recognized instead of leaking tag fragments into prose extraction.
+_IMG_SRC_RE = re.compile(r'<img[^>]*\bsrc="([^"]+)"', re.IGNORECASE)
+
 # HTML tag (used to drop naked <img> noise before prose extraction).
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+# Unterminated opening tag fragment at end of line — the first line of a
+# multi-line ``<img src="..."`` tag whose attributes continue on later
+# lines (#233). Requires a tag-name character after ``<`` so legit prose
+# like ``a < b`` is untouched.
+_UNCLOSED_TAG_RE = re.compile(r"<[A-Za-z!/][^>]*$")
 
 # Inline markdown formatting to unwrap before treating a line as prose.
 _BOLD_INLINE_RE = re.compile(r"\*\*([^*]+)\*\*")
@@ -107,8 +120,11 @@ def _extract_first_prose_line(lines: list[str]) -> str | None:
     matching here on `import`/`def` lines. Lines that reduce to empty
     text after stripping HTML, inline markdown formatting, and trailing
     terminal punctuation are skipped; lines with no word characters at
-    all are rejected.
+    all are rejected. A tag opened on one line and closed on a later one
+    (a multi-line ``<img …`` with per-line attributes, #233) is consumed
+    across lines so its attribute soup never reads as prose.
     """
+    in_tag = False
     for line in lines:
         # Skip blank markdown lines and any non-markdown line (e.g. raw
         # code statements in a code cell). Recognize either comment family.
@@ -118,7 +134,18 @@ def _extract_first_prose_line(lines: list[str]) -> str | None:
             content = line[3:]
         else:
             continue
+        if in_tag:
+            # Inside a multi-line tag: consume up to its ``>`` (or the
+            # whole line when the tag is still open).
+            if ">" not in content:
+                continue
+            content = content.split(">", 1)[1]
+            in_tag = False
         content = _HTML_TAG_RE.sub("", content)
+        m = _UNCLOSED_TAG_RE.search(content)
+        if m is not None:
+            in_tag = True
+            content = content[: m.start()]
         content = _BOLD_INLINE_RE.sub(r"\1", content)
         content = _ITALIC_INLINE_RE.sub(r"\1", content)
         content = _CODE_INLINE_RE.sub(r"\1", content)
@@ -137,8 +164,9 @@ def classify(content: str) -> Extraction:
 
     Precedence within the EXTRACTABLE category: first bullet/numbered item,
     then prominent bold line, then first ``<img alt="...">``, then the
-    first non-empty prose line. Whichever appears first in source order
-    wins among items of the same precedence.
+    first non-empty prose line, then — last, #233 — the filename stem of
+    the first ``<img src="...">`` without alt text. Whichever appears
+    first in source order wins among items of the same precedence.
     """
     lines = _iter_content_lines(content)
 
@@ -154,6 +182,7 @@ def classify(content: str) -> Extraction:
     first_bullet: str | None = None
     first_bold: str | None = None
     first_img_alt: str | None = None
+    first_img_src: str | None = None
 
     for line in lines:
         if first_bullet is None:
@@ -168,6 +197,10 @@ def classify(content: str) -> Extraction:
             m = _IMG_ALT_RE.search(line)
             if m:
                 first_img_alt = m.group(1).strip()
+        if first_img_src is None:
+            m = _IMG_SRC_RE.search(line)
+            if m:
+                first_img_src = m.group(1).strip()
 
     if first_bullet:
         return Extraction(Category.EXTRACTABLE, first_bullet, "bullet")
@@ -180,7 +213,26 @@ def classify(content: str) -> Extraction:
     if prose:
         return Extraction(Category.EXTRACTABLE, prose, "prose")
 
+    if first_img_src:
+        # Image-only cell with no alt text: derive from the image
+        # filename stem (#233) — ``img/robots-playing-checkers.png`` ->
+        # ``img robots-playing-checkers``. Real prose (a caption) still
+        # wins above; this only rescues the previously hard-refused case.
+        stem = _img_src_stem(first_img_src)
+        if stem:
+            return Extraction(Category.EXTRACTABLE, f"img {stem}", "img_src")
+
     return Extraction(Category.NON_EXTRACTABLE)
+
+
+def _img_src_stem(src: str) -> str:
+    """Filename stem of an image src (path/URL noise and extension dropped)."""
+    name = src.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    # Drop a URL query/fragment, then the extension.
+    name = name.split("?", 1)[0].split("#", 1)[0]
+    if "." in name:
+        name = name.rsplit(".", 1)[0]
+    return name.strip()
 
 
 def cell_text_for_llm(content: str, *, max_chars: int = 1500) -> str:

--- a/tests/cli/test_assign_ids_refusals.py
+++ b/tests/cli/test_assign_ids_refusals.py
@@ -9,12 +9,14 @@ from click.testing import CliRunner
 
 from clm.cli.main import cli
 
+# The hard-refusal cell is an HTML comment: an alt-less <img src> stopped
+# hard-refusing with the #233 filename-stem fallback.
 DECK = (
     '# %% [markdown] lang="en" tags=["slide"]\n'
     "# ## Introduction\n"
     "\n"
     '# %% [markdown] lang="en" tags=["slide"]\n'
-    '# <img src="img/diagram.png">\n'
+    "# <!-- placeholder-diagram -->\n"
 )
 
 
@@ -31,7 +33,7 @@ def test_report_refusals_lists_hard(tmp_path):
     assert "[hard]" in r.output
     assert "1 hard refusal(s)" in r.output
     # Without --context, no cell body is shown.
-    assert "img/diagram.png" not in r.output
+    assert "placeholder-diagram" not in r.output
 
 
 def test_report_refusals_does_not_write(tmp_path):
@@ -46,7 +48,7 @@ def test_context_implies_report_refusals_and_shows_body(tmp_path):
     # --context alone (no explicit --report-refusals) still produces the worklist.
     r = CliRunner().invoke(cli, ["slides", "assign-ids", str(f), "--context", "--report-only"])
     assert "[hard]" in r.output
-    assert "img/diagram.png" in r.output
+    assert "placeholder-diagram" in r.output
     assert 'heading "Introduction"' in r.output
 
 
@@ -59,7 +61,7 @@ def test_report_refusals_json(tmp_path):
     assert data["hard_refusals"] == 1
     ctx = data["refusals"][0]["context"]
     assert ctx["preceding_heading"] == "Introduction"
-    assert "diagram.png" in ctx["body"]
+    assert "placeholder-diagram" in ctx["body"]
 
 
 def test_clean_deck_reports_no_refusals(tmp_path):

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -194,8 +194,16 @@ class TestNonExtractableSlides:
         assert result.refusals[0].severity == "hard"
         assert new_text == text
 
-    def test_image_without_alt_hard_refuses(self):
+    def test_image_without_alt_soft_refuses_with_filename_proposal(self):
+        # Used to hard-refuse; since #233 the filename stem is proposed as
+        # a content-derived slug (accepted via --accept-content-derived).
         text = '# %% [markdown] lang="en" tags=["slide"]\n#\n# <img src="divider.png"/>\n'
+        new_text, result = _run(text)
+        assert result.refusals[0].severity == "soft"
+        assert result.refusals[0].proposed_slug == "img-divider"
+
+    def test_divider_cell_hard_refuses(self):
+        text = '# %% [markdown] lang="en" tags=["slide"]\n#\n# ---\n'
         new_text, result = _run(text)
         assert result.refusals[0].severity == "hard"
 
@@ -317,6 +325,67 @@ class TestVoiceoverInheritance:
         assert narrative[0].slide_id == "rag"
         assert 'slide_id="rag"' in new_text
         assert 'slide_id="old-cell-id"' not in new_text
+
+
+class TestPlaceholderVoiceoverReinherit:
+    """``<deck-stem>-cell-N`` placeholder ids are re-pointed without --force (#233)."""
+
+    DECK = (
+        '# %% [markdown] lang="de" tags=["slide"]\n'
+        "# ## RAG Architecture\n"
+        '# %% [markdown] lang="de" tags=["voiceover"] slide_id="{vo_id}"\n'
+        "# - voiceover content\n"
+    )
+
+    def _run_at(self, vo_id: str, path: str, **kwargs):
+        options = AssignOptions(**kwargs)
+        return assign_ids_for_text(self.DECK.format(vo_id=vo_id), Path(path), options)
+
+    def test_full_stem_placeholder_repointed(self):
+        new_text, result = self._run_at(
+            "slides_030v_simple_chatbot-cell-3", "slides_030v_simple_chatbot.de.py"
+        )
+        narrative = [a for a in result.assignments if a.source == "voiceover-reinherit"]
+        assert len(narrative) == 1
+        assert narrative[0].slide_id == "rag-architecture"
+        assert 'slide_id="rag-architecture"' in new_text
+        assert "cell-3" not in new_text
+
+    def test_stem_suffix_placeholder_repointed(self):
+        # Conversion tools stamped a *suffix* of the deck stem, e.g.
+        # ``simple_chatbot-cell-1`` in deck slides_030v_simple_chatbot.
+        new_text, result = self._run_at("simple_chatbot-cell-1", "slides_030v_simple_chatbot.de.py")
+        narrative = [a for a in result.assignments if a.source == "voiceover-reinherit"]
+        assert len(narrative) == 1
+        assert 'slide_id="rag-architecture"' in new_text
+
+    def test_unrelated_cell_n_id_kept(self):
+        # ``…-cell-N`` whose prefix is NOT this deck's stem is left alone.
+        new_text, result = self._run_at("other-deck-cell-2", "slides_030v_simple_chatbot.de.py")
+        assert not [a for a in result.assignments if a.source == "voiceover-reinherit"]
+        assert 'slide_id="other-deck-cell-2"' in new_text
+
+    def test_legit_existing_id_kept(self):
+        new_text, result = self._run_at("rag-overview", "slides_030v_simple_chatbot.de.py")
+        assert not [a for a in result.assignments if "voiceover" in a.source]
+        assert 'slide_id="rag-overview"' in new_text
+
+    def test_preserved_placeholder_wins(self):
+        new_text, result = self._run_at(
+            "!slides_030v_simple_chatbot-cell-3", "slides_030v_simple_chatbot.de.py"
+        )
+        assert not [a for a in result.assignments if "voiceover" in a.source]
+        assert 'slide_id="!slides_030v_simple_chatbot-cell-3"' in new_text
+
+    def test_report_only_proposes_without_writing(self):
+        new_text, result = self._run_at(
+            "slides_030v_simple_chatbot-cell-3",
+            "slides_030v_simple_chatbot.de.py",
+            report_only=True,
+        )
+        narrative = [a for a in result.assignments if a.source == "voiceover-reinherit"]
+        assert len(narrative) == 1
+        assert 'slide_id="slides_030v_simple_chatbot-cell-3"' in new_text
 
 
 # ---------------------------------------------------------------------------
@@ -763,13 +832,32 @@ class TestCodeDerivedFallback:
         assert new_text2 == new_text
 
     def test_collision_suffix_for_identical_code_lines(self):
+        # Comparison expressions stay on the code:line path (#233 moved
+        # subscript displays like letters[0:3] up to content:code:expr).
         text = (
-            '# %% lang="en" tags=["subslide"]\nletters[0:3]\n'
-            '# %% lang="en" tags=["subslide"]\nletters[0:3]\n'
+            '# %% lang="en" tags=["subslide"]\na == b\n# %% lang="en" tags=["subslide"]\na == b\n'
         )
         new_text, result = _run(text, accept_code_derived=True)
         slugs = [a.slide_id for a in result.assignments]
-        assert slugs == ["letters-0-3", "letters-0-3-2"]
+        assert slugs == ["a-b", "a-b-2"]
+
+    def test_subscript_display_is_content_derived(self):
+        # letters[0:3] is intent-extracted since #233: content:code:expr,
+        # gated by --accept-content-derived, with the clean base-name slug.
+        text = '# %% lang="en" tags=["subslide"]\nletters[0:3]\n'
+        new_text, result = _run(text, accept_content_derived=True)
+        assert [a.slide_id for a in result.assignments] == ["letters"]
+        assert result.assignments[0].source == "content:code:expr"
+
+    def test_for_loop_is_content_derived(self):
+        text = (
+            '# %% lang="en" tags=["subslide"]\n'
+            "for student in classroom:\n"
+            "    print(evaluate_student(student))\n"
+        )
+        new_text, result = _run(text, accept_content_derived=True)
+        assert [a.slide_id for a in result.assignments] == ["for-student-in-classroom"]
+        assert result.assignments[0].source == "content:code:for"
 
     def test_preserve_marker_untouched(self):
         text = '# %% lang="en" tags=["subslide"] slide_id="!keep"\n(1 + 1j) * (1 + 1j)\n'
@@ -819,26 +907,26 @@ class TestCodeDerivedFallback:
 
     def test_pair_safe_directory(self, tmp_path: Path):
         # find_slide_files only discovers slides_*/topic_*/project_* names.
-        _write(tmp_path, '# %% lang="de" tags=["subslide"]\nletters[0:3]\n', "slides_deck.de.py")
-        _write(tmp_path, '# %% lang="en" tags=["subslide"]\nletters[0:3]\n', "slides_deck.en.py")
+        _write(tmp_path, '# %% lang="de" tags=["subslide"]\na == b\n', "slides_deck.de.py")
+        _write(tmp_path, '# %% lang="en" tags=["subslide"]\na == b\n', "slides_deck.en.py")
         assign_ids_in_directory(tmp_path, AssignOptions(accept_code_derived=True))
         de_text = (tmp_path / "slides_deck.de.py").read_text(encoding="utf-8")
         en_text = (tmp_path / "slides_deck.en.py").read_text(encoding="utf-8")
-        assert 'slide_id="letters-0-3"' in de_text
-        assert 'slide_id="letters-0-3"' in en_text
+        assert 'slide_id="a-b"' in de_text
+        assert 'slide_id="a-b"' in en_text
 
     def test_pair_safe_per_file_twin(self, tmp_path: Path):
         # EN minted via code-derived, then the id-less DE half adopts the twin
         # id through the per-file twin path — code-derived ids stay in parity.
-        de = _write(tmp_path, '# %% lang="de" tags=["subslide"]\nletters[0:3]\n', "deck.de.py")
-        en = _write(tmp_path, '# %% lang="en" tags=["subslide"]\nletters[0:3]\n', "deck.en.py")
+        de = _write(tmp_path, '# %% lang="de" tags=["subslide"]\na == b\n', "deck.de.py")
+        en = _write(tmp_path, '# %% lang="en" tags=["subslide"]\na == b\n', "deck.en.py")
         assign_ids_in_file(en, AssignOptions(accept_code_derived=True))
         assign_ids_in_file(de, AssignOptions(accept_code_derived=True))
         import re
 
         de_id = re.search(r'slide_id="([^"]+)"', de.read_text(encoding="utf-8")).group(1)
         en_id = re.search(r'slide_id="([^"]+)"', en.read_text(encoding="utf-8")).group(1)
-        assert de_id == en_id == "letters-0-3"
+        assert de_id == en_id == "a-b"
 
     def test_non_python_pair_safe(self):
         # ast.parse can't parse C#; the comment-token-aware fallback completes
@@ -860,7 +948,9 @@ class TestLLMSuggestOnHardRefusal:
     entire hard-refusal set (the dominant pattern in real corpora).
     """
 
-    HARD_REFUSAL_TEXT = '# %% [markdown] lang="en" tags=["slide"]\n#\n# <img src="x.png"/>\n'
+    # A divider-only cell: genuinely nothing to extract (an alt-less <img>
+    # stopped being a hard refusal with the #233 filename-stem fallback).
+    HARD_REFUSAL_TEXT = '# %% [markdown] lang="en" tags=["slide"]\n#\n# ---\n'
 
     def test_llm_fires_on_hard_refusal(self):
         suggester = StaticTitleSuggester(default="RAG Architecture Diagram")

--- a/tests/slides/test_code_cell_extract.py
+++ b/tests/slides/test_code_cell_extract.py
@@ -52,8 +52,9 @@ class TestPrecedence:
 
     def test_call_when_nothing_else(self):
         source = "response.choices[0].message.content\n"
-        # Bare attribute access — not a Call expression — falls through.
-        # That's an ast.Expr wrapping ast.Attribute, not ast.Call.
+        # Bare attribute access — not a Call expression — falls through
+        # by default. The opt-in ``display_exprs`` extractor (#233) names
+        # it; see TestDisplayExprExtractors.
         e = extract_from_code(source)
         assert e is None
 
@@ -270,3 +271,83 @@ class TestFirstCodeLineFallback:
     def test_non_python_comment_only_returns_none(self):
         assert extract_from_code("// just a comment", "//", accept_code_derived=True) is None
         assert extract_from_code("/* block only */", "//", accept_code_derived=True) is None
+
+
+class TestDisplayExprExtractors:
+    """The opt-in ``display_exprs`` extractors for display-style cells (#233).
+
+    Off by default so the sync content-anchor (`construct_of`) keeps
+    deriving exactly the anchors recorded in existing watermark baselines;
+    ``assign-ids`` opts in.
+    """
+
+    def test_off_by_default(self):
+        assert extract_from_code("data[:5]\n") is None
+        assert extract_from_code("for x in items:\n    print(x)\n") is None
+
+    def test_subscript_slice(self):
+        e = extract_from_code("data[:5]\n", display_exprs=True)
+        assert e is not None
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "code:expr"
+        assert e.text == "data"
+
+    def test_subscript_string_key(self):
+        e = extract_from_code('result["choices"]\n', display_exprs=True)
+        assert e is not None
+        assert e.source == "code:expr"
+        assert e.text == "result choices"
+
+    def test_attribute_plus_subscript_key(self):
+        e = extract_from_code('response.headers["Content-Type"]\n', display_exprs=True)
+        assert e is not None
+        assert e.text == "response headers Content-Type"
+
+    def test_numeric_index_dropped(self):
+        e = extract_from_code("items[0]\n", display_exprs=True)
+        assert e is not None
+        assert e.text == "items"
+
+    def test_attribute_chain_with_numeric_index(self):
+        e = extract_from_code("response.choices[0].message.content\n", display_exprs=True)
+        assert e is not None
+        assert e.text == "response choices message content"
+
+    def test_bare_name(self):
+        e = extract_from_code("ice_cream_x\n", display_exprs=True)
+        assert e is not None
+        assert e.text == "ice_cream_x"
+
+    def test_for_loop(self):
+        source = "for student in classroom:\n    print(evaluate_student(student))\n"
+        e = extract_from_code(source, display_exprs=True)
+        assert e is not None
+        assert e.source == "code:for"
+        assert e.text == "for student in classroom"
+
+    def test_for_loop_over_call(self):
+        e = extract_from_code("for i in range(10):\n    pass\n", display_exprs=True)
+        assert e is not None
+        assert e.text == "for i in range"
+
+    def test_for_loop_tuple_target(self):
+        e = extract_from_code("for k, v in mapping.items():\n    pass\n", display_exprs=True)
+        assert e is not None
+        assert e.source == "code:for"
+        assert e.text.startswith("for k v in mapping")
+
+    def test_call_still_wins_over_expr(self):
+        e = extract_from_code("print(data[:5])\n", display_exprs=True)
+        assert e is not None
+        assert e.source == "code:call"
+
+    def test_arithmetic_still_refuses(self):
+        assert extract_from_code("(1 + 1j) * (1 + 1j)\n", display_exprs=True) is None
+
+    def test_comparison_still_refuses(self):
+        assert extract_from_code("a == b\n", display_exprs=True) is None
+
+    def test_falls_back_to_code_line_when_both_flags(self):
+        e = extract_from_code("a == b\n", display_exprs=True, accept_code_derived=True)
+        assert e is not None
+        assert e.source == "code:line"

--- a/tests/slides/test_headingless.py
+++ b/tests/slides/test_headingless.py
@@ -66,12 +66,69 @@ class TestClassify:
     def test_non_extractable_empty(self):
         assert classify("").category == Category.NON_EXTRACTABLE
 
-    def test_non_extractable_img_without_alt(self):
-        content = '#\n# <img src="divider.png"/>\n'
-        assert classify(content).category == Category.NON_EXTRACTABLE
-
     def test_non_extractable_only_whitespace(self):
         assert classify("#\n#  \n#\n").category == Category.NON_EXTRACTABLE
+
+
+class TestImgSrcFallback:
+    """Alt-less image cells derive a slug from the filename stem (#233)."""
+
+    def test_img_without_alt_uses_filename_stem(self):
+        content = '#\n# <img src="img/robots-playing-checkers.png" style="width:60%"/>\n'
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "img_src"
+        assert e.text == "img robots-playing-checkers"
+
+    def test_img_without_alt_short_src(self):
+        content = '#\n# <img src="divider.png"/>\n'
+        e = classify(content)
+        assert e.category == Category.EXTRACTABLE
+        assert e.source == "img_src"
+        assert e.text == "img divider"
+
+    def test_multiline_img_tag(self):
+        # src on the first line, attributes continuing on later lines —
+        # the tag fragments must not be mistaken for prose.
+        content = (
+            "#\n"
+            '# <img src="img/robots-playing-checkers.png"\n'
+            '#      style="display:block; width:60%"\n'
+            '#      class="centered">\n'
+        )
+        e = classify(content)
+        assert e.source == "img_src"
+        assert e.text == "img robots-playing-checkers"
+
+    def test_alt_still_wins_over_src(self):
+        content = '#\n# <img src="img/foo.png" alt="A diagram"/>\n'
+        e = classify(content)
+        assert e.source == "img_alt"
+        assert e.text == "A diagram"
+
+    def test_prose_still_wins_over_src(self):
+        content = '#\n# <img src="divider.png"/>\n# Real prose here\n'
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Real prose here"
+
+    def test_url_src_query_dropped(self):
+        content = '#\n# <img src="https://example.com/pics/foo.png?v=2#frag"/>\n'
+        e = classify(content)
+        assert e.source == "img_src"
+        assert e.text == "img foo"
+
+    def test_prose_after_multiline_img_tag_wins(self):
+        content = '#\n# <img src="img/foo.png"\n#      style="width:60%">\n# A caption line\n'
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "A caption line"
+
+    def test_comparison_prose_not_eaten_by_tag_rule(self):
+        content = "#\n# Check that a < b holds\n"
+        e = classify(content)
+        assert e.source == "prose"
+        assert e.text == "Check that a < b holds"
 
 
 class TestProseLineExtraction:
@@ -126,9 +183,12 @@ class TestProseLineExtraction:
         assert e.source == "prose"
         assert e.text == "Real prose here"
 
-    def test_naked_img_alone_refuses(self):
+    def test_naked_img_alone_is_not_prose(self):
+        # A naked <img> never reads as prose; since #233 it extracts via
+        # the filename-stem fallback instead of hard-refusing.
         content = '#\n# <img src="divider.png"/>\n'
-        assert classify(content).category == Category.NON_EXTRACTABLE
+        e = classify(content)
+        assert e.source == "img_src"
 
     def test_strips_inline_italic(self):
         content = "#\n# *Some italic prose*\n"

--- a/tests/slides/test_refusal_report.py
+++ b/tests/slides/test_refusal_report.py
@@ -11,8 +11,9 @@ from clm.slides.refusal_report import (
     worklist_to_dict,
 )
 
-# A deck with: a headed slide, a hard-refusal slide (img, no alt), and a
-# soft-refusal slide (bullet content but no heading).
+# A deck with: a headed slide, a hard-refusal slide (an HTML comment —
+# an alt-less <img src> stopped hard-refusing with the #233 filename-stem
+# fallback), and a soft-refusal slide (bullet content but no heading).
 DECK = (
     '# %% [markdown] lang="en" tags=["slide"]\n'
     "# ## Introduction\n"
@@ -20,7 +21,7 @@ DECK = (
     "# Welcome.\n"
     "\n"
     '# %% [markdown] lang="en" tags=["slide"]\n'
-    '# <img src="img/diagram.png">\n'
+    "# <!-- placeholder-diagram -->\n"
     "\n"
     '# %% [markdown] lang="en" tags=["slide"]\n'
     "# - first bullet here\n"
@@ -60,7 +61,7 @@ class TestBuildWorklist:
         hard = wl.hard[0]
         assert hard.context is not None
         assert hard.context.marker.startswith("# %% [markdown]")
-        assert "img/diagram.png" in hard.context.body
+        assert "placeholder-diagram" in hard.context.body
         assert hard.context.preceding_heading == "Introduction"
         assert hard.context.cell_type == "markdown"
         assert hard.context.lang == "en"
@@ -90,7 +91,7 @@ class TestBuildWorklist:
         assert wl.entries[0].context is None
 
     def test_start_of_deck_has_no_anchors(self, tmp_path):
-        text = '# %% [markdown] lang="en" tags=["slide"]\n# <img src="x.png">\n'
+        text = '# %% [markdown] lang="en" tags=["slide"]\n# <!-- x -->\n'
         f = _write(tmp_path, text)
         result = assign_ids_in_file(f, AssignOptions(report_only=True))
         wl = build_refusal_worklist(result.refusals, with_context=True)
@@ -111,7 +112,7 @@ class TestRender:
         out = render_worklist(build_refusal_worklist(result.refusals, with_context=True))
         assert "[hard]" in out
         assert 'heading "Introduction"' in out
-        assert "img/diagram.png" in out
+        assert "placeholder-diagram" in out
         assert "1 hard refusal(s)" in out
 
     def test_render_without_context_is_compact(self, tmp_path):
@@ -120,7 +121,7 @@ class TestRender:
         out = render_worklist(build_refusal_worklist(result.refusals))
         assert "[hard]" in out
         # No body lines piped in without context.
-        assert "img/diagram.png" not in out
+        assert "placeholder-diagram" not in out
 
 
 class TestToDict:


### PR DESCRIPTION
## Summary

Implements the three highest-cost manual-fix classes from #233 (items 1–3; item 5 — the slug collision cap bug — landed separately in #313):

### 1. Display expressions and `for` loops are intent-extracted (item 1)

`data[:5]`, `result["choices"]`, `response.headers["Content-Type"]`, and `for student in classroom: …` were hard-refused by the AST extractors and only completable via the opaque first-code-line fallback. Two new extractors (`code:expr`, `code:for`) now name them — string subscript keys are kept, slices/numeric indexes dropped — and route through `--accept-content-derived` like the other AST extractors.

**Anchor-stability guard:** `sync_writeback.construct_of` also calls `extract_from_code` to derive sync content anchors that are re-joined against persisted watermark baselines. The new extractors are therefore gated behind a `display_exprs` flag that only `assign-ids` enables, so anchors of unchanged cells cannot drift after upgrading.

One consequence: with only `--accept-code-derived`, subscript displays now soft-refuse pointing at `--accept-content-derived` (they moved up the quality ladder). The documented cold-start funnel passes both flags, so combined runs only get better slugs.

### 2. Image-filename slugs for alt-less `<img>` (item 2)

An image-only cell without alt text proposes `img-<filename-stem>` (`img-robots-playing-checkers`) instead of hard-refusing. Real prose in the cell still wins; `<img alt="…">` still wins over the stem. The prose scanner now also consumes multi-line `<img>` tags, which previously leaked `img-src-img-…` attribute fragments as "prose".

### 3. Placeholder voiceover ids re-pointed without `--force` (item 3)

A voiceover/notes cell carrying a `<deck-stem>-cell-N` conversion placeholder (e.g. `simple_chatbot-cell-1` in `slides_030v_simple_chatbot`) is recognized as non-authoritative and re-pointed to the preceding slide by the normal inherit pass (report source `voiceover-reinherit`). Recognition requires both the `-cell-N` shape and a deck-stem prefix match, so hand-written ids ending in numbers are never touched. This replaces the ~68-cell manual validator-output-parsing fix described in the issue.

Items 2 and 4 of #233 remain (validator suggestion polish + start/completed retagging); the issue stays open for those.

`clm info commands` (`info_topics/commands.md`) updated for all three behavior changes.

## Test plan

- New: `TestDisplayExprExtractors` (14 cases incl. off-by-default + anchor-stability), `TestImgSrcFallback` (8 cases incl. multi-line tags, URL srcs, `a < b` prose), `TestPlaceholderVoiceoverReinherit` (6 cases incl. preserve marker, unrelated `-cell-N`, report-only).
- Existing tests that encoded the old hard-refusals updated deliberately (refusal-report fixtures now use an HTML comment as the genuine hard refusal).
- Full `tests/slides/` + `tests/cli/` suites pass (3113 passed).

Part of #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
