### PR TITLE
feat(validate): hint at keep/start mis-tag on orphaned 'completed' (#233 item 4b)

### DIFF
--- a/changelog.d/233-keep-completed-hint.changed.md
+++ b/changelog.d/233-keep-completed-hint.changed.md
@@ -1,0 +1,4 @@
+- `clm validate`: the `'completed' tag without a preceding 'start' cell`
+  error now points at a `keep`-tagged preceding code cell when present
+  ("did you mean 'start'?") — the recurring incremental-build mis-tag
+  found during cold-start conversions (#233 item 4b).

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -343,6 +343,9 @@ def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
                 )
             )
 
+    # The most recent code cell per language stream — lets the orphaned
+    # 'completed' finding hint at a mis-tagged 'keep' predecessor (#233).
+    last_code_cell: dict[str | None, Cell] = {}
     for cell in cells:
         meta = cell.metadata
         if meta.is_j2:
@@ -400,6 +403,22 @@ def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
 
         if "completed" in tags:
             if pending_starts.pop(meta.lang, None) is None:
+                # An incremental class/function build whose "before" cell was
+                # tagged 'keep' instead of 'start' is a recurring authoring
+                # slip (#233) — point straight at it when the shape matches.
+                prev_code = last_code_cell.get(meta.lang)
+                if (
+                    meta.cell_type == "code"
+                    and prev_code is not None
+                    and "keep" in prev_code.metadata.tags
+                ):
+                    suggestion = (
+                        f"The preceding code cell (line {prev_code.line_number}) is "
+                        "tagged 'keep' — did you mean 'start'? Otherwise add a "
+                        "'start' cell before this 'completed' cell."
+                    )
+                else:
+                    suggestion = "Add a cell with tag 'start' before this 'completed' cell"
                 findings.append(
                     Finding(
                         severity="error",
@@ -407,9 +426,12 @@ def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
                         file=file_path,
                         line=cell.line_number,
                         message="'completed' tag without a preceding 'start' cell",
-                        suggestion="Add a cell with tag 'start' before this 'completed' cell",
+                        suggestion=suggestion,
                     )
                 )
+
+        if meta.cell_type == "code":
+            last_code_cell[meta.lang] = cell
 
     # Check for unclosed starts at end of file
     for prior in pending_starts.values():

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -251,6 +251,34 @@ class TestCheckTags:
         assert len(errors) == 1
         assert "completed" in errors[0].message
         assert "without" in errors[0].message
+        # No 'keep' predecessor: the generic suggestion, no #233 hint.
+        assert "did you mean 'start'" not in (errors[0].suggestion or "")
+
+    def test_completed_after_keep_hints_at_mistag(self, tmp_path):
+        # #233 item 4(b): an incremental build whose "before" cell was tagged
+        # 'keep' instead of 'start' leaves the 'completed' orphaned — the
+        # suggestion points at the likely mis-tag.
+        p = _write_slide(
+            tmp_path,
+            "slides_keep_completed.py",
+            """\
+            # %% tags=["keep"]
+            class PointV2:
+                def __init__(self):
+                    pass
+
+            # %% tags=["completed"]
+            class PointV2:
+                def __init__(self, x, y):
+                    self.x, self.y = x, y
+            """,
+        )
+        result = validate_file(p, checks=["tags"])
+        errors = [f for f in result.findings if f.severity == "error"]
+        assert len(errors) == 1
+        assert "completed" in errors[0].message
+        assert "did you mean 'start'" in (errors[0].suggestion or "")
+        assert "line 1" in (errors[0].suggestion or "")
 
     def test_consecutive_starts_without_completed(self, tmp_path):
         p = _write_slide(


### PR DESCRIPTION
## Summary

Small validator UX improvement from #233 item 4(b): the `'completed' tag without a preceding 'start' cell` error now checks whether the most recent same-language **code** cell is tagged `keep` and, if so, suggests the likely fix directly:

```
The preceding code cell (line 1) is tagged 'keep' — did you mean 'start'?
Otherwise add a 'start' cell before this 'completed' cell.
```

This is the `slides_010v_classes_and_methods` shape from the issue — an incremental class build whose "before" cell was tagged `keep`, orphaning the `completed`. The finding's severity and message are unchanged; only the suggestion is sharpened, so no downstream consumers are affected.

Item 4(a) (a `normalize` operation that demotes scaffolding-less `start` cells and retags markdown `completed` → `alt`) is deliberately **not** included — retagging workshop cells automatically needs more careful discriminator validation against real corpora; #233 stays open for it (items 1–3 landed in #314, item 5 in #313).

## Test plan

- New: `test_completed_after_keep_hints_at_mistag` (hint + line number); the existing orphan test now also asserts the generic suggestion stays hint-free when the predecessor isn't `keep`.
- Full `tests/slides/` + `tests/cli/` suites pass (3084 passed).

Part of #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
