### PR TITLE
fix: tag requests/aiohttp traffic for mitmproxy cassette routing

### DIFF
--- a/changelog.d/165-mitm-tag-requests-aiohttp.fixed.md
+++ b/changelog.d/165-mitm-tag-requests-aiohttp.fixed.md
@@ -1,0 +1,20 @@
+- **`requests`/`aiohttp` decks work under the mitmproxy replay transport
+  again.** The kernel's cassette-routing tag bootstrap only patched `httpx`,
+  so traffic from `requests` (and `aiohttp`) reached the shared replay proxy
+  *untagged* and was matched/recorded against the per-build catch-all cassette
+  instead of the topic's canonical cassette — record/replay was silently
+  broken for any deck using plain `requests.get` (the original motivating
+  use case for HTTP replay). The bootstrap now also tags
+  `requests.Session.send` and `aiohttp.ClientSession._request` (both
+  import-guarded — the libraries stay optional in kernel environments).
+  Affected topics need a one-time re-record (`--http-replay=refresh`): their
+  untagged interactions never made it into the committed cassette.
+- **Untagged replay-proxy traffic now triggers a loud build-log warning.**
+  When a request reaches the replay proxy without an `X-CLM-Cassette` routing
+  tag (an HTTP stack the tag bootstrap does not patch, e.g. `urllib.request`),
+  the mitmproxy addon logs a once-per-build `CLM-HTTP-REPLAY-UNTAGGED` warning
+  naming the first offending request, and the proxy manager relays it into the
+  CLM build log. Previously such traffic silently fell through to the
+  catch-all cassette — the failure mode that hid the missing `requests` patch.
+  Client-library coverage is now documented in
+  `docs/user-guide/http-replay.md` → "Client-library coverage".

--- a/docs/user-guide/http-replay.md
+++ b/docs/user-guide/http-replay.md
@@ -53,6 +53,33 @@ CLM_HTTP_REPLAY_TRANSPORT=vcrpy clm build course.xml   # opt back into the old p
 > passes. During the transition you can keep building against existing cassettes
 > by pinning `CLM_HTTP_REPLAY_TRANSPORT=vcrpy`.
 
+### Client-library coverage (mitmproxy transport)
+
+Under the mitmproxy transport, one shared proxy serves the whole build, so each
+notebook kernel tags its outgoing requests with the destination cassette
+(an `X-CLM-Cassette` header the proxy strips before recording or forwarding).
+The tagging is done by patching the HTTP client libraries inside the kernel.
+Covered:
+
+- **httpx** (`Client`/`AsyncClient`) — the stack the OpenAI/Anthropic/LangChain
+  SDKs use;
+- **requests** (`Session.send`, which the module-level `requests.get`/`post`
+  helpers funnel through);
+- **aiohttp** (`ClientSession`).
+
+Traffic from any *other* HTTP stack — `urllib.request`, raw
+`urllib3`/`http.client`, or a subprocess that honors `HTTP(S)_PROXY` — still
+flows through the proxy (the proxy env vars and CA bundle are set
+process-wide), but arrives **untagged**: it is matched and recorded against a
+per-build *catch-all* cassette in the build scratch directory, **not** the
+topic's canonical cassette, so its recordings are never committed and strict
+`replay` will miss. CLM logs a warning in the build log
+(`CLM-HTTP-REPLAY-UNTAGGED: …`, once per build, naming the first offending
+request) when this happens. If you hit it, either switch the deck to a covered
+client library or pin the build to the `vcrpy` transport
+(`CLM_HTTP_REPLAY_TRANSPORT=vcrpy`), which patches at the `http.client` level
+and covers `urllib` too.
+
 ## Opting a topic in
 
 Mark the topic in your course spec:

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -156,6 +156,17 @@ proxy is gated on the course actually containing an `http-replay` topic, so a
 replay-free build never spawns `mitmdump` and pays no cost. See
 `docs/user-guide/http-replay.md` → "Transports".
 
