### PR TITLE
Add clm query affected-specs: map changed files to affected course specs

### DIFF
--- a/changelog.d/350-query-affected-specs.added.md
+++ b/changelog.d/350-query-affected-specs.added.md
@@ -1,0 +1,10 @@
+- `clm query affected-specs` — map changed file paths (arguments and/or
+  `--stdin`) to the course specs whose builds they can influence, using the
+  same topic/include/dir-group resolution as the build (single-file topics
+  also claim the sibling files their content references). Fails open
+  (`"all": true`) for build-relevant paths no spec claims, so a CI matrix
+  built from the `--json` output never silently skips a course; clearly
+  build-irrelevant paths (`.github/`, top-level docs) and content invisible
+  to every build (unreferenced topics, `_archive` dirs) affect nothing.
+  First member of the new **`clm query`** group for read-only,
+  scripting-oriented introspection commands (issue #350).

--- a/src/clm/cli/commands/query/__init__.py
+++ b/src/clm/cli/commands/query/__init__.py
@@ -1,0 +1,21 @@
+"""The ``clm query`` group — read-only introspection for scripting (issue #350).
+
+The group name states the contract: queries never modify anything (no
+filesystem writes, no builds), and every member is safe to call from scripts
+and CI. One module per subcommand: ``clm query <cmd>`` lives in
+``commands/query/<cmd>.py`` (dashes become underscores).
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.group("query")
+def query_group() -> None:
+    """Read-only queries for scripting: never modify anything."""
+
+
+from clm.cli.commands.query.affected_specs import affected_specs_cmd  # noqa: E402
+
+query_group.add_command(affected_specs_cmd, name="affected-specs")

--- a/src/clm/cli/commands/query/affected_specs.py
+++ b/src/clm/cli/commands/query/affected_specs.py
@@ -1,0 +1,93 @@
+"""``clm query affected-specs`` — map changed files to affected course specs.
+
+Read-only CI helper (issue #350): feed it ``git diff --name-only`` output and
+it reports which course specs' builds those changes can influence, using the
+same topic/include/dir-group resolution as the build. Delegates to
+:mod:`clm.core.affected_specs`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.core.affected_specs import (
+    find_affected_specs,
+    render_report,
+    report_to_dict,
+)
+
+
+@click.command("affected-specs")
+@click.argument("paths", nargs=-1)
+@click.option(
+    "--spec-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default="course-specs",
+    show_default=True,
+    help="Directory containing the course spec *.xml files.",
+)
+@click.option(
+    "--course-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Course root that input paths are relative to. Default: parent of --spec-dir.",
+)
+@click.option(
+    "--stdin",
+    "read_stdin",
+    is_flag=True,
+    help="Read additional newline-separated paths from stdin.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report for scripting.")
+def affected_specs_cmd(
+    paths: tuple[str, ...],
+    spec_dir: Path,
+    course_root: Path | None,
+    read_stdin: bool,
+    as_json: bool,
+) -> None:
+    """Map changed paths to the course specs whose builds they can influence.
+
+    PATHS are changed files relative to the course root (pass them as
+    arguments and/or pipe them in with --stdin). Every spec in --spec-dir is
+    resolved once with the same rules the build uses; each path is then
+    attributed to the specs that claim it (topic dirs and the sibling files a
+    single-file topic references, <include> sources, <dir-group> paths, ...).
+
+    The mapping fails open: a build-relevant path that no spec claims (Jinja
+    macros, shared toplevel dirs, ...) sets "all": true and lists every spec,
+    so a CI matrix built from the output never silently skips a course. Only
+    clearly build-irrelevant paths (.github/, top-level docs) and content
+    invisible to every build (unreferenced topics, _archive dirs) affect
+    nothing. The exit code is always 0 — an empty result is data, not an
+    error.
+
+    \b
+    Examples:
+        clm query affected-specs slides/module_240_generics/type_name.hpp
+        git diff --name-only $BEFORE $HEAD | clm query affected-specs --stdin --json
+        clm query affected-specs --spec-dir course-specs --stdin --json < changed.txt
+    """
+    all_paths = list(paths)
+    if read_stdin:
+        all_paths.extend(line.strip() for line in sys.stdin if line.strip())
+
+    spec_files = sorted(spec_dir.glob("*.xml"))
+    if not spec_files:
+        raise click.ClickException(f"No *.xml specs found in {spec_dir}.")
+
+    report = find_affected_specs(all_paths, spec_dir, course_root=course_root)
+
+    for warning in report.warnings:
+        click.echo(f"warning: {warning}", err=True)
+
+    if as_json:
+        click.echo(json.dumps(report_to_dict(report), indent=2))
+    else:
+        click.echo(render_report(report))
+
+    sys.exit(0)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -18,7 +18,8 @@ clm [OPTIONS] COMMAND [ARGS]...
 The CLI is organised into a small top-level surface (the everyday verbs:
 `build`, `validate`, `run`, ...) plus domain groups: `slides` (deck-level
 authoring tools), `course` (course/spec structure: decks, targets, topics,
-includes, readiness gate), `export` (rendered course documents), `calendar`
+includes, readiness gate), `query` (read-only introspection for scripting),
+`export` (rendered course documents), `calendar`
 (cohort viewing calendars), `voiceover`, and the infrastructure groups
 (`db`, `docker`, `git`, `jobs`, `workers`, `zip`, ...). The reference below
 uses the canonical (group-qualified) names. Older flat names were removed
@@ -1090,6 +1091,75 @@ clm course sync-includes course-specs/ml-azav.xml --remove
 clm course sync-includes course-specs/ml-azav.xml --print-gitignore >> .gitignore
 clm course sync-includes course-specs/ml-azav.xml --dry-run
 clm course sync-includes course-specs/ml-azav.xml --data-dir /path/to/course
+```
+
+### `clm query affected-specs` (CLM {version}+)
+
+Map changed file paths to the course specs whose builds they can influence.
+First member of the **`clm query`** group: read-only introspection commands
+for scripting — queries never modify anything and are always safe to call
+from CI. Built for change-driven CI matrices: feed it
+`git diff --name-only` output and build only the affected courses.
+
+```
+clm query affected-specs [OPTIONS] [PATHS]...
+```
+
+Every spec in `--spec-dir` is resolved once with the same rules the build
+uses; each input path is attributed to the specs that claim it:
+
+- **Topic directories** (resolved by suffix match + section/topic `module=`
+  bindings) claim their whole subtree — slides, `img/`, loose data files.
+- **Single-file topics** additionally claim the sibling files their content
+  references (images, imported module files), mirroring the build's file
+  map — this is how a shared header next to several decks is owned by every
+  course that builds one of them.
+- **`<include source=...>`** and **`<dir-group path=...>`** claim their
+  course-root-relative sources; JupyterLite wheels/environment files,
+  output-target paths, and release-channel paths/ledgers map to their
+  owning spec.
+- Each spec file claims itself, so editing one spec affects only that course.
+
+The mapping **fails open**: a build-relevant path that no spec claims (Jinja
+macros, shared toplevel dirs, unattributable content in the spec dir, ...)
+sets `"all": true` and lists **every** spec, so a CI matrix built from the
+output never silently skips a course. Only clearly build-irrelevant paths
+(`.github/`, `.git*`, top-level `*.md` docs, `LICENSE`) and content invisible
+to every build (topics no spec references, underscore-prefixed `_archive`
+dirs under `slides/`) affect nothing. A spec that fails to parse is reported
+on stderr and conservatively marked affected by every build-relevant change.
+
+The exit code is always 0 — an empty result is data, not an error.
+
+| Option | Description |
+|--------|-------------|
+| `--spec-dir DIR` | Directory containing the course spec `*.xml` files (default: `course-specs`). |
+| `--course-root DIR` | Course root that input paths are relative to (default: parent of `--spec-dir`). |
+| `--stdin` | Read additional newline-separated paths from stdin (combinable with `PATHS` arguments). |
+| `--json` | Emit a JSON report for scripting. |
+
+JSON shape (`specs` lists every spec when `all` is true, so a consumer can
+feed it into a build matrix without branching; `paths` carries the per-path
+verdict with status `claimed` / `ignored` / `unreferenced` / `unknown`):
+
+```json
+{
+  "specs": ["cpp-for-programmers", "cpp-hs"],
+  "all": false,
+  "paths": [
+    {"path": "slides/module_240_generics/type_name.hpp",
+     "status": "claimed",
+     "specs": ["cpp-for-programmers", "cpp-hs"]}
+  ]
+}
+```
+
+Examples:
+
+```bash
+clm query affected-specs slides/module_240_generics/type_name.hpp
+git diff --name-only $BEFORE $HEAD | clm query affected-specs --spec-dir course-specs --stdin --json
+clm query affected-specs --stdin --json < changed-files.txt
 ```
 
 ### `clm validate` (slides mode)

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -64,6 +64,7 @@ _COMMANDS = "clm.cli.commands"
         "course": f"{_COMMANDS}.course:course_group",
         "export": f"{_COMMANDS}.export:export_group",
         "calendar": f"{_COMMANDS}.calendar:calendar_group",
+        "query": f"{_COMMANDS}.query:query_group",
         # -------------------------------------------------------------
         # Infrastructure groups.
         # -------------------------------------------------------------
@@ -172,6 +173,7 @@ _COMPAT_EXPORTS: dict[str, tuple[str, str]] = {
     "course_group": (f"{_COMMANDS}.course", "course_group"),
     "export_group": (f"{_COMMANDS}.export", "export_group"),
     "calendar_group": (f"{_COMMANDS}.calendar", "calendar_group"),
+    "query_group": (f"{_COMMANDS}.query", "query_group"),
     "cassette_group": (f"{_COMMANDS}.cassette", "cassette_group"),
     "config": (f"{_COMMANDS}.config", "config"),
     "db": (f"{_COMMANDS}.db", "db"),

--- a/src/clm/core/affected_specs.py
+++ b/src/clm/core/affected_specs.py
@@ -1,0 +1,439 @@
+"""Map changed source paths to the course specs whose builds they affect (issue #350).
+
+Backs ``clm query affected-specs``: given a set of changed paths (typically
+``git diff --name-only`` output) and a directory of course specs, report which
+specs' builds those changes can influence, so a CI matrix can build only the
+affected courses instead of all of them.
+
+The mapping is **build-faithful**: every spec's claimed input surface is
+derived from the same resolution the build uses —
+
+* topic references resolve through :func:`clm.core.topic_resolver.build_topic_map`
+  with the spec's section/topic ``module=`` bindings;
+* a directory topic claims its whole subtree (slides, ``img/``, data files);
+* a single-file topic additionally claims the sibling files its content
+  references, replicating ``FileTopic.build_file_map`` (images via
+  :func:`find_images`, imported modules via :func:`find_imports`);
+* ``<include source=...>`` and ``<dir-group path=...>`` claim their
+  course-root-relative sources;
+* JupyterLite wheels/environment, output-target paths, and release-channel
+  paths/ledgers are claimed by their owning spec.
+
+The mapping **fails open**: a path that no spec claims but that is not clearly
+build-irrelevant (Jinja macros, shared headers, the spec dir itself, ...)
+marks *every* spec as affected. Only obviously irrelevant paths (``.github/``,
+top-level docs) and content invisible to the build (topics no spec references,
+underscore-prefixed dirs under ``slides/``) affect nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.core.course_spec import CourseSpec, CourseSpecError
+from clm.core.topic_resolver import TopicMatch, build_topic_map, matches_for_binding
+from clm.core.utils.notebook_utils import find_images, find_imports
+from clm.infrastructure.utils.path_utils import (
+    is_private_dir_name,
+    prog_lang_to_extension,
+)
+
+__all__ = [
+    "STATUS_CLAIMED",
+    "STATUS_IGNORED",
+    "STATUS_UNKNOWN",
+    "STATUS_UNREFERENCED",
+    "AffectedSpecsReport",
+    "PathVerdict",
+    "SpecClaims",
+    "compute_spec_claims",
+    "find_affected_specs",
+    "render_report",
+    "report_to_dict",
+]
+
+# Verdict statuses for a single input path.
+STATUS_CLAIMED = "claimed"  # at least one spec's build consumes this path
+STATUS_IGNORED = "ignored"  # clearly build-irrelevant (.github/, top-level docs)
+STATUS_UNREFERENCED = "unreferenced"  # invisible to every build (unreferenced topic, _archive)
+STATUS_UNKNOWN = "unknown"  # build-relevant but unclaimed -> fail open, affects ALL specs
+
+# Top-level directories that can never influence a course build.
+_IRRELEVANT_TOP_DIRS = frozenset({".git", ".github", ".idea", ".vscode"})
+
+# Top-level files that can never influence a course build.
+_IRRELEVANT_TOP_FILES = frozenset(
+    {".gitignore", ".gitattributes", ".editorconfig", "LICENSE", "LICENSE.txt"}
+)
+
+
+@dataclass
+class SpecClaims:
+    """The course-root-relative input surface one spec's build consumes.
+
+    ``claims`` holds POSIX-style relative paths; a directory claim covers its
+    whole subtree. ``parse_error`` is set when the spec file could not be
+    parsed — its claims are then unknown and the spec is conservatively
+    treated as affected by every build-relevant change.
+    """
+
+    name: str
+    spec_file: Path
+    claims: set[str] = field(default_factory=set)
+    parse_error: str | None = None
+
+
+@dataclass
+class PathVerdict:
+    """Classification of a single input path."""
+
+    path: str
+    status: str
+    specs: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AffectedSpecsReport:
+    """Outcome of mapping a change set onto a spec directory.
+
+    ``specs`` is the sorted list of affected spec names (file stems). When
+    ``all_affected`` is set (fail open), it equals ``all_specs`` so scripted
+    consumers can feed it into a build matrix without branching.
+    """
+
+    specs: list[str]
+    all_affected: bool
+    all_specs: list[str]
+    verdicts: list[PathVerdict] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _rel_to_root(path: Path, course_root: Path) -> str | None:
+    """*path* as a POSIX path relative to *course_root*, or ``None`` if outside."""
+    try:
+        return path.resolve().relative_to(course_root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
+def _normalize_rel(raw: str) -> str | None:
+    """Normalize a spec-declared relative path to canonical POSIX form.
+
+    Returns ``None`` for empty, absolute, ``..``-escaping, or course-root
+    (``.``) paths — such claims are skipped (an unmatched path then fails
+    open, which is the safe direction).
+    """
+    cleaned = raw.strip().replace("\\", "/")
+    if not cleaned or cleaned.startswith("/") or (len(cleaned) > 1 and cleaned[1] == ":"):
+        return None
+    parts = [p for p in cleaned.split("/") if p not in ("", ".")]
+    if not parts or ".." in parts:
+        return None
+    return "/".join(parts)
+
+
+def _normalize_input(raw: str, course_root: Path) -> str | None:
+    """Normalize one user-supplied changed path to course-root-relative POSIX form.
+
+    Absolute paths are re-rooted at *course_root* when possible; an absolute
+    path outside the root is kept verbatim so it falls through to the
+    fail-open branch instead of silently matching nothing.
+    """
+    cleaned = raw.strip().strip('"').replace("\\", "/")
+    if not cleaned:
+        return None
+    if cleaned.startswith("/") or (len(cleaned) > 1 and cleaned[1] == ":"):
+        rel = _rel_to_root(Path(cleaned), course_root)
+        return rel if rel is not None else cleaned
+    parts = [p for p in cleaned.split("/") if p not in ("", ".")]
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
+def _overlaps(a: str, b: str) -> bool:
+    """True when one POSIX path equals or contains the other."""
+    return a == b or a.startswith(b + "/") or b.startswith(a + "/")
+
+
+def _is_under(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def _is_build_irrelevant(path: str) -> bool:
+    """Clearly build-irrelevant paths: CI config, repo metadata, top-level docs."""
+    parts = path.split("/")
+    if parts[0] in _IRRELEVANT_TOP_DIRS:
+        return True
+    if len(parts) == 1:
+        name = parts[0]
+        return name.lower().endswith(".md") or name in _IRRELEVANT_TOP_FILES
+    return False
+
+
+def _file_topic_sibling_claims(
+    topic_file: Path,
+    prog_lang: str,
+    course_root: Path,
+    cache: dict[tuple[Path, str], set[str]],
+) -> set[str]:
+    """Sibling files a single-file topic pulls in, per ``FileTopic.build_file_map``.
+
+    A file topic claims the images and imported module files its content
+    references, resolved against its parent (module) directory — this is how
+    a shared header next to several decks ends up owned by every course that
+    builds one of them.
+    """
+    try:
+        ext = prog_lang_to_extension(prog_lang)
+    except KeyError:
+        ext = ""
+    key = (topic_file, ext)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+
+    claims: set[str] = set()
+    try:
+        contents = topic_file.read_text(encoding="utf-8")
+    except OSError:
+        contents = ""
+    if contents:
+        referenced = set(find_images(contents))
+        referenced.update(module + ext for module in find_imports(contents))
+        for name in referenced:
+            rel = _rel_to_root(topic_file.parent / name, course_root)
+            if rel is not None:
+                claims.add(rel)
+    cache[key] = claims
+    return claims
+
+
+def compute_spec_claims(
+    spec_file: Path,
+    course_root: Path,
+    topic_map: dict[str, list[TopicMatch]],
+    *,
+    file_topic_cache: dict[tuple[Path, str], set[str]] | None = None,
+) -> SpecClaims:
+    """Compute the course-root-relative input surface of one spec's build.
+
+    Topic bindings resolve through *topic_map* exactly as the build does; an
+    unbound topic ID that exists in several modules claims **all** matches
+    (the build picks one first-occurrence-wins, but a change to either copy
+    may affect the outcome, so over-claiming is the safe direction).
+    """
+    if file_topic_cache is None:
+        file_topic_cache = {}
+
+    claims: set[str] = set()
+    spec_rel = _rel_to_root(spec_file, course_root)
+    if spec_rel is not None:
+        claims.add(spec_rel)
+
+    try:
+        spec = CourseSpec.from_file(spec_file)
+    except CourseSpecError as exc:
+        return SpecClaims(
+            name=spec_file.stem, spec_file=spec_file, claims=claims, parse_error=str(exc)
+        )
+
+    for binding in spec.iter_topic_bindings():
+        for match in matches_for_binding(topic_map, binding.topic_id, binding.effective_module):
+            match_rel = _rel_to_root(match.path, course_root)
+            if match_rel is not None:
+                claims.add(match_rel)
+            if match.path_type == "file":
+                prog_lang = binding.topic_spec.prog_lang or spec.prog_lang
+                claims.update(
+                    _file_topic_sibling_claims(match.path, prog_lang, course_root, file_topic_cache)
+                )
+        # Include sources are parse-time normalized course-root-relative POSIX paths.
+        for include in binding.section.includes_for(binding.topic_spec):
+            claims.add(include.source)
+
+    for dir_group in spec.dictionaries:
+        claim = _normalize_rel(dir_group.path)
+        if claim is not None:
+            claims.add(claim)
+
+    for jl in (spec.jupyterlite, *(target.jupyterlite for target in spec.output_targets)):
+        if jl is None:
+            continue
+        for wheel in jl.wheels:
+            claim = _normalize_rel(wheel)
+            if claim is not None:
+                claims.add(claim)
+        if jl.environment:
+            claim = _normalize_rel(jl.environment)
+            if claim is not None:
+                claims.add(claim)
+
+    # Output dirs and release working trees/ledgers are not build *inputs*,
+    # but a change there concerns exactly this spec — mapping them here is
+    # strictly better than letting them fall open to an all-specs rebuild.
+    for target in spec.output_targets:
+        claim = _normalize_rel(target.path)
+        if claim is not None:
+            claims.add(claim)
+    for block in spec.release_channel_blocks:
+        for channel in block.channels:
+            for raw in (channel.path, channel.ledger):
+                claim = _normalize_rel(raw)
+                if claim is not None:
+                    claims.add(claim)
+
+    return SpecClaims(name=spec_file.stem, spec_file=spec_file, claims=claims)
+
+
+def _classify_path(
+    path: str,
+    parsed_claims: list[SpecClaims],
+    topic_roots: set[str],
+    spec_dir_rel: str | None,
+) -> PathVerdict:
+    if _is_build_irrelevant(path):
+        return PathVerdict(path=path, status=STATUS_IGNORED)
+
+    matched = sorted(
+        {sc.name for sc in parsed_claims if any(_overlaps(path, c) for c in sc.claims)}
+    )
+    if matched:
+        return PathVerdict(path=path, status=STATUS_CLAIMED, specs=matched)
+
+    # Unclaimed content under the spec dir (a deleted spec, a shared fragment)
+    # cannot be attributed -> fail open.
+    if spec_dir_rel is not None and _is_under(path, spec_dir_rel):
+        return PathVerdict(path=path, status=STATUS_UNKNOWN)
+
+    if _is_under(path, "slides"):
+        # Inside a discovered topic that no spec references: only topic
+        # references consume topic dirs (includes were checked above), so
+        # the change affects no build.
+        if any(_overlaps(path, root) for root in topic_roots):
+            return PathVerdict(path=path, status=STATUS_UNREFERENCED)
+        # Underscore-prefixed dirs are invisible to topic discovery (issue
+        # #318); parked content affects no build unless an include claims it.
+        parts = path.split("/")
+        if any(is_private_dir_name(part) for part in parts[1:]):
+            return PathVerdict(path=path, status=STATUS_UNREFERENCED)
+
+    return PathVerdict(path=path, status=STATUS_UNKNOWN)
+
+
+def find_affected_specs(
+    raw_paths: list[str],
+    spec_dir: Path,
+    *,
+    course_root: Path | None = None,
+    topic_map: dict[str, list[TopicMatch]] | None = None,
+) -> AffectedSpecsReport:
+    """Map *raw_paths* (e.g. ``git diff --name-only`` output) to affected specs.
+
+    Paths are interpreted relative to *course_root* (default: the parent of
+    *spec_dir*, matching the ``<root>/course-specs/`` convention). Every
+    ``*.xml`` file in *spec_dir* is resolved once; an unparseable spec is
+    reported as a warning and conservatively marked affected whenever any
+    build-relevant path changed.
+    """
+    spec_dir = spec_dir.resolve()
+    root = (course_root if course_root is not None else spec_dir.parent).resolve()
+    if topic_map is None:
+        topic_map = build_topic_map(root / "slides")
+
+    spec_files = sorted(spec_dir.glob("*.xml"))
+    file_topic_cache: dict[tuple[Path, str], set[str]] = {}
+    all_claims = [
+        compute_spec_claims(f, root, topic_map, file_topic_cache=file_topic_cache)
+        for f in spec_files
+    ]
+    parsed_claims = [sc for sc in all_claims if sc.parse_error is None]
+    broken_specs = [sc for sc in all_claims if sc.parse_error is not None]
+
+    warnings = [
+        f"spec '{sc.spec_file.name}' failed to parse — treating it as affected by "
+        f"every build-relevant change: {sc.parse_error}"
+        for sc in broken_specs
+    ]
+
+    topic_roots = {
+        rel
+        for matches in topic_map.values()
+        for match in matches
+        if (rel := _rel_to_root(match.path, root)) is not None
+    }
+    spec_dir_rel = _rel_to_root(spec_dir, root)
+
+    verdicts: list[PathVerdict] = []
+    seen: set[str] = set()
+    affected: set[str] = set()
+    all_affected = False
+    any_relevant = False
+    for raw in raw_paths:
+        norm = _normalize_input(raw, root)
+        if norm is None or norm in seen:
+            continue
+        seen.add(norm)
+        verdict = _classify_path(norm, parsed_claims, topic_roots, spec_dir_rel)
+        verdicts.append(verdict)
+        if verdict.status == STATUS_CLAIMED:
+            affected.update(verdict.specs)
+            any_relevant = True
+        elif verdict.status == STATUS_UNKNOWN:
+            all_affected = True
+            any_relevant = True
+
+    # A spec whose claims are unknown is affected by any build-relevant change.
+    if any_relevant:
+        affected.update(sc.name for sc in broken_specs)
+
+    all_specs = sorted(sc.name for sc in all_claims)
+    specs = all_specs if all_affected else sorted(affected)
+    return AffectedSpecsReport(
+        specs=specs,
+        all_affected=all_affected,
+        all_specs=all_specs,
+        verdicts=verdicts,
+        warnings=warnings,
+    )
+
+
+_STATUS_LABELS = {
+    STATUS_IGNORED: "(ignored: build-irrelevant)",
+    STATUS_UNREFERENCED: "(unreferenced: affects no spec)",
+    STATUS_UNKNOWN: "(unclaimed: fail open -> ALL specs)",
+}
+
+
+def render_report(report: AffectedSpecsReport) -> str:
+    """Human-readable per-path table plus an affected-specs summary."""
+    lines: list[str] = []
+    if report.verdicts:
+        width = max(len(v.path) for v in report.verdicts)
+        for verdict in report.verdicts:
+            label = (
+                ", ".join(verdict.specs)
+                if verdict.status == STATUS_CLAIMED
+                else _STATUS_LABELS[verdict.status]
+            )
+            lines.append(f"{verdict.path:<{width}}  ->  {label}")
+        lines.append("")
+
+    total = len(report.all_specs)
+    if report.all_affected:
+        lines.append(f"Affected specs: ALL ({total}): {', '.join(report.all_specs)}")
+    elif report.specs:
+        lines.append(f"Affected specs ({len(report.specs)}/{total}): {', '.join(report.specs)}")
+    else:
+        lines.append(f"Affected specs (0/{total}): none")
+    return "\n".join(lines)
+
+
+def report_to_dict(report: AffectedSpecsReport) -> dict:
+    """JSON-serializable report. ``specs`` lists every spec when ``all`` is true."""
+    return {
+        "specs": report.specs,
+        "all": report.all_affected,
+        "paths": [{"path": v.path, "status": v.status, "specs": v.specs} for v in report.verdicts],
+    }

--- a/tests/cli/test_query_affected_specs.py
+++ b/tests/cli/test_query_affected_specs.py
@@ -1,0 +1,288 @@
+"""Tests for the ``clm query affected-specs`` CLI command (issue #350)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+SPEC_HEADER = """\
+<name><de>Test</de><en>Test</en></name>
+<prog-lang>python</prog-lang>
+<description><de></de><en></en></description>
+<certificate><de></de><en></en></certificate>
+"""
+
+
+def _write_spec(specs_dir: Path, name: str, body: str) -> Path:
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    spec_file = specs_dir / f"{name}.xml"
+    spec_file.write_text(
+        f"<course>\n{SPEC_HEADER}\n{body}\n</course>\n",
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _section(name: str, *topics: str, extra: str = "") -> str:
+    topic_xml = "".join(f"<topic>{t}</topic>" for t in topics)
+    return (
+        f"<section><name><de>{name}</de><en>{name}</en></name>"
+        f"{extra}<topics>{topic_xml}</topics></section>"
+    )
+
+
+@pytest.fixture()
+def course_tree(tmp_path: Path) -> Path:
+    """Two specs sharing one topic, plus an include, a dir-group, a file topic.
+
+    ``alpha`` references topics ``intro`` + ``variables`` and includes the
+    shared header next to the topic dirs. ``beta`` references ``variables`` +
+    the single-file topic ``meta`` (which imports a sibling module) and
+    declares a dir-group over ``examples/``.
+    """
+    slides = tmp_path / "slides"
+
+    m1 = slides / "module_100_basics"
+    (m1 / "topic_010_intro").mkdir(parents=True)
+    (m1 / "topic_010_intro" / "slides_intro.py").write_text("# intro", encoding="utf-8")
+    (m1 / "topic_020_variables").mkdir()
+    (m1 / "topic_020_variables" / "slides_variables.py").write_text("# vars", encoding="utf-8")
+    (m1 / "topic_020_variables" / "data.csv").write_text("a,b\n", encoding="utf-8")
+    (m1 / "topic_030_unused").mkdir()
+    (m1 / "topic_030_unused" / "slides_unused.py").write_text("# unused", encoding="utf-8")
+    (m1 / "shared.py").write_text("X = 1\n", encoding="utf-8")
+
+    m2 = slides / "module_200_advanced"
+    m2.mkdir()
+    (m2 / "topic_040_meta.py").write_text(
+        "import helper\n# %% [markdown]\n# meta\n", encoding="utf-8"
+    )
+    (m2 / "helper.py").write_text("def f(): pass\n", encoding="utf-8")
+
+    archive = slides / "_archive" / "module_100_basics" / "topic_010_intro"
+    archive.mkdir(parents=True)
+    (archive / "slides_intro.py").write_text("# parked", encoding="utf-8")
+
+    examples = tmp_path / "examples" / "Demo"
+    examples.mkdir(parents=True)
+    (examples / "demo.py").write_text("print('demo')\n", encoding="utf-8")
+
+    specs_dir = tmp_path / "course-specs"
+    _write_spec(
+        specs_dir,
+        "alpha",
+        "<sections>"
+        + _section(
+            "Week 1",
+            "intro",
+            "variables",
+            extra='<include source="slides/module_100_basics/shared.py"/>',
+        )
+        + "</sections>",
+    )
+    _write_spec(
+        specs_dir,
+        "beta",
+        "<sections>"
+        + _section("Week 1", "variables", "meta")
+        + "</sections>"
+        + "<dir-groups><dir-group><name>Examples</name>"
+        "<path>examples</path></dir-group></dir-groups>",
+    )
+    return tmp_path
+
+
+def _run(course_tree: Path, *args: str, input: str | None = None):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        [
+            "query",
+            "affected-specs",
+            "--spec-dir",
+            str(course_tree / "course-specs"),
+            *args,
+        ],
+        input=input,
+    )
+
+
+def _run_json(course_tree: Path, *args: str, input: str | None = None) -> dict:
+    result = _run(course_tree, "--json", *args, input=input)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+class TestClaimedPaths:
+    def test_topic_file_maps_to_single_spec(self, course_tree):
+        data = _run_json(course_tree, "slides/module_100_basics/topic_010_intro/slides_intro.py")
+        assert data == {
+            "specs": ["alpha"],
+            "all": False,
+            "paths": [
+                {
+                    "path": "slides/module_100_basics/topic_010_intro/slides_intro.py",
+                    "status": "claimed",
+                    "specs": ["alpha"],
+                }
+            ],
+        }
+
+    def test_shared_topic_maps_to_both_specs(self, course_tree):
+        data = _run_json(course_tree, "slides/module_100_basics/topic_020_variables/data.csv")
+        assert data["specs"] == ["alpha", "beta"]
+        assert data["all"] is False
+
+    def test_include_source_is_claimed(self, course_tree):
+        data = _run_json(course_tree, "slides/module_100_basics/shared.py")
+        assert data["specs"] == ["alpha"]
+
+    def test_dir_group_subtree_is_claimed(self, course_tree):
+        data = _run_json(course_tree, "examples/Demo/demo.py")
+        assert data["specs"] == ["beta"]
+
+    def test_file_topic_claims_itself_and_imported_sibling(self, course_tree):
+        data = _run_json(
+            course_tree,
+            "slides/module_200_advanced/topic_040_meta.py",
+            "slides/module_200_advanced/helper.py",
+        )
+        assert data["specs"] == ["beta"]
+        assert all(p["status"] == "claimed" for p in data["paths"])
+
+    def test_spec_file_maps_to_its_own_spec(self, course_tree):
+        data = _run_json(course_tree, "course-specs/alpha.xml")
+        assert data["specs"] == ["alpha"]
+        assert data["all"] is False
+
+
+class TestIrrelevantAndUnreferencedPaths:
+    def test_ci_config_and_top_level_docs_are_ignored(self, course_tree):
+        data = _run_json(course_tree, ".github/workflows/ci.yml", "README.md")
+        assert data["specs"] == []
+        assert data["all"] is False
+        assert {p["status"] for p in data["paths"]} == {"ignored"}
+
+    def test_unreferenced_topic_affects_nothing(self, course_tree):
+        data = _run_json(course_tree, "slides/module_100_basics/topic_030_unused/slides_unused.py")
+        assert data["specs"] == []
+        assert data["paths"][0]["status"] == "unreferenced"
+
+    def test_archived_content_affects_nothing(self, course_tree):
+        data = _run_json(
+            course_tree, "slides/_archive/module_100_basics/topic_010_intro/slides_intro.py"
+        )
+        assert data["specs"] == []
+        assert data["paths"][0]["status"] == "unreferenced"
+
+
+class TestFailOpen:
+    def test_unclaimed_path_affects_all_specs(self, course_tree):
+        (course_tree / "jinja").mkdir()
+        data = _run_json(course_tree, "jinja/macros.j2")
+        assert data["all"] is True
+        assert data["specs"] == ["alpha", "beta"]
+        assert data["paths"][0]["status"] == "unknown"
+
+    def test_unclaimed_spec_dir_content_affects_all_specs(self, course_tree):
+        data = _run_json(course_tree, "course-specs/deleted-course.xml")
+        assert data["all"] is True
+        assert data["specs"] == ["alpha", "beta"]
+
+    def test_loose_module_file_without_claim_fails_open(self, course_tree):
+        (course_tree / "slides" / "module_100_basics" / "loose.txt").write_text(
+            "x", encoding="utf-8"
+        )
+        data = _run_json(course_tree, "slides/module_100_basics/loose.txt")
+        assert data["all"] is True
+
+    def test_broken_spec_is_affected_by_any_relevant_change(self, course_tree):
+        (course_tree / "course-specs" / "broken.xml").write_text(
+            "<course><unclosed>", encoding="utf-8"
+        )
+        result = _run(
+            course_tree,
+            "--json",
+            "slides/module_100_basics/topic_010_intro/slides_intro.py",
+        )
+        assert result.exit_code == 0
+        # Depending on the click version, CliRunner mixes stderr into output
+        # (8.1) or captures it separately (8.2+) — check both streams.
+        combined = result.output + (result.stderr if result.stderr_bytes is not None else "")
+        assert "broken.xml" in combined
+        # Extract the JSON block (a stderr warning may precede it when mixed).
+        data = json.loads(result.output[result.output.index("{") : result.output.rindex("}") + 1])
+        assert data["specs"] == ["alpha", "broken"]
+        assert data["all"] is False
+
+
+class TestCliBehavior:
+    def test_stdin_input(self, course_tree):
+        data = _run_json(
+            course_tree,
+            "--stdin",
+            input="slides/module_100_basics/topic_010_intro/slides_intro.py\n\nexamples/Demo/demo.py\n",
+        )
+        assert data["specs"] == ["alpha", "beta"]
+        assert len(data["paths"]) == 2
+
+    def test_empty_input_is_data_not_error(self, course_tree):
+        data = _run_json(course_tree)
+        assert data == {"specs": [], "all": False, "paths": []}
+
+    def test_duplicate_and_dot_prefixed_paths_are_normalized(self, course_tree):
+        data = _run_json(
+            course_tree,
+            "./examples/Demo/demo.py",
+            "examples/Demo/demo.py",
+        )
+        assert len(data["paths"]) == 1
+        assert data["specs"] == ["beta"]
+
+    def test_human_readable_output(self, course_tree):
+        result = _run(course_tree, "slides/module_100_basics/topic_020_variables/data.csv")
+        assert result.exit_code == 0
+        assert "alpha, beta" in result.output
+        assert "Affected specs (2/2)" in result.output
+
+    def test_no_specs_found_is_an_error(self, tmp_path):
+        empty = tmp_path / "course-specs"
+        empty.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["query", "affected-specs", "--spec-dir", str(empty), "x.py"])
+        assert result.exit_code != 0
+        assert "No *.xml specs" in result.output
+
+
+class TestModuleBindings:
+    def test_module_bound_topic_resolves_only_in_bound_module(self, tmp_path):
+        slides = tmp_path / "slides"
+        live = slides / "module_100_live" / "topic_010_intro"
+        live.mkdir(parents=True)
+        (live / "slides_intro.py").write_text("# live", encoding="utf-8")
+        frozen = slides / "module_900_cohort" / "topic_010_intro"
+        frozen.mkdir(parents=True)
+        (frozen / "slides_intro.py").write_text("# frozen", encoding="utf-8")
+
+        specs_dir = tmp_path / "course-specs"
+        _write_spec(specs_dir, "live", "<sections>" + _section("W1", "intro") + "</sections>")
+        _write_spec(
+            specs_dir,
+            "cohort",
+            '<sections><section module="module_900_cohort">'
+            "<name><de>W1</de><en>W1</en></name>"
+            "<topics><topic>intro</topic></topics></section></sections>",
+        )
+
+        # The module-bound 'cohort' spec claims only its bound copy; the
+        # unbound 'live' spec conservatively claims both copies (resolution
+        # is first-occurrence-wins, which can flip when copies come and go).
+        data = _run_json(tmp_path, "slides/module_900_cohort/topic_010_intro/slides_intro.py")
+        assert data["specs"] == ["cohort", "live"]
+        data = _run_json(tmp_path, "slides/module_100_live/topic_010_intro/slides_intro.py")
+        assert data["specs"] == ["live"]


### PR DESCRIPTION
## Summary

Implements #350: a read-only CI helper that maps changed file paths to the course specs whose builds they can influence, so a change-driven CI matrix (CppCourses code-export compile, #333 phase 3) can build only the affected courses instead of all 12.

```
git diff --name-only $BEFORE $HEAD | clm query affected-specs --spec-dir course-specs --stdin --json
→ {"specs": ["cpp-for-programmers", "cpp-hs"], "all": false, "paths": [...]}
```

### New `clm query` group

Top-level group for read-only introspection commands aimed at scripting — the group name states the contract: queries never modify anything and are always safe to call from CI. `affected-specs` is the first member; future residents like `query topics` / `query outputs` have an obvious home.

### Build-faithful claim resolution (`clm.core.affected_specs`)

Every spec in `--spec-dir` is resolved once with the same rules the build uses:

- **Topic references** resolve through `build_topic_map` + `matches_for_binding`, honoring section/topic `module=` bindings. A directory topic claims its whole subtree (slides, `img/`, loose data files). An unbound topic ID that exists in several modules conservatively claims **all** copies (first-occurrence-wins resolution can flip when copies come and go).
- **Single-file topics** additionally claim the sibling files their content references (images via `find_images`, imported module files via `find_imports`), replicating `FileTopic.build_file_map` — this is the mechanism behind `slides/module_240_generics/type_name.hpp` breaking cpp-hs *and* cpp-for-programmers in the first shakedown.
- **`<include source=...>`** and **`<dir-group path=...>`** claim their course-root-relative sources; JupyterLite wheels/environment, output-target paths, and release-channel paths/ledgers map to their owning spec.
- Each spec file claims itself, so editing one spec affects only that course.

### Fail-open semantics

- A build-relevant path that **no spec claims** (Jinja macros, `div/` toplevel, unattributable spec-dir content, …) sets `"all": true` and lists **every** spec, so a matrix built from `fromJSON(output).specs` never silently skips a course and needs no branching.
- Only clearly build-irrelevant paths (`.github/`, `.git*`, top-level `*.md`, `LICENSE`) and content invisible to every build (topics no spec references, underscore-prefixed `_archive` dirs under `slides/`) affect nothing.
- A spec that fails to parse is reported on stderr and conservatively marked affected by every build-relevant change.
- Exit code is always 0 — an empty result is data, not an error. The JSON `paths` array carries a per-path verdict (`claimed` / `ignored` / `unreferenced` / `unknown`) for debugging CI shakedowns.

## Changes

- `src/clm/core/affected_specs.py` — claim computation + classification + report rendering
- `src/clm/cli/commands/query/` — new group + `affected-specs` command (lazy-loaded, registered in `main.py`)
- `src/clm/cli/info_topics/commands.md` — full command reference incl. JSON shape (info-topic maintenance rule)
- `changelog.d/350-query-affected-specs.added.md` — changelog fragment
- `tests/cli/test_query_affected_specs.py` — 19 tests covering claimed paths (topic dirs, shared topics, includes, dir-groups, file-topic sibling imports, spec files), ignored/unreferenced paths, fail-open cases (unclaimed paths, deleted spec, loose module files, broken specs), module bindings, and CLI behavior (stdin, empty input, normalization, human output)

## Testing

- 19 new tests pass; ruff check, ruff format, and mypy clean.
- Fast suite: 7967 passed; the 24 failures + 8 errors in this container are pre-existing environment issues (verified identical on the clean tree without this change).

## Follow-up (out of scope)

The CppCourses `.github/workflows/code-export-compile.yml` `detect` job (feeding `specs` into the build matrix, with `workflow_dispatch` / force-push fallbacks to all courses) is wired up in the CppCourses repo once this lands in a release.

Closes #350

https://claude.ai/code/session_01JKQjhuKPdr3s1UaEn74v3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKQjhuKPdr3s1UaEn74v3M)_