### PR TITLE
fix(git): guard is_behind_remote against empty rev-list output

### DIFF
--- a/changelog.d/git-sync-dry-run-empty-revlist.fixed.md
+++ b/changelog.d/git-sync-dry-run-empty-revlist.fixed.md
@@ -1,0 +1,5 @@
+- Fixed a crash (`ValueError: invalid literal for int()`) in `clm git sync`
+  (and `clm release sync --push`) when the remote-ahead check ran against
+  empty `git rev-list` output — most visibly under `--dry-run`, where the
+  mocked git call returns no stdout. The behind-remote count now treats empty
+  output as "not behind" instead of parsing it as an integer.

--- a/src/clm/cli/commands/git.py
+++ b/src/clm/cli/commands/git.py
@@ -241,7 +241,14 @@ def is_behind_remote(repo_path: Path, branch: str = "master") -> tuple[bool, int
     if result.returncode != 0:
         return False, 0
 
-    count = int(result.stdout.strip())
+    # Guard against empty output: git can print nothing here (e.g. the mock
+    # result returned in dry-run mode, or an unusual git state), and int("")
+    # would raise ValueError. Mirror get_remote_status()'s defensive parse.
+    out = result.stdout.strip()
+    if not out:
+        return False, 0
+
+    count = int(out)
     return count > 0, count
 
 

--- a/tests/cli/test_git_ops.py
+++ b/tests/cli/test_git_ops.py
@@ -847,6 +847,32 @@ class TestGitHelpers:
             assert behind is False
             assert count == 0
 
+    def test_is_behind_remote_empty_stdout(self, tmp_path: Path):
+        """Empty rev-list output must not raise (regression for dry-run crash).
+
+        In dry-run mode run_git returns a mock with returncode=0 and an empty
+        stdout; int("") previously raised ValueError. Treat empty output as
+        'not behind'.
+        """
+        with patch("clm.cli.commands.git.run_git") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # fetch
+                MagicMock(returncode=0, stdout=""),  # rev-list (empty)
+            ]
+            behind, count = is_behind_remote(tmp_path, "main")
+            assert behind is False
+            assert count == 0
+
+    def test_is_behind_remote_in_dry_run_mode(self, tmp_path: Path):
+        """is_behind_remote must not crash under the real dry-run mock path."""
+        _dry_run_mode.set(True)
+        try:
+            behind, count = is_behind_remote(tmp_path, "")
+            assert behind is False
+            assert count == 0
+        finally:
+            _dry_run_mode.set(False)
+
 
 class TestFindOutputRepos:
     """Tests for find_output_repos function."""


### PR DESCRIPTION
## Problem

`clm git sync --dry-run` (and `clm release sync --push`) crashed with:

```
ValueError: invalid literal for int() with base 10: ''
```

reproduced via:

```
clm git sync .\course-specs\machine-learning-azav-2026-04.xml -m "Add solutions week 8" --all-channels --dry-run
```

## Root cause

In dry-run mode, `run_git` returns a **mock** `CompletedProcess` with `returncode=0` and `stdout=""` — git is never executed. The chain:

1. `get_current_branch` returns `""` (empty mock stdout) — hence the `origin/` with no branch name in the dry-run output.
2. `is_behind_remote` runs the mocked `rev-list`, gets `returncode=0`, **passes** the returncode guard, then calls `int("")` → `ValueError`.

`is_behind_remote` was the only remote-status helper missing the empty-output guard that `get_remote_status` already applies to every `int()` parse.

## Fix

Treat empty `rev-list` output as "not behind" (`return False, 0`), mirroring `get_remote_status`'s defensive parse. Also covers any real git state that prints nothing.

Added regression tests for the empty-stdout path and the real `_dry_run_mode` path, plus a changelog fragment.

## Testing

- `pytest tests/cli/test_git_ops.py` — 99 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
