### PR TITLE
fix(workers): process the payload's data in Docker source-mount mode

### DIFF
--- a/changelog.d/324-docker-voiceover-payload-data.fixed.md
+++ b/changelog.d/324-docker-voiceover-payload-data.fixed.md
@@ -1,0 +1,6 @@
+- Docker source-mount workers no longer discard the host's voiceover-merged
+  notebook payload by re-reading the raw slide file from the mount (#324).
+  The payload's `data` is now the canonical input in both Direct and Docker
+  modes, so (1) companion narration reaches docker-built output and (2) the
+  worker-side `execution_cache_hash` agrees with the host's again, restoring
+  Stage-4 cache replay for voiceover decks built with docker workers.

--- a/src/clm/infrastructure/messaging/base_classes.py
+++ b/src/clm/infrastructure/messaging/base_classes.py
@@ -62,11 +62,15 @@ class Payload(TransferModel):
         exactly this way (issue #17), leaving every ``clm:`` link unrewritten.
 
         Only the file-bound fields are overridden, because at consume time they
-        do not come from the payload: the canonical input/output paths are
-        columns on the job row, and in Docker source-mount mode the ``content``
-        (notebook / diagram source) is read from the mounted filesystem rather
-        than carried inline. **Do not "simplify" these overrides away** — both
-        direct and Docker modes depend on them.
+        do not come from the payload verbatim: the canonical input/output paths
+        are columns on the job row (converted to container ``/source`` paths in
+        Docker source-mount mode), and ``content`` is whatever the worker
+        resolved as the notebook/diagram source — normally the payload's own
+        ``data``, which for notebooks already carries the host-merged voiceover
+        companion (re-reading the raw mounted file here used to drop that
+        narration, issue #324), with a filesystem read only as a fallback for
+        payloads that carry no data. **Do not "simplify" these overrides
+        away** — both direct and Docker modes depend on them.
 
         A required descriptor field missing from ``payload_data`` raises a
         ``ValidationError`` rather than being silently defaulted: the host

--- a/src/clm/workers/notebook/notebook_worker.py
+++ b/src/clm/workers/notebook/notebook_worker.py
@@ -143,28 +143,32 @@ class NotebookWorker(Worker):
             logger.debug(f"Processing job {job.id} with payload: {payload_data.keys()}")
 
             # Determine if we're in Docker mode with source mount
-            # If CLM_HOST_DATA_DIR is set, we can read input files from /source
+            # If CLM_HOST_DATA_DIR is set, input paths live under /source
             host_data_dir = os.environ.get("CLM_HOST_DATA_DIR")
 
-            notebook_text: str
             if host_data_dir:
-                # Docker mode with source mount: read from filesystem
                 from clm.infrastructure.workers.worker_base import convert_input_path_to_container
 
                 input_path = convert_input_path_to_container(job.input_file, host_data_dir)
-                logger.debug(f"Docker mode: reading from {input_path}")
-                notebook_text = input_path.read_text(encoding="utf-8")
             else:
-                # Direct mode or legacy Docker mode: use payload data
-                notebook_text = payload_data.get("data", "")
-                if not notebook_text:
-                    # Fallback: try reading from filesystem (direct mode)
-                    input_path = Path(job.input_file)
-                    if input_path.exists():
-                        notebook_text = input_path.read_text(encoding="utf-8")
-                    else:
-                        raise FileNotFoundError(f"Input file not found: {input_path}")
-                input_path = Path(job.input_file)  # Keep for logging/error messages
+                input_path = Path(job.input_file)
+
+            # The payload's ``data`` is the canonical notebook source in BOTH
+            # modes: the host builds it as slide text plus the merged voiceover
+            # companion (``ProcessNotebookOperation.payload``). Docker mode
+            # used to re-read the raw slide file from the mount instead, which
+            # silently dropped the merged narration from the output and made
+            # the worker's ``execution_cache_hash`` disagree with the host's,
+            # permanently defeating the Stage-4 replay gate for voiceover
+            # decks (issue #324). The filesystem read is only a fallback for
+            # jobs whose payload carries no data.
+            notebook_text: str = payload_data.get("data", "")
+            if not notebook_text:
+                if input_path.exists():
+                    logger.debug(f"Empty payload data: reading from {input_path}")
+                    notebook_text = input_path.read_text(encoding="utf-8")
+                else:
+                    raise FileNotFoundError(f"Input file not found: {input_path}")
 
             logger.debug(f"Processing notebook: {input_path.name}")
 

--- a/tests/workers/notebook/test_notebook_worker.py
+++ b/tests/workers/notebook/test_notebook_worker.py
@@ -925,6 +925,153 @@ class TestNotebookWorkerConfiguration:
         assert isinstance(notebook_worker.CACHE_DB_PATH, Path)
 
 
+class TestNotebookWorkerDockerPayloadData:
+    """Docker source-mount mode must process the payload's ``data`` (#324).
+
+    The host builds ``NotebookPayload.data`` as slide text plus the merged
+    voiceover companion. The worker used to discard that in Docker mode and
+    re-read the raw slide file from the mount, which (1) silently dropped the
+    narration from the built output and (2) made the worker-side
+    ``execution_cache_hash`` disagree with the host's, so the Stage-4 replay
+    gate (``_can_replay_from_cache``) never matched for voiceover decks.
+    """
+
+    RAW_SLIDE = "# %% [markdown]\n# <!-- slide_id: intro -->\n# Intro\n"
+    MERGED_SLIDE = (
+        "# %% [markdown]\n# <!-- slide_id: intro -->\n# Intro\n"
+        '# %% [markdown] tags=["notes"]\n# Narration from the companion.\n'
+    )
+
+    def _host_payload(self, input_file: Path, output_file: Path):
+        from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+
+        return NotebookPayload(
+            data=self.MERGED_SLIDE,
+            input_file=str(input_file),
+            input_file_name=input_file.name,
+            output_file=str(output_file),
+            kind="recording",
+            prog_lang="python",
+            language="en",
+            format="html",
+            correlation_id="cid-324",
+        )
+
+    @pytest.mark.asyncio
+    async def test_docker_mode_processes_host_merged_data(
+        self, worker_id, db_path, tmp_path, monkeypatch
+    ):
+        """With CLM_HOST_DATA_DIR set, the processed payload must carry the
+        host-merged data — not a re-read of the raw mounted slide file — and
+        its execution_cache_hash must equal the host payload's."""
+        from clm.workers.notebook.notebook_worker import NotebookWorker
+
+        host_data_dir = tmp_path / "course"
+        host_data_dir.mkdir()
+        input_file = host_data_dir / "slides" / "topic_100" / "slides_intro.py"
+        input_file.parent.mkdir(parents=True)
+        # The file on the (simulated) mount holds the RAW slide text.
+        input_file.write_text(self.RAW_SLIDE, encoding="utf-8")
+        output_file = tmp_path / "output" / "slides_intro.html"
+
+        monkeypatch.setenv("CLM_HOST_DATA_DIR", str(host_data_dir))
+
+        host_payload = self._host_payload(input_file, output_file)
+
+        job = Job(
+            id=1,
+            job_type="notebook",
+            input_file=str(input_file),
+            output_file=str(output_file),
+            content_hash=host_payload.content_hash(),
+            payload=host_payload.model_dump(mode="json"),
+            status="processing",
+            created_at=datetime.now(),
+        )
+
+        worker = NotebookWorker(worker_id, db_path)
+
+        captured_payload = None
+
+        async def mock_process_notebook(payload, source_dir=None):
+            nonlocal captured_payload
+            captured_payload = payload
+            return "<html>output</html>"
+
+        with patch.object(worker, "_ensure_cache_initialized", return_value=None):
+            with patch("clm.workers.notebook.notebook_worker.NotebookProcessor") as MockProcessor:
+                mock_processor = MagicMock()
+                mock_processor.process_notebook = mock_process_notebook
+                MockProcessor.return_value = mock_processor
+
+                await worker._process_job_async(job)
+
+        assert captured_payload is not None
+        # The merged narration survives the worker boundary ...
+        assert captured_payload.data == self.MERGED_SLIDE
+        assert "Narration from the companion." in captured_payload.data
+        # ... so the worker stores executions under the key the host's
+        # Stage-4 gate looks up.
+        assert captured_payload.execution_cache_hash() == host_payload.execution_cache_hash()
+        # The input path is still converted to the container mount point.
+        assert captured_payload.input_file.replace("\\", "/").startswith("/source/")
+
+    @pytest.mark.asyncio
+    async def test_docker_mode_falls_back_to_mount_read_for_empty_payload_data(
+        self, worker_id, db_path, tmp_path, monkeypatch
+    ):
+        """A payload without data still reads the mounted file (fallback)."""
+        from clm.workers.notebook.notebook_worker import NotebookWorker
+
+        # Stand in for /source: the converted container path must exist, so
+        # redirect the conversion to a real file.
+        mounted_file = tmp_path / "mounted" / "slides_intro.py"
+        mounted_file.parent.mkdir()
+        mounted_file.write_text(self.RAW_SLIDE, encoding="utf-8")
+
+        monkeypatch.setenv("CLM_HOST_DATA_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "clm.infrastructure.workers.worker_base.convert_input_path_to_container",
+            lambda host_path, host_data_dir: mounted_file,
+        )
+
+        job = Job(
+            id=1,
+            job_type="notebook",
+            input_file=str(tmp_path / "slides_intro.py"),
+            output_file=str(tmp_path / "output.html"),
+            content_hash="test-hash",
+            payload={
+                "kind": "completed",
+                "prog_lang": "python",
+                "language": "en",
+                "format": "html",
+            },
+            status="processing",
+            created_at=datetime.now(),
+        )
+
+        worker = NotebookWorker(worker_id, db_path)
+
+        captured_payload = None
+
+        async def mock_process_notebook(payload, source_dir=None):
+            nonlocal captured_payload
+            captured_payload = payload
+            return "<html>output</html>"
+
+        with patch.object(worker, "_ensure_cache_initialized", return_value=None):
+            with patch("clm.workers.notebook.notebook_worker.NotebookProcessor") as MockProcessor:
+                mock_processor = MagicMock()
+                mock_processor.process_notebook = mock_process_notebook
+                MockProcessor.return_value = mock_processor
+
+                await worker._process_job_async(job)
+
+        assert captured_payload is not None
+        assert captured_payload.data == self.RAW_SLIDE
+
+
 class TestNotebookWorkerSourceDirectory:
     """Test source directory handling for Docker mode with source mount.
 


### PR DESCRIPTION
## Summary

Fixes #324 — Docker source-mount mode discarded the host's voiceover-merged payload data by re-reading the raw slide file from the mount.

The host builds `NotebookPayload.data` as slide text **plus the merged voiceover companion** (`ProcessNotebookOperation.payload` → `merge_voiceover_text`) and always serializes it into the job payload (`model_dump(mode="json")` in `SqliteBackend` — there is no docker-mode stripping). But the notebook worker's `CLM_HOST_DATA_DIR` branch overrode it with `input_path.read_text(...)` of the raw mounted file, and no worker-side re-merge exists. Consequences:

1. **Narration loss**: recording HTML built with docker workers shipped without the companion's voiceover cells.
2. **Cache-hash asymmetry**: the worker stored `executed_notebooks` entries under a hash of the *raw* data while the host's Stage-4 gate (`_can_replay_from_cache`) looked up the *merged*-data hash — voiceover decks re-executed on every docker build even with a warm cache.

## Changes

- `notebook_worker.py`: the payload's `data` is now the canonical input in both Direct and Docker modes; the filesystem read remains only as a fallback for payloads carrying no data. The container path conversion is kept (`input_file` still needs the `/source` path for `source_dir` resolution and logging).
- `base_classes.py`: updated the `from_job_payload` docstring's Docker-mode rationale (the "do not simplify the overrides" warning stands — the overrides themselves are unchanged).
- Regression tests (`TestNotebookWorkerDockerPayloadData`): docker mode processes host-merged data with host/worker `execution_cache_hash` agreement and container-converted `input_file`; empty-payload fallback still reads from the mount. The main test fails against the pre-fix code (it attempts the raw mount re-read).

Diagram workers are untouched: their payload `data` is the raw file content (no merge), and their results cache keys on the host-computed job-row hash, so no asymmetry exists there.

## Test plan

- [x] New regression tests fail pre-fix, pass post-fix
- [x] Fast suite: 7806 passed, 3 skipped, 1 xfailed
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
