### PR TITLE
feat(release): let multiple streams release into the same destination repository (#325)

### DIFF
--- a/changelog.d/325-shared-release-destination.added.md
+++ b/changelog.d/325-shared-release-destination.added.md
@@ -1,0 +1,11 @@
+- **Shared release destinations.** Channels of *different* release streams may
+  now declare the same `path`, releasing e.g. materials and solutions into a
+  single cohort repository on independent per-topic timelines (#325). Frozen
+  manifests are now per stream (`.clm-released.<stream>.json`; a matching
+  legacy `.clm-released.json` is adopted and renamed automatically on the next
+  sync), skeleton files already present at the destination are kept rather
+  than overwritten (presence-as-frozen), `clm release sync` refuses to promote
+  when the sharing streams' built topic outputs overlap, spec validation
+  requires sharing channels to agree on `lang`, and `clm git --all-channels` /
+  `clm release provision` treat a shared destination as one repository. See
+  `clm info releases` ("Shared destination") and `clm info migration`.

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1149,7 +1149,9 @@ No optional extras — pure stdlib + `attrs`. Cohorts are declared in the spec's
 plain-text ledger, never in the spec.
 
 - `ledger` — read/append the per-channel released-topic ledger.
-- `frozen_manifest` — the per-cohort freeze record (`.clm-released.json`).
+- `frozen_manifest` — the per-cohort, per-stream freeze record
+  (`.clm-released.<stream>.json`; legacy `.clm-released.json` for a single
+  unnamed stream).
 - `sync` — promote released-but-not-frozen topics' bytes into a cohort repo
   (located via the build provenance manifest) and freeze them.
 

--- a/docs/user-guide/solution-release.md
+++ b/docs/user-guide/solution-release.md
@@ -22,7 +22,7 @@ The workflow has four moving parts:
 | **Channel** | One student cohort = one git repository | declared in `<release-channels>` in the spec |
 | **Ledger** | Plain-text list of released topic ids (one per line) | a file in your **course source** repo (e.g. `release/jan.txt`) |
 | **Provenance manifest** | Maps each built output file → its owning topic | `.clm-manifest.json`, written by `clm build` (on by default) |
-| **Frozen manifest** | The per-cohort freeze record (what was promoted, and the bytes' hash) | `.clm-released.json`, committed inside the cohort repo |
+| **Frozen manifest** | The per-cohort, per-stream freeze record (what was promoted, and the bytes' hash) | `.clm-released.<stream>.json` (legacy `.clm-released.json` for a single unnamed stream), committed inside the cohort repo |
 
 The **ledger** is the volatile state — it grows every week as you release more
 topics — and it deliberately lives *outside* the spec so the spec stays
@@ -99,8 +99,8 @@ clm release sync course.xml --channel jan --push -m "Release functions, lists"
 ```
 
 `release sync` copies only the released topics' bytes (located via the
-provenance manifest) into the cohort working tree, records them in
-`.clm-released.json`, and — with `--push` — commits and pushes the cohort repo
+provenance manifest) into the cohort working tree, records them in the frozen
+manifest, and — with `--push` — commits and pushes the cohort repo
 using `clm git`'s machinery. A topic that is already frozen is **never**
 re-copied, so re-running `sync` is safe and only ever adds new releases.
 
@@ -178,6 +178,36 @@ warned about and ignored — released topic content still changes only via
 `--refreeze`. Syncing never deletes; removing an evergreen file from the
 source just stops refreshing it.
 
+## Several streams, one cohort repository
+
+A course can declare several `<release-channels>` blocks — one per release
+*stream* (e.g. `materials` fed by a code-along/partial target and `solutions`
+fed by a `completed` target). Channels of **different** streams may point at
+the **same `path`**: both streams then release into a single repository
+students pull from, each on its own ledger and timeline:
+
+```xml
+<release-channels name="materials" source-target="shared">
+    <channel name="2026-04-de" lang="de" path="cohorts/2026-04/combined-de"
+             ledger="release/materials-2026-04-de.txt"/>
+</release-channels>
+<release-channels name="solutions" source-target="solutions">
+    <channel name="2026-04-de" lang="de" path="cohorts/2026-04/combined-de"
+             ledger="release/solutions-2026-04-de.txt"/>
+</release-channels>
+```
+
+Each stream keeps its own frozen manifest (`.clm-released.<stream>.json`), so
+releasing a topic's materials never freezes its solutions and `--refreeze`
+stays scoped to one stream. The streams' source targets must build **disjoint**
+topic outputs (`clm release sync` cross-checks and refuses overlap), channels
+sharing a path must agree on `lang`, and skeleton files already present in the
+destination are kept rather than overwritten — sync both streams after the
+same `clm build` so evergreen files don't ping-pong between builds. See
+`clm info releases` ("Shared destination") for the full rules and the
+trade-offs vs separate repos, and `clm info migration` for merging the repos
+of a running cohort.
+
 ## How `clm git --channel` differs from ordinary `clm git`
 
 The regular `clm git` subcommands operate on your `<output-targets>` repos.
@@ -193,8 +223,10 @@ clm git sync course.xml --channel jan -m "..."  # commit + push one cohort
 `clm release sync` is what *populates* a cohort working tree; `clm git --channel`
 is what *versions and distributes* it. (`release sync --push` simply chains the
 two for convenience.) The private `.clm-manifest.json` is always kept out of the
-distributed repos; the per-cohort `.clm-released.json` freeze record is committed
-normally.
+distributed repos; the per-cohort freeze records (`.clm-released*.json`) are
+committed normally. A destination shared by several streams is one repo to
+`clm git`: `--all-channels` visits it once, and `clm git reset` on it discards
+the *other* stream's uncommitted promotions too.
 
 ## See also
 

--- a/docs/user-guide/spec-file-reference.md
+++ b/docs/user-guide/spec-file-reference.md
@@ -962,7 +962,7 @@ the spec stays diff-clean as you release week by week.
 | `source-target` (attr) | `<release-channels>` | Yes | Name of the `completed`-kind `<output-target>` that is the frozen source. Topics are promoted out of this target's built tree. |
 | `<remote-path>` | `<release-channels>` | No | Default remote path (e.g. a GitLab group) for every channel that does not override it. |
 | `name` (attr) | `<channel>` | Yes | Cohort identifier. Addresses the channel on the CLI (`--channel jan`) and forms the derived repo name `{project-slug}-{name}`. |
-| `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). One repo per cohort; **not** language-scoped. |
+| `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). Unique within a stream; channels of *different* streams may share a path to release into one repository (issue #325, same `lang` required) — see `clm info releases`. |
 | `ledger` (attr) | `<channel>` | Yes | Path to the cohort's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. |
 | `<remote-path>` | `<channel>` | No | Override the block-level `<remote-path>` for this one cohort. |
 | `<evergreen>` | `<release-channels>` or `<channel>` | No | Glob pattern of **skeleton files exempt from the freeze**: every `clm release sync` re-copies a matching file whose built content differs from the cohort's copy (e.g. a NEWS file). Block-level patterns are inherited by every channel; channel-level patterns are additive. Skeleton-only — patterns matching topic-owned files are warned about and ignored. See the [Solution Release guide](solution-release.md#evergreen-files-eg-a-news-file). |
@@ -976,8 +976,9 @@ Per-topic promotion relies on the build **provenance manifest**
 (`.clm-manifest.json`, written by `clm build` on by default), which maps each
 output file to its owning topic — information the output path alone cannot
 recover. The manifest is private and is excluded from every distributed repo by
-`clm git`; the per-cohort **frozen manifest** (`.clm-released.json`) *does* ship
-in the channel repo as the freeze record. Drive the workflow with `clm release`
+`clm git`; the per-cohort, per-stream **frozen manifest**
+(`.clm-released.<stream>.json`; legacy `.clm-released.json` for a single
+unnamed block) *does* ship in the channel repo as the freeze record. Drive the workflow with `clm release`
 (`add` / `week` / `status` / `sync`) and `clm git --channel` (init/commit/push
 the cohort repos); run `clm info commands` for both.
 

--- a/src/clm/cli/commands/git.py
+++ b/src/clm/cli/commands/git.py
@@ -52,6 +52,10 @@ class OutputRepo:
         self.language = language
         self.remote_url = remote_url
         self.source = source
+        # Other channels releasing into this same destination (issue #325);
+        # filled in by _dedupe_shared_destinations so a shared repo is visited
+        # once but its display still names every stream it serves.
+        self.shared_refs: list[str] = []
 
     @property
     def git_dir(self) -> Path:
@@ -64,9 +68,10 @@ class OutputRepo:
     @property
     def display_name(self) -> str:
         # Channel repos carry no language, so drop the empty trailing segment.
-        if not self.language:
-            return self.target_name
-        return f"{self.target_name}/{self.language}"
+        name = self.target_name if not self.language else f"{self.target_name}/{self.language}"
+        if self.shared_refs:
+            name += " (+ " + ", ".join(self.shared_refs) + ")"
+        return name
 
     def has_remote(self) -> bool:
         """Check if this repo has a remote configured."""
@@ -454,10 +459,39 @@ def _select_repos(
                 f"--channel/--all-channels is not available for this course."
             )
         try:
-            return find_release_channel_repos(spec_file, channel or None)
+            repos = find_release_channel_repos(spec_file, channel or None)
         except CourseSpecError as e:
             raise click.ClickException(str(e)) from None
+        return _dedupe_shared_destinations(repos)
     return find_output_repos(spec_file, target)
+
+
+def _dedupe_shared_destinations(repos: list[OutputRepo]) -> list[OutputRepo]:
+    """Visit a destination shared by several streams only once (issue #325).
+
+    Git operations act on the repository, not the release stream, so channels
+    of different streams releasing into the same working tree collapse into a
+    single entry. The first channel (spec declaration order) keeps the entry
+    and the derived remote URL — only ``clm git init`` consumes the
+    derivation, and a shared repo can only have one origin; a differing
+    derivation from a collapsed channel is surfaced as a note.
+    """
+    by_path: dict[Path, OutputRepo] = {}
+    for repo in repos:
+        kept = by_path.get(repo.path.resolve())
+        if kept is None:
+            by_path[repo.path.resolve()] = repo
+            continue
+        kept.shared_refs.append(repo.target_name)
+        if repo.remote_url and repo.remote_url != kept.remote_url:
+            click.echo(
+                f"Note: channels {kept.target_name!r} and {repo.target_name!r} share "
+                f"the destination {kept.path} but derive different remote URLs; "
+                f"using the first ({kept.remote_url}). Set the repo's origin "
+                f"explicitly if another URL is intended.",
+                err=True,
+            )
+    return list(by_path.values())
 
 
 def _stage_all_excluding_sidecars(repo_path: Path) -> None:

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -36,7 +36,7 @@ from clm.core.provenance_manifest import (
     load_manifest,
     restrict_manifest_to_language,
 )
-from clm.release.frozen_manifest import FROZEN_FILENAME, FrozenManifest
+from clm.release.frozen_manifest import FROZEN_FILENAME, load_frozen_manifest
 from clm.release.ledger import Ledger, partition_known
 from clm.release.sync import (
     REFRESH,
@@ -45,6 +45,8 @@ from clm.release.sync import (
     apply_sync,
     plan_sync,
     scan_evergreen,
+    scan_skeleton,
+    topic_path_overlap,
 )
 
 logger = logging.getLogger(__name__)
@@ -80,6 +82,9 @@ class _ResolvedChannel:
     lang: str = ""
     # Evergreen glob patterns (block-level inherited + channel additions).
     evergreen: tuple[str, ...] = ()
+    # Release stream name (empty for the single unnamed block). Selects the
+    # per-stream frozen-manifest filename (issue #325).
+    stream: str = ""
 
 
 @click.group("release")
@@ -114,7 +119,61 @@ def _resolve_channel(spec_file: Path, channel_name: str) -> _ResolvedChannel:
         dest=_abs_under(course_root, channel.path),
         lang=channel.lang,
         evergreen=channel.evergreen,
+        stream=block.name,
     )
+
+
+def _check_shared_destination_overlap(
+    spec_file: Path, channel_ref: str, dest_path: Path, manifest: dict
+) -> None:
+    """Sync preflight for shared destinations (issue #325).
+
+    When another stream's channel releases into the same destination, its
+    source manifest and ours must claim **disjoint** topic files — skeleton
+    overlap is fine (presence-as-frozen keeps the first copy), but a
+    topic-owned path in both manifests means the streams' output targets
+    collide and a sync would clobber the other stream's frozen content. A
+    sharer whose source target has no manifest yet (not built) is skipped
+    with a note. *manifest* is this sync's already language-restricted
+    manifest, so paths compare in destination-relative form.
+    """
+    spec = CourseSpec.from_file(spec_file)
+    block, _ = spec.resolve_release_channel(channel_ref)
+    course_root, _ = resolve_course_paths(spec_file)
+    for other_block, other_channel in spec.iter_release_channels():
+        if other_block.name == block.name:
+            continue
+        if _abs_under(course_root, other_channel.path).resolve() != dest_path.resolve():
+            continue
+        other_ref = release_channel_ref(other_block, other_channel)
+        target = next((t for t in spec.output_targets if t.name == other_block.source_target), None)
+        if target is None:
+            continue
+        other_manifest_path = _abs_under(course_root, target.path) / MANIFEST_FILENAME
+        if not other_manifest_path.is_file():
+            click.echo(
+                f"Note: '{other_ref}' shares this destination but its source "
+                f"target is not built; the cross-stream overlap check will run "
+                f"once it is."
+            )
+            continue
+        other_manifest = load_manifest(other_manifest_path)
+        if other_channel.lang:
+            lang_dir = str(spec.output_dir_name[other_channel.lang])
+            other_manifest = restrict_manifest_to_language(
+                other_manifest, other_channel.lang, lang_dir
+            )
+        overlap = topic_path_overlap(manifest, other_manifest)
+        if overlap:
+            examples = ", ".join(overlap[:5]) + (", …" if len(overlap) > 5 else "")
+            raise click.ClickException(
+                f"Refusing to sync: {len(overlap)} topic-owned file(s) are claimed "
+                f"by both '{channel_ref}' and '{other_ref}', which share the "
+                f"destination {dest_path} — promoting would clobber the other "
+                f"stream's released content: {examples}. Streams sharing a "
+                f"destination must build disjoint outputs (e.g. code-along/partial "
+                f"vs completed kinds)."
+            )
 
 
 def _spec_topic_ids(spec_file: Path) -> list[str]:
@@ -238,6 +297,12 @@ def provision_cmd(spec_file: Path, channel: str, dry_run: bool) -> None:
         raise click.ClickException(f"{spec_file} has no <release-channels> block.")
 
     repos = {r.target_name: r for r in find_release_channel_repos(spec_file, channel or None)}
+    # Channels sharing one destination share one repository (issue #325):
+    # route every share through the first channel's entry (spec order) so all
+    # of them target the project that repo actually is.
+    canonical_by_dest: dict[Path, OutputRepo] = {}
+    for channel_repo in find_release_channel_repos(spec_file, None):
+        canonical_by_dest.setdefault(channel_repo.path.resolve(), channel_repo)
     if channel:
         try:
             pairs = [spec.resolve_release_channel(channel)]
@@ -247,6 +312,7 @@ def provision_cmd(spec_file: Path, channel: str, dry_run: bool) -> None:
         pairs = list(spec.iter_release_channels())
 
     work: list[tuple[str, str, str, str, str]] = []  # ref, base, project, group, access
+    seen: dict[tuple[str, str, str], tuple[str, str]] = {}
     for block, ch in pairs:
         ref = release_channel_ref(block, ch)
         if not ch.share_with:
@@ -254,6 +320,8 @@ def provision_cmd(spec_file: Path, channel: str, dry_run: bool) -> None:
                 click.echo(f"[{ref}] no <share-with> declared — nothing to provision.")
             continue
         repo = repos.get(ref)
+        if repo is not None:
+            repo = canonical_by_dest.get(repo.path.resolve(), repo)
         remote = parse_gitlab_remote(repo.remote_url or "") if repo else None
         if remote is None:
             click.echo(
@@ -263,6 +331,19 @@ def provision_cmd(spec_file: Path, channel: str, dry_run: bool) -> None:
             continue
         base_url, project_path = remote
         for share in ch.share_with:
+            # One share per (project, group) — channels sharing a destination
+            # would otherwise apply the same share once per stream.
+            key = (base_url, project_path, share.group)
+            prior = seen.get(key)
+            if prior is not None:
+                if prior[1] != share.access:
+                    click.echo(
+                        f"[{ref}] share with {share.group} ({share.access}) collapsed "
+                        f"into [{prior[0]}]'s {prior[1]} share — the channels share "
+                        f"one repository."
+                    )
+                continue
+            seen[key] = (ref, share.access)
             work.append((ref, base_url, project_path, share.group, share.access))
 
     if not work:
@@ -421,10 +502,13 @@ def status_cmd(
     spec_file: Path, channel: str, ledger_path: Path | None, dest_path: Path | None
 ) -> None:
     """Show released vs pending topics (and frozen state with --dest/--channel)."""
+    stream = ""
     if channel:
         resolved = _resolve_channel(spec_file, channel)
+        channel = resolved.name
         ledger_path = ledger_path or resolved.ledger
         dest_path = dest_path or resolved.dest
+        stream = resolved.stream
     if ledger_path is None:
         raise click.ClickException("Pass --ledger PATH or --channel NAME.")
 
@@ -440,7 +524,7 @@ def status_cmd(
         click.echo("  pending:  " + ", ".join(pending))
 
     if dest_path is not None:
-        frozen = FrozenManifest.load(dest_path / FROZEN_FILENAME, channel=channel or "?")
+        frozen = load_frozen_manifest(dest_path, stream=stream, channel=channel or "?").manifest
         awaiting = [tid for tid in ledger.released if not frozen.is_frozen(tid)]
         click.echo(
             f"Destination: {len(frozen.frozen)} frozen, {len(awaiting)} released "
@@ -543,6 +627,7 @@ def sync_cmd(
     """
     channel_lang = ""
     channel_evergreen: tuple[str, ...] = ()
+    stream = ""
     if channel:
         if spec_file is None:
             raise click.ClickException("--channel requires the SPEC_FILE argument.")
@@ -555,6 +640,7 @@ def sync_cmd(
         dest_path = dest_path or resolved.dest
         channel_lang = resolved.lang
         channel_evergreen = resolved.evergreen
+        stream = resolved.stream
 
     if ledger_path is None or source_path is None or dest_path is None:
         raise click.ClickException(
@@ -595,10 +681,22 @@ def sync_cmd(
                 f"built without that language?"
             )
         source_path = lang_root
+
+    # Shared-destination preflight (issue #325): when another stream releases
+    # into this destination, their built topic outputs must be disjoint.
+    if channel and spec_file is not None:
+        _check_shared_destination_overlap(spec_file, channel, dest_path, manifest)
+
     ledger = Ledger.load(ledger_path)
     channel_name = channel or dest_path.name
-    frozen_path = dest_path / FROZEN_FILENAME
-    frozen = FrozenManifest.load(frozen_path, channel=channel_name)
+    loaded = load_frozen_manifest(dest_path, stream=stream, channel=channel_name)
+    frozen = loaded.manifest
+    if loaded.ignored_legacy_channel is not None:
+        click.echo(
+            f"Note: leaving the legacy {FROZEN_FILENAME} alone — it records "
+            f"channel '{loaded.ignored_legacy_channel}', not '{channel_name}' "
+            f"(it migrates to a per-stream file on that channel's next sync)."
+        )
 
     # Channel patterns plus CLI additions; the scan runs against the
     # (possibly language-restricted) manifest, so patterns are matched on
@@ -620,12 +718,21 @@ def sync_cmd(
         )
 
     refreeze = set(ledger.released) if refreeze_all else set(refreeze_ids)
+    # Presence-as-frozen (issue #325): a needed skeleton copy is restricted to
+    # the files missing at the destination, so a stream joining a shared repo
+    # never overwrites the skeleton another stream already froze there.
+    skeleton_scan = (
+        scan_skeleton(manifest=manifest, dest_root=dest_path)
+        if not frozen.skeleton_frozen
+        else None
+    )
     plan = plan_sync(
         manifest=manifest,
         ledger_released=ledger.released,
         frozen=frozen,
         refreeze=refreeze,
         evergreen=scan.plans,
+        skeleton=skeleton_scan,
     )
 
     if manifest.get("partial"):
@@ -634,21 +741,24 @@ def sync_cmd(
             "errors); topics that failed in that build are refused below "
             "and promote once a build succeeds for them."
         )
-    click.echo(
+    skeleton_line = (
         f"Channel '{channel_name or '?'}': "
         f"skeleton {'copy' if plan.copy_skeleton else 'frozen'} "
         f"({plan.skeleton_file_count} files)"
     )
+    if plan.skeleton_present_count:
+        skeleton_line += f", {plan.skeleton_present_count} already present (kept)"
+    click.echo(skeleton_line)
     for topic_plan in plan.topics:
         click.echo(
             f"  {topic_plan.action:<11} {topic_plan.topic_id} ({topic_plan.file_count} files)"
         )
-    # On the first sync the skeleton copy delivers evergreen files itself, so
-    # the evergreen lines only appear once the skeleton is frozen.
+    # Refreshes the skeleton copy itself does not already deliver — on a plain
+    # first sync that is none, so the lines only appear once the skeleton is
+    # frozen (or kept via presence-as-frozen, issue #325).
+    for evergreen_plan in plan.evergreen_refresh:
+        click.echo(f"  {REFRESH:<11} {evergreen_plan.path} (evergreen)")
     if plan.evergreen and not plan.copy_skeleton:
-        for evergreen_plan in plan.evergreen:
-            if evergreen_plan.action == REFRESH:
-                click.echo(f"  {REFRESH:<11} {evergreen_plan.path} (evergreen)")
         up_to_date = sum(1 for e in plan.evergreen if e.action != REFRESH)
         if up_to_date:
             click.echo(f"  evergreen: {up_to_date} file(s) up-to-date")
@@ -667,7 +777,13 @@ def sync_cmd(
         frozen=frozen,
         copied_at=datetime.now(timezone.utc).isoformat(),
     )
-    frozen.save(frozen_path)
+    frozen.save(loaded.path)
+    if loaded.adopted_legacy is not None:
+        loaded.adopted_legacy.unlink(missing_ok=True)
+        click.echo(
+            f"Migrated the legacy {FROZEN_FILENAME} to the per-stream "
+            f"{loaded.path.name} (issue #325)."
+        )
     click.echo(
         f"Copied {result.files_copied} file(s): "
         f"{len(result.copied_topics)} newly frozen, "

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2655,10 +2655,14 @@ spec's `<release-channels>` block (see `clm info spec-files`) instead of the
 pointed at the cohort working trees. The private provenance manifest
 (`.clm-manifest.json`) is always excluded from staging (and a copy a pre-exclusion
 commit already tracked is purged on the next commit); the per-cohort frozen
-manifest (`.clm-released.json`) is committed normally. The course must declare a
+manifests (`.clm-released*.json`) are committed normally. The course must declare a
 `<release-channels>` block or these flags error. Populating these working trees
 is the job of `clm release sync`; `clm git --channel` then versions and
 distributes them (and `clm git init --channel` creates each cohort repo once).
+Channels of different streams sharing one destination path (issue #325) are one
+repo to `clm git`: `--all-channels` visits the shared working tree once, and
+`clm git reset` on it is repo-wide — it discards the other stream's uncommitted
+promotions too.
 
 ### `clm release`
 
@@ -2707,8 +2711,12 @@ Key options for `release sync`:
 
 The source must be built with the provenance manifest (`clm build` writes it by
 default since CLM {version}). Promotion copies bytes by manifest and records each
-topic in the cohort's frozen manifest (`.clm-released.json`); a frozen topic is
-never re-propagated unless you pass `--refreeze`.
+topic in the cohort's per-stream frozen manifest (`.clm-released.<stream>.json`;
+legacy `.clm-released.json` for a single unnamed stream — adopted and renamed
+automatically); a frozen topic is never re-propagated unless you pass
+`--refreeze`. Channels of different streams may share one destination repo —
+see `clm info releases` ("Shared destination") for the rules (disjoint outputs,
+same `lang`, presence-as-frozen skeleton).
 
 **Evergreen files.** Skeleton (global) files matching the channel's
 `<evergreen>` patterns — or `--evergreen` options — are exempt from the

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -233,12 +233,31 @@ timestamp and commit, so it never enters a reproducibility baseline).
      that topic into the cohort repo and push it.
 
 The ledger (one topic id per line) is the source-repo-side record of what was
-released; the per-cohort `.clm-released.json` is the freeze record that ships in
+released; the per-cohort frozen manifest is the freeze record that ships in
 the cohort repo. A frozen topic is never re-propagated unless you pass
 `--refreeze`. Full command reference: `clm info commands` → `clm release` and
 `clm git`.
 
-## Authoring sidecar subdirectories: `voiceover/` and `cassettes/` (additive — no break)
+## Per-stream frozen manifests / shared destination repos (issue #325, {version} — auto-migrating)
+
+Channels of **different** release streams may now share one destination `path`,
+releasing materials and solutions into a single repository students pull from
+(see `clm info releases` → "Shared destination"). To make that possible the
+frozen manifest is now **per stream**: a channel in a named stream writes
+`.clm-released.<stream>.json` instead of `.clm-released.json` (a single
+*unnamed* `<release-channels>` block keeps the legacy name).
+
+**No manual migration.** On a channel's next `clm release sync`, an existing
+legacy `.clm-released.json` whose `channel` field matches is adopted, rewritten
+under the per-stream name, and the legacy file is removed — freeze state is
+preserved (the sync output reports the migration). Commit the rename with the
+usual `--push` / `clm git sync`. A legacy file recording a *different* channel
+is left untouched (it belongs to the stream that has not synced yet).
+
+To merge an existing materials + solutions repo pair for a running cohort,
+point the solutions channels' `path` at the existing materials working trees —
+students keep their remotes; the standalone solutions repos simply stop
+receiving syncs.
 
 CLM {version} lets a topic keep its authoring **sidecars** — voiceover
 companions (`voiceover_*.py`) and HTTP-replay cassettes (`*.http-cassette.yaml`)

--- a/src/clm/cli/info_topics/releases.md
+++ b/src/clm/cli/info_topics/releases.md
@@ -12,7 +12,7 @@ never rewrite what students already received.
 | **Channel** | One student cohort's git repository, declared in the spec |
 | **Ledger** | Plain-text list of released topic ids for that cohort (`release/<name>.txt`) |
 | **Provenance manifest** | `.clm-manifest.json` — maps every built output file to its source topic; written by `clm build`; never distributed |
-| **Frozen manifest** | `.clm-released.json` — per-cohort freeze record inside the cohort repo; distributed to students |
+| **Frozen manifest** | `.clm-released.<stream>.json` (legacy `.clm-released.json` for a single unnamed stream) — per-cohort, per-stream freeze record inside the cohort repo; distributed to students |
 
 ## Spec configuration
 
@@ -35,7 +35,7 @@ never rewrite what students already received.
 | `source-target` | `<release-channels>` | yes | Name of the `<output-target>` to promote from (typically a `completed`-kind target) |
 | `name` | `<release-channels>` | when multiple blocks | Stream name; channels are addressed as `stream/channel` (e.g. `materials/jan`) |
 | `name` | `<channel>` | yes | Cohort identifier used on the CLI |
-| `path` | `<channel>` | yes | Path to the cohort's git working tree |
+| `path` | `<channel>` | yes | Path to the cohort's git working tree. Unique within a stream; channels of *different* streams may share a path to release into one repository (see below) |
 | `ledger` | `<channel>` | yes | Path to the release ledger file |
 | `lang` | `<channel>` | no | Restrict promotion to one language; re-roots files at the language directory |
 | `<share-with group="…" access="…">` | block or channel | no | GitLab group sharing (applied by `clm release provision`) |
@@ -83,9 +83,14 @@ automatically.
 `failed_topics` lists topics whose build errored; they are refused by sync until
 the next successful build.
 
-### Frozen manifest (`.clm-released.json`)
+### Frozen manifest (`.clm-released.<stream>.json`)
 
 Written into the cohort repo by `clm release sync`. Committed and distributed.
+The file is **per release stream**: a named stream writes
+`.clm-released.<stream>.json` (e.g. `.clm-released.materials.json`); a single
+unnamed `<release-channels>` block keeps the legacy `.clm-released.json` name.
+A pre-existing legacy file whose `channel` field matches is adopted and
+renamed on the channel's next sync — no manual migration.
 
 ```json
 {
@@ -163,6 +168,59 @@ comparison is stateless (destination hash vs. manifest hash), so nothing is
 recorded in the frozen manifest and re-runs are idempotent.
 `--push` chains `clm git commit` + `clm git push` after promotion.
 
+### Shared destination: several streams, one cohort repo
+
+Channels of **different** streams may point at the same `path` — both streams
+then release into a single repository students pull from (e.g. materials at
+session start, solutions after the exercise), each on its own ledger and
+timeline. Sharing is detected from the spec; no extra configuration:
+
+```xml
+<release-channels name="materials" source-target="shared">
+    <channel name="2026-04-de" lang="de" path="cohorts/2026-04/combined-de"
+             ledger="release/materials-2026-04-de.txt"/>
+</release-channels>
+<release-channels name="solutions" source-target="solutions">
+    <channel name="2026-04-de" lang="de" path="cohorts/2026-04/combined-de"
+             ledger="release/solutions-2026-04-de.txt"/>
+</release-channels>
+```
+
+How the pieces interact:
+
+- **Per-stream freeze records.** Each stream keeps its own
+  `.clm-released.<stream>.json`, so materials releasing a topic never freezes
+  it for solutions (and `--refreeze` stays scoped to one stream's files).
+- **Disjoint outputs required.** The streams' source targets must build
+  disjoint topic files (e.g. code-along/partial kinds vs completed kinds —
+  they land in different subtrees). `clm release sync` cross-checks the
+  source manifests of all streams sharing the destination and refuses to
+  promote if a topic-owned path is claimed twice. A sharer that is not built
+  yet is skipped with a note.
+- **Skeleton: presence-as-frozen.** A skeleton file already present in the
+  destination is kept, never overwritten — the second stream's first sync
+  copies only the skeleton files the first one didn't deliver. Evergreen
+  files still refresh by content. Because the two streams may sync from
+  different builds, **sync both streams after the same `clm build`** to keep
+  evergreen content from ping-ponging.
+- **Same `lang` required.** Channels sharing a path must declare the same
+  `lang` (spec validation error otherwise).
+- **One repo to `clm git`.** `--all-channels` visits the shared working tree
+  once (displayed as `materials/… (+ solutions/…)`); `clm release provision`
+  applies each group share once per repository. **Caveat:** `clm git reset
+  --channel` hard-resets the whole repo — it discards the *other* stream's
+  uncommitted promotions too; re-run that stream's sync afterward.
+- **What you give up.** With separate repos the materials repo *cannot*
+  contain a solution. Shared, the ledger is the only gate: a wrong
+  `release add` or premature sync publishes solutions into the repo students
+  already pull (and into its git history). Double-check `--dry-run` output
+  on the solutions stream.
+
+To migrate a running cohort, point the solutions channels' `path` at the
+existing materials working trees: students keep their remotes, the materials
+stream adopts the legacy `.clm-released.json` on its next sync, and the
+standalone solutions repos simply stop receiving syncs.
+
 ### `clm release provision`
 
 Share channel repos with GitLab groups (requires `CLM_GITLAB_TOKEN`).
@@ -175,8 +233,9 @@ clm release provision SPEC [--channel NAME] [--dry-run]
 
 All `clm git` subcommands operate on output targets by default; add
 `--channel NAME` or `--all-channels` to operate on cohort repos instead.
-`.clm-manifest.json` is always excluded from staging; `.clm-released.json`
-is always included.
+`.clm-manifest.json` is always excluded from staging; the frozen manifests
+(`.clm-released*.json`) are always included. Channels sharing a destination
+are visited once per repo, not once per channel.
 
 | Command | What it does |
 |---|---|
@@ -253,6 +312,7 @@ clm release sync course.xml --channel jan --push -m "Update NEWS"
   which follow the latest build by design.
 - **Provenance-driven** — files are promoted via manifest lookup, not path inference.
 - **Idempotent syncs** — re-running sync is safe; frozen topics are skipped.
-- **Manifest exclusion** — `.clm-manifest.json` is never distributed; the frozen manifest `.clm-released.json` is.
+- **Manifest exclusion** — `.clm-manifest.json` is never distributed; the per-stream frozen manifests (`.clm-released.<stream>.json`) are.
+- **Stream-scoped freezing** — streams sharing one destination repo freeze independently; presence-as-frozen protects the shared skeleton.
 
 See `clm info commands` for the full flag reference.

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -666,7 +666,7 @@ addressing unchanged.
 | `<share-with>` | `<release-channels>` | No | Default GitLab group share inherited by every channel (issue #294, see below). |
 | `<evergreen>` | `<release-channels>` | No | Glob pattern of **skeleton files exempt from the freeze**, inherited by every channel (see below). |
 | `name` (attr) | `<channel>` | Yes | Cohort identifier (no `/`). Addresses the channel on the CLI and forms the derived repo name. |
-| `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). One repo per channel; must be unique across **all** streams. |
+| `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). Unique within a stream. Channels of **different** streams may share a path — they then release into the same repository (issue #325, see below) and must agree on `lang`. |
 | `ledger` (attr) | `<channel>` | Yes | Path to the channel's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. Unique across all streams. |
 | `lang` (attr) | `<channel>` | No | Scope the channel to one language (`de`/`en`, issue #293). `clm release sync` then promotes only that language's files, **re-rooted** so the repo root is the language directory (matching per-language repos like `…-azav-de`), and the derived repo name appends `-{lang}`. **Unset**: the channel receives every built language root. |
 | `<remote-path>` | `<channel>` | No | Override the block-level `<remote-path>` for this one cohort. |
@@ -732,6 +732,39 @@ file is reported and ignored — released topic content changes only via
 Sync never deletes: removing an evergreen file from the source stops
 refreshing it but leaves the cohort's copy in place.
 
+#### Shared destination — several streams, one cohort repo (CLM {version}+)
+
+Channels of **different** streams may declare the same `path`: both streams
+then release into a single repository students pull from (issue #325) —
+e.g. materials at session start and solutions later, each on its own ledger:
+
+```xml
+<release-channels name="materials" source-target="shared">
+    <channel name="2026-04-de" lang="de" path="cohorts/2026-04/combined-de"
+             ledger="release/materials-2026-04-de.txt"/>
+</release-channels>
+<release-channels name="solutions" source-target="solutions">
+    <channel name="2026-04-de" lang="de" path="cohorts/2026-04/combined-de"
+             ledger="release/solutions-2026-04-de.txt"/>
+</release-channels>
+```
+
+Sharing is detected from the spec — no extra element. Constraints and
+behavior (`clm info releases` has the details):
+
+- channels sharing a path must agree on `lang` (validation error otherwise);
+- each stream keeps its own frozen manifest (`.clm-released.<stream>.json`),
+  so one stream releasing a topic never freezes it for the other;
+- the streams' built topic outputs must be **disjoint** (e.g. code-along /
+  partial kinds vs completed kinds) — `clm release sync` cross-checks the
+  source manifests and refuses overlap;
+- skeleton files already present in the destination are kept, not
+  overwritten (presence-as-frozen) — sync both streams after the same
+  `clm build` to avoid evergreen files ping-ponging between builds;
+- `clm git` treats the shared path as one repo (visited once by
+  `--all-channels`; note `clm git reset` is repo-wide and discards the other
+  stream's uncommitted state too).
+
 #### Provenance and freeze records
 
 The build artifact that makes per-topic promotion possible is the **provenance
@@ -739,7 +772,8 @@ manifest** (`.clm-manifest.json`, written by `clm build` — on by default since
 CLM {version}); it maps each output file to its owning topic, which the output
 path alone cannot recover. The manifest is private and is automatically excluded
 from every distributed repo by `clm git`. The per-cohort **frozen manifest**
-(`.clm-released.json`) *does* ship in the channel repo — it is the freeze record.
+(`.clm-released.<stream>.json`; `.clm-released.json` for the single unnamed
+block) *does* ship in the channel repo — it is the freeze record.
 
 Since CLM {version} (issue #295), a whole-course build that errors on some
 topics still writes the manifest for the cleanly-built subset, recording the

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -2150,15 +2150,21 @@ class CourseSpec:
         Stream naming: with several blocks every block needs a unique,
         ``/``-free ``name`` (the stream name used in ``stream/channel``
         addressing). Channels need unique, ``/``-free names within their block,
-        and a channel's destination ``path`` and ``ledger`` must be unique
-        across *all* streams — two streams writing the same destination would
-        fight over one frozen manifest.
+        and a channel's ``ledger`` must be unique across *all* streams.
+
+        Destination paths must be unique **within** a stream (one frozen
+        manifest per stream and destination). Channels of *different* streams
+        may share a destination — several streams releasing into one cohort
+        repository (issue #325) — but then they must agree on ``lang``: the
+        destination layout is re-rooted per language, so mixed-language
+        streams would interleave incompatible trees.
         """
         errors: list[str] = []
         blocks = self.release_channel_blocks
 
         block_names: set[str] = set()
-        dest_paths: dict[str, str] = {}
+        # Normalized dest path -> [(ref, stream name, lang)] of its claimants.
+        dest_paths: dict[str, list[tuple[str, str, str]]] = {}
         ledgers: dict[str, str] = {}
         for block in blocks:
             block_label = (
@@ -2204,14 +2210,25 @@ class CourseSpec:
 
                 if not channel.path:
                     errors.append(f"Channel '{ref}' needs a path attribute.")
-                elif channel.path in dest_paths:
-                    errors.append(
-                        f"Channels '{dest_paths[channel.path]}' and '{ref}' share the "
-                        f"destination path {channel.path!r}; every channel needs its own "
-                        f"destination repository."
-                    )
                 else:
-                    dest_paths[channel.path] = ref
+                    norm = str(Path(channel.path))
+                    for other_ref, other_stream, other_lang in dest_paths.get(norm, []):
+                        if other_stream == block.name:
+                            errors.append(
+                                f"Channels '{other_ref}' and '{ref}' share the "
+                                f"destination path {channel.path!r}; within one release "
+                                f"stream every channel needs its own destination "
+                                f"repository."
+                            )
+                        elif other_lang != channel.lang:
+                            errors.append(
+                                f"Channels '{other_ref}' and '{ref}' release into the "
+                                f"shared destination {channel.path!r} but declare "
+                                f"different lang values ({other_lang or '(all)'} vs "
+                                f"{channel.lang or '(all)'}); streams sharing a "
+                                f"destination must agree on lang."
+                            )
+                    dest_paths.setdefault(norm, []).append((ref, block.name, channel.lang))
 
                 if not channel.ledger:
                     errors.append(f"Channel '{ref}' needs a ledger attribute.")

--- a/src/clm/release/frozen_manifest.py
+++ b/src/clm/release/frozen_manifest.py
@@ -1,12 +1,22 @@
 """Frozen manifest: the per-destination record of what has been released.
 
-Written into the cohort's own repository as ``.clm-released.json``, this is the
-**freeze boundary**: a topic recorded here is never re-propagated by a later
-sync (so students keep exactly what they were given), unless an explicit
-``--refreeze`` overrides it. Each record is per-topic — ``source_commit`` (the
-build the cohort received), ``copied_at``, and a single rolled-up
-``topic_digest`` for tamper/drift detection — NOT a per-file hash map, keeping
-the student-shipped artifact small (issue #208, D7).
+Written into the cohort's own repository, this is the **freeze boundary**: a
+topic recorded here is never re-propagated by a later sync (so students keep
+exactly what they were given), unless an explicit ``--refreeze`` overrides it.
+Each record is per-topic — ``source_commit`` (the build the cohort received),
+``copied_at``, and a single rolled-up ``topic_digest`` for tamper/drift
+detection — NOT a per-file hash map, keeping the student-shipped artifact
+small (issue #208, D7).
+
+The file is **per release stream** (issue #325): a named stream writes
+``.clm-released.<stream>.json`` so several streams (e.g. materials and
+solutions) can release into the *same* destination repository without
+colliding on freeze records — topic ids are shared across streams, so a
+single file would make stream A's release freeze the topic for stream B. The
+unnamed single-block layout (issue #208) keeps the legacy
+``.clm-released.json`` name. :func:`load_frozen_manifest` adopts a legacy
+file whose ``channel`` field matches, so existing deployments migrate on
+their next sync.
 """
 
 from __future__ import annotations
@@ -21,6 +31,15 @@ logger = logging.getLogger(__name__)
 
 FROZEN_FILENAME = ".clm-released.json"
 FROZEN_VERSION = 1
+
+
+def frozen_manifest_filename(stream: str) -> str:
+    """The frozen manifest's filename for a release *stream* (issue #325).
+
+    A named stream owns ``.clm-released.<stream>.json``; the unnamed
+    single-block layout keeps the legacy ``.clm-released.json``.
+    """
+    return f".clm-released.{stream}.json" if stream else FROZEN_FILENAME
 
 
 @frozen
@@ -78,3 +97,49 @@ class FrozenManifest:
 
     def freeze(self, topic_id: str, record: FrozenRecord) -> None:
         self.frozen[topic_id] = record
+
+
+@frozen
+class LoadedFrozenManifest:
+    """A frozen manifest resolved to its per-stream location (issue #325).
+
+    ``path`` is where a subsequent :meth:`FrozenManifest.save` belongs (always
+    the per-stream filename). ``adopted_legacy`` names a legacy
+    ``.clm-released.json`` whose records were adopted — the caller deletes it
+    after a successful save so the destination carries one file per stream.
+    ``ignored_legacy_channel`` is set when a legacy file exists but records a
+    *different* channel (normal in a shared destination: it belongs to the
+    stream that has not migrated yet) so callers can surface a note.
+    """
+
+    manifest: FrozenManifest
+    path: Path
+    adopted_legacy: Path | None = None
+    ignored_legacy_channel: str | None = None
+
+
+def load_frozen_manifest(dest_root: Path, *, stream: str, channel: str) -> LoadedFrozenManifest:
+    """Load *channel*'s frozen manifest from *dest_root* (issue #325).
+
+    Reads the per-stream file (:func:`frozen_manifest_filename`). When a named
+    stream's file does not exist yet but the legacy ``.clm-released.json``
+    does **and** its ``channel`` field equals *channel*, the legacy records
+    are adopted — the pre-#325 deployment migrates to the per-stream name on
+    its next save. A legacy file recording a different channel is left alone
+    (it belongs to another stream sharing this destination).
+    """
+    path = dest_root / frozen_manifest_filename(stream)
+    if not stream or path.exists():
+        return LoadedFrozenManifest(FrozenManifest.load(path, channel=channel), path)
+    legacy = dest_root / FROZEN_FILENAME
+    if legacy.exists():
+        legacy_channel = json.loads(legacy.read_text(encoding="utf-8")).get("channel", "")
+        if legacy_channel == channel:
+            logger.info("adopting legacy frozen manifest %s for channel %r", legacy, channel)
+            return LoadedFrozenManifest(
+                FrozenManifest.load(legacy, channel=channel), path, adopted_legacy=legacy
+            )
+        return LoadedFrozenManifest(
+            FrozenManifest(channel=channel), path, ignored_legacy_channel=legacy_channel
+        )
+    return LoadedFrozenManifest(FrozenManifest(channel=channel), path)

--- a/src/clm/release/sync.py
+++ b/src/clm/release/sync.py
@@ -10,7 +10,10 @@ index. The rules (issue #208):
 * a released topic **already frozen** -> skip (students keep what they were
   given) unless it is in *refreeze*;
 * the skeleton (global, topic-less files) is copied once at channel init, then
-  frozen;
+  frozen — **presence-as-frozen** (issue #325): a skeleton file already present
+  at the destination is kept, not overwritten, so when several release streams
+  share one destination repository the later stream's first sync cannot clobber
+  the skeleton the earlier stream froze from a different build;
 * **evergreen** skeleton files (glob patterns from ``<evergreen>`` /
   ``--evergreen``) are exempt from the skeleton freeze: every sync re-copies a
   matching file whose built content differs from the destination's (e.g. a
@@ -94,15 +97,79 @@ class EvergreenScan:
 
 
 @frozen
+class SkeletonScan:
+    """Presence of the manifest's skeleton files at the destination (issue #325).
+
+    Files already ``present`` are kept, not overwritten — presence-as-frozen:
+    in a destination shared by several release streams, the skeleton an
+    earlier stream froze for its cohort must not be clobbered by a later
+    stream's first sync from a possibly newer build. Only ``missing`` files
+    are copied (evergreen patterns still refresh present files by content).
+    """
+
+    missing: tuple[str, ...] = ()
+    present: tuple[str, ...] = ()
+
+
+def scan_skeleton(*, manifest: dict[str, Any], dest_root: Path) -> SkeletonScan:
+    """Classify the manifest's skeleton entries by presence at *dest_root*."""
+    missing: list[str] = []
+    present: list[str] = []
+    for entry in manifest.get("files", []):
+        if entry.get("topic_id") is not None:
+            continue
+        rel = entry.get("path", "")
+        if _is_vcs_path(rel):
+            continue
+        (present if (dest_root / rel).is_file() else missing).append(rel)
+    return SkeletonScan(missing=tuple(missing), present=tuple(present))
+
+
+def topic_path_overlap(manifest_a: dict[str, Any], manifest_b: dict[str, Any]) -> tuple[str, ...]:
+    """Destination-relative paths claimed by a topic in *both* manifests.
+
+    Streams sharing one destination (issue #325) must own disjoint topic
+    files — only skeleton paths may overlap (byte-identical builds of the
+    same source). Any topic-owned overlap means the streams' output targets
+    produce colliding kinds and a sync would clobber the other stream's
+    frozen content; the sync preflight refuses it.
+    """
+    a = {e["path"] for e in manifest_a.get("files", []) if e.get("topic_id") is not None}
+    b = {e["path"] for e in manifest_b.get("files", []) if e.get("topic_id") is not None}
+    return tuple(sorted(a & b))
+
+
+@frozen
 class SyncPlan:
     copy_skeleton: bool
     skeleton_file_count: int
     topics: tuple[TopicPlan, ...]
     evergreen: tuple[EvergreenPlan, ...] = ()
+    # Skeleton paths the copy is restricted to (presence-as-frozen, issue
+    # #325). None = copy every skeleton file (no scan was taken — the
+    # pre-#325 contract, kept for callers that plan without a destination).
+    skeleton_to_copy: tuple[str, ...] | None = None
+    # Skeleton files kept because the destination already has them.
+    skeleton_present_count: int = 0
 
     @property
     def to_copy(self) -> tuple[TopicPlan, ...]:
         return tuple(t for t in self.topics if t.action in (COPY, REFREEZE))
+
+    @property
+    def evergreen_refresh(self) -> tuple[EvergreenPlan, ...]:
+        """The REFRESH plans the apply step executes.
+
+        A refresh already satisfied by this sync's own skeleton copy is
+        dropped: with a full copy (``skeleton_to_copy is None``) that is every
+        evergreen file; with a presence-restricted copy only the missing ones
+        — a *present* evergreen file whose content differs still refreshes,
+        even on a first sync (issue #325).
+        """
+        if self.copy_skeleton and self.skeleton_to_copy is None:
+            return ()
+        covered = frozenset(self.skeleton_to_copy or ()) if self.copy_skeleton else frozenset()
+        return tuple(p for p in self.evergreen if p.action == REFRESH and p.path not in covered)
 
     @property
     def skipped(self) -> tuple[TopicPlan, ...]:
@@ -176,6 +243,7 @@ def plan_sync(
     frozen: FrozenManifest,
     refreeze: Iterable[str] = (),
     evergreen: Iterable[EvergreenPlan] = (),
+    skeleton: SkeletonScan | None = None,
 ) -> SyncPlan:
     """Compute what a sync would do, without touching the filesystem.
 
@@ -185,8 +253,12 @@ def plan_sync(
     not being refrozen, in which case the ordinary :data:`SKIP_FROZEN` applies
     (the cohort already has it; nothing would be copied anyway).
 
-    *evergreen* carries the plans of a prior :func:`scan_evergreen` (which
-    reads the destination, so it stays out of this pure planning step).
+    *evergreen* and *skeleton* carry the results of prior
+    :func:`scan_evergreen` / :func:`scan_skeleton` calls (they read the
+    destination, so they stay out of this pure planning step). Without a
+    *skeleton* scan a needed skeleton copy covers every skeleton file; with
+    one it is restricted to the files missing at the destination
+    (presence-as-frozen, issue #325).
     """
     refreeze_set = set(refreeze)
     failed_topics = set(manifest.get("failed_topics", []))
@@ -204,11 +276,22 @@ def plan_sync(
             action = COPY
         plans.append(TopicPlan(topic_id, action, file_count))
     skeleton_files = by_topic.get(None, [])
+    copy_skeleton = not frozen.skeleton_frozen
+    if copy_skeleton and skeleton is not None:
+        skeleton_to_copy: tuple[str, ...] | None = skeleton.missing
+        skeleton_file_count = len(skeleton.missing)
+        skeleton_present_count = len(skeleton.present)
+    else:
+        skeleton_to_copy = None
+        skeleton_file_count = len(skeleton_files)
+        skeleton_present_count = 0
     return SyncPlan(
-        copy_skeleton=not frozen.skeleton_frozen,
-        skeleton_file_count=len(skeleton_files),
+        copy_skeleton=copy_skeleton,
+        skeleton_file_count=skeleton_file_count,
         topics=tuple(plans),
         evergreen=tuple(evergreen),
+        skeleton_to_copy=skeleton_to_copy,
+        skeleton_present_count=skeleton_present_count,
     )
 
 
@@ -227,9 +310,11 @@ def apply_sync(
     no files in the source manifest (e.g. released but not yet built) is logged
     and **not** frozen, so it is retried once it is built.
 
-    The evergreen pass runs only once the skeleton is frozen: on the first
-    sync the skeleton copy itself delivers every skeleton file — evergreen
-    ones included — so refreshing then would re-copy bytes just written.
+    The evergreen pass executes ``plan.evergreen_refresh`` — the refreshes not
+    already satisfied by this sync's own skeleton copy. On a plain first sync
+    the skeleton copy delivers every skeleton file, evergreen ones included;
+    with a presence-restricted copy (issue #325) a *present* evergreen file
+    whose content differs still refreshes.
     """
     by_topic = manifest_files_by_topic(manifest)
     source_commit = manifest.get("source_commit")
@@ -239,27 +324,30 @@ def apply_sync(
     skipped: list[str] = []
     failed: list[str] = []
     refreshed: list[str] = []
+    skeleton_entries = by_topic.get(None, [])
 
     if plan.copy_skeleton:
-        files_copied += _copy_files(by_topic.get(None, []), source_root, dest_root)
+        entries = skeleton_entries
+        if plan.skeleton_to_copy is not None:
+            wanted = set(plan.skeleton_to_copy)
+            entries = [e for e in skeleton_entries if e["path"] in wanted]
+        files_copied += _copy_files(entries, source_root, dest_root)
         frozen.skeleton_frozen = True
-    else:
-        skeleton_by_path = {e["path"]: e for e in by_topic.get(None, [])}
-        for evergreen_plan in plan.evergreen:
-            if evergreen_plan.action != REFRESH:
-                continue
-            entry = skeleton_by_path.get(evergreen_plan.path)
-            if entry is None:
-                # The scan only plans skeleton entries; a miss means the plan
-                # and manifest went out of sync — skip rather than guess.
-                logger.warning(
-                    "evergreen: %r is not a skeleton file in the manifest; skipped",
-                    evergreen_plan.path,
-                )
-                continue
-            if _copy_files([entry], source_root, dest_root):
-                files_copied += 1
-                refreshed.append(evergreen_plan.path)
+
+    skeleton_by_path = {e["path"]: e for e in skeleton_entries}
+    for evergreen_plan in plan.evergreen_refresh:
+        entry = skeleton_by_path.get(evergreen_plan.path)
+        if entry is None:
+            # The scan only plans skeleton entries; a miss means the plan
+            # and manifest went out of sync — skip rather than guess.
+            logger.warning(
+                "evergreen: %r is not a skeleton file in the manifest; skipped",
+                evergreen_plan.path,
+            )
+            continue
+        if _copy_files([entry], source_root, dest_root):
+            files_copied += 1
+            refreshed.append(evergreen_plan.path)
 
     for topic_plan in plan.topics:
         if topic_plan.action == SKIP_FROZEN:

--- a/tests/cli/test_git_release_channels.py
+++ b/tests/cli/test_git_release_channels.py
@@ -280,6 +280,21 @@ class TestSelectReposGuards:
         # private build input — default enumeration skips it (issue #292).
         assert repos == []
 
+    def test_all_channels_visits_a_shared_destination_once(self, tmp_path: Path):
+        """Channels of different streams releasing into one working tree are
+        one repo to ``clm git`` (issue #325)."""
+        shared = SPEC_TWO_STREAMS.replace(
+            "./release/solutions/2026-04", "./release/materials/2026-04"
+        )
+        spec_file = _write_spec(tmp_path, shared)
+        repos = _select_repos(spec_file, target=None, channel=None, all_channels=True)
+        assert [r.target_name for r in repos] == ["materials/2026-04", "solutions/2026-10"]
+        merged = repos[0]
+        assert merged.shared_refs == ["solutions/2026-04"]
+        assert merged.display_name == "materials/2026-04 (+ solutions/2026-04)"
+        # The first stream's URL derivation wins for the shared repo.
+        assert merged.remote_url == "https://github.com/Org/ml-course-2026-04-materials"
+
 
 # ---------------------------------------------------------------------------
 # distribute="false" / release-source auto-exclusion (issue #292)

--- a/tests/core/test_release_channels_spec.py
+++ b/tests/core/test_release_channels_spec.py
@@ -156,12 +156,44 @@ class TestMultiStreamValidation:
         errors = _spec(block, TWO_STREAM_TARGETS).validate()
         assert any("source-target" in e for e in errors)
 
-    def test_shared_dest_path_across_streams_rejected(self):
+    def test_shared_dest_path_across_streams_is_valid(self):
+        """Two streams may release into one destination repo (issue #325)."""
         shared_path = TWO_STREAMS.replace(
             "./release/solutions/2026-04", "./release/materials/2026-04"
         )
+        assert _spec(shared_path, TWO_STREAM_TARGETS).validate() == []
+
+    def test_shared_dest_detection_normalizes_paths(self):
+        """`./x` and `x` are the same destination — lang disagreement is caught."""
+        shared_path = TWO_STREAMS.replace(
+            'name="2026-04" path="./release/solutions/2026-04"',
+            'name="2026-04" lang="de" path="release/materials/2026-04"',
+        )
         errors = _spec(shared_path, TWO_STREAM_TARGETS).validate()
-        assert any("share the destination path" in e for e in errors)
+        assert any("must agree on lang" in e for e in errors)
+
+    def test_shared_dest_path_within_one_stream_rejected(self):
+        shared_path = TWO_STREAMS.replace(
+            "./release/materials/2026-10", "./release/materials/2026-04"
+        )
+        errors = _spec(shared_path, TWO_STREAM_TARGETS).validate()
+        assert any("within one release stream" in e for e in errors)
+
+    def test_shared_dest_with_different_lang_rejected(self):
+        shared_path = TWO_STREAMS.replace(
+            "./release/solutions/2026-04", "./release/materials/2026-04"
+        ).replace(
+            '<channel name="2026-04" path="./release/materials/2026-04" ledger="release/materials-2026-04.txt"/>',
+            '<channel name="2026-04" lang="de" path="./release/materials/2026-04" ledger="release/materials-2026-04.txt"/>',
+        )
+        errors = _spec(shared_path, TWO_STREAM_TARGETS).validate()
+        assert any("must agree on lang" in e for e in errors)
+
+    def test_shared_dest_with_same_lang_is_valid(self):
+        shared_path = TWO_STREAMS.replace(
+            "./release/solutions/2026-04", "./release/materials/2026-04"
+        ).replace('name="2026-04" path', 'name="2026-04" lang="de" path')
+        assert _spec(shared_path, TWO_STREAM_TARGETS).validate() == []
 
     def test_shared_ledger_across_streams_rejected(self):
         shared_ledger = TWO_STREAMS.replace(

--- a/tests/release/test_provision.py
+++ b/tests/release/test_provision.py
@@ -250,6 +250,41 @@ class TestProvisionCli:
         assert result.exit_code == 0, result.output
         assert "nothing to provision" in result.output.lower()
 
+    def test_shared_destination_shares_are_applied_once_per_repo(self, tmp_path, monkeypatch):
+        """Channels of different streams releasing into one repo (issue #325)
+        collapse identical shares; all of them target the first channel's
+        project, since that is the repository they all are."""
+        for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        spec = SPEC_WITH_SHARES.replace(
+            '<channel name="2026-10" path="release/2026-10" ledger="release/2026-10.txt">\n'
+            '      <share-with access="guest">trainers</share-with>\n'
+            "    </channel>\n"
+            "  </release-channels>",
+            "</release-channels>\n"
+            '  <release-channels name="materials" source-target="completed">\n'
+            '    <channel name="2026-04" path="release/2026-04" '
+            'ledger="release/materials-2026-04.txt">\n'
+            "      <share-with>students/azav-ml/ml-2026-04</share-with>\n"
+            '      <share-with access="developer">trainers</share-with>\n'
+            "    </channel>\n"
+            "  </release-channels>",
+        )
+        specs_dir = tmp_path / "course-specs"
+        specs_dir.mkdir()
+        spec_file = specs_dir / "course.xml"
+        spec_file.write_text(spec, encoding="utf-8")
+
+        result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        # The student share appears once, against the first stream's project.
+        assert result.output.count("-> students/azav-ml/ml-2026-04") == 1
+        assert result.output.count("ca/ml-2026-04-solutions") >= 1
+        assert "ca/ml-2026-04-materials" not in result.output
+        # The conflicting trainers access level is reported, not re-applied.
+        assert "collapsed" in result.output
+        assert result.output.count("-> trainers") == 1
+
     def test_api_error_exits_nonzero_but_continues(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLM_GITLAB_TOKEN", "tok")
         spec_file = _write_spec(tmp_path)

--- a/tests/release/test_release_cli.py
+++ b/tests/release/test_release_cli.py
@@ -11,7 +11,11 @@ from click.testing import CliRunner
 
 from clm.cli.commands.release import release_group
 from clm.core.provenance_manifest import MANIFEST_FILENAME
-from clm.release.frozen_manifest import FROZEN_FILENAME, FrozenManifest
+from clm.release.frozen_manifest import (
+    FROZEN_FILENAME,
+    FrozenManifest,
+    frozen_manifest_filename,
+)
 from clm.release.ledger import Ledger
 
 SPEC = Path(__file__).parent.parent / "test-data" / "course-specs" / "test-spec-1.xml"
@@ -270,9 +274,13 @@ def test_two_streams_release_independently_from_their_own_sources(tmp_path):
     solutions_dest = course_root / "release" / "solutions" / "2026-04"
     assert (solutions_dest / "Sec/01 Intro.ipynb").is_file()
 
-    # Each destination froze under its canonical stream/channel address.
-    frozen = FrozenManifest.load(solutions_dest / FROZEN_FILENAME, channel="?")
+    # Each destination froze under its canonical stream/channel address, in
+    # the stream's own frozen-manifest file (issue #325).
+    frozen = FrozenManifest.load(
+        solutions_dest / frozen_manifest_filename("solutions"), channel="?"
+    )
     assert frozen.channel == "solutions/2026-04"
+    assert not (solutions_dest / FROZEN_FILENAME).exists()
 
 
 def test_ambiguous_bare_channel_is_a_clear_error(tmp_path):

--- a/tests/release/test_shared_destination.py
+++ b/tests/release/test_shared_destination.py
@@ -1,0 +1,521 @@
+"""Tests for several release streams sharing one destination repo (issue #325).
+
+Covers the four pillars of the feature:
+
+* per-stream frozen manifests (``.clm-released.<stream>.json``) with adoption
+  of a legacy ``.clm-released.json`` whose channel matches;
+* presence-as-frozen skeleton policy (a later stream never overwrites the
+  skeleton an earlier stream froze);
+* the cross-stream overlap preflight (topic-owned paths must be disjoint);
+* ``clm git`` visiting a shared destination once.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.commands.git import OutputRepo, _dedupe_shared_destinations
+from clm.cli.commands.release import release_group
+from clm.core.provenance_manifest import MANIFEST_FILENAME
+from clm.release.frozen_manifest import (
+    FROZEN_FILENAME,
+    FrozenManifest,
+    FrozenRecord,
+    frozen_manifest_filename,
+    load_frozen_manifest,
+)
+from clm.release.ledger import Ledger
+from clm.release.sync import (
+    REFRESH,
+    apply_sync,
+    plan_sync,
+    scan_evergreen,
+    scan_skeleton,
+    topic_path_overlap,
+)
+
+# ---------------------------------------------------------------------------
+# frozen_manifest: per-stream filenames + legacy adoption
+# ---------------------------------------------------------------------------
+
+
+def _sha(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class TestPerStreamFrozenManifest:
+    def test_filename_per_stream_and_legacy_for_unnamed(self):
+        assert frozen_manifest_filename("materials") == ".clm-released.materials.json"
+        assert frozen_manifest_filename("") == FROZEN_FILENAME
+
+    def test_missing_files_yield_empty_manifest_at_per_stream_path(self, tmp_path):
+        loaded = load_frozen_manifest(tmp_path, stream="materials", channel="materials/jan")
+        assert loaded.manifest.frozen == {}
+        assert loaded.manifest.channel == "materials/jan"
+        assert loaded.path == tmp_path / ".clm-released.materials.json"
+        assert loaded.adopted_legacy is None
+        assert loaded.ignored_legacy_channel is None
+
+    def test_unnamed_stream_keeps_the_legacy_path(self, tmp_path):
+        legacy = FrozenManifest(channel="jan", skeleton_frozen=True)
+        legacy.save(tmp_path / FROZEN_FILENAME)
+        loaded = load_frozen_manifest(tmp_path, stream="", channel="jan")
+        assert loaded.path == tmp_path / FROZEN_FILENAME
+        assert loaded.manifest.skeleton_frozen is True
+
+    def test_matching_legacy_is_adopted(self, tmp_path):
+        legacy = FrozenManifest(channel="materials/jan", skeleton_frozen=True)
+        legacy.freeze("intro", FrozenRecord("abc", "t", "sha256:d"))
+        legacy.save(tmp_path / FROZEN_FILENAME)
+
+        loaded = load_frozen_manifest(tmp_path, stream="materials", channel="materials/jan")
+        assert loaded.manifest.is_frozen("intro")
+        assert loaded.manifest.skeleton_frozen is True
+        assert loaded.path == tmp_path / ".clm-released.materials.json"
+        assert loaded.adopted_legacy == tmp_path / FROZEN_FILENAME
+
+    def test_foreign_legacy_is_left_alone(self, tmp_path):
+        legacy = FrozenManifest(channel="materials/jan")
+        legacy.freeze("intro", FrozenRecord("abc", "t", "sha256:d"))
+        legacy.save(tmp_path / FROZEN_FILENAME)
+
+        loaded = load_frozen_manifest(tmp_path, stream="solutions", channel="solutions/jan")
+        assert not loaded.manifest.is_frozen("intro")
+        assert loaded.adopted_legacy is None
+        assert loaded.ignored_legacy_channel == "materials/jan"
+
+    def test_per_stream_file_wins_over_a_matching_legacy(self, tmp_path):
+        legacy = FrozenManifest(channel="materials/jan")
+        legacy.freeze("stale", FrozenRecord("old", "t", "sha256:d"))
+        legacy.save(tmp_path / FROZEN_FILENAME)
+        current = FrozenManifest(channel="materials/jan")
+        current.freeze("intro", FrozenRecord("new", "t", "sha256:d"))
+        current.save(tmp_path / ".clm-released.materials.json")
+
+        loaded = load_frozen_manifest(tmp_path, stream="materials", channel="materials/jan")
+        assert loaded.manifest.is_frozen("intro")
+        assert not loaded.manifest.is_frozen("stale")
+        assert loaded.adopted_legacy is None
+
+
+# ---------------------------------------------------------------------------
+# sync: presence-as-frozen skeleton + topic overlap
+# ---------------------------------------------------------------------------
+
+TOPIC_PATH = "Sec/01 Intro.ipynb"
+SKELETON_PATH = "shared/data.csv"
+
+
+def _manifest(*, topic_path=TOPIC_PATH, skeleton_text="skeleton v1"):
+    return {
+        "version": 1,
+        "source_commit": "abc",
+        "files": [
+            {"path": topic_path, "topic_id": "intro", "content_hash": "sha256:a"},
+            {"path": SKELETON_PATH, "topic_id": None, "content_hash": _sha(skeleton_text)},
+        ],
+    }
+
+
+def _materialize(root: Path, manifest, *, skeleton_text="skeleton v1"):
+    for entry in manifest["files"]:
+        path = root / entry["path"]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        text = skeleton_text if entry["topic_id"] is None else entry["content_hash"]
+        path.write_text(text, encoding="utf-8")
+    return root
+
+
+class TestSkeletonPresenceAsFrozen:
+    def test_scan_classifies_missing_and_present_and_skips_vcs(self, tmp_path):
+        manifest = _manifest()
+        manifest["files"].append(
+            {"path": ".git/index", "topic_id": None, "content_hash": "sha256:x"}
+        )
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        (dest / SKELETON_PATH).parent.mkdir(parents=True)
+        (dest / SKELETON_PATH).write_text("already here", encoding="utf-8")
+
+        scan = scan_skeleton(manifest=manifest, dest_root=dest)
+        assert scan.present == (SKELETON_PATH,)
+        assert scan.missing == ()
+
+        empty = scan_skeleton(manifest=manifest, dest_root=tmp_path / "fresh")
+        assert empty.missing == (SKELETON_PATH,)
+        assert empty.present == ()
+
+    def test_apply_keeps_present_skeleton_files_and_copies_missing(self, tmp_path):
+        manifest = _manifest(skeleton_text="newer build")
+        source = _materialize(tmp_path / "src", manifest, skeleton_text="newer build")
+        dest = tmp_path / "dest"
+        (dest / SKELETON_PATH).parent.mkdir(parents=True)
+        (dest / SKELETON_PATH).write_text("first stream's bytes", encoding="utf-8")
+        frozen = FrozenManifest(channel="solutions/jan")
+
+        scan = scan_skeleton(manifest=manifest, dest_root=dest)
+        plan = plan_sync(manifest=manifest, ledger_released=["intro"], frozen=frozen, skeleton=scan)
+        assert plan.copy_skeleton is True
+        assert plan.skeleton_to_copy == ()
+        assert plan.skeleton_file_count == 0
+        assert plan.skeleton_present_count == 1
+
+        result = apply_sync(
+            plan=plan,
+            manifest=manifest,
+            source_root=source,
+            dest_root=dest,
+            frozen=frozen,
+            copied_at="t1",
+        )
+        # The present skeleton file is kept verbatim; the topic still copies.
+        assert (dest / SKELETON_PATH).read_text(encoding="utf-8") == "first stream's bytes"
+        assert (dest / TOPIC_PATH).is_file()
+        assert frozen.skeleton_frozen is True
+        assert result.files_copied == 1
+
+    def test_without_a_scan_the_full_skeleton_copies_as_before(self, tmp_path):
+        manifest = _manifest()
+        source = _materialize(tmp_path / "src", manifest)
+        dest = tmp_path / "dest"
+        frozen = FrozenManifest(channel="jan")
+        plan = plan_sync(manifest=manifest, ledger_released=[], frozen=frozen)
+        assert plan.skeleton_to_copy is None
+        apply_sync(
+            plan=plan,
+            manifest=manifest,
+            source_root=source,
+            dest_root=dest,
+            frozen=frozen,
+            copied_at="t1",
+        )
+        assert (dest / SKELETON_PATH).is_file()
+
+    def test_stale_present_evergreen_file_refreshes_on_a_first_sync(self, tmp_path):
+        """A present-but-outdated evergreen file is not trapped by
+        presence-as-frozen: the refresh pass updates it even while this
+        stream's first sync copies the rest of the skeleton."""
+        manifest = _manifest(skeleton_text="news v2")
+        source = _materialize(tmp_path / "src", manifest, skeleton_text="news v2")
+        dest = tmp_path / "dest"
+        (dest / SKELETON_PATH).parent.mkdir(parents=True)
+        (dest / SKELETON_PATH).write_text("news v1", encoding="utf-8")
+        frozen = FrozenManifest(channel="solutions/jan")
+
+        evergreen = scan_evergreen(manifest=manifest, patterns=[SKELETON_PATH], dest_root=dest)
+        skeleton = scan_skeleton(manifest=manifest, dest_root=dest)
+        plan = plan_sync(
+            manifest=manifest,
+            ledger_released=[],
+            frozen=frozen,
+            evergreen=evergreen.plans,
+            skeleton=skeleton,
+        )
+        assert [p.path for p in plan.evergreen_refresh] == [SKELETON_PATH]
+
+        result = apply_sync(
+            plan=plan,
+            manifest=manifest,
+            source_root=source,
+            dest_root=dest,
+            frozen=frozen,
+            copied_at="t1",
+        )
+        assert result.refreshed_files == (SKELETON_PATH,)
+        assert (dest / SKELETON_PATH).read_text(encoding="utf-8") == "news v2"
+
+    def test_full_first_sync_still_satisfies_evergreen_via_the_skeleton_copy(self, tmp_path):
+        manifest = _manifest()
+        source = _materialize(tmp_path / "src", manifest)
+        dest = tmp_path / "dest"
+        frozen = FrozenManifest(channel="jan")
+        evergreen = scan_evergreen(manifest=manifest, patterns=[SKELETON_PATH], dest_root=dest)
+        skeleton = scan_skeleton(manifest=manifest, dest_root=dest)
+        plan = plan_sync(
+            manifest=manifest,
+            ledger_released=[],
+            frozen=frozen,
+            evergreen=evergreen.plans,
+            skeleton=skeleton,
+        )
+        # The missing evergreen file arrives with the skeleton copy itself.
+        assert plan.evergreen_refresh == ()
+        result = apply_sync(
+            plan=plan,
+            manifest=manifest,
+            source_root=source,
+            dest_root=dest,
+            frozen=frozen,
+            copied_at="t1",
+        )
+        assert result.refreshed_files == ()
+        assert (dest / SKELETON_PATH).is_file()
+
+
+class TestTopicPathOverlap:
+    def test_disjoint_topic_paths_have_no_overlap(self):
+        a = _manifest(topic_path="Sec/01 Intro-CodeAlong.ipynb")
+        b = _manifest(topic_path="Sec/01 Intro-Completed.ipynb")
+        assert topic_path_overlap(a, b) == ()
+
+    def test_shared_topic_path_is_reported_and_skeleton_overlap_ignored(self):
+        a = _manifest()
+        b = _manifest()
+        # Both manifests claim TOPIC_PATH for a topic and share the skeleton.
+        assert topic_path_overlap(a, b) == (TOPIC_PATH,)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: two streams, one destination
+# ---------------------------------------------------------------------------
+
+SPEC_SHARED_DEST = """
+<course>
+  <name><de>T</de><en>T</en></name>
+  <prog-lang>python</prog-lang>
+  <sections>
+    <section>
+      <name><de>S</de><en>S</en></name>
+      <topics><topic>intro</topic></topics>
+    </section>
+  </sections>
+  <output-targets>
+    <output-target name="shared">
+      <path>output/shared</path>
+      <kinds><kind>code-along</kind></kinds>
+    </output-target>
+    <output-target name="completed">
+      <path>output/completed</path>
+      <kinds><kind>completed</kind></kinds>
+    </output-target>
+  </output-targets>
+  <release-channels name="materials" source-target="shared">
+    <channel name="2026-04" path="release/combined/2026-04" ledger="release/materials-2026-04.txt"/>
+  </release-channels>
+  <release-channels name="solutions" source-target="completed">
+    <channel name="2026-04" path="release/combined/2026-04" ledger="release/solutions-2026-04.txt"/>
+  </release-channels>
+</course>
+""".strip()
+
+CODE_ALONG_PATH = "Sec/01 Intro-CodeAlong.ipynb"
+COMPLETED_PATH = "Sec/01 Intro-Completed.ipynb"
+
+
+def _write_spec(tmp_path: Path, body: str = SPEC_SHARED_DEST) -> Path:
+    specs_dir = tmp_path / "course-specs"
+    specs_dir.mkdir(exist_ok=True)
+    spec_file = specs_dir / "course.xml"
+    spec_file.write_text(body, encoding="utf-8")
+    return spec_file
+
+
+def _write_built_source(root: Path, *, topic_path: str, skeleton_text: str = "skeleton v1"):
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = _manifest(topic_path=topic_path, skeleton_text=skeleton_text)
+    (root / MANIFEST_FILENAME).write_text(json.dumps(manifest), encoding="utf-8")
+    _materialize(root, manifest, skeleton_text=skeleton_text)
+
+
+def _release_and_sync(runner, spec_file, channel):
+    add = runner.invoke(release_group, ["add", str(spec_file), "intro", "--channel", channel])
+    assert add.exit_code == 0, add.output
+    sync = runner.invoke(release_group, ["sync", str(spec_file), "--channel", channel])
+    return sync
+
+
+class TestSharedDestinationCli:
+    def test_two_streams_release_into_one_repo(self, tmp_path):
+        """The keystone scenario of issue #325: materials and solutions land in
+        the same cohort working tree, each gated by its own ledger and frozen
+        in its own per-stream manifest."""
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH)
+        _write_built_source(tmp_path / "output" / "completed", topic_path=COMPLETED_PATH)
+        dest = tmp_path / "release" / "combined" / "2026-04"
+
+        sync1 = _release_and_sync(runner, spec_file, "materials/2026-04")
+        assert sync1.exit_code == 0, sync1.output
+        assert (dest / CODE_ALONG_PATH).is_file()
+        assert not (dest / COMPLETED_PATH).exists()  # own ledger gates it
+
+        sync2 = _release_and_sync(runner, spec_file, "solutions/2026-04")
+        assert sync2.exit_code == 0, sync2.output
+        assert (dest / COMPLETED_PATH).is_file()
+        assert (dest / CODE_ALONG_PATH).is_file()  # untouched
+
+        materials = FrozenManifest.load(dest / frozen_manifest_filename("materials"), channel="?")
+        solutions = FrozenManifest.load(dest / frozen_manifest_filename("solutions"), channel="?")
+        assert materials.channel == "materials/2026-04"
+        assert solutions.channel == "solutions/2026-04"
+        # The core #325 fix: materials freezing 'intro' did NOT freeze it for
+        # solutions — each stream froze its own copy.
+        assert materials.is_frozen("intro")
+        assert solutions.is_frozen("intro")
+        assert not (dest / FROZEN_FILENAME).exists()
+
+    def test_second_stream_keeps_the_first_streams_skeleton(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(
+            tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH, skeleton_text="v1"
+        )
+        # Solutions built later, from a newer source: its skeleton differs.
+        _write_built_source(
+            tmp_path / "output" / "completed", topic_path=COMPLETED_PATH, skeleton_text="v2"
+        )
+        dest = tmp_path / "release" / "combined" / "2026-04"
+
+        assert _release_and_sync(runner, spec_file, "materials/2026-04").exit_code == 0
+        sync2 = _release_and_sync(runner, spec_file, "solutions/2026-04")
+        assert sync2.exit_code == 0, sync2.output
+
+        # Presence-as-frozen: the cohort keeps the skeleton it was given.
+        assert (dest / SKELETON_PATH).read_text(encoding="utf-8") == "v1"
+        assert "already present (kept)" in sync2.output
+        solutions = FrozenManifest.load(dest / frozen_manifest_filename("solutions"), channel="?")
+        assert solutions.skeleton_frozen is True
+
+    def test_overlapping_topic_outputs_are_refused(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        # Both targets (mis)build the same topic path -> would clobber.
+        _write_built_source(tmp_path / "output" / "shared", topic_path="Sec/01 Intro.ipynb")
+        _write_built_source(tmp_path / "output" / "completed", topic_path="Sec/01 Intro.ipynb")
+
+        sync = _release_and_sync(runner, spec_file, "materials/2026-04")
+        assert sync.exit_code != 0
+        assert "Refusing to sync" in sync.output
+        assert "Sec/01 Intro.ipynb" in sync.output
+        # Nothing was promoted.
+        assert not (tmp_path / "release" / "combined" / "2026-04").exists()
+
+    def test_unbuilt_sharer_is_noted_and_skipped(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH)
+        # output/completed is not built: no manifest to preflight against.
+
+        sync = _release_and_sync(runner, spec_file, "materials/2026-04")
+        assert sync.exit_code == 0, sync.output
+        assert "not built" in sync.output
+
+    def test_legacy_frozen_manifest_is_adopted_and_migrated(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH)
+        dest = tmp_path / "release" / "combined" / "2026-04"
+        dest.mkdir(parents=True)
+        legacy = FrozenManifest(channel="materials/2026-04", skeleton_frozen=True)
+        legacy.freeze("intro", FrozenRecord("old", "t", "sha256:d"))
+        legacy.save(dest / FROZEN_FILENAME)
+
+        sync = _release_and_sync(runner, spec_file, "materials/2026-04")
+        assert sync.exit_code == 0, sync.output
+        # The freeze survived the adoption: the topic was NOT re-copied.
+        assert "skip-frozen" in sync.output
+        assert not (dest / CODE_ALONG_PATH).exists()
+        assert "Migrated the legacy" in sync.output
+        assert not (dest / FROZEN_FILENAME).exists()
+        migrated = FrozenManifest.load(dest / frozen_manifest_filename("materials"), channel="?")
+        assert migrated.is_frozen("intro")
+        assert migrated.frozen["intro"].source_commit == "old"
+
+    def test_dry_run_does_not_migrate_the_legacy_manifest(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH)
+        dest = tmp_path / "release" / "combined" / "2026-04"
+        dest.mkdir(parents=True)
+        FrozenManifest(channel="materials/2026-04").save(dest / FROZEN_FILENAME)
+
+        add = runner.invoke(
+            release_group, ["add", str(spec_file), "intro", "--channel", "materials/2026-04"]
+        )
+        assert add.exit_code == 0
+        sync = runner.invoke(
+            release_group,
+            ["sync", str(spec_file), "--channel", "materials/2026-04", "--dry-run"],
+        )
+        assert sync.exit_code == 0, sync.output
+        assert (dest / FROZEN_FILENAME).exists()
+        assert not (dest / frozen_manifest_filename("materials")).exists()
+
+    def test_another_streams_legacy_manifest_is_left_alone(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH)
+        _write_built_source(tmp_path / "output" / "completed", topic_path=COMPLETED_PATH)
+        dest = tmp_path / "release" / "combined" / "2026-04"
+        dest.mkdir(parents=True)
+        legacy = FrozenManifest(channel="materials/2026-04", skeleton_frozen=True)
+        legacy.freeze("intro", FrozenRecord("old", "t", "sha256:d"))
+        legacy.save(dest / FROZEN_FILENAME)
+
+        sync = _release_and_sync(runner, spec_file, "solutions/2026-04")
+        assert sync.exit_code == 0, sync.output
+        assert "leaving the legacy" in sync.output
+        # Materials' freeze does not gate solutions: its copy still promotes.
+        assert (dest / COMPLETED_PATH).is_file()
+        assert (dest / FROZEN_FILENAME).exists()  # untouched
+        solutions = FrozenManifest.load(dest / frozen_manifest_filename("solutions"), channel="?")
+        assert solutions.is_frozen("intro")
+
+    def test_status_reads_the_per_stream_manifest(self, tmp_path):
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(tmp_path / "output" / "shared", topic_path=CODE_ALONG_PATH)
+        _write_built_source(tmp_path / "output" / "completed", topic_path=COMPLETED_PATH)
+        assert _release_and_sync(runner, spec_file, "materials/2026-04").exit_code == 0
+
+        status = runner.invoke(
+            release_group, ["status", str(spec_file), "--channel", "materials/2026-04"]
+        )
+        assert status.exit_code == 0, status.output
+        assert "1 frozen" in status.output
+
+        # The other stream sharing the destination sees ITS empty state.
+        other = runner.invoke(
+            release_group, ["status", str(spec_file), "--channel", "solutions/2026-04"]
+        )
+        assert other.exit_code == 0, other.output
+        assert "0 frozen" in other.output
+
+
+# ---------------------------------------------------------------------------
+# clm git: a shared destination is one repo
+# ---------------------------------------------------------------------------
+
+
+class TestGitSharedRepoDedupe:
+    def test_channels_sharing_a_path_collapse_to_one_repo(self, tmp_path):
+        materials = OutputRepo(
+            path=tmp_path / "combined",
+            target_name="materials/2026-04",
+            language="",
+            remote_url="https://gitlab.example.com/ca/ml-2026-04-materials",
+            source="channel",
+        )
+        solutions = OutputRepo(
+            path=tmp_path / "combined",
+            target_name="solutions/2026-04",
+            language="",
+            remote_url="https://gitlab.example.com/ca/ml-2026-04-solutions",
+            source="channel",
+        )
+        deduped = _dedupe_shared_destinations([materials, solutions])
+        assert len(deduped) == 1
+        repo = deduped[0]
+        assert repo.target_name == "materials/2026-04"
+        assert repo.shared_refs == ["solutions/2026-04"]
+        assert "solutions/2026-04" in repo.display_name
+        # First stream's derivation wins.
+        assert repo.remote_url == "https://gitlab.example.com/ca/ml-2026-04-materials"
+
+    def test_distinct_destinations_stay_separate(self, tmp_path):
+        a = OutputRepo(path=tmp_path / "a", target_name="x", language="", source="channel")
+        b = OutputRepo(path=tmp_path / "b", target_name="y", language="", source="channel")
+        assert len(_dedupe_shared_destinations([a, b])) == 2


### PR DESCRIPTION
Implements #325: channels of *different* release streams may now declare the same `path`, releasing e.g. materials and solutions into a **single cohort repository** that students pull from, while each stream keeps its own per-topic ledger and timeline. Sharing is detected from the spec — no new elements.

## What changed

**1. Per-stream frozen manifests** (`clm/release/frozen_manifest.py`)
- A named stream now writes `.clm-released.<stream>.json`; the single unnamed block keeps the legacy `.clm-released.json`. Topic ids are shared across streams, so a single file made stream A's release freeze the topic for stream B — the core blocker.
- `load_frozen_manifest()` adopts a legacy `.clm-released.json` whose `channel` field matches and migrates it (rename + delete) on the channel's next non-dry-run sync; a legacy file recording a *different* channel is left alone (it belongs to the stream that hasn't migrated yet) with a note.

**2. Presence-as-frozen skeleton policy** (`clm/release/sync.py`)
- A needed skeleton copy is now restricted to the files *missing* at the destination (`scan_skeleton` → `SyncPlan.skeleton_to_copy`), so a stream joining a shared repo never overwrites the skeleton another stream froze from a different build.
- The evergreen pass was unified under `SyncPlan.evergreen_refresh`: a *present-but-stale* evergreen file refreshes even on a first sync, while a plain first sync still delivers evergreen files via the skeleton copy alone (no behavior change for single-stream channels).

**3. Cross-stream overlap preflight** (`clm release sync`)
- When another stream releases into the same destination, the source manifests are cross-checked (after language re-rooting): any topic-owned path claimed by both streams aborts the sync before anything is copied. Skeleton overlap is fine. An unbuilt sharer is skipped with a note.

**4. Spec validation** (`course_spec.py`)
- Shared destination paths are now an error only *within* a stream; across streams they are allowed but must agree on `lang` (the layout is re-rooted per language). Path comparison is normalized (`./x` == `x`).

**5. `clm git` / `clm release provision` shared-repo awareness**
- `--all-channels` visits a shared destination once (displayed as `materials/… (+ solutions/…)`); the first stream's remote-URL derivation wins, with a note when derivations differ.
- `provision` routes every share through the first channel's repo entry and applies each `(project, group)` share once, reporting collapsed conflicting access levels.

**6. Docs**
- `clm info releases`: new "Shared destination" section (rules, evergreen ping-pong caveat, `clm git reset` repo-wide caveat, what you give up vs separate repos, migration of a running cohort).
- `clm info spec-files`, `clm info commands`, `clm info migration`, `docs/user-guide/solution-release.md`, `spec-file-reference.md`, `architecture.md` updated accordingly.
- Changelog fragment `changelog.d/325-shared-release-destination.added.md`.

## Migration

Automatic. On a channel's next sync an existing legacy `.clm-released.json` with a matching `channel` field is adopted and renamed; freeze state is preserved. To merge an existing materials + solutions repo pair, point the solutions channels' `path` at the materials working trees — zero student-side action.

## Tests

23 new tests in `tests/release/test_shared_destination.py` (per-stream filenames + legacy adoption, presence-as-frozen, evergreen-on-first-sync, overlap preflight, the keystone two-streams-one-repo CLI scenario, legacy migration incl. dry-run, `clm git` dedupe), plus new spec-validation cases, a `_select_repos` dedupe test, and a provision dedupe test. Full fast suite + `mypy` + `ruff` green.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
