### PR TITLE
Add `clm slides watermark` CLI (list / clear / prune)

### DIFF
--- a/src/clm/cli/commands/slides/__init__.py
+++ b/src/clm/cli/commands/slides/__init__.py
@@ -31,6 +31,7 @@ from clm.cli.commands.slides.sync import slides_sync_cmd  # noqa: E402
 from clm.cli.commands.slides.tidy import tidy_cmd  # noqa: E402
 from clm.cli.commands.slides.translate import slides_translate_cmd  # noqa: E402
 from clm.cli.commands.slides.unify import unify_cmd  # noqa: E402
+from clm.cli.commands.slides.watermark import watermark_group  # noqa: E402
 
 slides_group.add_command(normalize_slides_cmd, name="normalize")
 slides_group.add_command(assign_ids_cmd, name="assign-ids")
@@ -50,6 +51,7 @@ slides_group.add_command(referenced_by_cmd, name="referenced-by")
 slides_group.add_command(slug_report_cmd, name="slug-report")
 slides_group.add_command(coverage_report_cmd, name="coverage-report")
 slides_group.add_command(authoring_rules_cmd, name="rules")
+slides_group.add_command(watermark_group, name="watermark")
 
 # `polish` needs the [summarize] extra (LLM client); skip when absent.
 try:

