### PR TITLE
sync: add `--rebaseline` + stale-watermark hint (#364)

### DIFF
--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -405,6 +405,21 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
     ),
 )
 @click.option(
+    "--rebaseline",
+    is_flag=True,
+    default=False,
+    help=(
+        "Reset a STALE watermark. When the recorded watermark errors/conflicts but "
+        "the pair's halves are already consistent against git HEAD (the usual cause: "
+        "both halves edited + committed without an intervening sync), clear the "
+        "watermark and re-record it from the current state — the safe fix for the "
+        "'id-less localized cells edited on both decks' error. REFUSES if git HEAD "
+        "shows real changes/divergence, so it cannot silently mask an un-synced edit. "
+        "Writes the watermark; single-pair only; mutually exclusive with "
+        "--dry-run / --explain / --no-cache."
+    ),
+)
+@click.option(
     "--no-env-file",
     is_flag=True,
     default=False,
@@ -447,6 +462,7 @@ def slides_sync_cmd(
     verify_cold_pairs: bool | None,
     cache_dir: Path | None,
     no_cache: bool,
+    rebaseline: bool,
     no_env_file: bool,
     yes: bool,
     as_json: bool,
@@ -501,6 +517,15 @@ def slides_sync_cmd(
             "--explain and --json are mutually exclusive "
             "(--explain is a human-readable diagnostic; use --dry-run --json for the structured plan)"
         )
+    if rebaseline and (dry_run or explain):
+        raise click.UsageError(
+            "--rebaseline writes the watermark; it is mutually exclusive with "
+            "--dry-run / --explain (which write nothing)."
+        )
+    if rebaseline and no_cache:
+        raise click.UsageError(
+            "--rebaseline manages the watermark, so it cannot be combined with --no-cache."
+        )
 
     # Cold-start minting (#216 §12): a verifier is on by default when a provider is
     # configured; --no-verify-cold-pairs forces it off (cold pairs then refuse).
@@ -523,6 +548,11 @@ def slides_sync_cmd(
                 "--interactive cannot be combined with a directory (it walks one "
                 "pair's proposals). Sync a single deck/half interactively, or use "
                 "--dry-run / --explain over the directory."
+            )
+        if rebaseline:
+            raise click.UsageError(
+                "--rebaseline operates on a single deck pair; run it per deck "
+                "(e.g. `clm slides sync --rebaseline <deck>.de.py`), not over a directory."
             )
         batch_mode = "explain" if explain else ("dry-run" if dry_run else "apply")
         # One glossary resolution for the whole sweep (the translator is shared across
@@ -572,6 +602,20 @@ def slides_sync_cmd(
     # (a relative single-path run vs. a resolved batch run) and the second silently
     # misses the first's watermark and re-baselines off git HEAD.
     de_path, en_path = de_path.resolve(), en_path.resolve()
+
+    # --rebaseline: reset a stale watermark when the halves are already consistent
+    # against git HEAD. Self-contained (own cache lifetime); always sys.exit()s. No
+    # LLM is needed (a consistent pair has no proposals to reconcile), so this runs
+    # before the env load / judge resolution below.
+    if rebaseline:
+        _run_rebaseline(
+            de_path,
+            en_path,
+            cache_dir=cache_dir,
+            provider_available=provider_available,
+            as_json=as_json,
+        )
+        return  # _run_rebaseline always sys.exit()s; this is just for the type-checker.
 
     # Load the project .env before resolving the judge/translator, so keys kept
     # only in .env (the usual course-repo layout) are found. Without this, every
@@ -679,12 +723,30 @@ def slides_sync_cmd(
         _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
     )
 
+    # Stale-watermark hint: the run did not come out clean against the recorded
+    # watermark, yet the halves are consistent against git HEAD — the signature of a
+    # baseline that fell behind (both halves edited + committed without a sync). Point
+    # the user at the one-command fix rather than leaving them to diagnose it.
+    rebaseline_hint = not no_cache and _is_stale_but_consistent(
+        de_path, en_path, plan, provider_available=provider_available
+    )
+
     if mode == "explain":
         click.echo(explain_text)
     elif as_json:
-        click.echo(json.dumps(_to_dict(plan, apply_result, walk, mode, exit_code), indent=2))
+        click.echo(
+            json.dumps(
+                _to_dict(
+                    plan, apply_result, walk, mode, exit_code, rebaseline_hint=rebaseline_hint
+                ),
+                indent=2,
+            )
+        )
     else:
         _print_human(plan, apply_result, walk, mode=mode)
+
+    if rebaseline_hint and not as_json:
+        click.echo(_rebaseline_hint_text(de_path), err=True)
 
     sys.exit(exit_code)
 
@@ -1185,6 +1247,139 @@ def _resolve_verifier(verify_enabled: bool) -> CorrespondenceVerifier | None:
 
 
 # ---------------------------------------------------------------------------
+# Rebaseline (reset a stale watermark) — Issue #364
+# ---------------------------------------------------------------------------
+
+
+def _githead_plan(de_path: Path, en_path: Path, *, provider_available: bool) -> SyncPlan:
+    """Classify the pair against the git-HEAD baseline (ignoring any watermark).
+
+    Passing ``watermark_cache=None`` forces ``build_sync_plan`` down its git-HEAD
+    fallback, so the result reflects only what changed since each half's commit — the
+    same baseline a cold ``sync`` (or ``--no-cache``) uses.
+    """
+    return build_sync_plan(
+        de_path, en_path, watermark_cache=None, provider_available=provider_available
+    )
+
+
+def _is_stale_but_consistent(
+    de_path: Path, en_path: Path, plan: SyncPlan, *, provider_available: bool
+) -> bool:
+    """True when the watermark run was non-trivial but git HEAD shows the pair clean.
+
+    That combination — a watermark baseline that errors/conflicts, while the halves
+    are consistent against git HEAD — is the signature of a stale watermark (the
+    baseline fell behind a both-halves edit committed without a sync). Only the
+    watermark baseline is interrogated (``baseline_source == "watermark"``); a run
+    that already fell back to git HEAD has no watermark to be stale.
+    """
+    if plan.baseline_source != "watermark" or plan.is_noop:
+        return False
+    return _githead_plan(de_path, en_path, provider_available=provider_available).is_noop
+
+
+def _rebaseline_hint_text(de_path: Path) -> str:
+    return (
+        "note: this deck's halves are consistent against git HEAD, but its recorded "
+        "watermark is stale (the usual cause: both halves edited + committed without an "
+        "intervening sync). Reset it with "
+        f"`clm slides sync --rebaseline {de_path.name}` (refuses if HEAD shows real "
+        "changes), or `clm slides watermark clear`."
+    )
+
+
+def _run_rebaseline(
+    de_path: Path,
+    en_path: Path,
+    *,
+    cache_dir: Path | None,
+    provider_available: bool,
+    as_json: bool,
+) -> None:
+    """Reset a stale watermark, or refuse when git HEAD shows real changes.
+
+    Safe by construction: the watermark is re-recorded only when the git-HEAD plan is
+    a no-op (the halves are mutually consistent at their committed state), so nothing
+    that still needs syncing is masked. A non-no-op git-HEAD plan is refused with the
+    pending changes named — the divergence must be resolved (a normal ``sync``) first.
+    Always ``sys.exit``s.
+    """
+    cache_root = resolve_cache_dir(cli_override=cache_dir)
+    watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
+    try:
+        githead = _githead_plan(de_path, en_path, provider_available=provider_available)
+        if not githead.is_noop:
+            _emit_rebaseline_refused(de_path, githead, as_json=as_json)
+            sys.exit(2)
+        had = watermark_cache.has_pair(str(de_path), str(en_path))
+        removed = watermark_cache.clear_pair(str(de_path), str(en_path)) if had else 0
+        # Re-record the watermark from the current (consistent) state. A no-op plan has
+        # no proposals, so no judge/translator is needed; apply still writes the fresh
+        # whole-deck watermark.
+        result = apply_plan(githead, judge=None, watermark_cache=watermark_cache)
+    finally:
+        watermark_cache.close()
+    _emit_rebaseline_done(de_path, removed, result, as_json=as_json)
+    sys.exit(0)
+
+
+def _emit_rebaseline_refused(de_path: Path, githead: SyncPlan, *, as_json: bool) -> None:
+    reason = (
+        "git HEAD carries classifier errors"
+        if githead.has_errors
+        else f"git HEAD shows pending changes ({_counts_str(githead)})"
+    )
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "de_path": str(de_path),
+                    "mode": "rebaseline",
+                    "exit_code": 2,
+                    "rebaselined": False,
+                    "reason": reason,
+                },
+                indent=2,
+            )
+        )
+        return
+    click.echo(
+        f"refusing to --rebaseline {de_path.name}: {reason}. The halves are not "
+        "consistent at their committed state, so re-baselining could mask an un-synced "
+        "edit — resolve it with a normal `clm slides sync` first."
+    )
+
+
+def _emit_rebaseline_done(
+    de_path: Path, removed: int, result: ApplyResult, *, as_json: bool
+) -> None:
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "de_path": str(de_path),
+                    "mode": "rebaseline",
+                    "exit_code": 0,
+                    "rebaselined": True,
+                    "rows_cleared": removed,
+                    "watermark_recorded": result.watermark_recorded,
+                },
+                indent=2,
+            )
+        )
+        return
+    if removed:
+        click.echo(f"cleared {removed} stale watermark row(s) for {de_path.name}.")
+    else:
+        click.echo(f"{de_path.name} had no recorded watermark.")
+    click.echo(
+        "re-baselined off git HEAD (halves consistent); "
+        f"watermark {'recorded' if result.watermark_recorded else 'not recorded'}."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Exit codes
 # ---------------------------------------------------------------------------
 
@@ -1323,6 +1518,8 @@ def _to_dict(
     walk: PlanWalkResult | None,
     mode: str,
     exit_code: int,
+    *,
+    rebaseline_hint: bool = False,
 ) -> dict:
     return {
         "de_path": str(plan.de_path),
@@ -1332,6 +1529,7 @@ def _to_dict(
         "plan": _plan_dict(plan),
         "apply": _apply_dict(apply_result) if apply_result is not None else None,
         "walker": _walker_dict(walk) if walk is not None else None,
+        "rebaseline_hint": rebaseline_hint,
     }
 
 

--- a/tests/cli/test_slides_sync_rebaseline.py
+++ b/tests/cli/test_slides_sync_rebaseline.py
@@ -1,0 +1,203 @@
+"""CLI tests for ``clm slides sync --rebaseline`` and the stale-watermark hint (#364).
+
+A watermark goes *stale* when both halves of a split deck are edited and committed
+without an intervening ``sync``: the recorded baseline falls behind, so a later sync
+errors/conflicts against it even though the halves are mutually consistent. These
+tests reproduce that state (seed an old watermark + git-commit newer, consistent
+content) and assert:
+
+- a normal run surfaces an actionable stale-watermark hint;
+- ``--rebaseline`` resets the watermark when git HEAD is clean;
+- ``--rebaseline`` refuses when git HEAD shows real changes (so it cannot mask an
+  un-synced edit).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.sync import CACHE_DB_NAME, slides_sync_cmd
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import ordered_sync_cells
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+
+
+@pytest.fixture
+def cli_runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+def _deck(lang: str, body: str, *, sid: str = "intro") -> str:
+    return (
+        f"# j2 from 'macros.j2' import header_{lang}\n"
+        f'# {{{{ header_{lang}("T") }}}}\n'
+        f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n'
+        f"# {body}\n"
+    )
+
+
+def _commit_pair(tmp_path: Path, de_text: str, en_text: str, *, stem: str = "slides_intro"):
+    de_path = tmp_path / f"{stem}.de.py"
+    en_path = tmp_path / f"{stem}.en.py"
+    de_path.write_text(de_text, encoding="utf-8")
+    en_path.write_text(en_text, encoding="utf-8")
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=str(tmp_path), check=True, capture_output=True, text=True
+        )
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "Test")
+    _git("add", "-A")
+    _git("-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+    return de_path, en_path
+
+
+def _seed_watermark(cache_dir: Path, de_path: Path, en_path: Path, *, de_text: str, en_text: str):
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    wm = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
+    try:
+        for lang, text in (("de", de_text), ("en", en_text)):
+            cells = ordered_sync_cells(parse_cells(text), lang)
+            wm.put_deck(
+                de_path=str(de_path),
+                en_path=str(en_path),
+                lang=lang,
+                cells=[
+                    (c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells
+                ],
+            )
+    finally:
+        wm.close()
+
+
+def _rows(cache_dir: Path) -> int:
+    wm = SyncWatermarkCache(cache_dir / CACHE_DB_NAME)
+    try:
+        return len(wm.iter_entries())
+    finally:
+        wm.close()
+
+
+def _stale_consistent(tmp_path: Path):
+    """A committed, mutually-consistent pair with an *older* watermark (stale).
+
+    Returns ``(de_path, en_path, cache_dir)``. The current committed bodies differ
+    from the seeded watermark on *both* halves, so a watermark-baseline sync sees a
+    two-sided conflict; git HEAD (== current) is clean.
+    """
+    de_path, en_path = _commit_pair(tmp_path, _deck("de", "neu"), _deck("en", "new"))
+    cache = tmp_path / "cache"
+    _seed_watermark(cache, de_path, en_path, de_text=_deck("de", "alt"), en_text=_deck("en", "old"))
+    return de_path, en_path, cache
+
+
+class TestStaleHint:
+    def test_hint_on_dry_run(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--dry-run", "--cache-dir", str(cache), str(de_path)]
+        )
+        # A two-sided conflict against the stale watermark — not clean.
+        assert res.exit_code != 0
+        assert "watermark is stale" in res.stderr
+        assert "--rebaseline" in res.stderr
+
+    def test_hint_in_json(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--dry-run", "--json", "--cache-dir", str(cache), str(de_path)]
+        )
+        payload = json.loads(res.output[res.output.find("{") :])
+        assert payload["rebaseline_hint"] is True
+
+    def test_no_hint_when_consistent(self, cli_runner, tmp_path):
+        # Watermark matches the committed content → clean, no hint.
+        de_path, en_path = _commit_pair(tmp_path, _deck("de", "x"), _deck("en", "y"))
+        cache = tmp_path / "cache"
+        _seed_watermark(cache, de_path, en_path, de_text=_deck("de", "x"), en_text=_deck("en", "y"))
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--dry-run", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert res.exit_code == 0
+        assert "watermark is stale" not in res.stderr
+
+
+class TestRebaseline:
+    def test_resets_stale_watermark(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--rebaseline", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert res.exit_code == 0, res.output + res.stderr
+        assert "re-baselined" in res.output
+        # The watermark now matches the current state: a follow-up sync is clean.
+        follow = cli_runner.invoke(
+            slides_sync_cmd, ["--dry-run", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert follow.exit_code == 0
+        assert "watermark is stale" not in follow.stderr
+
+    def test_json(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--rebaseline", "--json", "--cache-dir", str(cache), str(de_path)]
+        )
+        payload = json.loads(res.output[res.output.find("{") :])
+        assert payload["rebaselined"] is True
+        assert payload["mode"] == "rebaseline"
+
+    def test_refuses_on_real_divergence(self, cli_runner, tmp_path):
+        # Commit a pair, then edit one half on disk (uncommitted) → git HEAD is NOT
+        # clean, so --rebaseline must refuse rather than mask the un-synced edit.
+        de_path, en_path = _commit_pair(tmp_path, _deck("de", "x"), _deck("en", "y"))
+        cache = tmp_path / "cache"
+        _seed_watermark(
+            cache, de_path, en_path, de_text=_deck("de", "old"), en_text=_deck("en", "old")
+        )
+        de_path.write_text(_deck("de", "edited-uncommitted"), encoding="utf-8")
+        rows_before = _rows(cache)
+
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--rebaseline", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert res.exit_code == 2
+        assert "refusing to --rebaseline" in res.output
+        assert _rows(cache) == rows_before  # watermark untouched
+
+    def test_rejects_dry_run_combo(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--rebaseline", "--dry-run", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert res.exit_code != 0
+        assert "mutually exclusive" in (res.stderr + res.output)
+
+    def test_rejects_no_cache_combo(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--rebaseline", "--no-cache", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert res.exit_code != 0
+        assert "no-cache" in (res.stderr + res.output)
+
+    def test_rejects_directory(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--rebaseline", "--cache-dir", str(cache), str(tmp_path)]
+        )
+        assert res.exit_code != 0
+        assert "single deck pair" in (res.stderr + res.output)


### PR DESCRIPTION
Implements the core of #364, building on the #363 watermark CLI.

## Problem

A watermark goes **stale** when both halves of a split deck are edited and
committed without an intervening `sync`: the recorded baseline falls behind, so a
later sync errors/conflicts against it (`id-less localized cells edited on both
decks`) even though the halves are mutually consistent. Recovery previously meant
deleting rows from the shared sqlite by hand.

## What

- **`--rebaseline`** — when the pair's halves are consistent against git HEAD,
  clear the stale watermark and re-record it from the current state. **Refuses**
  when git HEAD shows real changes/divergence, naming the pending changes, so it
  cannot silently mask an un-synced edit. This makes it strictly safer than a
  blind `watermark clear` (which trusts git HEAD unconditionally). Single-pair
  only; mutually exclusive with `--dry-run` / `--explain` / `--no-cache`.
- **Stale-watermark hint** — a normal run that comes out non-trivial against the
  watermark *but* clean against git HEAD now prints an actionable note (and sets
  `"rebaseline_hint": true` in `--json`) pointing at `--rebaseline`. This turns the
  previously-cryptic error into a one-command fix.

## Design note — why not silent auto-heal by default

#364 floats auto-healing a stale-but-consistent watermark automatically. I
deliberately kept it **explicit** (`--rebaseline` + a hint) rather than silent:

- Erroring loudly on a stale watermark is exactly what surfaced this bug; silently
  re-baselining would have hidden it.
- "git HEAD is clean" means each half is unchanged since its own commit — it does
  **not** by itself prove the two halves are mutually in-sync. `--rebaseline` makes
  that the user's explicit intent (and still refuses on a non-no-op HEAD), which is
  the honest contract. A safe always-on auto-heal needs a real mutual-consistency
  oracle (cold-start correspondence), which is a larger change.

## Follow-ups (still part of #364)

- Record the git commit/blob the watermark was taken at, for precise staleness
  detection without re-deriving a git-HEAD plan.
- `--explain`: show the watermark-baseline vs git-HEAD-baseline diff side by side.

## Tests

9 new tests (`tests/cli/test_slides_sync_rebaseline.py`): the hint on dry-run +
`--json`, no-hint when consistent, `--rebaseline` reset + follow-up-clean, JSON,
refusal on real divergence (watermark untouched), and the three flag-combo guards.
Existing sync + watermark + cache suites (131 tests) still pass; `ruff
check`/`format` clean.