### PR TITLE
feat: add clm build --no-diagrams to skip DrawIO/PlantUML processing (#353)

### DIFF
--- a/changelog.d/353-no-diagrams-build-flag.added.md
+++ b/changelog.d/353-no-diagrams-build-flag.added.md
@@ -1,0 +1,8 @@
+`clm build --no-diagrams` skips DrawIO and PlantUML processing entirely
+(#353), mirroring `--no-html`: diagram sources are excluded from the build,
+so no conversion jobs are scheduled and no plantuml/drawio workers are
+started. Rendered images committed next to the sources (`slides/**/img/`)
+still ship as ordinary image files, so output stays complete. Intended for
+machines without the diagram binaries — e.g. the code-export compile CI,
+where every diagram job previously failed and forced a blanket
+`--no-fail-on-error`.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -389,6 +389,15 @@ class BuildConfig:
     # (issue #333).
     no_html: bool = False
 
+    # Skip DrawIO and PlantUML processing entirely (``--no-diagrams``,
+    # issue #353): diagram sources never enter the course file map, so
+    # zero conversion jobs are scheduled and the plantuml/drawio workers
+    # are not started. Rendered images committed next to the sources
+    # (``slides/**/img/``) still ship as ordinary image files — the mode
+    # the code-export compile CI uses on runners without the diagram
+    # binaries.
+    no_diagrams: bool = False
+
     # Notebook execution mode
     force_execute: bool = False
 
@@ -788,6 +797,13 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
             for i, topic_spec in enumerate(section_spec.topics):
                 section_spec.topics[i] = evolve(topic_spec, skip_html=True)
 
+    # ``--no-diagrams``: exclude DrawIO/PlantUML sources from every
+    # topic's file map at course-construction time, so no conversion
+    # jobs are ever scheduled (issue #353). Committed rendered images
+    # are ordinary image files and still ship.
+    if config.no_diagrams:
+        logger.info("--no-diagrams: skipping DrawIO/PlantUML processing for all topics")
+
     # Create course object
     course = Course.from_spec(
         spec,
@@ -802,6 +818,7 @@ def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path]
         inline_images=effective_inline_images,
         section_selection=section_selection,
         http_replay_mode=config.http_replay_mode,
+        no_diagrams=config.no_diagrams,
     )
     # Cross-reference policy (Issue #17): propagate the resolved fail-on-missing
     # decision so payload-time rewrite and build-time validation agree.
@@ -897,6 +914,25 @@ def enable_jupyterlite_workers_if_needed(course, worker_config) -> None:
             "Enabling 1 jupyterlite worker: course has at least one target "
             "that requests 'jupyterlite' output."
         )
+
+
+def disable_diagram_workers_if_requested(config: BuildConfig, worker_config) -> None:
+    """Zero out the plantuml/drawio worker counts under ``--no-diagrams``.
+
+    With diagram sources excluded from the course file map (issue #353),
+    no conversion job can ever be scheduled, so starting the diagram
+    workers would only waste startup time — or fail noisily on machines
+    without the binaries (the code-export compile CI). ``count=0``
+    passes through ``compute_pool_size_cap`` unchanged: zero means "do
+    not run any workers of this type". This deliberately overrides an
+    explicit ``--plantuml-workers``/``--drawio-workers`` value — a
+    diagram worker can do nothing in a build with no diagram jobs.
+    """
+    if not config.no_diagrams:
+        return
+    worker_config.plantuml.count = 0
+    worker_config.drawio.count = 0
+    logger.info("--no-diagrams: not starting plantuml/drawio workers.")
 
 
 def start_managed_workers(lifecycle_manager, worker_config) -> list:
