### PR TITLE
feat(serve): Mobile Deck Studio P0/P1 — phone authoring with concurrency core

### DIFF
--- a/changelog.d/395-mobile-deck-studio-p0p1.added.md
+++ b/changelog.d/395-mobile-deck-studio-p0p1.added.md
@@ -1,0 +1,15 @@
+- **Mobile Deck Studio (P0/P1).** `clm serve --spec course.xml` now serves a
+  phone-friendly authoring surface at `/studio/` alongside the jobs Monitor:
+  browse the spec-resolved deck tree (with recents and a "not in spec" bucket),
+  full-text search deck titles and cell text, open a deck, and edit cell
+  bodies/tags. Writes go through CLM's byte-exact write-back engine and are
+  guarded by **optimistic concurrency** — each carries the deck and cell
+  versions the phone last saw, so a concurrent desktop edit (e.g. VS Code)
+  returns HTTP 409 "changed elsewhere" instead of silently clobbering; a
+  filesystem watcher additionally pushes a "changed on disk — reload" signal
+  over the WebSocket. Startup prints the Studio URL plus a scannable QR code
+  carrying a persistent bearer token (`--rotate-token` cycles it). Cells are
+  addressed by stable `(slide_id, role)` identity, never by index. Structural
+  ops, the bilingual language lock + sync-to-other-language, and the installable
+  offline PWA are planned later phases. Design of record:
+  `docs/claude/design/mobile-deck-studio.md`.

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -1,8 +1,9 @@
 # Mobile Deck Studio — authoring a course from a phone
 
