### PR TITLE
fix(cli): demote "Output targets" log line to DEBUG

### DIFF
--- a/changelog.d/quiet-output-targets-log.fixed.md
+++ b/changelog.d/quiet-output-targets-log.fixed.md
@@ -1,0 +1,5 @@
+- **Quieter CLI startup.** The `Output targets: [...]` log line emitted by
+  `Course.from_spec` / `Course.process_all` was demoted from INFO to DEBUG, so
+  commands that don't reconfigure logging (e.g. `clm export …`, `clm calendar`)
+  no longer print it to the console. `clm build` now shows the target names as
+  a dimmed startup message instead.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1694,6 +1694,10 @@ async def main_build(
     output_formatter.show_startup_message(
         f"Loaded {len(course.files)} files from {len(course.sections)} sections"
     )
+    if course.output_targets:
+        output_formatter.show_startup_message(
+            f"Output targets: {', '.join(t.name for t in course.output_targets)}"
+        )
 
     build_reporter = BuildReporter(output_formatter)
 

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -231,7 +231,7 @@ class Course(NotebookMixin):
             logger.info(f"Implicit executions required for cache population: {implicit}")
 
         logger.debug(f"Creating course from spec {spec}: {course_root} -> {effective_output_root}")
-        logger.info(f"Output targets: {[t.name for t in targets]}")
+        logger.debug(f"Output targets: {[t.name for t in targets]}")
 
         course = cls(
             spec,
@@ -372,7 +372,7 @@ class Course(NotebookMixin):
     async def process_all(self, backend: Backend):
         """Process all files for all output targets."""
         logger.info(f"Processing all files for {self.course_root}")
-        logger.info(f"Output targets: {[t.name for t in self.output_targets]}")
+        logger.debug(f"Output targets: {[t.name for t in self.output_targets]}")
 
         # Sweep orphan HTTP-replay staging files into their canonical
         # cassettes *before* any payload is constructed. Otherwise a


### PR DESCRIPTION
## Summary

Most interactive `clm` commands printed a log line like

```
2026-06-11 11:48:19,469 - clm.core.course - INFO - Output targets: ['shared', 'trainer', 'speaker']
```

at startup. Commands that don't reconfigure logging (`clm export …`, `clm calendar …`, `clm cache …`, `clm jupyterlite …`) inherit the module-level `logging.basicConfig(level=logging.INFO)` console handler from `clm.cli.main`, so the INFO-level line from `Course.from_spec` / `Course.process_all` leaked into interactive output.

## Changes

- Demote both `Output targets: […]` log calls in `src/clm/core/course.py` to DEBUG (still captured in the log file, which records all levels).
- `clm build` now shows the target names as a dimmed startup message (`show_startup_message`) right after the course is loaded, so the information stays visible where it is actually useful.
- Changelog fragment `changelog.d/quiet-output-targets-log.fixed.md`.

## Verification

- `clm export outline tests/test-data/course-specs/test-spec-1.xml` now prints only the outline, no log line.
- ruff, mypy, and the fast test suite pass (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
