### PR TITLE
fix: consult separated voiceover companions in validate --checks voiceover (#360)

### DIFF
--- a/changelog.d/360-voiceover-gap-separated-companion.fixed.md
+++ b/changelog.d/360-voiceover-gap-separated-companion.fixed.md
@@ -1,0 +1,1 @@
+Fixed `clm validate --checks voiceover` so it consults separated voiceover companions (the 1.8 `voiceover/` layout). Previously the gap check only scanned inline narrative cells and reported a false positive for every slide. Coverage is now based on the `voiceover` tag only, so `notes` cells no longer count as voiceover coverage.

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -1593,7 +1593,10 @@ def _extract_voiceover_gaps(cells: list[Cell], file_path: str) -> list[dict]:
         if meta.is_j2:
             continue
 
-        if meta.is_narrative:
+        if "voiceover" in meta.tags:
+            # Only real voiceover cells count as coverage. ``notes`` cells are
+            # also ``is_narrative`` but must not satisfy the voiceover
+            # requirement (issue #360).
             lang = meta.lang
             if lang == "de":
                 if last_de is not None:
@@ -1991,7 +1994,20 @@ def validate_file(
         if "code_quality" in review_checks:
             review_material.code_quality = _extract_code_quality(cells, file_str)
         if "voiceover" in review_checks:
-            review_material.voiceover_gaps = _extract_voiceover_gaps(cells, file_str)
+            # Merge a separated voiceover companion (if any) into the cell
+            # stream before checking coverage. Without this, the default 1.8
+            # layout (voiceover cells in voiceover/*.py) produces a false
+            # positive for every slide (issue #360).
+            voiceover_cells = cells
+            from clm.slides.voiceover_tools import merge_voiceover_text, resolve_companion
+
+            companion = resolve_companion(path)
+            if companion is not None:
+                merged_text, _unmatched = merge_voiceover_text(
+                    text, companion.read_text(encoding="utf-8"), comment_token
+                )
+                voiceover_cells = parse_cells(merged_text, comment_token)
+            review_material.voiceover_gaps = _extract_voiceover_gaps(voiceover_cells, file_str)
         if "completeness" in review_checks:
             review_material.completeness = _extract_completeness(cells, file_str)
 

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -2366,6 +2366,74 @@ class TestVoiceoverGapsExtraction:
         assert langs == {"de", "en"}
 
 
+class TestVoiceoverGapsWithSeparatedCompanion:
+    def test_no_gaps_when_voiceover_in_subdir_companion(self, tmp_path):
+        # Regression test for issue #360: a separated voiceover companion in
+        # the voiceover/ subdirectory must count as coverage, not produce
+        # false-positive gaps for every slide.
+        p = _write_slide(
+            tmp_path,
+            "slides_vo_companion.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Title
+            """,
+        )
+        companion_dir = tmp_path / "voiceover"
+        companion_dir.mkdir()
+        _write_slide(
+            companion_dir,
+            "voiceover_vo_companion.py",
+            """\
+            # %% [markdown] lang="de" tags=["voiceover"] for_slide="intro"
+            # Voiceover DE
+
+            # %% [markdown] lang="en" tags=["voiceover"] for_slide="intro"
+            # Voiceover EN
+            """,
+        )
+        result = validate_file(p, checks=["voiceover"])
+        assert result.review_material is not None
+        gaps = result.review_material.voiceover_gaps or []
+        assert gaps == []
+
+    def test_notes_in_companion_do_not_count_as_voiceover(self, tmp_path):
+        # Secondary issue #360: only the "voiceover" tag should count as
+        # coverage, not the broader "notes" tag.
+        p = _write_slide(
+            tmp_path,
+            "slides_notes_companion.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Title
+            """,
+        )
+        companion_dir = tmp_path / "voiceover"
+        companion_dir.mkdir()
+        _write_slide(
+            companion_dir,
+            "voiceover_notes_companion.py",
+            """\
+            # %% [markdown] lang="de" tags=["notes"] for_slide="intro"
+            # Notes DE
+
+            # %% [markdown] lang="en" tags=["notes"] for_slide="intro"
+            # Notes EN
+            """,
+        )
+        result = validate_file(p, checks=["voiceover"])
+        assert result.review_material is not None
+        gaps = result.review_material.voiceover_gaps or []
+        assert len(gaps) == 2
+        assert {g["lang"] for g in gaps} == {"de", "en"}
+
+
 class TestVoiceoverGapsInsideWorkshop:
     def test_workshop_internal_cells_are_suppressed(self, tmp_path):
         # Workshop heading has voiceover; subslides and code cells inside


### PR DESCRIPTION
Fixes #360.

The voiceover gap check in `clm validate --checks voiceover` only scanned inline narrative cells. For decks using the 1.8 `voiceover/` companion layout, this produced a false positive for every slide because the separated companion was never merged into the cell stream.

Changes:
- Resolve and merge the voiceover companion (if any) before computing gaps in `validate_file()`.
- Base coverage on the `voiceover` tag only; `notes` cells no longer count as voiceover coverage.
- Add regression tests for separated companions and notes-not-counting.
- Add changelog fragment.

Verification:
- New regression tests pass.
- `tests/slides/test_validator.py`: 158 passed.
- Full fast pytest suite: 8030 passed, 6 skipped, 1 xfailed.