### PR TITLE
fix(release): allow byte-identical topic files across streams sharing a destination

### DIFF
--- a/changelog.d/325-shared-release-destination.added.md
+++ b/changelog.d/325-shared-release-destination.added.md
@@ -5,7 +5,9 @@
   legacy `.clm-released.json` is adopted and renamed automatically on the next
   sync), skeleton files already present at the destination are kept rather
   than overwritten (presence-as-frozen), `clm release sync` refuses to promote
-  when the sharing streams' built topic outputs overlap, spec validation
+  when the sharing streams' builds claim a topic-owned path with differing
+  content (byte-identical static files, e.g. project scaffolding, are
+  allowed), spec validation
   requires sharing channels to agree on `lang`, and `clm git --all-channels` /
   `clm release provision` treat a shared destination as one repository. See
   `clm info releases` ("Shared destination") and `clm info migration`.

--- a/docs/user-guide/solution-release.md
+++ b/docs/user-guide/solution-release.md
@@ -199,9 +199,10 @@ students pull from, each on its own ledger and timeline:
 
 Each stream keeps its own frozen manifest (`.clm-released.<stream>.json`), so
 releasing a topic's materials never freezes its solutions and `--refreeze`
-stays scoped to one stream. The streams' source targets must build **disjoint**
-topic outputs (`clm release sync` cross-checks and refuses overlap), channels
-sharing a path must agree on `lang`, and skeleton files already present in the
+stays scoped to one stream. The streams' notebook outputs must be **disjoint**;
+topic-owned static files may appear in both builds when byte-identical
+(`clm release sync` cross-checks and refuses only *conflicting* content),
+channels sharing a path must agree on `lang`, and skeleton files already present in the
 destination are kept rather than overwritten — sync both streams after the
 same `clm build` so evergreen files don't ping-pong between builds. See
 `clm info releases` ("Shared destination") for the full rules and the

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -128,14 +128,18 @@ def _check_shared_destination_overlap(
 ) -> None:
     """Sync preflight for shared destinations (issue #325).
 
-    When another stream's channel releases into the same destination, its
-    source manifest and ours must claim **disjoint** topic files — skeleton
-    overlap is fine (presence-as-frozen keeps the first copy), but a
-    topic-owned path in both manifests means the streams' output targets
-    collide and a sync would clobber the other stream's frozen content. A
-    sharer whose source target has no manifest yet (not built) is skipped
-    with a note. *manifest* is this sync's already language-restricted
-    manifest, so paths compare in destination-relative form.
+    When another stream's channel releases into the same destination, the
+    topic-owned paths the two source manifests both claim must be
+    **byte-identical** (a topic's static files — project scaffolding, data —
+    are legitimately built into every target verbatim; copy order then does
+    not matter). A shared path whose content *differs* between the builds
+    would clobber the other stream's frozen content, so the sync is refused —
+    typically the targets were built from different source states; rebuild
+    both. Skeleton overlap is always fine (presence-as-frozen keeps the
+    first copy). A sharer whose source target has no manifest yet (not
+    built) is skipped with a note. *manifest* is this sync's already
+    language-restricted manifest, so paths compare in destination-relative
+    form.
     """
     spec = CourseSpec.from_file(spec_file)
     block, _ = spec.resolve_release_channel(channel_ref)
@@ -164,15 +168,25 @@ def _check_shared_destination_overlap(
                 other_manifest, other_channel.lang, lang_dir
             )
         overlap = topic_path_overlap(manifest, other_manifest)
-        if overlap:
-            examples = ", ".join(overlap[:5]) + (", …" if len(overlap) > 5 else "")
+        if overlap.identical:
+            click.echo(
+                f"Note: {len(overlap.identical)} topic-owned file(s) are built "
+                f"byte-identically by '{channel_ref}' and '{other_ref}' (shared "
+                f"static content, e.g. project scaffolding); whichever stream "
+                f"releases the owning topic first delivers them."
+            )
+        if overlap.conflicting:
+            paths = overlap.conflicting
+            examples = ", ".join(paths[:5]) + (", …" if len(paths) > 5 else "")
             raise click.ClickException(
-                f"Refusing to sync: {len(overlap)} topic-owned file(s) are claimed "
-                f"by both '{channel_ref}' and '{other_ref}', which share the "
-                f"destination {dest_path} — promoting would clobber the other "
-                f"stream's released content: {examples}. Streams sharing a "
-                f"destination must build disjoint outputs (e.g. code-along/partial "
-                f"vs completed kinds)."
+                f"Refusing to sync: {len(paths)} topic-owned file(s) are claimed "
+                f"by both '{channel_ref}' and '{other_ref}' with DIFFERENT "
+                f"content, which share the destination {dest_path} — promoting "
+                f"would clobber the other stream's released content: {examples}. "
+                f"Streams sharing a destination must build disjoint notebook "
+                f"outputs (e.g. code-along/partial vs completed kinds), and "
+                f"shared static files must come from the same build — rebuild "
+                f"both source targets and re-run."
             )
 
 

