### PR TITLE
fix(build): fold dependencies into notebook cache keys; fix cached-issue replay (#321)

### DIFF
--- a/changelog.d/321-execution-cache-dependency-keys.fixed.md
+++ b/changelog.d/321-execution-cache-dependency-keys.fixed.md
@@ -1,0 +1,22 @@
+- `clm build` notebook caches no longer replay stale execution results when
+  a dependency changes with unchanged deck text (#321): the cache keys now
+  cover every topic sibling shipped to the kernel (C++ `#include` headers,
+  Jinja `{% include %}` targets, runtime data files), a fingerprint of the
+  bundled Jinja templates (`macros.j2` etc.) plus the CLM version, and the
+  per-topic `evaluate=` / `skip-errors=` flags. The HTTP-replay cassette
+  remains deliberately excluded (record-after-run miss loop). The first
+  build after upgrading re-executes everything once (key schema change).
+- Cached-issue replay actually works for notebook jobs again (#321): stored
+  errors/warnings were keyed under `str(tuple)` output metadata while
+  lookups used the colon-joined form, so a cache hit never re-surfaced the
+  warnings/errors recorded for that content. Both cache layers (database
+  result cache and job-level cache) now replay stored issues on a hit; the
+  job-level path previously dropped them entirely.
+- A successful build of a deck now clears errors/warnings stored by earlier
+  runs of the same content (#321): previously a transient failure's stored
+  error would have been replayed on every later cache hit, and repeated
+  `--ignore-cache` runs accumulated duplicate warnings.
+- `clm build --output-mode verbose` now prints an explicit
+  `↻ Replayed from cache` line for every file served from a cache instead
+  of executed (#321) — replayed output is freshly timestamped and was
+  previously indistinguishable from executed output.

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -164,7 +164,7 @@ class BuildReporter:
             cached=self._stage_cached_count,
         )
 
-    def report_cache_hit(self, file_path: str, job_type: str) -> None:
+    def report_cache_hit(self, file_path: str, job_type: str, detail: str | None = None) -> None:
         """Report that a file was served from cache without worker execution.
 
         This method should be called when a cache hit occurs and the file
@@ -173,9 +173,15 @@ class BuildReporter:
         Args:
             file_path: Path to the cached file
             job_type: Type of job (notebook, plantuml, drawio)
+            detail: Optional cache-layer description shown in verbose mode
+                (issue #321: replayed output is freshly timestamped and
+                otherwise indistinguishable from executed output)
         """
         self._stage_cached_count += 1
         self._global_cached_count += 1
+
+        # Per-file replay line in verbose modes (no-op in other formatters)
+        self.formatter.show_cache_hit(file_path, job_type, detail)
 
         # Trigger a progress update to reflect the cache hit
         self.update_progress(

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,29 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Execution cache keys now cover dependencies (issue #321, after 1.11)
+
+`clm build` previously keyed its notebook execution caches on the deck text
+alone, so editing a sibling file the deck depends on (a C++ header it
+`#include`s, a Jinja `{% include %}` target, a CSV it reads) silently
+replayed stale execution output with a fresh timestamp, and only
+`--ignore-cache` recovered. The cache keys now also cover every non-image
+topic sibling, a fingerprint of CLM's bundled Jinja templates, and the
+per-topic `evaluate=` / `skip-errors=` attributes.
+
+Consequences for course repos:
+
+- **The first build after upgrading re-executes every deck once** (the key
+  schema changed). Subsequent builds cache normally.
+- Editing any non-image file in a topic directory re-executes the decks in
+  that topic — you no longer need `--ignore-cache` after changing a shared
+  header or data file.
+- Editing the HTTP-replay cassette still does **not** invalidate (deliberate;
+  record-capable modes rewrite cassettes after execution). Use
+  `--ignore-cache` after a manual cassette edit.
+- `clm build --output-mode verbose` now prints `↻ Replayed from cache` for
+  every file served from a cache instead of executed.
+
 ## Command-tree regrouping (issue #310, after 1.11)
 
 The single-command groups `topic`, `spec`, and `authoring` were merged into

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -167,6 +167,26 @@ class OutputFormatter(ABC):
             success: Whether processing succeeded
         """
 
+    def show_cache_hit(  # noqa: B027
+        self, file_path: str, job_type: str, detail: str | None = None
+    ) -> None:
+        """Show when a file is served from cache instead of executed (optional).
+
+        Replayed results are observationally indistinguishable from executed
+        ones in the output tree (freshly timestamped files), which made the
+        stale-replay class of issue #321 hard to even notice. Verbose mode
+        overrides this to say explicitly that no execution happened.
+
+        This method is intentionally not abstract - it's an optional hook that
+        subclasses may override for verbose output. The default implementation
+        is a no-op.
+
+        Args:
+            file_path: Path to the source file served from cache
+            job_type: Type of job (notebook, plantuml, drawio)
+            detail: Optional human-readable cache-layer description
+        """
+
     def show_startup_message(self, message: str) -> None:  # noqa: B027
         """Show a startup progress message (optional).
 
@@ -531,6 +551,20 @@ class VerboseOutputFormatter(DefaultOutputFormatter):
 
         job_info = f" (job #{job_id})" if job_id else ""
         self.console.print(f"  [dim]▶ Processing {job_type}:{job_info} {display_path}[/dim]")
+
+    def show_cache_hit(self, file_path: str, job_type: str, detail: str | None = None) -> None:
+        """Show when a file is served from cache instead of executed.
+
+        Args:
+            file_path: Path to the source file served from cache
+            job_type: Type of job (notebook, plantuml, drawio)
+            detail: Optional human-readable cache-layer description
+        """
+        display_path = format_error_path(file_path)
+        detail_info = f" ({detail})" if detail else ""
+        self.console.print(
+            f"  [cyan]↻[/cyan] [dim]Replayed from cache {job_type}: {display_path}{detail_info}[/dim]"
+        )
 
     def show_file_completed(
         self, file_path: str, job_type: str, job_id: int | None = None, success: bool = True

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -1,5 +1,8 @@
+import hashlib
 import logging
 from base64 import b64encode
+from functools import cache
+from importlib.resources import files as package_files
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +24,40 @@ from clm.infrastructure.utils.path_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@cache
+def compute_template_fingerprint(prog_lang: str) -> str:
+    """Digest of the bundled Jinja templates for *prog_lang* plus the CLM version.
+
+    Computed HOST-side at payload construction and shipped to the worker via
+    ``NotebookPayload.template_fingerprint``, where it is folded into the
+    cache keys. Templates (``macros.j2`` etc.) live inside the clm package
+    and are resolved worker-side, so they are otherwise invisible to the
+    cache: without this fingerprint a template change shipped with a clm
+    upgrade silently replays stale HTML from a warm cache (issue #321).
+
+    The CLM version is folded in as well, as a coarse proxy for everything
+    else the package ships that can affect output (worker code, bootstrap
+    templates). The fingerprint must be computed on ONE side only — host and
+    worker may run different clm versions (Docker images), and the cache key
+    must be computed identically by every layer, so the worker reuses the
+    host's value from the payload instead of recomputing.
+
+    ``lru_cache`` makes this a one-time cost per prog_lang per process; the
+    template directories are a handful of small files.
+    """
+    from clm import __version__
+
+    hasher = hashlib.sha256()
+    hasher.update(f"{__version__}:{prog_lang}".encode())
+    template_dir = package_files("clm") / "workers" / "notebook" / f"templates_{prog_lang}"
+    if template_dir.is_dir():
+        entries = sorted((entry.name, entry) for entry in template_dir.iterdir() if entry.is_file())
+        for name, entry in entries:
+            hasher.update(f"\n{name}:".encode())
+            hasher.update(entry.read_bytes())
+    return hasher.hexdigest()
 
 
 def _resolve_trace_dir_for_payload() -> str:
@@ -367,6 +404,7 @@ class ProcessNotebookOperation(Operation):
             prog_lang=self.prog_lang,
             language=self.language,
             format=self.format,
+            template_fingerprint=compute_template_fingerprint(self.prog_lang),
             other_files=self.compute_other_files(),
             fallback_execute=self.fallback_execute,
             skip_evaluation=self.skip_evaluation,

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -199,7 +199,11 @@ class SqliteBackend(LocalOpsBackend):
 
                 # Report cache hit to build reporter for progress tracking
                 if self.build_reporter:
-                    self.build_reporter.report_cache_hit(str(payload.input_file), job_type)
+                    self.build_reporter.report_cache_hit(
+                        str(payload.input_file),
+                        job_type,
+                        detail="stored result replayed, no execution",
+                    )
 
                 return
 
@@ -217,9 +221,26 @@ class SqliteBackend(LocalOpsBackend):
                 if not output_path.is_absolute():
                     output_path = self.workspace_path / output_path
                 if output_path.exists():
+                    # Replay stored errors/warnings for this result, exactly
+                    # like the database-cache path above. Without this, a
+                    # results_cache hit (e.g. after retention pruned the
+                    # processed_files entry) silently dropped the issues a
+                    # worker recorded for this content — the build went
+                    # green while the output still contained the flagged
+                    # content (issue #321: replay must be observationally
+                    # equivalent to execution).
+                    self._report_cached_issues(
+                        payload.input_file,
+                        payload.content_hash(),
+                        payload.output_metadata(),
+                    )
                     # Report cache hit to build reporter for progress tracking
                     if self.build_reporter:
-                        self.build_reporter.report_cache_hit(str(payload.input_file), job_type)
+                        self.build_reporter.report_cache_hit(
+                            str(payload.input_file),
+                            job_type,
+                            detail="output already on disk, no execution",
+                        )
                     return
                 else:
                     logger.warning(f"Cache indicated file exists but not found: {output_path}")
@@ -472,6 +493,16 @@ class SqliteBackend(LocalOpsBackend):
                         f"Job {job_id} completed: {job_info['input_file']} -> {job_info['output_file']}"
                     )
                     completed_jobs.append(job_id)
+
+                    # A successful run supersedes whatever issues earlier runs
+                    # stored under the same (file, content, metadata) key.
+                    # Without this, a transient failure's stored error is
+                    # replayed on every later cache hit even though the
+                    # content now builds cleanly — and re-runs of the same
+                    # content (--ignore-cache) accumulate duplicate warnings.
+                    # Must happen BEFORE the warning extraction below so the
+                    # fresh run's warnings survive.
+                    self._clear_stored_issues_for_job(job_id, job_info)
 
                     # Extract and report any warnings from the job result
                     self._extract_and_report_job_warnings(job_id, job_info)
@@ -1018,12 +1049,21 @@ class SqliteBackend(LocalOpsBackend):
             Output metadata string matching the format used in payload.output_metadata()
         """
         if job_type == "notebook":
-            # NotebookPayload.output_metadata() returns tuple of (kind, prog_lang, language, format)
+            # MUST match NotebookPayload.output_metadata() / NotebookResult
+            # .output_metadata() exactly — the colon-joined form, NOT
+            # ``str()`` of the tags tuple. Issues are *stored* under the key
+            # this function returns but *looked up* (``_report_cached_issues``)
+            # under ``payload.output_metadata()``; a previous ``str(tuple)``
+            # here keyed every stored notebook error/warning under
+            # ``"('completed', 'python', ...)"`` while lookups used
+            # ``"completed:python:..."``, silently disabling cached-issue
+            # replay for ALL notebook jobs (issue #321).
             from clm.infrastructure.messaging.notebook_classes import (
+                notebook_metadata,
                 notebook_metadata_tags_from_payload,
             )
 
-            return str(notebook_metadata_tags_from_payload(payload_dict))
+            return notebook_metadata(*notebook_metadata_tags_from_payload(payload_dict))
         elif job_type in ("plantuml", "drawio"):
             # ImagePayload.output_metadata() returns output_format
             output_format = payload_dict.get("output_format", "png")
@@ -1037,6 +1077,36 @@ class SqliteBackend(LocalOpsBackend):
             return f"jupyterlite:{target_name}:{language}:{kinds_str}:{kernel}"
         else:
             return ""
+
+    def _clear_stored_issues_for_job(self, job_id: int, job_info: dict) -> None:
+        """Drop stored errors/warnings superseded by a successful run.
+
+        ``processing_issues`` rows are keyed ``(file_path, content_hash,
+        output_metadata)`` and are replayed by ``_report_cached_issues`` on
+        every cache hit for that key. When a job for the exact same key
+        completes successfully, those stored issues describe a run that the
+        success just superseded (e.g. a transient kernel failure), so they
+        must not haunt future cache hits. Called before
+        ``_extract_and_report_job_warnings`` stores the fresh run's warnings.
+        """
+        if self.db_manager is None or self.job_queue is None:
+            return
+        try:
+            conn = self.job_queue._get_conn()
+            cursor = conn.execute("SELECT payload, content_hash FROM jobs WHERE id = ?", (job_id,))
+            row = cursor.fetchone()
+            if not row:
+                return
+            payload_dict = json.loads(row[0]) if row[0] else {}
+            content_hash = row[1]
+            output_metadata = self._get_output_metadata(job_info["job_type"], payload_dict)
+            self.db_manager.clear_issues(
+                file_path=job_info["input_file"],
+                content_hash=content_hash,
+                output_metadata=output_metadata,
+            )
+        except Exception as e:
+            logger.warning(f"Could not clear stored issues for job {job_id}: {e}")
 
     def _extract_and_report_job_warnings(self, job_id: int, job_info: dict) -> None:
         """Extract warnings from completed job and report/store them.

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -4,6 +4,14 @@ from typing import Any, Literal
 
 from clm.infrastructure.messaging.base_classes import Payload, ProcessingError, Result
 
+# Version tag folded into every notebook cache hash. Bump whenever the
+# *composition* of ``content_hash()`` / ``execution_cache_hash()`` changes so
+# that stale cache entries produced under the old key schema can never be
+# replayed as hits under the new one. Bumping invalidates all existing
+# notebook caches (one full re-execution on the next build) — deliberate and
+# visible, instead of an accidental partial overlap between key schemas.
+CACHE_HASH_SCHEMA_VERSION = 2
+
 
 def notebook_metadata(kind, prog_lang, language, output_format) -> str:
     return f"{kind}:{prog_lang}:{language}:{output_format}"
@@ -40,7 +48,15 @@ class NotebookPayload(Payload):
     prog_lang: str
     language: str
     format: str
-    template_dir: str = ""
+    # Digest of the bundled Jinja template directory for this payload's
+    # prog_lang plus the CLM version, computed HOST-side at payload
+    # construction (``compute_template_fingerprint``). Templates are
+    # resolved worker-side from the installed clm package, so without this
+    # field a ``macros.j2`` change (shipped with a new clm version) would
+    # invalidate nothing and every deck would replay stale title slides
+    # from a warm cache (issue #321 class 4). Folded into both cache
+    # hashes below.
+    template_fingerprint: str = ""
     other_files: dict[str, bytes] = {}
     fallback_execute: bool = False
     # If True, the notebook is rendered to all configured output formats
@@ -101,8 +117,52 @@ class NotebookPayload(Payload):
     def notebook_text(self) -> str:
         return self.data
 
+    def _dependency_digest(self) -> str:
+        """Digest of every dependency this payload carries besides ``data``.
+
+        Folds in ``other_files`` (the complete byte content of every
+        non-image topic sibling — C++ headers a deck ``#include``s, files
+        pulled in via Jinja ``{% include %}``, runtime data files), the
+        template fingerprint, and the ``skip_evaluation`` / ``skip_errors``
+        execution flags. Editing any topic sibling re-executes the deck:
+        that over-invalidates slightly (a sibling the deck never reads also
+        triggers re-execution), but over-invalidation is safe and cheap
+        relative to silently shipping stale teaching material (issue #321).
+
+        The HTTP-replay cassette entry (``other_files[http_replay_cassette_name]``)
+        is intentionally EXCLUDED. Folding cassette bytes into the key was
+        tried earlier and produced an unfixable cache-miss loop:
+        ``compute_other_files`` reads the cassette at payload construction
+        (before the kernel runs), while record-capable modes
+        (``once``/``new-episodes``/``refresh``) write the cassette after the
+        kernel runs. So the next build's lookup hash uses the post-execution
+        cassette and never matches the prior build's stored hash. The same
+        issue surfaces the first time a cassette is created (missing →
+        populated) and whenever ``.gitattributes`` normalizes CRLF↔LF
+        between builds. Users who want to invalidate cached execution after
+        a manual cassette edit should use ``--ignore-cache``. Do NOT "fix"
+        this exclusion when extending the digest.
+        """
+        hasher = hashlib.sha256()
+        hasher.update(
+            f"{self.template_fingerprint}:{self.skip_evaluation}:{self.skip_errors}".encode()
+        )
+        cassette_key = self.http_replay_cassette_name
+        for name in sorted(self.other_files):
+            if cassette_key is not None and name == cassette_key:
+                continue
+            content = self.other_files[name]
+            # Length-prefix name and content so (name, content) boundaries
+            # are unambiguous regardless of the bytes they contain.
+            hasher.update(f"\n{len(name)}:{name}:{len(content)}:".encode())
+            hasher.update(content)
+        return hasher.hexdigest()
+
     def content_hash(self) -> str:
-        hash_data = f"{self.output_metadata()}:{self.data}".encode()
+        hash_data = (
+            f"{CACHE_HASH_SCHEMA_VERSION}:{self.output_metadata()}:"
+            f"{self._dependency_digest()}:{self.data}"
+        ).encode()
         return hashlib.sha256(hash_data).hexdigest()
 
     def execution_cache_hash(self) -> str:
@@ -111,23 +171,20 @@ class NotebookPayload(Payload):
         This hash excludes 'kind' (speaker/completed/code_along) because
         Speaker and Completed HTML share the same executed notebook.
         Completed HTML is just Speaker HTML with "notes" cells filtered out.
+        Format is excluded because we only cache HTML execution results.
 
-        The cassette contents are intentionally NOT folded into the hash.
-        Doing so was tried earlier but produced an unfixable cache-miss
-        loop: ``compute_other_files`` reads the cassette at payload
-        construction (before the kernel runs), while record-capable
-        modes (``once``/``new-episodes``/``refresh``) write the cassette
-        after the kernel runs. So the next build's lookup hash uses the
-        post-execution cassette and never matches the prior build's
-        stored hash. The same issue surfaces the first time a cassette
-        is created (missing → populated) and whenever ``.gitattributes``
-        normalizes CRLF↔LF between builds. Users who want to invalidate
-        cached execution after a manual cassette edit should use
-        ``--ignore-cache``.
+        Besides the notebook text itself, the key covers the full dependency
+        set via :meth:`_dependency_digest` — sibling files, template
+        fingerprint, and execution flags — so editing a ``#include``d header
+        or upgrading clm's bundled templates re-executes the deck instead of
+        silently replaying stale outputs (issue #321). The cassette entry is
+        deliberately excluded from that digest; see ``_dependency_digest``
+        for the rationale.
         """
-        # Use prog_lang:language:data (without kind or format).
-        # Format is excluded because we only cache HTML execution results.
-        hash_data = f"{self.prog_lang}:{self.language}:{self.data}".encode()
+        hash_data = (
+            f"{CACHE_HASH_SCHEMA_VERSION}:{self.prog_lang}:{self.language}:"
+            f"{self._dependency_digest()}:{self.data}"
+        ).encode()
         return hashlib.sha256(hash_data).hexdigest()
 
     def output_metadata(self) -> str:

--- a/tests/cli/test_build_output.py
+++ b/tests/cli/test_build_output.py
@@ -801,6 +801,30 @@ class TestVerboseOutputFormatter:
         # Check that the file is being tracked
         assert "test.ipynb" in formatter._files_started
 
+    def test_verbose_formatter_shows_cache_replays(self, capsys):
+        """Verbose mode must say explicitly when a file was served from cache
+        (issue #321: replayed output is freshly timestamped and otherwise
+        indistinguishable from executed output)."""
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+
+        formatter.show_cache_hit("test.ipynb", "notebook", detail="stored result replayed")
+
+        # The rich console writes to stderr.
+        captured = capsys.readouterr()
+        assert "Replayed from cache" in captured.err
+        assert "test.ipynb" in captured.err
+        assert "stored result replayed" in captured.err
+
+    def test_default_formatter_cache_hit_is_silent(self, capsys):
+        """The default formatter keeps cache hits to the progress counter."""
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+
+        formatter.show_cache_hit("test.ipynb", "notebook", detail="stored result replayed")
+
+        captured = capsys.readouterr()
+        assert "Replayed from cache" not in captured.out
+        assert "Replayed from cache" not in captured.err
+
     def test_verbose_formatter_file_completed_success(self):
         """Test verbose formatter tracks file processing completion (success)."""
         formatter = VerboseOutputFormatter()

--- a/tests/cli/test_error_reporting_integration.py
+++ b/tests/cli/test_error_reporting_integration.py
@@ -75,8 +75,12 @@ class TestSqliteBackendErrorStorage:
             "format": "notebook",
         }
 
+        # Must be the colon-joined NotebookPayload.output_metadata() form so
+        # stored issues are found again by _report_cached_issues (issue #321:
+        # the old str(tuple) form keyed stored notebook issues under a string
+        # the lookup never used, silently disabling cached-issue replay).
         result = backend._get_output_metadata("notebook", payload_dict)
-        assert result == "('participant', 'python', 'en', 'notebook')"
+        assert result == "participant:python:en:notebook"
 
     def test_get_output_metadata_plantuml(self, backend_setup):
         """Test that _get_output_metadata correctly generates metadata for plantuml."""

--- a/tests/core/operations/test_process_notebook.py
+++ b/tests/core/operations/test_process_notebook.py
@@ -1,0 +1,46 @@
+"""Tests for ProcessNotebookOperation helpers.
+
+Currently covers ``compute_template_fingerprint`` (issue #321): the
+host-side digest of the bundled Jinja template directory that travels in
+``NotebookPayload.template_fingerprint`` and is folded into the cache keys.
+"""
+
+from clm.core.operations.process_notebook import compute_template_fingerprint
+
+
+class TestComputeTemplateFingerprint:
+    def test_deterministic_per_prog_lang(self):
+        """Same prog_lang must yield the same fingerprint (it is a cache
+        key component — any instability would invalidate on every build)."""
+        assert compute_template_fingerprint("python") == compute_template_fingerprint("python")
+
+    def test_is_sha256_hex(self):
+        fingerprint = compute_template_fingerprint("python")
+        assert len(fingerprint) == 64
+        int(fingerprint, 16)  # raises if not hex
+
+    def test_differs_across_prog_langs(self):
+        """templates_cpp and templates_python have different contents, so
+        their fingerprints must differ."""
+        assert compute_template_fingerprint("cpp") != compute_template_fingerprint("python")
+
+    def test_unknown_prog_lang_does_not_crash(self):
+        """A prog_lang without a bundled template directory still gets a
+        stable fingerprint (version + prog_lang only)."""
+        fingerprint = compute_template_fingerprint("not-a-real-language")
+        assert len(fingerprint) == 64
+
+    def test_covers_template_file_content(self):
+        """The fingerprint must be derived from template file bytes, not just
+        names: macros.j2 exists under both cpp and csharp template dirs with
+        (potentially) different content — and even where contents coincide,
+        the prog_lang itself is folded in. Guard the content sensitivity via
+        the digest helper's structure instead: hashing the same directory
+        twice in one process returns the lru_cached value, so clear the cache
+        and recompute to prove stability is content-based, not cache-based.
+        """
+        compute_template_fingerprint.cache_clear()
+        first = compute_template_fingerprint("cpp")
+        compute_template_fingerprint.cache_clear()
+        second = compute_template_fingerprint("cpp")
+        assert first == second

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -189,7 +189,7 @@ class _StubReporter:
     def on_progress_update(self, update):
         self.progress_updates.append(update)
 
-    def report_cache_hit(self, file_path, job_type):
+    def report_cache_hit(self, file_path, job_type, detail=None):
         self.cache_hits.append((file_path, job_type))
 
     def report_file_started(self, file_path, job_type, job_id=None):
@@ -564,15 +564,20 @@ async def test_get_available_workers_no_queue(temp_db, temp_workspace):
 async def test_get_output_metadata_all_types(temp_db, temp_workspace):
     backend = _backend(temp_db, temp_workspace)
     try:
-        assert backend._get_output_metadata(
-            "notebook",
-            {
-                "kind": "completed",
-                "prog_lang": "python",
-                "language": "en",
-                "format": "notebook",
-            },
-        ) == str(("completed", "python", "en", "notebook"))
+        # Colon-joined form, matching NotebookPayload.output_metadata() —
+        # store and lookup must agree or cached-issue replay is dead (#321).
+        assert (
+            backend._get_output_metadata(
+                "notebook",
+                {
+                    "kind": "completed",
+                    "prog_lang": "python",
+                    "language": "en",
+                    "format": "notebook",
+                },
+            )
+            == "completed:python:en:notebook"
+        )
 
         assert backend._get_output_metadata("plantuml", {"output_format": "svg"}) == "svg"
         assert backend._get_output_metadata("drawio", {"output_format": "png"}) == "png"
@@ -750,5 +755,153 @@ async def test_incremental_copy_skips_existing_output(temp_db, temp_workspace, t
         await backend.copy_file_to_output(data)
         # File content unchanged — incremental skipped the copy.
         assert dest.read_text() == "already here"
+    finally:
+        await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Issue #321: cached-result replay must be observationally equivalent to
+# execution (stored issues replayed on EVERY cache layer), and a successful
+# run must supersede issues stored by earlier runs under the same key.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_results_cache_hit_replays_stored_issues(temp_db, temp_workspace, tmp_path):
+    """A results_cache (job-level) hit must replay stored warnings/errors.
+
+    Previously only the processed_files path replayed issues; a results_cache
+    hit (e.g. after retention pruned the processed_files entry) returned
+    early and the build went silently green.
+    """
+    from clm.cli.build_data_classes import BuildWarning
+
+    cache_db = tmp_path / "cache.db"
+    backend = _backend(temp_db, temp_workspace, build_reporter=_StubReporter())
+    backend.db_manager = DatabaseManager(cache_db)
+    backend.db_manager.__enter__()
+    try:
+        payload = _MockPayload()
+
+        # The job-level cache requires the output to already exist on disk.
+        (temp_workspace / payload.output_file).write_text("output from prior build")
+
+        # Seed a job-level cache entry, but NO processed_files entry — the
+        # database-cache path must miss so the results_cache path is taken.
+        # Metadata must be non-empty: execute_operation treats the returned
+        # metadata dict itself as the hit indicator (`if cached:`), and real
+        # workers always store non-empty metadata.
+        assert backend.job_queue is not None
+        backend.job_queue.add_to_cache(
+            payload.output_file, payload.content_hash(), {"format": "notebook"}
+        )
+
+        # A warning recorded by the run that produced the cached output.
+        backend.db_manager.store_warning(
+            file_path=payload.input_file,
+            content_hash=payload.content_hash(),
+            output_metadata=payload.output_metadata(),
+            warning=BuildWarning(category="skip_errors_cell_failed", message="w", severity="low"),
+        )
+
+        await backend.execute_operation(_MockOp(), payload)
+
+        # Served from cache: no job submitted, hit reported, warning replayed.
+        assert backend.active_jobs == {}
+        assert backend.build_reporter.cache_hits == [(payload.input_file, "notebook")]
+        assert len(backend.build_reporter.warnings) == 1
+        assert backend.build_reporter.warnings[0].category == "skip_errors_cell_failed"
+    finally:
+        backend.db_manager.__exit__(None, None, None)
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_completed_job_clears_stale_stored_errors(temp_db, temp_workspace, tmp_path):
+    """A successful run clears errors stored by an earlier failed run.
+
+    Without this, a transient failure's stored error replays on every later
+    cache hit for the same (file, content, metadata) key even though the
+    content now builds cleanly.
+    """
+    cache_db = tmp_path / "cache.db"
+    backend = _backend(temp_db, temp_workspace, build_reporter=_StubReporter())
+    backend.db_manager = DatabaseManager(cache_db)
+    backend.db_manager.__enter__()
+    try:
+        payload = _MockPayload()
+        await backend.execute_operation(_MockOp(), payload)
+        job_id = next(iter(backend.active_jobs))
+
+        # The key a failed run of this exact job would have stored under.
+        output_metadata = backend._get_output_metadata("notebook", payload.model_dump(mode="json"))
+        backend.db_manager.store_error(
+            file_path=payload.input_file,
+            content_hash=payload.content_hash(),
+            output_metadata=output_metadata,
+            error=BuildError(
+                error_type="user",
+                category="execution",
+                severity="error",
+                file_path=payload.input_file,
+                message="transient kernel failure from a previous build",
+                actionable_guidance="none",
+            ),
+        )
+
+        # Mark the job completed and run the wait loop (integration path:
+        # the clearing must happen inside wait_for_completion's completed
+        # branch, before fresh warnings are extracted).
+        jq = JobQueue(temp_db)
+        try:
+            jq.update_job_status(job_id, "completed")
+        finally:
+            jq.close()
+        result = await backend.wait_for_completion()
+        assert result is True
+
+        errors, warnings = backend.db_manager.get_issues(
+            payload.input_file, payload.content_hash(), output_metadata
+        )
+        assert errors == []
+        assert warnings == []
+        # The stale error must not have been (re-)reported either.
+        assert backend.build_reporter.errors == []
+    finally:
+        backend.active_jobs.clear()
+        backend.db_manager.__exit__(None, None, None)
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_stored_issue_keys_match_lookup_keys_for_notebook_jobs(
+    temp_db, temp_workspace, tmp_path
+):
+    """End-to-end key agreement for notebook jobs (issue #321).
+
+    Issues are stored under ``_get_output_metadata(job_type, payload_dict)``
+    (failed-job and warning-extraction paths) but looked up under
+    ``payload.output_metadata()`` (cache-hit replay). These were silently
+    different for notebook jobs (str(tuple) vs colon-joined), which disabled
+    cached-issue replay entirely. Pin their agreement.
+    """
+    from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        payload = NotebookPayload(
+            correlation_id="cid",
+            input_file="slides.py",
+            input_file_name="slides.py",
+            output_file="slides.html",
+            data="content",
+            kind="completed",
+            prog_lang="python",
+            language="en",
+            format="html",
+        )
+        stored_key = backend._get_output_metadata("notebook", payload.model_dump(mode="json"))
+        lookup_key = payload.output_metadata()
+        assert stored_key == lookup_key
     finally:
         await backend.shutdown()

--- a/tests/infrastructure/messaging/test_notebook_classes.py
+++ b/tests/infrastructure/messaging/test_notebook_classes.py
@@ -57,7 +57,7 @@ class TestNotebookPayload:
 
     def test_payload_default_values(self, sample_payload):
         """Should have default values for optional fields."""
-        assert sample_payload.template_dir == ""
+        assert sample_payload.template_fingerprint == ""
         assert sample_payload.other_files == {}
         assert sample_payload.fallback_execute is False
 
@@ -90,7 +90,7 @@ class TestNotebookPayload:
             "prog_lang": "cpp",
             "language": "de",
             "format": "html",
-            "template_dir": "tmpl",
+            "template_fingerprint": "tfp-distinctive",
             "other_files": {"helper.py": b"x = 1"},
             "fallback_execute": True,
             "skip_evaluation": True,
@@ -263,7 +263,7 @@ class TestExecutionCacheHash:
 
     def test_hash_invariant_across_replay_mode(self):
         """The hash must not depend on whether replay is on, since the
-        cache key is over source data only."""
+        cache key is over source data and non-cassette dependencies only."""
         p_plain = self._payload()
         p_replay = self._payload(
             http_replay_mode="replay",
@@ -271,6 +271,148 @@ class TestExecutionCacheHash:
             other_files={"slides.http-cassette.yaml": b"cassette"},
         )
         assert p_plain.execution_cache_hash() == p_replay.execution_cache_hash()
+
+    def test_content_hash_invariant_under_cassette_bytes_change(self):
+        """The cassette exclusion must hold for ``content_hash`` too — the
+        host-side caches key on it, and a cassette rewritten post-execution
+        would otherwise reproduce the record-mode miss loop there."""
+        p_old = self._payload(
+            http_replay_mode="new-episodes",
+            http_replay_cassette_name="slides.http-cassette.yaml",
+            other_files={"slides.http-cassette.yaml": b"old-cassette-bytes"},
+        )
+        p_new = self._payload(
+            http_replay_mode="new-episodes",
+            http_replay_cassette_name="slides.http-cassette.yaml",
+            other_files={"slides.http-cassette.yaml": b"new-cassette-bytes"},
+        )
+        assert p_old.content_hash() == p_new.content_hash()
+
+
+class TestDependencyFoldingIntoHashes:
+    """Issue #321: the cache keys must cover the full dependency set.
+
+    ``other_files`` carries the byte content of every non-image topic
+    sibling — C++ headers a deck ``#include``s, Jinja ``{% include %}``
+    targets, runtime data files. A change to any of them must invalidate
+    both the host-side ``content_hash`` and the worker-side
+    ``execution_cache_hash``, otherwise freshly timestamped output ships
+    stale execution results.
+    """
+
+    def _payload(self, **overrides):
+        defaults = {
+            "correlation_id": "cid",
+            "input_file": "/slides.cpp",
+            "input_file_name": "slides.cpp",
+            "output_file": "/slides.html",
+            "data": "cell contents",
+            "kind": "speaker",
+            "prog_lang": "cpp",
+            "language": "en",
+            "format": "html",
+            "other_files": {"lifetime_observer.hpp": b"struct Obs { int id; };"},
+        }
+        defaults.update(overrides)
+        return NotebookPayload(**defaults)
+
+    def _both_hashes(self, payload):
+        return payload.content_hash(), payload.execution_cache_hash()
+
+    def test_sibling_content_change_invalidates_both_hashes(self):
+        """The observed #321 case: editing an ``#include``d sibling header
+        with unchanged deck text must change both cache keys."""
+        before = self._payload()
+        after = self._payload(
+            other_files={"lifetime_observer.hpp": b"struct Obs { int id; int generation; };"}
+        )
+        assert before.content_hash() != after.content_hash()
+        assert before.execution_cache_hash() != after.execution_cache_hash()
+
+    def test_sibling_added_or_removed_invalidates_both_hashes(self):
+        with_one = self._payload()
+        with_two = self._payload(
+            other_files={
+                "lifetime_observer.hpp": b"struct Obs { int id; };",
+                "data.csv": b"a,b\n1,2\n",
+            }
+        )
+        assert with_one.content_hash() != with_two.content_hash()
+        assert with_one.execution_cache_hash() != with_two.execution_cache_hash()
+
+    def test_sibling_rename_invalidates_both_hashes(self):
+        """Same bytes under a different name is a different include target."""
+        original = self._payload()
+        renamed = self._payload(other_files={"observer.hpp": b"struct Obs { int id; };"})
+        assert original.content_hash() != renamed.content_hash()
+        assert original.execution_cache_hash() != renamed.execution_cache_hash()
+
+    def test_sibling_order_is_irrelevant(self):
+        """dict insertion order must not leak into the key (the digest sorts)."""
+        ab = self._payload(other_files={"a.h": b"A", "b.h": b"B"})
+        ba = self._payload(other_files={"b.h": b"B", "a.h": b"A"})
+        assert ab.content_hash() == ba.content_hash()
+        assert ab.execution_cache_hash() == ba.execution_cache_hash()
+
+    def test_non_cassette_sibling_still_folded_when_replay_active(self):
+        """Only the cassette entry is excluded — a real sibling shipped
+        alongside an active cassette must still invalidate."""
+        before = self._payload(
+            http_replay_mode="replay",
+            http_replay_cassette_name="slides.http-cassette.yaml",
+            other_files={
+                "slides.http-cassette.yaml": b"cassette",
+                "lifetime_observer.hpp": b"v1",
+            },
+        )
+        after = self._payload(
+            http_replay_mode="replay",
+            http_replay_cassette_name="slides.http-cassette.yaml",
+            other_files={
+                "slides.http-cassette.yaml": b"cassette",
+                "lifetime_observer.hpp": b"v2",
+            },
+        )
+        assert before.content_hash() != after.content_hash()
+        assert before.execution_cache_hash() != after.execution_cache_hash()
+
+    def test_template_fingerprint_invalidates_both_hashes(self):
+        """A clm upgrade that changes bundled templates (``macros.j2``) must
+        invalidate, even though templates resolve worker-side."""
+        v1 = self._payload(template_fingerprint="fingerprint-1")
+        v2 = self._payload(template_fingerprint="fingerprint-2")
+        assert v1.content_hash() != v2.content_hash()
+        assert v1.execution_cache_hash() != v2.execution_cache_hash()
+
+    def test_skip_evaluation_flip_invalidates_both_hashes(self):
+        """Flipping ``evaluate="no"`` on a topic changes the output for
+        identical deck text; the old executed HTML must not replay."""
+        evaluated = self._payload(skip_evaluation=False)
+        unevaluated = self._payload(skip_evaluation=True)
+        assert evaluated.content_hash() != unevaluated.content_hash()
+        assert evaluated.execution_cache_hash() != unevaluated.execution_cache_hash()
+
+    def test_skip_errors_flip_invalidates_both_hashes(self):
+        strict = self._payload(skip_errors=False)
+        tolerant = self._payload(skip_errors=True)
+        assert strict.content_hash() != tolerant.content_hash()
+        assert strict.execution_cache_hash() != tolerant.execution_cache_hash()
+
+    def test_round_trip_preserves_hashes(self):
+        """Host and worker must compute identical keys from the same job:
+        the hash inputs have to survive the model_dump(mode="json") →
+        from_job_payload round trip exactly (bytes ↔ str coercion included)."""
+        original = self._payload(template_fingerprint="tfp")
+        dumped = original.model_dump(mode="json")
+        restored = NotebookPayload.from_job_payload(
+            dumped,
+            content=original.data,
+            input_file=original.input_file,
+            output_file=original.output_file,
+            fallback_correlation_id="cid-fallback",
+        )
+        assert restored.content_hash() == original.content_hash()
+        assert restored.execution_cache_hash() == original.execution_cache_hash()
 
 
 class TestNotebookResult:

--- a/tests/workers/notebook/test_worker_heartbeat_integration.py
+++ b/tests/workers/notebook/test_worker_heartbeat_integration.py
@@ -323,7 +323,6 @@ def test_three_cell_notebook_emits_heartbeats(db_path: Path, tmp_path: Path) -> 
         prog_lang="python",
         language="en",
         format="html",
-        template_dir="",
         other_files={},
         correlation_id=f"hb-test-{uuid.uuid4().hex[:8]}",
     )


### PR DESCRIPTION
## Summary

Implements the P1 (cache-key correctness) and P2 (cached-issue replay + transparency) phases from the [investigation of #321](https://github.com/hoelzl/clm/issues/321#issuecomment-4676384554). Addresses the dependency-key, issue-replay, and transparency items; worker-image identity, `clm cache explain`, and the failure-caching policy decision remain open on the issue.

### Cache keys now cover the dependency set (the observed staleness)

`NotebookPayload.content_hash()` and `execution_cache_hash()` now fold in:

- a digest of **`other_files`** — every non-image topic sibling shipped to the kernel (C++ `#include` headers, Jinja `{% include %}` targets, runtime data files). The **HTTP-replay cassette entry is excluded** (`other_files[http_replay_cassette_name]`, not just the field), preserving the documented record-after-run rationale, now re-stated in the new `_dependency_digest` docstring.
- a **template fingerprint** (`compute_template_fingerprint`): digest of the bundled `templates_<prog_lang>` package directory plus the CLM version, computed host-side and shipped via a new `template_fingerprint` payload field (replacing the dead `template_dir` field). Host-side computation is deliberate: the worker may run a different clm version, and all cache layers must compute the key identically, so the worker reuses the host's value from the payload.
- the **`skip_evaluation` / `skip_errors` flags** — flipping `evaluate=`/`skip-errors=` on a topic with unchanged deck text now invalidates instead of replaying mismatched output.
- an explicit **`CACHE_HASH_SCHEMA_VERSION`** so future key evolutions are deliberate and never partially overlap the old schema. Consequence: the first build after upgrading re-executes everything once (documented in `clm info migration`).

### Cached-issue replay was silently dead for notebook jobs

Found while verifying the owner's comment ("we replay the error messages for the failed deck … we should check that this still happens"): it didn't.

- `_get_output_metadata` stored notebook issues under `str(tuple)` keys (`"('completed', 'python', 'en', 'html')"`) while `_report_cached_issues` looked up the colon-joined `output_metadata()` form (`"completed:python:en:html"`) — the keys never matched, so stored warnings/errors were never re-surfaced on a cache hit for any notebook job. Store and lookup now agree (image jobs were unaffected).
- The job-level `results_cache` hit path returned without replaying stored issues at all (only the `processed_files` path did). It now replays them, so a hit after retention pruned `processed_files` no longer goes silently green.
- A successful run now **clears** issues stored by earlier runs of the same `(file, content, metadata)` key (wiring up the previously-unused `DatabaseManager.clear_issues`): a transient failure's stored error can no longer haunt every later cache hit, and repeated `--ignore-cache` runs no longer accumulate duplicate warnings.

### Replay transparency

`--output-mode verbose` prints `↻ Replayed from cache <job_type>: <file> (<cache layer>)` per cache-served file via a new optional `show_cache_hit` formatter hook — replayed output is freshly timestamped and was previously indistinguishable from executed output, which is what made #321 take an hour to diagnose instead of seconds.

## Tests

- `TestDependencyFoldingIntoHashes`: sibling content/rename/add-remove invalidate both hashes; dict-order irrelevance; cassette-only exclusion with replay active; template-fingerprint and skip-flag invalidation; host↔worker hash agreement across the `model_dump(mode="json")` → `from_job_payload` round trip.
- `content_hash` cassette-invariance (the exclusion now matters host-side too).
- `compute_template_fingerprint` determinism / per-prog_lang difference / unknown-language tolerance.
- Backend: `results_cache` hit replays stored warnings and skips submission; completed job clears stale stored errors through the real `wait_for_completion` path; store/lookup output-metadata key agreement pinned end-to-end.
- Verbose formatter prints the replay line; default formatter stays silent.

Full fast suite: **7751 passed, 3 skipped, 1 xfailed**. ruff + mypy clean.

## Notes

- Changelog fragment: `changelog.d/321-execution-cache-dependency-keys.fixed.md`.
- Migration section added to `clm info migration` (one-time full re-execution, sibling-edit invalidation, cassette exception, verbose replay line).
- Deliberately NOT auto-closing #321: worker-image identity in the key, `clm cache explain`, and the deterministic-failure caching policy (which, per the investigation, does not exist today — failed jobs always re-execute) are still open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
