### PR TITLE
docs(release): use multi-channel addressing in examples (#390)

### DIFF
--- a/docs/user-guide/solution-release.md
+++ b/docs/user-guide/solution-release.md
@@ -127,6 +127,47 @@ are **disabled-inclusive** — an `enabled="false"` section still consumes its
 index, and a selected-but-disabled section is reported and skipped rather than
 silently shifting which topics get released.
 
+## Releasing to several channels at once
+
+A cohort often spans **several** channels — e.g. `materials` and `solutions`
+streams, each in German and English, is four channels feeding the same group.
+Rather than repeat a command once per channel, `add`, `week`, `status`, and
+`sync` all accept more than one channel per invocation:
+
+```bash
+clm release channels course.xml                 # list the channel addresses first
+```
+
+```
+ADDRESS               LANG  SOURCE     LEDGER                            DEST
+materials/2026-04-de  de    shared     release/materials-2026-04-de.txt  cohorts/2026-04/de
+materials/2026-04-en  en    shared     release/materials-2026-04-en.txt  cohorts/2026-04/en
+solutions/2026-04-de  de    completed  release/solutions-2026-04-de.txt  cohorts/2026-04/de
+solutions/2026-04-en  en    completed  release/solutions-2026-04-en.txt  cohorts/2026-04/en
+```
+
+The `ADDRESS` column is exactly what `--channel` matches. Select many at once
+three ways:
+
+```bash
+# Glob — fnmatch against the address (quote it so the shell doesn't expand it):
+clm release add course.xml deep_dive --channel 'materials/*'
+clm release add course.xml deep_dive --channel '*/2026-04-de'
+
+# Repeat --channel:
+clm release add course.xml deep_dive --channel materials/2026-04-de --channel solutions/2026-04-de
+
+# Or every channel of every stream:
+clm release add course.xml deep_dive --all-channels
+```
+
+Matched channels are de-duplicated and processed in spec order; each one prints
+under its own `[address]` header. A single exact `--channel NAME` behaves
+exactly as before, and explicit `--ledger`/`--source`/`--dest` remain
+single-channel (they cannot be combined with a glob or `--all-channels`).
+`clm release channels` is the canonical list of what a glob will match — `--json`
+emits the same rows for scripting.
+
 ## Checking what's released
 
 ```bash
@@ -208,6 +249,23 @@ same `clm build` so evergreen files don't ping-pong between builds. See
 `clm info releases` ("Shared destination") for the full rules and the
 trade-offs vs separate repos, and `clm info migration` for merging the repos
 of a running cohort.
+
+With both language channels per stream, the pre-session materials and the
+post-workshop solutions each become a one-line release across the whole cohort:
+
+```bash
+# Before the session: release this week's materials to both languages and push.
+clm release week course.xml idx:3 --channel 'materials/*'
+clm release sync course.xml --channel 'materials/*' --push
+
+# After the workshop: the matching solutions, both languages, in one shot.
+clm release week course.xml idx:3 --channel 'solutions/*'
+clm release sync course.xml --channel 'solutions/*' --push
+```
+
+`sync` already iterates internally for the shared-destination overlap check, so
+a glob/`--all-channels` sync promotes each channel in turn under its own
+`=== address ===` header.
 
 ## How `clm git --channel` differs from ordinary `clm git`
 

--- a/docs/user-guide/spec-file-reference.md
+++ b/docs/user-guide/spec-file-reference.md
@@ -979,8 +979,10 @@ recover. The manifest is private and is excluded from every distributed repo by
 `clm git`; the per-cohort, per-stream **frozen manifest**
 (`.clm-released.<stream>.json`; legacy `.clm-released.json` for a single
 unnamed block) *does* ship in the channel repo as the freeze record. Drive the workflow with `clm release`
-(`add` / `week` / `status` / `sync`) and `clm git --channel` (init/commit/push
-the cohort repos); run `clm info commands` for both.
+(`add` / `week` / `status` / `sync` — each takes a single `--channel`, a glob
+like `--channel 'materials/*'`, or `--all-channels` to hit many cohorts at once;
+`clm release channels` lists the addresses) and `clm git --channel`
+(init/commit/push the cohort repos); run `clm info commands` for both.
 
 ---
 

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -36,6 +36,25 @@ what you would type at the prompt. `{spec}` expands to the absolute path of
 the spec file passed to `clm run`. See `clm info spec-files` for the full
 element reference (placeholders, quoting, path rules).
 
+### Releasing to every channel in one step
+
+Because `clm release` accepts a glob or `--all-channels` (see
+[Per-Topic Solution Release](solution-release.md#releasing-to-several-channels-at-once)),
+a release routine for a multi-channel cohort stays a fixed handful of steps
+instead of growing one `release sync` per channel:
+
+```xml
+<task name="weekly-release" description="Build, then release this week to every cohort channel">
+    <step>build {spec} --provenance-manifest</step>
+    <step>release sync {spec} --all-channels --push</step>
+</task>
+```
+
+The single `--all-channels` step promotes and pushes each channel in turn — a
+four-channel cohort no longer needs four near-identical steps. Use a glob
+(`release sync {spec} --channel 'materials/*' --push`) when a task should target
+just one stream.
+
 ## Running tasks
 
 ```bash

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -344,6 +344,12 @@ the cohort repo. A frozen topic is never re-propagated unless you pass
 `--refreeze`. Full command reference: `clm info commands` → `clm release` and
 `clm git`.
 
+When a cohort spans several channels (e.g. `materials`/`solutions` streams in
+two languages), `add`/`week`/`status`/`sync` take a glob or `--all-channels` so
+step 4 stays one command instead of one per channel (CLM {version}+):
+`clm release sync course.xml --all-channels --push`. List the addresses with
+`clm release channels course.xml`.
+
 ## Per-stream frozen manifests / shared destination repos (issue #325, {version} — auto-migrating)
 
 Channels of **different** release streams may now share one destination `path`,

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -945,14 +945,19 @@ Argument rules (CLM {version}+):
 
 ```xml
 <task name="release-week">
-    <step>release week {spec} {args} --channel materials/2026-04-de</step>
-    <step>release week {spec} {args} --channel materials/2026-04-en</step>
+    <step>release week {spec} {args} --channel 'materials/*'</step>
 </task>
 ```
 
 ```bash
 clm run release-week course.xml "name:Week 09"
 ```
+
+The `--channel 'materials/*'` glob (CLM {version}+) releases the week to every
+`materials` channel — both language cohorts here — in one step, replacing the
+per-channel repetition (`--channel materials/2026-04-de` then `…-en`) the task
+would otherwise need. Use `--all-channels` to span every stream, or `{1}` to
+build the address from an argument (`--channel=materials/{1}`).
 
 **Rules**:
 


### PR DESCRIPTION
Follow-up to #391 (now merged). Walks the documentation and updates/extends the `clm release` examples to use the new multi-channel form — globs, repeated `--channel`, and `--all-channels` — wherever they previously implied or showed one command per channel.

## Changes

- **`docs/user-guide/solution-release.md`** — new **"Releasing to several channels at once"** section (`clm release channels` listing + glob / repeat / `--all-channels`, with the four-channel `materials`/`solutions` × `de`/`en` cohort as the motivating case). The shared-repo multi-stream section gains a one-shot `release week`/`release sync --channel 'materials/*'` (then `'solutions/*'`) example.
- **`docs/user-guide/tasks.md`** — a `weekly-release` `<task>` whose single `release sync --all-channels --push` step replaces the per-channel repetition the issue called out.
- **`spec-files.md` info topic** — the `release-week` task example collapses from two near-identical steps (`--channel materials/2026-04-de` then `…-en`) to one `--channel 'materials/*'` step (still demonstrating the `{args}` placeholder, the section's point).
- **`migration.md` info topic** + **`spec-file-reference.md`** — point at the glob / `--all-channels` / `release channels` shortcuts from the adoption walkthrough and the `<release-channels>` summary.

Docs-only; no code changes. `{version}` placeholders render to 1.14.0; info-topic rendering tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