+**Client-library coverage (as of {version}):** under the mitmproxy transport
+the kernel tags traffic from **httpx**, **requests**, and **aiohttp** so the
+shared proxy routes it to the topic's cassette. (CLM releases between the
+transport switch and {version} tagged only httpx — `requests`-based decks
+recorded into a non-committed catch-all and could not strict-replay; upgrade
+and re-record those topics with `--http-replay=refresh`.) Other HTTP stacks
+(`urllib.request`, raw `urllib3`/`http.client`, subprocesses) are still
+proxied but untagged: they hit the per-build catch-all cassette, and the build
+log carries a `CLM-HTTP-REPLAY-UNTAGGED` warning. Use a covered client library
+in such decks, or pin `CLM_HTTP_REPLAY_TRANSPORT=vcrpy` for that course.
+
 ### 2. Python 3.11 support dropped
 
 `requires-python` is now `>=3.12` — mitmproxy, the new default replay transport,

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -21,9 +21,13 @@ a ``.completed`` marker on clean shutdown, and the host folds each staging
 file into its canonical via the existing ``merge_staging_into_canonical``.
 The tag header is stripped before recording or forwarding upstream.
 
-Untagged traffic (a kernel that somehow bypassed the tag bootstrap) falls
-back to the single ``clm_cassette_path`` catch-all so strict ``replay``
-mode still returns a non-retryable 404 instead of escaping to the network.
+Untagged traffic (a client stack the tag bootstrap does not patch, or a
+kernel that somehow bypassed it) falls back to the single
+``clm_cassette_path`` catch-all so strict ``replay`` mode still returns a
+non-retryable 404 instead of escaping to the network — and triggers a
+once-per-build :data:`UNTAGGED_FLOW_SENTINEL` warning that the manager
+relays into the build log, because catch-all routing means the topic's
+canonical cassette is silently out of the loop.
 """
 
 from __future__ import annotations
@@ -105,6 +109,14 @@ _STAGING_INFIX = ".staging-mitm-"
 # decoded body in memory, so the recorded content-length / transfer
 # framing no longer applies — let mitmproxy recompute them from the body.
 _SERVE_DROP_HEADERS = frozenset({"content-length", "transfer-encoding"})
+
+# Marker prefixing the once-per-build warning for untagged non-ignored
+# traffic. The addon runs inside mitmdump, so its log lines land in the
+# manager's stdout ring buffer; the manager greps drained lines for this
+# sentinel and re-logs them through CLM's own logger so the warning reaches
+# the build log (see ``MitmproxyManager._handle_output_line``). Keep the two
+# in lockstep.
+UNTAGGED_FLOW_SENTINEL = "CLM-HTTP-REPLAY-UNTAGGED"
 
 # Status synthesized for a strict-replay miss. It MUST be a status the LLM
 # SDKs do NOT retry, so a stale-cassette miss fails on the first attempt — the
@@ -236,6 +248,8 @@ class ClmReplayAddon:
         self._request_filter: Callable[..., object] | None = None
         # Keyed by canonical-path string; "" is the untagged catch-all.
         self._targets: dict[str, _Target] = {}
+        # Once-per-build latch for the untagged-flow warning (see request()).
+        self._warned_untagged = False
         # Forensic per-flow trace (issue #165 P5). Disabled until running()
         # reads ``clm_trace_dir``; off entirely unless the build sets
         # CLM_HTTP_REPLAY_TRACE=1 and the manager forwards the directory.
@@ -365,6 +379,29 @@ class ClmReplayAddon:
             flow.metadata[_FLOW_IGNORED_KEY] = True
             self._trace_request(flow, tag, "ignored")
             return
+
+        if tag is None and not self._warned_untagged:
+            # A kernel client stack the tag bootstrap does not patch (anything
+            # other than httpx/requests/aiohttp — e.g. urllib.request, raw
+            # urllib3/http.client, or a subprocess honouring HTTP(S)_PROXY)
+            # reached the proxy untagged. Its traffic is matched/recorded
+            # against the build's catch-all cassette, NOT the topic's canonical
+            # cassette, so record/replay is silently broken for it — exactly
+            # the failure mode that hid the missing ``requests`` patch. Warn
+            # loudly, once per build (the first flow names the culprit; a
+            # per-flow warning would flood the log on a chatty deck).
+            self._warned_untagged = True
+            logger.warning(
+                "%s: %s %s reached the replay proxy without an X-CLM-Cassette "
+                "routing tag; it is matched/recorded against the build's "
+                "catch-all cassette instead of the topic's canonical cassette. "
+                "Only httpx, requests and aiohttp clients are tag-routed by "
+                "the kernel bootstrap. Further untagged flows this build are "
+                "not logged.",
+                UNTAGGED_FLOW_SENTINEL,
+                flow.request.method,
+                flow.request.pretty_url,
+            )
 
         target = self._target_for(tag)
         if target is None:

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -87,6 +87,15 @@ _SHUTDOWN_GRACE_SECONDS = 5.0
 # tail, which is all startup-failure / shutdown diagnostics need.
 _OUTPUT_RING_LINES = 1000
 
+# Addon log lines carrying this sentinel are re-logged through CLM's own
+# logger as they are drained, so the addon's once-per-build untagged-flow
+# warning reaches the build log instead of dying in the ring buffer (which is
+# only ever shown on a startup failure). Must match
+# ``addon.UNTAGGED_FLOW_SENTINEL`` — duplicated as a literal because the addon
+# module is also loaded standalone inside the mitmdump interpreter; a
+# drift-guard test pins the two together.
+_UNTAGGED_FLOW_SENTINEL = "CLM-HTTP-REPLAY-UNTAGGED"
+
 
 class MitmproxyError(RuntimeError):
     """Raised when the proxy subprocess fails to start or exits unexpectedly."""
@@ -329,7 +338,7 @@ class MitmproxyManager:
         def _pump() -> None:
             try:
                 for raw in iter(stream.readline, b""):
-                    self._output.append(raw.decode("utf-8", errors="replace").rstrip("\r\n"))
+                    self._handle_output_line(raw.decode("utf-8", errors="replace").rstrip("\r\n"))
             except (ValueError, OSError):
                 # Stream closed underneath us during shutdown — expected.
                 return
@@ -338,6 +347,20 @@ class MitmproxyManager:
             target=_pump, name="mitmdump-stdout-reader", daemon=True
         )
         self._reader_thread.start()
+
+    def _handle_output_line(self, line: str) -> None:
+        """Buffer one drained mitmdump stdout line; surface flagged addon warnings.
+
+        Every line goes into the diagnostic ring buffer. Lines the addon marked
+        with the untagged-flow sentinel are additionally re-logged at WARNING
+        through CLM's logger immediately — the addon runs inside mitmdump, so
+        without this relay its warning would only ever be visible in the ring
+        buffer dump of a startup *failure*, i.e. never for the builds that
+        actually have the problem.
+        """
+        self._output.append(line)
+        if _UNTAGGED_FLOW_SENTINEL in line:
+            logger.warning("mitmproxy replay: %s", line)
 
     def _wait_for_ready(self) -> None:
         """Poll the listen port until it accepts a TCP connection or we time out."""

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -732,16 +732,31 @@ if _clm_trace_dir:
 # Out-of-process transport (issue #165, P2). Injected into the kernel
 # *instead of* the heavy vcrpy bootstrap when
 # ``CLM_HTTP_REPLAY_TRANSPORT=mitmproxy``. It does not patch httpcore or
-# enter any cassette context — it only tags every outgoing httpx request
-# with the destination cassette path so the single shared mitmproxy can
-# demux flows to the correct per-(topic,language,kind) cassette. The proxy
+# enter any cassette context — it only tags every outgoing request with
+# the destination cassette path so the single shared mitmproxy can demux
+# flows to the correct per-(topic,language,kind) cassette. The proxy
 # strips the ``X-CLM-Cassette`` header before recording or forwarding.
-# The patch is on the httpx ``Client``/``AsyncClient`` *classes*, so it
-# covers clients created before or after this cell (openai/langchain both
-# route through ``Client.send``). One tag per kernel (fresh kernel per
+# Three client stacks are tagged (the same ones decks actually use; the
+# legacy in-kernel vcrpy transport covered them all, so the tag bootstrap
+# must too — an untagged client records into the build's catch-all
+# cassette instead of the topic's canonical one and replay silently
+# breaks):
+#
+# * ``httpx`` — ``Client.send``/``AsyncClient.send`` (openai/langchain
+#   route through these);
+# * ``requests`` — ``Session.send`` (the module-level ``requests.get``
+#   helpers create a ``Session`` and funnel through it, so one class
+#   patch covers everything);
+# * ``aiohttp`` — ``ClientSession._request`` (every verb helper funnels
+#   through it; a plain-def wrapper returning the coroutine keeps the
+#   ``_RequestContextManager`` protocol intact).
+#
+# requests/aiohttp are optional in the kernel env, hence the import
+# guards. All patches are on the *classes*, so clients created before or
+# after this cell are covered. One tag per kernel (fresh kernel per
 # notebook), captured in the closure — the same lifetime the vcrpy
-# bootstrap relies on. No literal ``{}`` in the body so ``str.format`` only
-# substitutes ``{tag!r}``.
+# bootstrap relies on. No literal curly braces in the body so
+# ``str.format`` only substitutes ``{tag!r}``.
 _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE = """\
 # CLM HTTP REPLAY TAG BOOTSTRAP - DO NOT EDIT
 import httpx as _clm_httpx