@@ -1586,6 +1622,7 @@ async def main_build(
     provenance_manifest=True,
     telemetry_db_path: Path | None = None,
     no_html: bool = False,
+    no_diagrams: bool = False,
 ) -> BuildSummary | None:
     """Main orchestration function for course building.
 
@@ -1700,6 +1737,7 @@ async def main_build(
         speaker_only=speaker_only,
         selected_targets=selected_targets,
         no_html=no_html,
+        no_diagrams=no_diagrams,
         force_execute=force_execute,
         http_replay_mode=resolved_http_replay_mode,
         image_mode=image_mode,
@@ -1732,6 +1770,7 @@ async def main_build(
 
     worker_config = configure_workers(config)
     enable_jupyterlite_workers_if_needed(course, worker_config)
+    disable_diagram_workers_if_requested(config, worker_config)
 
     from clm.infrastructure.database.schema import init_database
     from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
@@ -2128,6 +2167,18 @@ async def main_build(
     ),
 )
 @click.option(
+    "--no-diagrams",
+    is_flag=True,
+    help=(
+        "Skip DrawIO and PlantUML processing entirely: diagram sources "
+        "are excluded from the build, so no conversion jobs are "
+        "scheduled and no plantuml/drawio workers are started. Rendered "
+        "images committed next to the sources (slides/**/img/) still "
+        "ship as ordinary image files. Intended for machines without "
+        "the diagram binaries, e.g. the code-export compile CI."
+    ),
+)
+@click.option(
     "--targets",
     "-T",
     type=str,
@@ -2250,6 +2301,7 @@ def build(
     language,
     speaker_only,
     no_html,
+    no_diagrams,
     targets,
     force_execute,
     http_replay,
@@ -2394,6 +2446,7 @@ def build(
             effective_provenance_manifest,
             telemetry_db_path=ctx.obj.get("TELEMETRY_DB_PATH") if ctx.obj else None,
             no_html=no_html,
+            no_diagrams=no_diagrams,
         )
     )
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -62,6 +62,8 @@ Key options:
 | `-O, --output-mode [default\|verbose\|quiet\|json]` | Progress output mode |
 | `-L, --language [de\|en]` | Generate only one language |
 | `--speaker-only` | Generate only the private (notes-bearing) outputs — both `trainer` and `recording` kinds. Skips public outputs (`code-along`, `completed`, `partial`). |
+| `--no-html` | Skip HTML generation for every topic, as if each carried `html="no"` in the spec. HTML is the only output format whose generation executes notebooks, so a `--no-html` build needs no Jupyter kernel — intended for the code-export compile CI and other kernel-free environments (CLM {version}). |
+| `--no-diagrams` | Skip DrawIO and PlantUML processing entirely: diagram sources are excluded from the build, so no conversion jobs are scheduled and no plantuml/drawio workers are started. Rendered images committed next to the sources (`slides/**/img/`) still ship as ordinary image files. Intended for machines without the diagram binaries, e.g. the code-export compile CI (CLM {version}). |
 | `-T, --targets TEXT` | Comma-separated target names from spec |
 | `--image-mode [duplicated\|shared]` | Image storage strategy |
 | `--image-format [png\|svg]` | Image output format |

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -106,6 +106,13 @@ class Course(NotebookMixin):
     # warning and the link is dropped (text kept). Wired from the build CLI
     # ``--fail-on-missing-xref`` flag / ``CLM_FAIL_ON_MISSING_XREF`` env var.
     fail_on_missing_xref: bool = False
+    # Skip DrawIO/PlantUML processing entirely (``clm build --no-diagrams``,
+    # issue #353): diagram source files never enter the topic file maps, so
+    # no conversion job is ever scheduled. Rendered images committed next to
+    # the sources (``slides/**/img/``) are ordinary image files and still
+    # ship, so output stays complete on machines without the diagram
+    # binaries (e.g. the code-export compile CI).
+    no_diagrams: bool = False
     # Lazily-built, course-scoped cross-reference resolver. Built once after
     # sections and notebook numbers are assigned (see ``cross_reference_resolver``).
     _cross_reference_resolver: "CrossReferenceResolver | None" = field(
@@ -127,6 +134,7 @@ class Course(NotebookMixin):
         inline_images: bool = False,
         section_selection: SectionSelection | None = None,
         http_replay_mode: str | None = None,
+        no_diagrams: bool = False,
     ) -> "Course":
         """Create a Course from a CourseSpec.
 
@@ -163,6 +171,10 @@ class Course(NotebookMixin):
                 whose topic has
                 ``http_replay="yes"`` honor this; other notebooks are
                 unaffected. When ``None``, HTTP replay is off.
