### PR TITLE
Open-issues triage: implement #339, #341, #342, #322 and the #348 fail-fast fixes

### DIFF
--- a/changelog.d/322-channel-repo-override.added.md
+++ b/changelog.d/322-channel-repo-override.added.md
@@ -1,0 +1,9 @@
+Release channels with non-derived repo names are now fully declarative
+(#322): a `<channel repo="...">` attribute overrides the derived repo name
+verbatim (remote path and URL template still apply), so lang-scoped
+channels whose name already carries the language no longer derive a
+duplicated `-{lang}` segment. `clm release provision` additionally prefers
+the channel working tree's actual `origin` over the derived URL when one
+is configured — matching the `clm git` philosophy that push/commit operate
+on whatever origin the repo actually has — so group shares target the real
+project without manual GitLab API calls.

--- a/changelog.d/339-prune-dot-dirs.fixed.md
+++ b/changelog.d/339-prune-dot-dirs.fixed.md
@@ -1,0 +1,7 @@
+Validation and normalization walks no longer descend into dot-directories
+such as `.ipynb_checkpoints` (#339). Jupyter's checkpoint copies of decks
+previously showed up as duplicate — or stale, contradictory — findings in
+`clm validate` and related discovery walks. Dot-dirs are now pruned in the
+same place as the `_`-prefixed author-parked directories from #318, so the
+rule applies uniformly to topic discovery, recursive slide-file walks,
+spec-orphan and pairing scans.

--- a/changelog.d/341-git-token-auth.added.md
+++ b/changelog.d/341-git-token-auth.added.md
@@ -1,0 +1,9 @@
+`clm git` and `clm release sync --push` can now authenticate HTTPS git
+operations with the GitLab token (#341): set `CLM_GIT_TOKEN_AUTH=1`
+together with `CLM_GITLAB_TOKEN` (or `GITLAB_TOKEN`) and every git network
+operation (push, fetch, ls-remote, clone) uses an ephemeral credential
+helper with `oauth2:<token>` basic auth — enabling unattended pushes from
+CI, cron, and containers where no credential helper exists. The token
+never appears in the URL, in `.git/config`, or on the command line, and
+the switch is opt-in so workstations keep using their stored credentials
+by default.

--- a/changelog.d/342-task-argument-placeholders.added.md
+++ b/changelog.d/342-task-argument-placeholders.added.md
@@ -1,0 +1,9 @@
+`clm run` now accepts extra arguments after the spec file and exposes them
+to task steps as `{args}` (all of them, expanded to one argv token per
+argument as a standalone token) and `{1}`, `{2}`, … (individually,
+embeddable in larger tokens) — `clm run release-week course.xml
+"name:Week 09"` (#342). A task whose steps reference these placeholders
+fails before any step runs when invoked without the corresponding
+arguments, and arguments a task never references are an error rather than
+silently dropped. `clm validate` accepts the new placeholders in `<tasks>`
+blocks.

--- a/changelog.d/348-missing-kernel-fail-fast.fixed.md
+++ b/changelog.d/348-missing-kernel-fail-fast.fixed.md
@@ -1,0 +1,11 @@
+Builds on machines without the required Jupyter kernel no longer stall
+into long timeout cascades (#348). A `NoSuchKernel` failure is now
+classified as `missing_kernel` — a permanent condition for the lifetime of
+the build — so the notebook worker fails the job on the first attempt
+instead of burning six kernel-startup/backoff cycles, and the error
+carries an actionable hint (install the kernelspec, or build with
+`--no-html`). Separately, a pre-registered worker whose subprocess dies
+before activation (e.g. an import crash from missing `clm[all-workers]`
+extras) is marked dead after the first activation-wait timeout, so
+subsequent job submissions fail fast with a pointer to the worker log
+instead of silently repeating a 30-second wait per job.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -215,7 +215,8 @@ in bulk.
 |----------|-------------|---------|
 | `CLM_GIT__REMOTE_TEMPLATE` | URL template for git remotes | `{repository_base}/{repo}` |
 | `CLM_GIT__REMOTE_PATH` | Path segment between base URL and repo name (e.g., GitLab group). Per-target `<remote-path>` overrides still win. | (unset) |
-| `CLM_GITLAB_TOKEN` | GitLab API token (`api` scope) used by `clm release provision` to share channel repos into access groups (issue #294). `GITLAB_TOKEN` is accepted as a fallback. | (unset) |
+| `CLM_GITLAB_TOKEN` | GitLab API token (`api` scope) used by `clm release provision` to share channel repos into access groups (issue #294), and — with `CLM_GIT_TOKEN_AUTH=1` — for git HTTPS transport. `GITLAB_TOKEN` is accepted as a fallback. | (unset) |
+| `CLM_GIT_TOKEN_AUTH` | Set to `1` to authenticate the git operations run by `clm git` / `clm release sync --push` against HTTPS remotes with `CLM_GITLAB_TOKEN`, via an ephemeral credential helper (issue #341 — headless/CI pushes where no credential helper exists). The token never appears in URLs, `.git/config`, or the command line. Opt-in: without it, git's own credential machinery (e.g. Git Credential Manager) is used. | (unset) |
 
 The remote template supports placeholders: `{repository_base}`, `{remote_path}`, `{repo}`, `{slug}`, `{lang}`, `{suffix}` — plus, for release-channel repos, `{stream}` (the release stream name, issue #291).
 This is useful for SSH access with custom host aliases:

--- a/src/clm/cli/commands/git.py
+++ b/src/clm/cli/commands/git.py
@@ -5,6 +5,7 @@ directories, enabling trainers to commit and push generated course content.
 """
 
 import logging
+import os
 import shlex
 import shutil
 import subprocess
@@ -23,6 +24,47 @@ logger = logging.getLogger(__name__)
 
 # Context variable for dry-run mode
 _dry_run_mode: ContextVar[bool] = ContextVar("dry_run_mode", default=False)
+
+#: Opt-in switch for token-authenticated HTTPS git transport (issue #341).
+TOKEN_AUTH_ENV_VAR = "CLM_GIT_TOKEN_AUTH"
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _token_auth_config_args() -> list[str]:
+    """``git -c`` options that authenticate HTTPS transport with the GitLab token.
+
+    Headless environments (CI, cron, containers) have no credential helper,
+    so ``clm git push``/``sync --push`` fail with ``could not read Username``
+    (issue #341). With ``CLM_GIT_TOKEN_AUTH=1`` and a token in
+    ``CLM_GITLAB_TOKEN``/``GITLAB_TOKEN``, an ephemeral credential helper is
+    injected instead: the token never appears in the URL, in ``.git/config``,
+    or on the command line — the helper reads it from the environment when
+    git asks for credentials. GitLab accepts ``oauth2:<token>`` basic auth
+    for PAT/OAuth tokens (an ``Authorization: Bearer`` header would be
+    rejected, so a credential helper — not ``http.extraHeader`` — is the
+    right mechanism).
+
+    Opt-in by design: a workstation with stored credentials (e.g. Git
+    Credential Manager) keeps using them unless this is explicitly enabled.
+    The empty first helper clears configured helpers so the token takes
+    precedence and no credential dialog can pop up in CI. The options are
+    only consulted when a command needs authentication, so they are passed
+    to every git invocation. Returns ``[]`` when disabled or no token is set.
+    """
+    if os.environ.get(TOKEN_AUTH_ENV_VAR, "").strip().lower() not in _TRUTHY:
+        return []
+    from clm.infrastructure.gitlab_api import TOKEN_ENV_VARS
+
+    token_var = next((v for v in TOKEN_ENV_VARS if os.environ.get(v, "").strip()), None)
+    if token_var is None:
+        logger.warning(
+            "%s is enabled but no token is set in %s; git will use its default credentials.",
+            TOKEN_AUTH_ENV_VAR,
+            "/".join(TOKEN_ENV_VARS),
+        )
+        return []
+    helper = f'!f() {{ echo username=oauth2; echo "password=${token_var}"; }}; f'
+    return ["-c", "credential.helper=", "-c", f"credential.helper={helper}"]
 
 
 # =============================================================================
@@ -106,7 +148,7 @@ def run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
         CompletedProcess with stdout/stderr captured.
         In dry-run mode, returns a mock result with returncode=0.
     """
-    cmd = ["git", "-C", str(repo_path), *args]
+    cmd = ["git", *_token_auth_config_args(), "-C", str(repo_path), *args]
     logger.debug(f"Running: {_format_command(cmd)}")
 
     if _dry_run_mode.get():
@@ -136,7 +178,7 @@ def run_git_global(*args: str) -> subprocess.CompletedProcess[str]:
         CompletedProcess with stdout/stderr captured.
         In dry-run mode, returns a mock result with returncode=0.
     """
-    cmd = ["git", *args]
+    cmd = ["git", *_token_auth_config_args(), *args]
     logger.debug(f"Running: {_format_command(cmd)}")
 
     if _dry_run_mode.get():

--- a/src/clm/cli/commands/git.py
+++ b/src/clm/cli/commands/git.py
@@ -459,6 +459,7 @@ def find_release_channel_repos(
             remote_path=effective_remote_path,
             stream=block.name,
             language=channel.lang,
+            repo_override=channel.repo,
         )
 
         repos.append(

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -23,7 +23,6 @@ from clm.cli.commands.git import (
     OutputRepo,
     commit_and_push_repo,
     find_release_channel_repos,
-    run_git,
 )
 from clm.core.course_paths import resolve_course_paths
 from clm.core.course_spec import (
@@ -279,10 +278,24 @@ def _push_channel_repo(
 
 
 def _actual_origin_url(repo: OutputRepo) -> str | None:
-    """The ``origin`` URL the channel working tree actually has, if any."""
+    """The ``origin`` URL the channel working tree actually has, if any.
+
+    Deliberately not :func:`clm.cli.commands.git.run_git`: that helper mocks
+    out commands under the ``clm git`` dry-run ContextVar, but this read-only
+    lookup must run even in (someone else's, or provision's own) dry-run mode
+    — the dry-run *output* has to name the project that would really be
+    shared.
+    """
     if not repo.has_git:
         return None
-    result = run_git(repo.path, "remote", "get-url", "origin")
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "-C", str(repo.path), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     if result.returncode != 0:
         return None
     return result.stdout.strip() or None

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -23,6 +23,7 @@ from clm.cli.commands.git import (
     OutputRepo,
     commit_and_push_repo,
     find_release_channel_repos,
+    run_git,
 )
 from clm.core.course_paths import resolve_course_paths
 from clm.core.course_spec import (
@@ -277,6 +278,16 @@ def _push_channel_repo(
         raise SystemExit(1)
 
 
+def _actual_origin_url(repo: OutputRepo) -> str | None:
+    """The ``origin`` URL the channel working tree actually has, if any."""
+    if not repo.has_git:
+        return None
+    result = run_git(repo.path, "remote", "get-url", "origin")
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 @release_group.command("provision")
 @_SPEC_ARG
 @click.option(
@@ -336,11 +347,19 @@ def provision_cmd(spec_file: Path, channel: str, dry_run: bool) -> None:
         repo = repos.get(ref)
         if repo is not None:
             repo = canonical_by_dest.get(repo.path.resolve(), repo)
-        remote = parse_gitlab_remote(repo.remote_url or "") if repo else None
+        # The working tree's actual origin wins over the derived URL (issue
+        # #322): push/commit already operate on whatever origin the repo has,
+        # and a repo whose name does not follow the derived convention would
+        # otherwise be provisioned against a nonexistent project. The derived
+        # URL remains the fallback for repos not yet initialized/pushed.
+        remote = None
+        if repo is not None:
+            remote = parse_gitlab_remote(_actual_origin_url(repo) or repo.remote_url or "")
         if remote is None:
             click.echo(
                 f"[{ref}] skipped: no GitLab remote URL could be derived "
-                f"(configure <github> repository-base / remote-path)."
+                f"(configure <github> repository-base / remote-path, set the "
+                f"channel's repo attribute, or set the repo's origin)."
             )
             continue
         base_url, project_path = remote

--- a/src/clm/cli/commands/run.py
+++ b/src/clm/cli/commands/run.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import click
 
 from clm.core.course_spec import CourseSpec, CourseSpecError, TaskSpec
-from clm.core.tasks import TaskStepError, resolve_step
+from clm.core.tasks import TaskStepError, resolve_step, step_argument_usage
 
 
 def unknown_cli_command_error(tokens: list[str]) -> str | None:
@@ -60,12 +60,46 @@ def unknown_cli_command_error(tokens: list[str]) -> str | None:
     return None
 
 
-def _resolve_task_steps(task: TaskSpec, spec_file: Path) -> list[list[str]]:
+def _check_argument_count(task: TaskSpec, args: tuple[str, ...]) -> None:
+    """Fail fast when *args* does not match the task's placeholder usage.
+
+    A task whose steps reference ``{args}``/``{n}`` must receive the
+    corresponding arguments, and arguments a task never references are an
+    error rather than silently dropped (issue #342). ``{args}`` consumes
+    every argument, so it lifts the upper bound entirely (and requires at
+    least one argument — a varying-argument task invoked without its
+    argument is a mistake, not an empty expansion).
+    """
+    uses_args = False
+    needed = 0
+    for step in task.steps:
+        step_uses_args, max_positional = step_argument_usage(step)
+        uses_args = uses_args or step_uses_args
+        needed = max(needed, max_positional)
+    if uses_args:
+        needed = max(needed, 1)
+
+    if len(args) < needed:
+        references = "{args}" if uses_args else f"{{{needed}}}"
+        raise click.ClickException(
+            f"Task '{task.name}' needs at least {needed} argument(s) after the "
+            f"spec file (its steps reference {references}), but {len(args)} "
+            f"were given. Usage: clm run {task.name} SPEC_FILE ARGS..."
+        )
+    if len(args) > needed and not uses_args:
+        extras = " ".join(args[needed:])
+        takes = f"at most {needed} argument(s)" if needed else "no extra arguments"
+        raise click.ClickException(
+            f"Task '{task.name}' takes {takes} — its steps reference no placeholder for: {extras}"
+        )
+
+
+def _resolve_task_steps(task: TaskSpec, spec_file: Path, args: tuple[str, ...]) -> list[list[str]]:
     """Resolve and validate every step of *task*; raise on the first problem."""
     resolved: list[list[str]] = []
     for i, step in enumerate(task.steps, start=1):
         try:
-            tokens = resolve_step(step, spec_path=spec_file)
+            tokens = resolve_step(step, spec_path=spec_file, args=args)
         except TaskStepError as e:
             raise click.ClickException(f"Task '{task.name}', step {i}: {e}") from None
         error = unknown_cli_command_error(tokens)
@@ -108,6 +142,7 @@ def _list_tasks(spec: CourseSpec, spec_file: Path) -> None:
     required=False,
     type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
 )
+@click.argument("task_args", metavar="[ARGS]...", nargs=-1)
 @click.option(
     "--list",
     "list_tasks",
@@ -119,18 +154,28 @@ def _list_tasks(spec: CourseSpec, spec_file: Path) -> None:
     is_flag=True,
     help="Print the fully resolved commands without executing anything.",
 )
-def run_cmd(task_name: str | None, spec_file: Path | None, list_tasks: bool, dry_run: bool) -> None:
+def run_cmd(
+    task_name: str | None,
+    spec_file: Path | None,
+    task_args: tuple[str, ...],
+    list_tasks: bool,
+    dry_run: bool,
+) -> None:
     """Run a named task sequence declared in the course spec.
 
     Tasks are sequences of clm commands declared in a <tasks> block of the
     spec file (see `clm info spec-files`). Steps run in order; the first
     failing step aborts the task and its exit code becomes clm's exit code.
 
+    Extra arguments after the spec file are exposed to steps as {args}
+    (all of them) and {1}, {2}, ... (individually).
+
     \b
     Examples:
         clm run pre-release course.xml            # run task 'pre-release'
         clm run course.xml                        # list available tasks
         clm run pre-release course.xml --dry-run  # show resolved commands
+        clm run release-week course.xml "name:Week 09"  # task with arguments
     """
     # `clm run course.xml` — a single argument naming an existing file is the
     # spec, and listing is implied.
@@ -147,6 +192,11 @@ def run_cmd(task_name: str | None, spec_file: Path | None, list_tasks: bool, dry
     spec = _load_spec(spec_file)
 
     if task_name is None or list_tasks:
+        if task_args:
+            raise click.UsageError(
+                "Extra arguments are only valid when running a task: "
+                f"clm run TASK SPEC_FILE {' '.join(task_args)}"
+            )
         _list_tasks(spec, spec_file)
         return
 
@@ -157,7 +207,8 @@ def run_cmd(task_name: str | None, spec_file: Path | None, list_tasks: bool, dry
             f"No task named {task_name!r} in {spec_file} (available: {available})."
         )
 
-    resolved = _resolve_task_steps(task, spec_file)
+    _check_argument_count(task, task_args)
+    resolved = _resolve_task_steps(task, spec_file, task_args)
 
     total = len(resolved)
     for i, tokens in enumerate(resolved, start=1):

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2812,6 +2812,16 @@ as a `<release-channels source-target>` (a private build input for `clm
 release`). Pass `--target NAME` explicitly to act on such a target anyway, or
 set `distribute="true"` on it to restore wholesale distribution.
 
+**Headless/CI authentication (issue #341, CLM {version}+).** Git network
+operations normally rely on git's own credential machinery, which fails with
+`could not read Username` where no credential helper exists (CI jobs, cron,
+containers). Set `CLM_GIT_TOKEN_AUTH=1` together with `CLM_GITLAB_TOKEN` (or
+`GITLAB_TOKEN`) and every git operation `clm git` / `clm release sync --push`
+performs authenticates HTTPS remotes via an ephemeral credential helper
+(`oauth2:<token>` basic auth). The token never appears in the URL, in
+`.git/config`, or on the command line. Opt-in by design: without the switch, a
+workstation keeps using its stored credentials (e.g. Git Credential Manager).
+
 Examples:
 
 ```bash

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -453,9 +453,15 @@ Run a named task sequence declared in the spec's `<tasks>` block (see
 so nothing is forgotten when promoting materials.
 
 ```
-clm run TASK SPEC_FILE [OPTIONS]   # run a task
-clm run SPEC_FILE                  # list the spec's tasks
+clm run TASK SPEC_FILE [ARGS]... [OPTIONS]   # run a task
+clm run SPEC_FILE                            # list the spec's tasks
 ```
+
+Extra arguments after the spec file are exposed to the task's steps as
+`{args}` (all of them, one argv token each) and `{1}`, `{2}`, …
+(individually) — see `clm info spec-files`. A task whose steps reference
+these placeholders fails fast when invoked without the corresponding
+arguments; arguments a task never references are likewise an error.
 
 | Option | Description |
 |--------|-------------|
@@ -482,6 +488,10 @@ clm run pre-release course.xml
 
 # Preview what would run:
 clm run pre-release course.xml --dry-run
+
+# A task whose steps use {args} / {1}, {2}, ... takes its arguments
+# after the spec file:
+clm run release-week course.xml "name:Week 09"
 ```
 
 ### `clm export`

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -675,6 +675,7 @@ addressing unchanged.
 | `path` (attr) | `<channel>` | Yes | The cohort repo's working tree (relative to the course root, or absolute). Unique within a stream. Channels of **different** streams may share a path — they then release into the same repository (issue #325, see below) and must agree on `lang`. |
 | `ledger` (attr) | `<channel>` | Yes | Path to the channel's release ledger — a plain-text file, **one released topic id per line**, created/appended by `clm release add`. Keep it in the course source repo. Unique across all streams. |
 | `lang` (attr) | `<channel>` | No | Scope the channel to one language (`de`/`en`, issue #293). `clm release sync` then promotes only that language's files, **re-rooted** so the repo root is the language directory (matching per-language repos like `…-azav-de`), and the derived repo name appends `-{lang}`. **Unset**: the channel receives every built language root. |
+| `repo` (attr) | `<channel>` | No | Override the **derived repo name** verbatim (issue #322, CLM {version}+) — for channels whose actual repository does not follow the derived convention, e.g. a lang-scoped channel whose name already carries the language (`name="2026-04-de" lang="de"` would otherwise derive `…-2026-04-de-solutions-de`). `<remote-path>` and the URL template still apply; only the repo-name segment changes. |
 | `<remote-path>` | `<channel>` | No | Override the block-level `<remote-path>` for this one cohort. |
 | `<share-with>` | `<channel>` | No | GitLab group(s) to share the channel repo into (issue #294, see below). |
 | `<evergreen>` | `<channel>` | No | Additional evergreen pattern(s) for this one cohort (additive to the block's). |
@@ -683,7 +684,11 @@ The remote URL is derived as
 `{repository-base}/{remote-path}/{project-slug}-{channel}[-{stream}][-{lang}]`
 (the `<remote-path>` segment is omitted when unset; the stream/lang segments
 appear only for named streams / language-scoped channels) — see `<github>`
-and `<project-slug>` above.
+and `<project-slug>` above. A `repo` attribute replaces the
+`{project-slug}-{channel}[-{stream}][-{lang}]` part verbatim. `clm release
+provision` additionally prefers the working tree's **actual `origin`** over
+the derived URL when one is configured (issue #322), matching how
+`clm git push`/`commit` already operate on whatever origin the repo has.
 
 #### `<share-with>` — cohort access groups (issue #294)
 

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -850,8 +850,31 @@ error):
 | Placeholder | Expands to |
 |---|---|
 | `{spec}` | Absolute path of the spec file passed to `clm run` |
+| `{args}` | All extra arguments passed after the spec file (`clm run TASK SPEC [ARGS]...`), one argv token per argument |
+| `{1}`, `{2}`, … | Individual extra arguments (1-based) |
 
 Literal braces are written `{{` / `}}`.
+
+Argument rules (CLM {version}+):
+
+- `{args}` must be a **standalone token** — it expands to one argv token per
+  argument, never re-quoted or re-parsed (an argument containing spaces stays
+  one token). To place an argument inside a larger token, use `{1}`, `{2}`, …
+  (`--channel=materials/{1}` works).
+- A task whose steps reference `{args}` or `{n}` fails **before any step
+  runs** when invoked without the corresponding arguments; extra arguments
+  passed to a task that references none are likewise an error.
+
+```xml
+<task name="release-week">
+    <step>release week {spec} {args} --channel materials/2026-04-de</step>
+    <step>release week {spec} {args} --channel materials/2026-04-en</step>
+</task>
+```
+
+```bash
+clm run release-week course.xml "name:Week 09"
+```
 
 **Rules**:
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -724,6 +724,7 @@ class GitHubSpec:
         remote_path: str = "",
         stream: str = "",
         language: str = "",
+        repo_override: str = "",
     ) -> str | None:
         """Derive the remote URL for a release channel (issues #208, #291, #293).
 
@@ -738,6 +739,14 @@ class GitHubSpec:
         stray ``--`` in the repo name; this method avoids that while sharing
         the same base/remote-path/template handling.
 
+        ``repo_override`` (the ``<channel repo="…">`` attribute, issue #322)
+        replaces the joined name verbatim — for channels whose actual repo
+        does not follow the derived convention, e.g. a lang-scoped channel
+        whose name already carries the language (``2026-04-de`` would
+        otherwise derive ``…-2026-04-de-solutions-de`` with a duplicated
+        lang segment). Base, remote-path, and template handling are
+        unchanged.
+
         The ``{suffix}`` template placeholder is bound to the empty string for
         channels; ``{stream}`` carries the stream name and ``{lang}`` the
         channel language (each empty when unset). Returns ``None`` when git
@@ -748,7 +757,9 @@ class GitHubSpec:
             return None
 
         effective_remote_path = remote_path or self.remote_path
-        repo = "-".join(part for part in (slug, channel_name, stream, language) if part)
+        repo = repo_override or "-".join(
+            part for part in (slug, channel_name, stream, language) if part
+        )
         template = remote_template or self.remote_template
         if not template:
             if effective_remote_path:
@@ -1200,6 +1211,12 @@ class ReleaseChannelSpec:
     sync`` re-promotes a matching file whenever the built content differs from
     the cohort's copy (e.g. a NEWS file). Block-level ``<evergreen>`` entries
     are inherited by every channel; channel-level entries are additive.
+
+    ``repo`` (issue #322) overrides the *derived* repo name verbatim for
+    channels whose actual repository does not follow the
+    ``{slug}-{channel}-{stream}-{lang}`` convention — the standing case for
+    lang-scoped channels whose name already carries the language. Remote
+    path and URL template still apply; only the ``{repo}`` segment changes.
     """
 
     name: str
@@ -1209,6 +1226,7 @@ class ReleaseChannelSpec:
     lang: str = ""
     share_with: tuple[ShareWithSpec, ...] = ()
     evergreen: tuple[str, ...] = ()
+    repo: str = ""
 
     @classmethod
     def from_element(
@@ -1236,6 +1254,7 @@ class ReleaseChannelSpec:
             lang=element.get("lang", ""),
             share_with=shares,
             evergreen=evergreen,
+            repo=element.get("repo", ""),
         )
 
 

--- a/src/clm/core/tasks.py
+++ b/src/clm/core/tasks.py
@@ -12,27 +12,43 @@ into an argv token list in two stages:
    after tokenization means substituted values (e.g. a Windows spec path
    containing backslashes or spaces) are never re-parsed by shlex.
 
+Besides ``{spec}``, steps may reference the extra arguments passed after
+the spec file (``clm run TASK SPEC [ARGS]...``, issue #342): ``{args}``
+expands — as a standalone token only — to one argv token per extra
+argument (never re-quoted or re-parsed), and ``{1}``, ``{2}``, … place
+individual arguments.
+
 Unknown placeholders are a hard error so typos surface before anything
 runs. Literal braces are written ``{{`` / ``}}``.
 
 This module is CLI-free on purpose: the spec validator
 (:mod:`clm.slides.spec_validator`) uses it to check ``<tasks>`` blocks
-without importing the Click command tree.
+without importing the Click command tree. The validator resolves steps
+without runtime arguments (``args=None``), which accepts ``{args}``/``{n}``
+references with stand-in values — the actual values only exist at
+``clm run`` time.
 """
 
 from __future__ import annotations
 
 import re
 import shlex
+from collections.abc import Sequence
 from pathlib import Path
 
 #: Placeholders available in task steps, with a short description each
-#: (used in error messages and documentation).
+#: (used in error messages and documentation). Positional placeholders
+#: ``{1}``, ``{2}``, … are recognized structurally (see
+#: :data:`_POSITIONAL_RE`) and not listed here.
 KNOWN_PLACEHOLDERS: dict[str, str] = {
     "spec": "absolute path of the spec file passed to `clm run`",
+    "args": "all extra arguments passed to `clm run TASK SPEC [ARGS]...` "
+    "(standalone token only; one argv token per argument)",
 }
 
 _PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
+#: ``{1}``, ``{2}``, … — 1-based references to single extra arguments.
+_POSITIONAL_RE = re.compile(r"[1-9][0-9]*")
 # Sentinels for the ``{{`` / ``}}`` escapes; chr(0) cannot appear in XML text.
 _OPEN_SENTINEL = "\x00<"
 _CLOSE_SENTINEL = "\x00>"
@@ -53,6 +69,11 @@ def substitute_placeholders(token: str, values: dict[str, str]) -> str:
     def _replace(match: re.Match[str]) -> str:
         name = match.group(1)
         if name not in values:
+            if _POSITIONAL_RE.fullmatch(name):
+                raise TaskStepError(
+                    f"step references argument {{{name}}} but only "
+                    f"{_positional_count(values)} extra argument(s) were given"
+                )
             known = ", ".join(f"{{{p}}}" for p in sorted(values))
             raise TaskStepError(f"unknown placeholder {{{name}}} (known placeholders: {known})")
         return values[name]
@@ -61,16 +82,54 @@ def substitute_placeholders(token: str, values: dict[str, str]) -> str:
     return substituted.replace(_OPEN_SENTINEL, "{").replace(_CLOSE_SENTINEL, "}")
 
 
-def resolve_step(step: str, *, spec_path: Path) -> list[str]:
+def _positional_count(values: dict[str, str]) -> int:
+    return sum(1 for name in values if _POSITIONAL_RE.fullmatch(name))
+
+
+def step_argument_usage(step: str) -> tuple[bool, int]:
+    """Report how one step's text uses the extra ``clm run`` arguments.
+
+    Returns ``(uses_args, max_positional)``: whether ``{args}`` appears, and
+    the highest ``{n}`` referenced (0 when none). Unparseable steps report
+    ``(False, 0)`` — resolution surfaces the parse error with full context.
+    """
+    try:
+        tokens = shlex.split(step, posix=True)
+    except ValueError:
+        return False, 0
+    uses_args = False
+    max_positional = 0
+    for token in tokens:
+        masked = token.replace("{{", _OPEN_SENTINEL).replace("}}", _CLOSE_SENTINEL)
+        for name in _PLACEHOLDER_RE.findall(masked):
+            if name == "args":
+                uses_args = True
+            elif _POSITIONAL_RE.fullmatch(name):
+                max_positional = max(max_positional, int(name))
+    return uses_args, max_positional
+
+
+def resolve_step(
+    step: str,
+    *,
+    spec_path: Path,
+    args: Sequence[str] | None = None,
+) -> list[str]:
     """Resolve one step's text into the argv tokens to pass after ``clm``.
 
     Args:
         step: The step text from the spec (without the leading ``clm``).
         spec_path: The spec file the task was loaded from; expands ``{spec}``.
+        args: The extra arguments from ``clm run TASK SPEC [ARGS]...``
+            (issue #342); expand ``{args}`` and ``{1}``, ``{2}``, ….
+            ``None`` (the default) means *validation mode*: argument
+            placeholders are accepted and replaced with stand-in values, so
+            the spec validator can check steps without runtime arguments.
 
     Raises:
-        TaskStepError: For empty steps, unbalanced quotes, or unknown
-            placeholders.
+        TaskStepError: For empty steps, unbalanced quotes, unknown
+            placeholders, an out-of-range ``{n}``, or ``{args}`` embedded
+            in a larger token.
     """
     if not step.strip():
         raise TaskStepError("step is empty")
@@ -81,5 +140,34 @@ def resolve_step(step: str, *, spec_path: Path) -> list[str]:
     if not tokens:
         raise TaskStepError("step is empty")
 
+    validation_mode = args is None
+    arg_list = [] if args is None else list(args)
+
     values = {"spec": str(spec_path.resolve())}
-    return [substitute_placeholders(token, values) for token in tokens]
+    if validation_mode:
+        # Stand-ins for every {n} actually referenced; values are only used
+        # for the command-tree check, where argument positions never matter.
+        for token in tokens:
+            masked = token.replace("{{", _OPEN_SENTINEL).replace("}}", _CLOSE_SENTINEL)
+            for name in _PLACEHOLDER_RE.findall(masked):
+                if _POSITIONAL_RE.fullmatch(name):
+                    values[name] = f"<{name}>"
+    else:
+        values.update({str(i): arg for i, arg in enumerate(arg_list, start=1)})
+
+    resolved: list[str] = []
+    for token in tokens:
+        masked = token.replace("{{", _OPEN_SENTINEL).replace("}}", _CLOSE_SENTINEL)
+        if masked == "{args}":
+            # A bare {args} token expands to one argv token per argument —
+            # values are never joined, re-quoted, or re-parsed.
+            resolved.extend(["<args>"] if validation_mode else arg_list)
+            continue
+        if "{args}" in masked:
+            raise TaskStepError(
+                "{args} must be a standalone token (it expands to one argv "
+                "token per argument); use {1}, {2}, … to place arguments "
+                "inside a larger token"
+            )
+        resolved.append(substitute_placeholders(token, values))
+    return resolved

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -1052,10 +1052,39 @@ class SqliteBackend(LocalOpsBackend):
 
                     time.sleep(poll_interval)
 
-                # Timeout waiting for activation
+                # Timeout waiting for activation. A pre-registered worker
+                # activates within seconds of its subprocess starting; one
+                # still 'created' after this wait (on top of its own age)
+                # is a startup casualty — typically an import crash in the
+                # worker subprocess (missing extras, broken env), visible
+                # only in the worker's own log file (issue #348). Mark these
+                # workers dead so every *subsequent* submission fails fast
+                # instead of repeating this full wait per job, which is what
+                # stalled builds for many minutes.
                 logger.warning(
                     f"Timeout waiting for {job_type} workers to activate after {timeout}s"
                 )
+                cursor = conn.execute(
+                    """
+                    UPDATE workers SET status = 'dead'
+                    WHERE worker_type = ?
+                    AND status = 'created'
+                    AND started_at < datetime('now', '-30 seconds')
+                    """,
+                    (job_type,),
+                )
+                if cursor.rowcount:
+                    conn.commit()
+                    from clm.infrastructure.logging.log_paths import get_worker_log_path
+
+                    log_dir = get_worker_log_path(job_type, 0).parent
+                    logger.error(
+                        f"Marked {cursor.rowcount} pre-registered {job_type} worker(s) "
+                        f"as dead: the worker process(es) never activated and likely "
+                        f"crashed at startup (e.g. missing worker dependencies — "
+                        f"install clm[all-workers]). Check the worker logs in "
+                        f"{log_dir} for the crash traceback."
+                    )
 
         return 0
 

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -281,7 +281,7 @@ def atomic_write_all(writes: list[tuple[Path, str]]) -> None:
 
 
 def is_private_dir_name(name: str) -> bool:
-    """True for underscore-prefixed directory names (``_archive``, ``_drafts``, …).
+    """True for underscore- or dot-prefixed directory names.
 
     Underscore-prefixed directories under ``slides/`` hold author-parked
     content (retired decks, drafts). They are excluded from module/topic
@@ -290,8 +290,13 @@ def is_private_dir_name(name: str) -> bool:
     not a course-file-map rule: the legacy ``_cassettes/`` sidecar inside a
     topic stays in the course file map because the kernel reads it at
     runtime (see ``SKIP_DIRS_FOR_OUTPUT``).
+
+    Dot-prefixed directories (``.ipynb_checkpoints``, ``.git``, ``.vscode``,
+    …) are tool sidecars, never course content; Jupyter's checkpoint copies
+    of decks otherwise surface as duplicate — possibly stale — findings in
+    validation and normalization walks (issue #339).
     """
-    return name.startswith("_")
+    return name.startswith(("_", "."))
 
 
 def is_ignored_dir_for_course(dir_path: Path) -> bool:

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1008,8 +1008,10 @@ def classify_execution_failure(error: BaseException) -> tuple[str, str]:
     Distinguishes the failure classes the xeus-cpp crash triage cares
     about: a cell raising (``cell_execution_error``), the kernel process
     dying (``dead_kernel``), the kernel never becoming ready
-    (``startup_timeout``), and a cell exceeding its timeout
-    (``cell_timeout``). Everything else is ``other``.
+    (``startup_timeout``), a cell exceeding its timeout (``cell_timeout``),
+    and the kernelspec not being installed at all (``missing_kernel`` —
+    permanent for the lifetime of the build, so the retry loop fails fast
+    on it, issue #348). Everything else is ``other``.
 
     Returns:
         ``(failure_type, error_class_name)``.
@@ -1024,6 +1026,10 @@ def classify_execution_failure(error: BaseException) -> tuple[str, str]:
     if isinstance(error, CellTimeoutError):
         return "cell_timeout", error_class
     message = str(error)
+    # Matched by class name (jupyter_client.kernelspec.NoSuchKernel) and
+    # message so wrapped/re-raised forms classify too.
+    if error_class == "NoSuchKernel" or "No such kernel" in message:
+        return "missing_kernel", error_class
     # jupyter_client raises plain RuntimeErrors for these kernel-level
     # failures, so the message is the only classification signal.
     if "Kernel died" in message:
@@ -2187,6 +2193,15 @@ class NotebookProcessor:
                 # ALWAYS cleanup kernel resources to prevent ZMQ leaks
                 await self._cleanup_kernel_resources(ep, cid)
 
+            # A missing kernelspec is a permanent condition for the lifetime
+            # of the build — every retry would fail identically while paying
+            # the kernel-startup and backoff cost each time (issue #348).
+            if failed_attempts and failed_attempts[-1]["failure_type"] == "missing_kernel":
+                logger.error(
+                    f"{cid}: kernel is not installed — failing fast without retries: {last_error}"
+                )
+                break
+
             # Exponential backoff before next retry
             if attempt < NUM_RETRIES_FOR_HTML:
                 await asyncio.sleep(1.0 * attempt)
@@ -2823,6 +2838,15 @@ class NotebookProcessor:
                 parts.append(f"  Cell content:\n    {snippet}")
 
         parts.append(f"  Error: {error_class}: {error_message}")
+
+        # A missing kernelspec has a known remedy — point at it instead of
+        # leaving the user to decode the jupyter_client error (issue #348).
+        if error_class == "NoSuchKernel" or "No such kernel" in error_str:
+            parts.append(
+                "  Hint: the Jupyter kernel is not installed on this machine; "
+                "HTML generation needs it. Install the kernelspec, or use "
+                "'clm build --no-html' for a kernel-free build."
+            )
 
         # Include line/column number if found (especially useful for C++)
         if cpp_error_info:

--- a/tests/cli/test_git_ops.py
+++ b/tests/cli/test_git_ops.py
@@ -631,6 +631,55 @@ class TestGitHelpers:
             assert result.returncode == 0
             mock_run.assert_called_once()
 
+    def test_token_auth_disabled_by_default(self, monkeypatch, tmp_path: Path):
+        """Without CLM_GIT_TOKEN_AUTH the command line is unchanged (#341)."""
+        monkeypatch.delenv("CLM_GIT_TOKEN_AUTH", raising=False)
+        monkeypatch.setenv("CLM_GITLAB_TOKEN", "secret-token")
+        with patch("clm.cli.commands.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            run_git(tmp_path, "push", "-u", "origin", "master")
+            cmd = mock_run.call_args[0][0]
+        assert cmd == ["git", "-C", str(tmp_path), "push", "-u", "origin", "master"]
+
+    def test_token_auth_injects_credential_helper(self, monkeypatch, tmp_path: Path):
+        """CLM_GIT_TOKEN_AUTH=1 + token injects the ephemeral helper (#341)."""
+        monkeypatch.setenv("CLM_GIT_TOKEN_AUTH", "1")
+        monkeypatch.setenv("CLM_GITLAB_TOKEN", "secret-token")
+        with patch("clm.cli.commands.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            run_git(tmp_path, "push", "-u", "origin", "master")
+            cmd = mock_run.call_args[0][0]
+        # Empty first helper clears configured helpers (GCM); the second one
+        # reads the token from the environment — never from the command line.
+        assert cmd[1:5] == [
+            "-c",
+            "credential.helper=",
+            "-c",
+            'credential.helper=!f() { echo username=oauth2; echo "password=$CLM_GITLAB_TOKEN"; }; f',
+        ]
+        assert "secret-token" not in " ".join(cmd)
+
+    def test_token_auth_applies_to_global_git_commands(self, monkeypatch):
+        monkeypatch.setenv("CLM_GIT_TOKEN_AUTH", "true")
+        monkeypatch.delenv("CLM_GITLAB_TOKEN", raising=False)
+        monkeypatch.setenv("GITLAB_TOKEN", "secret-token")
+        with patch("clm.cli.commands.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            run_git_global("ls-remote", "https://gitlab.example.com/g/repo.git")
+            cmd = mock_run.call_args[0][0]
+        assert cmd[1:3] == ["-c", "credential.helper="]
+        assert "$GITLAB_TOKEN" in cmd[4]
+
+    def test_token_auth_without_token_is_a_no_op(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setenv("CLM_GIT_TOKEN_AUTH", "1")
+        monkeypatch.delenv("CLM_GITLAB_TOKEN", raising=False)
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        with patch("clm.cli.commands.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            run_git(tmp_path, "fetch", "origin")
+            cmd = mock_run.call_args[0][0]
+        assert cmd == ["git", "-C", str(tmp_path), "fetch", "origin"]
+
     def test_remote_exists_true(self):
         """Test remote_exists returns True for existing remote."""
         with patch("clm.cli.commands.git.run_git_global") as mock_run:

--- a/tests/cli/test_run_cmd.py
+++ b/tests/cli/test_run_cmd.py
@@ -207,6 +207,62 @@ def test_unknown_cli_command_error_resolves_real_commands():
 
 
 # ---------------------------------------------------------------------------
+# Argument placeholders — {args} / {1}, {2}, … (issue #342)
+# ---------------------------------------------------------------------------
+
+ARGS_TASKS = """<tasks>
+  <task name="release-week">
+    <step>export outline {spec} -o {args}</step>
+    <step>export outline {spec} -o weekly/{1}</step>
+  </task>
+  <task name="no-args">
+    <step>build {spec}</step>
+  </task>
+</tasks>"""
+
+
+def test_extra_arguments_expand_args_and_positionals(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(tmp_path, ARGS_TASKS)
+    result = _RUNNER.invoke(run_cmd, ["release-week", str(spec), "Week 09"])
+    assert result.exit_code == 0, _out(result)
+    spec_abs = str(spec.resolve())
+    assert recorded_runs[0] == [
+        sys.executable,
+        "-m",
+        "clm",
+        "export",
+        "outline",
+        spec_abs,
+        "-o",
+        "Week 09",
+    ]
+    assert recorded_runs[1][-1] == "weekly/Week 09"
+
+
+def test_missing_arguments_fail_before_any_step_runs(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(tmp_path, ARGS_TASKS)
+    result = _RUNNER.invoke(run_cmd, ["release-week", str(spec)])
+    assert result.exit_code == 1
+    assert "needs at least 1 argument(s)" in _out(result)
+    assert recorded_runs == []
+
+
+def test_unused_arguments_are_an_error(tmp_path: Path, recorded_runs: list):
+    spec = _write_spec(tmp_path, ARGS_TASKS)
+    result = _RUNNER.invoke(run_cmd, ["no-args", str(spec), "stray"])
+    assert result.exit_code == 1
+    assert "no extra arguments" in _out(result)
+    assert "stray" in _out(result)
+    assert recorded_runs == []
+
+
+def test_list_mode_rejects_extra_arguments(spec_file: Path):
+    result = _RUNNER.invoke(run_cmd, ["--list", "pre-release", str(spec_file), "stray"])
+    assert result.exit_code == 2
+    assert "only valid when running a task" in _out(result)
+
+
+# ---------------------------------------------------------------------------
 # Execution
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_release_channels_spec.py
+++ b/tests/core/test_release_channels_spec.py
@@ -352,3 +352,55 @@ class TestLanguageScopedChannels:
         # Lang without stream (single unnamed block).
         url = gh.derive_channel_remote_url("jan", language="en")
         assert url == "https://gitlab.example.com/ca/ml-jan-en"
+
+
+class TestChannelRepoOverride:
+    """Channel `repo` attribute (issue #322): verbatim repo-name override."""
+
+    REPO_BLOCK = """
+    <release-channels name="solutions" source-target="shared">
+      <channel name="2026-04-de" lang="de" repo="ml-azav-2026-04-solutions-de"
+               path="./solutions/2026-04-de" ledger="release/2026-04-de.txt"/>
+      <channel name="2026-04-en" lang="en"
+               path="./solutions/2026-04-en" ledger="release/2026-04-en.txt"/>
+    </release-channels>
+    """
+
+    def test_repo_parses_and_defaults_to_empty(self):
+        block = _spec(self.REPO_BLOCK, TWO_STREAM_TARGETS).release_channel_blocks[0]
+        assert block.channel("2026-04-de").repo == "ml-azav-2026-04-solutions-de"
+        assert block.channel("2026-04-en").repo == ""
+
+    def test_repo_override_replaces_derived_name_verbatim(self):
+        from clm.core.course_spec import GitHubSpec
+
+        gh = GitHubSpec(project_slug="ml", repository_base="https://gitlab.example.com/ca")
+        # Without the override, the lang-scoped channel name duplicates the
+        # language: ml-2026-04-de-solutions-de.
+        url = gh.derive_channel_remote_url(
+            "2026-04-de",
+            stream="solutions",
+            language="de",
+            repo_override="ml-azav-2026-04-solutions-de",
+        )
+        assert url == "https://gitlab.example.com/ca/ml-azav-2026-04-solutions-de"
+
+    def test_repo_override_keeps_remote_path_and_template(self):
+        from clm.core.course_spec import GitHubSpec
+
+        gh = GitHubSpec(project_slug="ml", repository_base="https://gitlab.example.com/ca")
+        url = gh.derive_channel_remote_url(
+            "2026-04-de",
+            remote_path="cohorts",
+            repo_override="custom-name",
+        )
+        assert url == "https://gitlab.example.com/ca/cohorts/custom-name"
+        url = gh.derive_channel_remote_url(
+            "2026-04-de",
+            remote_template="git@host:{slug}/{repo}.git",
+            repo_override="custom-name",
+        )
+        assert url == "git@host:ml/custom-name.git"
+
+    def test_repo_override_validates_clean(self):
+        assert _spec(self.REPO_BLOCK, TWO_STREAM_TARGETS).validate() == []

--- a/tests/core/test_task_specs.py
+++ b/tests/core/test_task_specs.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import pytest
 
 from clm.core.course_spec import CourseSpec
-from clm.core.tasks import TaskStepError, resolve_step, substitute_placeholders
+from clm.core.tasks import (
+    TaskStepError,
+    resolve_step,
+    step_argument_usage,
+    substitute_placeholders,
+)
 
 
 def _spec(tasks_block: str) -> CourseSpec:
@@ -168,3 +173,91 @@ def test_unbalanced_quote_raises(tmp_path: Path):
 def test_escaped_braces_become_literal_braces():
     assert substitute_placeholders("a{{b}}c", {"spec": "X"}) == "a{b}c"
     assert substitute_placeholders("{spec}{{spec}}", {"spec": "X"}) == "X{spec}"
+
+
+# ---------------------------------------------------------------------------
+# Argument placeholders — {args} / {1}, {2}, … (issue #342)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_args_token_expands_to_one_token_per_argument(tmp_path: Path):
+    spec_path = tmp_path / "c.xml"
+    tokens = resolve_step(
+        "release week {spec} {args} --channel materials/2026-04-de",
+        spec_path=spec_path,
+        args=["name:Week 09", "--push"],
+    )
+    assert tokens == [
+        "release",
+        "week",
+        str(spec_path.resolve()),
+        "name:Week 09",
+        "--push",
+        "--channel",
+        "materials/2026-04-de",
+    ]
+
+
+def test_args_values_are_never_requoted_or_reparsed(tmp_path: Path):
+    # An argument containing spaces or quote characters stays one argv token.
+    tokens = resolve_step(
+        "release week {spec} {args}",
+        spec_path=tmp_path / "c.xml",
+        args=['name:"Week 09" extra'],
+    )
+    assert tokens[-1] == 'name:"Week 09" extra'
+
+
+def test_positional_placeholders_place_individual_arguments(tmp_path: Path):
+    tokens = resolve_step(
+        "release week {spec} {2} --channel {1}",
+        spec_path=tmp_path / "c.xml",
+        args=["materials/2026-04-de", "name:Week 09"],
+    )
+    assert tokens[3:] == ["name:Week 09", "--channel", "materials/2026-04-de"]
+
+
+def test_positional_placeholder_embedded_in_larger_token(tmp_path: Path):
+    tokens = resolve_step(
+        "build {spec} --channel=materials/{1}",
+        spec_path=tmp_path / "c.xml",
+        args=["2026-04"],
+    )
+    assert tokens[-1] == "--channel=materials/2026-04"
+
+
+def test_embedded_args_placeholder_is_an_error(tmp_path: Path):
+    with pytest.raises(TaskStepError, match=r"\{args\} must be a standalone token"):
+        resolve_step("build prefix-{args}", spec_path=tmp_path / "c.xml", args=["x"])
+
+
+def test_out_of_range_positional_is_an_error(tmp_path: Path):
+    with pytest.raises(TaskStepError, match=r"references argument \{2\} but only 1"):
+        resolve_step("build {2}", spec_path=tmp_path / "c.xml", args=["only-one"])
+
+
+def test_validation_mode_accepts_argument_placeholders(tmp_path: Path):
+    # args=None (the spec validator's call shape) must accept {args}/{n}
+    # references — the actual values only exist at `clm run` time.
+    tokens = resolve_step(
+        "release week {spec} {args} --channel {1}", spec_path=tmp_path / "c.xml"
+    )
+    assert tokens[0] == "release"
+    assert "<args>" in tokens
+    assert "<1>" in tokens
+
+
+def test_zero_positional_is_unknown(tmp_path: Path):
+    with pytest.raises(TaskStepError, match=r"unknown placeholder \{0\}"):
+        resolve_step("build {0}", spec_path=tmp_path / "c.xml", args=["x"])
+
+
+def test_step_argument_usage_reports_args_and_max_positional():
+    assert step_argument_usage("build {spec}") == (False, 0)
+    assert step_argument_usage("release week {spec} {args}") == (True, 0)
+    assert step_argument_usage("release week {1} --channel {3}") == (False, 3)
+    assert step_argument_usage("release week {args} {2}") == (True, 2)
+    # Escaped braces are literal, not references; unparseable steps report
+    # no usage (resolution surfaces the parse error).
+    assert step_argument_usage("build {{args}}") == (False, 0)
+    assert step_argument_usage('build "unclosed') == (False, 0)

--- a/tests/core/test_task_specs.py
+++ b/tests/core/test_task_specs.py
@@ -239,9 +239,7 @@ def test_out_of_range_positional_is_an_error(tmp_path: Path):
 def test_validation_mode_accepts_argument_placeholders(tmp_path: Path):
     # args=None (the spec validator's call shape) must accept {args}/{n}
     # references — the actual values only exist at `clm run` time.
-    tokens = resolve_step(
-        "release week {spec} {args} --channel {1}", spec_path=tmp_path / "c.xml"
-    )
+    tokens = resolve_step("release week {spec} {args} --channel {1}", spec_path=tmp_path / "c.xml")
     assert tokens[0] == "release"
     assert "<args>" in tokens
     assert "<1>" in tokens

--- a/tests/core/test_topic_resolver.py
+++ b/tests/core/test_topic_resolver.py
@@ -179,6 +179,17 @@ class TestBuildTopicMap:
         assert len(matches) == 1
         assert matches[0].path.name == "topic_010_intro"
 
+    def test_dot_dirs_are_invisible(self, slides_dir):
+        """Issue #339: dot-dirs (``.ipynb_checkpoints``) are never course content."""
+        checkpoints = slides_dir / ".ipynb_checkpoints" / "module_900_old" / "topic_010_intro"
+        checkpoints.mkdir(parents=True)
+        (checkpoints / "slides_intro-checkpoint.py").write_text("# stale", encoding="utf-8")
+
+        topic_map = build_topic_map(slides_dir)
+        matches = topic_map["intro"]
+        assert len(matches) == 1
+        assert matches[0].path.name == "topic_010_intro"
+
 
 class TestFindSlideFiles:
     def test_directory_topic(self, slides_dir):
@@ -369,6 +380,21 @@ class TestFindSlideFilesRecursive:
         files = find_slide_files_recursive(slides_dir)
         assert files
         assert all("_archive" not in f.parts for f in files)
+
+    def test_prunes_dot_dirs_below_root(self, slides_dir):
+        # Issue #339: Jupyter checkpoint copies must not be walked — they
+        # duplicate (or worse, contradict) findings from the real decks.
+        from clm.core.topic_resolver import find_slide_files_recursive
+
+        checkpoints = (
+            slides_dir / "module_100_basics" / "topic_020_variables" / ".ipynb_checkpoints"
+        )
+        checkpoints.mkdir(parents=True)
+        (checkpoints / "slides_variables-checkpoint.py").write_text("# stale", encoding="utf-8")
+
+        files = find_slide_files_recursive(slides_dir)
+        assert files
+        assert all(".ipynb_checkpoints" not in f.parts for f in files)
 
     def test_explicit_underscore_root_is_honoured(self, slides_dir):
         # The prune applies to components BELOW the walk root only, so an

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -546,6 +546,97 @@ async def test_get_available_workers_waits_for_pre_registered(temp_db, temp_work
 
 
 @pytest.mark.asyncio
+async def test_activation_timeout_marks_stuck_created_workers_dead(temp_db, temp_workspace):
+    """Issue #348: a 'created' worker whose subprocess died at startup never
+    activates. After the activation wait times out it is marked dead, so
+    subsequent submissions fail fast instead of repeating the full wait per
+    job (which stalled builds for many minutes)."""
+    worker_id = _seed_created_worker(temp_db, "notebook")
+    # Old enough for the stuck check (> 30s) — as it would be after the
+    # real 30s activation wait.
+    conn = sqlite3.connect(temp_db)
+    try:
+        conn.execute(
+            "UPDATE workers SET started_at = datetime('now', '-120 seconds') WHERE id = ?",
+            (worker_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        # Drive the wait loop with a fake clock so the 30s timeout elapses
+        # instantly.
+        fake_now = [time.time()]
+
+        def fast_sleep(seconds):
+            fake_now[0] += seconds
+
+        with (
+            patch(
+                "clm.infrastructure.backends.sqlite_backend.time.sleep",
+                side_effect=fast_sleep,
+            ),
+            patch(
+                "clm.infrastructure.backends.sqlite_backend.time.time",
+                side_effect=lambda: fake_now[0],
+            ),
+        ):
+            assert backend._get_available_workers("notebook") == 0
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            row = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,)).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "dead"
+
+        # No 'created' workers remain — the next check returns immediately
+        # (no activation wait), which is the fail-fast property.
+        start = time.time()
+        assert backend._get_available_workers("notebook") == 0
+        assert time.time() - start < 5
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_activation_timeout_spares_freshly_created_workers(temp_db, temp_workspace):
+    """A worker pre-registered moments ago (e.g. mid-wait by another process)
+    is not condemned by someone else's timeout."""
+    worker_id = _seed_created_worker(temp_db, "notebook")  # started_at = now
+
+    backend = _backend(temp_db, temp_workspace)
+    try:
+        fake_now = [time.time()]
+
+        def fast_sleep(seconds):
+            fake_now[0] += seconds
+
+        with (
+            patch(
+                "clm.infrastructure.backends.sqlite_backend.time.sleep",
+                side_effect=fast_sleep,
+            ),
+            patch(
+                "clm.infrastructure.backends.sqlite_backend.time.time",
+                side_effect=lambda: fake_now[0],
+            ),
+        ):
+            assert backend._get_available_workers("notebook") == 0
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            row = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,)).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "created"
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_get_available_workers_no_queue(temp_db, temp_workspace):
     backend = _backend(temp_db, temp_workspace)
     try:

--- a/tests/release/test_provision.py
+++ b/tests/release/test_provision.py
@@ -309,6 +309,8 @@ class TestProvisionCli:
         """Provision targets the repo's actual origin when one is set (#322)."""
         import subprocess
 
+        from clm.cli.commands.git import _dry_run_mode
+
         for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
             monkeypatch.delenv(var, raising=False)
         spec_file = _write_spec(tmp_path)
@@ -328,7 +330,15 @@ class TestProvisionCli:
             check=True,
         )
 
-        result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        # The origin lookup must really run even when the `clm git` dry-run
+        # ContextVar is set (it leaks across CliRunner invocations in one
+        # test process, and provision's own --dry-run must still name the
+        # project that would actually be shared).
+        token = _dry_run_mode.set(True)
+        try:
+            result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        finally:
+            _dry_run_mode.reset(token)
         assert result.exit_code == 0, result.output
         assert "ca/the-actual-repo -> trainers (maintainer)" in result.output
         assert "ca/ml-2026-04-solutions ->" not in result.output

--- a/tests/release/test_provision.py
+++ b/tests/release/test_provision.py
@@ -285,6 +285,56 @@ class TestProvisionCli:
         assert "collapsed" in result.output
         assert result.output.count("-> trainers") == 1
 
+    def test_channel_repo_attribute_overrides_derived_name(self, tmp_path, monkeypatch):
+        """`<channel repo="...">` makes provision target the real project (#322)."""
+        for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        spec = SPEC_WITH_SHARES.replace(
+            '<channel name="2026-04" ',
+            '<channel name="2026-04" repo="ml-azav-2026-04-solutions" ',
+        )
+        specs_dir = tmp_path / "course-specs"
+        specs_dir.mkdir()
+        spec_file = specs_dir / "course.xml"
+        spec_file.write_text(spec, encoding="utf-8")
+
+        result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "ca/ml-azav-2026-04-solutions -> trainers (maintainer)" in result.output
+        assert "ca/ml-2026-04-solutions ->" not in result.output
+        # The channel without an override keeps the derived name.
+        assert "ca/ml-2026-10-solutions -> trainers (guest)" in result.output
+
+    def test_working_tree_origin_wins_over_derived_url(self, tmp_path, monkeypatch):
+        """Provision targets the repo's actual origin when one is set (#322)."""
+        import subprocess
+
+        for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        spec_file = _write_spec(tmp_path)
+        dest = tmp_path / "release" / "2026-04"
+        dest.mkdir(parents=True)
+        subprocess.run(["git", "-C", str(dest), "init", "-q"], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(dest),
+                "remote",
+                "add",
+                "origin",
+                "https://gitlab.example.com/ca/the-actual-repo.git",
+            ],
+            check=True,
+        )
+
+        result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "ca/the-actual-repo -> trainers (maintainer)" in result.output
+        assert "ca/ml-2026-04-solutions ->" not in result.output
+        # 2026-10 has no working tree; the derived URL remains its fallback.
+        assert "ca/ml-2026-10-solutions -> trainers (guest)" in result.output
+
     def test_api_error_exits_nonzero_but_continues(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLM_GITLAB_TOKEN", "tok")
         spec_file = _write_spec(tmp_path)

--- a/tests/release/test_provision.py
+++ b/tests/release/test_provision.py
@@ -345,6 +345,21 @@ class TestProvisionCli:
         # 2026-10 has no working tree; the derived URL remains its fallback.
         assert "ca/ml-2026-10-solutions -> trainers (guest)" in result.output
 
+    def test_working_tree_without_origin_falls_back_to_derived_url(self, tmp_path, monkeypatch):
+        """An initialized repo with no origin yet keeps the derived URL (#322)."""
+        import subprocess
+
+        for var in ("CLM_GITLAB_TOKEN", "GITLAB_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        spec_file = _write_spec(tmp_path)
+        dest = tmp_path / "release" / "2026-04"
+        dest.mkdir(parents=True)
+        subprocess.run(["git", "-C", str(dest), "init", "-q"], check=True)
+
+        result = CliRunner().invoke(release_group, ["provision", str(spec_file), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "ca/ml-2026-04-solutions -> trainers (maintainer)" in result.output
+
     def test_api_error_exits_nonzero_but_continues(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLM_GITLAB_TOKEN", "tok")
         spec_file = _write_spec(tmp_path)

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -1241,3 +1241,26 @@ class TestValidateTasks:
         errors = [f for f in result.errors if f.type == "invalid_task_step"]
         assert len(errors) == 1
         assert "{sepc}" in errors[0].message
+
+    def test_argument_placeholders_validate_clean(self, tmp_path):
+        # {args} / {n} (issue #342) get their values only at `clm run` time;
+        # validation must accept them as known placeholders.
+        result = self._validate(
+            tmp_path,
+            """<tasks>
+              <task name="release-week">
+                <step>export outline {spec} -o {1}</step>
+                <step>export outline {spec} -o outline/ {args}</step>
+              </task>
+            </tasks>""",
+        )
+        assert result.findings == []
+
+    def test_embedded_args_placeholder_is_reported(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            '<tasks><task name="bad"><step>build {spec} -o prefix-{args}</step></task></tasks>',
+        )
+        errors = [f for f in result.errors if f.type == "invalid_task_step"]
+        assert len(errors) == 1
+        assert "standalone token" in errors[0].message

--- a/tests/workers/notebook/test_execution_telemetry.py
+++ b/tests/workers/notebook/test_execution_telemetry.py
@@ -61,6 +61,18 @@ class TestClassifyExecutionFailure:
             "TimeoutError",
         )
 
+    def test_no_such_kernel_by_class_name(self):
+        from jupyter_client.kernelspec import NoSuchKernel
+
+        failure_type, error_class = classify_execution_failure(NoSuchKernel("xcpp20"))
+        assert failure_type == "missing_kernel"
+        assert error_class == "NoSuchKernel"
+
+    def test_no_such_kernel_by_message(self):
+        # Wrapped/re-raised forms keep only the message.
+        error = RuntimeError("NoSuchKernel: No such kernel named xcpp20")
+        assert classify_execution_failure(error) == ("missing_kernel", "RuntimeError")
+
     def test_other(self):
         assert classify_execution_failure(ValueError("boom")) == ("other", "ValueError")
 
@@ -276,6 +288,26 @@ class TestRetryLoopTelemetry:
         assert telemetry["failure_type"] == "startup_timeout"
         assert telemetry["failing_cell_index"] is None
         assert telemetry["classification"] == "deterministic"
+
+    def test_missing_kernel_fails_fast_without_retries(self, scripted_execution, tmp_path):
+        """Issue #348: a missing kernelspec is permanent for the build —
+        retrying it only wastes kernel-startup and backoff time per job."""
+        from jupyter_client.kernelspec import NoSuchKernel
+
+        scripted_execution.reset([NoSuchKernel("xcpp20"), None])
+        processor = self._processor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _run_execution(processor, _make_payload(), tmp_path)
+
+        # Only one attempt was made; the scripted success on attempt 2 was
+        # never reached.
+        assert scripted_execution.calls == 1
+        telemetry = exc_info.value.execution_telemetry
+        assert telemetry["attempts"] == 1
+        assert telemetry["failure_type"] == "missing_kernel"
+        # The enhanced error points at the remedy.
+        assert "--no-html" in str(exc_info.value)
 
     def test_skip_errors_suppression_emits_suppressed_failure(self, scripted_execution, tmp_path):
         error = CellExecutionError("tb", "ValueError", "boom")


### PR DESCRIPTION
Full triage of the 9 open issues, with implementations for the five that are valid, feasible, and well-scoped. One commit per issue.

## Implemented

### #339 — dot-dirs pruned from discovery/validation walks (`fix`)
`is_private_dir_name` — the single prune point from #318 shared by topic discovery, recursive slide-file walks, spec-orphan and pairing scans — now also matches dot-prefixed names, so `.ipynb_checkpoints` copies no longer produce duplicate/stale findings.

### #342 — `clm run` argument placeholders (`feat`)
`clm run TASK SPEC [ARGS]...` with the semantics from the issue:
- a **standalone** `{args}` token expands to one argv token per argument (never re-quoted/re-parsed); embedded use is a hard error (the "keep semantics crisp" option),
- `{1}`, `{2}`, … place individual arguments and are embeddable (`--channel=materials/{1}`),
- a task referencing `{args}`/`{n}` fails **before any step runs** when invoked without the arguments; unreferenced extra arguments are an error rather than silently dropped,
- the spec validator accepts the new placeholders (validation mode substitutes stand-ins, since values only exist at run time).

Info topics (`commands`, `spec-files`) updated.

### #341 — token-authenticated HTTPS git transport (`feat`)
With `CLM_GIT_TOKEN_AUTH=1` and `CLM_GITLAB_TOKEN`/`GITLAB_TOKEN` set, every git operation run by `clm git` / `clm release sync --push` injects the ephemeral credential helper from the issue (`oauth2:<token>` basic auth; empty first helper clears GCM). The token is read from the environment at git time — never on the command line, in URLs, or in `.git/config`. I went with the issue's **conservative opt-in** option rather than automatic-when-set, so workstations keep using stored credentials by default. Applies to all network operations (push, fetch, ls-remote, clone). Docs: `configuration.md` + commands info topic.

### #322 — declarative provisioning for non-derived repo names (`feat`)
Both complementary pieces from the issue:
- `<channel repo="...">` overrides the derived repo name verbatim (remote-path/template handling unchanged; existing specs keep today's derived names),
- `clm release provision` prefers the working tree's **actual `origin`** over the derived URL when one is configured — making provision consistent with the documented `clm git` philosophy.

The optional lang-suffix dedupe was deliberately **not** done: it would silently change derived names for existing specs, and the `repo` override covers the case declaratively.

### #348 — fail fast on missing kernels and dead pre-registered workers (`fix`)
Two wedge classes addressed:
- `NoSuchKernel` is now classified `missing_kernel` (permanent for the build's lifetime) → the retry loop fails the job on attempt 1 instead of burning 6 kernel-startup/backoff cycles, and the enhanced error carries the remedy (install the kernelspec or `--no-html`).
- A pre-registered worker whose subprocess dies before activation (the import-crash case from the issue comment) previously made **every** submission repeat the full 30 s activation wait — the silent multi-minute CI stall. After the first activation-wait timeout, still-`created` workers older than 30 s are marked dead, so subsequent submissions fail immediately with an error pointing at the worker log directory where the crash traceback lives. (A build-level "fail every kernel-dependent job after first NoSuchKernel" pass and a startup `process.poll()` preflight are possible follow-ups, but the two changes here remove both observed stall mechanisms.)

## Triaged, not implemented (still valid)

- **#333** (C++ CMake code export) — largely **addressed**: phases 1 (translation-unit export), 2 (CMake generation), and 4 (code-along stubs) have landed (see `changelog.d/333-*`, PR #349); remaining work is the phase-3 CI compile check, which lives in CppCourses. Worth re-scoping the issue to what's left.
- **#165** (mitmproxy transport) — in progress by design: Phase 0 gates are green, opt-in transport is in draft #173; the remaining parity phases are a deliberate staged plan, not something to bolt onto this PR.
- **#167** (LLM model-selection spike) — an investigation whose sanctioned outcome may be "status quo"; needs a decision write-up, not code, and shouldn't be bundled here.
- **#236** (assisted interleave) — valid but explicitly lowest-priority/interactive; the issue's own suggestion of a non-interactive pairing-worklist first cut is the right next step when prioritized.

## Testing

- New/updated tests for every change: `test_topic_resolver`, `test_task_specs`, `test_run_cmd`, `test_spec_validator`, `test_git_ops`, `test_release_channels_spec`, `test_provision`, `test_execution_telemetry`, `test_sqlite_backend_resilience` — all green.
- Full fast suite run: the only failures (70F/112E) reproduce identically on clean `master` in this container (missing optional extras/tools, plus a global commit-signing config breaking tmp-repo commits) — no regressions from this branch.
- ruff check/format and mypy clean on all touched files.

Closes #339. Closes #342. Closes #341. Closes #322. Closes #348.

https://claude.ai/code/session_01Aw2QdpVBN2rf6VttaY3ks7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw2QdpVBN2rf6VttaY3ks7)_