### PR TITLE
feat(cli): clm cache explain — per-deck cache-key components and layer state (#328)

### DIFF
--- a/changelog.d/328-cache-explain.added.md
+++ b/changelog.d/328-cache-explain.added.md
@@ -1,0 +1,7 @@
+- New `clm cache explain SOURCE_FILE --spec SPEC` (#328): read-only, per-deck
+  view of the execution-cache key components (hashed topic siblings, template
+  fingerprint, worker image identity, execution flags), the resulting hashes,
+  and the hit/miss state of every cache layer with stored-at timestamps,
+  ending in a per-artifact "replays / skips / will execute" verdict — the
+  one-screen answer to "why did this deck replay stale output?" that the
+  #321 diagnosis lacked.

--- a/src/clm/cli/commands/cache.py
+++ b/src/clm/cli/commands/cache.py
@@ -1,0 +1,433 @@
+"""Read-only build-cache inspection commands (issue #328).
+
+``clm cache explain`` shows, for one slide source file, the exact cache-key
+components a build would compute, the resulting hashes, and the hit/miss
+state of every cache layer — so "would this build execute or replay, and
+why" is answerable in seconds. Issue #321 took an hour to diagnose because
+replayed output is freshly timestamped and nothing showed what the cache
+key did (and did not) cover.
+
+Everything here is read-only: cache databases are opened in SQLite ``ro``
+mode and no output directories are created.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from base64 import b64decode
+from pathlib import Path
+from typing import Any
+
+import click
+
+
+@click.group("cache")
+def cache_group():
+    """Inspect CLM's build caches."""
+
+
+def _open_readonly(db_path: Path) -> sqlite3.Connection | None:
+    """Open a SQLite database strictly read-only; None when absent."""
+    if not db_path.exists():
+        return None
+    return sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True)
+
+
+def _query_one(conn: sqlite3.Connection | None, sql: str, params: tuple) -> tuple | None:
+    if conn is None:
+        return None
+    try:
+        row: tuple | None = conn.execute(sql, params).fetchone()
+    except sqlite3.OperationalError:
+        # Tables are created lazily by their writers; a database file
+        # without this table is simply an empty cache layer.
+        return None
+    return row
+
+
+def _sibling_entries(payload) -> tuple[list[dict[str, Any]], str | None]:
+    """Describe ``other_files`` for display: (entries, excluded cassette name).
+
+    Sizes/digests are of the DECODED content so they match the files on
+    disk (``other_files`` values are base64-encoded in the payload).
+    """
+    cassette_key = payload.http_replay_cassette_name
+    entries = []
+    for name in sorted(payload.other_files):
+        raw = payload.other_files[name]
+        try:
+            content = b64decode(raw, validate=True)
+        except Exception:
+            content = raw
+        entries.append(
+            {
+                "name": name,
+                "size": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "excluded": cassette_key is not None and name == cassette_key,
+            }
+        )
+    excluded = cassette_key if any(e["excluded"] for e in entries) else None
+    return entries, excluded
+
+
+def _collect_artifact(payload, op, cache_db: Path, jobs_db: Path) -> dict[str, Any]:
+    """Compute hashes and per-layer cache state for one payload."""
+    content_hash = payload.content_hash()
+    execution_hash = payload.execution_cache_hash()
+    output_metadata = payload.output_metadata()
+
+    cache_conn = _open_readonly(cache_db)
+    jobs_conn = _open_readonly(jobs_db)
+    try:
+        processed = _query_one(
+            cache_conn,
+            """
+            SELECT created_at, correlation_id FROM processed_files
+            WHERE file_path = ? AND content_hash = ? AND output_metadata = ?
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (payload.input_file, content_hash, output_metadata),
+        )
+        executed = _query_one(
+            cache_conn,
+            """
+            SELECT created_at FROM executed_notebooks
+            WHERE input_file = ? AND content_hash = ? AND language = ? AND prog_lang = ?
+            """,
+            (payload.input_file, execution_hash, payload.language, payload.prog_lang),
+        )
+        issues = _query_one(
+            cache_conn,
+            """
+            SELECT
+                SUM(CASE WHEN issue_type = 'error' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN issue_type = 'warning' THEN 1 ELSE 0 END)
+            FROM processing_issues
+            WHERE file_path = ? AND content_hash = ? AND output_metadata = ?
+            """,
+            (payload.input_file, content_hash, output_metadata),
+        )
+        results = _query_one(
+            jobs_conn,
+            """
+            SELECT created_at, last_accessed, access_count FROM results_cache
+            WHERE output_file = ? AND content_hash = ?
+            """,
+            (payload.output_file, content_hash),
+        )
+    finally:
+        if cache_conn is not None:
+            cache_conn.close()
+        if jobs_conn is not None:
+            jobs_conn.close()
+
+    output_exists = Path(payload.output_file).exists()
+    artifact: dict[str, Any] = {
+        "kind": payload.kind,
+        "format": payload.format,
+        "language": payload.language,
+        "output_metadata": output_metadata,
+        "output_file": payload.output_file,
+        "output_exists": output_exists,
+        "content_hash": content_hash,
+        "execution_cache_hash": execution_hash,
+        "caches": {
+            "processed_files": (
+                {"stored_at": processed[0], "correlation_id": processed[1]} if processed else None
+            ),
+            "executed_notebooks": {"stored_at": executed[0]} if executed else None,
+            "results_cache": (
+                {
+                    "stored_at": results[0],
+                    "last_accessed": results[1],
+                    "access_count": results[2],
+                }
+                if results
+                else None
+            ),
+        },
+        "stored_issues": {
+            "errors": (issues[0] or 0) if issues else 0,
+            "warnings": (issues[1] or 0) if issues else 0,
+        },
+    }
+    artifact["verdict"] = _verdict(artifact)
+    return artifact
+
+
+def _verdict(artifact: dict[str, Any]) -> str:
+    """Mirror SqliteBackend.execute_operation's cache-consultation order."""
+    caches = artifact["caches"]
+    if caches["processed_files"] is not None:
+        # Stage-4 producer gate (_can_replay_from_cache): a Recording HTML
+        # processed_files hit only replays when the execution cache is warm,
+        # otherwise the worker runs to repopulate it for the consumers.
+        if (
+            artifact["kind"] in ("recording", "speaker")
+            and artifact["format"] == "html"
+            and caches["executed_notebooks"] is None
+        ):
+            return (
+                "will execute (processed_files hit, but the execution cache is "
+                "cold and this kind is its producer)"
+            )
+        return f"replays stored result from {caches['processed_files']['stored_at']}"
+    if caches["results_cache"] is not None:
+        if artifact["output_exists"]:
+            return (
+                f"skips execution (results_cache hit from "
+                f"{caches['results_cache']['stored_at']}, output already on disk)"
+            )
+        return "will execute (results_cache hit but output file is missing)"
+    if caches["executed_notebooks"] is not None and artifact["format"] == "html":
+        return "will run worker, reusing the cached execution (no kernel start)"
+    return "will execute"
+
+
+def _unwrap_operations(op) -> list:
+    """Flatten the Operation tree get_processing_operation returns."""
+    from clm.core.operations.process_notebook import ProcessNotebookOperation
+    from clm.infrastructure.operation import Concurrently
+
+    if isinstance(op, ProcessNotebookOperation):
+        return [op]
+    if isinstance(op, Concurrently):
+        result = []
+        for child in op.operations:
+            result.extend(_unwrap_operations(child))
+        return result
+    return []
+
+
+@cache_group.command("explain")
+@click.argument("source_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--spec",
+    "spec_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Course spec XML that builds this file.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Course data directory. Default: inferred from the spec location.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    help=(
+        "Output root the build uses. Must match the build's to resolve the "
+        "same output paths (the job-level cache keys on them). Default: the "
+        "same fallback as clm build (<course root>/output, or the spec's "
+        "output targets)."
+    ),
+)
+@click.option(
+    "--lang",
+    "-L",
+    "languages",
+    multiple=True,
+    help="Limit to output language(s), e.g. -L de.",
+)
+@click.option("--kind", "kinds", multiple=True, help="Limit to output kind(s).")
+@click.option("--format", "formats", multiple=True, help="Limit to output format(s).")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def explain_cmd(
+    ctx,
+    source_file: Path,
+    spec_file: Path,
+    data_dir: Path | None,
+    output_dir: Path | None,
+    languages: tuple[str, ...],
+    kinds: tuple[str, ...],
+    formats: tuple[str, ...],
+    as_json: bool,
+):
+    """Explain the cache keys and cache state for one slide source file.
+
+    Shows the exact key components a build would compute for SOURCE_FILE
+    (dependency set, template fingerprint, worker image identity, execution
+    flags), the resulting hashes, and whether each cache layer would hit —
+    i.e. whether the next build executes this deck or replays stored output,
+    and why.
+
+    Read-only: opens the cache databases in read-only mode and creates no
+    output directories. Use the same --cache-db-path/--jobs-db-path (and
+    --output-dir) as your builds, or the lookups will miss spuriously.
+
+    \b
+    Examples:
+        clm cache explain slides/.../slides_shared_ptr.cpp --spec cpp-einsteiger.xml
+        clm cache explain slides_intro.py --spec course.xml -L de --format html
+        clm cache explain slides_intro.py --spec course.xml --json
+    """
+    import asyncio
+
+    from clm.core.course import Course
+    from clm.core.course_files.notebook_file import NotebookFile
+    from clm.core.course_paths import resolve_course_paths
+    from clm.core.course_spec import CourseSpec, CourseSpecError
+    from clm.infrastructure.messaging.notebook_classes import (
+        CACHE_HASH_SCHEMA_VERSION,
+    )
+
+    cache_db: Path = ctx.obj["CACHE_DB_PATH"]
+    jobs_db: Path = ctx.obj["JOBS_DB_PATH"]
+
+    course_root, default_output = resolve_course_paths(spec_file.absolute(), data_dir)
+    try:
+        spec = CourseSpec.from_file(spec_file.absolute())
+    except CourseSpecError as e:
+        raise click.ClickException(f"Failed to parse course spec: {e}") from None
+
+    # Same fallback as `clm build`, but WITHOUT mkdir — this command is
+    # read-only and must work against a never-built tree.
+    effective_output = output_dir
+    if effective_output is None and not spec.output_targets:
+        effective_output = default_output
+
+    course = Course.from_spec(
+        spec,
+        course_root,
+        effective_output,
+        output_languages=list(languages) or None,
+        output_kinds=list(kinds) or None,
+    )
+
+    course_file = course.find_course_file(source_file.absolute())
+    if course_file is None:
+        raise click.ClickException(
+            f"'{source_file}' is not part of the course described by "
+            f"'{spec_file}'. Is the topic enabled in the spec?"
+        )
+    if not isinstance(course_file, NotebookFile):
+        raise click.ClickException(
+            f"'{source_file}' is a {type(course_file).__name__}, not a notebook "
+            f"slide file — only notebook execution is cached with explained keys."
+        )
+
+    async def _payloads():
+        operations = []
+        for target in course.output_targets:
+            op = await course_file.get_processing_operation(target.output_root, target=target)
+            operations.extend(_unwrap_operations(op))
+        if formats:
+            operations = [op for op in operations if op.format in formats]
+        # Across targets the same (kind, format, language) can repeat with
+        # different output roots; keep all (the results_cache key differs).
+        return [(op, await op.payload()) for op in operations]
+
+    pairs = asyncio.run(_payloads())
+    if not pairs:
+        raise click.ClickException(
+            "No output artifacts match the given language/kind/format filters."
+        )
+
+    # Components are payload-wide (same source text, siblings, fingerprints
+    # for every artifact); take them from the first payload.
+    first = pairs[0][1]
+    siblings, excluded_cassette = _sibling_entries(first)
+    components: dict[str, Any] = {
+        "schema_version": CACHE_HASH_SCHEMA_VERSION,
+        "data_chars": len(first.data),
+        "data_sha256": hashlib.sha256(first.data.encode("utf-8")).hexdigest(),
+        "prog_lang": first.prog_lang,
+        "template_fingerprint": first.template_fingerprint,
+        "worker_image_identity": first.worker_image_identity,
+        "skip_evaluation": first.skip_evaluation,
+        "skip_errors": first.skip_errors,
+        "other_files": siblings,
+        "excluded_cassette": excluded_cassette,
+    }
+
+    artifacts = [_collect_artifact(payload, op, cache_db, jobs_db) for op, payload in pairs]
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "source_file": str(source_file.absolute()),
+                    "spec": str(spec_file.absolute()),
+                    "cache_db": str(cache_db),
+                    "cache_db_exists": cache_db.exists(),
+                    "jobs_db": str(jobs_db),
+                    "jobs_db_exists": jobs_db.exists(),
+                    "components": components,
+                    "artifacts": artifacts,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    _print_human(source_file, cache_db, jobs_db, components, artifacts)
+
+
+def _print_human(
+    source_file: Path,
+    cache_db: Path,
+    jobs_db: Path,
+    components: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+) -> None:
+    def short(digest: str) -> str:
+        return digest[:12] + "…" if digest else "(empty)"
+
+    click.echo(f"Cache explanation for {source_file}")
+    click.echo("")
+    click.echo(f"Key components (schema v{components['schema_version']})")
+    click.echo(
+        f"  data                  {components['data_chars']:,} chars, "
+        f"sha256 {short(components['data_sha256'])}"
+    )
+    click.echo(f"  prog_lang             {components['prog_lang']}")
+    click.echo(f"  template fingerprint  {short(components['template_fingerprint'])}")
+    click.echo(f"  worker image          {components['worker_image_identity'] or '(unset)'}")
+    click.echo(
+        f"  skip_evaluation       {components['skip_evaluation']}    "
+        f"skip_errors  {components['skip_errors']}"
+    )
+    hashed = [e for e in components["other_files"] if not e["excluded"]]
+    click.echo(f"  other_files ({len(hashed)} hashed)")
+    for entry in components["other_files"]:
+        marker = "  excluded (cassette — documented exclusion)" if entry["excluded"] else ""
+        click.echo(
+            f"    {entry['name']}  {entry['size']:,} B  sha256 {short(entry['sha256'])}{marker}"
+        )
+    if not components["other_files"]:
+        click.echo("    (none)")
+    click.echo("")
+
+    for db_label, db_path in (("cache db", cache_db), ("jobs db", jobs_db)):
+        if not db_path.exists():
+            click.echo(
+                f"NOTE: {db_label} not found at {db_path} — every lookup below "
+                f"misses. Pass the same --{db_label.replace(' ', '-')}-path as your builds."
+            )
+    click.echo("Artifacts")
+    for artifact in artifacts:
+        caches = artifact["caches"]
+
+        def state(entry, _artifact=artifact):
+            return f"HIT   stored {entry['stored_at']}" if entry else "MISS"
+
+        click.echo(f"  {artifact['output_metadata']}")
+        click.echo(f"    output file         {artifact['output_file']}")
+        click.echo(f"    content_hash        {short(artifact['content_hash'])}")
+        click.echo(f"    execution_hash      {short(artifact['execution_cache_hash'])}")
+        click.echo(f"    processed_files     {state(caches['processed_files'])}")
+        click.echo(f"    executed_notebooks  {state(caches['executed_notebooks'])}")
+        click.echo(f"    results_cache       {state(caches['results_cache'])}")
+        issues = artifact["stored_issues"]
+        if issues["errors"] or issues["warnings"]:
+            click.echo(
+                f"    stored issues       {issues['errors']} error(s), "
+                f"{issues['warnings']} warning(s) — replayed on a cache hit"
+            )
+        click.echo(f"    verdict             {artifact['verdict']}")
+        click.echo("")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2547,6 +2547,46 @@ Manage CLM configuration files.
 | `config locate` | Show configuration file locations |
 | `config show` | Show current configuration values |
 
+### `clm cache` (CLM {version}+)
+
+Read-only build-cache inspection.
+
+#### `clm cache explain SOURCE_FILE --spec SPEC`
+
+Shows, for one slide source file, the exact cache-key components a build
+would compute (the deck text digest, every hashed topic sibling, the
+bundled-template fingerprint, the worker image identity, and the
+`evaluate=`/`skip-errors=` flags), the resulting `content_hash` /
+`execution_cache_hash` per output artifact, and the hit/miss state of every
+cache layer (`processed_files`, `executed_notebooks`, `results_cache`) with
+stored-at timestamps — ending in a per-artifact verdict: replays stored
+output, skips execution, or will execute (including the Recording-HTML
+producer-gate case where a stored result is bypassed to repopulate a cold
+execution cache).
+
+Use it to answer "why did this deck replay stale output?" / "why is
+everything re-executing?" in one screen. The HTTP-replay cassette entry is
+shown but marked excluded (its bytes are deliberately not part of the key).
+
+| Option | Description |
+|--------|-------------|
+| `--spec PATH` | Course spec XML that builds this file (required) |
+| `--data-dir PATH` | Course data directory (default: inferred from the spec) |
+| `--output-dir PATH` | Output root the build uses — must match the build's for `results_cache` lookups (default: same fallback as `clm build`) |
+| `-L, --lang LANG` | Limit to output language(s) |
+| `--kind KIND` | Limit to output kind(s) |
+| `--format FORMAT` | Limit to output format(s) |
+| `--json` | Output as JSON |
+
+Run it with the same global `--cache-db-path` / `--jobs-db-path` as your
+builds, or the lookups miss spuriously. Entirely read-only: databases are
+opened in read-only mode and no output directories are created.
+
+```bash
+clm cache explain slides/.../slides_shared_ptr.cpp --spec cpp-einsteiger.xml
+clm cache explain slides_intro.py --spec course.xml -L de --format html --json
+```
+
 ### `clm db`
 
 Database management commands.

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -66,6 +66,7 @@ _COMMANDS = "clm.cli.commands"
         # -------------------------------------------------------------
         # Infrastructure groups.
         # -------------------------------------------------------------
+        "cache": f"{_COMMANDS}.cache:cache_group",
         "cassette": f"{_COMMANDS}.cassette:cassette_group",
         "config": f"{_COMMANDS}.config:config",
         "db": f"{_COMMANDS}.db:db",

--- a/tests/cli/test_cache_explain.py
+++ b/tests/cli/test_cache_explain.py
@@ -1,0 +1,225 @@
+"""Tests for ``clm cache explain`` (issue #328).
+
+Read-only inspection: for one slide source file, show the cache-key
+components a build would compute, the resulting hashes, and the hit/miss
+state of every cache layer. The tests run against the committed
+single-notebook test course and seed real cache rows keyed by the hashes
+the command itself reports — pinning that explain's keys are the same keys
+the build machinery stores under.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+DATA_DIR = Path(__file__).parent.parent / "test-data"
+SPEC = DATA_DIR / "course-specs" / "test-spec-3.xml"
+SLIDE = (
+    DATA_DIR
+    / "slides"
+    / "module_030_single_notebook"
+    / "topic_100_simple_notebook"
+    / "slides_simple_notebook.py"
+)
+
+
+def _explain(tmp_path: Path, *extra_args: str):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        [
+            "--cache-db-path",
+            str(tmp_path / "cache.db"),
+            "--jobs-db-path",
+            str(tmp_path / "jobs.db"),
+            "cache",
+            "explain",
+            str(SLIDE),
+            "--spec",
+            str(SPEC),
+            "-L",
+            "en",
+            "--format",
+            "html",
+            *extra_args,
+        ],
+        catch_exceptions=False,
+    )
+
+
+def _explain_json(tmp_path: Path) -> dict:
+    result = _explain(tmp_path, "--json")
+    assert result.exit_code == 0, result.output
+    # Locate the JSON object in the output (logging lines may precede it).
+    return json.loads(result.output[result.output.index("{") :])
+
+
+def _artifact(data: dict, output_metadata: str) -> dict:
+    matches = [a for a in data["artifacts"] if a["output_metadata"] == output_metadata]
+    assert matches, (
+        f"no artifact {output_metadata} in {[a['output_metadata'] for a in data['artifacts']]}"
+    )
+    return matches[0]
+
+
+class TestCacheExplainCold:
+    def test_cold_caches_report_miss_and_execute(self, tmp_path):
+        data = _explain_json(tmp_path)
+
+        assert data["components"]["schema_version"] >= 2
+        assert data["components"]["template_fingerprint"]
+        assert data["components"]["worker_image_identity"].startswith(("direct", "docker:"))
+        assert data["cache_db_exists"] is False
+        assert data["artifacts"]
+
+        for artifact in data["artifacts"]:
+            assert artifact["caches"]["processed_files"] is None
+            assert artifact["caches"]["executed_notebooks"] is None
+            assert artifact["caches"]["results_cache"] is None
+            assert artifact["verdict"] == "will execute"
+
+    def test_execution_hash_is_kind_agnostic_content_hash_is_not(self, tmp_path):
+        """Speaker/Completed share the executed notebook, so their
+        execution key must agree while their content keys differ."""
+        data = _explain_json(tmp_path)
+        artifacts = data["artifacts"]
+        assert len({a["execution_cache_hash"] for a in artifacts}) == 1
+        assert len({a["content_hash"] for a in artifacts}) == len(artifacts)
+
+    def test_human_output_shows_components_and_verdicts(self, tmp_path):
+        result = _explain(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert "Key components" in result.output
+        assert "template fingerprint" in result.output
+        assert "worker image" in result.output
+        assert "verdict" in result.output
+        assert "will execute" in result.output
+
+    def test_file_not_in_course_fails_helpfully(self, tmp_path):
+        bogus = tmp_path / "not_in_course.py"
+        bogus.write_text("# not part of any course\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["cache", "explain", str(bogus), "--spec", str(SPEC)],
+        )
+        assert result.exit_code != 0
+        assert "not part of the course" in result.output
+
+
+class TestCacheExplainSeeded:
+    """Seed real cache rows under the hashes explain reports, re-run, and
+    assert the hit/verdict transitions — pinning key agreement between
+    explain and the storing machinery."""
+
+    def test_processed_files_hit_reports_replay(self, tmp_path):
+        from clm.infrastructure.database.db_operations import DatabaseManager
+        from clm.infrastructure.messaging.notebook_classes import NotebookResult
+
+        cold = _explain_json(tmp_path)
+        artifact = _artifact(cold, "completed:python:en:html")
+
+        with DatabaseManager(tmp_path / "cache.db") as dm:
+            dm.store_result(
+                file_path=cold["source_file"],
+                content_hash=artifact["content_hash"],
+                correlation_id="cid-test",
+                result=NotebookResult(
+                    correlation_id="cid-test",
+                    output_file=artifact["output_file"],
+                    input_file=cold["source_file"],
+                    content_hash=artifact["content_hash"],
+                    result="<html>cached</html>",
+                    output_metadata_tags=("completed", "python", "en", "html"),
+                ),
+            )
+
+        warm = _explain_json(tmp_path)
+        hit = _artifact(warm, "completed:python:en:html")
+        assert hit["caches"]["processed_files"] is not None
+        assert hit["verdict"].startswith("replays stored result")
+        # Other artifacts stay cold.
+        other = _artifact(warm, "code-along:python:en:html")
+        assert other["verdict"] == "will execute"
+
+    def test_recording_hit_with_cold_execution_cache_reports_producer_gate(self, tmp_path):
+        """Mirrors SqliteBackend._can_replay_from_cache: a Recording HTML
+        processed_files hit does NOT replay while executed_notebooks is
+        cold — the worker runs to repopulate the Stage-4 producer cache."""
+        from clm.infrastructure.database.db_operations import DatabaseManager
+        from clm.infrastructure.messaging.notebook_classes import NotebookResult
+
+        cold = _explain_json(tmp_path)
+        artifact = _artifact(cold, "recording:python:en:html")
+
+        with DatabaseManager(tmp_path / "cache.db") as dm:
+            dm.store_result(
+                file_path=cold["source_file"],
+                content_hash=artifact["content_hash"],
+                correlation_id="cid-test",
+                result=NotebookResult(
+                    correlation_id="cid-test",
+                    output_file=artifact["output_file"],
+                    input_file=cold["source_file"],
+                    content_hash=artifact["content_hash"],
+                    result="<html>cached</html>",
+                    output_metadata_tags=("recording", "python", "en", "html"),
+                ),
+            )
+
+        warm = _explain_json(tmp_path)
+        hit = _artifact(warm, "recording:python:en:html")
+        assert hit["caches"]["processed_files"] is not None
+        assert "execution cache is cold" in hit["verdict"]
+
+    def test_executed_notebooks_hit_reports_reuse(self, tmp_path):
+        from clm.infrastructure.database.executed_notebook_cache import (
+            ExecutedNotebookCache,
+        )
+
+        cold = _explain_json(tmp_path)
+        artifact = _artifact(cold, "completed:python:en:html")
+
+        with ExecutedNotebookCache(tmp_path / "cache.db") as nb_cache:
+            nb_cache.store(
+                input_file=cold["source_file"],
+                content_hash=artifact["execution_cache_hash"],
+                language="en",
+                prog_lang="python",
+                executed_notebook={"cells": []},  # opaque blob, content irrelevant
+            )
+
+        warm = _explain_json(tmp_path)
+        hit = _artifact(warm, "completed:python:en:html")
+        assert hit["caches"]["executed_notebooks"] is not None
+        assert "reusing the cached execution" in hit["verdict"]
+
+    def test_results_cache_hit_with_missing_output_reports_execute(self, tmp_path):
+        from clm.infrastructure.database.job_queue import JobQueue
+        from clm.infrastructure.database.schema import init_database
+
+        cold = _explain_json(tmp_path)
+        artifact = _artifact(cold, "completed:python:en:html")
+
+        init_database(tmp_path / "jobs.db")
+        jq = JobQueue(tmp_path / "jobs.db")
+        try:
+            jq.add_to_cache(artifact["output_file"], artifact["content_hash"], {"format": "html"})
+        finally:
+            jq.close()
+
+        warm = _explain_json(tmp_path)
+        hit = _artifact(warm, "completed:python:en:html")
+        assert hit["caches"]["results_cache"] is not None
+        # The committed test-data tree is normally unbuilt, but tolerate a
+        # leftover output tree from a local build: the verdict flips between
+        # the two results_cache outcomes on output existence.
+        if hit["output_exists"]:
+            assert "skips execution" in hit["verdict"]
+        else:
+            assert "output file is missing" in hit["verdict"]


### PR DESCRIPTION
## Summary

Implements #328 (the last tooling item from #321): a read-only `clm cache explain SOURCE_FILE --spec SPEC` that answers "would the next build execute this deck or replay stored output, and why" in one screen — the question the #321 staleness diagnosis spent an hour on.

### What it shows

- **Key components** (computed through the same `Course` → `get_processing_operation` → `payload()` machinery a build uses, so keys agree with the build by construction): deck-text digest, every hashed `other_files` sibling with size + sha256 (the cassette entry is listed but marked *excluded — documented exclusion*), template fingerprint, worker image identity, `evaluate=`/`skip-errors=` flags, `CACHE_HASH_SCHEMA_VERSION`.
- **Per artifact** (`kind:prog_lang:lang:format`): `content_hash`, `execution_cache_hash`, hit/miss with stored-at timestamps for all three layers (`processed_files`, `executed_notebooks`, `results_cache`), stored issues a hit would replay, and a **verdict** that mirrors `SqliteBackend.execute_operation`'s consultation order — including the Recording-HTML producer gate (`_can_replay_from_cache`: a `processed_files` hit with a cold execution cache re-executes) and the `results_cache`-hit-but-output-missing case.
- `--json` for scripting; `-L`/`--kind`/`--format` filters; `--data-dir`/`--output-dir` mirroring `clm build`'s path resolution so `results_cache` output-path keys match.

### Read-only by construction

Databases open with SQLite `mode=ro` (a missing file or lazily-uncreated table reads as an empty layer), and no output directories are created — works against a never-built tree.

### Example

```
Key components (schema v2)
  data                  272 chars, sha256 9fd8801c20a3…
  template fingerprint  fc075946d4a4…
  worker image          direct
  other_files (3 hashed)
    lifetime_observer.hpp  1,204 B  sha256 77e1aa…
  ...
Artifacts
  completed:python:en:html
    processed_files     HIT   stored 2026-06-11 01:32:04
    executed_notebooks  MISS
    results_cache       MISS
    verdict             replays stored result from 2026-06-11 01:32:04
```

## Tests

8 tests against the committed single-notebook test course. The seeded-hit tests store real rows via `DatabaseManager` / `ExecutedNotebookCache` / `JobQueue` **under the hashes the command itself reports**, then assert the hit/verdict transitions — pinning end-to-end key agreement between `explain` and the storing machinery (cold misses, `processed_files` replay, the Recording producer-gate verdict, executed-notebook reuse, results_cache with missing output, file-not-in-course error).

Full fast suite: **7767 passed, 3 skipped, 1 xfailed**. ruff + mypy clean. Documented in `clm info commands` (new `clm cache` section); changelog fragment included.

Explicit non-goal (per #328): miss *attribution* ("miss because header X changed") — that needs component persistence at store time; deferred until the need materializes.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
