### PR TITLE
ci: skip full test suite for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,46 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Detect whether the change touches anything that warrants running the full
+  # test/lint/docker pipeline. Docs-only changes (design notes, READMEs,
+  # changelog fragments) skip the expensive jobs to save CI minutes.
+  #
+  # IMPORTANT: "Test on Python 3.12", "Test on Python 3.13" and
+  # "Lint and type check" are *required* status checks (see the "Require CI
+  # green" ruleset). A required check that never reports leaves the PR stuck
+  # "Expected — waiting for status". So those jobs must always RUN and report
+  # success — we gate their individual steps on ``needs.changes.outputs.code``
+  # rather than skipping the whole job. The non-required docker job may be
+  # skipped wholesale.
+  #
+  # The doc-only globs are deliberately narrow: ``src/clm/cli/info_topics/*.md``
+  # and other markdown shipped under ``src/`` are covered by tests, so a blanket
+  # ``**/*.md`` would wrongly skip CI for them. Only ``docs/``, ``changelog.d/``
+  # and top-level ``*.md`` count as docs-only.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # ``code`` is true when at least one changed file is NOT docs-only.
+          filters: |
+            code:
+              - '!docs/**'
+              - '!changelog.d/**'
+              - '!*.md'
+
   test:
     name: Test on Python ${{ matrix.python-version }}
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -28,30 +66,36 @@ jobs:
     # docker/**) keeps LFS bandwidth down and guards against any large binary
     # ever re-landing under docker/ silently inflating every CI run.
     - name: Pull LFS test fixtures (excluding docker build inputs)
+      if: needs.changes.outputs.code == 'true'
       run: git lfs pull --exclude="docker/**"
 
     - name: Set up Python ${{ matrix.python-version }}
+      if: needs.changes.outputs.code == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up Java for PlantUML
+      if: needs.changes.outputs.code == 'true'
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'
 
     - name: Install system dependencies
+      if: needs.changes.outputs.code == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y xvfb libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libdrm2 libgbm1 libxcb-dri3-0
 
     - name: Install PlantUML
+      if: needs.changes.outputs.code == 'true'
       run: |
         wget -O plantuml.jar https://github.com/plantuml/plantuml/releases/download/v1.2024.6/plantuml-1.2024.6.jar
         echo "PLANTUML_JAR=$PWD/plantuml.jar" >> $GITHUB_ENV
 
     - name: Install DrawIO
+      if: needs.changes.outputs.code == 'true'
       run: |
         # Download DrawIO from GitHub releases
         wget -O drawio.deb https://github.com/jgraph/drawio-desktop/releases/download/v24.7.17/drawio-amd64-24.7.17.deb
@@ -59,11 +103,13 @@ jobs:
         echo "DRAWIO_EXECUTABLE=/opt/drawio/drawio" >> $GITHUB_ENV
 
     - name: Install uv
+      if: needs.changes.outputs.code == 'true'
       uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
 
     - name: Install dependencies
+      if: needs.changes.outputs.code == 'true'
       run: |
         # Install all dependencies except ML (PyTorch, FastAI, etc.) which aren't needed for tests.
         # ``replay`` is included so the HTTP-replay cassette tests (merge, format,
@@ -72,12 +118,14 @@ jobs:
         uv pip install --system -e ".[all-workers,summarize,recordings,slides,mcp,replay,dev,tui,web]"
 
     - name: Start Xvfb
+      if: needs.changes.outputs.code == 'true'
       run: |
         Xvfb :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &
         echo "DISPLAY=:99" >> $GITHUB_ENV
         sleep 2
 
     - name: Verify external tools
+      if: needs.changes.outputs.code == 'true'
       run: |
         echo "Checking Java..."
         java -version
@@ -91,15 +139,18 @@ jobs:
         pgrep -x Xvfb
 
     - name: Configure git identity for tests
+      if: needs.changes.outputs.code == 'true'
       run: |
         git config --global user.email "ci@github.actions"
         git config --global user.name "GitHub Actions CI"
 
     - name: Run unit tests
+      if: needs.changes.outputs.code == 'true'
       run: |
         pytest -v -m "not slow and not integration and not e2e and not docker" --timeout=120 --cov=src/clm --cov-report=xml --cov-report=term
 
     - name: Run integration tests
+      if: needs.changes.outputs.code == 'true'
       run: |
         pytest -v -m "integration and not docker and not slow" --timeout=240 --log-cli-level=INFO --cov=src/clm --cov-append --cov-report=xml --cov-report=term
       env:
@@ -107,6 +158,7 @@ jobs:
         CLM_LOG_LEVEL: INFO
 
     - name: Run E2E tests
+      if: needs.changes.outputs.code == 'true'
       run: |
         pytest -v -m "e2e and not docker and not slow" --timeout=600 --log-cli-level=INFO --cov=src/clm --cov-append --cov-report=xml --cov-report=term
       env:
@@ -121,10 +173,11 @@ jobs:
         files: ./coverage.xml
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
-      if: matrix.python-version == '3.12'
+      if: needs.changes.outputs.code == 'true' && matrix.python-version == '3.12'
 
   lint:
     name: Lint and type check
+    needs: changes
     runs-on: ubuntu-latest
 
     steps:
@@ -132,33 +185,43 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python
+      if: needs.changes.outputs.code == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
     - name: Install uv
+      if: needs.changes.outputs.code == 'true'
       uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
 
     - name: Install dependencies
+      if: needs.changes.outputs.code == 'true'
       run: |
         uv pip install --system -e ".[dev,tui,web,notebook,summarize,recordings,slides,mcp]"
 
     - name: Run ruff check
+      if: needs.changes.outputs.code == 'true'
       run: |
         ruff check src/ tests/
 
     - name: Run ruff format check
+      if: needs.changes.outputs.code == 'true'
       run: |
         ruff format --check src/ tests/
 
     - name: Run mypy
+      if: needs.changes.outputs.code == 'true'
       run: |
         mypy src/clm
 
   docker-test:
     name: Docker Integration Tests
+    needs: changes
+    # Not a required status check, so it is safe to skip the whole job for
+    # docs-only changes.
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
## Problem

Every push/PR to `master` runs the full matrix test suite (Python 3.12 + 3.13), the lint job, **and** three Docker image builds — regardless of what changed. A docs-only commit (e.g. a design note) pays the entire CI cost.

## Fix

Add a `changes` job using `dorny/paths-filter` that outputs `code = true` unless **every** changed file is docs-only.

- **`test` / `lint`** (required status checks per the "Require CI green" ruleset): the jobs still run so their required contexts always report success, but every heavy step is gated on `needs.changes.outputs.code == 'true'`. A docs-only change finishes instantly instead of leaving a required check stuck "Expected — waiting for status" (the trap you'd hit with a plain `paths-ignore`).
- **`docker-test`** (not a required check): skipped wholesale via a job-level `if`.

## Scoping note

The docs-only globs are deliberately narrow — `docs/**`, `changelog.d/**`, and root-level `*.md` only. Markdown shipped under `src/` (notably `src/clm/cli/info_topics/*.md`, the `clm info` topics) is covered by tests, so a blanket `**/*.md` would have wrongly skipped CI for it.

## Self-validating

Because `.github/**` counts as code, this PR runs the full suite — confirming the gated workflow still works. The skip path will exercise on the next docs-only PR (e.g. #368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
