### PR TITLE
feat(validate): per-deck voiceover-coverage opt-in marker (#178)

### DIFF
--- a/changelog.d/178-voiceover-coverage-marker.added.md
+++ b/changelog.d/178-voiceover-coverage-marker.added.md
@@ -1,0 +1,5 @@
+- `clm validate`: a deck meant to be fully narrated can opt into the
+  (default-off, #176) voiceover coverage check per deck with a
+  `# clm: voiceover-coverage` header directive (#178) — a default
+  validate run then coverage-checks that deck only, while an explicit
+  `--checks`/`checks=[…]` list is still honored verbatim.

--- a/src/clm/cli/commands/validate_slides.py
+++ b/src/clm/cli/commands/validate_slides.py
@@ -34,7 +34,9 @@ from clm.slides.validator import (
         "Review: code_quality, voiceover, completeness. "
         "Default: all deterministic checks. "
         "voiceover coverage is opt-in (voiceover is optional per deck) — "
-        "it runs only when you name it explicitly, e.g. --checks voiceover."
+        "it runs only when you name it explicitly (e.g. --checks voiceover) "
+        "or when a deck opts in via a `clm: voiceover-coverage` header "
+        "comment (#178; default run only)."
     ),
 )
 @click.option(
@@ -95,7 +97,10 @@ def validate_slides_cmd(
         result = validate_quick(path)
     else:
         check_list = _parse_checks(checks)
-        result = _dispatch_validation(path, check_list, data_dir)
+        # The per-deck `clm: voiceover-coverage` header marker (#178) applies
+        # on the default run only; an explicit --checks list is honored
+        # verbatim.
+        result = _dispatch_validation(path, check_list, data_dir, marker_opt_in=checks is None)
 
     if as_json:
         click.echo(json.dumps(_result_to_dict(result), indent=2))
@@ -144,16 +149,18 @@ def _dispatch_validation(
     path: Path,
     check_list: list[str] | None,
     data_dir: Path | None,
+    *,
+    marker_opt_in: bool,
 ) -> ValidationResult:
     """Dispatch to the right validate_* function based on path type."""
     if path.is_file() and path.suffix in (".xml",):
         # Course spec file
         slides_dir = _resolve_slides_dir(data_dir, path)
-        return validate_course(path, slides_dir, checks=check_list)
+        return validate_course(path, slides_dir, checks=check_list, marker_opt_in=marker_opt_in)
     elif path.is_dir():
-        return validate_directory(path, checks=check_list)
+        return validate_directory(path, checks=check_list, marker_opt_in=marker_opt_in)
     elif path.is_file():
-        return validate_file(path, checks=check_list)
+        return validate_file(path, checks=check_list, marker_opt_in=marker_opt_in)
     else:
         raise click.ClickException(f"Path is not a file or directory: {path}")
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1073,6 +1073,23 @@ tool / the `validate_file`/`validate_directory`/`validate_course` library
 functions now exclude `voiceover` from their `checks=None` default too. The other
 review checks (`code_quality`, `completeness`) still run by default.
 
+Since CLM {version}, a deck that **is** meant to be fully narrated can opt back
+in **per deck** (issue #178) with a header directive comment — any line before
+the first cell marker:
+
+```python
+# clm: voiceover-coverage
+```
+
+(`// clm: voiceover-coverage` in a `//`-comment-token deck, e.g. `.cs`/`.cpp`.)
+A default validate run (CLI without `--checks`, MCP / library `checks=None`)
+then includes the `voiceover` coverage check **for that deck only**, so a
+missing narration cell on a narrated deck is caught automatically while
+voiceover-less decks stay silent. An explicit `--checks` / `checks=[…]` list is
+always honored verbatim — the marker neither adds nor removes checks there.
+Use the marker (not a has-any-voiceover heuristic) so a deck mid-authoring
+isn't prematurely flooded with gap findings.
+
 The `pairing` check group covers DE/EN cell count, tag consistency,
 adjacency, and — since CLM {version} — **`slide_id` metadata**:
 

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -123,6 +123,32 @@ OPT_IN_CHECKS = frozenset({"voiceover"})
 # completeness).
 DEFAULT_CHECKS = ALL_CHECKS - OPT_IN_CHECKS
 
+# Per-deck opt-in marker (#178): a deck that is meant to be fully narrated
+# declares it with this directive comment in the file header (any line
+# before the first cell marker), e.g. ``# clm: voiceover-coverage`` (or
+# ``// clm: voiceover-coverage`` in a ``//``-comment-token deck). The
+# default check bundle then includes the ``voiceover`` coverage check for
+# THAT deck only — voiceover-less decks stay silent (#176). An explicit
+# ``checks=[…]`` request is honored verbatim and ignores the marker.
+VOICEOVER_COVERAGE_MARKER = "clm: voiceover-coverage"
+_VOICEOVER_MARKER_RE = re.compile(r"^(?:#|//)\s*clm:\s*voiceover-coverage\s*$")
+
+
+def has_voiceover_coverage_marker(text: str, comment_token: str = "#") -> bool:
+    """Whether the deck opts into voiceover coverage via its header (#178).
+
+    Scans only the file header — lines before the first ``<token> %%`` cell
+    marker — so the directive is a per-file declaration, not cell content.
+    """
+    cell_marker = f"{comment_token} %%"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(cell_marker):
+            break
+        if _VOICEOVER_MARKER_RE.match(stripped):
+            return True
+    return False
+
 
 def _check_format(cells: list[Cell], file_path: str) -> list[Finding]:
     """Check cell header syntax and structure."""
@@ -1658,6 +1684,7 @@ def validate_file(
     checks: list[str] | None = None,
     *,
     cross_file_parity: bool = True,
+    marker_opt_in: bool | None = None,
 ) -> ValidationResult:
     """Validate a single slide file.
 
@@ -1670,7 +1697,9 @@ def validate_file(
             Review: ``"code_quality"``, ``"voiceover"``, ``"completeness"``.
             ``"voiceover"`` is **opt-in** (issue #176): voiceover is optional
             per deck, so coverage runs only when you name it explicitly in
-            ``checks`` — never as part of the default bundle.
+            ``checks`` — never as part of the default bundle — or when the
+            deck itself opts in via the ``clm: voiceover-coverage`` header
+            marker (#178, see ``marker_opt_in``).
         cross_file_parity: When ``True`` (the default for standalone callers —
             the CLI single-file path, MCP, the pre-commit gate) and ``path`` is
             a split half whose twin exists on disk, run the #162 cross-file
@@ -1679,16 +1708,28 @@ def validate_file(
             (the both-language voiceover compatibility check). Directory/course
             entrypoints pass ``False`` and run those once at their own scope
             instead, so a directory run does not duplicate the findings.
+        marker_opt_in: Whether the per-deck ``clm: voiceover-coverage`` header
+            marker (#178) may promote ``voiceover`` into the effective check
+            set. ``None`` (the default) resolves to ``checks is None`` — the
+            marker applies on a default-bundle run and an explicit ``checks``
+            list is honored verbatim. The CLI passes ``True`` for its own
+            default run (which names the deterministic checks explicitly) and
+            ``False`` when the user gave ``--checks``.
 
     Returns:
         A :class:`ValidationResult` with findings and optional review material.
     """
-    check_set = set(checks) if checks else set(DEFAULT_CHECKS)
     file_str = str(path)
     comment_token = comment_token_for_path(path)
 
     text = path.read_text(encoding="utf-8")
     cells = parse_cells(text, comment_token)
+
+    check_set = set(checks) if checks else set(DEFAULT_CHECKS)
+    honor_marker = (checks is None) if marker_opt_in is None else marker_opt_in
+    if honor_marker and "voiceover" not in check_set:
+        if has_voiceover_coverage_marker(text, comment_token):
+            check_set.add("voiceover")
 
     findings: list[Finding] = []
 
@@ -1786,6 +1827,8 @@ def validate_quick(path: Path) -> ValidationResult:
 def validate_directory(
     path: Path,
     checks: list[str] | None = None,
+    *,
+    marker_opt_in: bool | None = None,
 ) -> ValidationResult:
     """Validate all slide files at or under ``path``.
 
@@ -1799,14 +1842,20 @@ def validate_directory(
         path: Path to a directory containing slide files (at any depth).
         checks: Which checks to run (passed to :func:`validate_file`).
             ``None`` runs the default bundle, which excludes the opt-in
-            ``voiceover`` coverage check (issue #176).
+            ``voiceover`` coverage check (issue #176) unless a deck opts in
+            via the ``clm: voiceover-coverage`` header marker (#178).
+        marker_opt_in: Passed to :func:`validate_file` (#178).
     """
-    return validate_files(find_slide_files_recursive(path), checks=checks)
+    return validate_files(
+        find_slide_files_recursive(path), checks=checks, marker_opt_in=marker_opt_in
+    )
 
 
 def validate_files(
     slide_files: list[Path],
     checks: list[str] | None = None,
+    *,
+    marker_opt_in: bool | None = None,
 ) -> ValidationResult:
     """Validate an explicit list of slide files (same logic as a directory walk).
 
@@ -1820,17 +1869,26 @@ def validate_files(
         slide_files: The slide files to validate.
         checks: Which checks to run (passed to :func:`validate_file`).
             ``None`` runs the default bundle, which excludes the opt-in
-            ``voiceover`` coverage check (issue #176).
+            ``voiceover`` coverage check (issue #176) unless a deck opts in
+            via the ``clm: voiceover-coverage`` header marker (#178).
+        marker_opt_in: Passed to :func:`validate_file` (#178).
     """
     all_findings: list[Finding] = []
-    combined_review = ReviewMaterial() if (not checks or set(checks) & ALL_REVIEW_CHECKS) else None
+    # Created lazily on the first file that produced review material, so a
+    # marker-driven voiceover pass (#178) is collected even when ``checks``
+    # is an explicit deterministic list.
+    combined_review: ReviewMaterial | None = None
 
     for sf in slide_files:
         # Cross-file parity is run once per pair below (not per file), so the
         # per-file pass skips it to avoid duplicate findings.
-        result = validate_file(sf, checks=checks, cross_file_parity=False)
+        result = validate_file(
+            sf, checks=checks, cross_file_parity=False, marker_opt_in=marker_opt_in
+        )
         all_findings.extend(result.findings)
-        if combined_review is not None and result.review_material is not None:
+        if result.review_material is not None:
+            if combined_review is None:
+                combined_review = ReviewMaterial()
             _merge_review_material(combined_review, result.review_material)
 
     # Phase 6: surface divergent shared cells between split pairs as
@@ -1857,6 +1915,8 @@ def validate_course(
     course_spec_path: Path,
     slides_dir: Path,
     checks: list[str] | None = None,
+    *,
+    marker_opt_in: bool | None = None,
 ) -> ValidationResult:
     """Validate all slides referenced by a course spec.
 
@@ -1865,7 +1925,9 @@ def validate_course(
         slides_dir: Path to the ``slides/`` directory.
         checks: Which checks to run (passed to :func:`validate_file`).
             ``None`` runs the default bundle, which excludes the opt-in
-            ``voiceover`` coverage check (issue #176).
+            ``voiceover`` coverage check (issue #176) unless a deck opts in
+            via the ``clm: voiceover-coverage`` header marker (#178).
+        marker_opt_in: Passed to :func:`validate_file` (#178).
     """
     from clm.core.course_spec import CourseSpec
 
@@ -1874,7 +1936,8 @@ def validate_course(
 
     all_findings: list[Finding] = []
     files_checked = 0
-    combined_review = ReviewMaterial() if (not checks or set(checks) & ALL_REVIEW_CHECKS) else None
+    # Lazy, like validate_files — see the comment there (#178).
+    combined_review: ReviewMaterial | None = None
 
     check_set = set(checks) if checks else set(DEFAULT_CHECKS)
 
@@ -1884,10 +1947,14 @@ def validate_course(
             slide_files = find_slide_files(match.path)
             for sf in slide_files:
                 # Cross-file parity runs once per pair below, not per file.
-                result = validate_file(sf, checks=checks, cross_file_parity=False)
+                result = validate_file(
+                    sf, checks=checks, cross_file_parity=False, marker_opt_in=marker_opt_in
+                )
                 all_findings.extend(result.findings)
                 files_checked += 1
-                if combined_review is not None and result.review_material is not None:
+                if result.review_material is not None:
+                    if combined_review is None:
+                        combined_review = ReviewMaterial()
                     _merge_review_material(combined_review, result.review_material)
 
             # Phase 6 shared-cell parity per topic: walk the topic's split

--- a/tests/cli/test_validate_slides.py
+++ b/tests/cli/test_validate_slides.py
@@ -339,3 +339,44 @@ class TestValidateSlidesCommand:
         data = json.loads(result.output)
         assert "review_material" in data
         assert "code_quality" in data["review_material"]
+
+
+class TestVoiceoverCoverageMarkerCli:
+    """Issue #178: the per-deck `clm: voiceover-coverage` header marker."""
+
+    _MARKED_GAPPY = """\
+        # clm: voiceover-coverage
+
+        # %% [markdown] lang="de" tags=["slide"] slide_id="title"
+        #
+        # ## Titel
+
+        # %% tags=["keep"]
+        x = 1
+        """
+
+    def test_default_run_reports_gaps_for_marked_deck(self, tmp_path):
+        p = _write_slide(tmp_path, "slides_marked.py", self._MARKED_GAPPY)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "voiceover_gaps" in data.get("review_material", {})
+        assert data["review_material"]["voiceover_gaps"]
+
+    def test_explicit_checks_ignore_marker(self, tmp_path):
+        p = _write_slide(tmp_path, "slides_marked.py", self._MARKED_GAPPY)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--checks", "format,tags", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "voiceover_gaps" not in data.get("review_material", {})
+
+    def test_unmarked_deck_stays_silent_on_default_run(self, tmp_path):
+        unmarked = self._MARKED_GAPPY.replace("# clm: voiceover-coverage\n\n", "")
+        p = _write_slide(tmp_path, "slides_unmarked.py", unmarked)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(p), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "voiceover_gaps" not in data.get("review_material", {})

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -13,6 +13,7 @@ from clm.slides.validator import (
     Finding,
     ReviewMaterial,
     ValidationResult,
+    has_voiceover_coverage_marker,
     validate_course,
     validate_directory,
     validate_file,
@@ -2627,6 +2628,103 @@ class TestVoiceoverOptIn:
         assert result.review_material is not None
         assert result.review_material.voiceover_gaps
         assert len(result.review_material.voiceover_gaps) > 0
+
+
+class TestVoiceoverCoverageMarker:
+    """Issue #178: a `clm: voiceover-coverage` header marker re-enables the
+    voiceover coverage check for THAT deck under the default bundle, so a
+    fully-narrated deck is coverage-checked automatically while
+    voiceover-less decks stay silent (#176)."""
+
+    # A gappy deck that DECLARES it should be fully narrated.
+    _MARKED_DECK = """\
+        # clm: voiceover-coverage
+
+        # %% [markdown] lang="de" tags=["slide"]
+        # ## Titel
+
+        # %% [markdown] lang="en" tags=["slide"]
+        # ## Title
+
+        # %% tags=["keep"]
+        x = 1
+        """
+
+    _UNMARKED_DECK = """\
+        # %% [markdown] lang="de" tags=["slide"]
+        # ## Titel
+
+        # %% [markdown] lang="en" tags=["slide"]
+        # ## Title
+
+        # %% tags=["keep"]
+        x = 1
+        """
+
+    def test_marker_detection(self):
+        assert has_voiceover_coverage_marker("# clm: voiceover-coverage\n")
+        assert has_voiceover_coverage_marker("#  clm:  voiceover-coverage  \n")
+        assert has_voiceover_coverage_marker("// clm: voiceover-coverage\n", "//")
+        assert not has_voiceover_coverage_marker("# clm: something-else\n")
+        assert not has_voiceover_coverage_marker("# voiceover-coverage\n")
+
+    def test_marker_inside_a_cell_does_not_count(self):
+        # The directive is a file-header declaration: a comment after the
+        # first cell marker is cell content, not a directive.
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# clm: voiceover-coverage\n'
+        assert not has_voiceover_coverage_marker(text)
+
+    def test_marked_deck_gets_coverage_under_default_bundle(self, tmp_path):
+        p = _write_slide(tmp_path, "slides_marked.py", self._MARKED_DECK)
+        result = validate_file(p, checks=None)
+        assert result.review_material is not None
+        assert result.review_material.voiceover_gaps is not None
+        assert len(result.review_material.voiceover_gaps) > 0
+
+    def test_unmarked_deck_stays_silent(self, tmp_path):
+        p = _write_slide(tmp_path, "slides_unmarked.py", self._UNMARKED_DECK)
+        result = validate_file(p, checks=None)
+        assert result.review_material is not None
+        assert result.review_material.voiceover_gaps is None
+
+    def test_explicit_checks_ignore_marker(self, tmp_path):
+        # An explicit checks list is honored verbatim (issue spec).
+        p = _write_slide(tmp_path, "slides_marked.py", self._MARKED_DECK)
+        result = validate_file(p, checks=["format", "tags"])
+        assert result.review_material is None
+
+    def test_marker_opt_in_true_promotes_on_explicit_list(self, tmp_path):
+        # The CLI default path: deterministic checks named explicitly, but
+        # marker_opt_in=True because the user did not pass --checks.
+        p = _write_slide(tmp_path, "slides_marked.py", self._MARKED_DECK)
+        result = validate_file(p, checks=["format", "pairing", "tags"], marker_opt_in=True)
+        assert result.review_material is not None
+        assert result.review_material.voiceover_gaps
+
+    def test_directory_mixes_marked_and_unmarked(self, tmp_path):
+        _write_slide(tmp_path, "slides_marked.py", self._MARKED_DECK)
+        _write_slide(tmp_path, "slides_unmarked.py", self._UNMARKED_DECK)
+        result = validate_directory(tmp_path, checks=None)
+        assert result.review_material is not None
+        gaps = result.review_material.voiceover_gaps or []
+        # Only the marked deck contributed coverage gaps.
+        assert gaps
+        assert all("slides_marked" in g["file"] for g in gaps)
+
+    def test_fully_narrated_marked_deck_is_clean(self, tmp_path):
+        deck = """\
+            # clm: voiceover-coverage
+
+            # %% [markdown] lang="de" tags=["slide"]
+            # ## Titel
+
+            # %% [markdown] lang="de" tags=["voiceover"]
+            # - sprich hier
+            """
+        p = _write_slide(tmp_path, "slides_narrated.py", deck)
+        result = validate_file(p, checks=None)
+        gaps = result.review_material.voiceover_gaps if result.review_material is not None else None
+        assert not gaps
 
 
 class TestCompletenessExtraction:


### PR DESCRIPTION
## Summary

Implements the deferred "ideally" half of #176: a deck that ships complete narration can now say so, and a **default** validate run will coverage-check it automatically — while voiceover-less decks stay silent.

### The marker

A directive comment in the file header (any line before the first cell marker):

```python
# clm: voiceover-coverage
```

(`// clm: voiceover-coverage` for `//`-comment-token decks, e.g. `.cs`/`.cpp` — relevant for the ongoing C++ course conversion.) Chosen over a `[tool.clm]` repo-wide setting per the issue's analysis: true per-deck granularity, travels with the file, git-diffable. An explicit marker (not a has-any-voiceover heuristic) so a deck mid-authoring isn't prematurely flooded with gap findings.

### Semantics

- **Default runs honor the marker**: library `checks=None`, the MCP default, and the CLI without `--checks` (the CLI names its deterministic default explicitly, so it passes the new `marker_opt_in=True`; `marker_opt_in=None` resolves to `checks is None` for library callers).
- **Explicit check lists are honored verbatim** — `--checks format,tags` on a marked deck runs exactly those.
- The marker only ever *adds* `voiceover` for the marked file; nothing else changes.
- `validate_files`/`validate_course` now create the combined review material lazily, so a marker-driven voiceover pass survives directory runs whose `checks` list contains no review checks.

`clm info commands` documents the directive (it's a durable authoring convention for downstream course repos).

Closes #178.

## Test plan

- New `TestVoiceoverCoverageMarker` (validator): marker detection incl. `//` family and inside-a-cell rejection; marked deck gains gaps under the default bundle; unmarked stays silent; explicit checks ignore the marker; `marker_opt_in=True` promotes on an explicit deterministic list (the CLI path); mixed directory attributes gaps to the marked deck only; fully-narrated marked deck is clean.
- New `TestVoiceoverCoverageMarkerCli`: default `clm validate` JSON carries `voiceover_gaps` for a marked deck, `--checks` suppresses, unmarked silent.
- Full `tests/slides/` + `tests/cli/` + `tests/mcp/` suites pass (3168 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
