### PR TITLE
fix(export): don't split expressions after a brace-init temporary (#333)

### DIFF
--- a/changelog.d/333-brace-expression-split.fixed.md
+++ b/changelog.d/333-brace-expression-split.fixed.md
@@ -1,0 +1,6 @@
+The C++ code export no longer splits an expression after a brace-init
+temporary (#333): `RequestBuilder{}.setTimeout(10).send();` or
+`auto n = std::vector<int>{1, 2}.size();` previously broke apart at the
+closing `}`, leaving a stray `.setTimeout(...)` item that cannot compile.
+A `}` at depth 0 now only ends an item when the next token cannot
+continue an expression.

--- a/src/clm/slides/cpp_code_analysis.py
+++ b/src/clm/slides/cpp_code_analysis.py
@@ -207,6 +207,14 @@ def extract_preprocessor(src: str) -> tuple[list[str], str]:
     return pp, "\n".join(rest)
 
 
+# Characters that continue an expression after a closing ``}`` at depth 0.
+# A brace-init temporary can sit mid-expression
+# (``RequestBuilder{}.setTimeout(10).send();``,
+# ``auto n = std::vector<int>{1, 2}.size();``) — a ``}`` followed by one of
+# these must not end the item.
+_EXPR_CONTINUATION_CHARS = frozenset(".,)]([<>+-*/%&|^?:!~=")
+
+
 def split_top_level_spans(src: str) -> list[tuple[int, int]]:
     """Like :func:`split_top_level`, but return ``(start, end)`` char spans.
 
@@ -242,7 +250,8 @@ def split_top_level_spans(src: str) -> list[tuple[int, int]]:
                     emit(i + 1)
                 else:
                     word = re.match(r"(else|while|catch)\b", src[j : j + 8])
-                    if not word:
+                    expr_continues = j < n and src[j] in _EXPR_CONTINUATION_CHARS
+                    if not word and not expr_continues:
                         emit(i + 1)
         elif c == "(":
             paren += 1

--- a/tests/slides/test_cpp_code_emitter.py
+++ b/tests/slides/test_cpp_code_emitter.py
@@ -81,6 +81,27 @@ class TestSplitTopLevelSpans:
         assert items == split_top_level(src)
         assert len(items) == 4
 
+    def test_brace_init_temporary_in_fluent_chain_is_one_item(self):
+        src = "RequestBuilder{}.setTimeout(10).send();"
+        assert split_top_level(src) == [src]
+
+    def test_brace_init_temporary_with_chain_on_next_line(self):
+        src = "RequestBuilder{}\n    .setTimeout(10)\n    .send();"
+        assert split_top_level(src) == [src.strip()]
+
+    def test_brace_init_mid_declaration_is_one_item(self):
+        src = "auto n = std::vector<int>{1, 2}.size();"
+        assert split_top_level(src) == [src]
+
+    def test_brace_init_followed_by_comma_continues_declaration(self):
+        src = "int a[] = {1, 2}, b[] = {3};"
+        assert split_top_level(src) == [src]
+
+    def test_adjacent_definitions_still_split(self):
+        src = "void f() {}\nint g() { return 1; }"
+        items = split_top_level(src)
+        assert items == ["void f() {}", "int g() { return 1; }"]
+
 
 # ---------------------------------------------------------------------------
 # classify_source_spans
@@ -181,6 +202,15 @@ class TestEmitBasicStructure:
         assert tu.count("#include <string>") == 1
         # Hoisted above all code.
         assert tu.index("#include <string>") < tu.index("std::vector<int> v{1};")
+
+    def test_brace_init_fluent_chain_stays_one_statement(self):
+        # Regression: the builder deck's `RequestBuilder{}.setTimeout(10)...`
+        # was split after the brace-init `}`, leaving a stray `.setTimeout`
+        # item that cannot compile.
+        cells = ["// Change only the timeout....\nRequestBuilder{}.setTimeout(10).send();"]
+        tu = emit_cpp_translation_unit(cells)
+        assert "    RequestBuilder{}.setTimeout(10).send();" in tu
+        assert "\n    .setTimeout" not in tu
 
     def test_statement_cells_become_numbered_slides_called_in_order(self):
         cells = ["f();", "g();", "h();"]


### PR DESCRIPTION
Found by the CppCourses code-export CI shakedown: the builder deck failed in four courses with *expected primary-expression before '.'* — the splitter cut \RequestBuilder{}.setTimeout(10).send();\ in half at the brace-init temporary's \}\. Details in the commit message. A depth-0 \}\ now only ends an item when the next token cannot continue an expression. Five new splitter regression tests + one emit-level test; verified end-to-end by building cpp-clean-arch/hs/for-programmers/tdd and compiling all Completed projects green with g++ on Ubuntu 24.04 (together with the CppCourses content-fix PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)