--- a/src/clm/cli/info_topics/releases.md
+++ b/src/clm/cli/info_topics/releases.md
@@ -191,12 +191,16 @@ How the pieces interact:
 - **Per-stream freeze records.** Each stream keeps its own
   `.clm-released.<stream>.json`, so materials releasing a topic never freezes
   it for solutions (and `--refreeze` stays scoped to one stream's files).
-- **Disjoint outputs required.** The streams' source targets must build
-  disjoint topic files (e.g. code-along/partial kinds vs completed kinds —
-  they land in different subtrees). `clm release sync` cross-checks the
-  source manifests of all streams sharing the destination and refuses to
-  promote if a topic-owned path is claimed twice. A sharer that is not built
-  yet is skipped with a note.
+- **No conflicting outputs.** The streams' notebook outputs must be disjoint
+  (e.g. code-along/partial kinds vs completed kinds — they land in different
+  subtrees). A topic's *static* files (project scaffolding, data) are built
+  verbatim into every target and may be claimed by both streams as long as
+  they are **byte-identical** — whichever stream releases the owning topic
+  first delivers them. `clm release sync` cross-checks the source manifests
+  of all streams sharing the destination and refuses to promote when a
+  shared topic-owned path has *differing* content (usually: the targets were
+  built from different source states — rebuild both). A sharer that is not
+  built yet is skipped with a note.
 - **Skeleton: presence-as-frozen.** A skeleton file already present in the
   destination is kept, never overwritten — the second stream's first sync
   copies only the skeleton files the first one didn't deliver. Evergreen

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -755,9 +755,10 @@ behavior (`clm info releases` has the details):
 - channels sharing a path must agree on `lang` (validation error otherwise);
 - each stream keeps its own frozen manifest (`.clm-released.<stream>.json`),
   so one stream releasing a topic never freezes it for the other;
-- the streams' built topic outputs must be **disjoint** (e.g. code-along /
-  partial kinds vs completed kinds) — `clm release sync` cross-checks the
-  source manifests and refuses overlap;
+- the streams' notebook outputs must be **disjoint** (e.g. code-along /
+  partial kinds vs completed kinds); topic-owned static files may appear in
+  both builds when byte-identical — `clm release sync` cross-checks the
+  source manifests and refuses only *conflicting* content;
 - skeleton files already present in the destination are kept, not
   overwritten (presence-as-frozen) — sync both streams after the same
   `clm build` to avoid evergreen files ping-ponging between builds;

--- a/src/clm/release/sync.py
+++ b/src/clm/release/sync.py
@@ -125,18 +125,49 @@ def scan_skeleton(*, manifest: dict[str, Any], dest_root: Path) -> SkeletonScan:
     return SkeletonScan(missing=tuple(missing), present=tuple(present))
 
 
-def topic_path_overlap(manifest_a: dict[str, Any], manifest_b: dict[str, Any]) -> tuple[str, ...]:
-    """Destination-relative paths claimed by a topic in *both* manifests.
+@frozen
+class TopicOverlap:
+    """Topic-owned paths claimed by *both* manifests of a shared destination.
 
