### PR TITLE
fix(cli): demote stray "Loaded environment from" log line to DEBUG

### DIFF
--- a/changelog.d/quiet-loaded-environment-log.fixed.md
+++ b/changelog.d/quiet-loaded-environment-log.fixed.md
@@ -1,0 +1,4 @@
+- **Quiet stray "Loaded environment from …" line at the start of `clm build`.** The
+  dotenv-loading step ran before `setup_logging` replaced the bootstrap
+  `basicConfig` console handler, so its `INFO` log leaked to the terminal even
+  with console logging off. Demoted to `DEBUG` so the build starts cleanly.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -2369,7 +2369,12 @@ def build(
         if env_file is not None:
             loaded = load_dotenv(env_file, override=False)
             if loaded:
-                logger.info(f"Loaded environment from {env_file}")
+                # Emitted at DEBUG, not INFO: this runs before ``setup_logging``
+                # has replaced the bootstrap ``basicConfig`` console handler
+                # (installed in ``cli/main.py``) with the real, file-routed
+                # handler set. An INFO call here leaks to the terminal in the
+                # bootstrap format even when console logging is off.
+                logger.debug(f"Loaded environment from {env_file}")
             else:
                 logger.warning(f"Could not load environment from {env_file}")
         else:
@@ -2379,7 +2384,7 @@ def build(
             dotenv_path = _find_env_file(spec_file.resolve().parent)
             if dotenv_path:
                 load_dotenv(dotenv_path, override=False)
-                logger.info(f"Loaded environment from {dotenv_path}")
+                logger.debug(f"Loaded environment from {dotenv_path}")
 
     # Resolve the effective HTTP replay mode once at the entry point so
     # the exit-policy resolver below can see it without re-implementing


### PR DESCRIPTION
## Problem

The very first line of `clm build` output is a stray INFO log:

```
2026-06-16 15:46:22,569 - clm.cli.commands.build - INFO - Loaded environment from .../.env
```

even though console logging is off by default and every *later* INFO log is silent (the build summary reports "0 warnings" and no other chatter).

## Root cause

It's an ordering bug between two logging configurations:

- `cli/main.py` calls `logging.basicConfig(level=INFO, …)` at CLI-import time, installing a transient INFO **stderr** handler whose format exactly matches the leaked line.
- The dotenv-loading block in the `build` callback (`build.py`) does `logger.info("Loaded environment from …")` **before** `setup_logging` runs (later, inside `main_build → initialize_paths_and_course`). `setup_logging` clears the root handlers and — with console logging off — routes INFO to a file. So this one INFO escapes through the bootstrap handler before the real config takes over.

This is the sibling of `a1319ca8` ("demote 'Output targets' log line to DEBUG"), which fixed the analogous leak for a different line but left this one untouched.

## Fix

Demote both env-load confirmations (explicit `--env-file` and the auto-detected path) to `DEBUG`. The "could not load" case stays a `WARNING`. A comment documents the ordering constraint so the level isn't innocently bumped back.

## Testing

- `ruff check` / `ruff format --check` clean; pre-push fast suite passed.
- This only changes the level of two log calls; no behavioral change to env loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
