### PR TITLE
fix(sync): guard edit judge against silent cell truncation (#377)

### DIFF
--- a/changelog.d/377-sync-judge-truncation-guard.fixed.md
+++ b/changelog.d/377-sync-judge-truncation-guard.fixed.md
@@ -1,0 +1,8 @@
+- **`clm slides sync` no longer silently truncates a reconciled cell.** When the
+  edit judge returned a body with an unescaped inner `"` (e.g. an English term
+  wrapped in German `„ … "` quotes), the lenient response parser could turn the
+  malformed reply into a *parseable but truncated* value and write it to disk with
+  `0 error(s)` reported (Issue #377). The parser now does a strict-first parse and
+  rejects any response with unexpected top-level keys, so such a reply is surfaced
+  as a hard error and the edit is rolled back atomically — the safe behavior other
+  affected cells already got — instead of shipping a corrupted cell.

--- a/src/clm/infrastructure/llm/ollama_client.py
+++ b/src/clm/infrastructure/llm/ollama_client.py
@@ -20,7 +20,7 @@ import os
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -668,12 +668,69 @@ class OllamaSyncJudge:
         return parse_sync_response(text)
 
 
+# The only top-level keys the judge contract defines (mirrors the
+# ``additionalProperties: False`` of :data:`sync_prompts.SYNC_RESPONSE_SCHEMA`).
+# Enforced in :func:`parse_sync_response` as a *truncation guard*: see its
+# docstring for why an unexpected key means silent data loss, not just noise.
+_SYNC_RESPONSE_KEYS = frozenset({"verdict", "proposed_text", "reason"})
+
+
+def _decode_sync_object(cleaned: str, raw: str) -> dict[str, Any]:
+    """Decode the judge reply to a JSON object, strict-first (Issue #377).
+
+    A faithful reply is a JSON object that parses *whole*, so try that first —
+    this keeps a clean body that legitimately contains ``{`` / ``}`` (markdown,
+    fenced code) from being re-carved. Only when the strict parse fails do we
+    fall back to the lenient ``find("{")`` / ``rfind("}")`` span, for models that
+    wrap the object in a prose preamble. Either way the result must be an object;
+    a parse failure or a non-object raises :class:`OllamaError` (a surfaced hard
+    error, not a silent recovery).
+    """
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        start = cleaned.find("{")
+        end = cleaned.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            raise OllamaError(
+                f"could not locate JSON object in sync response: {raw[:200]!r}"
+            ) from None
+        try:
+            parsed = json.loads(cleaned[start : end + 1])
+        except json.JSONDecodeError as exc:
+            raise OllamaError(f"sync response is not valid JSON: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise OllamaError(f"sync response is not a JSON object: {raw[:200]!r}")
+    return parsed
+
+
 def parse_sync_response(text: str) -> SyncProposal:
     """Parse the judge's raw response into a :class:`SyncProposal`.
 
-    Tolerates leading/trailing prose around the JSON body (some local
-    models tack on a one-line preamble despite the system prompt) by
-    locating the first ``{`` and the last ``}``.
+    Hardened against **silent truncation / data loss** (Issue #377). The judge
+    returns the reconciled cell body as a JSON string; when a hosted model emits
+    an *unescaped* inner ``"`` (e.g. wrapping an English term inside German
+    ``„ … "`` quotes), the string value terminates early. The old parser carved
+    the body with ``find("{")`` / ``rfind("}")`` and ran a tolerant
+    ``json.loads`` — which could turn that malformed reply into a *parseable but
+    truncated* object (the dropped lines swallowed as extra keys, or a smaller
+    balanced span carved out). The truncated prefix was then written to disk with
+    ``0 error(s)`` reported. Two defenses, both turning that into a surfaced hard
+    error (``OllamaError`` → the apply engine blocks the edit and rolls back
+    atomically, the safe path other cells already got):
+
+    1. **Strict-first parse.** A well-formed reply parses whole, so the lenient
+       ``find/rfind`` carve only runs as a fallback for models that wrap the
+       object in prose — never on a clean (or clean-looking-but-truncated) reply.
+    2. **No unexpected top-level keys.** Mirroring the structured-output schema's
+       ``additionalProperties: False``: when truncation swallows the dropped
+       content into bogus keys, the object now *fails* instead of yielding a
+       short ``proposed_text``.
+
+    Still tolerates the benign cases it always did: a code-fenced object, a
+    leading prose preamble, and an omitted ``verdict`` (inferred from
+    ``proposed_text``).
     """
     cleaned = text.strip()
     if cleaned.startswith("```"):
@@ -681,15 +738,19 @@ def parse_sync_response(text: str) -> SyncProposal:
         if cleaned.lower().startswith("json"):
             cleaned = cleaned[4:]
         cleaned = cleaned.strip()
-    start = cleaned.find("{")
-    end = cleaned.rfind("}")
-    if start == -1 or end == -1 or end <= start:
-        raise OllamaError(f"could not locate JSON object in sync response: {text[:200]!r}")
-    body = cleaned[start : end + 1]
-    try:
-        data = json.loads(body)
-    except json.JSONDecodeError as exc:
-        raise OllamaError(f"sync response is not valid JSON: {exc}") from exc
+
+    data = _decode_sync_object(cleaned, text)
+
+    # Truncation guard: a faithful reply carries exactly the contract's keys, so
+    # any extra one means the value boundaries shifted (an unescaped inner quote
+    # closed a string early and the remainder re-parsed as spurious keys). Refuse
+    # rather than write a possibly-truncated body. See this function's docstring.
+    extra = set(data) - _SYNC_RESPONSE_KEYS
+    if extra:
+        raise OllamaError(
+            "sync response has unexpected top-level keys "
+            f"{sorted(extra)!r} — refusing to write a possibly-truncated cell"
+        )
 
     proposed_text = data.get("proposed_text")
     if not isinstance(proposed_text, str):

--- a/tests/infrastructure/llm/test_ollama_client.py
+++ b/tests/infrastructure/llm/test_ollama_client.py
@@ -337,3 +337,49 @@ class TestParseSyncResponse:
 
         with pytest.raises(OllamaError):
             parse_sync_response('{"verdict":"update"}')
+
+    def test_unescaped_inner_quote_truncation_raises_not_silent(self):
+        """Issue #377: an unescaped inner ``"`` must not silently truncate.
+
+        The model wraps an English term in German ``„ … "`` quotes but emits a
+        literal ASCII ``"`` as the close. That stray quote ends ``proposed_text``
+        early; the dropped lines re-parse as a spurious extra key. The parser
+        must surface this as a hard error (→ atomic rollback) rather than write
+        the truncated prefix with ``0 error(s)``.
+        """
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        # Valid JSON, but proposed_text closed early at the stray quote after
+        # `Agents`; everything after became the bogus key "confuse them".
+        truncated = (
+            '{"verdict": "update", '
+            '"proposed_text": "# **Drei verschiedene „Agents", '
+            '"confuse them": "** \\n# - **Agent mode**", '
+            '"reason": "translated"}'
+        )
+        with pytest.raises(OllamaError, match="unexpected top-level keys"):
+            parse_sync_response(truncated)
+
+    def test_unexpected_key_rejected(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        with pytest.raises(OllamaError, match="unexpected top-level keys"):
+            parse_sync_response('{"verdict":"update","proposed_text":"# Hi","notes":"extra"}')
+
+    def test_clean_body_with_braces_parses_whole(self):
+        """Strict-first parse: a clean body containing ``{``/``}`` is not re-carved.
+
+        Without strict-first the ``find/rfind`` carve could mis-bracket a body
+        that legitimately contains braces (markdown, fenced code).
+        """
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        text = '{"verdict":"update","proposed_text":"code: if (x) { y(); }","reason":"r"}'
+        p = parse_sync_response(text)
+        assert p.proposed_text == "code: if (x) { y(); }"
+
+    def test_non_object_json_raises(self):
+        from clm.infrastructure.llm.ollama_client import parse_sync_response
+
+        with pytest.raises(OllamaError, match="not a JSON object"):
+            parse_sync_response('["just", "a", "list"]')


### PR DESCRIPTION
## Problem

`clm slides sync` could **silently truncate** a reconciled cell and write the
corrupted prefix to disk while reporting `applied: … 0 error(s)` (Issue #377).

When the edit judge returns the translated body as a JSON string and a hosted
model emits an **unescaped inner `"`** — e.g. an English term wrapped in German
`„ … "` quotes with a literal ASCII closing quote — the JSON string value
terminates early. The lenient `parse_sync_response`
(`find("{")` / `rfind("}")` + tolerant `json.loads`) could then turn that
malformed reply into a **parseable-but-truncated** object: the dropped lines
re-parse as spurious extra keys, and the truncated prefix is returned with no
error. The result is valid Jupytext/markdown, so `clm validate` passes and the
corruption ships unnoticed.

This is the *silent* sibling of the loud `sync response is not valid JSON`
failures — same bad input, but those errored and rolled back safely while these
were written.

## Fix

Two parser-level defenses in `parse_sync_response` (shared by both the OpenRouter
and local Ollama backends), each turning the truncation into a surfaced
`OllamaError` → the apply engine blocks the edit and rolls back atomically (the
safe behavior the loud cells already got):

1. **Strict-first parse** (`_decode_sync_object`) — a well-formed reply parses
   *whole*, so the lenient `find/rfind` salvage carve only runs as a fallback for
   a prose-wrapped object, never re-carving a clean (or clean-looking-but-
   truncated) body that legitimately contains `{`/`}`.
2. **Reject unexpected top-level keys** — mirroring the structured-output
   schema's `additionalProperties: False`. When truncation swallows the dropped
   content into bogus keys, the object now fails instead of yielding a short
   `proposed_text`.

This is **defense-in-depth alongside PR #374** (the structured-output judge),
which landed ~12h *after* the 1.14.0 release the issue was filed against. #374
makes a malformed reply far less likely on OpenRouter but does not close the
silent-write path, and does not cover the `--provider local` backend — both of
which this fixes.

## Tests

Added to `TestParseSyncResponse`:
- unescaped-inner-quote truncation → raises (the #377 reproduction)
- unexpected key → raises
- clean body containing `{`/`}` parses whole (strict-first; not re-carved)
- non-object JSON → raises

All existing parser, OpenRouter judge, structured-output, and `slides sync` CLI
tests still pass.

Fixes #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