-    Streams sharing one destination (issue #325) must own disjoint topic
-    files — only skeleton paths may overlap (byte-identical builds of the
-    same source). Any topic-owned overlap means the streams' output targets
-    produce colliding kinds and a sync would clobber the other stream's
-    frozen content; the sync preflight refuses it.
+    ``conflicting`` paths carry **different** content in the two builds —
+    promoting either stream would clobber the other stream's released bytes,
+    so the sync preflight refuses them. ``identical`` paths are byte-equal in
+    both builds (a topic's *static* files — project scaffolding, data — are
+    copied verbatim into every target that builds the topic, so they
+    legitimately appear in both streams): copying them is idempotent
+    regardless of sync order, so they are allowed and only surfaced as a
+    note. Notebook outputs stay disjoint by kind (Code-Along/Partial vs
+    Completed), so a notebook path showing up here at all means colliding
+    target kinds — its content differs and it lands in ``conflicting``.
     """
-    a = {e["path"] for e in manifest_a.get("files", []) if e.get("topic_id") is not None}
-    b = {e["path"] for e in manifest_b.get("files", []) if e.get("topic_id") is not None}
-    return tuple(sorted(a & b))
+
+    conflicting: tuple[str, ...] = ()
+    identical: tuple[str, ...] = ()
+
+
+def topic_path_overlap(manifest_a: dict[str, Any], manifest_b: dict[str, Any]) -> TopicOverlap:
+    """Classify the topic-owned paths claimed by both manifests (issue #325).
+
+    A shared path counts as ``identical`` only when **both** entries carry a
+    ``content_hash`` and they match; an absent hash cannot prove anything, so
+    it is treated as ``conflicting``. Hash-different paths mean the streams'
+    builds disagree about the file's content — typically the two source
+    targets were built from different states; rebuild both and re-sync.
+    """
+    a = {
+        e["path"]: e.get("content_hash")
+        for e in manifest_a.get("files", [])
+        if e.get("topic_id") is not None
+    }
+    b = {
+        e["path"]: e.get("content_hash")
+        for e in manifest_b.get("files", [])
+        if e.get("topic_id") is not None
+    }
+    shared = sorted(set(a) & set(b))
+    identical = tuple(p for p in shared if a[p] and a[p] == b[p])
+    conflicting = tuple(p for p in shared if not (a[p] and a[p] == b[p]))
+    return TopicOverlap(conflicting=conflicting, identical=identical)
 
 
 @frozen

--- a/tests/release/test_shared_destination.py
+++ b/tests/release/test_shared_destination.py
@@ -108,12 +108,12 @@ TOPIC_PATH = "Sec/01 Intro.ipynb"
 SKELETON_PATH = "shared/data.csv"
 
 
-def _manifest(*, topic_path=TOPIC_PATH, skeleton_text="skeleton v1"):
+def _manifest(*, topic_path=TOPIC_PATH, skeleton_text="skeleton v1", topic_hash="sha256:a"):
     return {
         "version": 1,
         "source_commit": "abc",
         "files": [
-            {"path": topic_path, "topic_id": "intro", "content_hash": "sha256:a"},
+            {"path": topic_path, "topic_id": "intro", "content_hash": topic_hash},
             {"path": SKELETON_PATH, "topic_id": None, "content_hash": _sha(skeleton_text)},
         ],
     }
@@ -258,13 +258,31 @@ class TestTopicPathOverlap:
     def test_disjoint_topic_paths_have_no_overlap(self):
         a = _manifest(topic_path="Sec/01 Intro-CodeAlong.ipynb")
         b = _manifest(topic_path="Sec/01 Intro-Completed.ipynb")
-        assert topic_path_overlap(a, b) == ()
+        overlap = topic_path_overlap(a, b)
+        assert overlap.conflicting == ()
+        assert overlap.identical == ()
 
-    def test_shared_topic_path_is_reported_and_skeleton_overlap_ignored(self):
-        a = _manifest()
-        b = _manifest()
-        # Both manifests claim TOPIC_PATH for a topic and share the skeleton.
-        assert topic_path_overlap(a, b) == (TOPIC_PATH,)
+    def test_hash_differing_shared_path_conflicts_and_skeleton_is_ignored(self):
+        a = _manifest(topic_hash="sha256:a")
+        b = _manifest(topic_hash="sha256:b")
+        overlap = topic_path_overlap(a, b)
+        assert overlap.conflicting == (TOPIC_PATH,)
+        assert overlap.identical == ()
+
+    def test_byte_identical_shared_path_is_allowed(self):
+        """A topic's static files (project scaffolding, data) are built
+        verbatim into every target — identical bytes may be claimed by both
+        streams; copy order does not matter."""
+        overlap = topic_path_overlap(_manifest(), _manifest())
+        assert overlap.conflicting == ()
+        assert overlap.identical == (TOPIC_PATH,)
+
+    def test_missing_hash_cannot_prove_identity_so_it_conflicts(self):
+        a = _manifest(topic_hash=None)
+        b = _manifest(topic_hash=None)
+        overlap = topic_path_overlap(a, b)
+        assert overlap.conflicting == (TOPIC_PATH,)
+        assert overlap.identical == ()
 
 
 # ---------------------------------------------------------------------------
@@ -312,9 +330,15 @@ def _write_spec(tmp_path: Path, body: str = SPEC_SHARED_DEST) -> Path:
     return spec_file
 
 
-def _write_built_source(root: Path, *, topic_path: str, skeleton_text: str = "skeleton v1"):
+def _write_built_source(
+    root: Path,
+    *,
+    topic_path: str,
+    skeleton_text: str = "skeleton v1",
+    topic_hash: str = "sha256:a",
+):
     root.mkdir(parents=True, exist_ok=True)
-    manifest = _manifest(topic_path=topic_path, skeleton_text=skeleton_text)
+    manifest = _manifest(topic_path=topic_path, skeleton_text=skeleton_text, topic_hash=topic_hash)
     (root / MANIFEST_FILENAME).write_text(json.dumps(manifest), encoding="utf-8")
     _materialize(root, manifest, skeleton_text=skeleton_text)
 
@@ -379,12 +403,19 @@ class TestSharedDestinationCli:
         solutions = FrozenManifest.load(dest / frozen_manifest_filename("solutions"), channel="?")
         assert solutions.skeleton_frozen is True
 
-    def test_overlapping_topic_outputs_are_refused(self, tmp_path):
+    def test_conflicting_topic_outputs_are_refused(self, tmp_path):
         runner = CliRunner()
         spec_file = _write_spec(tmp_path)
-        # Both targets (mis)build the same topic path -> would clobber.
-        _write_built_source(tmp_path / "output" / "shared", topic_path="Sec/01 Intro.ipynb")
-        _write_built_source(tmp_path / "output" / "completed", topic_path="Sec/01 Intro.ipynb")
+        # Both targets claim the same topic path with DIFFERENT content
+        # (e.g. colliding kinds, or targets built from different states).
+        _write_built_source(
+            tmp_path / "output" / "shared", topic_path="Sec/01 Intro.ipynb", topic_hash="sha256:a"
+        )
+        _write_built_source(
+            tmp_path / "output" / "completed",
+            topic_path="Sec/01 Intro.ipynb",
+            topic_hash="sha256:b",
+        )
 
         sync = _release_and_sync(runner, spec_file, "materials/2026-04")
         assert sync.exit_code != 0
@@ -392,6 +423,27 @@ class TestSharedDestinationCli:
         assert "Sec/01 Intro.ipynb" in sync.output
         # Nothing was promoted.
         assert not (tmp_path / "release" / "combined" / "2026-04").exists()
+
+    def test_byte_identical_shared_static_files_sync_with_a_note(self, tmp_path):
+        """A topic's static files (e.g. project scaffolding) are built
+        verbatim into both targets — identical bytes must not block the sync
+        (the real AZAV deployment shares 100+ such files)."""
+        runner = CliRunner()
+        spec_file = _write_spec(tmp_path)
+        _write_built_source(
+            tmp_path / "output" / "shared", topic_path="Projekte/scaffold.py", topic_hash="sha256:s"
+        )
+        _write_built_source(
+            tmp_path / "output" / "completed",
+            topic_path="Projekte/scaffold.py",
+            topic_hash="sha256:s",
+        )
+
+        sync = _release_and_sync(runner, spec_file, "materials/2026-04")
+        assert sync.exit_code == 0, sync.output
+        assert "byte-identically" in sync.output
+        dest = tmp_path / "release" / "combined" / "2026-04"
+        assert (dest / "Projekte/scaffold.py").is_file()
 
     def test_unbuilt_sharer_is_noted_and_skipped(self, tmp_path):
         runner = CliRunner()


### PR DESCRIPTION
Follow-up to #332 (issue #325), surfaced by deploying the shared-destination feature to the AZAV ML 2026-04 course.

## Problem

The cross-stream overlap preflight refused any topic-owned path claimed by both streams' manifests. In the real course, a topic's **static files** (project scaffolding under `Projekte/`, data files) are built verbatim into *every* output target that includes the topic, so the `shared` and `solutions` manifests both claim them at identical paths — 108 byte-identical files (3 topics × 2 languages). The first `clm release sync --dry-run` against real data was refused.

## Fix

`topic_path_overlap` now classifies shared paths by `content_hash`:

- **byte-identical** → allowed; copying is idempotent regardless of sync order (whichever stream releases the owning topic first delivers them). Surfaced as a one-line note.
- **differing or unhashed** → hard refusal, as before. This still catches colliding notebook kinds and targets built from different source states (the error now says to rebuild both targets).

New tests: identical-hash overlap passes with a note (mirroring the real AZAV data), differing-hash refusal, missing-hash treated as conflicting. Docs and the pending #325 changelog fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
