### PR TITLE
fix(core): exclude underscore-prefixed dirs from module/topic discovery (#318)

### DIFF
--- a/changelog.d/318-underscore-dirs-shadow-topics.fixed.md
+++ b/changelog.d/318-underscore-dirs-shadow-topics.fixed.md
@@ -1,0 +1,8 @@
+- Underscore-prefixed directories under `slides/` (e.g. `_archive/`, `_drafts/`)
+  are now invisible to module/topic discovery, to the recursive deck walks behind
+  the `clm slides` batch tools and `clm slides sync`, and to `clm course orphans`
+  — previously an archived module under `slides/_archive/` participated in topic
+  resolution and could silently shadow a live topic ID via first-occurrence-wins,
+  shipping retired decks in its place. A spec binding `module="_archive"` now
+  fails validation with `unknown_module`. The legacy `_cassettes/` sidecar inside
+  a topic is unaffected (#318).

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -812,7 +812,9 @@ clm course orphans [OPTIONS] SPECS_DIR
 `SPECS_DIR` is the directory of course spec `*.xml` files. Orphans are computed
 against the **union** of every spec (a deck unreferenced by one spec may be
 pulled in by another). The on-disk walk is extension-complete (`.py` / `.cpp` /
-`.cs` / …), so a non-Python orphan is not silently missed.
+`.cs` / …), so a non-Python orphan is not silently missed. Decks parked under
+underscore-prefixed dirs (`slides/_archive/`, …) are excluded — they are
+deliberately retired (invisible to discovery, issue #318), not forgotten.
 
 | Option | Description |
 |--------|-------------|
@@ -1212,7 +1214,7 @@ clm slides normalize [OPTIONS] PATH
 | `--json` | Output as JSON |
 | `--data-dir DIR` | Course data directory (contains slides/) |
 | `--only bilingual\|split` | (since CLM {version}) Scope a **directory** run to only bilingual decks (no `.de`/`.en` tag) or only split halves — e.g. normalize the bilingual decks while leaving `.de`/`.en` pairs for `clm slides sync`. |
-| `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude _archive` skips an `_archive/` directory). Repeatable. |
+| `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude old_decks` skips an `old_decks/` directory). Repeatable. Underscore-prefixed dirs (`_archive/`, `_drafts/`, …) are skipped automatically (issue #318) and need no `--exclude`. |
 | `--shipping-only` | (since CLM {version}) Scope a directory run to decks reachable from course specs (the shipping set), skipping archived / unreferenced decks. |
 | `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
 
@@ -1236,8 +1238,8 @@ clm slides normalize slides/module_010/ --operations preamble_code
 clm slides normalize slides/module_010/ --operations placeholder_start
 # Pre-conversion: canonicalize start/completed order so the split round-trips exactly
 clm slides normalize slides/module_010/topic_100_intro/ --operations interleaving --canonicalize-start-completed
-# Scope: mint ids on bilingual decks only, skipping an _archive/ dir
-clm slides normalize slides/ --operations slide_ids --only bilingual --exclude _archive
+# Scope: mint ids on bilingual decks only
+clm slides normalize slides/ --operations slide_ids --only bilingual
 # Scope: only the decks that actually ship
 clm slides normalize slides/ --shipping-only
 ```
@@ -1350,7 +1352,7 @@ clm slides assign-ids [OPTIONS] PATH
 | `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B model can exceed 60s). |
 | `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
 | `--only bilingual\|split` | (since CLM {version}) Scope a **directory** run to only bilingual decks (no `.de`/`.en` tag) or only split halves — e.g. `--only bilingual` mints bilingual decks while leaving `.de`/`.en` pairs for `clm slides sync`. |
-| `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude _archive` skips an `_archive/` dir). Repeatable. |
+| `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude old_decks` skips an `old_decks/` dir). Repeatable. Underscore-prefixed dirs (`_archive/`, …) are skipped automatically (issue #318). |
 | `--shipping-only` | (since CLM {version}) Scope a directory run to decks reachable from course specs (the shipping set). |
 | `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
 | `--data-dir DIR` | Course data directory (contains `slides/`); used to resolve the `--shipping-only` scope. |
@@ -1388,7 +1390,7 @@ clm slides assign-ids slides/module_110_basics/ --accept-content-derived --accep
 clm slides assign-ids slides/module_010/topic_100/slides_intro.py --llm-suggest
 clm slides assign-ids slides/module_010/ --force        # regenerate all derivable ids
 # Scope: mint only the bilingual decks, leaving split pairs for `clm slides sync`
-clm slides assign-ids slides/ --accept-content-derived --only bilingual --exclude _archive
+clm slides assign-ids slides/ --accept-content-derived --only bilingual
 # Scope: only the decks that actually ship
 clm slides assign-ids slides/ --accept-content-derived --shipping-only
 # Worklist of cells that still need a hand-authored id, with body + context
@@ -1417,7 +1419,7 @@ the decks it pulls in, via the same build-faithful logic as `clm course decks`).
 |--------|-------------|
 | `--min-severity low\|medium\|high` | Only show findings at or above this confidence (default `low` = all). `high` = very-short / generic only. |
 | `--only bilingual\|split` | Scope a **directory** scan to only bilingual decks (no `.de`/`.en` tag) or only split halves. |
-| `--exclude GLOB` | Skip decks matching `GLOB` (matched against the full path **and** each path component, so `--exclude _archive` skips an `_archive/` dir). Repeatable. |
+| `--exclude GLOB` | Skip decks matching `GLOB` (matched against the full path **and** each path component, so `--exclude old_decks` skips an `old_decks/` dir). Repeatable. Underscore-prefixed dirs (`_archive/`, …) are skipped automatically (issue #318). |
 | `--shipping-only` | Scope a directory scan to decks reachable from course specs (the shipping set). |
 | `--specs-dir DIR` | For `--shipping-only`: directory of `*.xml` specs. Default: `<course-root>/course-specs/`. |
 | `--data-dir DIR` | Course data directory (contains `slides/`); used for a spec `PATH` or `--shipping-only`. |
@@ -1443,7 +1445,7 @@ Examples:
 clm slides slug-report slides/module_010/                       # everything flagged
 clm slides slug-report slides/ --min-severity high              # just the high-confidence ids
 clm slides slug-report course-specs/python-course.xml --json    # only the decks that ship
-clm slides slug-report slides/ --exclude _archive --shipping-only
+clm slides slug-report slides/ --shipping-only
 ```
 
 ### `clm slides coverage-report`
@@ -1491,7 +1493,7 @@ The exit code is always `0` — this is a report. Examples:
 clm slides coverage-report slides/module_010/                   # everything not balanced
 clm slides coverage-report slides/ --status de_only             # just the untranslated decks
 clm slides coverage-report course-specs/python-course.xml --json
-clm slides coverage-report slides/ --exclude _archive --shipping-only
+clm slides coverage-report slides/ --shipping-only
 ```
 
 ### `clm slides sync`

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,30 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Underscore-prefixed dirs under `slides/` are no longer discovered (issue #318, after 1.11)
+
+Directories whose name starts with `_` (e.g. `slides/_archive/`,
+`slides/_drafts/`, or an `_old_…` dir inside a module) are now invisible to
+module/topic discovery, to the recursive deck walks behind the `clm slides`
+batch tools, and to `clm course orphans`. Previously an archived module under
+`slides/_archive/` participated in topic resolution and — because unbound
+resolution is first-occurrence-wins and `_archive` sorts before `module_*` —
+could silently *shadow* a live topic ID, shipping retired decks in its place.
+
+Consequences for course repos:
+
+- Parking retired content under `slides/_archive/` is now safe; moving the
+  archive out of `slides/` is no longer necessary.
+- A spec that binds `module="_archive"` (or any underscore-prefixed name) now
+  fails validation with `unknown_module` — archived content cannot be built.
+  Rename the directory (drop the leading underscore) if you genuinely need to
+  build from it.
+- `--exclude _archive` on `clm slides normalize` / `assign-ids` /
+  `slug-report` / `coverage-report` is now redundant for underscore-named
+  dirs (but still works, and is still needed for non-underscore names).
+- The legacy `_cassettes/` sidecar inside a topic is unaffected: it is not a
+  module/topic directory and stays in the course file map.
+
 ## Execution cache keys now cover dependencies (issue #321, after 1.11)
 
 `clm build` previously keyed its notebook execution caches on the deck text

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -94,6 +94,12 @@ Contains one or more `<section>` elements:
 Each `<topic>` references a topic by directory name (without numeric prefix).
 For `slides/module_001/topic_100_introduction/`, the ID is `introduction`.
 
+Underscore-prefixed directories under `slides/` (e.g. `slides/_archive/`,
+`slides/_drafts/`) are **invisible to topic discovery** at both the module
+and the topic level (since CLM {version}): content parked there never
+resolves, never shadows a live topic ID, and cannot be bound via `module=`.
+Use such a directory to retire decks in place without affecting builds.
+
 Optional `<section>` attributes:
 
 | Attribute | Description |

--- a/src/clm/core/spec_orphans.py
+++ b/src/clm/core/spec_orphans.py
@@ -24,7 +24,11 @@ from pathlib import Path
 
 from clm.core.spec_decks import shipping_set
 from clm.core.topic_resolver import TopicMatch, build_topic_map
-from clm.infrastructure.utils.path_utils import is_slides_file, split_lang_suffix
+from clm.infrastructure.utils.path_utils import (
+    is_private_dir_name,
+    is_slides_file,
+    split_lang_suffix,
+)
 
 __all__ = [
     "CHECKPOINT_DIR_NAME",
@@ -143,12 +147,18 @@ def _all_decks(slides_dir: Path) -> set[Path]:
     every supported program-language extension via :func:`is_slides_file`, so a
     ``.cs`` / ``.cpp`` orphan is not silently missed. Files inside a
     ``.ipynb_checkpoints/`` dir are excluded — they are reported as cruft, not
-    as orphan decks.
+    as orphan decks. Decks inside underscore-prefixed dirs (``_archive``, …)
+    are excluded too: discovery ignores them (issue #318), so they are
+    *deliberately* parked, not forgotten — reporting them as orphans would
+    drown the real signal.
     """
     return {
         p.resolve()
         for p in slides_dir.rglob("*")
-        if p.is_file() and is_slides_file(p) and not _is_checkpoint(p)
+        if p.is_file()
+        and is_slides_file(p)
+        and not _is_checkpoint(p)
+        and not any(is_private_dir_name(part) for part in p.relative_to(slides_dir).parts[:-1])
     }
 
 

--- a/src/clm/core/topic_resolver.py
+++ b/src/clm/core/topic_resolver.py
@@ -16,6 +16,7 @@ from typing import Literal
 
 from clm.infrastructure.utils.path_utils import (
     is_ignored_dir_for_course,
+    is_private_dir_name,
     is_slides_file,
     simplify_ordered_name,
     slide_family_key,
@@ -71,6 +72,11 @@ def build_topic_map(slides_dir: Path) -> dict[str, list[TopicMatch]]:
         slides_dir: Path to the ``slides/`` directory (should contain
             ``module_*/`` subdirectories).
 
+    Underscore-prefixed directories (``_archive``, ``_drafts``, …) are
+    invisible to discovery at both the module and the topic level: parked
+    content must never shadow a live topic ID via first-occurrence-wins
+    resolution (issue #318).
+
     Returns:
         Mapping from topic ID to a list of :class:`TopicMatch` objects.
         Most topic IDs will have exactly one match.  Multiple matches
@@ -87,8 +93,12 @@ def build_topic_map(slides_dir: Path) -> dict[str, list[TopicMatch]]:
             continue
         if is_ignored_dir_for_course(module_dir):
             continue
+        if is_private_dir_name(module_dir.name):
+            continue
 
         for topic_path in sorted(module_dir.iterdir()):
+            if is_private_dir_name(topic_path.name):
+                continue
             topic_id = simplify_ordered_name(topic_path.name)
             if not topic_id:
                 continue
@@ -261,6 +271,13 @@ def find_slide_files_recursive(path: Path) -> list[Path]:
     was lifted out of ``normalizer._find_slide_files_recursive``; it
     preserves topic-resolver semantics for topic dirs while still letting
     callers operate on coarser paths.
+
+    Underscore-prefixed directories *below* ``path`` are pruned from the
+    walk, matching :func:`build_topic_map` discovery (issue #318): a deck
+    parked under ``slides/_archive/`` is invisible when walking ``slides/``.
+    The prune is applied to each file's path relative to ``path``, so an
+    explicitly named root (``find_slide_files_recursive(Path("_archive"))``)
+    is still honoured.
     """
     if path.is_file():
         if is_slides_file(path):
@@ -276,7 +293,13 @@ def find_slide_files_recursive(path: Path) -> list[Path]:
 
     # rglob("*") (not "*.py") so the is_slides_file filter — which already accepts
     # every SUPPORTED_PROG_LANG_EXTENSIONS — finds .cs/.cpp/.java/.ts decks too.
-    return sorted(f.resolve() for f in path.rglob("*") if f.is_file() and is_slides_file(f))
+    return sorted(
+        f.resolve()
+        for f in path.rglob("*")
+        if f.is_file()
+        and is_slides_file(f)
+        and not any(is_private_dir_name(part) for part in f.relative_to(path).parts[:-1])
+    )
 
 
 def resolve_topic(

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -280,6 +280,20 @@ def atomic_write_all(writes: list[tuple[Path, str]]) -> None:
                 tmp.unlink()
 
 
+def is_private_dir_name(name: str) -> bool:
+    """True for underscore-prefixed directory names (``_archive``, ``_drafts``, …).
+
+    Underscore-prefixed directories under ``slides/`` hold author-parked
+    content (retired decks, drafts). They are excluded from module/topic
+    *discovery* and from the recursive slide-file walks so an archived copy
+    can never shadow a live topic ID (issue #318). This is a discovery rule,
+    not a course-file-map rule: the legacy ``_cassettes/`` sidecar inside a
+    topic stays in the course file map because the kernel reads it at
+    runtime (see ``SKIP_DIRS_FOR_OUTPUT``).
+    """
+    return name.startswith("_")
+
+
 def is_ignored_dir_for_course(dir_path: Path) -> bool:
     for part in dir_path.parts:
         if part in SKIP_DIRS_FOR_COURSE:

--- a/src/clm/slides/pairing.py
+++ b/src/clm/slides/pairing.py
@@ -19,6 +19,7 @@ from typing import Protocol
 from clm.infrastructure.utils.path_utils import (
     SUPPORTED_PROG_LANG_EXTENSIONS,
     is_ignored_dir_for_course,
+    is_private_dir_name,
     split_lang_suffix,
 )
 from clm.notebooks.slide_parser import CellMetadata
@@ -316,12 +317,14 @@ def find_split_slide_files_recursive(path: Path) -> list[Path]:
     ``(de_path, en_path)`` strings) is stable regardless of how ``path`` was spelled.
 
     Directories the course scan ignores (``.git``, ``.venv``, ``build``, ``dist``,
-    ``__pycache__`` …) are pruned, so a vendored or archived ``.de``/``.en`` copy
-    under one of them is never enumerated — and thus never **written** on a writing
-    batch. The ignored-dir test is applied to each file's path *relative to*
-    ``path``, so an ignored component in ``path``'s own prefix (e.g. a tree that
-    itself lives under ``build/``) cannot falsely exclude everything. The
-    single-file branch is exempt: an explicitly named file is always honoured.
+    ``__pycache__`` …) are pruned, as are underscore-prefixed dirs (``_archive``,
+    ``_drafts``, … — invisible to discovery per issue #318), so a vendored or
+    archived ``.de``/``.en`` copy under one of them is never enumerated — and thus
+    never **written** on a writing batch. Both tests are applied to each file's
+    path *relative to* ``path``, so an ignored component in ``path``'s own prefix
+    (e.g. a tree that itself lives under ``build/``, or an explicitly named
+    ``_archive/`` root) cannot falsely exclude everything. The single-file branch
+    is exempt: an explicitly named file is always honoured.
     """
     if path.is_file():
         return [path.resolve()] if _is_split_slide_file(path) else []
@@ -333,6 +336,7 @@ def find_split_slide_files_recursive(path: Path) -> list[Path]:
         if f.is_file()
         and _is_split_slide_file(f)
         and not is_ignored_dir_for_course(f.parent.relative_to(path))
+        and not any(is_private_dir_name(part) for part in f.parent.relative_to(path).parts)
     )
 
 

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -28,6 +28,7 @@ from clm.core.topic_resolver import (
     find_slide_files,
     matches_for_binding,
 )
+from clm.infrastructure.utils.path_utils import is_private_dir_name
 
 
 @dataclass
@@ -107,9 +108,13 @@ def validate_spec(
 
     # Set of module directory names (the immediate children of slides/).
     # Used to validate ``module=`` attributes on sections and topics.
+    # Underscore-prefixed dirs (``_archive``, …) are excluded: discovery
+    # ignores them (issue #318), so binding to one can never resolve.
     available_modules: set[str] = set()
     if slides_dir.is_dir():
-        available_modules = {p.name for p in slides_dir.iterdir() if p.is_dir()}
+        available_modules = {
+            p.name for p in slides_dir.iterdir() if p.is_dir() and not is_private_dir_name(p.name)
+        }
 
     findings: list[SpecFinding] = []
     topics_total = sum(len(s.topics) for s in spec.sections)

--- a/tests/core/test_spec_orphans.py
+++ b/tests/core/test_spec_orphans.py
@@ -120,6 +120,18 @@ class TestFindOrphans:
         assert all(".ipynb_checkpoints" not in p.parts for p in (o.path for o in report.orphans))
         assert len(report.checkpoints) == 1
 
+    def test_archived_decks_are_not_orphans(self, tmp_path):
+        # Decks under underscore-prefixed dirs are deliberately parked
+        # (discovery ignores them per issue #318), not forgotten — they
+        # must not appear in the orphan report.
+        specs = _course(tmp_path, ["a"], {})
+        parked = tmp_path / "slides" / "_archive" / "module_900_old" / "topic_010_b"
+        parked.mkdir(parents=True)
+        (parked / "slides_b.py").write_text(DECK, encoding="utf-8")
+        report = find_orphans(sorted(specs.glob("*.xml")), tmp_path / "slides")
+        assert report.orphans == []
+        assert report.total_decks == 1
+
     def test_non_py_orphan_detected(self, tmp_path):
         # A .cpp orphan must be found — the report walk is extension-complete.
         specs = _course(tmp_path, ["a"], {})

--- a/tests/core/test_topic_resolver.py
+++ b/tests/core/test_topic_resolver.py
@@ -146,6 +146,39 @@ class TestBuildTopicMap:
         for tid in topic_map:
             assert "__pycache__" not in tid
 
+    def test_underscore_module_dir_does_not_shadow_live_topic(self, slides_dir):
+        """Issue #318: ``slides/_archive`` must be invisible to discovery.
+
+        An archived module dir like ``_archive/module_240_functions``
+        simplifies to topic ID ``functions`` at the topic level, and
+        ``_archive`` sorts before ``module_*`` — so before the fix it won
+        first-occurrence resolution over the live topic.
+        """
+        live = slides_dir / "module_100_basics" / "topic_030_functions"
+        live.mkdir()
+        (live / "slides_functions.py").write_text("# live", encoding="utf-8")
+
+        archived = slides_dir / "_archive" / "module_240_functions" / "topic_010_overloading"
+        archived.mkdir(parents=True)
+        (archived / "slides_overloading.py").write_text("# retired", encoding="utf-8")
+
+        topic_map = build_topic_map(slides_dir)
+        matches = topic_map["functions"]
+        assert len(matches) == 1
+        assert matches[0].module == "module_100_basics"
+        assert "overloading" not in topic_map
+
+    def test_underscore_topic_dir_is_invisible(self, slides_dir):
+        """A parked topic-level dir (``_old_intro``) must not shadow the live ID."""
+        parked = slides_dir / "module_100_basics" / "_old_intro"
+        parked.mkdir()
+        (parked / "slides_intro.py").write_text("# parked", encoding="utf-8")
+
+        topic_map = build_topic_map(slides_dir)
+        matches = topic_map["intro"]
+        assert len(matches) == 1
+        assert matches[0].path.name == "topic_010_intro"
+
 
 class TestFindSlideFiles:
     def test_directory_topic(self, slides_dir):
@@ -325,6 +358,29 @@ class TestFindSlideFilesRecursive:
         from clm.core.topic_resolver import find_slide_files_recursive
 
         assert find_slide_files_recursive(tmp_path / "nope") == []
+
+    def test_prunes_underscore_dirs_below_root(self, slides_dir):
+        from clm.core.topic_resolver import find_slide_files_recursive
+
+        archived = slides_dir / "_archive" / "module_240_functions" / "topic_010_overloading"
+        archived.mkdir(parents=True)
+        (archived / "slides_overloading.py").write_text("# retired", encoding="utf-8")
+
+        files = find_slide_files_recursive(slides_dir)
+        assert files
+        assert all("_archive" not in f.parts for f in files)
+
+    def test_explicit_underscore_root_is_honoured(self, slides_dir):
+        # The prune applies to components BELOW the walk root only, so an
+        # explicitly named _archive/ root still enumerates its decks.
+        from clm.core.topic_resolver import find_slide_files_recursive
+
+        archived = slides_dir / "_archive" / "module_240_functions" / "topic_010_overloading"
+        archived.mkdir(parents=True)
+        (archived / "slides_overloading.py").write_text("# retired", encoding="utf-8")
+
+        files = find_slide_files_recursive(slides_dir / "_archive")
+        assert [f.name for f in files] == ["slides_overloading.py"]
 
 
 class TestResolveTopic:

--- a/tests/slides/test_pairing.py
+++ b/tests/slides/test_pairing.py
@@ -444,6 +444,29 @@ class TestFindSplitSlideFilesRecursive:
         found = find_split_slide_files_recursive(tmp_path)
         assert set(found) == {legit_de.resolve(), legit_en.resolve()}
 
+    def test_excludes_pairs_under_underscore_dirs(self, tmp_path: Path):
+        # Underscore-prefixed dirs (_archive, _drafts, …) are invisible to
+        # discovery (issue #318); a parked pair must never be enumerated —
+        # and thus never written on a directory apply.
+        legit_de = tmp_path / "module_x" / "topic_a" / "apis.de.py"
+        legit_en = tmp_path / "module_x" / "topic_a" / "apis.en.py"
+        self._touch(legit_de, legit_en)
+        self._touch(
+            tmp_path / "_archive" / "module_y" / "old.de.py",
+            tmp_path / "_archive" / "module_y" / "old.en.py",
+        )
+        found = find_split_slide_files_recursive(tmp_path)
+        assert set(found) == {legit_de.resolve(), legit_en.resolve()}
+
+    def test_root_named_underscore_still_enumerates(self, tmp_path: Path):
+        # Like the ignored-dir test, the underscore prune is applied RELATIVE
+        # to the root: explicitly walking _archive/ itself is honoured.
+        root = tmp_path / "_archive"
+        de, en = root / "apis.de.py", root / "apis.en.py"
+        self._touch(de, en)
+        found = find_split_slide_files_recursive(root)
+        assert set(found) == {de.resolve(), en.resolve()}
+
     def test_root_under_ignored_component_still_enumerates(self, tmp_path: Path):
         # The ignored-dir test is applied RELATIVE to the root, so a root that
         # itself lives under a dir named like an ignored one (e.g. ``build/``)

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -470,6 +470,26 @@ class TestModuleBindingValidation:
         assert len(unknown) == 1
         assert "module_999_nope" in unknown[0].message
 
+    def test_underscore_module_binding_is_unknown(self, tmp_path):
+        """``module="_archive"`` errors: discovery ignores underscore dirs (#318)."""
+        _make_topic(tmp_path, "module_100_live", "topic_010_intro")
+        _make_topic(tmp_path, "_archive", "topic_010_intro")
+
+        spec_file = _write_spec(
+            tmp_path,
+            """\
+            <sections>
+              <section module="_archive">
+                <name><de>X</de><en>X</en></name>
+                <topics><topic>intro</topic></topics>
+              </section>
+            </sections>""",
+        )
+        result = validate_spec(spec_file, tmp_path / "slides")
+        unknown = [f for f in result.findings if f.type == "unknown_module"]
+        assert len(unknown) == 1
+        assert "_archive" in unknown[0].message
+
     def test_topic_module_override_resolves(self, tmp_path):
         """Per-topic ``module=`` overrides the section default."""
         _make_topic(tmp_path, "module_100_live", "topic_010_intro")


### PR DESCRIPTION
## Summary

Fixes #318: `slides/_archive` (and any underscore-prefixed directory) was discovered as a module, so archived module dirs participated in topic resolution at the topic level. Because unbound resolution is first-occurrence-wins — and `_archive` sorts before `module_*` — retired decks silently shadowed live topic IDs while the build still exited 0 (CppCourses shipped Week 1 without the Functions deck).

## Changes

- **`build_topic_map`** skips underscore-prefixed names at both the module and the topic level (`slides/_archive/`, `module_x/_old_intro/`), mirroring the existing `.ipynb_checkpoints`-class exclusions.
- **`find_slide_files_recursive`** prunes underscore-prefixed dirs *below* the walk root, so the `clm slides` batch tools (normalize / assign-ids / slug-report / coverage-report) no longer enumerate parked decks. An explicitly named `_archive` root is still honoured (the prune is relative to the root).
- **`pairing.find_split_slide_files_recursive`** gets the same prune for the prefix-agnostic `clm slides sync DIR` surface, so a parked split pair is never written on a directory apply.
- **Spec validator**: `module="_archive"` bindings now report `unknown_module` — discovery ignores them, so they could never resolve anyway.
- **`clm course orphans`**: parked decks are deliberately retired, not forgotten — excluded from the orphan report like checkpoint cruft (otherwise every archived deck would flood the report after this fix).

The legacy `_cassettes/` sidecar is unaffected: this is a *discovery* rule, not a course-file-map rule (cassettes are consumed at kernel runtime and stay in the file map).

## Docs

- `clm info spec-files`: documents the discovery rule.
- `clm info migration`: migration entry (incl. the `module="_archive"` edge and the now-redundant `--exclude _archive`).
- `clm info commands`: orphans scan note; `--exclude` rows updated.
- Changelog fragment `changelog.d/318-underscore-dirs-shadow-topics.fixed.md`.

## Testing

- New tests: archived module dir no longer shadows a live topic (the exact #318 shape, with `_archive` sorting first), underscore topic-level dir invisible, recursive-walk prune + explicit-root exemption (both walkers), `_archive` module binding → `unknown_module`, parked decks not orphans.
- Fast suite: 7766 passed, 1 known-flaky worker test (`test_worker_stops_gracefully`) failed under xdist and passes in isolation — unrelated to this change.

## Not done (possible follow-up)

The issue also floats escalating ambiguous first-occurrence-wins resolution across *different* modules to an error under `--fail-on warning`. Left out of scope here; this fix removes the `_archive` source of such ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