+            no_diagrams: When True, exclude DrawIO/PlantUML diagram
+                sources from every topic's file map so no conversion
+                jobs are scheduled (``clm build --no-diagrams``, issue
+                #353). Committed rendered images still ship.
 
         Returns:
             Configured Course instance
@@ -247,6 +259,7 @@ class Course(NotebookMixin):
             inline_images=inline_images,
             section_selection=section_selection,
             http_replay_mode=http_replay_mode,
+            no_diagrams=no_diagrams,
         )
         course._build_sections()
         course._build_dir_groups()

--- a/src/clm/core/topic.py
+++ b/src/clm/core/topic.py
@@ -10,6 +10,7 @@ from clm.core.include_ledger import LEDGER_NAME, Ledger
 from clm.core.utils.notebook_mixin import NotebookMixin
 from clm.core.utils.notebook_utils import find_images, find_imports
 from clm.infrastructure.utils.path_utils import (
+    is_diagram_source,
     is_ignored_dir_for_course,
     is_ignored_file_for_course,
     is_in_dir,
@@ -116,6 +117,9 @@ class Topic(NotebookMixin, ABC):
         if not self.matches_path(path, False):
             logger.debug(f"Path not within topic: {path}")
             return
+        if self.course.no_diagrams and is_diagram_source(path):
+            logger.debug(f"--no-diagrams: skipping diagram source {path}")
+            return
         if self.file_for_path(path):
             logger.debug(f"Duplicate path when adding file: {path}")
             return
@@ -174,6 +178,9 @@ class Topic(NotebookMixin, ABC):
         Returns True when the virtual file was added; False when it was
         shadowed by a real file or otherwise rejected.
         """
+        if self.course.no_diagrams and is_diagram_source(virtual_path):
+            logger.debug(f"--no-diagrams: skipping included diagram source {virtual_path}")
+            return False
         if self.file_for_path(virtual_path):
             if not ledger_authorized:
                 self.course.loading_warnings.append(

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -133,6 +133,11 @@ SKIP_OUTPUT_FILE_GLOBS = [
 
 PLANTUML_EXTENSIONS = frozenset({".pu", ".puml", ".plantuml"})
 
+# Diagram sources that a build converts via the plantuml/drawio workers.
+# Narrower than IMG_SOURCE_FILE_EXTENSIONS, which also covers formats CLM
+# never converts (.psd, .xfc).
+DIAGRAM_SOURCE_EXTENSIONS = PLANTUML_EXTENSIONS | frozenset({".drawio"})
+
 IMG_FILE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".svg"})
 
 IMG_DATA_FOLDERS = frozenset({"imgdata"})
@@ -190,6 +195,11 @@ def is_image_file(input_path: Path) -> bool:
 
 def is_image_source_file(input_path: Path) -> bool:
     return input_path.suffix in IMG_SOURCE_FILE_EXTENSIONS
+
+
+def is_diagram_source(input_path: Path) -> bool:
+    """True for DrawIO/PlantUML sources that the build converts to images."""
+    return input_path.suffix in DIAGRAM_SOURCE_EXTENSIONS
 
 
 def is_slides_file(input_path: Path) -> bool:

--- a/tests/cli/test_cli_unit.py
+++ b/tests/cli/test_cli_unit.py
@@ -647,3 +647,62 @@ class TestOutputFiltering:
         notebook_files = [f for f in course.files if hasattr(f, "skip_html")]
         assert notebook_files, "test spec should contain notebook files"
         assert not any(f.skip_html for f in notebook_files)
+
+    def test_no_diagrams_excludes_diagram_sources(self):
+        """--no-diagrams keeps DrawIO/PlantUML sources out of the file map"""
+        from clm.cli.main import initialize_paths_and_course
+        from clm.core.course_files.drawio_file import DrawIoFile
+        from clm.core.course_files.plantuml_file import PlantUmlFile
+
+        config = self._create_config()
+        config.no_diagrams = True
+        course, root_dirs, data_dir = initialize_paths_and_course(config)
+
+        diagram_files = [f for f in course.files if isinstance(f, (PlantUmlFile, DrawIoFile))]
+        assert diagram_files == []
+        # Committed rendered images are ordinary image files and still ship.
+        assert any(f.path.name == "my_diag.png" for f in course.files)
+        assert any(f.path.name == "my_drawing.png" for f in course.files)
+
+    def test_default_includes_diagram_sources(self):
+        """Without --no-diagrams, DrawIO/PlantUML sources schedule conversions"""
+        from clm.cli.main import initialize_paths_and_course
+        from clm.core.course_files.drawio_file import DrawIoFile
+        from clm.core.course_files.plantuml_file import PlantUmlFile
+
+        config = self._create_config()
+        course, root_dirs, data_dir = initialize_paths_and_course(config)
+
+        assert any(isinstance(f, PlantUmlFile) for f in course.files)
+        assert any(isinstance(f, DrawIoFile) for f in course.files)
+
+    def test_no_diagrams_disables_diagram_workers(self):
+        """--no-diagrams zeroes the plantuml/drawio worker counts"""
+        from clm.cli.commands.build import disable_diagram_workers_if_requested
+        from clm.infrastructure.config import WorkersManagementConfig
+
+        config = self._create_config()
+        config.no_diagrams = True
+        worker_config = WorkersManagementConfig()
+        disable_diagram_workers_if_requested(config, worker_config)
+
+        assert worker_config.plantuml.count == 0
+        assert worker_config.drawio.count == 0
+        # Zero must survive the effective-config merge (0 means "disabled",
+        # not "fall back to the default count").
+        assert worker_config.get_worker_config("plantuml").count == 0
+        assert worker_config.get_worker_config("drawio").count == 0
+        # Notebook workers are unaffected.
+        assert worker_config.get_worker_config("notebook").count >= 1
+
+    def test_default_does_not_disable_diagram_workers(self):
+        """Without --no-diagrams the worker counts are left alone"""
+        from clm.cli.commands.build import disable_diagram_workers_if_requested
+        from clm.infrastructure.config import WorkersManagementConfig
+
+        config = self._create_config()
+        worker_config = WorkersManagementConfig()
+        disable_diagram_workers_if_requested(config, worker_config)
+
+        assert worker_config.plantuml.count is None
+        assert worker_config.drawio.count is None


### PR DESCRIPTION
## Summary

Adds a `--no-diagrams` flag to `clm build`, mirroring `--no-html` (#347): DrawIO and PlantUML processing is skipped entirely rather than letting the conversion jobs fail on machines without the binaries (the CppCourses code-export compile CI).

Closes #353

## How it works

- **Pre-construction switch**: `Course.no_diagrams` is threaded from the CLI through `Course.from_spec`. `Topic.add_file` and `Topic.add_virtual_file` (the `<include>` path) early-return for `.pu`/`.puml`/`.plantuml`/`.drawio` sources, so diagram files never enter any topic's file map — zero conversion jobs are scheduled, and every downstream derivation (stage counts, output writes, sweep, provenance) agrees the diagrams don't exist in this build. Watch-mode rebuilds go through the same `add_file` path, so they are covered too.
- **No diagram workers**: `disable_diagram_workers_if_requested` forces the plantuml/drawio worker counts to 0 (`count=0` is the supported "disable this worker type" path through `compute_pool_size_cap`), so the build doesn't waste startup time on workers that can never receive a job.
- **Output stays complete**: rendered images committed next to the sources (`slides/**/img/`) are ordinary image files and still ship — verified end-to-end below.

## Verification

End-to-end build of the test course with `--no-html --no-diagrams` on this machine:

- exit code 0, jobs db contains only `('notebook', 80)` — zero plantuml/drawio jobs
- committed `img/my_diag.png` / `img/my_drawing.png` still present in all output variants

## Docs

- `clm info commands`: documents `--no-diagrams` **and** the previously undocumented `--no-html`
- changelog fragment `changelog.d/353-no-diagrams-build-flag.added.md`

## Tests

- `--no-diagrams` excludes `PlantUmlFile`/`DrawIoFile` from the course file map while committed rendered images remain
- default builds still include both diagram file types
- worker counts: zeroed under `--no-diagrams` (and 0 survives the effective-config merge), untouched otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