@@ -760,6 +775,35 @@ if not getattr(_clm_httpx.AsyncClient.send, "_clm_tagged", False):
         return await _clm_orig_asend(self, request, *args, **kwargs)
     _clm_tagged_asend._clm_tagged = True
     _clm_httpx.AsyncClient.send = _clm_tagged_asend
+try:
+    import requests as _clm_requests
+except ImportError:
+    _clm_requests = None
+if _clm_requests is not None and not getattr(
+    _clm_requests.Session.send, "_clm_tagged", False
+):
+    _clm_orig_rsend = _clm_requests.Session.send
+    def _clm_tagged_rsend(self, request, *args, **kwargs):
+        request.headers["x-clm-cassette"] = _CLM_CASSETTE_TAG
+        return _clm_orig_rsend(self, request, *args, **kwargs)
+    _clm_tagged_rsend._clm_tagged = True
+    _clm_requests.Session.send = _clm_tagged_rsend
+try:
+    import aiohttp as _clm_aiohttp
+    from multidict import CIMultiDict as _clm_CIMultiDict
+except ImportError:
+    _clm_aiohttp = None
+if _clm_aiohttp is not None and not getattr(
+    _clm_aiohttp.ClientSession._request, "_clm_tagged", False
+):
+    _clm_orig_aio_request = _clm_aiohttp.ClientSession._request
+    def _clm_tagged_aio_request(self, method, str_or_url, **kwargs):
+        _headers = kwargs.pop("headers", None)
+        _merged = _clm_CIMultiDict(_headers) if _headers else _clm_CIMultiDict()
+        _merged["x-clm-cassette"] = _CLM_CASSETTE_TAG
+        return _clm_orig_aio_request(self, method, str_or_url, headers=_merged, **kwargs)
+    _clm_tagged_aio_request._clm_tagged = True
+    _clm_aiohttp.ClientSession._request = _clm_tagged_aio_request
 """
 
 
@@ -2525,9 +2569,9 @@ class NotebookProcessor:
 
         Under the out-of-process transport (``CLM_HTTP_REPLAY_TRANSPORT=
         mitmproxy``) this injects the lightweight cassette-routing *tag*
-        bootstrap (which patches httpx to tag each request with its
-        destination cassette so the shared proxy demuxes correctly); the
-        kernel's httpcore is never patched. Otherwise it injects the
+        bootstrap (which patches httpx/requests/aiohttp to tag each request
+        with its destination cassette so the shared proxy demuxes
+        correctly); the kernel's httpcore is never patched. Otherwise it injects the
         in-kernel vcrpy bootstrap using ``paths`` (the resolved
         canonical/staging pair from :meth:`_resolve_cassette_paths`).
         Returns ``True`` when a cell was injected so the caller runs the

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -20,7 +20,9 @@ guard below) or ``requests`` isn't installed.
 from __future__ import annotations
 
 import json
+import logging
 import threading
+import time
 from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -288,6 +290,41 @@ def test_strict_replay_miss_returns_nonretryable_404(
     assert _CountingHandler.upstream_hits == 1, (
         "strict-replay miss must not fall through to upstream"
     )
+
+
+def test_untagged_flow_warning_reaches_host_log(
+    upstream_server: str, cassette_path: Path, tmp_path: Path, caplog
+) -> None:
+    """An untagged flow (a client stack the tag bootstrap does not patch) must
+    produce a loud, host-visible warning: the addon logs it once per build
+    inside mitmdump, and the manager's stdout pump relays sentinel-marked
+    lines through CLM's own logger. Without this, untagged traffic silently
+    records into the catch-all instead of the topic cassette — the failure
+    mode that hid the missing ``requests`` patch."""
+    confdir = tmp_path / "mitm-confdir"
+    sentinel = "CLM-HTTP-REPLAY-UNTAGGED"
+    with caplog.at_level(logging.WARNING, logger="clm.infrastructure.http_replay_mitm"):
+        with MitmproxyManager(
+            cassette_path=cassette_path, mode="new-episodes", confdir=confdir
+        ) as proxy:
+            response = _get_via_proxy(f"{upstream_server}/untagged", proxy.proxy_url)
+            assert response.status_code == 200
+            # The warning travels addon -> mitmdump stdout -> pump thread, so
+            # poll (generous deadline, no fixed sleep) until it is drained.
+            deadline = time.monotonic() + 15.0
+            while time.monotonic() < deadline:
+                if any(sentinel in line for line in list(proxy._output)):
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail(
+                    "untagged-flow sentinel never appeared in mitmdump output:\n"
+                    + "\n".join(proxy._output)
+                )
+    relayed = [r.getMessage() for r in caplog.records if sentinel in r.getMessage()]
+    assert relayed, "manager did not relay the addon's untagged-flow warning to the host log"
+    # The warning names the offending request so the culprit deck is findable.
+    assert any("/untagged" in message for message in relayed)
 
 
 def test_routing_demuxes_tagged_requests_to_per_cassette_staging(

--- a/tests/infrastructure/test_http_replay_mitm_manager.py
+++ b/tests/infrastructure/test_http_replay_mitm_manager.py
@@ -8,9 +8,12 @@ plain Python subprocess that emits far more output than a pipe buffer holds.
 
 from __future__ import annotations
 
+import logging
+import re
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -73,6 +76,45 @@ def test_reader_thread_joined_and_output_available_after_exit(tmp_path) -> None:
         time.sleep(0.02)
 
     assert "hello from child" in mgr._drain_output()
+
+
+class TestUntaggedFlowWarningRelay:
+    """The addon's once-per-build untagged-flow warning is emitted inside the
+    mitmdump subprocess; the manager must relay sentinel-marked stdout lines
+    into CLM's own log, or the warning only ever shows up in the ring-buffer
+    dump of a startup *failure* — i.e. never for the builds that have the
+    problem."""
+
+    def test_sentinel_line_is_relogged_as_warning(self, caplog) -> None:
+        mgr = _manager()
+        line = (
+            "[10:00:00.000][warn] CLM-HTTP-REPLAY-UNTAGGED: GET http://example.com/x "
+            "reached the replay proxy without an X-CLM-Cassette routing tag"
+        )
+        with caplog.at_level(logging.WARNING, logger=proxy_manager.__name__):
+            mgr._handle_output_line(line)
+        # Buffered for diagnostics AND surfaced through the host logger.
+        assert line in mgr._output
+        assert any(line in record.getMessage() for record in caplog.records)
+
+    def test_ordinary_lines_are_buffered_silently(self, caplog) -> None:
+        mgr = _manager()
+        with caplog.at_level(logging.WARNING, logger=proxy_manager.__name__):
+            mgr._handle_output_line("[10:00:00.000][info] client connect")
+        assert "[10:00:00.000][info] client connect" in mgr._output
+        assert not caplog.records
+
+    def test_sentinel_constant_matches_addon_source(self) -> None:
+        """Drift guard: the manager greps for a literal because the addon is
+        also loaded standalone inside the mitmdump interpreter (importing it
+        here would require mitmproxy, which CI does not install). Parse the
+        addon source instead so the two constants cannot drift apart."""
+        addon_source = (Path(proxy_manager.__file__).parent / "addon.py").read_text(
+            encoding="utf-8"
+        )
+        match = re.search(r'^UNTAGGED_FLOW_SENTINEL = "([^"]+)"', addon_source, re.MULTILINE)
+        assert match is not None, "UNTAGGED_FLOW_SENTINEL not found in addon.py"
+        assert match.group(1) == proxy_manager._UNTAGGED_FLOW_SENTINEL
 
 
 class TestClientHostAndProxyUrl:

--- a/tests/workers/notebook/test_http_replay_mitm_tag.py
+++ b/tests/workers/notebook/test_http_replay_mitm_tag.py
@@ -15,11 +15,13 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from nbformat.v4 import new_code_cell, new_notebook
 
 from clm.workers.notebook.notebook_processor import (
     _HTTP_REPLAY_BOOTSTRAP_MARKER,
     _HTTP_REPLAY_SOCKET_TRACE_TEMPLATE,
+    _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE,
     NotebookProcessor,
     _inject_http_replay_tag_bootstrap,
     _strip_injected_cells,
@@ -57,6 +59,34 @@ def test_inject_tag_bootstrap_inserts_marked_cell():
     assert "httpcore" not in cell0["source"]
     assert "import vcr" not in cell0["source"]
     assert "httpx" in cell0["source"]
+
+
+def test_tag_bootstrap_patches_requests_and_aiohttp():
+    """All three kernel client stacks must be tag-routed (not just httpx).
+
+    The legacy vcrpy transport covered requests/aiohttp decks; the tag
+    bootstrap initially patched only httpx, so simple ``requests.get`` decks
+    recorded into the build catch-all instead of their canonical cassette.
+    Pin that requests/aiohttp patching (with import guards — both libraries
+    are optional in the kernel env) is part of the injected source.
+    """
+    src = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag="/x/foo.http-cassette.yaml")
+    assert "import requests as _clm_requests" in src
+    assert "_clm_requests.Session.send = _clm_tagged_rsend" in src
+    assert "import aiohttp as _clm_aiohttp" in src
+    assert "_clm_aiohttp.ClientSession._request = _clm_tagged_aio_request" in src
+    # Optional imports must be guarded so a kernel without them still boots.
+    assert src.count("except ImportError:") >= 2
+
+
+def test_tag_bootstrap_template_contains_no_unsubstituted_braces():
+    """The template is rendered with ``str.format``, so any literal curly
+    brace in the body (e.g. a ``dict`` literal in a newly added patch) would
+    raise ``KeyError``/``IndexError`` at injection time. Rendering succeeding
+    plus the tag landing verbatim pins that invariant."""
+    tag = "/some/dir/foo.http-cassette.yaml"
+    src = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag=tag)
+    assert repr(tag) in src
 
 
 def test_strip_removes_tag_bootstrap_cell():
@@ -113,6 +143,111 @@ def test_socket_trace_template_execs_standalone_and_emits(tmp_path):
     streams_events = {(r["stream"], r["event"]) for r in records}
     assert ("socket", "bootstrap.complete") in streams_events
     assert all(r["stream"] == "socket" for r in records)
+
+
+def test_tag_bootstrap_tags_requests_traffic_in_subprocess():
+    """End-to-end pin for the requests patch: exec the rendered bootstrap in a
+    clean interpreter, issue a plain ``requests.get`` against a local HTTP
+    server, and assert the ``x-clm-cassette`` header arrived. This is exactly
+    the deck pattern that regressed when only httpx was patched. Run in a
+    subprocess so the class-level ``requests.Session.send`` patch can never
+    leak into other tests in this process."""
+    pytest.importorskip("requests")
+    tag = "/src/topic/_cassettes/slides.http-cassette.yaml"
+    rendered = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag=tag)
+    script = rendered + (
+        "\n"
+        "import json, threading\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "import requests\n"
+        "seen = dict()\n"
+        "class _Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        seen['tag'] = self.headers.get('x-clm-cassette')\n"
+        "        self.send_response(200)\n"
+        "        self.send_header('Content-Length', '2')\n"
+        "        self.end_headers()\n"
+        "        self.wfile.write(b'ok')\n"
+        "    def log_message(self, *args):\n"
+        "        pass\n"
+        "server = HTTPServer(('127.0.0.1', 0), _Handler)\n"
+        "thread = threading.Thread(target=server.serve_forever, daemon=True)\n"
+        "thread.start()\n"
+        "response = requests.get(f'http://127.0.0.1:{server.server_address[1]}/x')\n"
+        "server.shutdown()\n"
+        "print(json.dumps(dict(status=response.status_code, tag=seen['tag'])))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    result = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert result["status"] == 200
+    assert result["tag"] == tag
+
+
+def test_tag_bootstrap_tags_aiohttp_traffic_in_subprocess():
+    """Same end-to-end pin as the requests test, for the aiohttp patch — it
+    wraps the private ``ClientSession._request``, so a behavioral check (not
+    just a source assert) is what catches an aiohttp-version signature drift."""
+    pytest.importorskip("aiohttp")
+    tag = "/src/topic/_cassettes/slides.http-cassette.yaml"
+    rendered = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag=tag)
+    script = rendered + (
+        "\n"
+        "import asyncio, json, threading\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "import aiohttp\n"
+        "seen = dict()\n"
+        "class _Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        seen['tag'] = self.headers.get('x-clm-cassette')\n"
+        "        self.send_response(200)\n"
+        "        self.send_header('Content-Length', '2')\n"
+        "        self.end_headers()\n"
+        "        self.wfile.write(b'ok')\n"
+        "    def log_message(self, *args):\n"
+        "        pass\n"
+        "server = HTTPServer(('127.0.0.1', 0), _Handler)\n"
+        "thread = threading.Thread(target=server.serve_forever, daemon=True)\n"
+        "thread.start()\n"
+        "async def _main():\n"
+        "    url = f'http://127.0.0.1:{server.server_address[1]}/x'\n"
+        "    async with aiohttp.ClientSession() as session:\n"
+        "        async with session.get(url, headers=dict(accept='*/*')) as response:\n"
+        "            return response.status\n"
+        "status = asyncio.run(_main())\n"
+        "server.shutdown()\n"
+        "print(json.dumps(dict(status=status, tag=seen['tag'])))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    result = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert result["status"] == 200
+    assert result["tag"] == tag
+
+
+def test_tag_bootstrap_execs_when_optional_libraries_are_missing():
+    """The requests/aiohttp patches are import-guarded: a kernel env without
+    them must still run the bootstrap. Simulate absence by poisoning both
+    imports in a clean subprocess (works whether or not they are actually
+    installed) and confirm httpx tagging is still applied."""
+    rendered = _HTTP_REPLAY_TAG_BOOTSTRAP_TEMPLATE.format(tag="/x/foo.http-cassette.yaml")
+    script = (
+        "import sys\n"
+        "sys.modules['requests'] = None\n"
+        "sys.modules['aiohttp'] = None\n"
+        + rendered
+        + "assert getattr(__import__('httpx').Client.send, '_clm_tagged', False)\n"
+        "print('bootstrap-ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "bootstrap-ok" in proc.stdout
 
 
 def test_maybe_inject_under_transport_injects_socket_trace_when_traced(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

Since the switch to the mitmproxy replay transport (#165), decks using plain `requests` calls were no longer covered by record/replay. Their traffic *did* reach the shared proxy (the `HTTP(S)_PROXY` env vars and CA bundle are honored by `requests`), but it arrived **untagged**: the kernel's cassette-routing tag bootstrap only patched `httpx.Client/AsyncClient`, so the `X-CLM-Cassette` header was never set. Untagged flows fall back to the per-build catch-all cassette (`<jobs-db-dir>/mitm/transport.http-cassette.yaml`), so:

- in recording modes, `requests` calls hit the live network every build and the recordings landed in a scratch file that is never merged into the topic's canonical cassette (and never committed);
- in strict `replay` (CI), the topic's committed cassette was never consulted — misses got the synthetic 404;
- locally it could *appear* to work because the catch-all persists in the jobs-db scratch dir, masking the breakage.

This regressed the original motivating use case for HTTP replay (`requests.get` against restcountries.com, the lead example in `docs/user-guide/http-replay.md`); the old in-kernel vcrpy transport patched urllib3/requests and so covered these decks.

## Fix

- **Tag bootstrap now patches `requests.Session.send` and `aiohttp.ClientSession._request`** alongside httpx (both import-guarded — the libraries stay optional in kernel environments). One class-level patch each covers all sessions/verb helpers, created before or after the bootstrap cell. The addon's demux/strip/merge pipeline is library-agnostic, so nothing downstream changes.
- **Untagged flows now warn loudly.** The addon logs a once-per-build `CLM-HTTP-REPLAY-UNTAGGED` warning naming the first untagged non-ignored request, and the proxy manager's stdout pump relays sentinel-marked lines into the CLM build log (previously addon output only ever surfaced on a startup failure). A drift-guard test pins the sentinel constants together.
- **Docs:** new "Client-library coverage" section in `docs/user-guide/http-replay.md`; migration info topic updated (httpx/requests/aiohttp covered, other stacks → catch-all + warning, affected topics need a one-time `--http-replay=refresh` re-record).

## Tests

- Behavioral subprocess tests: the rendered bootstrap is exec'd in a clean interpreter and a real `requests.get` / `aiohttp` GET against a local HTTP server must carry the tag header; a poisoned-import test pins that the bootstrap still runs when the optional libraries are absent.
- Manager unit tests for the sentinel relay (`_handle_output_line`) + sentinel drift guard.
- Integration test (real mitmdump): an untagged flow's warning travels addon → mitmdump stdout → pump → host log.

Full fast suite passes (8040 passed); all 40 mitm replay tests including the integration set pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