--- a/src/clm/cli/commands/slides/watermark.py
+++ b/src/clm/cli/commands/slides/watermark.py
@@ -1,0 +1,385 @@
+"""``clm slides watermark`` — inspect and maintain the sync structural watermark.
+
+Issue #363. ``clm slides sync`` records a per-language structural *watermark* — the
+last-synced state of a split deck pair — in the shared ``clm-llm.sqlite``, keyed by
+the absolute ``(de_path, en_path)`` of the pair (see :class:`SyncWatermarkCache`).
+The watermark is normally invisible, but it can go **stale** (a deck edited and
+committed on *both* halves without an intervening ``sync``, so the baseline falls
+behind the working tree) or **orphaned** (its files renamed / renumbered away, so the
+rows point at paths that no longer exist). Previously the only way to inspect or reset
+it was hand-written SQL against the shared database.
+
+This subcommand group exposes three maintenance operations over the same store the
+``sync`` command writes:
+
+- ``list``  — show every watermarked pair (row count, last sync, on-disk status).
+- ``clear`` — delete the watermark for a deck / half / stem / directory; the next
+  ``sync`` then re-baselines off git ``HEAD`` (the proven-clean cold-start path).
+- ``prune`` — drop watermarks whose files no longer exist on disk (orphans).
+
+``clear`` resolves the deck path through the same helpers ``sync`` uses
+(:func:`_resolve_single_path` / :func:`_resolve_sync_pair`) and keys by the same
+``str(path.resolve())`` form ``sync`` writes, so a cleared pair is exactly the pair a
+subsequent ``sync`` of that deck would look up.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+from attrs import define
+
+from clm.cli.commands.slides.sync import (
+    CACHE_DB_NAME,
+    _resolve_single_path,
+    _resolve_sync_pair,
+)
+from clm.infrastructure.llm.cache import SyncWatermarkCache, resolve_cache_dir
+from clm.slides.pairing import find_split_slide_files_recursive, iter_split_pairs
+
+
+@define
+class _PairWatermark:
+    """A pair's watermark, rolled up from the per-cell rows of ``iter_entries``."""
+
+    de_path: str
+    en_path: str
+    rows: int
+    langs: dict[str, int]
+    synced_at: str | None
+
+    @property
+    def de_exists(self) -> bool:
+        return Path(self.de_path).exists()
+
+    @property
+    def en_exists(self) -> bool:
+        return Path(self.en_path).exists()
+
+    @property
+    def orphan(self) -> bool:
+        """True when either half no longer exists on disk (a dead watermark)."""
+        return not (self.de_exists and self.en_exists)
+
+
+def _group_watermarks(cache: SyncWatermarkCache) -> list[_PairWatermark]:
+    """Roll the per-cell ``iter_entries`` rows up into one entry per pair.
+
+    Rows arrive ordered by ``(de_path, en_path, lang, position)``; we aggregate the
+    row count, per-language counts, and the latest ``synced_at`` per pair. Order of
+    the returned list follows first appearance, i.e. sorted by pair path.
+    """
+    by_pair: dict[tuple[str, str], _PairWatermark] = {}
+    for (
+        de_path,
+        en_path,
+        lang,
+        _pos,
+        _sid,
+        _role,
+        _chash,
+        _construct,
+        synced_at,
+    ) in cache.iter_entries():
+        key = (de_path, en_path)
+        entry = by_pair.get(key)
+        if entry is None:
+            entry = by_pair[key] = _PairWatermark(de_path, en_path, 0, {}, synced_at)
+        entry.rows += 1
+        entry.langs[lang] = entry.langs.get(lang, 0) + 1
+        if synced_at is not None and (entry.synced_at is None or synced_at > entry.synced_at):
+            entry.synced_at = synced_at
+    return list(by_pair.values())
+
+
+def _open_cache(cache_dir: Path | None) -> SyncWatermarkCache:
+    cache_root = resolve_cache_dir(cli_override=cache_dir)
+    return SyncWatermarkCache(cache_root / CACHE_DB_NAME)
+
+
+def _label(path_str: str) -> str:
+    """A deck label: relative to the cwd when possible, else the absolute path."""
+    try:
+        return str(Path(path_str).relative_to(Path.cwd()))
+    except ValueError:
+        return path_str
+
+
+def _resolve_pairs(deck: Path) -> list[tuple[str, str]]:
+    """Resolve a ``clear`` target to one or more ``(de_key, en_key)`` watermark keys.
+
+    A directory enumerates every split pair under it (batch); a file/stem is funnelled
+    through the same single-path + pairing guards ``sync`` uses, so ``clear`` accepts
+    exactly what ``sync`` accepts (a ``.de``/``.en`` half, or a bilingual ``<deck>.py``
+    stem with both halves on disk). Keys are ``str(path.resolve())`` to match the form
+    ``sync`` writes.
+    """
+    if deck.is_dir():
+        pairs, _solos = iter_split_pairs(find_split_slide_files_recursive(deck))
+        return [(str(de.resolve()), str(en.resolve())) for de, en in pairs]
+    de_path, en_path = _resolve_single_path(deck, None)
+    de_path, en_path = _resolve_sync_pair(de_path, en_path)
+    return [(str(de_path.resolve()), str(en_path.resolve()))]
+
+
+# ---------------------------------------------------------------------------
+# clm slides watermark  (group)
+# ---------------------------------------------------------------------------
+
+
+@click.group("watermark")
+def watermark_group() -> None:
+    """Inspect and maintain the ``slides sync`` structural watermark."""
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@watermark_group.command("list")
+@click.argument(
+    "path",
+    required=False,
+    default=None,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+)
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Directory holding the structural watermark (default: --cache-dir > "
+        "$CLM_CACHE_DIR > tool.clm.cache_dir in pyproject.toml > <cwd>/.clm-cache/)."
+    ),
+)
+@click.option("--orphans", is_flag=True, default=False, help="Show only orphaned watermarks.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit a JSON report.")
+def watermark_list_cmd(
+    path: Path | None, cache_dir: Path | None, orphans: bool, as_json: bool
+) -> None:
+    """List watermarked deck pairs: row count, last sync, and on-disk status.
+
+    With PATH (a directory), only pairs whose DE half resolves under it are shown.
+    ``ORPHAN`` marks a pair whose files no longer exist (clear it with
+    ``clm slides watermark prune``).
+    """
+    cache = _open_cache(cache_dir)
+    try:
+        entries = _group_watermarks(cache)
+    finally:
+        cache.close()
+
+    if path is not None:
+        root = path.resolve()
+        entries = [e for e in entries if _is_under(Path(e.de_path), root)]
+    if orphans:
+        entries = [e for e in entries if e.orphan]
+    entries.sort(key=lambda e: e.de_path)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "de_path": e.de_path,
+                        "en_path": e.en_path,
+                        "rows": e.rows,
+                        "langs": e.langs,
+                        "synced_at": e.synced_at,
+                        "orphan": e.orphan,
+                    }
+                    for e in entries
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    if not entries:
+        click.echo("no watermarks found." if path is None else f"no watermarks found under {path}.")
+        return
+    for e in entries:
+        status = "ORPHAN" if e.orphan else "OK    "
+        langs = ",".join(f"{lang}:{n}" for lang, n in sorted(e.langs.items()))
+        click.echo(f"{status} {_label(e.de_path)}  [{e.rows} rows: {langs}]  synced {e.synced_at}")
+    orphan_n = sum(1 for e in entries if e.orphan)
+    click.echo("")
+    click.echo(f"{len(entries)} pair(s), {orphan_n} orphan(ed).")
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+@watermark_group.command("clear")
+@click.argument("deck", type=click.Path(exists=True, dir_okay=True, path_type=Path))
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory holding the structural watermark (see `clm slides sync --cache-dir`).",
+)
+@click.option(
+    "--dry-run", is_flag=True, default=False, help="Report what would be cleared; delete nothing."
+)
+@click.option(
+    "--yes",
+    "-y",
+    "yes",
+    is_flag=True,
+    default=False,
+    help="Confirm clearing every pair under a directory without the interactive prompt.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit a JSON report.")
+def watermark_clear_cmd(
+    deck: Path, cache_dir: Path | None, dry_run: bool, yes: bool, as_json: bool
+) -> None:
+    """Delete the watermark for a deck so the next ``sync`` re-baselines off git HEAD.
+
+    DECK is a split half (``<deck>.de.py`` / ``<deck>.en.py``), a bilingual stem
+    (``<deck>.py`` with both halves on disk), or a **directory** (every pair under it).
+    Use this when a deck's halves are already consistent but ``sync`` errors against a
+    stale baseline — clearing forces a clean cold-start on the next run.
+    """
+    pairs = _resolve_pairs(deck)
+    cache = _open_cache(cache_dir)
+    try:
+        if deck.is_dir() and not pairs:
+            cache.close()
+            _emit_clear(deck, [], dry_run=dry_run, as_json=as_json)
+            return
+        # A directory clear can wipe many pairs' baselines — gate the write like
+        # `sync` gates a batch apply. A single explicitly-named deck is not gated.
+        if deck.is_dir() and not dry_run and not yes:
+            if as_json:
+                raise click.UsageError(
+                    f"clearing {len(pairs)} pair(s) under {deck} needs --yes (cannot prompt "
+                    "with --json); add --yes, or preview with --dry-run."
+                )
+            click.confirm(
+                f"About to clear the watermark for {len(pairs)} pair(s) under {deck}. Continue?",
+                abort=True,
+            )
+
+        existing = {(e.de_path, e.en_path): e for e in _group_watermarks(cache)}
+        results: list[tuple[str, str, int]] = []
+        for de_key, en_key in pairs:
+            entry = existing.get((de_key, en_key))
+            if dry_run:
+                removed = entry.rows if entry is not None else 0
+            elif entry is None:
+                removed = 0
+            else:
+                removed = cache.clear_pair(de_key, en_key)
+            results.append((de_key, en_key, removed))
+    finally:
+        cache.close()
+
+    _emit_clear(deck, results, dry_run=dry_run, as_json=as_json)
+
+
+def _emit_clear(
+    deck: Path,
+    results: list[tuple[str, str, int]],
+    *,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    verb = "would clear" if dry_run else "cleared"
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "deck": str(deck),
+                    "dry_run": dry_run,
+                    "pairs": [
+                        {"de_path": de, "en_path": en, "rows": rows} for de, en, rows in results
+                    ],
+                    "total_rows": sum(rows for _de, _en, rows in results),
+                },
+                indent=2,
+            )
+        )
+        return
+    if not results:
+        click.echo(f"no split-format deck pairs found under {deck}.")
+        return
+    for de_key, _en_key, rows in results:
+        if rows == 0 and not dry_run:
+            click.echo(f"no watermark for {_label(de_key)} (nothing to clear).")
+        else:
+            click.echo(f"{verb} {rows} row(s) for {_label(de_key)}.")
+    total = sum(rows for _de, _en, rows in results)
+    click.echo("")
+    click.echo(f"{verb}: {total} row(s) across {len(results)} pair(s).")
+    if not dry_run and total:
+        click.echo("The next `clm slides sync` for these decks will re-baseline off git HEAD.")
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+
+@watermark_group.command("prune")
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory holding the structural watermark (see `clm slides sync --cache-dir`).",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Report orphans; delete nothing.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit a JSON report.")
+def watermark_prune_cmd(cache_dir: Path | None, dry_run: bool, as_json: bool) -> None:
+    """Drop watermarks whose files no longer exist on disk (orphans from rename/renumber).
+
+    A watermark keyed by an absolute path that is gone from disk can never be matched
+    by a ``sync`` again, but it lingers and clutters ``list``. Pruning removes those
+    dead rows; live pairs are untouched.
+    """
+    cache = _open_cache(cache_dir)
+    try:
+        orphans = [e for e in _group_watermarks(cache) if e.orphan]
+        orphans.sort(key=lambda e: e.de_path)
+        results: list[tuple[str, str, int]] = []
+        for e in orphans:
+            removed = e.rows if dry_run else cache.clear_pair(e.de_path, e.en_path)
+            results.append((e.de_path, e.en_path, removed))
+    finally:
+        cache.close()
+
+    verb = "would prune" if dry_run else "pruned"
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "dry_run": dry_run,
+                    "pairs": [
+                        {"de_path": de, "en_path": en, "rows": rows} for de, en, rows in results
+                    ],
+                    "total_rows": sum(rows for _de, _en, rows in results),
+                },
+                indent=2,
+            )
+        )
+        return
+    if not results:
+        click.echo("no orphaned watermarks.")
+        return
+    for de_key, _en_key, rows in results:
+        click.echo(f"{verb} {rows} row(s) for {_label(de_key)} (orphaned).")
+    total = sum(rows for _de, _en, rows in results)
+    click.echo("")
+    click.echo(f"{verb}: {total} row(s) across {len(results)} orphaned pair(s).")

