### PR TITLE
feat(slides): normalize mis-tagged placeholder start cells (#233 item 4a)

### DIFF
--- a/changelog.d/233-placeholder-start.added.md
+++ b/changelog.d/233-placeholder-start.added.md
@@ -1,0 +1,8 @@
+- `clm slides normalize` gained a `placeholder_start` operation (issue #233
+  item 4a): a code cell tagged `start` whose body is only a solution
+  placeholder (`# Your solution here`, `pass`, `...`) followed by a markdown
+  `completed`/`alt` cell is demoted to a plain cell, and an already-promoted
+  markdown `completed` partner is renamed back to `alt`. Placeholder `start`
+  cells paired with a code `completed` cell are left untouched. Runs before
+  `tag_migration` (which otherwise promotes the adjacent markdown `alt` to
+  `completed`), is part of `all`, and is idempotent.

--- a/src/clm/cli/commands/slides/normalize.py
+++ b/src/clm/cli/commands/slides/normalize.py
@@ -106,13 +106,15 @@ def normalize_slides_cmd(
 
     \b
     Operations:
-        preamble_code   Wrap code that precedes the first cell into its own cell
-        tag_migration   Rename alt->completed after start cells
-        workshop_tags   Add workshop tag to workshop heading cells
-        interleaving    Normalize DE/EN cell ordering
-        slide_ids       Auto-generate slide_id metadata for cells
-        cell_spacing    Normalize blank-line separation between cells
-        all             All of the above (default)
+        preamble_code     Wrap code that precedes the first cell into its own cell
+        placeholder_start Untag scaffolding-less start cells whose solution
+                          follows as markdown (retags markdown completed->alt)
+        tag_migration     Rename alt->completed after start cells
+        workshop_tags     Add workshop tag to workshop heading cells
+        interleaving      Normalize DE/EN cell ordering
+        slide_ids         Auto-generate slide_id metadata for cells
+        cell_spacing      Normalize blank-line separation between cells
+        all               All of the above (default)
 
     \b
     Examples:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1167,8 +1167,21 @@ clm validate slides/module_010/topic_100_intro/ --quick
 
 Normalize slide files by applying mechanical fixes: tag migration (`alt`→`completed`),
 workshop tag insertion, DE/EN interleaving, slide ID auto-generation, **cell spacing**
-(`cell_spacing`), and — since CLM {version} — **preamble-code wrapping**
-(`preamble_code`).
+(`cell_spacing`), **preamble-code wrapping** (`preamble_code`), and — since CLM
+{version} — **placeholder-start demotion** (`placeholder_start`).
+
+The `placeholder_start` operation (since CLM {version}) fixes a recurring
+workshop mis-tag (issue #233): a code cell tagged `start` whose entire body is
+a solution placeholder (`# Your solution here`, `pass`, `...`) followed by a
+**markdown** cell tagged `completed` (or `alt`). Workshop solutions authored as
+markdown/`alt` runs need no `start`/`completed` pairing — the workshop range
+mechanism blanks them in code-along output — and the bogus `start` tag causes
+`tag_migration` to wrongly promote the adjacent markdown `alt` to `completed`.
+The op removes the `start` tag (the cell becomes a plain `# %%` cell) and
+renames an already-promoted markdown `completed` partner back to `alt`.
+Placeholder `start` cells paired with a **code** `completed` cell are left
+untouched (that is a valid live-coding pair). Runs before `tag_migration`,
+is default-on (part of `all`), and idempotent.
 
 The `cell_spacing` operation fixes the two formatting issues the `format`
 validator now warns about: it inserts a blank line before every cell that lacks
@@ -1193,7 +1206,7 @@ clm slides normalize [OPTIONS] PATH
 
 | Option | Description |
 |--------|-------------|
-| `--operations TEXT` | Comma-separated operations: `preamble_code`, `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
+| `--operations TEXT` | Comma-separated operations: `preamble_code`, `placeholder_start`, `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
 | `--dry-run` | Preview changes without modifying files |
 | `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--json` | Output as JSON |
@@ -1219,6 +1232,8 @@ clm slides normalize slides/module_010/ --operations slide_ids --json
 clm slides normalize slides/module_010/ --operations cell_spacing
 # Fix only preamble code (wrap code before the first cell into its own `# %%` cell)
 clm slides normalize slides/module_010/ --operations preamble_code
+# Fix only mis-tagged placeholder start cells (untag + markdown completed->alt)
+clm slides normalize slides/module_010/ --operations placeholder_start
 # Pre-conversion: canonicalize start/completed order so the split round-trips exactly
 clm slides normalize slides/module_010/topic_100_intro/ --operations interleaving --canonicalize-start-completed
 # Scope: mint ids on bilingual decks only, skipping an _archive/ dir

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -2,6 +2,10 @@
 
 Applies mechanical fixes to percent-format ``.py`` slide files:
 
+- **Placeholder start demotion**: removes the ``start`` tag from code cells
+  with no real scaffolding (body only ``# Your solution here`` / ``pass`` /
+  ``...``) when the workshop solution that follows is a markdown ``alt`` /
+  ``completed`` run rather than a paired ``completed`` code cell
 - **Tag migration**: ``alt`` → ``completed`` after ``start`` cells
 - **Workshop tag insertion**: adds ``workshop`` to workshop heading cells,
   and symmetrizes ``workshop``/``end-workshop`` tags across DE/EN heading
@@ -107,6 +111,7 @@ class NormalizationResult:
 ALL_OPERATIONS = frozenset(
     {
         "preamble_code",
+        "placeholder_start",
         "tag_migration",
         "workshop_tags",
         "interleaving",
@@ -150,6 +155,127 @@ def _apply_preamble_code(
                 ),
             )
         )
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# Placeholder start demotion: scaffolding-less start cells (#233 item 4a)
+# ---------------------------------------------------------------------------
+
+# A line that is *only* a solution-placeholder comment. Anchored on both ends:
+# a placeholder phrase followed by real text (e.g. "# Your code here: Train
+# linear model") is a genuine hint, not a placeholder.
+_PLACEHOLDER_COMMENT_RE = re.compile(
+    r"^(?:#|//)\s*(?:"
+    r"your (?:solution|code) here"
+    r"|(?:ihre?|deine?) l(?:ö|oe)sung hier"
+    r"|(?:ihr|dein) code hier"
+    r")\s*[:!.]?\s*$",
+    re.IGNORECASE,
+)
+
+# Code lines that carry no scaffolding on their own.
+_PLACEHOLDER_CODE_LINES = frozenset({"pass", "..."})
+
+
+def _is_placeholder_body(cell: _RawCell) -> bool:
+    """True if a code cell's body is only solution placeholders (no scaffolding)."""
+    non_blank = [ln.strip() for ln in cell.lines[1:] if ln.strip()]
+    if not non_blank:
+        return False
+    return all(
+        ln in _PLACEHOLDER_CODE_LINES or _PLACEHOLDER_COMMENT_RE.match(ln) for ln in non_blank
+    )
+
+
+def _remove_tag_from_header(header: str, tag: str) -> str:
+    """Remove a tag from a cell header line, dropping ``tags=[]`` if it empties."""
+    tags_match = re.search(r"tags=\[([^\]]*)\]", header)
+    if not tags_match:
+        return header
+    kept = [
+        t.strip()
+        for t in tags_match.group(1).split(",")
+        if t.strip() and t.strip().strip("\"'") != tag
+    ]
+    if kept:
+        new_attr = f"tags=[{', '.join(kept)}]"
+        return header[: tags_match.start()] + new_attr + header[tags_match.end() :]
+    before = header[: tags_match.start()].rstrip()
+    after = header[tags_match.end() :].strip()
+    return f"{before} {after}" if after else before
+
+
+def _apply_placeholder_start(cells: list[_RawCell], file_path: str) -> list[Change]:
+    """Demote ``start`` cells that hold no scaffolding (issue #233 item 4a).
+
+    Workshop tasks are authored as a plain placeholder cell (``# Your solution
+    here``) followed by markdown/code ``alt`` solution cells — the workshop
+    range mechanism blanks the solutions in code-along output, so the
+    ``start``/``completed`` pairing has no role there. Tagging the placeholder
+    ``start`` anyway is a recurring authoring slip, and ``tag_migration`` then
+    compounds it by promoting the adjacent markdown ``alt`` to ``completed`` —
+    a shape that is semantically impossible (a markdown cell cannot be the
+    solution code of a live-coding pair).
+
+    The fix mirrors the manual repair applied across the PythonCourses decks:
+    drop the ``start`` tag, and rename an already-promoted markdown
+    ``completed`` partner back to ``alt``. The discriminator is deliberately
+    a conjunction — the ``start`` body must be placeholder-only AND the
+    immediately following cell must be a markdown ``alt``/``completed`` cell.
+    Placeholder ``start`` cells paired with a *code* ``completed`` cell are
+    left untouched: that pairing validates and renders correctly.
+
+    Must run before ``_apply_tag_migration`` so the demotion wins before the
+    migration can promote the adjacent markdown ``alt``.
+    """
+    changes: list[Change] = []
+
+    for idx, cell in enumerate(cells):
+        meta = cell.metadata
+        if meta.is_j2 or meta.cell_type != "code" or "start" not in meta.tags:
+            continue
+        if not _is_placeholder_body(cell):
+            continue
+
+        nxt = cells[idx + 1] if idx + 1 < len(cells) else None
+        if nxt is None or nxt.metadata.is_j2 or nxt.metadata.cell_type != "markdown":
+            continue
+        nxt_tags = nxt.metadata.tags
+        if "completed" not in nxt_tags and "alt" not in nxt_tags:
+            continue
+
+        new_header = _remove_tag_from_header(cell.header, "start")
+        cell.header = new_header
+        cell.metadata = parse_cell_header(new_header)
+        changes.append(
+            Change(
+                file=file_path,
+                operation="placeholder_start",
+                line=cell.line_number,
+                description=(
+                    "Removed 'start' tag from placeholder-only cell "
+                    "(workshop solution follows as markdown, not a code 'completed')"
+                ),
+            )
+        )
+
+        if "completed" in nxt_tags:
+            new_nxt_header = nxt.header.replace('"completed"', '"alt"')
+            nxt.header = new_nxt_header
+            nxt.metadata = parse_cell_header(new_nxt_header)
+            changes.append(
+                Change(
+                    file=file_path,
+                    operation="placeholder_start",
+                    line=nxt.line_number,
+                    description=(
+                        'Renamed "completed" -> "alt" '
+                        "(markdown cell promoted after a placeholder-only start)"
+                    ),
+                )
+            )
+
     return changes
 
 
@@ -800,6 +926,12 @@ def normalize_file(
     # canonical cell structure with the code in its own cell.
     if "preamble_code" in op_set:
         all_changes.extend(_apply_preamble_code(cells, file_str, comment_token))
+
+    # Placeholder-start demotion must precede tag migration: once the bogus
+    # 'start' tag is gone, the migration no longer promotes the adjacent
+    # markdown 'alt' to 'completed' (#233 item 4a).
+    if "placeholder_start" in op_set:
+        all_changes.extend(_apply_placeholder_start(cells, file_str))
 
     if "tag_migration" in op_set:
         all_changes.extend(_apply_tag_migration(cells, file_str))

--- a/tests/cli/test_normalize_slides.py
+++ b/tests/cli/test_normalize_slides.py
@@ -40,6 +40,22 @@ class TestNormalizeSlidesCmd:
         assert result.exit_code == 0
         assert "tag_migration" in result.output
 
+    def test_placeholder_start(self, tmp_path):
+        path = _write_slide(
+            tmp_path / "slides_test.py",
+            '# %% tags=["start"]\n# Your solution here\n\n'
+            '# %% [markdown] tags=["completed"]\n# Discussion.\n',
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            normalize_slides_cmd, [str(path), "--operations", "placeholder_start"]
+        )
+        assert result.exit_code == 0
+        assert "placeholder_start" in result.output
+        new_text = path.read_text(encoding="utf-8")
+        assert '"start"' not in new_text
+        assert 'tags=["alt"]' in new_text
+
     def test_dry_run(self, tmp_path):
         text = '# %% tags=["start"]\nx = 1\n\n# %% tags=["alt"]\nx = 2\n'
         path = _write_slide(tmp_path / "slides_test.py", text)

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -14,6 +14,7 @@ from clm.slides.normalizer import (
     _apply_tag_migration,
     _apply_workshop_tags,
     _reconstruct,
+    _remove_tag_from_header,
     _split_raw_cells,
     normalize_directory,
     normalize_file,
@@ -137,6 +138,207 @@ class TestTagMigration:
 
         assert len(result.changes) == 0
         assert result.files_modified == 0
+
+
+# ---------------------------------------------------------------------------
+# Placeholder start demotion (#233 item 4a)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceholderStart:
+    def test_markdown_completed_after_placeholder_start_fixed(self, tmp_path):
+        text = (
+            '# %% tags=["start"]\n'
+            "# Your solution here\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["completed"]\n'
+            "# Die Loesung verwendet np.array.\n"
+            "\n"
+            '# %% tags=["alt"]\n'
+            "ages = np.array([25, 32, 18, 45, 28])\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 2
+        assert all(c.operation == "placeholder_start" for c in result.changes)
+        new_text = path.read_text(encoding="utf-8")
+        assert '"start"' not in new_text
+        assert new_text.startswith("# %%\n# Your solution here\n")
+        assert '# %% [markdown] lang="de" tags=["alt"]' in new_text
+        assert '"completed"' not in new_text
+
+    def test_markdown_alt_after_placeholder_start_demotes_start_only(self, tmp_path):
+        # The pre-migration authored shape: the markdown solution run is still
+        # tagged "alt". The start tag is dropped so tag_migration can no
+        # longer promote the alt cell.
+        text = (
+            '# %% tags=["start"]\n'
+            "# Your solution here\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["alt"]\n'
+            "# Die Loesung verwendet np.array.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 1
+        new_text = path.read_text(encoding="utf-8")
+        assert '"start"' not in new_text
+        assert 'tags=["alt"]' in new_text
+
+    def test_full_run_does_not_promote_alt_after_demoted_start(self, tmp_path):
+        # With all operations enabled, placeholder_start must win over
+        # tag_migration: the markdown alt stays alt.
+        text = (
+            '# %% tags=["start"]\n'
+            "# Your solution here\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["alt"]\n'
+            "#\n"
+            "# Die Loesung verwendet np.array.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        normalize_file(path)
+
+        new_text = path.read_text(encoding="utf-8")
+        assert '"start"' not in new_text
+        assert 'tags=["alt"]' in new_text
+        assert '"completed"' not in new_text
+
+    def test_code_completed_pair_untouched(self, tmp_path):
+        # A placeholder start paired with a *code* completed cell is a valid
+        # live-coding pair — never touched.
+        text = (
+            '# %% tags=["start"]\n'
+            "# Your solution here\n"
+            "\n"
+            '# %% tags=["completed"]\n'
+            "ages = np.array([25, 32, 18, 45, 28])\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 0
+        assert path.read_text(encoding="utf-8") == text
+
+    def test_real_scaffolding_start_untouched(self, tmp_path):
+        text = (
+            '# %% tags=["start"]\n'
+            "def evaluate(student):\n"
+            "    ...\n"
+            "\n"
+            '# %% [markdown] tags=["completed"]\n'
+            "# Discussion.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 0
+        assert path.read_text(encoding="utf-8") == text
+
+    def test_hint_comment_is_not_a_placeholder(self, tmp_path):
+        # A placeholder phrase followed by real text is a genuine hint.
+        text = (
+            '# %% tags=["start"]\n'
+            "# Your code here: Train linear model\n"
+            "\n"
+            '# %% [markdown] tags=["completed"]\n'
+            "# Discussion.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 0
+        assert path.read_text(encoding="utf-8") == text
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "pass\n",
+            "...\n",
+            "# Ihre Lösung hier\n",
+            "# Deine Loesung hier!\n",
+            "# Ihr Code hier:\n",
+            "# YOUR SOLUTION HERE\n",
+            "# Your solution here\npass\n",
+        ],
+    )
+    def test_placeholder_body_variants(self, tmp_path, body):
+        text = (
+            '# %% tags=["start"]\n'
+            + body
+            + "\n"
+            + '# %% [markdown] tags=["completed"]\n'
+            + "# Discussion.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 2
+        new_text = path.read_text(encoding="utf-8")
+        assert '"start"' not in new_text
+        assert 'tags=["alt"]' in new_text
+
+    def test_other_tags_on_start_cell_preserved(self, tmp_path):
+        text = (
+            '# %% tags=["start", "subslide"]\n'
+            "# Your solution here\n"
+            "\n"
+            '# %% [markdown] tags=["completed"]\n'
+            "# Discussion.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 2
+        new_text = path.read_text(encoding="utf-8")
+        assert 'tags=["subslide"]' in new_text
+        assert '"start"' not in new_text
+
+    def test_untagged_markdown_follower_untouched(self, tmp_path):
+        text = '# %% tags=["start"]\n# Your solution here\n\n# %% [markdown]\n# Plain markdown.\n'
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 0
+        assert path.read_text(encoding="utf-8") == text
+
+    def test_idempotent(self, tmp_path):
+        text = (
+            '# %% tags=["start"]\n'
+            "# Your solution here\n"
+            "\n"
+            '# %% [markdown] tags=["completed"]\n'
+            "# Discussion.\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        normalize_file(path, operations=["placeholder_start"])
+        first = path.read_text(encoding="utf-8")
+        result = normalize_file(path, operations=["placeholder_start"])
+
+        assert len(result.changes) == 0
+        assert path.read_text(encoding="utf-8") == first
+
+
+class TestRemoveTagFromHeader:
+    def test_sole_tag_drops_attribute(self):
+        assert _remove_tag_from_header('# %% tags=["start"]', "start") == "# %%"
+
+    def test_other_tags_kept(self):
+        assert (
+            _remove_tag_from_header('# %% tags=["start", "subslide"]', "start")
+            == '# %% tags=["subslide"]'
+        )
+
+    def test_trailing_attributes_kept(self):
+        assert (
+            _remove_tag_from_header('# %% tags=["start"] slide_id="abc"', "start")
+            == '# %% slide_id="abc"'
+        )
+
+    def test_no_tags_attribute_is_noop(self):
+        assert _remove_tag_from_header("# %%", "start") == "# %%"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the last open item of #233 (item 4a): a `placeholder_start` operation for `clm slides normalize` that mechanically repairs the recurring workshop mis-tag:

- a code cell tagged `start` whose **entire body is a solution placeholder** (`# Your solution here` and DE variants, `pass`, `...`)
- immediately followed by a **markdown** cell tagged `completed` (or `alt`)

is fixed by removing the `start` tag (the cell becomes a plain `# %%` cell) and renaming an already-promoted markdown `completed` partner back to `alt`.

## Discriminator validation (the reason 4a was deferred)

Validated against the PythonCourses corpus (2115 slide files) and its git history before enabling auto-retagging:

- **Root cause found in history**: the broken markdown-`completed` shape is *created* by `tag_migration` promoting the adjacent markdown `alt` after a mis-tagged placeholder `start` (PythonCourses `e2e7d653`). The new op therefore runs **before** `tag_migration` and also demotes the pre-migration `start`+markdown-`alt` shape, so the migration can no longer compound the slip.
- **True positives**: on the historically broken numpy decks the op reproduces the manual repair from PythonCourses `5565db63` **byte-for-byte**.
- **No false positives**: all 343 real-scaffolding `start` + code-`completed` pairs are untouched; the 6 placeholder-`start` + **code**-`completed` pairs are deliberately left alone (they validate and render correctly, and the human fixer also left them untouched); a dry run over the current corpus reports zero changes.

## Changes

- `src/clm/slides/normalizer.py`: new `placeholder_start` operation (`_apply_placeholder_start`, `_is_placeholder_body`, `_remove_tag_from_header`), wired before `tag_migration`
- `src/clm/cli/commands/slides/normalize.py`: operation listed in the command help
- `src/clm/cli/info_topics/commands.md`: documented under `clm slides normalize`
- Tests: engine tests (fix, demote-only, full-run interaction with `tag_migration`, code-`completed` exclusion, hint-comment exclusion, body variants, tag preservation, idempotency) + CLI test
- Changelog fragment `changelog.d/233-placeholder-start.added.md`

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
