### PR TITLE
fix(docker): mount all output-target roots, not just the first (#384)

### DIFF
--- a/changelog.d/384-docker-multitarget-workspace.fixed.md
+++ b/changelog.d/384-docker-multitarget-workspace.fixed.md
@@ -1,0 +1,11 @@
+- **Docker-mode multi-target builds no longer drop every target but the first.**
+  A `--workers docker` build of a spec with multiple `<output-targets>` (e.g. the
+  `shared`/`trainer`/`speaker` convention) mounted only the *first* target's root
+  at the worker `/workspace`, so notebook-worker writes under any other target
+  failed path conversion with `Path '…\output\speaker\…' is not under '…\output\shared'`
+  and were silently lost (Issue #384). The Docker worker now mounts the common
+  ancestor of all target roots (`Course.workspace_root`) so every target's
+  container-written output resolves. Single-target and default-structure builds
+  are unchanged. When the targets share no mountable common parent (e.g. different
+  Windows drives), the build now fails fast with an actionable message pointing to
+  the `--targets <name>` per-target workaround instead of mounting a whole volume.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -199,6 +199,27 @@ def _build_has_docker_notebook_worker(worker_config: object | None) -> bool:
         return False
 
 
+def _resolve_worker_workspace_path(course: Course, worker_config: object | None) -> Path:
+    """Host directory to mount at the worker /workspace, and the backend base.
+
+    Docker workers bind-mount a single host directory at ``/workspace`` and the
+    notebook worker converts absolute host output paths relative to it. With
+    multiple ``<output-targets>`` the mount must therefore cover **all** target
+    roots, not just the legacy "primary" ``output_root`` (= first target) — the
+    bug behind issue #384, where every non-primary target's container-written
+    output failed path conversion and was dropped.
+
+    Only Docker notebook workers write under ``/workspace`` (diagram workers
+    write into ``/source``), so the wider ``course.workspace_root`` — which may
+    raise if the targets share no mountable common parent — is required *only*
+    then. Direct-mode builds never translate paths, so they keep the historical
+    ``output_root`` and are unaffected by the multi-target validation.
+    """
+    if _build_has_docker_notebook_worker(worker_config):
+        return course.workspace_root
+    return course.output_root
+
+
 def _maybe_start_mitmproxy_transport(
     mode: str | None, jobs_db_path: Path, worker_config: object | None = None
 ):
@@ -1771,10 +1792,15 @@ async def main_build(
     logger.debug(f"Initializing job queue database: {config.jobs_db_path}")
     init_database(config.jobs_db_path)
 
+    # In Docker mode this is the common ancestor of all target roots so the
+    # /workspace bind-mount reaches every target's writes (issue #384); in
+    # Direct mode it stays the legacy primary ``output_root``.
+    worker_workspace_path = _resolve_worker_workspace_path(course, worker_config)
+
     lifecycle_manager = WorkerLifecycleManager(
         config=worker_config,
         db_path=config.jobs_db_path,
-        workspace_path=course.output_root,
+        workspace_path=worker_workspace_path,
         cache_db_path=config.cache_db_path,
         data_dir=data_dir,
     )
@@ -1817,7 +1843,9 @@ async def main_build(
         with DatabaseManager(config.cache_db_path, force_init=config.clear_cache) as db_manager:
             backend = SqliteBackend(
                 db_path=config.jobs_db_path,
-                workspace_path=course.output_root,
+                # Match the worker mount root so any relative output path the
+                # backend may resolve agrees with the container's view (#384).
+                workspace_path=worker_workspace_path,
                 db_manager=db_manager,
                 ignore_db=config.ignore_cache,
                 build_reporter=build_reporter,

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import sys
 from collections import defaultdict
 
@@ -288,6 +289,58 @@ class Course(NotebookMixin):
         from clm.slides.sidecar_layout import resolve_layout
 
         return resolve_layout(self.spec.sidecar_layout, self.course_root)
+
+    @property
+    def workspace_root(self) -> Path:
+        """Lowest host directory that contains *every* output target root.
+
+        The Docker worker bind-mounts this at ``/workspace`` and exports it as
+        ``CLM_HOST_WORKSPACE``; the notebook worker converts absolute host
+        output paths relative to it. Unlike ``output_root`` (the legacy
+        "primary" = first target's root), this must cover **all** targets so
+        multi-target Docker builds don't silently drop the non-primary
+        targets' container-written outputs (issue #384).
+
+        Returns the sole target root for single-target / default builds (so
+        behavior is unchanged there), otherwise the common ancestor of all
+        target roots.
+
+        Raises:
+            ValueError: When the target roots share no usable common parent
+                (e.g. on different Windows drives, or the only common ancestor
+                is a filesystem/drive root). Docker mode cannot mount such a
+                set with a single bind; the caller should build each target
+                separately with ``--targets``.
+        """
+        roots = [t.output_root for t in self.output_targets] or [self.output_root]
+        resolved = {r.resolve() for r in roots}
+        if len(resolved) == 1:
+            return next(iter(resolved))
+
+        sorted_roots = sorted(str(r) for r in resolved)
+        try:
+            common = Path(os.path.commonpath(list(resolved)))
+        except ValueError as err:
+            # Different drives / mixed absolute-relative: no common ancestor.
+            raise ValueError(
+                "Docker-mode builds require all <output-targets> to share a "
+                "common parent directory so they can be mounted together at "
+                f"/workspace. Targets resolve to unrelated roots: {sorted_roots}. "
+                "Build each target separately with `--targets <name>`, or place "
+                "the target output roots under a shared parent."
+            ) from err
+
+        # Refuse to bind-mount an entire volume: if the only shared ancestor is
+        # a drive/filesystem root, the mount would expose far more than the
+        # build output. Treat it like the no-common-ancestor case.
+        if common == common.parent:
+            raise ValueError(
+                "Docker-mode builds would have to mount a whole drive to cover "
+                f"these <output-targets>: {sorted_roots}. Build each target "
+                "separately with `--targets <name>`, or place the target "
+                "output roots under a shared parent directory."
+            )
+        return common
 
     @property
     def topics(self) -> list[Topic]:

--- a/tests/core/test_multi_target_course.py
+++ b/tests/core/test_multi_target_course.py
@@ -5,6 +5,7 @@ import io
 from pathlib import Path
 
 import pytest
+from attrs import evolve
 
 from clm.core.course import Course
 from clm.core.course_spec import (
@@ -791,3 +792,118 @@ class TestProcessJupyterLiteForTargets:
         # output_dir is the parent of the jupyterlite spec's output_dir
         # (i.e. not inside a per-kind subfolder).
         assert "completed" not in op.output_dir.parts  # type: ignore[attr-defined]
+
+
+class TestCourseWorkspaceRoot:
+    """Tests for ``Course.workspace_root`` — the Docker /workspace mount base.
+
+    Regression coverage for issue #384: a multi-target Docker build mounted
+    only the first target's root, so writes under other targets failed path
+    conversion. ``workspace_root`` must cover *every* target root.
+    """
+
+    @pytest.fixture
+    def course_root(self, tmp_path):
+        (tmp_path / "slides").mkdir()
+        return tmp_path
+
+    def _course(self, course_root, targets, *, output_root=None):
+        spec = CourseSpec(
+            name=Text(de="T", en="T"),
+            prog_lang="python",
+            description=Text(de="D", en="D"),
+            certificate=Text(de="C", en="C"),
+            sections=[],
+            github=GitHubSpec(),
+            output_targets=targets,
+        )
+        return Course.from_spec(spec, course_root, output_root=output_root)
+
+    def test_explicit_sibling_targets_use_common_ancestor(self, course_root):
+        """shared/trainer/speaker under ``output/`` → mount ``output/`` (#384).
+
+        ``output_root`` is the legacy primary (first target = ``output/shared``)
+        which does NOT contain the other targets — the bug. ``workspace_root``
+        must be their common parent so the Docker mount reaches all of them.
+        """
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(name="shared", path="./output/shared", kinds=["code-along"]),
+                OutputTargetSpec(name="trainer", path="./output/trainer", kinds=["completed"]),
+                OutputTargetSpec(name="speaker", path="./output/speaker", kinds=["speaker"]),
+            ],
+        )
+
+        # Precondition: the legacy primary is just the first target's root.
+        assert course.output_root == (course_root / "output" / "shared").resolve()
+
+        # The fix: cover all three targets.
+        assert course.workspace_root == (course_root / "output").resolve()
+        for target in course.output_targets:
+            # Every target root is reachable from the mounted workspace.
+            target.output_root.relative_to(course.workspace_root)
+
+    def test_single_target_workspace_is_sole_root(self, course_root):
+        """One target → ``workspace_root`` equals that root (no behavior change)."""
+        course = self._course(
+            course_root,
+            [OutputTargetSpec(name="only", path="./output/only", kinds=["completed"])],
+        )
+        assert course.workspace_root == course.output_root
+        assert course.workspace_root == (course_root / "output" / "only").resolve()
+
+    def test_default_structure_workspace_is_umbrella_output(self, course_root):
+        """No explicit targets → default shared/trainer/speaker under ``output/``.
+
+        Here ``output_root`` is already the umbrella ``output/`` so the build
+        was never broken, and ``workspace_root`` agrees with it.
+        """
+        spec = CourseSpec(
+            name=Text(de="T", en="T"),
+            prog_lang="python",
+            description=Text(de="D", en="D"),
+            certificate=Text(de="C", en="C"),
+            sections=[],
+            github=GitHubSpec(),
+        )
+        course = Course.from_spec(spec, course_root, output_root=None)
+        assert [t.name for t in course.output_targets] == ["shared", "trainer", "speaker"]
+        assert course.workspace_root == (course_root / "output").resolve()
+        assert course.workspace_root == course.output_root.resolve()
+
+    def test_cli_output_dir_targets_share_override_root(self, course_root):
+        """``--output-dir`` re-roots every target under ``DIR/<name>`` → common
+        ancestor is ``DIR`` (this case already worked; guard against regression)."""
+        output_dir = course_root / "cli_out"
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(name="a", path="./output/a", kinds=["completed"]),
+                OutputTargetSpec(name="b", path="./output/b", kinds=["speaker"]),
+            ],
+            output_root=output_dir,
+        )
+        assert course.workspace_root == output_dir.resolve()
+
+    def test_targets_with_no_common_parent_raise_actionable_error(self, course_root, monkeypatch):
+        """Targets that share only a drive/filesystem root must fail fast with
+        an actionable message, not silently mount a whole volume (#384)."""
+        # Two targets whose only common ancestor is the filesystem root.
+        course = self._course(
+            course_root,
+            [
+                OutputTargetSpec(name="a", path="./output/a", kinds=["completed"]),
+                OutputTargetSpec(name="b", path="./output/b", kinds=["speaker"]),
+            ],
+        )
+        # Force the resolved roots to be drive-root children so the common
+        # ancestor is the root itself, exercising the volume-mount guard.
+        root = Path(course_root.anchor or "/")
+        course.output_targets = [
+            evolve(course.output_targets[0], output_root=(root / "alpha")),
+            evolve(course.output_targets[1], output_root=(root / "beta")),
+        ]
+
+        with pytest.raises(ValueError, match="whole drive|common parent|--targets"):
+            _ = course.workspace_root

--- a/tests/infrastructure/workers/test_path_conversion.py
+++ b/tests/infrastructure/workers/test_path_conversion.py
@@ -405,3 +405,44 @@ class TestConvertOutputPathToContainer:
 
         # Should fall back to data_dir since path is under test-data, not output
         assert result == Path("/source/slides/module_000/topic_100/img/my_diag.png")
+
+
+class TestMultiTargetWorkspace:
+    """Regression tests for issue #384.
+
+    A multi-target Docker build mounts the common ancestor of all target
+    roots at /workspace (``Course.workspace_root``). With that wider mount,
+    every target's writes — not just the first target's — must convert
+    cleanly. Before the fix, the workspace was the first target's root
+    (``output/shared``) and writes under ``output/speaker`` raised
+    "is not under ...".
+    """
+
+    def test_non_primary_target_path_converts_under_common_ancestor(self):
+        """An ``output/speaker`` write converts when the mount is ``output/``."""
+        host_workspace = r"C:\course\output"  # common ancestor of all targets
+        host_path = r"C:\course\output\speaker\cpp-tdd-de\Html\Recording\deck.html"
+
+        result = convert_host_path_to_container(host_path, host_workspace)
+
+        assert result == Path("/workspace/speaker/cpp-tdd-de/Html/Recording/deck.html")
+
+    def test_each_sibling_target_converts_under_common_ancestor(self):
+        """shared/trainer/speaker all resolve under a single ``output/`` mount."""
+        host_workspace = "/home/u/course/output"
+        for tier in ("shared", "trainer", "speaker"):
+            host_path = f"/home/u/course/output/{tier}/deck-de/Html/deck.html"
+            result = convert_host_path_to_container(host_path, host_workspace)
+            assert result == Path(f"/workspace/{tier}/deck-de/Html/deck.html")
+
+    def test_first_target_root_mount_drops_other_targets(self):
+        """The pre-fix mount (first target's root) fails on other targets.
+
+        This documents the exact #384 failure: with ``output/shared`` mounted,
+        an ``output/speaker`` path is not under the workspace.
+        """
+        host_workspace = "/home/u/course/output/shared"  # legacy primary
+        host_path = "/home/u/course/output/speaker/deck-de/Html/deck.html"
+
+        with pytest.raises(ValueError, match="is not under"):
+            convert_host_path_to_container(host_path, host_workspace)


### PR DESCRIPTION
## Summary

Fixes #384. A Docker-mode build (`--workers docker`) of a spec with multiple
`<output-targets>` wrote output only for the **first** target; every
notebook-worker job whose output lives under a different target's root failed
path conversion and was silently dropped:

```
ValueError: Path '…\output\speaker\…\Html\Recording\…html'
            is not under '…\output\shared'
```

## Root cause

The Docker worker bind-mounts a single host directory at `/workspace` and
exports it as `CLM_HOST_WORKSPACE` (`worker_executor.py`). Both come from
`course.output_root`, which — for an explicit multi-target spec with no
`--output-dir` — is deliberately the **first** target's root (the legacy
"primary"; `core/course.py`). So only `output/shared` is mounted, and a
notebook worker writing under `output/speaker` hits
`Path.relative_to(output/shared)` → `ValueError`. The mount must cover the
**union** of all target output roots, not one "primary".

(Direct mode is unaffected — no path translation. Single-target and the
default shared/trainer/speaker structure already had a covering `output_root`.)

## Fix

- **`Course.workspace_root`** (new property): the lowest host directory that
  contains *every* output-target root — the common ancestor (`os.path.commonpath`)
  of all target roots, or the sole root for single-target/default builds (so
  those are byte-for-byte unchanged). Raises an **actionable** error when the
  targets share no mountable common parent (different Windows drives) or would
  require mounting a whole drive, pointing at the `--targets <name>` workaround
  instead of the old cryptic deep-in-worker failure + silent data loss.
- **`build.py`**: a small `_resolve_worker_workspace_path()` helper returns
  `workspace_root` **only when a Docker notebook worker is actually running**
  (reusing the existing `_build_has_docker_notebook_worker` detection), else the
  historical `output_root`. This way Direct-mode builds never trip the new
  multi-target validation. Both the worker lifecycle manager (the mount) and the
  `SqliteBackend` use this value so the container's and host's path views agree.
- **No worker-protocol change.** `convert_host_path_to_container` already
  converts relative to whatever `CLM_HOST_WORKSPACE` is; widening the mount to
  the common ancestor makes every target resolve (`/workspace/speaker/…`, etc.).

### Design note

The issue floated two options: mount the common ancestor, or mount each target
root and select a base per job. The per-target route needs a host-root→mount
*map* threaded into the worker (a protocol change) plus per-job base selection.
The common-ancestor route is a single mount, no worker change, and covers every
realistic spec (the default structure and essentially all hand-written specs
already nest targets under a shared `output/`). The only topology it can't
serve — targets with no common parent — now fails fast with guidance.

## Tests

- `tests/core/test_multi_target_course.py::TestCourseWorkspaceRoot` — common
  ancestor for sibling targets, sole root for single-target, umbrella `output/`
  for the default structure, `--output-dir` override, and the actionable raise
  for no-common-parent / drive-root targets.
- `tests/infrastructure/workers/test_path_conversion.py::TestMultiTargetWorkspace`
  — regression: `output/speaker` paths convert under an `output/` mount; the
  pre-fix first-target mount is shown to fail (documents the exact #384 error).

All new tests pass; `ruff`, `mypy`, and the related suites are green
(`test_multi_target_course`, `test_path_conversion`, `test_build_command`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