--- a/tests/cli/test_slides_watermark.py
+++ b/tests/cli/test_slides_watermark.py
@@ -1,0 +1,292 @@
+"""CLI tests for ``clm slides watermark`` (Issue #363).
+
+The ``watermark`` group inspects and maintains the structural watermark that
+``clm slides sync`` records in ``clm-llm.sqlite``. These tests seed watermark rows
+directly into a temp cache (via :class:`SyncWatermarkCache`) and drive the CLI
+surface — so they exercise pair resolution, on-disk orphan detection, the dry-run
+gate, and row deletion without a live sync.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.sync import CACHE_DB_NAME
+from clm.cli.commands.slides.watermark import (
+    watermark_clear_cmd,
+    watermark_list_cmd,
+    watermark_prune_cmd,
+)
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+
+
+@pytest.fixture
+def cli_runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+_DECK = (
+    "# j2 from 'macros.j2' import header_de\n"
+    '# {{ header_de("Titel") }}\n'
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+    "# Hallo\n"
+)
+
+
+def _make_pair(directory: Path, stem: str = "slides_intro") -> tuple[Path, Path]:
+    directory.mkdir(parents=True, exist_ok=True)
+    de_path = directory / f"{stem}.de.py"
+    en_path = directory / f"{stem}.en.py"
+    de_path.write_text(_DECK, encoding="utf-8")
+    en_path.write_text(_DECK, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed(
+    cache_dir: Path,
+    de_path: Path | str,
+    en_path: Path | str,
+    *,
+    langs: tuple[str, ...] = ("de", "en"),
+) -> None:
+    """Seed a watermark for a pair, keyed by the resolved-path strings sync writes."""
+    cache = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
+    de_key = str(Path(de_path).resolve())
+    en_key = str(Path(en_path).resolve())
+    for lang in langs:
+        cache.put_deck(
+            de_path=de_key,
+            en_path=en_key,
+            lang=lang,
+            cells=[(0, "intro", "slide", f"h-{lang}", None)],
+        )
+    cache.close()
+
+
+def _count_rows(cache_dir: Path) -> int:
+    cache = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
+    try:
+        return len(cache.iter_entries())
+    finally:
+        cache.close()
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_empty(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        res = cli_runner.invoke(watermark_list_cmd, ["--cache-dir", str(cache)])
+        assert res.exit_code == 0
+        assert "no watermarks found." in res.output
+
+    def test_lists_ok_and_orphan(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        _seed(
+            cache,
+            tmp_path / "decks" / "gone.de.py",
+            tmp_path / "decks" / "gone.en.py",
+            langs=("de",),
+        )
+
+        res = cli_runner.invoke(watermark_list_cmd, ["--cache-dir", str(cache)])
+        assert res.exit_code == 0
+        assert "OK    " in res.output
+        assert "ORPHAN" in res.output
+        assert "2 pair(s), 1 orphan(ed)." in res.output
+
+    def test_orphans_filter(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        _seed(
+            cache,
+            tmp_path / "decks" / "gone.de.py",
+            tmp_path / "decks" / "gone.en.py",
+            langs=("de",),
+        )
+
+        res = cli_runner.invoke(watermark_list_cmd, ["--cache-dir", str(cache), "--orphans"])
+        assert res.exit_code == 0
+        assert "gone.de.py" in res.output
+        assert "slides_intro.de.py" not in res.output
+
+    def test_json(self, cli_runner, tmp_path):
+        import json
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        res = cli_runner.invoke(watermark_list_cmd, ["--cache-dir", str(cache), "--json"])
+        assert res.exit_code == 0
+        data = json.loads(res.output)
+        assert len(data) == 1
+        assert data[0]["rows"] == 2
+        assert data[0]["orphan"] is False
+        assert data[0]["langs"] == {"de": 1, "en": 1}
+
+    def test_path_scoping(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de_a, en_a = _make_pair(tmp_path / "a")
+        de_b, en_b = _make_pair(tmp_path / "b")
+        _seed(cache, de_a, en_a)
+        _seed(cache, de_b, en_b)
+
+        res = cli_runner.invoke(
+            watermark_list_cmd, ["--cache-dir", str(cache), str(tmp_path / "a")]
+        )
+        assert res.exit_code == 0
+        assert str(Path("a") / "slides_intro.de.py") in res.output or "/a/" in res.output
+        assert "1 pair(s)" in res.output
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    def test_clear_by_de_half(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        assert _count_rows(cache) == 2
+
+        res = cli_runner.invoke(watermark_clear_cmd, ["--cache-dir", str(cache), str(de)])
+        assert res.exit_code == 0
+        assert "cleared 2 row(s)" in res.output
+        assert _count_rows(cache) == 0
+
+    def test_clear_by_en_twin(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        res = cli_runner.invoke(watermark_clear_cmd, ["--cache-dir", str(cache), str(en)])
+        assert res.exit_code == 0
+        assert _count_rows(cache) == 0
+
+    def test_dry_run_keeps_rows(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        res = cli_runner.invoke(
+            watermark_clear_cmd, ["--cache-dir", str(cache), "--dry-run", str(de)]
+        )
+        assert res.exit_code == 0
+        assert "would clear 2 row(s)" in res.output
+        assert _count_rows(cache) == 2
+
+    def test_clear_missing_watermark_is_noop(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, _en = _make_pair(tmp_path / "decks")
+        res = cli_runner.invoke(watermark_clear_cmd, ["--cache-dir", str(cache), str(de)])
+        assert res.exit_code == 0
+        assert "nothing to clear" in res.output
+
+    def test_clear_directory_requires_yes(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        decks = tmp_path / "decks"
+        de, en = _make_pair(decks)
+        _seed(cache, de, en)
+        # No --yes and declined prompt → aborts, rows survive.
+        res = cli_runner.invoke(
+            watermark_clear_cmd, ["--cache-dir", str(cache), str(decks)], input="n\n"
+        )
+        assert res.exit_code != 0
+        assert _count_rows(cache) == 2
+
+    def test_clear_directory_with_yes(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        decks = tmp_path / "decks"
+        de, en = _make_pair(decks)
+        de2, en2 = _make_pair(decks, stem="slides_two")
+        _seed(cache, de, en)
+        _seed(cache, de2, en2)
+        res = cli_runner.invoke(
+            watermark_clear_cmd, ["--cache-dir", str(cache), "--yes", str(decks)]
+        )
+        assert res.exit_code == 0
+        assert _count_rows(cache) == 0
+
+    def test_clear_directory_json_requires_yes(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        decks = tmp_path / "decks"
+        de, en = _make_pair(decks)
+        _seed(cache, de, en)
+        res = cli_runner.invoke(
+            watermark_clear_cmd, ["--cache-dir", str(cache), "--json", str(decks)]
+        )
+        assert res.exit_code != 0
+        assert _count_rows(cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+
+class TestPrune:
+    def test_prune_removes_only_orphans(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)  # live
+        _seed(
+            cache,
+            tmp_path / "decks" / "gone.de.py",
+            tmp_path / "decks" / "gone.en.py",
+            langs=("de",),
+        )
+
+        res = cli_runner.invoke(watermark_prune_cmd, ["--cache-dir", str(cache)])
+        assert res.exit_code == 0
+        assert "pruned 1 row(s)" in res.output
+        # The live pair's 2 rows remain; the orphan's 1 row is gone.
+        assert _count_rows(cache) == 2
+
+    def test_prune_dry_run(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        _seed(
+            cache,
+            tmp_path / "decks" / "gone.de.py",
+            tmp_path / "decks" / "gone.en.py",
+            langs=("de",),
+        )
+        res = cli_runner.invoke(watermark_prune_cmd, ["--cache-dir", str(cache), "--dry-run"])
+        assert res.exit_code == 0
+        assert "would prune" in res.output
+        assert _count_rows(cache) == 1
+
+    def test_prune_none(self, cli_runner, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        de, en = _make_pair(tmp_path / "decks")
+        _seed(cache, de, en)
+        res = cli_runner.invoke(watermark_prune_cmd, ["--cache-dir", str(cache)])
+        assert res.exit_code == 0
+        assert "no orphaned watermarks." in res.output
+        assert _count_rows(cache) == 2


### PR DESCRIPTION
Implements Tier 1 of #363.

## What

A new `clm slides watermark` subcommand group to inspect and maintain the
structural watermark that `clm slides sync` records in the shared
`clm-llm.sqlite` — previously only reachable via hand-written SQL.

- **`list [PATH]`** — every watermarked pair with row count, per-language
  breakdown, last sync time, and on-disk status (`OK` / `ORPHAN`). Supports
  `--orphans` and `--json`; an optional `PATH` scopes to pairs under a directory.
- **`clear <deck>`** — delete the watermark for a split half, a bilingual stem,
  or a whole directory, so the next `sync` re-baselines off git `HEAD` (the
  proven-clean cold-start path). `--dry-run` previews; a directory write is gated
  behind `--yes` (mirroring `sync`'s batch gate).
- **`prune`** — drop watermarks whose files no longer exist on disk (orphans left
  by a rename/renumber). `--dry-run` / `--json`.

## Why

A stale watermark (a deck edited **and committed on both halves** without an
intervening `sync`) or an orphan row (files renamed away) surfaces as a confusing
`sync` error — `id-less localized cells edited on both decks` — with no recovery
path. Diagnosing one such case required deleting rows from the shared sqlite by
hand. This gives a first-class, safe way to inspect and reset the baseline.

## Notes

- No store changes were needed: this exposes the existing
  `SyncWatermarkCache.clear_pair` / `has_pair` / `iter_entries` primitives
  (`iter_entries`'s docstring already anticipated "a future `sync --dump`").
- `clear` resolves the deck through the same `_resolve_single_path` /
  `_resolve_sync_pair` guards `sync` uses and keys by the same
  `str(path.resolve())` form, so a cleared pair is exactly the pair a subsequent
  `sync` of that deck looks up.
- 15 new CLI tests; existing sync + cache suites (116 tests) still pass; `ruff
  check` / `format` clean.

Companion follow-ups (separate issues): auto-heal a stale-but-consistent
watermark (#364), id all localized cells (#365), reduce watermark/commit coupling
(#366).