### PR TITLE
feat(build): fold worker image identity into notebook cache keys (#321)

### DIFF
--- a/changelog.d/321-execution-cache-dependency-keys.fixed.md
+++ b/changelog.d/321-execution-cache-dependency-keys.fixed.md
@@ -2,10 +2,14 @@
   a dependency changes with unchanged deck text (#321): the cache keys now
   cover every topic sibling shipped to the kernel (C++ `#include` headers,
   Jinja `{% include %}` targets, runtime data files), a fingerprint of the
-  bundled Jinja templates (`macros.j2` etc.) plus the CLM version, and the
-  per-topic `evaluate=` / `skip-errors=` flags. The HTTP-replay cassette
-  remains deliberately excluded (record-after-run miss loop). The first
-  build after upgrading re-executes everything once (key schema change).
+  bundled Jinja templates (`macros.j2` etc.) plus the CLM version, the
+  worker execution environment (`direct`, or the configured Docker image
+  reference — a cache populated under one worker image is no longer
+  replayed under another; pin versioned tags rather than `:latest` for
+  exact invalidation), and the per-topic `evaluate=` / `skip-errors=`
+  flags. The HTTP-replay cassette remains deliberately excluded
+  (record-after-run miss loop). The first build after upgrading re-executes
+  everything once (key schema change).
 - Cached-issue replay actually works for notebook jobs again (#321): stored
   errors/warnings were keyed under `str(tuple)` output metadata while
   lookups used the colon-joined form, so a cache hit never re-surfaced the

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -9,8 +9,9 @@ alone, so editing a sibling file the deck depends on (a C++ header it
 `#include`s, a Jinja `{% include %}` target, a CSV it reads) silently
 replayed stale execution output with a fresh timestamp, and only
 `--ignore-cache` recovered. The cache keys now also cover every non-image
-topic sibling, a fingerprint of CLM's bundled Jinja templates, and the
-per-topic `evaluate=` / `skip-errors=` attributes.
+topic sibling, a fingerprint of CLM's bundled Jinja templates, the worker
+execution environment (`direct` or the configured Docker image reference),
+and the per-topic `evaluate=` / `skip-errors=` attributes.
 
 Consequences for course repos:
 
@@ -19,6 +20,10 @@ Consequences for course repos:
 - Editing any non-image file in a topic directory re-executes the decks in
   that topic — you no longer need `--ignore-cache` after changing a shared
   header or data file.
+- Changing the configured Docker worker image (or switching direct↔docker)
+  invalidates too. The key uses the image *reference*, not a content digest:
+  a re-pulled `:latest` tag does not invalidate — pin worker images to
+  versioned tags or `@sha256:` digests for exact invalidation.
 - Editing the HTTP-replay cassette still does **not** invalidate (deliberate;
   record-capable modes rewrite cassettes after execution). Use
   `--ignore-cache` after a manual cassette edit.

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -41,10 +41,21 @@ def compute_template_fingerprint(prog_lang: str) -> str:
     else the package ships that can affect output (worker code, bootstrap
     templates). The fingerprint must be computed on ONE side only — host and
     worker may run different clm versions (Docker images), and the cache key
-    must be computed identically by every layer, so the worker reuses the
-    host's value from the payload instead of recomputing.
+    must be computed identically by every layer: two of the three cache
+    layers are consulted host-side at job-submission time, before any worker
+    (or its version) is known, so the worker reuses the host's value from
+    the payload instead of recomputing.
 
-    ``lru_cache`` makes this a one-time cost per prog_lang per process; the
+    Scope, stated honestly: this fingerprint covers HOST-side template
+    changes only. In direct mode workers run the host's environment, so it
+    is exact. In Docker mode it covers the common lockstep case (host and
+    image upgraded together) — but a worker-image change with an unchanged
+    host is invisible to it. That divergence is covered separately by
+    ``compute_worker_image_identity`` (the image reference is host-known
+    config, so it can change the key even when this fingerprint cannot see
+    inside the new image).
+
+    ``cache`` makes this a one-time cost per prog_lang per process; the
     template directories are a handful of small files.
     """
     from clm import __version__
@@ -58,6 +69,66 @@ def compute_template_fingerprint(prog_lang: str) -> str:
             hasher.update(f"\n{name}:".encode())
             hasher.update(entry.read_bytes())
     return hasher.hexdigest()
+
+
+def worker_image_identity_for(execution_mode: str, image: str | None) -> str:
+    """Resolve the execution-environment identity string for the cache key.
+
+    Pure resolution logic, separated from the global-config read in
+    :func:`compute_worker_image_identity` so it is directly testable.
+
+    - ``direct`` mode → ``"direct"``: the worker runs the host's own
+      environment, whose version/template content is already covered by
+      ``compute_template_fingerprint``.
+    - ``docker`` mode → ``"docker:<image>"`` with the same effective-image
+      resolution the pool starter uses (per-type override, else the bundled
+      default) — the key must describe the image that actually executes.
+    """
+    if execution_mode != "docker":
+        return "direct"
+    from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
+
+    effective = image or DEFAULT_WORKER_IMAGES.get("notebook", "")
+    return f"docker:{effective}"
+
+
+@cache
+def compute_worker_image_identity() -> str:
+    """Identity of the execution environment notebook jobs will run in.
+
+    Computed HOST-side at payload construction (like
+    ``compute_template_fingerprint``) and shipped via
+    ``NotebookPayload.worker_image_identity``, where it is folded into the
+    cache keys. This closes the worker-divergence gap the template
+    fingerprint cannot see: a Docker worker image carries its own clm
+    version, templates, and kernel (xeus-cpp etc.), so a cache populated
+    under one image must not be replayed under another (issue #321 class 5,
+    the xeus-cling → xeus-cpp incident). The image reference is host-known
+    configuration, so every cache layer can compute the key identically
+    without asking the worker.
+
+    Limitation: this is the configured image *reference*, not a content
+    digest. A mutable tag (``:latest``) that is re-pulled to point at a new
+    image does NOT change the key — pin worker images to versioned tags or
+    ``@sha256:...`` digests for the invalidation to be exact. (Resolving the
+    local digest at payload time would require a Docker API call per build
+    and a running daemon; not worth it host-side.)
+
+    Defensive ``""`` on any config error: a payload must never fail to
+    build because worker config is unreadable; an empty identity merely
+    reverts that build to the pre-#321 keying for this component.
+    """
+    try:
+        from clm.infrastructure.config import get_config
+
+        worker_management = get_config().worker_management
+        execution_mode = (
+            worker_management.notebook.execution_mode or worker_management.default_execution_mode
+        )
+        return worker_image_identity_for(execution_mode, worker_management.notebook.image)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(f"Could not resolve worker image identity for cache key: {exc}")
+        return ""
 
 
 def _resolve_trace_dir_for_payload() -> str:
@@ -405,6 +476,7 @@ class ProcessNotebookOperation(Operation):
             language=self.language,
             format=self.format,
             template_fingerprint=compute_template_fingerprint(self.prog_lang),
+            worker_image_identity=compute_worker_image_identity(),
             other_files=self.compute_other_files(),
             fallback_execute=self.fallback_execute,
             skip_evaluation=self.skip_evaluation,

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -39,6 +39,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Default Docker images per worker type, used when docker mode is active but
+# no per-type image is configured. Module-level so other components (e.g.
+# the cache-key image identity in ``compute_worker_image_identity``) resolve
+# the SAME effective image as the pool starter — a divergence here would make
+# the cache key describe a different image than the one actually executing.
+DEFAULT_WORKER_IMAGES = {
+    "notebook": "docker.io/mhoelzl/clm-notebook-processor:latest",
+    "plantuml": "docker.io/mhoelzl/clm-plantuml-converter:latest",
+    "drawio": "docker.io/mhoelzl/clm-drawio-converter:latest",
+}
+
 
 class LegacyEnvSettingsSource(PydanticBaseSettingsSource):
     """Custom settings source to handle legacy environment variables.
@@ -461,13 +472,7 @@ class WorkersManagementConfig(BaseModel):
         # Determine image
         image = type_config.image
         if execution_mode == "docker" and not image:
-            # Use default images
-            default_images = {
-                "notebook": "docker.io/mhoelzl/clm-notebook-processor:latest",
-                "plantuml": "docker.io/mhoelzl/clm-plantuml-converter:latest",
-                "drawio": "docker.io/mhoelzl/clm-drawio-converter:latest",
-            }
-            image = default_images.get(worker_type)
+            image = DEFAULT_WORKER_IMAGES.get(worker_type)
 
         return WorkerConfig(
             worker_type=worker_type,

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -54,9 +54,20 @@ class NotebookPayload(Payload):
     # resolved worker-side from the installed clm package, so without this
     # field a ``macros.j2`` change (shipped with a new clm version) would
     # invalidate nothing and every deck would replay stale title slides
-    # from a warm cache (issue #321 class 4). Folded into both cache
-    # hashes below.
+    # from a warm cache (issue #321 class 4). Covers HOST-side changes
+    # only; worker-image divergence is covered by ``worker_image_identity``
+    # below. Folded into both cache hashes.
     template_fingerprint: str = ""
+    # Identity of the execution environment this job is configured to run
+    # in: "direct", or "docker:<image reference>", computed HOST-side
+    # (``compute_worker_image_identity``). A Docker image carries its own
+    # clm version, templates, and kernel, so a cache populated under one
+    # image must not be replayed under another (issue #321 class 5) — and
+    # the template fingerprint above cannot see a worker-image change when
+    # the host is unchanged. Image reference, not content digest: mutable
+    # tags (":latest") weaken this; pin versioned tags/digests for exact
+    # invalidation. Folded into both cache hashes.
+    worker_image_identity: str = ""
     other_files: dict[str, bytes] = {}
     fallback_execute: bool = False
     # If True, the notebook is rendered to all configured output formats
@@ -123,8 +134,9 @@ class NotebookPayload(Payload):
         Folds in ``other_files`` (the complete byte content of every
         non-image topic sibling — C++ headers a deck ``#include``s, files
         pulled in via Jinja ``{% include %}``, runtime data files), the
-        template fingerprint, and the ``skip_evaluation`` / ``skip_errors``
-        execution flags. Editing any topic sibling re-executes the deck:
+        template fingerprint, the worker image identity, and the
+        ``skip_evaluation`` / ``skip_errors`` execution flags. Editing any
+        topic sibling re-executes the deck:
         that over-invalidates slightly (a sibling the deck never reads also
         triggers re-execution), but over-invalidation is safe and cheap
         relative to silently shipping stale teaching material (issue #321).
@@ -145,7 +157,8 @@ class NotebookPayload(Payload):
         """
         hasher = hashlib.sha256()
         hasher.update(
-            f"{self.template_fingerprint}:{self.skip_evaluation}:{self.skip_errors}".encode()
+            f"{self.template_fingerprint}:{self.worker_image_identity}:"
+            f"{self.skip_evaluation}:{self.skip_errors}".encode()
         )
         cassette_key = self.http_replay_cassette_name
         for name in sorted(self.other_files):

--- a/tests/core/operations/test_process_notebook.py
+++ b/tests/core/operations/test_process_notebook.py
@@ -1,11 +1,17 @@
 """Tests for ProcessNotebookOperation helpers.
 
-Currently covers ``compute_template_fingerprint`` (issue #321): the
-host-side digest of the bundled Jinja template directory that travels in
-``NotebookPayload.template_fingerprint`` and is folded into the cache keys.
+Covers the host-side cache-key components from issue #321:
+``compute_template_fingerprint`` (digest of the bundled Jinja template
+directory, shipped via ``NotebookPayload.template_fingerprint``) and
+``worker_image_identity_for`` (execution-environment identity, shipped via
+``NotebookPayload.worker_image_identity``).
 """
 
-from clm.core.operations.process_notebook import compute_template_fingerprint
+from clm.core.operations.process_notebook import (
+    compute_template_fingerprint,
+    compute_worker_image_identity,
+    worker_image_identity_for,
+)
 
 
 class TestComputeTemplateFingerprint:
@@ -44,3 +50,45 @@ class TestComputeTemplateFingerprint:
         compute_template_fingerprint.cache_clear()
         second = compute_template_fingerprint("cpp")
         assert first == second
+
+
+class TestWorkerImageIdentity:
+    def test_direct_mode(self):
+        """Direct mode has no image — the host environment (already covered
+        by the template fingerprint) is the identity."""
+        assert worker_image_identity_for("direct", None) == "direct"
+        # An image configured but unused (direct mode) must not leak into
+        # the key — it does not describe the executing environment.
+        assert worker_image_identity_for("direct", "ignored:1.0") == "direct"
+
+    def test_docker_mode_with_configured_image(self):
+        assert (
+            worker_image_identity_for("docker", "ghcr.io/me/clm-notebook:1.11.0")
+            == "docker:ghcr.io/me/clm-notebook:1.11.0"
+        )
+
+    def test_docker_mode_default_image_matches_pool_starter(self):
+        """With no per-type image configured, the identity must resolve the
+        SAME default the pool starter uses — otherwise the key describes a
+        different image than the one executing."""
+        from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
+
+        assert worker_image_identity_for("docker", None) == (
+            f"docker:{DEFAULT_WORKER_IMAGES['notebook']}"
+        )
+
+    def test_image_change_changes_identity(self):
+        """The whole point: two different images yield two different
+        identities, so the cache key differs."""
+        old = worker_image_identity_for("docker", "clm-notebook:xeus-cling")
+        new = worker_image_identity_for("docker", "clm-notebook:xeus-cpp")
+        assert old != new
+
+    def test_compute_from_global_config_is_stable_and_nonempty(self):
+        """The cached global-config wrapper returns a stable, non-empty
+        identity (cache-key components must not flap within a process)."""
+        compute_worker_image_identity.cache_clear()
+        first = compute_worker_image_identity()
+        second = compute_worker_image_identity()
+        assert first == second
+        assert first.startswith(("direct", "docker:"))

--- a/tests/infrastructure/messaging/test_notebook_classes.py
+++ b/tests/infrastructure/messaging/test_notebook_classes.py
@@ -91,6 +91,7 @@ class TestNotebookPayload:
             "language": "de",
             "format": "html",
             "template_fingerprint": "tfp-distinctive",
+            "worker_image_identity": "docker:mhoelzl/clm-notebook-processor:9.9.9",
             "other_files": {"helper.py": b"x = 1"},
             "fallback_execute": True,
             "skip_evaluation": True,
@@ -383,6 +384,23 @@ class TestDependencyFoldingIntoHashes:
         v2 = self._payload(template_fingerprint="fingerprint-2")
         assert v1.content_hash() != v2.content_hash()
         assert v1.execution_cache_hash() != v2.execution_cache_hash()
+
+    def test_worker_image_identity_invalidates_both_hashes(self):
+        """A cache populated under one worker image must not be replayed
+        under another (xeus-cling → xeus-cpp class of breakage): the image
+        carries its own clm version, templates, and kernel."""
+        old_image = self._payload(worker_image_identity="docker:clm-notebook-processor:1.10.0")
+        new_image = self._payload(worker_image_identity="docker:clm-notebook-processor:1.11.0")
+        assert old_image.content_hash() != new_image.content_hash()
+        assert old_image.execution_cache_hash() != new_image.execution_cache_hash()
+
+    def test_direct_vs_docker_identity_invalidates_both_hashes(self):
+        """Switching execution mode changes the environment that produced
+        the outputs, so it must invalidate too."""
+        direct = self._payload(worker_image_identity="direct")
+        docker = self._payload(worker_image_identity="docker:clm-notebook-processor:1.11.0")
+        assert direct.content_hash() != docker.content_hash()
+        assert direct.execution_cache_hash() != docker.execution_cache_hash()
 
     def test_skip_evaluation_flip_invalidates_both_hashes(self):
         """Flipping ``evaluate="no"`` on a topic changes the output for


### PR DESCRIPTION
## Summary

Follow-up to #323, implementing the deferred **worker-image identity** item from #321 (class 5: a cache populated under one worker image silently replayed under another — the xeus-cling → xeus-cpp incident class).

### Why the template fingerprint alone wasn't enough

The template fingerprint is computed host-side by necessity: two of the three cache layers are consulted at job-submission time, before any worker (or its version) is known, and every layer must compute the key identically. That makes it exact in direct mode and correct in the Docker lockstep case — but a **worker-image change with an unchanged host was invisible to it**. The image *reference* is host-known configuration, so it can change the key even though the host cannot see inside the new image.

### What this adds

- New `NotebookPayload.worker_image_identity` field, folded into the dependency digest of both cache hashes: `"direct"`, or `"docker:<effective image>"`.
- Resolution (`worker_image_identity_for` + cached `compute_worker_image_identity`) uses the **same effective-image logic as the pool starter** (per-type override, else bundled default) — the default-image mapping is lifted to `config.DEFAULT_WORKER_IMAGES` so both consumers share one source of truth and the key always describes the image that actually executes.
- `compute_template_fingerprint`'s docstring now states its scope honestly (host-side changes only; image divergence is the new field's job), per review discussion on #323.

### Documented limitation

The key uses the image **reference**, not a content digest: a re-pulled mutable tag (`:latest`) does not invalidate. Pin worker images to versioned tags or `@sha256:` digests for exact invalidation (resolving the local digest at payload time would need a Docker API call per build and a running daemon). Noted in the docstring, the changelog fragment, and `clm info migration`.

## Tests

- `worker_image_identity_for`: direct mode (configured-but-unused image must not leak into the key), docker with configured image, docker default matches the pool starter's resolution, image change → different identity.
- `compute_worker_image_identity`: stable and non-empty from global config.
- Hash folding: image change and direct↔docker switch invalidate both `content_hash` and `execution_cache_hash`; round-trip guard extended with the new field.

Full fast suite: **7758 passed, 3 skipped, 1 xfailed**. ruff + mypy clean.

Remaining open on #321: `clm cache explain` and the deterministic-failure caching policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
