### PR TITLE
feat(build): add --no-html flag for kernel-free builds (#333)

### DIFF
--- a/changelog.d/333-no-html-build-flag.added.md
+++ b/changelog.d/333-no-html-build-flag.added.md
@@ -1,0 +1,6 @@
+`clm build --no-html` skips HTML generation for every topic (#333), as if
+each carried `html="no"` in the spec. HTML is the only output format whose
+generation executes notebooks, so a `--no-html` build needs no Jupyter
+kernel — intended for the code-export compile CI and other kernel-free
+environments, where the HTML jobs would otherwise fail with `NoSuchKernel`
+and could wedge the worker pool until the job timeout.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -382,6 +382,13 @@ class BuildConfig:
     speaker_only: bool = False
     selected_targets: list[str] | None = None
 
+    # Skip HTML generation for every topic (``--no-html``), as if each
+    # carried ``html="no"`` in the spec. HTML is the only output format
+    # whose generation executes notebooks, so a ``--no-html`` build needs
+    # no Jupyter kernel — the mode the code-export compile CI uses
+    # (issue #333).
+    no_html: bool = False
+
     # Notebook execution mode
     force_execute: bool = False
 
@@ -769,6 +776,17 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
             f"Unselected sections' output directories will be left "
             f"untouched and dir-group processing will be skipped."
         )
+
+    # ``--no-html``: drop the HTML format from every topic before the
+    # course is constructed, so every downstream derivation (course
+    # files, output specs, the CMake export, provenance) agrees that
+    # HTML does not exist in this build. Same mechanism watch fast mode
+    # applies per-rebuild, but spec-level so the initial build sees it.
+    if config.no_html:
+        logger.info("--no-html: skipping HTML generation for all topics")
+        for section_spec in spec.sections:
+            for i, topic_spec in enumerate(section_spec.topics):
+                section_spec.topics[i] = evolve(topic_spec, skip_html=True)
 
     # Create course object
     course = Course.from_spec(
@@ -1567,6 +1585,7 @@ async def main_build(
     fail_on_missing_xref=False,
     provenance_manifest=True,
     telemetry_db_path: Path | None = None,
+    no_html: bool = False,
 ) -> BuildSummary | None:
     """Main orchestration function for course building.
 
@@ -1680,6 +1699,7 @@ async def main_build(
         language=language,
         speaker_only=speaker_only,
         selected_targets=selected_targets,
+        no_html=no_html,
         force_execute=force_execute,
         http_replay_mode=resolved_http_replay_mode,
         image_mode=image_mode,
@@ -2097,6 +2117,17 @@ async def main_build(
     help="Generate only speaker notes (skip public outputs like code-along and completed).",
 )
 @click.option(
+    "--no-html",
+    is_flag=True,
+    help=(
+        "Skip HTML generation for every topic (as if each carried "
+        'html="no" in the spec). HTML is the only output format whose '
+        "generation executes notebooks, so a --no-html build needs no "
+        "Jupyter kernel — intended for the code-export compile CI and "
+        "other kernel-free environments."
+    ),
+)
+@click.option(
     "--targets",
     "-T",
     type=str,
@@ -2218,6 +2249,7 @@ def build(
     verbose_logging,
     language,
     speaker_only,
+    no_html,
     targets,
     force_execute,
     http_replay,
@@ -2361,6 +2393,7 @@ def build(
             resolved_fail_on_missing_xref,
             effective_provenance_manifest,
             telemetry_db_path=ctx.obj.get("TELEMETRY_DB_PATH") if ctx.obj else None,
+            no_html=no_html,
         )
     )
 

--- a/tests/cli/test_cli_unit.py
+++ b/tests/cli/test_cli_unit.py
@@ -624,3 +624,26 @@ class TestOutputFiltering:
         # both private kinds so trainer and recording are both built.
         assert course.output_languages == ["de"]
         assert course.output_kinds == ["trainer", "recording"]
+
+    def test_no_html_skips_html_for_all_topics(self):
+        """--no-html flips skip_html on every topic before course creation"""
+        from clm.cli.main import initialize_paths_and_course
+
+        config = self._create_config()
+        config.no_html = True
+        course, root_dirs, data_dir = initialize_paths_and_course(config)
+
+        notebook_files = [f for f in course.files if hasattr(f, "skip_html")]
+        assert notebook_files, "test spec should contain notebook files"
+        assert all(f.skip_html for f in notebook_files)
+
+    def test_default_does_not_skip_html(self):
+        """Without --no-html, notebook files keep their spec-level skip_html"""
+        from clm.cli.main import initialize_paths_and_course
+
+        config = self._create_config()
+        course, root_dirs, data_dir = initialize_paths_and_course(config)
+
+        notebook_files = [f for f in course.files if hasattr(f, "skip_html")]
+        assert notebook_files, "test spec should contain notebook files"
+        assert not any(f.skip_html for f in notebook_files)


### PR DESCRIPTION
Part of #333 (phase 3): the CppCourses compile-check CI needs to build courses on runners without a Jupyter kernel.

## Problem

HTML generation is the only output format that executes notebooks. Building a real course on a machine without the `xcpp20` kernel doesn't just litter the log with `NoSuchKernel` errors — after a burst of fast failures the notebook worker pool wedges, the remaining jobs die at the 1200s job timeout, the build exits non-zero unconditionally (timeouts bypass `--no-fail-on-error`), and CMake-project generation is suppressed because the summary gate never passes. Observed end-to-end with `cpp-clean-code`: exit 1 after six 1200s timeouts, zero `CMakeLists.txt` written.

## Change

`clm build --no-html` flips `skip_html` on every `TopicSpec` before the course is constructed — the same mechanism watch fast mode applies per-rebuild, but at spec level so the initial build and every downstream derivation (course files, output specs, the CMake export, provenance) agree HTML does not exist in this build.

With the flag, the same kernel-less `cpp-clean-code` build completes with exit 0 and writes all ten per-kind CMake projects (5 kinds × 2 languages).

## Possible follow-up

The wedged-worker-pool behavior on `NoSuchKernel` might deserve its own issue — a missing kernel could fail jobs fast instead of stalling the pool into job timeouts. `--no-html` sidesteps it for the CI use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
