### PR TITLE
feat(slides): warn on id-less slide cells in `clm slides split` (#255)

### DIFF
--- a/changelog.d/255-split-idless-warning.added.md
+++ b/changelog.d/255-split-idless-warning.added.md
@@ -1,0 +1,7 @@
+- `clm slides split` now warns (without failing or rewriting the source) when
+  the bilingual source contains `slide`/`subslide` cells missing a `slide_id`,
+  pointing at `clm slides assign-ids`. Lightweight substitute for the deferred
+  `split --assign-ids` proposal (#255): the documented
+  `assign-ids --accept-content-derived --accept-code-derived` → `split`
+  pipeline already guarantees id-complete halves; the warning catches the
+  forgotten-first-step case at split time instead of one `validate` later.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2002,6 +2002,15 @@ own comment token (`# %%` for Python/Rust, `// %%` for C#/C++/Java/TS),
 so split/unify and the rest of the authoring tooling work on every
 supported prog_lang — the token is derived from the file extension.
 
+**Missing slide_id (issue #255).** Since CLM {version}, `split` emits a
+`warning:` (to stderr; does not fail) when SOURCE contains `slide`/`subslide`
+cells without a `slide_id` — the same cells the validator's missing-slide_id
+error covers. The split halves would fail `clm slides validate` and could pair
+only by adjacency in `unify`/`sync`. `split` never mints ids itself (it is a
+byte-faithful structural transform) — run
+`clm slides assign-ids <dir> --accept-content-derived --accept-code-derived`
+on the bilingual source first, then re-split.
+
 **Preamble code (issue #253).** Since CLM {version}, `split` emits a `warning:`
 (to stderr; does not fail) when SOURCE has executable code between the
 `# {{ header(…) }}` macro call and the first `# %%` cell. The split itself stays

--- a/src/clm/slides/split.py
+++ b/src/clm/slides/split.py
@@ -363,6 +363,7 @@ def split_in_file(
     de_text, en_text = split_text(text, comment_token)
 
     warnings = _preamble_code_warnings(text, source, comment_token)
+    warnings += _missing_slide_id_warnings(text, source, comment_token)
 
     companion = _plan_companion_split(source, de_path, en_path, comment_token)
 
@@ -426,6 +427,35 @@ def _preamble_code_warnings(text: str, source: Path, comment_token: str = "#") -
             f"cell, then re-split."
         )
     return warnings
+
+
+def _missing_slide_id_warnings(text: str, source: Path, comment_token: str = "#") -> list[str]:
+    """Warn (without rewriting) when slide/subslide cells lack a ``slide_id``.
+
+    The split itself tolerates id-less cells — they still route by ``lang``
+    and ``unify`` pairs them by adjacency — but the emitted halves fail
+    ``clm slides validate`` (missing slide_id is an error since 1.8) and
+    cannot pair by id during ``sync``. Minting ids belongs to ``assign-ids``
+    on the bilingual source, never to ``split``, which must stay a
+    byte-faithful structural transform (issue #255). Same rule as the
+    validator: only ``slide``/``subslide`` cells require an id.
+    """
+    _preamble, cells = split_cells(text, comment_token)
+    lines = [
+        cell.line_number
+        for cell in cells
+        if cell.metadata.is_slide_start and cell.metadata.slide_id is None
+    ]
+    if not lines:
+        return []
+    listed = ", ".join(str(n) for n in lines[:5]) + (", ..." if len(lines) > 5 else "")
+    return [
+        f"{source}: {len(lines)} slide/subslide cell(s) lack slide_id "
+        f"(line(s) {listed}). The split halves will fail `clm slides validate` "
+        f"and can pair only by adjacency. Run `clm slides assign-ids` on the "
+        f"bilingual source (EN-authority pair minting) first, then re-split "
+        f"(issue #255)."
+    ]
 
 
 def _split_target(source: Path, lang: str) -> Path:

--- a/tests/slides/test_split.py
+++ b/tests/slides/test_split.py
@@ -316,6 +316,42 @@ class TestSplitInFile:
         result = split_in_file(source)
         assert result.warnings == []
 
+    def test_missing_slide_id_emits_warning(self, tmp_path: Path) -> None:
+        source = tmp_path / "deck.py"
+        idless_pair = (
+            '# %% [markdown] lang="de" tags=["slide"]\n#\n# ## Eins\n\n'
+            '# %% [markdown] lang="en" tags=["slide"]\n#\n# ## One\n\n'
+        )
+        source.write_text(HEADER_PREAMBLE + idless_pair, encoding="utf-8")
+        result = split_in_file(source)
+        assert any("#255" in w for w in result.warnings)
+        assert any("assign-ids" in w for w in result.warnings)
+        # The warning never blocks — the split is still written.
+        assert result.wrote is True
+        assert (tmp_path / "deck.de.py").is_file()
+
+    def test_missing_slide_id_warning_in_dry_run(self, tmp_path: Path) -> None:
+        source = tmp_path / "deck.py"
+        idless = '# %% [markdown] lang="de" tags=["subslide"]\n#\n# ## Eins\n\n'
+        source.write_text(
+            HEADER_PREAMBLE + _slide_pair("a", "Eins", "One") + idless, encoding="utf-8"
+        )
+        result = split_in_file(source, dry_run=True)
+        assert result.wrote is False
+        assert any("#255" in w for w in result.warnings)
+
+    def test_no_warning_for_idless_code_cells(self, tmp_path: Path) -> None:
+        # Bare lang-tagged code cells legitimately carry no slide_id (the
+        # validator's rule covers slide/subslide cells only) — no warning.
+        source = tmp_path / "deck.py"
+        idless_code = '# %% lang="de"\nx = 1\n\n# %% lang="en"\nx = 1\n\n'
+        source.write_text(
+            HEADER_PREAMBLE + _slide_pair("a", "Eins", "One") + idless_code,
+            encoding="utf-8",
+        )
+        result = split_in_file(source)
+        assert result.warnings == []
+
 
 class TestUnifyInFile:
     def test_writes_target(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Lightweight substitute for the deferred `split --assign-ids` proposal in #255 (the issue itself is being closed as won't-do with rationale; this PR deliberately avoids auto-close keywords so the manual close comment stays the record).

Instead of minting ids inside `split` — which would break its byte-faithful contract, require a throwaway-mint dry-run path, and permanently couple `split` to the accept-flag stack — `split_in_file` now emits a **warning** (never blocks, never rewrites) when the bilingual source contains `slide`/`subslide` cells without a `slide_id`. The rule mirrors the validator's missing-slide_id error exactly (`is_slide_start` and no id), so the warning fires precisely when the emitted halves would fail the first post-split `validate`. The message points the operator at `clm slides assign-ids` on the bilingual source.

## Changes

- `src/clm/slides/split.py` — new `_missing_slide_id_warnings` helper, appended to `SplitResult.warnings` (same mechanism as the #253 preamble-code warning; CLI already prints warnings to stderr and includes them in `--json`).
- `tests/slides/test_split.py` — warning fires for id-less slide/subslide cells (split still written), fires in dry-run, and stays silent for bare lang-tagged code cells (which legitimately carry no id) and clean decks.
- `src/clm/cli/info_topics/commands.md` — new "Missing slide_id (issue #255)" note in the `clm slides split` section.
- `changelog.d/255-split-idless-warning.added.md` — fragment.

## Test plan

- `pytest tests/slides/test_split.py` — 39 passed, 2 skipped (course-repo fixtures absent).
- Pre-push fast suite green; ruff + mypy clean via pre-commit.

Issue: #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
