### PR TITLE
feat(slides): code_export validation — conformance rules for the C++ project export (#331)

### DIFF
--- a/changelog.d/331-code-export-conformance.added.md
+++ b/changelog.d/331-code-export-conformance.added.md
@@ -1,0 +1,11 @@
+- New deterministic validation check `code_export` (#331): verifies the structural
+  invariants the planned compilable C++ project export (#333) relies on, for
+  `.cpp` decks only (no-op elsewhere). Errors on variable/function/type
+  redefinitions within one (language × completed) output view — which xeus-cpp
+  forbids at runtime anyway — and on `main()` definitions in decks without the
+  new `// clm: allow-main` header marker; warns on Jinja directives inside code
+  cells; reports cells mixing definitions and statements as info. Overloads
+  (parameter types + const-ness), template specializations, DE/EN-paired cells,
+  and `start`/`completed` pairs are correctly not flagged. Backed by the new
+  heuristic classifier `clm.slides.cpp_code_analysis`, validated against the
+  full CppCourses corpus (4,818 top-level items, 99.9% classified).

--- a/src/clm/cli/commands/validate_slides.py
+++ b/src/clm/cli/commands/validate_slides.py
@@ -30,7 +30,8 @@ from clm.slides.validator import (
     default=None,
     help=(
         "Comma-separated list of checks to run. "
-        "Deterministic: format, pairing, tags. "
+        "Deterministic: format, pairing, tags, code_export "
+        "(code_export applies to .cpp decks only; #331). "
         "Review: code_quality, voiceover, completeness. "
         "Default: all deterministic checks. "
         "voiceover coverage is opt-in (voiceover is optional per deck) — "

--- a/src/clm/slides/cpp_code_analysis.py
+++ b/src/clm/slides/cpp_code_analysis.py
@@ -1,0 +1,387 @@
+"""Heuristic top-level item analysis for C++ code cells.
+
+Classifies the top-level items of a C++ code-cell body (includes, type /
+function / variable definitions, statements, display expressions, ...) without
+a real C++ parser. This drives the ``code_export`` validation rules (#331) and
+will drive the per-item dispatch of the compilable project export (#333).
+
+The heuristics were developed and validated against the full CppCourses
+corpus (298 decks, 4,818 top-level items, 99.9% classified; see
+``tools/scan_cell_structure.py`` and
+``course-planning/REPORT_CPP_CODE_EXPORT_FEASIBILITY.md`` in that repo).
+A libclang-based classifier could replace this module later without changing
+the call sites.
+
+Pipeline: :func:`strip_comments_and_strings` -> :func:`extract_preprocessor`
+-> :func:`split_top_level` -> :func:`classify_item`, or all at once via
+:func:`classify_source`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Item model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CppItem:
+    """One classified top-level item of a code cell.
+
+    ``name`` is set for definitions/declarations that introduce an entity
+    (variables, functions, types, aliases). For template specializations the
+    specialization arguments are part of the name (``TypeName<int>``), since
+    a specialization is a distinct entity from its primary template.
+
+    ``signature`` is set for functions: ``name(normalized-param-types)`` with
+    a trailing `` const`` marker for const member functions, so that legal
+    overloads compare unequal while true redefinitions compare equal.
+    """
+
+    category: str
+    name: str | None = None
+    signature: str | None = None
+    text: str = ""
+
+
+# Categories that introduce a named entity at namespace scope.
+DEFINITION_CATEGORIES = frozenset(
+    {"type_def", "fn_def", "member_fn_def", "alias_def", "namespace_def", "fn_decl", "type_decl"}
+)
+# Categories that are executable statements (need wrapping into a function
+# body for the code export).
+STATEMENT_CATEGORIES = frozenset(
+    {"control_stmt", "output_stmt", "call_stmt", "expr_stmt", "expr_display", "block_stmt"}
+)
+# Preprocessor categories (hoisted to the top of a translation unit).
+PREPROCESSOR_CATEGORIES = frozenset({"include", "preproc_other"})
+
+
+# ---------------------------------------------------------------------------
+# Comment / string stripping
+# ---------------------------------------------------------------------------
+
+
+def strip_comments_and_strings(src: str) -> str:
+    """Blank out comments and string/char literals (incl. raw strings).
+
+    Preserves the structural characters (braces, parens, semicolons) the
+    splitter and classifier rely on; replaces literals with empty
+    placeholders so their contents can't confuse them.
+    """
+    out: list[str] = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+        if c == "/" and nxt == "/":
+            j = src.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if c == "/" and nxt == "*":
+            j = src.find("*/", i + 2)
+            i = n if j < 0 else j + 2
+            out.append(" ")
+            continue
+        if c == "R" and nxt == '"':
+            m = re.match(r'R"([^(\s]*)\(', src[i:])
+            if m:
+                closer = ")" + m.group(1) + '"'
+                j = src.find(closer, i + m.end())
+                i = n if j < 0 else j + len(closer)
+                out.append('""')
+                continue
+        if c == '"':
+            j = i + 1
+            while j < n and src[j] != '"':
+                j += 2 if src[j] == "\\" else 1
+            out.append('""')
+            i = j + 1
+            continue
+        if c == "'":
+            j = i + 1
+            while j < n and src[j] != "'":
+                j += 2 if src[j] == "\\" else 1
+            out.append("' '")
+            i = j + 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Preprocessor extraction / top-level splitting
+# ---------------------------------------------------------------------------
+
+
+def extract_preprocessor(src: str) -> tuple[list[str], str]:
+    """Pull out preprocessor lines (with continuations); return (pp_lines, rest)."""
+    pp: list[str] = []
+    rest: list[str] = []
+    lines = src.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.lstrip().startswith("#"):
+            full = line
+            while full.rstrip().endswith("\\") and i + 1 < len(lines):
+                i += 1
+                full = full.rstrip()[:-1] + " " + lines[i]
+            pp.append(full.strip())
+        else:
+            rest.append(line)
+        i += 1
+    return pp, "\n".join(rest)
+
+
+def split_top_level(src: str) -> list[str]:
+    """Split comment/string-stripped C++ into top-level items.
+
+    Splits on ``;`` at depth 0 and on a ``}`` that closes back to depth 0 —
+    except when the closing brace is followed by ``;`` (the ``;`` ends the
+    item) or by ``else``/``while``/``catch`` (an ``if {} else {}``,
+    ``do {} while``, or ``try {} catch`` continuation of the same item).
+    """
+    items: list[str] = []
+    brace = paren = bracket = 0
+    start = 0
+    i, n = 0, len(src)
+
+    def emit(end: int) -> None:
+        nonlocal start
+        item = src[start:end].strip()
+        if item:
+            items.append(item)
+        start = end
+
+    while i < n:
+        c = src[i]
+        if c == "{":
+            brace += 1
+        elif c == "}":
+            brace -= 1
+            if brace == 0 and paren == 0 and bracket == 0:
+                j = i + 1
+                while j < n and src[j] in " \t\r\n":
+                    j += 1
+                if j < n and src[j] == ";":
+                    i = j
+                    emit(i + 1)
+                else:
+                    word = re.match(r"(else|while|catch)\b", src[j : j + 8])
+                    if not word:
+                        emit(i + 1)
+        elif c == "(":
+            paren += 1
+        elif c == ")":
+            paren -= 1
+        elif c == "[":
+            bracket += 1
+        elif c == "]":
+            bracket -= 1
+        elif c == ";" and brace == 0 and paren == 0 and bracket == 0:
+            emit(i + 1)
+        i += 1
+    emit(n)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+_SPECIFIERS = (
+    r"(?:(?:const|constexpr|consteval|constinit|static|inline|virtual|extern"
+    r"|friend|unsigned|signed|long|short|mutable)\s+)*"
+)
+_TYPE_TOKEN = r"[\w:]+(?:<[^;{}]*>)?"
+_CONTROL_KW = (
+    "if",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "try",
+    "return",
+    "throw",
+    "break",
+    "continue",
+    "goto",
+)
+
+_QUAL = r"(?:\w+(?:<[^;{}()]*>)?\s*::\s*)*"
+_FN_RE = re.compile(
+    rf"^{_SPECIFIERS}{_TYPE_TOKEN}(?:\s+const\b|\s*[&*]+|\s+)+"
+    rf"({_QUAL}~?\w+(?:<[^;{{}}()]*>)?|{_QUAL}operator\s*\S+)\s*\(",
+)
+# Out-of-class ctor/dtor definitions have no return type: MyVector<T>::MyVector(...)
+_CTOR_RE = re.compile(r"^((?:\w+(?:<[^;{}()]*>)?\s*::\s*)+~?\w+)\s*\(")
+_VAR_RE = re.compile(
+    rf"^{_SPECIFIERS}{_TYPE_TOKEN}(?:\s+const\b|\s*[&*]+|\s+)+(\w+)\s*"
+    rf"((?:\[[^\]]*\]\s*)*)(\{{|=|;|\(|,)",
+)
+# Out-of-class static member definitions: std::allocator<T> MyVector<T>::allocator{};
+_MEMBER_VAR_RE = re.compile(
+    rf"^{_SPECIFIERS}{_TYPE_TOKEN}(?:\s+const\b|\s*[&*]+|\s+)+{_QUAL}(\w+)\s*(\{{|=|;)",
+)
+_TYPE_DEF_RE = re.compile(r"^(?:class|struct|union|enum(?:\s+(?:class|struct))?)\s+(\w+)")
+
+
+def normalize_args(args: str) -> str:
+    """Strip parameter names and defaults so overloads compare by type.
+
+    ``int x, double const& y = 1.0`` -> ``int,doubleconst&``. Whitespace is
+    removed entirely; the result is only used for equality comparison.
+    """
+    parts = []
+    depth = 0
+    cur = ""
+    for ch in args + ",":
+        if ch == "," and depth == 0:
+            a = re.sub(r"=.*$", "", cur).strip()
+            a = re.sub(r"\s+", " ", a)
+            toks = a.split(" ")
+            if len(toks) > 1 and re.fullmatch(r"\w+", toks[-1]):
+                a = " ".join(toks[:-1])
+            parts.append(a.replace(" ", ""))
+            cur = ""
+            continue
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth -= 1
+        cur += ch
+    return ",".join(p for p in parts if p)
+
+
+def classify_item(item: str) -> CppItem:
+    """Classify one comment/string-stripped top-level item."""
+    text = re.sub(r"\s+", " ", item).strip()
+    text = re.sub(r"^(\[\[[^\]]*\]\]\s*)+", "", text)  # strip [[nodiscard]] etc.
+    if not text:
+        return CppItem("empty", text=text)
+    if text.startswith("template"):
+        # Classify by the declaration after the template<...> intro; the
+        # template parameters don't change the category or the entity name.
+        depth = 0
+        for k, ch in enumerate(text):
+            if ch == "<":
+                depth += 1
+            elif ch == ">":
+                depth -= 1
+                if depth == 0:
+                    inner = classify_item(text[k + 1 :])
+                    inner.text = text
+                    return inner
+        return CppItem("unknown", text=text)
+    m = _TYPE_DEF_RE.match(text)
+    if m:
+        cat = "type_def" if "{" in text else "type_decl"
+        name = m.group(1)
+        # Template specializations are distinct entities: TypeName<int>
+        spec = re.match(rf"{re.escape(name)}\s*(<[^{{;]*>)", text[m.start(1) :])
+        if spec:
+            name += re.sub(r"\s+", "", spec.group(1))
+        return CppItem(cat, name, text=text)
+    if text.startswith("namespace"):
+        return CppItem("namespace_def", text=text)
+    if re.match(r"^using\s+namespace\b", text):
+        return CppItem("using_directive", text=text)
+    if re.match(r"^using\s+\w+\s*=", text) or text.startswith("typedef"):
+        nm = re.match(r"^using\s+(\w+)\s*=", text)
+        return CppItem("alias_def", nm.group(1) if nm else None, text=text)
+    first_word = re.match(r"^\w+", text)
+    if first_word and first_word.group(0) in _CONTROL_KW:
+        return CppItem("control_stmt", text=text)
+    if re.match(r"^std\s*::\s*(cout|cerr|wcout)\b", text):
+        return CppItem("output_stmt", text=text)
+    if text.startswith("delete"):
+        return CppItem("expr_stmt", text=text)
+    if re.match(r"^,\s*\w+\s*(\{|=|\()", text):
+        # Continuation declarator from `int i{},\n j{};` style splits.
+        nm = re.match(r"^,\s*(\w+)", text)
+        return CppItem("var_decl", nm.group(1) if nm else None, text=text)
+    fm = _FN_RE.match(text) or _CTOR_RE.match(text)
+    if fm:
+        # Find the closing paren of the arg list; then `{` => def, `;` => decl.
+        open_idx = text.find("(", fm.start(1))
+        depth = 0
+        close_idx = -1
+        for k in range(open_idx, len(text)):
+            if text[k] == "(":
+                depth += 1
+            elif text[k] == ")":
+                depth -= 1
+                if depth == 0:
+                    close_idx = k
+                    break
+        if close_idx > 0:
+            tail = text[close_idx + 1 :].strip()
+            args = text[open_idx + 1 : close_idx]
+            name = re.sub(r"\s*::\s*", "::", fm.group(1))
+            const_marker = " const" if tail.startswith("const") else ""
+            sig = f"{name}({normalize_args(args)}){const_marker}"
+            if "{" in tail and not tail.startswith("="):
+                if name == "main":
+                    return CppItem("main_def", "main", sig, text=text)
+                if "::" in name:
+                    return CppItem("member_fn_def", name, sig, text=text)
+                return CppItem("fn_def", name, sig, text=text)
+            if tail.startswith(";") or tail.rstrip(";") in ("const", "noexcept", "override"):
+                return CppItem("fn_decl", name, sig, text=text)
+    vm = _VAR_RE.match(text)
+    if vm:
+        return CppItem("var_decl", vm.group(1), text=text)
+    mv = _MEMBER_VAR_RE.match(text)
+    if mv:
+        return CppItem("member_var_def", mv.group(1), text=text)
+    if re.match(r"^(::)?\w[\w:]*\s*\(", text):
+        return CppItem("call_stmt", text=text)
+    if text.startswith("{"):
+        return CppItem("block_stmt", text=text)
+    # Expression fallback: unary-op/literal/identifier-chain expressions.
+    # Bare expressions (no trailing `;`) relied on the kernel's auto-display.
+    expr_head = re.match(
+        r"^(\+\+|--|[!*&~+\-(.]|::|\d|true\b|false\b|nullptr\b|' '|\"\"|static_cast\b|sizeof\b|\w[\w:]*)",
+        text,
+    )
+    if expr_head:
+        body = text.rstrip(";").strip()
+        # A `{` is fine when it is a brace-init argument or functional cast,
+        # i.e. it appears after a `(` or `=`; a leading-position `{` we failed
+        # to parse stays unknown.
+        brace_pos = body.find("{")
+        ok = (
+            brace_pos < 0
+            or re.match(r"^[\w:]+(<[^{}]*>)?\s*\{", body)
+            or (0 <= body.find("(") < brace_pos)
+            or (0 <= body.find("=") < brace_pos)
+        )
+        if ok:
+            cat = "expr_stmt" if text.endswith(";") else "expr_display"
+            return CppItem(cat, text=text)
+    return CppItem("unknown", text=text)
+
+
+def classify_source(source: str) -> list[CppItem]:
+    """Classify all top-level items of one C++ code-cell body.
+
+    Returns preprocessor items (``include`` / ``preproc_other``) followed by
+    the classified code items, in source order within each group. ``empty``
+    items are dropped.
+    """
+    cleaned = strip_comments_and_strings(source)
+    pp_lines, rest = extract_preprocessor(cleaned)
+    items: list[CppItem] = [
+        CppItem("include" if pp.startswith("#include") else "preproc_other", text=pp)
+        for pp in pp_lines
+    ]
+    for raw in split_top_level(rest):
+        item = classify_item(raw)
+        if item.category != "empty":
+            items.append(item)
+    return items

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -22,6 +22,11 @@ from clm.core.topic_resolver import (
 )
 from clm.infrastructure.utils.path_utils import split_lang_suffix
 from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
+from clm.slides.cpp_code_analysis import (
+    DEFINITION_CATEGORIES,
+    STATEMENT_CATEGORIES,
+    classify_source,
+)
 from clm.slides.pairing import (
     TITLE_SLIDE_ID,
     build_slide_groups,
@@ -49,7 +54,7 @@ class Finding:
     """A single deterministic validation finding."""
 
     severity: str  # "error", "warning", "info"
-    category: str  # "format", "pairing", "tags"
+    category: str  # "format", "pairing", "tags", "code_export"
     file: str
     line: int
     message: str
@@ -104,7 +109,7 @@ class ValidationResult:
 # Deterministic check categories
 # ---------------------------------------------------------------------------
 
-ALL_DETERMINISTIC_CHECKS = frozenset({"format", "pairing", "tags"})
+ALL_DETERMINISTIC_CHECKS = frozenset({"format", "pairing", "tags", "code_export"})
 ALL_REVIEW_CHECKS = frozenset({"code_quality", "voiceover", "completeness"})
 # Universe of valid check names — used to validate an explicit ``--checks`` /
 # ``checks=`` request. A name in here is always *runnable* when asked for by
@@ -133,9 +138,17 @@ DEFAULT_CHECKS = ALL_CHECKS - OPT_IN_CHECKS
 VOICEOVER_COVERAGE_MARKER = "clm: voiceover-coverage"
 _VOICEOVER_MARKER_RE = re.compile(r"^(?:#|//)\s*clm:\s*voiceover-coverage\s*$")
 
+# Per-deck whitelist marker for the code-export conformance check (#331): a
+# deck that intentionally defines ``main()`` (e.g. to discuss documentation of
+# a complete program) declares it with ``// clm: allow-main`` in the file
+# header. The compilable project export (#333) will skip generating its own
+# ``main()`` for such decks.
+ALLOW_MAIN_MARKER = "clm: allow-main"
+_ALLOW_MAIN_MARKER_RE = re.compile(r"^(?:#|//)\s*clm:\s*allow-main\s*$")
 
-def has_voiceover_coverage_marker(text: str, comment_token: str = "#") -> bool:
-    """Whether the deck opts into voiceover coverage via its header (#178).
+
+def _has_header_marker(text: str, comment_token: str, marker_re: re.Pattern[str]) -> bool:
+    """Whether the deck's file header contains a ``clm:`` directive comment.
 
     Scans only the file header — lines before the first ``<token> %%`` cell
     marker — so the directive is a per-file declaration, not cell content.
@@ -145,9 +158,19 @@ def has_voiceover_coverage_marker(text: str, comment_token: str = "#") -> bool:
         stripped = line.strip()
         if stripped.startswith(cell_marker):
             break
-        if _VOICEOVER_MARKER_RE.match(stripped):
+        if marker_re.match(stripped):
             return True
     return False
+
+
+def has_voiceover_coverage_marker(text: str, comment_token: str = "#") -> bool:
+    """Whether the deck opts into voiceover coverage via its header (#178)."""
+    return _has_header_marker(text, comment_token, _VOICEOVER_MARKER_RE)
+
+
+def has_allow_main_marker(text: str, comment_token: str = "#") -> bool:
+    """Whether the deck whitelists its ``main()`` definition via its header (#331)."""
+    return _has_header_marker(text, comment_token, _ALLOW_MAIN_MARKER_RE)
 
 
 def _check_format(cells: list[Cell], file_path: str) -> list[Finding]:
@@ -1697,6 +1720,152 @@ def _brief_cell_context(cell: Cell) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Code-export conformance (#331)
+# ---------------------------------------------------------------------------
+
+# Jinja templating inside a code-cell *body* (the j2 header cells are a
+# separate cell type). ``{%`` cannot appear in valid C++; ``{{`` can (nested
+# brace-init), so the expression form additionally requires the whitespace
+# the course macros use: ``{{ header(...) }}``. The string-literal escape
+# idiom ``{{'{{...}}'}}`` (Jinja emitting literal braces) is intentionally
+# not flagged: it expands to plain C++ before the notebook pipeline and the
+# code export ever see it.
+_JINJA_IN_CODE_RE = re.compile(r"\{%|\{\{\s")
+
+
+def _check_code_export(
+    cells: list[Cell], file_path: str, *, allow_main: bool = False
+) -> list[Finding]:
+    """Check the structural invariants the compilable C++ export relies on.
+
+    The export (#333) turns each (language × kind) view of a deck into one
+    translation unit, so within such a view no variable, function (same
+    normalized signature incl. const-ness), or type may be defined twice —
+    which is also what xeus-cpp requires at runtime. Checks run per language
+    view: a ``lang="de"`` cell and its ``lang="en"`` sibling never coexist in
+    one output, so paired definitions are NOT redefinitions; untagged cells
+    count for both views. The view checked is the *completed* one (``start``
+    cells are replaced by their ``completed``/``alt`` twin there; ``del``
+    cells appear in no output).
+
+    Also flags ``main()`` definitions (the export generates its own ``main``
+    unless the deck carries the ``clm: allow-main`` header marker), Jinja
+    directives inside code cells (untransformable), and — informationally —
+    cells mixing definitions with statements.
+    """
+    findings: list[Finding] = []
+    # (lang, kind, key) -> line of first definition, in the completed view.
+    seen: dict[tuple[str, str, str], int] = {}
+    # (kind, display-name, first line, line) -> langs, to merge the DE and EN
+    # findings of an untagged-cell redefinition into one.
+    redefs: dict[tuple[str, str, int, int], set[str]] = {}
+
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2 or meta.cell_type != "code":
+            continue
+        source = cell.content
+        if not source.strip():
+            continue
+
+        if _JINJA_IN_CODE_RE.search(source):
+            findings.append(
+                Finding(
+                    severity="warning",
+                    category="code_export",
+                    file=file_path,
+                    line=cell.line_number,
+                    message="Jinja directive inside a code cell",
+                    suggestion=(
+                        "The code export classifies raw cell source and cannot "
+                        "transform templated code; move the Jinja part into a "
+                        "markdown cell or expand it manually."
+                    ),
+                )
+            )
+            continue
+
+        items = classify_source(source)
+
+        categories = {item.category for item in items}
+        has_statement = bool(categories & STATEMENT_CATEGORIES)
+        has_definition = bool(categories & DEFINITION_CATEGORIES) or "main_def" in categories
+        has_variable = "var_decl" in categories
+        if has_statement and (has_definition or has_variable):
+            findings.append(
+                Finding(
+                    severity="info",
+                    category="code_export",
+                    file=file_path,
+                    line=cell.line_number,
+                    message="Code cell mixes definitions and statements",
+                    suggestion=(
+                        "The export splits such cells automatically, but separate "
+                        "definition and usage cells read better on slides."
+                    ),
+                )
+            )
+
+        in_completed_view = "start" not in meta.tags and "del" not in meta.tags
+        langs = (meta.lang,) if meta.lang else ("de", "en")
+        for item in items:
+            if item.category == "main_def" and not allow_main:
+                findings.append(
+                    Finding(
+                        severity="error",
+                        category="code_export",
+                        file=file_path,
+                        line=cell.line_number,
+                        message="main() defined in a deck without the allow-main marker",
+                        suggestion=(
+                            "The code export generates its own main(). If this deck "
+                            f"intentionally defines main(), add a `{ALLOW_MAIN_MARKER}` "
+                            "comment to the file header (before the first cell)."
+                        ),
+                    )
+                )
+            if not in_completed_view:
+                continue
+            if item.category == "var_decl" and item.name:
+                kind, key, display = "variable", item.name, item.name
+            elif item.category in ("fn_def", "member_fn_def") and item.signature:
+                kind, key, display = "function", item.signature, item.signature
+            elif item.category == "type_def" and item.name:
+                kind, key, display = "type", item.name, item.name
+            else:
+                continue
+            for lang in langs:
+                first = seen.setdefault((lang, kind, key), cell.line_number)
+                if first != cell.line_number:
+                    redefs.setdefault((kind, display, first, cell.line_number), set()).add(lang)
+
+    for (kind, display, first_line, line), langs_hit in sorted(
+        redefs.items(), key=lambda kv: (kv[0][3], kv[0][0], kv[0][1])
+    ):
+        view = (
+            "both language views" if len(langs_hit) > 1 else f'lang="{next(iter(langs_hit))}" view'
+        )
+        findings.append(
+            Finding(
+                severity="error",
+                category="code_export",
+                file=file_path,
+                line=line,
+                message=(
+                    f"{kind} '{display}' redefined (first defined at line {first_line}, {view})"
+                ),
+                suggestion=(
+                    "xeus-cpp forbids redefinition and the code export emits one "
+                    "translation unit per deck; rename the entity or remove the "
+                    "duplicate definition."
+                ),
+            )
+        )
+
+    return sorted(findings, key=lambda f: f.line)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1715,7 +1884,9 @@ def validate_file(
         checks: Which checks to run. Default (``None``): every check except
             the opt-in ones — ``format``, ``pairing``, ``tags``,
             ``code_quality``, ``completeness``.
-            Deterministic: ``"format"``, ``"pairing"``, ``"tags"``.
+            Deterministic: ``"format"``, ``"pairing"``, ``"tags"``,
+            ``"code_export"`` (the latter applies to ``.cpp`` decks only and
+            is a no-op elsewhere, #331).
             Review: ``"code_quality"``, ``"voiceover"``, ``"completeness"``.
             ``"voiceover"`` is **opt-in** (issue #176): voiceover is optional
             per deck, so coverage runs only when you name it explicitly in
@@ -1789,6 +1960,15 @@ def validate_file(
             if pair is not None:
                 findings.extend(_check_split_slide_id_parity(*pair))
                 findings.extend(_check_split_companion_for_slide_parity(*pair))
+    if "code_export" in check_set and path.suffix == ".cpp":
+        # Structural invariants of the compilable C++ project export (#331).
+        # C++-only: the classifier heuristics are C++-specific, and other
+        # languages have no code-export backend.
+        findings.extend(
+            _check_code_export(
+                cells, file_str, allow_main=has_allow_main_marker(text, comment_token)
+            )
+        )
 
     # Review material extraction
     review_checks = check_set & ALL_REVIEW_CHECKS

--- a/tests/slides/test_validator_code_export.py
+++ b/tests/slides/test_validator_code_export.py
@@ -1,0 +1,485 @@
+"""Tests for the ``code_export`` conformance check (#331).
+
+The redefinition rule's negative tests encode the four false-positive traps
+found while validating the classifier against the full CppCourses corpus:
+language-paired cells, legal overloads, template specializations, and
+``start``/``completed`` pairs. Each of these cost a debugging round in the
+feasibility scan — they must never regress into findings.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from clm.slides.cpp_code_analysis import (
+    classify_item,
+    classify_source,
+    normalize_args,
+    split_top_level,
+    strip_comments_and_strings,
+)
+from clm.slides.validator import validate_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_deck(tmp_path, content, name="slides_test.cpp"):
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def _code_export_findings(path):
+    result = validate_file(path, checks=["code_export"])
+    return [f for f in result.findings if f.category == "code_export"]
+
+
+# ---------------------------------------------------------------------------
+# Classifier unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStripCommentsAndStrings:
+    def test_line_and_block_comments_removed(self):
+        src = "int i{}; // trailing {\n/* block ; */ int j{};"
+        cleaned = strip_comments_and_strings(src)
+        assert "{" not in cleaned.split(";")[0].replace("{}", "")
+        assert "block" not in cleaned
+        assert "int j{};" in cleaned
+
+    def test_raw_string_removed(self):
+        src = 'auto s = R"x(unbalanced { ; )x";'
+        cleaned = strip_comments_and_strings(src)
+        assert "unbalanced" not in cleaned
+        assert cleaned.count("{") == 0
+
+    def test_string_and_char_literals_blanked(self):
+        cleaned = strip_comments_and_strings("call(\"a;b\", ';');")
+        assert "a;b" not in cleaned
+        assert cleaned.count(";") == 1
+
+
+class TestSplitTopLevel:
+    def test_if_else_is_one_item(self):
+        items = split_top_level("if (x) { a(); } else { b(); }")
+        assert len(items) == 1
+
+    def test_do_while_is_one_item(self):
+        items = split_top_level("do { x(); } while (cond);")
+        assert len(items) == 1
+
+    def test_try_catch_is_one_item(self):
+        items = split_top_level("try { risky(); } catch (...) { handle(); }")
+        assert len(items) == 1
+
+    def test_definition_then_statement_splits(self):
+        items = split_top_level("int square(int x) { return x * x; } square(3);")
+        assert len(items) == 2
+
+
+class TestNormalizeArgs:
+    def test_strips_names_and_defaults(self):
+        assert normalize_args("int x, double y = 1.0") == "int,double"
+
+    def test_reference_and_const(self):
+        assert normalize_args("std::string const& name") == "std::stringconst&"
+
+    def test_template_args_keep_commas_inside(self):
+        assert normalize_args("std::map<int, int> m") == "std::map<int,int>"
+
+
+class TestClassifyItem:
+    def test_variable_declaration(self):
+        item = classify_item("int i{};")
+        assert (item.category, item.name) == ("var_decl", "i")
+
+    def test_east_const_variable(self):
+        assert classify_item("int const i{17};").category == "var_decl"
+
+    def test_array_variable(self):
+        item = classify_item("int numbers[5];")
+        assert (item.category, item.name) == ("var_decl", "numbers")
+
+    def test_function_definition_signature(self):
+        item = classify_item("int add(int x, int y) { return x + y; }")
+        assert item.category == "fn_def"
+        assert item.signature == "add(int,int)"
+
+    def test_const_member_function_signature_differs(self):
+        plain = classify_item("int MyVector::at(int i) { return 0; }")
+        const = classify_item("int MyVector::at(int i) const { return 0; }")
+        assert plain.category == const.category == "member_fn_def"
+        assert plain.signature != const.signature
+        assert const.signature.endswith(" const")
+
+    def test_out_of_class_constructor(self):
+        item = classify_item("MyVector::MyVector(int n) { resize(n); }")
+        assert item.category == "member_fn_def"
+
+    def test_type_definition(self):
+        item = classify_item("struct Point { int x; int y; };")
+        assert (item.category, item.name) == ("type_def", "Point")
+
+    def test_template_specialization_name_includes_args(self):
+        primary = classify_item("template <typename T> struct TypeName { };")
+        spec = classify_item("template <> struct TypeName<int> { };")
+        assert primary.name == "TypeName"
+        assert spec.name == "TypeName<int>"
+
+    def test_main_definition(self):
+        assert classify_item("int main() { return 0; }").category == "main_def"
+
+    def test_display_expression_vs_statement(self):
+        assert classify_item("i + 1").category == "expr_display"
+        assert classify_item("i + 1;").category == "expr_stmt"
+
+    def test_output_statement(self):
+        assert classify_item('std::cout << "hi" << i;').category == "output_stmt"
+
+
+class TestClassifySource:
+    def test_includes_extracted(self):
+        items = classify_source("#include <iostream>\nint i{};")
+        assert [it.category for it in items] == ["include", "var_decl"]
+
+    def test_comments_do_not_confuse_classification(self):
+        items = classify_source("// int shadow{};\nint real{};")
+        assert [it.name for it in items] == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# Redefinition rule — positives
+# ---------------------------------------------------------------------------
+
+
+class TestRedefinitionErrors:
+    def test_variable_redefined_in_untagged_cells(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %% tags=["keep"]
+            int i{};
+
+            // %%
+            int i{};
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert findings[0].severity == "error"
+        assert "variable 'i' redefined" in findings[0].message
+        # Untagged cells appear in both language views; the finding is merged.
+        assert "both language views" in findings[0].message
+
+    def test_function_redefined_same_signature(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            void greet(std::string name) {}
+
+            // %%
+            void greet(std::string who) {}
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert "function" in findings[0].message
+        assert findings[0].severity == "error"
+
+    def test_type_redefined(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            struct Point { int x; };
+
+            // %%
+            struct Point { int x; int y; };
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert "type 'Point' redefined" in findings[0].message
+
+    def test_redefinition_across_untagged_and_lang_cell(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            int i{};
+
+            // %% lang="de"
+            int i{};
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert 'lang="de" view' in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Redefinition rule — the four false-positive traps (must stay silent)
+# ---------------------------------------------------------------------------
+
+
+class TestRedefinitionFalsePositiveTraps:
+    def test_trap_1_language_paired_cells(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %% lang="de"
+            int i_vi{};
+
+            // %% lang="en"
+            int i_vi{};
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_trap_2a_overloads_by_parameter_type(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            void print(int value) {}
+
+            // %%
+            void print(double value) {}
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_trap_2b_const_vs_nonconst_member_function(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            int MyVector::at(int i) { return data[i]; }
+
+            // %%
+            int MyVector::at(int i) const { return data[i]; }
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_trap_3_template_specialization(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            template <typename T> struct TypeName { };
+
+            // %%
+            template <> struct TypeName<int> { };
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_trap_4_start_completed_pair(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %% tags=["start"]
+            class Stack {};
+
+            // %% tags=["completed"]
+            class Stack {
+            public:
+                void push(int value);
+            };
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_del_cells_are_excluded(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %% tags=["del"]
+            int i{};
+
+            // %%
+            int i{};
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+
+# ---------------------------------------------------------------------------
+# main() whitelist
+# ---------------------------------------------------------------------------
+
+
+class TestMainWhitelist:
+    def test_main_without_marker_is_error(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            int main() { return 0; }
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert findings[0].severity == "error"
+        assert "main()" in findings[0].message
+        assert "clm: allow-main" in findings[0].suggestion
+
+    def test_main_with_header_marker_is_allowed(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // clm: allow-main
+
+            // %%
+            int main() { return 0; }
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_marker_inside_cell_body_does_not_count(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            // clm: allow-main
+            int main() { return 0; }
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Jinja in code cells
+# ---------------------------------------------------------------------------
+
+
+class TestJinjaInCodeCells:
+    def test_jinja_expression_is_warning(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            print({{ value }});
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "Jinja" in findings[0].message
+
+    def test_jinja_statement_is_warning(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            {% if lang == "de" %}
+            int zaehler{};
+            {% endif %}
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+
+    def test_jinja_string_literal_escape_is_not_flagged(self, tmp_path):
+        # The escape idiom from the builder deck: Jinja emitting literal
+        # braces. It expands to plain C++ before the export runs.
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %% tags=["keep"]
+            sendRequest("https://example.com", {{'{{"Content-Type", "application/json"}}'}}, {});
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_nested_brace_init_is_not_jinja(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            std::array<std::array<int, 2>, 2> arr{{1, 2}, {3, 4}};
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+
+# ---------------------------------------------------------------------------
+# Mixed cells
+# ---------------------------------------------------------------------------
+
+
+class TestMixedCells:
+    def test_definition_plus_statement_is_info(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            int square(int x) { return x * x; }
+            square(3);
+            """,
+        )
+        findings = _code_export_findings(p)
+        assert len(findings) == 1
+        assert findings[0].severity == "info"
+        assert "mixes definitions and statements" in findings[0].message
+
+    def test_pure_definition_cell_is_silent(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            int square(int x) { return x * x; }
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+    def test_pure_statement_cell_is_silent(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            square(3);
+            """,
+        )
+        assert _code_export_findings(p) == []
+
+
+# ---------------------------------------------------------------------------
+# Scope: C++ decks only, default bundle membership
+# ---------------------------------------------------------------------------
+
+
+class TestCheckScope:
+    def test_noop_for_python_decks(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            # %%
+            i = 1
+
+            # %%
+            i = 1
+            """,
+            name="slides_test.py",
+        )
+        assert _code_export_findings(p) == []
+
+    def test_included_in_default_check_bundle(self, tmp_path):
+        p = _write_deck(
+            tmp_path,
+            """\
+            // %%
+            int i{};
+
+            // %%
+            int i{};
+            """,
+        )
+        result = validate_file(p)
+        assert any(f.category == "code_export" for f in result.findings)


### PR DESCRIPTION
Closes #331. Phase 0 of the compilable C++ project export (#333); kickoff context in [HANDOVER_CPP_CODE_EXPORT.md](https://github.com/hoelzl/CppCourses/blob/master/course-planning/HANDOVER_CPP_CODE_EXPORT.md).

## What

New deterministic validation check **`code_export`** (part of the default bundle; applies to `.cpp` decks only, no-op elsewhere):

| Finding | Severity |
|---|---|
| Variable / function / type redefined within one (language × completed) output view | error |
| `main()` defined in a deck without the `// clm: allow-main` header marker | error |
| Jinja directive inside a code cell (`{% ... %}` / `{{ ... }}`) | warning |
| Cell mixes definitions and statements | info |

The redefinition rule models the four false-positive traps found during the corpus scan, each locked in by a regression test: DE/EN-paired cells are alternatives (checks run per language view; untagged cells count for both), overloads compare by normalized parameter types + const-ness, template specializations are distinct entities (`TypeName<int>`), and `start`/`completed` pairs never coexist in one variant. `del` cells appear in no output and are excluded.

The `// clm: allow-main` whitelist marker reuses the `clm: voiceover-coverage` header-directive mechanism (#178) instead of introducing a config file.

The Jinja rule deliberately does **not** flag the string-literal escape idiom `{{'{{...}}'}}` (used in the builder deck to emit literal braces) — it expands to plain C++ before the pipeline ever classifies it.

## Classifier

`clm.slides.cpp_code_analysis` — heuristic top-level item analysis (comment/string/raw-string stripping, preprocessor extraction, brace-aware top-level splitting with `else`/`while`/`catch` continuation handling, category dispatch). It operates on plain source strings so the #333 export backend can reuse it directly. Ported from the validated CppCourses scanner (`tools/scan_cell_structure.py`); a libclang-based classifier could replace it later without changing call sites.

## Verification

- 45 new tests; full suite green (1650 passed, 2 skipped in tests/slides; full run green).
- Smoke-run against the full CppCourses corpus (master) reproduces the feasibility report exactly: **0 errors in all 259 buildable decks**; errors only in the 4 known non-buildable decks, the known `main()` deck (`topic_150_clean_code_comments_and_docs` — needs the marker added in CppCourses), and `projects/project_120_caesar_cipher.cpp` (real intentional redefinitions from the cling era; CppCourses follow-up).
- Bonus: run against a stale pre-1.9-cleanup checkout, the check correctly caught the `int dx` → `double dx` redefinitions that the 1.9 rebuild later fixed.

## Noted, not in scope

- Validation walks descend into `.ipynb_checkpoints/`, duplicating findings from stale checkpoint copies (89 of 122 errors in a real checkout were checkpoint noise). Pre-existing behavior of `find_slide_files_recursive` affecting all checks — the `_`-prefix prune from #318 should probably extend to dot-dirs. Separate issue material.
- Normalizer auto-split of mixed cells (optional item in #331) deferred; the export splits them automatically anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