-> **Status:** plan of record (not yet implemented). Chosen over the
-> `clm edit` prototype (PR #394, closed as superseded). See §9 for the
-> decision record and implementation steering notes.
+> **Status:** plan of record. **P0 + P1 implemented** (read-only browse +
+> the cell-editing concurrency core); P2–P4 not yet implemented. Chosen over
+> the `clm edit` prototype (PR #394, closed as superseded). See §9 for the
+> decision record, implementation steering notes, and the P0/P1 build record.
 > **Date:** 2026-06-20.
 > **Author:** design draft, worked through interactively.
 > **Scope:** a new **Studio** view on the existing `clm serve` web app
@@ -225,8 +226,8 @@ structural op. No naïve whole-file re-emit.
 
 | Phase | Delivers |
 |---|---|
-| **P0** | `clm serve` **Studio view** + Tailscale-HTTPS / QR / token auth scaffold; navigation (Recents, search, tree with badges, "Not in spec"); open a deck; **read-only** cell render (client markdown + server-side `is_j2` render); full-text search. Reuses `parse_cells`, `course decks`/`orphans`, `slides search`. No writes. |
-| **P1** | **Cell body/tag editing** + the **concurrency core**: optimistic `deck_version` + `cell_hash` (409/423), atomic `FileState` write-back, `watchfiles` external-change watcher, autosave + 409/disk-change UX. The safety keystone — built and tested first. |
+| **P0** ✅ | `clm serve` **Studio view** + Tailscale-HTTPS / QR / token auth scaffold; navigation (Recents, search, tree with badges, "Not in spec"); open a deck; **read-only** cell render (client markdown + server-side `is_j2` render); full-text search. Reuses `parse_cells`, `course decks`/`orphans`, `slides search`. No writes. *(Implemented — `is_j2` server render scaffolded; see §9.6.)* |
+| **P1** ✅ | **Cell body/tag editing** + the **concurrency core**: optimistic `deck_version` + `cell_hash` (409/423), atomic `FileState` write-back, `watchfiles` external-change watcher, autosave + 409/disk-change UX. The safety keystone — built and tested first. *(Implemented; 423 language-lock deferred to P3 — see §9.6.)* |
 | **P2** | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. |
 | **P3** | **Bilingual**: language-view + watermark-derived lock + Discard/unlock + **Sync-to-other-language** (server-side `sync` / `translate` / `assign-ids`, streamed over WS); stale badges. |
 | **P4** | **Build-preview** (tier-2 no-exec deck render streamed over WS) + installable PWA + **read-only offline cache** of the last-opened deck. |
@@ -373,3 +374,52 @@ Extend the existing `clm serve` app (`clm.web`) rather than adding a standalone
 command: it already ships the WebSocket, lifespan, and `watchfiles` plumbing,
 and the watcher *is* the two-editor guard, so sharing it is the cheaper path.
 Record the decision explicitly at P0.
+
+### 9.6 P0/P1 build record (2026-06-20)
+
+P0 + P1 shipped together. Layout: backend in `src/clm/web/studio/`
+(`service.py` = the engine + concurrency core, `routes.py` = `/api/studio/*`,
+`auth.py` = persistent bearer token, `qr.py` = lifted segno helper,
+`watcher.py` = `watchfiles` guard, `models.py` = wire models); lightweight
+frontend in `src/clm/web/static/studio/`; tests in `tests/web/studio/`.
+Enabled by `clm serve --spec course.xml`, mounted at `/studio/`. Decisions
+taken while building, several resolving open calls left by §9.1–§9.5:
+
+- **Integration (§9.5):** confirmed — Studio is opt-in on `clm serve` via
+  `--spec`; the Monitor view is unaffected when `--spec` is absent. The
+  lifespan starts the `watchfiles` watcher only when a spec is configured.
+- **Frontend (§9.4):** took the lightening option — P0/P1 ship a **vanilla-JS**
+  mobile surface (`index.html` + `app.js`, no build, no CodeMirror/Preact). It
+  exercises the full backend contract (browse, search, open, edit with 409 +
+  disk-change banner). The no-build Preact + vendored CodeMirror 6 PWA is
+  **deferred to P2+**, where structural editing makes the editor investment pay
+  off. Migration path is unchanged (§3.1).
+- **Cell addressing — the safety refinement:** `FileState.find_cell` keys by
+  `(slide_id, role)` and **ignores language**, returning the first match. CLM
+  ships decks as per-language `.de.py` / `.en.py` files, so the key is unique
+  per file in practice; to stay safe against a *genuinely interleaved* deck
+  where de+en share a `slide_id`, a cell is marked `editable` **only when its
+  `(slide_id, role)` is unique in the file**. Colliding keys are read-only in
+  P1 (bilingual editing is P3). Id-less cells (language-neutral/structural code)
+  are also read-only until id-minting lands in P2.
+- **Concurrency guard:** `deck_version` = first 16 hex of the whole-file SHA-256;
+  `cell_hash` = `cell_content_hash` of the target body. Both are validated
+  before any write (deck first, then cell), and **recomputed from disk after
+  flush** so the values returned to the phone exactly match a subsequent open.
+  The `423` language-lock path is **deferred to P3** (it needs the watermark
+  derivation); the route layer is shaped for it.
+- **Self-write echo suppression:** after a Studio write the service records a
+  short (`SELF_WRITE_WINDOW_SECONDS`) window so the watcher does not report the
+  app's *own* save back to the phone as an external "changed on disk" event.
+- **Tier-2 render scaffolded:** the working preview is **tier-1 client-side
+  markdown**. `POST /api/studio/deck/render-cell` exists but echoes the body
+  with `rendered=false`; wiring the jupytext+Jinja no-exec expansion for
+  `is_j2` cells is a focused follow-up (still inside the P0 design scope).
+- **WS auth:** REST is fully token-gated; the shared `/ws` endpoint is not yet
+  token-checked (it carries only low-sensitivity `deck-changed-on-disk`
+  notifications, no deck content). Gating WS without disrupting the Monitor
+  channel is a follow-up.
+- **Reuse (§9.3):** only `qr.py` was lifted from the closed #394 branch (with
+  the `[edit]`→`[web]` adaptation); the byte-exact "untouched cells unchanged"
+  test pattern was re-authored against `FileState`. `DeckFile`, routes, and
+  templates were **not** reused.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,8 @@ tui = [
 web = [
     "wsproto>=1.2.0",  # Use wsproto instead of websockets to avoid deprecation warnings
     "httptools>=0.6.2",  # HTTP protocol handling
-    "watchfiles>=0.18.0",  # For --reload support
+    "watchfiles>=0.18.0",  # For --reload support + the Studio external-change watcher
+    "segno>=1.6.0",  # Pure-Python QR codes for Mobile Deck Studio pairing
 ]
 # Everything
 all = [

--- a/src/clm/cli/commands/serve.py
+++ b/src/clm/cli/commands/serve.py
@@ -40,17 +40,33 @@ logger = logging.getLogger(__name__)
     multiple=True,
     help="CORS allowed origins (can specify multiple times, default: *)",
 )
-def serve(host, port, jobs_db_path, no_browser, reload, cors_origin):
+@click.option(
+    "--spec",
+    "spec_path",
+    type=click.Path(exists=True, path_type=Path),
+    help="Enable the Mobile Deck Studio scoped to this course spec (one course "
+    "per server instance).",
+)
+@click.option(
+    "--rotate-token",
+    is_flag=True,
+    help="Rotate the persistent Studio pairing token (invalidates old QR codes).",
+)
+def serve(host, port, jobs_db_path, no_browser, reload, cors_origin, spec_path, rotate_token):
     """Start web dashboard server.
 
     Launches FastAPI server with REST API and WebSocket support for
-    remote monitoring via web browser.
+    remote monitoring via web browser. With ``--spec`` it additionally serves
+    the Mobile Deck Studio — a phone-friendly authoring surface for the given
+    course's decks (browse, search, and edit cells with byte-exact write-back
+    and optimistic-concurrency guards against concurrent desktop edits).
 
     \b
     Examples:
         clm serve                           # Start on localhost:8000
         clm serve --host=0.0.0.0 --port=8080  # Bind to all interfaces
         clm serve --jobs-db-path=/data/clm_jobs.db  # Custom database
+        clm serve --spec course.xml         # Also enable Mobile Deck Studio
     """
     try:
         import uvicorn
@@ -76,6 +92,13 @@ def serve(host, port, jobs_db_path, no_browser, reload, cors_origin):
         click.echo("The server will start, but data will be unavailable.", err=True)
         click.echo("Run 'clm build course.xml' to initialize the system.", err=True)
 
+    # Studio pairing token (persistent across restarts so the QR stays valid).
+    studio_token: str | None = None
+    if spec_path is not None:
+        from clm.web.studio.auth import get_or_create_token
+
+        studio_token = get_or_create_token(rotate=rotate_token)
+
     # Create app
     cors_origins: list[str] | None = list(cors_origin) if cors_origin else None
     app = create_app(
@@ -83,7 +106,28 @@ def serve(host, port, jobs_db_path, no_browser, reload, cors_origin):
         host=host,
         port=port,
         cors_origins=cors_origins,
+        spec_path=spec_path,
+        studio_token=studio_token,
     )
+
+    # Mobile Deck Studio pairing: print the URL + a scannable QR code.
+    if spec_path is not None and studio_token is not None:
+        from clm.web.studio import qr
+
+        display_host = host if host != "0.0.0.0" else "localhost"
+        studio_url = f"http://{display_host}:{port}/studio/?token={studio_token}"
+        click.echo("")
+        click.echo(f"Mobile Deck Studio: {studio_url}")
+        if qr.is_available():
+            click.echo("Scan to pair a phone (or open the URL above):")
+            qr.print_terminal(studio_url)
+        else:
+            click.echo("(install the [web] extra's 'segno' for a scannable QR code)")
+        click.echo(
+            "Note: for phone access over Tailscale, run 'tailscale serve' so the "
+            "PWA gets a trusted HTTPS origin."
+        )
+        click.echo("")
 
     # Open browser
     if not no_browser:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3980,7 +3980,41 @@ publish a heartbeat and do not get the second line.
 
 ### `clm serve`
 
-Start web dashboard server. Requires `clm[web]` extra.
+Start the web dashboard server (jobs/workers Monitor). Requires the
+`clm[web]` extra.
+
+| Option | Description |
+|--------|-------------|
+| `--host HOST` | Host to bind to (default: `127.0.0.1`; `0.0.0.0` for all interfaces). |
+| `--port PORT` | Port to bind to (default: `8000`). |
+| `--jobs-db-path PATH` | Job-queue database (auto-detected if omitted). |
+| `--no-browser` | Do not auto-open a browser. |
+| `--reload` | Enable auto-reload for development. |
+| `--cors-origin ORIGIN` | CORS allowed origin (repeatable; default `*`). |
+| `--spec SPEC_FILE` | Also enable the **Mobile Deck Studio** scoped to this course spec. |
+| `--rotate-token` | Rotate the persistent Studio pairing token (invalidates old QR codes). |
+
+**Mobile Deck Studio** (`--spec`): a phone-friendly authoring surface for the
+given course's decks, served alongside the Monitor at `/studio/`. Browse the
+spec-resolved deck tree (plus recents and a "not in spec" bucket), search deck
+titles and cell text, open a deck, and edit cell bodies/tags. Edits are written
+through CLM's byte-exact write-back engine and guarded by **optimistic
+concurrency**: each write carries the deck and cell versions the phone last saw,
+and a concurrent desktop (e.g. VS Code) edit yields HTTP 409 "changed elsewhere"
+rather than a silent clobber. A filesystem watcher also pushes a
+"changed on disk — reload" signal over the WebSocket. On startup the command
+prints the Studio URL and a scannable QR code carrying a persistent bearer
+token; for phone access over Tailscale, run `tailscale serve` so the PWA gets a
+trusted HTTPS origin.
+
+This is the P0/P1 slice (read-only browse + the cell-editing concurrency core).
+Structural insert/delete/move, the bilingual language lock + sync-to-other-
+language, and the installable offline PWA are planned later phases.
+
+```bash
+clm serve                      # Monitor only, on localhost:8000
+clm serve --spec course.xml    # Monitor + Mobile Deck Studio at /studio/
+```
 
 ### `clm zip`
 

--- a/src/clm/web/app.py
+++ b/src/clm/web/app.py
@@ -30,10 +30,27 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     # import asyncio
     # asyncio.create_task(ws_manager.send_periodic_updates(app.state.monitor_service))
 
+    # Start the Studio external-change watcher (the two-editor guard) when a
+    # course spec was configured (clm serve --spec).
+    import asyncio
+
+    watcher_task = None
+    studio_service = getattr(app.state, "studio_service", None)
+    if studio_service is not None:
+        from clm.web.studio.watcher import watch_slides_dir
+
+        watcher_task = asyncio.create_task(watch_slides_dir(studio_service))
+
     yield
 
     # Shutdown
     logger.info("Shutting down CLM Dashboard Server...")
+    if watcher_task is not None:
+        watcher_task.cancel()
+        try:
+            await watcher_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 - best-effort stop
+            pass
 
 
 def create_app(
@@ -41,6 +58,8 @@ def create_app(
     host: str = "127.0.0.1",
     port: int = 8000,
     cors_origins: list[str] | None = None,
+    spec_path: Path | None = None,
+    studio_token: str | None = None,
 ) -> FastAPI:
     """Create and configure FastAPI application.
 
@@ -49,6 +68,10 @@ def create_app(
         host: Host to bind to
         port: Port to bind to
         cors_origins: CORS allowed origins
+        spec_path: When given, enable the Mobile Deck Studio view scoped to this
+            course spec (one course per server instance).
+        studio_token: Bearer token required by the Studio API/WS (ignored when
+            ``spec_path`` is None).
 
     Returns:
         Configured FastAPI application
@@ -67,6 +90,23 @@ def create_app(
 
     # Initialize monitor service
     app.state.monitor_service = MonitorService(db_path=db_path)
+
+    # Enable Mobile Deck Studio when a course spec was provided.
+    if spec_path is not None:
+        from clm.web.studio.routes import router as studio_router
+        from clm.web.studio.service import StudioService
+
+        app.state.studio_service = StudioService(spec_path)
+        app.state.studio_token = studio_token
+        app.include_router(studio_router)
+
+        studio_static = Path(__file__).parent / "static" / "studio"
+        if studio_static.exists():
+            app.mount(
+                "/studio",
+                StaticFiles(directory=studio_static, html=True),
+                name="studio",
+            )
 
     # Configure CORS
     if cors_origins is None:

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -1,0 +1,286 @@
+/*
+ * Mobile Deck Studio — P0/P1 lightweight frontend.
+ *
+ * Per design §9.4 this is intentionally a vanilla-JS surface (no build, no
+ * CodeMirror/Preact yet); the no-build Preact + CodeMirror PWA is deferred to
+ * P2+ where in-cell editing ergonomics start to pay off. It exercises the full
+ * backend contract: browse (tree/recents/orphans), search, open deck, and cell
+ * editing with optimistic-concurrency guards + the disk-change banner.
+ */
+"use strict";
+
+const TOKEN_KEY = "clm_studio_token";
+
+// --- token: from ?token= (QR deep link) then localStorage ---------------------
+function resolveToken() {
+  const url = new URL(window.location.href);
+  const fromQuery = url.searchParams.get("token");
+  if (fromQuery) {
+    localStorage.setItem(TOKEN_KEY, fromQuery);
+    url.searchParams.delete("token");
+    window.history.replaceState({}, "", url.pathname + url.hash);
+    return fromQuery;
+  }
+  return localStorage.getItem(TOKEN_KEY) || "";
+}
+
+let TOKEN = resolveToken();
+
+// --- API ----------------------------------------------------------------------
+async function api(path, opts = {}) {
+  const headers = Object.assign({ Authorization: "Bearer " + TOKEN }, opts.headers || {});
+  if (opts.body) headers["Content-Type"] = "application/json";
+  const res = await fetch("/api/studio" + path, Object.assign({}, opts, { headers }));
+  if (!res.ok) {
+    let detail;
+    try { detail = (await res.json()).detail; } catch { detail = res.statusText; }
+    const err = new Error(typeof detail === "string" ? detail : JSON.stringify(detail));
+    err.status = res.status;
+    err.detail = detail;
+    throw err;
+  }
+  return res.json();
+}
+
+// --- tiny markdown renderer (tier-1 client preview) ---------------------------
+function esc(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function renderMarkdown(src) {
+  const lines = src.split("\n");
+  const out = [];
+  let inCode = false, inList = false;
+  const flushList = () => { if (inList) { out.push("</ul>"); inList = false; } };
+  for (const line of lines) {
+    if (/^```/.test(line)) {
+      if (!inCode) { flushList(); out.push("<pre><code>"); inCode = true; }
+      else { out.push("</code></pre>"); inCode = false; }
+      continue;
+    }
+    if (inCode) { out.push(esc(line)); continue; }
+    const h = line.match(/^(#{1,6})\s+(.*)$/);
+    if (h) { flushList(); out.push(`<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`); continue; }
+    const li = line.match(/^\s*[-*]\s+(.*)$/);
+    if (li) { if (!inList) { out.push("<ul>"); inList = true; } out.push(`<li>${inline(li[1])}</li>`); continue; }
+    if (line.trim() === "") { flushList(); continue; }
+    flushList();
+    out.push(`<p>${inline(line)}</p>`);
+  }
+  flushList();
+  if (inCode) out.push("</code></pre>");
+  return out.join("\n");
+}
+function inline(s) {
+  return esc(s)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+}
+
+// --- UI helpers ---------------------------------------------------------------
+const appEl = document.getElementById("app");
+const titleEl = document.getElementById("title");
+const backEl = document.getElementById("back");
+const toastEl = document.getElementById("toast");
+let toastTimer = null;
+function toast(msg) {
+  toastEl.textContent = msg;
+  toastEl.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toastEl.classList.remove("show"), 2200);
+}
+function el(html) { const t = document.createElement("template"); t.innerHTML = html.trim(); return t.content.firstChild; }
+
+// --- state --------------------------------------------------------------------
+let currentDeck = null; // { deck_id, deck_version, cells: [...] }
+let diskChanged = false;
+
+// --- views --------------------------------------------------------------------
+async function showHome() {
+  currentDeck = null; diskChanged = false;
+  backEl.style.display = "none";
+  titleEl.textContent = "Mobile Deck Studio";
+  appEl.innerHTML = '<p class="muted">Loading decks&hellip;</p>';
+  if (!TOKEN) { appEl.innerHTML = '<div class="banner err">No pairing token. Re-scan the QR code from the desktop.</div>'; return; }
+
+  let tree;
+  try { tree = await api("/decks"); }
+  catch (e) { appEl.innerHTML = `<div class="banner err">Could not load decks: ${esc(e.message)}</div>`; return; }
+
+  appEl.innerHTML = "";
+  const search = el(`<input type="search" placeholder="Search decks & cells…" autocomplete="off" />`);
+  let searchTimer = null;
+  search.addEventListener("input", () => {
+    clearTimeout(searchTimer);
+    const q = search.value.trim();
+    searchTimer = setTimeout(() => renderSearch(q, results), 250);
+  });
+  appEl.appendChild(search);
+  const results = el(`<div></div>`);
+  appEl.appendChild(results);
+
+  if (tree.recents && tree.recents.length) {
+    appEl.appendChild(el(`<div class="section-title">Recent</div>`));
+    tree.recents.forEach((id) => appEl.appendChild(deckRow({ deck_id: id, filename: id.split("/").pop(), status: "present" })));
+  }
+
+  appEl.appendChild(el(`<div class="section-title">In spec</div>`));
+  const present = tree.decks.filter((d) => d.status === "present");
+  const missing = tree.decks.filter((d) => d.status === "missing");
+  if (!present.length) appEl.appendChild(el(`<p class="muted">No decks resolved.</p>`));
+  present.forEach((d) => appEl.appendChild(deckRow(d)));
+  missing.forEach((d) => appEl.appendChild(deckRow(d)));
+
+  if (tree.orphans && tree.orphans.length) {
+    appEl.appendChild(el(`<div class="section-title">Not in spec</div>`));
+    tree.orphans.forEach((d) => appEl.appendChild(deckRow(d)));
+  }
+}
+
+async function renderSearch(q, container) {
+  if (!q) { container.innerHTML = ""; return; }
+  try {
+    const res = await api("/search?q=" + encodeURIComponent(q));
+    container.innerHTML = `<div class="section-title">Results for &ldquo;${esc(q)}&rdquo;</div>`;
+    if (!res.hits.length) { container.appendChild(el(`<p class="muted">No matches.</p>`)); return; }
+    res.hits.forEach((h) => {
+      const title = h.title_en || h.title_de || h.topic_id;
+      h.deck_ids.forEach((id) =>
+        container.appendChild(deckRow({ deck_id: id, filename: id.split("/").pop(), topic_id: title, status: "present" })));
+    });
+  } catch (e) { container.innerHTML = `<div class="banner err">${esc(e.message)}</div>`; }
+}
+
+function deckRow(d) {
+  const openable = d.status !== "missing" && d.deck_id;
+  const node = el(`<div class="card deck-item row">
+      <div class="spacer">
+        <div><span class="chip ${d.status}">${d.status}</span>${esc(d.filename || d.deck_id)}</div>
+        ${d.topic_id ? `<div class="muted" style="font-size:.8rem">${esc(d.topic_id)}</div>` : ""}
+      </div>
+    </div>`);
+  if (openable) node.addEventListener("click", () => openDeck(d.deck_id));
+  else node.style.opacity = ".6";
+  return node;
+}
+
+async function openDeck(deckId) {
+  appEl.innerHTML = '<p class="muted">Opening&hellip;</p>';
+  try {
+    currentDeck = await api("/deck?id=" + encodeURIComponent(deckId));
+    diskChanged = false;
+    renderDeck();
+  } catch (e) {
+    appEl.innerHTML = `<div class="banner err">Could not open deck: ${esc(e.message)}</div>`;
+  }
+}
+
+function renderDeck() {
+  const deck = currentDeck;
+  backEl.style.display = "";
+  titleEl.textContent = deck.deck_id.split("/").pop();
+  appEl.innerHTML = "";
+  if (diskChanged) {
+    const b = el(`<div class="banner warn row">Changed on disk — reload to avoid conflicts.
+      <span class="spacer"></span></div>`);
+    const r = el(`<button>Reload</button>`);
+    r.addEventListener("click", () => openDeck(deck.deck_id));
+    b.appendChild(r);
+    appEl.appendChild(b);
+  }
+  deck.cells.forEach((cell, i) => appEl.appendChild(cellCard(cell, i)));
+}
+
+function cellCard(cell, idx) {
+  const langChip = cell.lang ? `<span class="chip">${cell.lang}</span>` : "";
+  const tagChips = (cell.tags || []).map((t) => `<span class="chip">${esc(t)}</span>`).join("");
+  const card = el(`<div class="cell ${cell.editable ? "editable" : ""}">
+      <div class="cell-head">
+        <span class="chip">${cell.cell_type}</span>${langChip}${tagChips}
+        <span class="spacer"></span>
+        ${cell.editable ? '<span class="muted">tap to edit</span>' : '<span class="muted">read-only</span>'}
+      </div>
+      <div class="cell-body"></div>
+    </div>`);
+  const body = card.querySelector(".cell-body");
+  if (cell.cell_type === "markdown") body.innerHTML = renderMarkdown(cell.body);
+  else body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
+  if (cell.editable) {
+    card.querySelector(".cell-head").addEventListener("click", () => editCell(cell, idx));
+  }
+  return card;
+}
+
+function editCell(cell, idx) {
+  if (diskChanged) { toast("Deck changed on disk — reload first."); return; }
+  appEl.innerHTML = "";
+  titleEl.textContent = "Edit " + (cell.slide_id || cell.role);
+  const ta = el(`<textarea></textarea>`);
+  ta.value = cell.body;
+  appEl.appendChild(el(`<div class="muted" style="margin-bottom:6px">${cell.cell_type} · ${esc(cell.slide_id || "")} · ${esc(cell.role || "")}</div>`));
+  appEl.appendChild(ta);
+  const actions = el(`<div class="edit-actions"></div>`);
+  const save = el(`<button>Save</button>`);
+  const cancel = el(`<button class="ghost">Cancel</button>`);
+  actions.appendChild(save); actions.appendChild(cancel);
+  appEl.appendChild(actions);
+  ta.focus();
+
+  cancel.addEventListener("click", renderDeck);
+  save.addEventListener("click", async () => {
+    save.disabled = true; cancel.disabled = true;
+    try {
+      const result = await api("/deck/edit-body", {
+        method: "POST",
+        body: JSON.stringify({
+          deck_id: currentDeck.deck_id,
+          slide_id: cell.slide_id,
+          role: cell.role,
+          new_body: ta.value,
+          expected_deck_version: currentDeck.deck_version,
+          expected_cell_hash: cell.content_hash,
+        }),
+      });
+      // Update in-memory state so further edits use fresh guards.
+      currentDeck.deck_version = result.deck_version;
+      cell.body = ta.value;
+      cell.content_hash = result.cell_hash;
+      toast("Saved");
+      renderDeck();
+    } catch (e) {
+      save.disabled = false; cancel.disabled = false;
+      if (e.status === 409) {
+        diskChanged = true;
+        toast("Changed elsewhere — reload.");
+        renderDeck();
+      } else if (e.status === 423) {
+        toast("Language locked — sync or discard first.");
+      } else {
+        toast("Save failed: " + e.message);
+      }
+    }
+  });
+}
+
+// --- WebSocket: disk-change notifications -------------------------------------
+function connectWs() {
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  let ws;
+  try { ws = new WebSocket(`${proto}://${location.host}/ws`); }
+  catch { return; }
+  ws.addEventListener("open", () => ws.send(JSON.stringify({ action: "subscribe", channels: ["studio"] })));
+  ws.addEventListener("message", (ev) => {
+    let msg; try { msg = JSON.parse(ev.data); } catch { return; }
+    if (msg.type === "deck-changed-on-disk" && currentDeck && msg.deck_id === currentDeck.deck_id) {
+      diskChanged = true;
+      renderDeck();
+    }
+  });
+  ws.addEventListener("close", () => setTimeout(connectWs, 3000));
+}
+
+// --- wiring -------------------------------------------------------------------
+backEl.addEventListener("click", showHome);
+document.getElementById("refresh").addEventListener("click", () => (currentDeck ? openDeck(currentDeck.deck_id) : showHome()));
+connectWs();
+showHome();

--- a/src/clm/web/static/studio/index.html
+++ b/src/clm/web/static/studio/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
+  <title>CLM — Mobile Deck Studio</title>
+  <style>
+    :root {
+      --bg: #ffffff; --fg: #1f2937; --muted: #6b7280; --line: #e5e7eb;
+      --accent: #2563eb; --card: #f9fafb; --warn-bg: #fef3c7; --warn-fg: #92400e;
+      --ok: #047857; --err: #b91c1c; --chip: #eef2ff; --chip-fg: #3730a3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --fg: #e2e8f0; --muted: #94a3b8; --line: #1e293b;
+        --accent: #60a5fa; --card: #1e293b; --warn-bg: #422006; --warn-fg: #fde68a;
+        --ok: #34d399; --err: #f87171; --chip: #1e293b; --chip-fg: #a5b4fc;
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 16px; line-height: 1.5; }
+    header { position: sticky; top: 0; z-index: 5; background: var(--bg);
+      border-bottom: 1px solid var(--line); padding: 10px 14px;
+      padding-top: max(10px, env(safe-area-inset-top)); display: flex;
+      align-items: center; gap: 10px; }
+    header h1 { font-size: 1rem; margin: 0; flex: 1; overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; }
+    button { font: inherit; background: var(--accent); color: #fff; border: 0;
+      border-radius: 8px; padding: 8px 12px; cursor: pointer; }
+    button.ghost { background: transparent; color: var(--accent); padding: 6px 8px; }
+    button:disabled { opacity: .5; cursor: not-allowed; }
+    main { padding: 12px 14px 40px; max-width: 820px; margin: 0 auto; }
+    input[type=search], textarea { width: 100%; font: inherit; color: var(--fg);
+      background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+      padding: 10px; }
+    textarea { min-height: 40vh; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: .92rem; }
+    .muted { color: var(--muted); }
+    .section-title { font-size: .78rem; text-transform: uppercase; letter-spacing: .04em;
+      color: var(--muted); margin: 18px 0 6px; }
+    .card { background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+      padding: 12px; margin: 8px 0; }
+    .row { display: flex; align-items: center; gap: 8px; }
+    .deck-item { cursor: pointer; }
+    .deck-item:active { background: var(--line); }
+    .chip { display: inline-block; font-size: .72rem; padding: 1px 7px; border-radius: 999px;
+      background: var(--chip); color: var(--chip-fg); margin-right: 4px; }
+    .chip.present { background: #dcfce7; color: #166534; }
+    .chip.missing { background: #fee2e2; color: #991b1b; }
+    .chip.orphan { background: #fef9c3; color: #854d0e; }
+    .cell { border: 1px solid var(--line); border-radius: 10px; margin: 10px 0;
+      overflow: hidden; }
+    .cell-head { display: flex; align-items: center; gap: 6px; padding: 6px 10px;
+      background: var(--card); border-bottom: 1px solid var(--line); font-size: .76rem; }
+    .cell-body { padding: 10px 12px; }
+    .cell-body pre { overflow-x: auto; background: rgba(127,127,127,.08); padding: 10px;
+      border-radius: 8px; }
+    .cell-body code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .cell.editable .cell-head { cursor: pointer; }
+    .banner { padding: 10px 12px; border-radius: 8px; margin: 10px 0; }
+    .banner.warn { background: var(--warn-bg); color: var(--warn-fg); }
+    .banner.err { background: #fee2e2; color: var(--err); }
+    .toast { position: fixed; left: 50%; bottom: 20px; transform: translateX(-50%);
+      background: #111827; color: #fff; padding: 10px 16px; border-radius: 999px;
+      font-size: .9rem; opacity: 0; transition: opacity .2s; z-index: 20; }
+    .toast.show { opacity: .96; }
+    .edit-actions { display: flex; gap: 8px; margin-top: 8px; }
+    .spacer { flex: 1; }
+    a { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <header>
+    <button id="back" class="ghost" style="display:none">&larr;</button>
+    <h1 id="title">Mobile Deck Studio</h1>
+    <button id="refresh" class="ghost" title="Refresh">&#x21bb;</button>
+  </header>
+  <main id="app"><p class="muted">Loading&hellip;</p></main>
+  <div id="toast" class="toast"></div>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/src/clm/web/studio/__init__.py
+++ b/src/clm/web/studio/__init__.py
@@ -1,0 +1,21 @@
+"""Mobile Deck Studio — phone-friendly deck authoring served by ``clm serve``.
+
+A second view on the existing ``clm serve`` FastAPI app (alongside the jobs
+Monitor) that lets a deck be browsed and edited from a phone over Tailscale.
+The phone is a thin authoring surface; the desktop does the heavy lifting
+(parse, byte-exact write-back, change watching).
+
+Design of record: ``docs/claude/design/mobile-deck-studio.md``. This package
+implements **P0** (read-only browse + search) and **P1** (cell editing with
+the optimistic-concurrency keystone + external-change watcher). Structural
+ops (P2), bilingual lock/sync (P3) and build-preview/PWA (P4) are not yet
+implemented.
+
+Per the design's §9.4 steering note the P0/P1 frontend is intentionally a
+lightweight vanilla-JS surface; the no-build Preact + CodeMirror PWA is
+deferred to P2+ where in-cell editing ergonomics start to pay off.
+"""
+
+from clm.web.studio.service import StudioService
+
+__all__ = ["StudioService"]

--- a/src/clm/web/studio/auth.py
+++ b/src/clm/web/studio/auth.py
@@ -1,0 +1,89 @@
+"""Bearer-token pairing for Mobile Deck Studio.
+
+Anyone who can reach the Studio URL (over Tailscale / LAN) must present a
+shared bearer token. The token is **persistent** — stored in the user config
+dir — so the pairing QR code is stable across server restarts (a phone that
+scanned it once keeps working). ``--rotate-token`` cycles it.
+
+The token is the real access gate: ``clm serve`` binds localhost and exposure
+is via ``tailscale serve`` / explicit ``--host``, so the network boundary is
+the tailnet; the token guards against anyone else on it. One token, full
+access — there are no per-user accounts (§3.2 of the design).
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from pathlib import Path
+
+from fastapi import Request
+from fastapi.security.utils import get_authorization_scheme_param
+
+logger = logging.getLogger(__name__)
+
+#: File name under the user config dir holding the persistent Studio token.
+_TOKEN_FILENAME = "studio_token"
+
+
+def _token_path() -> Path:
+    """Return the path of the persistent Studio token file.
+
+    Uses ``platformdirs`` so the location is correct per-OS (e.g. ``%APPDATA%``
+    on Windows, ``~/.config`` on Linux).
+    """
+    from platformdirs import user_config_dir
+
+    return Path(user_config_dir("clm")) / _TOKEN_FILENAME
+
+
+def _generate_token() -> str:
+    """Return a fresh URL-safe random token."""
+    return secrets.token_urlsafe(24)
+
+
+def get_or_create_token(*, rotate: bool = False) -> str:
+    """Return the persistent Studio token, creating (or rotating) it on disk.
+
+    Args:
+        rotate: When True, discard any existing token and write a new one.
+
+    Returns:
+        The bearer token (stable across restarts unless rotated).
+    """
+    path = _token_path()
+    if not rotate and path.exists():
+        existing = path.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    token = _generate_token()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token, encoding="utf-8")
+    logger.info("Studio token %s at %s", "rotated" if rotate else "created", path)
+    return token
+
+
+def extract_token(request: Request) -> str | None:
+    """Pull the presented token from a request.
+
+    Accepts either an ``Authorization: Bearer <token>`` header (used by the
+    PWA for REST/WS calls once paired) or a ``?token=`` query parameter (used
+    by the initial QR-code deep link, which the frontend then stores).
+    """
+    auth = request.headers.get("Authorization")
+    if auth:
+        scheme, param = get_authorization_scheme_param(auth)
+        if scheme.lower() == "bearer" and param:
+            return param
+    query_token = request.query_params.get("token")
+    if query_token:
+        return query_token
+    return None
+
+
+def token_matches(request: Request, expected: str) -> bool:
+    """Constant-time check that the request presents ``expected``."""
+    presented = extract_token(request)
+    if not presented:
+        return False
+    return secrets.compare_digest(presented, expected)

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -1,0 +1,134 @@
+"""Pydantic request/response models for the Studio API.
+
+These cross the phone↔desktop boundary, so per the repo convention messages
+are Pydantic (not ``attrs``). Field names are part of the wire contract the
+frontend depends on.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CellView(BaseModel):
+    """One cell as presented to the phone for browsing/editing.
+
+    ``index`` is an ordinal for display only — it is **never** a write key
+    (the keystone: index-keyed writes are unsafe against the two-editor race).
+    Writes target ``(slide_id, role)`` and are guarded by ``content_hash``.
+    """
+
+    index: int = Field(description="Display ordinal; not a write key.")
+    slide_id: str | None = Field(default=None, description="Hand-assigned slide id, if any.")
+    role: str | None = Field(default=None, description="Sync role (slide/notes/code/…), if any.")
+    cell_type: str = Field(description='"markdown" or "code".')
+    lang: str | None = Field(default=None, description='"de"/"en", or None for shared code.')
+    tags: list[str] = Field(default_factory=list)
+    body: str = Field(description="Cell body text.")
+    is_j2: bool = Field(default=False, description="Jinja header/macro cell.")
+    content_hash: str = Field(description="Hash of the cell body (optimistic-concurrency guard).")
+    anchor: str = Field(description="Content-derived stable identity (id:/construct:/hash:).")
+    editable: bool = Field(
+        description="True iff addressable by (slide_id, role) — only these are editable in P1."
+    )
+
+
+class DeckView(BaseModel):
+    """A single deck opened for viewing/editing."""
+
+    deck_id: str = Field(description="Slides-dir-relative POSIX path identifying the deck.")
+    deck_version: str = Field(description="Hash of the whole file (optimistic-concurrency guard).")
+    lang: str | None = Field(default=None, description="Language filter applied, if any.")
+    cells: list[CellView]
+
+
+class DeckSummary(BaseModel):
+    """A deck entry in the navigation tree / recents / orphan bucket."""
+
+    deck_id: str
+    filename: str
+    topic_id: str | None = None
+    section: str | None = None
+    status: str = Field(description='"present", "missing", or "orphan".')
+
+
+class DeckTree(BaseModel):
+    """Navigation payload: spec-resolved decks, recents, and orphans."""
+
+    spec_path: str
+    slides_dir: str
+    decks: list[DeckSummary] = Field(description="Spec-resolved decks (present + missing).")
+    orphans: list[DeckSummary] = Field(description='Decks "not in spec".')
+    recents: list[str] = Field(default_factory=list, description="Recently opened deck ids.")
+
+
+class SearchHit(BaseModel):
+    """One search result."""
+
+    score: float
+    topic_id: str
+    directory: str
+    title_de: str = ""
+    title_en: str = ""
+    deck_ids: list[str] = Field(default_factory=list)
+
+
+class SearchResults(BaseModel):
+    query: str
+    hits: list[SearchHit]
+
+
+class EditBodyRequest(BaseModel):
+    """An ``edit-body`` write, carrying the optimistic-concurrency expectations.
+
+    ``deck_id`` + ``slide_id`` travel in the body (not the URL path) because a
+    deck id is a slash-bearing relative path that a greedy path converter would
+    swallow; the write key is still ``(slide_id, role)``, never an index.
+    """
+
+    deck_id: str = Field(description="Slides-dir-relative deck path.")
+    slide_id: str = Field(description="Hand-assigned slide id of the target cell.")
+    role: str = Field(description="Sync role of the target cell.")
+    new_body: str = Field(description="Replacement cell body.")
+    expected_deck_version: str = Field(description="deck_version the phone last saw.")
+    expected_cell_hash: str = Field(description="content_hash the phone last saw for this cell.")
+
+
+class EditTagsRequest(BaseModel):
+    """An ``edit-tags`` write, carrying the optimistic-concurrency expectations."""
+
+    deck_id: str
+    slide_id: str
+    role: str
+    new_tags: list[str]
+    expected_deck_version: str
+    expected_cell_hash: str
+
+
+class EditResult(BaseModel):
+    """Result of a successful write: the fresh guards for the next edit."""
+
+    ok: bool = True
+    deck_version: str
+    cell_hash: str
+
+
+class RenderCellRequest(BaseModel):
+    """Tier-2 (no-exec) render request for one cell."""
+
+    body: str
+    is_j2: bool = False
+
+
+class RenderCellResult(BaseModel):
+    """Tier-2 render result.
+
+    P0/P1 ship tier-1 (client-side markdown) as the working preview; this
+    server endpoint is scaffolded and currently echoes the body with
+    ``rendered=False`` for ``is_j2`` cells. Wiring the jupytext+Jinja no-exec
+    expansion is a focused follow-up (still within the P0 design scope).
+    """
+
+    rendered: bool
+    html: str | None = None
+    body: str

--- a/src/clm/web/studio/qr.py
+++ b/src/clm/web/studio/qr.py
@@ -1,0 +1,72 @@
+"""QR-code generation for Mobile Deck Studio pairing.
+
+Renders the Studio URL (plus its bearer token) as a QR code so a phone can
+scan it instead of typing a Tailscale/LAN address and token by hand. Pure
+Python (``segno``) — no Pillow, no external API — so it stays fully offline.
+
+``segno`` is imported **lazily inside each function** (not at module top
+level) so that importing this module never fails when the ``[web]`` extra
+that provides ``segno`` is not installed: the QR surface degrades gracefully
+(``is_available()`` returns ``False``, ``print_terminal`` is a no-op) instead
+of making ``clm serve`` unimportable.
+
+Lifted, with light adaptation, from the closed ``clm edit`` prototype
+(PR #394) per the design's §9.3 reuse note — it is exactly the §3.2 pairing
+helper and a reimplementation would buy nothing.
+
+Surfaces:
+- :func:`svg_data_uri` — for embedding in a web page (``<img src=…>``).
+- :func:`print_terminal` — a desktop-console block rendering, shown by
+  ``clm serve`` next to the Studio URL.
+- :func:`is_available` — whether ``segno`` is importable.
+"""
+
+from __future__ import annotations
+
+from typing import TextIO
+
+#: Raised when segno is not installed; caught by callers to degrade gracefully.
+SEGNO_MISSING_MSG = "segno is not installed (needs the [web] extra)"
+
+
+def _require_segno():
+    """Import and return segno, raising a clear error if it is absent."""
+    try:
+        import segno
+    except ImportError as exc:  # pragma: no cover - exercised via the route guard
+        raise ImportError(SEGNO_MISSING_MSG) from exc
+    return segno
+
+
+def is_available() -> bool:
+    """Return True iff segno is importable (i.e. the ``[web]`` extra is installed)."""
+    try:
+        import segno  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def svg_data_uri(url: str, *, scale: int = 6) -> str:
+    """Return ``url`` as an inline-SVG ``data:`` URI for an ``<img>`` tag.
+
+    ``scale`` is pixels-per-module; 6 renders comfortably on a phone camera.
+    """
+    segno = _require_segno()
+    qr = segno.make(url, error="m")
+    return str(qr.svg_data_uri(scale=scale, svgns=False, omitsize=True))
+
+
+def print_terminal(url: str, *, file: TextIO | None = None) -> None:
+    """Print a scannable block-QR rendering of ``url`` to ``file`` (default stdout).
+
+    ``segno``'s terminal writer emits Unicode half-blocks directly; used by
+    ``clm serve`` so the QR code appears in the desktop console. No-op-safe:
+    any render error (including segno being absent) is swallowed so a QR
+    glitch never blocks the server.
+    """
+    try:
+        segno = _require_segno()
+        segno.make(url, error="m").terminal(out=file, compact=True)
+    except Exception:  # pragma: no cover - defensive; terminal quirks across envs
+        pass

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -1,0 +1,163 @@
+"""Studio API routes (mounted only when ``clm serve`` is given a course spec).
+
+REST under ``/api/studio``. Every call requires the bearer token (§3.2). Deck
+ids are slash-bearing relative paths, so they travel as query/body params
+rather than URL path segments (a greedy path converter would swallow them).
+
+Optimistic-concurrency failures surface as **409** (``deck_version`` or
+``cell_hash`` no longer current); the response carries the fresh guard so the
+phone can re-fetch and retry. The language lock (**423**) is P3 and not yet
+wired.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from clm.web.studio.auth import token_matches
+from clm.web.studio.models import (
+    DeckTree,
+    DeckView,
+    EditBodyRequest,
+    EditResult,
+    EditTagsRequest,
+    RenderCellRequest,
+    RenderCellResult,
+    SearchResults,
+)
+from clm.web.studio.service import (
+    CellNotFoundError,
+    DeckNotFoundError,
+    InvalidDeckIdError,
+    StaleWriteError,
+    StudioService,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/studio")
+
+
+def require_token(request: Request) -> None:
+    """FastAPI dependency: reject requests without a valid bearer token."""
+    expected = getattr(request.app.state, "studio_token", None)
+    if not expected or not token_matches(request, expected):
+        raise HTTPException(status_code=401, detail="Invalid or missing Studio token")
+
+
+def get_service(request: Request) -> StudioService:
+    """Resolve the per-instance StudioService from app state."""
+    service = getattr(request.app.state, "studio_service", None)
+    if service is None:
+        raise HTTPException(status_code=404, detail="Studio not enabled (start with --spec)")
+    return cast(StudioService, service)
+
+
+def _handle_write(call: Callable[[], EditResult]) -> EditResult:
+    """Run a write callable, translating service errors to HTTP responses."""
+    try:
+        return call()
+    except StaleWriteError as e:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "stale", "kind": e.kind, "current": e.current},
+        ) from e
+    except CellNotFoundError as e:
+        raise HTTPException(status_code=404, detail=f"Cell not found: {e}") from e
+    except DeckNotFoundError as e:
+        raise HTTPException(status_code=404, detail=f"Deck not found: {e}") from e
+    except InvalidDeckIdError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e
+
+
+@router.get("/decks", response_model=DeckTree, dependencies=[Depends(require_token)])
+async def list_decks(request: Request) -> DeckTree:
+    """Navigation tree: spec-resolved decks, recents, and the 'not in spec' bucket."""
+    service = get_service(request)
+    try:
+        return service.list_decks()
+    except Exception as e:  # pragma: no cover - surfaced to the client
+        logger.error("Studio list_decks failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Error listing decks: {e}") from e
+
+
+@router.get("/search", response_model=SearchResults, dependencies=[Depends(require_token)])
+async def search(
+    request: Request,
+    q: str = Query(..., min_length=1, description="Search query."),
+    limit: int = Query(20, ge=1, le=100),
+) -> SearchResults:
+    """Full-text search over deck titles + cell text."""
+    service = get_service(request)
+    try:
+        return service.search(q, max_results=limit)
+    except Exception as e:  # pragma: no cover
+        logger.error("Studio search failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Search error: {e}") from e
+
+
+@router.get("/deck", response_model=DeckView, dependencies=[Depends(require_token)])
+async def open_deck(
+    request: Request,
+    id: str = Query(..., description="Slides-dir-relative deck path."),
+    lang: str | None = Query(None, description='Optional language filter ("de"/"en").'),
+) -> DeckView:
+    """Open a deck for viewing/editing (read-only render)."""
+    service = get_service(request)
+    try:
+        return service.open_deck(id, lang=lang)
+    except InvalidDeckIdError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e
+    except DeckNotFoundError as e:
+        raise HTTPException(status_code=404, detail=f"Deck not found: {e}") from e
+
+
+@router.post("/deck/edit-body", response_model=EditResult, dependencies=[Depends(require_token)])
+async def edit_body(request: Request, req: EditBodyRequest) -> EditResult:
+    """Replace a cell body (optimistic concurrency)."""
+    service = get_service(request)
+    return _handle_write(
+        lambda: service.edit_body(
+            req.deck_id,
+            req.slide_id,
+            req.role,
+            req.new_body,
+            expected_deck_version=req.expected_deck_version,
+            expected_cell_hash=req.expected_cell_hash,
+        )
+    )
+
+
+@router.post("/deck/edit-tags", response_model=EditResult, dependencies=[Depends(require_token)])
+async def edit_tags(request: Request, req: EditTagsRequest) -> EditResult:
+    """Replace a cell's tags (optimistic concurrency)."""
+    service = get_service(request)
+    return _handle_write(
+        lambda: service.edit_tags(
+            req.deck_id,
+            req.slide_id,
+            req.role,
+            req.new_tags,
+            expected_deck_version=req.expected_deck_version,
+            expected_cell_hash=req.expected_cell_hash,
+        )
+    )
+
+
+@router.post(
+    "/deck/render-cell",
+    response_model=RenderCellResult,
+    dependencies=[Depends(require_token)],
+)
+async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellResult:
+    """Tier-2 (no-exec) render of one cell.
+
+    P0/P1 use client-side markdown (tier 1) as the working preview; this
+    endpoint is scaffolded and echoes the body with ``rendered=False`` until
+    the jupytext+Jinja no-exec expansion is wired (a focused follow-up).
+    """
+    return RenderCellResult(rendered=False, html=None, body=req.body)

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -1,0 +1,362 @@
+"""StudioService — the desktop-side engine behind the Studio API.
+
+One instance is bound to a single course (a spec + its ``slides/`` dir) per
+``clm serve`` instance. It exposes navigation (tree / recents / orphans),
+search, deck open (read-only render), and the **concurrency core**: cell
+edits routed through the byte-exact :class:`FileState` write-back engine,
+guarded by optimistic ``deck_version`` + ``cell_hash`` checks.
+
+Identity rules (the keystone — see design §3.6 / §9.1):
+
+* Cells are addressed by ``(slide_id, role)`` — **never** by index. An
+  insert/delete/reorder on the desktop side shifts indices; index-keyed
+  writes would then silently clobber the wrong cell.
+* Every write carries the ``deck_version`` (whole-file hash) and
+  ``cell_hash`` (target body hash) the phone last saw. A mismatch raises a
+  stale error (HTTP 409 at the route layer) instead of overwriting.
+* All writes go through :class:`FileState` (one write path — design §9.2);
+  untouched cells are left byte-for-byte unchanged.
+
+P1 only edits cells already addressable by ``(slide_id, role)``; id-less
+cells are read-only until structural ops / id-minting land in P2.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from pathlib import Path
+
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_writeback import (
+    FileState,
+    anchor_of,
+    cell_content_hash,
+    role_of,
+)
+from clm.web.studio.models import (
+    CellView,
+    DeckSummary,
+    DeckTree,
+    DeckView,
+    EditResult,
+    SearchHit,
+    SearchResults,
+)
+
+logger = logging.getLogger(__name__)
+
+#: How long (seconds) after the app writes a deck the watcher should treat a
+#: filesystem change to it as our own write rather than an external edit.
+SELF_WRITE_WINDOW_SECONDS = 2.0
+
+#: Cap on how many recently-opened decks to remember.
+_MAX_RECENTS = 20
+
+
+class StudioError(Exception):
+    """Base class for Studio service errors (mapped to HTTP at the route layer)."""
+
+
+class InvalidDeckIdError(StudioError):
+    """The deck id is malformed, escapes the slides dir, or is not a ``.py`` deck."""
+
+
+class DeckNotFoundError(StudioError):
+    """No deck file exists for the given id."""
+
+
+class CellNotFoundError(StudioError):
+    """No cell with the given ``(slide_id, role)`` exists in the deck."""
+
+
+class StaleWriteError(StudioError):
+    """An optimistic-concurrency guard failed; the caller must re-fetch.
+
+    ``current`` carries the up-to-date value (deck_version or cell_hash) so the
+    409 response can hand the phone the fresh guard.
+    """
+
+    def __init__(self, kind: str, current: str) -> None:
+        super().__init__(f"stale {kind}; expected value no longer current")
+        self.kind = kind
+        self.current = current
+
+
+class StudioService:
+    """Course-scoped engine for the Studio API."""
+
+    def __init__(self, spec_path: Path) -> None:
+        from clm.core.course_paths import resolve_course_paths
+        from clm.core.course_spec import CourseSpec
+
+        self.spec_path = Path(spec_path).resolve()
+        self.spec = CourseSpec.from_file(self.spec_path)
+        course_root, _ = resolve_course_paths(self.spec_path)
+        self.slides_dir = (course_root / "slides").resolve()
+        self._recents: list[str] = []
+        self._self_writes: dict[str, float] = {}
+
+    # ------------------------------------------------------------------ paths
+
+    def _rel(self, path: Path) -> str:
+        """Slides-dir-relative POSIX deck id for ``path``."""
+        return path.resolve().relative_to(self.slides_dir).as_posix()
+
+    def _resolve_deck_id(self, deck_id: str) -> Path:
+        """Resolve a deck id to an absolute path, rejecting traversal/non-decks."""
+        if not deck_id or deck_id.endswith("/"):
+            raise InvalidDeckIdError(deck_id)
+        candidate = (self.slides_dir / deck_id).resolve()
+        root = self.slides_dir
+        if candidate != root and root not in candidate.parents:
+            raise InvalidDeckIdError(deck_id)
+        if candidate.suffix != ".py":
+            raise InvalidDeckIdError(deck_id)
+        return candidate
+
+    def _deck_version(self, path: Path) -> str:
+        """Whole-file hash used as the deck-level optimistic-concurrency guard."""
+        return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+    # --------------------------------------------------------- self-write hint
+
+    def mark_self_write(self, deck_id: str) -> None:
+        """Record that we are about to write ``deck_id`` (suppresses watcher echo)."""
+        self._self_writes[deck_id] = time.monotonic() + SELF_WRITE_WINDOW_SECONDS
+
+    def is_self_write(self, deck_id: str) -> bool:
+        """Whether a recent filesystem change to ``deck_id`` was our own write."""
+        deadline = self._self_writes.get(deck_id)
+        return deadline is not None and time.monotonic() < deadline
+
+    # -------------------------------------------------------------- navigation
+
+    def _note_recent(self, deck_id: str) -> None:
+        if deck_id in self._recents:
+            self._recents.remove(deck_id)
+        self._recents.insert(0, deck_id)
+        del self._recents[_MAX_RECENTS:]
+
+    def list_decks(self) -> DeckTree:
+        """Spec-resolved deck tree + recents + the 'not in spec' bucket."""
+        from clm.core.spec_decks import resolve_spec_decks
+        from clm.core.spec_orphans import find_orphans
+        from clm.core.topic_resolver import build_topic_map
+
+        topic_map = build_topic_map(self.slides_dir)
+        resolution = resolve_spec_decks(self.spec, self.slides_dir, topic_map=topic_map)
+
+        decks: list[DeckSummary] = []
+        for topic in resolution.topics:
+            if topic.found:
+                for slide in topic.slide_files:
+                    decks.append(
+                        DeckSummary(
+                            deck_id=self._rel(slide),
+                            filename=slide.name,
+                            topic_id=topic.topic_id,
+                            section=topic.section,
+                            status="present",
+                        )
+                    )
+            else:
+                decks.append(
+                    DeckSummary(
+                        deck_id="",
+                        filename=topic.topic_id,
+                        topic_id=topic.topic_id,
+                        section=topic.section,
+                        status="missing",
+                    )
+                )
+
+        orphan_report = find_orphans([self.spec_path], self.slides_dir, topic_map=topic_map)
+        orphans = [
+            DeckSummary(
+                deck_id=self._rel(o.path),
+                filename=o.path.name,
+                topic_id=None,
+                section=None,
+                status="orphan",
+            )
+            for o in orphan_report.orphans
+        ]
+
+        return DeckTree(
+            spec_path=str(self.spec_path),
+            slides_dir=str(self.slides_dir),
+            decks=decks,
+            orphans=orphans,
+            recents=list(self._recents),
+        )
+
+    def search(self, query: str, *, max_results: int = 20) -> SearchResults:
+        """Full-text search over deck titles + cell text (reuses ``slides search``)."""
+        from clm.slides.search import search_slides
+
+        raw = search_slides(
+            query,
+            self.slides_dir,
+            course_spec_path=self.spec_path,
+            max_results=max_results,
+        )
+        hits: list[SearchHit] = []
+        for r in raw:
+            deck_ids: list[str] = []
+            for slide in r.slides:
+                try:
+                    deck_ids.append(self._rel(Path(r.directory) / slide.file))
+                except (ValueError, OSError):
+                    continue
+            hits.append(
+                SearchHit(
+                    score=r.score,
+                    topic_id=r.topic_id,
+                    directory=r.directory,
+                    title_de=r.slides[0].title_de if r.slides else "",
+                    title_en=r.slides[0].title_en if r.slides else "",
+                    deck_ids=deck_ids,
+                )
+            )
+        return SearchResults(query=query, hits=hits)
+
+    # ----------------------------------------------------------------- open
+
+    def _cell_views(self, text: str, lang: str | None) -> list[CellView]:
+        from collections import Counter
+
+        parsed = parse_cells(text)
+        # A cell is only safely addressable when its (slide_id, role) key is
+        # UNIQUE in the file — FileState.find_cell returns the first match and
+        # ignores language, so a colliding key (e.g. a genuinely interleaved
+        # de+en deck sharing a slide_id) would let a write hit the wrong half.
+        # Such cells are read-only in P1; bilingual editing is P3.
+        key_counts: Counter[tuple[str, str]] = Counter()
+        for c in parsed:
+            c_role = role_of(c.metadata)
+            if c.slide_id is not None and c_role is not None:
+                key_counts[(c.slide_id, c_role)] += 1
+        views: list[CellView] = []
+        for index, cell in enumerate(parsed):
+            if lang is not None and cell.lang is not None and cell.lang != lang:
+                continue
+            role = role_of(cell.metadata)
+            editable = (
+                cell.slide_id is not None
+                and role is not None
+                and key_counts[(cell.slide_id, role)] == 1
+            )
+            views.append(
+                CellView(
+                    index=index,
+                    slide_id=cell.slide_id,
+                    role=role,
+                    cell_type=cell.cell_type,
+                    lang=cell.lang,
+                    tags=list(cell.tags),
+                    body=cell.content,
+                    is_j2=cell.metadata.is_j2,
+                    content_hash=cell_content_hash(cell.content),
+                    anchor=anchor_of(cell.metadata, cell.content),
+                    editable=editable,
+                )
+            )
+        return views
+
+    def open_deck(self, deck_id: str, *, lang: str | None = None) -> DeckView:
+        """Parse a deck for viewing/editing (read-only render)."""
+        path = self._resolve_deck_id(deck_id)
+        if not path.exists():
+            raise DeckNotFoundError(deck_id)
+        text = path.read_text(encoding="utf-8")
+        self._note_recent(deck_id)
+        return DeckView(
+            deck_id=deck_id,
+            deck_version=self._deck_version(path),
+            lang=lang,
+            cells=self._cell_views(text, lang),
+        )
+
+    # ----------------------------------------------------- concurrency core
+
+    def _load_guarded(
+        self,
+        deck_id: str,
+        slide_id: str,
+        role: str,
+        expected_deck_version: str,
+        expected_cell_hash: str,
+    ) -> tuple[Path, FileState]:
+        """Validate the optimistic guards and return the loaded file state.
+
+        Raises:
+            DeckNotFoundError / CellNotFoundError: missing target.
+            StaleWriteError: deck_version or cell_hash no longer current (→ 409).
+        """
+        path = self._resolve_deck_id(deck_id)
+        if not path.exists():
+            raise DeckNotFoundError(deck_id)
+
+        current_version = self._deck_version(path)
+        if current_version != expected_deck_version:
+            raise StaleWriteError("deck_version", current_version)
+
+        state = FileState.load(path)
+        cell = state.find_cell(slide_id, role)
+        if cell is None:
+            raise CellNotFoundError(f"{slide_id!r}/{role!r}")
+
+        current_hash = cell_content_hash(cell.body)
+        if current_hash != expected_cell_hash:
+            raise StaleWriteError("cell_hash", current_hash)
+
+        return path, state
+
+    def _persist(
+        self, deck_id: str, path: Path, state: FileState, slide_id: str, role: str
+    ) -> EditResult:
+        """Flush ``state`` to disk and return fresh guards recomputed from disk."""
+        self.mark_self_write(deck_id)
+        state.flush()
+        fresh = FileState.load(path)
+        fresh_cell = fresh.find_cell(slide_id, role)
+        new_hash = cell_content_hash(fresh_cell.body) if fresh_cell is not None else ""
+        return EditResult(deck_version=self._deck_version(path), cell_hash=new_hash)
+
+    def edit_body(
+        self,
+        deck_id: str,
+        slide_id: str,
+        role: str,
+        new_body: str,
+        *,
+        expected_deck_version: str,
+        expected_cell_hash: str,
+    ) -> EditResult:
+        """Replace one cell's body, guarded by optimistic concurrency."""
+        path, state = self._load_guarded(
+            deck_id, slide_id, role, expected_deck_version, expected_cell_hash
+        )
+        if not state.replace_cell_body(slide_id, role, new_body):
+            raise CellNotFoundError(f"{slide_id!r}/{role!r}")
+        return self._persist(deck_id, path, state, slide_id, role)
+
+    def edit_tags(
+        self,
+        deck_id: str,
+        slide_id: str,
+        role: str,
+        new_tags: list[str],
+        *,
+        expected_deck_version: str,
+        expected_cell_hash: str,
+    ) -> EditResult:
+        """Replace one cell's tags, guarded by optimistic concurrency."""
+        path, state = self._load_guarded(
+            deck_id, slide_id, role, expected_deck_version, expected_cell_hash
+        )
+        if not state.replace_cell_tags(slide_id, role, new_tags):
+            raise CellNotFoundError(f"{slide_id!r}/{role!r}")
+        return self._persist(deck_id, path, state, slide_id, role)

--- a/src/clm/web/studio/watcher.py
+++ b/src/clm/web/studio/watcher.py
@@ -1,0 +1,66 @@
+"""External-change watcher — the cross-tool half of the two-editor guard.
+
+``watchfiles`` watches the course ``slides/`` dir. When a deck ``.py`` changes
+on disk *and the change was not our own write*, the server pushes a
+``deck-changed-on-disk`` event over the WebSocket so the phone can show
+"changed on disk — reload" and disable Save until the user re-fetches. This
+closes the fetch→write gap for the VS Code case that optimistic concurrency
+alone cannot see until a write is attempted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from clm.web.studio.service import StudioService
+
+logger = logging.getLogger(__name__)
+
+
+async def watch_slides_dir(service: StudioService) -> None:
+    """Watch the slides dir and broadcast external deck changes over WS.
+
+    Runs until cancelled (the ``clm serve`` lifespan cancels it at shutdown).
+    Self-writes (recent edits made through the Studio API) are filtered out so
+    the phone is not told its own save was an external change.
+    """
+    try:
+        from watchfiles import awatch
+    except ImportError:  # pragma: no cover - watchfiles ships with the [web] extra
+        logger.warning("watchfiles unavailable; Studio external-change watcher disabled")
+        return
+
+    from clm.web.api.websocket import ws_manager
+
+    slides_dir = service.slides_dir
+    if not slides_dir.exists():
+        logger.warning("Studio watcher: slides dir %s does not exist", slides_dir)
+        return
+
+    logger.info("Studio watcher: watching %s", slides_dir)
+    try:
+        async for changes in awatch(slides_dir):
+            seen: set[str] = set()
+            for _change, raw_path in changes:
+                from pathlib import Path
+
+                path = Path(raw_path)
+                if path.suffix != ".py":
+                    continue
+                try:
+                    deck_id = service._rel(path)
+                except (ValueError, OSError):
+                    continue
+                if deck_id in seen:
+                    continue
+                seen.add(deck_id)
+                if service.is_self_write(deck_id):
+                    continue
+                await ws_manager.broadcast(
+                    {"type": "deck-changed-on-disk", "deck_id": deck_id},
+                    channel="studio",
+                )
+    except asyncio.CancelledError:  # pragma: no cover - shutdown path
+        logger.info("Studio watcher: stopped")
+        raise

--- a/tests/web/studio/conftest.py
+++ b/tests/web/studio/conftest.py
@@ -1,0 +1,78 @@
+"""Fixtures for Mobile Deck Studio tests.
+
+Builds a minimal but realistic course on disk: a spec under ``course-specs/``
+and a per-language deck under ``slides/<module>/<topic>/`` (CLM ships decks as
+``.de.py`` / ``.en.py`` files, so ``(slide_id, role)`` is unique per file).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from clm.web.studio.service import StudioService
+
+# A single-language deck with two id'd markdown cells (distinct roles → distinct
+# keys) and one shared, id-less code cell (not per-cell addressable → read-only).
+DECK_SOURCE = dedent(
+    """\
+    # %% [markdown] lang="de" tags=["slide"] slide_id="intro-welcome"
+    # Willkommen
+    #
+    # Schön, dass du da bist.
+
+    # %% [markdown] lang="de" tags=["notes"] slide_id="intro-welcome"
+    # Sprechernotizen hier.
+
+    # %%
+    print("hello")
+    """
+)
+
+DECK_REL = "module_100_basics/topic_010_intro/slides_intro.de.py"
+
+
+@dataclass
+class Course:
+    spec_path: Path
+    slides_dir: Path
+    deck_id: str
+
+    @property
+    def deck_path(self) -> Path:
+        return self.slides_dir / self.deck_id
+
+
+@pytest.fixture()
+def course(tmp_path: Path) -> Course:
+    spec_file = tmp_path / "course-specs" / "test.xml"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(
+        dedent(
+            """\
+            <course>
+              <name><de>Test</de><en>Test</en></name>
+              <prog-lang>python</prog-lang>
+              <description><de></de><en></en></description>
+              <certificate><de></de><en></en></certificate>
+              <sections><section><name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics></section></sections>
+            </course>
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    deck = tmp_path / "slides" / DECK_REL
+    deck.parent.mkdir(parents=True, exist_ok=True)
+    deck.write_text(DECK_SOURCE, encoding="utf-8")
+
+    return Course(spec_path=spec_file, slides_dir=tmp_path / "slides", deck_id=DECK_REL)
+
+
+@pytest.fixture()
+def service(course: Course) -> StudioService:
+    return StudioService(course.spec_path)

--- a/tests/web/studio/test_auth_qr.py
+++ b/tests/web/studio/test_auth_qr.py
@@ -1,0 +1,61 @@
+"""Tests for Studio pairing: persistent token + QR helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.web.studio import auth, qr
+
+
+class _FakeRequest:
+    def __init__(self, headers=None, query=None):
+        self.headers = headers or {}
+        self.query_params = query or {}
+
+
+class TestToken:
+    def test_create_is_stable_then_rotates(self, tmp_path: Path, monkeypatch):
+        token_file = tmp_path / "studio_token"
+        monkeypatch.setattr(auth, "_token_path", lambda: token_file)
+
+        first = auth.get_or_create_token()
+        assert first
+        assert token_file.read_text(encoding="utf-8").strip() == first
+        # Stable across calls…
+        assert auth.get_or_create_token() == first
+        # …until rotated.
+        rotated = auth.get_or_create_token(rotate=True)
+        assert rotated != first
+        assert auth.get_or_create_token() == rotated
+
+    def test_extract_from_bearer_header(self):
+        req = _FakeRequest(headers={"Authorization": "Bearer abc123"})
+        assert auth.extract_token(req) == "abc123"
+
+    def test_extract_from_query_param(self):
+        req = _FakeRequest(query={"token": "qtok"})
+        assert auth.extract_token(req) == "qtok"
+
+    def test_token_matches_is_constant_time_check(self):
+        req = _FakeRequest(headers={"Authorization": "Bearer secret"})
+        assert auth.token_matches(req, "secret")
+        assert not auth.token_matches(req, "other")
+
+    def test_no_token_does_not_match(self):
+        assert not auth.token_matches(_FakeRequest(), "secret")
+
+
+class TestQr:
+    def test_available(self):
+        # segno ships with the [web] extra used in the test env.
+        assert qr.is_available() is True
+
+    def test_svg_data_uri(self):
+        uri = qr.svg_data_uri("http://example.test/studio")
+        assert uri.startswith("data:image/svg+xml")
+
+    def test_print_terminal_is_safe(self, capsys):
+        qr.print_terminal("http://example.test/studio")
+        # Should emit *something* and never raise.
+        captured = capsys.readouterr()
+        assert captured.out != "" or captured.err == ""

--- a/tests/web/studio/test_routes.py
+++ b/tests/web/studio/test_routes.py
@@ -1,0 +1,108 @@
+"""Tests for the Studio API routes (auth + concurrency surfaced over HTTP)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.web.app import create_app
+
+from .conftest import Course
+
+TOKEN = "test-studio-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.fixture()
+def client(course: Course) -> TestClient:
+    app = create_app(
+        db_path=course.slides_dir.parent / "jobs.db",
+        spec_path=course.spec_path,
+        studio_token=TOKEN,
+    )
+    # No `with` → lifespan (and the filesystem watcher) is not started; routes
+    # work because StudioService is wired in create_app, not the lifespan.
+    return TestClient(app)
+
+
+class TestAuth:
+    def test_missing_token_is_401(self, client: TestClient):
+        assert client.get("/api/studio/decks").status_code == 401
+
+    def test_wrong_token_is_401(self, client: TestClient):
+        r = client.get("/api/studio/decks", headers={"Authorization": "Bearer nope"})
+        assert r.status_code == 401
+
+    def test_token_via_query_param(self, client: TestClient):
+        r = client.get(f"/api/studio/decks?token={TOKEN}")
+        assert r.status_code == 200
+
+
+class TestReadEndpoints:
+    def test_list_decks(self, client: TestClient, course: Course):
+        r = client.get("/api/studio/decks", headers=AUTH)
+        assert r.status_code == 200
+        ids = [d["deck_id"] for d in r.json()["decks"]]
+        assert course.deck_id in ids
+
+    def test_open_deck(self, client: TestClient, course: Course):
+        r = client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["deck_version"]
+        assert any(c["role"] == "slide" and c["editable"] for c in body["cells"])
+
+    def test_open_unknown_deck_404(self, client: TestClient):
+        r = client.get(
+            "/api/studio/deck?id=module_100_basics/topic_010_intro/ghost.de.py",
+            headers=AUTH,
+        )
+        assert r.status_code == 404
+
+    def test_search(self, client: TestClient):
+        r = client.get("/api/studio/search?q=intro", headers=AUTH)
+        assert r.status_code == 200
+        assert "hits" in r.json()
+
+
+class TestWriteEndpoints:
+    def _open_slide(self, client: TestClient, course: Course):
+        body = client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH).json()
+        slide = next(c for c in body["cells"] if c["role"] == "slide")
+        return body["deck_version"], slide
+
+    def test_edit_body_ok(self, client: TestClient, course: Course):
+        deck_version, slide = self._open_slide(client, course)
+        r = client.post(
+            "/api/studio/deck/edit-body",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "slide_id": slide["slide_id"],
+                "role": slide["role"],
+                "new_body": "# Neu\n#\n# Inhalt",
+                "expected_deck_version": deck_version,
+                "expected_cell_hash": slide["content_hash"],
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["deck_version"] != deck_version
+
+    def test_stale_write_is_409_with_fresh_guard(self, client: TestClient, course: Course):
+        _, slide = self._open_slide(client, course)
+        r = client.post(
+            "/api/studio/deck/edit-body",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "slide_id": slide["slide_id"],
+                "role": slide["role"],
+                "new_body": "x",
+                "expected_deck_version": "staleversion00000",
+                "expected_cell_hash": slide["content_hash"],
+            },
+        )
+        assert r.status_code == 409
+        detail = r.json()["detail"]
+        assert detail["kind"] == "deck_version"
+        assert detail["current"]  # fresh guard handed back for retry

--- a/tests/web/studio/test_service.py
+++ b/tests/web/studio/test_service.py
@@ -1,0 +1,196 @@
+"""Tests for :class:`clm.web.studio.service.StudioService`.
+
+The concurrency core is the keystone: these assert that stale writes are
+rejected (409-grade) and that untouched cells stay byte-for-byte unchanged
+after an edit (the §3.7 invariant lifted from the closed prototype's tests).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides.raw_cells import split_cells
+from clm.web.studio.service import (
+    CellNotFoundError,
+    DeckNotFoundError,
+    InvalidDeckIdError,
+    StaleWriteError,
+    StudioService,
+)
+
+from .conftest import Course
+
+
+class TestNavigation:
+    def test_list_decks_includes_present_deck(self, service: StudioService, course: Course):
+        tree = service.list_decks()
+        ids = [d.deck_id for d in tree.decks if d.status == "present"]
+        assert course.deck_id in ids
+
+    def test_search_matches_topic(self, service: StudioService, course: Course):
+        results = service.search("intro")
+        assert results.hits, "expected at least one search hit for 'intro'"
+
+    def test_recents_updates_on_open(self, service: StudioService, course: Course):
+        assert service.list_decks().recents == []
+        service.open_deck(course.deck_id)
+        assert service.list_decks().recents[0] == course.deck_id
+
+
+class TestOpenDeck:
+    def test_open_returns_cells_and_version(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        assert view.deck_id == course.deck_id
+        assert view.deck_version
+        # two markdown cells + one code cell
+        assert len(view.cells) == 3
+
+    def test_id_markdown_cells_are_editable(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        notes = next(c for c in view.cells if c.role == "notes")
+        assert slide.editable and slide.slide_id == "intro-welcome"
+        assert notes.editable and notes.slide_id == "intro-welcome"
+
+    def test_idless_code_cell_is_read_only(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        code = next(c for c in view.cells if c.cell_type == "code")
+        assert not code.editable
+        assert code.slide_id is None
+
+    def test_missing_deck_raises(self, service: StudioService):
+        with pytest.raises(DeckNotFoundError):
+            service.open_deck("module_100_basics/topic_010_intro/nope.de.py")
+
+    def test_traversal_is_rejected(self, service: StudioService):
+        with pytest.raises(InvalidDeckIdError):
+            service.open_deck("../../../etc/passwd")
+
+    def test_non_py_rejected(self, service: StudioService):
+        with pytest.raises(InvalidDeckIdError):
+            service.open_deck("module_100_basics/topic_010_intro/slides_intro.de.txt")
+
+
+class TestConcurrencyCore:
+    def _slide_cell(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        return view, next(c for c in view.cells if c.role == "slide")
+
+    def test_edit_body_success_round_trips(self, service: StudioService, course: Course):
+        view, slide = self._slide_cell(service, course)
+        result = service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "# Willkommen (überarbeitet)\n#\n# Neuer Text.",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        assert result.ok
+        assert result.deck_version != view.deck_version
+        # A fresh open reports the same guards the write returned.
+        reopened = service.open_deck(course.deck_id)
+        assert reopened.deck_version == result.deck_version
+        reslide = next(c for c in reopened.cells if c.role == "slide")
+        assert reslide.content_hash == result.cell_hash
+        assert "überarbeitet" in reslide.body
+
+    def test_stale_deck_version_is_rejected(self, service: StudioService, course: Course):
+        view, slide = self._slide_cell(service, course)
+        with pytest.raises(StaleWriteError) as exc:
+            service.edit_body(
+                course.deck_id,
+                slide.slide_id,
+                slide.role,
+                "x",
+                expected_deck_version="deadbeefdeadbeef",
+                expected_cell_hash=slide.content_hash,
+            )
+        assert exc.value.kind == "deck_version"
+        assert exc.value.current == view.deck_version
+
+    def test_stale_cell_hash_is_rejected(self, service: StudioService, course: Course):
+        view, slide = self._slide_cell(service, course)
+        with pytest.raises(StaleWriteError) as exc:
+            service.edit_body(
+                course.deck_id,
+                slide.slide_id,
+                slide.role,
+                "x",
+                expected_deck_version=view.deck_version,  # deck is current…
+                expected_cell_hash="0" * 64,  # …but the cell guard is wrong
+            )
+        assert exc.value.kind == "cell_hash"
+
+    def test_unknown_cell_raises(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        with pytest.raises(CellNotFoundError):
+            service.edit_body(
+                course.deck_id,
+                "no-such-id",
+                "slide",
+                "x",
+                expected_deck_version=view.deck_version,
+                expected_cell_hash="0" * 64,
+            )
+
+    def test_untouched_cells_are_byte_exact_after_edit(
+        self, service: StudioService, course: Course
+    ):
+        before = course.deck_path.read_text(encoding="utf-8")
+        _, before_cells = split_cells(before)
+
+        view, slide = self._slide_cell(service, course)
+        service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "# Geänderter Titel\n#\n# Geänderter Inhalt.",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+
+        after = course.deck_path.read_text(encoding="utf-8")
+        _, after_cells = split_cells(after)
+        assert len(after_cells) == len(before_cells)
+        # Every cell except the edited slide is byte-for-byte identical.
+        for b, a in zip(before_cells, after_cells, strict=True):
+            if b.metadata.tags == ["slide"]:
+                continue
+            assert a.lines == b.lines
+
+    def test_edit_tags_changes_header_not_body_hash(self, service: StudioService, course: Course):
+        view, slide = self._slide_cell(service, course)
+        result = service.edit_tags(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            ["slide", "keep"],
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        # Body unchanged → same cell hash; file changed → new deck version.
+        assert result.cell_hash == slide.content_hash
+        assert result.deck_version != view.deck_version
+        assert 'tags=["slide", "keep"]' in course.deck_path.read_text(encoding="utf-8")
+
+
+class TestSelfWriteHint:
+    def test_marks_and_expires(self, course: Course, monkeypatch):
+        svc = StudioService(course.spec_path)
+        assert not svc.is_self_write(course.deck_id)
+        svc.mark_self_write(course.deck_id)
+        assert svc.is_self_write(course.deck_id)
+
+    def test_edit_marks_self_write(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "# x\n#\n# y",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        assert service.is_self_write(course.deck_id)

--- a/uv.lock
+++ b/uv.lock
@@ -1064,6 +1064,7 @@ all = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
+    { name = "segno" },
     { name = "sentencepiece" },
     { name = "skorch" },
     { name = "soundfile" },
@@ -1246,6 +1247,7 @@ voiceover-granite = [
 ]
 web = [
     { name = "httptools" },
+    { name = "segno" },
     { name = "watchfiles" },
     { name = "wsproto" },
 ]
@@ -1374,6 +1376,7 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'ml'", specifier = ">=1.5.1" },
     { name = "scipy", marker = "extra == 'ml'", specifier = ">=1.14.0" },
     { name = "seaborn", marker = "extra == 'ml'", specifier = ">=0.13.2" },
+    { name = "segno", marker = "extra == 'web'", specifier = ">=1.6.0" },
     { name = "sentencepiece", marker = "extra == 'ml'", specifier = ">=0.2.1" },
     { name = "sentencepiece", marker = "extra == 'voiceover-cohere'", specifier = ">=0.1.99" },
     { name = "skorch", marker = "extra == 'ml'", git = "https://github.com/skorch-dev/skorch.git" },
@@ -7293,6 +7296,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "segno"
+version = "1.6.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/2e/b396f750c53f570055bf5a9fc1ace09bed2dff013c73b7afec5702a581ba/segno-1.6.6.tar.gz", hash = "sha256:e60933afc4b52137d323a4434c8340e0ce1e58cec71439e46680d4db188f11b3", size = 1628586, upload-time = "2025-03-12T22:12:53.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/02/12c73fd423eb9577b97fc1924966b929eff7074ae6b2e15dd3d30cb9e4ae/segno-1.6.6-py3-none-any.whl", hash = "sha256:28c7d081ed0cf935e0411293a465efd4d500704072cdb039778a2ab8736190c7", size = 76503, upload-time = "2025-03-12T22:12:48.106Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements **P0** (read-only browse + search) and **P1** (cell editing + the optimistic-concurrency keystone) of the Mobile Deck Studio, following the plan of record in `docs/claude/design/mobile-deck-studio.md` (chosen over the closed `clm edit` prototype #394). Enabled with `clm serve --spec course.xml`, served at `/studio/` alongside the jobs Monitor.

## What's in this slice

**The concurrency core (the keystone).** Cells are addressed by stable `(slide_id, role)` identity — **never by index**, the failure mode that sank #394. Every write carries the `deck_version` (whole-file hash) and `cell_hash` (target body hash) the phone last saw; a concurrent desktop edit (e.g. VS Code) yields **HTTP 409 "changed elsewhere"** with the fresh guard handed back for retry, instead of a silent clobber. All writes go through the byte-exact `FileState` engine (one write path — design §9.2), so untouched cells stay byte-for-byte unchanged. A `watchfiles` watcher pushes `deck-changed-on-disk` over the WebSocket (self-write echoes suppressed).

**Safe addressing refinement.** `FileState.find_cell` ignores language and returns the first `(slide_id, role)` match. CLM ships per-language `.de.py`/`.en.py` files (key unique per file), but to stay safe against a genuinely interleaved deck a cell is `editable` **only when its key is unique in the file**; colliding/id-less cells are read-only until P2/P3.

**Pairing & auth.** Persistent bearer token in the user config dir (`--rotate-token` cycles it); startup prints the Studio URL + a scannable QR code (`segno`, lifted from #394's `qr.py` per §9.3). REST is token-gated.

**Frontend (§9.4 call).** P0/P1 ship a **lightweight vanilla-JS** mobile surface (no build, no CodeMirror/Preact) that exercises the full backend contract — browse tree/recents/orphans, search, open, edit with the 409 + disk-change banner. The no-build Preact + vendored CodeMirror PWA is **deferred to P2+**.

## Layout
- `src/clm/web/studio/` — `service.py` (engine + concurrency core), `routes.py`, `auth.py`, `qr.py`, `watcher.py`, `models.py`
- `src/clm/web/static/studio/` — `index.html` + `app.js`
- `tests/web/studio/` — 34 tests

## Deferred (recorded in design §9.6)
- `423` language-lock (needs the watermark derivation) → **P3**
- Tier-2 server-side `is_j2` render → scaffolded (`render-cell` echoes body; tier-1 client markdown is the working preview)
- WebSocket token gating (REST is gated; WS carries only `deck_id` notifications)
- Structural insert/delete/move (P2), bilingual sync (P3), installable offline PWA (P4)

## Testing
- `tests/web/studio/` — 34 pass (navigation/open, stale `deck_version`/`cell_hash` → 409, **byte-exact untouched cells after edit**, tag edit, traversal rejection, auth, QR)
- Full `tests/web/` — 137 pass; ruff + mypy clean; pre-push fast suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
